### PR TITLE
fix(tui): inherit terminal background on chat panels via chat.transparent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `chat.transparent` appearance setting (default off): when enabled, the chat-panel surfaces — user messages, custom messages, and tool-state panels — skip the theme's `userMessageBg`/`customMessageBg`/`toolPendingBg`/`toolSuccessBg`/`toolErrorBg` fills so the bubbles inherit the terminal's default background. Mirrors the existing `statusLine.transparent` opt-in for terminals (e.g. Ghostty) whose background does not match the theme's hardcoded chat-panel colors ([#2394](https://github.com/can1357/oh-my-pi/issues/2394))
+
 ## [15.11.8] - 2026-06-12
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -508,6 +508,18 @@ export const SETTINGS_SCHEMA = {
 				"Use the terminal's default background for the status line instead of the theme's `statusLineBg`. Powerline end caps are dropped because they need a contrasting fill to bridge into the surrounding terminal.",
 		},
 	},
+
+	"chat.transparent": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Theme",
+			label: "Transparent Chat Surfaces",
+			description:
+				"Drop the theme's chat-panel backgrounds (user messages, custom messages, and tool-state panels) so they inherit the terminal's default background — useful in Ghostty and other terminals whose theme background does not match the theme's hardcoded chat colors.",
+		},
+	},
 	"tools.artifactSpillThreshold": {
 		type: "number",
 		default: 50,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1028,6 +1028,7 @@ export async function runRootCommand(
 		settingsInstance.get("colorBlindMode"),
 		settingsInstance.get("theme.dark"),
 		settingsInstance.get("theme.light"),
+		settingsInstance.get("chat.transparent"),
 	);
 
 	let scopedModels: ScopedModel[] = [];

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -21,6 +21,7 @@ import {
 	getAvailableThemes,
 	getSymbolTheme,
 	previewTheme,
+	setChatTransparent,
 	setColorBlindMode,
 	setSymbolPreset,
 	setTheme,
@@ -341,6 +342,14 @@ export class SelectorController {
 			}
 			case "colorBlindMode": {
 				setColorBlindMode(value === "true" || value === true).then(() => {
+					this.ctx.ui.invalidate();
+				});
+				break;
+			}
+			case "chat.transparent": {
+				setChatTransparent(value === "true" || value === true).then(() => {
+					this.ctx.statusLine.invalidate();
+					this.ctx.updateEditorTopBorder();
 					this.ctx.ui.invalidate();
 				});
 				break;

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1440,6 +1440,7 @@ export class Theme {
 		private readonly symbolPreset: SymbolPreset,
 		symbolOverrides: Partial<Record<SymbolKey, string>>,
 		spinnerFramesOverrides: Partial<Record<SpinnerType, string[]>> = {},
+		transparentSurfaces: readonly ThemeBg[] = [],
 	) {
 		this.statusLineLuminance = colorLuma(bgColors.statusLineBg);
 		this.#statusLineContrastLuminance = relativeLuminance(bgColors.statusLineBg);
@@ -1456,6 +1457,14 @@ export class Theme {
 		for (const [key, value] of Object.entries(bgColors) as [ThemeBg, string | number][]) {
 			this.#bgColors[key] = bgAnsi(value, mode);
 			this.#hexBgColors[key] = resolveToHex(value, slIsLight);
+		}
+		// Drop fill ANSI on the requested surfaces so `theme.bg(key, …)` and
+		// `theme.getBgAnsi(key)` resolve to the terminal default (`\x1b[49m`),
+		// matching the empty-string sentinel themes can set per-key. Hex bgs
+		// keep their original values — HTML export and color-aggregation paths
+		// stay intact.
+		for (const key of transparentSurfaces) {
+			if (key in this.#bgColors) this.#bgColors[key] = "\x1b[49m";
 		}
 		// Build symbol map from preset + overrides
 		const baseSymbols = SYMBOL_PRESETS[symbolPreset];
@@ -1983,13 +1992,26 @@ interface CreateThemeOptions {
 	mode?: ColorMode;
 	symbolPresetOverride?: SymbolPreset;
 	colorBlindMode?: boolean;
+	/** When true, paint chat-surface backgrounds (user messages, custom
+	 * messages, tool-state panels) with the terminal default — same opt-in
+	 * shape as `statusLine.transparent` but for the chat scroll. */
+	chatTransparent?: boolean;
 }
+
+/** Chat-scroll surfaces dropped when `chat.transparent` is on. */
+const CHAT_TRANSPARENT_SURFACES: readonly ThemeBg[] = [
+	"userMessageBg",
+	"customMessageBg",
+	"toolPendingBg",
+	"toolSuccessBg",
+	"toolErrorBg",
+];
 
 /** HSV adjustment to shift green toward blue for colorblind mode (red-green colorblindness) */
 const COLORBLIND_ADJUSTMENT = { h: 60, s: 0.71 };
 
 function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = {}): Theme {
-	const { mode, symbolPresetOverride, colorBlindMode } = options;
+	const { mode, symbolPresetOverride, colorBlindMode, chatTransparent } = options;
 	const colorMode = mode ?? detectColorMode();
 	const resolvedColors = resolveThemeColors(themeJson.colors, themeJson.vars);
 
@@ -2022,7 +2044,16 @@ function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = {}): Th
 	const symbolPreset: SymbolPreset = symbolPresetOverride ?? themeJson.symbols?.preset ?? "unicode";
 	const symbolOverrides = themeJson.symbols?.overrides ?? {};
 	const spinnerFramesOverrides = normalizeSpinnerFramesOverride(themeJson.symbols?.spinnerFrames);
-	return new Theme(fgColors, bgColors, colorMode, symbolPreset, symbolOverrides, spinnerFramesOverrides);
+	const transparentSurfaces = chatTransparent ? CHAT_TRANSPARENT_SURFACES : [];
+	return new Theme(
+		fgColors,
+		bgColors,
+		colorMode,
+		symbolPreset,
+		symbolOverrides,
+		spinnerFramesOverrides,
+		transparentSurfaces,
+	);
 }
 
 async function loadTheme(name: string, options: CreateThemeOptions = {}): Promise<Theme> {
@@ -2094,6 +2125,7 @@ export function getCurrentThemeName(): string | undefined {
 }
 var currentSymbolPresetOverride: SymbolPreset | undefined;
 var currentColorBlindMode: boolean = false;
+var currentChatTransparent: boolean = false;
 var themeWatcher: fs.FSWatcher | undefined;
 var themeReloadTimer: NodeJS.Timeout | undefined;
 var sigwinchHandler: (() => void) | undefined;
@@ -2107,6 +2139,7 @@ function getCurrentThemeOptions(): CreateThemeOptions {
 	return {
 		symbolPresetOverride: currentSymbolPresetOverride,
 		colorBlindMode: currentColorBlindMode,
+		chatTransparent: currentChatTransparent,
 	};
 }
 
@@ -2116,6 +2149,7 @@ export async function initTheme(
 	colorBlindMode?: boolean,
 	darkTheme?: string,
 	lightTheme?: string,
+	chatTransparent?: boolean,
 ): Promise<void> {
 	autoDetectedTheme = true;
 	autoDarkTheme = darkTheme ?? "dark";
@@ -2124,6 +2158,7 @@ export async function initTheme(
 	currentThemeName = name;
 	currentSymbolPresetOverride = symbolPreset;
 	currentColorBlindMode = colorBlindMode ?? false;
+	currentChatTransparent = chatTransparent ?? false;
 	try {
 		theme = await loadTheme(name, getCurrentThemeOptions());
 		if (enableWatcher) {
@@ -2290,6 +2325,37 @@ export async function setColorBlindMode(enabled: boolean): Promise<void> {
  */
 export function getColorBlindMode(): boolean {
 	return currentColorBlindMode;
+}
+
+/**
+ * Set chat-surface transparency, reloading the theme so user / custom message
+ * bubbles and tool-state panels paint with the terminal default background
+ * (or restore the theme's own fill when toggled off). Mirrors the
+ * `statusLine.transparent` opt-in.
+ */
+export async function setChatTransparent(enabled: boolean): Promise<void> {
+	currentChatTransparent = enabled;
+	if (!currentThemeName) return;
+
+	const requestId = ++themeLoadRequestId;
+	try {
+		const loadedTheme = await loadTheme(currentThemeName, getCurrentThemeOptions());
+		if (requestId !== themeLoadRequestId) return;
+		theme = loadedTheme;
+	} catch {
+		if (requestId !== themeLoadRequestId) return;
+		// Fall back to dark theme
+		theme = await loadTheme("dark", getCurrentThemeOptions());
+		if (requestId !== themeLoadRequestId) return;
+	}
+	onThemeChangeCallback?.();
+}
+
+/**
+ * Get the current chat-surface transparency setting.
+ */
+export function getChatTransparent(): boolean {
+	return currentChatTransparent;
 }
 
 export function onThemeChange(callback: () => void): void {

--- a/packages/coding-agent/test/chat-transparent.test.ts
+++ b/packages/coding-agent/test/chat-transparent.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
+import { initTheme, setChatTransparent, setTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+	// Anchor the fixture on a theme whose chat surfaces are painted with explicit
+	// hex bgs (titanium is the theme used in the original repro), so the
+	// transparency toggle has a non-vacuous off->on transition to assert.
+	const result = await setTheme("titanium");
+	if (!result.success) throw new Error(`setTheme failed: ${result.error}`);
+});
+
+afterAll(async () => {
+	await setChatTransparent(false);
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+const CHAT_SURFACES = ["userMessageBg", "customMessageBg", "toolPendingBg", "toolSuccessBg", "toolErrorBg"] as const;
+const TRANSPARENT_BG_ANSI = "\x1b[49m";
+
+describe("chat.transparent appearance setting", () => {
+	it("paints chat-surface backgrounds from the theme when disabled (default)", async () => {
+		await setChatTransparent(false);
+		for (const key of CHAT_SURFACES) {
+			// The fixture relies on every chat surface having a real bg fill — otherwise
+			// the negative case in the transparent test would be vacuous.
+			expect(theme.getBgAnsi(key)).toMatch(/\x1b\[48;/);
+		}
+
+		const userBg = theme.getBgAnsi("userMessageBg");
+		const rendered = new UserMessageComponent("hello chat surfaces").render(80).join("\n");
+		expect(rendered).toContain(userBg);
+	});
+
+	it("drops chat-surface bg ANSI in favor of the terminal default when enabled", async () => {
+		await setChatTransparent(true);
+		for (const key of CHAT_SURFACES) {
+			expect(theme.getBgAnsi(key)).toBe(TRANSPARENT_BG_ANSI);
+		}
+
+		// User message ANSI no longer contains any `\x1b[48;…` background escape —
+		// every emitted bg is the terminal-default reset.
+		const rendered = new UserMessageComponent("hello chat surfaces").render(80).join("\n");
+		expect(rendered).not.toMatch(/\x1b\[48;/);
+		expect(rendered).toContain(TRANSPARENT_BG_ANSI);
+
+		// Unrelated theme surfaces still paint normally — only the listed chat keys flip.
+		expect(theme.getBgAnsi("statusLineBg")).not.toBe(TRANSPARENT_BG_ANSI);
+		expect(theme.getBgAnsi("selectedBg")).not.toBe(TRANSPARENT_BG_ANSI);
+	});
+
+	it("restores the theme's chat-surface fills when toggled back off", async () => {
+		await setChatTransparent(true);
+		await setChatTransparent(false);
+		for (const key of CHAT_SURFACES) {
+			expect(theme.getBgAnsi(key)).toMatch(/\x1b\[48;/);
+		}
+	});
+});


### PR DESCRIPTION
## Repro

In Ghostty 1.3.1 on macOS with `theme=titanium`, `statusLine.transparent=true`, the user-prompt bubbles, custom messages, and tool execution panels render as visible near-black rectangles against the terminal's configured background — separate cards pasted on top of the terminal instead of UI surfaces that blend in. Verified by rendering a `UserMessageComponent` and reading the bg ANSI off the active theme:

```
$ bun packages/coding-agent/test/chat-transparent.test.ts (pre-fix surrogate)
titanium userMessageBg ansi: "\u001b[48;5;233m"
titanium customMessageBg ansi: "\u001b[48;5;236m"
titanium toolSuccessBg  ansi: "\u001b[48;5;233m"
user msg contains bg ANSI: true
custom msg contains bg ANSI: true
```

## Cause

The chat-scroll surfaces paint themselves with five theme-defined backgrounds:

- `userMessageBg` — `UserMessageComponent` and `collab-prompt-message.ts` Markdown `bgColor`
- `customMessageBg` — `CustomMessageComponent`, `HookMessageComponent`, `SkillMessageComponent`, `BranchSummaryMessageComponent`, `CompactionSummaryMessageComponent`
- `toolPendingBg` / `toolSuccessBg` / `toolErrorBg` — `ToolExecutionComponent` state fill + framed-block fill in `tui/output-block.ts`

Themes resolve these to hex bg ANSI (`\x1b[48;2;…` / `\x1b[48;5;…`), so the panels emit an opaque fill regardless of the terminal's own background. `statusLine.transparent` solved the same shape for the status bar (#2306) by routing one surface to `\x1b[49m`, but the chat surfaces had no opt-in.

## Fix

Added the `chat.transparent` appearance setting (default off). It threads through `CreateThemeOptions` to the `Theme` constructor the same way `colorBlindMode` does — when enabled, the constructor swaps `userMessageBg` / `customMessageBg` / `toolPendingBg` / `toolSuccessBg` / `toolErrorBg` ANSI fills to `\x1b[49m` (the existing empty-string sentinel for terminal default). The fix is applied **only** to the in-memory `#bgColors` map; `#hexBgColors` retains the originals so HTML export, the major-color aggregator, and the status-line luminance probe are unaffected.

- `packages/coding-agent/src/modes/theme/theme.ts`: `Theme` accepts a `transparentSurfaces: readonly ThemeBg[]` constructor parameter; `createTheme`/`CreateThemeOptions` expose `chatTransparent`; module-level `currentChatTransparent` plus a `setChatTransparent` setter (mirrors `setColorBlindMode`) reload the theme through the existing `themeLoadRequestId` race-safe path and fire `onThemeChangeCallback` so the chat scroll and editor border re-render. `initTheme` accepts the toggle as its sixth argument so every theme reload (auto-detect, OSC 11 mode flip, file watcher, terminal appearance change) preserves it via `getCurrentThemeOptions()`.
- `packages/coding-agent/src/config/settings-schema.ts`: `chat.transparent` boolean, default off, `tab: "appearance"`, `group: "Theme"`, with a description pointing at Ghostty and other terminals whose theme background doesn't match the theme's hardcoded chat colors.
- `packages/coding-agent/src/modes/controllers/selector-controller.ts`: live-toggle handler — calls `setChatTransparent`, then `statusLine.invalidate()` + `updateEditorTopBorder()` + `ui.invalidate()` so the toggle takes effect on the next frame, no restart.
- `packages/coding-agent/src/main.ts`: passes `settings.get("chat.transparent")` into the final `initTheme` call on cold boot.
- `packages/coding-agent/CHANGELOG.md`: `## [Unreleased]` → `### Added`.

## Verification

```
$ cd packages/coding-agent && bun test test/chat-transparent.test.ts
 3 pass    20 expect() calls
$ bun test test/chat-transparent.test.ts test/status-line-transparent.test.ts \
       test/theme-auto-detection.test.ts test/theme-islight.test.ts \
       test/theme-spinner-frames.test.ts \
       test/modes/components/user-message-keywords.test.ts \
       test/modes/components/user-message-selector.test.ts \
       test/modes/components/chat-block.test.ts
 35 pass   106 expect() calls
$ bun run check:types
(no output, 0 exit)
```

Smoke-tested the live toggle end-to-end against the `titanium` theme:

```
--- Default (chat.transparent=false) ---
userMessageBg ansi: "\u001b[48;5;233m"
toolSuccessBg  ansi: "\u001b[48;5;233m"
user msg contains explicit bg: true

--- chat.transparent=true ---
userMessageBg ansi: "\u001b[49m"
toolSuccessBg  ansi: "\u001b[49m"
user msg contains 48; ansi: false
user msg contains 49m ansi: true
statusLineBg (unaffected): "\u001b[48;5;233m"

--- toggle back off ---
userMessageBg ansi: "\u001b[48;5;233m"
```

Confirmed `statusLine.transparent` is decoupled from `chat.transparent` (each surface is independently overridable), the test suite restores the original fills when the toggle is turned off, and the unrelated `selectedBg` surface is unaffected.

Fixes #2394