### PR TITLE
feat(coding-agent): make task.eager reinforce subagent delegation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `task.eager` ("Prefer Task Delegation") now actively reinforces delegation instead of only emitting a prompt hint: a first-turn delegation reminder is injected for the main agent, and the `task` tool is force-exposed under `tools.discoveryMode: "all"` so the setting takes effect in every discovery mode ([#2534](https://github.com/can1357/oh-my-pi/issues/2534)).
+
 ### Fixed
 
 - Fixed session JSONL persistence so the first assistant turn materializes the file synchronously, leaves the append writer open, and writes later entries with a sync append writer even during writer-close races instead of waiting on a queued rewrite.

--- a/packages/coding-agent/src/prompts/system/eager-task.md
+++ b/packages/coding-agent/src/prompts/system/eager-task.md
@@ -1,0 +1,7 @@
+<system-reminder>
+Task delegation is enabled — subagents are the default for this request.
+
+Explore and settle the approach FIRST. Once the design is settled, you MUST fan the work out to `task` subagents instead of implementing it yourself. Batch independent slices into ONE parallel `task` call; never serialize work that can run concurrently.
+
+Work alone only for: a single-file edit under ~30 lines, a direct answer requiring no code changes, or a command the user explicitly asked you to run.
+</system-reminder>

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -102,11 +102,11 @@ Pattern syntax (metavariables, `$$$` spreads) is in each tool's description.
 {{#if eagerTasks}}
 {{#has tools "task"}}
 # Eager Tasks
-You SHOULD delegate work to subagents by default. You MAY work alone only when:
-- The change is a single-file edit under ~30 lines
-- The request is a direct answer or explanation with no code changes
-- The user asked you to run a command yourself
-For multi-file changes, refactors, new features, tests, or investigations, you SHOULD break the work into tasks and delegate after the design is settled.
+Delegation is the default here, not the exception. Once the design is settled, you MUST fan the work out to `{{toolRefs.task}}` subagents rather than doing it yourself. Work alone ONLY when one of these is unambiguously true:
+- A single-file edit under ~30 lines
+- A direct answer or explanation requiring no code changes
+- The user explicitly asked you to run a command yourself
+Everything else — multi-file changes, refactors, new features, tests, investigations — MUST be decomposed and delegated. Batch independent slices into one parallel `{{toolRefs.task}}` call; never serialize what can run concurrently.
 {{/has}}
 {{/if}}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2247,10 +2247,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (effectiveDiscoveryMode === "all") {
 			// Tools a forced tool_choice will target must stay active, or the named
 			// choice references a tool absent from the request (provider 400). Eager
-			// todos force a named `todo` choice on the first turn.
+			// todos force a named `todo` choice on the first turn. `task` is also kept
+			// active under discovery-all when `task.eager` is on, so eager delegation is
+			// possible and the Eager Tasks prompt section renders, even though nothing
+			// forces a `task` tool_choice.
 			const forceActive = new Set<string>();
 			if (settings.get("todo.eager") && settings.get("todo.enabled") && toolRegistry.has("todo")) {
 				forceActive.add("todo");
+			}
+			if (settings.get("task.eager") && toolRegistry.has("task")) {
+				forceActive.add("task");
 			}
 			initialToolNames = filterInitialToolsForDiscoveryAll(initialToolNames, {
 				loadModeOf: name => toolRegistry.get(name)?.loadMode,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -187,6 +187,7 @@ import { containsWorkflow, WORKFLOW_NOTICE } from "../modes/workflow";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
+import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
 import eagerTodoPrompt from "../prompts/system/eager-todo.md" with { type: "text" };
 import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with { type: "text" };
 import ircAutoReplyTemplate from "../prompts/system/irc-autoreply.md" with { type: "text" };
@@ -198,6 +199,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 };
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
+import { MAIN_AGENT_ID } from "../registry/agent-registry";
 import {
 	deobfuscateSessionContext,
 	obfuscateProviderContext,
@@ -4605,10 +4607,12 @@ export class AgentSession {
 			return true;
 		}
 
-		// Skip eager todo prelude when the user has already queued a directive
+		// Skip eager preludes when the user has already queued a directive
 		const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
 		const eagerTodoPrelude =
 			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
+		const eagerTaskPrelude =
+			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTaskPrelude(expandedText) : undefined;
 		const normalizedImages = await this.#normalizeImagesForModel(options?.images);
 
 		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
@@ -4621,17 +4625,22 @@ export class AgentSession {
 			? { role: "developer" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() }
 			: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
 
+		const preludeMessages: AgentMessage[] = [];
 		if (eagerTodoPrelude) {
 			this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
 				label: "eager-todo",
 			});
+			preludeMessages.push(eagerTodoPrelude.message);
+		}
+		if (eagerTaskPrelude) {
+			preludeMessages.push(eagerTaskPrelude);
 		}
 
 		try {
 			await this.#promptWithMessage(message, expandedText, {
 				...options,
 				images: normalizedImages,
-				prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
+				prependMessages: preludeMessages.length > 0 ? preludeMessages : undefined,
 				appendMessages: keywordNotices.length > 0 ? keywordNotices : undefined,
 			});
 		} finally {
@@ -7090,6 +7099,28 @@ export class AgentSession {
 				timestamp: Date.now(),
 			},
 			toolChoice: todoToolChoice,
+		};
+	}
+
+	#createEagerTaskPrelude(promptText: string): AgentMessage | undefined {
+		if (!this.settings.get("task.eager")) return undefined;
+		// Main agent only: subagents keep `task` active (the parent only filters `todo`),
+		// so a salient delegate-reminder there would amplify nested fan-out. Eager-todo
+		// avoids subs only because `todo` is filtered; `task` is not, so gate explicitly.
+		const agentId = this.getAgentId();
+		if (agentId !== undefined && agentId !== MAIN_AGENT_ID) return undefined;
+		if (this.#planModeState?.enabled) return undefined;
+		if (this.agent.state.messages.some(m => m.role === "user")) return undefined;
+		const trimmed = promptText.trimEnd();
+		if (trimmed.endsWith("?") || trimmed.endsWith("!")) return undefined;
+		if (!this.getActiveToolNames().includes("task")) return undefined;
+		return {
+			role: "custom",
+			customType: "eager-task-prelude",
+			content: prompt.render(eagerTaskPrompt),
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
 		};
 	}
 	/**

--- a/packages/coding-agent/test/agent-session-eager-task.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-task.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { TextContent } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TodoTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { z } from "zod/v4";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+type ObservedPromptCall = {
+	toolChoice: string | undefined;
+	toolNames: string[];
+	messageRoles: AgentMessage["role"][];
+	messageTexts: string[];
+	lastMessageRole: AgentMessage["role"];
+	lastMessageText: string;
+};
+
+type Harness = {
+	session: AgentSession;
+	observedCalls: ObservedPromptCall[];
+	authStorage: AuthStorage;
+};
+
+function isTextContentBlock(value: unknown): value is TextContent {
+	if (!value || typeof value !== "object") return false;
+	return (value as TextContent).type === "text" && typeof (value as TextContent).text === "string";
+}
+
+function getToolChoiceName(choice: unknown): string | undefined {
+	if (!choice) return undefined;
+	if (typeof choice === "string") return choice;
+	if (typeof choice !== "object" || !("type" in choice)) return undefined;
+	const toolChoice = choice as { type?: string; name?: string; function?: { name?: string } };
+	if (toolChoice.type === "tool") return toolChoice.name;
+	if (toolChoice.type === "function") return toolChoice.name ?? toolChoice.function?.name;
+	return undefined;
+}
+
+function getMessageText(message: AgentMessage): string {
+	if (!("content" in message)) {
+		return "";
+	}
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+	if (!Array.isArray(message.content)) {
+		return "";
+	}
+	return message.content
+		.filter(isTextContentBlock)
+		.map(content => content.text)
+		.join("\n");
+}
+
+describe("AgentSession eager task prelude", () => {
+	let tempDir: TempDir;
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-agent-session-eager-task-");
+		harnesses.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const harness of harnesses) {
+			await harness.session.dispose();
+			harness.authStorage.close();
+		}
+		harnesses.length = 0;
+		tempDir.removeSync();
+	});
+
+	async function createHarness(settingsOverride: Record<string, unknown> = {}, agentId?: string): Promise<Harness> {
+		const observedCalls: ObservedPromptCall[] = [];
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${harnesses.length}.db`));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${harnesses.length}.yml`));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"task.eager": true,
+			"todo.enabled": false,
+			"todo.eager": false,
+			...settingsOverride,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+
+		const mockTaskTool: AgentTool = {
+			name: "task",
+			label: "Task",
+			description: "Mock task tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		};
+		const mockBashTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock bash tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		};
+		const todoEnabled = settings.get("todo.enabled") === true;
+		const toolSession: ToolSession = {
+			cwd: tempDir.path(),
+			hasUI: false,
+			getSessionFile: () => sessionManager.getSessionFile() ?? null,
+			getSessionSpawns: () => "*",
+			settings,
+		};
+		const todoTool = todoEnabled ? new TodoTool(toolSession) : undefined;
+		const tools: AgentTool[] = todoTool
+			? [todoTool as unknown as AgentTool, mockTaskTool, mockBashTool]
+			: [mockTaskTool, mockBashTool];
+
+		let session: AgentSession;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools,
+				messages: [],
+			},
+			convertToLlm,
+			getToolChoice: () => session?.nextToolChoice(),
+			streamFn: (_model, context, options) => {
+				const lastMessage = context.messages.at(-1);
+				if (!lastMessage) {
+					throw new Error("Expected prompt context to include a message");
+				}
+				observedCalls.push({
+					toolChoice: getToolChoiceName(options?.toolChoice),
+					toolNames: (context.tools ?? []).map(tool => tool.name),
+					messageRoles: context.messages.map(message => message.role),
+					messageTexts: context.messages.map(message => getMessageText(message)),
+					lastMessageRole: lastMessage.role,
+					lastMessageText: getMessageText(lastMessage),
+				});
+				const response = createAssistantMessage("done");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+
+		const toolRegistry = new Map<string, AgentTool>([
+			[mockTaskTool.name, mockTaskTool],
+			[mockBashTool.name, mockBashTool],
+		]);
+		if (todoTool) toolRegistry.set(todoTool.name, todoTool as unknown as AgentTool);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			agentId,
+		});
+
+		const harness = { session, observedCalls, authStorage };
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("prepends a hidden eager task reminder without forcing task or repeating the prompt text", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "user"]);
+		expect(observedCalls[0]?.messageTexts[0]).toContain("delegation is enabled");
+		expect(
+			observedCalls[0]?.messageTexts.filter(text => text.includes("refactor the parser across modules")),
+		).toHaveLength(1);
+		expect(observedCalls[0]?.messageTexts[0]).not.toContain("refactor the parser across modules");
+	});
+
+	it("skips eager task prelude for prompts ending with a question mark", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("should I refactor the parser?");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["should I refactor the parser?"]);
+	});
+
+	it("skips eager task prelude for prompts ending with an exclamation mark", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser now!");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser now!"]);
+	});
+
+	it("skips eager task prelude for subsequent user messages", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser across modules");
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "user"]);
+
+		observedCalls.length = 0;
+		await session.prompt("now update the serializer too");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.messageRoles.at(-1)).toBe("user");
+		// The turn-1 prelude persists in history; the contract is that NO fresh prelude is
+		// prepended adjacent to the new user message on a subsequent turn.
+		expect(observedCalls[0]?.messageRoles.at(-2)).not.toBe("developer");
+		expect(observedCalls[0]?.messageTexts.at(-1)).toBe("now update the serializer too");
+	});
+
+	it("skips eager task prelude when task.eager is disabled", async () => {
+		const { session, observedCalls } = await createHarness({ "task.eager": false });
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser across modules"]);
+	});
+
+	it("skips eager task prelude for subagent sessions", async () => {
+		const { session, observedCalls } = await createHarness({}, "SubAgent");
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser across modules"]);
+	});
+
+	it("prepends both todo and task preludes when both are eager, keeping the forced todo choice", async () => {
+		const { session, observedCalls } = await createHarness({
+			"todo.enabled": true,
+			"todo.eager": true,
+			"todo.reminders": false,
+		});
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		// eager-todo still forces the todo tool choice on the first turn
+		expect(observedCalls[0]?.toolChoice).toBe("todo");
+		// both hidden preludes precede the user message: todo first, then task
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "developer", "user"]);
+		const texts = observedCalls[0]?.messageTexts ?? [];
+		expect(texts.at(-1)).toBe("refactor the parser across modules");
+		// the task reminder is the second prelude (after the todo reminder)
+		expect(texts.findIndex(text => text.includes("delegation is enabled"))).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -159,6 +159,48 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		expect(searchTool?.description).toContain("Total discoverable tools available:");
 	});
 
+	it("exposes task under tools.discoveryMode all when task.eager is on", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all", "task.eager": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.getActiveToolNames()).toContain("task");
+		await session.dispose();
+	});
+
+	it("hides task under tools.discoveryMode all when task.eager is off", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.getActiveToolNames()).not.toContain("task");
+		await session.dispose();
+	});
+
 	it("preserves explicitly requested MCP tools in discovery mode", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,


### PR DESCRIPTION
## What
Makes `task.eager` ("Prefer Task Delegation") actually drive subagent use, closing the gap with `todo.eager`.

Fixes #2534

## Changes
- Exposure (`sdk.ts`): force `task` active under `tools.discoveryMode: "all"` when `task.eager` is on, mirroring the existing `todo` line — otherwise `task` (a discoverable tool) is hidden and the Eager Tasks prompt section silently does not render.
- Salience (`session/agent-session.ts` + new `prompts/system/eager-task.md`): a first-turn delegation reminder prelude (`#createEagerTaskPrelude`), gated to the main agent and the first user message, suppressed in plan mode and on questions. Reminder-only — it never forces a `task` call, honoring "delegate after the design is settled."
- Prompt (`prompts/system/system-prompt.md`): tightened the `# Eager Tasks` section.

## Why main-agent-only
`todo.eager`'s prelude effectively never fires in subagents because `todo` is parent-owned and filtered there. `task` stays active in subagents, so an unguarded reminder would amplify nested fan-out; gating to the main agent keeps behavior faithful to the todo precedent.

## Tests
- `agent-session-eager-task.test.ts`: reminder fires on the first user message, forces no tool choice, and is suppressed on questions, follow-up turns, when the setting is off, and for subagent sessions.
- `sdk-mcp-discovery.test.ts`: `task` is exposed under `tools.discoveryMode: "all"` when `task.eager` is on, and hidden when it is off.
- `bun check` clean; `agent-session-eager-todo.test.ts` regression green.
