### PR TITLE
fix(tui): respect OSC 8 hyperlinks under tmux >= 3.4

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `PI_FORCE_HYPERLINKS=1` / `PI_NO_HYPERLINKS=1` env overrides for the OSC 8 hyperlink capability, mirroring the `PI_FORCE_SYNC_OUTPUT`/`PI_NO_SYNC_OUTPUT` shape (opt-out beats force-on).
+
+### Changed
+
+- Auto-enable OSC 8 hyperlinks inside tmux when tmux self-reports >= 3.4 via `TERM_PROGRAM_VERSION`; tmux 3.4 stores OSC 8 as a cell attribute and forwards it to outer terminals whose `terminal-features` include `hyperlinks`. Older tmux, GNU screen, and tmux without a reported version still default off. Resolution is factored into `hyperlinksUserOverride()` and `shouldEnableHyperlinksByDefault()` mirroring the sync-output helpers ([#2403](https://github.com/can1357/oh-my-pi/issues/2403)).
+
 ## [15.11.8] - 2026-06-12
 
 ### Changed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -249,6 +249,66 @@ export function detectRectangularSgrSupport(terminalId: TerminalId, env: NodeJS.
 	}
 	return true;
 }
+/**
+ * Resolve an explicit user override for OSC 8 hyperlinks. Returns `false` for
+ * an opt-out, `true` for a force-on, or `null` when the user has expressed no
+ * preference. Opt-out beats force-on so a kill switch is unambiguous, mirroring
+ * {@link synchronizedOutputUserOverride}.
+ */
+export function hyperlinksUserOverride(env: NodeJS.ProcessEnv = Bun.env): boolean | null {
+	if (env.PI_NO_HYPERLINKS === "1") return false;
+	if (env.PI_FORCE_HYPERLINKS === "1") return true;
+	return null;
+}
+
+/**
+ * Parse tmux's self-reported version from `TERM_PROGRAM_VERSION`. tmux sets
+ * `TERM_PROGRAM=tmux` and `TERM_PROGRAM_VERSION=<version>` automatically since
+ * 3.2a; older releases (or any path that does not surface the version) yield
+ * `null` and the caller treats tmux conservatively.
+ */
+function parseTmuxVersionFromEnv(env: NodeJS.ProcessEnv): { major: number; minor: number } | null {
+	if (env.TERM_PROGRAM?.toLowerCase() !== "tmux") return null;
+	return parseMajorMinorVersion(env.TERM_PROGRAM_VERSION);
+}
+
+/**
+ * Whether OSC 8 hyperlinks should be enabled by default.
+ *
+ * Policy (highest precedence first):
+ *   1. Explicit user override (`PI_NO_HYPERLINKS=1` off, `PI_FORCE_HYPERLINKS=1`
+ *      on). Opt-out wins ties.
+ *   2. Static terminal capability — terminals whose {@link TerminalInfo} marks
+ *      `hyperlinks: false` (e.g. `base`) stay off unless the user forced on.
+ *   3. GNU screen always off: screen never gained OSC 8 support.
+ *   4. tmux: enabled when tmux self-reports >= 3.4 via `TERM_PROGRAM_VERSION`
+ *      (tmux 3.4 stores OSC 8 as a cell attribute and forwards it to outer
+ *      terminals whose `terminal-features` include `hyperlinks`). Older or
+ *      unknown versions stay off; on outer terminals without the feature
+ *      configured, tmux silently drops the sequence — identical to today.
+ *   5. Otherwise honor the static terminal capability.
+ */
+export function shouldEnableHyperlinksByDefault(
+	env: NodeJS.ProcessEnv = Bun.env,
+	terminalId: TerminalId = TERMINAL_ID,
+): boolean {
+	const override = hyperlinksUserOverride(env);
+	if (override !== null) return override;
+
+	if (!getTerminalInfo(terminalId).hyperlinks) return false;
+
+	const term = env.TERM?.toLowerCase() ?? "";
+	if (env.STY || term.startsWith("screen")) return false;
+
+	if (env.TMUX || term.startsWith("tmux")) {
+		const version = parseTmuxVersionFromEnv(env);
+		if (!version) return false;
+		return version.major > 3 || (version.major === 3 && version.minor >= 4);
+	}
+
+	return true;
+}
+
 function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null {
 	if (!process.stdout.isTTY) return null;
 	if (terminalId === "vscode" || terminalId === "alacritty") return null;
@@ -336,12 +396,12 @@ export const TERMINAL: RuntimeTerminal = (() => {
 		const fallbackImageProtocol = getFallbackImageProtocol(resolved.id);
 		if (fallbackImageProtocol) resolved.imageProtocol = fallbackImageProtocol;
 	}
-	// tmux and screen multiplexers do not reliably forward OSC 8 hyperlinks
-	// to the outer terminal, so force them off regardless of detected terminal.
-	const term = Bun.env.TERM?.toLowerCase() ?? "";
-	if (resolved.hyperlinks && (Bun.env.TMUX || term.startsWith("tmux") || term.startsWith("screen"))) {
-		resolved.hyperlinks = false;
-	}
+	// Hyperlink (OSC 8) capability. The static per-terminal flag lives on
+	// KNOWN_TERMINALS; shouldEnableHyperlinksByDefault folds in runtime context —
+	// PI_FORCE_HYPERLINKS / PI_NO_HYPERLINKS overrides plus a tmux>=3.4 gate so
+	// modern tmux forwards OSC 8 to outer terminals that opt in via
+	// `terminal-features "*:hyperlinks"`.
+	resolved.hyperlinks = shouldEnableHyperlinksByDefault(Bun.env, resolved.id);
 	// DECCARA rectangular-SGR background fills. The static per-terminal capability
 	// lives on KNOWN_TERMINALS; here we fold in runtime context — multiplexer and
 	// the PI_NO_DECCARA kill switch via detectRectangularSgrSupport — and force it

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -280,7 +280,9 @@ function parseTmuxVersionFromEnv(env: NodeJS.ProcessEnv): { major: number; minor
  *      on). Opt-out wins ties.
  *   2. Static terminal capability — terminals whose {@link TerminalInfo} marks
  *      `hyperlinks: false` (e.g. `base`) stay off unless the user forced on.
- *   3. tmux session (`TMUX` set): enabled when tmux self-reports >= 3.4 via
+ *   3. GNU screen's explicit session marker (`STY`) always off, even if tmux is
+ *      also present: a screen layer anywhere in the path cannot forward OSC 8.
+ *   4. tmux session (`TMUX` set): enabled when tmux self-reports >= 3.4 via
  *      `TERM_PROGRAM_VERSION` (tmux 3.4 stores OSC 8 as a cell attribute and
  *      forwards it to outer terminals whose `terminal-features` include
  *      `hyperlinks`). Older or unknown versions stay off; on outer terminals
@@ -288,11 +290,11 @@ function parseTmuxVersionFromEnv(env: NodeJS.ProcessEnv): { major: number; minor
  *      identical to today. Checked before the screen-family TERM heuristic
  *      because tmux's historical `default-terminal` is `screen-256color`, so
  *      `TERM=screen*` inside a tmux session must NOT short-circuit to off.
- *   4. GNU screen (`STY` set, or screen-family TERM without `TMUX`) always off:
- *      screen never gained OSC 8 support.
- *   5. tmux-family TERM without `TMUX` env — unusual (e.g. inspection scripts);
+ *   5. screen-family TERM without `TMUX` always off: screen never gained OSC 8
+ *      support.
+ *   6. tmux-family TERM without `TMUX` env — unusual (e.g. inspection scripts);
  *      no version available, so off.
- *   6. Otherwise honor the static terminal capability.
+ *   7. Otherwise honor the static terminal capability.
  */
 export function shouldEnableHyperlinksByDefault(
 	env: NodeJS.ProcessEnv = Bun.env,
@@ -303,9 +305,14 @@ export function shouldEnableHyperlinksByDefault(
 
 	if (!getTerminalInfo(terminalId).hyperlinks) return false;
 
-	// tmux check first: TMUX is the authoritative current-session signal and
-	// supersedes TERM, which may be `screen-256color` under tmux's historical
-	// default-terminal setting.
+	// STY is GNU screen's explicit session marker. It vetoes tmux enabling when
+	// multiplexers are nested because screen cannot forward OSC 8 anywhere in the
+	// path.
+	if (env.STY) return false;
+
+	// tmux check before TERM heuristics: TMUX is the authoritative current-session
+	// signal and supersedes TERM, which may be `screen-256color` under tmux's
+	// historical default-terminal setting.
 	if (env.TMUX) {
 		const version = parseTmuxVersionFromEnv(env);
 		if (!version) return false;
@@ -313,7 +320,7 @@ export function shouldEnableHyperlinksByDefault(
 	}
 
 	const term = env.TERM?.toLowerCase() ?? "";
-	if (env.STY || term.startsWith("screen")) return false;
+	if (term.startsWith("screen")) return false;
 	if (term.startsWith("tmux")) return false;
 
 	return true;

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -280,13 +280,19 @@ function parseTmuxVersionFromEnv(env: NodeJS.ProcessEnv): { major: number; minor
  *      on). Opt-out wins ties.
  *   2. Static terminal capability — terminals whose {@link TerminalInfo} marks
  *      `hyperlinks: false` (e.g. `base`) stay off unless the user forced on.
- *   3. GNU screen always off: screen never gained OSC 8 support.
- *   4. tmux: enabled when tmux self-reports >= 3.4 via `TERM_PROGRAM_VERSION`
- *      (tmux 3.4 stores OSC 8 as a cell attribute and forwards it to outer
- *      terminals whose `terminal-features` include `hyperlinks`). Older or
- *      unknown versions stay off; on outer terminals without the feature
- *      configured, tmux silently drops the sequence — identical to today.
- *   5. Otherwise honor the static terminal capability.
+ *   3. tmux session (`TMUX` set): enabled when tmux self-reports >= 3.4 via
+ *      `TERM_PROGRAM_VERSION` (tmux 3.4 stores OSC 8 as a cell attribute and
+ *      forwards it to outer terminals whose `terminal-features` include
+ *      `hyperlinks`). Older or unknown versions stay off; on outer terminals
+ *      without the feature configured, tmux silently drops the sequence —
+ *      identical to today. Checked before the screen-family TERM heuristic
+ *      because tmux's historical `default-terminal` is `screen-256color`, so
+ *      `TERM=screen*` inside a tmux session must NOT short-circuit to off.
+ *   4. GNU screen (`STY` set, or screen-family TERM without `TMUX`) always off:
+ *      screen never gained OSC 8 support.
+ *   5. tmux-family TERM without `TMUX` env — unusual (e.g. inspection scripts);
+ *      no version available, so off.
+ *   6. Otherwise honor the static terminal capability.
  */
 export function shouldEnableHyperlinksByDefault(
 	env: NodeJS.ProcessEnv = Bun.env,
@@ -297,14 +303,18 @@ export function shouldEnableHyperlinksByDefault(
 
 	if (!getTerminalInfo(terminalId).hyperlinks) return false;
 
-	const term = env.TERM?.toLowerCase() ?? "";
-	if (env.STY || term.startsWith("screen")) return false;
-
-	if (env.TMUX || term.startsWith("tmux")) {
+	// tmux check first: TMUX is the authoritative current-session signal and
+	// supersedes TERM, which may be `screen-256color` under tmux's historical
+	// default-terminal setting.
+	if (env.TMUX) {
 		const version = parseTmuxVersionFromEnv(env);
 		if (!version) return false;
 		return version.major > 3 || (version.major === 3 && version.minor >= 4);
 	}
+
+	const term = env.TERM?.toLowerCase() ?? "";
+	if (env.STY || term.startsWith("screen")) return false;
+	if (term.startsWith("tmux")) return false;
 
 	return true;
 }

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+	hyperlinksUserOverride,
+	shouldEnableHyperlinksByDefault,
 	shouldEnableSynchronizedOutputByDefault,
 	synchronizedOutputUserOverride,
 } from "@oh-my-pi/pi-tui/terminal-capabilities";
@@ -90,5 +92,116 @@ describe("shouldEnableSynchronizedOutputByDefault", () => {
 		expect(
 			shouldEnableSynchronizedOutputByDefault({ PI_FORCE_SYNC_OUTPUT: "1", SSH_CONNECTION: "1 2 3 4" }, "base"),
 		).toBe(true);
+	});
+});
+
+describe("hyperlinksUserOverride", () => {
+	it("returns null when neither override is set", () => {
+		expect(hyperlinksUserOverride({})).toBeNull();
+		expect(hyperlinksUserOverride({ TERM: "xterm-256color" })).toBeNull();
+	});
+
+	it("returns true for the force-on flag", () => {
+		expect(hyperlinksUserOverride({ PI_FORCE_HYPERLINKS: "1" })).toBe(true);
+	});
+
+	it("returns false for the opt-out flag", () => {
+		expect(hyperlinksUserOverride({ PI_NO_HYPERLINKS: "1" })).toBe(false);
+	});
+
+	it("resolves opt-out ahead of force-on when both are set", () => {
+		expect(hyperlinksUserOverride({ PI_NO_HYPERLINKS: "1", PI_FORCE_HYPERLINKS: "1" })).toBe(false);
+	});
+
+	it("ignores values other than the literal '1'", () => {
+		// Mirrors the sync-output knobs: only the canonical `1` toggles them;
+		// `true`/`yes` are not accepted to keep the contract obvious.
+		expect(hyperlinksUserOverride({ PI_FORCE_HYPERLINKS: "true" })).toBeNull();
+		expect(hyperlinksUserOverride({ PI_FORCE_HYPERLINKS: "0" })).toBeNull();
+		expect(hyperlinksUserOverride({ PI_NO_HYPERLINKS: "0" })).toBeNull();
+	});
+});
+
+describe("shouldEnableHyperlinksByDefault", () => {
+	it("enables hyperlinks on every known direct terminal", () => {
+		for (const id of ["kitty", "ghostty", "wezterm", "iterm2", "alacritty", "vscode"] as const) {
+			expect(shouldEnableHyperlinksByDefault({}, id)).toBe(true);
+		}
+	});
+
+	it("keeps the base/trueColor fallback terminals off", () => {
+		expect(shouldEnableHyperlinksByDefault({}, "base")).toBe(false);
+		expect(shouldEnableHyperlinksByDefault({}, "trueColor")).toBe(false);
+	});
+
+	it("keeps GNU screen always off, even when the inner terminal supports OSC 8", () => {
+		expect(shouldEnableHyperlinksByDefault({ STY: "1234.pts-0.host" }, "wezterm")).toBe(false);
+		expect(shouldEnableHyperlinksByDefault({ TERM: "screen-256color" }, "kitty")).toBe(false);
+	});
+
+	it("keeps tmux off when no version is reported (old tmux without TERM_PROGRAM_VERSION)", () => {
+		expect(shouldEnableHyperlinksByDefault({ TMUX: "/tmp/tmux-1000/default,1,0" }, "wezterm")).toBe(false);
+		expect(shouldEnableHyperlinksByDefault({ TERM: "tmux-256color" }, "wezterm")).toBe(false);
+	});
+
+	it("keeps tmux off when self-reported version is below 3.4", () => {
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "3.3a" },
+				"wezterm",
+			),
+		).toBe(false);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "2.9" },
+				"kitty",
+			),
+		).toBe(false);
+	});
+
+	it("enables tmux >= 3.4 since tmux forwards OSC 8 cell attributes to the outer terminal", () => {
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "3.4" },
+				"wezterm",
+			),
+		).toBe(true);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "3.5a" },
+				"wezterm",
+			),
+		).toBe(true);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "4.0" },
+				"kitty",
+			),
+		).toBe(true);
+	});
+
+	it("respects the static per-terminal flag even when force-on is absent", () => {
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ TMUX: "/tmp/tmux-1000/default,1,0", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "3.5a" },
+				"base",
+			),
+		).toBe(false);
+	});
+
+	it("lets PI_NO_HYPERLINKS beat every positive heuristic", () => {
+		expect(shouldEnableHyperlinksByDefault({ PI_NO_HYPERLINKS: "1" }, "kitty")).toBe(false);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{ PI_NO_HYPERLINKS: "1", TERM_PROGRAM: "tmux", TERM_PROGRAM_VERSION: "3.5a", TMUX: "1" },
+				"wezterm",
+			),
+		).toBe(false);
+	});
+
+	it("lets PI_FORCE_HYPERLINKS override the conservative defaults (old tmux, screen, base terminal)", () => {
+		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "base")).toBe(true);
+		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", TMUX: "1" }, "wezterm")).toBe(true);
+		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", STY: "1.pts-0" }, "kitty")).toBe(true);
 	});
 });

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -167,6 +167,32 @@ describe("shouldEnableHyperlinksByDefault", () => {
 		).toBe(false);
 	});
 
