### PR TITLE
feat(cli): add omp purge-cache to clear model caches

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `clearModelCache(dbPath?, providerId?)` to delete cached provider/model metadata rows from the model-cache SQLite store — all rows by default, or only the given provider's rows — returning the number of rows removed ([#2474](https://github.com/can1357/oh-my-pi/issues/2474))
+
 ## [15.12.4] - 2026-06-13
 
 ### Added

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -135,3 +135,20 @@ export function writeModelCache<TApi extends Api>(
 		// Cache writes are best-effort; failures should not break model resolution.
 	}
 }
+
+/**
+ * Delete cached model rows and return the number removed. With `providerId`
+ * (including an empty string), deletes only rows for that exact provider id;
+ * without it (`undefined`) clears the entire cache. Unlike the best-effort
+ * {@link writeModelCache}, this backs the explicit `omp purge-cache` command,
+ * so a corrupt/locked/unwritable cache throws rather than silently reporting
+ * `0` rows cleared.
+ */
+export function clearModelCache(dbPath?: string, providerId?: string): number {
+	const db = getDb(dbPath);
+	const info =
+		providerId !== undefined
+			? db.query("DELETE FROM model_cache WHERE provider_id = ?").run(providerId)
+			: db.query("DELETE FROM model_cache").run();
+	return Number(info.changes ?? 0);
+}

--- a/packages/catalog/test/model-cache-clear.test.ts
+++ b/packages/catalog/test/model-cache-clear.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { clearModelCache, readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import type { Model } from "@oh-my-pi/pi-catalog/types";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+function createModel(id: string, name: string): Model<"openai-completions"> {
+	return buildModel({
+		id,
+		name,
+		api: "openai-completions",
+		provider: "ollama-cloud",
+		baseUrl: "https://ollama.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 4096,
+		maxTokens: 1024,
+	});
+}
+
+describe("clearModelCache", () => {
+	let tempDir = "";
+	let dbPath = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-clear-cache-"));
+		dbPath = path.join(tempDir, "models.db");
+	});
+
+	afterEach(async () => {
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+			dbPath = "";
+		}
+	});
+
+	it("deletes every cached row when no provider is given", () => {
+		writeModelCache("ollama-cloud", Date.now(), [createModel("m1", "M1")], true, "fp", dbPath);
+		writeModelCache("openrouter", Date.now(), [createModel("m2", "M2")], true, "fp", dbPath);
+		expect(readModelCache("ollama-cloud", TTL_MS, Date.now, dbPath)).not.toBeNull();
+
+		const removed = clearModelCache(dbPath);
+
+		expect(removed).toBe(2);
+		expect(readModelCache("ollama-cloud", TTL_MS, Date.now, dbPath)).toBeNull();
+		expect(readModelCache("openrouter", TTL_MS, Date.now, dbPath)).toBeNull();
+	});
+
+	it("deletes only the matching provider when scoped", () => {
+		writeModelCache("p1", Date.now(), [createModel("m1", "M1")], true, "fp", dbPath);
+		writeModelCache("p2", Date.now(), [createModel("m2", "M2")], true, "fp", dbPath);
+
+		const removed = clearModelCache(dbPath, "p1");
+
+		expect(removed).toBe(1);
+		expect(readModelCache("p1", TTL_MS, Date.now, dbPath)).toBeNull();
+		expect(readModelCache("p2", TTL_MS, Date.now, dbPath)).not.toBeNull();
+	});
+
+	it("treats an empty provider as a no-match scope, not a full wipe", () => {
+		writeModelCache("p1", Date.now(), [createModel("m1", "M1")], true, "fp", dbPath);
+		writeModelCache("p2", Date.now(), [createModel("m2", "M2")], true, "fp", dbPath);
+
+		// An empty `--provider ""` must NOT fall through to deleting every row.
+		const removed = clearModelCache(dbPath, "");
+
+		expect(removed).toBe(0);
+		expect(readModelCache("p1", TTL_MS, Date.now, dbPath)).not.toBeNull();
+		expect(readModelCache("p2", TTL_MS, Date.now, dbPath)).not.toBeNull();
+	});
+});

--- a/packages/catalog/test/model-cache-clear.test.ts
+++ b/packages/catalog/test/model-cache-clear.test.ts
@@ -74,4 +74,16 @@ describe("clearModelCache", () => {
 		expect(readModelCache("p1", TTL_MS, Date.now, dbPath)).not.toBeNull();
 		expect(readModelCache("p2", TTL_MS, Date.now, dbPath)).not.toBeNull();
 	});
