### PR TITLE
fix(models): make unconfigured smol role fall back to default instead of cloud list

### DIFF
--- a/packages/coding-agent/src/priority.json
+++ b/packages/coding-agent/src/priority.json
@@ -1,14 +1,5 @@
 {
-	"smol": [
-		"cerebras/zai-glm-4.7",
-		"cerebras/zai-glm-4.6",
-		"cerebras/zai-glm",
-		"haiku-4-5",
-		"haiku-4.5",
-		"haiku",
-		"flash",
-		"mini"
-	],
+	"smol": [],
 	"slow": [
 		"gpt-5.4",
 		"gpt-5.3-codex",


### PR DESCRIPTION
Fixes the `smol` part of #2336.

## Problem

When `modelRoles.smol` is unset, role resolution falls back to the hardcoded cloud-first list in `priority.json` (`cerebras/zai-glm-*`, `haiku-*`, `flash`, `mini`) instead of the user's `modelRoles.default`. A user who sets `default` to a local model and never configures `smol` gets all `pi/smol` subagents silently routed to a paid cloud model — no warning, unexpected billing, breaks an all-local setup.

## Change

Set `priority.json` `"smol": []`.

With an empty list, `resolveConfiguredRolePattern` returns `undefined` for an unconfigured `smol`, so `resolveAgentModelPatterns` falls through to `settings.getModelRole("default")` — i.e. `smol` now inherits `default`, consistent with how `task`/`default` already behave.

## Why `[]` and not `null`

Three call sites iterate the list directly with `for (const pattern of MODEL_PRIO.smol)`:

- `config/model-resolver.ts` (`findSmolModel`) → post-loop fallback `availableModels[0]`
- `commit/model-selection.ts` → post-loop fallback `fallbackModel`
- `utils/commit-message-generator.ts` → post-loop fallback over all available models

`null` would throw (`null is not iterable`) in all three — including commit-message generation, which runs on every commit. `[]` skips the loops cleanly and each falls through to its existing fallback. No code changes required.

## Notes

This is the minimal, self-contained first step suggested in #2336. A more complete fix (have unconfigured roles fall back to `modelRoles.default` at the resolver level, and/or warn when a role resolves to a cloud model while `default` is local) can follow separately. Left `slow`/`designer` untouched here to keep the change scoped.
