### PR TITLE
fix(goals): retry turns failing with Gemini MALFORMED_FUNCTION_CALL

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -483,6 +483,7 @@ function injectIntentIntoSchema(schema: unknown, mode: "require" | "optional" = 
 		properties: {
 			[INTENT_FIELD]: {
 				type: "string",
+				description: "Concise intent in present participle form (2-6 words) strictly on a single line, no newlines",
 			},
 			...properties,
 		},

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `ConfigFile.tryLoadAsync()`, `ConfigFile.loadAsync()`, `ConfigFile.loadOrDefaultAsync()`, `ConfigFile.getMtimeMsAsync()`, and `ConfigFile.warmup(file)` so the rest of the codebase can migrate config reads off the sync path.
 
 ### Fixed
+- Fixed a bug where Gemini MALFORMED_FUNCTION_CALL tool-generation errors (which are transient) surfaced as terminal error blocks. Added "malformed function call" to the transient transport error classifier so the session automatically retries the turn.
 
 - Fixed `Test & smoke (TS)` CI timeouts caused by parallel test files racing on the process-global Settings singleton. `CustomEditor` now accepts a `magicKeywordsEnabledOverride` injection point so the shimmer-gate test can assert behaviour without calling `resetSettingsForTest()` / `Settings.init()`; the "streaming tool call preview height" describe drops its gratuitous Settings reset+init. Production wiring is unchanged ([#2582](https://github.com/can1357/oh-my-pi/issues/2582))
 - Fixed MCP OAuth fallback rendering to show a short terminal hyperlink and keep the raw authorization URL on one unwrapped copy line ([#2121](https://github.com/can1357/oh-my-pi/issues/2121)).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8466,7 +8466,7 @@ export class AgentSession {
 		// src/http/h2_client/dispatch.zig)
 		return (
 			isUnexpectedSocketCloseMessage(errorMessage) ||
-			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)/i.test(
+			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|malformed.?function.?call/i.test(
 				errorMessage,
 			)
 		);

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1237,4 +1237,56 @@ describe("AgentSession retry fallback", () => {
 		await modelRegistry.refresh("offline");
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o")).toBe(false);
 	});
+
+	it("auto-retries Gemini MALFORMED_FUNCTION_CALL transient errors", async () => {
+		const model = getBundledModel("google", "gemini-1.5-flash");
+		if (!model) {
+			throw new Error("Expected bundled Google test model to exist");
+		}
+
+		const malformedError = "Generation failed with finish reason: MALFORMED_FUNCTION_CALL";
+		const requestedModels: string[] = [];
+
+		const mock = createMockModel({
+			responses: [{ throw: malformedError }, { content: ["Recovered after Gemini malformed function call"] }],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+
+		await session.prompt("recover from Gemini malformed error");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(2);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(session.agent.state.messages).toHaveLength(2);
+		expect(session.agent.state.messages[1].role).toBe("assistant");
+		expect(session.agent.state.messages[1].content[0].text).toBe("Recovered after Gemini malformed function call");
+	});
 });


### PR DESCRIPTION
This pull request fixes a transient `MALFORMED_FUNCTION_CALL` error when using Google Gemini models for tool calling.

### 🐛 The Issue (Root Cause)
During tool-use generation, Gemini models occasionally output a literal newline character inside the string value of the `_i` (intent) parameter (especially when intents are long and near the model's typical line-wrapping width). In standard JSON, raw newlines are illegal inside string literals. The Gemini API's internal parser rejects the unescaped newline, failing the generation with:
`finishReason: "MALFORMED_FUNCTION_CALL"`

OMP previously treated this finish reason as a hard, terminal error, halting execution.

### 🛠️ The Fixes
1. **Preventative (Constrained Decoding)**: Added a `description` to the injected `_i` schema property inside `injectIntentIntoSchema`:
   `description: "Concise intent in present participle form (2-6 words) strictly on a single line, no newlines"`
   This guides the model's logit generation to keep intents short and avoid outputting line breaks in the parameter value.
2. **Defensive (Transient Retry)**: Added `malformed.?function.?call` (case-insensitively) to the transient transport error classifier in `agent-session.ts` so that if a malformed call occurs, OMP automatically retries the turn and continues execution smoothly.