### PR TITLE
fix(utils): retry TempDir rm on Windows EBUSY

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `TempDir` cleanup retry transient Windows `EBUSY`/`EPERM`/`ENOTEMPTY` removal failures so tests are less likely to fail when deleting just-used temp directories.
+
 ## [15.11.4] - 2026-06-12
 
 ### Added

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -1,3 +1,4 @@
+import * as fsPromises from "node:fs/promises";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -13,7 +14,7 @@ export class TempDir {
 	}
 
 	static async create(prefix?: string): Promise<TempDir> {
-		return new TempDir(await fs.promises.mkdtemp(normalizePrefix(prefix)));
+		return new TempDir(await fsPromises.mkdtemp(normalizePrefix(prefix)));
 	}
 
 	#removePromise: Promise<void> | null = null;
@@ -30,13 +31,13 @@ export class TempDir {
 		if (this.#removePromise) {
 			return this.#removePromise;
 		}
-		const removePromise = fs.promises.rm(this.#path, { recursive: true, force: true });
+		const removePromise = removeWithRetries(this.#path);
 		this.#removePromise = removePromise;
 		return removePromise;
 	}
 
 	removeSync(): void {
-		fs.rmSync(this.#path, { recursive: true, force: true });
+		removeSyncWithRetries(this.#path);
 		this.#removePromise = Promise.resolve();
 	}
 
@@ -74,4 +75,57 @@ function normalizePrefix(prefix?: string): string {
 		return path.join(kTempDir, prefix.slice(1));
 	}
 	return prefix;
+}
+
+const kRemoveOptions = { recursive: true, force: true } as const;
+const kRemoveRetries = 4;
+const kRemoveRetryDelayMs = 10;
+const kRetryableRemoveErrorCodes = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
+const kSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+async function removeWithRetries(target: string): Promise<void> {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await fsPromises.rm(target, kRemoveOptions);
+			return;
+		} catch (err) {
+			if (!shouldRetryRemove(err, attempt)) throw err;
+			await Bun.sleep(kRemoveRetryDelayMs);
+		}
+	}
+}
+
+function removeSyncWithRetries(target: string): void {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			fs.rmSync(target, kRemoveOptions);
+			return;
+		} catch (err) {
+			if (!shouldRetryRemove(err, attempt)) throw err;
+			sleepSync(kRemoveRetryDelayMs);
+		}
+	}
+}
+
+function shouldRetryRemove(err: unknown, attempt: number): boolean {
+	return attempt < kRemoveRetries && process.platform === "win32" && isRetryableRemoveError(err);
+}
+
+function isRetryableRemoveError(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		"code" in err &&
+		typeof err.code === "string" &&
+		kRetryableRemoveErrorCodes.has(err.code)
+	);
+}
+
+function sleepSync(ms: number): void {
+	const bunWithSleepSync = Bun as typeof Bun & { sleepSync?: (ms: number) => void };
+	if (bunWithSleepSync.sleepSync) {
+		bunWithSleepSync.sleepSync(ms);
+	} else {
+		Atomics.wait(kSleepBuffer, 0, 0, ms);
+	}
 }

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -122,10 +122,9 @@ function isRetryableRemoveError(err: unknown): boolean {
 }
 
 function sleepSync(ms: number): void {
-	const bunWithSleepSync = Bun as typeof Bun & { sleepSync?: (ms: number) => void };
-	if (bunWithSleepSync.sleepSync) {
-		bunWithSleepSync.sleepSync(ms);
-	} else {
-		Atomics.wait(kSleepBuffer, 0, 0, ms);
+	if ("sleepSync" in Bun && typeof Bun.sleepSync === "function") {
+		Bun.sleepSync(ms);
+		return;
 	}
+	Atomics.wait(kSleepBuffer, 0, 0, ms);
 }

--- a/packages/utils/test/temp.test.ts
+++ b/packages/utils/test/temp.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
+import { TempDir } from "../src/temp";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("TempDir.remove retry", () => {
+	it("retries async removal on Windows EBUSY before succeeding", async () => {
+		const dir = await TempDir.create("@pi-utils-tempdir-retry-async-");
+		let attempts = 0;
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		vi.spyOn(fsPromises, "rm").mockImplementation(async () => {
+			attempts++;
+			if (attempts < 2) {
+				const err = new Error("EBUSY") as NodeJS.ErrnoException;
+				err.code = "EBUSY";
+				throw err;
+			}
+		});
+
+		await dir.remove();
+
+		expect(attempts).toBe(2);
+	});
+
+	it("retries sync removal on Windows EBUSY before succeeding", async () => {
+		const dir = await TempDir.create("@pi-utils-tempdir-retry-sync-");
+		let attempts = 0;
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		vi.spyOn(fs, "rmSync").mockImplementation(() => {
+			attempts++;
+			if (attempts < 2) {
+				const err = new Error("EBUSY") as NodeJS.ErrnoException;
+				err.code = "EBUSY";
+				throw err;
+			}
+		});
+
+		dir.removeSync();
+
+		expect(attempts).toBe(2);
+	});
+});


### PR DESCRIPTION
Bounded retries on EBUSY/EPERM/ENOTEMPTY for `TempDir.remove` / `removeSync` to reduce flaky coding-agent test teardown on Windows.