### PR TITLE
fix(ai): added GITLAB_CLIENT_ID and GITLAB_REDIRECT_URI overrides for gitlab-duo OAuth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `GITLAB_CLIENT_ID` and `GITLAB_REDIRECT_URI` env-var overrides for the GitLab Duo OAuth login flow so users running with their own GitLab OAuth application can replace the bundled credentials when GitLab rejects the bundled `client_id`'s redirect URI. Setting `GITLAB_REDIRECT_URI` also disables the random-port fallback (strict OAuth providers reject mismatched URIs anyway). ([#2424](https://github.com/can1357/oh-my-pi/issues/2424))
+
 ## [15.12.1] - 2026-06-12
 
 ### Added

--- a/packages/ai/src/registry/oauth/gitlab-duo.ts
+++ b/packages/ai/src/registry/oauth/gitlab-duo.ts
@@ -1,17 +1,78 @@
 import { clearGitLabDuoDirectAccessCache } from "../../providers/gitlab-duo";
-import { OAuthCallbackFlow } from "./callback-server";
+import type { FetchImpl } from "../../types";
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "./types";
 
 const GITLAB_COM_URL = "https://gitlab.com";
-const BUNDLED_CLIENT_ID = "da4edff2e6ebd2bc3208611e2768bc1c1dd7be791dc5ff26ca34ca9ee44f7d4b";
+/**
+ * Default OAuth client id baked into the bundled GitLab Duo login flow. GitLab
+ * authorize requests are rejected outright (`The redirect URI included is not
+ * valid`) whenever this client id's registered redirect URI list drifts from
+ * `http://localhost:8080/callback`. Users hitting that case can either:
+ *
+ * - register their own GitLab OAuth application and override the bundled
+ *   credentials with `GITLAB_CLIENT_ID` + `GITLAB_REDIRECT_URI`, or
+ * - skip OAuth entirely and supply a Personal Access Token via `GITLAB_TOKEN`.
+ *
+ * @see https://github.com/can1357/oh-my-pi/issues/2424
+ */
+const DEFAULT_CLIENT_ID = "da4edff2e6ebd2bc3208611e2768bc1c1dd7be791dc5ff26ca34ca9ee44f7d4b";
 const OAUTH_SCOPES = ["api"];
