### PR TITLE
feat(extensions): expose model resolve() + family() to extensions (ctx.models)

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -151,11 +151,29 @@ Handlers and tool `execute` receive `ctx` with:
 - `cwd`
 - `sessionManager` (read-only)
 - `modelRegistry`, `model`
+- `models` (read-only model query — see below)
 - `getContextUsage()`
 - `compact(...)`
 - `isIdle()`, `hasPendingMessages()`, `abort()`
 - `shutdown()`
 - `getSystemPrompt()`
+
+### Model selection (`ctx.models`)
+
+`ctx.models` is a read-only facade for picking and comparing models the same way core does:
+
+- `list()` — authenticated models available this session.
+- `current()` — the live session model (read lazily, so it reflects `/model` switches).
+- `resolve(spec)` — a model string (`provider/id`, bare id) or role alias (`pi/slow`, a configured role) → `Model`, honoring the same settings-backed aliases and match preferences as `--model`. Returns `undefined` when nothing matches.
+- `family(model)` — an opaque lineage token for "same family?" checks (Claude point releases share a token; Claude and GPT differ). Compare it; don't persist it (the vocabulary tracks new releases).
+
+```ts
+// Pick a model from a different family than the current one (e.g. a cross-family reviewer).
+const current = ctx.models.current();
+const contrasting = ctx.models
+  .list()
+  .find(m => current && ctx.models.family(m) !== ctx.models.family(current));
+```
 
 ## 3) Command context (`ExtensionCommandContext`)
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -41,6 +41,10 @@
 - Ignored zero-cost `x-ai` subscription entries as reference sources when backfilling limits so inflated values are not propagated
 - Fixed the model cache opening with `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`, so concurrent omp startups could crash inside `getDb()` on `SQLITE_BUSY` during WAL recovery instead of waiting through the transient lock. The busy handler is now installed before the first lock-taking statement ([#2421](https://github.com/can1357/oh-my-pi/issues/2421)).
 
+### Added
+
+- Added `modelFamilyToken(modelId)` to `@oh-my-pi/pi-catalog/identity`: a coarse vendor-lineage token (`anthropic`/`openai`/`gemini`/`kimi`/…) for "are two models the same family?" comparisons, backed by `parseKnownModel` canonical-id normalization. Opaque and comparison-only; kind/variant collapsed onto the vendor token ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 ## [15.11.8] - 2026-06-12
 
 ### Fixed

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Added `modelFamilyToken(modelId)` to `@oh-my-pi/pi-catalog/identity`: a coarse vendor-lineage token (`anthropic`/`openai`/`gemini`/`kimi`/…) for "are two models the same family?" comparisons, backed by `parseKnownModel` canonical-id normalization. Opaque and comparison-only; kind/variant collapsed onto the vendor token ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 ### Changed
 
 - Changed catalog metadata to update a model’s per-token pricing to input 0.09 and output 0.18
@@ -40,10 +45,6 @@
 - Filled missing `contextWindow` and `maxTokens` in generated `models.json` for proxy/reseller variants by inheriting limits from canonical-family and segment-reference models
 - Ignored zero-cost `x-ai` subscription entries as reference sources when backfilling limits so inflated values are not propagated
 - Fixed the model cache opening with `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`, so concurrent omp startups could crash inside `getDb()` on `SQLITE_BUSY` during WAL recovery instead of waiting through the transient lock. The busy handler is now installed before the first lock-taking statement ([#2421](https://github.com/can1357/oh-my-pi/issues/2421)).
-
-### Added
-
-- Added `modelFamilyToken(modelId)` to `@oh-my-pi/pi-catalog/identity`: a coarse vendor-lineage token (`anthropic`/`openai`/`gemini`/`kimi`/…) for "are two models the same family?" comparisons, backed by `parseKnownModel` canonical-id normalization. Opaque and comparison-only; kind/variant collapsed onto the vendor token ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
 
 ## [15.11.8] - 2026-06-12
 

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -7,7 +7,7 @@
  * here.
  */
 
-import { bareModelId, isFableOrMythos, parseAnthropicModel, parseGlmModel, semverGte } from "./classify";
+import { bareModelId, isFableOrMythos, parseAnthropicModel, parseGlmModel, parseKnownModel, semverGte } from "./classify";
 
 /** Kimi family ids in any namespace form (`moonshotai/kimi-*`, `kimi-k2.6`, `vendor/kimi.x`). */
 export function isKimiModelId(modelId: string): boolean {
@@ -92,6 +92,25 @@ export function isReasoningGlmModelId(modelId: string): boolean {
 /** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */
 export function isGlmVisionModelId(modelId: string): boolean {
 	return parseGlmModel(bareModelId(modelId))?.vision === true;
+}
+/**
+ * Coarse vendor-lineage token for "are two models the same family?" checks
+ * (e.g. picking a cross-family reviewer). All Claude point releases share a token,
+ * Claude and GPT differ; namespace prefixes and aggregator mirrors fold onto the
+ * lineage via {@link parseKnownModel}'s `bareModelId` normalization. Opaque and
+ * comparison-only — not a stable key to persist, since the vocabulary tracks new
+ * releases. Returns `""` for ids it cannot classify; callers fall back to the provider.
+ */
+export function modelFamilyToken(modelId: string): string {
+	const parsed = parseKnownModel(modelId);
+	if (parsed.family !== "unknown") return parsed.family;
+	if (isKimiModelId(modelId)) return "kimi";
+	if (isQwenModelId(modelId)) return "qwen";
+	if (isMinimaxM2FamilyModelId(modelId)) return "minimax";
+	if (isOpenAIGptOssModelId(modelId)) return "gpt-oss";
+	if (isDeepseekModelIdOrName(modelId)) return "deepseek";
+	if (isMimoModelIdOrName(modelId)) return "mimo";
+	return "";
 }
 
 /**

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -100,6 +100,9 @@ export function isGlmVisionModelId(modelId: string): boolean {
  * lineage via {@link parseKnownModel}'s `bareModelId` normalization. Opaque and
  * comparison-only — not a stable key to persist, since the vocabulary tracks new
  * releases. Returns `""` for ids it cannot classify; callers fall back to the provider.
+ *
+ * Vendor-only by design: a model's kind/variant (opus vs sonnet, codex vs base) is
+ * collapsed onto the single vendor token; use {@link parseKnownModel} for finer breakdowns.
  */
 export function modelFamilyToken(modelId: string): string {
 	const parsed = parseKnownModel(modelId);

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -7,6 +7,7 @@ import {
 	isMinimaxM2FamilyModelId,
 	isOpenAIGptOssModelId,
 	isReasoningGlmModelId,
+	modelFamilyToken,
 	supportsAdaptiveThinkingDisplay,
 } from "@oh-my-pi/pi-catalog/identity";
 
@@ -148,5 +149,29 @@ describe("isGlmVisionModelId", () => {
 		expect(isGlmVisionModelId("glm-5-preview")).toBe(false);
 		expect(isGlmVisionModelId("glm-4.5")).toBe(false);
 		expect(isGlmVisionModelId("glm-5-turbo")).toBe(false);
+	});
+});
+describe("modelFamilyToken", () => {
+	test("groups point releases within a vendor and separates across vendors", () => {
+		expect(modelFamilyToken("claude-opus-4-7")).toBe("anthropic");
+		expect(modelFamilyToken("claude-opus-4-8")).toBe("anthropic");
+		expect(modelFamilyToken("claude-opus-4-7")).toBe(modelFamilyToken("claude-opus-4-8"));
+		expect(modelFamilyToken("gpt-5.4")).toBe("openai");
+		expect(modelFamilyToken("gemini-3-pro")).toBe("gemini");
+		expect(modelFamilyToken("claude-opus-4-8")).not.toBe(modelFamilyToken("gpt-5.4"));
+	});
+
+	test("folds aggregator mirrors and namespace prefixes onto the lineage", () => {
+		expect(modelFamilyToken("anthropic/claude-opus-4.8")).toBe("anthropic");
+		expect(modelFamilyToken("openrouter/anthropic/claude-opus-4-8")).toBe("anthropic");
+	});
+
+	test("classifies non-first-party families", () => {
+		expect(modelFamilyToken("moonshotai/kimi-k2")).toBe("kimi");
+		expect(modelFamilyToken("qwen/qwen3-coder")).toBe("qwen");
+	});
+
+	test("returns an empty token for unclassifiable ids so callers fall back to provider", () => {
+		expect(modelFamilyToken("some-unknown-model")).toBe("");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -127,6 +127,10 @@
 
 - Restored the intended double-Esc default to `/tree` and fixed the Esc-opened selector path to reset the terminal display instead of preserving stale scrollback when the selector opens.
 
+### Added
+
+- Added a read-only `ctx.models` facade for extensions: `list()` (authenticated models), `current()` (live session model), `resolve(spec)` (a model string or role alias → `Model`, using the same settings-backed aliases and match preferences as core selection), and `family(model)` (opaque canonical-identity lineage token for cross-family comparisons). Lets extension tools select models the way core does without reaching into the mutable registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 ## [15.12.2] - 2026-06-12
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added a `/guided-goal` slash command that interviews you to refine an objective before enabling goal mode, then seeds goal mode with the agreed objective. The bounded interview (up to six turns) runs on the plan or slow model and falls back with a hint when the goal is still too vague ([#2502](https://github.com/can1357/oh-my-pi/issues/2502)).
 - Added a large-paste menu: when a paste reaches `paste.largeMenuThreshold` lines (default 100; `0` disables), the editor offers to wrap it in a code block, wrap it in `<pasted_text>` XML tags (both collapse to a `[Paste]` marker that expands on submit), or save it to the session's `local://` store and insert a clean `local://attachment-N` reference the agent can `read` on demand. Esc keeps the previous inline-paste behavior, so the content is never lost.
 - Added `8on22-bw` (leading) and `11on16-bw` (tracking) options to the `snapcompact.shape` setting, the spacing-tuned cells that are now the per-provider defaults (Anthropic → tracking, OpenAI/Google → leading)
+- Added `skills.enableAgentsUser` and `skills.enableAgentsProject` settings (default on) so the canonical OMP-native `~/.agent[s]/skills` and project-walkup `.agent[s]/skills` are configurable independently from the third-party Claude/Codex/Pi toggles.
+- Added a read-only `ctx.models` facade for extensions: `list()` (authenticated models), `current()` (live session model), `resolve(spec)` (a model string or role alias → `Model`, using the same settings-backed aliases and match preferences as core selection), and `family(model)` (opaque canonical-identity lineage token for cross-family comparisons). Lets extension tools select models the way core does without reaching into the mutable registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 
 ### Changed
 
@@ -126,10 +129,6 @@
 ### Fixed
 
 - Restored the intended double-Esc default to `/tree` and fixed the Esc-opened selector path to reset the terminal display instead of preserving stale scrollback when the selector opens.
-
-### Added
-
-- Added a read-only `ctx.models` facade for extensions: `list()` (authenticated models), `current()` (live session model), `resolve(spec)` (a model string or role alias → `Model`, using the same settings-backed aliases and match preferences as core selection), and `family(model)` (opaque canonical-identity lineage token for cross-family comparisons). Lets extension tools select models the way core does without reaching into the mutable registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
 
 ## [15.12.2] - 2026-06-12
 

--- a/packages/coding-agent/src/extensibility/extensions/model-api.ts
+++ b/packages/coding-agent/src/extensibility/extensions/model-api.ts
@@ -1,0 +1,38 @@
+/**
+ * Model query facade exposed to extensions as `ctx.models`.
+ *
+ * Read-only: lets an extension select a model the same way core does — list
+ * authenticated models, read the session model, resolve a model string or role
+ * alias, and compare model families — without touching the mutable registry or
+ * duplicating resolution/family heuristics.
+ */
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { modelFamilyToken } from "@oh-my-pi/pi-catalog/identity";
+import type { ModelRegistry } from "../../config/model-registry";
+import { expandRoleAlias, getModelMatchPreferences, resolveModelFromString } from "../../config/model-resolver";
+import type { Settings } from "../../config/settings";
+import type { ExtensionModelQuery } from "./types";
+
+/**
+ * Build the `ctx.models` facade. `getModel` is read lazily so `current()` always
+ * reflects the live session model (it can change mid-session via `/model`).
+ */
+export function createExtensionModelQuery(
+	modelRegistry: ModelRegistry,
+	settings: Settings | undefined,
+	getModel: () => Model | undefined,
+): ExtensionModelQuery {
+	return {
+		list: () => modelRegistry.getAvailable(),
+		current: () => getModel(),
+		resolve: (spec: string): Model<Api> | undefined =>
+			resolveModelFromString(
+				expandRoleAlias(spec, settings),
+				modelRegistry.getAvailable(),
+				getModelMatchPreferences(settings),
+				modelRegistry,
+			),
+		family: (model: Model<Api>): string =>
+			modelFamilyToken(modelRegistry.getCanonicalId(model) ?? model.id) || model.provider.toLowerCase(),
+	};
+}

--- a/packages/coding-agent/src/extensibility/extensions/model-api.ts
+++ b/packages/coding-agent/src/extensibility/extensions/model-api.ts
@@ -9,7 +9,7 @@
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { modelFamilyToken } from "@oh-my-pi/pi-catalog/identity";
 import type { ModelRegistry } from "../../config/model-registry";
-import { expandRoleAlias, getModelMatchPreferences, resolveModelFromString } from "../../config/model-resolver";
+import { getModelMatchPreferences, resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import type { ExtensionModelQuery } from "./types";
 
@@ -25,13 +25,16 @@ export function createExtensionModelQuery(
 	return {
 		list: () => modelRegistry.getAvailable(),
 		current: () => getModel(),
+		// resolveModelRoleValue expands a role alias (`pi/slow`) to its full configured
+		// priority list and tries each pattern — the same path core selection uses — so a
+		// fallback model lower in the list still resolves. Plain model strings pass through
+		// as a single pattern.
 		resolve: (spec: string): Model<Api> | undefined =>
-			resolveModelFromString(
-				expandRoleAlias(spec, settings),
-				modelRegistry.getAvailable(),
-				getModelMatchPreferences(settings),
+			resolveModelRoleValue(spec, modelRegistry.getAvailable(), {
+				settings,
+				matchPreferences: getModelMatchPreferences(settings),
 				modelRegistry,
-			),
+			}).model,
 		family: (model: Model<Api>): string =>
 			modelFamilyToken(modelRegistry.getCanonicalId(model) ?? model.id) || model.provider.toLowerCase(),
 	};

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -6,9 +6,11 @@ import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMeta
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
+import type { Settings } from "../../config/settings";
 import type { MemoryRuntimeContext } from "../../memory-backend";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { SessionManager } from "../../session/session-manager";
+import { createExtensionModelQuery } from "./model-api";
 import type {
 	AfterProviderResponseEvent,
 	AssistantThinkingRenderer,
@@ -207,6 +209,7 @@ export class ExtensionRunner {
 		private readonly sessionManager: SessionManager,
 		private readonly modelRegistry: ModelRegistry,
 		getMemory?: () => MemoryRuntimeContext | undefined,
+		private readonly settings?: Settings,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
@@ -479,6 +482,7 @@ export class ExtensionRunner {
 			get model() {
 				return getModel();
 			},
+			models: createExtensionModelQuery(this.modelRegistry, this.settings, getModel),
 			isIdle: () => this.#isIdleFn(),
 			abort: () => this.#abortFn(),
 			hasPendingMessages: () => this.#hasPendingMessagesFn(),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -293,6 +293,32 @@ export interface CompactOptions {
 // surface (model registry, system prompt, shutdown, full session manager
 // access). Field overlap is incidental; merging into a base would require
 // hooks to widen their public contract.
+/**
+ * Read-only model query facade exposed at `ctx.models`. Lets an extension select a
+ * model the same way core does — list authenticated models, read the session model,
+ * resolve a model string or role alias, and compare model families — without reaching
+ * into the mutable registry or re-implementing matching/family heuristics.
+ */
+export interface ExtensionModelQuery {
+	/** Authenticated models available this session (the same set `--model` selection sees). */
+	list(): Model[];
+	/** The current session model, if one is set. */
+	current(): Model | undefined;
+	/**
+	 * Resolve a model string (`provider/id`, bare id) or role alias (`pi/slow`, a
+	 * configured role) to a Model, using the same settings-backed aliases and match
+	 * preferences as core selection. Thinking/routing suffixes are accepted and resolved
+	 * to the base model (pass effort separately). Returns undefined when nothing matches.
+	 */
+	resolve(spec: string): Model | undefined;
+	/**
+	 * Opaque lineage token for "are these the same family?" comparisons — every Claude
+	 * point release shares a token, Claude and GPT differ. Backed by catalog canonical
+	 * identity. Compare it; do not persist it (the vocabulary tracks new releases).
+	 */
+	family(model: Model): string;
+}
+
 export interface ExtensionContext {
 	/** UI methods for user interaction */
 	ui: ExtensionUIContext;
@@ -310,6 +336,8 @@ export interface ExtensionContext {
 	modelRegistry: ModelRegistry;
 	/** Current model (may be undefined) */
 	model: Model | undefined;
+	/** Read-only model query facade: list / current / resolve / family. */
+	models: ExtensionModelQuery;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** Abort the current agent operation */

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -17,6 +17,7 @@ import type {
 	TerminalInputHandler,
 } from "../../extensibility/extensions";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
+import { createExtensionModelQuery } from "../../extensibility/extensions/model-api";
 import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
 import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/components/hook-selector";
@@ -491,6 +492,11 @@ export class ExtensionUiController {
 						sessionManager: this.ctx.session.sessionManager,
 						modelRegistry: this.ctx.session.modelRegistry,
 						model: this.ctx.session.model,
+						models: createExtensionModelQuery(
+							this.ctx.session.modelRegistry,
+							this.ctx.session.settings,
+							() => this.ctx.session.model,
+						),
 						isIdle: () => !this.ctx.session.isStreaming,
 						hasPendingMessages: () => this.ctx.session.queuedMessageCount > 0,
 						abort: () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1967,6 +1967,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			sessionManager,
 			modelRegistry,
 			() => (hasSession ? createSessionMemoryRuntimeContext(session, agentDir, cwd) : undefined),
+			settings,
 		);
 
 		credentialDisabledTarget = extensionRunner;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -166,6 +166,7 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../extensibility/extensions";
+import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import type { HookCommandContext } from "../extensibility/hooks/types";
@@ -4926,6 +4927,7 @@ export class AgentSession {
 			sessionManager: this.sessionManager,
 			modelRegistry: this.#modelRegistry,
 			model: this.model ?? undefined,
+			models: createExtensionModelQuery(this.#modelRegistry, this.settings, () => this.model ?? undefined),
 			isIdle: () => !this.isStreaming,
 			abort: () => {
 				void this.abort();

--- a/packages/coding-agent/test/extensibility/ext-model-query.test.ts
+++ b/packages/coding-agent/test/extensibility/ext-model-query.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { createExtensionModelQuery } from "../../src/extensibility/extensions/model-api";
+
+function model(id: string, name: string, provider: string): Model<"anthropic-messages"> {
+	return buildModel({
+		id,
+		name,
+		api: "anthropic-messages",
+		provider,
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	});
+}
+
+const claude = model("claude-opus-4-8", "Claude Opus 4.8", "anthropic");
+const claudePrev = model("claude-opus-4-7", "Claude Opus 4.7", "anthropic");
+const gpt = model("gpt-5.4", "GPT-5.4", "openai");
+
+const available = [claude, gpt] as Model<Api>[];
+
+/** Minimal registry stub: only the methods the facade and core resolver touch. */
+function registry(): ModelRegistry {
+	return {
+		getAvailable: () => available,
+		getCanonicalId: (m: Model<Api>) => m.id,
+	} as unknown as ModelRegistry;
+}
+
+describe("createExtensionModelQuery", () => {
+	test("list() and current() pass through to the registry and session model", () => {
+		const q = createExtensionModelQuery(registry(), undefined, () => gpt);
+		expect(q.list()).toEqual(available);
+		expect(q.current()).toBe(gpt);
+	});
+
+	test("current() reflects the live session model, read lazily", () => {
+		let active: Model<Api> | undefined = claude;
+		const q = createExtensionModelQuery(registry(), undefined, () => active);
+		expect(q.current()).toBe(claude);
+		active = gpt;
+		expect(q.current()).toBe(gpt);
+	});
+
+	test("resolve() matches model strings through the core resolver", () => {
+		const q = createExtensionModelQuery(registry(), undefined, () => undefined);
+		expect(q.resolve("anthropic/claude-opus-4-8")).toBe(claude);
+		expect(q.resolve("gpt-5.4")?.provider).toBe("openai");
+		expect(q.resolve("definitely-not-a-model")).toBeUndefined();
+	});
+
+	test("family() groups a vendor's point releases and separates vendors", () => {
+		const q = createExtensionModelQuery(registry(), undefined, () => undefined);
+		expect(q.family(claude)).toBe(q.family(claudePrev));
+		expect(q.family(claude)).not.toBe(q.family(gpt));
+	});
+
+	test("supports cross-family reviewer selection (the second-opinion use case)", () => {
+		const q = createExtensionModelQuery(registry(), undefined, () => claude);
+		const current = q.current();
+		expect(current).toBeDefined();
+		const reviewer = q.list().find(m => q.family(m) !== q.family(current as Model<Api>));
+		expect(reviewer).toBe(gpt);
+	});
+});

--- a/packages/coding-agent/test/extensibility/ext-model-query.test.ts
+++ b/packages/coding-agent/test/extensibility/ext-model-query.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createExtensionModelQuery } from "../../src/extensibility/extensions/model-api";
 
 function model(id: string, name: string, provider: string): Model<"anthropic-messages"> {
@@ -55,17 +56,29 @@ describe("createExtensionModelQuery", () => {
 		expect(q.resolve("definitely-not-a-model")).toBeUndefined();
 	});
 
+	test("resolve() honors configured role aliases via the same settings-backed path as core", () => {
+		const settings = {
+			getModelRole: (role: string) => (role === "slow" ? "anthropic/claude-opus-4-8" : undefined),
+		} as unknown as Settings;
+		const q = createExtensionModelQuery(registry(), settings, () => undefined);
+		expect(q.resolve("pi/slow")).toBe(claude);
+	});
+
 	test("family() groups a vendor's point releases and separates vendors", () => {
 		const q = createExtensionModelQuery(registry(), undefined, () => undefined);
 		expect(q.family(claude)).toBe(q.family(claudePrev));
 		expect(q.family(claude)).not.toBe(q.family(gpt));
 	});
 
-	test("supports cross-family reviewer selection (the second-opinion use case)", () => {
-		const q = createExtensionModelQuery(registry(), undefined, () => claude);
-		const current = q.current();
-		expect(current).toBeDefined();
-		const reviewer = q.list().find(m => q.family(m) !== q.family(current as Model<Api>));
-		expect(reviewer).toBe(gpt);
+	test("family() folds an opaque proxy id onto its canonical lineage", () => {
+		// "proxy-xyz-1" classifies to no family on its own; canonical resolution maps it
+		// onto claude-opus-4-8, so it must group with Claude rather than its own provider.
+		const proxy = model("proxy-xyz-1", "Proxy Claude", "someproxy") as Model<Api>;
+		const reg = {
+			getAvailable: () => available,
+			getCanonicalId: (m: Model<Api>) => (m === proxy ? "claude-opus-4-8" : m.id),
+		} as unknown as ModelRegistry;
+		const q = createExtensionModelQuery(reg, undefined, () => undefined);
+		expect(q.family(proxy)).toBe(q.family(claude));
 	});
 });


### PR DESCRIPTION
Implements #2406 — the read-only model-query half of the extension model API.

## What

Adds a `ctx.models` facade so extension tools can select models the same way core does, without reaching into the mutable registry or re-implementing matching/family heuristics:

- `list()` — authenticated models available this session (`modelRegistry.getAvailable()`).
- `current()` — the live session model (read lazily; reflects `/model` switches).
- `resolve(spec)` — a model string (`provider/id`, bare id) or role alias (`pi/slow`, a configured role) → `Model`, via the **same** `expandRoleAlias` + `resolveModelFromString` + settings-backed match preferences as core selection. Returns `undefined` when nothing matches.
- `family(model)` — an opaque canonical-identity lineage token for "same family?" comparisons (every Claude point release shares a token; Claude vs GPT differ).

## How it addresses the triage decisions on #2406

- **Read-only facade, not a registry backdoor** — `ctx.models` exposes only these four methods.
- **`resolve()` shares core's aliases + match preferences** — it calls the same resolver path with `getModelMatchPreferences(settings)`; settings is threaded into `ExtensionRunner` (optional last constructor param, so existing call sites are untouched).
- **`family()` backed by `@oh-my-pi/pi-catalog/identity`**, not provider/id string heuristics — new `modelFamilyToken()` derives the lineage from `parseKnownModel` (which normalizes namespaces/mirrors via `bareModelId`) plus the existing family predicates, applied to the model's canonical id.
- **`family()` is opaque/comparison-only** — documented as not-to-persist (the vocabulary tracks releases).
- **`resolve()` accepts thinking/routing suffixes** and resolves to the base model (effort is passed separately at completion time).
- **Surface kept on handler `ctx.models`** for now (no factory-time `pi.models` mirror until a concrete need appears).

## Tests

- `packages/catalog/test/identity-family.test.ts` — `modelFamilyToken`: point-release grouping, Claude-vs-GPT split, aggregator-mirror/namespace folding, unknown → `""`.
- `packages/coding-agent/test/extensibility/ext-model-query.test.ts` — facade `list`/`current` (lazy) / `resolve` (string match + miss) / `family` grouping + the cross-family reviewer-selection use case.
- `tsgo --noEmit` clean (catalog + coding-agent); `biome check` clean. Pre-existing Windows-only `EBUSY` afterEach temp-dir failures in `sdk-credential-disabled-bridge.test.ts` are unrelated (verified: identical on clean main with this branch stashed).

## Next

Companion #2407 (`ctx.models.complete()`, out-of-band one-shot completion) builds on this; that PR adds `complete()` to the same namespace and is what unblocks a userland second-opinion/rubber-duck tool.