### PR TITLE
fix(skills): load ~/.agents/skills even when third-party source toggles are off

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -99,7 +99,7 @@ Dedup key is skill name. First item with a given name wins.
 
 `loadSkills()` applies these controls:
 
-- source toggles: `enableCodexUser`, `enableClaudeUser`, `enableClaudeProject`, `enablePiUser`, `enablePiProject`
+- source toggles: `enableCodexUser`, `enableClaudeUser`, `enableClaudeProject`, `enablePiUser`, `enablePiProject`, `enableAgentsUser`, `enableAgentsProject`
 - `disabledExtensions` entries with `skill:<name>`
 - `ignoredSkills` (exclude; glob patterns)
 - `includeSkills` (include allowlist; glob patterns; empty means include all)
@@ -110,7 +110,8 @@ Filter order is:
 2. source enabled
 3. not ignored
 4. included (if include list present)
-   For providers other than codex/claude/native (for example `agents`, `claude-plugins`, `opencode`), enablement currently falls back to: enabled if **any** built-in source toggle is enabled.
+
+The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location and has its own `enableAgentsUser`/`enableAgentsProject` toggles — disabling Claude/Codex/Pi does **not** turn it off. For providers without a dedicated toggle (`claude-plugins`, `opencode`, `gemini`, `github`, …), enablement falls back to: enabled if **any** named source toggle is enabled.
 
 ### Collision and duplicate handling
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `skills.enableAgentsUser` and `skills.enableAgentsProject` settings (default on) so the canonical OMP-native `~/.agent[s]/skills` and project-walkup `.agent[s]/skills` are configurable independently from the third-party Claude/Codex/Pi toggles.
+
+### Fixed
+
+- Fixed `~/.agent[s]/skills` not appearing as `/skill:<name>` commands when every named source toggle (`skills.enableCodexUser`, `skills.enableClaudeUser`, `skills.enableClaudeProject`, `skills.enablePiUser`, `skills.enablePiProject`) was off: `loadSkills` gated the `agents` provider on `anyBuiltInSkillSourceEnabled`, so a user who turned off the Claude/Codex/Pi sources to clean noise also lost their own canonical OMP-native skills. The `agents` provider now reads the dedicated `enableAgentsUser`/`enableAgentsProject` toggles, decoupled from the third-party fall-through ([#2401](https://github.com/can1357/oh-my-pi/issues/2401)).
+
 ## [15.12.3] - 2026-06-12
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3527,6 +3527,10 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.enablePiProject": { type: "boolean", default: true },
 
+	"skills.enableAgentsUser": { type: "boolean", default: true },
+
+	"skills.enableAgentsProject": { type: "boolean", default: true },
+
 	"skills.customDirectories": { type: "array", default: [] as string[] },
 
 	"skills.ignoredSkills": { type: "array", default: [] as string[] },
@@ -4138,6 +4142,8 @@ export interface SkillsSettings {
 	enableClaudeProject?: boolean;
 	enablePiUser?: boolean;
 	enablePiProject?: boolean;
+	enableAgentsUser?: boolean;
+	enableAgentsProject?: boolean;
 	customDirectories?: string[];
 	ignoredSkills?: string[];
 	includeSkills?: string[];

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -107,6 +107,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		enableClaudeProject = true,
 		enablePiUser = true,
 		enablePiProject = true,
+		enableAgentsUser = true,
+		enableAgentsProject = true,
 		customDirectories = [],
 		ignoredSkills = [],
 		includeSkills = [],
@@ -118,9 +120,21 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		return { skills: [], warnings: [] };
 	}
 
+	// Fall-through gate for third-party CLI providers (claude-plugins, opencode,
+	// gemini, github, ...) that share user intent with the named source toggles
+	// but don't have a dedicated control of their own. The OMP-native providers
+	// (`agents`, `native`) get explicit toggles above and never fall through:
+	// disabling Claude/Codex must not silently break `.agent[s]/skills`
+	// discovery (issue #2401).
 	const anyBuiltInSkillSourceEnabled =
-		enableCodexUser || enableClaudeUser || enableClaudeProject || enablePiUser || enablePiProject;
-	// Helper to check if a source is enabled
+		enableCodexUser ||
+		enableClaudeUser ||
+		enableClaudeProject ||
+		enablePiUser ||
+		enablePiProject ||
+		enableAgentsUser ||
+		enableAgentsProject;
+
 	function isSourceEnabled(source: SourceMeta): boolean {
 		const { provider, level } = source;
 		if (provider === "codex" && level === "user") return enableCodexUser;
@@ -128,7 +142,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		if (provider === "claude" && level === "project") return enableClaudeProject;
 		if (provider === "native" && level === "user") return enablePiUser;
 		if (provider === "native" && level === "project") return enablePiProject;
-		// For other providers (agents, claude-plugins, etc.), treat them as built-in skill sources.
+		if (provider === "agents" && level === "user") return enableAgentsUser;
+		if (provider === "agents" && level === "project") return enableAgentsProject;
 		return anyBuiltInSkillSourceEnabled;
 	}
 

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -18,6 +18,24 @@ const expectedFixtureSkillOrder: string[] = [
 	"unknown-field",
 	"valid-skill",
 ];
+
+/**
+ * Disable every named built-in skill source. Used by `loadSkills` option tests
+ * that need to isolate a custom directory or assert "no built-in leakage". Tests
+ * MUST spread this in: the discovery surface only ignores `~/.<dir>/skills/*` if
+ * every provider toggle resolves to false, otherwise stray skills from the
+ * developer's real `$HOME` (e.g. `~/.agents/skills/<name>/SKILL.md`) leak into
+ * the assertion.
+ */
+const DISABLE_ALL_BUILTIN_SKILLS = {
+	enableCodexUser: false,
+	enableClaudeUser: false,
+	enableClaudeProject: false,
+	enablePiUser: false,
+	enablePiProject: false,
+	enableAgentsUser: false,
+	enableAgentsProject: false,
+} as const;
 
 describe("skills", () => {
 	describe("loadSkillsFromDir", () => {
@@ -133,28 +151,14 @@ describe("skills", () => {
 
 	describe("loadSkills with options", () => {
 		it("should load from customDirectories only when built-ins disabled", async () => {
-			const { skills } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [fixturesDir],
-			});
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
 			expect(skills.length).toBeGreaterThan(0);
 			// Custom directory skills have source "custom:user"
 			expect(skills.every(s => s.source.startsWith("custom"))).toBe(true);
 		});
 
 		it("should return customDirectory skills sorted by name (case-insensitive)", async () => {
-			const { skills } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [fixturesDir],
-			});
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
 
 			expect(skills.map(s => s.name)).toEqual(expectedFixtureSkillOrder);
 		});
@@ -191,29 +195,73 @@ describe("skills", () => {
 			}
 		});
 
+
+		// Regression for issue #2401: a user who disables the named third-party
+		// CLI toggles (codex/claude/native) MUST still see skills from the
+		// canonical OMP-native `~/.agent[s]/skills` (the `agents` provider).
+		// Pre-fix `loadSkills` gated `agents` on `anyBuiltInSkillSourceEnabled`,
+		// so flipping the five third-party toggles off silently disabled it.
+		it("should still load ~/.agents/skills when codex/claude/native toggles are off (#2401)", async () => {
+			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-home-"));
+			const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-cwd-"));
+			const skillDir = path.join(tempHome, ".agents", "skills", "user-agents-skill");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", "description: Loaded from ~/.agents/skills", "---", "", "# user-agents-skill"].join("\n"),
+			);
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+			try {
+				const { skills } = await loadSkills({
+					enableCodexUser: false,
+					enableClaudeUser: false,
+					enableClaudeProject: false,
+					enablePiUser: false,
+					enablePiProject: false,
+					// enableAgentsUser/enableAgentsProject left at their default-true value
+					cwd: tempCwd,
+				});
+				expect(skills.some(s => s.name === "user-agents-skill" && s.source === "agents:user")).toBe(true);
+			} finally {
+				homedirSpy.mockRestore();
+				await fs.rm(tempHome, { recursive: true, force: true });
+				await fs.rm(tempCwd, { recursive: true, force: true });
+			}
+		});
+
+		it("respects an explicit enableAgentsUser: false (#2401)", async () => {
+			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-home-off-"));
+			const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-cwd-off-"));
+			const skillDir = path.join(tempHome, ".agents", "skills", "opted-out");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", "description: Should be filtered out", "---", "", "# opted-out"].join("\n"),
+			);
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+			try {
+				const { skills } = await loadSkills({
+					...DISABLE_ALL_BUILTIN_SKILLS,
+					enableAgentsUser: false,
+					cwd: tempCwd,
+				});
+				expect(skills.some(s => s.name === "opted-out")).toBe(false);
+			} finally {
+				homedirSpy.mockRestore();
+				await fs.rm(tempHome, { recursive: true, force: true });
+				await fs.rm(tempCwd, { recursive: true, force: true });
+			}
+		});
+
 		it("should filter out ignoredSkills", async () => {
-			const { skills } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [fixturesDir],
-				ignoredSkills: ["valid-skill"],
-			});
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+				ignoredSkills: ["valid-skill"], });
 			expect(skills.some(s => s.name === "valid-skill")).toBe(false);
 		});
 
 		it("should support glob patterns in ignoredSkills", async () => {
-			const { skills } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [fixturesDir],
-				ignoredSkills: ["valid-*"],
-			});
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+				ignoredSkills: ["valid-*"], });
 			expect(skills.every(s => !s.name.startsWith("valid-"))).toBe(true);
 		});
 
