### PR TITLE
fix(stats): dropped git from profanity list

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Dropped `git` from the profanity list so normal repository mentions no longer count as profanity
+
 ## [15.12.4] - 2026-06-13
 
 ### Fixed

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -38,7 +38,7 @@ let db: Database | null = null;
 
 const BACKFILL_COMPLETE = "complete";
 const BACKFILL_PENDING = "pending";
-const USER_MESSAGES_BACKFILL_KEY = "user_messages_v5";
+const USER_MESSAGES_BACKFILL_KEY = "user_messages_v6";
 const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
 const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 function shouldResetBackfill(value: string | undefined): boolean {
@@ -776,6 +776,8 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
  *   left those metrics matching nothing in real prose.
  * - v5: renamed `yelling_sentences` column to `yelling` to match the other
  *   single-word signal columns (profanity, anguish, negation, ...).
+ * - v6: dropped `git` from the profanity word list - it collided with the
+ *   version-control tool name, so existing rows over-counted profanity.
  *
  * Existing `messages` rows are unaffected - `INSERT OR IGNORE` keeps them.
  */

--- a/packages/stats/src/user-metrics.ts
+++ b/packages/stats/src/user-metrics.ts
@@ -381,7 +381,6 @@ const PROFANITY: readonly string[] = [
 	"jerk",
 	"jerks",
 	"jerkface",
-	"git",
 	"gits",
 	"sod",
 	"sodding",


### PR DESCRIPTION
I was taking a look at stats, realized I hadn't noticed the tabs before, and discovered the behavior page. Pretty funny.

So I wrote a little tool to show messages where I was having tantrums...and whew boy, there are some good ones, but I came across this:

<img width="957" height="394" alt="image" src="https://github.com/user-attachments/assets/e2b00786-7ba4-4242-93e9-aa17becad52c" />

Which confused me...until I realized, "git" is profanity to some. 

But it isn't to us. So I removed it.

(And I know this entire thing's a joke, but this fruit is just hanging too low.)

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
