### PR TITLE
fix(tui): parse and format raw HTML tags in Markdown renderer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pretty-printed HTML list formatting whitespace rendering as terminal indentation or blank rows before and between list items.
+
 ## [16.0.9] - 2026-06-18
 
 ### Fixed
 
 - Fixed bottom-anchored fullscreen overlays keeping their body rows but clipping off footer actions when terminal-height clamping is applied, restoring plan-mode approval options on short or stale-size terminals ([#2957](https://github.com/can1357/oh-my-pi/issues/2957)).
+### Fixed
+
+- Fixed Markdown renderer rendering raw HTML tags (like `<br>`, `<li>`, `<ul>`, `<ol>`, and `<p>`) literally in the terminal by parsing and converting them to appropriate terminal formatting, preserving repeated HTML line breaks, nested HTML list indentation, ordered list numbering, paragraph-wrapped list item markers, paragraph separation, and table sizing after HTML line breaks.
 
 ## [16.0.8] - 2026-06-18
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -31,6 +31,202 @@ function isOsc66Line(line: string): boolean {
 	return line.includes(OSC66_LINE_PREFIX);
 }
 
+function normalizeHtmlEntitiesForTerminal(raw: string): string {
+	return raw.replace(/&nbsp;/gi, " ");
+}
+
+interface HtmlListState {
+	type: "ol" | "ul";
+	next: number;
+}
+
+interface HtmlNormalizationState {
+	lists: HtmlListState[];
+	openItems: boolean[];
+	itemHasContent: boolean[];
+	previousTagName: string;
+}
+
+function createHtmlNormalizationState(): HtmlNormalizationState {
+	return { lists: [], openItems: [], itemHasContent: [], previousTagName: "" };
+}
+
+const HTML_TAG_REGEX = /<\/?(?:br|p|ol|ul|li)\b(?:\s[^>]*)?\s*\/?>/gi;
+
+function isHtmlFormattingBoundaryTagName(name: string): boolean {
+	switch (name) {
+		case "br":
+		case "p":
+		case "ol":
+		case "ul":
+		case "li":
+			return true;
+		default:
+			return false;
+	}
+}
+
+function isHtmlFormattingWhitespace(text: string, previousTagName: string, nextTagName: string): boolean {
+	return (
+		text.trim() === "" &&
+		(isHtmlFormattingBoundaryTagName(previousTagName) || isHtmlFormattingBoundaryTagName(nextTagName))
+	);
+}
+
+function htmlTagName(tag: string): string {
+	const match = /^<\/?\s*([A-Za-z][A-Za-z0-9:-]*)/.exec(tag);
+	return match ? match[1].toLowerCase() : "";
+}
+
+function htmlOlStart(tag: string): number {
+	const match = /\bstart\s*=\s*(?:"(\d+)"|'(\d+)'|(\d+))/i.exec(tag);
+	if (!match) return 1;
+	return Number(match[1] ?? match[2] ?? match[3]);
+}
+
+function htmlTagNameFromToken(token: Token | undefined): string {
+	return token?.type === "html" && "raw" in token && typeof token.raw === "string" ? htmlTagName(token.raw) : "";
+}
+
+function appendHtmlLineBreak(output: string, force: boolean = false): string {
+	const trimmed = output.replace(/[ \t]+$/u, "");
+	return !force && trimmed.endsWith("\n") ? trimmed : `${trimmed}\n`;
+}
+
+function htmlListIndent(state: HtmlNormalizationState): string {
+	return "  ".repeat(Math.max(0, state.lists.length - 1));
+}
+
+function appendHtmlListBreak(output: string, state: HtmlNormalizationState): string {
+	const indent = htmlListIndent(state);
+	return output.endsWith(`${indent}\n`) ? output : appendHtmlLineBreak(output);
+}
+
+function markCurrentHtmlItemContent(state: HtmlNormalizationState, text: string): void {
+	if (text.trim() !== "" && state.itemHasContent.length > 0) {
+		state.itemHasContent[state.itemHasContent.length - 1] = true;
+	}
+}
+
+function isAtEmptyHtmlListItem(state: HtmlNormalizationState): boolean {
+	const itemIndex = state.itemHasContent.length - 1;
+	return state.openItems[itemIndex] === true && state.itemHasContent[itemIndex] !== true;
+}
+
+function shouldSkipHtmlListBreak(state: HtmlNormalizationState): boolean {
+	const itemIndex = state.openItems.length - 1;
+	return state.lists.length > 0 && state.openItems[itemIndex] === true && state.itemHasContent[itemIndex] === false;
+}
+
+function normalizeHtmlForTerminal(raw: string, state: HtmlNormalizationState = createHtmlNormalizationState()): string {
+	let output = "";
+	let lastIndex = 0;
+
+	for (const match of raw.matchAll(HTML_TAG_REGEX)) {
+		const tag = match[0];
+		const name = htmlTagName(tag);
+		const index = match.index ?? 0;
+		const textBeforeTag = normalizeHtmlEntitiesForTerminal(raw.slice(lastIndex, index));
+		if (!isHtmlFormattingWhitespace(textBeforeTag, state.previousTagName, name)) {
+			output += textBeforeTag;
+			markCurrentHtmlItemContent(state, textBeforeTag);
+			if (textBeforeTag.trim() !== "") state.previousTagName = "";
+		}
+		lastIndex = index + tag.length;
+
+		state.previousTagName = name;
+		const isClosing = /^<\//.test(tag);
+		const isSelfClosing = /\/\s*>$/.test(tag);
+
+		switch (name) {
+			case "br":
+				output = appendHtmlLineBreak(output, true);
+				break;
+			case "p":
+				if (isClosing) {
+					output = appendHtmlLineBreak(output);
+				} else if (output.trim() !== "" && !output.endsWith("\n") && !isAtEmptyHtmlListItem(state)) {
+					output = appendHtmlLineBreak(output);
+				}
+				break;
+			case "ol":
+				if (isClosing) {
+					state.lists.pop();
+					state.openItems.pop();
+					state.itemHasContent.pop();
+				} else if (!isSelfClosing) {
+					if (state.openItems.length > 0 && state.openItems[state.openItems.length - 1]) {
+						output = appendHtmlListBreak(output, state);
+					}
+					state.lists.push({ type: "ol", next: htmlOlStart(tag) });
+					state.openItems.push(false);
+					state.itemHasContent.push(false);
+				}
+				break;
+			case "ul":
+				if (isClosing) {
+					state.lists.pop();
+					state.openItems.pop();
+					state.itemHasContent.pop();
+				} else if (!isSelfClosing) {
+					if (state.openItems.length > 0 && state.openItems[state.openItems.length - 1]) {
+						output = appendHtmlListBreak(output, state);
+					}
+					state.lists.push({ type: "ul", next: 1 });
+					state.openItems.push(false);
+					state.itemHasContent.push(false);
+				}
+				break;
+			case "li": {
+				if (isClosing) {
+					output = appendHtmlLineBreak(output);
+					break;
+				}
+				if (state.openItems.length > 0) {
+					const itemOpenIndex = state.openItems.length - 1;
+					if (
+						state.openItems[itemOpenIndex] &&
+						state.itemHasContent[itemOpenIndex] &&
+						state.previousTagName !== "li"
+					) {
+						output = appendHtmlListBreak(output, state);
+					}
+					state.openItems[itemOpenIndex] = true;
+					state.itemHasContent[itemOpenIndex] = false;
+				} else if (output.trim() !== "" && !output.endsWith("\n")) {
+					output = appendHtmlLineBreak(output);
+				}
+				const list = state.lists[state.lists.length - 1];
+				const indent = htmlListIndent(state);
+				if (list?.type === "ol") {
+					output += `${indent}${list.next}. `;
+					list.next++;
+				} else {
+					output += `${indent}• `;
+				}
+				break;
+			}
+			default:
+				output += tag;
+				break;
+		}
+	}
+
+	const remainingText = normalizeHtmlEntitiesForTerminal(raw.slice(lastIndex));
+	if (isHtmlFormattingWhitespace(remainingText, state.previousTagName, "")) return output;
+	markCurrentHtmlItemContent(state, remainingText);
+	if (remainingText.trim() !== "") state.previousTagName = "";
+	return output + remainingText;
+}
+
+function splitTerminalLines(text: string): string[] {
+	const lines = text.split("\n");
+	while (lines.length > 1 && lines[lines.length - 1] === "") {
+		lines.pop();
+	}
+	return lines;
+}
+
 class StrictStrikethroughTokenizer extends Tokenizer {
 	override del(src: string): Tokens.Del | undefined {
 		const match = STRICT_STRIKETHROUGH_REGEX.exec(src);
@@ -997,9 +1193,13 @@ export class Markdown implements Component {
 				break;
 
 			case "html":
-				// Render HTML as plain text (escaped for terminal)
 				if ("raw" in token && typeof token.raw === "string") {
-					lines.push(this.#applyDefaultStyle(token.raw.trim()));
+					const cleaned = normalizeHtmlForTerminal(token.raw);
+					const blockLines = splitTerminalLines(cleaned);
+					for (const line of blockLines) {
+						const trimmed = line.trimEnd();
+						lines.push(trimmed.trim() === "" ? "" : this.#applyDefaultStyle(trimmed));
+					}
 				}
 				break;
 
@@ -1024,31 +1224,64 @@ export class Markdown implements Component {
 		const { applyText, stylePrefix } = resolvedStyleContext;
 		const applyTextWithNewlines = (text: string): string => {
 			const segments: string[] = text.split("\n");
-			return segments.map((segment: string) => applyText(segment)).join("\n");
+			return segments.map((segment: string) => (segment === "" ? "" : applyText(segment))).join("\n");
 		};
 		const swatchGlyph = this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH;
+		let trimLeadingWhitespace = false;
+		const htmlState = createHtmlNormalizationState();
+		const markHtmlItemWhenContent = (text: string): void => {
+			markCurrentHtmlItemContent(htmlState, text);
+		};
+		const nextHtmlTagName = (index: number): string => {
+			for (let i = index + 1; i < tokens.length; i++) {
+				const token = tokens[i];
+				if (token?.type === "html") return htmlTagNameFromToken(token);
+				if (
+					token?.type === "text" &&
+					"text" in token &&
+					typeof token.text === "string" &&
+					token.text.trim() === ""
+				) {
+					continue;
+				}
+				return "";
+			}
+			return "";
+		};
 
-		for (const token of tokens) {
+		for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+			const token = tokens[tokenIndex];
 			if (isMathToken(token)) {
+				markHtmlItemWhenContent(token.text);
 				result += applyTextWithNewlines(renderMathToken(token.text));
 				continue;
 			}
 			switch (token.type) {
-				case "text":
+				case "text": {
+					const rawText = trimLeadingWhitespace ? token.text.replace(/^\s+/, "") : token.text;
+					const text = normalizeHtmlEntitiesForTerminal(rawText);
+					if (isHtmlFormattingWhitespace(text, htmlState.previousTagName, nextHtmlTagName(tokenIndex))) break;
+					trimLeadingWhitespace = false;
+					markHtmlItemWhenContent(text);
+					if (token.tokens) markHtmlItemWhenContent(plainInlineTokens(token.tokens));
 					// Text tokens in list items can have nested tokens for inline formatting
 					if (token.tokens && token.tokens.length > 0) {
 						result += this.#renderInlineTokens(token.tokens, resolvedStyleContext);
 					} else {
-						result += renderTextWithSwatches(token.text, applyTextWithNewlines, swatchGlyph);
+						result += renderTextWithSwatches(text, applyTextWithNewlines, swatchGlyph);
 					}
+					if (text.trim() !== "") htmlState.previousTagName = "";
 					break;
+				}
 
 				case "paragraph":
 					// Paragraph tokens contain nested inline tokens
+					markHtmlItemWhenContent(plainInlineTokens(token.tokens || []));
 					result += this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					break;
 
 				case "strong": {
+					markHtmlItemWhenContent(plainInlineTokens(token.tokens || []));
 					const boldContent = this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					result += this.#theme.bold(boldContent) + stylePrefix;
 					break;
@@ -1056,16 +1289,19 @@ export class Markdown implements Component {
 
 				case "em": {
 					const italicContent = this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
+					markHtmlItemWhenContent(plainInlineTokens(token.tokens || []));
 					result += this.#theme.italic(italicContent) + stylePrefix;
 					break;
 				}
 
 				case "codespan": {
+					markHtmlItemWhenContent(token.text);
 					result += codespanSwatch(token.text, swatchGlyph) + this.#theme.code(token.text) + stylePrefix;
 					break;
 				}
 
 				case "link": {
+					markHtmlItemWhenContent(token.text);
 					const linkText = this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					const styledLinkText = this.#theme.link(this.#theme.underline(linkText));
 					const clickableLinkText = formatHyperlink(styledLinkText, token.href);
@@ -1085,25 +1321,39 @@ export class Markdown implements Component {
 
 				case "br":
 					result += "\n";
+					trimLeadingWhitespace = true;
 					break;
 
 				case "del": {
 					const delContent = this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
+					markHtmlItemWhenContent(plainInlineTokens(token.tokens || []));
 					result += this.#theme.strikethrough(delContent) + stylePrefix;
 					break;
 				}
 
 				case "html":
-					// Render inline HTML as plain text
 					if ("raw" in token && typeof token.raw === "string") {
-						result += applyTextWithNewlines(token.raw);
+						const cleaned = normalizeHtmlForTerminal(token.raw, htmlState);
+						if (cleaned === "\n" && shouldSkipHtmlListBreak(htmlState)) break;
+						result += applyTextWithNewlines(cleaned);
+						if (cleaned.endsWith("\n")) {
+							trimLeadingWhitespace = true;
+						} else if (cleaned.length > 0) {
+							trimLeadingWhitespace = false;
+						}
 					}
 					break;
 
 				default:
 					// Handle any other inline token types as plain text
 					if ("text" in token && typeof token.text === "string") {
-						result += applyTextWithNewlines(token.text);
+						const rawText = trimLeadingWhitespace ? token.text.replace(/^\s+/, "") : token.text;
+						const text = normalizeHtmlEntitiesForTerminal(rawText);
+						if (isHtmlFormattingWhitespace(text, htmlState.previousTagName, nextHtmlTagName(tokenIndex))) break;
+						trimLeadingWhitespace = false;
+						markHtmlItemWhenContent(text);
+						result += applyTextWithNewlines(text);
+						if (text.trim() !== "") htmlState.previousTagName = "";
 					}
 			}
 		}
@@ -1260,6 +1510,10 @@ export class Markdown implements Component {
 		return Math.min(longest, maxWidth);
 	}
 
+	#terminalLineWidths(text: string): number[] {
+		return splitTerminalLines(text).map(line => visibleWidth(line));
+	}
+
 	/**
 	 * Wrap a table cell to fit into a column.
 	 *
@@ -1267,7 +1521,8 @@ export class Markdown implements Component {
 	 * consistently with the rest of the renderer.
 	 */
 	#wrapCellText(text: string, maxWidth: number): string[] {
-		return wrapTextWithAnsi(text, Math.max(1, maxWidth));
+		const cellWidth = Math.max(1, maxWidth);
+		return splitTerminalLines(text).flatMap(line => wrapTextWithAnsi(line, cellWidth));
 	}
 
 	/**
@@ -1307,13 +1562,15 @@ export class Markdown implements Component {
 		const minWordWidths: number[] = [];
 		for (let i = 0; i < numCols; i++) {
 			const headerText = this.#renderInlineTokens(token.header[i].tokens || [], styleContext);
-			naturalWidths[i] = visibleWidth(headerText);
+			const headerLineWidths = this.#terminalLineWidths(headerText);
+			naturalWidths[i] = Math.max(...headerLineWidths, 0);
 			minWordWidths[i] = Math.max(1, this.#getLongestWordWidth(headerText, maxUnbrokenWordWidth));
 		}
 		for (const row of token.rows) {
 			for (let i = 0; i < row.length; i++) {
 				const cellText = this.#renderInlineTokens(row[i].tokens || [], styleContext);
-				naturalWidths[i] = Math.max(naturalWidths[i] || 0, visibleWidth(cellText));
+				const cellLineWidths = this.#terminalLineWidths(cellText);
+				naturalWidths[i] = Math.max(naturalWidths[i] || 0, ...cellLineWidths);
 				minWordWidths[i] = Math.max(
 					minWordWidths[i] || 1,
 					this.#getLongestWordWidth(cellText, maxUnbrokenWordWidth),

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1435,6 +1435,184 @@ describe("Markdown.render reference stability", () => {
 		expect(narrow.every(line => visibleWidth(line) <= 30)).toBe(true);
 		expect(wide.every(line => visibleWidth(line) <= 60)).toBe(true);
 	});
+
+	it("formats common HTML tags inside table cells", () => {
+		const md = new Markdown(
+			"| Gemini result |\n| --- |\n| <ul><li>None. Static checks <br> are green.</li></ul> |",
+			0,
+			0,
+			defaultMarkdownTheme,
+		);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+		const bulletLineIndex = lines.findIndex(line => line.includes("• None. Static checks"));
+		const continuationLineIndex = lines.findIndex(line => line.includes("are green."));
+
+		expect(lines.some(line => /<\/?(?:br|ul|li)\b/i.test(line))).toBe(false);
+		expect(bulletLineIndex).toBeGreaterThan(-1);
+		expect(continuationLineIndex).toBeGreaterThan(bulletLineIndex);
+	});
+
+	it("drops pretty-printed HTML list whitespace", () => {
+		const block = new Markdown("<ul>\n  <li>First</li>\n  <li>Second</li>\n</ul>", 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line).trimEnd());
+		const table = new Markdown(
+			"| Result |\n| --- |\n| <ul>  <li>First</li>  <li>Second</li> </ul> |",
+			0,
+			0,
+			defaultMarkdownTheme,
+		)
+			.render(80)
+			.map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(block).toEqual(["• First", "• Second"]);
+		expect(table).toContain("| • First  |");
+		expect(table).toContain("| • Second |");
+		expect(table.some(line => /^\| {3,}\|$/.test(line))).toBe(false);
+	});
+
+	it("preserves separators between adjacent HTML tags inside table cells", () => {
+		const md = new Markdown(
+			"| Result |\n| --- |\n| <ul><li>First</li></ul><p>Second&nbsp;result.</p> |",
+			0,
+			0,
+			defaultMarkdownTheme,
+		);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+		const firstLineIndex = lines.findIndex(line => line.includes("• First"));
+		const secondLineIndex = lines.findIndex(line => line.includes("Second result."));
+
+		expect(lines.some(line => /<\/?(?:p|ul|li)\b|&nbsp;/i.test(line))).toBe(false);
+		expect(firstLineIndex).toBeGreaterThan(-1);
+		expect(secondLineIndex).toBeGreaterThan(firstLineIndex);
+	});
+
+	it("preserves ordered HTML list numbering", () => {
+		const md = new Markdown("<ol><li>First</li><li>Second</li></ol>", 0, 0, defaultMarkdownTheme);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(lines).toContain("1. First");
+		expect(lines).toContain("2. Second");
+		expect(lines.some(line => line.includes("• First") || line.includes("• Second"))).toBe(false);
+	});
+
+	it("keeps HTML list markers with paragraph-wrapped list text", () => {
+		const unordered = new Markdown("<ul><li><p>First</p></li></ul>", 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line).trimEnd());
+		const ordered = new Markdown('<ol start="3"><li><p>Third</p></li></ol>', 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line).trimEnd());
+		const table = new Markdown("| Result |\n| --- |\n| <ul><li><p>First</p></li></ul> |", 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(unordered).toContain("• First");
+		expect(unordered).not.toContain("•");
+		expect(unordered).not.toContain("First");
+		expect(ordered).toContain("3. Third");
+		expect(ordered).not.toContain("3.");
+		expect(ordered).not.toContain("Third");
+		expect(table).toContain("| • First |");
+		expect(table).not.toContain("| •       |");
+	});
+
+	it("fits table columns to split HTML lines", () => {
+		const md = new Markdown("| Result |\n| --- |\n| <ul><li>Pass<br>OK</li></ul> |", 0, 0, defaultMarkdownTheme);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+		const topBorder = lines.find(line => line.startsWith("+"));
+
+		expect(topBorder).toBe("+--------+");
+		expect(lines).toContain("| • Pass |");
+		expect(lines).toContain("| OK     |");
+	});
+
+	it("preserves repeated HTML line breaks as intentional blank spacing", () => {
+		const cases = ["First<br><br>Second", "First<br /><br />Second"];
+
+		for (const input of cases) {
+			const md = new Markdown(input, 0, 0, defaultMarkdownTheme);
+			const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+			const firstLineIndex = lines.indexOf("First");
+
+			expect(firstLineIndex).toBeGreaterThan(-1);
+			expect(lines[firstLineIndex + 1]).toBe("");
+			expect(lines[firstLineIndex + 2]).toBe("Second");
+		}
+	});
+
+	it("preserves repeated HTML line breaks inside table cells", () => {
+		const md = new Markdown("| Result |\n| --- |\n| First<br><br>Second |", 0, 0, defaultMarkdownTheme);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+		const firstLineIndex = lines.findIndex(line => line.includes("| First"));
+
+		expect(firstLineIndex).toBeGreaterThan(-1);
+		expect(lines[firstLineIndex + 1]).toContain("|        |");
+		expect(lines[firstLineIndex + 2]).toContain("| Second |");
+	});
+
+	it("indents nested HTML list items by list stack depth", () => {
+		const md = new Markdown(
+			'<ul><li>Parent<ul><li>Child</li><li>Second child</li></ul><ol start="3"><li>Ordered child</li></ol></li><li>Sibling</li></ul>',
+			0,
+			0,
+			defaultMarkdownTheme,
+		);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(lines).toContain("• Parent");
+		expect(lines).toContain("  • Child");
+		expect(lines).toContain("  • Second child");
+		expect(lines).toContain("  3. Ordered child");
+		expect(lines).toContain("• Sibling");
+		expect(lines).not.toContain("• Child");
+		expect(lines).not.toContain("• Second child");
+		expect(lines).not.toContain("3. Ordered child");
+	});
+
+	it("indents nested HTML list items inside table cells", () => {
+		const md = new Markdown(
+			"| Result |\n| --- |\n| <ul><li>Parent<ul><li>Child</li></ul></li></ul> |",
+			0,
+			0,
+			defaultMarkdownTheme,
+		);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(lines.some(line => line.includes("| • Parent"))).toBe(true);
+		expect(lines.some(line => line.includes("|   • Child"))).toBe(true);
+		expect(lines.some(line => line.includes("| • Child"))).toBe(false);
+	});
+
+	it("does not emit ANSI-only lines for empty styled HTML replacements", () => {
+		const md = new Markdown("<p></p>Visible", 0, 0, defaultMarkdownTheme, {
+			color: text => chalk.gray(text),
+			italic: true,
+		});
+		const lines = md.render(80);
+
+		const blankLines = lines.filter(line => stripVTControlCharacters(line).trimEnd() === "");
+		expect(blankLines.length).toBeGreaterThan(0);
+		expect(blankLines.every(line => !line.includes("\x1b["))).toBe(true);
+		expect(lines.some(line => stripVTControlCharacters(line).trimEnd() === "Visible")).toBe(true);
+	});
+
+	it("decodes non-breaking spaces in table text", () => {
+		const md = new Markdown("| Result |\n| --- |\n| A&nbsp;B |", 0, 0, defaultMarkdownTheme);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(lines.some(line => line.includes("A B"))).toBe(true);
+		expect(lines.some(line => line.includes("&nbsp;"))).toBe(false);
+	});
+
+	it("separates paragraph HTML tags instead of concatenating text", () => {
+		const md = new Markdown("<p>First result.</p><p>Second result.</p>", 0, 0, defaultMarkdownTheme);
+		const lines = md.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+		expect(lines).toContain("First result.");
+		expect(lines).toContain("Second result.");
+		expect(lines).not.toContain("First result.Second result.");
+	});
 });
 
 describe("Math rendering", () => {


### PR DESCRIPTION
The Markdown parser sometimes processes HTML blocks and inline HTML tags (like `<br>`, `<li>`, `<ul>`) that models output (e.g. inside table cells or formatted paragraphs). This PR cleans and formats these common HTML tags into terminal newlines and list bullets instead of rendering raw HTML tags literally.