### PR TITLE
fix(cli): expose Claude plugin skills as slash commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Claude Code marketplace plugin skills installed under `skills/<name>/SKILL.md` to also appear as bare slash commands such as `/understand`, matching Claude-native plugin docs ([#2415](https://github.com/can1357/oh-my-pi/issues/2415)).
+- Fixed Claude Code marketplace plugin skills installed under `skills/<name>/SKILL.md` to also appear as bare slash commands such as `/understand`, matching Claude-native plugin docs. The slash command name is taken from the skill directory basename so display-style frontmatter names like `name: Understand Anything` still resolve to `/understand` ([#2415](https://github.com/can1357/oh-my-pi/issues/2415)).
 
 ## [15.12.3] - 2026-06-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude Code marketplace plugin skills installed under `skills/<name>/SKILL.md` to also appear as bare slash commands such as `/understand`, matching Claude-native plugin docs ([#2415](https://github.com/can1357/oh-my-pi/issues/2415)).
+
 ## [15.12.3] - 2026-06-12
 
 ### Fixed

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -141,8 +141,12 @@ async function loadSkillSlashCommands(ctx: LoadContext, root: ClaudePluginRoot):
 				warnings.push(`Failed to read skill slash command: ${skill.path}`);
 				return null;
 			}
+			// Slash command name MUST come from the skill directory basename, not
+			// frontmatter `name`: `expandSlashCommand` splits the command at the first
+			// whitespace, so a display name like "Understand Anything" would never match
+			// `/understand`. The documented layout is `skills/<name>/SKILL.md` → `/<name>`.
 			const command: SlashCommand = {
-				name: skill.name,
+				name: path.basename(path.dirname(skill.path)),
 				path: skill.path,
 				content,
 				level: skill.level,

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -124,6 +124,39 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	}
 	return { items, warnings };
 }
+async function loadSkillSlashCommands(ctx: LoadContext, root: ClaudePluginRoot): Promise<LoadResult<SlashCommand>> {
+	const { dir: skillsDir, warning } = await resolvePluginDir(root, ["skills"], "skills");
+	const warnings: string[] = warning ? [warning] : [];
+	const skillsResult = await scanSkillsFromDir(ctx, {
+		dir: skillsDir,
+		providerId: PROVIDER_ID,
+		level: root.scope,
+	});
+	warnings.push(...(skillsResult.warnings ?? []));
+
+	const commands = await Promise.all(
+		skillsResult.items.map(async skill => {
+			const content = await readFile(skill.path);
+			if (content === null) {
+				warnings.push(`Failed to read skill slash command: ${skill.path}`);
+				return null;
+			}
+			const command: SlashCommand = {
+				name: skill.name,
+				path: skill.path,
+				content,
+				level: skill.level,
+				_source: skill._source,
+			};
+			return command;
+		}),
+	);
+
+	return {
+		items: commands.filter((command): command is SlashCommand => command !== null),
+		warnings,
+	};
+}
 
 // =============================================================================
 // Slash Commands
@@ -139,7 +172,7 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 	const results = await Promise.all(
 		roots.map(async root => {
 			const { dir: commandsDir, warning } = await resolvePluginDir(root, ["commands", "slash-commands"], "commands");
-			const result = await loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
+			const commandResult = await loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
 				extensions: ["md"],
 				transform: (name, content, filePath, source) => {
 					const cmdName = name.replace(/\.md$/, "");
@@ -152,14 +185,16 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 					};
 				},
 			});
-			return { result, warning };
+			const skillCommandResult = await loadSkillSlashCommands(ctx, root);
+			return { commandResult, skillCommandResult, warning };
 		}),
 	);
 
