### PR TITLE
fix(tui): detect tmux/screen via TERM prefix when TMUX env is stripped

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed overlays without an explicit `maxHeight` dropping their bottom rows off-screen when taller than the terminal: `#resolveOverlayLayout` now defaults the height cap to the available rows, so a tall overlay is sliced to fit (and re-clamps on resize) instead of overflowing the visible region.
 - Fixed `Editor.#decorate` rejecting keyword matches glued to the cursor: `CURSOR_MARKER` begins with ESC (non-whitespace), so decorators with a right-boundary lookahead (e.g. `/(?<!\S)ultrathink(?!\S)/`) failed at the seam and dropped highlighting until a trailing character was typed. The decorate hook now splits around the marker and decorates each user-text segment in isolation so word-boundary lookarounds resolve correctly on both sides ([#2475](https://github.com/can1357/oh-my-pi/issues/2475)).
+- Fixed `isMultiplexerSession()` only checking the `TMUX`/`STY`/`ZELLIJ` env vars and missing the `TERM=tmux-*`/`screen-*` fallback every sibling detector uses. When the multiplexer env was stripped but `TERM` survived (`sudo` without `-E`, `su`, env-sanitizing launchers/ssh), the renderer misclassified the pane as a direct terminal and emitted ED3 (`CSI 3 J`) on resize/replace/`resetDisplay`, which wipes tmux pane history — scrollback only reappeared after a full rerender (Ctrl+L). The check now aligns with `shouldEnableSynchronizedOutputByDefault`, `detectRectangularSgrSupport`, and `getFallbackImageProtocol` in `terminal-capabilities.ts` ([#2544](https://github.com/can1357/oh-my-pi/issues/2544)).
 
 ## [15.12.6] - 2026-06-14
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -349,7 +349,13 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
-	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+	// TMUX/STY/ZELLIJ are the authoritative signals, but they can be stripped while
+	// TERM survives (`sudo` without -E, `su`, env-sanitizing launchers/ssh). Fall back to
+	// the TERM prefix like every sibling multiplexer check (terminal-capabilities.ts) so a
+	// resize never emits ED3 into a tmux/screen pane and wipes its scrollback history.
+	if (Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ) return true;
+	const term = Bun.env.TERM?.toLowerCase() ?? "";
+	return term.startsWith("tmux") || term.startsWith("screen");
 }
 
 /**

--- a/packages/tui/test/issue-2088-repro.test.ts
+++ b/packages/tui/test/issue-2088-repro.test.ts
@@ -98,7 +98,15 @@ function visible(term: VirtualTerminal): string[] {
 }
 
 const TMUX_ENV: Record<string, string | undefined> = { TMUX: "1", STY: undefined, ZELLIJ: undefined };
-const NO_MULTIPLEXER_ENV: Record<string, string | undefined> = { TMUX: undefined, STY: undefined, ZELLIJ: undefined };
+// Pin TERM to a non-multiplexer value: `isMultiplexerSession()` falls back to
+// the TERM prefix, so leaving the host's TERM (which may be `tmux-*`/`screen-*`
+// under CI-in-tmux) would misclassify this "direct terminal" case.
+const NO_MULTIPLEXER_ENV: Record<string, string | undefined> = {
+	TMUX: undefined,
+	STY: undefined,
+	ZELLIJ: undefined,
+	TERM: "xterm-256color",
+};
 
 describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 	let monotonicNow = 0;
@@ -319,6 +327,103 @@ describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
 				await settle(term);
 				expect(tui.fullRedraws - baselineRedraws).toBe(1);
+				expect(visible(term)).toEqual(Array.from({ length: 10 }, (_v, i) => `line-${i + 10}`));
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+});
+
+// Regression for tmux auto-detection: `isMultiplexerSession()` gates the
+// renderer's resize behavior. It previously checked only TMUX/STY/ZELLIJ, while
+// every sibling multiplexer check (terminal-capabilities.ts) also falls back to
+// the TERM prefix. When TMUX is stripped but TERM survives (`sudo` without -E,
+// `su`, env-sanitizing launchers/ssh), the engine misclassified tmux as a direct
+// terminal and emitted ED3 (CSI 3 J) on resize — which wipes tmux pane history
+// (verified against tmux 3.6a: a 20-line pane drops to its 6 on-screen rows
+// after ED3), so scrollback only reappeared after a full rerender.
+describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped", () => {
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 40;
+			return monotonicNow;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ED3 clears native scrollback; the renderer must never emit it in a mux.
+	const ED3 = "\x1b[3J";
+
+	// tmux/screen panes whose authoritative env signal was stripped but whose
+	// TERM still names the multiplexer — the case previously misclassified.
+	const strippedMuxTerms: Array<[string, Record<string, string | undefined>]> = [
+		["tmux-256color", { TERM: "tmux-256color", TMUX: undefined, STY: undefined, ZELLIJ: undefined }],
+		["screen-256color", { TERM: "screen-256color", TMUX: undefined, STY: undefined, ZELLIJ: undefined }],
+	];
+
+	for (const [label, env] of strippedMuxTerms) {
+		it(`debounces the resize and emits no ED3 when only TERM=${label} marks the multiplexer`, async () => {
+			await withEnvPatch(env, async () => {
+				const term = new VirtualTerminal(40, 10, 1000);
+				const tui = new TUI(term);
+				tui.addChild(new MutableLinesComponent(Array.from({ length: 20 }, (_v, i) => `line-${i}`)));
+
+				try {
+					tui.start();
+					await settle(term);
+
+					const baselineRedraws = tui.fullRedraws;
+					const writes = captureWrites(term);
+
+					// SIGWINCH must route through the multiplexer debounce, not the
+					// immediate forced render: detection via TERM alone is the proof.
+					term.resize(80, 10);
+					await Bun.sleep(10);
+					expect(writes.length).toBe(0);
+					expect(tui.fullRedraws).toBe(baselineRedraws);
+
+					// The settled paint repaints at the new geometry without clearing
+					// native scrollback, so the pane keeps its history.
+					await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+					await settle(term);
+					const out = writes.join("");
+					expect(out.length).toBeGreaterThan(0);
+					expect(out).not.toContain(ED3);
+					expect(tui.fullRedraws - baselineRedraws).toBe(1);
+					expect(visible(term)).toEqual(Array.from({ length: 10 }, (_v, i) => `line-${i + 10}`));
+				} finally {
+					tui.stop();
+				}
+			});
+		});
+	}
+
+	it("still clears native scrollback (ED3) on a genuine direct-terminal resize", async () => {
+		await withEnvPatch(NO_MULTIPLEXER_ENV, async () => {
+			const term = new VirtualTerminal(40, 10, 1000);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(Array.from({ length: 20 }, (_v, i) => `line-${i}`)));
+
+			try {
+				tui.start();
+				await settle(term);
+
+				// Capture only the resize-driven paint; the initial paint never
+				// clears scrollback, so any ED3 in `out` belongs to the resize.
+				// Wait past the 120 ms viewport-settle window — that deferred
+				// `requestRender(true, { clearScrollback: true })` is what emits ED3.
+				const writes = captureWrites(term);
+				term.resize(80, 10);
+				await settleResize(term);
+				const out = writes.join("");
+				expect(out).toContain(ED3);
 				expect(visible(term)).toEqual(Array.from({ length: 10 }, (_v, i) => `line-${i + 10}`));
 			} finally {
 				tui.stop();


### PR DESCRIPTION
## Repro

Run `omp` inside tmux from a context that strips the multiplexer env vars but keeps `TERM` (e.g. `sudo omp` without `-E`, `su`, env-sanitizing launchers/ssh). After any resize / pane replace / `resetDisplay`, tmux's pane history disappears — scrolling up shows nothing outside the current viewport; only a full rerender (Ctrl+L) restores it.

The packaged regression (`packages/tui/test/issue-2088-repro.test.ts`, `describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped")`) reproduces it deterministically with `TERM=tmux-256color` / `TERM=screen-256color` and `TMUX/STY/ZELLIJ` cleared:

```
bun test packages/tui/test/issue-2088-repro.test.ts -t "multiplexer detection"
```

Before the fix, both stripped-mux cases emit an immediate write on `term.resize(...)` (the renderer runs the direct-terminal fast path instead of debouncing) and the geometry-rebuild full paint emits ED3 (`CSI 3 J`), which wipes tmux pane history (verified against tmux 3.6a: a 20-line pane drops to its 6 on-screen rows after ED3).

## Cause

`isMultiplexerSession()` in `packages/tui/src/tui.ts` was the only multiplexer detector that tested *just* `Bun.env.TMUX || STY || ZELLIJ`. Every sibling check (`shouldEnableSynchronizedOutputByDefault`, `detectRectangularSgrSupport`, `getFallbackImageProtocol` in `terminal-capabilities.ts`) also falls back to a `TERM` prefix match (`tmux*` / `screen*`).

When the authoritative env var is stripped, `isMultiplexerSession()` returned `false`, so:

- `geometryRebuild = geometryChanged && !isMultiplexerSession()` → `true` → full paint with `clearScrollback: true` → emits ED3.
- The SIGWINCH handler skipped `#armMultiplexerResizeTimer` and ran `#beginResizeViewport()` immediately, racing tmux's reflow.

## Fix

- `packages/tui/src/tui.ts` — `isMultiplexerSession()` returns `true` when `TERM?.toLowerCase()` starts with `tmux` or `screen`, after the existing env-var check. Comment ties it back to the sibling detectors so the next maintainer keeps them in lockstep.
- `packages/tui/test/issue-2088-repro.test.ts` — new `describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped")` block covers both `tmux-256color` and `screen-256color`, asserts no immediate write + no ED3 in the settled paint, and pins a direct-terminal control case (`TERM=xterm-256color`) that still does emit ED3. `NO_MULTIPLEXER_ENV` now pins `TERM=xterm-256color` so the direct-terminal cases don't pick up a `tmux-*` host TERM under CI-in-tmux.
- `packages/tui/CHANGELOG.md` — entry under `[Unreleased] → Fixed`.

Credit to @DeprecatedLuke for the diagnosis in their fork.

## Verification

```
bun test packages/tui/test/issue-2088-repro.test.ts
# 9 pass, 0 fail (3 new mux-detection cases, 6 existing #2088 cases)

bun test packages/tui
# 891 pass, 3 skip, 0 fail
```

Fixes #2544