@@ -234,14 +282,7 @@ enabled: false
 			);
 
 			try {
-				const { skills } = await loadSkills({
-					enableCodexUser: false,
-					enableClaudeUser: false,
-					enableClaudeProject: false,
-					enablePiUser: false,
-					enablePiProject: false,
-					customDirectories: [tempDir],
-				});
+				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir], });
 				expect(skills.some(s => s.name === "disabled-skill")).toBe(false);
 			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
@@ -258,14 +299,7 @@ enabled: false
 			);
 
 			try {
-				const { skills } = await loadSkills({
-					enableCodexUser: false,
-					enableClaudeUser: false,
-					enableClaudeProject: false,
-					enablePiUser: false,
-					enablePiProject: false,
-					customDirectories: [tempDir],
-				});
+				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir], });
 				const skill = skills.find(s => s.name === "hidden-by-spec");
 				expect(skill).toBeDefined();
 				expect(skill!.hide).toBe(true);
@@ -275,16 +309,9 @@ enabled: false
 		});
 
 		it("should let ignoredSkills override includeSkills", async () => {
-			const { skills } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [fixturesDir],
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
 				includeSkills: ["valid-*"],
-				ignoredSkills: ["valid-skill"],
-			});
+				ignoredSkills: ["valid-skill"], });
 			expect(skills.every(s => s.name !== "valid-skill")).toBe(true);
 		});
 	});
