### PR TITLE
fix(coding-agent): guard Windows task fan-out render cycles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Fixed the `Working…` loader vanishing for the rest of a turn after an auto-compaction (context-overflow recovery) or auto-retry. Those overlays took over the shared status container with a bare `statusContainer.clear()`, which detached the working loader but left `loadingAnimation` set; the resumed turn's `agent_start` → `ensureLoadingAnimation()` is guarded by `if (!this.loadingAnimation)`, so it skipped re-attaching the loader and the spinner stayed gone while the agent kept streaming. The overlay handlers now fully tear the working loader down (stop + dereference) via `#stopWorkingLoader()`, so the next `agent_start` recreates and re-attaches it.
 
 - Fixed JS eval helper optional arguments rejecting Python-style positional calls. `read(path, offset, limit)` now works alongside `read(path, { offset, limit })`, `null`/`undefined` skip optional positional slots, and non-local URI reads such as `artifact://...` delegate through the read tool so line slicing works on spilled artifacts.
+- Fixed Windows plan-mode task fan-out crashing the TUI when nested async task progress formed a cycle; task rendering now cuts recursive snapshots and long Windows `local://` roots are shortened under temp storage ([#2551](https://github.com/can1357/oh-my-pi/issues/2551)).
+
 ## [15.12.6] - 2026-06-14
 ### Breaking Changes
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -34,9 +34,11 @@ function safeSessionId(options: LocalProtocolOptions): string {
 	return safe.length > 0 ? safe : "session";
 }
 
-function shortLocalRoot(candidate: string, options: LocalProtocolOptions): string {
-	const hash = Bun.hash(candidate).toString(36);
-	return path.join(os.tmpdir(), "omp-local", `${safeSessionId(options)}-${hash}`);
+function shortLocalRoot(options: LocalProtocolOptions): string {
+	// Derive the short root from the stable session id, never the artifact path,
+	// so `SessionManager.moveTo()` and the resume-after-move flow keep finding
+	// the same `local://` directory the session wrote pre-move.
+	return path.join(os.tmpdir(), "omp-local", safeSessionId(options));
 }
 
 function getContentType(filePath: string): InternalResource["contentType"] {
@@ -126,7 +128,7 @@ export function resolveLocalRoot(options: LocalProtocolOptions, platform: NodeJS
 	if (artifactsDir) {
 		const candidate = path.resolve(artifactsDir, "local");
 		if (platform === "win32" && candidate.length >= WINDOWS_LOCAL_ROOT_MAX_CHARS) {
-			return shortLocalRoot(candidate, options);
+			return shortLocalRoot(options);
 		}
 		return candidate;
 	}

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -26,6 +26,18 @@ function toLocalValidationError(error: unknown): Error {
 	const message = error instanceof Error ? error.message : String(error);
 	return new Error(message.replace("skill://", "local://"));
 }
+const WINDOWS_LOCAL_ROOT_MAX_CHARS = 180;
+
+function safeSessionId(options: LocalProtocolOptions): string {
+	const raw = options.getSessionId?.() ?? "session";
+	const safe = raw.replace(/[^a-zA-Z0-9_.-]/g, "_");
+	return safe.length > 0 ? safe : "session";
+}
+
+function shortLocalRoot(candidate: string, options: LocalProtocolOptions): string {
+	const hash = Bun.hash(candidate).toString(36);
+	return path.join(os.tmpdir(), "omp-local", `${safeSessionId(options)}-${hash}`);
+}
 
 function getContentType(filePath: string): InternalResource["contentType"] {
 	const ext = path.extname(filePath).toLowerCase();
@@ -108,20 +120,28 @@ function extractRelativePath(url: InternalUrl): string {
 	return decoded;
 }
 
-export function resolveLocalRoot(options: LocalProtocolOptions): string {
+/** Resolve the session-scoped local:// root, shortening long Windows artifact paths before writes hit MAX_PATH. */
+export function resolveLocalRoot(options: LocalProtocolOptions, platform: NodeJS.Platform = process.platform): string {
 	const artifactsDir = options.getArtifactsDir?.();
 	if (artifactsDir) {
-		return path.resolve(artifactsDir, "local");
+		const candidate = path.resolve(artifactsDir, "local");
+		if (platform === "win32" && candidate.length >= WINDOWS_LOCAL_ROOT_MAX_CHARS) {
+			return shortLocalRoot(candidate, options);
+		}
+		return candidate;
 	}
 
-	const sessionId = options.getSessionId?.() ?? "session";
-	const safeSessionId = sessionId.replace(/[^a-zA-Z0-9_.-]/g, "_");
-	return path.join(os.tmpdir(), "omp-local", safeSessionId);
+	return path.join(os.tmpdir(), "omp-local", safeSessionId(options));
 }
 
-export function resolveLocalUrlToPath(input: string | InternalUrl, options: LocalProtocolOptions): string {
+/** Resolve a local:// URL to an on-disk path under the active session's local root. */
+export function resolveLocalUrlToPath(
+	input: string | InternalUrl,
+	options: LocalProtocolOptions,
+	platform: NodeJS.Platform = process.platform,
+): string {
 	const url = typeof input === "string" ? parseLocalUrl(input) : input;
-	const localRoot = path.resolve(resolveLocalRoot(options));
+	const localRoot = path.resolve(resolveLocalRoot(options, platform));
 	const relativePath = extractRelativePath(url);
 
 	if (!relativePath) {

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -47,6 +47,12 @@ interface TaskRenderContext {
 }
 type TaskRenderOptions = RenderResultOptions & { renderContext?: TaskRenderContext };
 
+const MAX_NESTED_TASK_RENDER_DEPTH = 8;
+
+function renderNestedCycleLine(theme: Theme): string {
+	return theme.fg("dim", "… nested task progress already shown");
+}
+
 /**
  * Get status icon for agent state.
  * For running status, uses animated spinner if spinnerFrame is provided.
@@ -687,6 +693,8 @@ function renderAgentProgress(
 	theme: Theme,
 	spinnerFrame?: number,
 	frozen = false,
+	seenNestedTasks?: WeakSet<object>,
+	nestedDepth = 0,
 ): string[] {
 	const lines: string[] = [];
 
@@ -859,7 +867,15 @@ function renderAgentProgress(
 	const inflight = progress.inflightTaskDetails;
 	if (completedTaskCalls.length > 0 || inflight) {
 		const snapshots = inflight ? [...completedTaskCalls, inflight] : completedTaskCalls;
-		const nestedLines = renderNestedTaskTree(snapshots, expanded, theme, spinnerFrame, frozen);
+		const nestedLines = renderNestedTaskTree(
+			snapshots,
+			expanded,
+			theme,
+			spinnerFrame,
+			frozen,
+			seenNestedTasks,
+			nestedDepth,
+		);
 		for (const line of nestedLines) {
 			lines.push(`${continuePrefix}${line}`);
 		}
@@ -984,6 +1000,8 @@ function renderAgentResult(
 	continuePrefix: string,
 	expanded: boolean,
 	theme: Theme,
+	seenNestedTasks?: WeakSet<object>,
+	nestedDepth = 0,
 ): string[] {
 	const lines: string[] = [];
 
@@ -1088,11 +1106,24 @@ function renderAgentResult(
 			// Skip review tools - handled above
 			if (toolName === "yield" || toolName === "report_finding") continue;
 
+			const isTaskTool = toolName === "task";
+			if (isTaskTool && (dataArray as unknown[]).length > 0) {
+				for (const line of renderNestedTaskResults(
+					dataArray as TaskToolDetails[],
+					expanded,
+					theme,
+					seenNestedTasks,
+					nestedDepth,
+				)) {
+					deferredToolLines.push(`${continuePrefix}${line}`);
+				}
+				continue;
+			}
+
 			const handler = subprocessToolRegistry.getHandler(toolName);
 			if (handler?.renderFinal && (dataArray as unknown[]).length > 0) {
-				const isTaskTool = toolName === "task";
 				const component = handler.renderFinal(dataArray as unknown[], theme, expanded);
-				const target = isTaskTool ? deferredToolLines : lines;
+				const target = lines;
 				if (!isTaskTool) {
 					hasCustomRendering = true;
 					target.push(`${continuePrefix}${theme.fg("dim", `Tool: ${toolName}`)}`);
@@ -1417,15 +1448,34 @@ function nestedMarkers(isLast: boolean, theme: Theme): { prefix: string; continu
 	};
 }
 
-function renderNestedTaskResults(detailsList: TaskToolDetails[], expanded: boolean, theme: Theme): string[] {
+function renderNestedTaskResults(
+	detailsList: TaskToolDetails[],
+	expanded: boolean,
+	theme: Theme,
+	seen: WeakSet<object> = new WeakSet<object>(),
+	depth = 0,
+): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
-		if (!details.results || details.results.length === 0) continue;
+		if (seen.has(details)) {
+			lines.push(renderNestedCycleLine(theme));
+			continue;
+		}
+		if (depth >= MAX_NESTED_TASK_RENDER_DEPTH) {
+			lines.push(theme.fg("dim", "… nested task depth limit reached"));
+			continue;
+		}
+		seen.add(details);
+		if (!details.results || details.results.length === 0) {
+			seen.delete(details);
+			continue;
+		}
 		const ordered = orderResultsForDisplay(details.results);
 		ordered.forEach((result, index) => {
 			const { prefix, continuePrefix } = nestedMarkers(index === ordered.length - 1, theme);
-			lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme));
+			lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1));
 		});
+		seen.delete(details);
 	}
 	return lines;
 }
@@ -1441,16 +1491,28 @@ function renderNestedTaskTree(
 	theme: Theme,
 	spinnerFrame?: number,
 	frozen = false,
+	seen: WeakSet<object> = new WeakSet<object>(),
+	depth = 0,
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
+		if (seen.has(details)) {
+			lines.push(renderNestedCycleLine(theme));
+			continue;
+		}
+		if (depth >= MAX_NESTED_TASK_RENDER_DEPTH) {
+			lines.push(theme.fg("dim", "… nested task depth limit reached"));
+			continue;
+		}
+		seen.add(details);
 		const hasResults = Boolean(details.results && details.results.length > 0);
 		if (hasResults) {
 			const ordered = orderResultsForDisplay(details.results);
 			ordered.forEach((result, index) => {
 				const { prefix, continuePrefix } = nestedMarkers(index === ordered.length - 1, theme);
-				lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme));
+				lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1));
 			});
+			seen.delete(details);
 			continue;
 		}
 		const inflight = details.progress;
@@ -1458,9 +1520,22 @@ function renderNestedTaskTree(
 			const ordered = orderProgressForDisplay(inflight);
 			ordered.forEach((prog, index) => {
 				const { prefix, continuePrefix } = nestedMarkers(index === ordered.length - 1, theme);
-				lines.push(...renderAgentProgress(prog, prefix, continuePrefix, expanded, theme, spinnerFrame, frozen));
+				lines.push(
+					...renderAgentProgress(
+						prog,
+						prefix,
+						continuePrefix,
+						expanded,
+						theme,
+						spinnerFrame,
+						frozen,
+						seen,
+						depth + 1,
+					),
+				);
 			});
 		}
+		seen.delete(details);
 	}
 	return lines;
 }

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -90,6 +90,21 @@ describe("LocalProtocolHandler", () => {
 		);
 	});
 
+	it("uses a short temp root for long Windows artifact paths", async () => {
+		const longArtifactsDir = path.join(os.tmpdir(), "a".repeat(220), "artifacts");
+		const options = {
+			getArtifactsDir: () => longArtifactsDir,
+			getSessionId: () => "session:long",
+		};
+		const root = resolveLocalRoot(options, "win32");
+		const resolved = resolveLocalUrlToPath("local://memo.txt", options, "win32");
+
+		expect(root).toContain(path.join("omp-local", "session_long-"));
+		expect(root).not.toContain(longArtifactsDir);
+		expect(root.length).toBeLessThan(path.join(longArtifactsDir, "local").length);
+		expect(resolved).toBe(path.join(root, "memo.txt"));
+	});
+
 	it("blocks symlink escapes outside local root", async () => {
 		if (process.platform === "win32") return;
 

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -90,8 +90,9 @@ describe("LocalProtocolHandler", () => {
 		);
 	});
 
-	it("uses a short temp root for long Windows artifact paths", async () => {
+	it("uses a stable short temp root for long Windows artifact paths", async () => {
 		const longArtifactsDir = path.join(os.tmpdir(), "a".repeat(220), "artifacts");
+		const expectedRoot = path.join(os.tmpdir(), "omp-local", "session_long");
 		const options = {
 			getArtifactsDir: () => longArtifactsDir,
 			getSessionId: () => "session:long",
@@ -99,10 +100,17 @@ describe("LocalProtocolHandler", () => {
 		const root = resolveLocalRoot(options, "win32");
 		const resolved = resolveLocalUrlToPath("local://memo.txt", options, "win32");
 
-		expect(root).toContain(path.join("omp-local", "session_long-"));
-		expect(root).not.toContain(longArtifactsDir);
-		expect(root.length).toBeLessThan(path.join(longArtifactsDir, "local").length);
-		expect(resolved).toBe(path.join(root, "memo.txt"));
+		expect(root).toBe(expectedRoot);
+		expect(resolved).toBe(path.join(expectedRoot, "memo.txt"));
+
+		// The short root must survive moves of the artifact directory so
+		// `local://PLAN.md` and handoff files written pre-move stay reachable
+		// after `SessionManager.moveTo()` updates `getArtifactsDir()`.
+		const movedOptions = {
+			getArtifactsDir: () => path.join(os.tmpdir(), "b".repeat(220), "artifacts"),
+			getSessionId: () => "session:long",
+		};
+		expect(resolveLocalRoot(movedOptions, "win32")).toBe(expectedRoot);
 	});
 
 	it("blocks symlink escapes outside local root", async () => {

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -160,6 +160,29 @@ describe("task renderer: nested live rendering", () => {
 		expect(text).toContain("Parent>DeltaSub");
 	});
 
+	it("does not recurse forever when a nested task snapshot points at itself", async () => {
+		const inflight: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [],
+			totalDurationMs: 0,
+			progress: [],
+		};
+		const child = makeRunningSubProgress("Parent.CycleSub", "Cycle child running");
+		child.inflightTaskDetails = inflight;
+		inflight.progress = [child];
+		const parent = makeRunningProgress({
+			id: "Parent",
+			currentTool: "task",
+			currentToolStartMs: Date.now(),
+			inflightTaskDetails: inflight,
+		});
+
+		const text = await render(parent);
+
+		expect(text).toContain("Cycle child running");
+		expect(text).toContain("nested task progress already shown");
+	});
+
 	it("combines completed and in-flight nested snapshots in one tree", async () => {
 		const parent = makeRunningProgress({
 			currentTool: "task",


### PR DESCRIPTION
## Repro
A focused regression test against the pre-fix tree built a self-referential in-flight nested `task` progress snapshot and rendered it through `taskToolRenderer.renderResult(...)`; `bun test packages/coding-agent/test/task/render-nested-cycle-repro.test.ts` failed with `RangeError: Maximum call stack size exceeded` in `packages/coding-agent/src/task/render.ts`.

## Cause
`packages/coding-agent/src/task/render.ts` rendered nested async `TaskToolDetails` snapshots recursively without tracking already-rendered detail objects or bounding depth. A cyclic `progress[].inflightTaskDetails` shape from async task fan-out could recurse through `renderNestedTaskTree()` and `renderAgentProgress()` until the TUI process crashed. Separately, `packages/coding-agent/src/internal-urls/local-protocol.ts` always placed `local://` under `<artifacts>/local`, so long Windows overlay/session artifact paths could push plan/handoff writes over MAX_PATH.

## Fix
- Added a nested task render guard using a `WeakSet` plus a fixed depth cap, preserving visible child progress while cutting cycles with a dim elision row.
- Routed finalized nested task render paths through the same guarded renderer.
- Shortened long Windows `local://` roots to temp-backed `omp-local/<session>-<hash>` roots before resolving plan/handoff paths.
- Added regression coverage for self-referential nested task progress and long Windows local roots.
- Added the coding-agent changelog entry.

## Verification
Reproduced pre-fix with `bun test packages/coding-agent/test/task/render-nested-cycle-repro.test.ts` in a detached HEAD worktree: failed with `RangeError: Maximum call stack size exceeded`. After the fix, `bun test packages/coding-agent/test/task/render-nested-live.test.ts packages/coding-agent/test/internal-urls/local-protocol.test.ts` passed (15 tests, 40 assertions), `bun --cwd=packages/coding-agent run check` passed, and `gh_push_branch` completed its pre-publish gate. Fixes #2551