### PR TITLE
feat(tui): PI_FORCE_HYPERLINKS / PI_NO_HYPERLINKS overrides for the multiplexer OSC 8 gate

### DIFF
--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -336,10 +336,18 @@ export const TERMINAL: RuntimeTerminal = (() => {
 		const fallbackImageProtocol = getFallbackImageProtocol(resolved.id);
 		if (fallbackImageProtocol) resolved.imageProtocol = fallbackImageProtocol;
 	}
-	// tmux and screen multiplexers do not reliably forward OSC 8 hyperlinks
-	// to the outer terminal, so force them off regardless of detected terminal.
+	// Hyperlinks under multiplexers: tmux >= 3.4 stores OSC 8 as a cell
+	// attribute and forwards it to clients whose terminal-features include
+	// "hyperlinks" (`set -as terminal-features "wezterm*:hyperlinks"`), but
+	// older tmux and screen drop the sequence silently. Keep the conservative
+	// default and let users opt in or out explicitly, mirroring the
+	// PI_FORCE_SYNC_OUTPUT / PI_NO_SYNC_OUTPUT convention.
 	const term = Bun.env.TERM?.toLowerCase() ?? "";
-	if (resolved.hyperlinks && (Bun.env.TMUX || term.startsWith("tmux") || term.startsWith("screen"))) {
+	if (Bun.env.PI_NO_HYPERLINKS) {
+		resolved.hyperlinks = false;
+	} else if (Bun.env.PI_FORCE_HYPERLINKS === "1") {
+		resolved.hyperlinks = true;
+	} else if (resolved.hyperlinks && (Bun.env.TMUX || term.startsWith("tmux") || term.startsWith("screen"))) {
 		resolved.hyperlinks = false;
 	}
 	// DECCARA rectangular-SGR background fills. The static per-terminal capability


### PR DESCRIPTION
Closes #2403.

## What

Adds `PI_FORCE_HYPERLINKS=1` / `PI_NO_HYPERLINKS` env overrides around the multiplexer OSC 8 gate in `packages/tui/src/terminal-capabilities.ts`, mirroring the existing `PI_FORCE_SYNC_OUTPUT` / `PI_NO_SYNC_OUTPUT` convention (`NO_*` = any truthy value, `FORCE_*` = `"1"`).

Default behavior is unchanged: without either variable set, hyperlinks remain disabled under tmux/screen exactly as before.

## Why

The blanket disable is stale for tmux >= 3.4, which stores OSC 8 as a cell attribute and forwards it to clients whose `terminal-features` include `hyperlinks`:

```tmux
set -as terminal-features "wezterm*:hyperlinks"
```

With that configured, the full chain (omp → tmux → outer terminal) works — verified on tmux 3.5a + WezTerm. OSC 8 also fixes a real usability problem in TUIs: hard-wrapped URLs at the pane edge are unclickable via regex-based link detection (no soft-wrap continuation to join) and copy with an embedded newline. With OSC 8, every wrapped segment carries the full target.

Since omp cannot cheaply detect the *outer* terminal's negotiated features from inside the pane, an explicit opt-in is the conservative fix; auto-detection (e.g. tmux version) can layer on later.

## Testing

- `Bun.Transpiler` parse pass on the edited file; logic mirrors the existing sync-output override structure 1:1.
- Default path (no env vars set) is the old gate unchanged — no behavior change.
- tmux-side prerequisite verified on tmux 3.5a + WezTerm: with `wezterm*:hyperlinks` in `terminal-features`, the attached client negotiates `hyperlinks` (`tmux display -p '#{client_termfeatures}'`).
- Happy to add a regression test if you can point me at the preferred place to exercise the `TERMINAL` init IIFE.
