### PR TITLE
feat(magic-keywords): glow keywords while typing — cursor-seam fix + animated shimmer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an animated shimmer to the magic-keyword glow in the prompt editor (Claude Code style). While a magic keyword (`ultrathink`/`orchestrate`/`workflowz`) is present and the editor is focused, a 30 fps ticker rotates the gradient palette phase; combined with the cursor-seam fix the keyword now also glows immediately as it is typed. Gated on the existing `magicKeywords.enabled` setting; the idle (phase-0) gradient is byte-identical to before, so sent-message rendering is unchanged ([#2475](https://github.com/can1357/oh-my-pi/issues/2475))
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,7 +1,8 @@
 import { addKeyAliases, canonicalKeyId, Editor, type KeyId, parseKey, parseKittySequence } from "@oh-my-pi/pi-tui";
 import type { AppKeybinding } from "../../config/keybindings";
+import { advanceGlowPhase, resetGlowPhase } from "../gradient-highlight";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
-import { highlightMagicKeywords } from "../magic-keywords";
+import { containsAnyMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
 import { theme } from "../theme/theme";
 
 type ConfigurableEditorAction = Extract<
@@ -60,6 +61,9 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const BRACKETED_IMAGE_PATH_REGEX = /\.(?:png|jpe?g|gif|webp)$/i;
 const BRACKETED_IMAGE_PATH_BOUNDARY_REGEX = /\.(?:png|jpe?g|gif|webp)(?=$|["']?\s)/gi;
 const SHELL_ESCAPED_PATH_CHAR_REGEX = /\\([\\\s'"()[\]{}&;<>|?*!$`])/g;
+
+/** Magic-keyword glow shimmer redraw cadence (30fps), mirroring the Loader spinner cadence. */
+const GLOW_RENDER_INTERVAL_MS = 1000 / 30;
 
 function isPastedPathSeparator(char: string | undefined): boolean {
 	return char === undefined || char === " " || char === "\t" || char === "\r" || char === "\n";
@@ -178,6 +182,18 @@ export class CustomEditor extends Editor {
 	/** Called when left-arrow is pressed while the editor is empty (cursor necessarily at start). */
 	onLeftAtStart?: () => void;
 
+	/** Fired on each live glow-shimmer frame so the host can repaint this editor. */
+	onGlowTick?: () => void;
+	/** Gate for the glow shimmer; when set and returning false the ticker never starts
+	 *  (e.g. the `magicKeywords.enabled` setting is off). Defaults to always-on. */
+	isMagicKeywordsEnabled?: () => boolean;
+
+	/** 30fps phase ticker driving the magic-keyword glow shimmer; unset while idle. */
+	#glowTimer?: ReturnType<typeof setInterval>;
+	/** Cached magic-keyword presence, recomputed only on text change so the 30fps
+	 *  shimmer frame loop never re-scans the whole buffer. */
+	#hasMagicKeyword = false;
+
 	/** Custom key handlers from extensions and non-built-in app actions. */
 	#customKeyHandlers = new Map<KeyId, () => void>();
 	#customMatchKeys = new Map<string, () => void>();
@@ -236,6 +252,86 @@ export class CustomEditor extends Editor {
 	clearCustomKeyHandlers(): void {
 		this.#customKeyHandlers.clear();
 		this.#rebuildCustomMatchKeys();
+	}
+
+	/**
+	 * Re-sync hardware/software cursor mode. The TUI calls this when focus is
+	 * (re)assigned, so it doubles as our focus hook: re-evaluate the glow so a
+	 * restored draft containing a keyword starts shimmering once the editor is focused.
+	 */
+	override setUseTerminalCursor(useTerminalCursor: boolean): void {
+		super.setUseTerminalCursor(useTerminalCursor);
+		this.#updateGlowAnimation();
+	}
+
+	/** Lifecycle teardown: stop the glow shimmer timer. Idempotent. */
+	dispose(): void {
+		this.#stopGlowAnimation();
+	}
+
+	/** Whether the live glow shimmer should currently run. */
+	#shouldGlow(): boolean {
+		return this.focused && (this.isMagicKeywordsEnabled?.() ?? true) && this.#hasMagicKeyword;
+	}
+
+	/**
+	 * Start or stop the glow shimmer to match {@link #shouldGlow}. Idempotent, so it
+	 * is safe to call on every text change and focus sync.
+	 */
+	#updateGlowAnimation(): void {
+		if (this.#shouldGlow()) {
+			this.#startGlowAnimation();
+		} else {
+			this.#stopGlowAnimation();
+		}
+	}
+
+	#startGlowAnimation(): void {
+		if (this.#glowTimer !== undefined) return;
+		this.#glowTimer = setInterval(() => {
+			// Re-check every frame so blur, submit/clear, or disabling the setting stops the
+			// shimmer within one frame — no idle CPU and no animation while the editor is unfocused.
+			if (!this.#shouldGlow()) {
+				this.#stopGlowAnimation();
+				this.onGlowTick?.();
+				return;
+			}
+			advanceGlowPhase();
+			this.onGlowTick?.();
+		}, GLOW_RENDER_INTERVAL_MS);
+		// Never keep the event loop alive for the shimmer; it only animates while the TUI runs.
+		this.#glowTimer.unref?.();
+	}
+
+	#stopGlowAnimation(): void {
+		if (this.#glowTimer !== undefined) {
+			clearInterval(this.#glowTimer);
+			this.#glowTimer = undefined;
+		}
+		resetGlowPhase();
+	}
+
+	/** Recompute the cached magic-keyword presence and (re)sync the shimmer. Called
+	 *  only on text changes (keystrokes, paste, programmatic set/insert) — never per
+	 *  frame — so a large buffer is scanned once per edit, not 30 times a second. */
+	#refreshMagicKeyword(): void {
+		this.#hasMagicKeyword = containsAnyMagicKeyword(this.getText());
+		this.#updateGlowAnimation();
+	}
+
+	override setText(text: string): void {
+		super.setText(text);
+		this.#refreshMagicKeyword();
+	}
+
+	override insertText(text: string): void {
+		super.insertText(text);
+		this.#refreshMagicKeyword();
+	}
+
+	override pasteText(text: string): void {
+		super.pasteText(text);
+		this.#refreshMagicKeyword();
 	}
 
 	handleInput(data: string): void {
@@ -394,5 +490,7 @@ export class CustomEditor extends Editor {
 
 		// Pass to parent for normal handling
 		super.handleInput(data);
+		// Typing may have completed or removed a magic keyword: (re)evaluate the shimmer.
+		this.#refreshMagicKeyword();
 	}
 }

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,6 +1,5 @@
 import { addKeyAliases, canonicalKeyId, Editor, type KeyId, parseKey, parseKittySequence } from "@oh-my-pi/pi-tui";
 import type { AppKeybinding } from "../../config/keybindings";
-import { advanceGlowPhase, resetGlowPhase } from "../gradient-highlight";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { containsAnyMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
 import { theme } from "../theme/theme";
@@ -145,7 +144,7 @@ export class CustomEditor extends Editor {
 	 *  pasted image placeholders visually distinct and hyperlink them once their blob file exists. */
 	decorateText = (text: string): string =>
 		renderPlaceholders(text, {
-			renderText: value => highlightMagicKeywords(value),
+			renderText: value => highlightMagicKeywords(value, undefined, this.#glowPhase),
 			renderReference: (value, kind, index) =>
 				kind === "image"
 					? imageReferenceHyperlink(value, index, this.imageLinks, label =>
@@ -189,7 +188,11 @@ export class CustomEditor extends Editor {
 	isMagicKeywordsEnabled?: () => boolean;
 
 	/** 30fps phase ticker driving the magic-keyword glow shimmer; unset while idle. */
-	#glowTimer?: ReturnType<typeof setInterval>;
+	#glowTimer?: Timer;
+	/** Editor-local shimmer phase advanced once per glow frame and threaded into the
+	 *  keyword highlighter, so only this focused editor animates; static transcript /
+	 *  user-message renders pass phase 0 and stay byte-identical to the idle gradient. */
+	#glowPhase = 0;
 	/** Cached magic-keyword presence, recomputed only on text change so the 30fps
 	 *  shimmer frame loop never re-scans the whole buffer. */
 	#hasMagicKeyword = false;
@@ -296,7 +299,7 @@ export class CustomEditor extends Editor {
 				this.onGlowTick?.();
 				return;
 			}
-			advanceGlowPhase();
+			this.#glowPhase = (this.#glowPhase + 1) >>> 0;
 			this.onGlowTick?.();
 		}, GLOW_RENDER_INTERVAL_MS);
 		// Never keep the event loop alive for the shimmer; it only animates while the TUI runs.
@@ -308,7 +311,7 @@ export class CustomEditor extends Editor {
 			clearInterval(this.#glowTimer);
 			this.#glowTimer = undefined;
 		}
-		resetGlowPhase();
+		this.#glowPhase = 0;
 	}
 
 	/** Recompute the cached magic-keyword presence and (re)sync the shimmer. Called

--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -4,28 +4,9 @@ import { theme } from "./theme/theme";
 /** A gradient keyword highlighter. `resetTo` is the SGR foreground sequence
  *  re-emitted after each painted keyword so surrounding text keeps its color;
  *  it defaults to a plain foreground reset (editor / default-colored text). */
-export type KeywordHighlighter = (text: string, resetTo?: string) => string;
+export type KeywordHighlighter = (text: string, resetTo?: string, phase?: number) => string;
 
 const FG_RESET = "\x1b[39m";
-
-/**
- * Shared rotation phase for the live editor shimmer. {@link advanceGlowPhase}
- * bumps it once per animation frame; {@link createGradientHighlighter}'s `paint`
- * offsets each character's gradient stop by it so the colors sweep over time.
- * At phase 0 the offset is a no-op, so static renders (sent message bubbles, the
- * idle prompt) stay byte-identical to the un-animated gradient.
- */
-let glowPhase = 0;
-
-/** Advance the shared shimmer phase by one stop. Wraps as an unsigned 32-bit counter. */
-export function advanceGlowPhase(): void {
-	glowPhase = (glowPhase + 1) >>> 0;
-}
-
-/** Reset the shimmer phase to 0, restoring byte-identical static gradient output. */
-export function resetGlowPhase(): void {
-	glowPhase = 0;
-}
 
 /** Declarative spec for {@link createGradientHighlighter}. */
 export interface GradientHighlightSpec {
@@ -71,15 +52,15 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 	};
 
 	/** Paint each character of `word` with the next gradient stop, restoring `resetTo` after. */
-	const paint = (word: string, resetTo: string): string => {
+	const paint = (word: string, resetTo: string, phase: number): string => {
 		const stopsArr = palette();
 		const n = word.length;
 		let out = "";
 		let prev = "";
 		for (let i = 0; i < n; i++) {
-			// Offset by the shared shimmer phase so the gradient rotates across frames;
+			// Offset by the caller-supplied shimmer phase so the gradient rotates across frames;
 			// at phase 0 this is a no-op (`idx % len === idx` for idx in [0, len)).
-			const idx = (Math.floor((i / n) * stopsArr.length) + glowPhase) % stopsArr.length;
+			const idx = (Math.floor((i / n) * stopsArr.length) + phase) % stopsArr.length;
 			const color = stopsArr[idx] ?? stopsArr[0] ?? "";
 			// Coalesce consecutive characters that resolve to the same stop.
 			if (color !== prev) {
@@ -91,7 +72,7 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		return `${out}${resetTo}`;
 	};
 
-	return (text: string, resetTo: string = FG_RESET): string => {
+	return (text: string, resetTo: string = FG_RESET, phase: number = 0): string => {
 		if (!probe.test(text)) return text;
 		// Match against a code/markup-masked copy so keywords inside code spans,
 		// fenced blocks, or XML sections never paint; indices still address `text`.
@@ -101,7 +82,7 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		for (const m of masked.matchAll(highlight)) {
 			const start = m.index ?? 0;
 			const end = start + m[0].length;
-			out += text.slice(last, start) + paint(text.slice(start, end), resetTo);
+			out += text.slice(last, start) + paint(text.slice(start, end), resetTo, phase);
 			last = end;
 		}
 		return out + text.slice(last);

--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -8,6 +8,25 @@ export type KeywordHighlighter = (text: string, resetTo?: string) => string;
 
 const FG_RESET = "\x1b[39m";
 
+/**
+ * Shared rotation phase for the live editor shimmer. {@link advanceGlowPhase}
+ * bumps it once per animation frame; {@link createGradientHighlighter}'s `paint`
+ * offsets each character's gradient stop by it so the colors sweep over time.
+ * At phase 0 the offset is a no-op, so static renders (sent message bubbles, the
+ * idle prompt) stay byte-identical to the un-animated gradient.
+ */
+let glowPhase = 0;
+
+/** Advance the shared shimmer phase by one stop. Wraps as an unsigned 32-bit counter. */
+export function advanceGlowPhase(): void {
+	glowPhase = (glowPhase + 1) >>> 0;
+}
+
+/** Reset the shimmer phase to 0, restoring byte-identical static gradient output. */
+export function resetGlowPhase(): void {
+	glowPhase = 0;
+}
+
 /** Declarative spec for {@link createGradientHighlighter}. */
 export interface GradientHighlightSpec {
 	/** Cheap, stateless presence probe used to skip the boundary regex on most lines. Must be non-global. */
@@ -58,7 +77,10 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		let out = "";
 		let prev = "";
 		for (let i = 0; i < n; i++) {
-			const color = stopsArr[Math.floor((i / n) * stopsArr.length)] ?? stopsArr[0] ?? "";
+			// Offset by the shared shimmer phase so the gradient rotates across frames;
+			// at phase 0 this is a no-op (`idx % len === idx` for idx in [0, len)).
+			const idx = (Math.floor((i / n) * stopsArr.length) + glowPhase) % stopsArr.length;
+			const color = stopsArr[idx] ?? stopsArr[0] ?? "";
 			// Coalesce consecutive characters that resolve to the same stop.
 			if (color !== prev) {
 				out += color;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -533,6 +533,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
+		this.editor.onGlowTick = () => {
+			// Component-scoped repaint: the shimmer changes only the editor, so the TUI
+			// reuses every other root subtree instead of re-walking the tree at 30fps.
+			this.ui.requestComponentRender(this.editor);
+		};
+		this.editor.isMagicKeywordsEnabled = () => this.settings.get("magicKeywords.enabled");
 		this.#syncEditorMaxHeight();
 		this.#resizeHandler = () => {
 			this.#syncEditorMaxHeight();
@@ -2713,6 +2719,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry.dispose();
 		this.#eventController.dispose();
 		this.statusLine.dispose();
+		this.editor.dispose();
 		if (this.#resizeHandler) {
 			process.stdout.removeListener("resize", this.#resizeHandler);
 			this.#resizeHandler = undefined;
@@ -2806,6 +2813,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
+		nextEditor.onGlowTick = () => {
+			this.ui.requestComponentRender(this.editor);
+		};
+		nextEditor.isMagicKeywordsEnabled = () => this.settings.get("magicKeywords.enabled");
 		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());
 		if (this.historyStorage) {
 			nextEditor.setHistoryStorage(this.historyStorage);
@@ -2813,6 +2824,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setText(previousText);
 
 		this.editorContainer.clear();
+		previousEditor.dispose();
 		this.editor = nextEditor;
 		this.editorContainer.addChild(nextEditor);
 		this.ui.setFocus(nextEditor);

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -15,8 +15,12 @@ import { containsWorkflow, highlightWorkflow } from "./workflow";
  * a themed message bubble) so the gradient does not bleed into the rest of the
  * line. Defaults to a plain foreground reset for default-colored editor text.
  */
-export function highlightMagicKeywords(text: string, resetTo?: string): string {
-	return highlightWorkflow(highlightOrchestrate(highlightUltrathink(text, resetTo), resetTo), resetTo);
+export function highlightMagicKeywords(text: string, resetTo?: string, phase?: number): string {
+	return highlightWorkflow(
+		highlightOrchestrate(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+		resetTo,
+		phase,
+	);
 }
 
 /**

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -1,6 +1,6 @@
-import { highlightOrchestrate } from "./orchestrate";
-import { highlightUltrathink } from "./ultrathink";
-import { highlightWorkflow } from "./workflow";
+import { containsOrchestrate, highlightOrchestrate } from "./orchestrate";
+import { containsUltrathink, highlightUltrathink } from "./ultrathink";
+import { containsWorkflow, highlightWorkflow } from "./workflow";
 
 /**
  * Gradient-highlight every magic keyword ("ultrathink", "orchestrate",
@@ -17,4 +17,14 @@ import { highlightWorkflow } from "./workflow";
  */
 export function highlightMagicKeywords(text: string, resetTo?: string): string {
 	return highlightWorkflow(highlightOrchestrate(highlightUltrathink(text, resetTo), resetTo), resetTo);
+}
+
+/**
+ * Whether `text` contains any standalone magic keyword ("ultrathink",
+ * "orchestrate", or "workflowz") in prose — never inside a code block, inline
+ * code span, or XML/HTML section. Cheap presence probe used to gate the live
+ * editor glow shimmer.
+ */
+export function containsAnyMagicKeyword(text: string): boolean {
+	return containsUltrathink(text) || containsOrchestrate(text) || containsWorkflow(text);
 }

--- a/packages/coding-agent/test/modes/custom-editor-glow.test.ts
+++ b/packages/coding-agent/test/modes/custom-editor-glow.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
+import * as magicKeywords from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
+import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+// The glow shimmer is a 30fps setInterval driven by CustomEditor. These tests
+// pin the ticker lifecycle (start/stop/dispose), the focus + enabled gating,
+// and the contract that keyword presence is scanned on text change, never per
+// frame (the per-frame full-buffer scan was the reviewed perf hazard).
+describe("CustomEditor glow shimmer ticker", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	function focusedEditor(): CustomEditor {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.isMagicKeywordsEnabled = () => true;
+		editor.focused = true;
+		return editor;
+	}
+
+	it("ticks only while focused, enabled, and a magic keyword is present", () => {
+		const editor = focusedEditor();
+		let ticks = 0;
+		editor.onGlowTick = () => {
+			ticks += 1;
+		};
+
+		editor.setText("ultrathink");
+		vi.advanceTimersByTime(100);
+		expect(ticks).toBeGreaterThan(0);
+
+		const whileGlowing = ticks;
+		editor.setText("a plain prompt with no magic word");
+		vi.advanceTimersByTime(100);
+		expect(ticks).toBe(whileGlowing); // keyword removed -> ticker stopped
+	});
+
+	it("never starts while the magicKeywords gate is disabled", () => {
+		const editor = focusedEditor();
+		editor.isMagicKeywordsEnabled = () => false;
+		let ticks = 0;
+		editor.onGlowTick = () => {
+			ticks += 1;
+		};
+
+		editor.setText("ultrathink");
+		vi.advanceTimersByTime(100);
+		expect(ticks).toBe(0);
+	});
+
+	it("starts a restored draft only once focus is (re)assigned", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.isMagicKeywordsEnabled = () => true;
+		editor.focused = false;
+		let ticks = 0;
+		editor.onGlowTick = () => {
+			ticks += 1;
+		};
+
+		editor.setText("orchestrate the plan"); // keyword present but unfocused
+		vi.advanceTimersByTime(100);
+		expect(ticks).toBe(0);
+
+		editor.focused = true;
+		editor.setUseTerminalCursor(false); // the TUI focus (re)assignment hook
+		vi.advanceTimersByTime(100);
+		expect(ticks).toBeGreaterThan(0);
+	});
+
+	it("stops the ticker on dispose without leaking the interval", () => {
+		const editor = focusedEditor();
+		let ticks = 0;
+		editor.onGlowTick = () => {
+			ticks += 1;
+		};
+
+		editor.setText("workflowz");
+		vi.advanceTimersByTime(66);
+		const beforeDispose = ticks;
+		expect(beforeDispose).toBeGreaterThan(0);
+
+		editor.dispose();
+		vi.advanceTimersByTime(330); // ~10 frames
+		expect(ticks).toBe(beforeDispose); // disposed -> no further ticks
+	});
+
+	it("scans for keywords on text change, not on every shimmer frame", () => {
+		const editor = focusedEditor();
+		editor.onGlowTick = () => {};
+		const scanSpy = spyOn(magicKeywords, "containsAnyMagicKeyword");
+
+		editor.setText("ultrathink");
+		const afterEdit = scanSpy.mock.calls.length;
+		expect(afterEdit).toBeGreaterThan(0);
+
+		vi.advanceTimersByTime(330); // ~10 frames at 30fps
+		// The frame loop must read the cached presence, not re-scan the buffer.
+		expect(scanSpy.mock.calls.length).toBe(afterEdit);
+	});
+});

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { advanceGlowPhase, resetGlowPhase } from "@oh-my-pi/pi-coding-agent/modes/gradient-highlight";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -47,17 +46,13 @@ describe("highlightMagicKeywords", () => {
 });
 
 describe("glow shimmer phase", () => {
-	afterEach(() => {
-		// Shared module-level phase: never leak a non-idle phase into the static-gradient tests.
-		resetGlowPhase();
-	});
-
-	it("rotates the gradient with phase, preserving visible text and width, and restores idle bytes on reset", () => {
+	it("rotates the gradient with the supplied phase, preserving visible text and width; phase 0 stays idle", () => {
 		const input = "please ultrathink now";
 		const frame0 = highlightMagicKeywords(input);
 
-		advanceGlowPhase();
-		const frame1 = highlightMagicKeywords(input);
+		// Phase is a per-call parameter (no shared module state), so a focused editor can
+		// animate without mutating the static transcript / user-message gradient.
+		const frame1 = highlightMagicKeywords(input, undefined, 1);
 
 		// Shimmer: the per-character stop indices shift, so the SGR byte stream changes…
 		expect(frame1).not.toBe(frame0);
@@ -65,8 +60,8 @@ describe("glow shimmer phase", () => {
 		expect(Bun.stripANSI(frame1)).toBe(input);
 		expect(Bun.stringWidth(Bun.stripANSI(frame1))).toBe(Bun.stringWidth(input));
 
-		// Idle (phase 0) output is byte-identical to the pre-animation gradient.
-		resetGlowPhase();
-		expect(highlightMagicKeywords(input)).toBe(frame0);
+		// Phase 0 is byte-identical to the default (un-animated) gradient — the static
+		// transcript / user-message path never picks up the editor's live shimmer.
+		expect(highlightMagicKeywords(input, undefined, 0)).toBe(frame0);
 	});
 });

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { advanceGlowPhase, resetGlowPhase } from "@oh-my-pi/pi-coding-agent/modes/gradient-highlight";
 import { highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -42,5 +43,30 @@ describe("highlightMagicKeywords", () => {
 		expect(decorated).toContain(reset);
 		// The reset must land before the trailing prose so it keeps the bubble color.
 		expect(decorated.endsWith(`${reset} go`)).toBe(true);
+	});
+});
+
+describe("glow shimmer phase", () => {
+	afterEach(() => {
+		// Shared module-level phase: never leak a non-idle phase into the static-gradient tests.
+		resetGlowPhase();
+	});
+
+	it("rotates the gradient with phase, preserving visible text and width, and restores idle bytes on reset", () => {
+		const input = "please ultrathink now";
+		const frame0 = highlightMagicKeywords(input);
+
+		advanceGlowPhase();
+		const frame1 = highlightMagicKeywords(input);
+
+		// Shimmer: the per-character stop indices shift, so the SGR byte stream changes…
+		expect(frame1).not.toBe(frame0);
+		// …but the visible text and its width are untouched (decoration is zero-width).
+		expect(Bun.stripANSI(frame1)).toBe(input);
+		expect(Bun.stringWidth(Bun.stripANSI(frame1))).toBe(Bun.stringWidth(input));
+
+		// Idle (phase 0) output is byte-identical to the pre-animation gradient.
+		resetGlowPhase();
+		expect(highlightMagicKeywords(input)).toBe(frame0);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the editor's software-cursor render dropping a `decorateText` decoration on text ending exactly at the cursor. The four end-of-text software-cursor branches now decorate the pre-cursor segment in isolation (instead of relying on the whole-line fallback, where the appended ESC-prefixed cursor marker broke a trailing word boundary such as a magic-keyword's `(?!\S)`), so an end-anchored match is decorated as it is typed while visible width is unchanged ([#2475](https://github.com/can1357/oh-my-pi/issues/2475))
+
 ## [15.12.5] - 2026-06-13
 ### Added
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -917,10 +917,12 @@ export class Editor implements Component, Focusable {
 					} else if (inlineHint) {
 						const availWidth = Math.max(0, lineContentWidth - displayWidth - overrideWidth);
 						const hintText = hintStyle(truncateToWidth(inlineHint, availWidth));
-						displayText = before + marker + this.cursorOverride + hintText;
+						displayText = this.#decorate(before) + marker + this.cursorOverride + hintText;
+						decorated = true;
 						displayWidth += overrideWidth + Math.min(visibleWidth(inlineHint), availWidth);
 					} else {
-						displayText = before + marker + this.cursorOverride;
+						displayText = this.#decorate(before) + marker + this.cursorOverride;
+						decorated = true;
 						displayWidth += overrideWidth;
 					}
 				} else {
@@ -935,10 +937,12 @@ export class Editor implements Component, Focusable {
 					} else if (inlineHint) {
 						const availWidth = Math.max(0, lineContentWidth - displayWidth - cursorWidth);
 						const hintText = hintStyle(truncateToWidth(inlineHint, availWidth));
-						displayText = before + marker + cursor + hintText;
+						displayText = this.#decorate(before) + marker + cursor + hintText;
+						decorated = true;
 						displayWidth += cursorWidth + Math.min(visibleWidth(inlineHint), availWidth);
 					} else {
-						displayText = before + marker + cursor;
+						displayText = this.#decorate(before) + marker + cursor;
+						decorated = true;
 						displayWidth += cursorWidth;
 					}
 					if (displayWidth > lineContentWidth && paddingX > 0) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2279,4 +2279,47 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("");
 		});
 	});
+
+	describe("magic-keyword glow at the cursor seam", () => {
+		// Mirror the real gradient highlighter's whitespace-delimited boundary so the test
+		// genuinely exercises the seam: an ESC-prefixed cursor marker right after the keyword
+		// is non-whitespace, so `(?!\S)` only matches when `before` is decorated in isolation.
+		const SGR = "\x1b[38;2;255;0;0m";
+		const RESET = "\x1b[39m";
+		const glow = (text: string): string => text.replace(/(?<!\S)ultrathink(?!\S)/g, m => `${SGR}${m}${RESET}`);
+		const cursorWidth = visibleWidth(defaultEditorTheme.symbols.inputCursor);
+
+		it("glows a keyword typed with the cursor at its end, preserving visible width", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setBorderVisible(false);
+			editor.focused = true; // software cursor: useTerminalCursor stays false
+			editor.decorateText = glow;
+			editor.setText("ultrathink"); // cursor lands at end-of-text — the broken seam
+
+			const [line] = editor.render(80);
+
+			// Seam: the gradient SGR wraps the keyword even though the ESC cursor marker and
+			// glyph follow it immediately. Before the fix the whole-line decorate ran on
+			// "ultrathink\x1b…" and the `(?!\S)` right boundary dropped the match.
+			expect(line).toContain(`${SGR}ultrathink${RESET}`);
+
+			// Decoration is zero-width: visible content is the keyword plus the cursor glyph.
+			const visible = stripVTControlCharacters(line!.replaceAll(CURSOR_MARKER, "")).trimEnd();
+			expect(visible).toBe(`ultrathink${defaultEditorTheme.symbols.inputCursor}`);
+			expect(Bun.stringWidth(visible)).toBe(Bun.stringWidth("ultrathink") + cursorWidth);
+		});
+
+		it("still glows when the cursor sits mid-line after the keyword (regression guard)", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setBorderVisible(false);
+			editor.focused = true;
+			editor.decorateText = glow;
+			editor.setText("ultrathink go");
+			editor.handleInput("\x1b[D"); // Left: cursor off the end, onto a later grapheme
+
+			const [line] = editor.render(80);
+
+			expect(line).toContain(`${SGR}ultrathink${RESET}`);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #2475

Magic keywords (`ultrathink`/`orchestrate`/`workflowz`) did not glow at the instant they were typed: with the software cursor at the keyword's end, the editor appended an ESC-prefixed cursor marker to the highlighted segment, so the keyword regex right boundary `(?!\S)` failed against `\x1b` until a trailing character was typed. They also did not animate.

## Change
- **Cursor-seam fix** (`packages/tui/src/components/editor.ts`): the four end-of-text software-cursor branches decorate the pre-cursor segment in isolation (mirroring the mid-line branch) instead of relying on the whole-line fallback that the marker corrupts. Width-limited branches and the no-cursor fallback are untouched.
- **Animated shimmer** (`gradient-highlight.ts` + `magic-keywords.ts` + `custom-editor.ts` + `interactive-mode.ts`): a module-level `glowPhase` (with `advanceGlowPhase`/`resetGlowPhase`) offsets the gradient stop index; a 30 fps ticker in `CustomEditor` advances it while the editor is focused, `magicKeywords.enabled` is on, and `containsAnyMagicKeyword(text)` holds, calling back into `requestComponentRender`. Phase 0 output is byte-identical to the previous static gradient.

## Tests
- tui `editor.test.ts`: a keyword typed with the cursor at its end glows (gradient SGR within the keyword) with preserved visible width; still glows mid-line.
- coding-agent `magic-keywords.test.ts`: `advanceGlowPhase()` changes the painted bytes while visible text + width are unchanged; `resetGlowPhase()` restores the idle bytes.