### PR TITLE
feat(tools): compact provider tool definitions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `/context` (TUI panel and ACP report) now shows estimated snapcompact wire savings when `snapcompact.systemPrompt` or `snapcompact.toolResults` is enabled — per-feature text → frames token deltas, the reason a swap does not apply (savings margin, image budget, or text-only model), and the estimated size of the next request. The estimate and the live provider-request transform share one planner (`planInlineSwaps`) so displayed numbers cannot drift from wire behavior.
 - Added `/debug dump-request` and `/debug next-request` as aliases for `/debug dump-next-request` when arming a one-shot AI provider request dump
 - Added `/debug dump-next-request <path>` to dump the next AI provider HTTP request JSON to a chosen file.
+- Added `tools.compactProviderDefinitions` (`off` | `description` | `schema`) to shrink tool definitions on provider API requests only: short first-line summaries and optional removal of nested JSON Schema property descriptions. `/context` and the status line estimate **System tools** using the same compacted wire shape; in-session tools and `/tools` remain full-fidelity.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -826,7 +826,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Discovery & MCP",
 			label: "Compact Provider Tool Definitions",
 			description:
-				"Shrink tool name/description/schema sent to the model API (not the in-session tool list). 'description' keeps the first summary line; 'schema' also drops nested JSON Schema property descriptions.",
+				"Shrink tool description and JSON Schema sent to the model API (not the in-session tool list). 'description' keeps the first summary line; 'schema' also drops nested JSON Schema property descriptions.",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -817,6 +817,19 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tools.compactProviderDefinitions": {
+		type: "enum",
+		values: ["off", "description", "schema"] as const,
+		default: "off",
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "Compact Provider Tool Definitions",
+			description:
+				"Shrink tool name/description/schema sent to the model API (not the in-session tool list). 'description' keeps the first summary line; 'schema' also drops nested JSON Schema property descriptions.",
+		},
+	},
+
 	personality: {
 		type: "enum",
 		values: ["default", "friendly", "pragmatic", "none"] as const,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -608,7 +608,8 @@ export class StatusLineComponent implements Component {
 		const tools = this.session.agent?.state?.tools ?? [];
 		const skills = this.session.skills ?? [];
 		const modelId = this.session.model?.id ?? "";
-		return `${modelId}|${sp.length}:${sp[0]?.length ?? 0}|${tools.length}|${skills.length}`;
+		const compactMode = this.session.settings.get("tools.compactProviderDefinitions");
+		return `${modelId}|${sp.length}:${sp[0]?.length ?? 0}|${tools.length}|${skills.length}|${compactMode}`;
 	}
 
 	#buildSegmentContext(

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -8,6 +8,7 @@ import type { Skill } from "../../extensibility/skills";
 import type { AgentSession } from "../../session/agent-session";
 import { estimateInlineSavings, type SnapcompactSavingsEstimate } from "../../session/snapcompact-inline";
 import type { Tool } from "../../tools";
+import { finalizeProviderToolDefinitions } from "../../tools/finalize-provider-tools";
 import type { theme as Theme } from "../theme/theme";
 
 const GRID_COLS = 20;
@@ -84,8 +85,11 @@ export function estimateToolSchemaTokens(
  */
 export function computeNonMessageTokens(session: AgentSession): number {
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
-	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
-	return countTokens(systemPromptParts) + estimateToolSchemaTokens(tools);
+	const providerTools = finalizeProviderToolDefinitions(session.agent?.state?.tools ?? EMPTY_TOOLS, {
+		obfuscator: session.obfuscator,
+		compactMode: session.settings.get("tools.compactProviderDefinitions"),
+	});
+	return countTokens(systemPromptParts) + estimateToolSchemaTokens(providerTools ?? []);
 }
 
 /**
@@ -101,7 +105,11 @@ function computeNonMessageBreakdown(session: AgentSession): {
 	systemPromptTokens: number;
 } {
 	const skillsTokens = estimateSkillsTokens(session.skills ?? []);
-	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? []);
+	const providerTools = finalizeProviderToolDefinitions(session.agent?.state?.tools ?? [], {
+		obfuscator: session.obfuscator,
+		compactMode: session.settings.get("tools.compactProviderDefinitions"),
+	});
+	const toolsTokens = estimateToolSchemaTokens(providerTools ?? []);
 	const systemPromptParts = session.systemPrompt ?? [];
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));
 	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens);

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -8,7 +8,6 @@ import type { Skill } from "../../extensibility/skills";
 import type { AgentSession } from "../../session/agent-session";
 import { estimateInlineSavings, type SnapcompactSavingsEstimate } from "../../session/snapcompact-inline";
 import type { Tool } from "../../tools";
-import { finalizeProviderToolDefinitions } from "../../tools/finalize-provider-tools";
 import type { theme as Theme } from "../theme/theme";
 
 const GRID_COLS = 20;
@@ -85,10 +84,7 @@ export function estimateToolSchemaTokens(
  */
 export function computeNonMessageTokens(session: AgentSession): number {
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
-	const providerTools = finalizeProviderToolDefinitions(session.agent?.state?.tools ?? EMPTY_TOOLS, {
-		obfuscator: session.obfuscator,
-		compactMode: session.settings.get("tools.compactProviderDefinitions"),
-	});
+	const providerTools = session.finalizeProviderToolsForContext(session.agent?.state?.tools ?? EMPTY_TOOLS);
 	return countTokens(systemPromptParts) + estimateToolSchemaTokens(providerTools ?? []);
 }
 
@@ -105,10 +101,7 @@ function computeNonMessageBreakdown(session: AgentSession): {
 	systemPromptTokens: number;
 } {
 	const skillsTokens = estimateSkillsTokens(session.skills ?? []);
-	const providerTools = finalizeProviderToolDefinitions(session.agent?.state?.tools ?? [], {
-		obfuscator: session.obfuscator,
-		compactMode: session.settings.get("tools.compactProviderDefinitions"),
-	});
+	const providerTools = session.finalizeProviderToolsForContext(session.agent?.state?.tools ?? []);
 	const toolsTokens = estimateToolSchemaTokens(providerTools ?? []);
 	const systemPromptParts = session.systemPrompt ?? [];
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -181,6 +181,7 @@ import {
 	warmupLspServers,
 } from "./tools";
 import { ToolContextStore } from "./tools/context";
+import { compactProviderContext } from "./tools/compact-provider-tools";
 import { getImageGenTools } from "./tools/image-gen";
 import { wrapToolWithMetaNotice } from "./tools/output-meta";
 import { queueResolveHandler } from "./tools/resolve";
@@ -2170,11 +2171,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						renderToolResults: settings.get("snapcompact.toolResults"),
 					})
 				: undefined;
+		const compactProviderDefinitions = settings.get("tools.compactProviderDefinitions");
 		const transformProviderContext =
-			obfuscator || snapcompactInline
+			obfuscator || snapcompactInline || compactProviderDefinitions !== "off"
 				? (context: Context, transformModel: Model): Context => {
 						let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
 						if (snapcompactInline) transformed = snapcompactInline.transform(transformed, transformModel);
+						if (compactProviderDefinitions !== "off") {
+							transformed = compactProviderContext(transformed, compactProviderDefinitions);
+						}
 						return transformed;
 					}
 				: undefined;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2171,18 +2171,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						renderToolResults: settings.get("snapcompact.toolResults"),
 					})
 				: undefined;
