### PR TITLE
feat(task): inline `role` specialization for spawned subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -117,6 +117,9 @@
 - Fixed read-only collab sessions so prompting, interrupts, and other write actions are blocked with a read-only warning instead of being applied
 - Fixed Mnemopi local embeddings in bundled and compiled installs failing with `Cannot find module '../bin/napi-v3/.../onnxruntime_binding.node'`: the Bun bundle inlined fastembed's loader so its relative native require resolved against `dist/cli.js`. `fastembed`/`onnxruntime-node` are no longer bundled; on first use Mnemopi `bun install`s the pinned pair into `~/.omp/cache/fastembed-runtime/<version-key>` and loads the binding from there ([#2389](https://github.com/can1357/oh-my-pi/issues/2389))
 - Fixed the interactive Model scope startup banner so models without an explicit thinking level do not show `:undefined`, and entries that were scoped without a `:level` are no longer rendered with the global default thinking level (which `applyRootSessionOptions` pre-fills on the cycling array for Ctrl+P) ([#2385](https://github.com/can1357/oh-my-pi/issues/2385)).
+### Added
+
+- Added an optional `role` field to `task` spawns that gives each subagent a tailored specialist identity: the role is injected as a system-prompt specialization preamble and becomes the subagent's display name and telemetry identity in the registry, IRC roster, and Agent Hub, so delegated trees are no longer clones of one generic worker ([#2467](https://github.com/can1357/oh-my-pi/issues/2467))
 
 ## [15.11.8] - 2026-06-12
 

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -438,6 +438,7 @@ export class AgentHubOverlayComponent extends Container {
 	#renderRow(ref: AgentRef, selected: boolean, width: number): string {
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
 		const parts: string[] = [statusBadge(ref.status), theme.bold(replaceTabs(ref.id))];
+		parts.push(theme.fg("dim", replaceTabs(ref.displayName)));
 		parts.push(theme.fg("dim", ref.parentId ? `${ref.kind} · of ${ref.parentId}` : ref.kind));
 		const observed = this.#observableFor(ref.id);
 		const task = observed?.description ?? observed?.progress?.task;

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -3,6 +3,10 @@ ROLE
 
 {{agent}}
 
+{{#if role}}
+You are specializing as: **{{role}}**. Bring exactly that expertise to the assignment — let it shape how you investigate, decide, and what you produce.
+{{/if}}
+
 {{#if context}}
 CONTEXT
 ===================================

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -56,7 +56,9 @@ import {
 	type AgentProgress,
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
+	oneLineLabel,
 	type ReviewFinding,
+	resolveSubagentDisplayName,
 	type SingleResult,
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
@@ -192,6 +194,8 @@ export interface ExecutorOptions {
 	 */
 	planReference?: { path: string; content: string };
 	description?: string;
+	/** Specialist role/expertise for this spawn; drives the system-prompt preamble, display name, and telemetry identity. */
+	role?: string;
 	index: number;
 	id: string;
 	parentToolCallId?: string;
@@ -1618,6 +1622,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		agent.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
 	);
 	const maxRecursionDepth = settings.get("task.maxRecursionDepth") ?? 2;
+	// Tailored specialist identity for this spawn. `subagentRole` is the full
+	// (trimmed) role text fed to the system-prompt preamble; `subagentDisplayName`
+	// is the label-normalized form the registry/roster show, falling back to the
+	// agent type name when no role was given.
+	const subagentRole = options.role?.trim() || undefined;
+	const subagentDisplayName = resolveSubagentDisplayName(options.role, agent.name);
 	const maxRuntimeMs = Math.max(
 		0,
 		Math.trunc(Number(options.maxRuntimeMs ?? settings.get("task.maxRuntimeMs") ?? 0) || 0),
@@ -1816,7 +1826,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// carry the subagent's own agent identity, and use the subagent's
 			// own session id for `gen_ai.conversation.id`.
 			const subagentAgentIdentity: AgentIdentity | undefined = options.parentTelemetry
-				? { id, name: agent.name, description: agent.description }
+				? {
+						id,
+						name: subagentDisplayName,
+						description: subagentRole ? oneLineLabel(subagentRole) : agent.description,
+					}
 				: undefined;
 			const subagentTelemetry: AgentTelemetryConfig | undefined =
 				options.parentTelemetry && subagentAgentIdentity
@@ -1866,6 +1880,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				systemPrompt: defaultPrompt => {
 					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
 						agent: agent.systemPrompt,
+						role: subagentRole ? oneLineLabel(subagentRole) : "",
 						context: options.context?.trim() ?? "",
 						planReference: options.planReference?.content ?? "",
 						planReferencePath: options.planReference?.path ?? "",
@@ -1886,7 +1901,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
 				parentTaskPrefix: id,
 				agentId: id,
-				agentDisplayName: agent.name,
+				agentDisplayName: subagentDisplayName,
 				enableLsp: lspEnabled,
 				skipPythonPreflight,
 				enableMCP,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -310,7 +310,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
 		return params.tasks;
 	}
-	return [{ id: params.id, description: params.description, assignment: params.assignment }];
+	return [{ id: params.id, description: params.description, role: params.role, assignment: params.assignment }];
 }
 
 /**
@@ -324,6 +324,7 @@ function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
 	const spawn: TaskParams = { agent: params.agent };
 	if (item.id !== undefined) spawn.id = item.id;
 	if (item.description !== undefined) spawn.description = item.description;
+	if (item.role !== undefined) spawn.role = item.role;
 	if (item.assignment !== undefined) spawn.assignment = item.assignment;
 	if (params.context !== undefined) spawn.context = params.context;
 	if (item.isolated !== undefined) {
@@ -388,6 +389,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (typeof params.agent === "string") {
 			lines.push(`Agent: ${truncateForPrompt(params.agent)}`);
 		}
+		if (typeof params.role === "string" && params.role.trim()) {
+			lines.push(`Role: ${truncateForPrompt(params.role)}`);
+		}
 		if (typeof params.id === "string" && params.id.trim()) {
 			lines.push(`Task: ${truncateForPrompt(params.id)}`);
 		}
@@ -402,6 +406,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (firstTask) {
 			if (typeof firstTask.id === "string" && firstTask.id.trim()) {
 				lines.push(`Task: ${truncateForPrompt(firstTask.id)}`);
+			}
+			if (typeof firstTask.role === "string" && firstTask.role.trim()) {
+				lines.push(`Role: ${truncateForPrompt(firstTask.role)}`);
 			}
 			if (typeof firstTask.assignment === "string") {
 				lines.push(`Assignment:\n${truncateForPrompt(firstTask.assignment)}`);
@@ -1146,6 +1153,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				context: sharedContext,
 				planReference,
 				description: params.description,
+				role: params.role,
 				index: spawnIndex,
 				parentToolCallId: toolCallId,
 				detached,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -74,6 +74,11 @@ export interface SubagentLifecyclePayload {
 	detached?: boolean;
 }
 
+/** Display cap for a normalized one-line label (roster line, registry `displayName`, prompt field). */
+export const ROLE_LABEL_MAX = 80;
+/** Schema bound on the raw `role` input, before it is label-normalized at every use site. */
+export const ROLE_INPUT_MAX = 256;
+
 /**
  * One unit of work. The single-spawn schema is `{ agent, ...taskItemSchema }`;
  * the batch schema (`task.batch`) is `{ agent, context, tasks: taskItemSchema[] }`.
@@ -83,6 +88,13 @@ export interface SubagentLifecyclePayload {
 const taskItemShape = {
 	id: z.string().max(48).optional().describe("stable agent id; default generated"),
 	description: z.string().optional().describe("ui label, not seen by subagent"),
+	role: z
+		.string()
+		.max(ROLE_INPUT_MAX)
+		.optional()
+		.describe(
+			"specialist role/expertise this subagent embodies (e.g. 'Rust async-runtime specialist'); shapes its identity and display name",
+		),
 	assignment: z.string().describe("the work; self-contained instructions"),
 };
 const isolatedShape = {
@@ -104,6 +116,8 @@ export interface TaskItem {
 	id?: string;
 	/** UI label, not seen by the subagent. */
 	description?: string;
+	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */
+	role?: string;
 	/** The work; required by the schema. */
 	assignment?: string;
 	/** Run this spawn in an isolated worktree (batch form; flat form carries it top-level). */
@@ -149,6 +163,8 @@ export interface TaskParams {
 	id?: string;
 	/** UI label (flat form), not seen by the subagent. */
 	description?: string;
+	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */
+	role?: string;
 	/** The work (flat form). */
 	assignment?: string;
 	/** Batch form (`task.batch`): one subagent per item. */
@@ -157,6 +173,34 @@ export interface TaskParams {
 	context?: string;
 	/** Run in an isolated worktree (flat form; per-item in batch form). */
 	isolated?: boolean;
+}
+
+/**
+ * One-line, length-capped label safe for a single roster line, a registry
+ * `displayName`, or a system-prompt field. Collapses every run of whitespace
+ * AND control/format characters — including U+0085 NEL, ESC/ANSI, and the
+ * zero-width separators that `\s` misses — to a single space, then caps length.
+ * So untrusted text (a spawn `role`, a peer activity gist) can neither break the
+ * line, inject prompt structure, nor smuggle terminal escapes. Caps at `max`
+ * characters (clamped to >= 1; default `ROLE_LABEL_MAX`), appending an ellipsis when truncated.
+ */
+export function oneLineLabel(text: string, max = ROLE_LABEL_MAX): string {
+	const oneLine = text.replace(/[\p{Cc}\p{Cf}\s]+/gu, " ").trim();
+	const cap = Math.max(1, max);
+	// Count/cut by code point, not UTF-16 code unit, so truncation can never
+	// split an astral character into a lone surrogate.
+	const chars = [...oneLine];
+	return chars.length > cap ? `${chars.slice(0, cap - 1).join("")}…` : oneLine;
+}
+
+/**
+ * Display name for a spawned subagent: its tailored `role` (label-normalized)
+ * when one is given, else the agent type's name. Empty/whitespace roles fall
+ * back to the agent name.
+ */
+export function resolveSubagentDisplayName(role: string | undefined, agentName: string): string {
+	const trimmed = role?.trim();
+	return trimmed ? oneLineLabel(trimmed) : agentName;
 }
 
 /** A code review finding reported by the reviewer agent */

--- a/packages/coding-agent/test/task/role-specialization.test.ts
+++ b/packages/coding-agent/test/task/role-specialization.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TaskTool, taskSchema } from "@oh-my-pi/pi-coding-agent/task";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import {
+	getTaskSchema,
+	oneLineLabel,
+	ROLE_INPUT_MAX,
+	resolveSubagentDisplayName,
+} from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { prompt } from "@oh-my-pi/pi-utils";
+import subagentSystemPromptTemplate from "../../src/prompts/system/subagent-system-prompt.md" with { type: "text" };
+
+// Contract: a per-spawn `role` gives a subagent a tailored identity. The role
+// becomes its registry/roster display name and is injected as a system-prompt
+// specialization preamble; an absent/blank role falls back to the agent type.
+
+describe("resolveSubagentDisplayName", () => {
+	it("uses the role as the display name when one is given", () => {
+		expect(resolveSubagentDisplayName("Rust async-runtime specialist", "task")).toBe("Rust async-runtime specialist");
+	});
+
+	it("falls back to the agent name for an absent role", () => {
+		expect(resolveSubagentDisplayName(undefined, "task")).toBe("task");
+	});
+
+	it("falls back to the agent name for an empty or whitespace role", () => {
+		expect(resolveSubagentDisplayName("", "explore")).toBe("explore");
+		expect(resolveSubagentDisplayName("   \n\t ", "explore")).toBe("explore");
+	});
+
+	it("collapses internal whitespace so a multi-line role stays one roster line", () => {
+		expect(resolveSubagentDisplayName("Auth\n  flow   reviewer", "task")).toBe("Auth flow reviewer");
+	});
+
+	it("caps an overlong role label with an ellipsis", () => {
+		const long = "x".repeat(200);
+		const label = resolveSubagentDisplayName(long, "task");
+		expect(label.length).toBe(80);
+		expect(label.endsWith("…")).toBe(true);
+	});
+});
+
+describe("oneLineLabel", () => {
+	it("returns short text unchanged", () => {
+		expect(oneLineLabel("DB migration specialist")).toBe("DB migration specialist");
+	});
+
+	it("collapses control and zero-width characters that \\s alone misses", () => {
+		// U+0085 (NEL) and U+200B (zero-width space) are NOT matched by \s, so a
+		// bare replace(/\s+/) would leak them into a prompt/roster field.
+		const out = oneLineLabel("Auth\u0085flow\u200breviewer");
+		expect(out).toBe("Auth flow reviewer");
+		expect(out).not.toMatch(/[\p{Cc}\p{Cf}]/u);
+	});
+
+	it("respects a minimal cap without a negative-slice blowup", () => {
+		expect(oneLineLabel("abcdef", 1)).toBe("…");
+		expect(oneLineLabel("abcdef", 0)).toBe("…");
+	});
+
+	it("truncates on a code-point boundary without splitting a surrogate pair", () => {
+		// The cut would land mid-emoji at the default cap; the result must stay
+		// well-formed (a lone surrogate makes encodeURIComponent throw).
+		const out = oneLineLabel(`${"a".repeat(78)}😀tail`);
+		expect(out.endsWith("…")).toBe(true);
+		expect(() => encodeURIComponent(out)).not.toThrow();
+	});
+});
+
+describe("subagent system prompt role preamble", () => {
+	function render(role: string): string {
+		return prompt.render(subagentSystemPromptTemplate, { agent: "Base worker body.", role });
+	}
+
+	it("injects the specialization preamble when a role is provided", () => {
+		const out = render("Rust async-runtime specialist");
+		expect(out).toContain("specializing as: **Rust async-runtime specialist**");
+	});
+
+	it("omits the preamble entirely when the role is blank", () => {
+		expect(render("")).not.toContain("specializing as");
+	});
+});
+
+describe("task schema accepts role", () => {
+	it("keeps role on the flat single-spawn shape", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "Rust specialist" });
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.role).toBe("Rust specialist");
+		}
+	});
+
+	it("keeps role on batch task items", () => {
+		const batch = getTaskSchema({ isolationEnabled: false, batchEnabled: true });
+		const parsed = batch.safeParse({
+			agent: "task",
+			context: "ctx",
+			tasks: [{ assignment: "x", role: "DB migration specialist" }],
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success && "tasks" in parsed.data) {
+			const tasks = parsed.data.tasks as Array<{ role?: string }>;
+			expect(tasks[0]?.role).toBe("DB migration specialist");
+		}
+	});
+
+	it("rejects a role longer than the schema bound", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "x".repeat(ROLE_INPUT_MAX + 1) });
+		expect(parsed.success).toBe(false);
+	});
+
+	it("accepts a role at the schema bound", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "x".repeat(ROLE_INPUT_MAX) });
+		expect(parsed.success).toBe(true);
+	});
+});
+
+// Contract: a role shapes the spawned subagent's system prompt and identity, so
+// an approval-gated session must surface it before the user authorizes the spawn.
+describe("task approval details surface role", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	async function makeTool(): Promise<TaskTool> {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [], projectAgentsDir: null });
+		return TaskTool.create({
+			cwd: "/tmp",
+			hasUI: false,
+			settings: Settings.isolated({ "task.isolation.mode": "none", "task.batch": false }),
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+		} as unknown as ToolSession);
+	}
+
+	it("includes the role line for a flat spawn", async () => {
+		const tool = await makeTool();
+		const lines = tool.formatApprovalDetails({ agent: "task", role: "Security reviewer", assignment: "x" });
+		expect(lines).toContain("Role: Security reviewer");
+	});
+
+	it("includes the role line for the first batch task", async () => {
+		const tool = await makeTool();
+		const lines = tool.formatApprovalDetails({
+			agent: "task",
+			tasks: [{ role: "DB migration specialist", assignment: "x" }],
+		});
+		expect(lines).toContain("Role: DB migration specialist");
+	});
+});


### PR DESCRIPTION
**Part 1 of 5 — subagent tailoring overhaul.** Stack foundation; bases directly on `main`, so this PR's diff is exactly its one commit.

Adds an optional `role` field to `task` spawns, threaded end-to-end so each spawn gets a bespoke specialist identity — no new agent files.

- `role?: string` on `taskItemShape`/`TaskItem`/`TaskParams`, threaded via `resolveSpawnItems`/`spawnParamsFor` into `ExecutorOptions`.
- Injects a `{{#if role}}` specialization preamble into the subagent system prompt; sets the subagent `displayName` + telemetry identity via `resolveSubagentDisplayName`/`subagentRoleLabel`. Empty/whitespace role → falls back to the agent type name.
- Renders the role-derived `displayName` in the Agent Hub row so specialists are legible there too.

Tests: display-name resolution (role wins, blank → agent name, whitespace-collapse, length cap), the prompt preamble (present with role, absent without), and the wire schema accepting `role` on both the flat and batch shapes.

Verification: `tsgo --noEmit` clean; scoped `bun test` green.

Closes #2467
