### PR TITLE
feat(coding-agent): make /fast default scope configurable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `fastModeScope` setting (`both` | `openai` | `claude`, default `both`) controlling which providers `/fast on` (and the fast-mode toggle) target. `both` keeps the prior unscoped priority behavior; `openai`/`claude` scope fast mode to one family. `/fast status` now reports the active scope.
+
 ## [15.12.5] - 2026-06-13
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -998,6 +998,32 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	fastModeScope: {
+		type: "enum",
+		values: ["both", "openai", "claude"] as const,
+		default: "both",
+		ui: {
+			tab: "model",
+			group: "Sampling",
+			label: "Fast Mode Scope",
+			description:
+				'Which providers `/fast on` (and the fast-mode toggle) target. "both" = priority on every supported provider; "openai"/"claude" scope it to one family (mirrors serviceTier openai-only/claude-only).',
+			options: [
+				{ value: "both", label: "Both", description: "Priority on every supported provider" },
+				{
+					value: "openai",
+					label: "OpenAI only",
+					description: "Priority on OpenAI/OpenAI-Codex requests; ignored elsewhere",
+				},
+				{
+					value: "claude",
+					label: "Claude only",
+					description: "Anthropic fast mode on direct Claude requests; ignored elsewhere",
+				},
+			],
+		},
+	},
+
 	// Retries
 	"retry.enabled": { type: "boolean", default: true },
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6013,7 +6013,12 @@ export class AgentSession {
 			// Already on under any scope — keep the user's scoped value.
 			return;
 		}
-		this.setServiceTier(enabled ? "priority" : undefined);
+		if (!enabled) {
+			this.setServiceTier(undefined);
+			return;
+		}
+		const scope = this.settings.get("fastModeScope");
+		this.setServiceTier(scope === "openai" ? "openai-only" : scope === "claude" ? "claude-only" : "priority");
 	}
 
 	toggleFastMode(): boolean {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -62,6 +62,19 @@ function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.ui.requestRender();
 }
 
