### PR TITLE
feat(coding-agent): add /workflowz-mode session toggle with rainbow badge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `/workflowz-mode` slash command that toggles a persistent, session-only workflowz posture. While active, every real turn injects the `workflowz` eval-fan-out contract — drive the task as a deterministic multi-subagent workflow via `agent()`/`parallel()`/`pipeline()` — without typing the keyword, and the status line shows a rainbow "Workflowz" badge mirroring Claude Code's "Ultra Code" indicator. The mode coexists with plan/goal mode, resets on session resume, and suppresses the duplicate keyword notice when `workflowz` is also typed.
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -124,6 +124,7 @@ export class StatusLineComponent implements Component {
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#loopModeStatus: { enabled: boolean } | null = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
+	#workflowzModeStatus: { enabled: boolean } | null = null;
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 
@@ -216,6 +217,10 @@ export class StatusLineComponent implements Component {
 
 	setGoalModeStatus(status: { enabled: boolean; paused: boolean } | undefined): void {
 		this.#goalModeStatus = status ?? null;
+	}
+
+	setWorkflowzModeStatus(status: { enabled: boolean } | undefined): void {
+		this.#workflowzModeStatus = status ?? null;
 	}
 
 	setCollabStatus(status: CollabStatus | null): void {
@@ -595,6 +600,7 @@ export class StatusLineComponent implements Component {
 			planMode: this.#planModeStatus,
 			loopMode: this.#loopModeStatus,
 			goalMode: this.#goalModeStatus,
+			workflowzMode: this.#workflowzModeStatus,
 			collab: this.#collabStatus,
 			usageStats,
 			contextPercent,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -6,6 +6,7 @@ import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePath
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath } from "../../../tools/render-utils";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
+import { type GradientSpec, paintGradient } from "../../gradient-highlight";
 import { sanitizeStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
 import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
@@ -156,10 +157,19 @@ function renderGoalMode(ctx: SegmentContext, mode: { enabled: boolean; paused: b
 	return { content: theme.fg(color, parts.join(" ")), visible: true };
 }
 
+/** Full-spectrum rainbow for the workflowz-mode badge (Claude Code "Ultra Code" style). */
+const WORKFLOWZ_BADGE_GRADIENT: GradientSpec = { stops: 14, hue: t => t * 330 };
+
 const modeSegment: StatusLineSegment = {
 	id: "mode",
 	render(ctx) {
 		const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+
+		const workflowz = ctx.workflowzMode;
+		if (workflowz?.enabled) {
+			const content = withIcon(theme.icon.workflowz, "Workflowz");
+			return { content: paintGradient(content, WORKFLOWZ_BADGE_GRADIENT), visible: true };
+		}
 
 		const plan = ctx.planMode;
 		if (plan && (plan.enabled || plan.paused)) {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -164,33 +164,33 @@ const modeSegment: StatusLineSegment = {
 	id: "mode",
 	render(ctx) {
 		const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+		const badges: string[] = [];
 
+		// Workflowz is a standing posture that coexists with plan/goal/loop, so it
+		// renders as an additional badge rather than replacing the active mode badge.
 		const workflowz = ctx.workflowzMode;
 		if (workflowz?.enabled) {
-			const content = withIcon(theme.icon.workflowz, "Workflowz");
-			return { content: paintGradient(content, WORKFLOWZ_BADGE_GRADIENT), visible: true };
+			badges.push(paintGradient(withIcon(theme.icon.workflowz, "Workflowz"), WORKFLOWZ_BADGE_GRADIENT));
 		}
 
 		const plan = ctx.planMode;
+		const goal = ctx.goalMode;
+		const loop = ctx.loopMode;
 		if (plan && (plan.enabled || plan.paused)) {
 			const label = plan.paused ? `Plan${pauseSuffix}` : "Plan";
 			const content = withIcon(theme.icon.plan, label);
 			const color = plan.paused ? "warning" : "accent";
-			return { content: theme.fg(color, content), visible: true };
+			badges.push(theme.fg(color, content));
+		} else if (goal && (goal.enabled || goal.paused)) {
+			badges.push(renderGoalMode(ctx, goal).content);
+		} else if (loop?.enabled) {
+			badges.push(theme.fg("customMessageLabel", withIcon(theme.icon.loop, "Loop")));
 		}
 
-		const goal = ctx.goalMode;
-		if (goal && (goal.enabled || goal.paused)) {
-			return renderGoalMode(ctx, goal);
+		if (badges.length === 0) {
+			return { content: "", visible: false };
 		}
-
-		const loop = ctx.loopMode;
-		if (loop?.enabled) {
-			const content = withIcon(theme.icon.loop, "Loop");
-			return { content: theme.fg("customMessageLabel", content), visible: true };
-		}
-
-		return { content: "", visible: false };
+		return { content: badges.join(" "), visible: true };
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -60,6 +60,9 @@ export interface SegmentContext {
 		enabled: boolean;
 		paused: boolean;
 	} | null;
+	workflowzMode: {
+		enabled: boolean;
+	} | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -10,6 +10,7 @@ Did you know? Each kitty/tmux/cmux split keeps its own session — `omp -c` resu
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
 Say `orchestrate` in your message to drive a multi-phase task with parallel subagents — watch it glow as you type
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
+Toggle `/workflowz-mode` to make every turn fan out as parallel eval subagents without typing the keyword — a rainbow badge shows it's on
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically
 Run `omp auth-broker serve` once and every machine pulls live tokens over the wire — refresh keys never leave the host; `omp auth-gateway` fronts it as a drop-in proxy any OpenAI-compatible client can hit
 Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow -> etc

--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -8,12 +8,8 @@ export type KeywordHighlighter = (text: string, resetTo?: string) => string;
 
 const FG_RESET = "\x1b[39m";
 
-/** Declarative spec for {@link createGradientHighlighter}. */
-export interface GradientHighlightSpec {
-	/** Cheap, stateless presence probe used to skip the boundary regex on most lines. Must be non-global. */
-	probe: RegExp;
-	/** Global, word-bounded match regex walked by `.replace`. */
-	highlight: RegExp;
+/** Color-stop parameters for a gradient sweep. */
+export interface GradientSpec {
 	/** Number of color stops swept across the gradient. */
 	stops: number;
 	/** Maps a normalized position `t` in [0, 1) to an HSL hue in degrees. */
@@ -24,6 +20,62 @@ export interface GradientHighlightSpec {
 	lightness?: number;
 }
 
+/** Declarative spec for {@link createGradientHighlighter}. */
+export interface GradientHighlightSpec extends GradientSpec {
+	/** Cheap, stateless presence probe used to skip the boundary regex on most lines. Must be non-global. */
+	probe: RegExp;
+	/** Global, word-bounded match regex walked by `.replace`. */
+	highlight: RegExp;
+}
+
+/**
+ * Gradient palettes compiled per spec, then per active color mode. Keyed on the
+ * spec object so module-level specs (keyword highlighters, status badges) reuse
+ * one compiled palette per mode instead of recomputing the HSL stops every call.
+ */
+const paletteCache = new WeakMap<GradientSpec, Map<string, readonly string[]>>();
+
+function gradientPalette(spec: GradientSpec): readonly string[] {
+	const mode = theme.getColorMode();
+	let byMode = paletteCache.get(spec);
+	if (!byMode) {
+		byMode = new Map();
+		paletteCache.set(spec, byMode);
+	}
+	const cached = byMode.get(mode);
+	if (cached) return cached;
+	const { stops, hue, saturation = 90, lightness = 62 } = spec;
+	const format = mode === "truecolor" ? "ansi-16m" : "ansi-256";
+	const next: string[] = [];
+	for (let i = 0; i < stops; i++) {
+		next.push(Bun.color(`hsl(${Math.round(hue(i / stops))}, ${saturation}%, ${lightness}%)`, format) ?? "");
+	}
+	byMode.set(mode, next);
+	return next;
+}
+
+/**
+ * Paint every character of `text` with `spec`'s HSL gradient, re-emitting
+ * `resetTo` once at the end so following text keeps its color. Adds only
+ * zero-width SGR escapes — the visible width is unchanged.
+ */
+export function paintGradient(text: string, spec: GradientSpec, resetTo: string = FG_RESET): string {
+	const stopsArr = gradientPalette(spec);
+	const n = text.length;
+	let out = "";
+	let prev = "";
+	for (let i = 0; i < n; i++) {
+		const color = stopsArr[Math.floor((i / n) * stopsArr.length)] ?? stopsArr[0] ?? "";
+		// Coalesce consecutive characters that resolve to the same stop.
+		if (color !== prev) {
+			out += color;
+			prev = color;
+		}
+		out += text[i];
+	}
+	return `${out}${resetTo}`;
+}
+
 /**
  * Build a stateless highlighter that paints each standalone match of `highlight`
  * with a smooth HSL gradient for editor display. The returned function adds only
@@ -32,43 +84,7 @@ export interface GradientHighlightSpec {
  * memoized per active color mode.
  */
 export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordHighlighter {
-	const { probe, highlight, stops, hue, saturation = 90, lightness = 62 } = spec;
-
-	let cachedMode: string | undefined;
-	let cachedPalette: readonly string[] | undefined;
-
-	/** Gradient foreground escapes for the active color mode, compiled once per mode. */
-	const palette = (): readonly string[] => {
-		const mode = theme.getColorMode();
-		if (cachedPalette && cachedMode === mode) return cachedPalette;
-		const format = mode === "truecolor" ? "ansi-16m" : "ansi-256";
-		const next: string[] = [];
-		for (let i = 0; i < stops; i++) {
-			next.push(Bun.color(`hsl(${Math.round(hue(i / stops))}, ${saturation}%, ${lightness}%)`, format) ?? "");
-		}
-		cachedMode = mode;
-		cachedPalette = next;
-		return next;
-	};
-
-	/** Paint each character of `word` with the next gradient stop, restoring `resetTo` after. */
-	const paint = (word: string, resetTo: string): string => {
-		const stopsArr = palette();
-		const n = word.length;
-		let out = "";
-		let prev = "";
-		for (let i = 0; i < n; i++) {
-			const color = stopsArr[Math.floor((i / n) * stopsArr.length)] ?? stopsArr[0] ?? "";
-			// Coalesce consecutive characters that resolve to the same stop.
-			if (color !== prev) {
-				out += color;
-				prev = color;
-			}
-			out += word[i];
-		}
-		return `${out}${resetTo}`;
-	};
-
+	const { probe, highlight } = spec;
 	return (text: string, resetTo: string = FG_RESET): string => {
 		if (!probe.test(text)) return text;
 		// Match against a code/markup-masked copy so keywords inside code spans,
@@ -79,7 +95,7 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 		for (const m of masked.matchAll(highlight)) {
 			const start = m.index ?? 0;
 			const end = start + m[0].length;
-			out += text.slice(last, start) + paint(text.slice(start, end), resetTo);
+			out += text.slice(last, start) + paintGradient(text.slice(start, end), spec, resetTo);
 			last = end;
 		}
 		return out + text.slice(last);

--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -60,6 +60,7 @@ function gradientPalette(spec: GradientSpec): readonly string[] {
  * zero-width SGR escapes — the visible width is unchanged.
  */
 export function paintGradient(text: string, spec: GradientSpec, resetTo: string = FG_RESET): string {
+	if (text.length === 0) return "";
 	const stopsArr = gradientPalette(spec);
 	const n = text.length;
 	let out = "";

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -503,6 +503,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.mcpManager = mcpManager;
 		this.#eventBus = eventBus;
 		this.titleSystemPrompt = titleSystemPrompt;
+		// Register the mode reconciler up front so a session switch OR a fresh
+		// session (switchSession / newSession, including programmatic ctx.newSession())
+		// re-syncs the transient mode badges — plan/goal/workflowz — from session state.
+		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession());
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -737,7 +741,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.initHooksAndCustomTools();
 
 		// Restore mode from session (e.g. plan mode on resume)
-		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession());
 		await this.#reconcileModeFromSession();
 
 		// Restore unsent editor draft from previous session shutdown (Ctrl+D).
@@ -1043,8 +1046,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.session.setWorkflowzModeEnabled(true);
 		this.#updateWorkflowzModeStatus();
 		this.showStatus("Workflowz mode enabled — tasks run as parallel multi-subagent eval workflows.");
-		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+		if (initialPrompt) {
+			if (this.onInputCallback) {
+				this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+			} else if (this.session.isStreaming) {
+				// The slash command consumed the editor but the input waiter already
+				// resolved (it ran while a turn was streaming), so there is no
+				// onInputCallback to deliver the trailing prompt. Route it through
+				// prompt() as a steer so it isn't dropped and inherits the workflowz
+				// posture just enabled.
+				await this.withLocalSubmission(initialPrompt, () =>
+					this.session.prompt(initialPrompt, { streamingBehavior: "steer" }),
+				);
+			} else {
+				// Between turns (no waiter, not streaming): steer so the scheduled
+				// continue delivers it without racing a fresh turn from here.
+				await this.withLocalSubmission(initialPrompt, () => this.session.steer(initialPrompt));
+			}
 		}
 	}
 
@@ -3182,9 +3200,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.clearPinnedError();
 		this.#hidePlanReview();
-		this.workflowzModeEnabled = false;
-		this.session.setWorkflowzModeEnabled(false);
-		this.#updateWorkflowzModeStatus();
 	}
 
 	handleClearCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -354,6 +354,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	planModePaused = false;
 	goalModeEnabled = false;
 	goalModePaused = false;
+	workflowzModeEnabled = false;
 	planModePlanFilePath: string | undefined = undefined;
 	loopModeEnabled = false;
 	loopPrompt: string | undefined = undefined;
@@ -1030,6 +1031,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 	}
 
+	async handleWorkflowzModeCommand(initialPrompt?: string): Promise<void> {
+		if (this.workflowzModeEnabled) {
+			this.workflowzModeEnabled = false;
+			this.session.setWorkflowzModeEnabled(false);
+			this.#updateWorkflowzModeStatus();
+			this.showStatus("Workflowz mode disabled.");
+			return;
+		}
+		this.workflowzModeEnabled = true;
+		this.session.setWorkflowzModeEnabled(true);
+		this.#updateWorkflowzModeStatus();
+		this.showStatus("Workflowz mode enabled — tasks run as parallel multi-subagent eval workflows.");
+		if (initialPrompt && this.onInputCallback) {
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+		}
+	}
+
 	recordLocalSubmission(text: string, imageCount = 0): () => void {
 		if (this.isKnownSlashCommand(text)) {
 			return () => {};
@@ -1469,6 +1487,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
+	#updateWorkflowzModeStatus(): void {
+		this.statusLine.setWorkflowzModeStatus(this.workflowzModeEnabled ? { enabled: true } : undefined);
+		this.updateEditorTopBorder();
+		this.ui.requestRender();
+	}
+
 	#resetGoalContinuationSuppression(): void {
 		this.#goalSuppressNextContinuation = false;
 	}
@@ -1627,6 +1651,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#goalSuppressNextContinuation = false;
 			this.#cancelGoalContinuation();
 			this.#updateGoalModeStatus();
+		}
+
+		if (this.workflowzModeEnabled) {
+			this.workflowzModeEnabled = false;
+			this.session.setWorkflowzModeEnabled(false);
+			this.#updateWorkflowzModeStatus();
 		}
 	}
 
@@ -3152,6 +3182,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.clearPinnedError();
 		this.#hidePlanReview();
+		this.workflowzModeEnabled = false;
+		this.session.setWorkflowzModeEnabled(false);
+		this.#updateWorkflowzModeStatus();
 	}
 
 	handleClearCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -95,6 +95,7 @@ export type SymbolKey =
 	| "icon.goal"
 	| "icon.pause"
 	| "icon.loop"
+	| "icon.workflowz"
 	| "icon.folder"
 	| "icon.search"
 	| "icon.scratchFolder"
@@ -294,6 +295,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.goal": "🎯",
 	"icon.pause": "⏸",
 	"icon.loop": "↻",
+	"icon.workflowz": "⚡",
 	"icon.folder": "📁",
 	"icon.search": "🔍",
 	"icon.scratchFolder": "🗑",
@@ -548,6 +550,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.pause": "\uf04c",
 	// pick: ↻ | alt: ⟳
 	"icon.loop": "\uf021",
+	// nf-fa-bolt
+	"icon.workflowz": "\uf0e7",
 	// pick:  | alt:  
 	"icon.folder": "\uf115",
 	"icon.search": "\uf002",
@@ -794,6 +798,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.goal": "goal",
 	"icon.pause": "||",
 	"icon.loop": "loop",
+	"icon.workflowz": "wfz",
 	"icon.folder": "[D]",
 	"icon.search": "[/]",
 	"icon.scratchFolder": "[T]",
@@ -1763,6 +1768,7 @@ export class Theme {
 			goal: this.#symbols["icon.goal"],
 			pause: this.#symbols["icon.pause"],
 			loop: this.#symbols["icon.loop"],
+			workflowz: this.#symbols["icon.workflowz"],
 			folder: this.#symbols["icon.folder"],
 			scratchFolder: this.#symbols["icon.scratchFolder"],
 			file: this.#symbols["icon.file"],

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -130,6 +130,7 @@ export interface InteractiveModeContext {
 	planModeEnabled: boolean;
 	goalModeEnabled: boolean;
 	goalModePaused: boolean;
+	workflowzModeEnabled: boolean;
 	loopModeEnabled: boolean;
 	loopPrompt?: string;
 	loopLimit?: LoopLimitRuntime;
@@ -333,6 +334,7 @@ export interface InteractiveModeContext {
 	handlePlanModeCommand(initialPrompt?: string): Promise<void>;
 	handleGoalModeCommand(rest?: string): Promise<void>;
 	handleLoopCommand(args?: string): Promise<void>;
+	handleWorkflowzModeCommand(initialPrompt?: string): Promise<void>;
 	disableLoopMode(): void;
 	pauseLoop(): void;
 	handlePlanApproval(details: PlanApprovalDetails): Promise<void>;

--- a/packages/coding-agent/src/modes/workflow.ts
+++ b/packages/coding-agent/src/modes/workflow.ts
@@ -1,3 +1,4 @@
+import { prompt } from "@oh-my-pi/pi-utils";
 import workflowNotice from "../prompts/system/workflow-notice.md" with { type: "text" };
 import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
 import { keywordInProse } from "./markdown-prose";
@@ -18,7 +19,14 @@ import { keywordInProse } from "./markdown-prose";
 const WORKFLOW_WORD = /(?<!\S)workflowz(?!\S)/;
 
 /** Hidden system notice appended after a user message that mentions "workflowz". */
-export const WORKFLOW_NOTICE: string = workflowNotice.trim();
+export const WORKFLOW_NOTICE: string = prompt.render(workflowNotice, { mode: false }).trim();
+
+/**
+ * Standing system context injected on every real turn while workflowz mode is
+ * active. Carries the same eval-fan-out contract as {@link WORKFLOW_NOTICE}, but
+ * opened as a session-wide posture rather than a per-message keyword reaction.
+ */
+export const WORKFLOWZ_MODE_CONTEXT: string = prompt.render(workflowNotice, { mode: true }).trim();
 
 /**
  * Whether `text` contains the standalone keyword "workflowz"

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -1,5 +1,9 @@
 <system-notice>
+{{#if mode}}
+**Workflowz mode is active.** Drive every task this session as a deterministic multi-subagent workflow. Author the orchestration as Python in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+{{else}}
 The user's message above contains the **workflowz** keyword: drive this task as a deterministic multi-subagent workflow. Author the orchestration as Python in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+{{/if}}
 
 <when>
 Worth it when the task benefits from decomposition + parallel coverage, or from independent/adversarial cross-checking before you commit. For a quick lookup or single edit, just do it directly — don't spin up agents. Scout inline FIRST (list the files, scope the diff, find the call sites) to discover the work-list, then fan out over it — you don't need to know the shape before the *task*, only before the *fan-out*. Common shapes, each a well-scoped `eval` call you can chain across turns:

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -183,7 +183,7 @@ import { getCurrentThemeName, theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
 import { containsUltrathink, ULTRATHINK_NOTICE } from "../modes/ultrathink";
 import { computeNonMessageTokens } from "../modes/utils/context-usage";
-import { containsWorkflow, WORKFLOW_NOTICE } from "../modes/workflow";
+import { containsWorkflow, WORKFLOW_NOTICE, WORKFLOWZ_MODE_CONTEXT } from "../modes/workflow";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
@@ -933,6 +933,7 @@ export class AgentSession {
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#planModeState: PlanModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
+	#workflowzModeEnabled = false;
 	#goalRuntime: GoalRuntime;
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
@@ -4269,6 +4270,14 @@ export class AgentSession {
 		this.#goalModeState = state;
 	}
 
+	setWorkflowzModeEnabled(enabled: boolean): void {
+		this.#workflowzModeEnabled = enabled;
+	}
+
+	getWorkflowzModeEnabled(): boolean {
+		return this.#workflowzModeEnabled;
+	}
+
 	get goalRuntime(): GoalRuntime {
 		return this.#goalRuntime;
 	}
@@ -4471,6 +4480,18 @@ export class AgentSession {
 		};
 	}
 
+	#buildWorkflowzModeMessage(): CustomMessage | null {
+		if (!this.#workflowzModeEnabled) return null;
+		return {
+			role: "custom",
+			customType: "workflowz-mode-context",
+			content: WORKFLOWZ_MODE_CONTEXT,
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+	}
+
 	#normalizeImagesForModel(images: ImageContent[] | undefined): Promise<ImageContent[] | undefined> {
 		return normalizeModelContextImages(images, { model: this.model });
 	}
@@ -4525,7 +4546,7 @@ export class AgentSession {
 				timestamp,
 			});
 		}
-		if (this.#magicKeywordEnabled("workflow") && containsWorkflow(text)) {
+		if (!this.#workflowzModeEnabled && this.#magicKeywordEnabled("workflow") && containsWorkflow(text)) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "workflow-notice",
@@ -4675,6 +4696,10 @@ export class AgentSession {
 				deliverAs: options.streamingBehavior,
 				queueChipText: options.queueChipText,
 			});
+			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
+			if (workflowzModeMessage) {
+				await this.sendCustomMessage(workflowzModeMessage, { deliverAs: options.streamingBehavior });
+			}
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
@@ -4760,6 +4785,10 @@ export class AgentSession {
 			const goalModeMessage = this.#buildGoalModeMessage();
 			if (goalModeMessage) {
 				messages.push(goalModeMessage);
+			}
+			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
+			if (workflowzModeMessage) {
+				messages.push(workflowzModeMessage);
 			}
 			if (options?.prependMessages) {
 				messages.push(...options.prependMessages);
@@ -5051,6 +5080,21 @@ export class AgentSession {
 				attribution: "user",
 				timestamp: Date.now(),
 			});
+		}
+		// Workflowz mode is a standing per-turn posture: queue its context alongside
+		// every real-user steer/follow-up message. #queueUserMessage is the single
+		// chokepoint for queued user messages during streaming (prompt() streaming,
+		// public steer()/followUp(), sendUserMessage()); the idle path is covered by
+		// #promptWithMessage. Only inject while streaming: sendCustomMessage queues a
+		// steer/follow-up only when streaming, and when idle it would append the context
+		// straight to history out-of-band and leave a custom message as the last entry,
+		// which strands the just-queued user message in #scheduleIdleQueueDrain. No-op
+		// when the mode is disabled.
+		if (this.isStreaming) {
+			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
+			if (workflowzModeMessage) {
+				await this.sendCustomMessage(workflowzModeMessage, { deliverAs: mode });
+			}
 		}
 		this.#scheduleIdleQueueDrain();
 	}
@@ -5455,6 +5499,11 @@ export class AgentSession {
 		}
 		await this.sessionManager.newSession(options);
 		this.setTodoPhases([]);
+		// Workflowz mode is session-only; a fresh session (new/drop, including
+		// programmatic ctx.newSession()) must clear the standing posture so its context
+		// is never injected into the new session. switchSession() clears it via the
+		// mode reconciler; newSession() does not run that reconciler, so reset here.
+		this.#workflowzModeEnabled = false;
 		this.#freshProviderSessionId = undefined;
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4480,18 +4480,6 @@ export class AgentSession {
 		};
 	}
 
-	#buildWorkflowzModeMessage(): CustomMessage | null {
-		if (!this.#workflowzModeEnabled) return null;
-		return {
-			role: "custom",
-			customType: "workflowz-mode-context",
-			content: WORKFLOWZ_MODE_CONTEXT,
-			display: false,
-			attribution: "agent",
-			timestamp: Date.now(),
-		};
-	}
-
 	#normalizeImagesForModel(images: ImageContent[] | undefined): Promise<ImageContent[] | undefined> {
 		return normalizeModelContextImages(images, { model: this.model });
 	}
@@ -4551,6 +4539,16 @@ export class AgentSession {
 				role: "custom",
 				customType: "workflow-notice",
 				content: WORKFLOW_NOTICE,
+				display: false,
+				attribution: "user",
+				timestamp,
+			});
+		}
+		if (this.#workflowzModeEnabled) {
+			keywordNotices.push({
+				role: "custom",
+				customType: "workflowz-mode-context",
+				content: WORKFLOWZ_MODE_CONTEXT,
 				display: false,
 				attribution: "user",
 				timestamp,
@@ -4696,10 +4694,6 @@ export class AgentSession {
 				deliverAs: options.streamingBehavior,
 				queueChipText: options.queueChipText,
 			});
-			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
-			if (workflowzModeMessage) {
-				await this.sendCustomMessage(workflowzModeMessage, { deliverAs: options.streamingBehavior });
-			}
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
@@ -4785,10 +4779,6 @@ export class AgentSession {
 			const goalModeMessage = this.#buildGoalModeMessage();
 			if (goalModeMessage) {
 				messages.push(goalModeMessage);
-			}
-			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
-			if (workflowzModeMessage) {
-				messages.push(workflowzModeMessage);
 			}
 			if (options?.prependMessages) {
 				messages.push(...options.prependMessages);
@@ -5081,21 +5071,6 @@ export class AgentSession {
 				timestamp: Date.now(),
 			});
 		}
-		// Workflowz mode is a standing per-turn posture: queue its context alongside
-		// every real-user steer/follow-up message. #queueUserMessage is the single
-		// chokepoint for queued user messages during streaming (prompt() streaming,
-		// public steer()/followUp(), sendUserMessage()); the idle path is covered by
-		// #promptWithMessage. Only inject while streaming: sendCustomMessage queues a
-		// steer/follow-up only when streaming, and when idle it would append the context
-		// straight to history out-of-band and leave a custom message as the last entry,
-		// which strands the just-queued user message in #scheduleIdleQueueDrain. No-op
-		// when the mode is disabled.
-		if (this.isStreaming) {
-			const workflowzModeMessage = this.#buildWorkflowzModeMessage();
-			if (workflowzModeMessage) {
-				await this.sendCustomMessage(workflowzModeMessage, { deliverAs: mode });
-			}
-		}
 		this.#scheduleIdleQueueDrain();
 	}
 
@@ -5345,8 +5320,8 @@ export class AgentSession {
 
 	/** Clear queued messages and return them (text plus any attached images). */
 	clearQueue(): { steering: RestoredQueuedMessage[]; followUp: RestoredQueuedMessage[] } {
-		const steering = this.agent.peekSteeringQueue().map(toRestoredQueuedMessage);
-		const followUp = this.agent.peekFollowUpQueue().map(toRestoredQueuedMessage);
+		const steering = this.agent.peekSteeringQueue().filter(isDisplayableQueuedMessage).map(toRestoredQueuedMessage);
+		const followUp = this.agent.peekFollowUpQueue().filter(isDisplayableQueuedMessage).map(toRestoredQueuedMessage);
 		this.agent.clearAllQueues();
 		return { steering, followUp };
 	}
@@ -5500,9 +5475,10 @@ export class AgentSession {
 		await this.sessionManager.newSession(options);
 		this.setTodoPhases([]);
 		// Workflowz mode is session-only; a fresh session (new/drop, including
-		// programmatic ctx.newSession()) must clear the standing posture so its context
-		// is never injected into the new session. switchSession() clears it via the
-		// mode reconciler; newSession() does not run that reconciler, so reset here.
+		// programmatic ctx.newSession()) must clear the standing posture so its
+		// context is never injected into the new session. The TUI mirror is
+		// re-synced by the session-switch reconciler below; this direct reset
+		// covers headless/SDK contexts where no reconciler is registered.
 		this.#workflowzModeEnabled = false;
 		this.#freshProviderSessionId = undefined;
 		this.#syncAgentSessionId();
@@ -5530,6 +5506,17 @@ export class AgentSession {
 		this.#planReferenceSent = false;
 		this.#planReferencePath = "local://PLAN.md";
 		this.#reconnectToAgent();
+		// Re-sync the TUI from the fresh session state (mirrors switchSession).
+		// Clears any transient mode badges — including the session-only workflowz
+		// posture — left over from the previous session, so a programmatic
+		// ctx.newSession() can never leave a stale "enabled" badge.
+		try {
+			await this.#sessionSwitchReconciler?.();
+		} catch (error) {
+			logger.warn("Failed to reconcile session mode after new session", {
+				error: String(error),
+			});
+		}
 
 		// Emit session_switch event with reason "new" to hooks
 		if (this.#extensionRunner) {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -283,6 +283,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "workflowz-mode",
+		description: "Toggle workflowz mode (drive tasks as parallel multi-subagent eval workflows)",
+		inlineHint: "[prompt]",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.handleWorkflowzModeCommand(command.args || undefined);
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "model",
 		aliases: ["models"],
 		description: "Select model (opens selector UI)",

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -117,4 +117,169 @@ describe("AgentSession magic keyword settings", () => {
 		expect(session.thinkingLevel).toBe(Effort.Low);
 		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Low);
 	});
+
+	it("injects the workflowz-mode context on every turn while the mode is active", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("do the thing");
+		await session.prompt("do the next thing");
+
+		// Standing posture: exactly one context per turn, on *every* turn. A one-shot
+		// implementation that injected once and stopped would fail the second turn.
+		expect(promptSpy.mock.calls.length).toBe(2);
+		for (const call of promptSpy.mock.calls) {
+			const messages = call[0] as unknown as Array<{ customType?: string; content?: string }>;
+			const modeContext = messages.filter(message => message.customType === "workflowz-mode-context");
+			expect(modeContext).toHaveLength(1);
+			expect(modeContext[0]!.content).toContain("Workflowz mode is active");
+			expect(modeContext[0]!.content).toContain("parallel(");
+		}
+	});
+
+	it("does not duplicate the workflow notice when the keyword is typed while the mode is active", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please workflowz this rollout");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		const types = promptMessages.map(message => message.customType).filter(Boolean);
+		expect(types).toContain("workflowz-mode-context");
+		expect(types).not.toContain("workflow-notice");
+		expect(types.filter(type => type === "workflowz-mode-context")).toHaveLength(1);
+	});
+
+	it("queues the workflowz-mode context for steer turns while streaming", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const customSpy = vi.spyOn(session, "sendCustomMessage");
+
+		await session.prompt("do the thing", { streamingBehavior: "steer" });
+
+		const queued = customSpy.mock.calls.filter(call => call[0].customType === "workflowz-mode-context");
+		expect(queued).toHaveLength(1);
+		expect(String(queued[0]![0].content)).toContain("parallel(");
+		expect(queued[0]![1]).toMatchObject({ deliverAs: "steer" });
+	});
+
+	it("queues the workflowz-mode context for custom prompts while streaming", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const customSpy = vi.spyOn(session, "sendCustomMessage");
+
+		await session.promptCustomMessage(
+			{ customType: "user-note", content: "do the thing", display: false, attribution: "user" },
+			{ streamingBehavior: "steer" },
+		);
+
+		const queued = customSpy.mock.calls
+			.map(call => call[0])
+			.filter(message => message.customType === "workflowz-mode-context");
+		expect(queued).toHaveLength(1);
+		expect(String(queued[0]!.content)).toContain("parallel(");
+	});
+
+	it("injects the workflowz-mode context for idle custom prompts", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.promptCustomMessage({
+			customType: "user-note",
+			content: "do the thing",
+			display: false,
+			attribution: "user",
+		});
+
+		const messages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		const modeContext = messages.filter(message => message.customType === "workflowz-mode-context");
+		expect(modeContext).toHaveLength(1);
+	});
+
+	it("queues the workflowz-mode context for public steer() turns", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const customSpy = vi.spyOn(session, "sendCustomMessage");
+
+		// Regression guard: the public steer()/followUp() path queues user messages
+		// through #queueUserMessage without going through prompt(); while streaming the
+		// mode context must ride along, or workflowz silently no-ops on steered turns.
+		await session.steer("keep going");
+
+		const queued = customSpy.mock.calls.filter(call => call[0].customType === "workflowz-mode-context");
+		expect(queued).toHaveLength(1);
+		expect(queued[0]![1]).toMatchObject({ deliverAs: "steer" });
+	});
+
+	it("queues the workflowz-mode context for public followUp() turns", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const customSpy = vi.spyOn(session, "sendCustomMessage");
+
+		// The follow-up delivery branch must carry the context with the matching
+		// deliverAs, not just the steer branch.
+		await session.followUp("and then continue");
+
+		const queued = customSpy.mock.calls.filter(call => call[0].customType === "workflowz-mode-context");
+		expect(queued).toHaveLength(1);
+		expect(queued[0]![1]).toMatchObject({ deliverAs: "followUp" });
+	});
+
+	it("does not append the workflowz context out-of-band on an idle steer()", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		// Not streaming: a public steer() between turns must NOT append the mode context
+		// straight to history. sendCustomMessage ignores deliverAs when idle and would
+		// appendMessage the context, leaving a custom message as the last entry that
+		// strands the just-queued user message in the idle drain. The context rides
+		// streaming steers only; idle turns are covered by #promptWithMessage.
+		expect(session.isStreaming).toBe(false);
+
+		await session.steer("between turns");
+
+		const messages = session.agent.state.messages as unknown as Array<{ customType?: string }>;
+		const appended = messages.filter(message => message.customType === "workflowz-mode-context");
+		expect(appended).toHaveLength(0);
+	});
+
+	it("clears the session-only workflowz flag on newSession() so it never carries over", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+
+		// newSession() does not run the mode reconciler that switchSession() uses, so
+		// the session-only flag must be reset in newSession() itself; otherwise the
+		// standing context leaks into a programmatically-created fresh session.
+		await session.newSession();
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		await session.prompt("fresh session work");
+		const messages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(messages.some(message => message.customType === "workflowz-mode-context")).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -10,6 +10,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 
@@ -172,46 +173,44 @@ describe("AgentSession magic keyword settings", () => {
 		expect(queued[0]![1]).toMatchObject({ deliverAs: "steer" });
 	});
 
-	it("queues the workflowz-mode context for custom prompts while streaming", async () => {
-		const created = await createMagicKeywordSession(root);
-		session = created.session;
-		authStorage = created.authStorage;
-		session.setWorkflowzModeEnabled(true);
-		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
-		const customSpy = vi.spyOn(session, "sendCustomMessage");
-
-		await session.promptCustomMessage(
-			{ customType: "user-note", content: "do the thing", display: false, attribution: "user" },
-			{ streamingBehavior: "steer" },
-		);
-
-		const queued = customSpy.mock.calls
-			.map(call => call[0])
-			.filter(message => message.customType === "workflowz-mode-context");
-		expect(queued).toHaveLength(1);
-		expect(String(queued[0]!.content)).toContain("parallel(");
-	});
-
-	it("injects the workflowz-mode context for idle custom prompts", async () => {
+	it("injects the workflowz-mode context for user-attributed skill prompts", async () => {
 		const created = await createMagicKeywordSession(root);
 		session = created.session;
 		authStorage = created.authStorage;
 		session.setWorkflowzModeEnabled(true);
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 
+		// Skill invocations are real user turns, so they ride the same keyword-notice
+		// rails as a typed prompt and carry the standing posture.
 		await session.promptCustomMessage({
-			customType: "user-note",
-			content: "do the thing",
-			display: false,
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "run the skill",
+			display: true,
 			attribution: "user",
+			details: { args: "" },
 		});
 
 		const messages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
-		const modeContext = messages.filter(message => message.customType === "workflowz-mode-context");
-		expect(modeContext).toHaveLength(1);
+		expect(messages.filter(message => message.customType === "workflowz-mode-context")).toHaveLength(1);
 	});
 
-	it("queues the workflowz-mode context for public steer() turns", async () => {
+	it("does not inject the workflowz-mode context on synthetic prompts", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		// Synthetic/agent-authored turns (plan-mode recovery, todo reminders) are not
+		// real user turns. The eval fan-out posture must not derail those corrective
+		// turns, so it is gated exactly like the magic-keyword notices.
+		await session.prompt("internal reminder", { synthetic: true });
+
+		const messages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(messages.some(message => message.customType === "workflowz-mode-context")).toBe(false);
+	});
+
+	it("does not inject the workflowz-mode context on public steer()/followUp() turns", async () => {
 		const created = await createMagicKeywordSession(root);
 		session = created.session;
 		authStorage = created.authStorage;
@@ -219,31 +218,14 @@ describe("AgentSession magic keyword settings", () => {
 		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
 		const customSpy = vi.spyOn(session, "sendCustomMessage");
 
-		// Regression guard: the public steer()/followUp() path queues user messages
-		// through #queueUserMessage without going through prompt(); while streaming the
-		// mode context must ride along, or workflowz silently no-ops on steered turns.
+		// The posture rides the magic-keyword-notice rails (prompt()/skill prompts
+		// only), matching ultrathink/orchestrate/workflow. Programmatic steer() and
+		// followUp() queue raw user messages and intentionally do not carry it.
 		await session.steer("keep going");
-
-		const queued = customSpy.mock.calls.filter(call => call[0].customType === "workflowz-mode-context");
-		expect(queued).toHaveLength(1);
-		expect(queued[0]![1]).toMatchObject({ deliverAs: "steer" });
-	});
-
-	it("queues the workflowz-mode context for public followUp() turns", async () => {
-		const created = await createMagicKeywordSession(root);
-		session = created.session;
-		authStorage = created.authStorage;
-		session.setWorkflowzModeEnabled(true);
-		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
-		const customSpy = vi.spyOn(session, "sendCustomMessage");
-
-		// The follow-up delivery branch must carry the context with the matching
-		// deliverAs, not just the steer branch.
 		await session.followUp("and then continue");
 
 		const queued = customSpy.mock.calls.filter(call => call[0].customType === "workflowz-mode-context");
-		expect(queued).toHaveLength(1);
-		expect(queued[0]![1]).toMatchObject({ deliverAs: "followUp" });
+		expect(queued).toHaveLength(0);
 	});
 
 	it("does not append the workflowz context out-of-band on an idle steer()", async () => {
@@ -251,11 +233,8 @@ describe("AgentSession magic keyword settings", () => {
 		session = created.session;
 		authStorage = created.authStorage;
 		session.setWorkflowzModeEnabled(true);
-		// Not streaming: a public steer() between turns must NOT append the mode context
-		// straight to history. sendCustomMessage ignores deliverAs when idle and would
-		// appendMessage the context, leaving a custom message as the last entry that
-		// strands the just-queued user message in the idle drain. The context rides
-		// streaming steers only; idle turns are covered by #promptWithMessage.
+		// A public steer() between turns must never push the hidden mode context into
+		// history; the posture is delivered only through prompt()'s keyword-notice rails.
 		expect(session.isStreaming).toBe(false);
 
 		await session.steer("between turns");
@@ -265,15 +244,30 @@ describe("AgentSession magic keyword settings", () => {
 		expect(appended).toHaveLength(0);
 	});
 
+	it("filters the hidden workflowz context out of restored queued messages", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		session.setWorkflowzModeEnabled(true);
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+
+		// Streaming prompt() queues a visible user steer plus the hidden posture
+		// (display:false). The Esc/dequeue editor-restore path (clearQueue) must hand
+		// back only the user's text, never the hidden notice.
+		await session.prompt("ship it", { streamingBehavior: "steer" });
+		const { steering } = session.clearQueue();
+		expect(steering.map(entry => entry.text)).toEqual(["ship it"]);
+	});
+
 	it("clears the session-only workflowz flag on newSession() so it never carries over", async () => {
 		const created = await createMagicKeywordSession(root);
 		session = created.session;
 		authStorage = created.authStorage;
 		session.setWorkflowzModeEnabled(true);
 
-		// newSession() does not run the mode reconciler that switchSession() uses, so
-		// the session-only flag must be reset in newSession() itself; otherwise the
-		// standing context leaks into a programmatically-created fresh session.
+		// newSession() resets the session-only flag directly (covering headless/SDK
+		// contexts with no reconciler) so the standing context never leaks into a
+		// programmatically-created fresh session.
 		await session.newSession();
 		expect(session.getWorkflowzModeEnabled()).toBe(false);
 

--- a/packages/coding-agent/test/gradient-highlight.test.ts
+++ b/packages/coding-agent/test/gradient-highlight.test.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { paintGradient } from "@oh-my-pi/pi-coding-agent/modes/gradient-highlight";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+const SPEC = { stops: 8, hue: (t: number) => t * 330 };
+
+describe("paintGradient", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("returns an empty string for empty input instead of a stray ANSI reset", () => {
+		// Empty text must round-trip to empty; emitting only the reset escape would
+		// leak \x1b[39m into otherwise-empty cells (e.g. an unset status badge).
+		expect(paintGradient("", SPEC)).toBe("");
+	});
+
+	it("paints non-empty text and re-emits the reset so following text keeps its color", () => {
+		const painted = paintGradient("Hi", SPEC, "\x1b[39m");
+		expect(Bun.stripANSI(painted)).toBe("Hi");
+		expect(painted.endsWith("\x1b[39m")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-workflowz.test.ts
+++ b/packages/coding-agent/test/interactive-mode-workflowz.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("InteractiveMode workflowz mode", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-workflowz-mode-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		vi.spyOn(mode, "addMessageToChat").mockReturnValue([]);
+		vi.spyOn(mode, "ensureLoadingAnimation").mockImplementation(() => {});
+		mode.ui.requestRender = vi.fn();
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("toggles both the UI flag and the session injection flag on and off", async () => {
+		expect(mode.workflowzModeEnabled).toBe(false);
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+		expect(session.getWorkflowzModeEnabled()).toBe(true);
+
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(false);
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+	});
+
+	it("resets the mode through the /new command path", async () => {
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+
+		await mode.handleClearCommand();
+		expect(mode.workflowzModeEnabled).toBe(false);
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+	});
+
+	it("resets the mode through the /drop command path", async () => {
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+
+		await mode.handleDropCommand();
+		expect(mode.workflowzModeEnabled).toBe(false);
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+	});
+
+	it("persists through a non-session-reset transition (loop toggle)", async () => {
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+
+		// Enabling an unrelated runtime mode must not clear workflowz: the reset is
+		// scoped to session switches (/new, /drop), not arbitrary transitions.
+		await mode.handleLoopCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+		expect(session.getWorkflowzModeEnabled()).toBe(true);
+	});
+
+	it("repaints the border and feeds the badge an enabled status when toggled", async () => {
+		const borderSpy = vi.spyOn(mode, "updateEditorTopBorder");
+		const statusSpy = vi.spyOn(mode.statusLine, "setWorkflowzModeStatus");
+		const enableBorderBefore = borderSpy.mock.calls.length;
+		await mode.handleWorkflowzModeCommand();
+		// Toggling on must both repaint the border and feed the badge an enabled status;
+		// asserting only the repaint would pass even if the badge data were never set.
+		expect(borderSpy.mock.calls.length).toBeGreaterThan(enableBorderBefore);
+		expect(statusSpy).toHaveBeenLastCalledWith({ enabled: true });
+		const disableBorderBefore = borderSpy.mock.calls.length;
+		await mode.handleWorkflowzModeCommand();
+		expect(borderSpy.mock.calls.length).toBeGreaterThan(disableBorderBefore);
+		expect(statusSpy).toHaveBeenLastCalledWith(undefined);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-workflowz.test.ts
+++ b/packages/coding-agent/test/interactive-mode-workflowz.test.ts
@@ -106,4 +106,29 @@ describe("InteractiveMode workflowz mode", () => {
 		expect(borderSpy.mock.calls.length).toBeGreaterThan(disableBorderBefore);
 		expect(statusSpy).toHaveBeenLastCalledWith(undefined);
 	});
+
+	it("reconciles the TUI badge when newSession is invoked programmatically", async () => {
+		await mode.handleWorkflowzModeCommand();
+		expect(mode.workflowzModeEnabled).toBe(true);
+
+		// A tool/extension calling ctx.newSession() directly (not via /new) must still
+		// clear the badge: newSession runs the mode reconciler registered on construction.
+		await session.newSession();
+		expect(mode.workflowzModeEnabled).toBe(false);
+		expect(session.getWorkflowzModeEnabled()).toBe(false);
+	});
+
+	it("steers the trailing prompt instead of dropping it when enabled mid-stream", async () => {
+		(session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(true);
+		// No input waiter is active while a turn streams; the slash command already
+		// cleared the editor, so the trailing prompt must be steered (not lost) and
+		// run with the posture just enabled.
+		expect(mode.onInputCallback).toBeUndefined();
+
+		await mode.handleWorkflowzModeCommand("fix the build");
+
+		expect(mode.workflowzModeEnabled).toBe(true);
+		expect(promptSpy).toHaveBeenCalledWith("fix the build", { streamingBehavior: "steer" });
+	});
 });

--- a/packages/coding-agent/test/issue-953-repro.test.ts
+++ b/packages/coding-agent/test/issue-953-repro.test.ts
@@ -20,6 +20,7 @@ function createCtx(usage: Partial<SegmentContext["usageStats"]>): SegmentContext
 		planMode: null,
 		loopMode: null,
 		goalMode: null,
+		workflowzMode: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -26,7 +26,12 @@ afterAll(() => {
 });
 
 /** Minimal SegmentContext factory — only path/git fields matter for these tests. */
-function createCtx(overrides?: { pathMaxLength?: number; branch?: string | null }): SegmentContext {
+function createCtx(overrides?: {
+	pathMaxLength?: number;
+	branch?: string | null;
+	planMode?: { enabled: boolean; paused: boolean } | null;
+	workflowzMode?: { enabled: boolean } | null;
+}): SegmentContext {
 	return {
 		session: {
 			state: {},
@@ -42,9 +47,10 @@ function createCtx(overrides?: { pathMaxLength?: number; branch?: string | null 
 				stripWorkPrefix: false,
 			},
 		},
-		planMode: null,
+		planMode: overrides?.planMode ?? null,
 		loopMode: null,
 		goalMode: null,
+		workflowzMode: overrides?.workflowzMode ?? null,
 		collab: null,
 		usageStats: {
 			input: 0,
@@ -324,5 +330,22 @@ describe("overflow: path shrinks before git is dropped", () => {
 		} finally {
 			setProjectDir(tmpDir);
 		}
+	});
+});
+
+describe("workflowz mode badge", () => {
+	it("renders a rainbow Workflowz badge that wins priority over plan mode", () => {
+		const ctx = createCtx({
+			workflowzMode: { enabled: true },
+			planMode: { enabled: true, paused: false },
+		});
+		const rendered = renderSegment("mode", ctx);
+		expect(rendered.visible).toBe(true);
+		const visible = Bun.stripANSI(rendered.content);
+		expect(visible).toContain("Workflowz");
+		expect(visible).not.toContain("Plan");
+		// Rainbow = several distinct SGR color escapes, not one solid foreground color.
+		const colors = [...rendered.content.matchAll(/\x1b\[[0-9;]*m/g)].map(m => m[0]).filter(c => c !== "\x1b[39m");
+		expect(new Set(colors).size).toBeGreaterThan(1);
 	});
 });

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -334,7 +334,7 @@ describe("overflow: path shrinks before git is dropped", () => {
 });
 
 describe("workflowz mode badge", () => {
-	it("renders a rainbow Workflowz badge that wins priority over plan mode", () => {
+	it("renders the rainbow Workflowz badge alongside the active plan badge", () => {
 		const ctx = createCtx({
 			workflowzMode: { enabled: true },
 			planMode: { enabled: true, paused: false },
@@ -342,10 +342,19 @@ describe("workflowz mode badge", () => {
 		const rendered = renderSegment("mode", ctx);
 		expect(rendered.visible).toBe(true);
 		const visible = Bun.stripANSI(rendered.content);
+		// Workflowz is a standing posture that coexists with plan/goal/loop, so it
+		// renders as an additional badge rather than replacing the active mode badge.
 		expect(visible).toContain("Workflowz");
-		expect(visible).not.toContain("Plan");
+		expect(visible).toContain("Plan");
 		// Rainbow = several distinct SGR color escapes, not one solid foreground color.
 		const colors = [...rendered.content.matchAll(/\x1b\[[0-9;]*m/g)].map(m => m[0]).filter(c => c !== "\x1b[39m");
 		expect(new Set(colors).size).toBeGreaterThan(1);
+	});
+
+	it("renders only the Workflowz badge when no other mode is active", () => {
+		const ctx = createCtx({ workflowzMode: { enabled: true } });
+		const rendered = renderSegment("mode", ctx);
+		expect(rendered.visible).toBe(true);
+		expect(Bun.stripANSI(rendered.content)).toContain("Workflowz");
 	});
 });

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -31,6 +31,7 @@ function createPathContext(): SegmentContext {
 		planMode: null,
 		loopMode: null,
 		goalMode: null,
+		workflowzMode: null,
 		collab: null,
 		usageStats: {
 			input: 0,


### PR DESCRIPTION
## Summary

Implements a switchable, session-only TUI **workflowz mode** toggled by a new `/workflowz-mode` slash command. While active, every real user turn injects the existing `workflowz` eval fan-out contract — drive the task as a deterministic multi-subagent workflow via `agent()` / `parallel()` / `pipeline()` — without typing the keyword, and the status line shows a rainbow "Workflowz" badge mirroring Claude Code's "Ultra Code" indicator.

Closes #2517.

## What changed

- **Shared contract (no duplication):** `prompts/system/workflow-notice.md` becomes a Handlebars template with a `{{#if mode}}` opening switch; `modes/workflow.ts` renders `WORKFLOW_NOTICE` (keyword path — byte-identical to before) and the new `WORKFLOWZ_MODE_CONTEXT` (standing-mode path).
- **Per-turn injection:** `session/agent-session.ts` injects the mode context on every real turn across **all** prompt paths (`prompt()` and `promptCustomMessage()`, idle and streaming) and dedupes the keyword notice while the mode is active.
- **Toggle + lifecycle:** `modes/interactive-mode.ts` adds the toggle handler, status updater, and session-switch reset. The mode resets on `/new` and `/drop` and persists on other in-process transitions (consistent with loop/plan/goal); it coexists with plan/goal. `slash-commands/builtin-registry.ts` registers the command.
- **Rainbow badge:** `modes/gradient-highlight.ts` extracts a reusable, behavior-preserving `paintGradient()`; the status line (`components/status-line/*`) and `modes/theme/theme.ts` wire the `icon.workflowz` badge with a full-spectrum gradient.

The mode is opt-in and session-only; thinking effort is unchanged.

## Verification

- `bun check` (TypeScript + Rust) passes.
- Tests (added/updated): keyword path unchanged (`WORKFLOW_NOTICE` still carries the `**workflowz** keyword` + `parallel(` markers); per-turn injection emits exactly one `workflowz-mode-context` with no duplicate keyword notice; streaming injection for both `prompt()` and `promptCustomMessage()`; toggle flips both the UI and session flags; `/new` resets the mode; the rainbow badge renders and wins the mode-segment priority slot.
