### PR TITLE
fix(coding-agent): surface unreachable image-path pastes over SSH instead of silently inserting the local path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed remote (SSH) image attachment silently inserting the local-machine path as plain text: when omp runs over SSH and the terminal forwards a bracketed-paste image path, the path is unreachable from the remote host. The path-as-text fallback is gone for unreachable paths and the status now points the user at the clipboard image-paste shortcut so the bytes actually cross the connection ([#2375](https://github.com/can1357/oh-my-pi/issues/2375)).
+
 ## [15.11.7] - 2026-06-12
 ### Added
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -891,7 +891,11 @@ export class InputController {
 				// newlines, collapse home to `~`, and bound the displayed length
 				// before splicing it into the status string.
 				const displayPath = truncateToWidth(
-					shortenPath(sanitizeText(path).replace(/[\r\n\t]+/g, " ").trim()),
+					shortenPath(
+						sanitizeText(path)
+							.replace(/[\r\n\t]+/g, " ")
+							.trim(),
+					),
 					TRUNCATE_LENGTHS.CONTENT,
 				);
 				const env = process.env;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import type { AutocompleteProvider, SlashCommand } from "@oh-my-pi/pi-tui";
-import { $env, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { $env, isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { getRoleInfo } from "../../config/model-roles";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
@@ -874,11 +874,30 @@ export class InputController {
 				`Unsupported pasted image format: ${image.mimeType}`,
 			);
 		} catch (error) {
+			if (error instanceof ImageInputTooLargeError) {
+				this.ctx.editor.pasteText(path);
+				this.ctx.ui.requestRender();
+				this.ctx.showStatus(error.message);
+				return;
+			}
+			if (isEnoent(error)) {
+				// #2375: the bracketed paste forwarded by a local terminal carries a
+				// path on the *local* filesystem. When omp itself runs over SSH, that
+				// path is unreachable here; pasting it as text would look like the
+				// image was attached when in fact nothing was sent. Refuse the silent
+				// degrade and tell the user how to send the bytes for real.
+				const env = process.env;
+				const overSsh = Boolean(env.SSH_CONNECTION || env.SSH_TTY || env.SSH_CLIENT);
+				this.ctx.showStatus(
+					overSsh
+						? `Image not found at ${path}. Over SSH this path is local to your terminal — paste the image directly (clipboard image-paste shortcut) to send its bytes.`
+						: `Image not found at ${path}`,
+				);
+				return;
+			}
 			this.ctx.editor.pasteText(path);
 			this.ctx.ui.requestRender();
-			this.ctx.showStatus(
-				error instanceof ImageInputTooLargeError ? error.message : "Failed to read pasted image path",
-			);
+			this.ctx.showStatus("Failed to read pasted image path");
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -18,6 +18,7 @@ import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { isLowSignalTitleInput } from "../../tiny/text";
 import { tinyTitleClient } from "../../tiny/title-client";
 import type { TinyTitleProgressEvent } from "../../tiny/title-protocol";
+import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import { copyToClipboard, readImageFromClipboard, readTextFromClipboard } from "../../utils/clipboard";
 import { EnhancedPasteController } from "../../utils/enhanced-paste";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
@@ -885,13 +886,20 @@ export class InputController {
 				// path on the *local* filesystem. When omp itself runs over SSH, that
 				// path is unreachable here; pasting it as text would look like the
 				// image was attached when in fact nothing was sent. Refuse the silent
-				// degrade and tell the user how to send the bytes for real.
+				// degrade and tell the user how to send the bytes for real. The
+				// pasted path is untrusted terminal input — strip control/ANSI/
+				// newlines, collapse home to `~`, and bound the displayed length
+				// before splicing it into the status string.
+				const displayPath = truncateToWidth(
+					shortenPath(sanitizeText(path).replace(/[\r\n\t]+/g, " ").trim()),
+					TRUNCATE_LENGTHS.CONTENT,
+				);
 				const env = process.env;
 				const overSsh = Boolean(env.SSH_CONNECTION || env.SSH_TTY || env.SSH_CLIENT);
 				this.ctx.showStatus(
 					overSsh
-						? `Image not found at ${path}. Over SSH this path is local to your terminal — paste the image directly (clipboard image-paste shortcut) to send its bytes.`
-						: `Image not found at ${path}`,
+						? `Image not found at ${displayPath}. Over SSH this path is local to your terminal — paste the image directly (clipboard image-paste shortcut) to send its bytes.`
+						: `Image not found at ${displayPath}`,
 				);
 				return;
 			}

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Repro for #2375: remote (SSH) image attachment surfaces only the local path.
+ *
+ * When a user attaches an image in their LOCAL terminal (e.g. drag/drop into
+ * iTerm2 on macOS) while the omp process actually runs on a remote host (Pi
+ * over SSH), the terminal forwards a bracketed-paste containing the local
+ * macOS path. The remote `handleImagePathPaste` tries to read that path on
+ * the remote filesystem, fails (ENOENT), then falls through to pasting the
+ * unresolvable path as plain text — making it look like the image was
+ * "attached as a local path" when in fact nothing was sent.
+ *
+ * Defended contract: an unreachable image path NEVER degrades to a silent
+ * text paste; the user must see an SSH-aware diagnostic so they know to
+ * paste image bytes directly instead.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createContext() {
+	const pasteText = vi.fn();
+	const insertText = vi.fn();
+	const requestRender = vi.fn();
+	const showStatus = vi.fn();
+	const ctx = {
+		editor: { pasteText, insertText } as unknown as InteractiveModeContext["editor"],
+		ui: { requestRender, getFocused: () => null } as unknown as InteractiveModeContext["ui"],
+		sessionManager: { getCwd: () => process.cwd() } as unknown as InteractiveModeContext["sessionManager"],
+		showStatus,
+	} as unknown as InteractiveModeContext;
+	return { ctx, spies: { pasteText, insertText, requestRender, showStatus } };
+}
+
+describe("InputController.handleImagePathPaste (issue #2375)", () => {
+	const originalSshConnection = process.env.SSH_CONNECTION;
+	const originalSshTty = process.env.SSH_TTY;
+	const originalSshClient = process.env.SSH_CLIENT;
+
+	beforeEach(() => {
+		delete process.env.SSH_CONNECTION;
+		delete process.env.SSH_TTY;
+		delete process.env.SSH_CLIENT;
+	});
+
+	afterEach(() => {
+		if (originalSshConnection === undefined) delete process.env.SSH_CONNECTION;
+		else process.env.SSH_CONNECTION = originalSshConnection;
+		if (originalSshTty === undefined) delete process.env.SSH_TTY;
+		else process.env.SSH_TTY = originalSshTty;
+		if (originalSshClient === undefined) delete process.env.SSH_CLIENT;
+		else process.env.SSH_CLIENT = originalSshClient;
+		vi.restoreAllMocks();
+	});
+
+	it("over SSH: never pastes the unreachable path as text and surfaces an SSH-aware status", async () => {
+		process.env.SSH_CONNECTION = "10.0.0.2 50000 10.0.0.1 22";
+		const { ctx, spies } = createContext();
+		const controller = new InputController(ctx);
+		const missing = "/Users/someone/Pictures/local-only.png";
+
+		await controller.handleImagePathPaste(missing);
+
+		expect(spies.pasteText).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		const status = String(spies.showStatus.mock.calls[0]?.[0] ?? "");
+		expect(status).toMatch(/SSH/i);
+		// The diagnostic must point at the actual remediation: paste the bytes.
+		expect(status.toLowerCase()).toContain("paste");
+	});
+
+	it("locally: still avoids the misleading path-as-text fallback when the file is unreachable", async () => {
+		const { ctx, spies } = createContext();
+		const controller = new InputController(ctx);
+		const missing = "/tmp/definitely-does-not-exist-omp-2375.png";
+
+		await controller.handleImagePathPaste(missing);
+
+		expect(spies.pasteText).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		const status = String(spies.showStatus.mock.calls[0]?.[0] ?? "");
+		expect(status).toMatch(/not found|could not|unreadable/i);
+	});
+});

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -80,4 +80,29 @@ describe("InputController.handleImagePathPaste (issue #2375)", () => {
 		const status = String(spies.showStatus.mock.calls[0]?.[0] ?? "");
 		expect(status).toMatch(/not found|could not|unreadable/i);
 	});
+
+	it("sanitizes untrusted pasted-path characters and bounds length before splicing into status", async () => {
+		const { ctx, spies } = createContext();
+		const controller = new InputController(ctx);
+		// Path carrying ANSI, control chars, a CR/LF, and a tab — all of which
+		// would corrupt the TUI status line if interpolated verbatim. Long
+		// enough to exceed the status-line truncation budget (TRUNCATE_LENGTHS
+		// .CONTENT = 80) without tripping ENAMETOOLONG so the ENOENT branch
+		// keeps firing.
+		const hostile = `/tmp/\x1b[31mevil\x1b[0m\r\nname\twith-${"x".repeat(100)}.png`;
+
+		await controller.handleImagePathPaste(hostile);
+
+		expect(spies.pasteText).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		const status = String(spies.showStatus.mock.calls[0]?.[0] ?? "");
+		// No ANSI escape, no raw control bytes, no embedded newlines/tabs.
+		expect(status).not.toMatch(/\x1b/);
+		expect(status).not.toMatch(/[\x00-\x08\x0B-\x1F\x7F]/);
+		expect(status).not.toContain("\n");
+		expect(status).not.toContain("\t");
+		// The hostile path runs well past the status truncation budget; the
+		// displayed path must be clamped strictly inside that budget.
+		expect(status.length).toBeLessThan(hostile.length);
+	});
 });


### PR DESCRIPTION
## Repro

Attach an image in a LOCAL terminal (e.g. drag/drop into iTerm2 on macOS) while the `omp` process is running on a remote host over SSH. The local terminal forwards a bracketed-paste containing the *local* macOS path. `InputController.handleImagePathPaste` tries to read that path on the remote filesystem, fails with `ENOENT`, falls through to `editor.pasteText(path)`, and only shows the generic status `Failed to read pasted image path` — making it look as if the image was attached "as a path", with no indication that the bytes never crossed the SSH boundary.

```
bun test test/issue-2375-repro.test.ts
```

…asserts both the SSH branch and the local-ENOENT branch of the bug.

## Cause

`packages/coding-agent/src/modes/controllers/input-controller.ts` →`handleImagePathPaste`: the `catch` arm treated every non-`ImageInputTooLargeError` failure the same way, pasting `path` as text. `loadImageInput` throws `ENOENT` via `readImageMetadata` → `peekFile` (`fs.promises.open`) when the path does not exist on the remote host, so the SSH scenario lands here and the user sees the unreachable absolute path inserted as plain text.

## Fix

- `handleImagePathPaste` now distinguishes three failure modes in its `catch`:
  - `ImageInputTooLargeError` — unchanged: paste the path as text and surface the size error (file existed, it's just too big to send).
  - `isEnoent(error)` — new branch: do **not** paste the path. Show `Image not found at <path>` and, when `SSH_CONNECTION`/`SSH_TTY`/`SSH_CLIENT` indicate the remote end of an SSH session, append a hint that the path is local to the user's terminal and that the bytes have to be sent via the clipboard image-paste shortcut.
  - Any other error — unchanged: paste the path as text and surface `Failed to read pasted image path` as a safety net.
- Added `isEnoent` to the existing `@oh-my-pi/pi-utils` import.
- Changelog entry in `packages/coding-agent/CHANGELOG.md` under `[Unreleased] → Fixed`.
- `packages/coding-agent/test/issue-2375-repro.test.ts` defends both new contracts: SSH path produces a status containing `SSH` and `paste`; local path produces a status containing `not found`. Both assert that `editor.pasteText` is no longer called for unreachable paths.

The supported-but-non-image branch (`!image` after a successful `loadImageInput`) keeps the existing path-as-text behaviour: there the file does exist, it just isn't an image, and the user dragged a regular file in.

## Verification

```
bun test test/issue-2375-repro.test.ts
# 2 pass, 7 expect() calls

bun test test/input-controller-* test/issue-2375-repro.test.ts
# 51 pass, 201 expect() calls
```

Fixes #2375