### PR TITLE
hs-eval-support

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added Haskell (`"hs"`) compiler-backend support to the `eval` tool. Exposes a new `"hs"` option for execution of standalone Haskell code via `runhaskell`.
 - Added `skills.enableAgentsUser` and `skills.enableAgentsProject` settings (default on) so the canonical OMP-native `~/.agent[s]/skills` and project-walkup `.agent[s]/skills` are configurable independently from the third-party Claude/Codex/Pi toggles.
 
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2653,6 +2653,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Allow the eval tool to dispatch JavaScript cells to the in-process runtime",
 		},
 	},
+	"eval.hs": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "shell",
+			group: "Eval & Python",
+			label: "Haskell Eval Backend",
+			description: "Allow the eval tool to dispatch Haskell cells to runhaskell",
+		},
+	},
 
 	// Python kernel knobs (consumed by the eval py backend and the /python slash command)
 	"python.kernelMode": {

--- a/packages/coding-agent/src/eval/hs/executor.ts
+++ b/packages/coding-agent/src/eval/hs/executor.ts
@@ -1,0 +1,221 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Subprocess } from "bun";
+import { DEFAULT_MAX_BYTES, OutputSink } from "../../session/streaming-output";
+import type { ToolSession } from "../../tools";
+import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../../tools/output-meta";
+import type { EvalDisplayOutput, EvalStatusEvent } from "../types";
+
+export interface HsExecutorOptions {
+	cwd?: string;
+	timeoutMs?: number;
+	deadlineMs?: number;
+	idleTimeoutMs?: number;
+	onChunk?: (chunk: string) => Promise<void> | void;
+	onStatus?: (event: EvalStatusEvent) => void;
+	signal?: AbortSignal;
+	sessionId: string;
+	reset?: boolean;
+	sessionFile?: string;
+	artifactPath?: string;
+	artifactId?: string;
+	session: ToolSession;
+	localRoots?: Record<string, string>;
+}
+
+export interface HsResult {
+	output: string;
+	exitCode: number | undefined;
+	cancelled: boolean;
+	truncated: boolean;
+	artifactId?: string;
+	totalLines: number;
+	totalBytes: number;
+	outputLines: number;
+	outputBytes: number;
+	displayOutputs: EvalDisplayOutput[];
+}
+
+export async function executeHs(code: string, options: HsExecutorOptions): Promise<HsResult> {
+	const displayOutputs: EvalDisplayOutput[] = [];
+	const outputSink = new OutputSink({
+		artifactPath: options.artifactPath,
+		artifactId: options.artifactId,
+		spillThreshold: DEFAULT_MAX_BYTES,
+		headBytes: resolveOutputSinkHeadBytes(options.session.settings),
+		maxColumns: resolveOutputMaxColumns(options.session.settings),
+		onChunk: chunk => options.onChunk?.(chunk),
+	});
+
+	let tempDir: string | undefined;
+	let proc: Subprocess | undefined;
+	let aborted = false;
+
+	const onAbort = () => {
+		aborted = true;
+		if (proc) {
+			try {
+				proc.kill("SIGKILL");
+			} catch {
+				// ignore
+			}
+		}
+	};
+
+	if (options.signal) {
+		if (options.signal.aborted) {
+			onAbort();
+		} else {
+			options.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	try {
+		if (aborted) {
+			throw new DOMException("Execution aborted", "AbortError");
+		}
+
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-hs-"));
+		const tempFile = path.join(tempDir, "Main.hs");
+		fs.writeFileSync(tempFile, code, "utf8");
+
+		const envPatch: Record<string, string> = {};
+		if (options.sessionFile) {
+			envPatch.PI_SESSION_FILE = options.sessionFile;
+		}
+		const artifactsDir = options.session.getArtifactsDir?.();
+		if (artifactsDir) {
+			envPatch.PI_ARTIFACTS_DIR = artifactsDir;
+		}
+		if (options.localRoots && Object.keys(options.localRoots).length > 0) {
+			envPatch.PI_EVAL_LOCAL_ROOTS = JSON.stringify(options.localRoots);
+		}
+
+		const targetCwd = options.cwd ?? options.session.cwd;
+		if (!fs.existsSync(targetCwd)) {
+			fs.mkdirSync(targetCwd, { recursive: true });
+		}
+
+		const fullEnv = {
+			...process.env,
+			...envPatch,
+		} as Record<string, string>;
+
+		proc = Bun.spawn(["runhaskell", tempFile], {
+			cwd: targetCwd,
+			env: fullEnv,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		const decoder = new TextDecoder();
+		const stdoutReader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+		const stderrReader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
+
+		const stdoutPromise = (async () => {
+			try {
+				while (true) {
+					const { done, value } = await stdoutReader.read();
+					if (done) {
+						break;
+					}
+					const text = decoder.decode(value, { stream: true });
+					outputSink.push(text);
+				}
+				outputSink.push(decoder.decode());
+			} finally {
+				stdoutReader.releaseLock();
+			}
+		})();
+
+		const stderrPromise = (async () => {
+			try {
+				while (true) {
+					const { done, value } = await stderrReader.read();
+					if (done) {
+						break;
+					}
+					const text = decoder.decode(value, { stream: true });
+					outputSink.push(text);
+				}
+				outputSink.push(decoder.decode());
+			} finally {
+				stderrReader.releaseLock();
+			}
+		})();
+
+		await Promise.all([stdoutPromise, stderrPromise]);
+		const exitCode = await proc.exited;
+
+		if (aborted) {
+			throw new DOMException("Execution aborted", "AbortError");
+		}
+
+		const summary = await outputSink.dump();
+		return {
+			output: summary.output,
+			exitCode,
+			cancelled: false,
+			truncated: summary.truncated,
+			artifactId: summary.artifactId,
+			totalLines: summary.totalLines,
+			totalBytes: summary.totalBytes,
+			outputLines: summary.outputLines,
+			outputBytes: summary.outputBytes,
+			displayOutputs,
+		};
+	} catch (error) {
+		const isTimeout =
+			(options.signal?.reason && (options.signal.reason as Error).name === "TimeoutError") ||
+			(error instanceof Error && error.name === "TimeoutError");
+
+		if (aborted || isTimeout) {
+			if (isTimeout) {
+				const timeoutMs = options.timeoutMs ?? options.idleTimeoutMs;
+				const secs = timeoutMs ? Math.max(1, Math.round(timeoutMs / 1000)) : 30;
+				outputSink.push(`Command timed out after ${secs} seconds.`);
+			}
+			const summary = await outputSink.dump();
+			return {
+				output: summary.output,
+				exitCode: undefined,
+				cancelled: true,
+				truncated: summary.truncated,
+				artifactId: summary.artifactId,
+				totalLines: summary.totalLines,
+				totalBytes: summary.totalBytes,
+				outputLines: summary.outputLines,
+				outputBytes: summary.outputBytes,
+				displayOutputs,
+			};
+		}
+
+		const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+		outputSink.push(message);
+		const summary = await outputSink.dump();
+		return {
+			output: summary.output,
+			exitCode: 1,
+			cancelled: false,
+			truncated: summary.truncated,
+			artifactId: summary.artifactId,
+			totalLines: summary.totalLines,
+			totalBytes: summary.totalBytes,
+			outputLines: summary.outputLines,
+			outputBytes: summary.outputBytes,
+			displayOutputs,
+		};
+	} finally {
+		if (options.signal) {
+			options.signal.removeEventListener("abort", onAbort);
+		}
+		if (tempDir) {
+			try {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/eval/hs/executor.ts
+++ b/packages/coding-agent/src/eval/hs/executor.ts
@@ -109,7 +109,8 @@ export async function executeHs(code: string, options: HsExecutorOptions): Promi
 			stderr: "pipe",
 		});
 
-		const decoder = new TextDecoder();
+		const stdoutDecoder = new TextDecoder();
+		const stderrDecoder = new TextDecoder();
 		const stdoutReader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
 		const stderrReader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
 
@@ -120,10 +121,10 @@ export async function executeHs(code: string, options: HsExecutorOptions): Promi
 					if (done) {
 						break;
 					}
-					const text = decoder.decode(value, { stream: true });
+					const text = stdoutDecoder.decode(value, { stream: true });
 					outputSink.push(text);
 				}
-				outputSink.push(decoder.decode());
+				outputSink.push(stdoutDecoder.decode());
 			} finally {
 				stdoutReader.releaseLock();
 			}
@@ -136,10 +137,10 @@ export async function executeHs(code: string, options: HsExecutorOptions): Promi
 					if (done) {
 						break;
 					}
-					const text = decoder.decode(value, { stream: true });
+					const text = stderrDecoder.decode(value, { stream: true });
 					outputSink.push(text);
 				}
-				outputSink.push(decoder.decode());
+				outputSink.push(stderrDecoder.decode());
 			} finally {
 				stderrReader.releaseLock();
 			}

--- a/packages/coding-agent/src/eval/hs/index.ts
+++ b/packages/coding-agent/src/eval/hs/index.ts
@@ -1,0 +1,54 @@
+import type { ToolSession } from "../../tools";
+import {
+	type ExecutorBackend,
+	type ExecutorBackendExecOptions,
+	type ExecutorBackendResult,
+	resolveEvalUrlRoots,
+} from "../backend";
+import { executeHs } from "./executor";
+
+export default {
+	id: "hs",
+	label: "Haskell",
+	highlightLang: "haskell",
+
+	async isAvailable(_session: ToolSession): Promise<boolean> {
+		try {
+			const proc = Bun.spawn(["runhaskell", "--version"], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+			const exitCode = await proc.exited;
+			return exitCode === 0;
+		} catch {
+			return false;
+		}
+	},
+
+	async execute(code: string, opts: ExecutorBackendExecOptions): Promise<ExecutorBackendResult> {
+		const result = await executeHs(code, {
+			cwd: opts.cwd,
+			idleTimeoutMs: opts.idleTimeoutMs,
+			signal: opts.signal,
+			sessionId: opts.sessionId,
+			sessionFile: opts.sessionFile,
+			reset: opts.reset,
+			onChunk: opts.onChunk,
+			onStatus: opts.onStatus,
+			session: opts.session,
+			localRoots: resolveEvalUrlRoots(opts.session),
+		});
+		return {
+			output: result.output,
+			exitCode: result.exitCode,
+			cancelled: result.cancelled,
+			truncated: result.truncated,
+			artifactId: result.artifactId,
+			totalLines: result.totalLines,
+			totalBytes: result.totalBytes,
+			outputLines: result.outputLines,
+			outputBytes: result.outputBytes,
+			displayOutputs: result.displayOutputs,
+		};
+	},
+} satisfies ExecutorBackend;

--- a/packages/coding-agent/src/eval/index.ts
+++ b/packages/coding-agent/src/eval/index.ts
@@ -1,4 +1,5 @@
 export * from "./backend";
+export { default as hsBackend } from "./hs";
 export { default as jsBackend } from "./js";
 export { default as pythonBackend } from "./py";
 export * from "./types";

--- a/packages/coding-agent/src/eval/types.ts
+++ b/packages/coding-agent/src/eval/types.ts
@@ -1,5 +1,5 @@
 /** Runtime backend that an eval cell dispatches to. */
-export type EvalLanguage = "python" | "js";
+export type EvalLanguage = "python" | "js" | "hs";
 
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import type { OutputMeta } from "../tools/output-meta";

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -16,6 +16,7 @@ Work incrementally: one logical step per cell (imports, define, test, use); pass
 On failure, errors name the failing cell ("Cell 3 failed") — resubmit only the fixed cell (plus any remaining).
 </instruction>
 
+{{#ifAny py js}}
 <prelude>
 {{#ifAll py js}}Same helpers in both runtimes, same positional order. Python: helpers run synchronously; trailing options are keyword args. JavaScript: helpers are async and `await`able; trailing options are ONE trailing object literal, never positional (extra positional args throw).{{else}}{{#if py}}Helpers run synchronously. Trailing options are keyword arguments.{{/if}}{{#if js}}Helpers are async and `await`able. Trailing options are ONE trailing object literal, never positional (extra positional args throw).{{/if}}{{/ifAll}}
 ```
@@ -58,7 +59,9 @@ budget → per-turn token budget
     {{#if py}}`budget.total` (ceiling or None), `budget.spent()`, `budget.remaining()` (math.inf when no ceiling), `budget.hard` (bool).{{/if}}{{#if js}}`await budget.total()` (ceiling or null), `await budget.spent()`, `await budget.remaining()` (Infinity when no ceiling), `await budget.hard()`.{{/if}} Ceiling comes from a `+Nk` directive (advisory) or `+Nk!`/Goal Mode (hard — `agent()` refuses to spawn past it); otherwise None/null, spend still tracked across the turn.
 ```
 </prelude>
+{{/ifAny}}
 
+{{#if py}}
 <example>
 {
   "cells": [
@@ -67,3 +70,14 @@ budget → per-turn token budget
   ]
 }
 </example>
+{{/if}}
+
+{{#if hs}}
+<example>
+{
+  "cells": [
+    { "language": "hs", "title": "factorial", "code": "main = print (product [1..100])" }
+  ]
+}
+</example>
+{{/if}}

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -5,7 +5,7 @@ Cells run in array order. State persists per language — across cells, tool cal
 
 Cell fields:
 
-- `language` — {{#if py}}`"py"` for the IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}`"js"` for the persistent JavaScript VM{{/if}}.
+- `language` — {{#if py}}`"py"` for the IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}`"js"` for the persistent JavaScript VM{{/if}}{{#if hs}}, `"hs"` for the Haskell compiler-backend{{/if}}.
 - `code` — cell body, verbatim. Newlines and quotes JSON-encoded; no fences, no headers.
 - `title` (optional) — short transcript label (e.g. `"imports"`).
 - `timeout` (optional) — per-cell seconds (1-3600, default 30). Bounds the cell's own work only; the clock pauses while `agent()`/`parallel()`/`completion()` calls are in flight, so fanouts never need a raise. Raise only for heavy local compute or long non-agent tool calls.

--- a/packages/coding-agent/src/tools/eval-backends.ts
+++ b/packages/coding-agent/src/tools/eval-backends.ts
@@ -4,6 +4,7 @@ import type { ToolSession } from ".";
 export interface EvalBackendsAllowance {
 	python: boolean;
 	js: boolean;
+	hs: boolean;
 }
 
 /** Read per-backend allowance from settings (defaults true). */
@@ -11,6 +12,7 @@ export function readEvalBackendsAllowance(session: ToolSession): EvalBackendsAll
 	return {
 		python: session.settings.get("eval.py") ?? true,
 		js: session.settings.get("eval.js") ?? true,
+		hs: session.settings.get("eval.hs") ?? true,
 	};
 }
 
@@ -23,5 +25,6 @@ export function resolveEvalBackends(session: ToolSession): EvalBackendsAllowance
 	return {
 		python: $flag("PI_PY", settings.python),
 		js: $flag("PI_JS", settings.js),
+		hs: $flag("PI_HS", settings.hs),
 	};
 }

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -41,8 +41,10 @@ import {
 } from "./render-utils";
 export const EVAL_DEFAULT_PREVIEW_LINES = 10;
 
-function languageForHighlighter(language: EvalLanguage | undefined): "python" | "javascript" {
-	return language === "js" ? "javascript" : "python";
+function languageForHighlighter(language: EvalLanguage | undefined): "python" | "javascript" | "haskell" {
+	if (language === "js") return "javascript";
+	if (language === "hs") return "haskell";
+	return "python";
 }
 
 interface EvalRenderCellArg {
@@ -70,7 +72,9 @@ interface EvalRenderCell {
 }
 
 function normalizeRenderLanguage(value: string | undefined): EvalLanguage {
-	return value === "js" ? "js" : "python";
+	if (value === "js") return "js";
+	if (value === "hs") return "hs";
+	return "python";
 }
 
 function getRenderCells(args: EvalRenderArgs | undefined): EvalRenderCell[] {

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -103,12 +103,21 @@ export interface EvalToolDescriptionOptions {
 	spawns?: boolean;
 }
 
+export class LanguageSelectedPromptInjectionFunctor {
+	constructor(private readonly options: EvalToolDescriptionOptions) {}
+
+	map(template: string): string {
+		const py = this.options.py ?? true;
+		const js = this.options.js ?? true;
+		const hs = this.options.hs ?? true;
+		const spawns = this.options.spawns ?? true;
+		return prompt.render(template, { py, js, hs, spawns });
+	}
+}
+
 export function getEvalToolDescription(options: EvalToolDescriptionOptions = {}): string {
-	const py = options.py ?? true;
-	const js = options.js ?? true;
-	const hs = options.hs ?? true;
-	const spawns = options.spawns ?? true;
-	return prompt.render(evalDescription, { py, js, hs, spawns });
+	const functor = new LanguageSelectedPromptInjectionFunctor(options);
+	return functor.map(evalDescription);
 }
 
 export interface EvalToolOptions {
@@ -198,7 +207,42 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const spawnsAllowed = sessionSpawns !== "" && sessionSpawns !== null;
 		return getEvalToolDescription({ py: backends.python, js: backends.js, hs: backends.hs, spawns: spawnsAllowed });
 	}
-	readonly parameters = evalSchema;
+	get parameters(): typeof evalSchema {
+		const backends = this.session ? resolveEvalBackends(this.session) : { python: true, js: true, hs: true };
+		const enabledLangs: string[] = [];
+		if (backends.python) enabledLangs.push("py");
+		if (backends.js) enabledLangs.push("js");
+		if (backends.hs) enabledLangs.push("hs");
+
+		const langEnum =
+			enabledLangs.length > 0 ? z.enum(enabledLangs as [string, ...string[]]) : z.enum(["py", "js", "hs"]);
+
+		const dynamicCellSchema = z.object({
+			language: langEnum.describe(
+				'runtime: "py" for the IPython kernel, "js" for the persistent JS VM, "hs" for the Haskell compiler-backend',
+			),
+			code: z.string().describe("cell body, verbatim. Use top-level await freely."),
+			title: z.string().optional().describe('short label shown in transcript (e.g. "imports", "load config")'),
+			timeout: z
+				.number()
+				.int()
+				.min(1)
+				.max(3600)
+				.optional()
+				.describe("per-cell timeout in seconds (1-3600, default 30)"),
+			reset: z
+				.boolean()
+				.optional()
+				.describe("wipe this cell's language kernel before running. Other languages are untouched."),
+		});
+
+		return z.object({
+			cells: z
+				.array(dynamicCellSchema)
+				.min(1)
+				.describe("cells executed in order. State persists within each language across cells and tool calls."),
+		}) as unknown as typeof evalSchema;
+	}
 	readonly concurrency = "exclusive";
 	readonly strict = true;
 	readonly intent = (args: Partial<z.infer<typeof evalSchema>>): string | undefined => {

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -2,7 +2,7 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
-import { jsBackend, pythonBackend } from "../eval";
+import { hsBackend, jsBackend, pythonBackend } from "../eval";
 import type { ExecutorBackend, ExecutorBackendResult } from "../eval/backend";
 import { EVAL_TIMEOUT_PAUSE_OP, EVAL_TIMEOUT_RESUME_OP } from "../eval/bridge-timeout";
 import { IdleTimeout } from "../eval/idle-timeout";
@@ -27,7 +27,11 @@ export { EVAL_DEFAULT_PREVIEW_LINES, evalToolRenderer } from "./eval-render";
  * across cells and across tool calls.
  */
 const evalCellSchema = z.object({
-	language: z.enum(["py", "js"]).describe('runtime: "py" for the IPython kernel, "js" for the persistent JS VM'),
+	language: z
+		.enum(["py", "js", "hs"])
+		.describe(
+			'runtime: "py" for the IPython kernel, "js" for the persistent JS VM, "hs" for the Haskell compiler-backend',
+		),
 	code: z.string().describe("cell body, verbatim. Use top-level await freely."),
 	title: z.string().optional().describe('short label shown in transcript (e.g. "imports", "load config")'),
 	timeout: z.number().int().min(1).max(3600).optional().describe("per-cell timeout in seconds (1-3600, default 30)"),
@@ -88,6 +92,7 @@ function formatDisplayOutputsForText(outputs: EvalDisplayOutput[]): string {
 export interface EvalToolDescriptionOptions {
 	py?: boolean;
 	js?: boolean;
+	hs?: boolean;
 	/**
 	 * Whether `agent()` is allowed in this session. Driven by the parent's
 	 * spawn policy (`getSessionSpawns`). Defaults to `true` for backward
@@ -101,8 +106,9 @@ export interface EvalToolDescriptionOptions {
 export function getEvalToolDescription(options: EvalToolDescriptionOptions = {}): string {
 	const py = options.py ?? true;
 	const js = options.js ?? true;
+	const hs = options.hs ?? true;
 	const spawns = options.spawns ?? true;
-	return prompt.render(evalDescription, { py, js, spawns });
+	return prompt.render(evalDescription, { py, js, hs, spawns });
 }
 
 export interface EvalToolOptions {
@@ -142,6 +148,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 	const backends = resolveEvalBackends(session);
 	const allowPy = backends.python;
 	const allowJs = backends.js;
+	const allowHs = backends.hs;
 
 	if (language === "python") {
 		if (!allowPy) throw new ToolError("Python backend is disabled (PI_PY=0 or eval.py = false).");
@@ -151,6 +158,15 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 			);
 		}
 		return { backend: pythonBackend };
+	}
+	if (language === "hs") {
+		if (!allowHs) throw new ToolError("Haskell backend is disabled (PI_HS=0 or eval.hs = false).");
+		if (!(await hsBackend.isAvailable(session))) {
+			throw new ToolError(
+				"Haskell backend is unavailable in this session. Make sure GHC / runhaskell is installed.",
+			);
+		}
+		return { backend: hsBackend };
 	}
 	if (!allowJs) throw new ToolError("JavaScript backend is disabled (PI_JS=0 or eval.js = false).");
 	return { backend: jsBackend };
@@ -180,7 +196,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const backends = resolveEvalBackends(this.session);
 		const sessionSpawns = this.session.getSessionSpawns?.() ?? "*";
 		const spawnsAllowed = sessionSpawns !== "" && sessionSpawns !== null;
-		return getEvalToolDescription({ py: backends.python, js: backends.js, spawns: spawnsAllowed });
+		return getEvalToolDescription({ py: backends.python, js: backends.js, hs: backends.hs, spawns: spawnsAllowed });
 	}
 	readonly parameters = evalSchema;
 	readonly concurrency = "exclusive";
@@ -223,7 +239,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const cells: ResolvedEvalCell[] = [];
 		for (let i = 0; i < params.cells.length; i++) {
 			const cell = params.cells[i];
-			const language: EvalLanguage = cell.language === "py" ? "python" : "js";
+			const language: EvalLanguage = cell.language === "py" ? "python" : cell.language === "js" ? "js" : "hs";
 			const resolved = await resolveBackend(session, language);
 			cells.push({
 				index: i,

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -103,6 +103,23 @@ export interface EvalToolDescriptionOptions {
 	spawns?: boolean;
 }
 
+let cachedHsAvailable: boolean | undefined;
+
+function checkHsAvailable(): boolean {
+	if (cachedHsAvailable !== undefined) {
+		return cachedHsAvailable;
+	}
+	try {
+		const result = Bun.spawnSync(["runhaskell", "--version"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		cachedHsAvailable = result.exitCode === 0;
+	} catch {
+		cachedHsAvailable = false;
+	}
+	return cachedHsAvailable;
+}
 export class LanguageSelectedPromptInjectionFunctor {
 	constructor(private readonly options: EvalToolDescriptionOptions) {}
 
@@ -205,14 +222,15 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const backends = resolveEvalBackends(this.session);
 		const sessionSpawns = this.session.getSessionSpawns?.() ?? "*";
 		const spawnsAllowed = sessionSpawns !== "" && sessionSpawns !== null;
-		return getEvalToolDescription({ py: backends.python, js: backends.js, hs: backends.hs, spawns: spawnsAllowed });
+		const hsActive = backends.hs && checkHsAvailable();
+		return getEvalToolDescription({ py: backends.python, js: backends.js, hs: hsActive, spawns: spawnsAllowed });
 	}
 	get parameters(): typeof evalSchema {
 		const backends = this.session ? resolveEvalBackends(this.session) : { python: true, js: true, hs: true };
 		const enabledLangs: string[] = [];
 		if (backends.python) enabledLangs.push("py");
 		if (backends.js) enabledLangs.push("js");
-		if (backends.hs) enabledLangs.push("hs");
+		if (backends.hs && checkHsAvailable()) enabledLangs.push("hs");
 
 		const langEnum =
 			enabledLangs.length > 0 ? z.enum(enabledLangs as [string, ...string[]]) : z.enum(["py", "js", "hs"]);

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -458,16 +458,27 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	const allowJs = backends.js;
 	const allowHs = backends.hs;
 	const skipPythonPreflight = session.skipPythonPreflight === true;
-	// Eval tool is enabled if EITHER backend is reachable. We only need to know
-	// whether python is reachable when JS and HS are disabled — otherwise allowEval is
-	// already true and the python-availability check can be deferred to first
-	// invocation of the python backend (already handled inside the executor).
 	let pythonAvailable = true;
+	let hsAvailable = false;
+
+	if (allowHs) {
+		try {
+			const result = Bun.spawnSync(["runhaskell", "--version"], { stdout: "ignore", stderr: "ignore" });
+			hsAvailable = result.exitCode === 0;
+		} catch {
+			hsAvailable = false;
+		}
+	}
+
+	const hasRunnableHs = allowHs && hsAvailable;
+
+	// Eval tool is enabled if ANY backend is reachable. We only need to run the slow
+	// Python availability check when both JavaScript and Haskell are unavailable.
 	if (
 		!skipPythonPreflight &&
 		allowPython &&
 		!allowJs &&
-		!allowHs &&
+		!hasRunnableHs &&
 		(requestedTools === undefined || requestedTools.includes("eval"))
 	) {
 		const availability = await logger.time(
@@ -483,17 +494,6 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			});
 		}
 	}
-
-	let hsAvailable = true;
-	if (allowHs && !allowJs && !allowPython && (requestedTools === undefined || requestedTools.includes("eval"))) {
-		try {
-			const result = Bun.spawnSync(["runhaskell", "--version"], { stdout: "ignore", stderr: "ignore" });
-			hsAvailable = result.exitCode === 0;
-		} catch {
-			hsAvailable = false;
-		}
-	}
-
 	const effectivePythonAllowed = allowPython && pythonAvailable;
 	const effectiveHsAllowed = allowHs && hsAvailable;
 	// Eval is exposed whenever any backend is reachable.

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -456,9 +456,10 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	const backends = resolveEvalBackends(session);
 	const allowPython = backends.python;
 	const allowJs = backends.js;
+	const allowHs = backends.hs;
 	const skipPythonPreflight = session.skipPythonPreflight === true;
 	// Eval tool is enabled if EITHER backend is reachable. We only need to know
-	// whether python is reachable when JS is disabled — otherwise allowEval is
+	// whether python is reachable when JS and HS are disabled — otherwise allowEval is
 	// already true and the python-availability check can be deferred to first
 	// invocation of the python backend (already handled inside the executor).
 	let pythonAvailable = true;
@@ -466,6 +467,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		!skipPythonPreflight &&
 		allowPython &&
 		!allowJs &&
+		!allowHs &&
 		(requestedTools === undefined || requestedTools.includes("eval"))
 	) {
 		const availability = await logger.time(
@@ -476,16 +478,26 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		);
 		pythonAvailable = availability.ok;
 		if (!availability.ok) {
-			logger.warn("Python kernel unavailable and JS backend disabled; eval will be unavailable", {
+			logger.warn("Python kernel unavailable and other backends disabled; eval will be unavailable", {
 				reason: availability.reason,
 			});
 		}
 	}
 
+	let hsAvailable = true;
+	if (allowHs && !allowJs && !allowPython && (requestedTools === undefined || requestedTools.includes("eval"))) {
+		try {
+			const result = Bun.spawnSync(["runhaskell", "--version"], { stdout: "ignore", stderr: "ignore" });
+			hsAvailable = result.exitCode === 0;
+		} catch {
+			hsAvailable = false;
+		}
+	}
+
 	const effectivePythonAllowed = allowPython && pythonAvailable;
-	// Eval is exposed whenever any backend is reachable. The python backend may
-	// be unreachable, in which case eval dispatches exclusively to js.
-	const allowEval = effectivePythonAllowed || allowJs;
+	const effectiveHsAllowed = allowHs && hsAvailable;
+	// Eval is exposed whenever any backend is reachable.
+	const allowEval = effectivePythonAllowed || allowJs || effectiveHsAllowed;
 
 	// Auto-include AST counterparts when their text-based sibling is present
 	if (requestedTools) {

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -8,8 +8,9 @@ import { resolveEvalBackends } from "@oh-my-pi/pi-coding-agent/tools/eval-backen
 
 let originalPiPy: string | undefined;
 let originalPiJs: string | undefined;
+let originalPiHs: string | undefined;
 
-function restoreEnv(name: "PI_PY" | "PI_JS", value: string | undefined): void {
+function restoreEnv(name: "PI_PY" | "PI_JS" | "PI_HS", value: string | undefined): void {
 	if (value === undefined) {
 		delete Bun.env[name];
 		return;
@@ -43,14 +44,17 @@ describe("EvalTool language dispatch", () => {
 	beforeEach(() => {
 		originalPiPy = Bun.env.PI_PY;
 		originalPiJs = Bun.env.PI_JS;
+		originalPiHs = Bun.env.PI_HS;
 		delete Bun.env.PI_PY;
 		delete Bun.env.PI_JS;
+		delete Bun.env.PI_HS;
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 		restoreEnv("PI_PY", originalPiPy);
 		restoreEnv("PI_JS", originalPiJs);
+		restoreEnv("PI_HS", originalPiHs);
 	});
 
 	it('dispatches to the JS backend when cell.language === "js"', async () => {
@@ -66,6 +70,33 @@ describe("EvalTool language dispatch", () => {
 		expect(pythonExecuteSpy).not.toHaveBeenCalled();
 	});
 
+	it('dispatches to the Haskell backend when cell.language === "hs"', async () => {
+		const hsExecuteSpy = vi.spyOn(evalIndex.hsBackend, "execute").mockResolvedValue(mockResult);
+		const jsExecuteSpy = vi.spyOn(evalIndex.jsBackend, "execute");
+		const pythonExecuteSpy = vi.spyOn(evalIndex.pythonBackend, "execute");
+
+		const tool = new EvalTool(makeSession());
+		await tool.execute("call-hs", {
+			cells: [{ language: "hs", code: 'main = putStrLn "hello"' }],
+		});
+
+		expect(hsExecuteSpy).toHaveBeenCalledTimes(1);
+		expect(jsExecuteSpy).not.toHaveBeenCalled();
+		expect(pythonExecuteSpy).not.toHaveBeenCalled();
+	});
+	it("executes a real Haskell cell via runhaskell", async () => {
+		const session = makeSession();
+		if (!(await evalIndex.hsBackend.isAvailable(session))) {
+			return;
+		}
+		const tool = new EvalTool(session);
+		const result = await tool.execute("call-hs-real", {
+			cells: [{ language: "hs", code: 'main = putStrLn "Hello from Haskell!"' }],
+		});
+		const first = result.content[0];
+		const text = first && "text" in first ? first.text : "";
+		expect(text).toContain("Hello from Haskell!");
+	});
 	it('dispatches to the Python backend when cell.language === "py"', async () => {
 		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
 		vi.spyOn(evalIndex.pythonBackend, "isAvailable").mockResolvedValue(true);
@@ -127,7 +158,7 @@ describe("EvalTool language dispatch", () => {
 		settings.set("eval.py", false);
 		settings.set("eval.js", false);
 
-		expect(resolveEvalBackends(makeSession(settings))).toEqual({ python: true, js: false });
+		expect(resolveEvalBackends(makeSession(settings))).toEqual({ python: true, js: false, hs: true });
 	});
 
 	it("lets PI_JS disable js execution even when eval.js is enabled", async () => {
@@ -141,5 +172,28 @@ describe("EvalTool language dispatch", () => {
 				cells: [{ language: "js", code: "const x = 1;" }],
 			}),
 		).rejects.toThrow(/PI_JS=0/);
+	});
+	it("rejects hs cells when eval.hs is disabled", async () => {
+		const settings = Settings.isolated();
+		settings.set("eval.hs", false);
+		const tool = new EvalTool(makeSession(settings));
+		await expect(
+			tool.execute("call-hs-disabled", {
+				cells: [{ language: "hs", code: 'main = putStrLn "hello"' }],
+			}),
+		).rejects.toThrow(/eval\.hs = false/);
+	});
+
+	it("lets PI_HS disable hs execution even when eval.hs is enabled", async () => {
+		Bun.env.PI_HS = "0";
+		const settings = Settings.isolated();
+		settings.set("eval.hs", true);
+		const tool = new EvalTool(makeSession(settings));
+
+		await expect(
+			tool.execute("call-hs-env-disabled", {
+				cells: [{ language: "hs", code: 'main = putStrLn "hello"' }],
+			}),
+		).rejects.toThrow(/PI_HS=0/);
 	});
 });


### PR DESCRIPTION
## What

Extended Eval tool to support haskell language, and many the eval prompt dynamic. the language description is only added if hs language supported

## Why

I feel haskell(declarative language) is token efficient.

## Testing

```sh
bun run --cwd=packages/coding-agent check
bun run --cwd=packages/coding-agent build
bun test packages/coding-agent/test/tools/eval-fallback.test.ts
```

- [X] `bun check` passes
- [X] Tested locally
- [ ] CHANGELOG updated (if user-facing) 

