### PR TITLE
feat(coding-agent): add model-preset engine with non-destructive overlay apply

### DIFF
--- a/packages/coding-agent/src/config/model-presets.ts
+++ b/packages/coding-agent/src/config/model-presets.ts
@@ -1,0 +1,229 @@
+import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "./model-registry";
+import { getModelMatchPreferences, resolveModelRoleValue } from "./model-resolver";
+import { MODEL_ROLE_IDS } from "./model-roles";
+import type { Settings } from "./settings";
+
+export const BUILTIN_MODEL_PRESET_IDS = ["budget", "balanced", "smart", "ultra"] as const;
+export type BuiltInModelPresetId = (typeof BUILTIN_MODEL_PRESET_IDS)[number];
+/** Any preset id — a built-in or a user-defined custom preset key. */
+export type ModelPresetId = string;
+
+export interface ModelPresetInfo {
+	id: ModelPresetId;
+	label: string;
+	description: string;
+}
+
+export type ModelPresetRoleMap = Record<string, string>;
+export type ModelPresetOverrides = Record<string, ModelPresetRoleMap>;
+
+export interface ResolvedModelPresetRole {
+	role: string;
+	selector: string;
+	model: Model<Api>;
+	thinkingLevel?: ThinkingLevel;
+	explicitThinkingLevel: boolean;
+}
+
+export interface ResolvedModelPreset {
+	id: ModelPresetId;
+	info: ModelPresetInfo;
+	roles: ResolvedModelPresetRole[];
+	defaultRole: ResolvedModelPresetRole;
+}
+
+const MODEL_PRESET_INFOS: Record<BuiltInModelPresetId, ModelPresetInfo> = {
+	budget: {
+		id: "budget",
+		label: "Budget",
+		description: "Use the fastest economical model profile for every role.",
+	},
+	balanced: {
+		id: "balanced",
+		label: "Balanced",
+		description: "Use the normal default role with slower models for planning.",
+	},
+	smart: {
+		id: "smart",
+		label: "Smart",
+		description: "Use thinking models with high reasoning for complex work.",
+	},
+	ultra: {
+		id: "ultra",
+		label: "Ultra",
+		description: "Use the strongest thinking profile for every heavy role.",
+	},
+};
+
+const BALANCED_PRESET: ModelPresetRoleMap = {
+	default: "pi/default",
+	smol: "pi/smol",
+	slow: "pi/slow",
+	plan: "pi/slow",
+	task: "pi/default",
+	commit: "pi/default",
+	designer: "pi/designer",
+};
+
+const SMART_PRESET: ModelPresetRoleMap = {
+	default: "pi/slow:high",
+	smol: "pi/smol",
+	slow: "pi/slow:high",
+	plan: "pi/slow:high",
+	task: "pi/slow:high",
+	commit: "pi/slow:high",
+	designer: "pi/designer:high",
+};
+
+const ULTRA_PRESET: ModelPresetRoleMap = {
+	default: "pi/slow:xhigh",
+	smol: "pi/slow:high",
+	slow: "pi/slow:xhigh",
+	plan: "pi/slow:xhigh",
+	task: "pi/slow:xhigh",
+	commit: "pi/slow:xhigh",
+	designer: "pi/designer:xhigh",
+};
+
+function getBudgetPreset(settings: Settings): ModelPresetRoleMap {
+	const preset: ModelPresetRoleMap = {
+		default: "pi/smol",
+		smol: "pi/smol",
+		slow: "pi/smol",
+		plan: "pi/smol",
+		task: "pi/smol",
+		commit: "pi/smol",
+		designer: "pi/smol",
+	};
+	if (settings.getModelRole("vision")) {
+		preset.vision = "pi/vision";
+	}
+	return preset;
+}
+
+function getBuiltInModelPresetRoleMap(settings: Settings, id: BuiltInModelPresetId): ModelPresetRoleMap {
+	switch (id) {
+		case "budget":
+			return getBudgetPreset(settings);
+		case "balanced":
+			return { ...BALANCED_PRESET };
+		case "smart":
+			return { ...SMART_PRESET };
+		case "ultra":
+			return { ...ULTRA_PRESET };
+	}
+}
+
+function stringRoleMap(value: unknown): ModelPresetRoleMap | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const roles: ModelPresetRoleMap = {};
+	for (const [role, selector] of Object.entries(value)) {
+		if (typeof selector === "string" && selector.trim()) {
+			roles[role] = selector;
+		}
+	}
+	return roles;
+}
+
+export function isBuiltInModelPresetId(value: string): value is BuiltInModelPresetId {
+	return (BUILTIN_MODEL_PRESET_IDS as readonly string[]).includes(value);
+}
+
+/** All preset ids: the four built-ins (in order) then custom keys in definition order. */
+export function getAllModelPresetIds(settings: Settings): ModelPresetId[] {
+	const ids: ModelPresetId[] = [...BUILTIN_MODEL_PRESET_IDS];
+	for (const key of Object.keys(settings.getModelPresets())) {
+		if (!isBuiltInModelPresetId(key)) ids.push(key);
+	}
+	return ids;
+}
+
+/** Resolve a raw preset name (case-insensitive exact match) to a known preset id. */
+export function resolvePresetId(settings: Settings, raw: string): ModelPresetId | undefined {
+	const normalized = raw.trim().toLowerCase();
+	if (!normalized) return undefined;
+	return getAllModelPresetIds(settings).find(id => id.toLowerCase() === normalized);
+}
+
+export function getModelPresetInfo(id: ModelPresetId): ModelPresetInfo {
+	if (isBuiltInModelPresetId(id)) return MODEL_PRESET_INFOS[id];
+	return { id, label: id, description: "Custom preset." };
+}
+
+export function getModelPresetRoleMap(settings: Settings, id: ModelPresetId): ModelPresetRoleMap {
+	if (isBuiltInModelPresetId(id)) {
+		const roles = getBuiltInModelPresetRoleMap(settings, id);
+		const override = settings.getModelPreset(id);
+		return override ? { ...roles, ...override } : roles;
+	}
+	const custom = settings.getModelPreset(id);
+	return custom ? { ...custom } : {};
+}
+
+export function resolveModelPreset(
+	settings: Settings,
+	modelRegistry: ModelRegistry,
+	availableModels: readonly Model<Api>[],
+	id: ModelPresetId,
+): ResolvedModelPreset {
+	const info = getModelPresetInfo(id);
+	const roleMap = getModelPresetRoleMap(settings, id);
+	if (Object.keys(roleMap).length === 0) {
+		throw new Error(`Unknown preset: ${id}`);
+	}
+	const available = [...availableModels];
+	const matchPreferences = getModelMatchPreferences(settings);
+	const roles: ResolvedModelPresetRole[] = [];
+
+	for (const role of orderPresetRoles(roleMap)) {
+		const selector = roleMap[role];
+		if (!selector) continue;
+		const resolved = resolveModelRoleValue(selector, available, {
+			settings,
+			matchPreferences,
+			modelRegistry,
+			roleLookup: r => settings.getBaseModelRole(r),
+		});
+		if (!resolved.model) {
+			throw new Error(`Preset ${info.label} cannot resolve role ${role}: ${selector}`);
+		}
+		roles.push({
+			role,
+			selector,
+			model: resolved.model,
+			thinkingLevel: resolved.thinkingLevel,
+			explicitThinkingLevel: resolved.explicitThinkingLevel,
+		});
+	}
+
+	const defaultRole = roles.find(role => role.role === "default");
+	if (!defaultRole) {
+		throw new Error(`Preset ${info.label} cannot resolve role default: ${roleMap.default ?? ""}`);
+	}
+
+	return { id, info, roles, defaultRole };
+}
+
+function orderPresetRoles(roleMap: ModelPresetRoleMap): string[] {
+	const roles = new Set<string>();
+	for (const role of MODEL_ROLE_IDS) {
+		if (role in roleMap) roles.add(role);
+	}
+	for (const role of Object.keys(roleMap)) roles.add(role);
+	return [...roles];
+}
+
+export function modelPresetsFromUnknown(value: unknown): ModelPresetOverrides {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const presets: ModelPresetOverrides = {};
+	for (const [key, item] of Object.entries(value)) {
+		const id = key.trim();
+		const roles = stringRoleMap(item);
+		if (id && roles) {
+			presets[id] = roles;
+		}
+	}
+	return presets;
+}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -674,6 +674,7 @@ function resolveDefaultInheritedPatterns(
 	roleDefaults: string[],
 	settings: Settings | undefined,
 	visited: Set<ModelRole>,
+	roleLookup?: (role: ModelRole | string) => string | undefined,
 ): string[] {
 	if (!shouldInheritDefaultBeforePriority(role) || !configuredDefault) return [];
 
@@ -695,7 +696,7 @@ function resolveDefaultInheritedPatterns(
 			// Cross-role alias (e.g. modelRoles.default = "pi/slow"): resolve the
 			// target role's patterns now so downstream one-layer expanders see
 			// concrete model patterns instead of another role alias.
-			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
+			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited), roleLookup);
 			if (recursed && recursed.length > 0) {
 				resolved.push(...recursed);
 				continue;
@@ -710,6 +711,7 @@ function resolveConfiguredRolePattern(
 	value: string,
 	settings?: Settings,
 	visited: Set<ModelRole> = new Set(),
+	roleLookup?: (role: ModelRole | string) => string | undefined,
 ): string[] | undefined {
 	const normalized = value.trim();
 	if (!normalized) return undefined;
@@ -720,12 +722,12 @@ function resolveConfiguredRolePattern(
 	if (visited.has(role)) return undefined;
 	visited.add(role);
 
-	const configured = settings?.getModelRole(role)?.trim();
-	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
+	const configured = (roleLookup?.(role) ?? settings?.getModelRole(role))?.trim();
+	const configuredDefault = (roleLookup?.(DEFAULT_MODEL_ROLE) ?? settings?.getModelRole(DEFAULT_MODEL_ROLE))?.trim();
 	const roleDefaults = normalizeModelPatternList(MODEL_PRIO[role as keyof typeof MODEL_PRIO]);
 	const resolved = configured
 		? normalizeModelPatternList(configured)
-		: resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited);
+		: resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited, roleLookup);
 	if (resolved.length === 0) {
 		resolved.push(...roleDefaults);
 	}
@@ -749,10 +751,14 @@ export function expandRoleAlias(value: string, settings?: Settings): string {
 	return resolved ?? value;
 }
 
-export function resolveConfiguredModelPatterns(value: string | string[] | undefined, settings?: Settings): string[] {
+export function resolveConfiguredModelPatterns(
+	value: string | string[] | undefined,
+	settings?: Settings,
+	roleLookup?: (role: ModelRole | string) => string | undefined,
+): string[] {
 	const patterns = normalizeModelPatternList(value);
 	return patterns.flatMap(pattern => {
-		const resolved = resolveConfiguredRolePattern(pattern, settings);
+		const resolved = resolveConfiguredRolePattern(pattern, settings, new Set(), roleLookup);
 		return resolved ?? [];
 	});
 }
@@ -797,7 +803,12 @@ export interface ResolvedModelRoleValue {
 export function resolveModelRoleValue(
 	roleValue: string | undefined,
 	availableModels: Model<Api>[],
-	options?: { settings?: Settings; matchPreferences?: ModelMatchPreferences; modelRegistry?: CanonicalModelRegistry },
+	options?: {
+		settings?: Settings;
+		matchPreferences?: ModelMatchPreferences;
+		modelRegistry?: CanonicalModelRegistry;
+		roleLookup?: (role: ModelRole | string) => string | undefined;
+	},
 ): ResolvedModelRoleValue {
 	if (!roleValue) {
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
@@ -808,7 +819,7 @@ export function resolveModelRoleValue(
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
 	}
 
-	const effectivePatterns = resolveConfiguredModelPatterns(normalized, options?.settings);
+	const effectivePatterns = resolveConfiguredModelPatterns(normalized, options?.settings, options?.roleLookup);
 	if (!effectivePatterns || effectivePatterns.length === 0) {
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
 	}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -254,6 +254,7 @@ export interface ModelTagDef {
 export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
 }
+export type ModelPresetsSettings = Record<string, Record<string, string>>;
 
 // Typed defaults for array/record settings — named constants avoid `as` casts
 // under `as const` while still letting SettingValue infer the correct element type.
@@ -261,6 +262,7 @@ const EMPTY_STRING_ARRAY: string[] = [];
 const EMPTY_STRING_RECORD: Record<string, string> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
+const EMPTY_MODEL_PRESETS_RECORD: ModelPresetsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
@@ -380,6 +382,12 @@ export const SETTINGS_SCHEMA = {
 	disabledExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
 	modelRoles: { type: "record", default: EMPTY_STRING_RECORD },
+	modelPreset: {
+		type: "string",
+		default: "balanced",
+	},
+
+	modelPresets: { type: "record", default: EMPTY_MODEL_PRESETS_RECORD },
 
 	modelTags: { type: "record", default: EMPTY_MODEL_TAGS_RECORD },
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -33,6 +33,12 @@ import { AgentStorage } from "../session/agent-storage";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { withFileLock } from "./file-lock";
 import {
+	type ModelPresetId,
+	type ModelPresetOverrides,
+	type ModelPresetRoleMap,
+	modelPresetsFromUnknown,
+} from "./model-presets";
+import {
 	type BashInterceptorRule,
 	type GroupPrefix,
 	type GroupTypeMap,
@@ -208,6 +214,10 @@ export class Settings {
 	#overrides: RawSettings = {};
 	/** Merged view (global + project + overrides) */
 	#merged: RawSettings = {};
+	/** Base (pre-preset-overlay) model roles, snapshotted on each merge for preset resolution */
+	#baseModelRoles: Record<string, string> = {};
+	/** Session-scoped preset role overlay (top merge layer, never persisted) */
+	#sessionPresetRoles: Record<string, string> = {};
 	/** Cached resolved values from the merged view, including defaults/path scoping */
 	#resolvedCache = new Map<SettingPath, unknown>();
 
@@ -406,6 +416,7 @@ export class Settings {
 		cloned.#configFiles = [...this.#configFiles];
 		cloned.#configOverlay = structuredClone(this.#configOverlay);
 		cloned.#overrides = structuredClone(this.#overrides);
+		cloned.#sessionPresetRoles = { ...this.#sessionPresetRoles };
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
 		return cloned;
@@ -520,6 +531,29 @@ export class Settings {
 			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
 		}
 	}
+	/**
+	 * Replace the session preset role overlay (top merge layer, never persisted).
+	 * An empty map clears the overlay.
+	 */
+	setSessionPresetRoles(map: ReadOnlyDict<string>): void {
+		this.#sessionPresetRoles = shallowStringRecord(map);
+		this.#rebuildMerged();
+	}
+
+	/** Base model role value, excluding the session preset overlay. */
+	getBaseModelRole(role: ModelRole | string): string | undefined {
+		return this.#baseModelRoles[role];
+	}
+
+	/** Keys of the base model role map, excluding the session preset overlay. */
+	getBaseModelRoleKeys(): Set<string> {
+		return new Set(Object.keys(this.#baseModelRoles));
+	}
+
+	/** Keys set via runtime overrides (e.g. --model/--smol/--slow/--plan). */
+	getOverrideModelRoleKeys(): Set<string> {
+		return new Set(Object.keys(shallowStringRecord(getByPath(this.#overrides, ["modelRoles"]))));
+	}
 
 	/**
 	 * Get a model role (helper for modelRoles record).
@@ -536,7 +570,7 @@ export class Settings {
 		return { ...this.get("modelRoles") };
 	}
 
-	/*
+	/**
 	 * Override model roles (helper for modelRoles record).
 	 */
 	overrideModelRoles(roles: ReadOnlyDict<string>): void {
@@ -547,6 +581,14 @@ export class Settings {
 			}
 		}
 		this.override("modelRoles", next);
+	}
+
+	getModelPreset(id: ModelPresetId): ModelPresetRoleMap | undefined {
+		return this.getModelPresets()[id];
+	}
+
+	getModelPresets(): ModelPresetOverrides {
+		return modelPresetsFromUnknown(this.get("modelPresets"));
 	}
 
 	/**
@@ -985,6 +1027,12 @@ export class Settings {
 		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
 		this.#merged = this.#deepMerge(this.#merged, this.#configOverlay);
 		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
+		// Snapshot the base model roles (pre preset overlay) for base-relative preset resolution.
+		this.#baseModelRoles = shallowStringRecord(getByPath(this.#merged, ["modelRoles"]));
+		// Apply the session preset overlay as the top, never-persisted layer.
+		if (Object.keys(this.#sessionPresetRoles).length > 0) {
+			setByPath(this.#merged, ["modelRoles"], { ...this.#baseModelRoles, ...this.#sessionPresetRoles });
+		}
 		this.#resolvedCache.clear();
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -65,6 +65,7 @@ import {
 } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
 import type {
+	Api,
 	AssistantMessage,
 	Context,
 	ImageContent,
@@ -117,6 +118,13 @@ import { classifyDifficulty } from "../auto-thinking/classifier";
 import { reset as resetCapabilities } from "../capability";
 import type { Rule } from "../capability/rule";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
+import {
+	getAllModelPresetIds,
+	type ModelPresetId,
+	type ResolvedModelPreset,
+	type ResolvedModelPresetRole,
+	resolveModelPreset,
+} from "../config/model-presets";
 import type { ModelRegistry } from "../config/model-registry";
 import {
 	extractExplicitThinkingSelector,
@@ -492,6 +500,12 @@ export interface RoleModelCycleResult {
 	model: Model;
 	thinkingLevel: ThinkingLevel | undefined;
 	role: string;
+}
+export interface AppliedModelPreset {
+	preset: ModelPresetId;
+	label: string;
+	defaultModel: Model<Api>;
+	roles: readonly ResolvedModelPresetRole[];
 }
 
 /** A configured role resolved to a concrete model, used by role cycling and
@@ -5701,6 +5715,89 @@ export class AgentSession {
 		if (currentIndex === -1) currentIndex = 0;
 
 		return { models, currentIndex };
+	}
+
+	getResolvedModelPreset(preset: ModelPresetId): ResolvedModelPreset {
+		return resolveModelPreset(this.settings, this.#modelRegistry, this.getAvailableModels(), preset);
+	}
+
+	async applyModelPreset(preset: ModelPresetId): Promise<AppliedModelPreset> {
+		const resolved = this.getResolvedModelPreset(preset);
+		await this.#applyResolvedPreset(resolved, { pinnedKeys: new Set(), setDefault: true });
+		this.settings.set("modelPreset", preset);
+
+		return {
+			preset,
+			label: resolved.info.label,
+			defaultModel: resolved.defaultRole.model,
+			roles: resolved.roles,
+		};
+	}
+
+	/**
+	 * Apply a resolved preset as a runtime overlay. Never writes persistent
+	 * `modelRoles`. Pinned role keys are skipped so the lower config layer wins.
+	 */
+	async #applyResolvedPreset(
+		resolved: ResolvedModelPreset,
+		opts: { pinnedKeys: Set<string>; setDefault: boolean },
+	): Promise<void> {
+		const overlay: Record<string, string> = {};
+		for (const role of resolved.roles) {
+			if (opts.pinnedKeys.has(role.role)) continue;
+			overlay[role.role] = formatModelSelectorValue(
+				formatModelString(role.model),
+				role.explicitThinkingLevel ? role.thinkingLevel : undefined,
+			);
+		}
+		this.settings.setSessionPresetRoles(overlay);
+
+		if (opts.setDefault && !opts.pinnedKeys.has("default")) {
+			await this.setModel(resolved.defaultRole.model, "default");
+			if (resolved.defaultRole.explicitThinkingLevel) {
+				this.setThinkingLevel(resolved.defaultRole.thinkingLevel);
+			}
+		}
+	}
+
+	/**
+	 * Apply the persisted (or explicitly requested) preset at session start.
+	 * Roles configured in YAML/CLI win — the overlay fills only the rest.
+	 * Auto-apply of the persisted default is skipped on resume.
+	 */
+	async initializeModelPreset(opts: { explicitId?: string; resuming: boolean }): Promise<void> {
+		const explicit = !!opts.explicitId;
+		const id = opts.explicitId ?? this.settings.get("modelPreset");
+		if (!id) return;
+		if (!explicit && opts.resuming) return;
+
+		let resolved: ResolvedModelPreset;
+		try {
+			resolved = this.getResolvedModelPreset(id);
+		} catch (e) {
+			logger.warn("startup preset apply skipped", { id, error: e instanceof Error ? e.message : String(e) });
+			return;
+		}
+
+		const pinnedKeys = explicit ? this.settings.getOverrideModelRoleKeys() : this.settings.getBaseModelRoleKeys();
+		try {
+			await this.#applyResolvedPreset(resolved, { pinnedKeys, setDefault: true });
+		} catch (e) {
+			logger.warn("startup preset apply failed", { id, error: e instanceof Error ? e.message : String(e) });
+		}
+	}
+
+	async cycleModelPreset(direction: "forward" | "backward" = "forward"): Promise<AppliedModelPreset | undefined> {
+		const ids = getAllModelPresetIds(this.settings);
+		if (ids.length <= 1) return undefined;
+
+		const stored = this.settings.get("modelPreset");
+		const current = stored && ids.includes(stored) ? stored : "balanced";
+		const currentIndex = Math.max(0, ids.indexOf(current));
+		const step = direction === "backward" ? -1 : 1;
+		const next = ids[(currentIndex + step + ids.length) % ids.length];
+
+		return this.applyModelPreset(next);
 	}
 
 	/**

--- a/packages/coding-agent/test/model-presets.test.ts
+++ b/packages/coding-agent/test/model-presets.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import {
+	getAllModelPresetIds,
+	modelPresetsFromUnknown,
+	resolveModelPreset,
+	resolvePresetId,
+} from "@oh-my-pi/pi-coding-agent/config/model-presets";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+function model(provider: string, id: string): Model<Api> {
+	return { provider, id, name: id, api: "test" } as unknown as Model<Api>;
+}
+
+const availableModels = [
+	model("test", "default"),
+	model("test", "smol"),
+	model("test", "slow"),
+	model("test", "designer"),
+];
+
+const registry = {} as ModelRegistry;
+
+function presetSettings(overrides: Record<string, unknown> = {}): Settings {
+	return Settings.isolated({
+		modelRoles: {
+			default: "test/default",
+			smol: "test/smol",
+			slow: "test/slow",
+			designer: "test/designer",
+		},
+		...overrides,
+	});
+}
+
+describe("model presets", () => {
+	it("resolves all built-in presets through role aliases", () => {
+		const settings = presetSettings();
+
+		for (const id of ["budget", "balanced", "smart", "ultra"] as const) {
+			const preset = resolveModelPreset(settings, registry, availableModels, id);
+			expect(preset.id).toBe(id);
+			expect(preset.defaultRole.model.provider).toBe("test");
+			expect(preset.roles.some(role => role.role === "default")).toBe(true);
+		}
+	});
+
+	it("user preset overrides replace only configured roles", () => {
+		const settings = presetSettings({ modelPresets: { smart: { default: "test/default" } } });
+
+		const preset = resolveModelPreset(settings, registry, availableModels, "smart");
+
+		expect(preset.defaultRole.selector).toBe("test/default");
+		expect(preset.roles.find(role => role.role === "slow")?.selector).toBe("pi/slow:high");
+	});
+
+	it("throws before returning a partial preset when a role cannot resolve", () => {
+		const settings = presetSettings({ modelPresets: { smart: { task: "missing/provider" } } });
+
+		expect(() => resolveModelPreset(settings, registry, availableModels, "smart")).toThrow(
+			"Preset Smart cannot resolve role task: missing/provider",
+		);
+	});
+});
+
+describe("custom preset identity", () => {
+	it("lists built-ins first, then custom presets in definition order", () => {
+		const settings = Settings.isolated({
+			modelPresets: { "fast-cheap": { default: "test/smol" }, nightly: { default: "test/slow" } },
+		});
+		expect(getAllModelPresetIds(settings)).toEqual(["budget", "balanced", "smart", "ultra", "fast-cheap", "nightly"]);
+	});
+
+	it("does not duplicate a built-in id overridden via modelPresets", () => {
+		const settings = Settings.isolated({ modelPresets: { smart: { default: "test/slow" } } });
+		expect(getAllModelPresetIds(settings)).toEqual(["budget", "balanced", "smart", "ultra"]);
+	});
+
+	it("resolvePresetId matches case-insensitively and rejects unknown names", () => {
+		const settings = Settings.isolated({ modelPresets: { "Fast-Cheap": { default: "test/smol" } } });
+		expect(resolvePresetId(settings, "SMART")).toBe("smart");
+		expect(resolvePresetId(settings, "fast-cheap")).toBe("Fast-Cheap");
+		expect(resolvePresetId(settings, "  ultra  ")).toBe("ultra");
+		expect(resolvePresetId(settings, "nope")).toBeUndefined();
+	});
+
+	it("resolveModelPreset throws for an unknown preset id", () => {
+		const settings = presetSettings();
+		expect(() => resolveModelPreset(settings, registry, availableModels, "nope")).toThrow("Unknown preset: nope");
+	});
+
+	it("modelPresetsFromUnknown keeps arbitrary keys and drops non-object values", () => {
+		const parsed = modelPresetsFromUnknown({ "fast-cheap": { default: "pi/smol" }, bad: "nope", arr: [1, 2] });
+		expect(parsed["fast-cheap"]).toEqual({ default: "pi/smol" });
+		expect(parsed.bad).toBeUndefined();
+		expect(parsed.arr).toBeUndefined();
+	});
+});
+
+describe("preset overlay (non-destructive apply)", () => {
+	it("overlay preserves base roles it does not name", () => {
+		const settings = Settings.isolated({
+			modelRoles: { default: "test/default", slow: "test/slow", vision: "test/vision" },
+		});
+		settings.setSessionPresetRoles({ default: "test/smol", slow: "test/smol" });
+		expect(settings.getModelRole("default")).toBe("test/smol");
+		expect(settings.getModelRole("vision")).toBe("test/vision");
+	});
+
+	it("clearing the overlay restores base roles", () => {
+		const settings = Settings.isolated({ modelRoles: { default: "test/default" } });
+		settings.setSessionPresetRoles({ default: "test/smol" });
+		expect(settings.getModelRole("default")).toBe("test/smol");
+		settings.setSessionPresetRoles({});
+		expect(settings.getModelRole("default")).toBe("test/default");
+	});
+
+	it("resolves preset aliases against base config, not a prior preset overlay", () => {
+		const settings = Settings.isolated({
+			modelRoles: { default: "test/default", smol: "test/smol", slow: "test/slow", designer: "test/designer" },
+		});
+		// Simulate a prior preset (e.g. ultra) having overlaid xhigh selectors.
+		settings.setSessionPresetRoles({ slow: "test/slow:xhigh", default: "test/slow:xhigh" });
+		const balanced = resolveModelPreset(settings, registry, availableModels, "balanced");
+		const slow = balanced.roles.find(role => role.role === "slow");
+		expect(slow?.model.id).toBe("slow");
+		// Would be true (xhigh) if the prior overlay leaked into resolution.
+		expect(slow?.explicitThinkingLevel).toBe(false);
+	});
+
+	it("overrideModelRoles composes over base instead of replacing the map", () => {
+		const settings = Settings.isolated({ modelRoles: { default: "a", slow: "b", task: "c" } });
+		settings.overrideModelRoles({ smol: "X" });
+		expect(settings.getModelRoles()).toEqual({ default: "a", slow: "b", task: "c", smol: "X" });
+	});
+});


### PR DESCRIPTION
## Summary
Adds the model-preset engine: built-in presets, `modelPreset`/`modelPresets` settings, and a **non-destructive runtime overlay** apply. Persistent `modelRoles` is never rewritten; only the active preset id is persisted. Preset `pi/<role>` aliases resolve against the user's base config, so switching presets no longer corrupts subsequent resolution (alias-chaining fix) and never drops un-enumerated roles like `vision`.

## Scope
- `config/model-presets.ts` — built-in defs, `getAllModelPresetIds`, `resolvePresetId`, `isBuiltInModelPresetId`, `modelPresetsFromUnknown` (arbitrary custom keys), `resolveModelPreset` with base `roleLookup`.
- `config/settings.ts` — `#sessionPresetRoles` overlay layer + base accessors; key-by-key `modelRoles` merge (no destructive replace).
- `config/settings-schema.ts` — `modelPreset` (string) + `modelPresets` (record).
- `config/model-resolver.ts` — optional `roleLookup` threaded through resolution.
- `session/agent-session.ts` — `applyModelPreset` (overlay), `#applyResolvedPreset`, `initializeModelPreset`, `cycleModelPreset`.

## Verification
`bun --cwd=packages/coding-agent run check:types` clean; `test/model-presets.test.ts` (12 tests) green — including alias-chaining, overlay-preservation, and `overrideModelRoles` merge regressions.

Part of the atomic stack that supersedes #2391. **This is the base PR** — the /preset UI, keybindings, and CLI PRs depend on it.

Closes https://github.com/can1357/oh-my-pi/issues/2494
