### PR TITLE
feat(tui): support ctrl+j as an additional newline key

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ctrl+j` as a second default binding for the `tui.input.newLine` action alongside `shift+enter`, so terminals that cannot emit `shift+enter` still have a newline key. On terminals with Kitty-protocol / `modifyOtherKeys` disambiguation `ctrl+j` inserts a newline while `Enter` still submits; on legacy terminals where `ctrl+j` and `Enter` are both byte-identical `LF` it submits (documented limitation). User keybinding overrides still take precedence ([#2473](https://github.com/can1357/oh-my-pi/issues/2473))
+
 ## [15.12.5] - 2026-06-13
 ### Added
 

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -118,7 +118,7 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.yank": { defaultKeys: "ctrl+y", description: "Yank" },
 	"tui.editor.yankPop": { defaultKeys: "alt+y", description: "Yank pop" },
 	"tui.editor.undo": { defaultKeys: ["ctrl+-", "ctrl+_"], description: "Undo" },
-	"tui.input.newLine": { defaultKeys: "shift+enter", description: "Insert newline" },
+	"tui.input.newLine": { defaultKeys: ["shift+enter", "ctrl+j"], description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 	"tui.input.copy": { defaultKeys: "ctrl+c", description: "Copy selection" },

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -44,6 +44,14 @@ describe("KeybindingsManager", () => {
 		expect(keybindings.getKeys("tui.editor.cursorLeft")).toEqual(["left", "ctrl+b"]);
 	});
 
+	it("ships ctrl+j alongside shift+enter as default newline keys", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+
+		const newLineKeys = keybindings.getKeys("tui.input.newLine");
+		expect(newLineKeys).toContain("ctrl+j");
+		expect(newLineKeys).toContain("shift+enter");
+	});
+
 	it("exports the canonical alias helpers used by matching", () => {
 		const aliases = new Set<string>();
 		for (const key of ["esc", "return", "?", "shift+a"] as const) {


### PR DESCRIPTION
Fixes #2473

The `tui.input.newLine` action defaulted to `shift+enter` only. This adds `ctrl+j` as a second default key.

## Change
- `TUI_KEYBINDINGS["tui.input.newLine"].defaultKeys`: `"shift+enter"` -> `["shift+enter", "ctrl+j"]`. Array defaults are already resolved/merged by `normalizeKeys` + `KeybindingsManager`; the matcher and user-config layer are untouched.

## Behavior
- Kitty-protocol / `modifyOtherKeys` terminals: `ctrl+j` inserts a newline, `Enter` still submits.
- Legacy terminals (no disambiguation): `ctrl+j` == `Enter` == `LF` submits — documented limitation.
- User keybinding overrides still win.

## Tests
`packages/tui/test/keybindings.test.ts`: the resolved default key list for `tui.input.newLine` contains both `ctrl+j` and `shift+enter`.