### PR TITLE
Fix resolve gate for OpenCode Go Kimi K2.7 Code

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible providers that reject forced `tool_choice` on thinking-required models by downgrading unsupported forced choices to `auto` while keeping tools available ([#2546](https://github.com/can1357/oh-my-pi/issues/2546)).
+
 ## [15.12.6] - 2026-06-14
 
 ### Changed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1233,6 +1233,7 @@ function buildParams(
 		Boolean(options?.reasoning) && !options?.disableReasoning && Boolean(model.reasoning);
 	const forcedToolChoiceSuppressesThinking =
 		compat.disableReasoningOnForcedToolChoice &&
+		compat.supportsForcedToolChoice &&
 		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
 	if (compat.whenThinking && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
 		compat = compat.whenThinking; // precomputed at model build — pointer swap, no allocation
@@ -1333,6 +1334,12 @@ function buildParams(
 
 	if (options?.toolChoice && compat.supportsToolChoice) {
 		params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
+	}
+	if (isForcedToolChoice(params.tool_choice) && !compat.supportsForcedToolChoice) {
+		// Some thinking-required OpenAI-compatible models reject forced
+		// `tool_choice` while still accepting tools with the default auto
+		// selector. Keep the tool available and let the model choose it.
+		params.tool_choice = "auto";
 	}
 
 	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -33,6 +33,7 @@ const compat: ResolvedOpenAICompat = {
 	reasoningEffortMap: {},
 	supportsUsageInStreaming: true,
 	supportsToolChoice: true,
+	supportsForcedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -135,6 +135,7 @@ describe("openai-completions compatibility", () => {
 			reasoningEffortMap: {},
 			supportsUsageInStreaming: true,
 			supportsToolChoice: true,
+			supportsForcedToolChoice: true,
 			disableReasoningOnForcedToolChoice: false,
 			disableReasoningOnToolChoice: false,
 			maxTokensField: "max_completion_tokens",
@@ -1083,6 +1084,96 @@ describe("kimi model detection via detectCompat", () => {
 		// The forced-tool guard must still strip the request-level thinking
 		// signal so neither end of the wire mentions reasoning.
 		expect(payload.reasoning_effort).toBeUndefined();
+	});
+
+	it("downgrades unsupported forced tool_choice without suppressing thinking", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			id: "kimi-k2.7-code",
+			reasoning: true,
+			compat: { supportsForcedToolChoice: false },
+		} as ModelSpec<"openai-completions">);
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Plan first, then call the tool.",
+					thinkingSignature: "reasoning_content",
+				},
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		const readTool: Tool = {
+			name: "read",
+			description: "Read a file",
+			parameters: {
+				type: "object",
+				properties: { path: { type: "string" } },
+				required: ["path"],
+			},
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const fetchMock = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+				tools: [readTool],
+			},
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				reasoning: "high",
+				toolChoice: { type: "tool", name: "read" },
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as {
+			messages: Array<Record<string, unknown>>;
+			reasoning_effort?: unknown;
+			tool_choice?: unknown;
+		};
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Plan first, then call the tool.");
+		expect(payload.reasoning_effort).toBe("high");
+		expect(payload.tool_choice).toBe("auto");
 	});
 
 	// #1484 follow-up: DeepSeek V4 on opencode-go exhibits the same gateway

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -22,6 +22,7 @@ const compat: ResolvedOpenAICompat = {
 	reasoningEffortMap: {},
 	supportsUsageInStreaming: true,
 	supportsToolChoice: true,
+	supportsForcedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenCode Go MiMo catalog metadata so title generation and other tool-enabled calls omit unsupported `tool_choice` instead of triggering provider 400s ([#2509](https://github.com/can1357/oh-my-pi/issues/2509)).
+- Fixed OpenCode Go `kimi-k2.7-code` catalog metadata so resolve-gate requests use automatic tool selection instead of Moonshot-rejected forced `tool_choice` ([#2546](https://github.com/can1357/oh-my-pi/issues/2546)).
 
 ## [15.12.6] - 2026-06-14
 

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -211,6 +211,12 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 			supportsToolChoice: false,
 		};
 	}
+	if (model.api === "openai-completions" && model.provider === "opencode-go" && model.id === "kimi-k2.7-code") {
+		model.compat = {
+			...(model.compat ?? {}),
+			supportsForcedToolChoice: false,
+		};
+	}
 	if (
 		model.api === "openai-completions" &&
 		model.provider === "opencode-go" &&

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -217,6 +217,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
+		supportsForcedToolChoice: true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: false,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -22904,6 +22904,7 @@
 				"disableReasoningOnForcedToolChoice": true,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
 				"maxTokensField": "max_completion_tokens",
 				"requiresToolResultName": false,
 				"requiresAssistantAfterToolResult": false,
@@ -25327,6 +25328,7 @@
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
 				"maxTokensField": "max_completion_tokens",
 				"requiresToolResultName": false,
 				"requiresAssistantAfterToolResult": false,
@@ -25778,6 +25780,7 @@
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
 				"maxTokensField": "max_completion_tokens",
 				"requiresToolResultName": false,
 				"requiresAssistantAfterToolResult": false,
@@ -26058,6 +26061,7 @@
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
 				"maxTokensField": "max_completion_tokens",
 				"requiresToolResultName": false,
 				"requiresAssistantAfterToolResult": false,
@@ -51042,6 +51046,9 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
+			"compat": {
+				"supportsForcedToolChoice": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55024,13 +55031,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.098,
-				"output": 0.196,
+				"input": 0.09,
+				"output": 0.18,
 				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -187,6 +187,12 @@ export interface OpenAICompat {
 	/** Whether the provider supports the `tool_choice` parameter. Default: true. */
 	supportsToolChoice?: boolean;
 	/**
+	 * Whether forced `tool_choice` values (`"required"` or named tools) are accepted.
+	 * When false, request builders keep tools available but downgrade forced choices
+	 * to provider-default auto selection. Default: true.
+	 */
+	supportsForcedToolChoice?: boolean;
+	/**
 	 * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
 	 * the request when `tool_choice` forces a tool call. Mirrors the Anthropic
 	 * `disableThinkingIfToolChoiceForced` rule for backends like Kimi that

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -175,6 +175,20 @@ describe("generated model policies", () => {
 		expect(models[0]?.compat?.supportsToolChoice).toBe(false);
 	});
 
+	it("marks OpenCode Go Kimi K2.7 Code as not supporting forced tool_choice", () => {
+		const models: ModelSpec<"openai-completions">[] = [
+			createSpec({
+				id: "kimi-k2.7-code",
+				api: "openai-completions",
+				provider: "opencode-go",
+			}),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.compat?.supportsForcedToolChoice).toBe(false);
+	});
+
 	it("links spark variants and gpt-5.5 to their context promotion targets", () => {
 		const models = [
 			createSpec({ id: "gpt-5.3-codex-spark", api: "openai-codex-responses", provider: "openai-codex" }),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added a `fastModeScope` setting (`both` | `openai` | `claude`, default `both`) controlling which providers `/fast on` (and the fast-mode toggle) target. `both` keeps the prior unscoped priority behavior; `openai`/`claude` scope fast mode to one family. `/fast status` now reports the active scope.
 - Added the `mnemopi.embeddingVariant` setting (`en` | `multilingual`) selecting a stronger SOTA local embedding model — `en` → `BAAI/bge-base-en-v1.5` (768d), `multilingual` → `intfloat/multilingual-e5-large` (1024d). Resolution precedence is `mnemopi.embeddingModel` setting > `MNEMOPI_EMBEDDING_MODEL` env > variant default, so the documented env override is still honored. Changing the active model wipes and rebuilds stored embeddings on the next writable start ([#2476](https://github.com/can1357/oh-my-pi/issues/2476))
 - Added a `/guided-goal` slash command that interviews you to refine an objective before enabling goal mode, then seeds goal mode with the agreed objective. The bounded interview (up to six turns) runs on the plan or slow model and falls back with a hint when the goal is still too vague ([#2502](https://github.com/can1357/oh-my-pi/issues/2502)).
+- Added the `compat.supportsForcedToolChoice` custom-model flag for OpenAI-compatible models whose endpoints accept tools but reject forced `tool_choice` values ([#2546](https://github.com/can1357/oh-my-pi/issues/2546)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -35,6 +35,7 @@ const OpenAICompatFieldsSchema = z.object({
 	allowsSyntheticReasoningContentForToolCalls: z.boolean().optional(),
 	requiresAssistantContentForToolCalls: z.boolean().optional(),
 	supportsToolChoice: z.boolean().optional(),
+	supportsForcedToolChoice: z.boolean().optional(),
 	disableReasoningOnForcedToolChoice: z.boolean().optional(),
 	disableReasoningOnToolChoice: z.boolean().optional(),
 	thinkingFormat: z.enum(["openai", "openrouter", "zai", "qwen", "qwen-chat-template"]).optional(),

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -57,8 +57,10 @@ const TITLE_MARKER_RE = /<title>([\s\S]*?)<\/title>/i;
 function modelSupportsForcedToolChoice(model: Model<Api>): boolean {
 	const compat = model.compat;
 	if (!compat) return true;
-	if ("supportsForcedToolChoice" in compat) return compat.supportsForcedToolChoice;
-	if ("supportsToolChoice" in compat) return compat.supportsToolChoice;
+	const forcedToolChoice = Reflect.get(compat, "supportsForcedToolChoice");
+	if (typeof forcedToolChoice === "boolean") return forcedToolChoice;
+	const toolChoice = Reflect.get(compat, "supportsToolChoice");
+	if (typeof toolChoice === "boolean") return toolChoice;
 	return true;
 }
 


### PR DESCRIPTION
## Repro
A mocked `opencode-go/kimi-k2.7-code` chat-completions turn with the resolve tool available and `toolChoice: { type: "tool", name: "resolve" }` reproduced the reporter's 400: the request serialized `tool_choice: { type: "function", function: { name: "resolve" } }`, and a Moonshot-compatible mock rejected it with `tool_choice specified is incompatible with thinking enabled`.

## Cause
`packages/ai/src/providers/openai-completions.ts` treated every OpenAI-compatible Kimi forced tool choice as a reason to suppress request-level reasoning, but `opencode-go/kimi-k2.7-code` has thinking forced on by the upstream proxy/model, so removing `reasoning_effort` does not disable thinking. The catalog also had no OpenAI-compatible compat bit to say a model supports tools but rejects forced `tool_choice`.

## Fix
- Added `compat.supportsForcedToolChoice` to OpenAI-compatible model metadata and custom-model schema.
- Downgraded unsupported forced OpenAI-compatible `tool_choice` values to `auto` while leaving tools available and preserving thinking-mode request handling.
- Marked bundled OpenCode Go `kimi-k2.7-code` with `supportsForcedToolChoice: false` during catalog generation and regenerated `models.json`.
- Updated title generation to honor `supportsForcedToolChoice` before falling back to marker-wrapped titles.

## Verification
Ran `bun test packages/ai/test/openai-completions-compat.test.ts packages/catalog/test/generated-policies.test.ts`, `bun --cwd=packages/ai run check && bun --cwd=packages/catalog run check && bun --cwd=packages/coding-agent run check`, and reran the repro script; the fixed payload sends `tool_choice: "auto"`, keeps `reasoning_effort: "high"`, and completes with `stopReason: "toolUse"`. Fixes #2546