### PR TITLE
fix(pi-iso): satisfy clippy for projfs and block-clone

### DIFF
--- a/crates/pi-iso/src/projfs.rs
+++ b/crates/pi-iso/src/projfs.rs
@@ -553,7 +553,16 @@ mod imp {
 			};
 
 			if matched {
-				let extended_info = symlink_extended_info(entry.symlink_target.as_deref());
+				let extended_info = entry
+					.symlink_target
+					.as_deref()
+					.map(|target| PRJ_EXTENDED_INFO {
+						InfoType:       PRJ_EXT_INFO_TYPE_SYMLINK,
+						NextInfoOffset: 0,
+						Anonymous:      PRJ_EXTENDED_INFO_0 {
+							Symlink: PRJ_EXTENDED_INFO_0_0 { TargetName: target.as_ptr() },
+						},
+					});
 				let extended_info_ptr = extended_info
 					.as_ref()
 					.map_or(std::ptr::null(), |info| info as *const _);
@@ -599,7 +608,13 @@ mod imp {
 			Ok(target) => target,
 			Err(err) => return io_error_to_hresult(&err),
 		};
-		let extended_info = symlink_extended_info(symlink_target.as_deref());
+		let extended_info = symlink_target.as_deref().map(|target| PRJ_EXTENDED_INFO {
+			InfoType:       PRJ_EXT_INFO_TYPE_SYMLINK,
+			NextInfoOffset: 0,
+			Anonymous:      PRJ_EXTENDED_INFO_0 {
+				Symlink: PRJ_EXTENDED_INFO_0_0 { TargetName: target.as_ptr() },
+			},
+		});
 		let extended_info_ptr = extended_info
 			.as_ref()
 			.map_or(std::ptr::null(), |info| info as *const _);
@@ -780,16 +795,6 @@ mod imp {
 		let mut target = to_wide(fs::read_link(path)?.as_os_str());
 		target.shrink_to_fit();
 		Ok(Some(target))
-	}
-
-	fn symlink_extended_info(target: Option<&[u16]>) -> Option<PRJ_EXTENDED_INFO> {
-		target.map(|target| PRJ_EXTENDED_INFO {
-			InfoType:       PRJ_EXT_INFO_TYPE_SYMLINK,
-			NextInfoOffset: 0,
-			Anonymous:      PRJ_EXTENDED_INFO_0 {
-				Symlink: PRJ_EXTENDED_INFO_0_0 { TargetName: target.as_ptr() },
-			},
-		})
 	}
 
 	fn callback_relative_path(callback_data: &PRJ_CALLBACK_DATA) -> PathBuf {

--- a/crates/pi-iso/src/windows_block_clone.rs
+++ b/crates/pi-iso/src/windows_block_clone.rs
@@ -111,9 +111,7 @@ mod imp {
 		let resolved = if path.is_absolute() {
 			path.to_path_buf()
 		} else {
-			std::env::current_dir()
-				.map(|cwd| cwd.join(path))
-				.unwrap_or_else(|_| path.to_path_buf())
+			std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
 		};
 		let meta = fs::metadata(&resolved).map_err(|err| {
 			IsoError::other(format!("invalid block-clone source {}: {err}", resolved.display()))
@@ -164,6 +162,13 @@ mod imp {
 		}
 		let mut permissions = meta.permissions();
 		if permissions.readonly() {
+			// This backend only removes a temporary Windows block-clone tree; clearing
+			// the readonly file attribute is required so removal can proceed.
+			#[allow(
+				clippy::permissions_set_readonly_false,
+				reason = "Windows block-clone cleanup must clear the readonly file attribute before \
+				          deletion"
+			)]
 			permissions.set_readonly(false);
 			let _ = fs::set_permissions(path, permissions);
 		}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `pi-iso` Windows clippy failures in symlink placeholder metadata, block-clone path resolution, and readonly cleanup handling.
+- Fixed `pi-iso` Windows clippy failures in symlink placeholder metadata, block-clone path resolution, and readonly cleanup handling ([#2379](https://github.com/can1357/oh-my-pi/pull/2379) by [@oldschoola](https://github.com/oldschoola)).
 
 ## [15.11.7] - 2026-06-12
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pi-iso` Windows clippy failures in symlink placeholder metadata, block-clone path resolution, and readonly cleanup handling.
+
 ## [15.11.7] - 2026-06-12
 
 ### Added


### PR DESCRIPTION
Unblocks `bun check:rs` / `cargo clippy -p pi-iso -- -D warnings` on Windows.

- Inline symlink extended info (single_option_map)
- map_or_else for current_dir join
- Targeted allow for Windows readonly attribute clear before delete