@@ -308,22 +335,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 		);
 
 		try {
-			const { skills: withTilde } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [tildeDir],
-			});
-			const { skills: withoutTilde } = await loadSkills({
-				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enablePiUser: false,
-				enablePiProject: false,
-				customDirectories: [tempHomeSkillsDir],
-			});
+			const { skills: withTilde } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tildeDir], });
+			const { skills: withoutTilde } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempHomeSkillsDir], });
 			expect(withTilde.length).toBe(withoutTilde.length);
 			expect(withTilde.some(skill => skill.name === "tilde-skill")).toBe(true);
 		} finally {
@@ -332,74 +345,33 @@ description: Skill loaded from a tilde-expanded custom directory.
 	});
 
 	it("should return empty when all sources disabled and no custom dirs", async () => {
-		const { skills } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-		});
+		const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS,  });
 		expect(skills).toHaveLength(0);
 	});
 
 	it("should filter skills with includeSkills glob patterns", async () => {
 		// Load all skills from fixtures
-		const { skills: allSkills } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			customDirectories: [fixturesDir],
-		});
+		const { skills: allSkills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
 		expect(allSkills.length).toBeGreaterThan(0);
 
 		// Filter to only include "valid-skill"
-		const { skills: filtered } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			customDirectories: [fixturesDir],
-			includeSkills: ["valid-skill"],
-		});
+		const { skills: filtered } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+			includeSkills: ["valid-skill"], });
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].name).toBe("valid-skill");
 	});
 
 	it("should support glob patterns in includeSkills", async () => {
-		const { skills } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			customDirectories: [fixturesDir],
-			includeSkills: ["valid-*"],
-		});
+		const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+			includeSkills: ["valid-*"], });
 		expect(skills.length).toBeGreaterThan(0);
 		expect(skills.every(s => s.name.startsWith("valid-"))).toBe(true);
 	});
 
 	it("should return all skills when includeSkills is empty", async () => {
-		const { skills: withEmpty } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			customDirectories: [fixturesDir],
-			includeSkills: [],
-		});
-		const { skills: withoutOption } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			customDirectories: [fixturesDir],
-		});
+		const { skills: withEmpty } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+			includeSkills: [], });
+		const { skills: withoutOption } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
 		expect(withEmpty.length).toBe(withoutOption.length);
 	});
 });

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -151,14 +151,14 @@ describe("skills", () => {
 
 	describe("loadSkills with options", () => {
 		it("should load from customDirectories only when built-ins disabled", async () => {
-			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir] });
 			expect(skills.length).toBeGreaterThan(0);
 			// Custom directory skills have source "custom:user"
 			expect(skills.every(s => s.source.startsWith("custom"))).toBe(true);
 		});
 
 		it("should return customDirectory skills sorted by name (case-insensitive)", async () => {
-			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
+			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir] });
 
 			expect(skills.map(s => s.name)).toEqual(expectedFixtureSkillOrder);
 		});
