### PR TITLE
fix(coding-agent): preserve explicit RPC host-defaulted settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -173,6 +173,8 @@
 - Fixed a collapsed, still-streaming tool preview (an `eval`/`bash`/`ssh` box with output streaming in) reading as "weirdly truncated" — top border and head rows missing — once its box outgrew the viewport, snapping back to whole only while expanded with `ctrl+o` and breaking again when collapsed. A streaming preview was classified commit-unstable whenever collapsed, so the transcript offered none of its rows to native scrollback; once the box outgrew the window its head fell into the gap between the commit boundary and the window top, committed nowhere and repainted nowhere. The `provisionalPendingPreview` flag now applies only to the pending call preview (before any result) — once a streaming result exists the result renderer is the live, top-anchored shape and the block is commit-stable in both collapsed and expanded states, so its durable head always reaches scrollback.
 - Fixed a crash in subagent task execution and extensions when a string (instead of a string array) was returned or set for the system prompt. Gracefully wrap string values in arrays.
 
+- Fixed RPC/ACP host-defaulted settings overwriting explicit `config.yml` or `--config` values, including `todo.reminders: false` being replaced by schema defaults in RPC mode ([#2598](https://github.com/can1357/oh-my-pi/issues/2598)).
+
 ## [15.13.0] - 2026-06-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -149,8 +149,20 @@ const RPC_BACKGROUND_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"bash.autoBackground.thresholdMs",
 ];
 
+// Some legacy settings are both a leaf setting and a parent for a newer nested
+// setting; defaulting the child must not replace an explicitly configured scalar parent.
+const DEFAULT_OVERRIDE_PARENT_PATHS: Partial<Record<SettingPath, SettingPath>> = {
+	"todo.reminders.max": "todo.reminders",
+};
+
+function hasConfiguredOverridePath(settingPath: SettingPath, targetSettings: Settings): boolean {
+	const parentPath = DEFAULT_OVERRIDE_PARENT_PATHS[settingPath];
+	return targetSettings.isConfigured(settingPath) || (!!parentPath && targetSettings.isConfigured(parentPath));
+}
+
 function applyDefaultSettingOverrides(settingPaths: SettingPath[], targetSettings: Settings): void {
 	for (const settingPath of settingPaths) {
+		if (hasConfiguredOverridePath(settingPath, targetSettings)) continue;
 		targetSettings.override(settingPath, getDefault(settingPath));
 	}
 }

--- a/packages/coding-agent/test/rpc-host-defaults.test.ts
+++ b/packages/coding-agent/test/rpc-host-defaults.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+type HostSettingsSnapshot = {
+	todoEnabled: unknown;
+	todoReminders: unknown;
+	todoEager: unknown;
+	taskIsolationMode: unknown;
+	taskIsolationMerge: unknown;
+	taskIsolationCommits: unknown;
+	taskEager: unknown;
+	taskBatch: unknown;
+	taskMaxConcurrency: unknown;
+	taskMaxRecursionDepth: unknown;
+	taskDisabledAgents: unknown;
+	taskAgentModelOverrides: unknown;
+	memoryBackend: unknown;
+	memoriesEnabled: unknown;
+};
+
+type RpcBackgroundSettingsSnapshot = {
+	asyncEnabled: unknown;
+	asyncMaxJobs: unknown;
+	bashAutoBackground: unknown;
+	bashAutoBackgroundThresholdMs: unknown;
+};
+
+type ObservedSettingsSnapshot = {
+	host: HostSettingsSnapshot;
+	rpcBackground: RpcBackgroundSettingsSnapshot;
+};
+
+describe("RPC host-defaulted settings", () => {
+	const hostConfig = [
+		"todo:",
+		"  enabled: false",
+		"  reminders: false",
+		"  eager: always",
+		"task:",
+		"  isolation:",
+		"    mode: auto",
+		"    merge: branch",
+		"    commits: ai",
+		"  eager: always",
+		"  batch: false",
+		"  maxConcurrency: 2",
+		"  maxRecursionDepth: 0",
+		"  disabledAgents:",
+		"    - explore",
+		"    - quick_task",
+		"  agentModelOverrides:",
+		"    explore: anthropic/claude-test",
+		"memory:",
+		"  backend: local",
+		"memories:",
+		"  enabled: true",
+		"async:",
+		"  enabled: false",
+		"  maxJobs: 7",
+		"bash:",
+		"  autoBackground:",
+		"    enabled: true",
+		"    thresholdMs: 1234",
+		"",
+	].join("\n");
+
+	const remindersMaxConfig = ["todo:", "  reminders:", "    max: 5", ""].join("\n");
+
+	function observeHostSettings(settings: Settings): HostSettingsSnapshot {
+		return {
+			todoEnabled: settings.get("todo.enabled"),
+			todoReminders: settings.get("todo.reminders"),
+			todoEager: settings.get("todo.eager"),
+			taskIsolationMode: settings.get("task.isolation.mode"),
+			taskIsolationMerge: settings.get("task.isolation.merge"),
+			taskIsolationCommits: settings.get("task.isolation.commits"),
+			taskEager: settings.get("task.eager"),
+			taskBatch: settings.get("task.batch"),
+			taskMaxConcurrency: settings.get("task.maxConcurrency"),
+			taskMaxRecursionDepth: settings.get("task.maxRecursionDepth"),
+			taskDisabledAgents: settings.get("task.disabledAgents"),
+			taskAgentModelOverrides: settings.get("task.agentModelOverrides"),
+			memoryBackend: settings.get("memory.backend"),
+			memoriesEnabled: settings.get("memories.enabled"),
+		};
+	}
+
+	function observeRpcBackgroundSettings(settings: Settings): RpcBackgroundSettingsSnapshot {
+		return {
+			asyncEnabled: settings.get("async.enabled"),
+			asyncMaxJobs: settings.get("async.maxJobs"),
+			bashAutoBackground: settings.get("bash.autoBackground.enabled"),
+			bashAutoBackgroundThresholdMs: settings.get("bash.autoBackground.thresholdMs"),
+		};
+	}
+
+	async function observeStartupSettings(mode: "rpc" | "acp", configText: string) {
+		using tempDir = TempDir.createSync(`@omp-${mode}-host-defaults-`);
+		const root = tempDir.path();
+		const agentDir = path.join(root, "agent");
+		await Bun.write(path.join(agentDir, "config.yml"), configText);
+		resetSettingsForTest();
+		const settings = await Settings.init({ agentDir, cwd: root });
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		let observed: ObservedSettingsSnapshot | undefined;
+		const stopMessage = "stop after settings observation";
+		const capture = (observedSettings: Settings): never => {
+			observed = {
+				host: observeHostSettings(observedSettings),
+				rpcBackground: observeRpcBackgroundSettings(observedSettings),
+			};
+			throw new Error(stopMessage);
+		};
+
+		try {
+			await runRootCommand(
+				{
+					mode,
+					messages: [],
+					fileArgs: [],
+					unknownFlags: new Map(),
+					unrecognizedFlags: [],
+					noSkills: true,
+					noRules: true,
+					noTools: true,
+					noLsp: true,
+					sessionDir: root,
+				},
+				[],
+				{
+					discoverAuthStorage: async () => authStorage,
+					settings,
+					createAgentSession: async (options): Promise<never> => {
+						if (!options?.settings) throw new Error("Expected RPC session settings");
+						return capture(options.settings);
+					},
+					runAcpMode: async (): Promise<never> => capture(settings),
+				},
+			);
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== stopMessage) {
+				throw error;
+			}
+		} finally {
+			authStorage.close();
+			resetSettingsForTest();
+		}
+
+		if (!observed) throw new Error(`Expected ${mode} settings observation`);
+		return observed;
+	}
+
+	const expectedHostSettings = {
+		todoEnabled: false,
+		todoReminders: false,
+		todoEager: "always",
+		taskIsolationMode: "auto",
+		taskIsolationMerge: "branch",
+		taskIsolationCommits: "ai",
+		taskEager: "always",
+		taskBatch: false,
+		taskMaxConcurrency: 2,
+		taskMaxRecursionDepth: 0,
+		taskDisabledAgents: ["explore", "quick_task"],
+		taskAgentModelOverrides: { explore: "anthropic/claude-test" },
+		memoryBackend: "local",
+		memoriesEnabled: true,
+	};
+
+	it("preserves explicit host-defaulted config values in RPC mode", async () => {
+		await expect(observeStartupSettings("rpc", hostConfig)).resolves.toEqual({
+			host: expectedHostSettings,
+			rpcBackground: {
+				asyncEnabled: false,
+				asyncMaxJobs: 7,
+				bashAutoBackground: true,
+				bashAutoBackgroundThresholdMs: 1234,
+			},
+		});
+	});
+
+	it("preserves explicit host-defaulted config values in ACP mode", async () => {
+		await expect(observeStartupSettings("acp", hostConfig)).resolves.toMatchObject({
+			host: expectedHostSettings,
+		});
+	});
+
+	it("preserves todo.reminders.max without replacing the reminders object", async () => {
+		await expect(observeStartupSettings("rpc", remindersMaxConfig)).resolves.toMatchObject({
+			host: {
+				todoReminders: { max: 5 },
+			},
+		});
+		await expect(observeStartupSettings("acp", remindersMaxConfig)).resolves.toMatchObject({
+			host: {
+				todoReminders: { max: 5 },
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-host-defaults.test.ts
+++ b/packages/coding-agent/test/rpc-host-defaults.test.ts
@@ -105,6 +105,7 @@ describe("RPC host-defaulted settings", () => {
 		await Bun.write(path.join(agentDir, "config.yml"), configText);
 		resetSettingsForTest();
 		const settings = await Settings.init({ agentDir, cwd: root });
+		const previousNoTitle = Bun.env.PI_NO_TITLE;
 		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
 		let observed: ObservedSettingsSnapshot | undefined;
 		const stopMessage = "stop after settings observation";
@@ -147,6 +148,11 @@ describe("RPC host-defaulted settings", () => {
 			}
 		} finally {
 			authStorage.close();
+			if (previousNoTitle === undefined) {
+				delete Bun.env.PI_NO_TITLE;
+			} else {
+				Bun.env.PI_NO_TITLE = previousNoTitle;
+			}
 			resetSettingsForTest();
 		}
 


### PR DESCRIPTION
## Repro
In RPC mode, load `config.yml` with `todo.reminders: false`, then start `runRootCommand({ mode: "rpc" })` with a test `createAgentSession` hook that observes the effective settings before the RPC transport starts. Before the fix, `bun --cwd=packages/coding-agent test test/rpc-host-defaults.test.ts` failed with `Expected: false` and `Received: { max: 3 }`, proving host defaults overwrote the explicit config.

## Cause
`packages/coding-agent/src/main.ts` applied `applyDefaultSettingOverrides()` unconditionally for RPC/ACP host-defaulted paths. That wrote schema defaults into the runtime override layer even when `Settings.isConfigured(path)` was already true from `config.yml` or `--config`; `todo.reminders.max` also clobbered an explicit scalar `todo.reminders: false` because `Settings.override()` creates nested objects for child paths.

## Fix
- Guard host-default application with `Settings.isConfigured()` so explicit global/project/overlay values win.
- Skip child default overrides when an explicitly configured parent setting would otherwise be replaced.
- Add `test/rpc-host-defaults.test.ts` to assert RPC startup preserves explicit `todo.reminders`, `task.maxConcurrency`, and `async.enabled` config values.
- Add an Unreleased changelog entry for the RPC/ACP settings precedence fix.

## Verification
Ran `bun --cwd=packages/coding-agent run check` and `bun --cwd=packages/coding-agent test test/rpc-host-defaults.test.ts test/acp-lazy-startup.test.ts`; both passed. Fixes #2598