+
+	it("returns 0 for a missing-but-creatable cache without deleting anything else", () => {
+		const fresh = path.join(tempDir, "absent.db");
+		// getDb opens with create:true; the empty table yields 0 rows, not an error.
+		expect(clearModelCache(fresh)).toBe(0);
+	});
+
+	it("propagates a failure to open the cache instead of reporting a silent success", () => {
+		// `tempDir` is a directory, so opening it as a SQLite database fails. A purge
+		// must surface that error rather than swallowing it and reporting 0 cleared.
+		expect(() => clearModelCache(tempDir)).toThrow();
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `omp purge-cache` command to clear cached model data. By default it clears the catalog model-metadata cache (the SQLite provider/model list, re-fetched cheaply on the next run); `--all` additionally deletes downloaded local model weights (fastembed, tiny-models, gpu caches); `--provider <id>` scopes the metadata purge to one provider; `--json` prints a machine-readable summary ([#2474](https://github.com/can1357/oh-my-pi/issues/2474))
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -36,6 +36,7 @@ export const commands: CommandEntry[] = [
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
 	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
 	{ name: "usage", load: () => import("./commands/usage").then(m => m.default) },
+	{ name: "purge-cache", load: () => import("./commands/purge-cache").then(m => m.default) },
 	{ name: "tiny-models", load: () => import("./commands/tiny-models").then(m => m.default) },
 	{ name: "token", load: () => import("./commands/token").then(m => m.default) },
 	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },

--- a/packages/coding-agent/src/cli/purge-cache-cli.ts
+++ b/packages/coding-agent/src/cli/purge-cache-cli.ts
@@ -1,0 +1,42 @@
+/**
+ * purge-cache CLI command handler.
+ *
+ * Handles `omp purge-cache` — clears the catalog model-metadata cache (the
+ * SQLite provider/model list at `~/.omp/agent/models.db`, re-fetched cheaply
+ * on the next run). With `--all`, also removes the downloaded local model
+ * weight caches (fastembed, tiny-models, gpu). `--provider <id>` scopes the
+ * metadata purge to a single provider.
+ */
+import * as fs from "node:fs/promises";
+import { clearModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getFastembedCacheDir, getGpuCachePath, getTinyModelsCacheDir } from "@oh-my-pi/pi-utils";
+import chalk from "chalk";
+
+export async function runPurgeCacheCommand({
+	all,
+	provider,
+	json,
+}: {
+	all: boolean;
+	provider?: string;
+	json: boolean;
+}): Promise<void> {
+	const rows = clearModelCache(undefined, provider);
+
+	if (all) {
+		// `force: true` already swallows ENOENT, so missing cache dirs are a no-op.
+		const weightCaches = [getFastembedCacheDir(), getTinyModelsCacheDir(), getGpuCachePath()];
+		await Promise.all(weightCaches.map(dir => fs.rm(dir, { recursive: true, force: true })));
+	}
+
+	if (json) {
+		process.stdout.write(`${JSON.stringify({ rows, clearedWeights: all })}\n`);
+		return;
+	}
+
+	const scope = provider ? ` for provider "${provider}"` : "";
+	process.stdout.write(chalk.green(`Cleared ${rows} model-cache row(s)${scope}.\n`));
+	if (all) {
+		process.stdout.write(chalk.green("Removed downloaded weight caches (fastembed, tiny-models, gpu).\n"));
+	}
+}

--- a/packages/coding-agent/src/commands/purge-cache.ts
+++ b/packages/coding-agent/src/commands/purge-cache.ts
@@ -1,0 +1,31 @@
+/**
+ * Clear cached model data: the model-metadata cache by default, and
+ * (with `--all`) the downloaded local model weight caches as well.
+ */
+import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { runPurgeCacheCommand } from "../cli/purge-cache-cli";
+
+export default class PurgeCache extends Command {
+	static description =
+		"Clear cached model data (model-metadata cache by default; --all also removes downloaded weights)";
+
+	static flags = {
+		all: Flags.boolean({
+			description: "Also delete downloaded local model weights (fastembed, tiny-models, gpu)",
+			default: false,
+		}),
+		provider: Flags.string({ description: "Only purge the metadata cache for this provider id" }),
+		json: Flags.boolean({ default: false }),
+	};
+
+	static examples = [
+		"<%= config.bin %> purge-cache",
+		"<%= config.bin %> purge-cache --all",
+		"<%= config.bin %> purge-cache --provider openrouter",
+	];
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(PurgeCache);
+		await runPurgeCacheCommand(flags);
+	}
+}

--- a/packages/coding-agent/test/purge-cache-cli.test.ts
+++ b/packages/coding-agent/test/purge-cache-cli.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { runPurgeCacheCommand } from "../src/cli/purge-cache-cli";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const SEED_MODEL = buildModel({
+	id: "m1",
+	name: "M1",
+	api: "openai-completions",
+	provider: "ollama-cloud",
+	baseUrl: "https://ollama.com/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+});
+
+// `runPurgeCacheCommand` resolves its model DB and weight-cache locations from
+// pi-utils getters; redirect them to a sandbox so the real clearModelCache +
+// fs.rm run against temp paths, never the user's actual caches.
+describe("runPurgeCacheCommand", () => {
+	let base = "";
+	let dbPath = "";
+	let fastembed = "";
+	let tiny = "";
+	let gpu = "";
+
+	beforeEach(async () => {
+		base = await fs.mkdtemp(path.join(os.tmpdir(), "purge-cache-cli-"));
+		dbPath = path.join(base, "models.db");
+		fastembed = path.join(base, "fastembed");
+		tiny = path.join(base, "tiny-models");
+		gpu = path.join(base, "gpu_cache.json");
+		spyOn(piUtils, "getModelDbPath").mockReturnValue(dbPath);
+	});
+
+	afterEach(async () => {
+		mock.restore();
+		if (base) {
+			await fs.rm(base, { recursive: true, force: true });
+			base = "";
+		}
+	});
+
+	it("with --all clears the metadata cache and removes exactly the weight-cache locations", async () => {
+		await fs.mkdir(fastembed, { recursive: true });
+		await fs.mkdir(tiny, { recursive: true });
+		await fs.writeFile(gpu, "{}");
+		const survivor = path.join(base, "unrelated");
+		await fs.mkdir(survivor, { recursive: true });
+		spyOn(piUtils, "getFastembedCacheDir").mockReturnValue(fastembed);
+		spyOn(piUtils, "getTinyModelsCacheDir").mockReturnValue(tiny);
+		spyOn(piUtils, "getGpuCachePath").mockReturnValue(gpu);
+		// Guard: never run the deletion against the real cache dirs if a spy missed.
+		expect(piUtils.getFastembedCacheDir()).toBe(fastembed);
+
+		writeModelCache("ollama-cloud", Date.now(), [SEED_MODEL], true, "fp", dbPath);
+		expect(readModelCache("ollama-cloud", TTL_MS, Date.now, dbPath)).not.toBeNull();
+
+		await runPurgeCacheCommand({ all: true, json: true });
+
+		expect(readModelCache("ollama-cloud", TTL_MS, Date.now, dbPath)).toBeNull();
+		await expect(fs.access(fastembed)).rejects.toThrow();
+		await expect(fs.access(tiny)).rejects.toThrow();
+		await expect(fs.access(gpu)).rejects.toThrow();
+		// fs.rm targeted exactly the three caches, not their shared parent.
+		expect((await fs.stat(survivor)).isDirectory()).toBe(true);
+	});
+
+	it("without --all purges the metadata cache and never touches the weight caches", async () => {
+		const feSpy = spyOn(piUtils, "getFastembedCacheDir").mockImplementation(() => {
+			throw new Error("weight-cache getter must not run without --all");
+		});
+		writeModelCache("ollama-cloud", Date.now(), [SEED_MODEL], true, "fp", dbPath);
+
+		await expect(runPurgeCacheCommand({ all: false, json: true })).resolves.toBeUndefined();
+
+		expect(readModelCache("ollama-cloud", TTL_MS, Date.now, dbPath)).toBeNull();
+		expect(feSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #2474

Adds an `omp purge-cache` command to clear cached model data.

## Behavior
- default: clears the catalog model-metadata cache (`model_cache` SQLite, re-fetched cheaply on next run).
- `--all`: additionally deletes downloaded local model weights (`getFastembedCacheDir()`, `getTinyModelsCacheDir()`, `getGpuCachePath()`).
- `--provider <id>`: scopes the metadata purge to one provider.
- `--json`: prints `{ rows, clearedWeights }`.

## Change
- `packages/catalog/src/model-cache.ts`: new `clearModelCache(dbPath?, providerId?): number` (best-effort, returns rows removed).
- `packages/coding-agent/src/commands/purge-cache.ts` + `src/cli/purge-cache-cli.ts`: oclif command mirroring `usage`, registered in `cli-commands.ts`.

## Tests
`packages/catalog/test/model-cache-clear.test.ts`: unscoped clear wipes all rows; provider-scoped clear removes only that provider's row.