### PR TITLE
fix(natives): avoid linux addon load hang

### DIFF
--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -53,48 +53,58 @@ pub mod tokens;
 pub(crate) mod utils;
 pub mod workspace;
 
+#[cfg(target_os = "windows")]
 use std::sync::{
 	Arc,
 	atomic::{AtomicBool, Ordering},
 };
 
+#[cfg(target_os = "windows")]
 use napi::bindgen_prelude::create_custom_tokio_runtime;
 use napi_derive::{module_init, napi};
 
-/// Upper bound on Tokio *scheduler* workers. These only drive async I/O
+/// Upper bound on Windows Tokio *scheduler* workers. These only drive async I/O
 /// futures (shell/process/PTY/ISO) and light glue tasks; all CPU-heavy and
 /// blocking native work runs elsewhere — libuv tasks (`task::blocking`), Rayon,
 /// or Tokio's separate blocking pool via `spawn_blocking` — so a handful of
 /// async workers is plenty regardless of core count.
+#[cfg(target_os = "windows")]
 const NAPI_TOKIO_MAX_WORKER_THREADS: usize = 4;
 /// Cap on Tokio's lazily-grown blocking pool (used by `spawn_blocking` offloads
 /// such as `iso_start`/`iso_stop`/`pty.start`/`walk_diff`). Threads here are
 /// created on demand, not at load, so this only bounds peak fan-out.
+#[cfg(target_os = "windows")]
 const NAPI_TOKIO_MAX_BLOCKING_THREADS: usize = 8;
 
-/// Worker count we'd *like*, before checking what the OS will actually grant:
-/// the Tokio default (one per core) clamped to
+/// Windows worker count we'd *like*, before checking what the OS will actually
+/// grant: the Tokio default (one per core) clamped to
 /// [`NAPI_TOKIO_MAX_WORKER_THREADS`].
+#[cfg(target_os = "windows")]
 fn desired_worker_threads() -> usize {
 	std::thread::available_parallelism()
 		.map_or(1, |threads| threads.get())
 		.clamp(1, NAPI_TOKIO_MAX_WORKER_THREADS)
 }
 
-/// Probe how many worker threads the OS will let us hold alive
+/// Probe how many worker threads Windows will let us hold alive
 /// *simultaneously*, up to `target`. Returns the count actually spawned (0 when
 /// not even one extra thread is possible).
 ///
 /// `Builder::build()` for a multi-thread runtime spawns every worker eagerly
