### PR TITLE
fix(mnemopi): drain global bank on enqueue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Fixed Mnemopi `per-project-tagged` enqueue maintenance to flush and consolidate the shared global bank alongside the project bank ([#2321](https://github.com/can1357/oh-my-pi/issues/2321)).
+
 - Fixed CDP attach target selection for Chromium/Edge endpoints that expose page targets through discovery before `browser.pages()` is populated, and improved `ws://` `app.cdp_url` diagnostics ([#2246](https://github.com/can1357/oh-my-pi/issues/2246)).
 - Fixed local memory consolidation on Responses-style models that reject user-only requests by sending a dedicated stage-two system prompt.
 - Fixed extension, custom-tool, custom-command, and hook loaders injecting `pi` through bare `@oh-my-pi/pi-coding-agent` self-imports, which could pull a different cached package version into global installs during plugin load and trigger mixed-runtime stack overflows.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Mnemopi `per-project-tagged` enqueue maintenance to flush and consolidate the shared global bank alongside the project bank ([#2321](https://github.com/can1357/oh-my-pi/issues/2321)).
+
 ## [15.11.2] - 2026-06-11
 
 ### Added
@@ -16,8 +20,6 @@
 - Bash tool calls in one assistant message now run in parallel instead of serializing the batch: non-pty `bash` is scheduled as a shared tool (`pty: true` stays exclusive), and overlapping calls on the same shell session key degrade to isolated one-shot shells so they cannot queue behind or abort each other
 
 ### Fixed
-
-- Fixed Mnemopi `per-project-tagged` enqueue maintenance to flush and consolidate the shared global bank alongside the project bank ([#2321](https://github.com/can1357/oh-my-pi/issues/2321)).
 
 - Fixed CDP attach target selection for Chromium/Edge endpoints that expose page targets through discovery before `browser.pages()` is populated, and improved `ws://` `app.cdp_url` diagnostics ([#2246](https://github.com/can1357/oh-my-pi/issues/2246)).
 - Fixed local memory consolidation on Responses-style models that reject user-only requests by sending a dedicated stage-two system prompt.

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -137,10 +137,10 @@ export const mnemopiBackend: MemoryBackend = {
 				setMnemopiSessionState(session, state);
 			}
 			await state?.forceRetainCurrentSession();
-			// Drain the background fact extraction scheduled by the final retain
-			// before the process can exit, otherwise the last turn's facts are lost.
-			await state?.memory.flushExtractions();
-			state?.memory.sleepAllSessions(false);
+			// Drain background extraction scheduled by the final retain for every
+			// scoped bank before the process can exit, otherwise last-turn facts
+			// in the project or global bank are lost.
+			await state?.drainScopedBanks();
 		} catch (error) {
 			logger.warn("Mnemopi: enqueue failed.", { error: String(error) });
 		}

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -154,6 +154,14 @@ export class MnemopiSessionState {
 		return this.scoped.retain;
 	}
 
+	/** Flushes pending extractions and consolidation for each bank owned by this session. */
+	async drainScopedBanks(): Promise<void> {
+		for (const memory of this.scoped.owned) {
+			await memory.flushExtractions();
+			memory.sleepAllSessions(false);
+		}
+	}
+
 	editScopedMemory(
 		op: MnemopiMemoryEditOperation,
 		id: string,

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -498,6 +498,33 @@ describe("Mnemopi backend lifecycle", () => {
 		childState?.dispose();
 	});
 
+	it("flushes project and global Mnemopi banks during enqueue in per-project-tagged mode", async () => {
+		const config = makeMnemopiConfig({
+			scoping: "per-project-tagged",
+			bank: "project-alpha",
+			globalBank: "default",
+			retainBank: "project-alpha",
+			recallBanks: ["project-alpha", "default"],
+		});
+		const state = registerMnemopiState(config, { cwd: "/work/project-alpha" });
+		const session = state.session;
+		setMnemopiSessionState(session, state);
+		const retainFlush = vi.spyOn(state.memory, "flushExtractions").mockResolvedValue();
+		const retainSleep = vi.spyOn(state.memory, "sleepAllSessions").mockReturnValue({ status: "noop" } as never);
+		const globalFlush = vi.spyOn(state.globalMemory!, "flushExtractions").mockResolvedValue();
+		const globalSleep = vi
+			.spyOn(state.globalMemory!, "sleepAllSessions")
+			.mockReturnValue({ status: "noop" } as never);
+		vi.spyOn(state, "forceRetainCurrentSession").mockResolvedValue();
+
+		await mnemopiBackend.enqueue(path.dirname(config.dbPath), "/work/project-alpha", session);
+
+		expect(retainFlush).toHaveBeenCalledTimes(1);
+		expect(globalFlush).toHaveBeenCalledTimes(1);
+		expect(retainSleep).toHaveBeenCalledWith(false);
+		expect(globalSleep).toHaveBeenCalledWith(false);
+	});
+
 	it("clears every scoped Mnemopi database for per-project-tagged mode", async () => {
 		const config = makeMnemopiConfig({
 			scoping: "per-project-tagged",


### PR DESCRIPTION
## Repro
Added and ran `bun test packages/coding-agent/test/memory-tools.test.ts -t "flushes project and global Mnemopi banks"`; before the fix, the project bank `flushExtractions()` spy was called once while `globalMemory.flushExtractions()` stayed at 0 calls.

## Cause
`packages/coding-agent/src/mnemopi/backend.ts` called `state.memory.flushExtractions()` and `state.memory.sleepAllSessions(false)` directly after `forceRetainCurrentSession()`, so `MnemopiSessionState.globalMemory` opened by `per-project-tagged` scoping in `packages/coding-agent/src/mnemopi/state.ts` was never drained during enqueue maintenance.

## Fix
- Added `MnemopiSessionState.drainScopedBanks()` to flush pending extractions and run `sleepAllSessions(false)` for every owned scoped bank.
- Updated `mnemopiBackend.enqueue()` to call the scoped drain path instead of only the retain/project bank.
- Added a lifecycle regression test that asserts enqueue drains both project and global banks in `per-project-tagged` mode.
- Added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/memory-tools.test.ts` passed: 41 tests, 122 assertions. `bun --cwd=packages/coding-agent run check` passed. `bun run fix` completed with no remaining fixes. Fixes #2321