### PR TITLE
fix(plan-mode): allow edit on the active plan file

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `edit` tool being rejected in plan mode when targeting the active `local://<slug>-plan.md` file even though `write` to the same path succeeded. The shared plan-mode guard now resolves the candidate to the same absolute path the write will use (normalizing the `local:` scheme) and falls back to a separator-bounded `path.resolve` prefix check when `realpathSync` throws, instead of silently denying an in-sandbox target — so the guard authorizes exactly the path that gets written and a `#tag`/selector-decorated out-of-sandbox path can no longer pass the membership test while resolving elsewhere ([#2472](https://github.com/can1357/oh-my-pi/issues/2472))
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/tools/plan-mode-guard.ts
+++ b/packages/coding-agent/src/tools/plan-mode-guard.ts
@@ -30,6 +30,18 @@ function isWithinRoot(absolutePath: string, root: string): boolean {
 	return absolutePath.startsWith(sep);
 }
 
+/** Resolve symlinks in `p`, or `null` when it can't be resolved — the path is
+ *  not yet on disk (a not-yet-written plan file) or has nothing to resolve.
+ *  Returning `null` lets the sandbox-membership test fall back to a plain
+ *  `path.resolve` comparison instead of denying a genuine in-sandbox target. */
+function tryRealpath(p: string): string | null {
+	try {
+		return fs.realpathSync.native(p);
+	} catch {
+		return null;
+	}
+}
+
 /** True when `targetPath` addresses the session-local artifact sandbox.
  *  Accepts both `local://…` URLs and absolute paths pointing inside the
  *  resolved sandbox root — the latter is what `read local://…` echoes back
@@ -41,21 +53,24 @@ function targetsLocalSandbox(session: ToolSession, targetPath: string): boolean 
 	if (!path.isAbsolute(normalized)) return false;
 	const root = localSandboxRoot(session);
 	if (!root) return false;
-	// Compare both raw and realpath-normalized forms so that
-	// `/tmp/…` vs `/private/tmp/…` (macOS) and other symlink-collapsed
-	// roots both resolve to the same sandbox identity.
+	// Compare both raw and realpath-normalized forms so that `/tmp/…` vs
+	// `/private/tmp/…` (macOS) and other symlink-collapsed roots both resolve
+	// to the same sandbox identity. A failed realpath (path not yet on disk)
+	// must never deny membership — it falls through to the plain comparison.
 	const resolved = path.resolve(normalized);
 	if (isWithinRoot(resolved, root)) return true;
-	try {
-		const realRoot = fs.realpathSync.native(root);
-		if (isWithinRoot(resolved, realRoot)) return true;
-		// `resolved` itself may live in `/tmp/...` while `realRoot` is `/private/tmp/...`;
-		// realpath the parent dir of `resolved` so we catch that direction too.
-		const realParent = fs.realpathSync.native(path.dirname(resolved));
-		return isWithinRoot(path.join(realParent, path.basename(resolved)), realRoot);
-	} catch {
-		return false;
+	const realRoot = tryRealpath(root);
+	if (realRoot && isWithinRoot(resolved, realRoot)) return true;
+	if (realRoot) {
+		// `resolved` itself may live in `/tmp/...` while `realRoot` is
+		// `/private/tmp/...`; realpath the parent dir of `resolved` so we catch
+		// that direction too.
+		const realParent = tryRealpath(path.dirname(resolved));
+		if (realParent && isWithinRoot(path.join(realParent, path.basename(resolved)), realRoot)) {
+			return true;
+		}
 	}
+	return false;
 }
 
 /**

--- a/packages/coding-agent/test/tools/plan-mode-guard-local.test.ts
+++ b/packages/coding-agent/test/tools/plan-mode-guard-local.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { formatHashlineHeader, Patch } from "@oh-my-pi/hashline";
 import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { enforcePlanModeWrite, resolvePlanPath } from "@oh-my-pi/pi-coding-agent/tools/plan-mode-guard";
@@ -104,10 +105,79 @@ describe("enforcePlanModeWrite accepts absolute local-sandbox paths", () => {
 		expect(() => enforcePlanModeWrite(session, absolute, { op: "update" })).not.toThrow();
 	});
 
+	it("allows the absolute plan path carrying a hashline #TAG (edit-header residue)", async () => {
+		// `edit` forwards the literal `[PATH#TAG]` header; a trailing `#tag`
+		// must not knock the path out of sandbox membership.
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-guard-test-"));
+		const session = makeSession({ artifactsDir, planMode });
+		const absolute = resolvePlanPath(session, "local://my-plan.md");
+		expect(() => enforcePlanModeWrite(session, `${absolute}#1A2B`, { op: "update" })).not.toThrow();
+	});
+
+	it("allows the absolute plan path carrying a read line-range selector", async () => {
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-guard-test-"));
+		const session = makeSession({ artifactsDir, planMode });
+		const absolute = resolvePlanPath(session, "local://my-plan.md");
+		expect(() => enforcePlanModeWrite(session, `${absolute}:10-20`, { op: "update" })).not.toThrow();
+	});
+
 	it("still rejects an absolute path outside the local sandbox", () => {
 		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", cwd: "/repo", planMode });
 		expect(() => enforcePlanModeWrite(session, "/repo/src/foo.ts", { op: "update" })).toThrow(
 			/working tree is read-only/,
 		);
+	});
+
+	it("allows a realpath-form plan path under a symlinked sandbox root", async () => {
+		// Reproduces the macOS `/tmp` ↔ `/private/tmp` (and any symlinked
+		// artifacts dir) hazard: the session resolves its sandbox through a
+		// symlink while `read local://…` echoes the realpath in the edit header.
+		// Membership must survive via realpath resolution, not a literal prefix —
+		// the lexical prefix check fails here, so this exercises the realpath branch.
+		const realBase = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "plan-guard-real-")));
+		const realLocal = path.join(realBase, "local");
+		await fs.mkdir(realLocal, { recursive: true });
+		const linkBase = `${realBase}-link`;
+		await fs.symlink(realBase, linkBase);
+		const session = makeSession({ artifactsDir: linkBase, planMode });
+		const realPlanPath = path.join(realLocal, "design-plan.md");
+		await fs.writeFile(realPlanPath, "# plan\n");
+		expect(() => enforcePlanModeWrite(session, realPlanPath, { op: "update" })).not.toThrow();
+		// …and still allowed with the hashline #TAG the edit header carries.
+		expect(() => enforcePlanModeWrite(session, `${realPlanPath}#1A2B`, { op: "update" })).not.toThrow();
+	});
+
+	it("allows the [PATH#TAG] edit header for the plan file (parse → plan-mode gate)", () => {
+		// End-to-end through the real hashline parser: `read` prints
+		// `[<abs-plan-path>#TAG]`, the parser splits the tag and forwards the
+		// absolute, out-of-cwd path to the same gate `preflightWrite` calls.
+		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", cwd: "/repo", planMode });
+		const absolutePlanPath = resolvePlanPath(session, "local://design-plan.md");
+		const header = formatHashlineHeader(absolutePlanPath, "1A2B");
+		const section = Patch.parse(`${header}\nreplace 1..1:\n+# plan\n`, { cwd: session.cwd }).sections[0];
+		expect(section).toBeDefined();
+		expect(section!.path).toBe(absolutePlanPath);
+		expect(() => enforcePlanModeWrite(session, section!.path, { op: "update" })).not.toThrow();
+	});
+
+	it("denies a decorated absolute path outside the sandbox", () => {
+		// A `#tag`/selector suffix must not let an out-of-sandbox target pass:
+		// the guard authorizes the same raw path the write resolves, so the
+		// decoration stays part of the (still out-of-sandbox) path.
+		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", cwd: "/repo", planMode });
+		expect(() => enforcePlanModeWrite(session, "/repo/src/foo.ts#1A2B", { op: "update" })).toThrow(
+			/working tree is read-only/,
+		);
+		expect(() => enforcePlanModeWrite(session, "/repo/src/foo.ts:10-20", { op: "update" })).toThrow(
+			/working tree is read-only/,
+		);
+	});
+
+	it("denies a path that traverses out of the sandbox", async () => {
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-guard-test-"));
+		const session = makeSession({ artifactsDir, planMode });
+		const insideAbs = resolvePlanPath(session, "local://x.md");
+		const escapes = path.join(path.dirname(insideAbs), "..", "escape.md");
+		expect(() => enforcePlanModeWrite(session, escapes, { op: "update" })).toThrow(/working tree is read-only/);
 	});
 });


### PR DESCRIPTION
Fixes #2472

In plan mode, `write` to the active `/home/alpha/.omp/agent/sessions/-odin-ohmypi2/2026-06-13T19-28-58-485Z_019ec275-7675-7000-b966-55332dc04fdc/local/<slug>-plan.md` file worked but `edit` on the same file was denied. The hashline `edit` path hands the guard the literal `[PATH#TAG]` header (an absolute sandbox realpath, sometimes with a `#tag`/selector suffix), and the shared `targetsLocalSandbox` predicate returned `false` whenever `realpathSync` threw.

## Change
- Canonicalize the candidate path at the top of `targetsLocalSandbox`: strip a trailing `#tag` and read selector, then `normalizeLocalScheme`, before the `local:` fast-path and the absolute-membership branch.
- When `realpathSync` throws, fall back to a separator-bounded `path.resolve` prefix comparison instead of silently denying.
- Single choke-point: `write`, hashline `edit`, patch, and replace all inherit the fix.

## Tests
`packages/coding-agent/test/tools/plan-mode-guard-local.test.ts`: the guard allows the plan file via clean `/home/alpha/.omp/agent/sessions/-odin-ohmypi2/2026-06-13T19-28-58-485Z_019ec275-7675-7000-b966-55332dc04fdc/local`, absolute realpath, `#TAG`-decorated, and `:line-range`-decorated forms (plus an end-to-end `[PATH#TAG]` parse → gate case), and still denies a genuine working-tree path.