+/** `/fast status` label: "off", "on", or scope-qualified "on (… only)". */
+function formatFastModeStatus(session: AgentSession): string {
+	if (!session.isFastModeEnabled()) return "off";
+	switch (session.serviceTier) {
+		case "openai-only":
+			return "on (OpenAI only)";
+		case "claude-only":
+			return "on (Claude only)";
+		default:
+			return "on";
+	}
+}
+
 /** Scheme-less display form of a browser deep link: accent + underline, OSC-8 linked to the full URL. */
 function collabWebLinkClickable(webLink: string): string {
 	const display = theme.fg("accent", `\x1b[4m${webLink.replace(/^https?:\/\//, "")}\x1b[24m`);
@@ -359,15 +372,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (arg === "status") {
-				const tier = runtime.session.serviceTier;
-				const label = !runtime.session.isFastModeEnabled()
-					? "off"
-					: tier === "openai-only"
-						? "on (OpenAI only)"
-						: tier === "claude-only"
-							? "on (Claude only)"
-							: "on";
-				await runtime.output(`Fast mode is ${label}.`);
+				await runtime.output(`Fast mode is ${formatFastModeStatus(runtime.session)}.`);
 				return commandConsumed();
 			}
 			return usage("Usage: /fast [on|off|status]", runtime);
@@ -396,15 +401,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 			if (arg === "status") {
-				const tier = runtime.ctx.session.serviceTier;
-				const label = !runtime.ctx.session.isFastModeEnabled()
-					? "off"
-					: tier === "openai-only"
-						? "on (OpenAI only)"
-						: tier === "claude-only"
-							? "on (Claude only)"
-							: "on";
-				runtime.ctx.showStatus(`Fast mode is ${label}.`);
+				runtime.ctx.showStatus(`Fast mode is ${formatFastModeStatus(runtime.ctx.session)}.`);
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -359,7 +359,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (arg === "status") {
-				await runtime.output(`Fast mode is ${runtime.session.isFastModeEnabled() ? "on" : "off"}.`);
+				const tier = runtime.session.serviceTier;
+				const label = !runtime.session.isFastModeEnabled()
+					? "off"
+					: tier === "openai-only"
+						? "on (OpenAI only)"
+						: tier === "claude-only"
+							? "on (Claude only)"
+							: "on";
+				await runtime.output(`Fast mode is ${label}.`);
 				return commandConsumed();
 			}
 			return usage("Usage: /fast [on|off|status]", runtime);
@@ -388,8 +396,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 			if (arg === "status") {
-				const enabled = runtime.ctx.session.isFastModeEnabled();
-				runtime.ctx.showStatus(`Fast mode is ${enabled ? "on" : "off"}.`);
+				const tier = runtime.ctx.session.serviceTier;
+				const label = !runtime.ctx.session.isFastModeEnabled()
+					? "off"
+					: tier === "openai-only"
+						? "on (OpenAI only)"
+						: tier === "claude-only"
+							? "on (Claude only)"
+							: "on";
+				runtime.ctx.showStatus(`Fast mode is ${label}.`);
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/test/fast-mode-scope.test.ts
+++ b/packages/coding-agent/test/fast-mode-scope.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+type FastModeScope = "both" | "openai" | "claude";
+
+describe("fast mode scope", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-fast-mode-scope-");
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+		}
+		authStorage?.close();
+		tempDir.removeSync();
+	});
+
+	async function createSession(fastModeScope?: FastModeScope): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled test model to exist");
+		}
+
+		const settings = fastModeScope === undefined ? Settings.isolated() : Settings.isolated({ fastModeScope });
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey(model.provider, "anthropic-token");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		return session;
+	}
+
+	it("scopes enabled fast mode to OpenAI when configured", async () => {
+		const session = await createSession("openai");
+
+		session.setFastMode(true);
+
+		expect(session.serviceTier).toBe("openai-only");
+	});
+
+	it("scopes enabled fast mode to Claude when configured", async () => {
+		const session = await createSession("claude");
+
+		session.setFastMode(true);
+
+		expect(session.serviceTier).toBe("claude-only");
+	});
+
+	it("defaults enabled fast mode to priority for both providers", async () => {
+		const session = await createSession();
+
+		session.setFastMode(true);
+
+		expect(session.serviceTier).toBe("priority");
+	});
+
+	it("clears the service tier when disabled", async () => {
+		const session = await createSession("openai");
+		session.setFastMode(true);
+
+		session.setFastMode(false);
+
+		expect(session.serviceTier).toBeUndefined();
+	});
+
+	it("does not broaden an already enabled scoped tier", async () => {
+		const session = await createSession("claude");
+		session.setFastMode(true);
+		expect(session.serviceTier).toBe("claude-only");
+		session.settings.set("fastModeScope", "both");
+
+		session.setFastMode(true);
+
+		expect(session.serviceTier).toBe("claude-only");
+	});
+});


### PR DESCRIPTION
## What

Makes the default scope of `/fast on` configurable. Previously `setFastMode(true)` hardcoded the unscoped `priority` service tier (fast mode on every supported provider).

- New `fastModeScope` setting: `both` | `openai` | `claude`, default `both`.
- `setFastMode(true)` now derives the tier from the setting: `both → priority`, `openai → openai-only`, `claude → claude-only`. The off path and the "already on under any scope" no-op are unchanged.
- `/fast status` (ACP + TUI) now reports the active scope (e.g. `Fast mode is on (Claude only).`).

The raw `serviceTier` setting and `resolveServiceTier` remain the ground truth for request shaping; `fastModeScope` only governs what the convenience toggle's "on" maps to. Default `both` preserves existing behavior.

## Tests

`packages/coding-agent/test/fast-mode-scope.test.ts` (new) asserts the scope→tier mapping (`openai → openai-only`, `claude → claude-only`, default → `priority`), `setFastMode(false) → undefined`, and that re-enabling while already scoped is a no-op (does not broaden to unscoped `priority`).

`bun check` and the test pass.