-/// and **panics** (not `Err`) when the OS refuses one — on a memory-constrained
-/// Windows host (tiny pagefile / commit limit, `os error 1455`) that aborts the
-/// whole process at addon load before any JS error can surface. The release
-/// profile is `panic = "abort"`, so the panic can't even be caught. We instead
-/// pre-flight with `std::thread::Builder::spawn`, which returns an
-/// `io::Result`, holding each probe thread alive (so their stacks are committed
-/// concurrently, matching how real workers coexist) until we know the safe
-/// count. Probe threads use the std default stack, exactly like Tokio's workers
-/// (it leaves `thread_stack_size` unset), so the probe is representative.
+/// and **panics** (not `Err`) when Windows refuses one — on a memory-constrained
+/// host (tiny pagefile / commit limit, `os error 1455`) that aborts the whole
+/// process at addon load before any JS error can surface. The release profile is
+/// `panic = "abort"`, so the panic can't even be caught. We instead pre-flight
+/// with `std::thread::Builder::spawn`, which returns an `io::Result`, holding
+/// each probe thread alive (so their stacks are committed concurrently,
+/// matching how real workers coexist) until we know the safe count. Probe
+/// threads use the std default stack, exactly like Tokio's workers (it leaves
+/// `thread_stack_size` unset), so the probe is representative.
+///
+/// Keep this Windows-only. On Linux, spawning probe threads from `module_init`
+/// can deadlock while Bun is loading the `.node`; napi-rs's default runtime
+/// loads cleanly there and avoids any custom loader-time thread probe.
+#[cfg(target_os = "windows")]
 fn probe_spawnable_workers(target: usize) -> usize {
 	let keep_running = Arc::new(AtomicBool::new(true));
 	let mut handles = Vec::with_capacity(target);
@@ -118,13 +128,15 @@ fn probe_spawnable_workers(target: usize) -> usize {
 	spawned
 }
 
-/// Build the Tokio runtime napi-rs hands async exports, sized to what the host
-/// can actually spawn. Never panics: backs off from [`desired_worker_threads`]
-/// to whatever the probe allows, and falls back to a current-thread runtime
-/// (which spawns no workers at build time, so it can't abort under commit-limit
-/// pressure) when not even one worker is available. Returns `None` only if even
-/// that fails, in which case we leave napi-rs to construct its own default.
-fn create_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
+/// Build the custom Tokio runtime napi-rs uses on Windows, sized to what the
+/// host can actually spawn. Never panics: backs off from
+/// [`desired_worker_threads`] to whatever the probe allows, and falls back to a
+/// current-thread runtime (which spawns no workers at build time, so it can't
+/// abort under commit-limit pressure) when not even one worker is available.
+/// Returns `None` only if even that fails, in which case we leave napi-rs to
+/// construct its own default.
+#[cfg(target_os = "windows")]
+fn create_windows_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
 	let workers = probe_spawnable_workers(desired_worker_threads());
 	let multi_thread = (workers > 0)
 		.then(|| {
@@ -164,17 +176,23 @@ fn create_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
 pub const fn pi_natives_version_sentinel() {}
 
 /// Native module entry point: install crash diagnostics before any tool can
-/// invoke a panicking or allocating native call, then hand napi-rs a
-/// host-sized Tokio runtime before it registers the module. napi-rs would
-/// otherwise build its own default runtime — one worker per CPU spawned eagerly
-/// at load — which aborts the whole process (`os error 1455`) on a
-/// memory-constrained Windows host before any JS error can surface. See
-/// [`create_napi_tokio_runtime`]. If we can't build any runtime we leave
-/// napi-rs to its default rather than failing here.
+/// invoke a panicking or allocating native call.
+///
+/// On Windows, also hand napi-rs a host-sized Tokio runtime before it registers
+/// the module. napi-rs would otherwise build its own default runtime — one
+/// worker per CPU spawned eagerly at load — which aborts the whole process
+/// (`os error 1455`) on a memory-constrained Windows host before any JS error
+/// can surface. See [`create_windows_napi_tokio_runtime`]. If we can't build any
+/// runtime we leave napi-rs to its default rather than failing here.
+///
+/// Non-Windows builds intentionally use napi-rs's default path. Linux source
+/// builds can deadlock if this module initializer performs its own thread probe
+/// while Bun is loading the `.node`, before the JS loader can return.
 #[module_init]
 fn install_native_crash_handler() {
 	crash_handler::install();
-	if let Some(runtime) = create_napi_tokio_runtime() {
+	#[cfg(target_os = "windows")]
+	if let Some(runtime) = create_windows_napi_tokio_runtime() {
 		create_custom_tokio_runtime(runtime);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Linux source-built native addons hanging during package import by keeping the Windows-only Tokio worker probe out of non-Windows module initialization ([#2553](https://github.com/can1357/oh-my-pi/issues/2553)).
+
 ## [15.12.6] - 2026-06-14
 
 ### Fixed

--- a/packages/natives/test/issue-2553-repro.test.ts
+++ b/packages/natives/test/issue-2553-repro.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/2553.
+ *
+ * Linux source builds hung while requiring the `.node` because the module
+ * initializer spawned probe threads before Bun finished loading the addon.
+ * The exposed contract is simple: importing the package must return promptly
+ * and emit the loader's completion marker when startup debugging is enabled.
+ */
+import { describe, expect, it } from "bun:test";
+
+const LOAD_TIMEOUT_MS = 5_000;
+const TIMED_OUT = Symbol("timed out");
+
+describe("issue 2553: linux source-built native load", () => {
+	it("returns from package import instead of hanging in addon initialization", async () => {
+		const proc = Bun.spawn([process.execPath, "-e", "import '@oh-my-pi/pi-natives'; console.log('ok natives');"], {
+			cwd: pathFromRepoRoot(),
+			env: { ...process.env, PI_DEBUG_STARTUP: "1" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		// Real timeout is the contract here: a broken native load never resolves.
+		const outcome = await Promise.race([proc.exited, Bun.sleep(LOAD_TIMEOUT_MS).then(() => TIMED_OUT)]);
+		if (outcome === TIMED_OUT) {
+			proc.kill("SIGKILL");
+		}
+
+		const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+		expect(outcome).not.toBe(TIMED_OUT);
+		expect(outcome).toBe(0);
+		expect(stderr).toContain("[startup] native:loadNative:done");
+		expect(stdout).toBe("ok natives\n");
+	});
+});
+
+function pathFromRepoRoot(): string {
+	return new URL("../../..", import.meta.url).pathname;
+}


### PR DESCRIPTION
## Repro
After rebuilding Linux native variants from source, `timeout 10s env PI_DEBUG_STARTUP=1 bun -e "await import('@oh-my-pi/pi-natives'); console.log('ok natives')"` hung after `native:require:pi_natives.linux-x64-modern.node` and exited 124. The compiled CLI path also blocked before printing `omp completions bash`.

## Cause
`crates/pi-natives/src/lib.rs` installed a custom napi-rs Tokio runtime from `#[module_init]` on every platform. That Windows-focused runtime sizing path called `probe_spawnable_workers()`, which spawns and joins probe threads while Bun is still loading the Linux `.node`; source-built Linux addons can deadlock there before `require()` returns.

## Fix
- Kept the custom Tokio runtime sizing/probe behind `#[cfg(target_os = "windows")]`, preserving the Windows commit-limit protection without running loader-time probe threads on Linux.
- Left non-Windows builds on napi-rs's default runtime path.
- Added `packages/natives/test/issue-2553-repro.test.ts` to spawn a child Bun import with `PI_DEBUG_STARTUP=1` and fail if the import never reaches `native:loadNative:done`.
- Added a `packages/natives/CHANGELOG.md` Unreleased fix entry.

## Verification
Reproduced the original hang before the fix with `TARGET_PLATFORM=linux TARGET_ARCH=x64 TARGET_VARIANTS='baseline modern' bun run ci:build:native` followed by `timeout 10s env PI_DEBUG_STARTUP=1 bun -e "await import('@oh-my-pi/pi-natives'); console.log('ok natives')"` (exit 124). After the fix: `TARGET_PLATFORM=linux TARGET_ARCH=x64 TARGET_VARIANTS='baseline modern' bun run ci:build:native && timeout 10s env PI_DEBUG_STARTUP=1 bun -e "await import('@oh-my-pi/pi-natives'); console.log('ok natives')"` printed `native:loadNative:done` and `ok natives`; `RELEASE_TARGETS='linux-x64' bun run ci:release:build-binaries && timeout 10s env PI_DEBUG_STARTUP=1 HOME="$PWD/.tmp-completion/home" XDG_DATA_HOME="$PWD/.tmp-completion/xdg" ./packages/coding-agent/binaries/omp-linux-x64 completions bash` printed the bash completion script; `bun --cwd=packages/natives test test/issue-2553-repro.test.ts`, `bun --cwd=packages/natives test`, `bun --cwd=packages/natives run check`, and `cargo check -p pi-natives` all passed. Fixes #2553