-	for (const { result, warning } of results) {
+	for (const { commandResult, skillCommandResult, warning } of results) {
 		if (warning) warnings.push(warning);
-		items.push(...result.items);
-		if (result.warnings) warnings.push(...result.warnings);
+		items.push(...commandResult.items, ...skillCommandResult.items);
+		if (commandResult.warnings) warnings.push(...commandResult.warnings);
+		if (skillCommandResult.warnings) warnings.push(...skillCommandResult.warnings);
 	}
 
 	return { items, warnings };

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -389,6 +389,42 @@ describe("listClaudePluginRoots", () => {
 		expect(found?.description).toBe("Build an understanding graph");
 		expect(expandSlashCommand("/understand --language zh", commands)).toContain("Analyze the project.");
 	});
+	test("uses skill directory basename when frontmatter name contains spaces", async () => {
+		const pluginsDir = path.join(tempDir, ".omp", "plugins");
+		const pluginPath = path.join(tempDir, ".omp", "plugins", "cache", "plugins", "display-name-skill");
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "skills", "understand"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"display-name-skill@display-name-skill": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2026-06-12T00:00:00Z",
+						lastUpdated: "2026-06-12T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, "skills", "understand", "SKILL.md"),
+			"---\nname: Understand Anything\ndescription: Build an understanding graph\n---\nAnalyze the project.\n",
+		);
+
+		const commands = await loadSlashCommands({ cwd: tempDir });
+		// Skill is registered by directory basename so `/understand` resolves,
+		// even though the frontmatter `name` is the multi-word display label.
+		const found = commands.find(command => command.name === "understand");
+		expect(found?.description).toBe("Build an understanding graph");
+		expect(commands.find(command => command.name === "Understand Anything")).toBeUndefined();
+		expect(expandSlashCommand("/understand", commands)).toContain("Analyze the project.");
+	});
+
 
 	test("reads slash commands directory from plugin manifest slash-commands field", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -9,6 +9,7 @@ import {
 	listClaudePluginRoots,
 	parseClaudePluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { expandSlashCommand, loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
@@ -354,6 +355,39 @@ describe("listClaudePluginRoots", () => {
 
 		expect(found).toBeDefined();
 		expect(found?.path).toContain(path.join(".claude", "skills", "manifest-skill", "SKILL.md"));
+	});
+	test("exposes plugin skills as bare slash commands", async () => {
+		const pluginsDir = path.join(tempDir, ".omp", "plugins");
+		const pluginPath = path.join(tempDir, ".omp", "plugins", "cache", "plugins", "understand-anything");
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "skills", "understand"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"understand-anything@understand-anything": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "2.7.7",
+						installedAt: "2026-06-12T00:00:00Z",
+						lastUpdated: "2026-06-12T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, "skills", "understand", "SKILL.md"),
+			"---\nname: understand\ndescription: Build an understanding graph\n---\nAnalyze the project.\n",
+		);
+
+		const commands = await loadSlashCommands({ cwd: tempDir });
+		const found = commands.find(command => command.name === "understand");
+
+		expect(found?.description).toBe("Build an understanding graph");
+		expect(expandSlashCommand("/understand --language zh", commands)).toContain("Analyze the project.");
 	});
 
 	test("reads slash commands directory from plugin manifest slash-commands field", async () => {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -425,7 +425,6 @@ describe("listClaudePluginRoots", () => {
 		expect(expandSlashCommand("/understand", commands)).toContain("Analyze the project.");
 	});
 
-
 	test("reads slash commands directory from plugin manifest slash-commands field", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const pluginPath = path.join(tempDir, "plugins", "manifest-commands");


### PR DESCRIPTION
## Repro
A focused fixture installs an OMP marketplace plugin in `.omp/plugins/installed_plugins.json` with `skills/understand/SKILL.md`, then runs `bun --cwd packages/coding-agent test test/discovery/claude-plugins.test.ts -t "exposes plugin skills as bare slash commands"`; before the fix `loadSlashCommands({ cwd })` had no `understand` command, so `/understand` could not appear in autocomplete or expand.

## Cause
`packages/coding-agent/src/discovery/claude-plugins.ts` loaded Claude marketplace plugin `skills/` only through `loadSkills`, while `loadSlashCommands` scanned only `commands/` / `slash-commands/`; Claude-native plugins like Understand Anything document their `skills/<name>/SKILL.md` entries as bare slash commands, so the slash-command capability never saw `/understand`.

## Fix
- Converted Claude plugin skills into slash-command capability entries using the original `SKILL.md` content and skill name.
- Kept explicit plugin `commands/` entries ahead of synthesized skill commands so real command files still win on same-provider name collisions.
- Added a regression for OMP-installed plugin skills expanding through `/understand`.
- Added the coding-agent changelog entry.

## Verification
`bun --cwd packages/coding-agent test test/discovery/claude-plugins.test.ts` passed (21 tests); `bun --cwd=packages/coding-agent run check` passed; `gh_push_branch` pre-publish gate completed successfully. Fixes #2415