### PR TITLE
fix(coding-agent): restore compaction-queued messages on Alt+Up dequeue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed session JSONL persistence so the first assistant turn materializes the file synchronously, leaves the append writer open, and writes later entries with a sync append writer even during writer-close races instead of waiting on a queued rewrite.
+- Fixed `Alt+Up` (dequeue) reporting "No queued messages to restore" for messages — including skills — typed while the session was compacting. `restoreQueuedMessagesToEditor` now drains `compactionQueuedMessages` alongside the agent queue, so the `Alt+Up to edit` hint restores every pending message it advertises.
 
 ## [15.12.5] - 2026-06-13
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -924,7 +924,20 @@ export class InputController {
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
 		this.ctx.locallySubmittedUserSignatures.clear();
 		const { steering, followUp } = this.ctx.session.clearQueue();
-		const allQueued = [...steering, ...followUp];
+		// Messages typed while compacting live in `compactionQueuedMessages`, not the
+		// agent queue `clearQueue()` drains — but the pending bar shows the same
+		// "Alt+Up to edit" hint for them (ui-helpers `updatePendingMessagesDisplay`).
+		// Drain them here too so the dequeue restores every message the hint
+		// advertises; otherwise a skill/text queued during compaction is stranded and
+		// Alt+Up reports "No queued messages to restore".
+		const compactionQueued = this.ctx.compactionQueuedMessages;
+		this.ctx.compactionQueuedMessages = [];
+		const allQueued = [
+			...steering,
+			...compactionQueued.filter(e => e.mode === "steer").map(e => ({ text: e.text, images: e.images })),
+			...followUp,
+			...compactionQueued.filter(e => e.mode === "followUp").map(e => ({ text: e.text, images: e.images })),
+		];
 		if (allQueued.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();
 			if (options?.abort) {

--- a/packages/coding-agent/test/input-controller-compaction-image.test.ts
+++ b/packages/coding-agent/test/input-controller-compaction-image.test.ts
@@ -21,6 +21,7 @@ import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/inp
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import type { RestoredQueuedMessage } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 beforeAll(() => {
 	initTheme();
@@ -39,7 +40,7 @@ function makeCtx(initialQueue: CompactionQueuedMessage[] = []) {
 		extensionRunner: undefined,
 		customCommands: [] as Array<{ command: { name: string } }>,
 		getQueuedMessages: () => ({ steering: [] as string[], followUp: [] as string[] }),
-		clearQueue: () => ({ steering: [] as string[], followUp: [] as string[] }),
+		clearQueue: () => ({ steering: [] as RestoredQueuedMessage[], followUp: [] as RestoredQueuedMessage[] }),
 		prompt: mock(async (text: string, opts?: PromptOpts): Promise<void> => {
 			promptCalls.push({ text, opts });
 		}),
@@ -155,7 +156,7 @@ describe("compaction queue Alt+Up restore", () => {
 			{ text: "compaction steer", mode: "steer", images: undefined },
 			{ text: "compaction followup", mode: "followUp", images: undefined },
 		]);
-		(session as unknown as { clearQueue: () => unknown }).clearQueue = () => ({
+		session.clearQueue = () => ({
 			steering: [{ text: "session steer" }],
 			followUp: [{ text: "session followup" }],
 		});

--- a/packages/coding-agent/test/input-controller-compaction-image.test.ts
+++ b/packages/coding-agent/test/input-controller-compaction-image.test.ts
@@ -17,6 +17,7 @@
 
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -50,6 +51,8 @@ function makeCtx(initialQueue: CompactionQueuedMessage[] = []) {
 		}),
 	};
 
+	let editorText = "";
+
 	const ctx = {
 		session,
 		compactionQueuedMessages: [...initialQueue],
@@ -58,8 +61,10 @@ function makeCtx(initialQueue: CompactionQueuedMessage[] = []) {
 		pendingMessagesContainer: { clear: () => {}, addChild: () => {}, removeChild: () => {} },
 		editor: {
 			addToHistory: () => {},
-			setText: () => {},
-			getText: () => "",
+			setText: (text: string) => {
+				editorText = text;
+			},
+			getText: () => editorText,
 			imageLinks: undefined as (string | undefined)[] | undefined,
 		},
 		keybindings: { getDisplayString: () => "Alt+Up" },
@@ -125,5 +130,37 @@ describe("compaction queue image forwarding", () => {
 		await new UiHelpers(ctx).flushCompactionQueue({ willRetry: true });
 
 		expect(followUpCalls).toEqual([{ text: "and this one", images: [image] }]);
+	});
+});
+
+describe("compaction queue Alt+Up restore", () => {
+	test("restoreQueuedMessagesToEditor drains a compaction-queued skill", () => {
+		const { ctx } = makeCtx([{ text: "/skill:foo bar", mode: "followUp", images: undefined }]);
+		const restored = new InputController(ctx).restoreQueuedMessagesToEditor();
+		expect(restored).toBe(1);
+		expect(ctx.editor.getText()).toBe("/skill:foo bar");
+		expect(ctx.compactionQueuedMessages).toEqual([]);
+	});
+
+	test("restored compaction images return to the pending-image buffer", () => {
+		const image = img("YmF6");
+		const { ctx } = makeCtx([{ text: "look", mode: "steer", images: [image] }]);
+		const restored = new InputController(ctx).restoreQueuedMessagesToEditor();
+		expect(restored).toBe(1);
+		expect(ctx.pendingImages).toEqual([image]);
+	});
+
+	test("session and compaction queues restore in pending-bar order", () => {
+		const { ctx, session } = makeCtx([
+			{ text: "compaction steer", mode: "steer", images: undefined },
+			{ text: "compaction followup", mode: "followUp", images: undefined },
+		]);
+		(session as unknown as { clearQueue: () => unknown }).clearQueue = () => ({
+			steering: [{ text: "session steer" }],
+			followUp: [{ text: "session followup" }],
+		});
+		const restored = new InputController(ctx).restoreQueuedMessagesToEditor();
+		expect(restored).toBe(4);
+		expect(ctx.editor.getText()).toBe("session steer\n\ncompaction steer\n\nsession followup\n\ncompaction followup");
 	});
 });


### PR DESCRIPTION
## Problem

Pressing **Alt+Up** (`app.message.dequeue`) should pull every queued message back into the editor — the pending bar shows a `↳ Alt+Up to edit` hint for each. But it occasionally did nothing ("No queued messages to restore"), most often for messages typed while the session was **compacting**, and especially for skills.

## Root cause

`restoreQueuedMessagesToEditor()` drained only the agent queue via `session.clearQueue()` (steering + follow-up). The pending-bar hint, however, is rendered by `updatePendingMessagesDisplay()` for the **union** of that queue and `ctx.compactionQueuedMessages`. Input typed while `session.isCompacting` lands in `compactionQueuedMessages` — and a `/skill:*` follow-up is routed there explicitly, because the follow-up path's `isCompacting` check precedes its skill check. Those messages were advertised by the hint yet had no consumer other than the post-compaction flush, so Alt+Up could not reach them.

`test/issue-825-repro.test.ts` already documented the gap: such messages were "stranded in `compactionQueuedMessages` with no consumer."

## Fix

`restoreQueuedMessagesToEditor` now drains and clears `compactionQueuedMessages` alongside the agent queue, merging the entries in the same order the pending bar renders them (session-steer → compaction-steer → session-follow-up → compaction-follow-up). The existing text-join, image hand-back, and abort branches operate on the merged list unchanged. No double-delivery with `flushCompactionQueue` (single-threaded; whichever drains first leaves the array empty for the other).

## Tests

Three new contract tests in `test/input-controller-compaction-image.test.ts`:
- a compaction-queued skill is restored (count, editor text, queue emptied);
- restored compaction images return to the pending-image buffer;
- session + compaction queues restore in pending-bar order.

They fail against the pre-fix handler (`restored` would be `0`). `bun test` (including the skill-queue regression guard) and `bun check` pass.