@@ -194,7 +194,6 @@ describe("skills", () => {
 				await fs.rm(tempHomeDir, { recursive: true, force: true });
 			}
 		});
-
 
 		// Regression for issue #2401: a user who disables the named third-party
 		// CLI toggles (codex/claude/native) MUST still see skills from the
@@ -254,14 +253,20 @@ describe("skills", () => {
 		});
 
 		it("should filter out ignoredSkills", async () => {
-			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
-				ignoredSkills: ["valid-skill"], });
+			const { skills } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [fixturesDir],
+				ignoredSkills: ["valid-skill"],
+			});
 			expect(skills.some(s => s.name === "valid-skill")).toBe(false);
 		});
 
 		it("should support glob patterns in ignoredSkills", async () => {
-			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
-				ignoredSkills: ["valid-*"], });
+			const { skills } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [fixturesDir],
+				ignoredSkills: ["valid-*"],
+			});
 			expect(skills.every(s => !s.name.startsWith("valid-"))).toBe(true);
 		});
 
@@ -282,7 +287,7 @@ enabled: false
 			);
 
 			try {
-				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir], });
+				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir] });
 				expect(skills.some(s => s.name === "disabled-skill")).toBe(false);
 			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
@@ -299,7 +304,7 @@ enabled: false
 			);
 
 			try {
-				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir], });
+				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir] });
 				const skill = skills.find(s => s.name === "hidden-by-spec");
 				expect(skill).toBeDefined();
 				expect(skill!.hide).toBe(true);
@@ -309,9 +314,12 @@ enabled: false
 		});
 
 		it("should let ignoredSkills override includeSkills", async () => {
-			const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
+			const { skills } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [fixturesDir],
 				includeSkills: ["valid-*"],
-				ignoredSkills: ["valid-skill"], });
+				ignoredSkills: ["valid-skill"],
+			});
 			expect(skills.every(s => s.name !== "valid-skill")).toBe(true);
 		});
 	});
@@ -335,8 +343,14 @@ description: Skill loaded from a tilde-expanded custom directory.
 		);
 
 		try {
-			const { skills: withTilde } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tildeDir], });
-			const { skills: withoutTilde } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempHomeSkillsDir], });
+			const { skills: withTilde } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [tildeDir],
+			});
+			const { skills: withoutTilde } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [tempHomeSkillsDir],
+			});
 			expect(withTilde.length).toBe(withoutTilde.length);
 			expect(withTilde.some(skill => skill.name === "tilde-skill")).toBe(true);
 		} finally {
@@ -345,33 +359,48 @@ description: Skill loaded from a tilde-expanded custom directory.
 	});
 
 	it("should return empty when all sources disabled and no custom dirs", async () => {
-		const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS,  });
+		const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS });
 		expect(skills).toHaveLength(0);
 	});
 
 	it("should filter skills with includeSkills glob patterns", async () => {
 		// Load all skills from fixtures
-		const { skills: allSkills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
+		const { skills: allSkills } = await loadSkills({
+			...DISABLE_ALL_BUILTIN_SKILLS,
+			customDirectories: [fixturesDir],
+		});
 		expect(allSkills.length).toBeGreaterThan(0);
 
 		// Filter to only include "valid-skill"
-		const { skills: filtered } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
-			includeSkills: ["valid-skill"], });
+		const { skills: filtered } = await loadSkills({
+			...DISABLE_ALL_BUILTIN_SKILLS,
+			customDirectories: [fixturesDir],
+			includeSkills: ["valid-skill"],
+		});
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].name).toBe("valid-skill");
 	});
 
 	it("should support glob patterns in includeSkills", async () => {
-		const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
-			includeSkills: ["valid-*"], });
+		const { skills } = await loadSkills({
+			...DISABLE_ALL_BUILTIN_SKILLS,
+			customDirectories: [fixturesDir],
+			includeSkills: ["valid-*"],
+		});
 		expect(skills.length).toBeGreaterThan(0);
 		expect(skills.every(s => s.name.startsWith("valid-"))).toBe(true);
 	});
 
 	it("should return all skills when includeSkills is empty", async () => {
-		const { skills: withEmpty } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir],
-			includeSkills: [], });
-		const { skills: withoutOption } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [fixturesDir], });
+		const { skills: withEmpty } = await loadSkills({
+			...DISABLE_ALL_BUILTIN_SKILLS,
+			customDirectories: [fixturesDir],
+			includeSkills: [],
+		});
+		const { skills: withoutOption } = await loadSkills({
+			...DISABLE_ALL_BUILTIN_SKILLS,
+			customDirectories: [fixturesDir],
+		});
 		expect(withEmpty.length).toBe(withoutOption.length);
 	});
 });


