### PR TITLE
fix(tui): restore double-Esc message history

### DIFF
--- a/docs/tree.md
+++ b/docs/tree.md
@@ -27,7 +27,7 @@ Any of the following opens the same selector:
 
 - `/tree`
 - configured keybinding for the `app.session.tree` action
-- double-escape on empty editor when `doubleEscapeAction = "tree"` (default)
+- double-escape on empty editor when `doubleEscapeAction = "tree"`
 - `/branch` when `doubleEscapeAction = "tree"` (routes to tree selector instead of user-only branch picker)
 
 ## Tree UI model

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the default double-Esc behavior to open the editable message-history selector instead of `/tree` so pressing Esc twice can edit a previous message again ([#2396](https://github.com/can1357/oh-my-pi/issues/2396)).
+
 ## [15.12.0] - 2026-06-12
 
 ### Added
@@ -30,7 +34,6 @@
 
 ### Fixed
 
-- Restored the default double-Esc behavior to open the editable message-history selector instead of `/tree` so pressing Esc twice can edit a previous message again ([#2396](https://github.com/can1357/oh-my-pi/issues/2396)).
 - Filtered silent abort markers from Agent Hub assistant output so failed turns now render as normal error text
 - Reset focus-session state when switching transcript rendering between the main session and a focused subagent so streaming/progress context no longer leaks across sessions
 - Fixed read-only collab sessions so prompting, interrupts, and other write actions are blocked with a read-only warning instead of being applied

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixed
 
+- Restored the default double-Esc behavior to open the editable message-history selector instead of `/tree` so pressing Esc twice can edit a previous message again ([#2396](https://github.com/can1357/oh-my-pi/issues/2396)).
 - Filtered silent abort markers from Agent Hub assistant output so failed turns now render as normal error text
 - Reset focus-session state when switching transcript rendering between the main session and a focused subagent so streaming/progress context no longer leaks across sessions
 - Fixed read-only collab sessions so prompting, interrupts, and other write actions are blocked with a read-only warning instead of being applied

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1132,7 +1132,7 @@ export const SETTINGS_SCHEMA = {
 	doubleEscapeAction: {
 		type: "enum",
 		values: ["branch", "tree", "none"] as const,
-		default: "tree",
+		default: "branch",
 		ui: {
 			tab: "interaction",
 			group: "Input",

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, type Mock, vi } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -208,6 +209,14 @@ function createContext(): {
 	};
 }
 
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
 describe("InputController escape behavior", () => {
 	it("prefers canceling a pending optimistic submission before aborting the session", async () => {
 		const { ctx, editor, spies } = createContext();
@@ -331,6 +340,18 @@ describe("InputController escape behavior", () => {
 		expect(spies.handleBtwEscape).toHaveBeenCalledTimes(1);
 		expect(spies.abortBash).not.toHaveBeenCalled();
 		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("opens the editable message-history selector on default double-Esc", () => {
+		const { ctx, editor } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(ctx.showUserMessageSelector).toHaveBeenCalledTimes(1);
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 	});
 
 	it("aborts streaming even when the working loader is no longer present", () => {


### PR DESCRIPTION
## Repro
With default settings, pressing Esc twice on an empty editor after a message should open the editable message-history selector. I reproduced the regression with `bun test packages/coding-agent/test/input-controller-escape.test.ts`: the new default double-Esc assertion failed because `showUserMessageSelector` was never called.

## Cause
`packages/coding-agent/src/config/settings-schema.ts` defaulted `doubleEscapeAction` to `"tree"`. `InputController.setupKeyHandlers()` reads that setting and routes the second Esc to `showTreeSelector()` for `"tree"`, so the default path no longer opened the previous-message editor (`showUserMessageSelector()`).

## Fix
- Restored `doubleEscapeAction`'s default to `"branch"`.
- Added a regression test covering the default double-Esc route to the editable user-message selector.
- Updated `/tree` docs and the coding-agent changelog to match the restored default.

## Verification
`bun test packages/coding-agent/test/input-controller-escape.test.ts` passes: 12 tests, 36 assertions. `bun run check` passes in `packages/coding-agent`. Fixes #2396