### PR TITLE
feat(coding-agent): three-level eagerness enum for task.eager and todo.eager

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `task.eager` ("Prefer Task Delegation") and `todo.eager` ("Create Todos Automatically") are now three-level enums (`default` / `preferred` / `always`) instead of booleans. For `todo.eager`, `preferred` suggests a todo list on the first message while `always` forces it (the previous "on" behavior); for `task.eager`, `preferred` adds delegation guidance to the system prompt while `always` also injects a first-turn delegation reminder. Existing boolean configs migrate automatically (`true → always`, `false → default`). On models that cannot be forced to call `todo`, `todo.eager: "always"` now emits the first-turn reminder without forcing the call (previously such models received nothing) ([#2539](https://github.com/can1357/oh-my-pi/issues/2539)).
+
 ## [15.12.6] - 2026-06-14
 ### Breaking Changes
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2772,13 +2772,23 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	"todo.eager": {
-		type: "boolean",
-		default: false,
+		type: "enum",
+		values: ["default", "preferred", "always"] as const,
+		default: "default",
 		ui: {
 			tab: "tools",
 			group: "Todos",
 			label: "Create Todos Automatically",
-			description: "Automatically create a comprehensive todo list after the first message",
+			description: "How strongly to push automatic todo-list creation after the first message",
+			options: [
+				{ value: "default", label: "Default", description: "Model decides; no automatic todo list" },
+				{
+					value: "preferred",
+					label: "Preferred",
+					description: "Suggests a todo list on the first message (reminder, not forced)",
+				},
+				{ value: "always", label: "Always", description: "Forces a comprehensive todo list on the first message" },
+			],
 		},
 	},
 
@@ -3352,13 +3362,19 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	"task.eager": {
-		type: "boolean",
-		default: false,
+		type: "enum",
+		values: ["default", "preferred", "always"] as const,
+		default: "default",
 		ui: {
 			tab: "tasks",
 			group: "Subagents",
 			label: "Prefer Task Delegation",
-			description: "Encourage the agent to delegate work to subagents unless changes are trivial",
+			description: "How strongly to push delegating work to subagents",
+			options: [
+				{ value: "default", label: "Default", description: "Model decides when to delegate" },
+				{ value: "preferred", label: "Preferred", description: "Adds delegation guidance to the system prompt" },
+				{ value: "always", label: "Always", description: "Prompt guidance plus a first-turn delegation reminder" },
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -752,6 +752,16 @@ export class Settings {
 			delete taskObj.simple;
 		}
 
+		// task.eager / todo.eager: boolean -> enum (default | preferred | always).
+		// `true` reproduced the previous "on" behavior, which is now `always`.
+		if (taskObj && typeof taskObj.eager === "boolean") {
+			taskObj.eager = taskObj.eager ? "always" : "default";
+		}
+		const todoObj = raw.todo as Record<string, unknown> | undefined;
+		if (todoObj && typeof todoObj.eager === "boolean") {
+			todoObj.eager = todoObj.eager ? "always" : "default";
+		}
+
 		// task.isolation.mode: legacy values from before the pi-iso PAL refactor.
 		// `worktree` was git worktree → now lives under `rcopy`. `fuse-overlay`
 		// and `fuse-projfs` are now the platform-named `overlayfs` / `projfs`

--- a/packages/coding-agent/src/prompts/system/eager-task.md
+++ b/packages/coding-agent/src/prompts/system/eager-task.md
@@ -1,0 +1,7 @@
+<system-reminder>
+Task delegation is enabled — subagents are the default for this request.
+
+Explore and settle the approach FIRST. Once the design is settled, you MUST fan the work out to `{{toolRefs.task}}` subagents instead of implementing it yourself.{{#if taskBatch}} Batch independent slices into ONE parallel `{{toolRefs.task}}` call; never serialize work that can run concurrently.{{/if}}
+
+Work alone only for: a single-file edit under ~30 lines, a direct answer requiring no code changes, or a command the user explicitly asked you to run.
+</system-reminder>

--- a/packages/coding-agent/src/prompts/system/eager-todo.md
+++ b/packages/coding-agent/src/prompts/system/eager-todo.md
@@ -1,13 +1,13 @@
 <system-reminder>
 Before substantive work, create a phased todo.
 
-You MUST call `todo` first in this turn.
+You MUST call `{{toolRefs.todo}}` first in this turn.
 You MUST initialize the todo list with a single `init` op.
 You MUST cover the entire request from investigation through implementation and verification — not just the next immediate step.
 Task descriptions MUST be specific. A future turn MUST be able to execute them without re-planning.
 You MUST keep task `content` to a short label (5-10 words). Put file paths, implementation steps, and specifics in `details`.
 You MUST keep exactly one task `in_progress` and all later tasks `pending`.
 
-After `todo` succeeds, continue the request in the same turn.
-NEVER call `todo` again unless task state has materially changed.
+After `{{toolRefs.todo}}` succeeds, continue the request in the same turn.
+NEVER call `{{toolRefs.todo}}` again unless task state has materially changed.
 </system-reminder>

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -102,11 +102,11 @@ Pattern syntax (metavariables, `$$$` spreads) is in each tool's description.
 {{#if eagerTasks}}
 {{#has tools "task"}}
 # Eager Tasks
-You SHOULD delegate work to subagents by default. You MAY work alone only when:
-- The change is a single-file edit under ~30 lines
-- The request is a direct answer or explanation with no code changes
-- The user asked you to run a command yourself
-For multi-file changes, refactors, new features, tests, or investigations, you SHOULD break the work into tasks and delegate after the design is settled.
+Delegation is the default here, not the exception. Once the design is settled, you MUST fan the work out to `{{toolRefs.task}}` subagents rather than doing it yourself. Work alone ONLY when one of these is unambiguously true:
+- A single-file edit under ~30 lines
+- A direct answer or explanation requiring no code changes
+- The user explicitly asked you to run a command yourself
+Everything else — multi-file changes, refactors, new features, tests, investigations — MUST be decomposed and delegated.{{#if taskBatch}} Batch independent slices into one parallel `{{toolRefs.task}}` call; never serialize what can run concurrently.{{/if}}
 {{/has}}
 {{/if}}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2083,7 +2083,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 
 		const repeatToolDescriptions = settings.get("repeatToolDescriptions");
-		const eagerTasks = settings.get("task.eager");
+		const eagerTasks = settings.get("task.eager") !== "default";
 		const intentField = $flag("PI_INTENT_TRACING", settings.get("tools.intentTracing")) ? INTENT_FIELD : undefined;
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
@@ -2150,6 +2150,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				mcpDiscoveryMode: hasDiscoverableTools,
 				mcpDiscoveryServerSummaries: discoverableToolSummary.servers.map(formatDiscoverableToolServerSummary),
 				eagerTasks,
+				taskBatch: settings.get("task.batch"),
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
 				memoryRootEnabled: memoryBackend.id === "local",
@@ -2248,10 +2249,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (effectiveDiscoveryMode === "all") {
 			// Tools a forced tool_choice will target must stay active, or the named
 			// choice references a tool absent from the request (provider 400). Eager
-			// todos force a named `todo` choice on the first turn.
+			// todos force a named `todo` choice on the first turn. `task` is also kept
+			// active under discovery-all when `task.eager` is not `default`, so eager delegation is
+			// possible and the Eager Tasks prompt section renders, even though nothing
+			// forces a `task` tool_choice.
 			const forceActive = new Set<string>();
-			if (settings.get("todo.eager") && settings.get("todo.enabled") && toolRegistry.has("todo")) {
+			if (settings.get("todo.eager") !== "default" && settings.get("todo.enabled") && toolRegistry.has("todo")) {
 				forceActive.add("todo");
+			}
+			if (settings.get("task.eager") !== "default" && toolRegistry.has("task")) {
+				forceActive.add("task");
 			}
 			initialToolNames = filterInitialToolsForDiscoveryAll(initialToolNames, {
 				loadModeOf: name => toolRegistry.get(name)?.loadMode,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -187,6 +187,7 @@ import { containsWorkflow, WORKFLOW_NOTICE } from "../modes/workflow";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
+import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
 import eagerTodoPrompt from "../prompts/system/eager-todo.md" with { type: "text" };
 import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with { type: "text" };
 import ircAutoReplyTemplate from "../prompts/system/irc-autoreply.md" with { type: "text" };
@@ -198,6 +199,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 };
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
+import { MAIN_AGENT_ID } from "../registry/agent-registry";
 import {
 	deobfuscateSessionContext,
 	obfuscateProviderContext,
@@ -4617,10 +4619,12 @@ export class AgentSession {
 			return true;
 		}
 
-		// Skip eager todo prelude when the user has already queued a directive
+		// Skip eager preludes when the user has already queued a directive
 		const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
 		const eagerTodoPrelude =
 			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
+		const eagerTaskPrelude =
+			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTaskPrelude(expandedText) : undefined;
 		const normalizedImages = await this.#normalizeImagesForModel(options?.images);
 
 		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
@@ -4633,17 +4637,24 @@ export class AgentSession {
 			? { role: "developer" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() }
 			: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
 
+		const preludeMessages: AgentMessage[] = [];
 		if (eagerTodoPrelude) {
-			this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
-				label: "eager-todo",
-			});
+			if (eagerTodoPrelude.toolChoice) {
+				this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
+					label: "eager-todo",
+				});
+			}
+			preludeMessages.push(eagerTodoPrelude.message);
+		}
+		if (eagerTaskPrelude) {
+			preludeMessages.push(eagerTaskPrelude);
 		}
 
 		try {
 			await this.#promptWithMessage(message, expandedText, {
 				...options,
 				images: normalizedImages,
-				prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
+				prependMessages: preludeMessages.length > 0 ? preludeMessages : undefined,
 				appendMessages: keywordNotices.length > 0 ? keywordNotices : undefined,
 			});
 		} finally {
@@ -7068,10 +7079,28 @@ export class AgentSession {
 		});
 	}
 
-	#createEagerTodoPrelude(promptText: string): { message: AgentMessage; toolChoice: ToolChoice } | undefined {
-		const eagerTodosEnabled = this.settings.get("todo.eager");
+	/**
+	 * Render context shared by the eager todo/task preludes. `toolRefs` resolves each
+	 * tool's wire name (matching `buildSystemPrompt`'s `toolRefs`) so the reminder names
+	 * the tool the model actually sees when an extension renames it; `taskBatch` gates
+	 * batch-call guidance that would steer toward a failing call shape when `task.batch`
+	 * is off (the flat single-spawn schema rejects `tasks`/`context`).
+	 */
+	#buildEagerPreludeContext(): { toolRefs: Record<string, string>; taskBatch: boolean } {
+		const wireName = (name: string): string => {
+			const tool = this.#toolRegistry.get(name);
+			return typeof tool?.customWireName === "string" ? tool.customWireName : name;
+		};
+		return {
+			toolRefs: { task: wireName("task"), todo: wireName("todo") },
+			taskBatch: this.settings.get("task.batch"),
+		};
+	}
+
+	#createEagerTodoPrelude(promptText: string): { message: AgentMessage; toolChoice?: ToolChoice } | undefined {
+		const mode = this.settings.get("todo.eager");
 		const todosEnabled = this.settings.get("todo.enabled");
-		if (!eagerTodosEnabled || !todosEnabled) {
+		if (mode === "default" || !todosEnabled) {
 			return undefined;
 		}
 
@@ -7106,27 +7135,53 @@ export class AgentSession {
 			return undefined;
 		}
 
+		const message: AgentMessage = {
+			role: "custom",
+			customType: "eager-todo-prelude",
+			content: prompt.render(eagerTodoPrompt, this.#buildEagerPreludeContext()),
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		// `preferred` suggests a todo list (reminder only); `always` also forces the
+		// `todo` tool on the first turn — the previous boolean-on behavior.
+		if (mode === "preferred") {
+			return { message };
+		}
 		const todoToolChoice = buildNamedToolChoice("todo", this.model);
 		if (!todoToolChoice) {
-			logger.warn("Eager todo enforcement skipped because the current model does not support forcing todo", {
-				modelApi: this.model?.api,
-				modelId: this.model?.id,
-			});
-			return undefined;
+			// `always` on a model that can't be forced degrades to reminder-only (no
+			// tool_choice). For `todo.eager: true` users migrated to `always`, such
+			// models now receive the first-turn reminder where they previously got
+			// nothing (see the CHANGELOG entry); `always ⊇ preferred` is preserved.
+			logger.warn(
+				"Eager todo proceeding with the reminder only because the current model does not support a forced todo tool_choice",
+				{ modelApi: this.model?.api, modelId: this.model?.id },
+			);
+			return { message };
 		}
+		return { message, toolChoice: todoToolChoice };
+	}
 
-		const eagerTodoReminder = prompt.render(eagerTodoPrompt);
-
+	#createEagerTaskPrelude(promptText: string): AgentMessage | undefined {
+		if (this.settings.get("task.eager") !== "always") return undefined;
+		// Main agent only: subagents keep `task` active (the parent only filters `todo`),
+		// so a salient delegate-reminder there would amplify nested fan-out. Eager-todo
+		// avoids subs only because `todo` is filtered; `task` is not, so gate explicitly.
+		const agentId = this.getAgentId();
+		if (agentId !== undefined && agentId !== MAIN_AGENT_ID) return undefined;
+		if (this.#planModeState?.enabled) return undefined;
+		if (this.agent.state.messages.some(m => m.role === "user")) return undefined;
+		const trimmed = promptText.trimEnd();
+		if (trimmed.endsWith("?") || trimmed.endsWith("!")) return undefined;
+		if (!this.getActiveToolNames().includes("task")) return undefined;
 		return {
-			message: {
-				role: "custom",
-				customType: "eager-todo-prelude",
-				content: eagerTodoReminder,
-				display: false,
-				attribution: "agent",
-				timestamp: Date.now(),
-			},
-			toolChoice: todoToolChoice,
+			role: "custom",
+			customType: "eager-task-prelude",
+			content: prompt.render(eagerTaskPrompt, this.#buildEagerPreludeContext()),
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
 		};
 	}
 	/**

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -385,6 +385,8 @@ export interface BuildSystemPromptOptions {
 	mcpDiscoveryServerSummaries?: string[];
 	/** Encourage the agent to delegate via tasks unless changes are trivial. */
 	eagerTasks?: boolean;
+	/** Whether `task.batch` is enabled; gates batch-call guidance in the Eager Tasks section. */
+	taskBatch?: boolean;
 	/** Rules with alwaysApply=true — their full content is injected into the prompt. */
 	alwaysApplyRules?: AlwaysApplyRule[];
 	/** Whether secret obfuscation is active. When true, explains the redaction format in the prompt. */
@@ -427,6 +429,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryMode = false,
 		mcpDiscoveryServerSummaries = [],
 		eagerTasks = false,
+		taskBatch = true,
 		secretsEnabled = false,
 		workspaceTree: providedWorkspaceTree,
 		memoryRootEnabled = false,
@@ -610,6 +613,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		hasMCPDiscoveryServers: mcpDiscoveryServerSummaries.length > 0,
 		mcpDiscoveryServerSummaries,
 		eagerTasks,
+		taskBatch,
 		secretsEnabled,
 		hasMemoryRoot: memoryRootEnabled,
 		hasObsidian: hasObsidian(),

--- a/packages/coding-agent/test/agent-session-bash-detach.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-detach.test.ts
@@ -146,7 +146,7 @@ describe("BashTool through AgentSession runs children in their own session (e2e)
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"todo.enabled": false,
-			"todo.eager": false,
+			"todo.eager": "default",
 			"todo.reminders": false,
 			// BashTool consults these — keep them off so the test path is the simple
 			// synchronous `executeBash` call, not the async-job manager.

--- a/packages/coding-agent/test/agent-session-eager-task.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-task.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { TextContent } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TodoTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { z } from "zod/v4";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+type ObservedPromptCall = {
+	toolChoice: string | undefined;
+	toolNames: string[];
+	messageRoles: AgentMessage["role"][];
+	messageTexts: string[];
+	lastMessageRole: AgentMessage["role"];
+	lastMessageText: string;
+};
+
+type Harness = {
+	session: AgentSession;
+	observedCalls: ObservedPromptCall[];
+	authStorage: AuthStorage;
+};
+
+function isTextContentBlock(value: unknown): value is TextContent {
+	if (!value || typeof value !== "object") return false;
+	return (value as TextContent).type === "text" && typeof (value as TextContent).text === "string";
+}
+
+function getToolChoiceName(choice: unknown): string | undefined {
+	if (!choice) return undefined;
+	if (typeof choice === "string") return choice;
+	if (typeof choice !== "object" || !("type" in choice)) return undefined;
+	const toolChoice = choice as { type?: string; name?: string; function?: { name?: string } };
+	if (toolChoice.type === "tool") return toolChoice.name;
+	if (toolChoice.type === "function") return toolChoice.name ?? toolChoice.function?.name;
+	return undefined;
+}
+
+function getMessageText(message: AgentMessage): string {
+	if (!("content" in message)) {
+		return "";
+	}
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+	if (!Array.isArray(message.content)) {
+		return "";
+	}
+	return message.content
+		.filter(isTextContentBlock)
+		.map(content => content.text)
+		.join("\n");
+}
+
+describe("AgentSession eager task prelude", () => {
+	let tempDir: TempDir;
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-agent-session-eager-task-");
+		harnesses.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const harness of harnesses) {
+			await harness.session.dispose();
+			harness.authStorage.close();
+		}
+		harnesses.length = 0;
+		tempDir.removeSync();
+	});
+
+	async function createHarness(
+		settingsOverride: Record<string, unknown> = {},
+		agentId?: string,
+		taskWireName?: string,
+	): Promise<Harness> {
+		const observedCalls: ObservedPromptCall[] = [];
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${harnesses.length}.db`));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${harnesses.length}.yml`));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"task.eager": "always",
+			"todo.enabled": false,
+			"todo.eager": "default",
+			...settingsOverride,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+
+		const mockTaskTool: AgentTool = {
+			name: "task",
+			label: "Task",
+			description: "Mock task tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+			...(taskWireName !== undefined ? { customWireName: taskWireName } : {}),
+		};
+		const mockBashTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock bash tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		};
+		const todoEnabled = settings.get("todo.enabled") === true;
+		const toolSession: ToolSession = {
+			cwd: tempDir.path(),
+			hasUI: false,
+			getSessionFile: () => sessionManager.getSessionFile() ?? null,
+			getSessionSpawns: () => "*",
+			settings,
+		};
+		const todoTool = todoEnabled ? new TodoTool(toolSession) : undefined;
+		const tools: AgentTool[] = todoTool
+			? [todoTool as unknown as AgentTool, mockTaskTool, mockBashTool]
+			: [mockTaskTool, mockBashTool];
+
+		let session: AgentSession;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools,
+				messages: [],
+			},
+			convertToLlm,
+			getToolChoice: () => session?.nextToolChoice(),
+			streamFn: (_model, context, options) => {
+				const lastMessage = context.messages.at(-1);
+				if (!lastMessage) {
+					throw new Error("Expected prompt context to include a message");
+				}
+				observedCalls.push({
+					toolChoice: getToolChoiceName(options?.toolChoice),
+					toolNames: (context.tools ?? []).map(tool => tool.name),
+					messageRoles: context.messages.map(message => message.role),
+					messageTexts: context.messages.map(message => getMessageText(message)),
+					lastMessageRole: lastMessage.role,
+					lastMessageText: getMessageText(lastMessage),
+				});
+				const response = createAssistantMessage("done");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+
+		const toolRegistry = new Map<string, AgentTool>([
+			[mockTaskTool.name, mockTaskTool],
+			[mockBashTool.name, mockBashTool],
+		]);
+		if (todoTool) toolRegistry.set(todoTool.name, todoTool as unknown as AgentTool);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			agentId,
+		});
+
+		const harness = { session, observedCalls, authStorage };
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("prepends a hidden eager task reminder without forcing task or repeating the prompt text", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "user"]);
+		expect(observedCalls[0]?.messageTexts[0]).toContain("delegation is enabled");
+		expect(observedCalls[0]?.messageTexts[0]).toContain("Batch independent slices");
+		expect(observedCalls[0]?.messageTexts[0]).toContain("`task`");
+		expect(
+			observedCalls[0]?.messageTexts.filter(text => text.includes("refactor the parser across modules")),
+		).toHaveLength(1);
+		expect(observedCalls[0]?.messageTexts[0]).not.toContain("refactor the parser across modules");
+	});
+
+	it("skips eager task prelude for prompts ending with a question mark", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("should I refactor the parser?");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["should I refactor the parser?"]);
+	});
+
+	it("skips eager task prelude for prompts ending with an exclamation mark", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser now!");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser now!"]);
+	});
+
+	it("skips eager task prelude for subsequent user messages", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		await session.prompt("refactor the parser across modules");
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "user"]);
+
+		observedCalls.length = 0;
+		await session.prompt("now update the serializer too");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.messageRoles.at(-1)).toBe("user");
+		// The turn-1 prelude persists in history; the contract is that NO fresh prelude is
+		// prepended adjacent to the new user message on a subsequent turn.
+		expect(observedCalls[0]?.messageRoles.at(-2)).not.toBe("developer");
+		expect(observedCalls[0]?.messageTexts.at(-1)).toBe("now update the serializer too");
+	});
+
+	it("skips eager task prelude when task.eager is disabled", async () => {
+		const { session, observedCalls } = await createHarness({ "task.eager": "default" });
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser across modules"]);
+	});
+
+	it("skips eager task prelude when task.eager is preferred (prompt section only, no reminder)", async () => {
+		const { session, observedCalls } = await createHarness({ "task.eager": "preferred" });
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser across modules"]);
+	});
+
+	it("skips eager task prelude for subagent sessions", async () => {
+		const { session, observedCalls } = await createHarness({}, "SubAgent");
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+		expect(observedCalls[0]?.messageTexts).toEqual(["refactor the parser across modules"]);
+	});
+
+	it("prepends both todo and task preludes when both are eager, keeping the forced todo choice", async () => {
+		const { session, observedCalls } = await createHarness({
+			"todo.enabled": true,
+			"todo.eager": "always",
+			"todo.reminders": false,
+		});
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		// eager-todo still forces the todo tool choice on the first turn
+		expect(observedCalls[0]?.toolChoice).toBe("todo");
+		// both hidden preludes precede the user message: todo first, then task
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "developer", "user"]);
+		const texts = observedCalls[0]?.messageTexts ?? [];
+		expect(texts.at(-1)).toBe("refactor the parser across modules");
+		// the task reminder is the second prelude (after the todo reminder)
+		expect(texts.findIndex(text => text.includes("delegation is enabled"))).toBe(1);
+	});
+
+	it("omits batch-call guidance from the eager task reminder when task.batch is disabled", async () => {
+		const { session, observedCalls } = await createHarness({ "task.batch": false });
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		const reminder = observedCalls[0]?.messageTexts[0] ?? "";
+		expect(reminder).toContain("delegation is enabled");
+		expect(reminder).not.toContain("Batch independent slices");
+	});
+
+	it("renders the task tool's wire name in the eager reminder", async () => {
+		const { session, observedCalls } = await createHarness({}, undefined, "delegate");
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		const reminder = observedCalls[0]?.messageTexts[0] ?? "";
+		expect(reminder).toContain("`delegate`");
+		expect(reminder).not.toContain("`task`");
+	});
+});

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -90,12 +90,7 @@ describe("AgentSession eager todo enforcement", () => {
 	let authStorage: AuthStorage | undefined;
 	const observedCalls: ObservedPromptCall[] = [];
 
-	beforeEach(async () => {
-		tempDir = TempDir.createSync("@pi-agent-session-eager-todo-");
-		streamCallCount = 0;
-		scriptedResponses = [];
-		observedCalls.length = 0;
-
+	async function createSession(settingsOverride: Record<string, unknown> = {}): Promise<void> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
 
@@ -105,8 +100,9 @@ describe("AgentSession eager todo enforcement", () => {
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"todo.enabled": true,
-			"todo.eager": true,
+			"todo.eager": "always",
 			"todo.reminders": false,
+			...settingsOverride,
 		});
 		const sessionManager = SessionManager.inMemory(tempDir.path());
 
@@ -174,6 +170,14 @@ describe("AgentSession eager todo enforcement", () => {
 			modelRegistry,
 			toolRegistry,
 		});
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-agent-session-eager-todo-");
+		streamCallCount = 0;
+		scriptedResponses = [];
+		observedCalls.length = 0;
+		await createSession();
 	});
 
 	afterEach(async () => {
@@ -280,5 +284,19 @@ describe("AgentSession eager todo enforcement", () => {
 			lastMessageRole: "user",
 			lastMessageText: "actually skip that, just fix the typo",
 		});
+	});
+
+	it("prepends the eager todo reminder without forcing the todo tool when todo.eager is preferred", async () => {
+		await session.dispose();
+		authStorage?.close();
+		await createSession({ "todo.eager": "preferred" });
+
+		await session.prompt("list all work trees");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.messageRoles).toEqual(["developer", "user"]);
+		expect(observedCalls[0]?.messageTexts.at(-1)).toBe("list all work trees");
+		expect(observedCalls[0]?.messageTexts[0]).not.toContain("list all work trees");
 	});
 });

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -81,7 +81,7 @@ async function createHarness(
 		"compaction.enabled": false,
 		"retry.enabled": false,
 		"todo.enabled": false,
-		"todo.eager": false,
+		"todo.eager": "default",
 		"todo.reminders": false,
 		...settingsOverrides,
 	});

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -159,6 +159,74 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		expect(searchTool?.description).toContain("Total discoverable tools available:");
 	});
 
