### PR TITLE
fix(coding-agent): surface prompt templates in slash-command autocomplete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed prompt templates discovered from `cwd/.omp/prompts/` and the agent prompts directory not appearing in the slash-command autocomplete picker. `InteractiveMode.refreshSlashCommandState()` now feeds `session.promptTemplates` into the autocomplete provider alongside builtins and file-based slash commands; templates whose names collide with an existing command are skipped to mirror the runtime expansion order (`expandSlashCommand` precedes `expandPromptTemplate`) ([#2462](https://github.com/can1357/oh-my-pi/issues/2462)).
+
 ## [15.12.4] - 2026-06-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -810,8 +810,24 @@ export class InteractiveMode implements InteractiveModeContext {
 			name: cmd.name,
 			description: cmd.description,
 		}));
+		// Surface discovered prompt templates in the picker. AgentSession.prompt() expands
+		// `expandSlashCommand` before `expandPromptTemplate`, so a file-based slash command
+		// of the same name shadows the template at runtime — mirror that here by skipping
+		// templates whose names already appear in builtins/hooks/custom/skill/file commands.
+		const reservedNames = new Set<string>([
+			...this.#pendingSlashCommands.map(cmd => cmd.name),
+			...fileSlashCommands.map(cmd => cmd.name),
+		]);
+		const promptTemplateCommands: SlashCommand[] = this.session.promptTemplates
+			.filter(template => !reservedNames.has(template.name))
+			.map(template => ({
+				name: template.name,
+				// `PromptTemplate.description` from `loadTemplatesFromDir` already includes the
+				// source suffix (e.g. "Review code (project)"), so pass it through verbatim.
+				description: template.description,
+			}));
 		const autocompleteProvider = this.#inputController.createAutocompleteProvider(
