### PR TITLE
fix(coding-agent): ship fastembed ONNX binding in bundled CLI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the npm bundled CLI package to ship fastembed's nested ONNX `napi-v3` native binding at the path Bun-bundled fastembed resolves, restoring local Mnemopi embeddings in bundled installs ([#2389](https://github.com/can1357/oh-my-pi/issues/2389)).
+
 ## [15.11.8] - 2026-06-12
 
 ### Added
@@ -24,7 +28,6 @@
 
 ### Fixed
 
-- Fixed the npm bundled CLI package to ship fastembed's nested ONNX `napi-v3` native binding at the path Bun-bundled fastembed resolves, restoring local Mnemopi embeddings in bundled installs ([#2389](https://github.com/can1357/oh-my-pi/issues/2389)).
 - Fixed remote (SSH) image attachment silently inserting the local-machine path as plain text: when omp runs over SSH and the terminal forwards a bracketed-paste image path, the path is unreachable from the remote host. The path-as-text fallback is gone for unreachable paths and the status now points the user at the clipboard image-paste shortcut so the bytes actually cross the connection ([#2375](https://github.com/can1357/oh-my-pi/issues/2375)).
 
 ### Security

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed the npm bundled CLI package to ship fastembed's nested ONNX `napi-v3` native binding at the path Bun-bundled fastembed resolves, restoring local Mnemopi embeddings in bundled installs ([#2389](https://github.com/can1357/oh-my-pi/issues/2389)).
 - Fixed remote (SSH) image attachment silently inserting the local-machine path as plain text: when omp runs over SSH and the terminal forwards a bracketed-paste image path, the path is unreachable from the remote host. The path-as-text fallback is gone for unreachable paths and the status now points the user at the clipboard image-paste shortcut so the bytes actually cross the connection ([#2375](https://github.com/can1357/oh-my-pi/issues/2375)).
 
 ### Security

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -93,6 +93,7 @@
 		"src",
 		"dist/cli.js",
 		"dist/*.node",
+		"bin",
 		"scripts",
 		"examples",
 		"README.md",

--- a/packages/coding-agent/scripts/bundle-dist.ts
+++ b/packages/coding-agent/scripts/bundle-dist.ts
@@ -9,6 +9,51 @@ const outDir = path.join(packageDir, "dist");
 const cliPath = path.join(outDir, "cli.js");
 const shebang = "#!/usr/bin/env bun\n";
 
+const nativeAssetRoot = path.join(packageDir, "bin");
+const fastembedOrtNapiVersion = "napi-v3";
+
+export interface FastembedNativeAssetPaths {
+	sourceDir: string;
+	outputDir: string;
+}
+
+async function findPackageRoot(startDir: string): Promise<string> {
+	let dir = startDir;
+	while (true) {
+		try {
+			await fs.stat(path.join(dir, "package.json"));
+			return dir;
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) throw new Error(`Package root not found from ${startDir}`);
+		dir = parent;
+	}
+}
+
+/** Resolve the ONNX native assets fastembed's bundled loader requires after Bun bundling. */
+export async function resolveFastembedNativeAssetPaths(
+	rootDir: string = packageDir,
+): Promise<FastembedNativeAssetPaths> {
+	const fastembedEntry = Bun.resolveSync("fastembed", packageDir);
+	const fastembedRoot = await findPackageRoot(path.dirname(fastembedEntry));
+	const ortEntry = Bun.resolveSync("onnxruntime-node", fastembedRoot);
+	const ortRoot = await findPackageRoot(path.dirname(ortEntry));
+	return {
+		sourceDir: path.join(ortRoot, "bin", fastembedOrtNapiVersion),
+		outputDir: path.join(rootDir, "bin", fastembedOrtNapiVersion),
+	};
+}
+
+/** Copy fastembed's nested ONNX binding tree to the path its bundled require resolves. */
+export async function copyFastembedNativeAssets(rootDir: string = packageDir): Promise<FastembedNativeAssetPaths> {
+	const paths = await resolveFastembedNativeAssetPaths(rootDir);
+	await fs.rm(paths.outputDir, { recursive: true, force: true });
+	await fs.cp(paths.sourceDir, paths.outputDir, { recursive: true });
+	return paths;
+}
+
 async function runCommand(command: string[]): Promise<void> {
 	const proc = Bun.spawn(command, {
 		cwd: packageDir,
@@ -34,18 +79,18 @@ function formatBytes(bytes: number): string {
 async function cleanBundleOutputs(): Promise<void> {
 	// dist/ is shared with the dev binary (dist/omp); only remove this
 	// script's own outputs (entry bundle + copied native assets).
-	let entries: string[];
+	let entries: string[] = [];
 	try {
 		entries = await fs.readdir(outDir);
 	} catch (err) {
-		if (isEnoent(err)) return;
-		throw err;
+		if (!isEnoent(err)) throw err;
 	}
 	await Promise.all(
 		entries
 			.filter(entry => entry === "cli.js" || entry.endsWith(".node") || entry.endsWith(".js.map"))
 			.map(entry => fs.rm(path.join(outDir, entry), { force: true })),
 	);
+	await fs.rm(nativeAssetRoot, { recursive: true, force: true });
 }
 
 async function main(): Promise<void> {
@@ -79,6 +124,7 @@ async function main(): Promise<void> {
 	} finally {
 		await runCommand(["bun", "--cwd=../stats", "scripts/generate-client-bundle.ts", "--reset"]);
 	}
+	await copyFastembedNativeAssets();
 	await ensureShebang();
 	const stat = await fs.stat(cliPath);
 	const elapsedMs = (Bun.nanoseconds() - start) / 1_000_000;
@@ -87,4 +133,6 @@ async function main(): Promise<void> {
 	);
 }
 
-await main();
+if (import.meta.main) {
+	await main();
+}

--- a/packages/coding-agent/test/bundle-dist-assets.test.ts
+++ b/packages/coding-agent/test/bundle-dist-assets.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { copyFastembedNativeAssets } from "../scripts/bundle-dist";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("bundle-dist native assets", () => {
+	test("copies fastembed's nested ONNX napi-v3 binding where the bundled require resolves", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-bundle-assets-"));
+		tempDirs.push(tempDir);
+
+		const assets = await copyFastembedNativeAssets(tempDir);
+		const sourceBinding = path.join(assets.sourceDir, process.platform, process.arch, "onnxruntime_binding.node");
+		const copiedBinding = path.join(assets.outputDir, process.platform, process.arch, "onnxruntime_binding.node");
+		const sourceStat = await fs.stat(sourceBinding);
+		const copiedStat = await fs.stat(copiedBinding);
+
+		expect(assets.outputDir).toBe(path.join(tempDir, "bin", "napi-v3"));
+		expect(copiedStat.size).toBe(sourceStat.size);
+	});
+});


### PR DESCRIPTION
## Repro
A minimal Bun bundle that imports `fastembed` fails the same way as the bundled `pi-coding-agent` distribution: `bun build --target=bun --outdir .wt/repro-dist .wt/repro-fastembed.ts && bun .wt/repro-dist/repro-fastembed.js` exits with `Cannot find module '../bin/napi-v3/linux/x64/onnxruntime_binding.node'` from the bundled entry path before model download.

## Cause
`packages/coding-agent/scripts/bundle-dist.ts` bundled fastembed's JavaScript into `dist/cli.js` but only cleaned/copied the assets Bun emitted directly into `dist/`. fastembed's nested `onnxruntime-node@1.21.0` loader keeps a relative `../bin/napi-v3/${process.platform}/${process.arch}/onnxruntime_binding.node` require, which resolves from `dist/cli.js` to `packages/coding-agent/bin/napi-v3/...`; that tree was never generated or included by `packages/coding-agent/package.json`.

## Fix
- Added `copyFastembedNativeAssets()` to resolve fastembed's nested `onnxruntime-node` package and copy its `bin/napi-v3` tree to `packages/coding-agent/bin/napi-v3` during `prepack`.
- Added `bin` to the coding-agent package files so the generated native binding tree is included in the npm tarball.
- Added a focused packaging test that verifies the host-platform `onnxruntime_binding.node` is copied to the bundled require path.
- Added an Unreleased changelog entry for the bundled Mnemopi local-embedding fix.

## Verification
`bun --cwd=packages/coding-agent test test/bundle-dist-assets.test.ts` passed; `bun --cwd=packages/coding-agent run check` passed; `bun --cwd=packages/coding-agent run prepack` generated the bundle and native asset tree; a follow-up bundle placed under `packages/coding-agent/dist` importing `fastembed` printed `function` for `FlagEmbedding.init` instead of failing native binding resolution. Fixes #2389