-const CALLBACK_PORT = 8080;
-const CALLBACK_PATH = "/callback";
+const DEFAULT_CALLBACK_PORT = 8080;
+const DEFAULT_CALLBACK_PATH = "/callback";
+const DEFAULT_CALLBACK_HOSTNAME = "localhost";
 
 interface PKCEPair {
 	verifier: string;
 	challenge: string;
+}
+
+/**
+ * Resolve the OAuth client id, preferring `GITLAB_CLIENT_ID` when set so users
+ * with their own GitLab OAuth application can bypass the bundled credentials.
+ */
+function resolveClientId(): string {
+	const env = process.env.GITLAB_CLIENT_ID?.trim();
+	return env && env.length > 0 ? env : DEFAULT_CLIENT_ID;
+}
+
+/**
+ * Resolve callback-server options from `GITLAB_REDIRECT_URI`. When set, the
+ * exact string is advertised to GitLab (strict matching), random-port fallback
+ * is disabled, and the local listener is bound to the URI's loopback host/port
+ * so the browser callback lands on us. Non-loopback URIs bind a random local
+ * port — only the paste-code path can complete in that case.
+ */
+function resolveCallbackOptions(): OAuthCallbackFlowOptions {
+	const raw = process.env.GITLAB_REDIRECT_URI?.trim();
+	if (!raw) {
+		return {
+			preferredPort: DEFAULT_CALLBACK_PORT,
+			callbackPath: DEFAULT_CALLBACK_PATH,
+			callbackHostname: DEFAULT_CALLBACK_HOSTNAME,
+		};
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		throw new Error(`Invalid GITLAB_REDIRECT_URI: ${raw}`);
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new Error(`GITLAB_REDIRECT_URI must use http:// or https://, got: ${raw}`);
+	}
+
+	const isLoopback = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]";
+	const port = parsed.port ? Number.parseInt(parsed.port, 10) : parsed.protocol === "https:" ? 443 : 80;
+
+	return {
+		preferredPort: isLoopback ? port : 0,
+		callbackPath: parsed.pathname || DEFAULT_CALLBACK_PATH,
+		callbackHostname: isLoopback ? parsed.hostname : DEFAULT_CALLBACK_HOSTNAME,
+		redirectUri: raw,
+	};
 }
 
 function mapTokenResponse(payload: {
@@ -38,15 +99,19 @@ function mapTokenResponse(payload: {
 
 class GitLabDuoOAuthFlow extends OAuthCallbackFlow {
 	#pkce: PKCEPair;
+	#clientId: string;
+	#fetch: FetchImpl;
 
-	constructor(ctrl: OAuthLoginCallbacks, pkce: PKCEPair) {
-		super(ctrl, CALLBACK_PORT, CALLBACK_PATH);
+	constructor(ctrl: OAuthLoginCallbacks, pkce: PKCEPair, clientId: string, options: OAuthCallbackFlowOptions) {
+		super(ctrl, options);
 		this.#pkce = pkce;
+		this.#clientId = clientId;
+		this.#fetch = ctrl.fetch ?? fetch;
 	}
 
 	override async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
 		const authParams = new URLSearchParams({
-			client_id: BUNDLED_CLIENT_ID,
+			client_id: this.#clientId,
 			redirect_uri: redirectUri,
 			response_type: "code",
 			scope: OAUTH_SCOPES.join(" "),
@@ -57,16 +122,19 @@ class GitLabDuoOAuthFlow extends OAuthCallbackFlow {
 
 		return {
 			url: `${GITLAB_COM_URL}/oauth/authorize?${authParams.toString()}`,
-			instructions: "Complete GitLab login in browser. Authentication will finish automatically.",
+			instructions:
+				'Complete GitLab login in browser. If GitLab responds with "The redirect URI included is not valid", ' +
+				"register your own GitLab OAuth application and set GITLAB_CLIENT_ID + GITLAB_REDIRECT_URI, or use a " +
+				"Personal Access Token via GITLAB_TOKEN.",
 		};
 	}
 
 	override async exchangeToken(code: string, _state: string, redirectUri: string): Promise<OAuthCredentials> {
-		const response = await fetch(`${GITLAB_COM_URL}/oauth/token`, {
+		const response = await this.#fetch(`${GITLAB_COM_URL}/oauth/token`, {
 			method: "POST",
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 			body: new URLSearchParams({
-				client_id: BUNDLED_CLIENT_ID,
+				client_id: this.#clientId,
 				grant_type: "authorization_code",
 				code,
 				code_verifier: this.#pkce.verifier,
@@ -92,7 +160,9 @@ class GitLabDuoOAuthFlow extends OAuthCallbackFlow {
 
 export async function loginGitLabDuo(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
 	const pkce = await generatePKCE();
-	const flow = new GitLabDuoOAuthFlow(callbacks, pkce);
+	const clientId = resolveClientId();
+	const options = resolveCallbackOptions();
+	const flow = new GitLabDuoOAuthFlow(callbacks, pkce, clientId, options);
 	return flow.login();
 }
 
@@ -101,7 +171,7 @@ export async function refreshGitLabDuoToken(credentials: OAuthCredentials): Prom
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: new URLSearchParams({
-			client_id: BUNDLED_CLIENT_ID,
+			client_id: resolveClientId(),
 			grant_type: "refresh_token",
 			refresh_token: credentials.refresh,
 		}).toString(),

--- a/packages/ai/test/issue-2424-repro.test.ts
+++ b/packages/ai/test/issue-2424-repro.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression: `/login gitlab-duo` fails with "The redirect URI included is not
+ * valid" because the bundled OAuth `client_id` no longer matches a registered
+ * redirect URI on the GitLab OAuth app.
+ *
+ * Contract verified here: `GITLAB_CLIENT_ID` and `GITLAB_REDIRECT_URI`
+ * environment variables override the bundled values both in the authorize URL
+ * we send the browser and in the token-exchange / refresh POSTs we send to
+ * `/oauth/token`. When the overrides are absent, the bundled defaults remain
+ * in effect.
+ *
+ * @see https://github.com/can1357/oh-my-pi/issues/2424
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { loginGitLabDuo, refreshGitLabDuoToken } from "@oh-my-pi/pi-ai/registry/oauth/gitlab-duo";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+const BUNDLED_CLIENT_ID = "da4edff2e6ebd2bc3208611e2768bc1c1dd7be791dc5ff26ca34ca9ee44f7d4b";
+
+function tokenResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			access_token: "access-token",
+			refresh_token: "refresh-token",
+			expires_in: 7200,
+			created_at: 1_700_000_000,
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+describe("gitlab-duo OAuth env overrides (issue #2424)", () => {
+	let originalClientId: string | undefined;
+	let originalRedirectUri: string | undefined;
+
+	beforeEach(() => {
+		originalClientId = process.env.GITLAB_CLIENT_ID;
+		originalRedirectUri = process.env.GITLAB_REDIRECT_URI;
+		delete process.env.GITLAB_CLIENT_ID;
+		delete process.env.GITLAB_REDIRECT_URI;
+	});
+
+	afterEach(() => {
+		if (originalClientId === undefined) delete process.env.GITLAB_CLIENT_ID;
+		else process.env.GITLAB_CLIENT_ID = originalClientId;
+		if (originalRedirectUri === undefined) delete process.env.GITLAB_REDIRECT_URI;
+		else process.env.GITLAB_REDIRECT_URI = originalRedirectUri;
+		vi.restoreAllMocks();
+	});
+
+	it("threads GITLAB_CLIENT_ID and GITLAB_REDIRECT_URI through the authorize URL and token exchange", async () => {
+		// Use a high random local port so this test never collides with another
+		// process holding 8080. The local server still binds, but the manual
+		// code input below wins the race so no HTTP callback is ever received.
+		process.env.GITLAB_CLIENT_ID = "custom-client-abc";
+		process.env.GITLAB_REDIRECT_URI = "http://127.0.0.1:0/oauth-cb";
+
+		const tokenBodies: URLSearchParams[] = [];
+		const fetchMock: FetchImpl = vi.fn(async (_input, init) => {
+			tokenBodies.push(new URLSearchParams((init?.body as string) ?? ""));
+			return tokenResponse();
+		});
+
+		let capturedAuthUrl = "";
+		const credentials = await loginGitLabDuo({
+			onAuth: info => {
+				capturedAuthUrl = info.url;
+			},
+			onManualCodeInput: async () => "auth-code-xyz",
+			onPrompt: async () => "",
+			signal: AbortSignal.timeout(5_000),
+			fetch: fetchMock,
+		});
+
+		const params = new URL(capturedAuthUrl).searchParams;
+		expect(params.get("client_id")).toBe("custom-client-abc");
+		expect(params.get("redirect_uri")).toBe("http://127.0.0.1:0/oauth-cb");
+
+		expect(tokenBodies).toHaveLength(1);
+		expect(tokenBodies[0].get("client_id")).toBe("custom-client-abc");
+		expect(tokenBodies[0].get("redirect_uri")).toBe("http://127.0.0.1:0/oauth-cb");
+		expect(tokenBodies[0].get("code")).toBe("auth-code-xyz");
+		expect(tokenBodies[0].get("grant_type")).toBe("authorization_code");
+		expect(credentials.access).toBe("access-token");
+	});
+
+	it("falls back to the bundled defaults when no overrides are set", async () => {
+		const fetchMock: FetchImpl = vi.fn(async () => tokenResponse());
+
+		let capturedAuthUrl = "";
+		await loginGitLabDuo({
+			onAuth: info => {
+				capturedAuthUrl = info.url;
+			},
+			onManualCodeInput: async () => "c",
+			onPrompt: async () => "",
+			signal: AbortSignal.timeout(5_000),
+			fetch: fetchMock,
+		});
+
+		const params = new URL(capturedAuthUrl).searchParams;
+		expect(params.get("client_id")).toBe(BUNDLED_CLIENT_ID);
+		// The default redirect URI is the localhost callback. Match the path
+		// pattern rather than the exact port: if 8080 is busy on the test
+		// machine, callback-server.ts silently falls back to a random port
+		// (which itself is the broader brokenness the env-var overrides exist
+		// to work around — strict OAuth providers like GitLab reject the
+		// random-port URI). The `localhost:.../callback` shape is what we
+		// guarantee here.
+		const redirectUri = params.get("redirect_uri") ?? "";
+		expect(redirectUri).toMatch(/^http:\/\/localhost:\d+\/callback$/);
+	});
+
+	it("rejects an unparseable GITLAB_REDIRECT_URI without leaking the bundled client id", async () => {
+		process.env.GITLAB_REDIRECT_URI = "not a uri";
+		await expect(
+			loginGitLabDuo({
+				onAuth: () => {},
+				onManualCodeInput: async () => "x",
+				onPrompt: async () => "",
+				signal: AbortSignal.timeout(1_000),
+			}),
+		).rejects.toThrow(/Invalid GITLAB_REDIRECT_URI/);
+	});
+
+	it("threads GITLAB_CLIENT_ID through the refresh request", async () => {
+		process.env.GITLAB_CLIENT_ID = "rotation-client";
+
+		const refreshBodies: URLSearchParams[] = [];
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (_input, init) => {
+			refreshBodies.push(new URLSearchParams((init?.body as string) ?? ""));
+			return tokenResponse();
+		}) as typeof globalThis.fetch);
+
+		try {
+			await refreshGitLabDuoToken({
+				access: "old-access",
+				refresh: "old-refresh",
+				expires: Date.now() + 60_000,
+			});
+		} finally {
+			fetchSpy.mockRestore();
+		}
+
+		expect(refreshBodies).toHaveLength(1);
+		expect(refreshBodies[0].get("client_id")).toBe("rotation-client");
+		expect(refreshBodies[0].get("grant_type")).toBe("refresh_token");
+		expect(refreshBodies[0].get("refresh_token")).toBe("old-refresh");
+	});
+});


### PR DESCRIPTION
## Repro

`/login gitlab-duo` opens `https://gitlab.com/oauth/authorize?...` with the
bundled `client_id` `da4edff2…d4b` and `redirect_uri=http://localhost:8080/callback`.
GitLab responds with the strict-mode rejection page: _"An error has occurred.
The redirect URI included is not valid."_

Probing `/oauth/token` confirms the `client_id` resolves on GitLab — the
endpoint returns `invalid_grant`, not `invalid_client` — so the failure is
strictly a redirect-URI registration mismatch on the bundled OAuth app, and
the `callback-server.ts` random-port fallback is guaranteed to fail with the
same provider for the same reason.

```console
$ curl -sS -X POST 'https://gitlab.com/oauth/token' \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    --data 'client_id=da4edff2e6ebd2bc3208611e2768bc1c1dd7be791dc5ff26ca34ca9ee44f7d4b&grant_type=authorization_code&code=bogus&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&code_verifier=test'
{"error":"invalid_grant", ...}
```

## Cause

`packages/ai/src/registry/oauth/gitlab-duo.ts` hardcodes
`BUNDLED_CLIENT_ID` and `CALLBACK_PORT = 8080` / `CALLBACK_PATH = "/callback"`.
Whenever the GitLab OAuth app's registered redirect URI list drifts away
from that exact loopback URI, every `loginGitLabDuo()` invocation builds an
authorize URL GitLab refuses, with no way for users to swap in their own
OAuth application. Worse, when port `8080` is busy, the parent
`OAuthCallbackFlow.#startCallbackServer` silently picks a random port and
advertises that to GitLab — strict redirect-URI matching guarantees the
random URI is rejected too.

## Fix

- `packages/ai/src/registry/oauth/gitlab-duo.ts`:
  - Read `GITLAB_CLIENT_ID` (override of the bundled `client_id`) and
    `GITLAB_REDIRECT_URI` (override of the local-callback URI) from
    `process.env`, threading both through the authorize URL and the
    token-exchange / refresh POSTs.
  - Parse `GITLAB_REDIRECT_URI` once; bind the local callback server to
    the URI's loopback host/port when loopback, otherwise pick a random
    local port (only paste-code completion is reachable in that case).
    Pass `OAuthCallbackFlowOptions.redirectUri` so the parent class's
    silent random-port fallback is disabled — a mismatched URI now
    surfaces the bind error instead of producing a token GitLab refuses
    to redeem.
  - Refactor the flow class to take `OAuthCallbackFlowOptions` directly
    and to honour `ctrl.fetch`, matching the xiaomi / anthropic
    patterns.
  - Update the browser instructions text to call out the new env-var
    overrides and the existing `GITLAB_TOKEN` PAT path when GitLab
    rejects the URI.

## Verification

- `bun test packages/ai/test/issue-2424-repro.test.ts` — 4/4 passing.
  Covers: env vars threaded through the authorize URL **and** the token
  exchange; refresh request picks up `GITLAB_CLIENT_ID`; bundled
  defaults survive when no overrides are set; unparseable
  `GITLAB_REDIRECT_URI` raises early.
- `bun test packages/ai` — 1668 pass / 0 fail (337 e2e skips unrelated).
- `bun check` — clean.

Pre-existing GitLab OAuth-app registration drift is outside this repo's
control; users hitting the rejection page can now either register their
own OAuth application (via the new env vars) or fall back to a Personal
Access Token via `GITLAB_TOKEN`.

Fixes #2424