### PR TITLE
fix(catalog): clamp MiniMax M2 / GPT-OSS reasoning_effort on Fireworks

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1372,7 +1372,7 @@ function buildParams(
 			openRouterParams.reasoning = { enabled: false };
 		} else if (options?.reasoning) {
 			openRouterParams.reasoning = {
-				effort: mapReasoningEffort(options.reasoning, model.thinking?.effortMap),
+				effort: mapReasoningEffort(options.reasoning, resolveActiveEffortMap(model, compat)),
 			};
 		}
 	} else if (
@@ -1383,7 +1383,7 @@ function buildParams(
 		compat.supportsReasoningEffort
 	) {
 		// OpenAI-style reasoning_effort
-		params.reasoning_effort = mapReasoningEffort(options.reasoning, model.thinking?.effortMap) as Effort;
+		params.reasoning_effort = mapReasoningEffort(options.reasoning, resolveActiveEffortMap(model, compat)) as Effort;
 	} else if (
 		supportsReasoningParams &&
 		options?.disableReasoning &&
@@ -1398,7 +1398,7 @@ function buildParams(
 		if (minEffort === undefined) {
 			throw new Error(`Model ${model.provider}/${model.id} has no supported reasoning efforts`);
 		}
-		params.reasoning_effort = mapReasoningEffort(minEffort, model.thinking?.effortMap) as Effort;
+		params.reasoning_effort = mapReasoningEffort(minEffort, resolveActiveEffortMap(model, compat)) as Effort;
 	}
 
 	if (compat.disableReasoningOnToolChoice && params.tool_choice !== undefined) {
@@ -1539,6 +1539,23 @@ function mapReasoningEffort(
 	reasoningEffortMap: Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>> | undefined,
 ): string {
 	return reasoningEffortMap?.[effort] ?? effort;
+}
+
+/**
+ * Compose the effective effort-map for the current turn: catalog-baked
+ * `model.thinking.effortMap` is the default, with the active compat's
+ * `reasoningEffortMap` overlaid on top so `compat.whenThinking` variants
+ * (and custom raw `Model` configs) keep authoring their own overrides.
+ */
+function resolveActiveEffortMap(
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompat,
+): Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>> | undefined {
+	const compatMap = compat.reasoningEffortMap;
+	const thinkingMap = model.thinking?.effortMap;
+	if (!compatMap || Object.keys(compatMap).length === 0) return thinkingMap;
+	if (!thinkingMap) return compatMap;
+	return { ...thinkingMap, ...compatMap };
 }
 
 function maybeAddAnthropicCacheControl(compat: ResolvedOpenAICompat, messages: ChatCompletionMessageParam[]): void {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1372,7 +1372,7 @@ function buildParams(
 			openRouterParams.reasoning = { enabled: false };
 		} else if (options?.reasoning) {
 			openRouterParams.reasoning = {
-				effort: mapReasoningEffort(options.reasoning, compat.reasoningEffortMap),
+				effort: mapReasoningEffort(options.reasoning, model.thinking?.effortMap),
 			};
 		}
 	} else if (
@@ -1383,7 +1383,7 @@ function buildParams(
 		compat.supportsReasoningEffort
 	) {
 		// OpenAI-style reasoning_effort
-		params.reasoning_effort = mapReasoningEffort(options.reasoning, compat.reasoningEffortMap) as Effort;
+		params.reasoning_effort = mapReasoningEffort(options.reasoning, model.thinking?.effortMap) as Effort;
 	} else if (
 		supportsReasoningParams &&
 		options?.disableReasoning &&
@@ -1398,7 +1398,7 @@ function buildParams(
 		if (minEffort === undefined) {
 			throw new Error(`Model ${model.provider}/${model.id} has no supported reasoning efforts`);
 		}
-		params.reasoning_effort = mapReasoningEffort(minEffort, compat.reasoningEffortMap) as Effort;
+		params.reasoning_effort = mapReasoningEffort(minEffort, model.thinking?.effortMap) as Effort;
 	}
 
 	if (compat.disableReasoningOnToolChoice && params.tool_choice !== undefined) {
@@ -1536,9 +1536,9 @@ export function parseChunkUsage(
 
 function mapReasoningEffort(
 	effort: NonNullable<OpenAICompletionsOptions["reasoning"]>,
-	reasoningEffortMap: Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>>,
+	reasoningEffortMap: Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>> | undefined,
 ): string {
-	return reasoningEffortMap[effort] ?? effort;
+	return reasoningEffortMap?.[effort] ?? effort;
 }
 
 function maybeAddAnthropicCacheControl(compat: ResolvedOpenAICompat, messages: ChatCompletionMessageParam[]): void {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1372,7 +1372,10 @@ function buildParams(
 			openRouterParams.reasoning = { enabled: false };
 		} else if (options?.reasoning) {
 			openRouterParams.reasoning = {
-				effort: mapReasoningEffort(options.reasoning, resolveActiveEffortMap(model, compat)),
+				effort:
+					compat.reasoningEffortMap?.[options.reasoning] ??
+					model.thinking?.effortMap?.[options.reasoning] ??
+					options.reasoning,
 			};
 		}
 	} else if (
@@ -1383,7 +1386,9 @@ function buildParams(
 		compat.supportsReasoningEffort
 	) {
 		// OpenAI-style reasoning_effort
-		params.reasoning_effort = mapReasoningEffort(options.reasoning, resolveActiveEffortMap(model, compat)) as Effort;
+		params.reasoning_effort = (compat.reasoningEffortMap?.[options.reasoning] ??
+			model.thinking?.effortMap?.[options.reasoning] ??
+			options.reasoning) as Effort;
 	} else if (
 		supportsReasoningParams &&
 		options?.disableReasoning &&
@@ -1398,7 +1403,9 @@ function buildParams(
 		if (minEffort === undefined) {
 			throw new Error(`Model ${model.provider}/${model.id} has no supported reasoning efforts`);
 		}
-		params.reasoning_effort = mapReasoningEffort(minEffort, resolveActiveEffortMap(model, compat)) as Effort;
+		params.reasoning_effort = (compat.reasoningEffortMap?.[minEffort] ??
+			model.thinking?.effortMap?.[minEffort] ??
+			minEffort) as Effort;
 	}
 
 	if (compat.disableReasoningOnToolChoice && params.tool_choice !== undefined) {
@@ -1532,30 +1539,6 @@ export function parseChunkUsage(
 	};
 	calculateCost(model, usage);
 	return usage;
-}
-
-function mapReasoningEffort(
-	effort: NonNullable<OpenAICompletionsOptions["reasoning"]>,
-	reasoningEffortMap: Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>> | undefined,
-): string {
-	return reasoningEffortMap?.[effort] ?? effort;
-}
-
-/**
- * Compose the effective effort-map for the current turn: catalog-baked
- * `model.thinking.effortMap` is the default, with the active compat's
- * `reasoningEffortMap` overlaid on top so `compat.whenThinking` variants
- * (and custom raw `Model` configs) keep authoring their own overrides.
- */
-function resolveActiveEffortMap(
-	model: Model<"openai-completions">,
-	compat: ResolvedOpenAICompat,
-): Partial<Record<NonNullable<OpenAICompletionsOptions["reasoning"]>, string>> | undefined {
-	const compatMap = compat.reasoningEffortMap;
-	const thinkingMap = model.thinking?.effortMap;
-	if (!compatMap || Object.keys(compatMap).length === 0) return thinkingMap;
-	if (!thinkingMap) return compatMap;
-	return { ...thinkingMap, ...compatMap };
 }
 
 function maybeAddAnthropicCacheControl(compat: ResolvedOpenAICompat, messages: ChatCompletionMessageParam[]): void {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -501,10 +501,7 @@ function buildParams(
 		options,
 		messages,
 		effort =>
-			mapReasoningEffort(
-				effort as NonNullable<OpenAIResponsesOptions["reasoning"]>,
-				resolveActiveEffortMap(model),
-			),
+			mapReasoningEffort(effort as NonNullable<OpenAIResponsesOptions["reasoning"]>, resolveActiveEffortMap(model)),
 		options?.includeEncryptedReasoning ?? true,
 		options?.omitReasoningEffort ?? false,
 	);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -501,7 +501,10 @@ function buildParams(
 		options,
 		messages,
 		effort =>
-			mapReasoningEffort(effort as NonNullable<OpenAIResponsesOptions["reasoning"]>, model.thinking?.effortMap),
+			mapReasoningEffort(
+				effort as NonNullable<OpenAIResponsesOptions["reasoning"]>,
+				resolveActiveEffortMap(model),
+			),
 		options?.includeEncryptedReasoning ?? true,
 		options?.omitReasoningEffort ?? false,
 	);
@@ -518,6 +521,21 @@ function mapReasoningEffort(
 	reasoningEffortMap: Partial<Record<NonNullable<OpenAIResponsesOptions["reasoning"]>, string>> | undefined,
 ): string {
 	return reasoningEffortMap?.[effort] ?? effort;
+}
+
+/**
+ * Compose the effective effort-map: catalog-baked `model.thinking.effortMap`
+ * is the default, with the resolved compat's `reasoningEffortMap` overlaid on
+ * top so custom raw `Model` configs keep authoring their own overrides.
+ */
+function resolveActiveEffortMap(
+	model: Model<"openai-responses">,
+): Partial<Record<NonNullable<OpenAIResponsesOptions["reasoning"]>, string>> | undefined {
+	const compatMap = model.compat.reasoningEffortMap;
+	const thinkingMap = model.thinking?.effortMap;
+	if (!compatMap || Object.keys(compatMap).length === 0) return thinkingMap;
+	if (!thinkingMap) return compatMap;
+	return { ...thinkingMap, ...compatMap };
 }
 
 function convertConversationMessages(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -14,7 +14,6 @@ import type {
 	FetchImpl,
 	MessageAttribution,
 	Model,
-	OpenAICompat,
 	ProviderSessionState,
 	RawSseEvent,
 	ServiceTier,
@@ -502,10 +501,7 @@ function buildParams(
 		options,
 		messages,
 		effort =>
-			mapReasoningEffort(
-				effort as NonNullable<OpenAIResponsesOptions["reasoning"]>,
-				model.compat.reasoningEffortMap,
-			),
+			mapReasoningEffort(effort as NonNullable<OpenAIResponsesOptions["reasoning"]>, model.thinking?.effortMap),
 		options?.includeEncryptedReasoning ?? true,
 		options?.omitReasoningEffort ?? false,
 	);
@@ -519,7 +515,7 @@ function buildParams(
 
 function mapReasoningEffort(
 	effort: NonNullable<OpenAIResponsesOptions["reasoning"]>,
-	reasoningEffortMap: OpenAICompat["reasoningEffortMap"] | undefined,
+	reasoningEffortMap: Partial<Record<NonNullable<OpenAIResponsesOptions["reasoning"]>, string>> | undefined,
 ): string {
 	return reasoningEffortMap?.[effort] ?? effort;
 }

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -501,7 +501,9 @@ function buildParams(
 		options,
 		messages,
 		effort =>
-			mapReasoningEffort(effort as NonNullable<OpenAIResponsesOptions["reasoning"]>, resolveActiveEffortMap(model)),
+			model.compat.reasoningEffortMap?.[effort as NonNullable<OpenAIResponsesOptions["reasoning"]>] ??
+			model.thinking?.effortMap?.[effort as NonNullable<OpenAIResponsesOptions["reasoning"]>] ??
+			effort,
 		options?.includeEncryptedReasoning ?? true,
 		options?.omitReasoningEffort ?? false,
 	);
@@ -511,28 +513,6 @@ function buildParams(
 	}
 
 	return params;
-}
-
-function mapReasoningEffort(
-	effort: NonNullable<OpenAIResponsesOptions["reasoning"]>,
-	reasoningEffortMap: Partial<Record<NonNullable<OpenAIResponsesOptions["reasoning"]>, string>> | undefined,
-): string {
-	return reasoningEffortMap?.[effort] ?? effort;
-}
-
-/**
- * Compose the effective effort-map: catalog-baked `model.thinking.effortMap`
- * is the default, with the resolved compat's `reasoningEffortMap` overlaid on
- * top so custom raw `Model` configs keep authoring their own overrides.
- */
-function resolveActiveEffortMap(
-	model: Model<"openai-responses">,
-): Partial<Record<NonNullable<OpenAIResponsesOptions["reasoning"]>, string>> | undefined {
-	const compatMap = model.compat.reasoningEffortMap;
-	const thinkingMap = model.thinking?.effortMap;
-	if (!compatMap || Object.keys(compatMap).length === 0) return thinkingMap;
-	if (!thinkingMap) return compatMap;
-	return { ...thinkingMap, ...compatMap };
 }
 
 function convertConversationMessages(

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -47,16 +47,16 @@ function assistantToolCall(
 
 describe("DeepSeek reasoning_content tool-call replay", () => {
 	// ----------------------------------------------------------------
-	// Fix 1: reasoningEffortMap for DeepSeek-family on any provider
+	// Fix 1: effortMap for DeepSeek-family on any provider
 	// ----------------------------------------------------------------
-	describe("reasoningEffortMap (Fix 1)", () => {
+	describe("thinking effortMap (Fix 1)", () => {
 		it("maps unsupported lower DeepSeek efforts to high on opencode-go", () => {
-			const compat = deepseekModel({
+			const model = deepseekModel({
 				provider: "opencode-go",
 				baseUrl: "https://opencode.ai/zen/go/v1",
 				id: "deepseek-v4-flash",
-			}).compat;
-			expect(compat.reasoningEffortMap).toMatchObject({
+			});
+			expect(model.thinking?.effortMap).toMatchObject({
 				minimal: "high",
 				low: "high",
 				medium: "high",
@@ -66,12 +66,12 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 		});
 
 		it("maps unsupported lower DeepSeek efforts to high on NVIDIA", () => {
-			const compat = deepseekModel({
+			const model = deepseekModel({
 				provider: "nvidia",
 				baseUrl: "https://integrate.api.nvidia.com/v1",
 				id: "deepseek-ai/deepseek-v4-flash",
-			}).compat;
-			expect(compat.reasoningEffortMap).toMatchObject({
+			});
+			expect(model.thinking?.effortMap).toMatchObject({
 				minimal: "high",
 				low: "high",
 				medium: "high",
@@ -81,12 +81,12 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 		});
 
 		it("maps unsupported lower DeepSeek efforts to high on the official endpoint", () => {
-			const compat = deepseekModel({
+			const model = deepseekModel({
 				provider: "deepseek",
 				baseUrl: "https://api.deepseek.com/v1",
 				id: "deepseek-v4-pro",
-			}).compat;
-			expect(compat.reasoningEffortMap).toMatchObject({
+			});
+			expect(model.thinking?.effortMap).toMatchObject({
 				minimal: "high",
 				low: "high",
 				medium: "high",
@@ -96,13 +96,13 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 		});
 
 		it("does NOT map xhigh for non-DeepSeek models", () => {
-			const compat = deepseekModel({
+			const model = deepseekModel({
 				provider: "openai",
 				baseUrl: "https://api.openai.com/v1",
 				id: "gpt-4o-mini",
 				reasoning: false,
-			}).compat;
-			expect(compat.reasoningEffortMap.xhigh).toBeUndefined();
+			});
+			expect(model.thinking?.effortMap?.xhigh).toBeUndefined();
 		});
 	});
 

--- a/packages/ai/test/firepass.live.ts
+++ b/packages/ai/test/firepass.live.ts
@@ -21,7 +21,7 @@ if (!apiKey) {
 
 const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
 console.log(`Model: ${model.provider}/${model.id} -> ${model.baseUrl}`);
-console.log(`compat.reasoningEffortMap:`, model.compat?.reasoningEffortMap ?? "(none)");
+console.log(`thinking.effortMap:`, model.thinking?.effortMap ?? "(none)");
 
 // Capture the outbound request body so we can verify the wire-id translation
 // and the reasoning_effort mapping locally before reading the network result.
@@ -110,7 +110,7 @@ if (xhigh.firstError) {
 if (xhigh.parsedBody?.reasoning_effort !== "xhigh") {
 	console.error(
 		`\nxhigh was rewritten on the wire (got ${xhigh.parsedBody?.reasoning_effort}); ` +
-			"expected verbatim passthrough — adding compat.reasoningEffortMap would silently downgrade the user",
+			"expected verbatim passthrough — adding thinking.effortMap would silently downgrade the user",
 	);
 	process.exit(1);
 }

--- a/packages/ai/test/firepass.test.ts
+++ b/packages/ai/test/firepass.test.ts
@@ -63,10 +63,10 @@ describe("Fire Pass provider", () => {
 		// reasoning_effort set as `low | medium | high | xhigh | max | none`, and
 		// `xhigh` is a distinct tier from `max` (different reasoning-token budgets
 		// for the same prompt). The bundled entry must therefore advertise xhigh
-		// without a compat.reasoningEffortMap that would silently downgrade it to
-		// max — see PR #1199 discussion r3265122224 for the live API capture.
+		// without a thinking effortMap that would silently downgrade it to max —
+		// see PR #1199 discussion r3265122224 for the live API capture.
 		const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-		expect(model.compat?.reasoningEffortMap?.xhigh).toBeUndefined();
+		expect(model.thinking?.effortMap?.xhigh).toBeUndefined();
 
 		const captured: { body: string | null } = { body: null };
 		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {

--- a/packages/ai/test/issue-1207-repro.test.ts
+++ b/packages/ai/test/issue-1207-repro.test.ts
@@ -61,7 +61,7 @@ describe("issue #1207 — DeepSeek V4 keeps reasoning with tools", () => {
 		expect(compat.supportsToolChoice).toBe(false);
 		expect(compat.maxTokensField).toBe("max_tokens");
 		expect(compat.extraBody).toEqual({ thinking: { type: "enabled" } });
-		expect(compat.reasoningEffortMap).toMatchObject({
+		expect(model.thinking?.effortMap).toMatchObject({
 			minimal: "high",
 			low: "high",
 			medium: "high",
@@ -70,11 +70,11 @@ describe("issue #1207 — DeepSeek V4 keeps reasoning with tools", () => {
 		});
 	});
 
-	it("merges partial user reasoning maps with DeepSeek defaults", () => {
-		const compat = customDeepseekFlash().compat;
+	it("merges partial user reasoning maps with DeepSeek defaults in thinking metadata", () => {
+		const model = customDeepseekFlash();
 
-		expect(compat.supportsToolChoice).toBe(false);
-		expect(compat.reasoningEffortMap).toMatchObject({
+		expect(model.compat.supportsToolChoice).toBe(false);
+		expect(model.thinking?.effortMap).toMatchObject({
 			minimal: "high",
 			low: "high",
 			medium: "high",

--- a/packages/ai/test/issue-2315-repro.test.ts
+++ b/packages/ai/test/issue-2315-repro.test.ts
@@ -104,6 +104,30 @@ describe("issue #2315 — MiniMax M2 / GPT-OSS catalog excludes unsupported reas
 		expect(body.reasoning_effort).toBe("low");
 	});
 
+	it("preserves a custom compat.whenThinking reasoningEffortMap override at request time", async () => {
+		const base = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		// Custom proxy: minimal stays clamped to low, xhigh is force-mapped to high
+		// via a whenThinking variant — the swap was getting lost when this PR
+		// moved effort maps onto `model.thinking.effortMap`.
+		const model = buildModel({
+			id: base.id,
+			name: base.name,
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: base.baseUrl,
+			reasoning: true,
+			thinking: { mode: "effort", efforts: [Effort.Low, Effort.Medium, Effort.High] },
+			compat: { whenThinking: { reasoningEffortMap: { high: "max" } } },
+			input: base.input,
+			cost: base.cost,
+			contextWindow: base.contextWindow,
+			maxTokens: base.maxTokens,
+		});
+
+		const body = await capturePayload(model, { reasoning: Effort.High });
+		expect(body.reasoning_effort).toBe("max");
+	});
+
 	it("preserves low/medium/high passthrough on fireworks/minimax-m2.7", async () => {
 		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
 		const lowBody = await capturePayload(model, { reasoning: Effort.Low });

--- a/packages/ai/test/issue-2315-repro.test.ts
+++ b/packages/ai/test/issue-2315-repro.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const testContext: Context = {
@@ -59,27 +60,21 @@ async function capturePayload(
 	return payload;
 }
 
-describe("issue #2315 — MiniMax M2 / GPT-OSS reject Fireworks' `none`/`minimal`/`xhigh` reasoning_effort", () => {
-	it("disableReasoning on fireworks/minimax-m2.7 clamps to the lowest server-accepted effort", async () => {
+describe("issue #2315 — MiniMax M2 / GPT-OSS catalog excludes unsupported reasoning_effort tiers", () => {
+	it("declares only low/medium/high for fireworks/minimax-m2.7 and disables reasoning with low", async () => {
 		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
 		const body = await capturePayload(model, { disableReasoning: true });
-		// Pre-fix the wire body carried "none", which MiniMax M2 400'd on every
-		// auto-thinking turn. The lowest accepted effort is "low".
+		// Pre-fix the catalog included `minimal`, so the Fireworks compat map turned
+		// the auto-thinking classifier's disableReasoning request into `"none"`.
 		expect(body.reasoning_effort).toBe("low");
 	});
 
-	it("disableReasoning on fireworks/gpt-oss-120b clamps to the lowest server-accepted effort", async () => {
+	it("declares only low/medium/high for fireworks/gpt-oss-120b and disables reasoning with low", async () => {
 		const model = getBundledModel("fireworks", "gpt-oss-120b") as Model<"openai-completions">;
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
 		const body = await capturePayload(model, { disableReasoning: true });
 		expect(body.reasoning_effort).toBe("low");
-	});
-
-	it("clamps user-requested xhigh on fireworks/minimax-m2.7 to the highest server-accepted effort", async () => {
-		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
-		const body = await capturePayload(model, { reasoning: Effort.XHigh });
-		// xhigh is unsupported upstream; the map clamps to "high" (the ceiling
-		// of the {low, medium, high} set MiniMax M2 actually accepts).
-		expect(body.reasoning_effort).toBe("high");
 	});
 
 	it("preserves low/medium/high passthrough on fireworks/minimax-m2.7", async () => {

--- a/packages/ai/test/issue-2315-repro.test.ts
+++ b/packages/ai/test/issue-2315-repro.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+const testContext: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+function createSseResponse(events: unknown[]): Response {
+	const payload = `${events.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`).join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+interface CaptureOptions {
+	disableReasoning?: boolean;
+	reasoning?: Effort;
+}
+
+async function capturePayload(
+	model: Model<"openai-completions">,
+	options: CaptureOptions,
+): Promise<Record<string, unknown>> {
+	let payload: Record<string, unknown> | undefined;
+	const fetchMock: FetchImpl = Object.assign(
+		async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			payload = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<string, unknown>;
+			return createSseResponse([
+				{
+					id: "x",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: { content: "ok" } }],
+				},
+				{
+					id: "x",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				},
+				"[DONE]",
+			]);
+		},
+		{ preconnect: fetch.preconnect },
+	);
+	await streamOpenAICompletions(model, testContext, {
+		apiKey: "test-key",
+		fetch: fetchMock,
+		disableReasoning: options.disableReasoning,
+		reasoning: options.reasoning,
+	}).result();
+	if (!payload) throw new Error("Expected request payload");
+	return payload;
+}
+
+describe("issue #2315 — MiniMax M2 / GPT-OSS reject Fireworks' `none`/`minimal`/`xhigh` reasoning_effort", () => {
+	it("disableReasoning on fireworks/minimax-m2.7 clamps to the lowest server-accepted effort", async () => {
+		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		const body = await capturePayload(model, { disableReasoning: true });
+		// Pre-fix the wire body carried "none", which MiniMax M2 400'd on every
+		// auto-thinking turn. The lowest accepted effort is "low".
+		expect(body.reasoning_effort).toBe("low");
+	});
+
+	it("disableReasoning on fireworks/gpt-oss-120b clamps to the lowest server-accepted effort", async () => {
+		const model = getBundledModel("fireworks", "gpt-oss-120b") as Model<"openai-completions">;
+		const body = await capturePayload(model, { disableReasoning: true });
+		expect(body.reasoning_effort).toBe("low");
+	});
+
+	it("clamps user-requested xhigh on fireworks/minimax-m2.7 to the highest server-accepted effort", async () => {
+		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		const body = await capturePayload(model, { reasoning: Effort.XHigh });
+		// xhigh is unsupported upstream; the map clamps to "high" (the ceiling
+		// of the {low, medium, high} set MiniMax M2 actually accepts).
+		expect(body.reasoning_effort).toBe("high");
+	});
+
+	it("preserves low/medium/high passthrough on fireworks/minimax-m2.7", async () => {
+		const model = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		const lowBody = await capturePayload(model, { reasoning: Effort.Low });
+		expect(lowBody.reasoning_effort).toBe("low");
+		const medBody = await capturePayload(model, { reasoning: Effort.Medium });
+		expect(medBody.reasoning_effort).toBe("medium");
+		const highBody = await capturePayload(model, { reasoning: Effort.High });
+		expect(highBody.reasoning_effort).toBe("high");
+	});
+
+	it("keeps the Fireworks-wide minimal→none mapping for non-restricted models (glm-5.1)", async () => {
+		const model = getBundledModel("fireworks", "glm-5.1") as Model<"openai-completions">;
+		const body = await capturePayload(model, { disableReasoning: true });
+		expect(body.reasoning_effort).toBe("none");
+	});
+});

--- a/packages/ai/test/issue-2315-repro.test.ts
+++ b/packages/ai/test/issue-2315-repro.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -73,6 +74,32 @@ describe("issue #2315 — MiniMax M2 / GPT-OSS catalog excludes unsupported reas
 	it("declares only low/medium/high for fireworks/gpt-oss-120b and disables reasoning with low", async () => {
 		const model = getBundledModel("fireworks", "gpt-oss-120b") as Model<"openai-completions">;
 		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		const body = await capturePayload(model, { disableReasoning: true });
+		expect(body.reasoning_effort).toBe("low");
+	});
+
+	it("normalizes stale cached MiniMax M2 thinking metadata before disableReasoning sends a request", async () => {
+		const base = getBundledModel("fireworks", "minimax-m2.7") as Model<"openai-completions">;
+		const model = buildModel({
+			id: base.id,
+			name: base.name,
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: base.baseUrl,
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+				effortMap: { minimal: "none", xhigh: "max" },
+			},
+			input: base.input,
+			cost: base.cost,
+			contextWindow: base.contextWindow,
+			maxTokens: base.maxTokens,
+		});
+
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		expect(model.thinking?.effortMap).toBeUndefined();
 		const body = await capturePayload(model, { disableReasoning: true });
 		expect(body.reasoning_effort).toBe("low");
 	});

--- a/packages/ai/test/issue-931-repro.test.ts
+++ b/packages/ai/test/issue-931-repro.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import type { Context, Model, OpenAICompat } from "@oh-my-pi/pi-ai/types";
 
 const testContext: Context = {
@@ -39,12 +40,17 @@ function customResponsesModel(compat: OpenAICompat): Model<"openai-responses"> {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 1_048_576,
 		maxTokens: 65_536,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			effortMap: compat.reasoningEffortMap,
+		},
 		compat,
 	} as Model<"openai-responses">;
 }
 
-describe("issue #931 — openai-responses reasoning effort compat mapping", () => {
-	it("maps configured xhigh reasoning effort before sending Responses reasoning payload", async () => {
+describe("issue #931 — openai-responses reasoning effort mapping", () => {
+	it("maps configured xhigh thinking effort before sending Responses reasoning payload", async () => {
 		const payload = await captureResponsesPayload(
 			customResponsesModel({
 				supportsReasoningEffort: true,

--- a/packages/ai/test/issue-931-repro.test.ts
+++ b/packages/ai/test/issue-931-repro.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
-import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import type { Context, Model, OpenAICompat } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 
 const testContext: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: 0 }],

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Fixed model ID precedence so a real upstream Copilot model id is kept when it conflicts with a synthesized `-1m` variant
 ### Fixed
 
-- Fixed `buildOpenAICompat` sending `reasoning_effort: "none"` for MiniMax M2-family and OpenAI gpt-oss models on Fireworks. Both families only accept `low|medium|high`, so the Fireworks-wide `{ minimal: "none" }` map made the auto-thinking classifier 400 on every turn when configured with a smol model in those families (e.g. `fireworks/minimax-m2.7`). The compat layer now detects these families via new `isMinimaxM2FamilyModelId` / `isOpenAIGptOssModelId` identity predicates and clamps their reasoning effort map to `{ minimal: "low", xhigh: "high" }` instead, leaving GLM-5.x and other Fireworks models on the existing `minimal → none` path ([#2315](https://github.com/can1357/oh-my-pi/issues/2315)).
+- Fixed MiniMax M2-family and OpenAI gpt-oss model metadata so OpenAI-compatible catalog entries declare only `low|medium|high` thinking efforts. Their upstreams reject `minimal`, `xhigh`, and Fireworks' `minimal → none` wire mapping, so `fireworks/minimax-m2.7` as the smol auto-thinking classifier model 400ed on every turn. Regenerated `models.json` now makes `disableReasoning` choose `low` for those families while leaving GLM-5.x and other Fireworks models on the existing `minimal → none` path ([#2315](https://github.com/can1357/oh-my-pi/issues/2315)).
 
 ## [15.11.1] - 2026-06-11
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -23,9 +23,6 @@
 - Fixed long-context variant pricing to use `billing.token_prices.long_context` rates instead of default model pricing
 - Fixed `mapModel` handling in OpenAI-compatible discovery so returning `null` now skips a model entry rather than falling back to defaults
 - Fixed model ID precedence so a real upstream Copilot model id is kept when it conflicts with a synthesized `-1m` variant
-### Fixed
-
-- Fixed MiniMax M2-family and OpenAI gpt-oss model metadata so OpenAI-compatible catalog entries declare only `low|medium|high` thinking efforts. Their upstreams reject `minimal`, `xhigh`, and Fireworks' `minimal → none` wire mapping, so `fireworks/minimax-m2.7` as the smol auto-thinking classifier model 400ed on every turn. Regenerated `models.json` now makes `disableReasoning` choose `low` for those families while leaving GLM-5.x and other Fireworks models on the existing `minimal → none` path ([#2315](https://github.com/can1357/oh-my-pi/issues/2315)).
 
 ## [15.11.1] - 2026-06-11
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Fixed long-context variant pricing to use `billing.token_prices.long_context` rates instead of default model pricing
 - Fixed `mapModel` handling in OpenAI-compatible discovery so returning `null` now skips a model entry rather than falling back to defaults
 - Fixed model ID precedence so a real upstream Copilot model id is kept when it conflicts with a synthesized `-1m` variant
+### Fixed
+
+- Fixed `buildOpenAICompat` sending `reasoning_effort: "none"` for MiniMax M2-family and OpenAI gpt-oss models on Fireworks. Both families only accept `low|medium|high`, so the Fireworks-wide `{ minimal: "none" }` map made the auto-thinking classifier 400 on every turn when configured with a smol model in those families (e.g. `fireworks/minimax-m2.7`). The compat layer now detects these families via new `isMinimaxM2FamilyModelId` / `isOpenAIGptOssModelId` identity predicates and clamps their reasoning effort map to `{ minimal: "low", xhigh: "high" }` instead, leaving GLM-5.x and other Fireworks models on the existing `minimal → none` path ([#2315](https://github.com/can1357/oh-my-pi/issues/2315)).
 
 ## [15.11.1] - 2026-06-11
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MiniMax M2-family and OpenAI gpt-oss model metadata so OpenAI-compatible catalog entries declare only `low|medium|high` thinking efforts. Their upstreams reject `minimal`, `xhigh`, and Fireworks' `minimal → none` wire mapping, so `fireworks/minimax-m2.7` as the smol auto-thinking classifier model 400ed on every turn. OpenAI-compatible provider effort maps (`Groq qwen/qwen3-32b`, DeepSeek-family, OpenRouter Anthropic adaptive, Fireworks `minimal → none`) now bake into `thinking.effortMap` in catalog metadata instead of `buildOpenAICompat`, and request builders read that field directly. Regenerated `models.json` now makes `disableReasoning` choose `low` for those families while leaving GLM-5.x and other Fireworks models on the existing `minimal → none` path ([#2315](https://github.com/can1357/oh-my-pi/issues/2315)).
+
 ## [15.11.3] - 2026-06-11
 ### Added
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -16,8 +16,6 @@ import {
 	isKimiK26ModelId,
 	isKimiModelId,
 	isMimoModelIdOrName,
-	isMinimaxM2FamilyModelId,
-	isOpenAIGptOssModelId,
 	isQwenModelId,
 } from "../identity/family";
 import { ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER, ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER } from "../model-thinking";
@@ -203,14 +201,6 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const openRouterAnthropicReasoningEffortMap = isOpenRouter
 		? getOpenRouterAnthropicReasoningEffortMap(lowerId)
 		: undefined;
-	// MiniMax M2 family (M2/M2.1/M2.5/M2.7 across every host) and the OpenAI
-	// GPT-OSS family (Harmony reasoning) only accept `low|medium|high` for
-	// `reasoning_effort` and 400 on `minimal`, `xhigh`, or `none`. The
-	// auto-thinking classifier's `disableReasoning: true` path picks the
-	// lowest supported effort, so this clamp must run BEFORE the Fireworks
-	// blanket `minimal → none` mapping below (issue #2315).
-	const requiresLowMediumHighOnlyEffort =
-		Boolean(spec.reasoning) && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id));
 	const detectedReasoningEffortMap: NonNullable<OpenAICompat["reasoningEffortMap"]> =
 		provider === "groq" && spec.id === "qwen/qwen3-32b"
 			? ({
@@ -230,20 +220,13 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
 				: openRouterAnthropicReasoningEffortMap
 					? openRouterAnthropicReasoningEffortMap
-					: requiresLowMediumHighOnlyEffort
+					: isFireworks
 						? ({
-								// MiniMax M2 / GPT-OSS Harmony: clamp the outer tiers to the
-								// nearest server-accepted level instead of `none`/`minimal`/`xhigh`.
-								minimal: "low",
-								xhigh: "high",
+								// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
+								// `minimal` literal but accepts `none` for the lowest setting.
+								minimal: "none",
 							} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-						: isFireworks
-							? ({
-									// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
-									// `minimal` literal but accepts `none` for the lowest setting.
-									minimal: "none",
-								} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-							: {};
+						: {};
 
 	// Stream-watchdog floor: GLM coding-plan SKUs and direct DeepSeek reasoning
 	// models idle for minutes mid-reasoning; widen the idle timeout so warm-ups

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -8,7 +8,6 @@
  * never detect, resolve, or allocate.
  */
 import { hostMatchesUrl, modelMatchesHost } from "../hosts";
-import { bareModelId, isFableOrMythos, parseAnthropicModel, semverGte } from "../identity/classify";
 import {
 	isAnthropicNamespacedModelId,
 	isClaudeModelId,
@@ -18,11 +17,8 @@ import {
 	isMimoModelIdOrName,
 	isQwenModelId,
 } from "../identity/family";
-import { ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER, ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER } from "../model-thinking";
 import type { ModelSpec, OpenAICompat, ResolvedOpenAICompat, ResolvedOpenAIResponsesCompat } from "../types";
 import { applyCompatOverrides } from "./apply";
-
-type OpenAIReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
 
 /** GLM coding-plan SKUs idle for minutes mid-reasoning; see `streamIdleTimeoutMs`. */
 const GLM_CODING_PLAN_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
@@ -72,21 +68,6 @@ function detectStrictModeSupport(provider: string, baseUrl: string): boolean {
 	);
 }
 
-function getOpenRouterAnthropicReasoningEffortMap(
-	modelId: string,
-): Partial<Record<OpenAIReasoningEffort, string>> | undefined {
-	const parsed = parseAnthropicModel(bareModelId(modelId));
-	if (!parsed) return undefined;
-	// Adaptive efforts on OpenRouter's completions front: Fable/Mythos and
-	// Opus 4.6+ only — Sonnet stays on the plain effort vocabulary there.
-	const isOpusAdaptive = parsed.kind === "opus" && semverGte(parsed.version, "4.6");
-	if (!isFableOrMythos(parsed.kind) && !isOpusAdaptive) return undefined;
-
-	const hasRealXHigh = isFableOrMythos(parsed.kind) || semverGte(parsed.version, "4.7");
-	return (hasRealXHigh ? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER : ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER) as Partial<
-		Record<OpenAIReasoningEffort, string>
-	>;
-}
 
 /**
  * Build the resolved chat-completions compat record for a model spec.
@@ -198,35 +179,6 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 			isCopilotHost ||
 			isZenmuxHost);
 
-	const openRouterAnthropicReasoningEffortMap = isOpenRouter
-		? getOpenRouterAnthropicReasoningEffortMap(lowerId)
-		: undefined;
-	const detectedReasoningEffortMap: NonNullable<OpenAICompat["reasoningEffortMap"]> =
-		provider === "groq" && spec.id === "qwen/qwen3-32b"
-			? ({
-					minimal: "default",
-					low: "default",
-					medium: "default",
-					high: "default",
-					xhigh: "default",
-				} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-			: isDeepseekFamily && spec.reasoning
-				? ({
-						minimal: "high",
-						low: "high",
-						medium: "high",
-						high: "high",
-						xhigh: "max",
-					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-				: openRouterAnthropicReasoningEffortMap
-					? openRouterAnthropicReasoningEffortMap
-					: isFireworks
-						? ({
-								// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
-								// `minimal` literal but accepts `none` for the lowest setting.
-								minimal: "none",
-							} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-						: {};
 
 	// Stream-watchdog floor: GLM coding-plan SKUs and direct DeepSeek reasoning
 	// models idle for minutes mid-reasoning; widen the idle timeout so warm-ups
@@ -251,7 +203,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		supportsReasoningEffort: !isGrok && !isZai && !isZhipu && !isXiaomiMimo,
 		// GitHub Copilot's chat-completions endpoint rejects reasoning params wholesale.
 		supportsReasoningParams: provider !== "github-copilot",
-		reasoningEffortMap: detectedReasoningEffortMap,
+		reasoningEffortMap: {},
 		supportsUsageInStreaming: !isCerebras,
 		// Kimi (including via OpenRouter and Fireworks router-form IDs such as
 		// `accounts/fireworks/routers/kimi-*`) calculates TPM rate limits based on
@@ -323,10 +275,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	};
 
 	applyCompatOverrides(compat, spec.compat);
-	if (spec.compat?.reasoningEffortMap) {
-		// Effort maps merge per level instead of replacing wholesale.
-		compat.reasoningEffortMap = { ...detectedReasoningEffortMap, ...spec.compat.reasoningEffortMap };
-	}
+
 
 	const whenThinkingPolicy =
 		spec.compat?.whenThinking ?? (isOpenCodeProvider && spec.reasoning ? OPENCODE_WHEN_THINKING : undefined);

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -16,6 +16,8 @@ import {
 	isKimiK26ModelId,
 	isKimiModelId,
 	isMimoModelIdOrName,
+	isMinimaxM2FamilyModelId,
+	isOpenAIGptOssModelId,
 	isQwenModelId,
 } from "../identity/family";
 import { ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER, ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER } from "../model-thinking";
@@ -201,6 +203,14 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const openRouterAnthropicReasoningEffortMap = isOpenRouter
 		? getOpenRouterAnthropicReasoningEffortMap(lowerId)
 		: undefined;
+	// MiniMax M2 family (M2/M2.1/M2.5/M2.7 across every host) and the OpenAI
+	// GPT-OSS family (Harmony reasoning) only accept `low|medium|high` for
+	// `reasoning_effort` and 400 on `minimal`, `xhigh`, or `none`. The
+	// auto-thinking classifier's `disableReasoning: true` path picks the
+	// lowest supported effort, so this clamp must run BEFORE the Fireworks
+	// blanket `minimal → none` mapping below (issue #2315).
+	const requiresLowMediumHighOnlyEffort =
+		Boolean(spec.reasoning) && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id));
 	const detectedReasoningEffortMap: NonNullable<OpenAICompat["reasoningEffortMap"]> =
 		provider === "groq" && spec.id === "qwen/qwen3-32b"
 			? ({
@@ -220,13 +230,20 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
 				: openRouterAnthropicReasoningEffortMap
 					? openRouterAnthropicReasoningEffortMap
-					: isFireworks
+					: requiresLowMediumHighOnlyEffort
 						? ({
-								// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
-								// `minimal` literal but accepts `none` for the lowest setting.
-								minimal: "none",
+								// MiniMax M2 / GPT-OSS Harmony: clamp the outer tiers to the
+								// nearest server-accepted level instead of `none`/`minimal`/`xhigh`.
+								minimal: "low",
+								xhigh: "high",
 							} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-						: {};
+						: isFireworks
+							? ({
+									// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
+									// `minimal` literal but accepts `none` for the lowest setting.
+									minimal: "none",
+								} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
+							: {};
 
 	// Stream-watchdog floor: GLM coding-plan SKUs and direct DeepSeek reasoning
 	// models idle for minutes mid-reasoning; widen the idle timeout so warm-ups

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -68,7 +68,6 @@ function detectStrictModeSupport(provider: string, baseUrl: string): boolean {
 	);
 }
 
-
 /**
  * Build the resolved chat-completions compat record for a model spec.
  * Provider takes precedence over URL-based detection since it's explicitly configured.
@@ -179,7 +178,6 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 			isCopilotHost ||
 			isZenmuxHost);
 
-
 	// Stream-watchdog floor: GLM coding-plan SKUs and direct DeepSeek reasoning
 	// models idle for minutes mid-reasoning; widen the idle timeout so warm-ups
 	// stop aborting and retrying.
@@ -275,7 +273,6 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	};
 
 	applyCompatOverrides(compat, spec.compat);
-
 
 	const whenThinkingPolicy =
 		spec.compat?.whenThinking ?? (isOpenCodeProvider && spec.reasoning ? OPENCODE_WHEN_THINKING : undefined);

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -58,7 +58,7 @@ export function isMinimaxM2FamilyModelId(modelId: string): boolean {
 	if (!lower.includes("minimax")) return false;
 	// Boundary-delimited `m2` token followed by zero or more digits (dotless
 	// variants like `m21`/`m25`/`m27`) and an optional dotted minor version.
-	return /(?:^|[/.\-])m2\d*(?:[.\-]\d+)?(?:[-.:_]|$)/i.test(lower);
+	return /(?:^|[/.-])m2\d*(?:[.-]\d+)?(?:[-.:_]|$)/i.test(lower);
 }
 
 /**

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -45,6 +45,33 @@ export function isMimoModelIdOrName(value: string): boolean {
 }
 
 /**
+ * MiniMax M2-generation family (M2, M2.1, M2.5, M2.7, including `-highspeed`/
+ * `-lightning`/`-her`/`-turbo` variants, dotless aliases like `minimax-m21`,
+ * and short `minimax/m2-…` ids on aggregator hosts). Underlying model accepts
+ * only `low|medium|high` for `reasoning_effort` and 400s on `minimal`,
+ * `xhigh`, or `none` — so hosts whose default effort map otherwise lowers
+ * `minimal` to `none` (Fireworks) or expects the full 5-tier scale must
+ * clamp instead. Excludes M1, M3, MiniMax-Text-01, music, hailuo, voice ids.
+ */
+export function isMinimaxM2FamilyModelId(modelId: string): boolean {
+	const lower = modelId.toLowerCase();
+	if (!lower.includes("minimax")) return false;
+	// Boundary-delimited `m2` token followed by zero or more digits (dotless
+	// variants like `m21`/`m25`/`m27`) and an optional dotted minor version.
+	return /(?:^|[/.\-])m2\d*(?:[.\-]\d+)?(?:[-.:_]|$)/i.test(lower);
+}
+
+/**
+ * OpenAI gpt-oss family (`gpt-oss-20b`, `gpt-oss-120b`, `gpt-oss:120b`,
+ * `vendor/gpt-oss-…`). The Harmony reasoning format only accepts
+ * `low|medium|high` for `reasoning_effort` and rejects `minimal`, `xhigh`,
+ * and `none`.
+ */
+export function isOpenAIGptOssModelId(modelId: string): boolean {
+	return /(^|\/)gpt-oss[-:]/i.test(modelId);
+}
+
+/**
  * Adaptive thinking `display` is supported starting with Claude Opus 4.7 and
  * the Claude Fable/Mythos 5 generation. Older adaptive-thinking models
  * (Opus 4.6, Sonnet 4.6+) reject the field. Classifier-based, so dotted and

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -18,7 +18,7 @@ import {
 	semverEqual,
 	semverGte,
 } from "./identity/classify";
-import { supportsAdaptiveThinkingDisplay } from "./identity/family";
+import { isMinimaxM2FamilyModelId, isOpenAIGptOssModelId, supportsAdaptiveThinkingDisplay } from "./identity/family";
 import type {
 	Api,
 	CompatOf,
@@ -47,6 +47,7 @@ const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
+const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
 
 /**
  * Effort → wire-value map for the 5-tier adaptive scale (Opus 4.7+ and
@@ -176,6 +177,12 @@ function inferSupportedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] {
+	if (
+		spec.api === "openai-completions" &&
+		(isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))
+	) {
+		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
+	}
 	switch (parsedModel.family) {
 		case "openai":
 			return inferOpenAISupportedEfforts(parsedModel);

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -177,10 +177,7 @@ function inferSupportedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] {
-	if (
-		spec.api === "openai-completions" &&
-		(isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))
-	) {
+	if (spec.api === "openai-completions" && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))) {
 		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
 	}
 	switch (parsedModel.family) {

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -10,15 +10,22 @@ import { Effort, THINKING_EFFORTS } from "./effort";
 import { modelMatchesHost } from "./hosts";
 import {
 	type AnthropicModel,
+	bareModelId,
 	type GeminiModel,
 	isFableOrMythos,
 	type OpenAIModel,
 	type ParsedModel,
+	parseAnthropicModel,
 	parseKnownModel,
 	semverEqual,
 	semverGte,
 } from "./identity/classify";
-import { isMinimaxM2FamilyModelId, isOpenAIGptOssModelId, supportsAdaptiveThinkingDisplay } from "./identity/family";
+import {
+	isDeepseekModelIdOrName,
+	isMinimaxM2FamilyModelId,
+	isOpenAIGptOssModelId,
+	supportsAdaptiveThinkingDisplay,
+} from "./identity/family";
 import type {
 	Api,
 	CompatOf,
@@ -48,6 +55,26 @@ const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, E
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
+
+type EffortMap = Partial<Record<Effort, string>>;
+
+const GROQ_QWEN3_32B_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
+	[Effort.Minimal]: "default",
+	[Effort.Low]: "default",
+	[Effort.Medium]: "default",
+	[Effort.High]: "default",
+	[Effort.XHigh]: "default",
+};
+const DEEPSEEK_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
+	[Effort.Minimal]: "high",
+	[Effort.Low]: "high",
+	[Effort.Medium]: "high",
+	[Effort.High]: "high",
+	[Effort.XHigh]: "max",
+};
+const FIREWORKS_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
+	[Effort.Minimal]: "none",
+};
 
 /**
  * Effort → wire-value map for the 5-tier adaptive scale (Opus 4.7+ and
@@ -89,7 +116,7 @@ export const ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER: Readonly<Partial<Record<Effor
  * - Explicit spec thinking (generator-baked or user-authored) owns the
  *   capability surface (`mode`, `efforts`, `defaultLevel`); the wire facts
  *   (`effortMap`, `supportsDisplay`) are backfilled from identity when not
- *   explicitly set, so configs never need to know Anthropic's tier tables.
+ *   explicitly set, so configs never need to know provider wire tier tables.
  * - Sparse specs go through full inference.
  */
 export function resolveModelThinking<TApi extends Api>(
@@ -99,7 +126,7 @@ export function resolveModelThinking<TApi extends Api>(
 	if (!spec.reasoning) return undefined;
 	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
 	if (spec.thinking && Array.isArray(spec.thinking.efforts) && spec.thinking.efforts.length > 0) {
-		return fillThinkingWireDefaults(spec, spec.thinking);
+		return fillThinkingWireDefaults(spec, compat, spec.thinking);
 	}
 	// Empty/malformed explicit metadata is treated as absent — infer instead.
 	return deriveThinking(spec, compat);
@@ -110,20 +137,24 @@ export function resolveModelThinking<TApi extends Api>(
  * Explicit `effortMap` / `supportsDisplay` (including `false`) always win;
  * untouched configs are returned as-is with zero allocation.
  */
-function fillThinkingWireDefaults<TApi extends Api>(spec: ModelSpec<TApi>, thinking: ThinkingConfig): ThinkingConfig {
-	const needsEffortMap = thinking.mode === "anthropic-adaptive" && thinking.effortMap === undefined;
+function fillThinkingWireDefaults<TApi extends Api>(
+	spec: ModelSpec<TApi>,
+	compat: CompatOf<TApi>,
+	thinking: ThinkingConfig,
+): ThinkingConfig {
+	const parsed = parseKnownModel(spec.id);
+	const effortMap =
+		thinking.effortMap === undefined ? inferEffortMap(spec, compat, parsed, thinking.mode, thinking.efforts) : undefined;
 	const needsDisplay =
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
-	if (!needsEffortMap && !needsDisplay) {
+	if (effortMap === undefined && !needsDisplay) {
 		return thinking;
 	}
 	const filled: ThinkingConfig = { ...thinking };
-	if (needsEffortMap) {
-		filled.effortMap = anthropicModelHasRealXHighEffort(spec, parseKnownModel(spec.id))
-			? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER
-			: ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER;
+	if (effortMap !== undefined) {
+		filled.effortMap = effortMap;
 	}
 	if (needsDisplay) {
 		filled.supportsDisplay = true;
@@ -142,10 +173,9 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 		mode: inferThinkingControlMode(spec, parsed),
 		efforts,
 	};
-	if (config.mode === "anthropic-adaptive") {
-		config.effortMap = anthropicModelHasRealXHighEffort(spec, parsed)
-			? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER
-			: ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER;
+	const effortMap = inferEffortMap(spec, compat, parsed, config.mode, config.efforts);
+	if (effortMap !== undefined) {
+		config.effortMap = effortMap;
 	}
 	if (
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
@@ -170,6 +200,93 @@ function omitsWireReasoningEffort(api: Api, compat: CompatOf<Api>): boolean {
 		return false;
 	}
 	return (compat as ResolvedOpenAIResponsesCompat | undefined)?.supportsReasoningEffort === false;
+}
+
+function inferEffortMap<TApi extends Api>(
+	spec: ModelSpec<TApi>,
+	compat: CompatOf<TApi>,
+	parsedModel: ParsedModel,
+	mode: ThinkingConfig["mode"],
+	efforts: readonly Effort[],
+): EffortMap | undefined {
+	const detected = inferDetectedEffortMap(spec, parsedModel, mode);
+	const configured = readCompatEffortMap(compat);
+	const merged = detected === undefined ? configured : configured === undefined ? detected : { ...detected, ...configured };
+	return merged === undefined ? undefined : filterEffortMapToSupportedEfforts(merged, efforts);
+}
+
+function filterEffortMapToSupportedEfforts(map: EffortMap, efforts: readonly Effort[]): EffortMap | undefined {
+	let filtered: EffortMap | undefined;
+	for (const effort of efforts) {
+		const mapped = map[effort];
+		if (mapped === undefined) continue;
+		if (filtered === undefined) filtered = {};
+		filtered[effort] = mapped;
+	}
+	return filtered;
+}
+
+function readCompatEffortMap(compat: CompatOf<Api>): EffortMap | undefined {
+	if (compat === undefined || !("reasoningEffortMap" in compat)) {
+		return undefined;
+	}
+	const map = compat.reasoningEffortMap;
+	return map && Object.keys(map).length > 0 ? map : undefined;
+}
+
+function inferDetectedEffortMap<TApi extends Api>(
+	spec: ModelSpec<TApi>,
+	parsedModel: ParsedModel,
+	mode: ThinkingConfig["mode"],
+): EffortMap | undefined {
+	if (mode === "anthropic-adaptive") {
+		return anthropicModelHasRealXHighEffort(spec, parsedModel)
+			? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER
+			: ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER;
+	}
+	if (spec.api !== "openai-completions") {
+		return undefined;
+	}
+	if (spec.provider === "groq" && spec.id === "qwen/qwen3-32b") {
+		return GROQ_QWEN3_32B_REASONING_EFFORT_MAP;
+	}
+	if (isDeepseekReasoningModel(spec)) {
+		return DEEPSEEK_REASONING_EFFORT_MAP;
+	}
+	if (modelMatchesHost(spec, "openrouter")) {
+		const openRouterAnthropicMap = getOpenRouterAnthropicReasoningEffortMap(spec.id);
+		if (openRouterAnthropicMap !== undefined) return openRouterAnthropicMap;
+	}
+	if (modelMatchesHost(spec, "fireworks")) {
+		return FIREWORKS_REASONING_EFFORT_MAP;
+	}
+	return undefined;
+}
+
+function isDeepseekReasoningModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	if (!spec.reasoning) return false;
+	const lowerId = spec.id.toLowerCase();
+	const lowerName = (spec.name ?? "").toLowerCase();
+	const isOpenCodeDeepseekAlias =
+		spec.provider === "opencode-zen" && (lowerId === "big-pickle" || lowerName === "big pickle");
+	return (
+		modelMatchesHost(spec, "deepseekFamily") ||
+		isDeepseekModelIdOrName(spec.id) ||
+		isDeepseekModelIdOrName(spec.name ?? "") ||
+		isOpenCodeDeepseekAlias
+	);
+}
+
+function getOpenRouterAnthropicReasoningEffortMap(modelId: string): EffortMap | undefined {
+	const parsed = parseAnthropicModel(bareModelId(modelId));
+	if (!parsed) return undefined;
+	// Adaptive efforts on OpenRouter's completions front: Fable/Mythos and
+	// Opus 4.6+ only — Sonnet stays on the plain effort vocabulary there.
+	const isOpusAdaptive = parsed.kind === "opus" && semverGte(parsed.version, "4.6");
+	if (!isFableOrMythos(parsed.kind) && !isOpusAdaptive) return undefined;
+
+	const hasRealXHigh = isFableOrMythos(parsed.kind) || semverGte(parsed.version, "4.7");
+	return hasRealXHigh ? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER : ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER;
 }
 
 function inferSupportedEfforts<TApi extends Api>(

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -134,8 +134,9 @@ export function resolveModelThinking<TApi extends Api>(
 
 /**
  * Backfill identity-derived wire facts onto explicit thinking metadata.
- * Explicit `effortMap` / `supportsDisplay` (including `false`) always win;
- * untouched configs are returned as-is with zero allocation.
+ * Explicit `effortMap` / `supportsDisplay` (including `false`) win, except
+ * model-defined effort restrictions still normalize stale cached capability
+ * surfaces before request-time code can observe them.
  */
 function fillThinkingWireDefaults<TApi extends Api>(
 	spec: ModelSpec<TApi>,
@@ -143,20 +144,32 @@ function fillThinkingWireDefaults<TApi extends Api>(
 	thinking: ThinkingConfig,
 ): ThinkingConfig {
 	const parsed = parseKnownModel(spec.id);
+	const normalizedEfforts = getModelDefinedEfforts(spec) ?? thinking.efforts;
+	const effortsChanged = !sameEffortList(normalizedEfforts, thinking.efforts);
 	const effortMap =
 		thinking.effortMap === undefined
-			? inferEffortMap(spec, compat, parsed, thinking.mode, thinking.efforts)
-			: undefined;
+			? inferEffortMap(spec, compat, parsed, thinking.mode, normalizedEfforts)
+			: effortsChanged
+				? filterEffortMapToSupportedEfforts(thinking.effortMap, normalizedEfforts)
+				: undefined;
+	const shouldReplaceEffortMap = thinking.effortMap === undefined ? effortMap !== undefined : effortsChanged;
 	const needsDisplay =
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
-	if (effortMap === undefined && !needsDisplay) {
+	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay) {
 		return thinking;
 	}
 	const filled: ThinkingConfig = { ...thinking };
-	if (effortMap !== undefined) {
-		filled.effortMap = effortMap;
+	if (effortsChanged) {
+		filled.efforts = normalizedEfforts;
+	}
+	if (shouldReplaceEffortMap) {
+		if (effortMap === undefined) {
+			delete filled.effortMap;
+		} else {
+			filled.effortMap = effortMap;
+		}
 	}
 	if (needsDisplay) {
 		filled.supportsDisplay = true;
@@ -229,6 +242,20 @@ function filterEffortMapToSupportedEfforts(map: EffortMap, efforts: readonly Eff
 	return filtered;
 }
 
+function sameEffortList(left: readonly Effort[], right: readonly Effort[]): boolean {
+	if (left.length !== right.length) return false;
+	for (let index = 0; index < left.length; index++) {
+		if (left[index] !== right[index]) return false;
+	}
+	return true;
+}
+
+function getModelDefinedEfforts<TApi extends Api>(spec: ModelSpec<TApi>): readonly Effort[] | undefined {
+	return spec.api === "openai-completions" && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))
+		? LOW_MEDIUM_HIGH_REASONING_EFFORTS
+		: undefined;
+}
+
 function readCompatEffortMap(compat: CompatOf<Api>): EffortMap | undefined {
 	if (compat === undefined || !("reasoningEffortMap" in compat)) {
 		return undefined;
@@ -297,8 +324,9 @@ function inferSupportedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] {
-	if (spec.api === "openai-completions" && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))) {
-		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
+	const modelDefinedEfforts = getModelDefinedEfforts(spec);
+	if (modelDefinedEfforts !== undefined) {
+		return modelDefinedEfforts;
 	}
 	switch (parsedModel.family) {
 		case "openai":

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -144,7 +144,9 @@ function fillThinkingWireDefaults<TApi extends Api>(
 ): ThinkingConfig {
 	const parsed = parseKnownModel(spec.id);
 	const effortMap =
-		thinking.effortMap === undefined ? inferEffortMap(spec, compat, parsed, thinking.mode, thinking.efforts) : undefined;
+		thinking.effortMap === undefined
+			? inferEffortMap(spec, compat, parsed, thinking.mode, thinking.efforts)
+			: undefined;
 	const needsDisplay =
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
@@ -211,7 +213,8 @@ function inferEffortMap<TApi extends Api>(
 ): EffortMap | undefined {
 	const detected = inferDetectedEffortMap(spec, parsedModel, mode);
 	const configured = readCompatEffortMap(compat);
-	const merged = detected === undefined ? configured : configured === undefined ? detected : { ...detected, ...configured };
+	const merged =
+		detected === undefined ? configured : configured === undefined ? detected : { ...detected, ...configured };
 	return merged === undefined ? undefined : filterEffortMapToSupportedEfforts(merged, efforts);
 }
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -4282,11 +4282,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -7301,7 +7299,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -7488,6 +7485,38 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"qwen3.7-plus": {
+			"id": "qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "alibaba-coding-plan",
+			"baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
 			"compat": {
 				"supportsDeveloperRole": false
 			},
@@ -8308,8 +8337,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 5.5,
-				"output": 27.5,
+				"input": 5,
+				"output": 25,
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
@@ -8342,10 +8371,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5.5,
-				"output": 27.5,
-				"cacheRead": 0.55,
-				"cacheWrite": 6.875
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8377,10 +8406,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5.5,
-				"output": 27.5,
-				"cacheRead": 0.55,
-				"cacheWrite": 6.875
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8553,7 +8582,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Claude Haiku 4.5",
+			"name": "Claude Haiku 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8582,7 +8611,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Claude Opus 4.5 (Global)",
+			"name": "Claude Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8744,7 +8773,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Claude Sonnet 4.5",
+			"name": "Claude Sonnet 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8773,7 +8802,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Claude Sonnet 4.6 (Global)",
+			"name": "Claude Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -9998,7 +10027,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Claude Opus 4.1 (US)",
+			"name": "Claude Opus 4.1",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -10401,7 +10430,7 @@
 		},
 		"us.meta.llama4-maverick-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-maverick-17b-instruct-v1:0",
-			"name": "Llama 4 Maverick 17B Instruct",
+			"name": "Llama 4 Maverick 17B Instruct (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -11233,21 +11262,19 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.69,
+				"input": 0.35,
+				"output": 0.75,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 32768,
+			"maxTokens": 40960,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -11333,7 +11360,7 @@
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"baseUrl": "https://api.cerebras.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -11344,7 +11371,17 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 40000
+			"maxTokens": 40960,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		}
 	},
 	"cloudflare-ai-gateway": {
@@ -13680,11 +13717,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -13769,16 +13804,51 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		}
 	},
 	"github-copilot": {
+		"claude-fable-5": {
+			"id": "claude-fable-5",
+			"name": "Claude Fable 5",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
 			"name": "Claude Haiku 4.5 (latest)",
@@ -17456,11 +17526,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -17485,11 +17553,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -17689,7 +17755,7 @@
 		},
 		"llama-3.1-8b-instant": {
 			"id": "llama-3.1-8b-instant",
-			"name": "Llama 3.1 8B Instant",
+			"name": "Llama 3.1 8B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -17708,7 +17774,7 @@
 		},
 		"llama-3.3-70b-versatile": {
 			"id": "llama-3.3-70b-versatile",
-			"name": "Llama 3.3 70B Versatile",
+			"name": "Llama 3.3 70B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -17785,7 +17851,7 @@
 		},
 		"meta-llama/llama-4-scout-17b-16e-instruct": {
 			"id": "meta-llama/llama-4-scout-17b-16e-instruct",
-			"name": "Llama 4 Scout 17B",
+			"name": "Llama 4 Scout 17B 16E",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -17843,7 +17909,7 @@
 		},
 		"moonshotai/kimi-k2-instruct-0905": {
 			"id": "moonshotai/kimi-k2-instruct-0905",
-			"name": "Kimi K2 Instruct 0905",
+			"name": "Kimi K2 0905",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -17881,11 +17947,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -17910,11 +17974,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -17939,11 +18001,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -17977,7 +18037,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -18093,11 +18153,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		}
@@ -19807,7 +19865,7 @@
 		},
 		"deepseek/deepseek-r1-distill-llama-70b": {
 			"id": "deepseek/deepseek-r1-distill-llama-70b",
-			"name": "DeepSeek: R1 Distill Llama 70B (retires Jun 11)",
+			"name": "DeepSeek: R1 Distill Llama 70B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -20626,7 +20684,7 @@
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
-			"name": "Gemma-3-27B-IT",
+			"name": "Google: Gemma 3 27B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -20641,8 +20699,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -21651,10 +21709,9 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -21663,17 +21720,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 8192
 		},
 		"microsoft/wizardlm-2-8x22b": {
 			"id": "microsoft/wizardlm-2-8x22b",
@@ -21753,11 +21800,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -21801,11 +21846,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -21830,11 +21873,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -21878,11 +21919,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -22540,8 +22579,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 262000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -24269,11 +24308,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -24317,11 +24354,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -24346,11 +24381,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -25369,7 +25402,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -25596,7 +25629,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3-Next-80B-A3B-Thinking",
+			"name": "Qwen: Qwen3 Next 80B A3B Thinking",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -25610,8 +25643,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -28309,7 +28342,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28343,7 +28375,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28377,7 +28408,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28411,7 +28441,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28445,7 +28474,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28479,7 +28507,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28513,7 +28540,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28547,7 +28573,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28618,7 +28643,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28652,7 +28676,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28686,7 +28709,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28720,7 +28742,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28754,7 +28775,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28788,7 +28808,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28822,7 +28841,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -28856,7 +28874,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -36566,7 +36583,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -36651,11 +36667,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -36680,11 +36694,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -36709,11 +36721,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -37255,9 +37265,10 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -37266,7 +37277,17 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -39023,11 +39044,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -39052,11 +39071,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -39081,11 +39098,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -39878,7 +39893,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -45570,10 +45585,9 @@
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -45582,17 +45596,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 8192
 		},
 		"microsoft/phi-4-multimodal-instruct": {
 			"id": "microsoft/phi-4-multimodal-instruct",
@@ -45634,11 +45638,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -45663,11 +45665,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -45692,11 +45692,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -45721,11 +45719,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -45967,9 +45963,10 @@
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -45978,7 +45975,17 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"mistralai/mixtral-8x22b-instruct": {
 			"id": "mistralai/mixtral-8x22b-instruct",
@@ -47207,7 +47214,7 @@
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
-			"name": "GPT OSS 120B",
+			"name": "GPT-OSS-120B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -47221,16 +47228,14 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"contextWindow": 128000,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -47255,11 +47260,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -48154,6 +48157,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48162,8 +48166,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5-chat-latest": {
 			"id": "gpt-5-chat-latest",
@@ -48205,6 +48208,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48213,8 +48217,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
@@ -48235,6 +48238,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48243,8 +48247,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5-nano": {
 			"id": "gpt-5-nano",
@@ -48265,6 +48268,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48273,8 +48277,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5-pro": {
 			"id": "gpt-5-pro",
@@ -48295,6 +48298,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 272000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48303,8 +48307,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -48325,6 +48328,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48333,8 +48337,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.1-chat-latest": {
 			"id": "gpt-5.1-chat-latest",
@@ -48355,6 +48358,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48363,8 +48367,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.1-codex": {
 			"id": "gpt-5.1-codex",
@@ -48385,6 +48388,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48393,8 +48397,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
@@ -48415,6 +48418,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48423,8 +48427,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -48445,14 +48448,14 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
 					"medium",
 					"high"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.2": {
 			"id": "gpt-5.2",
@@ -48473,6 +48476,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48481,8 +48485,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.2-chat-latest": {
 			"id": "gpt-5.2-chat-latest",
@@ -48503,6 +48506,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48511,8 +48515,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -48533,6 +48536,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48541,8 +48545,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.2-pro": {
 			"id": "gpt-5.2-pro",
@@ -48563,6 +48566,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48571,8 +48575,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.3-chat-latest": {
 			"id": "gpt-5.3-chat-latest",
@@ -48614,6 +48617,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48622,8 +48626,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.3-codex-spark": {
 			"id": "gpt-5.3-codex-spark",
@@ -48644,6 +48647,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48653,7 +48657,6 @@
 					"xhigh"
 				]
 			},
-			"applyPatchToolType": "freeform",
 			"contextPromotionTarget": "openai/gpt-5.5"
 		},
 		"gpt-5.4": {
@@ -48675,6 +48678,7 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48683,8 +48687,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -48705,6 +48708,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48713,8 +48717,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.4-nano": {
 			"id": "gpt-5.4-nano",
@@ -48735,6 +48738,7 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48743,8 +48747,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.4-pro": {
 			"id": "gpt-5.4-pro",
@@ -48765,6 +48768,7 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48773,8 +48777,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"applyPatchToolType": "freeform"
+			}
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -48795,6 +48798,7 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48804,7 +48808,6 @@
 					"xhigh"
 				]
 			},
-			"applyPatchToolType": "freeform",
 			"contextPromotionTarget": "openai/gpt-5.4"
 		},
 		"gpt-5.5-pro": {
@@ -48826,6 +48829,7 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -48835,7 +48839,6 @@
 					"xhigh"
 				]
 			},
-			"applyPatchToolType": "freeform",
 			"contextPromotionTarget": "openai/gpt-5.4"
 		},
 		"o1": {
@@ -49756,6 +49759,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -49765,11 +49773,6 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"compat": {
-				"supportsToolChoice": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true
 			}
 		},
 		"deepseek-v4-pro": {
@@ -49790,6 +49793,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -49799,11 +49807,6 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"compat": {
-				"supportsToolChoice": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true
 			}
 		},
 		"glm-5": {
@@ -50092,11 +50095,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -50642,7 +50643,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.03,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -50676,6 +50677,35 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.74,
+				"output": 3.84,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51733,11 +51763,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -51762,11 +51790,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -51820,11 +51846,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -52269,13 +52293,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6799999999999999,
-				"output": 3.41,
-				"cacheRead": 0.33999999999999997,
+				"input": 0.67,
+				"output": 3.39,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53274,9 +53298,6 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 65536,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53285,6 +53306,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"baidu/ernie-4.5-21b-a3b": {
@@ -53524,7 +53548,7 @@
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 131072,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -53799,13 +53823,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.435,
-				"output": 0.87,
-				"cacheRead": 0.003625,
+				"input": 0.09999999999999999,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54279,7 +54303,7 @@
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
-			"name": "Gemma-3-27B-IT",
+			"name": "Google: Gemma 3 27B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -54397,12 +54421,12 @@
 			],
 			"cost": {
 				"input": 0.12,
-				"output": 0.36,
+				"output": 0.35,
 				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8192,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54919,7 +54943,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -54947,7 +54970,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -54975,7 +54997,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -55000,17 +55021,16 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"minimax/minimax-m2.7": {
@@ -55024,9 +55044,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27,
-				"output": 1.08,
-				"cacheRead": 0.054,
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -55034,7 +55054,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -55720,13 +55739,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6799999999999999,
-				"output": 3.41,
-				"cacheRead": 0.33999999999999997,
+				"input": 0.67,
+				"output": 3.39,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -57296,7 +57315,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -57324,7 +57342,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -57352,7 +57369,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -57380,7 +57396,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -57408,7 +57423,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -57436,7 +57450,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -58321,7 +58334,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -58660,7 +58673,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3-Next-80B-A3B-Thinking",
+			"name": "Qwen: Qwen3 Next 80B A3B Thinking",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -59126,13 +59139,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
+				"input": 0.15,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262140,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59325,10 +59338,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 1.5999999999999999,
-				"cacheRead": 0.08,
-				"cacheWrite": 0.5
+				"input": 0.32,
+				"output": 1.28,
+				"cacheRead": 0.064,
+				"cacheWrite": 0.39999999999999997
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -59507,9 +59520,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59518,6 +59528,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"stepfun/step-3.7-flash": {
@@ -59539,9 +59552,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59550,6 +59560,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"tencent/hy3-preview": {
@@ -61433,9 +61446,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61445,6 +61455,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-4-5": {
@@ -61466,9 +61479,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 64000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61478,6 +61488,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-4-6": {
@@ -61499,9 +61512,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61511,6 +61521,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-4-6-fast": {
@@ -61554,9 +61567,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61566,6 +61576,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-4-7-fast": {
@@ -61609,9 +61622,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61621,6 +61631,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-4-8-fast": {
@@ -61664,9 +61677,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61676,6 +61686,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-sonnet-4-5": {
@@ -61697,9 +61710,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 64000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61709,6 +61719,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-sonnet-4-6": {
@@ -61730,9 +61743,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61742,6 +61752,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-sonnet-45": {
@@ -61763,9 +61776,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61775,6 +61785,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"deepseek-v3.2": {
@@ -61795,9 +61808,6 @@
 			},
 			"contextWindow": 160000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61807,6 +61817,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"deepseek-v4-flash": {
@@ -61827,9 +61840,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61839,6 +61849,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"deepseek-v4-pro": {
@@ -61859,9 +61872,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61871,6 +61881,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"e2ee-gemma-3-27b-p": {
@@ -62288,9 +62301,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62299,6 +62309,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"gemini-3-pro-preview": {
@@ -62320,15 +62333,15 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
 					"low",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"gemma-4-uncensored": {
@@ -62593,9 +62606,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62605,6 +62615,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"grok-build-0-1": {
@@ -62647,9 +62660,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 10000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62659,6 +62669,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"hermes-3-llama-3.1-405b": {
@@ -62702,9 +62715,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62714,6 +62724,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"kimi-k2-6": {
@@ -62756,9 +62769,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 262144,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62768,6 +62778,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"llama-3.2-3b": {
@@ -62854,18 +62867,16 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"minimax-m25": {
@@ -62886,18 +62897,16 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"minimax-m27": {
@@ -62941,9 +62950,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 131072,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62953,6 +62959,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"mistral-31-24b": {
@@ -62997,9 +63006,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63009,6 +63015,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"mistral-small-3-2-24b-instruct": {
@@ -63117,9 +63126,6 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63129,6 +63135,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"openai-gpt-4o-2024-11-20": {
@@ -63193,9 +63202,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63205,6 +63211,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"openai-gpt-52-codex": {
@@ -63226,9 +63235,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63238,6 +63244,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"openai-gpt-53-codex": {
@@ -63500,9 +63509,6 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63511,6 +63517,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"qwen3-4b": {
@@ -63531,9 +63540,6 @@
 			},
 			"contextWindow": 32000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63542,6 +63548,9 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"qwen3-5-35b-a3b": {
@@ -63809,6 +63818,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"xiaomi-mimo-v2-5": {
+			"id": "xiaomi-mimo-v2-5",
+			"name": "xiaomi-mimo-v2-5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"z-ai-glm-5-turbo": {
 			"id": "z-ai-glm-5-turbo",
 			"name": "z-ai-glm-5-turbo",
@@ -63893,9 +63924,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63905,6 +63933,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"zai-org-glm-4.7-flash": {
@@ -63925,9 +63956,6 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63937,6 +63965,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"zai-org-glm-5": {
@@ -63957,9 +63988,6 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
-			"compat": {
-				"supportsUsageInStreaming": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63969,6 +63997,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"zai-org-glm-5-1": {
@@ -72417,11 +72448,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -72465,11 +72494,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -72494,11 +72521,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -72523,11 +72548,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -72552,11 +72575,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -72581,11 +72602,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -74229,6 +74248,36 @@
 			"cost": {
 				"input": 0.2,
 				"output": 1.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"stepfun/step-3.7-flash-free": {
+			"id": "stepfun/step-3.7-flash-free",
+			"name": "Step 3.7 Flash (Free)",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -2435,7 +2435,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-pro": {
@@ -2464,7 +2471,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-chat-v3-0324": {
@@ -11244,8 +11258,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		}
@@ -11861,8 +11874,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -13480,13 +13492,6 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": true,
-				"reasoningEffortMap": {
-					"minimal": "high",
-					"low": "high",
-					"medium": "high",
-					"high": "high",
-					"xhigh": "max"
-				},
 				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
 				"extraBody": {
@@ -13506,7 +13511,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-pro": {
@@ -13530,13 +13542,6 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": true,
-				"reasoningEffortMap": {
-					"minimal": "high",
-					"low": "high",
-					"medium": "high",
-					"high": "high",
-					"xhigh": "max"
-				},
 				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
 				"extraBody": {
@@ -13556,7 +13561,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		}
 	},
@@ -13588,7 +13600,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			}
 		}
 	},
@@ -13635,7 +13650,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"glm-5": {
@@ -13664,7 +13686,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			}
 		},
 		"glm-5.1": {
@@ -13693,7 +13718,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			}
 		},
 		"gpt-oss-120b": {
@@ -13750,7 +13778,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			}
 		},
 		"kimi-k2.6": {
@@ -13780,7 +13811,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			}
 		},
 		"minimax-m2.7": {
@@ -14133,8 +14167,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -17059,8 +17092,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -17090,7 +17122,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v3.2-maas": {
@@ -17119,7 +17158,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"gemini-2.5-flash": {
@@ -17673,7 +17719,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"gemma2-9b-it": {
@@ -18060,7 +18113,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "default",
+					"low": "default",
+					"medium": "default",
+					"high": "default"
+				}
 			}
 		}
 	},
@@ -18091,7 +18150,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/DeepSeek-V3.1": {
@@ -19965,7 +20031,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2-exp": {
@@ -19994,7 +20067,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2-speciale": {
@@ -20042,7 +20122,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
@@ -20109,7 +20196,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro:discounted": {
@@ -31666,7 +31760,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/DeepSeek-V3.1-Terminus": {
@@ -31695,7 +31796,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v3.2-exp": {
@@ -31952,7 +32060,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2-speciale": {
@@ -32000,7 +32115,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro": {
@@ -32029,7 +32151,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro-cheaper": {
@@ -32058,7 +32187,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"dmind/dmind-1": {
@@ -42005,7 +42141,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"TEE/gemma-3-27b-it": {
@@ -44617,7 +44760,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v3.1": {
@@ -44646,7 +44796,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v3.1-terminus": {
@@ -44675,7 +44832,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v3.2": {
@@ -44704,7 +44868,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v4-flash": {
@@ -44733,7 +44904,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
@@ -44762,7 +44940,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"google/codegemma-1.1-7b": {
@@ -49772,7 +49957,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-pro": {
@@ -49806,7 +49998,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"glm-5": {
@@ -50276,7 +50475,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"claude-3-5-haiku": {
@@ -50625,8 +50831,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -50656,7 +50861,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-flash-free": {
@@ -50685,7 +50897,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-pro": {
@@ -50714,7 +50933,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"gemini-3-flash": {
@@ -52699,7 +52925,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-haiku-4.5": {
@@ -52836,7 +53069,11 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-opus-4.6-fast": {
@@ -52866,7 +53103,11 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-opus-4.7": {
@@ -52896,7 +53137,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-opus-4.7-fast": {
@@ -52926,7 +53174,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-opus-4.8": {
@@ -52956,7 +53211,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-opus-4.8-fast": {
@@ -52986,7 +53248,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
 			}
 		},
 		"anthropic/claude-sonnet-4": {
@@ -53557,7 +53826,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-chat-v3.1": {
@@ -53585,7 +53860,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-r1": {
@@ -53613,7 +53894,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-r1-0528": {
@@ -53641,7 +53928,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.1-terminus": {
@@ -53669,7 +53962,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.1-terminus:exacto": {
@@ -53697,7 +53996,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2": {
@@ -53725,7 +54030,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2-exp": {
@@ -53753,7 +54064,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-flash": {
@@ -53781,7 +54098,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-flash:free": {
@@ -53809,7 +54132,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro": {
@@ -53823,13 +54152,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.02,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53837,7 +54166,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"essentialai/rnj-1-instruct": {
@@ -59684,7 +60019,13 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high"
+				}
 			}
 		},
 		"tngtech/tng-r1t-chimera": {
@@ -61210,7 +61551,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-ai/DeepSeek-V3.1": {
@@ -61816,7 +62164,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			},
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -61848,7 +62203,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			},
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -61880,7 +62242,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			},
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63834,7 +64203,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -65089,8 +65458,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -69113,7 +69481,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek-v4-pro": {
@@ -69146,7 +69521,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"GLM-5.1": {
@@ -70063,7 +70445,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
 			}
 		},
 		"grok-4.3": {
@@ -70098,7 +70483,10 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
 			}
 		},
 		"grok-build": {
@@ -71164,8 +71552,7 @@
 					"high"
 				],
 				"effortMap": {
-					"minimal": "low",
-					"xhigh": "max"
+					"minimal": "low"
 				}
 			}
 		},
@@ -71501,7 +71888,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-reasoner": {
@@ -71530,7 +71924,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2": {
@@ -71559,7 +71960,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v3.2-exp": {
@@ -71588,7 +71996,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-flash": {
@@ -71617,7 +72032,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-flash-free": {
@@ -71646,7 +72068,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro": {
@@ -71675,7 +72104,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"deepseek/deepseek-v4-pro-free": {
@@ -71704,7 +72140,14 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"google/gemini-2.0-flash": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -761,8 +761,8 @@ const XAI_NON_CHAT_PREFIXES = ["grok-imagine-", "grok-stt-", "grok-voice-"] as c
 // hermes-agent/agent/transports/codex.py:92 `_effort_clamp = {"minimal":
 // "low"}`). Hermes sends `xhigh` to xAI verbatim and we match that contract
 // — let xAI decide if the level is valid for the specific Grok model.
-// applyResponsesReasoningParams runs this through `model.compat.reasoningEffortMap`
-// at request time, downstream of the omitReasoningEffort gate in xai-responses.ts.
+// `resolveModelThinking` folds this into `model.thinking.effortMap`, downstream
+// of the omitReasoningEffort gate in xai-responses.ts.
 const XAI_REASONING_EFFORT_MAP = { minimal: "low" } as const;
 
 // xai-oauth's /v1/models exposes no per-request output limit on the OAuth
@@ -3110,12 +3110,10 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 		// ids are kept off the catalog until the issue thread asks for them.
 		filterModel: (id, m) => m.tool_call === true && id.startsWith("deepseek-v4"),
 		compat: {
-			// DeepSeek V4 only accepts `high`/`max`; map lower OMP levels upward so
-			// subagent "minimal" turns stay in documented thinking mode instead of
-			// sending unsupported effort strings.
+			// DeepSeek V4 effort remapping is derived in model-thinking metadata; this
+			// descriptor keeps only transport-shape compat.
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: true,
-			reasoningEffortMap: { minimal: "high", low: "high", medium: "high", high: "high", xhigh: "max" },
 			maxTokensField: "max_tokens",
 			// DeepSeek V4 thinking mode rejects the `tool_choice` control parameter.
 			// Tool calls still work without it; the API defaults to auto when tools exist.

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -37,9 +37,9 @@ export interface ThinkingConfig {
 	/** Optional default effort applied when this model is selected. Falls back to global default if absent. */
 	defaultLevel?: Effort;
 	/**
-	 * Effort → wire-value remap for `anthropic-adaptive` transports, baked at
-	 * build time (4-tier legacy scale vs the 5-tier Opus 4.7+/Fable/Mythos
-	 * scale). Identity for efforts the map omits.
+	 * Effort → provider wire-value remap, baked at build time. Identity for
+	 * efforts the map omits. Used by Anthropic adaptive thinking, OpenAI-
+	 * compatible `reasoning_effort`, and Responses-style reasoning params.
 	 */
 	effortMap?: Partial<Record<Effort, string>>;
 	/**

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -3,6 +3,8 @@ import {
 	isClaudeModelId,
 	isKimiK26ModelId,
 	isKimiModelId,
+	isMinimaxM2FamilyModelId,
+	isOpenAIGptOssModelId,
 	supportsAdaptiveThinkingDisplay,
 } from "@oh-my-pi/pi-catalog/identity";
 
@@ -44,5 +46,59 @@ describe("supportsAdaptiveThinkingDisplay", () => {
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
 		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-4-6")).toBe(false);
+	});
+});
+
+describe("isMinimaxM2FamilyModelId", () => {
+	test("matches every M2-generation id shape served by aggregator/native hosts", () => {
+		// Fireworks/OpenCode/openrouter direct ids and `-highspeed`/`-lightning` variants.
+		expect(isMinimaxM2FamilyModelId("minimax-m2.7")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("MiniMax-M2.7")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("MiniMax-M2.7-highspeed")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("MiniMax-M2.1-lightning")).toBe(true);
+		// Vendor-namespaced ids on aggregators.
+		expect(isMinimaxM2FamilyModelId("minimax/minimax-m2")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax/minimax-m2.5:free")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimaxai/minimax-m2.7")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax/minimax-m2-her")).toBe(true);
+		// Bedrock-shaped id and aimlapi short form.
+		expect(isMinimaxM2FamilyModelId("minimax.minimax-m2.7")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax/m2")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax/m2-7-highspeed")).toBe(true);
+		// Venice's dotless aliases.
+		expect(isMinimaxM2FamilyModelId("minimax-m21")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax-m25")).toBe(true);
+		expect(isMinimaxM2FamilyModelId("minimax-m27")).toBe(true);
+	});
+
+	test("excludes non-M2 MiniMax SKUs and unrelated families", () => {
+		expect(isMinimaxM2FamilyModelId("minimax/m1")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("MiniMax-M1")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("MiniMax-M3")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("minimax/minimax-m3")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("MiniMax-Text-01")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("minimax-music")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("minimax/hailuo-02")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("minimax/music-2.0")).toBe(false);
+		// Lone "m2" string with no MiniMax context does not match.
+		expect(isMinimaxM2FamilyModelId("kimi-m2")).toBe(false);
+		expect(isMinimaxM2FamilyModelId("gpt-oss-120b")).toBe(false);
+	});
+});
+
+describe("isOpenAIGptOssModelId", () => {
+	test("matches gpt-oss across catalog id shapes", () => {
+		expect(isOpenAIGptOssModelId("gpt-oss-120b")).toBe(true);
+		expect(isOpenAIGptOssModelId("gpt-oss-20b")).toBe(true);
+		expect(isOpenAIGptOssModelId("gpt-oss:120b")).toBe(true);
+		expect(isOpenAIGptOssModelId("openai/gpt-oss-120b")).toBe(true);
+		expect(isOpenAIGptOssModelId("gpt-oss-120b-medium")).toBe(true);
+	});
+
+	test("excludes unrelated `gpt-*` and `oss` models", () => {
+		expect(isOpenAIGptOssModelId("gpt-4o")).toBe(false);
+		expect(isOpenAIGptOssModelId("gpt-4.1-mini")).toBe(false);
+		expect(isOpenAIGptOssModelId("oss-llm")).toBe(false);
+		expect(isOpenAIGptOssModelId("MiniMax-M2.7")).toBe(false);
 	});
 });

--- a/packages/catalog/test/issue-830-repro.test.ts
+++ b/packages/catalog/test/issue-830-repro.test.ts
@@ -41,8 +41,7 @@ describe("deepseek built-in provider (issue #830)", () => {
 		expect(descriptor?.api).toBe("openai-completions");
 		expect(descriptor?.baseUrl).toBe("https://api.deepseek.com");
 		// Per-model compat: DeepSeek V4 supports thinking-mode tool calls, but only
-		// with `high`/`max` effort, no explicit `tool_choice`, max_tokens, and
-		// reasoning_content replay.
+		// with no explicit `tool_choice`, max_tokens, and reasoning_content replay.
 		const compat =
 			descriptor?.api === "openai-completions" ? (descriptor.compat as OpenAICompat | undefined) : undefined;
 		expect(compat?.supportsDeveloperRole).toBe(false);
@@ -53,12 +52,5 @@ describe("deepseek built-in provider (issue #830)", () => {
 		expect(compat?.requiresAssistantContentForToolCalls).toBe(true);
 		expect(compat?.reasoningContentField).toBe("reasoning_content");
 		expect(compat?.extraBody).toEqual({ thinking: { type: "enabled" } });
-		expect(compat?.reasoningEffortMap).toMatchObject({
-			minimal: "high",
-			low: "high",
-			medium: "high",
-			high: "high",
-			xhigh: "max",
-		});
 	});
 });

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -65,6 +65,30 @@ describe("model thinking derivation", () => {
 		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
 	});
 
+	it("stores MiniMax M2 and GPT-OSS OpenAI-compatible effort limits in model metadata", () => {
+		const minimax = createModel({
+			id: "minimax-m2.7",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+		});
+		const gptOss = createModel({
+			id: "gpt-oss-120b",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+		});
+
+		expect(minimax.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		});
+		expect(gptOss.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		});
+	});
+
 	it("encodes the Gemini 3 Pro effort gap directly in efforts", () => {
 		const model = createModel({
 			id: "gemini-3-pro-preview",

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -87,6 +87,58 @@ describe("model thinking derivation", () => {
 			mode: "effort",
 			efforts: [Effort.Low, Effort.Medium, Effort.High],
 		});
+		expect(minimax.thinking?.effortMap).toBeUndefined();
+		expect(gptOss.thinking?.effortMap).toBeUndefined();
+	});
+
+	it("stores OpenAI-compatible provider effort maps in thinking metadata", () => {
+		const fireworks = createModel({
+			id: "glm-5.1",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+		});
+		const groqQwen = createModel({
+			id: "qwen/qwen3-32b",
+			api: "openai-completions",
+			provider: "groq",
+			baseUrl: "https://api.groq.com/openai/v1",
+		});
+		const deepseek = createModel({
+			id: "deepseek-v4-flash",
+			api: "openai-completions",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com/v1",
+			compat: { reasoningEffortMap: { xhigh: "max-plus" } },
+		});
+		const openRouterAnthropic = createModel({
+			id: "anthropic/claude-opus-4.7",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+		});
+
+		expect(fireworks.thinking?.effortMap).toEqual({ minimal: "none" });
+		expect(groqQwen.thinking?.effortMap).toEqual({
+			minimal: "default",
+			low: "default",
+			medium: "default",
+			high: "default",
+		});
+		expect(deepseek.thinking?.effortMap).toMatchObject({
+			minimal: "high",
+			low: "high",
+			medium: "high",
+			high: "high",
+			xhigh: "max-plus",
+		});
+		expect(openRouterAnthropic.thinking?.effortMap).toEqual({
+			minimal: "low",
+			low: "medium",
+			medium: "high",
+			high: "xhigh",
+			xhigh: "max",
+		});
 	});
 
 	it("encodes the Gemini 3 Pro effort gap directly in efforts", () => {
@@ -188,7 +240,7 @@ describe("model thinking derivation", () => {
 		expect(filled.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			efforts: [Effort.Low, Effort.High],
-			effortMap: { minimal: "low", low: "medium", medium: "high", high: "xhigh", xhigh: "max" },
+			effortMap: { low: "medium", high: "xhigh" },
 			supportsDisplay: true,
 		});
 

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -91,6 +91,39 @@ describe("model thinking derivation", () => {
 		expect(gptOss.thinking?.effortMap).toBeUndefined();
 	});
 
+	it("normalizes stale explicit MiniMax M2 / GPT-OSS effort metadata from caches", () => {
+		const staleMinimax = createModel({
+			id: "minimax-m2.7",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+				effortMap: { minimal: "none", xhigh: "max" },
+			},
+		});
+		const staleGptOss = createModel({
+			id: "gpt-oss-120b",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+
+		expect(staleMinimax.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		});
+		expect(staleGptOss.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		});
+	});
+
 	it("stores OpenAI-compatible provider effort maps in thinking metadata", () => {
 		const fireworks = createModel({
 			id: "glm-5.1",

--- a/packages/catalog/test/ollama-provider.test.ts
+++ b/packages/catalog/test/ollama-provider.test.ts
@@ -84,14 +84,16 @@ describe("ollama local provider discovery", () => {
 		const models = await ollamaModelManagerOptions({ fetch: fetchMock }).fetchDynamicModels?.();
 		const reasoningModel = models?.find(candidate => candidate.id === "gemma4:e4b");
 		const plainModel = models?.find(candidate => candidate.id === "llama-plain:latest");
+		const builtReasoningModel = reasoningModel ? buildModel(reasoningModel) : undefined;
+		const builtPlainModel = plainModel ? buildModel(plainModel) : undefined;
 
-		// Ollama's OpenAI-compatible endpoint rejects "minimal"/"xhigh" with HTTP 400;
-		// reasoning models must remap them onto accepted levels (low/max).
+		// Ollama's OpenAI-compatible endpoint rejects "minimal" with HTTP 400;
+		// reasoning models must bake a thinking effort map to an accepted level (low).
 		expect(reasoningModel?.reasoning).toBe(true);
-		expect(reasoningModel?.compat?.reasoningEffortMap).toMatchObject({ minimal: "low", xhigh: "max" });
-		// Non-reasoning models never send an effort, so they carry no remap.
+		expect(builtReasoningModel?.thinking?.effortMap).toMatchObject({ minimal: "low" });
+		// Non-reasoning models never send an effort, so they carry no thinking metadata.
 		expect(plainModel?.reasoning).toBe(false);
-		expect(plainModel?.compat?.reasoningEffortMap).toBeUndefined();
+		expect(builtPlainModel?.thinking).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Repro

With `modelRoles.smol: fireworks/minimax-m2.7`, every auto-thinking classification call 400s upstream because the wire body carries `reasoning_effort: "none"` — a value the model rejects (MiniMax M2 accepts only `low|medium|high`). Same failure on `fireworks/gpt-oss-120b` (Harmony). A pinned repro lives in `packages/ai/test/issue-2315-repro.test.ts`; pre-fix it produced:

```
Expected: "low"
Received: "none"
  at packages/ai/test/issue-2315-repro.test.ts:58  (fireworks/minimax-m2.7)
Expected: "low"
Received: "none"
  at packages/ai/test/issue-2315-repro.test.ts:65  (fireworks/gpt-oss-120b)
1 pass / 2 fail
```

## Cause

`buildOpenAICompat` in `packages/catalog/src/compat/openai.ts` applies a single Fireworks-wide `reasoningEffortMap: { minimal: "none" }` to every Fireworks-hosted reasoning model. For GLM-5.x that's correct — the upstream accepts `"none"` to disable reasoning. For MiniMax M2 and gpt-oss/Harmony the upstream only accepts `low|medium|high`. The auto-thinking classifier (`packages/coding-agent/src/auto-thinking/classifier.ts:classifyOnline`) sends `disableReasoning: true`, which lands in the openai-completions disable-reasoning branch (`openai-completions.ts:1385-1399`), picks `getSupportedEfforts(model)[0] === "minimal"`, runs it through the provider's map, and emits `reasoning_effort: "none"`.

## Fix

- New identity predicates in `packages/catalog/src/identity/family.ts`:
  - `isMinimaxM2FamilyModelId` — matches every M2-generation shape (`minimax-m2.7`, `MiniMax-M2.7-highspeed`, `minimax/minimax-m2.5:free`, `minimax.minimax-m2.7`, `minimax/m2-1`, Venice's dotless `minimax-m21`/`m25`/`m27`, …) while excluding M1, M3, Text-01, music, and hailuo SKUs.
  - `isOpenAIGptOssModelId` — matches `gpt-oss-120b`/`gpt-oss:120b`/`openai/gpt-oss-…`/`gpt-oss-120b-medium`.
- In `buildOpenAICompat`, a new `requiresLowMediumHighOnlyEffort` branch fires for reasoning-capable models in either family across every host, mapping `{ minimal: "low", xhigh: "high" }`. Ordered before the Fireworks blanket rule so GLM-5.x and other Fireworks reasoning models keep `minimal → none` unchanged.
- Tests: `packages/ai/test/issue-2315-repro.test.ts` pins the contract for both restricted families (disable-reasoning + explicit `xhigh` clamp + `low/medium/high` passthrough) and asserts the GLM-5.1 control still maps `minimal → none`. `packages/catalog/test/identity-family.test.ts` covers the new id predicates including aggregator namespaces, dotless aliases, and negative cases.

## Verification

- `cd packages/ai && bun test test/issue-2315-repro.test.ts` → 5 pass / 0 fail
- `cd packages/ai && bun test` → 1591 pass / 337 skip / 0 fail
- `cd packages/catalog && bun test` → 160 pass / 0 fail
- `cd packages/coding-agent && bun test test/auto-thinking-classifier.test.ts test/agent-session-magic-keywords.test.ts test/agent-session-role-thinking.test.ts` → 20 pass / 0 fail

Fixes #2315