### PR TITLE
fix(cli): correct Model scope thinking suffix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the interactive Model scope startup banner so models without an explicit thinking level do not show `:undefined`, while scoped models with one still show `:<level>` ([#2385](https://github.com/can1357/oh-my-pi/issues/2385)).
+- Fixed the interactive Model scope startup banner so models without an explicit thinking level do not show `:undefined`, and entries that were scoped without a `:level` are no longer rendered with the global default thinking level (which `applyRootSessionOptions` pre-fills on the cycling array for Ctrl+P) ([#2385](https://github.com/can1357/oh-my-pi/issues/2385)).
 
 ## [15.11.8] - 2026-06-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the interactive Model scope startup banner so models without an explicit thinking level do not show `:undefined`, while scoped models with one still show `:<level>` ([#2385](https://github.com/can1357/oh-my-pi/issues/2385)).
+
 ## [15.11.8] - 2026-06-12
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1268,9 +1268,12 @@ export async function runRootCommand(
 			const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
 			const changelogMarkdown = await logger.time("main:getChangelogForDisplay", getChangelogForDisplay, parsedArgs);
 
-			const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
-			if (scopedModelsForDisplay.length > 0) {
-				const modelList = formatModelScopeList(scopedModelsForDisplay);
+			if (scopedModels.length > 0) {
+				// Use the original `ScopedModel[]` here (not `sessionOptions.scopedModels`,
+				// whose thinking levels are pre-filled with the global default for Ctrl+P
+				// cycling) so the banner only shows `:level` suffixes the user actually
+				// scoped.
+				const modelList = formatModelScopeList(scopedModels);
 				// Routed through the TUI (not stdout): the startup capture owns the
 				// terminal in raw mode here, and the TUI's first clearScrollback paint
 				// would wipe a pre-TUI line anyway.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -51,6 +51,7 @@ import { ExtensionRunner } from "./extensibility/extensions/runner";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import { scheduleMarketplaceAutoUpdate } from "./extensibility/plugins/marketplace-auto-update";
 import type { MCPManager } from "./mcp";
+import { formatModelScopeList } from "./model-scope-display";
 import { InteractiveMode } from "./modes/interactive-mode";
 import type { PrintModeOptions } from "./modes/print-mode";
 import { CURRENT_SETUP_VERSION } from "./modes/setup-version";
@@ -1269,12 +1270,7 @@ export async function runRootCommand(
 
 			const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
 			if (scopedModelsForDisplay.length > 0) {
-				const modelList = scopedModelsForDisplay
-					.map(scopedModel => {
-						const thinkingStr = !scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
-						return `${scopedModel.model.id}${thinkingStr}`;
-					})
-					.join(", ");
+				const modelList = formatModelScopeList(scopedModelsForDisplay);
 				// Routed through the TUI (not stdout): the startup capture owns the
 				// terminal in raw mode here, and the TUI's first clearScrollback paint
 				// would wipe a pre-TUI line anyway.

--- a/packages/coding-agent/src/model-scope-display.ts
+++ b/packages/coding-agent/src/model-scope-display.ts
@@ -1,16 +1,25 @@
-/** Formats scoped model selectors for interactive startup notifications. */
+/**
+ * Display shape for one entry in the interactive Model scope banner.
+ *
+ * `thinkingLevel` carries the suffix value, but it is only rendered when
+ * `explicitThinkingLevel` is true — the caller may have filled the field with
+ * the global default for runtime use (e.g. Ctrl+P cycling), and the banner
+ * must not present that default as if the user had requested it.
+ */
 export interface ModelScopeDisplayEntry {
 	model: {
 		id: string;
 	};
 	thinkingLevel?: string;
+	explicitThinkingLevel: boolean;
 }
 
 /** Builds the compact `id[:thinking]` list shown in the Model scope banner. */
 export function formatModelScopeList(scopedModels: ReadonlyArray<ModelScopeDisplayEntry>): string {
 	return scopedModels
 		.map(scopedModel => {
-			const thinkingStr = scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
+			const thinkingStr =
+				scopedModel.explicitThinkingLevel && scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
 			return `${scopedModel.model.id}${thinkingStr}`;
 		})
 		.join(", ");

--- a/packages/coding-agent/src/model-scope-display.ts
+++ b/packages/coding-agent/src/model-scope-display.ts
@@ -1,0 +1,17 @@
+/** Formats scoped model selectors for interactive startup notifications. */
+export interface ModelScopeDisplayEntry {
+	model: {
+		id: string;
+	};
+	thinkingLevel?: string;
+}
+
+/** Builds the compact `id[:thinking]` list shown in the Model scope banner. */
+export function formatModelScopeList(scopedModels: ReadonlyArray<ModelScopeDisplayEntry>): string {
+	return scopedModels
+		.map(scopedModel => {
+			const thinkingStr = scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
+			return `${scopedModel.model.id}${thinkingStr}`;
+		})
+		.join(", ");
+}

--- a/packages/coding-agent/test/model-scope-display.test.ts
+++ b/packages/coding-agent/test/model-scope-display.test.ts
@@ -4,11 +4,22 @@ import { formatModelScopeList } from "../src/model-scope-display";
 describe("formatModelScopeList", () => {
 	it("omits thinking suffixes when unset and includes explicit levels", () => {
 		const modelList = formatModelScopeList([
-			{ model: { id: "openai/gpt-5.5" } },
-			{ model: { id: "anthropic/claude-opus-4.8" }, thinkingLevel: "high" },
+			{ model: { id: "openai/gpt-5.5" }, explicitThinkingLevel: false },
+			{ model: { id: "anthropic/claude-opus-4.8" }, thinkingLevel: "high", explicitThinkingLevel: true },
 		]);
 
 		expect(modelList).toBe("openai/gpt-5.5, anthropic/claude-opus-4.8:high");
 		expect(modelList).not.toContain(":undefined");
+	});
+
+	it("hides the suffix when the level was filled from the global default", () => {
+		// `applyRootSessionOptions` fills `sessionOptions.scopedModels[*].thinkingLevel`
+		// with the global default for Ctrl+P cycling — the banner must not surface that
+		// default as if the user had scoped `:high`.
+		const modelList = formatModelScopeList([
+			{ model: { id: "openai/gpt-5.5" }, thinkingLevel: "high", explicitThinkingLevel: false },
+		]);
+
+		expect(modelList).toBe("openai/gpt-5.5");
 	});
 });

--- a/packages/coding-agent/test/model-scope-display.test.ts
+++ b/packages/coding-agent/test/model-scope-display.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { formatModelScopeList } from "../src/model-scope-display";
+
+describe("formatModelScopeList", () => {
+	it("omits thinking suffixes when unset and includes explicit levels", () => {
+		const modelList = formatModelScopeList([
+			{ model: { id: "openai/gpt-5.5" } },
+			{ model: { id: "anthropic/claude-opus-4.8" }, thinkingLevel: "high" },
+		]);
+
+		expect(modelList).toBe("openai/gpt-5.5, anthropic/claude-opus-4.8:high");
+		expect(modelList).not.toContain(":undefined");
+	});
+});


### PR DESCRIPTION
## Repro
The existing Model scope formatter logic renders an unset thinking level as a literal suffix and drops an explicit level. Reproduced with `bun -e 'const scopedModel={ model:{ id:"openai/gpt-5.5" }, thinkingLevel: undefined }; const thinkingStr = !scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : ""; console.log(`${scopedModel.model.id}${thinkingStr}`); const scopedModelWithLevel={ model:{ id:"anthropic/claude-opus-4.8" }, thinkingLevel: "high" }; const thinkingStrWithLevel = !scopedModelWithLevel.thinkingLevel ? `:${scopedModelWithLevel.thinkingLevel}` : ""; console.log(`${scopedModelWithLevel.model.id}${thinkingStrWithLevel}`);'`, which printed `openai/gpt-5.5:undefined` and omitted `:high`.

## Cause
`packages/coding-agent/src/main.ts` built the Model scope startup list inline with an inverted ternary: `!scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : ""`. That branch appends `:undefined` for the common unset case and returns an empty suffix when the user provided an explicit thinking level.

## Fix
- Added `formatModelScopeList` in `packages/coding-agent/src/model-scope-display.ts` to centralize the `id[:thinking]` display contract.
- Updated the interactive startup banner in `packages/coding-agent/src/main.ts` to use the formatter.
- Added `packages/coding-agent/test/model-scope-display.test.ts` covering both unset and explicit thinking-level entries.
- Added a `packages/coding-agent/CHANGELOG.md` Unreleased fix entry.

## Verification
`bun test packages/coding-agent/test/model-scope-display.test.ts` passed. `bun run check` from `packages/coding-agent` passed. Fixes #2385