### PR TITLE
feat(catalog): add glm-5.2 to the bundled zai provider

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `glm-5.2` to the bundled `zai` provider catalog (1,000,000-token context window, `anthropic-messages` API), so it is selectable out of the box without a manual `models.yml` entry. Matches the `glm-5.1` shape with the expanded context window.
+
 ### Fixed
 
 - Fixed the model cache opening with `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`, so concurrent omp startups could crash inside `getDb()` on `SQLITE_BUSY` during WAL recovery instead of waiting through the transient lock. The busy handler is now installed before the first lock-taking statement ([#2421](https://github.com/can1357/oh-my-pi/issues/2421)).

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -71777,6 +71777,35 @@
 				]
 			}
 		},
+		"glm-5.2": {
+			"id": "glm-5.2",
+			"name": "GLM-5.2",
+			"api": "anthropic-messages",
+			"provider": "zai",
+			"baseUrl": "https://api.z.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"glm-5v-turbo": {
 			"id": "glm-5v-turbo",
 			"name": "GLM-5V-Turbo",


### PR DESCRIPTION
## Summary

Adds `glm-5.2` to the bundled `zai` provider catalog so it is selectable out of the box, without requiring a manual `models.yml` entry.

## Problem

GLM-5.2 is available on the z.ai coding plan (per the official [How to Switch Models](https://docs.z.ai/devpack/latest-model) guide) but is absent from the bundled `zai` catalog, which tops out at `glm-5.1`. As a result, users today must add a hand-written `models.yml` override to use it — e.g.:

```yaml
providers:
  zai:
    baseUrl: https://api.z.ai/api/anthropic
    api: anthropic-messages
    auth: none
    models:
      - id: glm-5.2
        ...
```

That workaround is error-prone (e.g. setting a provider-level `apiKey` in `models.yml` silently overrides the stored credential, since config keys sit above stored credentials in the auth resolution order) and should not be necessary for a first-party model.

## Change

Adds one entry to `packages/catalog/src/models.json` under the `zai` provider, matching the `glm-5.1` shape with the documented expanded context window:

| field | value |
| --- | --- |
| `id` / `name` | `glm-5.2` / `GLM-5.2` |
| `api` | `anthropic-messages` |
| `baseUrl` | `https://api.z.ai/api/anthropic` |
| `contextWindow` | `1000000` (1M — the headline capability) |
| `maxTokens` | `131072` |
| `reasoning` | `true` |
| `thinking` | `budget` mode, `minimal`–`xhigh` efforts |
| `cost` | all-zero (coding plan) |

The committed `models.json` is the catalog snapshot that the generator carries forward via its `prev-snapshot` fallback when a model is not surfaced by the z.ai discovery API at regeneration time, so the entry ships and survives regenerations. If/when discovery returns `glm-5.2`, the dynamic entry takes precedence as expected.

Canonical model identity needs no change — the GLM family regex in `identity/equivalence.ts` already matches `glm-5.2`. The `zhipu-coding-plan` provider has no bundled models, so only `zai` is touched.

## Verification

- `bun test --parallel` in `packages/catalog` — **198 pass, 0 fail**.
- Confirmed `buildModel("zai"/"glm-5.2")` materializes correctly: `anthropic-messages` compat resolved, budget-mode thinking across the full effort ladder, canonical segment `glm-5.2`.
- Verified `zai` now lists `glm-5.2` in the correct alphabetical position (`glm-5.1` → `glm-5.2` → `glm-5v-turbo`).

\* Deliberately did **not** change the `zai` `defaultModel` (still `glm-5.1`) — that is a separate product decision.
