### PR TITLE
fix(magic-keywords): glow keywords through the cursor seam and animate a focused shimmer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ultrathink` / `orchestrate` / `workflowz` keywords not glowing while typing — the editor appended a CURSOR_MARKER (ESC-prefixed) after each render, so the magic-keyword regex's right-boundary `(?!\S)` tripped on ESC and dropped the gradient until a trailing character was typed. The marker-aware editor decorate (`packages/tui`) plus a phase-aware `highlightMagicKeywords` overload restore the live glow and add a Claude-Code-style shimmer while the prompt is focused, gated on `magicKeywords.enabled` ([#2475](https://github.com/can1357/oh-my-pi/issues/2475)).
+
+### Added
+
+- `highlightMagicKeywords(text, resetTo?, phase?)` now accepts an optional `phase` ∈ [0, 1) that rotates the gradient cyclically; sent bubbles omit it (static palette unchanged). `hasMagicKeyword(text)` exported from `modes/magic-keywords` is the cheap shimmer-gate the editor uses on every render.
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,7 +1,8 @@
 import { addKeyAliases, canonicalKeyId, Editor, type KeyId, parseKey, parseKittySequence } from "@oh-my-pi/pi-tui";
 import type { AppKeybinding } from "../../config/keybindings";
+import { isSettingsInitialized, settings } from "../../config/settings";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
-import { highlightMagicKeywords } from "../magic-keywords";
+import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
 import { theme } from "../theme/theme";
 
 type ConfigurableEditorAction = Extract<
@@ -136,12 +137,36 @@ export class CustomEditor extends Editor {
 	 *  instead of corrupting `[Paste #1, +30 lines]` into plain text. */
 	override atomicTokenPattern = PLACEHOLDER_REGEX;
 
+	/** Magic-keyword shimmer cadence — drives one editor repaint every 70 ms while
+	 *  a keyword is on screen and the prompt is focused. ~14 frames/s is smooth
+	 *  without flooding the renderer. */
+	static readonly SHIMMER_FRAME_MS = 70;
+	/** Time for the gradient to sweep one full cycle across each keyword. */
+	static readonly SHIMMER_PERIOD_MS = 1800;
+
+	/** Per-render scratch flag: did any layout line in this render contain a magic
+	 *  keyword that should shimmer? Reset by {@link #scheduleShimmerIfNeeded} each
+	 *  time a frame is queued. */
+	#shimmerTimer: ReturnType<typeof setTimeout> | undefined;
+	/** Repaint hook the host wires once at construction. Called from the shimmer
+	 *  timer to request the next animation frame. Undefined when nobody is
+	 *  listening (tests, headless callers); the timer chain still self-cleans. */
+	#requestShimmerRepaint: (() => void) | undefined;
+
 	/** Gradient-highlight the "ultrathink" / "orchestrate" / "workflowz" keywords as the user types
 	 *  them, skipping any occurrence inside code spans, fenced blocks, or XML sections. Also make
-	 *  pasted image placeholders visually distinct and hyperlink them once their blob file exists. */
-	decorateText = (text: string): string =>
-		renderPlaceholders(text, {
-			renderText: value => highlightMagicKeywords(value),
+	 *  pasted image placeholders visually distinct and hyperlink them once their blob file exists.
+	 *  When the editor is focused, the buffer contains a magic keyword, and `magicKeywords.enabled`
+	 *  is on, the gradient shifts every frame to produce a Claude-Code-style shimmer; each render
+	 *  schedules the next frame, so losing focus, deleting the keyword, or flipping the setting
+	 *  stops the animation on its own. The static glow itself runs even when shimmering is gated
+	 *  off, matching existing behavior for the editor and sent bubbles. */
+	decorateText = (text: string): string => {
+		const animated = this.focused && this.#shimmerEnabled() && hasMagicKeyword(this.getText());
+		const phase = animated ? (Date.now() % CustomEditor.SHIMMER_PERIOD_MS) / CustomEditor.SHIMMER_PERIOD_MS : 0;
+		if (animated) this.#scheduleShimmerFrame();
+		return renderPlaceholders(text, {
+			renderText: value => highlightMagicKeywords(value, undefined, phase),
 			renderReference: (value, kind, index) =>
 				kind === "image"
 					? imageReferenceHyperlink(value, index, this.imageLinks, label =>
@@ -149,6 +174,38 @@ export class CustomEditor extends Editor {
 						)
 					: theme.fg("accent", `\x1b[1m${value}\x1b[22m`),
 		});
+	};
+
+	/** Whether the shimmer should advance this frame. Defaults to "on" before
+	 *  settings have initialised (tests, early boot) so the animation does not
+	 *  silently disappear during a race; settings disabling the feature wins
+	 *  once they are loaded. */
+	#shimmerEnabled(): boolean {
+		return isSettingsInitialized() ? settings.get("magicKeywords.enabled") : true;
+	}
+
+	/** Bind the host's render request callback. Idempotent — the host wires this
+	 *  once after construction (and again after `setEditorComponent` swaps the
+	 *  editor). Passing `undefined` clears any pending frame. */
+	setShimmerRepaintHandler(handler: (() => void) | undefined): void {
+		this.#requestShimmerRepaint = handler;
+		if (!handler && this.#shimmerTimer) {
+			clearTimeout(this.#shimmerTimer);
+			this.#shimmerTimer = undefined;
+		}
+	}
+
+	/** Schedule one shimmer frame if none is already pending. The next render
+	 *  decides whether to schedule another, so the chain stops by itself when
+	 *  `focused` flips off or the keyword leaves the buffer. */
+	#scheduleShimmerFrame(): void {
+		if (this.#shimmerTimer || !this.#requestShimmerRepaint) return;
+		this.#shimmerTimer = setTimeout(() => {
+			this.#shimmerTimer = undefined;
+			this.#requestShimmerRepaint?.();
+		}, CustomEditor.SHIMMER_FRAME_MS);
+		this.#shimmerTimer.unref?.();
+	}
 	onEscape?: () => void;
 	onClear?: () => void;
 	onExit?: () => void;

--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -1,10 +1,15 @@
 import { maskNonProse } from "./markdown-prose";
 import { theme } from "./theme/theme";
 
-/** A gradient keyword highlighter. `resetTo` is the SGR foreground sequence
- *  re-emitted after each painted keyword so surrounding text keeps its color;
- *  it defaults to a plain foreground reset (editor / default-colored text). */
-export type KeywordHighlighter = (text: string, resetTo?: string) => string;
+/** A gradient keyword highlighter.
+ *
+ * - `resetTo` is the SGR foreground sequence re-emitted after each painted
+ *   keyword so surrounding text keeps its color; it defaults to a plain
+ *   foreground reset (editor / default-colored text).
+ * - `phase` ∈ [0, 1) rotates the gradient stops cyclically; pass `Date.now()`-
+ *   derived values to animate a shimmer. Defaults to `0` (the static
+ *   sent-bubble palette). */
+export type KeywordHighlighter = (text: string, resetTo?: string, phase?: number) => string;
 
 const FG_RESET = "\x1b[39m";
 
@@ -51,14 +56,19 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		return next;
 	};
 
-	/** Paint each character of `word` with the next gradient stop, restoring `resetTo` after. */
-	const paint = (word: string, resetTo: string): string => {
+	/** Paint each character of `word` with the next gradient stop, restoring `resetTo` after.
+	 *  `phase` ∈ [0, 1) cyclically rotates the palette index so successive renders
+	 *  with monotonically increasing phase produce a moving shimmer; `0` yields the
+	 *  static palette. */
+	const paint = (word: string, resetTo: string, phase: number): string => {
 		const stopsArr = palette();
+		const m = stopsArr.length;
 		const n = word.length;
 		let out = "";
 		let prev = "";
 		for (let i = 0; i < n; i++) {
-			const color = stopsArr[Math.floor((i / n) * stopsArr.length)] ?? stopsArr[0] ?? "";
+			const t = (i / n + phase) % 1;
+			const color = stopsArr[Math.floor(t * m) % m] ?? stopsArr[0] ?? "";
 			// Coalesce consecutive characters that resolve to the same stop.
 			if (color !== prev) {
 				out += color;
@@ -69,8 +79,10 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		return `${out}${resetTo}`;
 	};
 
-	return (text: string, resetTo: string = FG_RESET): string => {
+	return (text: string, resetTo: string = FG_RESET, phase: number = 0): string => {
 		if (!probe.test(text)) return text;
+		// Wrap phase into [0, 1) so negative inputs and values ≥ 1 stay well-defined.
+		const wrappedPhase = ((phase % 1) + 1) % 1;
 		// Match against a code/markup-masked copy so keywords inside code spans,
 		// fenced blocks, or XML sections never paint; indices still address `text`.
 		const masked = maskNonProse(text);
@@ -79,7 +91,7 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		for (const m of masked.matchAll(highlight)) {
 			const start = m.index ?? 0;
 			const end = start + m[0].length;
-			out += text.slice(last, start) + paint(text.slice(start, end), resetTo);
+			out += text.slice(last, start) + paint(text.slice(start, end), resetTo, wrappedPhase);
 			last = end;
 		}
 		return out + text.slice(last);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -533,6 +533,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
+		this.editor.setShimmerRepaintHandler(() => this.ui.requestComponentRender(this.editor));
 		this.#syncEditorMaxHeight();
 		this.#resizeHandler = () => {
 			this.#syncEditorMaxHeight();
@@ -2806,6 +2807,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
+		nextEditor.setShimmerRepaintHandler(() => this.ui.requestComponentRender(this.editor));
 		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());
 		if (this.historyStorage) {
 			nextEditor.setHistoryStorage(this.historyStorage);

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -1,6 +1,6 @@
-import { highlightOrchestrate } from "./orchestrate";
-import { highlightUltrathink } from "./ultrathink";
-import { highlightWorkflow } from "./workflow";
+import { containsOrchestrate, highlightOrchestrate } from "./orchestrate";
+import { containsUltrathink, highlightUltrathink } from "./ultrathink";
+import { containsWorkflow, highlightWorkflow } from "./workflow";
 
 /**
  * Gradient-highlight every magic keyword ("ultrathink", "orchestrate",
@@ -14,7 +14,29 @@ import { highlightWorkflow } from "./workflow";
  * pass the surrounding text color when decorating already-colored content (e.g.
  * a themed message bubble) so the gradient does not bleed into the rest of the
  * line. Defaults to a plain foreground reset for default-colored editor text.
+ *
+ * `phase` ∈ [0, 1) cyclically rotates each gradient — the editor passes a
+ * `Date.now()`-derived value to animate a Claude-Code-style shimmer while a
+ * keyword is on screen and the prompt is focused; sent message bubbles omit it
+ * to keep the static gradient.
  */
-export function highlightMagicKeywords(text: string, resetTo?: string): string {
-	return highlightWorkflow(highlightOrchestrate(highlightUltrathink(text, resetTo), resetTo), resetTo);
+export function highlightMagicKeywords(text: string, resetTo?: string, phase?: number): string {
+	return highlightWorkflow(
+		highlightOrchestrate(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+		resetTo,
+		phase,
+	);
+}
+
+/**
+ * Cheap test for "does this text contain any magic keyword as standalone prose?".
+ * Short-circuits on a substring probe before paying for the markdown-aware
+ * prose check, so the common "no keyword in buffer" path is just three
+ * `String#indexOf`s. Used by the live editor to gate the shimmer timer.
+ */
+export function hasMagicKeyword(text: string): boolean {
+	if (!text.includes("ultrathink") && !text.includes("orchestrate") && !text.includes("workflowz")) {
+		return false;
+	}
+	return containsUltrathink(text) || containsOrchestrate(text) || containsWorkflow(text);
 }

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it, vi } from "bun:test";
+import { beforeAll, describe, expect, it, vi } from "bun:test";
 import {
 	CustomEditor,
 	extractBracketedImagePastePath,
 	extractBracketedImagePastePaths,
 } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
+
+beforeAll(async () => {
+	// CustomEditor.decorateText resolves theme colors during shimmer rendering;
+	// load a deterministic theme so colour-mode-dependent palettes are cached.
+	await initTheme(false);
+});
 
 function ctrl(key: string): string {
 	return String.fromCharCode(key.toLowerCase().charCodeAt(0) & 31);
@@ -238,5 +245,101 @@ describe("CustomEditor configurable key dispatch precedence", () => {
 		expect(onClear).not.toHaveBeenCalled();
 		expect(customHandler).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("hello");
+	});
+});
+
+describe("CustomEditor magic-keyword shimmer", () => {
+	function createFocusedEditor() {
+		const editor = new CustomEditor(defaultEditorTheme);
+		editor.focused = true;
+		return editor;
+	}
+
+	it("schedules a repaint frame after rendering a focused editor that contains a keyword", async () => {
+		const editor = createFocusedEditor();
+		const repaint = vi.fn();
+		editor.setShimmerRepaintHandler(repaint);
+		editor.setText("please ultrathink this carefully");
+
+		// Drive a render frame: that's what arms the shimmer setTimeout chain.
+		editor.render(80);
+		await Bun.sleep(CustomEditor.SHIMMER_FRAME_MS + 30);
+
+		expect(repaint).toHaveBeenCalledTimes(1);
+		// Clean up so the next render does not arm a stray timer leaking into other tests.
+		editor.setShimmerRepaintHandler(undefined);
+	});
+
+	it("does not schedule a repaint when the editor is not focused", async () => {
+		const editor = new CustomEditor(defaultEditorTheme);
+		editor.focused = false;
+		const repaint = vi.fn();
+		editor.setShimmerRepaintHandler(repaint);
+		editor.setText("please ultrathink this carefully");
+
+		editor.render(80);
+		await Bun.sleep(CustomEditor.SHIMMER_FRAME_MS + 30);
+
+		expect(repaint).not.toHaveBeenCalled();
+		editor.setShimmerRepaintHandler(undefined);
+	});
+
+	it("does not schedule a repaint when no magic keyword is in the buffer", async () => {
+		const editor = createFocusedEditor();
+		const repaint = vi.fn();
+		editor.setShimmerRepaintHandler(repaint);
+		editor.setText("just a plain prompt");
+
+		editor.render(80);
+		await Bun.sleep(CustomEditor.SHIMMER_FRAME_MS + 30);
+
+		expect(repaint).not.toHaveBeenCalled();
+		editor.setShimmerRepaintHandler(undefined);
+	});
+
+	it("clears any pending shimmer frame when the handler is unbound", async () => {
+		const editor = createFocusedEditor();
+		const repaint = vi.fn();
+		editor.setShimmerRepaintHandler(repaint);
+		editor.setText("ultrathink please");
+
+		editor.render(80);
+		// Unbind the handler before the in-flight frame fires; the timer is dropped.
+		editor.setShimmerRepaintHandler(undefined);
+		await Bun.sleep(CustomEditor.SHIMMER_FRAME_MS + 30);
+
+		expect(repaint).not.toHaveBeenCalled();
+	});
+
+	it("paints the keyword glyph through the trailing CURSOR_MARKER (no cursor seam)", () => {
+		const editor = createFocusedEditor();
+		editor.setText("ultrathink");
+
+		const rendered = editor.render(40).join("\n");
+		// The keyword is broken into per-character runs by SGR escapes once the
+		// gradient paints it; with the cursor-seam bug the keyword would survive
+		// verbatim. Strip ANSI to make the visible-width invariant explicit.
+		expect(rendered).not.toContain("ultrathink");
+		expect(rendered).toContain("\x1b[38");
+	});
+
+	it("respects the magicKeywords.enabled setting (no shimmer when disabled)", async () => {
+		const { Settings, resetSettingsForTest } = await import("@oh-my-pi/pi-coding-agent/config/settings");
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, overrides: { "magicKeywords.enabled": false } });
+		try {
+			const editor = createFocusedEditor();
+			const repaint = vi.fn();
+			editor.setShimmerRepaintHandler(repaint);
+			editor.setText("ultrathink please");
+
+			editor.render(80);
+			await Bun.sleep(CustomEditor.SHIMMER_FRAME_MS + 30);
+
+			expect(repaint).not.toHaveBeenCalled();
+			editor.setShimmerRepaintHandler(undefined);
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import { highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
+import { hasMagicKeyword, highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 beforeAll(async () => {
@@ -42,5 +42,49 @@ describe("highlightMagicKeywords", () => {
 		expect(decorated).toContain(reset);
 		// The reset must land before the trailing prose so it keeps the bubble color.
 		expect(decorated.endsWith(`${reset} go`)).toBe(true);
+	});
+
+	it("shifts the gradient when phase advances — same visible text, different SGR bytes", () => {
+		const text = "go ultrathink now";
+		const frame0 = highlightMagicKeywords(text, undefined, 0);
+		const frame1 = highlightMagicKeywords(text, undefined, 0.5);
+		expect(Bun.stripANSI(frame0)).toBe(text);
+		expect(Bun.stripANSI(frame1)).toBe(text);
+		// The visible output is unchanged width-wise but the painted bytes differ
+		// because the per-stop palette has cycled.
+		expect(frame0).not.toBe(frame1);
+	});
+
+	it("treats out-of-range phase values as wrapping into [0, 1)", () => {
+		const text = "do ultrathink please";
+		// 1.0 wraps back to 0, so the painted output must match.
+		expect(highlightMagicKeywords(text, undefined, 1)).toBe(highlightMagicKeywords(text, undefined, 0));
+		// Negative phase wraps too — -0.25 ≡ 0.75.
+		expect(highlightMagicKeywords(text, undefined, -0.25)).toBe(highlightMagicKeywords(text, undefined, 0.75));
+	});
+});
+
+describe("hasMagicKeyword", () => {
+	it("detects every standalone keyword in prose", () => {
+		expect(hasMagicKeyword("please ultrathink this")).toBe(true);
+		expect(hasMagicKeyword("now orchestrate everything")).toBe(true);
+		expect(hasMagicKeyword("just workflowz the steps")).toBe(true);
+	});
+
+	it("rejects keywords embedded in longer words or paths", () => {
+		expect(hasMagicKeyword("ultrathinking is fun")).toBe(false);
+		expect(hasMagicKeyword("orchestrate.ts is a file")).toBe(false);
+		expect(hasMagicKeyword("workflowzed already")).toBe(false);
+	});
+
+	it("rejects keywords inside code spans, fences, and xml sections", () => {
+		expect(hasMagicKeyword("`ultrathink`")).toBe(false);
+		expect(hasMagicKeyword("```\norchestrate\n```")).toBe(false);
+		expect(hasMagicKeyword("<x>workflowz</x>")).toBe(false);
+	});
+
+	it("returns false for empty / keyword-free text", () => {
+		expect(hasMagicKeyword("")).toBe(false);
+		expect(hasMagicKeyword("plain message with no keywords")).toBe(false);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Editor.#decorate` rejecting keyword matches glued to the cursor: `CURSOR_MARKER` begins with ESC (non-whitespace), so decorators with a right-boundary lookahead (e.g. `/(?<!\S)ultrathink(?!\S)/`) failed at the seam and dropped highlighting until a trailing character was typed. The decorate hook now splits around the marker and decorates each user-text segment in isolation so word-boundary lookarounds resolve correctly on both sides ([#2475](https://github.com/can1357/oh-my-pi/issues/2475)).
+
 ## [15.12.5] - 2026-06-13
 ### Added
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -660,10 +660,20 @@ export class Editor implements Component, Focusable {
 	}
 
 	/** Apply the optional input decorator to a plain (ANSI-free) text segment.
-	 *  Decoration only adds zero-width SGR codes, so visible width is unchanged. */
+	 *  Decoration only adds zero-width SGR codes, so visible width is unchanged.
+	 *  Splits around CURSOR_MARKER so each user-text segment is decorated in
+	 *  isolation: the marker begins with ESC, and a keyword regex that pins
+	 *  the right boundary with `(?!\S)` would otherwise reject an otherwise-
+	 *  valid match at the cursor seam (e.g. `ultrathink` immediately followed
+	 *  by the marker stops glowing until a trailing character is typed). */
 	#decorate(text: string): string {
 		const decorate = this.decorateText;
-		return decorate !== undefined && text.length > 0 ? decorate(text) : text;
+		if (decorate === undefined || text.length === 0) return text;
+		const idx = text.indexOf(CURSOR_MARKER);
+		if (idx === -1) return decorate(text);
+		const before = text.slice(0, idx);
+		const after = text.slice(idx + CURSOR_MARKER.length);
+		return (before.length > 0 ? decorate(before) : "") + CURSOR_MARKER + (after.length > 0 ? decorate(after) : "");
 	}
 
 	#getStyledInputCursor(): { text: string; width: number } {
@@ -947,9 +957,9 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
-			// No cursor on this line, or a branch that left the user text intact: decorate the
-			// whole line. CURSOR_MARKER and cursor glyphs begin with ESC, so word boundaries
-			// around a decorated keyword stay intact when matched against the assembled line.
+			// No cursor on this line, or a branch that left the user text intact: decorate
+			// the whole line. `#decorate` splits around CURSOR_MARKER so a keyword glued to
+			// the cursor still satisfies its right-boundary lookahead.
 			if (!decorated) {
 				displayText = this.#decorate(displayText);
 			}

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2279,4 +2279,60 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("");
 		});
 	});
+
+	describe("decorateText around the cursor seam", () => {
+		// Editor.#decorate is the only seam that sees both the user prose AND the
+		// trailing CURSOR_MARKER, so a decorator with a right-boundary lookahead
+		// (like the magic-keyword regex /(?<!\S)ultrathink(?!\S)/g) would reject
+		// matches glued to the marker — ESC is non-whitespace. The editor must
+		// split around the marker so each side decorates as if it were a complete
+		// line. This guards the "ultrathink doesn't glow until you type a trailing
+		// character" regression reported in #2475.
+		const WORD_RE = /(?<!\S)ultrathink(?!\S)/g;
+		const PAINT_PREFIX = "<<";
+		const PAINT_SUFFIX = ">>";
+		const paintKeyword = (text: string): string => text.replace(WORD_RE, m => `${PAINT_PREFIX}${m}${PAINT_SUFFIX}`);
+
+		it("decorates a keyword glued to the trailing cursor marker", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.decorateText = paintKeyword;
+			editor.focused = true;
+			editor.setText("ultrathink");
+
+			const line = editor.render(40).join("\n");
+			// Without the seam fix, the decorator's right-boundary `(?!\S)` would
+			// trip on ESC (the first byte of CURSOR_MARKER) and the keyword would
+			// survive verbatim. With it, the marker bookends the painted region.
+			expect(line).toContain(`${PAINT_PREFIX}ultrathink${PAINT_SUFFIX}`);
+		});
+
+		it("decorates keywords on both sides of the cursor in terminal-cursor mode", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.decorateText = paintKeyword;
+			editor.focused = true;
+			editor.setUseTerminalCursor(true);
+			editor.setText("ultrathink ultrathink");
+			// Position the hardware cursor between the two keywords.
+			editor.handleInput("\x01"); // Ctrl+A → start of line
+			editor.handleInput("\x05"); // Ctrl+E → end of line
+			for (let i = 0; i < "ultrathink".length; i++) editor.handleInput("\x1b[D"); // 10× left
+
+			const line = editor.render(60).join("\n");
+			// Both keywords are painted independently — left side ends just before
+			// the marker, right side begins right after it.
+			const occurrences = line.split(`${PAINT_PREFIX}ultrathink${PAINT_SUFFIX}`).length - 1;
+			expect(occurrences).toBe(2);
+			expect(line).toContain(CURSOR_MARKER);
+		});
+
+		it("preserves the marker as-is — never splits or duplicates it", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.decorateText = paintKeyword;
+			editor.focused = true;
+			editor.setText("ultrathink");
+
+			const line = editor.render(40).join("\n");
+			expect(line.split(CURSOR_MARKER).length - 1).toBe(1);
+		});
+	});
 });


### PR DESCRIPTION
## Repro

With magic keywords on, type `ultrathink` in the prompt editor — the keyword stays plain. Add any character after it and the gradient appears. Programmatic repro (renders the same `displayText` the editor builds for an end-of-line cursor):

```ts
import { highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
import { CURSOR_MARKER } from "@oh-my-pi/pi-tui";

await initTheme(false);
const displayText = `ultrathink${CURSOR_MARKER}\x1b[7m \x1b[0m`;
console.log(highlightMagicKeywords(displayText) === displayText); // true — no gradient applied
```

## Cause

`Editor.#decorate` (`packages/tui/src/components/editor.ts`) ran on the assembled `displayText` AFTER the editor appended `CURSOR_MARKER` (`\x1b_pi:c\x07`) and the cursor glyph. Both start with ESC, which is non-whitespace, so the magic-keyword regexes' right-boundary lookahead `(?!\S)` (in `ultrathink.ts`, `orchestrate.ts`, `workflow.ts`) rejected a keyword sitting right before the marker. The comment at the post-hoc decorate site (`"CURSOR_MARKER and cursor glyphs begin with ESC, so word boundaries around a decorated keyword stay intact"`) documented the wrong assumption.

## Fix

- `packages/tui/src/components/editor.ts` — `#decorate` splits its input on `CURSOR_MARKER` and decorates each user-text segment independently, so the right-boundary lookahead resolves against end-of-segment (and the left-boundary lookbehind resolves against start-of-segment) on both sides; the stale comment is corrected.
- `packages/coding-agent/src/modes/gradient-highlight.ts` — `KeywordHighlighter` and `createGradientHighlighter` accept an optional `phase` ∈ [0, 1) that cyclically rotates the gradient stops. `phase = 0` (the default) reproduces the existing static palette, so sent-bubble rendering is unaffected.
- `packages/coding-agent/src/modes/magic-keywords.ts` — `highlightMagicKeywords(text, resetTo?, phase?)` propagates `phase` to every highlighter, and a new `hasMagicKeyword(text)` performs a cheap substring guard + `containsX` prose check so the shimmer gate avoids paying for `maskNonProse` when no keyword is present.
- `packages/coding-agent/src/modes/components/custom-editor.ts` — `decorateText` derives `phase` from `Date.now() % SHIMMER_PERIOD_MS` and arms a `setTimeout(SHIMMER_FRAME_MS)` while `this.focused`, the buffer contains a magic keyword, and `magicKeywords.enabled` is on. Each render schedules the next frame, so losing focus, removing the keyword, or flipping the setting stops the chain automatically. `setShimmerRepaintHandler` lets the host bind / unbind the repaint callback (host wires `requestComponentRender(editor)`); unbinding also drops any pending timer.
- `packages/coding-agent/src/modes/interactive-mode.ts` — wires the shimmer repaint handler at editor construction and after every `setEditorComponent` swap.

## Verification

- `bun --cwd packages/tui test test/editor.test.ts` — 872 pass / 3 skip, including the new `decorateText around the cursor seam` block.
- `bun --cwd packages/coding-agent test test/custom-editor-keybindings.test.ts test/modes/magic-keywords.test.ts test/modes/orchestrate.test.ts test/modes/workflow.test.ts` — 55 pass, covering the seam fix, the phase cycle (`shifts the gradient when phase advances`, `treats out-of-range phase values as wrapping`), `hasMagicKeyword` prose handling, shimmer scheduling, focus-gate, no-keyword gate, handler-unbind cleanup, and the `magicKeywords.enabled` gate.
- `bun run check` — passes (biome + tsc + clippy).
- End-to-end smoke against the real `CustomEditor`: focused editor with text `ultrathink` renders the gradient at the cursor seam, the literal keyword no longer survives in the rendered bytes, the shimmer repaint hook fires within `SHIMMER_FRAME_MS + 30 ms`, and two consecutive renders 150 ms apart produce different SGR bytes while visible width is unchanged.

Fixes #2475