-		const compactProviderDefinitions = settings.get("tools.compactProviderDefinitions");
-		const transformProviderContext =
-			obfuscator || snapcompactInline || compactProviderDefinitions !== "off"
-				? (context: Context, transformModel: Model): Context => {
-						let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
-						if (snapcompactInline) transformed = snapcompactInline.transform(transformed, transformModel);
-						if (compactProviderDefinitions !== "off") {
-							transformed = compactProviderContext(transformed, compactProviderDefinitions);
-						}
-						return transformed;
-					}
-				: undefined;
+		const transformProviderContext = (context: Context, transformModel: Model): Context => {
+			let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
+			if (snapcompactInline) transformed = snapcompactInline.transform(transformed, transformModel);
+			const compactMode = settings.get("tools.compactProviderDefinitions");
+			if (compactMode !== "off") transformed = compactProviderContext(transformed, compactMode);
+			return transformed;
+		};
 		const onPayload = async (payload: unknown, _model?: Model) => {
 			return await extensionRunner.emitBeforeProviderRequest(payload);
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -180,8 +180,8 @@ import {
 	WriteTool,
 	warmupLspServers,
 } from "./tools";
-import { ToolContextStore } from "./tools/context";
 import { compactProviderContext } from "./tools/compact-provider-tools";
+import { ToolContextStore } from "./tools/context";
 import { getImageGenTools } from "./tools/image-gen";
 import { wrapToolWithMetaNotice } from "./tools/output-meta";
 import { queueResolveHandler } from "./tools/resolve";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -79,6 +79,7 @@ import type {
 	ServiceTier,
 	SimpleStreamOptions,
 	TextContent,
+	Tool,
 	ToolCall,
 	ToolChoice,
 	Usage,
@@ -197,13 +198,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 };
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
-import {
-	deobfuscateSessionContext,
-	obfuscateProviderContext,
-	type SecretObfuscator,
-} from "../secrets/obfuscator";
-import { compactProviderContext } from "../tools/compact-provider-tools";
-import { finalizeProviderToolDefinitions } from "../tools/finalize-provider-tools";
+import { deobfuscateSessionContext, obfuscateProviderContext, type SecretObfuscator } from "../secrets/obfuscator";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import {
 	AUTO_THINKING,
@@ -227,6 +222,8 @@ import {
 } from "../tool-discovery/tool-index";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import type { CheckpointState } from "../tools/checkpoint";
+import { compactProviderContext } from "../tools/compact-provider-tools";
+import { finalizeProviderToolDefinitions } from "../tools/finalize-provider-tools";
 import { outputMeta } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
 import { isAutoQaEnabled } from "../tools/report-tool-issue";
@@ -3278,8 +3275,12 @@ export class AgentSession {
 		return this.agent.state.model;
 	}
 
-	get obfuscator(): SecretObfuscator | undefined {
-		return this.#obfuscator;
+	/** Provider-visible tool definitions for context estimates and side requests. */
+	finalizeProviderToolsForContext(tools: Tool[] | undefined): Tool[] | undefined {
+		return finalizeProviderToolDefinitions(tools, {
+			obfuscator: this.#obfuscator,
+			compactMode: this.settings.get("tools.compactProviderDefinitions"),
+		});
 	}
 
 	/** Effective thinking level applied to the agent (the resolved level when `auto`). */
@@ -6613,10 +6614,7 @@ export class AgentSession {
 				this.#modelRegistry.resolver(model, this.sessionId),
 				{
 					systemPrompt: this.#obfuscateForProvider(this.#baseSystemPrompt),
-					tools: finalizeProviderToolDefinitions(this.agent.state.tools, {
-						obfuscator: this.#obfuscator,
-						compactMode: this.settings.get("tools.compactProviderDefinitions"),
-					}),
+					tools: this.finalizeProviderToolsForContext(this.agent.state.tools),
 					customInstructions: this.#obfuscateTextForProvider(customInstructions),
 					convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 					initiatorOverride: "agent",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -200,9 +200,10 @@ import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" w
 import {
 	deobfuscateSessionContext,
 	obfuscateProviderContext,
-	obfuscateProviderTools,
 	type SecretObfuscator,
 } from "../secrets/obfuscator";
+import { compactProviderContext } from "../tools/compact-provider-tools";
+import { finalizeProviderToolDefinitions } from "../tools/finalize-provider-tools";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import {
 	AUTO_THINKING,
@@ -3275,6 +3276,10 @@ export class AgentSession {
 	/** Current model (may be undefined if not yet selected) */
 	get model(): Model | undefined {
 		return this.agent.state.model;
+	}
+
+	get obfuscator(): SecretObfuscator | undefined {
+		return this.#obfuscator;
 	}
 
 	/** Effective thinking level applied to the agent (the resolved level when `auto`). */
@@ -6608,7 +6613,10 @@ export class AgentSession {
 				this.#modelRegistry.resolver(model, this.sessionId),
 				{
 					systemPrompt: this.#obfuscateForProvider(this.#baseSystemPrompt),
-					tools: obfuscateProviderTools(this.#obfuscator, this.agent.state.tools),
+					tools: finalizeProviderToolDefinitions(this.agent.state.tools, {
+						obfuscator: this.#obfuscator,
+						compactMode: this.settings.get("tools.compactProviderDefinitions"),
+					}),
 					customInstructions: this.#obfuscateTextForProvider(customInstructions),
 					convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 					initiatorOverride: "agent",
@@ -9378,7 +9386,10 @@ export class AgentSession {
 		let providerReplyText = "";
 		let emittedReplyText = "";
 		let assistantMessage: AssistantMessage | undefined;
-		const stream = streamSimple(model, obfuscateProviderContext(this.#obfuscator, context), options);
+		let ephemeralContext = obfuscateProviderContext(this.#obfuscator, context);
+		const compactMode = this.settings.get("tools.compactProviderDefinitions");
+		if (compactMode !== "off") ephemeralContext = compactProviderContext(ephemeralContext, compactMode);
+		const stream = streamSimple(model, ephemeralContext, options);
 		for await (const event of stream) {
 			if (event.type === "text_delta") {
 				providerReplyText += event.delta;

--- a/packages/coding-agent/src/tools/compact-provider-tools.ts
+++ b/packages/coding-agent/src/tools/compact-provider-tools.ts
@@ -32,11 +32,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function stripSchemaArrayKeyword(value: unknown): unknown {
+	if (!Array.isArray(value)) return value;
+	return value.map(entry => stripNestedSchemaDescriptions(entry));
+}
+
 /** Remove nested `description` fields from a JSON Schema object (wire shape). */
 export function stripNestedSchemaDescriptions(schema: unknown): unknown {
-	if (Array.isArray(schema)) {
-		return schema.map(entry => stripNestedSchemaDescriptions(entry));
-	}
 	if (!isPlainObject(schema)) return schema;
 
 	const out: Record<string, unknown> = {};
@@ -52,6 +54,14 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 		}
 		if (key === "items") {
 			out.items = stripNestedSchemaDescriptions(value);
+			continue;
+		}
+		if (key === "prefixItems") {
+			out.prefixItems = stripSchemaArrayKeyword(value);
+			continue;
+		}
+		if (key === "anyOf" || key === "oneOf" || key === "allOf") {
+			out[key] = stripSchemaArrayKeyword(value);
 			continue;
 		}
 		if (key === "additionalProperties" && isPlainObject(value)) {
@@ -80,6 +90,10 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 				mapped[name] = stripNestedSchemaDescriptions(sub);
 			}
 			out.$defs = mapped;
+			continue;
+		}
+		if (key === "enum" || key === "const" || key === "required" || key === "type") {
+			out[key] = value;
 			continue;
 		}
 		out[key] = stripNestedSchemaDescriptions(value);

--- a/packages/coding-agent/src/tools/compact-provider-tools.ts
+++ b/packages/coding-agent/src/tools/compact-provider-tools.ts
@@ -1,0 +1,133 @@
+import type { Context, Tool } from "@oh-my-pi/pi-ai";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import type { SettingValue } from "../config/settings-schema";
+
+export type CompactProviderToolDefinitionsMode = SettingValue<"tools.compactProviderDefinitions">;
+
+const DEFAULT_DESCRIPTION_MAX = 280;
+
+function dropDescriptionField(schema: unknown): unknown {
+	if (!isPlainObject(schema) || !("description" in schema)) return schema;
+	const { description: _d, ...rest } = schema;
+	return rest;
+}
+
+/** First substantive line of a tool description (drops empty lines and markdown headings). */
+export function compactToolDescription(description: string, maxLen = DEFAULT_DESCRIPTION_MAX): string {
+	const trimmed = description.trim();
+	if (!trimmed) return trimmed;
+
+	const lines = trimmed.split(/\r?\n/);
+	for (const line of lines) {
+		if (/^#+\s/.test(line)) continue;
+		const stripped = line.trim();
+		if (stripped.length > 0) {
+			if (stripped.length <= maxLen) return stripped;
+			return `${stripped.slice(0, maxLen - 1)}…`;
+		}
+	}
+
+	if (trimmed.length <= maxLen) return trimmed;
+	return `${trimmed.slice(0, maxLen - 1)}…`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Remove nested `description` fields from a JSON Schema object (wire shape). */
+export function stripNestedSchemaDescriptions(schema: unknown): unknown {
+	if (Array.isArray(schema)) {
+		return schema.map(entry => stripNestedSchemaDescriptions(entry));
+	}
+	if (!isPlainObject(schema)) return schema;
+
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "description") continue;
+		if (key === "properties" && isPlainObject(value)) {
+			const props: Record<string, unknown> = {};
+			for (const [propName, propSchema] of Object.entries(value)) {
+				props[propName] = dropDescriptionField(stripNestedSchemaDescriptions(propSchema));
+			}
+			out.properties = props;
+			continue;
+		}
+		if (key === "items") {
+			out.items = dropDescriptionField(stripNestedSchemaDescriptions(value));
+			continue;
+		}
+		if (key === "additionalProperties" && isPlainObject(value)) {
+			out.additionalProperties = dropDescriptionField(stripNestedSchemaDescriptions(value));
+			continue;
+		}
+		if (key === "patternProperties" && isPlainObject(value)) {
+			const mapped: Record<string, unknown> = {};
+			for (const [pattern, sub] of Object.entries(value)) {
+				mapped[pattern] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+			}
+			out.patternProperties = mapped;
+			continue;
+		}
+		if (key === "definitions" && isPlainObject(value)) {
+			const mapped: Record<string, unknown> = {};
+			for (const [name, sub] of Object.entries(value)) {
+				mapped[name] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+			}
+			out.definitions = mapped;
+			continue;
+		}
+		if (key === "$defs" && isPlainObject(value)) {
+			const mapped: Record<string, unknown> = {};
+			for (const [name, sub] of Object.entries(value)) {
+				mapped[name] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+			}
+			out.$defs = mapped;
+			continue;
+		}
+		out[key] = stripNestedSchemaDescriptions(value);
+	}
+	return out;
+}
+
+function compactWireTool(tool: Tool, mode: CompactProviderToolDefinitionsMode): Tool {
+	if (mode === "off") return tool;
+
+	let description = tool.description;
+	if (mode === "description" || mode === "schema") {
+		description = compactToolDescription(description);
+	}
+
+	let parameters = tool.parameters;
+	if (mode === "schema") {
+		const wire = toolWireSchema(tool);
+		parameters = stripNestedSchemaDescriptions(wire) as Tool["parameters"];
+	}
+
+	return {
+		...tool,
+		description,
+		parameters,
+	};
+}
+
+/** Shrink tool definitions for provider requests only (session tools stay full-fidelity). */
+export function compactProviderTools(
+	tools: Tool[] | undefined,
+	mode: CompactProviderToolDefinitionsMode,
+): Tool[] | undefined {
+	if (!tools || mode === "off") return tools;
+	return tools.map(tool => compactWireTool(tool, mode));
+}
+
+/** Apply compaction to an outbound provider context. */
+export function compactProviderContext(
+	context: Context,
+	mode: CompactProviderToolDefinitionsMode,
+): Context {
+	if (mode === "off" || !context.tools) return context;
+	return {
+		...context,
+		tools: compactProviderTools(context.tools, mode) ?? context.tools,
+	};
+}

--- a/packages/coding-agent/src/tools/compact-provider-tools.ts
+++ b/packages/coding-agent/src/tools/compact-provider-tools.ts
@@ -1,16 +1,13 @@
 import type { Context, Tool } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { stamp } from "@oh-my-pi/pi-ai/utils/schema/stamps";
 import type { SettingValue } from "../config/settings-schema";
 
 export type CompactProviderToolDefinitionsMode = SettingValue<"tools.compactProviderDefinitions">;
 
 const DEFAULT_DESCRIPTION_MAX = 280;
 
-function dropDescriptionField(schema: unknown): unknown {
-	if (!isPlainObject(schema) || !("description" in schema)) return schema;
-	const { description: _d, ...rest } = schema;
-	return rest;
-}
+const kCompactToolByMode = Symbol("pi.coding-agent.compactProviderToolByMode");
 
 /** First substantive line of a tool description (drops empty lines and markdown headings). */
 export function compactToolDescription(description: string, maxLen = DEFAULT_DESCRIPTION_MAX): string {
@@ -48,23 +45,23 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 		if (key === "properties" && isPlainObject(value)) {
 			const props: Record<string, unknown> = {};
 			for (const [propName, propSchema] of Object.entries(value)) {
-				props[propName] = dropDescriptionField(stripNestedSchemaDescriptions(propSchema));
+				props[propName] = stripNestedSchemaDescriptions(propSchema);
 			}
 			out.properties = props;
 			continue;
 		}
 		if (key === "items") {
-			out.items = dropDescriptionField(stripNestedSchemaDescriptions(value));
+			out.items = stripNestedSchemaDescriptions(value);
 			continue;
 		}
 		if (key === "additionalProperties" && isPlainObject(value)) {
-			out.additionalProperties = dropDescriptionField(stripNestedSchemaDescriptions(value));
+			out.additionalProperties = stripNestedSchemaDescriptions(value);
 			continue;
 		}
 		if (key === "patternProperties" && isPlainObject(value)) {
 			const mapped: Record<string, unknown> = {};
 			for (const [pattern, sub] of Object.entries(value)) {
-				mapped[pattern] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+				mapped[pattern] = stripNestedSchemaDescriptions(sub);
 			}
 			out.patternProperties = mapped;
 			continue;
@@ -72,7 +69,7 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 		if (key === "definitions" && isPlainObject(value)) {
 			const mapped: Record<string, unknown> = {};
 			for (const [name, sub] of Object.entries(value)) {
-				mapped[name] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+				mapped[name] = stripNestedSchemaDescriptions(sub);
 			}
 			out.definitions = mapped;
 			continue;
@@ -80,7 +77,7 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 		if (key === "$defs" && isPlainObject(value)) {
 			const mapped: Record<string, unknown> = {};
 			for (const [name, sub] of Object.entries(value)) {
-				mapped[name] = dropDescriptionField(stripNestedSchemaDescriptions(sub));
+				mapped[name] = stripNestedSchemaDescriptions(sub);
 			}
 			out.$defs = mapped;
 			continue;
@@ -90,9 +87,7 @@ export function stripNestedSchemaDescriptions(schema: unknown): unknown {
 	return out;
 }
 
-function compactWireTool(tool: Tool, mode: CompactProviderToolDefinitionsMode): Tool {
-	if (mode === "off") return tool;
-
+function computeCompactWireTool(tool: Tool, mode: CompactProviderToolDefinitionsMode): Tool {
 	let description = tool.description;
 	if (mode === "description" || mode === "schema") {
 		description = compactToolDescription(description);
@@ -111,6 +106,20 @@ function compactWireTool(tool: Tool, mode: CompactProviderToolDefinitionsMode): 
 	};
 }
 
+function compactWireTool(tool: Tool, mode: CompactProviderToolDefinitionsMode): Tool {
+	if (mode === "off") return tool;
+	const cache = stamp(
+		tool as object,
+		kCompactToolByMode,
+		(): Partial<Record<CompactProviderToolDefinitionsMode, Tool>> => ({}),
+	);
+	const hit = cache[mode];
+	if (hit) return hit;
+	const compacted = computeCompactWireTool(tool, mode);
+	cache[mode] = compacted;
+	return compacted;
+}
+
 /** Shrink tool definitions for provider requests only (session tools stay full-fidelity). */
 export function compactProviderTools(
 	tools: Tool[] | undefined,
@@ -121,10 +130,7 @@ export function compactProviderTools(
 }
 
 /** Apply compaction to an outbound provider context. */
-export function compactProviderContext(
-	context: Context,
-	mode: CompactProviderToolDefinitionsMode,
-): Context {
+export function compactProviderContext(context: Context, mode: CompactProviderToolDefinitionsMode): Context {
 	if (mode === "off" || !context.tools) return context;
 	return {
 		...context,

--- a/packages/coding-agent/src/tools/finalize-provider-tools.ts
+++ b/packages/coding-agent/src/tools/finalize-provider-tools.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@oh-my-pi/pi-ai";
+import type { SecretObfuscator } from "../secrets/obfuscator";
+import { obfuscateProviderTools } from "../secrets/obfuscator";
+import {
+	type CompactProviderToolDefinitionsMode,
+	compactProviderTools,
+} from "./compact-provider-tools";
+
+/** Provider-visible tool definitions (obfuscation + optional compaction). Session tools stay unchanged. */
+export function finalizeProviderToolDefinitions(
+	tools: Tool[] | undefined,
+	opts: {
+		obfuscator: SecretObfuscator | undefined;
+		compactMode: CompactProviderToolDefinitionsMode;
+	},
+): Tool[] | undefined {
+	const obfuscated = obfuscateProviderTools(opts.obfuscator, tools);
+	return compactProviderTools(obfuscated, opts.compactMode);
+}

--- a/packages/coding-agent/src/tools/finalize-provider-tools.ts
+++ b/packages/coding-agent/src/tools/finalize-provider-tools.ts
@@ -1,10 +1,7 @@
 import type { Tool } from "@oh-my-pi/pi-ai";
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import { obfuscateProviderTools } from "../secrets/obfuscator";
-import {
-	type CompactProviderToolDefinitionsMode,
-	compactProviderTools,
-} from "./compact-provider-tools";
+import { type CompactProviderToolDefinitionsMode, compactProviderTools } from "./compact-provider-tools";
 
 /** Provider-visible tool definitions (obfuscation + optional compaction). Session tools stay unchanged. */
 export function finalizeProviderToolDefinitions(

--- a/packages/coding-agent/test/tools/compact-provider-tools.test.ts
+++ b/packages/coding-agent/test/tools/compact-provider-tools.test.ts
@@ -40,6 +40,17 @@ describe("stripNestedSchemaDescriptions", () => {
 		expect(stripped.properties.path.type).toBe("string");
 		expect(stripped.properties._i.description).toBeUndefined();
 	});
+
+	it("does not recurse into enum instance values", () => {
+		const schema = {
+			type: "string",
+			enum: [{ description: "fast", value: 1 }],
+		};
+		const stripped = stripNestedSchemaDescriptions(schema) as {
+			enum: Array<Record<string, unknown>>;
+		};
+		expect(stripped.enum[0]).toEqual({ description: "fast", value: 1 });
+	});
 });
 
 describe("compactProviderTools", () => {

--- a/packages/coding-agent/test/tools/compact-provider-tools.test.ts
+++ b/packages/coding-agent/test/tools/compact-provider-tools.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-ai";
+import { z } from "@oh-my-pi/pi-ai";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import {
+	compactProviderContext,
+	compactProviderTools,
+	compactToolDescription,
+	stripNestedSchemaDescriptions,
+} from "../../src/tools/compact-provider-tools";
+
+describe("compactToolDescription", () => {
+	it("keeps the first substantive line and drops markdown headings", () => {
+		const description = "# Read\n\nReads files and directories.\n\nLong body that should not appear.";
+		expect(compactToolDescription(description)).toBe("Reads files and directories.");
+	});
+
+	it("truncates long single-line summaries", () => {
+		const long = "x".repeat(400);
+		const compact = compactToolDescription(long, 50);
+		expect(compact.length).toBeLessThanOrEqual(50);
+		expect(compact.endsWith("…")).toBe(true);
+	});
+});
+
+describe("stripNestedSchemaDescriptions", () => {
+	it("removes property description fields from wire schema", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				path: { type: "string", description: "very long path guidance" },
+				_i: { type: "string", description: "intent" },
+			},
+			required: ["path"],
+		};
+		const stripped = stripNestedSchemaDescriptions(schema) as {
+			properties: Record<string, Record<string, unknown>>;
+		};
+		expect(stripped.properties.path.description).toBeUndefined();
+		expect(stripped.properties.path.type).toBe("string");
+		expect(stripped.properties._i.description).toBeUndefined();
+	});
+});
+
+describe("compactProviderTools", () => {
+	const schema = z.object({
+		path: z.string().describe("Path to read"),
+		_i: z.string().optional(),
+	});
+
+	const tool: Tool = {
+		name: "read",
+		description: `# Read\n\nReads files.\n\n${"detail ".repeat(200)}`,
+		parameters: schema,
+	};
+
+	it("returns tools unchanged when mode is off", () => {
+		const out = compactProviderTools([tool], "off");
+		expect(out?.[0]?.description).toBe(tool.description);
+	});
+
+	it("shortens descriptions in description mode", () => {
+		const out = compactProviderTools([tool], "description")!;
+		expect(out[0]!.description).toBe("Reads files.");
+		const wire = toolWireSchema(out[0]!);
+		const props = (wire as { properties?: Record<string, { description?: string }> }).properties;
+		expect(props?.path?.description).toBe("Path to read");
+	});
+
+	it("strips nested schema descriptions in schema mode", () => {
+		const out = compactProviderTools([tool], "schema")!;
+		const wire = toolWireSchema(out[0]!);
+		const props = (wire as { properties?: Record<string, { description?: string }> }).properties;
+		expect(props?.path?.description).toBeUndefined();
+	});
+});
+
+describe("compactProviderContext", () => {
+	it("leaves context unchanged when mode is off", () => {
+		const ctx = { systemPrompt: ["hi"], messages: [], tools: [{ name: "t", description: "d", parameters: {} }] };
+		expect(compactProviderContext(ctx, "off")).toBe(ctx);
+	});
+});

--- a/packages/coding-agent/test/tools/compact-provider-tools.test.ts
+++ b/packages/coding-agent/test/tools/compact-provider-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { Tool } from "@oh-my-pi/pi-ai";
+import type { Context, Tool } from "@oh-my-pi/pi-ai";
 import { z } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import {
@@ -73,11 +73,32 @@ describe("compactProviderTools", () => {
 		const props = (wire as { properties?: Record<string, { description?: string }> }).properties;
 		expect(props?.path?.description).toBeUndefined();
 	});
+
+	it("reuses compacted wire tool per mode on repeated calls", () => {
+		const first = compactProviderTools([tool], "description")![0]!;
+		const second = compactProviderTools([tool], "description")![0]!;
+		expect(second).toBe(first);
+	});
 });
 
 describe("compactProviderContext", () => {
 	it("leaves context unchanged when mode is off", () => {
 		const ctx = { systemPrompt: ["hi"], messages: [], tools: [{ name: "t", description: "d", parameters: {} }] };
 		expect(compactProviderContext(ctx, "off")).toBe(ctx);
+	});
+
+	it("compacts tools and preserves other context fields in description mode", () => {
+		const longDesc = `# Read\n\nReads files.\n\n${"detail ".repeat(50)}`;
+		const ctx: Context = {
+			systemPrompt: ["hi"],
+			messages: [{ role: "user", content: "ping", timestamp: 0 }],
+			tools: [{ name: "read", description: longDesc, parameters: {} }],
+		};
+		const out = compactProviderContext(ctx, "description");
+		expect(out).not.toBe(ctx);
+		expect(out.systemPrompt).toBe(ctx.systemPrompt);
+		expect(out.messages).toBe(ctx.messages);
+		expect(out.tools?.[0]?.description).toBe("Reads files.");
+		expect(out.tools?.[0]?.description).not.toBe(longDesc);
 	});
 });


### PR DESCRIPTION
## Summary

Adds `tools.compactProviderDefinitions` to shrink tool payloads on **provider API requests only**. In-session tools, `/tools` panel content, and tool execution stay full-fidelity.

## Setting

`off` (default) | `description` | `schema`

- **description** — first non-heading summary line per tool (~280 chars); tool **names** unchanged
- **schema** — description compaction + strip nested JSON Schema `description` fields on wire schemas (not `enum` / `const` instance literals)

Configure in `config.yml` or **Settings → Tools → Compact Provider Tool Definitions**.

## Wiring

- `transformProviderContext` in `sdk.ts` (obfuscation → snapcompact → compaction); reads `settings.get("tools.compactProviderDefinitions")` **on each LLM call** so mid-session Settings changes apply without restart
- IRC / side-channel `streamSimple` in `agent-session.ts`
- `/context` and status line **System tools** via `AgentSession.finalizeProviderToolsForContext()` (same obfuscate + compact pipeline)

## Motivation

**System tools** in `/context` is dominated by active tool `name` + `description` + `parameters` sent to the model. This setting reduces that bucket without hiding tools or enabling `repeatToolDescriptions` (which duplicates into the system prompt).

## Review follow-ups (addressed)

- [x] Settings UI copy: no longer claims tool names are shrunk
- [x] `bun run check` clean on branch
- [x] Tests: `compactProviderContext` compaction path, per-tool/mode memoization, enum literal preservation
- [x] Memoize compacted wire tools via `stamp()` per source tool + mode
- [x] Removed dead `dropDescriptionField`; simplified schema walk
- [x] Replaced public `get obfuscator()` with `finalizeProviderToolsForContext()`
- [x] Dynamic setting read in `transformProviderContext` (Codex P2)
- [x] Do not recurse `enum` arrays as subschemas (Codex P2)

## Test plan

- [x] `bun test test/tools/compact-provider-tools.test.ts` (10 tests)
- [x] `bun run check` in `packages/coding-agent`
- [ ] Manual: toggle `tools.compactProviderDefinitions` in Settings during a session → next turn + `/context` agree on wire shape