### PR TITLE
fix(native): handle Windows worker pressure and OpenCode MiMo tool choice

### DIFF
--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -53,7 +53,9 @@ pub mod tokens;
 pub(crate) mod utils;
 pub mod workspace;
 
+use napi::bindgen_prelude::create_custom_tokio_runtime;
 use napi_derive::{module_init, napi};
+use tokio::runtime::{Builder, Runtime};
 
 /// Version sentinel — exists solely so the JS loader can prove at load time
 /// that the `.node` file on disk is from the same package release as the
@@ -74,9 +76,43 @@ use napi_derive::{module_init, napi};
 #[napi(js_name = "__piNativesV15_12_5")]
 pub const fn pi_natives_version_sentinel() {}
 
-/// Native module entry point: install crash diagnostics before any tool can
-/// invoke a panicking or allocating native call. Runs once at `.node` load.
+const NAPI_TOKIO_WORKER_THREADS: usize = 1;
+const NAPI_TOKIO_MAX_BLOCKING_THREADS: usize = 4;
+const NAPI_TOKIO_THREAD_STACK_SIZE: usize = 1024 * 1024;
+
+fn build_napi_tokio_runtime() -> std::io::Result<Runtime> {
+	Builder::new_multi_thread()
+		.enable_all()
+		.worker_threads(NAPI_TOKIO_WORKER_THREADS)
+		.max_blocking_threads(NAPI_TOKIO_MAX_BLOCKING_THREADS)
+		.thread_stack_size(NAPI_TOKIO_THREAD_STACK_SIZE)
+		.thread_name("pi-natives-tokio")
+		.build()
+}
+
+/// Native module entry point: install crash diagnostics and replace napi-rs's
+/// default Tokio runtime before any async export can initialize it.
 #[module_init]
