### PR TITLE
feat(task): nudge generic spawns toward specialization

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,6 +120,7 @@
 ### Added
 
 - Added an optional `role` field to `task` spawns that gives each subagent a tailored specialist identity: the role is injected as a system-prompt specialization preamble and becomes the subagent's display name and telemetry identity in the registry, IRC roster, and Agent Hub, so delegated trees are no longer clones of one generic worker ([#2467](https://github.com/can1357/oh-my-pi/issues/2467))
+- Added a non-blocking specialization advisory to the `task` tool: when a spawner with remaining depth capacity spawns generic role-less workers (a `task`/`quick_task` spawn without a `role`, or the same agent cloned ≥2× all without roles), the result steers it toward tailored specialists. Gated so a leaf at max recursion depth is never nudged; the task-tool depth gate is extracted into a shared `canSpawnAtDepth` helper ([#2469](https://github.com/can1357/oh-my-pi/issues/2469))
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -117,6 +117,9 @@
 - Fixed read-only collab sessions so prompting, interrupts, and other write actions are blocked with a read-only warning instead of being applied
 - Fixed Mnemopi local embeddings in bundled and compiled installs failing with `Cannot find module '../bin/napi-v3/.../onnxruntime_binding.node'`: the Bun bundle inlined fastembed's loader so its relative native require resolved against `dist/cli.js`. `fastembed`/`onnxruntime-node` are no longer bundled; on first use Mnemopi `bun install`s the pinned pair into `~/.omp/cache/fastembed-runtime/<version-key>` and loads the binding from there ([#2389](https://github.com/can1357/oh-my-pi/issues/2389))
 - Fixed the interactive Model scope startup banner so models without an explicit thinking level do not show `:undefined`, and entries that were scoped without a `:level` are no longer rendered with the global default thinking level (which `applyRootSessionOptions` pre-fills on the cycling array for Ctrl+P) ([#2385](https://github.com/can1357/oh-my-pi/issues/2385)).
+### Added
+
+- Added an optional `role` field to `task` spawns that gives each subagent a tailored specialist identity: the role is injected as a system-prompt specialization preamble and becomes the subagent's display name and telemetry identity in the registry, IRC roster, and Agent Hub, so delegated trees are no longer clones of one generic worker ([#2467](https://github.com/can1357/oh-my-pi/issues/2467))
 
 ## [15.11.8] - 2026-06-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -121,6 +121,10 @@
 
 - Added an optional `role` field to `task` spawns that gives each subagent a tailored specialist identity: the role is injected as a system-prompt specialization preamble and becomes the subagent's display name and telemetry identity in the registry, IRC roster, and Agent Hub, so delegated trees are no longer clones of one generic worker ([#2467](https://github.com/can1357/oh-my-pi/issues/2467))
 
+### Changed
+
+- Documented the `role` task parameter in the task-tool description (both the batch and single-spawn shapes) and made tailored specialists the default delegation guidance, so the model gives each spawn a specialist identity instead of cloning generic workers ([#2468](https://github.com/can1357/oh-my-pi/issues/2468))
+
 ## [15.11.8] - 2026-06-12
 
 ### Added

--- a/packages/coding-agent/src/commit/agentic/tools/analyze-file.ts
+++ b/packages/coding-agent/src/commit/agentic/tools/analyze-file.ts
@@ -38,6 +38,9 @@ function buildToolSession(
 	return {
 		cwd: options.cwd,
 		hasUI: false,
+		// Programmatic fan-out: results feed the commit agent's evidence, not a
+		// model choosing further spawns, so the specialization nudge is noise here.
+		suppressSpawnAdvisory: true,
 		getSessionFile: () => ctx.sessionManager.getSessionFile() ?? null,
 		getSessionSpawns: () => options.spawns,
 		settings: options.settings,

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -438,6 +438,7 @@ export class AgentHubOverlayComponent extends Container {
 	#renderRow(ref: AgentRef, selected: boolean, width: number): string {
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
 		const parts: string[] = [statusBadge(ref.status), theme.bold(replaceTabs(ref.id))];
+		parts.push(theme.fg("dim", replaceTabs(ref.displayName)));
 		parts.push(theme.fg("dim", ref.parentId ? `${ref.kind} · of ${ref.parentId}` : ref.kind));
 		const observed = this.#observableFor(ref.id);
 		const task = observed?.description ?? observed?.progress?.task;

--- a/packages/coding-agent/src/prompts/agents/task.md
+++ b/packages/coding-agent/src/prompts/agents/task.md
@@ -13,4 +13,5 @@ You MUST maintain hyperfocus on the assigned task. NEVER deviate from it.
 - You SHOULD prefer edits to existing files over creating new ones.
 - You NEVER create documentation files (*.md) unless explicitly requested.
 - You MUST follow the assignment and the instructions given to you. They were given for a reason.
+- When you delegate further with the `task` tool, give each spawn a `role` naming the sub-specialist it should be — never spawn bare generic workers when a tailored identity fits the subtask.
 </directives>

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -3,6 +3,10 @@ ROLE
 
 {{agent}}
 
+{{#if role}}
+You are specializing as: **{{role}}**. Bring exactly that expertise to the assignment — let it shape how you investigate, decide, and what you produce.
+{{/if}}
+
 {{#if context}}
 CONTEXT
 ===================================

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,12 +25,14 @@
   - `assignment`: complete self-contained instructions; one-liners and missing acceptance criteria are PROHIBITED
   - `id`: stable agent id, CamelCase, ≤32 chars; generated when omitted
   - `description`: UI label only — subagent never sees it
+  - `role`: specialist identity this subagent embodies (e.g. "Auth-flow security reviewer") — sets its system-prompt persona and roster display name; tailor every spawn rather than cloning a generic worker
 {{#if isolationEnabled}}
   - `isolated`: run this spawn in an isolated env; returns patches. Isolated agents are torn down at completion — not addressable afterwards
 {{/if}}
 {{else}}
 - `id`: stable agent id, CamelCase, ≤32 chars; generated when omitted
 - `description`: UI label only — subagent never sees it
+- `role`: specialist identity this subagent embodies (e.g. "Auth-flow security reviewer") — sets its system-prompt persona and roster display name; tailor every spawn rather than cloning a generic worker
 - `assignment`: complete self-contained instructions; one-liners and missing acceptance criteria are PROHIBITED
 {{#if isolationEnabled}}
 - `isolated`: run in isolated env; returns patches. Isolated agents are torn down at completion — not addressable afterwards
@@ -42,6 +44,7 @@
 - **Maximize fan-out.** Issue the widest {{#if batchEnabled}}`tasks[]` batch{{else}}set of parallel `task` calls{{/if}} the work decomposes into. NEVER serialize work that could run concurrently.
 - **Subagents do not verify, lint, or format.** Every assignment MUST instruct the subagent to skip all gates, formatters, and project-wide build/test/lint. You run them once at the end across the union of changed files.
 - No globs, no "update all", no package-wide scope. Fan out.
+- **Tailor every spawn with a `role`.** A role naming the specialist (e.g. "Parser edge-case tester", "SSE backpressure specialist") makes a sharper agent than a bare generic `task`/`quick_task` worker; decompose into named specialists, never clones of one generic worker. A role-less generic spawn is the exception.
 - NEVER slow down or serialize because tasks might overlap on some files. Agents resolve collisions among themselves in real time.
 - Subagents have no conversation history. Every fact, file path, and direction they need MUST be explicit in {{#if batchEnabled}}`context` or the item's `assignment`{{else}}the `assignment`{{/if}}.
 {{#if batchEnabled}}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -56,7 +56,9 @@ import {
 	type AgentProgress,
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
+	oneLineLabel,
 	type ReviewFinding,
+	resolveSubagentDisplayName,
 	type SingleResult,
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
@@ -192,6 +194,8 @@ export interface ExecutorOptions {
 	 */
 	planReference?: { path: string; content: string };
 	description?: string;
+	/** Specialist role/expertise for this spawn; drives the system-prompt preamble, display name, and telemetry identity. */
+	role?: string;
 	index: number;
 	id: string;
 	parentToolCallId?: string;
@@ -1618,6 +1622,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		agent.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
 	);
 	const maxRecursionDepth = settings.get("task.maxRecursionDepth") ?? 2;
+	// Tailored specialist identity for this spawn. `subagentRole` is the full
+	// (trimmed) role text fed to the system-prompt preamble; `subagentDisplayName`
+	// is the label-normalized form the registry/roster show, falling back to the
+	// agent type name when no role was given.
+	const subagentRole = options.role?.trim() || undefined;
+	const subagentDisplayName = resolveSubagentDisplayName(options.role, agent.name);
 	const maxRuntimeMs = Math.max(
 		0,
 		Math.trunc(Number(options.maxRuntimeMs ?? settings.get("task.maxRuntimeMs") ?? 0) || 0),
@@ -1816,7 +1826,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// carry the subagent's own agent identity, and use the subagent's
 			// own session id for `gen_ai.conversation.id`.
 			const subagentAgentIdentity: AgentIdentity | undefined = options.parentTelemetry
-				? { id, name: agent.name, description: agent.description }
+				? {
+						id,
+						name: subagentDisplayName,
+						description: subagentRole ? oneLineLabel(subagentRole) : agent.description,
+					}
 				: undefined;
 			const subagentTelemetry: AgentTelemetryConfig | undefined =
 				options.parentTelemetry && subagentAgentIdentity
@@ -1866,6 +1880,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				systemPrompt: defaultPrompt => {
 					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
 						agent: agent.systemPrompt,
+						role: subagentRole ? oneLineLabel(subagentRole) : "",
 						context: options.context?.trim() ?? "",
 						planReference: options.planReference?.content ?? "",
 						planReferencePath: options.planReference?.path ?? "",
@@ -1886,7 +1901,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
 				parentTaskPrefix: id,
 				agentId: id,
-				agentDisplayName: agent.name,
+				agentDisplayName: subagentDisplayName,
 				enableLsp: lspEnabled,
 				skipPythonPreflight,
 				enableMCP,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -33,6 +33,7 @@ import { formatBytes, formatDuration } from "../tools/render-utils";
 import {
 	type AgentDefinition,
 	type AgentProgress,
+	canSpawnAtDepth,
 	getTaskSchema,
 	type SingleResult,
 	type TaskItem,
@@ -335,6 +336,36 @@ function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
 	return spawn;
 }
 
+/** Generic worker agents whose output sharpens with a tailored `role` rather than the bare type. */
+const GENERIC_SPAWN_AGENTS: ReadonlySet<string> = new Set(["task", "quick_task"]);
+
+/**
+ * Advisory — never a rejection — nudging the spawner toward tailored
+ * specialists when it spawns generic role-less workers and still holds spawn
+ * capacity (DepthCapacity: it currently has the `task` tool). Fires when a
+ * generic `task`/`quick_task` spawn carries no `role`, or when one call clones
+ * the same agent ≥2× all without roles. Returns undefined when no nudge applies.
+ */
+export function buildSpecializationAdvisory(
+	agentName: string | undefined,
+	items: TaskItem[],
+	depthCapacity: boolean,
+): string | undefined {
+	if (!depthCapacity) return undefined;
+	const rolelessCount = items.filter(item => !item.role?.trim()).length;
+	if (rolelessCount === 0) return undefined;
+	const generic = agentName !== undefined && GENERIC_SPAWN_AGENTS.has(agentName);
+	const cloned = items.length >= 2 && rolelessCount === items.length;
+	if (!generic && !cloned) return undefined;
+	const label = agentName ?? "task";
+	return (
+		`Tip: spawned ${rolelessCount} \`${label}\` worker${rolelessCount === 1 ? "" : "s"} without a \`role\`. ` +
+		`Tailored specialists outperform generic workers — give each spawn a \`role\` naming its expertise ` +
+		`(e.g. "Auth-flow security reviewer"). Depth budget remains, so decompose into named specialists ` +
+		`rather than cloning one generic worker.`
+	);
+}
+
 /** Sentinel for async jobs whose subagent finished with a failing result; progress is already updated. */
 class TaskJobError extends Error {}
 
@@ -504,6 +535,21 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const selectedAgent = this.#discoveredAgents.find(agent => agent.name === params.agent);
 		const asyncEnabled = this.session.settings.get("async.enabled");
 		const manager = asyncEnabled ? this.session.asyncJobManager : undefined;
+		const depthCapacity = canSpawnAtDepth(
+			this.session.settings.get("task.maxRecursionDepth") ?? 2,
+			this.session.taskDepth ?? 0,
+		);
+		const advisory = buildSpecializationAdvisory(params.agent, spawnItems, depthCapacity);
+		const withAdvisory = (result: AgentToolResult<TaskToolDetails>): AgentToolResult<TaskToolDetails> => {
+			if (!advisory) return result;
+			const textPart = result.content.find(part => part.type === "text");
+			if (textPart && typeof textPart.text === "string") {
+				textPart.text = `${textPart.text}\n\n${advisory}`;
+			} else {
+				result.content.push({ type: "text", text: advisory });
+			}
+			return result;
+		};
 		if (!asyncEnabled || !manager || selectedAgent?.blocking === true) {
 			// Sync fallback: async execution disabled, orphaned host that never
 			// wired a job manager, or an agent definition that declares
@@ -512,7 +558,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (asyncEnabled && !manager) {
 				logger.warn("task: no AsyncJobManager registered; falling back to sync execution");
 			}
-			return this.#executeSyncFanout(toolCallId, params, spawnItems, signal, onUpdate);
+			return withAdvisory(await this.#executeSyncFanout(toolCallId, params, spawnItems, signal, onUpdate));
 		}
 
 		// Resolve agent ids up front so the immediate result can name them.
@@ -620,7 +666,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				content: [{ type: "text", text: `Spawned agent \`${agentId}\`...` }],
 				details: buildAsyncDetails("running", jobId),
 			});
-			return {
+			return withAdvisory({
 				content: [
 					{
 						type: "text",
@@ -628,7 +674,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					},
 				],
 				details: buildAsyncDetails("running", jobId),
-			};
+			});
 		}
 
 		const coordinationHint = ircEnabled
@@ -648,7 +694,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			content: [{ type: "text", text: `Spawned ${started.length} agents...` }],
 			details: buildAsyncDetails("running", primaryJobId),
 		});
-		return {
+		return withAdvisory({
 			content: [
 				{
 					type: "text",
@@ -656,7 +702,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				},
 			],
 			details: buildAsyncDetails("running", primaryJobId),
-		};
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -310,7 +310,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
 		return params.tasks;
 	}
-	return [{ id: params.id, description: params.description, assignment: params.assignment }];
+	return [{ id: params.id, description: params.description, role: params.role, assignment: params.assignment }];
 }
 
 /**
@@ -324,6 +324,7 @@ function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
 	const spawn: TaskParams = { agent: params.agent };
 	if (item.id !== undefined) spawn.id = item.id;
 	if (item.description !== undefined) spawn.description = item.description;
+	if (item.role !== undefined) spawn.role = item.role;
 	if (item.assignment !== undefined) spawn.assignment = item.assignment;
 	if (params.context !== undefined) spawn.context = params.context;
 	if (item.isolated !== undefined) {
@@ -388,6 +389,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (typeof params.agent === "string") {
 			lines.push(`Agent: ${truncateForPrompt(params.agent)}`);
 		}
+		if (typeof params.role === "string" && params.role.trim()) {
+			lines.push(`Role: ${truncateForPrompt(params.role)}`);
+		}
 		if (typeof params.id === "string" && params.id.trim()) {
 			lines.push(`Task: ${truncateForPrompt(params.id)}`);
 		}
@@ -402,6 +406,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (firstTask) {
 			if (typeof firstTask.id === "string" && firstTask.id.trim()) {
 				lines.push(`Task: ${truncateForPrompt(firstTask.id)}`);
+			}
+			if (typeof firstTask.role === "string" && firstTask.role.trim()) {
+				lines.push(`Role: ${truncateForPrompt(firstTask.role)}`);
 			}
 			if (typeof firstTask.assignment === "string") {
 				lines.push(`Assignment:\n${truncateForPrompt(firstTask.assignment)}`);
@@ -1146,6 +1153,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				context: sharedContext,
 				planReference,
 				description: params.description,
+				role: params.role,
 				index: spawnIndex,
 				parentToolCallId: toolCallId,
 				detached,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -203,6 +203,15 @@ export function resolveSubagentDisplayName(role: string | undefined, agentName: 
 	return trimmed ? oneLineLabel(trimmed) : agentName;
 }
 
+/**
+ * Whether an agent at `taskDepth` may still spawn children — i.e. it currently
+ * holds the `task` tool. Mirrors the task-tool availability gate;
+ * `maxRecursionDepth < 0` disables the cap entirely.
+ */
+export function canSpawnAtDepth(maxRecursionDepth: number, taskDepth: number): boolean {
+	return maxRecursionDepth < 0 || taskDepth < maxRecursionDepth;
+}
+
 /** A code review finding reported by the reviewer agent */
 export interface ReviewFinding {
 	title: string;

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -74,6 +74,11 @@ export interface SubagentLifecyclePayload {
 	detached?: boolean;
 }
 
+/** Display cap for a normalized one-line label (roster line, registry `displayName`, prompt field). */
+export const ROLE_LABEL_MAX = 80;
+/** Schema bound on the raw `role` input, before it is label-normalized at every use site. */
+export const ROLE_INPUT_MAX = 256;
+
 /**
  * One unit of work. The single-spawn schema is `{ agent, ...taskItemSchema }`;
  * the batch schema (`task.batch`) is `{ agent, context, tasks: taskItemSchema[] }`.
@@ -83,6 +88,13 @@ export interface SubagentLifecyclePayload {
 const taskItemShape = {
 	id: z.string().max(48).optional().describe("stable agent id; default generated"),
 	description: z.string().optional().describe("ui label, not seen by subagent"),
+	role: z
+		.string()
+		.max(ROLE_INPUT_MAX)
+		.optional()
+		.describe(
+			"specialist role/expertise this subagent embodies (e.g. 'Rust async-runtime specialist'); shapes its identity and display name",
+		),
 	assignment: z.string().describe("the work; self-contained instructions"),
 };
 const isolatedShape = {
@@ -104,6 +116,8 @@ export interface TaskItem {
 	id?: string;
 	/** UI label, not seen by the subagent. */
 	description?: string;
+	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */
+	role?: string;
 	/** The work; required by the schema. */
 	assignment?: string;
 	/** Run this spawn in an isolated worktree (batch form; flat form carries it top-level). */
@@ -149,6 +163,8 @@ export interface TaskParams {
 	id?: string;
 	/** UI label (flat form), not seen by the subagent. */
 	description?: string;
+	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */
+	role?: string;
 	/** The work (flat form). */
 	assignment?: string;
 	/** Batch form (`task.batch`): one subagent per item. */
@@ -157,6 +173,34 @@ export interface TaskParams {
 	context?: string;
 	/** Run in an isolated worktree (flat form; per-item in batch form). */
 	isolated?: boolean;
+}
+
+/**
+ * One-line, length-capped label safe for a single roster line, a registry
+ * `displayName`, or a system-prompt field. Collapses every run of whitespace
+ * AND control/format characters — including U+0085 NEL, ESC/ANSI, and the
+ * zero-width separators that `\s` misses — to a single space, then caps length.
+ * So untrusted text (a spawn `role`, a peer activity gist) can neither break the
+ * line, inject prompt structure, nor smuggle terminal escapes. Caps at `max`
+ * characters (clamped to >= 1; default `ROLE_LABEL_MAX`), appending an ellipsis when truncated.
+ */
+export function oneLineLabel(text: string, max = ROLE_LABEL_MAX): string {
+	const oneLine = text.replace(/[\p{Cc}\p{Cf}\s]+/gu, " ").trim();
+	const cap = Math.max(1, max);
+	// Count/cut by code point, not UTF-16 code unit, so truncation can never
+	// split an astral character into a lone surrogate.
+	const chars = [...oneLine];
+	return chars.length > cap ? `${chars.slice(0, cap - 1).join("")}…` : oneLine;
+}
+
+/**
+ * Display name for a spawned subagent: its tailored `role` (label-normalized)
+ * when one is given, else the agent type's name. Empty/whitespace roles fall
+ * back to the agent name.
+ */
+export function resolveSubagentDisplayName(role: string | undefined, agentName: string): string {
+	const trimmed = role?.trim();
+	return trimmed ? oneLineLabel(trimmed) : agentName;
 }
 
 /** A code review finding reported by the reviewer agent */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -25,6 +25,7 @@ import type { CustomMessage } from "../session/messages";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
+import { canSpawnAtDepth } from "../task/types";
 import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "../tool-discovery/mode";
 import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../tool-discovery/tool-index";
 import type { EventBus } from "../utils/event-bus";
@@ -144,6 +145,13 @@ export interface ToolSession {
 	cwd: string;
 	/** Whether UI is available */
 	hasUI: boolean;
+	/**
+	 * Suppress the spawn specialization/coordination advisory appended to `task`
+	 * results. Set by internal/programmatic callers (e.g. the commit agent's
+	 * file-analysis fan-out) whose results are consumed by code — not by a model
+	 * orchestrating further spawns — so the nudge would only be noise.
+	 */
+	suppressSpawnAdvisory?: boolean;
 	/** Optional fetch implementation injected into the URL read pipeline (tests, proxies). Defaults to global fetch. */
 	fetch?: FetchImpl;
 	/** Skip Python kernel availability check and warmup */
@@ -544,9 +552,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			return ["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "");
 		}
 		if (name === "task") {
-			const maxDepth = session.settings.get("task.maxRecursionDepth") ?? 2;
-			const currentDepth = session.taskDepth ?? 0;
-			return maxDepth < 0 || currentDepth < maxDepth;
+			return canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0);
 		}
 		return true;
 	};

--- a/packages/coding-agent/test/task/role-specialization.test.ts
+++ b/packages/coding-agent/test/task/role-specialization.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TaskTool, taskSchema } from "@oh-my-pi/pi-coding-agent/task";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import {
+	getTaskSchema,
+	oneLineLabel,
+	ROLE_INPUT_MAX,
+	resolveSubagentDisplayName,
+} from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { prompt } from "@oh-my-pi/pi-utils";
+import subagentSystemPromptTemplate from "../../src/prompts/system/subagent-system-prompt.md" with { type: "text" };
+
+// Contract: a per-spawn `role` gives a subagent a tailored identity. The role
+// becomes its registry/roster display name and is injected as a system-prompt
+// specialization preamble; an absent/blank role falls back to the agent type.
+
+describe("resolveSubagentDisplayName", () => {
+	it("uses the role as the display name when one is given", () => {
+		expect(resolveSubagentDisplayName("Rust async-runtime specialist", "task")).toBe("Rust async-runtime specialist");
+	});
+
+	it("falls back to the agent name for an absent role", () => {
+		expect(resolveSubagentDisplayName(undefined, "task")).toBe("task");
+	});
+
+	it("falls back to the agent name for an empty or whitespace role", () => {
+		expect(resolveSubagentDisplayName("", "explore")).toBe("explore");
+		expect(resolveSubagentDisplayName("   \n\t ", "explore")).toBe("explore");
+	});
+
+	it("collapses internal whitespace so a multi-line role stays one roster line", () => {
+		expect(resolveSubagentDisplayName("Auth\n  flow   reviewer", "task")).toBe("Auth flow reviewer");
+	});
+
+	it("caps an overlong role label with an ellipsis", () => {
+		const long = "x".repeat(200);
+		const label = resolveSubagentDisplayName(long, "task");
+		expect(label.length).toBe(80);
+		expect(label.endsWith("…")).toBe(true);
+	});
+});
+
+describe("oneLineLabel", () => {
+	it("returns short text unchanged", () => {
+		expect(oneLineLabel("DB migration specialist")).toBe("DB migration specialist");
+	});
+
+	it("collapses control and zero-width characters that \\s alone misses", () => {
+		// U+0085 (NEL) and U+200B (zero-width space) are NOT matched by \s, so a
+		// bare replace(/\s+/) would leak them into a prompt/roster field.
+		const out = oneLineLabel("Auth\u0085flow\u200breviewer");
+		expect(out).toBe("Auth flow reviewer");
+		expect(out).not.toMatch(/[\p{Cc}\p{Cf}]/u);
+	});
+
+	it("respects a minimal cap without a negative-slice blowup", () => {
+		expect(oneLineLabel("abcdef", 1)).toBe("…");
+		expect(oneLineLabel("abcdef", 0)).toBe("…");
+	});
+
+	it("truncates on a code-point boundary without splitting a surrogate pair", () => {
+		// The cut would land mid-emoji at the default cap; the result must stay
+		// well-formed (a lone surrogate makes encodeURIComponent throw).
+		const out = oneLineLabel(`${"a".repeat(78)}😀tail`);
+		expect(out.endsWith("…")).toBe(true);
+		expect(() => encodeURIComponent(out)).not.toThrow();
+	});
+});
+
+describe("subagent system prompt role preamble", () => {
+	function render(role: string): string {
+		return prompt.render(subagentSystemPromptTemplate, { agent: "Base worker body.", role });
+	}
+
+	it("injects the specialization preamble when a role is provided", () => {
+		const out = render("Rust async-runtime specialist");
+		expect(out).toContain("specializing as: **Rust async-runtime specialist**");
+	});
+
+	it("omits the preamble entirely when the role is blank", () => {
+		expect(render("")).not.toContain("specializing as");
+	});
+});
+
+describe("task schema accepts role", () => {
+	it("keeps role on the flat single-spawn shape", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "Rust specialist" });
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.role).toBe("Rust specialist");
+		}
+	});
+
+	it("keeps role on batch task items", () => {
+		const batch = getTaskSchema({ isolationEnabled: false, batchEnabled: true });
+		const parsed = batch.safeParse({
+			agent: "task",
+			context: "ctx",
+			tasks: [{ assignment: "x", role: "DB migration specialist" }],
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success && "tasks" in parsed.data) {
+			const tasks = parsed.data.tasks as Array<{ role?: string }>;
+			expect(tasks[0]?.role).toBe("DB migration specialist");
+		}
+	});
+
+	it("rejects a role longer than the schema bound", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "x".repeat(ROLE_INPUT_MAX + 1) });
+		expect(parsed.success).toBe(false);
+	});
+
+	it("accepts a role at the schema bound", () => {
+		const parsed = taskSchema.safeParse({ agent: "task", assignment: "x", role: "x".repeat(ROLE_INPUT_MAX) });
+		expect(parsed.success).toBe(true);
+	});
+});
+
+// Contract: a role shapes the spawned subagent's system prompt and identity, so
+// an approval-gated session must surface it before the user authorizes the spawn.
+describe("task approval details surface role", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	async function makeTool(): Promise<TaskTool> {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [], projectAgentsDir: null });
+		return TaskTool.create({
+			cwd: "/tmp",
+			hasUI: false,
+			settings: Settings.isolated({ "task.isolation.mode": "none", "task.batch": false }),
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+		} as unknown as ToolSession);
+	}
+
+	it("includes the role line for a flat spawn", async () => {
+		const tool = await makeTool();
+		const lines = tool.formatApprovalDetails({ agent: "task", role: "Security reviewer", assignment: "x" });
+		expect(lines).toContain("Role: Security reviewer");
+	});
+
+	it("includes the role line for the first batch task", async () => {
+		const tool = await makeTool();
+		const lines = tool.formatApprovalDetails({
+			agent: "task",
+			tasks: [{ role: "DB migration specialist", assignment: "x" }],
+		});
+		expect(lines).toContain("Role: DB migration specialist");
+	});
+});

--- a/packages/coding-agent/test/task/spawn-advisory.test.ts
+++ b/packages/coding-agent/test/task/spawn-advisory.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { buildSpecializationAdvisory } from "@oh-my-pi/pi-coding-agent/task";
+import type { TaskItem } from "@oh-my-pi/pi-coding-agent/task/types";
+
+// Contract: the task tool appends an advisory (never a rejection) steering the
+// spawner toward tailored specialists when it spawns generic role-less workers
+// and still holds spawn capacity (DepthCapacity). It is gated on depth so a
+// leaf at max recursion is never nagged.
+
+const item = (role?: string): TaskItem => ({ assignment: "do the thing", role });
+
+describe("buildSpecializationAdvisory", () => {
+	it("nudges a generic role-less spawn when depth capacity remains", () => {
+		const advice = buildSpecializationAdvisory("task", [item()], true);
+		expect(advice).toBeDefined();
+		expect(advice).toContain("`role`");
+	});
+
+	it("stays silent at max depth even for a generic role-less spawn", () => {
+		expect(buildSpecializationAdvisory("task", [item()], false)).toBeUndefined();
+	});
+
+	it("stays silent when the spawn already carries a role", () => {
+		expect(buildSpecializationAdvisory("task", [item("Rust async-runtime specialist")], true)).toBeUndefined();
+	});
+
+	it("treats a whitespace-only role as absent and nudges", () => {
+		expect(buildSpecializationAdvisory("quick_task", [item("   ")], true)).toBeDefined();
+	});
+
+	it("nudges when one call clones the same agent twice without roles", () => {
+		expect(buildSpecializationAdvisory("reviewer", [item(), item()], true)).toBeDefined();
+	});
+
+	it("stays silent for a single non-generic role-less spawn", () => {
+		expect(buildSpecializationAdvisory("reviewer", [item()], true)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/task/task-prompt-role.test.ts
+++ b/packages/coding-agent/test/task/task-prompt-role.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { prompt } from "@oh-my-pi/pi-utils";
+import taskDescriptionTemplate from "../../src/prompts/tools/task.md" with { type: "text" };
+
+// Contract: the task tool description the model sees advertises the `role`
+// parameter (in both the batch and flat shapes) and steers toward tailored
+// specialists. Without this the `role` field added in #2467 stays dormant.
+
+function render(batchEnabled: boolean): string {
+	return prompt.render(taskDescriptionTemplate, {
+		agents: [{ name: "explore", description: "scout", readOnly: true }],
+		spawningDisabled: false,
+		MAX_CONCURRENCY: 32,
+		isolationEnabled: true,
+		batchEnabled,
+		asyncEnabled: true,
+		ircEnabled: true,
+	});
+}
+
+describe("task tool description: role parameter", () => {
+	it("documents `role` in the batch parameter list", () => {
+		const out = render(true);
+		expect(out).toContain("`role`:");
+		expect(out).toMatch(/specialist identity/i);
+	});
+
+	it("documents `role` in the flat (single-spawn) parameter list", () => {
+		const out = render(false);
+		expect(out).toContain("`role`:");
+	});
+
+	it("makes tailored specialists the default, not the exception, in the rules", () => {
+		const out = render(true);
+		// Stable invariant — tailoring tied to `role` on one directive line —
+		// rather than the exact copy-edited wording/capitalization.
+		expect(out).toMatch(/tailor[^\n]*role/i);
+	});
+});


### PR DESCRIPTION
**Part 3 of 5 — subagent tailoring overhaul.** Stacked; merge order #2478 → #2479 → this. Until they land, this cross-fork PR's diff includes the commits beneath it; the net new change here is the top commit.

Adds a non-blocking specialization advisory to `TaskTool.execute`: when a spawner with remaining depth capacity spawns generic role-less workers (a `task`/`quick_task` spawn without a `role`, or the same agent cloned ≥2× all without roles), the result steers it toward tailored specialists. Gated so a leaf at max recursion depth is never nudged; the task-tool depth gate is extracted into a shared `canSpawnAtDepth` helper reused by the tool gate and the advisory.

Tests: advisory present with depth capacity, absent at max depth, absent when a role is present, the cloned-without-role case, silent for a single named spawn.

Closes #2469
