### PR TITLE
fix(coding-agent): remap legacy OAuth imports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Fixed the `Working…` loader vanishing for the rest of a turn after an auto-compaction (context-overflow recovery) or auto-retry. Those overlays took over the shared status container with a bare `statusContainer.clear()`, which detached the working loader but left `loadingAnimation` set; the resumed turn's `agent_start` → `ensureLoadingAnimation()` is guarded by `if (!this.loadingAnimation)`, so it skipped re-attaching the loader and the spinner stayed gone while the agent kept streaming. The overlay handlers now fully tear the working loader down (stop + dereference) via `#stopWorkingLoader()`, so the next `agent_start` recreates and re-attaches it.
 
 - Fixed JS eval helper optional arguments rejecting Python-style positional calls. `read(path, offset, limit)` now works alongside `read(path, { offset, limit })`, `null`/`undefined` skip optional positional slots, and non-local URI reads such as `artifact://...` delegate through the read tool so line slicing works on spilled artifacts.
+- Fixed legacy extension compatibility remapping for `@*-pi-ai/utils/oauth` imports so background workers load the relocated `@oh-my-pi/pi-ai/oauth` exports instead of resolving missing `src/utils/oauth/*` files ([#2566](https://github.com/can1357/oh-my-pi/issues/2566)).
+
 ## [15.12.6] - 2026-06-14
 ### Breaking Changes
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -30,15 +30,27 @@ const PI_PACKAGE_ALTERNATION = PI_PACKAGE_NAMES.join("|");
 // root that we relocated under a different folder. Each entry rewrites
 // `<pkg>/<from>` → `<pkg>/<to>` after the scope has been canonicalised, so
 // plugins importing the upstream layout still resolve to a real file in our
-// bundled copy. Add new entries as `pkg/from -> pkg/to` whenever a plugin
-// surfaces another upstream-only subpath that breaks resolution.
+// bundled copy. Entries ending in `/` rewrite the whole subtree; add new
+// `pkg/from -> pkg/to` pairs whenever an upstream-only subpath breaks resolution.
 const PI_SUBPATH_REMAPS: ReadonlyMap<string, string> = new Map<string, string>([
-	// (currently empty) Upstream `@mariozechner/pi-ai/oauth` re-exported
-	// `./utils/oauth/index.js`. Our pi-ai now exposes the same surface at the
-	// real `@oh-my-pi/pi-ai/oauth` export, so the legacy subpath canonicalizes
-	// straight to it with no rewrite. Add `from -> to` entries here whenever a
-	// future upstream-only subpath surfaces that breaks resolution.
+	["pi-ai/utils/oauth", "pi-ai/oauth"],
+	["pi-ai/utils/oauth/", "pi-ai/oauth/"],
 ]);
+
+function remapLegacyPiSubpath(rest: string): string {
+	const exact = PI_SUBPATH_REMAPS.get(rest);
+	if (exact) {
+		return exact;
+	}
+
+	for (const [from, to] of PI_SUBPATH_REMAPS) {
+		if (from.endsWith("/") && rest.startsWith(from)) {
+			return `${to}${rest.slice(from.length)}`;
+		}
+	}
+
+	return rest;
+}
 
 const LEGACY_PI_SPECIFIER_FILTER = new RegExp(`^@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/.*)?$`);
 const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
@@ -208,7 +220,7 @@ function remapLegacyPiSpecifier(specifier: string): string | null {
 		return null;
 	}
 	const rest = specifier.slice(slashIdx + 1);
-	const remappedSubpath = PI_SUBPATH_REMAPS.get(rest) ?? rest;
+	const remappedSubpath = remapLegacyPiSubpath(rest);
 	return `${CANONICAL_PI_SCOPE}/${remappedSubpath}`;
 }
 

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -103,6 +103,27 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.hasZod).toBe(true);
 	});
 
+	it("remaps legacy pi-ai utils/oauth subpaths to registry OAuth exports", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "legacy-oauth-ext", version: "1.0.0" }),
+			"index.ts": [
+				'import { registerOAuthProvider } from "@mariozechner/pi-ai/utils/oauth";',
+				'import { refreshAnthropicToken } from "@mariozechner/pi-ai/utils/oauth/anthropic";',
+				'export const hasRegisterOAuthProvider = typeof registerOAuthProvider === "function";',
+				'export const hasRefreshAnthropicToken = typeof refreshAnthropicToken === "function";',
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as {
+			hasRegisterOAuthProvider: boolean;
+			hasRefreshAnthropicToken: boolean;
+		};
+
+		expect(mod.hasRegisterOAuthProvider).toBe(true);
+		expect(mod.hasRefreshAnthropicToken).toBe(true);
+	});
+
 	it("rewrites legacy imports in ../src modules reached through relative imports", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "dist-ext", version: "1.0.0" }),


### PR DESCRIPTION
## Repro
A temp legacy extension loaded through `loadLegacyPiModule()` with `export { refreshAnthropicToken } from "@mariozechner/pi-ai/utils/oauth/anthropic"` failed before the worker could load the refresh helper. Command: `bun --eval "$REPRO_CODE"` exited 1 with `Cannot find module '@mariozechner/pi-ai/utils/oauth/anthropic'`.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` canonicalized legacy pi scopes but left `PI_SUBPATH_REMAPS` empty, so `@*-pi-ai/utils/oauth` imports stayed on the removed `packages/ai/src/utils/oauth/*` layout instead of the relocated `packages/ai/src/registry/oauth/*` exports.

## Fix
- Added exact and subtree remaps from `pi-ai/utils/oauth` to `pi-ai/oauth` in the legacy Pi compat loader.
- Added a regression test covering both the legacy OAuth index subpath and `utils/oauth/anthropic` through `loadLegacyPiModule()`.
- Added a coding-agent changelog entry for the background-worker OAuth import fix.

## Verification
`bun --eval "$REPRO_CODE"` now prints `function`; `bun test test/extensibility/legacy-pi-inplace-load.test.ts` passes 6 tests; `bun run check` passes in `packages/coding-agent`. Fixes #2566