### PR DESCRIPTION
## Repro

A user reports that skills placed at `~/.agents/skills/<name>/SKILL.md` never appear as `/skill:<name>` commands in the TUI command picker. Reproduced with a fixture HOME and a `~/.omp/agent/config.yml` that flips off the five named third-party skill source toggles (a reasonable cleanup for someone who doesn't use Claude/Codex/Pi but wants their own canonical agent skills):

```bash
mkdir -p ~/.agents/skills/greet && cat > ~/.agents/skills/greet/SKILL.md <<EOF
---
description: say hi
---
# greet
EOF
cat > ~/.omp/agent/config.yml <<EOF
skills:
  enableCodexUser: false
  enableClaudeUser: false
  enableClaudeProject: false
  enablePiUser: false
  enablePiProject: false
EOF
omp # then press `/`
```

`/skill:greet` is missing. The repro script (`HOME=… bun run packages/coding-agent/_repro_2401.ts`) prints `count: 0` against the same setup; with default toggles it prints `count: 2`.

## Cause

`loadSkills()` in `packages/coding-agent/src/extensibility/skills.ts` filters every skill returned by the capability layer through `isSourceEnabled`. That helper hard-codes per-toggle handling for `codex`/`claude`/`native` but routes the OMP-native `agents` provider (and every other provider without a dedicated toggle) through a `anyBuiltInSkillSourceEnabled` fall-through — the OR of the five third-party source toggles. With all five flipped off, the fall-through returned `false` and silently dropped every skill returned by the `agents` provider, including the user's `~/.agent[s]/skills/<name>/SKILL.md`. The `agents` provider had no toggle of its own and no documented coupling to Claude/Codex/Pi, so the failure mode was invisible.

## Fix

- Added `skills.enableAgentsUser` and `skills.enableAgentsProject` to `packages/coding-agent/src/config/settings-schema.ts` (default `true`) and to the `SkillsSettings` shape.
- Routed `isSourceEnabled` in `packages/coding-agent/src/extensibility/skills.ts` to the new toggles for `provider === "agents"` (per level). The fall-through still covers providers without a dedicated toggle (`claude-plugins`, `opencode`, `gemini`, `github`, …); `agents` joins claude/codex/native at the named-source layer where it always belonged.
- Updated `docs/skills.md` to document the new toggles and the corrected enablement rule.
- Refactored `packages/coding-agent/test/skills.test.ts` to share a `DISABLE_ALL_BUILTIN_SKILLS` helper (so existing isolation tests stay sound as toggles grow) and added two regression tests covering the user-reported scenario and the explicit `enableAgentsUser: false` opt-out.
- Added a CHANGELOG entry under `[Unreleased]` (`Added` for the new toggles, `Fixed` for the regression).

## Verification

`cd packages/coding-agent && bun test test/skills.test.ts test/sdk-skills.test.ts test/discovery/` → `155 pass, 1 fail (371 expect calls)`. The single failure is `skills > should expand ~ in customDirectories`, which fails the same way on a pristine `main` checkout (`EACCES: permission denied, mkdtemp '/srv/agent-home/.pi-skills-test-…'`) — the sandbox blocks writes under `$HOME`; unrelated to this diff.

Manual repro confirmation: with my changes and the same all-toggles-off `config.yml`, `HOME=/tmp/issue2401/home bun run packages/coding-agent/_repro_2401.ts` (script discarded post-verification) now prints both fixture skills with `source=agents:user`. Setting `enableAgentsUser: false` returns `count: 0` as expected.

Fixes #2401
