### PR TITLE
fix(theme): classify HTML export defaults by status-line luminance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed HTML session export rendering empty text tokens (`text`, `userMessageText`, `customMessageText`, `toolTitle`) as the dark-theme grey `#e5e5e7` on every theme not literally named `light`, making transcripts illegible on custom light themes like `sandstone`, `limestone`, and `porcelain`. `getResolvedThemeColors` and the standalone `isLightTheme` helper now classify against the resolved `statusLineBg` luminance (the same surface `Theme.isLight` uses), so the HTML `defaultText` falls back to `#000000` on light themes and the standalone helper stays in lockstep with `Theme.isLight` ([#2516](https://github.com/can1357/oh-my-pi/issues/2516)).
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2521,16 +2521,37 @@ function ansi256ToHex(index: number): string {
 }
 
 /**
+ * Classify a parsed theme JSON as light/dark by the perceived luminance of its
+ * status-line background. Mirrors {@link Theme.isLight} so the synchronous
+ * helpers below stay in lockstep with the runtime classifier — see the comment
+ * on `Theme.statusLineLuminance` for why `statusLineBg` is the source of truth
+ * (themes like `porcelain` style a dark chat bubble on an otherwise-light
+ * theme, so `userMessageBg` is unreliable).
+ */
+function isLightThemeJson(themeJson: ThemeJson): boolean {
+	try {
+		const resolved = resolveVarRefs(themeJson.colors.statusLineBg, themeJson.vars ?? {});
+		const luminance = colorLuma(resolved);
+		return luminance !== undefined && luminance > 0.5;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Get resolved theme colors as CSS-compatible hex strings.
  * Used by HTML export to generate CSS custom properties.
  */
 export async function getResolvedThemeColors(themeName?: string): Promise<Record<string, string>> {
 	const name = themeName ?? getDefaultTheme();
-	const isLight = name === "light";
 	const themeJson = await loadThemeJson(name);
+	const isLight = isLightThemeJson(themeJson);
 	const resolved = resolveThemeColors(themeJson.colors, themeJson.vars);
 
-	// Default text color for empty values (terminal uses default fg color)
+	// Default text color for empty values (terminal uses default fg color).
+	// Must follow the actual theme appearance — hardcoding `name === "light"`
+	// makes every custom light theme (sandstone, limestone, porcelain, …) fall
+	// through to the dark-theme grey and renders the HTML export illegible.
 	const defaultText = isLight ? "#000000" : "#e5e5e7";
 
 	const cssColors: Record<string, string> = {};
@@ -2548,8 +2569,9 @@ export async function getResolvedThemeColors(themeName?: string): Promise<Record
 }
 
 /**
- * Check if a theme is a "light" theme by analyzing its background color luminance.
- * Loads theme JSON synchronously (built-in or custom file) and resolves userMessageBg.
+ * Check if a theme is a "light" theme by analyzing its status-line background
+ * luminance. Loads theme JSON synchronously (built-in or custom file on disk)
+ * for callers in synchronous flows (settings migration, setup wizard).
  */
 export function isLightTheme(themeName?: string): boolean {
 	const name = themeName ?? "dark";
@@ -2566,13 +2588,7 @@ export function isLightTheme(themeName?: string): boolean {
 			return false;
 		}
 	}
-	try {
-		const resolved = resolveVarRefs(themeJson.colors.userMessageBg, themeJson.vars ?? {});
-		const luminance = colorLuma(resolved);
-		return luminance !== undefined && luminance > 0.5;
-	} catch {
-		return false;
-	}
+	return isLightThemeJson(themeJson);
 }
 
 /**

--- a/packages/coding-agent/test/theme-islight.test.ts
+++ b/packages/coding-agent/test/theme-islight.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import {
+	getResolvedThemeColors,
+	getThemeByName,
+	isLightTheme,
+} from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 describe("Theme.isLight", () => {
 	it("classifies built-in themes by their status-line surface", async () => {
@@ -18,5 +22,41 @@ describe("Theme.isLight", () => {
 		expect(light?.accentSurfaceLuminance).toBeGreaterThan(0.5);
 		// ...dark themes pass undefined so accents stay vivid.
 		expect(dark?.accentSurfaceLuminance).toBeUndefined();
+	});
+});
+
+describe("isLightTheme (standalone)", () => {
+	// Regression for #2516: the standalone helper used to classify on
+	// userMessageBg, mismatching Theme.isLight (statusLineBg) and the HTML
+	// export's defaultText. porcelain is the canonical mismatch (dark bubble,
+	// light status line); sandstone/limestone exercise the custom-light path.
+	it.each([
+		["sandstone", true],
+		["limestone", true],
+		["porcelain", true],
+		["light", true],
+		["dark", false],
+		["dark-catppuccin", false],
+	])("classifies %s as isLight=%s", (name, expected) => {
+		expect(isLightTheme(name)).toBe(expected);
+	});
+});
+
+describe("getResolvedThemeColors HTML export defaults", () => {
+	// Regression for #2516: empty color tokens fell back to #e5e5e7 (the
+	// dark-theme grey) for every theme not literally named "light", making the
+	// session transcript text illegible on every custom light theme.
+	it("uses near-black for empty text tokens on light themes", async () => {
+		const colors = await getResolvedThemeColors("sandstone");
+		expect(colors.text).toBe("#000000");
+		expect(colors.userMessageText).toBe("#000000");
+		expect(colors.customMessageText).toBe("#000000");
+		expect(colors.toolTitle).toBe("#000000");
+	});
+
+	it("uses light grey for empty text tokens on dark themes", async () => {
+		const colors = await getResolvedThemeColors("dark");
+		expect(colors.text).toBe("#e5e5e7");
+		expect(colors.userMessageText).toBe("#e5e5e7");
 	});
 });

--- a/packages/coding-agent/test/theme-islight.test.ts
+++ b/packages/coding-agent/test/theme-islight.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	getResolvedThemeColors,
-	getThemeByName,
-	isLightTheme,
-} from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getResolvedThemeColors, getThemeByName, isLightTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 describe("Theme.isLight", () => {
 	it("classifies built-in themes by their status-line surface", async () => {


### PR DESCRIPTION
## Repro

HTML session export resolved every empty text token (`text`, `userMessageText`, `customMessageText`, `toolTitle`) to `#e5e5e7` on every theme not literally named `light`, leaving the transcript illegible on custom light themes like `sandstone`, `limestone`, and `porcelain`.

```
$ bun -e 'import { getResolvedThemeColors } from "@oh-my-pi/pi-coding-agent/modes/theme/theme"; const c = await getResolvedThemeColors("sandstone"); console.log({ text: c.text, userMessageText: c.userMessageText, customMessageText: c.customMessageText, toolTitle: c.toolTitle, userMessageBg: c.userMessageBg });'
{ text: '#e5e5e7', userMessageText: '#e5e5e7', customMessageText: '#e5e5e7', toolTitle: '#e5e5e7', userMessageBg: '#f0e6d8' }
```

## Cause

`packages/coding-agent/src/modes/theme/theme.ts`:

- `getResolvedThemeColors` picked `defaultText` off `name === "light"`, so every non-`"light"` theme (every custom light theme included) fell through to the dark-theme grey.
- The standalone `isLightTheme` helper classified on `userMessageBg`, diverging from `Theme.isLight`, which has classified on `statusLineBg` since `porcelain` proved `userMessageBg` unreliable (dark chat bubble on an otherwise-light theme).

## Fix

- New `isLightThemeJson(themeJson)` derives light/dark from the resolved `statusLineBg` luminance, mirroring `Theme.statusLineLuminance`.
- `getResolvedThemeColors` and `isLightTheme` both delegate to it. `defaultText` is now `#000000` for light themes and `#e5e5e7` for dark, matching `Theme.getColorHex`.
- Side-effect: the standalone helper now agrees with `Theme.isLight` for `porcelain` (previously returned `false` on its dark bubble).

## Verification

```
$ bun test test/theme-islight.test.ts
 10 pass
 0 fail
 17 expect() calls

$ bun -e '…getResolvedThemeColors("sandstone")…'
{ text: '#000000', userMessageText: '#000000', customMessageText: '#000000', toolTitle: '#000000', userMessageBg: '#f0e6d8' }
```

Extended `test/theme-islight.test.ts` with regression coverage for the standalone helper (`sandstone`/`limestone`/`porcelain`/`light` → true, `dark`/`dark-catppuccin` → false) and `getResolvedThemeColors` HTML defaults for both light (`sandstone` → `#000000`) and dark (`dark` → `#e5e5e7`).

Fixes #2516