### PR TITLE
fix(cli): suppress model scope banner when quiet

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -244,6 +244,22 @@ export interface InteractiveModeNotify {
 	message: string;
 }
 
+export function buildModelScopeNotification(
+	scopedModelsForDisplay: readonly Pick<ScopedModel, "model" | "thinkingLevel">[],
+	startupQuiet: boolean,
+): InteractiveModeNotify | null {
+	if (startupQuiet || scopedModelsForDisplay.length === 0) {
+		return null;
+	}
+	const modelList = scopedModelsForDisplay
+		.map(scopedModel => {
+			const thinkingStr = scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
+			return `${scopedModel.model.id}${thinkingStr}`;
+		})
+		.join(", ");
+	return { kind: "info", message: `Model scope: ${modelList} (Ctrl+P to cycle)` };
+}
+
 export async function submitInteractiveInput(
 	mode: Pick<
 		InteractiveMode,
@@ -1268,17 +1284,15 @@ export async function runRootCommand(
 			const changelogMarkdown = await logger.time("main:getChangelogForDisplay", getChangelogForDisplay, parsedArgs);
 
 			const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
-			if (scopedModelsForDisplay.length > 0) {
-				const modelList = scopedModelsForDisplay
-					.map(scopedModel => {
-						const thinkingStr = !scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
-						return `${scopedModel.model.id}${thinkingStr}`;
-					})
-					.join(", ");
+			const modelScopeNotification = buildModelScopeNotification(
+				scopedModelsForDisplay,
+				settingsInstance.get("startup.quiet"),
+			);
+			if (modelScopeNotification) {
 				// Routed through the TUI (not stdout): the startup capture owns the
 				// terminal in raw mode here, and the TUI's first clearScrollback paint
 				// would wipe a pre-TUI line anyway.
-				notifs.push({ kind: "info", message: `Model scope: ${modelList} (Ctrl+P to cycle)` });
+				notifs.push(modelScopeNotification);
 			}
 
 			if ($env.PI_TIMING) {

--- a/packages/coding-agent/test/main-model-scope-notification.test.ts
+++ b/packages/coding-agent/test/main-model-scope-notification.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ScopedModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { buildModelScopeNotification } from "@oh-my-pi/pi-coding-agent/main";
+
+function scopedModel(id: string): ScopedModel {
+	return {
+		model: buildModel({
+			id,
+			name: id,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 8_192,
+		}),
+		explicitThinkingLevel: false,
+	};
+}
+
+describe("buildModelScopeNotification", () => {
+	it("does not emit startup model scope chrome while startup.quiet is enabled", () => {
+		expect(buildModelScopeNotification([scopedModel("claude-sonnet-4-5")], true)).toBeNull();
+	});
+
+	it("emits the startup model scope banner when startup.quiet is disabled", () => {
+		expect(buildModelScopeNotification([scopedModel("claude-sonnet-4-5")], false)).toEqual({
+			kind: "info",
+			message: "Model scope: claude-sonnet-4-5 (Ctrl+P to cycle)",
+		});
+	});
+});


### PR DESCRIPTION
## Repro
`startup.quiet: true` suppresses the startup splash, but the interactive startup path still built the `Model scope: ... (Ctrl+P to cycle)` notification for non-empty `enabledModels` / `--models` scopes. Reproduced with `bun test packages/coding-agent/test/main-model-scope-notification.test.ts`, which failed because `buildModelScopeNotification([...], true)` returned the info banner instead of `null`.

## Cause
`packages/coding-agent/src/main.ts` pushed the model-scope notification inside the interactive startup branch without consulting `settingsInstance.get("startup.quiet")`; only `maybeShowStartupSplash()` received that setting.

## Fix
- Added `buildModelScopeNotification()` in `packages/coding-agent/src/main.ts` so model-scope banner construction has a single quiet-aware gate.
- Updated the interactive startup path to pass `settingsInstance.get("startup.quiet")` before enqueueing the notification.
- Added `packages/coding-agent/test/main-model-scope-notification.test.ts` covering both quiet suppression and normal banner emission.

## Verification
`bun test packages/coding-agent/test/main-model-scope-notification.test.ts` passed. `bun run --cwd packages/coding-agent check` passed. `gh_push_branch` pre-publish gate passed. Fixes #2386