### PR TITLE
fix(coding-agent): avoid placeholder crash before theme init

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed paste and image placeholders crashing when the editor renders before theme initialization.
+
 ## [15.13.0] - 2026-06-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { $ } from "bun";
 import { getEditorTheme, initTheme } from "../theme/theme";
 import { CustomEditor, SPACE_HOLD_RELEASE_MS, SPACE_HOLD_THRESHOLD } from "./custom-editor";
 
@@ -14,6 +15,32 @@ function makeEditor() {
 function holdSpace(editor: CustomEditor, count: number): void {
 	for (let i = 0; i < count; i++) editor.handleInput(" ");
 }
+
+async function decorateInFreshProcess(text: string): Promise<string> {
+	const customEditorUrl = new URL("./custom-editor.ts", import.meta.url).href;
+	const script = `
+import { CustomEditor } from ${JSON.stringify(customEditorUrl)};
+const editor = new CustomEditor({});
+process.stdout.write(editor.decorateText(${JSON.stringify(text)}));
+`;
+	const child = await $`bun -e ${script}`.quiet().nothrow();
+	const stdout = child.stdout.toString();
+	const stderr = child.stderr.toString();
+	if (child.exitCode !== 0) throw new Error(stderr || stdout || `decorate subprocess exited with ${child.exitCode}`);
+	return stdout;
+}
+
+describe("CustomEditor placeholder decoration", () => {
+	it("renders paste placeholders before theme initialization", async () => {
+		const output = await decorateInFreshProcess("[Paste #1, +30 lines]");
+		expect(output).toBe("[Paste #1, +30 lines]");
+	});
+
+	it("renders image placeholders before theme initialization", async () => {
+		const output = await decorateInFreshProcess("[Image #1]");
+		expect(output).toBe("[Image #1]");
+	});
+});
 
 describe("CustomEditor space-hold push-to-talk", () => {
 	beforeAll(async () => {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -3,7 +3,7 @@ import type { AppKeybinding } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
-import { theme } from "../theme/theme";
+import { fgOrPlain } from "../theme/theme";
 
 type ConfigurableEditorAction = Extract<
 	AppKeybinding,
@@ -178,9 +178,9 @@ export class CustomEditor extends Editor {
 			renderReference: (value, kind, index) =>
 				kind === "image"
 					? imageReferenceHyperlink(value, index, this.imageLinks, label =>
-							theme.fg("accent", `\x1b[1m\x1b[4m${label}\x1b[24m\x1b[22m`),
+							fgOrPlain("accent", label, `\x1b[1m\x1b[4m${label}\x1b[24m\x1b[22m`),
 						)
-					: theme.fg("accent", `\x1b[1m${value}\x1b[22m`),
+					: fgOrPlain("accent", value, `\x1b[1m${value}\x1b[22m`),
 		});
 	};
 

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2098,6 +2098,11 @@ var currentThemeName: string | undefined;
 export function getCurrentThemeName(): string | undefined {
 	return currentThemeName;
 }
+
+/** Returns unstyled `text` before `initTheme()` assigns the global theme; use only for early-render paths. */
+export function fgOrPlain(color: ThemeColor, text: string, styledText: string = text): string {
+	return typeof theme === "undefined" ? text : theme.fg(color, styledText);
+}
 var currentSymbolPresetOverride: SymbolPreset | undefined;
 var currentColorBlindMode: boolean = false;
 var themeWatcher: fs.FSWatcher | undefined;


### PR DESCRIPTION
## Summary

Fixes a crash when the coding-agent editor renders paste or image placeholders before the global theme has finished initializing.

Large pastes are collapsed into markers such as `[Paste #1, +30 lines]`, and image references use `[Image #1]`. Rendering those markers previously called the module-global `theme.fg(...)` directly from `CustomEditor.decorateText()`. In programmatic or early-render paths, `theme` can still be undefined because it is assigned asynchronously by `initTheme()`, causing a `TypeError` before the editor can render.

## Reproduction

Before this fix, from a fresh checkout with dependencies installed and the native addon built:

```sh
bun -e 'import { CustomEditor } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const e = new CustomEditor({}); console.log(e.decorateText("[Paste #1, +30 lines]"));'
```

failed with:

```txt
TypeError: undefined is not an object (evaluating 'theme.fg')
    at renderReference (.../packages/coding-agent/src/modes/components/custom-editor.ts)
    at renderPlaceholders (.../packages/coding-agent/src/modes/image-references.ts)
```

The same path after `await initTheme()` succeeded, confirming the crash was specific to placeholder rendering before theme initialization.

## Fix

- Added a small `fgOrPlain()` helper in the theme module that applies foreground styling when the theme exists and returns plain text before initialization.
- Updated paste and image placeholder rendering to use that helper instead of dereferencing `theme` directly.
- Added regression coverage that renders paste and image placeholders in a fresh process before `initTheme()` runs.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification

- `bun --cwd=packages/coding-agent test src/modes/components/custom-editor.test.ts`
- `bun --cwd=packages/coding-agent run fmt`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run lint`
