### PR TITLE
fix(cli): defer goal objectives while streaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Retried assistant turns that stop with reasoning/thinking only and no final text or tool call, so Gemini/Antigravity thought-only `STOP` responses continue instead of silently ending the session.
 - Fixed `~/.agent[s]/skills` not appearing as `/skill:<name>` commands when every named source toggle (`skills.enableCodexUser`, `skills.enableClaudeUser`, `skills.enableClaudeProject`, `skills.enablePiUser`, `skills.enablePiProject`) was off: `loadSkills` gated the `agents` provider on `anyBuiltInSkillSourceEnabled`, so a user who turned off the Claude/Codex/Pi sources to clean noise also lost their own canonical OMP-native skills. The `agents` provider now reads the dedicated `enableAgentsUser`/`enableAgentsProject` toggles, decoupled from the third-party fall-through ([#2401](https://github.com/can1357/oh-my-pi/issues/2401)).
 - Fixed Windows PowerShell image paste so Ctrl+V can fall back to the PowerShell clipboard bridge when the native clipboard reader reports no image ([#2429](https://github.com/can1357/oh-my-pi/issues/2429)).
+- Fixed `/goal <objective>` and `/goal set <objective>` during streaming so goal context is steered immediately but objective submission waits for the active turn to finish instead of spamming `AgentBusyError` ([#2454](https://github.com/can1357/oh-my-pi/issues/2454)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2435,7 +2435,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #startGoalFromObjective(objective: string): Promise<void> {
 		await this.#enterGoalMode({ objective, silent: true });
 		this.#resetGoalContinuationSuppression();
-		if (this.onInputCallback) {
+		if (!this.session.isStreaming && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective }));
 		}
 	}
@@ -2450,7 +2450,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.session.isStreaming) {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });
 		}
-		if (this.onInputCallback) {
+		if (!this.session.isStreaming && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective }));
 		}
 	}

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -112,6 +112,26 @@ async function toolNamesFor(harness: GoalHarness): Promise<string[]> {
 	return (await createTools(harness.toolSession, harness.session.getActiveToolNames())).map(tool => tool.name);
 }
 
+async function waitForMicrotasks(): Promise<void> {
+	await Bun.sleep(0);
+}
+
+async function armInputWaiter(mode: InteractiveMode): Promise<{
+	inputPromise: Promise<void>;
+	getResolvedText: () => string | undefined;
+}> {
+	let resolvedText: string | undefined;
+	const inputPromise = mode.getUserInput().then(input => {
+		resolvedText = input.text;
+	});
+	await waitForMicrotasks();
+	return {
+		inputPromise,
+		getResolvedText: () => resolvedText,
+	};
+}
+
+
 describe("InteractiveMode goal mode integration", () => {
 	let harness: GoalHarness;
 	let shared: SharedFixture;
@@ -168,6 +188,44 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModeEnabled).toBe(true);
 		expect(await toolNamesFor(harness)).toContain("goal");
 	});
+
+	it("defers initial goal objective submission while streaming", async () => {
+		let streaming = true;
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => streaming });
+		const sendGoalModeContext = vi.spyOn(harness.session, "sendGoalModeContext").mockResolvedValue();
+		const waiter = await armInputWaiter(harness.mode);
+
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		await waitForMicrotasks();
+
+		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship the release");
+		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
+		expect(waiter.getResolvedText()).toBeUndefined();
+
+		streaming = false;
+		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
+		await waiter.inputPromise;
+	});
+
+	it("defers replacement goal objective submission while streaming", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		let streaming = true;
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => streaming });
+		const sendGoalModeContext = vi.spyOn(harness.session, "sendGoalModeContext").mockResolvedValue();
+		const waiter = await armInputWaiter(harness.mode);
+
+		await harness.mode.handleGoalModeCommand("set Replace the objective");
+		await waitForMicrotasks();
+
+		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Replace the objective");
+		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
+		expect(waiter.getResolvedText()).toBeUndefined();
+
+		streaming = false;
+		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
+		await waiter.inputPromise;
+	});
+
 
 	it("refuses /goal while plan mode is active", async () => {
 		const showWarning = vi.spyOn(harness.mode, "showWarning");

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -131,7 +131,6 @@ async function armInputWaiter(mode: InteractiveMode): Promise<{
 	};
 }
 
-
 describe("InteractiveMode goal mode integration", () => {
 	let harness: GoalHarness;
 	let shared: SharedFixture;
@@ -225,7 +224,6 @@ describe("InteractiveMode goal mode integration", () => {
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
 		await waiter.inputPromise;
 	});
-
 
 	it("refuses /goal while plan mode is active", async () => {
 		const showWarning = vi.spyOn(harness.mode, "showWarning");


### PR DESCRIPTION
## Repro
Setting `/goal <objective>` or `/goal set <objective>` while `session.isStreaming === true` reproduced in `bun test packages/coding-agent/test/goals/goal-mode-integration.test.ts`: the added regression tests failed before the fix because the pending input waiter resolved immediately with the objective text.

## Cause
`packages/coding-agent/src/modes/interactive-mode.ts` had `#startGoalFromObjective` and `#replaceGoalFromObjective` unconditionally call `onInputCallback(this.startPendingSubmission({ text: objective }))` after entering goal mode. When the agent was already streaming, `#enterGoalMode`/replacement correctly delivered goal context through `sendGoalModeContext({ deliverAs: "steer" })`, but the extra input callback drove the main loop into `session.prompt()` without a streaming behavior and surfaced `AgentBusyError`.

## Fix
- Gate both objective submission callbacks on `!this.session.isStreaming` so streaming sessions only receive the goal context steer.
- Add goal-mode integration coverage for initial objective creation and active-goal replacement while streaming.
- Add the coding-agent changelog entry for #2454.

## Verification
`bun test packages/coding-agent/test/goals/goal-mode-integration.test.ts` passes: 11 tests, 54 assertions. `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #2454