+	it("exposes task under tools.discoveryMode all when task.eager is preferred", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all", "task.eager": "preferred" }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.getActiveToolNames()).toContain("task");
+		expect(session.systemPrompt.join("\n")).toContain("# Eager Tasks");
+		expect(session.systemPrompt.join("\n")).toContain("Batch independent slices");
+		await session.dispose();
+	});
+
+	it("omits batch guidance from the Eager Tasks section when task.batch is disabled", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all", "task.eager": "preferred", "task.batch": false }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		const prompt = session.systemPrompt.join("\n");
+		expect(prompt).toContain("# Eager Tasks");
+		expect(prompt).not.toContain("Batch independent slices");
+		await session.dispose();
+	});
+
+	it("hides task under tools.discoveryMode all when task.eager is default", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.getActiveToolNames()).not.toContain("task");
+		expect(session.systemPrompt.join("\n")).not.toContain("# Eager Tasks");
+		await session.dispose();
+	});
+
 	it("preserves explicitly requested MCP tools in discovery mode", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -412,6 +412,33 @@ describe("Settings", () => {
 			expect(settings.get("mnemopi.dbPath")).toBe("/tmp/new.db");
 		});
 
+		it("migrates boolean task.eager/todo.eager true to always", async () => {
+			await writeSettings({
+				task: { eager: true },
+				todo: { eager: true },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			// `true` reproduced the previous "on" behavior, now `always`.
+			expect(settings.get("task.eager")).toBe("always");
+			expect(settings.get("todo.eager")).toBe("always");
+		});
+
+		it("migrates boolean task.eager/todo.eager false to default", async () => {
+			await writeSettings({
+				task: { eager: false },
+				todo: { eager: false },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			// Load-bearing direction: consumers treat any non-`default` value as enabled
+			// (`false !== "default"`), so an un-coerced boolean `false` would read as ON.
+			expect(settings.get("task.eager")).toBe("default");
+			expect(settings.get("todo.eager")).toBe("default");
+		});
+
 		it("moves legacy lastChangelogVersion out of config.yml into the marker file", async () => {
 			await writeSettings({ lastChangelogVersion: "0.40.0" });
 


### PR DESCRIPTION
## Summary

Replaces the boolean `task.eager` ("Prefer Task Delegation") and `todo.eager` ("Create Todos Automatically") settings with a three-level eagerness enum — `default` / `preferred` / `always` — as proposed by @DeprecatedLuke in #2534. A single boolean conflated "off" with "maximum reinforcement"; the enum lets users opt into a light-touch nudge without the heaviest lever.

Builds on the #2534 delegation fix (force `task` active under `tools.discoveryMode: "all"`, a first-turn main-agent-only delegation reminder, tightened `# Eager Tasks` section) and grades it across the new tiers.

Fixes #2539.

## Semantics

The two settings reinforce through different mechanisms, so each gets its own ladder. `default` is off; the previous boolean-`true` behavior maps to `always`.

**`todo.eager` — force ladder:**
- `default` — model decides; no automatic todo list.
- `preferred` — hidden first-turn reminder suggesting a todo list; **does not force** the `todo` call.
- `always` — reminder **and** forces the first `todo` call (previous "on").

**`task.eager` — salience ladder** (`task` is never force-called — delegation must follow design):
- `default` — model decides when to delegate.
- `preferred` — `# Eager Tasks` guidance in the system prompt; `task` kept exposed under `discoveryMode: "all"`.
- `always` — guidance **plus** a first-turn main-agent-only delegation reminder (previous "on").

When `always` is set but the model cannot be forced to call `todo`, `todo.eager` degrades to reminder-only, preserving `always ⊇ preferred`.

## Migration

`#migrateRawSettings` coerces persisted booleans in place: `true → always`, `false → default`. This is load-bearing — `Settings.get()` returns the raw stored value with no enum coercion, so without migration an existing `eager: true` would fail every `=== "preferred"`/`=== "always"` check and silently read as off. Upgraders keep identical behavior.

## Implementation

- `settings-schema.ts` — both keys retyped `boolean → enum`, values `["default","preferred","always"]`, default `"default"`, with per-option UI descriptions.
- `settings.ts` — boolean→enum migration alongside the existing `task.*` migrations.
- `sdk.ts` — exposure / `forceActive` / prompt-section gating switch from truthiness to `!== "default"`; `eagerTasks` stays a `boolean` feeding the `{{#if eagerTasks}}` gate (renders for `preferred` and `always`).
- `agent-session.ts` — `#createEagerTaskPrelude` fires only for `always`; `#createEagerTodoPrelude` returns the reminder for both non-default tiers and attaches the forced `todo` tool-choice only for `always` (return type's `toolChoice` is now optional; the caller guards it).

## Testing

- `bun check` — clean across all packages.
- New migration-contract test (`settings-manager.test.ts`): persisted `task.eager:true → "always"`, `todo.eager:false → "default"` via the real on-disk load path.
- New tier-behavior cases: `task.eager:"preferred"` injects **no** reminder (prompt-section only); `todo.eager:"preferred"` injects the reminder **without** forcing the `todo` call.
- `sdk-mcp-discovery.test.ts`: `task` exposed under `discoveryMode:"all"` for `preferred`, hidden for `default`.
- Existing prelude/exposure tests migrated from booleans to the equivalent enum strings.
