### PR TITLE
fix(discovery): follow symlinked extension packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fixed extension discovery ignoring package directories symlinked into an `extensions/` directory.
 - Retried assistant turns that stop with reasoning/thinking only and no final text or tool call, so Gemini/Antigravity thought-only `STOP` responses continue instead of silently ending the session.
 - Fixed `~/.agent[s]/skills` not appearing as `/skill:<name>` commands when every named source toggle (`skills.enableCodexUser`, `skills.enableClaudeUser`, `skills.enableClaudeProject`, `skills.enablePiUser`, `skills.enablePiProject`) was off: `loadSkills` gated the `agents` provider on `anyBuiltInSkillSourceEnabled`, so a user who turned off the Claude/Codex/Pi sources to clean noise also lost their own canonical OMP-native skills. The `agents` provider now reads the dedicated `enableAgentsUser`/`enableAgentsProject` toggles, decoupled from the third-party fall-through ([#2401](https://github.com/can1357/oh-my-pi/issues/2401)).
 - Fixed Windows PowerShell image paste so Ctrl+V can fall back to the PowerShell clipboard bridge when the native clipboard reader reports no image ([#2429](https://github.com/can1357/oh-my-pi/issues/2429)).

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -491,6 +491,42 @@ interface ExtensionModuleManifest {
 	extensions?: string[];
 }
 
+async function discoverLinkedExtensionModuleFiles(dir: string): Promise<{
+	indexFiles: Array<{ path: string }>;
+	packageJsonFiles: Array<{ path: string }>;
+}> {
+	const entries = await readDirEntries(dir);
+	const indexFiles: Array<{ path: string }> = [];
+	const packageJsonFiles: Array<{ path: string }> = [];
+
+	await Promise.all(
+		entries.map(async entry => {
+			if (entry.name.startsWith(".") || entry.isDirectory()) return;
+
+			const entryPath = path.join(dir, entry.name);
+			const stat = await fs.promises.stat(entryPath).catch(() => null);
+			if (!stat?.isDirectory()) return;
+
+			const [packageJsonContent, indexTsContent, indexJsContent] = await Promise.all([
+				readFile(path.join(entryPath, "package.json")),
+				readFile(path.join(entryPath, "index.ts")),
+				readFile(path.join(entryPath, "index.js")),
+			]);
+
+			if (packageJsonContent !== null) {
+				packageJsonFiles.push({ path: `${entry.name}/package.json` });
+			}
+			if (indexTsContent !== null) {
+				indexFiles.push({ path: `${entry.name}/index.ts` });
+			} else if (indexJsContent !== null) {
+				indexFiles.push({ path: `${entry.name}/index.js` });
+			}
+		}),
+	);
+
+	return { indexFiles, packageJsonFiles };
+}
+
 async function readExtensionModuleManifest(
 	_ctx: LoadContext,
 	packageJsonPath: string,
@@ -520,14 +556,18 @@ async function readExtensionModuleManifest(
 export async function discoverExtensionModulePaths(_ctx: LoadContext, dir: string): Promise<string[]> {
 	const discovered = new Set<string>();
 	// Find all candidate files in parallel using glob
-	const [directFiles, indexFiles, packageJsonFiles] = await Promise.all([
+	const [directFiles, globIndexFiles, globPackageJsonFiles, linkedFiles] = await Promise.all([
 		// 1. Direct *.ts or *.js files
 		globIf(dir, "*.{ts,js}", FileType.File, false),
 		// 2. Subdirectory index files
 		globIf(dir, "*/index.{ts,js}", FileType.File, false),
 		// 3. Subdirectory package.json files
 		globIf(dir, "*/package.json", FileType.File, false),
+		// Native glob does not follow linked extension directories.
+		discoverLinkedExtensionModuleFiles(dir),
 	]);
+	const indexFiles = [...globIndexFiles, ...linkedFiles.indexFiles];
+	const packageJsonFiles = [...globPackageJsonFiles, ...linkedFiles.packageJsonFiles];
 
 	// Process direct files
 	for (const match of directFiles) {

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -152,6 +152,32 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("linked-package/src/main.ts");
 	});
 
+	it("discovers index.ts in a symlinked extension directory", async () => {
+		const packageDir = path.join(tempDir.path(), "linked-index-ts");
+		fs.mkdirSync(packageDir);
+		fs.writeFileSync(path.join(packageDir, "index.ts"), extensionCode);
+		fs.symlinkSync(packageDir, path.join(extensionsDir, "linked-index-ts"), "dir");
+
+		const result = await discoverForTest();
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].path).toContain("linked-index-ts/index.ts");
+	});
+
+	it("discovers index.js in a symlinked extension directory", async () => {
+		const packageDir = path.join(tempDir.path(), "linked-index-js");
+		fs.mkdirSync(packageDir);
+		fs.writeFileSync(path.join(packageDir, "index.js"), extensionCode);
+		fs.symlinkSync(packageDir, path.join(extensionsDir, "linked-index-js"), "dir");
+
+		const result = await discoverForTest();
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].path).toContain("linked-index-js/index.js");
+	});
+
 	it("package.json can declare multiple extensions", async () => {
 		const subdir = path.join(extensionsDir, "my-package");
 		fs.mkdirSync(subdir);

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -129,6 +129,29 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("main.ts");
 	});
 
+	it("discovers a symlinked extension package directory", async () => {
+		const packageDir = path.join(tempDir.path(), "linked-package");
+		const sourceDir = path.join(packageDir, "src");
+		fs.mkdirSync(sourceDir, { recursive: true });
+		fs.writeFileSync(path.join(sourceDir, "main.ts"), extensionCode);
+		fs.writeFileSync(
+			path.join(packageDir, "package.json"),
+			JSON.stringify({
+				name: "linked-package",
+				pi: {
+					extensions: ["./src/main.ts"],
+				},
+			}),
+		);
+		fs.symlinkSync(packageDir, path.join(extensionsDir, "linked-package"), "dir");
+
+		const result = await discoverForTest();
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].path).toContain("linked-package/src/main.ts");
+	});
+
 	it("package.json can declare multiple extensions", async () => {
 		const subdir = path.join(extensionsDir, "my-package");
 		fs.mkdirSync(subdir);


### PR DESCRIPTION
## What

Make extension discovery inspect symlinked package directories for `package.json`, `index.ts`, and `index.js` entrypoints.

## Why

The native glob used for one-level extension discovery does not follow directory symlinks. A package linked into `.omp/extensions/` is therefore invisible even though the same package works when copied as a real directory. This breaks the documented local-development/link workflow.

The fallback only inspects directory symlinks missed by the glob. Existing direct-directory and manifest precedence behavior stays unchanged.

## Testing

- `bun test packages/coding-agent/test/extensions-discovery.test.ts` - 31 pass, 0 fail, 98 assertions
- Biome check on the changed implementation and test files - passed
- GitHub CI lint, type check, web build, native builds, and install smoke tests - passed
- GitHub CI full TypeScript test and smoke job - pending

---

- [x] Targeted tests pass
- [x] Tested locally
- [x] Regression coverage includes symlinked manifest, `index.ts`, and `index.js` entrypoints
- [x] CHANGELOG updated
