### PR TITLE
fix(natives): resolve bash for extensionless shell rc files (zshrc/.bashrc)

### DIFF
--- a/crates/pi-ast/src/block.rs
+++ b/crates/pi-ast/src/block.rs
@@ -299,6 +299,19 @@ mod tests {
 	}
 
 	#[test]
+	fn resolves_zsh_if_block_in_extensionless_rc_file() {
+		// Regression: an extensionless shell rc file (`zshrc`/`.zshrc`) must
+		// infer the bash grammar so `replace block` / `insert after block`
+		// works. Previously `Path::extension` returned `None`, leaving block
+		// ops permanently unresolvable on these files.
+		let code = "ZSH_COMPDUMP=x\nif [[ -f \"$ZSH_COMPDUMP\" ]]; then\n  compinit -C\nelse\n  compinit\nfi\n";
+		let span = Some(BlockRange { start_line: 2, end_line: 6 });
+		assert_eq!(resolve(code, "modules/zsh/zshrc", 2), span);
+		assert_eq!(resolve(code, ".zshrc", 2), span);
+		assert_eq!(resolve(code, "/home/u/.bashrc", 2), span);
+	}
+
+	#[test]
 	fn resolves_top_level_python_def() {
 		let code = "x = 1\ndef greet():\n    return 1\n";
 		assert_eq!(resolve(code, "g.py", 2), Some(BlockRange { start_line: 2, end_line: 3 }));

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -627,6 +627,31 @@ fn from_extension(path: &Path) -> Option<SupportLang> {
 		return Some(SupportLang::Dockerfile);
 	}
 
+	// Extensionless shell rc/profile files. `Path::extension` returns `None`
+	// for both bare (`zshrc`) and dotfile (`.zshrc`) forms, so they would
+	// otherwise resolve to no language and disable block-aware ops on them.
+	let stem = name.strip_prefix('.').unwrap_or(name);
+	if matches!(
+		stem,
+		"zshrc"
+			| "zshenv"
+			| "zprofile"
+			| "zlogin"
+			| "zlogout"
+			| "zsh_aliases"
+			| "bashrc"
+			| "bash_profile"
+			| "bash_login"
+			| "bash_logout"
+			| "bash_aliases"
+			| "profile"
+			| "kshrc"
+			| "mkshrc"
+			| "shrc"
+	) {
+		return Some(SupportLang::Bash);
+	}
+
 	let ext = path.extension()?.to_str()?;
 	SupportLang::all_langs()
 		.iter()

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `blockRangeAt` (and thus the edit tool's `replace block` / `insert after block` ops) failing on extensionless shell rc/profile files. `Path::extension` returns `None` for both bare (`zshrc`) and dotfile (`.zshrc`, `.bashrc`) forms, so language inference fell through to "unrecognized" and block resolution was permanently unresolvable on those files — an agent retrying the block op would loop on the same error. Known shell rc/profile basenames (`zshrc`/`zshenv`/`zprofile`/`zlogin`/`zlogout`/`bashrc`/`bash_profile`/`bash_login`/`bash_logout`/`bash_aliases`/`profile`/`kshrc`/`mkshrc`/`shrc`, with or without a leading dot) now resolve to the bash grammar.
+
 ## [15.11.0] - 2026-06-10
 ### Breaking Changes
 


### PR DESCRIPTION
## Problem

`blockRangeAt` infers a language only from the file path. For extensionless shell rc/profile files — `zshrc`, `.zshrc`, `.bashrc`, `.profile`, etc. — `Path::extension()` returns `None` (true for both bare names and leading-dot dotfiles), so `from_extension` falls through to "unrecognized" and returns `None`.

That makes the edit tool's `replace block N:` / `insert after block N:` operators **permanently unresolvable** on those files: every attempt fails with

```
could not resolve a syntactic block beginning on line N. The language may be unsupported...
```

`bash` is already a supported grammar and `sh`/`zsh`/`ksh` are in the extension and alias tables — the construct would parse fine. Inference just died before reaching the parser because the file carries no extension.

Observed failure mode: an agent editing a `zshrc` retries the same `insert after block N:` op and loops on the identical error (the repeated identical failures in context reinforce the loop), eventually abandoning structured edits for a whole-file rewrite.

## Fix

`from_extension` now special-cases known shell rc/profile basenames before the `path.extension()?` short-circuit, mirroring the existing `Makefile`/`Dockerfile` basename handling. A leading dot is stripped first so both `zshrc` and `.zshrc` match:

`zshrc`, `zshenv`, `zprofile`, `zlogin`, `zlogout`, `zsh_aliases`, `bashrc`, `bash_profile`, `bash_login`, `bash_logout`, `bash_aliases`, `profile`, `kshrc`, `mkshrc`, `shrc` → `SupportLang::Bash`.

(csh/tcsh rc files are intentionally excluded — they aren't bash syntax.)

## Verification

- New regression test `resolves_zsh_if_block_in_extensionless_rc_file` resolves a zsh `if [[ ... ]]; then ... fi` block to its full span for `modules/zsh/zshrc`, `.zshrc`, and `/home/u/.bashrc`.
- `cargo test --lib` for `pi-ast` is green (block suite 21/21); the unknown-extension case still correctly returns `None`.
- End-to-end through the JS binding: `blockRangeAt({ path: "modules/zsh/zshrc", line: 2 })` returns `{startLine:2,endLine:6}`; `x.unknownext` returns `null`.
- Changelog entry added under `packages/natives` `[Unreleased]` → `Fixed`.
