### PR TITLE
fix(coding-agent): derive bundled self root from dist path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Fixed npm prebuilt extension compatibility shims deriving their own package root through bare `@oh-my-pi/pi-coding-agent` resolution, which could select an older Bun cache copy in global installs and reintroduce mixed-runtime plugin loading stack overflows.
 - Fixed Ctrl+T thinking-block toggles clearing the pending user message and loader before the assistant stream starts ([#2370](https://github.com/can1357/oh-my-pi/issues/2370)).
 - Fixed Windows CodeGraph MCP launches from npm `.cmd` shims by resolving the shim's Node entry point and spawning it directly, keeping stdio attached to CodeGraph instead of the transient `cmd.exe` wrapper ([#2367](https://github.com/can1357/oh-my-pi/issues/2367)).
 - Fixed snapcompact archives going partially unreadable on OpenRouter, which hard-caps requests at 8 images and silently drops the excess: compaction now passes a provider-aware frame budget (`providerFrameBudget`) so the archive never exceeds the cap (unknown providers get a safe floor of 5), with overflow kept as a text tail on the summary instead of rendering frames the gateway would drop; inline system-prompt/tool-result imaging shares the same per-provider budget (`providerImageBudget`), so once existing images exhaust it (e.g. 8 archive frames on OpenRouter) tool results ship verbatim as text

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -101,6 +101,28 @@ export function __computeBunfsPackageRoot(metaDir: string, pathImpl: typeof path
 	return pathImpl.join(metaDir, "packages");
 }
 
+/**
+ * Compute the package root for the npm prebuilt `dist/cli.js` bundle.
+ *
+ * `bundle-dist.ts` defines `process.env.PI_BUNDLED="true"`; after bundling,
+ * `import.meta.dir` points at `<package>/dist`. Do not resolve the package via
+ * bare `@oh-my-pi/pi-coding-agent` here: from a global install Bun can pick an
+ * older cache entry, recreating mixed-runtime plugin loading.
+ */
+export function __computeBundledSelfPackageRoot(metaDir: string, pathImpl: typeof path = path): string {
+	const normalizedMetaDir = pathImpl.normalize(metaDir);
+	if (pathImpl.basename(normalizedMetaDir) === "dist") {
+		return pathImpl.resolve(metaDir, "..");
+	}
+
+	const pluginsDirSuffix = pathImpl.join("src", "extensibility", "plugins");
+	if (normalizedMetaDir.endsWith(pluginsDirSuffix)) {
+		return pathImpl.resolve(metaDir, "..", "..", "..");
+	}
+
+	return pathImpl.resolve(metaDir);
+}
+
 const BUNFS_PACKAGE_ROOT = IS_COMPILED_BINARY ? __computeBunfsPackageRoot(import.meta.dir) : null;
 
 function bunfsPath(...segments: string[]): string {
@@ -112,11 +134,7 @@ function bunfsPath(...segments: string[]): string {
 
 function resolveBundledSelfPackageRoot(): string | undefined {
 	if (!process.env.PI_BUNDLED) return undefined;
-	try {
-		return path.dirname(Bun.resolveSync("@oh-my-pi/pi-coding-agent/package.json", import.meta.dir));
-	} catch {
-		return undefined;
-	}
+	return __computeBundledSelfPackageRoot(import.meta.dir);
 }
 
 const BUNDLED_SELF_PACKAGE_ROOT = resolveBundledSelfPackageRoot();

--- a/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { __computeBunfsPackageRoot } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+import {
+	__computeBundledSelfPackageRoot,
+	__computeBunfsPackageRoot,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
 
 // Regression for issue #1514: legacy pi compat shim paths were built from a
 // hardcoded POSIX literal `/$bunfs/root/packages`. On Windows the bunfs root
@@ -35,5 +38,29 @@ describe("legacy pi compat bunfs root computation (issue #1514)", () => {
 	it("uses the current host path implementation for production calls", () => {
 		const metaDir = path.join("/", "anywhere", "root");
 		expect(__computeBunfsPackageRoot(metaDir)).toBe(path.join("/", "anywhere", "root", "packages"));
+	});
+
+	it("derives the npm prebuilt bundle package root from dist import.meta.dir", () => {
+		const computeBundledSelfPackageRoot = __computeBundledSelfPackageRoot;
+
+		const winMetaDir = "C:\\Users\\me\\.bun\\install\\global\\node_modules\\@oh-my-pi\\pi-coding-agent\\dist";
+		expect(computeBundledSelfPackageRoot(winMetaDir, path.win32)).toBe(
+			"C:\\Users\\me\\.bun\\install\\global\\node_modules\\@oh-my-pi\\pi-coding-agent",
+		);
+
+		const posixMetaDir = "/home/me/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist";
+		expect(computeBundledSelfPackageRoot(posixMetaDir, path.posix)).toBe(
+			"/home/me/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent",
+		);
+	});
+
+	it("derives the source package root when PI_BUNDLED is used outside dist", () => {
+		const computeBundledSelfPackageRoot = __computeBundledSelfPackageRoot;
+
+		const winMetaDir = "C:\\repo\\packages\\coding-agent\\src\\extensibility\\plugins";
+		expect(computeBundledSelfPackageRoot(winMetaDir, path.win32)).toBe("C:\\repo\\packages\\coding-agent");
+
+		const posixMetaDir = "/repo/packages/coding-agent/src/extensibility/plugins";
+		expect(computeBundledSelfPackageRoot(posixMetaDir, path.posix)).toBe("/repo/packages/coding-agent");
 	});
 });


### PR DESCRIPTION
## Summary
- stop the npm prebuilt CLI bundle from resolving its own package root through bare @oh-my-pi/pi-coding-agent resolution
- derive the bundled self root directly from dist import.meta.dir so global installs do not pick stale Bun cache copies
- add Windows/POSIX regression coverage for dist and source-layout root derivation

## Root cause
The dist bundle is built with process.env.PI_BUNDLED=true. In global installs, legacy-pi-compat.ts used Bun.resolveSync('@oh-my-pi/pi-coding-agent/package.json', import.meta.dir) to locate the running package root. On the affected Windows machine, the running global install was @oh-my-pi/pi-coding-agent@15.11.2, but that bare self resolution returned a cached @oh-my-pi/pi-coding-agent@15.11.0 path. Loading plugins through that mixed runtime reproduced RangeError: Maximum call stack size exceeded.

## Verification
- bun test packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
- bun test packages/coding-agent/test/extension-loader-self-import.test.ts
- bun test packages/coding-agent/test/pi-scope-aliases.test.ts packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts packages/coding-agent/test/issue-1215-legacy-pi-ai-import.test.ts packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts packages/coding-agent/test/extensibility/legacy-pi-override-fallback.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts --no-errors-on-unmatched
- bun packages/coding-agent/scripts/bundle-dist.ts

Also applied the same temporary patch to the affected global 15.11.2 install and rebuilt dist/cli.js. Verified locally:
- omp --no-title --print ping -> pong, exit 0
- omp --extension C:/Users/34404/.omp/plugins/node_modules/omp-openai-provider-tools/src/extension.ts --no-title --print ping -> pong, exit 0
- direct loadExtensions(provider extension) -> loaded 1, errors 0