### PR TITLE
feat(coding-agent): add preset cycle keybindings and canonicalize reserved shortcuts

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -381,7 +381,7 @@ Provide `renderCall` / `renderResult` on `registerTool` definitions for custom t
 - Runtime actions are unavailable during extension load.
 - `tool_call` errors block execution (fail-closed).
 - Command name conflicts with built-ins are skipped with diagnostics.
-- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+shift+right`, `alt+shift+left`, `alt+enter`, `escape`, `enter`).
 - Treat `ctx.reload()` as terminal for the current command handler frame.
 
 ## Extensions vs hooks vs custom-tools

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -10,6 +10,7 @@ User remaps live in `~/.omp/agent/keybindings.yml`. The file is a YAML mapping w
 app.model.cycleForward: Ctrl+P
 app.model.selectTemporary: Alt+P
 app.plan.toggle: Alt+Shift+P
+app.modelPreset.cycleForward: Alt+Shift+Right
 ```
 
 Chord names are case-insensitive and use the same notation shown in the UI, such as `Ctrl+P`, `Alt+Shift+P`, `Shift+Enter`, and `Ctrl+Backspace`.
@@ -22,25 +23,27 @@ app.stt.toggle: []
 
 ## Common action IDs
 
-| Action ID                   | Default                                | Meaning                                       |
-| --------------------------- | -------------------------------------- | --------------------------------------------- |
-| `app.model.cycleForward`    | `Ctrl+P`                               | Cycle role models forward                     |
-| `app.model.cycleBackward`   | `Shift+Ctrl+P`                         | Cycle role models backward                    |
-| `app.model.selectTemporary` | `Alt+P`                                | Pick a model temporarily for this session     |
-| `app.model.select`          | `Alt+M`                                | Open the model selector and set roles         |
-| `app.plan.toggle`           | `Alt+Shift+P`                          | Toggle plan mode                              |
-| `app.history.search`        | `Ctrl+R`                               | Search prompt history                         |
-| `app.tools.expand`          | `Ctrl+O`                               | Toggle tool-output expansion                  |
-| `app.thinking.toggle`       | `Ctrl+T`                               | Toggle thinking-block visibility              |
-| `app.thinking.cycle`        | `Shift+Tab`                            | Cycle thinking level                          |
-| `app.editor.external`       | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
-| `app.message.followUp`      | `Ctrl+Q`, `Ctrl+Enter`                 | Queue a follow-up message                     |
-| `app.message.dequeue`       | `Alt+Up`                               | Dequeue a queued message back into the editor |
-| `app.display.reset`         | `Ctrl+L`                               | Reset terminal display                        |
-| `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |
-| `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |
-| `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste from the clipboard (image preferred, text fallback) |
-| `app.stt.toggle`            | `Alt+H`                                | Toggle speech-to-text recording               |
+| Action ID                         | Default                                | Meaning                                       |
+| --------------------------------- | -------------------------------------- | --------------------------------------------- |
+| `app.model.cycleForward`          | `Ctrl+P`                               | Cycle role models forward                     |
+| `app.model.cycleBackward`         | `Shift+Ctrl+P`                         | Cycle role models backward                    |
+| `app.modelPreset.cycleForward`    | `Alt+Shift+Right`                      | Cycle model presets forward (`/preset next`)  |
+| `app.modelPreset.cycleBackward`   | `Alt+Shift+Left`                       | Cycle model presets backward (`/preset prev`) |
+| `app.model.selectTemporary`       | `Alt+P`                                | Pick a model temporarily for this session     |
+| `app.model.select`                | `Alt+M`                                | Open the model selector and set roles         |
+| `app.plan.toggle`                 | `Alt+Shift+P`                          | Toggle plan mode                              |
+| `app.history.search`              | `Ctrl+R`                               | Search prompt history                         |
+| `app.tools.expand`                | `Ctrl+O`                               | Toggle tool-output expansion                  |
+| `app.thinking.toggle`             | `Ctrl+T`                               | Toggle thinking-block visibility              |
+| `app.thinking.cycle`              | `Shift+Tab`                            | Cycle thinking level                          |
+| `app.editor.external`             | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
+| `app.message.followUp`            | `Ctrl+Q`, `Ctrl+Enter`                 | Queue a follow-up message                     |
+| `app.message.dequeue`             | `Alt+Up`                               | Dequeue a queued message back into the editor |
+| `app.display.reset`               | `Ctrl+L`                               | Reset terminal display                        |
+| `app.clipboard.copyLine`          | `Alt+Shift+L`                          | Copy the current line                         |
+| `app.clipboard.copyPrompt`        | `Alt+Shift+C`                          | Copy the whole prompt                         |
+| `app.clipboard.pasteImage`        | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste from the clipboard (image preferred, text fallback) |
+| `app.stt.toggle`                  | `Alt+H`                                | Toggle speech-to-text recording               |
 
 On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. When the clipboard holds no image, `app.clipboard.pasteImage` pastes the clipboard text instead, so hosts that deliver only this chord (VS Code's integrated terminal when configured to forward `Ctrl+V`, Windows clipboard history via `Win+V`) work for both payload kinds. Windows Terminal also swallows `Ctrl+Enter`, so the follow-up shortcut also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -242,7 +242,7 @@ The derived name is the filename stem (or directory name for `index.ts`-style en
 - **Do not call runtime actions during load.** Methods like `pi.sendMessage()` throw `ExtensionRuntimeNotInitializedError` if called synchronously during module evaluation (before a session is active). Register handlers/tools/commands during load; perform runtime actions only from event handlers, tools, or commands.
 - **`tool_call` errors are fail-closed.** If a `tool_call` handler throws, the tool is blocked.
 - **Command names must not clash with built-ins.** Conflicts are skipped with a diagnostic log.
-- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+shift+right`, `alt+shift+left`, `alt+enter`, `escape`, `enter`).
 
 ## Further reading
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -26,6 +26,8 @@ interface AppKeybindings {
 	"app.thinking.toggle": true;
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
+	"app.modelPreset.cycleForward": true;
+	"app.modelPreset.cycleBackward": true;
 	"app.model.select": true;
 	"app.model.selectTemporary": true;
 	"app.tools.expand": true;
@@ -102,11 +104,19 @@ export const KEYBINDINGS = {
 	},
 	"app.model.cycleForward": {
 		defaultKeys: "ctrl+p",
-		description: "Cycle to next model",
+		description: "Cycle role models forward",
 	},
 	"app.model.cycleBackward": {
 		defaultKeys: "shift+ctrl+p",
-		description: "Cycle to previous model",
+		description: "Cycle role models backward",
+	},
+	"app.modelPreset.cycleForward": {
+		defaultKeys: "alt+shift+right",
+		description: "Cycle model preset forward",
+	},
+	"app.modelPreset.cycleBackward": {
+		defaultKeys: "alt+shift+left",
+		description: "Cycle model preset backward",
 	},
 	"app.model.select": {
 		defaultKeys: "alt+m",

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -3,7 +3,7 @@
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
-import type { KeyId } from "@oh-my-pi/pi-tui";
+import { canonicalKeyId, type KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { MemoryRuntimeContext } from "../../memory-backend";
@@ -363,18 +363,26 @@ export class ExtensionRunner {
 		"ctrl+q": true,
 		"shift+tab": true,
 		"shift+ctrl+p": true,
+		"alt+shift+right": true,
+		"alt+shift+left": true,
 		"alt+enter": true,
 		escape: true,
 		enter: true,
 	};
 
+	// Reserved chords are authored in human-readable form above; canonicalize them so lookups match
+	// the canonical ids extension shortcuts are normalized to (e.g. `shift+ctrl+p` -> `ctrl+shift+p`).
+	static readonly #RESERVED_SHORTCUT_IDS: ReadonlySet<string> = new Set(
+		Object.keys(ExtensionRunner.#RESERVED_SHORTCUTS).map(key => canonicalKeyId(key)),
+	);
+
 	getShortcuts(): Map<KeyId, ExtensionShortcut> {
 		const allShortcuts = new Map<KeyId, ExtensionShortcut>();
 		for (const ext of this.extensions) {
 			for (const [key, shortcut] of ext.shortcuts) {
-				const normalizedKey = key.toLowerCase() as KeyId;
+				const normalizedKey = canonicalKeyId(key) as KeyId;
 
-				if (ExtensionRunner.#RESERVED_SHORTCUTS[normalizedKey]) {
+				if (ExtensionRunner.#RESERVED_SHORTCUT_IDS.has(normalizedKey)) {
 					logger.warn("Extension shortcut conflicts with built-in shortcut", {
 						key,
 						extensionPath: shortcut.extensionPath,

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -12,7 +12,7 @@ Say `orchestrate` in your message to drive a multi-phase task with parallel suba
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically
 Run `omp auth-broker serve` once and every machine pulls live tokens over the wire — refresh keys never leave the host; `omp auth-gateway` fronts it as a drop-in proxy any OpenAI-compatible client can hit
-Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow -> etc
+Press alt+p (or /switch) to switch provider, ctrl+p to cycle role models, or alt+shift+right/left to cycle model presets
 Press ctrl+r to search your prompt history and reuse a past message
 `/force read` pins the next turn to one specific tool when the model keeps reaching for the wrong one
 `/copy code` grabs the last code block to your clipboard — `/copy cmd` grabs the last shell/python command

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my-pi/pi-tui";
 import { $env, isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { getAllModelPresetIds, getModelPresetInfo } from "../../config/model-presets";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { renderSegmentTrack } from "../../modes/components/segment-track";
@@ -307,6 +308,12 @@ export class InputController {
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.clipboard.copyLine")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyCurrentLine());
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.modelPreset.cycleForward")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => void this.cycleModelPreset("forward"));
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.modelPreset.cycleBackward")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => void this.cycleModelPreset("backward"));
 		}
 		const hubKeys = new Set([
 			...this.ctx.keybindings.getKeys("app.agents.hub"),
@@ -1189,7 +1196,7 @@ export class InputController {
 			return;
 		}
 		try {
-			const cycleOrder = settings.get("cycleOrder");
+			const cycleOrder = this.ctx.session.settings.get("cycleOrder");
 			const result = await this.ctx.session.cycleRoleModels(cycleOrder, direction);
 			if (!result) {
 				this.ctx.showStatus("Only one role model available");
@@ -1198,12 +1205,35 @@ export class InputController {
 
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
-			// The status line already reports the resolved model + thinking level, so
-			// the cycle status is just a status-line-style chip track (active role
-			// filled), matching the plan-approval model slider.
+			const cycle = this.ctx.session.getRoleModelCycle(cycleOrder);
+			const track =
+				cycle && cycle.models.length > 1
+					? renderSegmentTrack(
+							cycle.models.map(entry => ({ label: entry.role })),
+							cycle.currentIndex,
+						)
+					: `${result.role}: ${result.model.name || result.model.id}`;
+			this.ctx.showStatus(track, { dim: false });
+		} catch (error) {
+			this.ctx.showError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	async cycleModelPreset(direction: "forward" | "backward" = "forward"): Promise<void> {
+		try {
+			const result = await this.ctx.session.cycleModelPreset(direction);
+			if (!result) {
+				this.ctx.showStatus("Only one model preset available");
+				return;
+			}
+
+			this.ctx.statusLine.invalidate();
+			this.ctx.updateEditorBorderColor();
+			const ids = getAllModelPresetIds(this.ctx.session.settings);
+			const activeIndex = ids.indexOf(result.preset);
 			const track = renderSegmentTrack(
-				cycleOrder.map(role => ({ label: role })),
-				cycleOrder.indexOf(result.role),
+				ids.map((id: string) => ({ label: getModelPresetInfo(id).label })),
+				activeIndex,
 			);
 			this.ctx.showStatus(track, { dim: false });
 		} catch (error) {

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -41,6 +41,8 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,
 		`| \`${appKey(bindings, "app.model.cycleForward")}\` | Cycle role models (slow/default/smol) |`,
 		`| \`${appKey(bindings, "app.model.cycleBackward")}\` | Cycle role models (backward) |`,
+		`| \`${appKey(bindings, "app.modelPreset.cycleForward")}\` | Cycle model presets (Budget/Balanced/Smart/Ultra) |`,
+		`| \`${appKey(bindings, "app.modelPreset.cycleBackward")}\` | Cycle model presets (backward) |`,
 		`| \`${appKey(bindings, "app.model.selectTemporary")}\` | Select model (temporary) |`,
 		`| \`${appKey(bindings, "app.model.select")}\` | Select model (set roles) |`,
 		`| \`${appKey(bindings, "app.plan.toggle")}\` | Toggle plan mode |`,

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -38,6 +38,10 @@ async function createContext() {
 		"app.display.reset": ["ctrl+l"],
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["alt+m"],
+		"app.model.cycleForward": ["ctrl+p"],
+		"app.model.cycleBackward": ["shift+ctrl+p"],
+		"app.modelPreset.cycleForward": ["alt+shift+right"],
+		"app.modelPreset.cycleBackward": ["alt+shift+left"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -56,6 +60,27 @@ async function createContext() {
 	const prompt = vi.fn(async () => {});
 	const abort = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
+	const cycleRoleModels = vi.fn(async () => ({
+		model: { provider: "test", id: "slow-model", name: "Slow Model" },
+		role: "slow",
+		thinkingLevel: undefined,
+	}));
+	const cycleModelPreset = vi.fn(async () => ({
+		preset: "smart",
+		label: "Smart",
+		defaultModel: { provider: "test", id: "smart-model" },
+		roles: [],
+	}));
+	const getRoleModelCycle = vi.fn(() => ({
+		models: [
+			{ role: "default", model: { provider: "test", id: "default-model" } },
+			{ role: "slow", model: { provider: "test", id: "slow-model" } },
+		],
+		currentIndex: 1,
+	}));
+	const showStatus = vi.fn();
+	const showError = vi.fn();
+	const invalidateStatusLine = vi.fn();
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -95,6 +120,14 @@ async function createContext() {
 			prompt,
 			queuedMessageCount: 0,
 			abort,
+			cycleRoleModels,
+			cycleModelPreset,
+			getRoleModelCycle,
+			settings: {
+				get(key: string) {
+					return key === "cycleOrder" ? ["default", "slow"] : undefined;
+				},
+			},
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -144,8 +177,10 @@ async function createContext() {
 		toggleThinkingBlockVisibility: vi.fn(),
 		showModelSelector,
 		updateEditorBorderColor: vi.fn(),
+		showStatus,
+		showError,
+		statusLine: { invalidate: invalidateStatusLine },
 		hasActiveBtw: vi.fn(() => false),
-		showError: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -161,6 +196,11 @@ async function createContext() {
 			requestRender,
 			abort,
 			resetDisplay,
+			cycleRoleModels,
+			cycleModelPreset,
+			showStatus,
+			showError,
+			invalidateStatusLine,
 		},
 	};
 }
@@ -187,6 +227,24 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps role model cycling on model keys and presets on separate keys", async () => {
+		const { InputController, ctx, editor, customHandlers, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		await editor.onCycleModelForward?.();
+		await editor.onCycleModelBackward?.();
+		customHandlers.get("alt+shift+right")?.();
+		customHandlers.get("alt+shift+left")?.();
+
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.cycleForward", ["ctrl+p"]);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.cycleBackward", ["shift+ctrl+p"]);
+		expect(spies.cycleRoleModels).toHaveBeenNthCalledWith(1, ["default", "slow"], "forward");
+		expect(spies.cycleRoleModels).toHaveBeenNthCalledWith(2, ["default", "slow"], "backward");
+		expect(spies.cycleModelPreset).toHaveBeenNthCalledWith(1, "forward");
+		expect(spies.cycleModelPreset).toHaveBeenNthCalledWith(2, "backward");
 	});
 
 	it("empty Enter aborts the active stream when queued messages are pending", async () => {


### PR DESCRIPTION
## Summary
Adds preset cycle keybindings (`app.modelPreset.cycleForward/Backward`, Alt+Shift+Right/Left) separate from role-model cycling, and canonicalizes the extension reserved-shortcut lookup so the built-in cycle chords can't be hijacked regardless of modifier order.

## Scope
`config/keybindings.ts`, `modes/controllers/input-controller.ts`, `extensibility/extensions/runner.ts`, `modes/components/tips.txt`, `modes/utils/hotkeys-markdown.ts`, key docs, `test/input-controller-keybindings.test.ts`.

## Verification
`test/input-controller-keybindings.test.ts` green on the combined stack.

> **Stacked PR** — supersedes #2391. Depends on the `feat/preset-engine` PR; merge that first.

Closes https://github.com/can1357/oh-my-pi/issues/2492
