### PR TITLE
feat(coding-agent): add /preset command and /model PRESETS tab

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -17,6 +17,12 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
+import {
+	getAllModelPresetIds,
+	getModelPresetInfo,
+	type ModelPresetId,
+	resolveModelPreset,
+} from "../../config/model-presets";
 import type { ModelRegistry } from "../../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo, MODEL_ROLE_IDS, MODEL_ROLES } from "../../config/model-roles";
@@ -24,6 +30,7 @@ import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -103,6 +110,18 @@ interface ScopedModelItem {
 	model: Model;
 	thinkingLevel?: string;
 }
+interface PresetItem {
+	kind: "preset";
+	id: ModelPresetId;
+	selector: string;
+	label: string;
+	description: string;
+	defaultModelLabel: string;
+	roleSummary: string;
+	error?: string;
+	/** True when this preset is the session's currently-applied `modelPreset`. */
+	isActive: boolean;
+}
 
 interface RoleAssignment {
 	model: Model;
@@ -116,6 +135,7 @@ type RoleSelectCallback = (
 	thinkingLevel?: ConfiguredThinkingLevel,
 	selector?: string,
 ) => void;
+type PresetSelectCallback = (preset: ModelPresetId) => void | Promise<void>;
 type CancelCallback = () => void;
 interface MenuRoleAction {
 	label: string;
@@ -127,10 +147,17 @@ interface ProviderTabState {
 	label: string;
 	providerId?: string;
 }
+const PRESETS_TAB = "PRESETS";
 const ALL_TAB = "ALL";
 const CANONICAL_TAB = "CANONICAL";
 
-const STATIC_PROVIDER_TABS: ProviderTabState[] = [
+const STATIC_MODEL_TABS: ProviderTabState[] = [
+	{ id: PRESETS_TAB, label: PRESETS_TAB },
+	{ id: ALL_TAB, label: ALL_TAB },
+	{ id: CANONICAL_TAB, label: CANONICAL_TAB },
+];
+
+const STATIC_TEMPORARY_TABS: ProviderTabState[] = [
 	{ id: ALL_TAB, label: ALL_TAB },
 	{ id: CANONICAL_TAB, label: CANONICAL_TAB },
 ];
@@ -161,11 +188,13 @@ export class ModelSelectorComponent extends Container {
 	#filteredModels: ModelItem[] = [];
 	#canonicalModels: CanonicalModelItem[] = [];
 	#filteredCanonicalModels: CanonicalModelItem[] = [];
+	#presetItems: PresetItem[] = [];
 	#selectedIndex: number = 0;
 	#roles = {} as Record<string, RoleAssignment | undefined>;
 	#settings = null as unknown as Settings;
 	#modelRegistry = null as unknown as ModelRegistry;
 	#onSelectCallback = (() => {}) as RoleSelectCallback;
+	#onPresetSelectCallback: PresetSelectCallback | undefined;
 	#onCancelCallback = (() => {}) as CancelCallback;
 	#errorMessage?: unknown;
 	#tui: TUI;
@@ -176,7 +205,7 @@ export class ModelSelectorComponent extends Container {
 	#menuRoleActions: MenuRoleAction[] = [];
 
 	// Tab state
-	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
+	#providers: ProviderTabState[] = STATIC_MODEL_TABS;
 	#activeTabIndex: number = 0;
 	#refreshingProviders: Set<string> = new Set();
 	#scheduledProviderRefreshes: Map<string, ReturnType<typeof setTimeout>> = new Map();
@@ -197,7 +226,12 @@ export class ModelSelectorComponent extends Container {
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string; currentContextTokens?: number },
+		options?: {
+			temporaryOnly?: boolean;
+			initialSearchInput?: string;
+			currentContextTokens?: number;
+			onPresetSelect?: PresetSelectCallback;
+		},
 	) {
 		super();
 
@@ -206,6 +240,7 @@ export class ModelSelectorComponent extends Container {
 		this.#modelRegistry = modelRegistry;
 		this.#scopedModels = scopedModels;
 		this.#onSelectCallback = onSelect;
+		this.#onPresetSelectCallback = options?.onPresetSelect;
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		const currentContextTokens = options?.currentContextTokens ?? 0;
@@ -243,8 +278,12 @@ export class ModelSelectorComponent extends Container {
 			this.#searchInput.setValue(initialSearchInput);
 		}
 		this.#searchInput.onSubmit = () => {
-			// Enter on search input opens menu if we have an enabled selection
-			if (this.#getSelectedItem()) {
+			const preset = this.#getSelectedPresetItem();
+			if (preset) {
+				void this.#handlePresetSelect(preset);
+				return;
+			}
+			if (this.#getSelectedModelItem()) {
 				this.#openMenu();
 			}
 		};
@@ -445,6 +484,48 @@ export class ModelSelectorComponent extends Container {
 		});
 	}
 
+	#loadPresetItems(candidates: readonly Model[]): void {
+		if (this.#temporaryOnly) {
+			this.#presetItems = [];
+			return;
+		}
+
+		const activePreset = this.#settings.get("modelPreset");
+		this.#presetItems = getAllModelPresetIds(this.#settings).map((id: ModelPresetId) => {
+			const info = getModelPresetInfo(id);
+			const isActive = id === activePreset;
+			try {
+				const resolved = resolveModelPreset(this.#settings, this.#modelRegistry, candidates, id);
+				const roles = resolved.roles.map(role => role.role).join(", ");
+				return {
+					kind: "preset",
+					id,
+					selector: `preset:${id}`,
+					label: info.label,
+					description: info.description,
+					defaultModelLabel: `${resolved.defaultRole.model.provider}/${resolved.defaultRole.model.id}`,
+					roleSummary: roles,
+					isActive,
+				};
+			} catch (error) {
+				const message = replaceTabs(
+					truncateToWidth(error instanceof Error ? error.message : String(error), TRUNCATE_LENGTHS.LINE),
+				);
+				return {
+					kind: "preset",
+					id,
+					selector: `preset:${id}`,
+					label: info.label,
+					description: info.description,
+					defaultModelLabel: "unavailable",
+					roleSummary: message,
+					error: message,
+					isActive,
+				};
+			}
+		});
+	}
+
 	#loadModelsFromCurrentRegistryState(): void {
 		let models: ModelItem[];
 		if (this.#scopedModels.length > 0) {
@@ -477,6 +558,7 @@ export class ModelSelectorComponent extends Container {
 				this.#filteredModels = [];
 				this.#canonicalModels = [];
 				this.#filteredCanonicalModels = [];
+				this.#presetItems = [];
 				this.#errorMessage = error instanceof Error ? error.message : String(error);
 				return;
 			}
@@ -484,6 +566,7 @@ export class ModelSelectorComponent extends Container {
 
 		const candidates = models.map(item => item.model);
 		this.#loadRoleModels(candidates);
+		this.#loadPresetItems(candidates);
 		const canonicalSelections = this.#modelRegistry.getCanonicalModelSelections({
 			availableOnly: this.#scopedModels.length === 0,
 			candidates,
@@ -495,7 +578,10 @@ export class ModelSelectorComponent extends Container {
 				selectedModel.provider,
 				selectedModel.id,
 				selectedModel.name,
-				...record.variants.flatMap(variant => [variant.selector, variant.model.name]),
+				...record.variants.flatMap((variant: { selector: string; model: { name: string } }) => [
+					variant.selector,
+					variant.model.name,
+				]),
 			].join(" ");
 			return {
 				kind: "canonical",
@@ -516,7 +602,7 @@ export class ModelSelectorComponent extends Container {
 		this.#filteredModels = models;
 		this.#canonicalModels = canonicalModels;
 		this.#filteredCanonicalModels = canonicalModels;
-		const visibleModels = this.#isCanonicalTab() ? canonicalModels : models;
+		const visibleModels = this.#getVisibleItems();
 		this.#selectedIndex = this.#coerceSelectedIndex(
 			Math.min(this.#selectedIndex, Math.max(0, visibleModels.length - 1)),
 			visibleModels,
@@ -558,10 +644,10 @@ export class ModelSelectorComponent extends Container {
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>
 			formatProviderTabLabel(left).localeCompare(formatProviderTabLabel(right)),
 		);
-		this.#providers = [...STATIC_PROVIDER_TABS, ...sortedProviderIds.map(createProviderTab)];
+		const staticTabs = this.#temporaryOnly ? STATIC_TEMPORARY_TABS : STATIC_MODEL_TABS;
+		this.#providers = [...staticTabs, ...sortedProviderIds.map(createProviderTab)];
 		const activeIndex = this.#providers.findIndex(tab => tab.id === activeTabId);
-		this.#activeTabIndex =
-			activeIndex >= 0 ? activeIndex : Math.min(this.#activeTabIndex, this.#providers.length - 1);
+		this.#activeTabIndex = activeIndex >= 0 ? activeIndex : 0;
 	}
 
 	#getActiveProviderRefreshStatusText(): string | undefined {
@@ -683,7 +769,8 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#getActiveTab(): ProviderTabState {
-		return this.#providers[this.#activeTabIndex] ?? STATIC_PROVIDER_TABS[0]!;
+		const fallback = this.#temporaryOnly ? STATIC_TEMPORARY_TABS[0] : STATIC_MODEL_TABS[0];
+		return this.#providers[this.#activeTabIndex] ?? fallback!;
 	}
 
 	#getActiveTabId(): string {
@@ -692,6 +779,10 @@ export class ModelSelectorComponent extends Container {
 
 	#getActiveProviderId(): string | undefined {
 		return this.#getActiveTab().providerId;
+	}
+
+	#isPresetTab(): boolean {
+		return this.#getActiveTabId() === PRESETS_TAB;
 	}
 
 	#isCanonicalTab(): boolean {
@@ -703,8 +794,8 @@ export class ModelSelectorComponent extends Container {
 		return this.#currentContextTokens > 0 && contextWindow > 0 && this.#currentContextTokens > contextWindow;
 	}
 
-	#isItemDisabled(item: ModelItem | CanonicalModelItem): boolean {
-		return this.#isModelOverContextLimit(item.model);
+	#isItemDisabled(item: PresetItem | ModelItem | CanonicalModelItem): boolean {
+		return item.kind !== "preset" && this.#isModelOverContextLimit(item.model);
 	}
 
 	#formatContextLimitSuffix(model: Model): string {
@@ -714,13 +805,14 @@ export class ModelSelectorComponent extends Container {
 		return ` ${theme.status.disabled} context>${formatNumber(model.contextWindow ?? 0).toLowerCase()}`;
 	}
 
-	#getVisibleItems(): ReadonlyArray<ModelItem | CanonicalModelItem> {
+	#getVisibleItems(): ReadonlyArray<PresetItem | ModelItem | CanonicalModelItem> {
+		if (this.#isPresetTab()) return this.#presetItems;
 		return this.#isCanonicalTab() ? this.#filteredCanonicalModels : this.#filteredModels;
 	}
 
 	#coerceSelectedIndex(
 		index: number,
-		visibleItems: ReadonlyArray<ModelItem | CanonicalModelItem> = this.#getVisibleItems(),
+		visibleItems: ReadonlyArray<PresetItem | ModelItem | CanonicalModelItem> = this.#getVisibleItems(),
 	): number {
 		const maxIndex = visibleItems.length - 1;
 		if (maxIndex < 0) {
@@ -769,6 +861,7 @@ export class ModelSelectorComponent extends Container {
 	#filterModels(query: string): void {
 		const activeTabId = this.#getActiveTabId();
 		const activeProviderId = this.#getActiveProviderId();
+		const isPresetTab = activeTabId === PRESETS_TAB;
 		const isCanonicalTab = activeTabId === CANONICAL_TAB;
 
 		// Start with all models or filter by provider/canonical view
@@ -780,11 +873,12 @@ export class ModelSelectorComponent extends Container {
 
 		// Apply fuzzy filter if query is present
 		if (query.trim()) {
-			// If user is searching from a provider tab, auto-switch to ALL to show global provider results.
-			if (activeProviderId && !isCanonicalTab) {
-				this.#activeTabIndex = 0;
-				if (this.#tabBar && this.#tabBar.getActiveIndex() !== 0) {
-					this.#tabBar.setActiveIndex(0);
+			// Searching from PRESETS or provider tabs switches to ALL to show global provider results.
+			if ((isPresetTab || activeProviderId) && !isCanonicalTab) {
+				const allIndex = this.#providers.findIndex(tab => tab.id === ALL_TAB);
+				this.#activeTabIndex = allIndex >= 0 ? allIndex : 0;
+				if (this.#tabBar && this.#tabBar.getActiveIndex() !== this.#activeTabIndex) {
+					this.#tabBar.setActiveIndex(this.#activeTabIndex);
 					return;
 				}
 				this.#updateTabBar();
@@ -836,7 +930,7 @@ export class ModelSelectorComponent extends Container {
 			this.#filteredCanonicalModels = baseCanonicalModels;
 		}
 
-		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
+		const visibleItems = this.#getVisibleItems();
 		this.#selectedIndex = this.#coerceSelectedIndex(
 			Math.min(this.#selectedIndex, Math.max(0, visibleItems.length - 1)),
 			visibleItems,
@@ -909,8 +1003,9 @@ export class ModelSelectorComponent extends Container {
 
 	#updateList(): void {
 		this.#listContainer.clear();
+		const isPresetTab = this.#isPresetTab();
 		const isCanonicalTab = this.#isCanonicalTab();
-		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
+		const visibleItems = this.#getVisibleItems();
 
 		const maxVisible = 10;
 		const startIndex = Math.max(
@@ -922,18 +1017,27 @@ export class ModelSelectorComponent extends Container {
 		const showProvider = this.#getActiveTabId() === ALL_TAB;
 
 		const rows: string[] = [];
-		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = visibleItems[i];
 			if (!item) continue;
-			const canonicalItem = isCanonicalTab ? (item as CanonicalModelItem) : undefined;
-			const providerItem = isCanonicalTab ? undefined : (item as ModelItem);
 
 			const isSelected = i === this.#selectedIndex;
+			const prefix = isSelected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+
+			if (item.kind === "preset") {
+				const defaultLabel = item.error ? theme.fg("error", item.defaultModelLabel) : item.defaultModelLabel;
+				const summary = theme.fg("dim", ` — ${defaultLabel}; roles: ${item.roleSummary}`);
+				const label = isSelected ? theme.fg("accent", item.label) : item.label;
+				const activeBadge = item.isActive ? ` ${makeInvertedBadge("active", "success")}` : "";
+				rows.push(`${prefix}${label}${activeBadge}${summary}`);
+				continue;
+			}
+
+			const canonicalItem = isCanonicalTab ? (item as CanonicalModelItem) : undefined;
+			const providerItem = isCanonicalTab ? undefined : (item as ModelItem);
 			const isDisabled = this.#isItemDisabled(item);
 			const disabledSuffix = this.#formatContextLimitSuffix(item.model);
 
-			// Build role badges. Solid badges are configured; outlined badges are auto-selected defaults.
 			const roleBadgeTokens: string[] = [];
 			for (const role of MODEL_ROLE_IDS) {
 				const { tag, color } = getRoleInfo(role, this.#settings);
@@ -942,7 +1046,6 @@ export class ModelSelectorComponent extends Container {
 
 				roleBadgeTokens.push(makeRoleBadgeToken(tag, color ?? "success", assigned));
 			}
-			// Custom role badges
 			for (const [role, assigned] of Object.entries(this.#roles)) {
 				if (role in MODEL_ROLES || !assigned || !modelsAreEqual(assigned.model, item.model)) continue;
 				const roleInfo = getRoleInfo(role, this.#settings);
@@ -951,31 +1054,17 @@ export class ModelSelectorComponent extends Container {
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 
-			let line = "";
-			if (isSelected) {
-				const prefix = theme.fg("accent", `${theme.nav.cursor} `);
-				if (isCanonicalTab) {
-					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
-					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${theme.fg("accent", item.id)}${variants}${backing}${badgeText}${disabledSuffix}`;
-				} else if (showProvider) {
-					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${theme.fg("accent", providerItem?.id ?? item.id)}${badgeText}${disabledSuffix}`;
-				} else {
-					line = `${prefix}${theme.fg("accent", item.id)}${badgeText}${disabledSuffix}`;
-				}
+			let line: string;
+			if (isCanonicalTab) {
+				const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
+				const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
+				line = `${prefix}${isSelected ? theme.fg("accent", item.id) : item.id}${variants}${backing}${badgeText}${disabledSuffix}`;
+			} else if (showProvider) {
+				const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
+				const id = providerItem?.id ?? item.id;
+				line = `${prefix}${providerPrefix}${isSelected ? theme.fg("accent", id) : id}${badgeText}${disabledSuffix}`;
 			} else {
-				const prefix = "  ";
-				if (isCanonicalTab) {
-					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
-					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${item.id}${variants}${backing}${badgeText}${disabledSuffix}`;
-				} else if (showProvider) {
-					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${providerItem?.id ?? item.id}${badgeText}${disabledSuffix}`;
-				} else {
-					line = `${prefix}${item.id}${badgeText}${disabledSuffix}`;
-				}
+				line = `${prefix}${isSelected ? theme.fg("accent", item.id) : item.id}${badgeText}${disabledSuffix}`;
 			}
 
 			if (isDisabled) {
@@ -995,21 +1084,22 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(sv);
 		}
 
-		// Show error message or "no results" if empty
 		if (this.#errorMessage) {
 			const errorLines = String(this.#errorMessage).split("\n");
 			for (const line of errorLines) {
 				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
 		} else if (visibleItems.length === 0) {
-			const statusMessage = this.#getProviderEmptyStateMessage();
+			const statusMessage = isPresetTab ? "  No model presets" : this.#getProviderEmptyStateMessage();
 			this.#listContainer.addChild(new Text(theme.fg("muted", statusMessage ?? "  No matching models"), 0, 0));
 		} else {
 			const selected = visibleItems[this.#selectedIndex];
-			if (!selected) {
+			if (!selected) return;
+			this.#listContainer.addChild(new Spacer(1));
+			if (selected.kind === "preset") {
+				this.#listContainer.addChild(new Text(theme.fg("muted", `  ${selected.description}`), 0, 0));
 				return;
 			}
-			this.#listContainer.addChild(new Spacer(1));
 			const suffix = isCanonicalTab
 				? ` (${selected.model.provider}/${selected.model.id}, ${(selected as CanonicalModelItem).variantCount} variants)`
 				: "";
@@ -1039,14 +1129,22 @@ export class ModelSelectorComponent extends Container {
 		return foundIndex >= 0 ? foundIndex : 0;
 	}
 
-	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
-		return this.#isCanonicalTab()
-			? this.#filteredCanonicalModels[this.#selectedIndex]
-			: this.#filteredModels[this.#selectedIndex];
+	#getSelectedItem(): PresetItem | ModelItem | CanonicalModelItem | undefined {
+		return this.#getVisibleItems()[this.#selectedIndex];
+	}
+
+	#getSelectedModelItem(): ModelItem | CanonicalModelItem | undefined {
+		const item = this.#getSelectedItem();
+		return item?.kind === "preset" ? undefined : item;
+	}
+
+	#getSelectedPresetItem(): PresetItem | undefined {
+		const item = this.#getSelectedItem();
+		return item?.kind === "preset" ? item : undefined;
 	}
 
 	#openMenu(): void {
-		const selectedItem = this.#getSelectedItem();
+		const selectedItem = this.#getSelectedModelItem();
 		if (!selectedItem || this.#isItemDisabled(selectedItem)) return;
 
 		this.#isMenuOpen = true;
@@ -1066,7 +1164,7 @@ export class ModelSelectorComponent extends Container {
 	#updateMenu(): void {
 		this.#menuContainer.clear();
 
-		const selectedItem = this.#getSelectedItem();
+		const selectedItem = this.#getSelectedModelItem();
 		if (!selectedItem) return;
 
 		const showingThinking = this.#menuStep === "thinking" && this.#menuSelectedRole !== null;
@@ -1122,6 +1220,17 @@ export class ModelSelectorComponent extends Container {
 		this.#menuContainer.addChild(new Text(theme.fg("border", theme.boxSharp.horizontal.repeat(menuWidth)), 0, 0));
 	}
 
+	async #handlePresetSelect(item: PresetItem): Promise<void> {
+		if (!this.#onPresetSelectCallback) return;
+		try {
+			await this.#onPresetSelectCallback(item.id);
+		} catch (error) {
+			this.#errorMessage = error instanceof Error ? error.message : String(error);
+			this.#updateList();
+			this.#tui.requestRender();
+		}
+	}
+
 	handleInput(keyData: string): void {
 		if (this.#isMenuOpen) {
 			this.#handleMenuInput(keyData);
@@ -1147,7 +1256,13 @@ export class ModelSelectorComponent extends Container {
 
 		// Enter - open context menu or select directly in temporary mode
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const selectedItem = this.#getSelectedItem();
+			const preset = this.#getSelectedPresetItem();
+			if (preset) {
+				void this.#handlePresetSelect(preset);
+				return;
+			}
+
+			const selectedItem = this.#getSelectedModelItem();
 			if (selectedItem && !this.#isItemDisabled(selectedItem)) {
 				if (this.#temporaryOnly) {
 					// In temporary mode, skip menu and select directly
@@ -1170,7 +1285,7 @@ export class ModelSelectorComponent extends Container {
 		this.#filterModels(this.#searchInput.getValue());
 	}
 	#handleMenuInput(keyData: string): void {
-		const selectedItem = this.#getSelectedItem();
+		const selectedItem = this.#getSelectedModelItem();
 		if (!selectedItem || this.#isItemDisabled(selectedItem)) return;
 
 		const optionCount =

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -5,6 +5,7 @@ import type { OAuthProvider } from "@oh-my-pi/pi-ai/oauth/types";
 import type { Component, OverlayHandle } from "@oh-my-pi/pi-tui";
 import { Input, Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath, getProjectDir, normalizePathForComparison } from "@oh-my-pi/pi-utils";
+import type { ModelPresetId } from "../../config/model-presets";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import { getRoleInfo } from "../../config/model-roles";
 import { settings } from "../../config/settings";
@@ -499,7 +500,20 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				{ ...options, currentContextTokens },
+				{
+					...options,
+					currentContextTokens,
+					onPresetSelect: async (preset: ModelPresetId) => {
+						const result = await this.ctx.session.applyModelPreset(preset);
+						this.ctx.statusLine.invalidate();
+						this.ctx.updateEditorBorderColor();
+						this.ctx.showStatus(
+							`Preset ${result.label}: ${result.defaultModel.provider}/${result.defaultModel.id}`,
+						);
+						done();
+						this.ctx.ui.requestRender();
+					},
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -7,6 +7,7 @@ import type { AutocompleteItem } from "@oh-my-pi/pi-tui";
 import { APP_NAME, setProjectDir } from "@oh-my-pi/pi-utils";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
+import { getAllModelPresetIds, getModelPresetInfo, type ModelPresetId, resolvePresetId } from "../config/model-presets";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {
@@ -89,6 +90,30 @@ function collabLinkHint(host: CollabHost, heading: string, view = false): string
 function formatFreshSessionResult(result: FreshSessionResult): string {
 	const stateLabel = result.closedProviderSessions === 1 ? "provider state" : "provider states";
 	return `Fresh provider session started (${result.closedProviderSessions} ${stateLabel} pruned).`;
+}
+
+/**
+ * Build the "Model presets:" listing shared by the ACP (`handle`) and TUI
+ * (`handleTui`) `/preset` handlers. Each row shows the active marker (`*` when
+ * the id matches `settings.modelPreset`), the preset label/id, and either the
+ * resolved default model or a sanitized resolution error.
+ */
+function buildPresetListLines(session: AgentSession): string[] {
+	const activePreset = session.settings.get("modelPreset");
+	const lines = ["Model presets:"];
+	for (const preset of getAllModelPresetIds(session.settings)) {
+		const info = getModelPresetInfo(preset);
+		const active = activePreset === preset ? "*" : " ";
+		try {
+			const resolved = session.getResolvedModelPreset(preset);
+			lines.push(
+				`${active} ${info.label} (${preset}) - ${resolved.defaultRole.model.provider}/${resolved.defaultRole.model.id}`,
+			);
+		} catch (error) {
+			lines.push(`${active} ${info.label} (${preset}) - unavailable: ${errorMessage(error)}`);
+		}
+	}
+	return lines;
 }
 
 const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime): SlashCommandResult => {
@@ -320,6 +345,104 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "preset",
+		description: "Apply or list model presets",
+		acpDescription: "Apply or list model presets",
+		inlineHint: "[<name>|next|prev|list]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const arg = (command.args ?? "").trim().toLowerCase();
+			const usageText = "Usage: /preset [<name>|next|prev|list]";
+			const applyPreset = async (preset: ModelPresetId) => {
+				const result = await runtime.session.applyModelPreset(preset);
+				await runtime.output(
+					`Preset ${result.label} applied: ${result.defaultModel.provider}/${result.defaultModel.id}.`,
+				);
+				await runtime.notifyTitleChanged?.();
+				await runtime.notifyConfigChanged?.();
+				return commandConsumed();
+			};
+
+			if (!arg || arg === "list") {
+				await runtime.output(buildPresetListLines(runtime.session).join("\n"));
+				return commandConsumed();
+			}
+
+			try {
+				if (arg === "next") {
+					const result = await runtime.session.cycleModelPreset("forward");
+					if (!result) {
+						await runtime.output("Only one model preset available.");
+						return commandConsumed();
+					}
+					await runtime.output(
+						`Preset ${result.label} applied: ${result.defaultModel.provider}/${result.defaultModel.id}.`,
+					);
+					await runtime.notifyTitleChanged?.();
+					await runtime.notifyConfigChanged?.();
+					return commandConsumed();
+				}
+				if (arg === "prev" || arg === "previous") {
+					const result = await runtime.session.cycleModelPreset("backward");
+					if (!result) {
+						await runtime.output("Only one model preset available.");
+						return commandConsumed();
+					}
+					await runtime.output(
+						`Preset ${result.label} applied: ${result.defaultModel.provider}/${result.defaultModel.id}.`,
+					);
+					await runtime.notifyTitleChanged?.();
+					await runtime.notifyConfigChanged?.();
+					return commandConsumed();
+				}
+
+				const preset = resolvePresetId(runtime.session.settings, arg);
+				if (!preset) {
+					return usage(`Unknown preset: ${arg}. ${usageText}`, runtime);
+				}
+				return await applyPreset(preset);
+			} catch (error) {
+				return usage(`Failed to apply preset: ${errorMessage(error)}`, runtime);
+			}
+		},
+		handleTui: async (command, runtime) => {
+			const arg = (command.args ?? "").trim().toLowerCase();
+			if (!arg || arg === "list") {
+				runtime.ctx.showStatus(buildPresetListLines(runtime.ctx.session).join("\n"));
+				runtime.ctx.editor.setText("");
+				return commandConsumed();
+			}
+
+			try {
+				const direction =
+					arg === "next" ? "forward" : arg === "prev" || arg === "previous" ? "backward" : undefined;
+				let result: { label: string; defaultModel: { provider: string; id: string } } | undefined;
+				if (direction) {
+					result = await runtime.ctx.session.cycleModelPreset(direction);
+				} else {
+					const preset = resolvePresetId(runtime.ctx.session.settings, arg);
+					if (!preset) {
+						runtime.ctx.showWarning("Usage: /preset [<name>|next|prev|list]");
+						return commandConsumed();
+					}
+					result = await runtime.ctx.session.applyModelPreset(preset);
+				}
+				if (!result) {
+					runtime.ctx.showWarning("Only one model preset available");
+					return commandConsumed();
+				}
+				refreshStatusLine(runtime.ctx);
+				runtime.ctx.showStatus(
+					`Preset ${result.label} applied: ${result.defaultModel.provider}/${result.defaultModel.id}.`,
+				);
+			} catch (error) {
+				runtime.ctx.showError(errorMessage(error));
+			}
+			runtime.ctx.editor.setText("");
+			return commandConsumed();
 		},
 	},
 	{

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -5,10 +5,11 @@ import type {
 	ResetCreditTarget,
 	UsageReport,
 } from "@oh-my-pi/pi-ai";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { lookupBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 
 interface FakeAcpBuiltinSession {
 	fastMode: boolean;
@@ -18,6 +19,7 @@ interface FakeAcpBuiltinSession {
 	sessionId: string;
 	sessionName: string;
 	_todoPhases: Array<{ name: string; tasks: Array<{ content: string; status: string }> }>;
+	cycleDirection?: "forward" | "backward";
 	toggleFastMode(): boolean;
 	setFastMode(enabled: boolean): void;
 	isFastModeEnabled(): boolean;
@@ -42,12 +44,25 @@ interface FakeAcpBuiltinSession {
 	getContextUsage(): { tokens?: number; contextWindow: number } | undefined;
 	getAvailableModels(): Array<{ provider: string; id: string; contextWindow?: number }>;
 	setModel(model: unknown): Promise<void>;
+	applyModelPreset(preset: string): Promise<{
+		preset: string;
+		label: string;
+		defaultModel: { provider: string; id: string };
+	}>;
+	cycleModelPreset(direction?: "forward" | "backward"): Promise<{
+		preset: string;
+		label: string;
+		defaultModel: { provider: string; id: string };
+	}>;
+	getResolvedModelPreset(preset: string): {
+		defaultRole: { model: { provider: string; id: string } };
+	};
 	listResetCredits: () => Promise<ResetCreditAccountStatus[]>;
 	redeemResetCredit: (target: ResetCreditTarget) => Promise<ResetCreditRedeemOutcome>;
 }
 
-function createRuntime() {
-	const settings = Settings.isolated();
+function createRuntime(settingsOverrides: Partial<Record<SettingPath, unknown>> = {}) {
+	const settings = Settings.isolated(settingsOverrides);
 	const output: string[] = [];
 	const session: FakeAcpBuiltinSession = {
 		fastMode: false,
@@ -107,6 +122,24 @@ function createRuntime() {
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
 		async setModel(_model: unknown) {},
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
+		async applyModelPreset(preset) {
+			const labels: Record<string, string> = {
+				budget: "Budget",
+				balanced: "Balanced",
+				smart: "Smart",
+				ultra: "Ultra",
+			};
+			this.settings.set("modelPreset", preset);
+			this.model = { provider: "test", id: `${preset}-model` };
+			return { preset, label: labels[preset] ?? preset, defaultModel: this.model };
+		},
+		async cycleModelPreset(direction = "forward") {
+			this.cycleDirection = direction;
+			return this.applyModelPreset(direction === "backward" ? "budget" : "smart");
+		},
+		getResolvedModelPreset(preset) {
+			return { defaultRole: { model: { provider: "test", id: `${preset}-model` } } };
+		},
 	};
 	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
 	const fakeSessionManager = {
@@ -913,6 +946,101 @@ describe("wave 5 — adapters and polish", () => {
 		const result = await executeAcpBuiltinSlashCommand("/jobs", runtime);
 		expect(result).toEqual({ consumed: true });
 		expect(output[0]).toContain("background jobs");
+	});
+
+	it("/preset lists presets without mutating state", async () => {
+		const { output, runtime } = createRuntime();
+		const before = runtime.session.settings.get("modelPreset");
+
+		const result = await executeAcpBuiltinSlashCommand("/preset", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.session.settings.get("modelPreset")).toBe(before);
+		expect(output[0]).toContain("Budget");
+		expect(output[0]).toContain("Balanced");
+		expect(output[0]).toContain("Smart");
+		expect(output[0]).toContain("Ultra");
+	});
+
+	it("/preset smart applies preset and notifies clients", async () => {
+		const { output, runtime } = createRuntime();
+		let titleUpdates = 0;
+		let configUpdates = 0;
+		runtime.notifyTitleChanged = () => {
+			titleUpdates++;
+		};
+		runtime.notifyConfigChanged = () => {
+			configUpdates++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/preset smart", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output).toEqual(["Preset Smart applied: test/smart-model."]);
+		expect(runtime.session.settings.get("modelPreset")).toBe("smart");
+		expect(titleUpdates).toBe(1);
+		expect(configUpdates).toBe(1);
+	});
+
+	it("/preset bogus emits usage without notifications", async () => {
+		const { output, runtime } = createRuntime();
+		let titleUpdates = 0;
+		runtime.notifyTitleChanged = () => {
+			titleUpdates++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/preset bogus", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Unknown preset: bogus");
+		expect(output[0]).toContain("Usage: /preset [<name>|next|prev|list]");
+		expect(titleUpdates).toBe(0);
+	});
+
+	it("/preset next cycles forward", async () => {
+		const { output, runtime } = createRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/preset next", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.session.cycleDirection).toBe("forward");
+		expect(output).toEqual(["Preset Smart applied: test/smart-model."]);
+	});
+
+	it("/preset listing includes custom presets defined in settings", async () => {
+		const { output, runtime } = createRuntime({ modelPresets: { ace: { default: "test/ace-model" } } });
+
+		const result = await executeAcpBuiltinSlashCommand("/preset", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Model presets:");
+		expect(output[0]).toContain("(ace)");
+		expect(output[0]).toContain("test/ace-model");
+	});
+
+	it("/preset <custom> applies a custom preset", async () => {
+		const { output, runtime } = createRuntime({ modelPresets: { ace: { default: "test/ace-model" } } });
+
+		const result = await executeAcpBuiltinSlashCommand("/preset ace", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.session.settings.get("modelPreset")).toBe("ace");
+		expect(output[0]).toContain("applied");
+	});
+
+	it("/preset with undefined args lists presets without throwing", async () => {
+		const { output, runtime } = createRuntime();
+		const command = lookupBuiltinSlashCommand("preset");
+		expect(command?.handle).toBeDefined();
+
+		const result = await command?.handle?.(
+			{ name: "preset", args: undefined as unknown as string, text: "/preset" },
+			runtime,
+		);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Model presets:");
+		expect(output[0]).toContain("Budget");
 	});
 
 	// /marketplace discover bulleted list


### PR DESCRIPTION
## Summary
Adds the in-app preset surfaces: `/preset` (built-in + custom, `next`/`prev`/`list`, defensive no-arg handling, shared ACP/TUI list builder) and the `/model` PRESETS tab (scoped-candidate resolution, active marker, sanitized error path).

## Scope
`slash-commands/builtin-registry.ts` (`/preset`), `modes/components/model-selector.ts` (PRESETS tab), `modes/controllers/selector-controller.ts`, `test/acp-builtins.test.ts`.

## Verification
Covered by `test/acp-builtins.test.ts` (custom-preset listing/apply, no-arg, unknown). Full-tree `check:types` is green on the combined stack.

> **Stacked PR** — part of the atomic stack that supersedes #2391. Depends on the `feat/preset-engine` PR (model-preset engine); merge that first. CI here is red until the engine lands.

Closes https://github.com/can1357/oh-my-pi/issues/2493
