### PR TITLE
Fix working loader scrollback duplication

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stale `Working…` loader rows being committed to native scrollback above the live loader: the interactive status container now reports a live-region seam while it has mounted content ([#2328](https://github.com/can1357/oh-my-pi/pull/2328) by [@35844493](https://github.com/35844493)).
+
 ## [15.11.2] - 2026-06-11
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -257,6 +257,13 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 }
 
+class StatusContainer extends Container {
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		return this.children.length > 0 ? 0 : undefined;
+	}
+}
+
+
 export class InteractiveMode implements InteractiveModeContext {
 	session: AgentSession;
 	sessionManager: SessionManager;
@@ -418,7 +425,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		setTerminalTextSizing(settings.get("tui.textSizing") && TERMINAL.textSizing);
 		this.chatContainer = new TranscriptContainer();
 		this.pendingMessagesContainer = new Container();
-		this.statusContainer = new Container();
+		this.statusContainer = new StatusContainer();
 		this.todoContainer = new Container();
 		this.btwContainer = new Container();
 		this.omfgContainer = new Container();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -14,7 +14,14 @@ import {
 import type { CompactionOutcome } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, ImageContent, Message, Model, UsageReport } from "@oh-my-pi/pi-ai";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import type { Component, EditorTheme, LoaderMessageColorFn, OverlayHandle, SlashCommand } from "@oh-my-pi/pi-tui";
+import type {
+	Component,
+	EditorTheme,
+	LoaderMessageColorFn,
+	NativeScrollbackLiveRegion,
+	OverlayHandle,
+	SlashCommand,
+} from "@oh-my-pi/pi-tui";
 import {
 	Container,
 	clearRenderCache,
@@ -257,12 +264,18 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 }
 
-class StatusContainer extends Container {
+/**
+ * Hosts the working loader and transient status rows. While anything is
+ * mounted, every row is live: report a seam at 0 so the engine never commits
+ * a still-animating loader to native scrollback (stale `Working…` rows would
+ * otherwise pile up above the live one). The transcript's own seam, when
+ * present, sits higher and wins (topmost-seam merge in TUI.render).
+ */
+class StatusContainer extends Container implements NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined {
 		return this.children.length > 0 ? 0 : undefined;
 	}
 }
-
 
 export class InteractiveMode implements InteractiveModeContext {
 	session: AgentSession;

--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -78,6 +78,17 @@ afterEach(() => {
 });
 
 describe("InteractiveMode working-message session accent cache", () => {
+	it("keeps the working loader out of native scrollback", async () => {
+		const { mode } = await createHarness("Live status");
+		const statusContainer = mode.statusContainer as typeof mode.statusContainer & {
+			getNativeScrollbackLiveRegionStart(): number | undefined;
+		};
+
+		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+		startStableLoader(mode);
+		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
 	it("reuses one computed accent across loader spinner and message colorizers", async () => {
 		const { mode } = await createHarness("Cached session");
 		const getHex = vi.spyOn(sessionColor, "getSessionAccentHex");

--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -5,6 +5,7 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as sessionColor from "@oh-my-pi/pi-coding-agent/utils/session-color";
+import type { Container, NativeScrollbackLiveRegion } from "@oh-my-pi/pi-tui";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 type Harness = {
@@ -78,13 +79,14 @@ afterEach(() => {
 });
 
 describe("InteractiveMode working-message session accent cache", () => {
-	it("keeps the working loader out of native scrollback", async () => {
+	it("reports a live seam only while status content is mounted", async () => {
 		const { mode } = await createHarness("Live status");
-		const statusContainer = mode.statusContainer as typeof mode.statusContainer & {
-			getNativeScrollbackLiveRegionStart(): number | undefined;
-		};
+		const statusContainer = mode.statusContainer as Container & NativeScrollbackLiveRegion;
 
+		// Empty: no seam — the engine may commit freely past the container.
 		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+		// Loader mounted: every row is live, so the seam sits at 0 and keeps
+		// the animating loader out of immutable native scrollback.
 		startStableLoader(mode);
 		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
 	});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the root compose letting a lower child's native-scrollback live seam overwrite a higher one: the topmost seam (and its commit-safe extension) now defines the commit boundary, so a status loader below a streaming transcript can no longer cause still-mutable transcript rows to be committed as stale history ([#2328](https://github.com/can1357/oh-my-pi/pull/2328)).
+
 ## [15.11.2] - 2026-06-11
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -185,6 +185,10 @@ export interface Component {
  * of history until it finalizes. Volatile live blocks (tool previews that
  * collapse) omit it. Defaults to `liveRegionStart` when absent; a root that
  * reports no seam at all commits everything that scrolls (shell semantics).
+ *
+ * When several root children report a seam in the same frame, the topmost
+ * one (and its commit-safe extension) defines the boundary: commits are
+ * prefix-only, so everything below the first seam is already excluded.
  */
 export interface NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined;
@@ -833,7 +837,13 @@ export class TUI extends Container {
 				// the last render the engine actually observed.
 				reported = getRenderStablePrefixRows(child);
 			}
-			if (liveLocalStart !== undefined) {
+			// Topmost seam wins. Commits are prefix-only: the first child that
+			// reports a live region (plus its own commit-safe extension) already
+			// bounds everything below it, so a lower sibling's seam (e.g. a
+			// status loader under a streaming transcript) must never overwrite
+			// it — moving the boundary down would commit the earlier child's
+			// still-mutable rows as stale history.
+			if (liveLocalStart !== undefined && this.#nativeScrollbackLiveRegionStart === undefined) {
 				this.#nativeScrollbackLiveRegionStart = offset + liveLocalStart;
 				if (commitLocalEnd !== undefined) {
 					this.#nativeScrollbackCommitSafeEnd = offset + commitLocalEnd;

--- a/packages/tui/test/streaming-scrollback-defer.test.ts
+++ b/packages/tui/test/streaming-scrollback-defer.test.ts
@@ -234,6 +234,46 @@ describe("streaming scrollback defer", () => {
 		}
 	});
 
+	it("keeps the topmost live seam when a lower sibling also reports one", async () => {
+		if (process.platform === "win32") return;
+		const term = new VirtualTerminal(24, 4);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const sealed = new LineList(rows("prior-", 12));
+		// Volatile live transcript block: seam at 0, no commit-safe end.
+		const live = new LiveLineList([]);
+		// Status loader below the transcript: also reports a seam. Commits are
+		// prefix-only, so the engine must keep the TOPMOST seam — letting the
+		// lower sibling's seam win would move the boundary past the transcript's
+		// still-mutable rows and commit them as stale history.
+		const loader = new LiveLineList(["Working..."]);
+
+		try {
+			tui.addChild(sealed);
+			tui.addChild(live);
+			tui.addChild(loader);
+			tui.start();
+			await settle(term);
+
+			const writes = capture(term);
+
+			live.setLines(rows("pending-stale-", 10));
+			tui.requestRender();
+			await settle(term);
+
+			live.setLines(rows("running-fresh-", 10));
+			tui.requestRender();
+			await settle(term);
+
+			const buffer = term.getScrollBuffer().map(line => line.trimEnd());
+			expect(eraseScrollbackCount(writes)).toBe(0);
+			expect(buffer.some(line => line.startsWith("pending-stale-"))).toBe(false);
+			expect(buffer).toContain("running-fresh-9");
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("commits scrolled streaming rows to history exactly once without ED3", async () => {
 		if (process.platform === "win32") return;
 		const term = new VirtualTerminal(40, 10);


### PR DESCRIPTION
## Summary
- keep the interactive status container out of native scrollback while it owns a live loader
- prevent stale `Working…` rows from being committed above the current live loader
- add a regression assertion for the status container live-region seam

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/interactive-mode-working-accent.test.ts` — 5 pass, 0 fail
- Local installed CLI smoke: `omp gallery --tool bash --state success --width 80 --plain`