### PR TITLE
fix(hashline): forward slashes in cwd-relative header paths

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalized cwd-relative hashline paths to forward-slash form on Windows.
+
 ## [15.11.4] - 2026-06-12
 
 ### Added

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -88,8 +88,9 @@ function normalizeHashlinePath(rawPath: string, cwd?: string): string {
 	const unquoted = stripApplyPatchPathNoise(unquoteHashlinePath(rawPath.trim()));
 	if (!cwd || !path.isAbsolute(unquoted)) return unquoted;
 	const relative = path.relative(path.resolve(cwd), path.resolve(unquoted));
+	const normalizedRelative = relative.split(path.sep).join("/");
 	const isWithinCwd = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-	return isWithinCwd ? relative || "." : unquoted;
+	return isWithinCwd ? normalizedRelative || "." : unquoted;
 }
 
 interface RawSection {


### PR DESCRIPTION
Fixes Windows test expecting `src/foo.ts` not `src\\foo.ts` when normalizing absolute paths under cwd.