### PR TITLE
fix(agent): correct eager todo init prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Fixed the `Working…` loader vanishing for the rest of a turn after an auto-compaction (context-overflow recovery) or auto-retry. Those overlays took over the shared status container with a bare `statusContainer.clear()`, which detached the working loader but left `loadingAnimation` set; the resumed turn's `agent_start` → `ensureLoadingAnimation()` is guarded by `if (!this.loadingAnimation)`, so it skipped re-attaching the loader and the spinner stayed gone while the agent kept streaming. The overlay handlers now fully tear the working loader down (stop + dereference) via `#stopWorkingLoader()`, so the next `agent_start` recreates and re-attaches it.
 
 - Fixed JS eval helper optional arguments rejecting Python-style positional calls. `read(path, offset, limit)` now works alongside `read(path, { offset, limit })`, `null`/`undefined` skip optional positional slots, and non-local URI reads such as `artifact://...` delegate through the read tool so line slicing works on spilled artifacts.
+- Fixed eager todo initialization prompting GPT-5.5 to emit unsupported task metadata fields, which could leave fresh sessions stuck on the forced first `todo` call ([#2561](https://github.com/can1357/oh-my-pi/issues/2561)).
+
 ## [15.12.6] - 2026-06-14
 ### Breaking Changes
 

--- a/packages/coding-agent/src/prompts/system/eager-todo.md
+++ b/packages/coding-agent/src/prompts/system/eager-todo.md
@@ -4,9 +4,8 @@ Before substantive work, create a phased todo.
 You MUST call `todo` first in this turn.
 You MUST initialize the todo list with a single `init` op.
 You MUST cover the entire request from investigation through implementation and verification — not just the next immediate step.
-Task descriptions MUST be specific. A future turn MUST be able to execute them without re-planning.
-You MUST keep task `content` to a short label (5-10 words). Put file paths, implementation steps, and specifics in `details`.
-You MUST keep exactly one task `in_progress` and all later tasks `pending`.
+Task descriptions MUST be concise, specific 5-10 word labels.
+The `init` op only accepts phase names and task-label strings; do not invent task metadata fields.
 
 After `todo` succeeds, continue the request in the same turn.
 NEVER call `todo` again unless task state has materially changed.

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -15,6 +15,7 @@ import { TodoTool } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
+import eagerTodoPrompt from "../src/prompts/system/eager-todo.md" with { type: "text" };
 
 type ObservedPromptCall = {
 	toolChoice: string | undefined;
@@ -183,6 +184,14 @@ describe("AgentSession eager todo enforcement", () => {
 		authStorage?.close();
 		authStorage = undefined;
 		tempDir.removeSync();
+	});
+
+	it("keeps eager init instructions aligned with the todo schema", () => {
+		expect(eagerTodoPrompt).toContain("single `init` op");
+		expect(eagerTodoPrompt).toContain("phase names and task-label strings");
+		expect(eagerTodoPrompt).not.toContain("`details`");
+		expect(eagerTodoPrompt).not.toContain("in_progress");
+		expect(eagerTodoPrompt).not.toContain("pending");
 	});
 
 	it("prepends a hidden eager todo reminder without repeating the prompt text", async () => {

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -14,8 +14,8 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TodoTool } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
-import { createAssistantMessage } from "./helpers/agent-session-setup";
 import eagerTodoPrompt from "../src/prompts/system/eager-todo.md" with { type: "text" };
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 type ObservedPromptCall = {
 	toolChoice: string | undefined;


### PR DESCRIPTION
## Repro
A fresh GPT-5.5 session with eager todos forces the first model call to `todo` with a single `init` op. The pre-fix eager prelude also instructed the model to emit unsupported per-task metadata (`details`, `in_progress`, `pending`), which conflicts with the strict `todo` init schema that accepts only phase names and task-label strings.

## Cause
`packages/coding-agent/src/prompts/system/eager-todo.md` described fields that do not exist in `packages/coding-agent/src/tools/todo.ts`'s init schema. Because the first turn pins `tool_choice` to `todo` from `AgentSession.#createEagerTodoPrelude`, GPT-5.5 had to satisfy contradictory prompt and schema constraints before any real work could continue.

## Fix
- Remove schema-incompatible task metadata instructions from the eager todo prelude.
- Tell the model that `init` accepts only phase names and task-label strings.
- Add regression coverage in `packages/coding-agent/test/agent-session-eager-todo.test.ts` so the eager prelude does not reintroduce unsupported fields.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/agent-session-eager-todo.test.ts` passes: 6 tests, 26 assertions. `gh_push_branch` pre-publish gate completed `bun run fix`/`bun check` before pushing. Fixes #2561