### PR TITLE
feat(cli): add --preset flag with PI_PRESET, --profile alias, list, and startup auto-apply

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -18,6 +18,7 @@ export interface Args {
 	smol?: string;
 	slow?: string;
 	plan?: string;
+	preset?: string;
 	apiKey?: string;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -141,6 +142,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.slow = args[++i];
 		} else if (arg === "--plan" && i + 1 < args.length) {
 			result.plan = args[++i];
+		} else if ((arg === "--preset" || arg === "--profile") && i + 1 < args.length) {
+			result.preset = args[++i];
 		} else if (arg === "--api-key" && i + 1 < args.length) {
 			result.apiKey = args[++i];
 		} else if (arg === "--system-prompt" && i + 1 < args.length) {
@@ -295,6 +298,7 @@ export function getExtraHelpText(): string {
   PI_SMOL_MODEL              - Override smol/fast model (see --smol)
   PI_SLOW_MODEL              - Override slow/reasoning model (see --slow)
   PI_PLAN_MODEL              - Override planning model (see --plan)
+  PI_PRESET                  - Model preset profile (see --preset)
   PI_NO_PTY                  - Disable PTY-based interactive bash execution
 
   For complete environment variable reference, see:

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -34,6 +34,9 @@ export default class Index extends Command {
 		plan: Flags.string({
 			description: "Plan model for architectural planning (or PI_PLAN_MODEL env)",
 		}),
+		preset: Flags.string({
+			description: 'Model preset profile (e.g. "smart"; alias --profile; "--preset list" to list)',
+		}),
 		provider: Flags.string({
 			description: "Provider to use (legacy; prefer --model)",
 		}),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -28,6 +28,12 @@ import { buildInitialMessage } from "./cli/initial-message";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
+import {
+	getAllModelPresetIds,
+	getModelPresetInfo,
+	getModelPresetRoleMap,
+	resolvePresetId,
+} from "./config/model-presets";
 import { ModelRegistry } from "./config/model-registry";
 import {
 	getModelMatchPreferences,
@@ -994,6 +1000,35 @@ export async function runRootCommand(
 	// Initialize discovery system with settings for provider persistence
 	logger.time("initializeWithSettings", initializeWithSettings, settingsInstance);
 
+	// `--preset list`: print available presets (id + label + role-map selectors from settings) and
+	// exit. Reads selectors straight from settings; does not resolve them against the model registry.
+	if (parsedArgs.preset?.trim().toLowerCase() === "list") {
+		let out = `${chalk.bold("Model presets:")}\n`;
+		for (const id of getAllModelPresetIds(settingsInstance)) {
+			out += `  ${chalk.cyan(id)} ${chalk.dim(getModelPresetInfo(id).label)}\n`;
+			for (const [role, selector] of Object.entries(getModelPresetRoleMap(settingsInstance, id))) {
+				out += `      ${role}: ${selector}\n`;
+			}
+		}
+		process.stdout.write(out);
+		process.exit(0);
+	}
+
+	// Resolve a startup model preset from --preset / PI_PRESET. The overlay is applied later by the
+	// session (initializeModelPreset); here we only validate and pass the id through.
+	let startupPresetId: string | undefined;
+	const rawPreset = parsedArgs.preset ?? $env.PI_PRESET;
+	if (rawPreset?.trim()) {
+		const resolvedPresetId = resolvePresetId(settingsInstance, rawPreset);
+		if (!resolvedPresetId) {
+			process.stderr.write(
+				`${chalk.red(`Unknown preset '${rawPreset}'. Available: ${getAllModelPresetIds(settingsInstance).join(", ")}`)}\n`,
+			);
+			process.exit(1);
+		}
+		startupPresetId = resolvedPresetId;
+	}
+
 	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted)
 	const smolModel = parsedArgs.smol ?? $env.PI_SMOL_MODEL;
 	const slowModel = parsedArgs.slow ?? $env.PI_SLOW_MODEL;
@@ -1162,6 +1197,12 @@ export async function runRootCommand(
 		// discovery arms; running these concurrently contends for the event loop and stretches
 		// every parallel arm by ~30ms.
 		modelRegistry.refreshInBackground();
+		// Apply the startup model preset (CLI --preset / PI_PRESET, or the persisted default) once the
+		// session exists; non-destructive runtime overlay that never rewrites persistent modelRoles.
+		await result.session.initializeModelPreset({
+			explicitId: startupPresetId,
+			resuming: !!(parsedArgs.continue || parsedArgs.resume),
+		});
 		return result;
 	};
 

--- a/packages/coding-agent/test/cli-args-preset.test.ts
+++ b/packages/coding-agent/test/cli-args-preset.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+
+describe("parseArgs — --preset flag", () => {
+	it("parses --preset with a space-separated value", () => {
+		const result = parseArgs(["--preset", "smart"]);
+		expect(result.preset).toBe("smart");
+		expect(result.messages).toEqual([]);
+	});
+
+	it("accepts --profile as an alias for --preset", () => {
+		const result = parseArgs(["--profile", "smart"]);
+		expect(result.preset).toBe("smart");
+		expect(result.messages).toEqual([]);
+	});
+
+	it("parses the special 'list' value verbatim (resolution happens later)", () => {
+		const result = parseArgs(["--preset", "list"]);
+		expect(result.preset).toBe("list");
+	});
+
+	it("parses --preset=value without leaking the value into messages", () => {
+		const result = parseArgs(["--preset=smart", "hello"]);
+		expect(result.preset).toBe("smart");
+		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("leaves preset undefined when no value follows --preset", () => {
+		const result = parseArgs(["--preset"]);
+		expect(result.preset).toBeUndefined();
+		expect(result.messages).toEqual([]);
+	});
+
+	it("defaults preset to undefined when the flag is absent", () => {
+		const result = parseArgs(["hello"]);
+		expect(result.preset).toBeUndefined();
+	});
+
+	it("coexists with other flags", () => {
+		const result = parseArgs(["--preset", "smart", "--model", "opus", "hello"]);
+		expect(result.preset).toBe("smart");
+		expect(result.model).toBe("opus");
+		expect(result.messages).toContain("hello");
+	});
+});


### PR DESCRIPTION
## Summary
Adds `--preset <name>` (alias `--profile`), `PI_PRESET` env, and `--preset list`, plus startup auto-apply of the persisted default preset via a single `createSession` chokepoint. Explicit per-role flags win over the preset; auto-apply is skipped on resume.

## Scope
`cli/args.ts`, `commands/launch.ts`, `main.ts`, `test/cli-args-preset.test.ts`.

## Verification
`test/cli-args-preset.test.ts` covers the parse matrix (`--preset`/`--profile`/`list`/no-value/coexistence). Combined-stack `check:types` green.

> **Stacked PR** — supersedes #2391. Depends on the `feat/preset-engine` PR; merge that first.

Closes https://github.com/can1357/oh-my-pi/issues/2491
