### PR TITLE
feat(extensions): expose model resolve() + family() to extensions (ctx.models)

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Added the Umans AI Coding Plan provider catalog with Anthropic-compatible model metadata and dynamic discovery ([#2636](https://github.com/can1357/oh-my-pi/pull/2636) by [@oldschoola](https://github.com/oldschoola)).
 
+### Changed
+
+- Extended `modelFamilyToken(modelId)` to also classify GLM ids (`glm-*`) so provider mirrors fold onto one `glm` lineage (e.g. `zai/glm-5.2` and `zhipu-coding-plan/glm-5.2`), which `parseKnownModel` excludes ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 ## [16.0.0] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -110,6 +110,7 @@ export function isReasoningGlmModelId(modelId: string): boolean {
 export function isGlmVisionModelId(modelId: string): boolean {
 	return parseGlmModel(bareModelId(modelId))?.vision === true;
 }
+
 /**
  * Coarse vendor-lineage token for "are two models the same family?" checks
  * (e.g. picking a cross-family reviewer). All Claude point releases share a token,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -111,6 +111,10 @@
 - External editor (Ctrl-G) now shows full pasted content instead of `[paste #N ...]` placeholders ([#444](https://github.com/badlogic/pi-mono/pull/444) by [@aliou](https://github.com/aliou))
 - Subagent example README referenced incorrect filename `subagent.ts` instead of `index.ts` ([#427](https://github.com/badlogic/pi-mono/pull/427) by [@Whamp](https://github.com/Whamp))
 
+### Changed
+
+- Extended the extension `ctx.models` facade so `list()`/`resolve()` honor the session's path-scoped `enabledModels` allow-list — an extension now selects from the same scoped set core selection sees rather than the raw authenticated registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 ## [16.0.0] - 2026-06-15
 
 ### Breaking Changes
@@ -257,6 +261,7 @@
 - Added live (streaming) speech-to-text: with `stt.enabled` on, transcription now appears in the composer *as you speak* instead of all at once after you stop. The recorder streams raw 16 kHz mono PCM from sox/ffmpeg/arecord stdout to the warm STT worker, where an energy-based endpointer (no extra model) splits speech into segments at natural pauses; each finalized segment is committed into the editor while the in-progress segment shows a live volatile preview that refreshes in place and is kept out of the undo history. Works with both the default Parakeet (sherpa-onnx) and the Whisper (transformers.js) tiers. Recorders that cannot stream to a pipe (the Windows PowerShell mci fallback) transparently fall back to single-shot transcription.
 - Added `skills.enableAgentsUser` and `skills.enableAgentsProject` settings (default on) so the canonical OMP-native `~/.agent[s]/skills` and project-walkup `.agent[s]/skills` are configurable independently from the third-party Claude/Codex/Pi toggles.
 - Added a read-only `ctx.models` facade for extensions: `list()` (authenticated models), `current()` (live session model), `resolve(spec)` (a model string or role alias → `Model`, using the same settings-backed aliases and match preferences as core selection), and `family(model)` (opaque canonical-identity lineage token for cross-family comparisons). Lets extension tools select models the way core does without reaching into the mutable registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
+
 - Added RPC prompt lifecycle hints so hosts can distinguish scheduled agent turns from local-only slash commands via `data.agentInvoked` and `prompt_result`.
 - Added extension lifecycle events for tool approval prompts: `tool_approval_requested` before the approval wait and `tool_approval_resolved` after approve, deny, or approval prompt failure.
 

--- a/packages/coding-agent/src/extensibility/extensions/model-api.ts
+++ b/packages/coding-agent/src/extensibility/extensions/model-api.ts
@@ -9,7 +9,11 @@
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { modelFamilyToken } from "@oh-my-pi/pi-catalog/identity";
 import type { ModelRegistry } from "../../config/model-registry";
-import { getModelMatchPreferences, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	filterAvailableModelsByEnabledPatterns,
+	getModelMatchPreferences,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import type { ExtensionModelQuery } from "./types";
 
@@ -22,15 +26,31 @@ export function createExtensionModelQuery(
 	settings: Settings | undefined,
 	getModel: () => Model | undefined,
 ): ExtensionModelQuery {
+	// Honor the session's path-scoped `enabledModels` allow-list so an extension
+	// selects from the same scoped set core selection uses, not the raw auth set.
+	const available = (): Model<Api>[] => {
+		const all = modelRegistry.getAvailable();
+		const patterns = settings?.get("enabledModels");
+		if (!patterns || patterns.length === 0) return all;
+		const scoped = filterAvailableModelsByEnabledPatterns(all, patterns, modelRegistry);
+		// The live session model (e.g. an explicit `--model` override) wins over
+		// enabledModels in core selection, so keep it listable/resolvable even when
+		// it falls outside the configured scope.
+		const current = getModel();
+		if (current && !scoped.some(m => m.provider === current.provider && m.id === current.id)) {
+			return [current, ...scoped];
+		}
+		return scoped;
+	};
 	return {
-		list: () => modelRegistry.getAvailable(),
+		list: () => available(),
 		current: () => getModel(),
 		// resolveModelRoleValue expands a role alias (`pi/slow`) to its full configured
 		// priority list and tries each pattern — the same path core selection uses — so a
 		// fallback model lower in the list still resolves. Plain model strings pass through
 		// as a single pattern.
 		resolve: (spec: string): Model<Api> | undefined =>
-			resolveModelRoleValue(spec, modelRegistry.getAvailable(), {
+			resolveModelRoleValue(spec, available(), {
 				settings,
 				matchPreferences: getModelMatchPreferences(settings),
 				modelRegistry,

--- a/packages/coding-agent/test/extensibility/ext-model-query.test.ts
+++ b/packages/coding-agent/test/extensibility/ext-model-query.test.ts
@@ -59,6 +59,7 @@ describe("createExtensionModelQuery", () => {
 	test("resolve() honors configured role aliases via the same settings-backed path as core", () => {
 		const settings = {
 			getModelRole: (role: string) => (role === "slow" ? "anthropic/claude-opus-4-8" : undefined),
+			get: () => undefined,
 		} as unknown as Settings;
 		const q = createExtensionModelQuery(registry(), settings, () => undefined);
 		expect(q.resolve("pi/slow")).toBe(claude);
@@ -80,5 +81,27 @@ describe("createExtensionModelQuery", () => {
 		} as unknown as ModelRegistry;
 		const q = createExtensionModelQuery(reg, undefined, () => undefined);
 		expect(q.family(proxy)).toBe(q.family(claude));
+	});
+
+	test("list() and resolve() honor the session enabledModels allow-list", () => {
+		const settings = {
+			get: (key: string) => (key === "enabledModels" ? ["anthropic/*"] : undefined),
+			getModelRole: () => undefined,
+		} as unknown as Settings;
+		const reg = {
+			getAvailable: () => available,
+			getCanonicalId: (m: Model<Api>) => m.id,
+			getCanonicalVariants: () => [],
+		} as unknown as ModelRegistry;
+		const q = createExtensionModelQuery(reg, settings, () => undefined);
+		// gpt is authenticated but outside the anthropic-only scope: hidden + unresolvable.
+		expect(q.list()).toEqual([claude]);
+		expect(q.resolve("gpt-5.4")).toBeUndefined();
+		expect(q.resolve("anthropic/claude-opus-4-8")).toBe(claude);
+		// An explicit session model outside the scope (e.g. a `--model` override, which
+		// core honors over enabledModels) stays listable and resolvable.
+		const qOverride = createExtensionModelQuery(reg, settings, () => gpt);
+		expect(qOverride.list()).toContain(gpt);
+		expect(qOverride.resolve("openai/gpt-5.4")).toBe(gpt);
 	});
 });


### PR DESCRIPTION
Implements #2406 — the read-only model-query half of the extension model API.

> Supersedes #2410, which GitHub put into an unreopenable state after a force-push (its PR head desynced from the branch and `reopen` returns `422: branch was force-pushed or recreated`). Same branch (`feat/ext-model-query`), same commits, all review feedback already addressed — re-filed here so it can land.

## What

Adds a `ctx.models` facade so extension tools can select models the same way core does, without reaching into the mutable registry or re-implementing matching/family heuristics:

- `list()` — authenticated models available **this session** (scoped by `enabledModels`, see below).
- `current()` — the live session model (read lazily; reflects `/model` switches).
- `resolve(spec)` — a model string (`provider/id`, bare id) or role alias (`pi/slow`, a configured role) → `Model`, via `resolveModelRoleValue` (full configured role-priority list + settings-backed match preferences), the same path core selection uses. Returns `undefined` when nothing matches.
- `family(model)` — an opaque canonical-identity lineage token for "same family?" comparisons (every Claude point release shares a token; Claude vs GPT differ).

## Review feedback addressed (was on #2410's threads)

- **Resolve all role fallback patterns** — `resolve()` uses `resolveModelRoleValue` (full priority list), so a lower-priority authenticated fallback like `opus-4.8` resolves instead of returning `undefined`.
- **`family()` backed by `@oh-my-pi/pi-catalog/identity`** (`modelFamilyToken`), opaque/comparison-only, kind/variant collapsed (JSDoc notes it).
- **Respect `enabledModels`** — `list()`/`resolve()` now filter through `filterAvailableModelsByEnabledPatterns(getAvailable(), patterns, registry)` when the session configures `enabledModels`, so an extension selects from the same scoped set core selection sees rather than the raw authenticated registry (this also makes the facade match its own "available this session" docstring).
- **Classify GLM / fold OpenAI mirrors** — `modelFamilyToken()` falls back to `parseGlmModel` for GLM (which `parseKnownModel` excludes) and to a predicate for the `gpt-4o` / `chatgpt-*` / `o1`·`o3`·`o4-mini` ids that `parseOpenAIModel`'s `gpt-<n>` shape misses, so OpenRouter/direct mirrors fold onto one lineage. `gpt-oss` keeps its own token.
- CHANGELOG entries under `[Unreleased]` in both touched packages.

## Tests

- `packages/catalog/test/identity-family.test.ts` — `modelFamilyToken`: point-release grouping, Claude-vs-GPT split, aggregator-mirror/namespace folding, GLM cross-provider grouping, OpenAI `gpt-4o`/o-series mirror folding.
- `packages/coding-agent/test/extensibility/ext-model-query.test.ts` — facade `list`/`current` (lazy) / `resolve` (string + role alias + miss) / `family` grouping / `enabledModels` scoping (an out-of-scope authenticated model is hidden from `list()` and `resolve()`).
- `tsgo --noEmit` + `biome check` clean for the touched packages. (Note: current `main` has an unrelated pre-existing `tsgo` error in `src/modes/runtime-init.ts:59` — `Promise<boolean>` vs `Promise<void>` — reproducible on a clean `origin/main` checkout; not introduced here.)

## Next

Companion #2407 (`ctx.models.complete()`) builds on this — PR #2411, stacked on this branch.
