### PR TITLE
docs(coding-agent): document model presets, custom profiles, and --preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Setting-gated, off by default: `github`, `inspect_image`, `render_mermaid`, `tts
 
 ## Forty-plus providers, hundreds of models, _one /model away_.
 
-Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle through the configured models for the active role with `Ctrl+P`. Swap the active model mid-session with the `/model` slash command.
+Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle role models with `Ctrl+P` / `Shift+Ctrl+P`; switch complete Budget/Balanced/Smart/Ultra role profiles — or your own custom presets defined in `modelPresets` — with `--preset <name>`, `Alt+Shift+Right` / `Alt+Shift+Left`, `/preset`, or the `PRESETS` tab in `/model`. Swap the active model mid-session with the `/model` slash command.
 
 Auth tags below: `oauth` signs in with your provider account, `plan` routes through a coding-plan subscription, `local` runs against a local server with the key optional.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -423,6 +423,47 @@ Role aliases like `pi/smol` expand through `settings.modelRoles`. Each role valu
 
 If a role points at another role, the target model still inherits normally and any explicit suffix on the referring role wins for that role-specific use.
 
+### Model presets
+
+A preset is a complete role profile (a `role → selector` map), not an alias for one model. Four built-ins ship in order: `budget`, `balanced`, `smart`, and `ultra`. `modelPreset` stores the active preset id (default `balanced`).
+
+Applying a preset is a **non-destructive runtime overlay**: it layers the preset's role map over the live session and updates the active `default` model, keeping role-specific thinking suffixes. It **never writes persistent `modelRoles`** — only the selected preset's id is persisted to `modelPreset` (so it becomes the default for the next start). Your configured `modelRoles` stay intact, and roles the overlay does not mention (for example `vision`) are left as-is rather than dropped. Switching between presets re-overlays cleanly and does not corrupt later role resolution.
+
+#### In-app surfaces
+
+- `/preset` to list profiles, `/preset smart` to apply one, and `/preset next` or `/preset prev` to cycle.
+- The `/model` selector has a `PRESETS` tab listing built-in and custom presets.
+
+`modelPreset` and `modelPresets` are **config-file-only** settings — there is no `/settings` UI for them; edit `models.yml` (or apply a preset in-app, which persists `modelPreset`).
+
+#### CLI and env
+
+- `--preset <name>` (alias `--profile <name>`) applies a preset at launch.
+- `PI_PRESET=<name>` selects a preset via environment.
+- `--preset list` prints the available preset names and exits.
+
+Per-role flags win over the preset: explicit `--model`, `--smol`, `--slow`, or `--plan` override the role the preset would otherwise set.
+
+#### Startup auto-apply
+
+The persisted default preset (`modelPreset`) auto-applies at startup, but explicitly configured roles win — the overlay fills only the roles you have not already configured via `models.yml` `modelRoles` or CLI role flags. Auto-apply is **skipped on `--continue` / `--resume`** so a resumed session keeps the model state it was saved with.
+
+#### Custom presets
+
+Define your own presets (or override built-in ones) with the `modelPresets` map, keyed by preset name (arbitrary names allowed) → a `role → selector` map:
+
+```yaml
+modelPresets:
+  fast-cheap:
+    default: pi/smol
+    plan: pi/slow
+  smart:
+    default: openai/gpt-5.4:high
+    task: anthropic/claude-sonnet-4-5:high
+```
+
+Custom keys (such as `fast-cheap`) appear after the built-ins in `/preset`, the `/model` PRESETS tab, and `--preset list`, and are usable with `--preset`/`--profile`/`PI_PRESET`. When a key matches a built-in (such as `smart`), only the named role entries are overridden; the rest of the built-in profile is inherited.
+
 Related settings:
 
 - `modelRoles` (record)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Budget, Balanced, Smart, and Ultra model presets with `/preset`, separate preset-cycling shortcuts, and a `PRESETS` tab in `/model`.
+- Added `/guided-goal` for a Plan/Slow-model interview that refines a rough objective before entering goal mode.
+- Added custom model presets via the `modelPresets` config map (arbitrary preset names → `role → selector` maps), surfaced alongside the built-ins in the `/model` PRESETS tab, `/preset`, and `--preset list`.
+- Added `--preset <name>` (alias `--profile <name>`) and the `PI_PRESET` environment variable to select a model preset at launch, plus `--preset list` to print the available presets and exit.
+
+### Changed
+
+- Applying a model preset is now a non-destructive runtime overlay: it layers the preset's role map over the live session and persists only the active `modelPreset` id, instead of rewriting persistent `modelRoles`. The persisted default preset auto-applies at startup, but explicitly configured roles (YAML `modelRoles` and `--model`/`--smol`/`--slow`/`--plan` flags) win — the overlay fills only the roles you have not already set — and auto-apply is skipped on `--continue` / `--resume`.
+
+### Fixed
+
+- Fixed preset switching corrupting later model-role resolution, and fixed applying a preset rewriting `modelRoles` or dropping roles such as `vision` that the preset did not mention.
+
 ## [15.12.4] - 2026-06-13
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary
Documents the model-preset feature in `docs/models.md`, the changelog, and README: custom presets (`modelPresets` keyed by name), `--preset`/`--profile`/`list`/`PI_PRESET`, the non-destructive overlay semantics, startup auto-apply + precedence, and `/model` PRESETS as the in-app surface (config-file-only settings, no /settings UI).

## Scope
`docs/models.md`, `packages/coding-agent/CHANGELOG.md`, `README.md`.

> **Stacked PR** — supersedes #2391. Documents behavior introduced by the preset feature PRs; merge after them.

Closes https://github.com/can1357/oh-my-pi/issues/2496