-fn install_native_crash_handler() {
+fn initialize_native_module() {
 	crash_handler::install();
+	create_custom_tokio_runtime(
+		build_napi_tokio_runtime().expect("create pi-natives napi Tokio runtime"),
+	);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::build_napi_tokio_runtime;
+
+	#[test]
+	fn napi_tokio_runtime_drives_async_and_blocking_tasks() {
+		let runtime = build_napi_tokio_runtime().expect("runtime builds");
+		let thread_name = runtime.block_on(async {
+			tokio::task::spawn_blocking(|| std::thread::current().name().map(str::to_owned))
+				.await
+				.expect("blocking task joins")
+		});
+
+		assert_eq!(thread_name.as_deref(), Some("pi-natives-tokio"));
+	}
 }

--- a/packages/ai/test/issue-945-repro.test.ts
+++ b/packages/ai/test/issue-945-repro.test.ts
@@ -21,9 +21,12 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-async function capturePayload(opts: Parameters<typeof streamOpenAICompletions>[2]): Promise<Record<string, unknown>> {
+async function capturePayload(
+	model: Model<"openai-completions">,
+	opts: Parameters<typeof streamOpenAICompletions>[2],
+): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
-	streamOpenAICompletions(getBundledModel("opencode-go", "deepseek-v4-pro"), context, {
+	streamOpenAICompletions(model, context, {
 		...opts,
 		apiKey: "test-key",
 		signal: abortedSignal(),
@@ -32,14 +35,28 @@ async function capturePayload(opts: Parameters<typeof streamOpenAICompletions>[2
 	return (await promise) as Record<string, unknown>;
 }
 
-describe("issue #945 — OpenCode Go DeepSeek tool_choice is disabled", () => {
+describe("OpenCode Go tool_choice compatibility", () => {
 	it("marks deepseek-v4-pro as not supporting tool_choice via compat override", () => {
 		const model = getBundledModel("opencode-go", "deepseek-v4-pro") as Model<"openai-completions">;
 		expect(model.compat?.supportsToolChoice).toBe(false);
 	});
 
-	it("omits tool_choice from payload but preserves tools and reasoning_effort", async () => {
-		const body = await capturePayload({ reasoning: "high", toolChoice: "auto" });
+	it("marks mimo-v2.5-pro as not supporting tool_choice via compat override", () => {
+		const model = getBundledModel("opencode-go", "mimo-v2.5-pro") as Model<"openai-completions">;
+		expect(model.compat?.supportsToolChoice).toBe(false);
+	});
+
+	it("omits tool_choice from MiMo title-style payloads while preserving tools", async () => {
+		const model = getBundledModel("opencode-go", "mimo-v2.5-pro") as Model<"openai-completions">;
+		const body = await capturePayload(model, { reasoning: "high", toolChoice: { type: "tool", name: "echo" } });
+		expect(body.tools).toBeDefined();
+		expect(body.tool_choice).toBeUndefined();
+		expect(body.reasoning_effort).toBe("high");
+	});
+
+	it("omits tool_choice from DeepSeek payloads but preserves tools and reasoning_effort", async () => {
+		const model = getBundledModel("opencode-go", "deepseek-v4-pro") as Model<"openai-completions">;
+		const body = await capturePayload(model, { reasoning: "high", toolChoice: "auto" });
 		expect(body.tools).toBeDefined();
 		expect(body.tool_choice).toBeUndefined();
 		expect(body.reasoning_effort).toBe("high");

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Pinned zai `glm-5.2` to 1M context during catalog generation so endpoint discovery and older fallbacks cannot regress it to 200k.
 
+### Fixed
+
+- Fixed OpenCode Go MiMo catalog metadata so title generation and other tool-enabled calls omit unsupported `tool_choice` instead of triggering provider 400s ([#2509](https://github.com/can1357/oh-my-pi/issues/2509)).
+
 ## [15.12.4] - 2026-06-13
 
 ### Added

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -14,6 +14,7 @@ import {
 	semverEqual,
 } from "../src/identity/classify";
 import { buildCanonicalModelIndex, buildCanonicalReferenceData } from "../src/identity/equivalence";
+import { isMimoModelIdOrName } from "../src/identity/family";
 import { getLongestModelLikeIdSegment } from "../src/identity/id";
 import { buildModelReferenceIndex, resolveModelReference } from "../src/identity/reference";
 import { resolveModelThinking } from "../src/model-thinking";
@@ -203,6 +204,12 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 			reasoningContentField: "reasoning_content",
 		};
 		delete model.compat.thinkingFormat;
+	}
+	if (model.api === "openai-completions" && model.provider === "opencode-go" && isMimoModelIdOrName(model.id)) {
+		model.compat = {
+			...(model.compat ?? {}),
+			supportsToolChoice: false,
+		};
 	}
 	if (
 		model.api === "openai-completions" &&

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -39194,8 +39194,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"openai/gpt-5-codex": {
 			"id": "openai/gpt-5-codex",
@@ -51081,6 +51081,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"mimo-v2-pro": {
@@ -51110,6 +51113,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsToolChoice": false
 			}
 		},
 		"mimo-v2.5": {
@@ -51131,6 +51137,9 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
+			"compat": {
+				"supportsToolChoice": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51160,6 +51169,9 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 128000,
+			"compat": {
+				"supportsToolChoice": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -57075,9 +57087,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.95,
-				"output": 4,
-				"cacheRead": 0.19,
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -59989,7 +60001,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": null
+			"maxTokens": 16384
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
@@ -64583,7 +64595,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": null,
+			"maxTokens": 16384,
 			"compat": {
 				"supportsUsageInStreaming": false
 			}

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -161,6 +161,20 @@ describe("generated model policies", () => {
 		expect(models[2]?.maxTokens).toBe(64000);
 	});
 
+	it("marks OpenCode Go MiMo models as not supporting tool_choice", () => {
+		const models: ModelSpec<"openai-completions">[] = [
+			createSpec({
+				id: "mimo-v2.5-pro",
+				api: "openai-completions",
+				provider: "opencode-go",
+			}),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.compat?.supportsToolChoice).toBe(false);
+	});
+
 	it("links spark variants and gpt-5.5 to their context promotion targets", () => {
 		const models = [
 			createSpec({ id: "gpt-5.3-codex-spark", api: "openai-codex-responses", provider: "openai-codex" }),

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pi-natives` using napi-rs's default multi-worker Tokio runtime on Windows, reducing native worker/thread reservation so low-pagefile machines are less likely to abort while creating the async runtime ([#2509](https://github.com/can1357/oh-my-pi/issues/2509)).
+
 ## [15.12.4] - 2026-06-13
 
 ### Fixed


### PR DESCRIPTION
## Repro
The failing title path is reproducible by capturing the OpenAI-completions payload for `opencode-go/mimo-v2.5-pro` with the title generator's named `set_title` tool: before this change the model resolved with `compat.supportsToolChoice: true` and the payload contained `tool_choice: { type: "function", function: { name: "set_title" } }`, matching the reported provider 400. The native panic path comes from napi-rs initializing its default multi-worker Tokio runtime inside `pi-natives`, which reserves several worker stacks before any native async export can run.

## Cause
`packages/catalog/scripts/generated-policies.ts` only disabled `tool_choice` for OpenCode Go DeepSeek V4 models, so generated `packages/catalog/src/models.json` left MiMo entries such as `mimo-v2.5-pro` on the OpenAI-compatible default of `supportsToolChoice: true`. Separately, `crates/pi-natives/src/lib.rs` installed crash hooks but did not replace napi-rs's default Tokio runtime, so Windows low-pagefile thread creation failures surfaced as Tokio worker-thread panics during runtime startup.

## Fix
- Mark OpenCode Go MiMo models as `compat.supportsToolChoice: false` during catalog generation and regenerate `models.json`.
- Extend OpenCode Go wire regression coverage so MiMo title-style payloads keep `tools` but omit `tool_choice`.
- Install a smaller named napi-rs Tokio runtime from `pi-natives` module init before async exports can initialize the default runtime.
- Add a native runtime construction test and changelog entries for the catalog/native packages.

## Verification
Ran `bun --eval` payload capture before and after the fix; after the fix `opencode-go/mimo-v2.5-pro` reports `supportsToolChoice: false` and no `tool_choice` field. Ran `bun test packages/catalog/test/generated-policies.test.ts packages/ai/test/issue-945-repro.test.ts`, `bun --cwd=packages/catalog run check:types`, and `cargo test -p pi-natives napi_tokio_runtime_drives_async_and_blocking_tasks`; all passed. `gh_push_branch` also passed the pre-publish `bun run fix` and `bun check` gate before pushing. Fixes #2509