+	it("lets GNU screen's STY marker veto tmux enabling in nested multiplexer sessions", () => {
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{
+					STY: "1234.pts-0.host",
+					TMUX: "/tmp/tmux-1000/default,1,0",
+					TERM_PROGRAM: "tmux",
+					TERM_PROGRAM_VERSION: "3.4",
+				},
+				"wezterm",
+			),
+		).toBe(false);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{
+					STY: "1234.pts-0.host",
+					TMUX: "/tmp/tmux-1000/default,1,0",
+					TERM: "screen-256color",
+					TERM_PROGRAM: "tmux",
+					TERM_PROGRAM_VERSION: "3.5a",
+				},
+				"kitty",
+			),
+		).toBe(false);
+	});
+
 	it("keeps tmux off when no version is reported (old tmux without TERM_PROGRAM_VERSION)", () => {
 		expect(shouldEnableHyperlinksByDefault({ TMUX: "/tmp/tmux-1000/default,1,0" }, "wezterm")).toBe(false);
 		expect(shouldEnableHyperlinksByDefault({ TERM: "tmux-256color" }, "wezterm")).toBe(false);

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -139,6 +139,34 @@ describe("shouldEnableHyperlinksByDefault", () => {
 		expect(shouldEnableHyperlinksByDefault({ TERM: "screen-256color" }, "kitty")).toBe(false);
 	});
 
+	it("treats TMUX as authoritative even when TERM is screen-family (tmux's historical default-terminal)", () => {
+		// tmux's historical `default-terminal` is `screen-256color`, so a tmux
+		// session can have a screen-family TERM. The TMUX env signals tmux is the
+		// immediate layer and its version gate must run regardless of TERM.
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{
+					TMUX: "/tmp/tmux-1000/default,1,0",
+					TERM: "screen-256color",
+					TERM_PROGRAM: "tmux",
+					TERM_PROGRAM_VERSION: "3.4",
+				},
+				"wezterm",
+			),
+		).toBe(true);
+		expect(
+			shouldEnableHyperlinksByDefault(
+				{
+					TMUX: "/tmp/tmux-1000/default,1,0",
+					TERM: "screen",
+					TERM_PROGRAM: "tmux",
+					TERM_PROGRAM_VERSION: "3.3a",
+				},
+				"wezterm",
+			),
+		).toBe(false);
+	});
+
 	it("keeps tmux off when no version is reported (old tmux without TERM_PROGRAM_VERSION)", () => {
 		expect(shouldEnableHyperlinksByDefault({ TMUX: "/tmp/tmux-1000/default,1,0" }, "wezterm")).toBe(false);
 		expect(shouldEnableHyperlinksByDefault({ TERM: "tmux-256color" }, "wezterm")).toBe(false);


### PR DESCRIPTION
## Repro

Inside tmux 3.4+ (issue used 3.5a) on an outer terminal that supports OSC 8 (e.g. WezTerm with `set -as terminal-features "wezterm*:hyperlinks"`), URLs rendered by omp come out as plain text. When a URL wraps at the pane edge it becomes unclickable and copies with a newline embedded — `pi-tui` is force-disabling OSC 8 even though tmux is the link-capable middleware.

```
TMUX=/tmp/tmux-1000/default,1,0 TERM_PROGRAM=tmux TERM_PROGRAM_VERSION=3.5a \
  node -e 'import("@oh-my-pi/pi-tui/terminal-capabilities").then(m => console.log(m.TERMINAL.hyperlinks))'
# before: false
# after:  true
```

## Cause

`packages/tui/src/terminal-capabilities.ts` (TERMINAL IIFE) carried a tmux/screen blanket force-off that dated back to tmux < 3.4:

```ts
if (resolved.hyperlinks && (Bun.env.TMUX || term.startsWith("tmux") || term.startsWith("screen"))) {
    resolved.hyperlinks = false;
}
```

There was also no env override for hyperlinks (unlike `PI_FORCE_SYNC_OUTPUT`, `PI_FORCE_IMAGE_PROTOCOL`, `PI_NO_DECCARA`), so users on modern tmux had no escape hatch.

## Fix

- Add `hyperlinksUserOverride(env)` — reads `PI_NO_HYPERLINKS=1` / `PI_FORCE_HYPERLINKS=1`; opt-out beats force-on, mirroring `synchronizedOutputUserOverride`.
- Add `shouldEnableHyperlinksByDefault(env, terminalId)` — folds in: user override > static per-terminal flag > GNU-screen-always-off > tmux gate (parse `TERM_PROGRAM_VERSION` when `TERM_PROGRAM=tmux`; allow when version >= 3.4) > static flag. tmux self-sets `TERM_PROGRAM`/`TERM_PROGRAM_VERSION` since 3.2a, so the gate degrades safely on older releases (stays off).
- Replace the inline force-off block in the `TERMINAL` IIFE with a single call to `shouldEnableHyperlinksByDefault(Bun.env, resolved.id)`.
- Add 12 unit tests modeled on the existing `synchronizedOutput*` tests: env overrides (both flags and the precedence between them), screen always off, tmux off without/with stale versions, tmux on at 3.4/3.5a/4.0, base-terminal force-on, and PI_NO_HYPERLINKS beating positive heuristics.

Outer terminals without `hyperlinks` in `terminal-features` see tmux silently drop the OSC 8 sequence — identical to today's plain-text output — so the upgrade is safe for misconfigured setups.

## Verification

`bun test --parallel test/*.test.ts` from `packages/tui`: 864 pass / 0 fail (3 skip, 3658 expect calls). The new `hyperlinksUserOverride` and `shouldEnableHyperlinksByDefault` blocks cover the env-precedence and tmux-version contracts.

Fixes #2403