### PR TITLE
fix(coding-agent): stabilize mnemopi per-project bank derivation (#2412)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Mnemopi `per-project` / `per-project-tagged` bank derivation is now stable for one cwd, ignoring the surrounding git layout. Previously the bank id was hashed from `git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd)`, so adding or removing a `.git` anywhere above the working directory silently repointed the same conversation to a new bank and stranded its memories (e.g. `/home/x/projects/repo` flipping between `projects-…` and `repo-…`). The derivation in `packages/coding-agent/src/mnemopi/config.ts` now hashes `path.resolve(cwd)` directly, and session startup widens the recall set with any sibling bank under `<dbDir>/banks/` whose `working_memory` rows already carry the active cwd in `metadata_json.$.cwd`, so memories stranded by the old, less-stable derivation become visible again on the next session without manual migration ([#2412](https://github.com/can1357/oh-my-pi/issues/2412)).
+
 ## [15.12.3] - 2026-06-12
 
 ### Fixed

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -1,8 +1,9 @@
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
-import { getMemoriesDir } from "@oh-my-pi/pi-utils";
+import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
-import * as git from "../utils/git";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
 
@@ -42,15 +43,18 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 	const configuredDbPath = settings.get("mnemopi.dbPath");
 	const cwd = settings.getCwd();
 	const scoping = settings.get("mnemopi.scoping");
-	const scope = resolveBankScope(settings.get("mnemopi.bank"), cwd, scoping);
+	const dbPath = configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db");
+	const scope = computeMnemopiBankScope(settings.get("mnemopi.bank"), cwd, scoping);
+	const recallBanks =
+		scoping === "global" ? scope.recallBanks : extendRecallWithLegacyBanks(scope.recallBanks, dbPath, cwd);
 	const llmMode = settings.get("mnemopi.llmMode");
 	return {
-		dbPath: configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db"),
+		dbPath,
 		baseBank: scope.baseBank,
 		bank: scope.bank,
 		globalBank: scope.globalBank,
 		retainBank: scope.retainBank,
-		recallBanks: scope.recallBanks,
+		recallBanks,
 		scoping,
 		autoRecall: settings.get("mnemopi.autoRecall"),
 		autoRetain: settings.get("mnemopi.autoRetain"),
@@ -86,7 +90,11 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 
 const DEFAULT_SHARED_BANK = "default";
 
-interface MnemopiBankScope {
+// Cap legacy-bank scanning at session start so a pathological banks/
+// directory cannot dominate startup latency.
+const LEGACY_BANK_SCAN_LIMIT = 64;
+
+export interface MnemopiBankScope {
 	baseBank: string;
 	bank: string;
 	globalBank: string;
@@ -94,9 +102,19 @@ interface MnemopiBankScope {
 	recallBanks: readonly string[];
 }
 
-// Mnemopi does not have built-in tag-filtered recall, so `per-project-tagged`
-// maps to a project-local write bank plus a shared recall-visible bank.
-function resolveBankScope(configured: string | undefined, cwd: string, scoping: MnemopiScoping): MnemopiBankScope {
+/**
+ * Resolve write/recall banks for a session.
+ *
+ * Mnemopi has no tag-filtered recall, so `per-project-tagged` maps to a
+ * project-local write bank plus a shared recall-visible bank. The project
+ * bank is derived purely from {@link cwd} — see {@link projectBank} for the
+ * stability contract.
+ */
+export function computeMnemopiBankScope(
+	configured: string | undefined,
+	cwd: string,
+	scoping: MnemopiScoping,
+): MnemopiBankScope {
 	const project = projectBank(configured, cwd);
 	const globalBank = sharedBank(configured);
 	switch (scoping) {
@@ -131,8 +149,17 @@ function sharedBank(configured: string | undefined): string {
 	return sanitizeBankName(configured) ?? DEFAULT_SHARED_BANK;
 }
 
+/**
+ * Derive the per-project bank id from `cwd` alone.
+ *
+ * Earlier versions resolved the enclosing git root before hashing, which
+ * made the bank id unstable: removing or adding a `.git` anywhere above the
+ * cwd repointed the same conversation directory to a different bank and
+ * fragmented memories (#2412). The git lookup is gone here; the rescue path
+ * for already-fragmented installs lives in {@link extendRecallWithLegacyBanks}.
+ */
 function projectBank(configured: string | undefined, cwd: string): string {
-	const projectRoot = git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd);
+	const projectRoot = path.resolve(cwd || ".");
 	const project = projectBankSegment(projectRoot);
 	const base = sanitizeBankName(configured);
 	return limitBankName(base ? `${base}-${project}` : project);
@@ -140,7 +167,64 @@ function projectBank(configured: string | undefined, cwd: string): string {
 
 function projectBankSegment(projectRoot: string): string {
 	const project = sanitizeBankName(path.basename(projectRoot)) ?? "default";
-	return limitBankName(`${project}-${Bun.hash(path.resolve(projectRoot)).toString(36)}`);
+	return limitBankName(`${project}-${Bun.hash(projectRoot).toString(36)}`);
+}
+
+/**
+ * Discover sibling banks under `<dbDir>/banks/` whose `working_memory` rows
+ * already carry the active `cwd` in `metadata_json.$.cwd`, and add them to
+ * the recall set. This rescues memories stranded by a previous, less-stable
+ * bank derivation (#2412) without changing the write target — only recall is
+ * widened.
+ *
+ * Robust by design: a missing banks directory, unreadable bank dir, or
+ * corrupt SQLite file is silently skipped. Scanning is capped at
+ * {@link LEGACY_BANK_SCAN_LIMIT} to bound startup cost.
+ */
+export function extendRecallWithLegacyBanks(
+	resolved: readonly string[],
+	dbPath: string,
+	cwd: string,
+): readonly string[] {
+	const banksDir = path.join(path.dirname(dbPath), "banks");
+	const cwdAbs = path.resolve(cwd || ".");
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(banksDir, { withFileTypes: true });
+	} catch {
+		return resolved;
+	}
+	const have = new Set(resolved);
+	const extras: string[] = [];
+	let scanned = 0;
+	for (const entry of entries) {
+		if (!entry.isDirectory() || have.has(entry.name)) continue;
+		if (scanned >= LEGACY_BANK_SCAN_LIMIT) break;
+		scanned++;
+		const candidate = path.join(banksDir, entry.name, "mnemopi.db");
+		if (bankHasCwd(candidate, cwdAbs)) extras.push(entry.name);
+	}
+	return extras.length === 0 ? resolved : [...resolved, ...extras];
+}
+
+function bankHasCwd(dbPath: string, cwd: string): boolean {
+	let db: Database | undefined;
+	try {
+		db = new Database(dbPath, { readonly: true });
+		const row = db
+			.query("SELECT 1 FROM working_memory WHERE json_extract(metadata_json, '$.cwd') = ? LIMIT 1")
+			.get(cwd);
+		return row !== null;
+	} catch (error) {
+		logger.debug("Mnemopi: legacy bank probe failed", { dbPath, error: String(error) });
+		return false;
+	} finally {
+		try {
+			db?.close();
+		} catch {
+			// nothing to do — read-only handle.
+		}
+	}
 }
 
 function sanitizeBankName(value: string | undefined): string | undefined {

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -1,0 +1,134 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { computeMnemopiBankScope, extendRecallWithLegacyBanks } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
+
+// Set up a fixture filesystem we can reuse across the two regression
+// suites — same shape as `~/.omp/memories/mnemopi/` on a real install.
+let rootDir: string;
+let dbDir: string;
+let banksDir: string;
+let mainDbPath: string;
+
+beforeAll(async () => {
+	rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-bank-derivation-"));
+	dbDir = path.join(rootDir, "mnemopi");
+	banksDir = path.join(dbDir, "banks");
+	await fs.mkdir(banksDir, { recursive: true });
+	mainDbPath = path.join(dbDir, "mnemopi.db");
+});
+
+afterAll(async () => {
+	if (rootDir) await fs.rm(rootDir, { recursive: true, force: true });
+});
+
+// Schema mirrors the subset of `packages/mnemopi/src/core/beam/schema.ts`
+// that this code path needs to probe. We deliberately do not run the
+// full schema setup — the cwd-probing query only touches working_memory.
+function createBankFixture(bank: string, metadataRows: readonly Record<string, unknown>[]): void {
+	const bankDir = path.join(banksDir, bank);
+	const dbPath = path.join(bankDir, "mnemopi.db");
+	require("node:fs").mkdirSync(bankDir, { recursive: true });
+	const db = new Database(dbPath, { create: true });
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS working_memory (
+				id TEXT PRIMARY KEY,
+				content TEXT,
+				metadata_json TEXT
+			)
+		`);
+		const insert = db.prepare("INSERT INTO working_memory (id, content, metadata_json) VALUES (?, ?, ?)");
+		for (const [index, meta] of metadataRows.entries()) {
+			insert.run(`row-${bank}-${index}`, "content", JSON.stringify(meta));
+		}
+	} finally {
+		db.close();
+	}
+}
+
+describe("computeMnemopiBankScope (#2412)", () => {
+	// Regression: same cwd must hash to the same bank no matter what the
+	// ambient git layout looks like. The previous derivation walked
+	// `git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd)`, so a
+	// disappearing/appearing ancestor `.git` repointed the same conversation
+	// directory to a different bank and stranded its memories.
+	it("returns the same per-project bank for one cwd regardless of git state", async () => {
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-stable-bank-"));
+		try {
+			const project = path.join(baseDir, "projects", "omp-workstation");
+			await fs.mkdir(project, { recursive: true });
+			const withoutGit = computeMnemopiBankScope(undefined, project, "per-project").bank;
+
+			// Plant an ancestor `.git` marker — the old code path resolved
+			// `project` to `baseDir/projects` via this file, producing a
+			// `projects-<hash>` bank id distinct from the cwd-derived one.
+			await fs.mkdir(path.join(baseDir, "projects"), { recursive: true });
+			await fs.writeFile(path.join(baseDir, "projects", ".git"), "gitdir: /dev/null\n");
+			const withAncestorGit = computeMnemopiBankScope(undefined, project, "per-project").bank;
+			expect(withAncestorGit).toBe(withoutGit);
+
+			await fs.rm(path.join(baseDir, "projects", ".git"));
+			const afterGitRemoved = computeMnemopiBankScope(undefined, project, "per-project").bank;
+			expect(afterGitRemoved).toBe(withoutGit);
+		} finally {
+			await fs.rm(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("derives different banks for different cwds (sanity)", () => {
+		const a = computeMnemopiBankScope(undefined, "/projects/repo-a", "per-project").bank;
+		const b = computeMnemopiBankScope(undefined, "/projects/repo-b", "per-project").bank;
+		expect(a).not.toBe(b);
+	});
+
+	it("per-project-tagged opens both the project bank and the shared default", () => {
+		const scope = computeMnemopiBankScope(undefined, "/projects/repo", "per-project-tagged");
+		expect(scope.retainBank).toBe(scope.bank);
+		expect(scope.recallBanks).toContain(scope.bank);
+		expect(scope.recallBanks).toContain("default");
+	});
+
+	it("global ignores the cwd entirely", () => {
+		const here = computeMnemopiBankScope(undefined, "/projects/here", "global");
+		const there = computeMnemopiBankScope(undefined, "/elsewhere", "global");
+		expect(here).toEqual(there);
+		expect(here.bank).toBe("default");
+	});
+});
+
+describe("extendRecallWithLegacyBanks (#2412)", () => {
+	it("adds a sibling bank when working_memory rows tag the active cwd", () => {
+		const activeCwd = "/home/user/projects/myrepo";
+		createBankFixture("legacy-A", [{ session_id: "old", cwd: activeCwd }]);
+		createBankFixture("unrelated-B", [{ session_id: "other", cwd: "/some/other/place" }]);
+		const extended = extendRecallWithLegacyBanks(["active-bank"], mainDbPath, activeCwd);
+		expect(extended).toContain("active-bank");
+		expect(extended).toContain("legacy-A");
+		expect(extended).not.toContain("unrelated-B");
+	});
+
+	it("ignores banks already in the recall set", () => {
+		const cwd = "/home/user/projects/already-in-set";
+		createBankFixture("already-in-set", [{ cwd }]);
+		const extended = extendRecallWithLegacyBanks(["already-in-set"], mainDbPath, cwd);
+		expect(extended).toEqual(["already-in-set"]);
+	});
+
+	it("returns the input unchanged when banks/ does not exist", () => {
+		const missingRoot = path.join(rootDir, "no-such-mnemopi", "mnemopi.db");
+		const out = extendRecallWithLegacyBanks(["one"], missingRoot, "/home/user/anywhere");
+		expect(out).toEqual(["one"]);
+	});
+
+	it("tolerates a corrupt bank database without throwing", async () => {
+		const corruptDir = path.join(banksDir, "corrupt-C");
+		await fs.mkdir(corruptDir, { recursive: true });
+		await fs.writeFile(path.join(corruptDir, "mnemopi.db"), "not a sqlite file");
+		const out = extendRecallWithLegacyBanks(["active"], mainDbPath, "/some/cwd");
+		expect(out).toContain("active");
+		expect(out).not.toContain("corrupt-C");
+	});
+});


### PR DESCRIPTION
## Repro

With `mnemopi.scoping: per-project` (or `per-project-tagged`) the per-project bank id was hashed from `git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd)`. Same cwd `/home/x/projects/omp-workstation` resolved to two different banks across the lifetime of an install, depending on whether an ancestor `.git` existed: `projects-<hash>` (parent dir) when the parent looked like a repo, `omp-workstation-<hash>` (cwd basename) otherwise. The reporter ended up with 37 working memories + 157 facts in the old `projects-…` bank and 12 working memories + 29 facts in the new `omp-workstation-…` bank, with no recall path between them.

```text
$ bun run /tmp/probe.ts   # emulates old vs new derivation for one cwd
{
  "old": {
    "noGit":           "omp-workstation-1r8o5efr9cdl4",
    "ancestorGit":     "projects-2jppqmxhzwwc3",
    "ancestorRemoved": "omp-workstation-1r8o5efr9cdl4"
  },
  "new": {
    "noGit":           "omp-workstation-1r8o5efr9cdl4",
    "ancestorGit":     "omp-workstation-1r8o5efr9cdl4",
    "ancestorRemoved": "omp-workstation-1r8o5efr9cdl4"
  }
}
```

## Cause

`packages/coding-agent/src/mnemopi/config.ts:135` (old line) made bank identity an observation of the live filesystem rather than a function of the conversation cwd:

```ts
const projectRoot = git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd);
const project = projectBankSegment(projectRoot);  // basename + Bun.hash(absPath)
```

Any change to that observation — `.git` added/removed in an ancestor, a parent directory renamed into existence, git uninstalled, even a worktree config flip — rehashed the bank id for the same cwd. Mnemopi has no tag-filtered recall under `per-project*` scoping, so once writes moved to the new id the old bank stopped being searched.

## Fix

- `packages/coding-agent/src/mnemopi/config.ts`: drop the `git.repo.resolveSync` call from `projectBank` and hash `path.resolve(cwd)` directly. Same cwd → same bank, regardless of ambient git state.
- Rename `resolveBankScope` → `computeMnemopiBankScope` and export it + the `MnemopiBankScope` shape so the derivation is testable as a pure function (mirrors `computeBankScope` in `hindsight/bank.ts`).
- Add `extendRecallWithLegacyBanks`: at session start, scan `<dbDir>/banks/` for sibling banks not already in the recall set; for each, open the SQLite file read-only and probe `SELECT 1 FROM working_memory WHERE json_extract(metadata_json, '$.cwd') = ? LIMIT 1`. Matches are appended to `recallBanks` so already-fragmented installs see their old memories on the next session — no migration step. Scanning is bounded by `LEGACY_BANK_SCAN_LIMIT = 64`, missing/corrupt banks are silently skipped (debug-logged), and `scoping: global` skips the scan entirely.
- Test: `packages/coding-agent/test/mnemopi-bank-derivation.test.ts` asserts derivation is stable under appearance/disappearance of an ancestor `.git`, that `per-project-tagged` opens both project and shared banks, that sibling banks with matching cwd metadata get added to recall while unrelated banks do not, that an already-recalled bank is not double-added, that a missing `banks/` directory is a no-op, and that a corrupt sibling DB does not throw.

## Verification

```text
$ bun test packages/coding-agent/test/mnemopi-bank-derivation.test.ts \
            packages/coding-agent/test/memory-tools.test.ts \
            packages/coding-agent/test/memory-backend-resolve.test.ts
 55 pass
 0 fail
 173 expect() calls

$ bun check
bun check: passed
```

Manual sanity (see the JSON above): the OLD derivation flipped between two bank ids for one cwd; the NEW derivation returns a single bank id across all three ambient git states, and the legacy-bank probe finds the stranded sibling.

Fixes #2412