-			[...this.#pendingSlashCommands, ...fileSlashCommands],
+			[...this.#pendingSlashCommands, ...fileSlashCommands, ...promptTemplateCommands],
 			basePath,
 		);
 		this.editor.setAutocompleteProvider(autocompleteProvider);

--- a/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Issue #2462: prompt templates discovered from `cwd/.omp/prompts/` were never
+ * surfaced in the slash-command autocomplete picker. The runtime expansion in
+ * `AgentSession.prompt()` worked, but `InteractiveMode.refreshSlashCommandState`
+ * never passed `session.promptTemplates` into the autocomplete provider.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { PromptTemplate } from "@oh-my-pi/pi-coding-agent/config/prompt-templates";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { AutocompleteProvider } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { z } from "zod/v4";
+
+function makeTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `Fake ${name}`,
+		parameters: z.object({}),
+		async execute() {
+			return { content: [{ type: "text" as const, text: "ok" }] };
+		},
+	};
+}
+
+describe("InteractiveMode prompt-template autocomplete (#2462)", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode | undefined;
+	let session: AgentSession | undefined;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		Bun.gc(true);
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-prompt-template-autocomplete-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		mode = undefined;
+		session = undefined;
+		authStorage = undefined as unknown as AuthStorage;
+		tempDir = undefined as unknown as TempDir;
+		resetSettingsForTest();
+		Bun.gc(true);
+	});
+
+	function modelOrThrow(registry: ModelRegistry, id: string): Model<Api> {
+		const model = registry.find("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	async function createHarness(
+		templates: PromptTemplate[],
+	): Promise<{ mode: InteractiveMode; session: AgentSession }> {
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${Bun.nanoseconds()}.yml`));
+		const model = modelOrThrow(registry, "claude-sonnet-4-5");
+		const tools = [makeTool("read")];
+		const manager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), `active-${Bun.nanoseconds()}`));
+		const created = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools,
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: manager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: registry,
+			toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+			promptTemplates: templates,
+		});
+		const createdMode = new InteractiveMode(created, "test");
+		session = created;
+		mode = createdMode;
+		return { mode: createdMode, session: created };
+	}
+
+	function captureAutocompleteProvider(target: InteractiveMode): { current: AutocompleteProvider | undefined } {
+		const slot: { current: AutocompleteProvider | undefined } = { current: undefined };
+		vi.spyOn(target.editor, "setAutocompleteProvider").mockImplementation(provider => {
+			slot.current = provider;
+		});
+		return slot;
+	}
+
+	async function fetchSlashSuggestions(provider: AutocompleteProvider, query: string): Promise<string[]> {
+		const result = await provider.getSuggestions([query], 0, query.length);
+		if (!result) return [];
+		return result.items.map(item => item.value);
+	}
+
+	it("includes discovered prompt templates in slash-command autocomplete", async () => {
+		const created = await createHarness([
+			{
+				name: "review",
+				description: "Review code for bugs (project)",
+				content: "Please review the following code:\n",
+				source: "(project)",
+			},
+		]);
+		const slot = captureAutocompleteProvider(created.mode);
+
+		await created.mode.refreshSlashCommandState(tempDir.path());
+
+		const provider = slot.current;
+		expect(provider).toBeDefined();
+
+		// Empty `/` shows the full menu.
+		const all = await fetchSlashSuggestions(provider!, "/");
+		expect(all).toContain("review");
+
+		// Fuzzy prefix `/rev` also surfaces the template.
+		const prefixMatches = await fetchSlashSuggestions(provider!, "/rev");
+		expect(prefixMatches).toContain("review");
+	});
+
+	it("does not duplicate templates whose names collide with builtin slash commands", async () => {
+		const created = await createHarness([
+			{
+				name: "exit",
+				description: "Custom exit template (project)",
+				content: "ignored",
+				source: "(project)",
+			},
+		]);
+		const slot = captureAutocompleteProvider(created.mode);
+
+		await created.mode.refreshSlashCommandState(tempDir.path());
+
+		const provider = slot.current;
+		expect(provider).toBeDefined();
+		const matches = await fetchSlashSuggestions(provider!, "/exit");
+		// Builtin `/exit` stays; the colliding template is filtered out so the picker
+		// shows a single entry rather than two `exit` rows.
+		expect(matches.filter(name => name === "exit")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Repro

Create `cwd/.omp/prompts/review.md` (with a frontmatter `description:` if you want), run `omp` in that project, type `/` to open the picker or `/rev` for fuzzy completion. The `review` template never appears, even though `/review<Enter>` still expands and submits the template.

The new regression test `packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts` exercises this end-to-end: it constructs an `InteractiveMode` with a session that carries a `review` prompt template, spies on `editor.setAutocompleteProvider`, calls `refreshSlashCommandState()`, then queries the captured provider with `/` and `/rev`. Pre-fix output:

```
Expected to contain: "review"
Received: ["settings", "setup", "plan", ..., "init"]  // 57 builtins, no templates
```

## Cause

`InteractiveMode.refreshSlashCommandState()` (`packages/coding-agent/src/modes/interactive-mode.ts:805`) builds the autocomplete provider from `#pendingSlashCommands` (builtins + hooks + custom + skill) and `fileSlashCommands` only. `this.session.promptTemplates` — populated by `createAgentSession()` from `cwd/.omp/prompts/` and the agent prompts directory and stored on `AgentSession.#promptTemplates` (`packages/coding-agent/src/session/agent-session.ts:1205`) — is never read by this path. Manual `/review` invocations still work because `AgentSession.prompt()` expands templates via `expandPromptTemplate(...)` at `agent-session.ts:4582`, so the picker was the only blind spot.

## Fix

- `refreshSlashCommandState()` now appends `session.promptTemplates` to the autocomplete command list as a third source after builtins+hooks+custom+skill and file commands.
- Templates whose names collide with any of those existing commands are skipped: at runtime `AgentSession.prompt()` runs `expandSlashCommand` (file commands) before `expandPromptTemplate`, so a same-named slash command always wins — the picker mirrors that precedence and avoids two `/foo` rows.
- `PromptTemplate.description` already carries the `(user)`/`(project)` suffix appended by `loadTemplatesFromDir` (`packages/coding-agent/src/config/prompt-templates.ts:110`), so it is passed through verbatim — no double-decoration.
- New `packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts` covers the discovery contract (`/`, `/rev`) and the dedup contract against the builtin `/exit`.

## Verification

```
$ cd packages/coding-agent
$ bun test test/interactive-mode-prompt-template-autocomplete.test.ts
 2 pass / 0 fail / 5 expect() calls

$ bun test \
    test/interactive-mode-status.test.ts \
    test/interactive-mode-loop.test.ts \
    test/interactive-mode-resume-mode.test.ts \
    test/interactive-mode-editor-component.test.ts \
    test/interactive-mode-prompt-template-autocomplete.test.ts \
    test/prompt-templates.test.ts \
    test/slash-command-format.test.ts \
    test/autocomplete-max-visible.test.ts
 80 pass / 0 fail
```

Manually confirmed the new test fails pre-fix (it cannot find `review` among the 57 builtin completions) and passes after the fix.

Fixes #2462