### PR TITLE
fix(providers/google): normalize tool schemas for non-CCA Google models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool schema conversion for non-Cloud Code Assist Google Gemini models by normalizing parameters with `normalizeSchemaForGoogle` to prevent un-normalized schema properties (such as `additionalProperties: false` or type arrays) from causing Gemini API errors.
+
 ## [15.12.4] - 2026-06-13
 
 ### Added

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -372,7 +372,7 @@ export function convertTools(
 				description: tool.description || "",
 				...(useParameters
 					? { parameters: normalizeSchemaForCCA(toolWireSchema(tool)) }
-					: { parametersJsonSchema: toolWireSchema(tool) }),
+					: { parametersJsonSchema: normalizeSchemaForGoogle(toolWireSchema(tool)) }),
 			})),
 		},
 	];

--- a/packages/ai/test/google-tool-schema.test.ts
+++ b/packages/ai/test/google-tool-schema.test.ts
@@ -172,7 +172,7 @@ describe("Cloud Code Assist Claude tool schema conversion", () => {
 		expect(claudeDeclaration.parametersJsonSchema).toBeUndefined();
 		expect(
 			(geminiDeclaration.parametersJsonSchema as { properties?: Record<string, unknown> })?.properties?.lines,
-		).toEqual((parameters as { properties: { lines: unknown } }).properties.lines);
+		).toEqual(normalizeSchemaForGoogle((parameters as { properties: { lines: unknown } }).properties.lines));
 	});
 
 	it("collapses mixed anyOf with shared metadata for edit-style lines fields", () => {
@@ -285,7 +285,7 @@ describe("Cloud Code Assist Claude tool schema conversion", () => {
 		expect(JSON.stringify(claudeDeclaration.parameters)).not.toContain('"anyOf"');
 		expect(
 			(geminiDeclaration.parametersJsonSchema as { properties?: Record<string, unknown> })?.properties?.value,
-		).toEqual((parameters as { properties: { value: unknown } }).properties.value);
+		).toEqual(normalizeSchemaForGoogle((parameters as { properties: { value: unknown } }).properties.value));
 	});
 
 	it("falls back to minimal object schema when non-null unresolved unions remain for CCA Claude", () => {
@@ -343,6 +343,32 @@ describe("Cloud Code Assist Claude tool schema conversion", () => {
 				value: {
 					type: "string",
 					nullable: true,
+				},
+			},
+		});
+	});
+
+	it("normalizes schemas for gemini models using normalizeSchemaForGoogle", () => {
+		const parameters = {
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
+				},
+			},
+			additionalProperties: false,
+		} as unknown as TJsonSchema;
+		const tools: Tool[] = [{ name: "test_tool", description: "Test tool", parameters }];
+		const model = createModel("gemini-3.5-flash");
+
+		const result = convertTools(tools, model);
+		const declaration = result?.[0]?.functionDeclarations[0] as Record<string, unknown>;
+
+		expect(declaration.parametersJsonSchema).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
 				},
 			},
 		});


### PR DESCRIPTION
Bypassing `normalizeSchemaForGoogle` for the `parametersJsonSchema` path was causing Gemini API requests to be rejected due to un-normalized schema properties (e.g. `additionalProperties: false`, type arrays, etc.) which are forbidden by the Gemini API. This fix wraps the tool schema in `normalizeSchemaForGoogle` before passing it to `parametersJsonSchema`, resolving the Gemini tool calling failures and conforming to the rule defined in `CONSTRAINTS.md`.