### PR TITLE
fix(anthropic): drop eager_input_streaming on github-copilot transport

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenAI-compatible providers that reject forced `tool_choice` on thinking-required models by downgrading unsupported forced choices to `auto` while keeping tools available ([#2546](https://github.com/can1357/oh-my-pi/issues/2546)).
+- Fixed GitHub Copilot Anthropic transport (`api.githubcopilot.com/v1/messages`) returning `400 tools.0.custom.eager_input_streaming: Extra inputs are not permitted` on every tool-bearing turn by stopping the emission of the per-tool `eager_input_streaming` flag and the `fine-grained-tool-streaming-2025-05-14` beta header on the Copilot transport — the proxy whitelists neither ([#2558](https://github.com/can1357/oh-my-pi/issues/2558)).
 
 ## [15.12.6] - 2026-06-14
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2311,10 +2311,11 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	const cchFetch = oauthToken ? wrapFetchForCch(baseFetch) : baseFetch;
 	if (model.provider === "github-copilot") {
 		const copilotApiKey = parseGitHubCopilotApiKey(apiKey).accessToken;
+		// The GitHub Copilot Anthropic proxy doesn't accept Anthropic beta
+		// features (and the catalog already forces `supportsEagerToolInputStreaming
+		// = false` for this host, so `needsFineGrainedToolStreamingBeta` is true
+		// whenever tools are present). Forward only caller-supplied betas.
 		const betaFeatures = [...extraBetas];
-		if (needsFineGrainedToolStreamingBeta) {
-			betaFeatures.push(fineGrainedToolStreamingBeta);
-		}
 		const defaultHeaders = mergeHeaders(
 			{
 				Accept: stream ? "text/event-stream" : "application/json",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed OpenCode Go MiMo catalog metadata so title generation and other tool-enabled calls omit unsupported `tool_choice` instead of triggering provider 400s ([#2509](https://github.com/can1357/oh-my-pi/issues/2509)).
 - Fixed OpenCode Go `kimi-k2.7-code` catalog metadata so resolve-gate requests use automatic tool selection instead of Moonshot-rejected forced `tool_choice` ([#2546](https://github.com/can1357/oh-my-pi/issues/2546)).
+- Fixed Anthropic compat for the `github-copilot` host so `supportsEagerToolInputStreaming` defaults to `false` there, matching the Copilot proxy which rejects the per-tool `eager_input_streaming` field ([#2558](https://github.com/can1357/oh-my-pi/issues/2558)).
 
 ## [15.12.6] - 2026-06-14
 

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -34,11 +34,17 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 	const official = isOfficialAnthropicApiUrl(baseUrl);
 	// Z.AI's Anthropic-compatible proxy lives at `api.z.ai/api/anthropic`.
 	const isZai = modelMatchesHost(spec, "zai");
+	// GitHub Copilot's Anthropic-compatible proxy (api.githubcopilot.com/v1/messages)
+	// rejects the per-tool `eager_input_streaming` field with
+	// `tools.0.custom.eager_input_streaming: Extra inputs are not permitted` and
+	// doesn't whitelist the `fine-grained-tool-streaming-2025-05-14` beta either
+	// (issue #2558), so eager tool-input streaming is unavailable on this host.
+	const isCopilot = modelMatchesHost(spec, "githubCopilot");
 	const compat: ResolvedAnthropicCompat = {
 		officialEndpoint: official,
 		disableStrictTools: false,
 		disableAdaptiveThinking: false,
-		supportsEagerToolInputStreaming: true,
+		supportsEagerToolInputStreaming: !isCopilot,
 		// Long cache retention is only sent to the official API by default;
 		// proxies opt in explicitly via `compat.supportsLongCacheRetention: true`.
 		supportsLongCacheRetention: official,

--- a/packages/catalog/test/issue-2558-repro.test.ts
+++ b/packages/catalog/test/issue-2558-repro.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #2558 — `400 Error when using Claude Haiku 4.6 via Github Copilot`
+ *
+ * Reporter: sending any tool-bearing turn to a GitHub Copilot Claude model
+ * (e.g. `github-copilot/claude-haiku-4.5`) returns
+ * `400 tools.0.custom.eager_input_streaming: Extra inputs are not permitted`.
+ *
+ * Root cause: `buildAnthropicCompat` defaulted `supportsEagerToolInputStreaming`
+ * to `true` regardless of host. That made `convertTools` emit
+ * `eager_input_streaming: true` on every tool sent to
+ * `api.githubcopilot.com/v1/messages`, which the Copilot proxy rejects.
+ *
+ * Fix: turn the flag off for the `github-copilot` host in the Anthropic
+ * compat builder, AND stop pushing the legacy
+ * `fine-grained-tool-streaming-2025-05-14` beta header on the Copilot
+ * transport (the proxy doesn't whitelist Anthropic beta features either).
+ */
+import { describe, expect, it } from "bun:test";
+import { buildAnthropicClientOptions, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Context, Model, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+const COPILOT_BEARER = JSON.stringify({ token: "ghc_test" });
+
+const TOOLS: Tool[] = [
+	{
+		name: "ping",
+		description: "ping",
+		parameters: {
+			type: "object",
+			properties: { msg: { type: "string" } },
+			required: ["msg"],
+		} as TJsonSchema,
+	},
+];
+
+const CONTEXT: Context = {
+	systemPrompt: ["Stay concise."],
+	messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+	tools: TOOLS,
+};
+
+function aborted(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+describe("issue #2558 — GitHub Copilot Anthropic transport rejects eager_input_streaming", () => {
+	const model = getBundledModel("github-copilot", "claude-haiku-4.5") as Model<"anthropic-messages">;
+
+	it("disables eager tool-input streaming on the github-copilot host", () => {
+		expect(model.provider).toBe("github-copilot");
+		expect(model.compat.supportsEagerToolInputStreaming).toBe(false);
+	});
+
+	it("omits the per-tool eager_input_streaming flag on the wire payload", async () => {
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: COPILOT_BEARER,
+			signal: aborted(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
+		expect(payload.tools).toHaveLength(1);
+		expect(payload.tools?.[0]).not.toHaveProperty("eager_input_streaming");
+	});
+
+	it("omits the fine-grained-tool-streaming beta header on the github-copilot transport", () => {
+		const options = buildAnthropicClientOptions({
+			model,
+			apiKey: COPILOT_BEARER,
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: false,
+			hasTools: true,
+		});
+		// Either the header is absent or, if other betas pile in later, it must
+		// not list `fine-grained-tool-streaming-2025-05-14`.
+		expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain(
+			"fine-grained-tool-streaming-2025-05-14",
+		);
+	});
+});

--- a/packages/catalog/test/issue-2558-repro.test.ts
+++ b/packages/catalog/test/issue-2558-repro.test.ts
@@ -17,8 +17,8 @@
  */
 import { describe, expect, it } from "bun:test";
 import { buildAnthropicClientOptions, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { Context, Model, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { Context, Model, ModelSpec, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 const COPILOT_BEARER = JSON.stringify({ token: "ghc_test" });
 
@@ -34,6 +34,19 @@ const TOOLS: Tool[] = [
 	},
 ];
 
+const COPILOT_MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
+	id: "claude-haiku-4.5",
+	name: "Claude Haiku 4.5",
+	api: "anthropic-messages",
+	provider: "github-copilot",
+	baseUrl: "https://api.githubcopilot.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
 const CONTEXT: Context = {
 	systemPrompt: ["Stay concise."],
 	messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
@@ -47,7 +60,7 @@ function aborted(): AbortSignal {
 }
 
 describe("issue #2558 — GitHub Copilot Anthropic transport rejects eager_input_streaming", () => {
-	const model = getBundledModel("github-copilot", "claude-haiku-4.5") as Model<"anthropic-messages">;
+	const model: Model<"anthropic-messages"> = buildModel(COPILOT_MODEL_SPEC);
 
 	it("disables eager tool-input streaming on the github-copilot host", () => {
 		expect(model.provider).toBe("github-copilot");

--- a/packages/catalog/test/issue-2558-repro.test.ts
+++ b/packages/catalog/test/issue-2558-repro.test.ts
@@ -17,8 +17,9 @@
  */
 import { describe, expect, it } from "bun:test";
 import { buildAnthropicClientOptions, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { Context, Model, ModelSpec, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
+import type { Context, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 const COPILOT_BEARER = JSON.stringify({ token: "ghc_test" });
 

--- a/packages/catalog/test/issue-2558-repro.test.ts
+++ b/packages/catalog/test/issue-2558-repro.test.ts
@@ -77,8 +77,6 @@ describe("issue #2558 — GitHub Copilot Anthropic transport rejects eager_input
 		});
 		// Either the header is absent or, if other betas pile in later, it must
 		// not list `fine-grained-tool-streaming-2025-05-14`.
-		expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain(
-			"fine-grained-tool-streaming-2025-05-14",
-		);
+		expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain("fine-grained-tool-streaming-2025-05-14");
 	});
 });


### PR DESCRIPTION
## Repro

Sending any tool-bearing turn to a GitHub Copilot Claude model (`github-copilot/claude-haiku-4.5`, `claude-sonnet-4`, etc.) returned `400 tools.0.custom.eager_input_streaming: Extra inputs are not permitted`. Captured payload from `streamAnthropic` showed the per-tool flag the Copilot proxy rejects:

```json
{
  "model": "claude-haiku-4.5",
  "provider": "github-copilot",
  "tool_keys": ["name", "description", "input_schema", "eager_input_streaming"],
  "eager_input_streaming": true,
  "compat_supportsEagerToolInputStreaming": true
}
```

## Cause

`buildAnthropicCompat` (`packages/catalog/src/compat/anthropic.ts`) defaulted `supportsEagerToolInputStreaming: true` regardless of host. `convertTools` in `packages/ai/src/providers/anthropic.ts:3669-3681` then attached `eager_input_streaming: true` to every tool sent to `api.githubcopilot.com/v1/messages`, which validates tool definitions with `additionalProperties: false` and bounces the request. Falling back to the legacy `fine-grained-tool-streaming-2025-05-14` beta header on the Copilot transport wouldn't help — the proxy doesn't whitelist Anthropic beta features either.

## Fix

- `packages/catalog/src/compat/anthropic.ts`: detect the `github-copilot` host via `modelMatchesHost(spec, "githubCopilot")` and set `supportsEagerToolInputStreaming: !isCopilot`, mirroring the existing `supportsLongCacheRetention: official` pattern.
- `packages/ai/src/providers/anthropic.ts`: in the github-copilot branch of `buildAnthropicClientOptions`, stop pushing `fineGrainedToolStreamingBeta`; the catalog now forces compat to `false` for this host, so the legacy beta would otherwise be added on every tool turn and 400 the same way.
- `packages/catalog/test/issue-2558-repro.test.ts`: regression covering both surfaces (catalog compat flag, wire-side per-tool field, wire-side `anthropic-beta` header) against the bundled `github-copilot/claude-haiku-4.5`.

## Verification

```
$ bun --cwd packages/catalog test test/issue-2558-repro.test.ts
 3 pass · 5 expect() calls

$ bun --cwd packages/ai test test/anthropic-alignment.test.ts test/anthropic-stream-envelope.test.ts test/github-copilot-reasoning.test.ts
 91 pass · 354 expect() calls

$ bun --cwd packages/catalog test
 222 pass · 1158 expect() calls
```

Manual probe (now removed) confirmed the post-fix payload omits the per-tool flag and the `anthropic-beta` header is absent on the Copilot transport.

Fixes #2558