### PR TITLE
fix(providers/google): avoid creating empty text blocks on stream ending

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini / Antigravity streams (Google Cloud Code Assist API) creating a trailing empty text block and emitting redundant `text_start`/`text_delta`/`text_end` events at the end of the turn when the final SSE chunk contains an empty text part (`text: ""`). The parser now ignores empty text parts, preserving the active transcript block state and ensuring proper nesting and rendering of subsequent background jobs or new turns.
+- Preserved terminal Google `thoughtSignature`s by still extracting and applying the signature on the active block even when the text part is empty or undefined.
+
 ## [15.12.6] - 2026-06-14
 
 ### Changed

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -447,7 +447,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					const candidate = responseData.candidates?.[0];
 					if (candidate?.content?.parts) {
 						for (const part of candidate.content.parts) {
-							if (part.text !== undefined) {
+							if (part.text !== undefined && part.text !== "") {
 								const isThinking = isThinkingPart(part);
 								if (
 									!currentBlock ||
@@ -483,6 +483,18 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 										delta: part.text,
 										partial: output,
 									});
+								}
+							} else if (part.thoughtSignature && currentBlock) {
+								if (currentBlock.type === "thinking") {
+									currentBlock.thinkingSignature = retainThoughtSignature(
+										currentBlock.thinkingSignature,
+										part.thoughtSignature,
+									);
+								} else {
+									currentBlock.textSignature = retainThoughtSignature(
+										currentBlock.textSignature,
+										part.thoughtSignature,
+									);
 								}
 							}
 

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -609,7 +609,7 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 		const candidate = chunk.candidates?.[0];
 		if (candidate?.content?.parts) {
 			for (const part of candidate.content.parts) {
-				if (part.text !== undefined) {
+				if (part.text !== undefined && part.text !== "") {
 					if (!firstTokenSeen) {
 						firstTokenSeen = true;
 						onFirstToken?.();
@@ -649,6 +649,18 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 							delta: part.text,
 							partial: output,
 						});
+					}
+				} else if (part.thoughtSignature && currentBlock) {
+					if (currentBlock.type === "thinking") {
+						currentBlock.thinkingSignature = retainThoughtSignature(
+							currentBlock.thinkingSignature,
+							part.thoughtSignature,
+						);
+					} else if (retainTextSignature) {
+						currentBlock.textSignature = retainThoughtSignature(
+							currentBlock.textSignature,
+							part.thoughtSignature,
+						);
 					}
 				}
 

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { streamGoogle } from "@oh-my-pi/pi-ai/providers/google";
 import { streamGoogleGeminiCli } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
+import { streamGoogleVertex } from "@oh-my-pi/pi-ai/providers/google-vertex";
 import type { AssistantMessageEvent, Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
@@ -45,6 +46,19 @@ const genaiModel: Model<"google-generative-ai"> = buildModel({
 	id: "gemini-3-flash",
 	name: "Gemini 3 Flash",
 	api: "google-generative-ai",
+	provider: "google",
+	baseUrl: "",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_000,
+});
+
+const vertexModel: Model<"google-vertex"> = buildModel({
+	id: "gemini-3-flash",
+	name: "Gemini 3 Flash (Vertex)",
+	api: "google-vertex",
 	provider: "google",
 	baseUrl: "",
 	reasoning: true,
@@ -99,6 +113,53 @@ describe("Google empty-response retry (public + Vertex path)", () => {
 		expect(calls).toBe(3); // MAX_EMPTY_STREAM_RETRIES (2) + 1 initial attempt
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toContain("empty response");
+	});
+
+	it("filters out empty text parts at stream end but preserves terminal thought signatures", async () => {
+		const chunks = [
+			{ candidates: [{ content: { parts: [{ text: "Hello" }] } }] },
+			{
+				candidates: [
+					{ content: { parts: [{ text: "", thoughtSignature: "terminal-sig" }] }, finishReason: "STOP" },
+				],
+			},
+		];
+
+		const fetchMock: FetchImpl = async input => {
+			const url = input instanceof Request ? input.url : input.toString();
+			if (url.includes("oauth2.googleapis.com/token") || url.includes("metadata.google.internal")) {
+				return new Response(JSON.stringify({ access_token: "token", expires_in: 3600 }));
+			}
+			return sse(...chunks);
+		};
+
+		const stream = streamGoogleVertex(vertexModel, context, {
+			project: "project",
+			location: "location",
+			fetch: fetchMock,
+		});
+		const { events } = await drain(stream);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]).toEqual({
+			type: "text",
+			text: "Hello",
+			textSignature: "terminal-sig",
+		});
+
+		const textStartEvents = events.filter(e => e.type === "text_start");
+		expect(textStartEvents).toHaveLength(1);
+		expect(textStartEvents[0].contentIndex).toBe(0);
+
+		const textDeltaEvents = events.filter(e => e.type === "text_delta");
+		expect(textDeltaEvents).toHaveLength(1);
+		expect(textDeltaEvents[0].delta).toBe("Hello");
+
+		const textEndEvents = events.filter(e => e.type === "text_end");
+		expect(textEndEvents).toHaveLength(1);
+		expect(textEndEvents[0].content).toBe("Hello");
 	});
 });
 

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -8,7 +8,7 @@ import {
 	streamGoogleGeminiCli,
 } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
 import { getOAuthApiKey } from "@oh-my-pi/pi-ai/registry/oauth";
-import type { Context, FetchImpl, Model, TJsonSchema } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessageEvent, Context, FetchImpl, Model, TJsonSchema } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
@@ -250,6 +250,67 @@ describe("Google Gemini CLI alignment", () => {
 		expect(requestHeaders!.get("anthropic-beta")).toBe("interleaved-thinking-2025-05-14");
 		expect(requestHeaders!.get("X-Goog-Api-Client")).toBeNull();
 		expect(requestHeaders!.get("Client-Metadata")).toBeNull();
+	});
+
+	it("filters out empty text parts at stream end but preserves terminal thought signatures", async () => {
+		const sseChunks = [
+			'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}\n\n',
+			'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"","thoughtSignature":"terminal-sig"}]},"finishReason":"STOP"}]}}\n\n',
+		];
+
+		const fetchMock: FetchImpl = async () => {
+			const stream = new ReadableStream({
+				async start(controller) {
+					const encoder = new TextEncoder();
+					for (const chunk of sseChunks) {
+						controller.enqueue(encoder.encode(chunk));
+						await Bun.sleep(5);
+					}
+					controller.close();
+				},
+			});
+			return new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		};
+
+		const model: Model<"google-gemini-cli"> = buildModel({
+			...createModel("google-antigravity"),
+			id: "gemini-3.5-flash",
+			name: "Gemini 3.5 Flash",
+			reasoning: true,
+		} as ModelSpec<"google-gemini-cli">);
+
+		const events: AssistantMessageEvent[] = [];
+		const stream = streamGoogleGeminiCli(model, createContext(), {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			fetch: fetchMock,
+		});
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]).toEqual({
+			type: "text",
+			text: "Hello",
+			textSignature: "terminal-sig",
+		});
+
+		const textStartEvents = events.filter(e => e.type === "text_start");
+		expect(textStartEvents).toHaveLength(1);
+		expect(textStartEvents[0].contentIndex).toBe(0);
+
+		const textDeltaEvents = events.filter(e => e.type === "text_delta");
+		expect(textDeltaEvents).toHaveLength(1);
+		expect(textDeltaEvents[0].delta).toBe("Hello");
+
+		const textEndEvents = events.filter(e => e.type === "text_end");
+		expect(textEndEvents).toHaveLength(1);
+		expect(textEndEvents[0].content).toBe("Hello");
 	});
 
 	describe("retry guardrails", () => {


### PR DESCRIPTION
Avoids creating empty text blocks on stream ending for Gemini/Antigravity models, while preserving terminal thoughtSignatures and adding regression tests.