### PR TITLE
feat: canonical-equivalence failover + swarm patterns + synthetic blended models

### DIFF
--- a/packages/catalog/src/identity/selection.ts
+++ b/packages/catalog/src/identity/selection.ts
@@ -29,17 +29,16 @@ const SOURCE_RANK: Record<CanonicalModelVariant["source"], number> = {
 };
 
 /**
- * Pick the preferred variant. Sort order: configured provider rank →
+ * Rank the variants, best-first. Sort order: configured provider rank →
  * exact-id match → variant source (override/bundled > heuristic > fallback)
- * → shorter id → candidate-list order.
+ * → shorter id → candidate-list order. Returns the full ranked chain so
+ * callers can fall through to lower-ranked variants when the top pick is
+ * unavailable.
  */
-export function resolveCanonicalVariant(
+export function rankCanonicalVariants(
 	variants: readonly CanonicalModelVariant[],
 	preferences: CanonicalVariantPreferences,
-): CanonicalModelVariant | undefined {
-	if (variants.length === 0) {
-		return undefined;
-	}
+): CanonicalModelVariant[] {
 	const { providerRank, modelOrder } = preferences;
 	return [...variants].sort((left, right) => {
 		const leftProviderRank = providerRank.get(left.model.provider.toLowerCase()) ?? Number.MAX_SAFE_INTEGER;
@@ -61,5 +60,21 @@ export function resolveCanonicalVariant(
 		const leftOrder = modelOrder.get(left.selector) ?? Number.MAX_SAFE_INTEGER;
 		const rightOrder = modelOrder.get(right.selector) ?? Number.MAX_SAFE_INTEGER;
 		return leftOrder - rightOrder;
-	})[0];
+	});
+}
+
+/**
+ * Pick the preferred variant — the top of {@link rankCanonicalVariants}.
+ * Sort order: configured provider rank → exact-id match → variant source
+ * (override/bundled > heuristic > fallback) → shorter id → candidate-list
+ * order.
+ */
+export function resolveCanonicalVariant(
+	variants: readonly CanonicalModelVariant[],
+	preferences: CanonicalVariantPreferences,
+): CanonicalModelVariant | undefined {
+	if (variants.length === 0) {
+		return undefined;
+	}
+	return rankCanonicalVariants(variants, preferences)[0];
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -418,6 +418,80 @@ export type CompatOf<TApi extends Api> = TApi extends "openai-completions"
 			? ResolvedAnthropicCompat
 			: undefined;
 
+/**
+ * One member of a blended (synthetic) model. A member is either a leaf model
+ * (`kind: "model"`, the default) streamed through `streamSimple`, or a full
+ * subagent (`kind: "subagent"`) run through the in-package subagent runner.
+ * `model` is a model id or `provider/id` string resolved against the registry
+ * (so each member fails over independently via the provider order).
+ */
+export interface SwarmMember {
+	/**
+	 * The member's role within the blend. Strategy-specific:
+	 * - `router`: candidate targets (`selector` picks one);
+	 * - `sequence`/`draft-refine`: ordered stages (e.g. `draft`, `refine`);
+	 * - `moa`: `proposer` members fan out; an `aggregator` synthesizes/votes.
+	 */
+	role: string;
+	/** Model id or `provider/id` to resolve for this member. */
+	model: string;
+	/**
+	 * Effect edge for this member. `"model"` (default) streams the resolved
+	 * model via `streamSimple`; `"subagent"` runs a full subagent.
+	 */
+	kind?: "model" | "subagent";
+	/**
+	 * When `true`, this member's content events are forwarded to the outer
+	 * blended stream (the user-visible surface). Exactly one member is the
+	 * surface; if none sets it, the strategy's natural terminal member surfaces.
+	 */
+	surface?: boolean;
+}
+
+/**
+ * How a `router` strategy chooses a single member. `"classifier"` asks a
+ * classifier model to pick by difficulty/intent; `"rule"` applies a static
+ * heuristic. The chosen member is the one whose `role` matches the result.
+ */
+export interface SwarmSelector {
+	/** Selection mechanism: an LLM classifier or a static rule. */
+	kind: "classifier" | "rule";
+	/** Model id / `provider/id` used to classify when `kind === "classifier"`. */
+	model?: string;
+}
+
+/**
+ * Declarative spec for a synthetic blended model (`api: "omp-swarm"`). Blends
+ * several members' streams into one coherent `AssistantMessageEventStream`:
+ * - `router`: classify the request, dispatch to exactly one member;
+ * - `draft-refine`/`sequence`: pipe each member's output into the next;
+ * - `moa`: run `proposer` members in parallel, then an `aggregator` synthesizes.
+ *
+ * The executor reads this off `Model.swarm`; `buildModel` preserves it via
+ * spread, so no build step or wire serialization touches it.
+ */
+export interface SwarmSpec {
+	/** Blend strategy selecting the reduce semantics over `members`. */
+	strategy: "router" | "draft-refine" | "sequence" | "moa";
+	/** The blend members, in order (order is significant for `sequence`). */
+	members: SwarmMember[];
+	/** How a `router` strategy picks the single member to run. */
+	selector?: SwarmSelector;
+	/**
+	 * Role of the member whose content is surfaced to the user. Falls back to
+	 * any member's `surface: true`, else the strategy's terminal member.
+	 */
+	surface?: string;
+	/** Hard cap on members actually run (guards runaway blends; default 5). */
+	maxMembers?: number;
+	/**
+	 * Watchdog budget for the first content event of the surfaced stream. A
+	 * parallel/`moa` blend emits an early `start` + status so the agent-loop
+	 * first-event watchdog doesn't misfire on pre-aggregation latency.
+	 */
+	firstEventTimeoutMs?: number;
+}
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
 	id: string;
@@ -482,6 +556,13 @@ export interface Model<TApi extends Api = Api> {
 	priority?: number;
 	/** Canonical thinking capability metadata for this model. */
 	thinking?: ThinkingConfig;
+	/**
+	 * Blend spec for a synthetic model (`api: "omp-swarm"`). When present, this
+	 * model is virtual: its `streamSimple` fans out across `swarm.members` and
+	 * reduces their streams into one. Preserved verbatim through `buildModel`'s
+	 * spread; the blend executor reads it at dispatch time.
+	 */
+	swarm?: SwarmSpec;
 	/**
 	 * Fully-resolved compatibility record, materialized once by `buildModel`.
 	 * Protocol handlers read fields; they never detect, resolve, or allocate.

--- a/packages/catalog/test/canonical-variant-ranking.test.ts
+++ b/packages/catalog/test/canonical-variant-ranking.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import type { CanonicalModelVariant } from "@oh-my-pi/pi-catalog/identity/equivalence";
+import {
+	type CanonicalVariantPreferences,
+	rankCanonicalVariants,
+	resolveCanonicalVariant,
+} from "@oh-my-pi/pi-catalog/identity/selection";
+import type { Api, Model } from "@oh-my-pi/pi-catalog/types";
+
+function variant(opts: {
+	provider: string;
+	id: string;
+	canonicalId: string;
+	source?: CanonicalModelVariant["source"];
+}): CanonicalModelVariant {
+	const selector = `${opts.provider}/${opts.id}`;
+	return {
+		canonicalId: opts.canonicalId,
+		selector,
+		source: opts.source ?? "heuristic",
+		model: { id: opts.id, provider: opts.provider } as unknown as Model<Api>,
+	};
+}
+
+function prefs(opts?: {
+	providerRank?: Iterable<[string, number]>;
+	modelOrder?: Iterable<[string, number]>;
+}): CanonicalVariantPreferences {
+	return {
+		providerRank: new Map(opts?.providerRank ?? []),
+		modelOrder: new Map(opts?.modelOrder ?? []),
+	};
+}
+
+describe("rankCanonicalVariants / resolveCanonicalVariant", () => {
+	test("resolve equals rank[0] for a single variant", () => {
+		const variants = [variant({ provider: "openai", id: "gpt-5", canonicalId: "gpt-5" })];
+		const preferences = prefs();
+		const ranked = rankCanonicalVariants(variants, preferences);
+		expect(ranked).toHaveLength(1);
+		expect(resolveCanonicalVariant(variants, preferences)).toBe(ranked[0]!);
+	});
+
+	test("resolve equals rank[0] across multi-provider variants by provider rank", () => {
+		const variants = [
+			variant({ provider: "together", id: "llama-3", canonicalId: "llama-3" }),
+			variant({ provider: "openrouter", id: "llama-3", canonicalId: "llama-3" }),
+			variant({ provider: "aimlapi", id: "llama-3", canonicalId: "llama-3" }),
+		];
+		const preferences = prefs({
+			providerRank: [
+				["openrouter", 0],
+				["aimlapi", 1],
+				["together", 2],
+			],
+		});
+		const ranked = rankCanonicalVariants(variants, preferences);
+		expect(ranked.map(v => v.model.provider)).toEqual(["openrouter", "aimlapi", "together"]);
+		expect(resolveCanonicalVariant(variants, preferences)).toBe(ranked[0]!);
+	});
+
+	test("resolve equals rank[0] when modelOrder breaks the final tie", () => {
+		// Same provider rank, same exact-id status, same source, same id length:
+		// only modelOrder distinguishes them.
+		const variants = [
+			variant({ provider: "openai", id: "abc", canonicalId: "xyz" }),
+			variant({ provider: "openai", id: "def", canonicalId: "xyz" }),
+		];
+		const preferences = prefs({
+			modelOrder: [
+				["openai/def", 0],
+				["openai/abc", 1],
+			],
+		});
+		const ranked = rankCanonicalVariants(variants, preferences);
+		expect(ranked.map(v => v.selector)).toEqual(["openai/def", "openai/abc"]);
+		expect(resolveCanonicalVariant(variants, preferences)).toBe(ranked[0]!);
+	});
+
+	test("rank is byte-identical with resolve over a mixed variant set", () => {
+		const variants = [
+			variant({ provider: "fallbackco", id: "model-long-id", canonicalId: "canon", source: "fallback" }),
+			variant({ provider: "openai", id: "canon", canonicalId: "canon", source: "bundled" }),
+			variant({ provider: "anthropic", id: "canon-x", canonicalId: "canon", source: "override" }),
+			variant({ provider: "heuristicco", id: "canon-y", canonicalId: "canon", source: "heuristic" }),
+		];
+		const preferences = prefs({
+			providerRank: [
+				["openai", 0],
+				["anthropic", 0],
+				["heuristicco", 1],
+			],
+			modelOrder: [["anthropic/canon-x", 5]],
+		});
+		const ranked = rankCanonicalVariants(variants, preferences);
+		expect(ranked).toHaveLength(variants.length);
+		expect(resolveCanonicalVariant(variants, preferences)).toBe(ranked[0]!);
+		// resolve must always equal the head of the ranked chain.
+		expect(resolveCanonicalVariant(variants, preferences)).toBe(rankCanonicalVariants(variants, preferences)[0]!);
+	});
+
+	test("empty input: resolve is undefined, rank is empty", () => {
+		const preferences = prefs();
+		expect(rankCanonicalVariants([], preferences)).toEqual([]);
+		expect(resolveCanonicalVariant([], preferences)).toBeUndefined();
+	});
+});

--- a/packages/catalog/test/swarm-spec.test.ts
+++ b/packages/catalog/test/swarm-spec.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec, SwarmSpec } from "@oh-my-pi/pi-catalog/types";
+
+function swarmModelSpec(swarm: SwarmSpec): ModelSpec<"omp-swarm"> {
+	return {
+		id: "router-balanced",
+		name: "Router Balanced",
+		api: "omp-swarm",
+		provider: "omp",
+		baseUrl: "omp://",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 32_000,
+		swarm,
+	};
+}
+
+function plainModelSpec(): ModelSpec<"openai-completions"> {
+	return {
+		id: "plain-model",
+		name: "Plain Model",
+		api: "openai-completions",
+		provider: "custom",
+		baseUrl: "https://api.example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+describe("Model.swarm round-trip through buildModel", () => {
+	it("preserves a router SwarmSpec deep-equal (spread carries it, no build step touches it)", () => {
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			members: [
+				{ role: "weak", model: "openai/gpt-4o-mini", kind: "model" },
+				{ role: "strong", model: "anthropic/claude-opus-4.6", kind: "model", surface: true },
+			],
+			selector: { kind: "classifier", model: "openai/gpt-4o-mini" },
+			surface: "strong",
+			maxMembers: 3,
+			firstEventTimeoutMs: 30_000,
+		};
+
+		const model = buildModel(swarmModelSpec(swarm));
+
+		expect(model.swarm).toEqual(swarm);
+		expect(model.api).toBe("omp-swarm");
+	});
+
+	it("preserves a draft-refine sequence SwarmSpec deep-equal", () => {
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "openai/gpt-4o-mini" },
+				{ role: "refine", model: "anthropic/claude-opus-4.6", surface: true },
+			],
+		};
+
+		const model = buildModel(swarmModelSpec(swarm));
+
+		expect(model.swarm).toEqual(swarm);
+		expect(model.swarm?.strategy).toBe("draft-refine");
+		expect(model.swarm?.members[0]?.kind).toBeUndefined();
+	});
+
+	it("preserves a moa SwarmSpec with a subagent leaf member deep-equal", () => {
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "openai/gpt-4o" },
+				{ role: "proposer", model: "openai/gpt-4o" },
+				{ role: "aggregator", model: "anthropic/claude-opus-4.6", surface: true },
+				{ role: "reviewer", model: "task/reviewer", kind: "subagent" },
+			],
+		};
+
+		const model = buildModel(swarmModelSpec(swarm));
+
+		expect(model.swarm).toEqual(swarm);
+		expect(model.swarm?.members.find(member => member.kind === "subagent")?.role).toBe("reviewer");
+	});
+});
+
+describe("Model.swarm is absent on non-swarm models", () => {
+	it("yields swarm === undefined for a normal model (no contamination)", () => {
+		const model = buildModel(plainModelSpec());
+
+		expect(model.swarm).toBeUndefined();
+		expect("swarm" in model).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -56,6 +56,7 @@ import {
 	getBundledCanonicalReferenceData,
 	getBundledModelReferenceIndex,
 	type ModelEquivalenceConfig,
+	rankCanonicalVariants,
 	resolveCanonicalVariant,
 	resolveModelReference,
 } from "@oh-my-pi/pi-catalog/identity";
@@ -1770,6 +1771,39 @@ export class ModelRegistry {
 
 	getCanonicalId(model: Model<Api>): string | undefined {
 		return this.#ensureCanonicalIndex().bySelector.get(formatCanonicalVariantSelector(model).toLowerCase());
+	}
+
+	/**
+	 * Rank the available canonical-equivalent *siblings* of a model — the
+	 * failover chain — ordered by the configured `modelProviderOrder` (and
+	 * candidate order), most-preferred first.
+	 *
+	 * The input `model` is its own canonical equivalent, so it is excluded from
+	 * the result: the chain is the set of OTHER providers/variants serving the
+	 * same canonical id that a caller can fall back to. Consequences:
+	 *   - a singleton-canonical model (only its own provider serves the id)
+	 *     yields `[]` — there is nothing to fail over to, so callers never face
+	 *     an empty-chain hazard nor a chain that retries the primary first;
+	 *   - an unknown-canonical model (not in the equivalence index, so
+	 *     {@link getCanonicalId} returns `undefined`) also yields `[]`.
+	 *
+	 * Availability is always enforced (`availableOnly`), so the chain only ever
+	 * contains models whose provider currently has auth configured.
+	 */
+	rankCanonicalVariantsFor(model: Model<Api>, options?: CanonicalModelQueryOptions): Model<Api>[] {
+		const canonicalId = this.getCanonicalId(model);
+		if (!canonicalId) {
+			return [];
+		}
+		const variants = this.getCanonicalVariants(canonicalId, { ...options, availableOnly: true });
+		if (variants.length === 0) {
+			return [];
+		}
+		const candidates = options?.candidates ?? this.getAvailable();
+		const selfSelector = formatCanonicalVariantSelector(model).toLowerCase();
+		return rankCanonicalVariants(variants, this.#variantPreferences(candidates))
+			.map(variant => variant.model)
+			.filter(candidate => formatCanonicalVariantSelector(candidate).toLowerCase() !== selfSelector);
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import * as path from "node:path";
-import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { getCustomApi, registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Api, Context, Model, ModelSpec, SimpleStreamOptions, ThinkingConfig } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
@@ -65,7 +65,14 @@ import {
 import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import { parseModelString, resolveModelFromString, resolveProviderModelReference } from "../config/model-resolver";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
-import { OMP_PROVIDER_SOURCE_ID, registerSwarmApi } from "../swarm/executor";
+import {
+	OMP_BASE_URL,
+	OMP_PROVIDER_NAME,
+	OMP_PROVIDER_SOURCE_ID,
+	OMP_SWARM_API,
+	registerSwarmApi,
+} from "../swarm/executor";
+import { OMP_PRESET_MODELS, OMP_PRESET_SOURCE_ID } from "../swarm/presets";
 import { type ApiKeyResolverModel, type ApiKeyResolverOptions, createApiKeyResolver } from "./api-key-resolver";
 import type { ConfigError, ConfigFile } from "./config-file";
 import {
@@ -707,6 +714,9 @@ export class ModelRegistry {
 		// neither rebinds nor breaks an existing owner), so this is safe on every
 		// construction.
 		this.#registerOmpSwarmApi();
+		// Register the built-in `omp/*` blend presets (U9). Runtime overlays so they
+		// survive refresh(); a DISTINCT source id keeps them off the dispatcher's slot.
+		this.#registerOmpPresets();
 	}
 
 	/**
@@ -744,6 +754,50 @@ export class ModelRegistry {
 			return streamSimple(model, context, { ...options, apiKey });
 		};
 		registerSwarmApi({ resolveModel, streamSimple: memberStreamSimple }, OMP_PROVIDER_SOURCE_ID);
+	}
+
+	/**
+	 * Register the built-in `omp/*` blend presets (U9): `omp/router-balanced`,
+	 * `omp/draft-refine`, `omp/moa-synthesis`. Each carries a {@link SwarmSpec} and
+	 * surfaces via `getAvailable()` / `resolveModelFromString` like any model.
+	 *
+	 * Deferred concern #1 (keyless registration): the `omp` provider is keyless
+	 * (added to `#keylessProviders` in `#addImplicitDiscoverableProviders`, run by
+	 * the preceding `#loadModels()`), so `registerProvider` passes `keyless: true`
+	 * into `validateProviderConfiguration` and the "apiKey/oauth required when
+	 * models[] defined" check is relaxed — these presets register with no credential
+	 * (members authenticate independently). No non-secret sentinel key is needed;
+	 * relaxing the check for keyless providers is the cleaner of the two options
+	 * because it (a) avoids a fake credential that the resolver would otherwise try
+	 * to use, and (b) reuses the registry's existing keyless concept rather than
+	 * inventing a sentinel string the rest of the auth path must learn to ignore.
+	 *
+	 * Deferred concern #2 (source-id collision): presets register under
+	 * {@link OMP_PRESET_SOURCE_ID} (`"omp-presets"`), DISTINCT from the dispatcher's
+	 * `OMP_PROVIDER_SOURCE_ID` (`"omp-builtin"`). The `omp-swarm` custom-API
+	 * dispatcher is a process-global, instance-free, first-writer-wins singleton
+	 * registered under `"omp-builtin"`; if the presets shared that id, a
+	 * `clearSourceRegistrations("omp-builtin")` would `unregisterCustomApis` and
+	 * tear the live dispatcher down. Keeping the per-registry preset PROVIDER
+	 * lifecycle separate from the dispatcher API lifecycle decouples the two. As a
+	 * defensive belt-and-suspenders, we also re-assert the dispatcher here if its
+	 * slot is somehow empty (`getCustomApi` self-heal), mirroring `registerSwarmApi`.
+	 *
+	 * Per-`Model` deps binding (so several live registries each attribute their own
+	 * member resolver/auth) remains the optional follow-up noted on the dispatcher.
+	 */
+	#registerOmpPresets(): void {
+		// Self-heal: if the dispatcher slot was torn down (e.g. a prior
+		// clearSourceRegistrations on its source), re-assert it before the presets go
+		// live so a resolved `omp/*` model can actually dispatch.
+		if (getCustomApi(OMP_SWARM_API) === undefined) {
+			this.#registerOmpSwarmApi();
+		}
+		this.registerProvider(
+			OMP_PROVIDER_NAME,
+			{ api: OMP_SWARM_API, baseUrl: OMP_BASE_URL, models: OMP_PRESET_MODELS },
+			OMP_PRESET_SOURCE_ID,
+		);
 	}
 
 	/**
@@ -2058,6 +2112,10 @@ export class ModelRegistry {
 				apiKey: config.apiKey,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
+				// Keyless providers (the synthetic `omp` blend shell) may declare models
+				// with no credential: each blend member authenticates independently. This
+				// relaxes the "apiKey/oauth required when models[] defined" check for them.
+				keyless: this.#keylessProviders.has(providerName),
 				models: (config.models ?? []) as ProviderValidationModel[],
 			},
 			"runtime-register",

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -18,6 +18,7 @@ import {
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 } from "@oh-my-pi/pi-catalog/provider-models";
+import type { SwarmSpec } from "@oh-my-pi/pi-catalog/types";
 import {
 	collapseBuiltModelVariants,
 	getVariantAliasSources,
@@ -431,6 +432,7 @@ interface CustomModelDefinitionLike extends ModelPatch {
 	api?: Api;
 	baseUrl?: string;
 	cost?: Model<Api>["cost"];
+	swarm?: SwarmSpec;
 }
 
 interface CustomModelBuildOptions {
@@ -444,6 +446,7 @@ interface CustomModelOverlay extends ModelPatch {
 	baseUrl: string;
 	cost?: Model<Api>["cost"];
 	isOAuth?: boolean;
+	swarm?: SwarmSpec;
 }
 
 function mergeCustomModelHeaders(
@@ -516,6 +519,7 @@ function buildCustomModelOverlay(
 		contextPromotionTarget: modelDef.contextPromotionTarget,
 		premiumMultiplier: modelDef.premiumMultiplier,
 		isOAuth: resolveCustomModelIsOAuth(api, providerAuth),
+		swarm: modelDef.swarm,
 	};
 }
 
@@ -554,6 +558,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		contextPromotionTarget: resolvedModel.contextPromotionTarget,
 		premiumMultiplier: resolvedModel.premiumMultiplier,
 		isOAuth: resolvedModel.isOAuth,
+		swarm: resolvedModel.swarm,
 	} as ModelSpec<Api>);
 }
 
@@ -1065,6 +1070,11 @@ export class ModelRegistry {
 			});
 			this.#keylessProviders.add("lm-studio");
 		}
+		// The synthetic-blend provider `omp` (api: "omp-swarm") needs no credentials
+		// of its own — each blend member resolves and authenticates independently.
+		// Mark it keyless unconditionally (re-applied on every reload, so it survives
+		// refresh()) so getAvailable() surfaces runtime-registered `omp/*` models.
+		this.#keylessProviders.add("omp");
 	}
 
 	#loadCustomModels(): CustomModelsResult {
@@ -2246,5 +2256,6 @@ export interface ProviderConfigInput {
 		compat?: ModelSpec<Api>["compat"];
 		contextPromotionTarget?: string;
 		premiumMultiplier?: number;
+		swarm?: SwarmSpec;
 	}>;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import * as path from "node:path";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Api, Context, Model, ModelSpec, SimpleStreamOptions, ThinkingConfig } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -62,8 +63,9 @@ import {
 	resolveModelReference,
 } from "@oh-my-pi/pi-catalog/identity";
 import { isRecord, logger } from "@oh-my-pi/pi-utils";
-import { parseModelString, resolveProviderModelReference } from "../config/model-resolver";
+import { parseModelString, resolveModelFromString, resolveProviderModelReference } from "../config/model-resolver";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
+import { OMP_PROVIDER_SOURCE_ID, registerSwarmApi } from "../swarm/executor";
 import { type ApiKeyResolverModel, type ApiKeyResolverOptions, createApiKeyResolver } from "./api-key-resolver";
 import type { ConfigError, ConfigFile } from "./config-file";
 import {
@@ -700,6 +702,48 @@ export class ModelRegistry {
 		});
 		// Load models synchronously in constructor.
 		this.#loadModels();
+		// Register the synthetic-blend `omp-swarm` custom API. The global dispatcher
+		// is installed once and is instance-free (first-writer-wins: re-construction
+		// neither rebinds nor breaks an existing owner), so this is safe on every
+		// construction.
+		this.#registerOmpSwarmApi();
+	}
+
+	/**
+	 * Register the `omp-swarm` blend executor as a custom streaming API. The
+	 * executor resolves each blend member id against this registry and streams it
+	 * with the member's own per-model API-key resolver, so members fail over and
+	 * authenticate independently (the synthetic `omp` provider itself is keyless).
+	 *
+	 * The custom-API slot is keyed by the literal `"omp-swarm"` string, so it is
+	 * shared process-wide. The instance-free global dispatcher ({@link registerSwarmApi})
+	 * is installed once and is first-writer-wins: the first registry to register
+	 * owns the slot and its deps, and a later (possibly transient) registry neither
+	 * rebinds it (no hijack of a live blend's members/auth) nor breaks it (no
+	 * poison-latch). One active owner per process; per-`Model` deps binding for the
+	 * multi-registry case is a follow-up (U9). Members still authenticate and fail
+	 * over independently via the owner's per-member resolver; the `omp` shell itself
+	 * is keyless.
+	 */
+	#registerOmpSwarmApi(): void {
+		const resolveModel = (modelId: string): Model<Api> => {
+			const resolved = resolveModelFromString(modelId, this.getAll(), undefined, this);
+			if (!resolved) {
+				throw new Error(`omp-swarm: cannot resolve blend member model "${modelId}".`);
+			}
+			return resolved;
+		};
+		// Per-member transport: stream each member with its own provider resolver so
+		// auth/baseUrl follow the member, not the keyless `omp` shell.
+		const memberStreamSimple = (
+			model: Model<Api>,
+			context: Context,
+			options?: SimpleStreamOptions,
+		): AssistantMessageEventStream => {
+			const apiKey = this.resolver(model);
+			return streamSimple(model, context, { ...options, apiKey });
+		};
+		registerSwarmApi({ resolveModel, streamSimple: memberStreamSimple }, OMP_PROVIDER_SOURCE_ID);
 	}
 
 	/**

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -59,6 +59,36 @@ export const OpenAICompatSchema = OpenAICompatFieldsSchema.extend({
 	whenThinking: OpenAICompatFieldsSchema.optional(),
 });
 
+/**
+ * Zod mirror of the catalog `SwarmSpec`/`SwarmMember`/`SwarmSelector`
+ * (`packages/catalog/src/types.ts`). Required so user-authored `swarm:` blocks
+ * in the models config survive parsing — `ModelsConfigSchema` strips unknown
+ * keys, so without this mirror the field is silently dropped before it reaches
+ * the custom-model build pipeline (KTD-4). Members are bounded by `.min(1)`
+ * (an empty blend has nothing to run); the strategy enum and selector kind are
+ * closed enums so an invalid blend fails parse rather than silently mis-routing.
+ */
+const SwarmMemberSchema = z.object({
+	role: z.string().min(1),
+	model: z.string().min(1),
+	kind: z.enum(["model", "subagent"]).optional(),
+	surface: z.boolean().optional(),
+});
+
+const SwarmSelectorSchema = z.object({
+	kind: z.enum(["classifier", "rule"]),
+	model: z.string().min(1).optional(),
+});
+
+const SwarmSpecSchema = z.object({
+	strategy: z.enum(["router", "draft-refine", "sequence", "moa"]),
+	members: z.array(SwarmMemberSchema).min(1),
+	selector: SwarmSelectorSchema.optional(),
+	surface: z.string().min(1).optional(),
+	maxMembers: z.number().optional(),
+	firstEventTimeoutMs: z.number().optional(),
+});
+
 const EffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh"]);
 
 const ThinkingControlModeSchema = z.enum([
@@ -127,11 +157,13 @@ const ModelDefinitionSchema = z.object({
 			"google-generative-ai",
 			"google-gemini-cli",
 			"google-vertex",
+			"omp-swarm",
 		])
 		.optional(),
 	baseUrl: z.string().min(1).optional(),
 	reasoning: z.boolean().optional(),
 	thinking: ModelThinkingSchema.optional(),
+	swarm: SwarmSpecSchema.optional(),
 	input: z.array(z.enum(["text", "image"])).optional(),
 	cost: z
 		.object({
@@ -196,6 +228,7 @@ const ProviderConfigSchema = z.object({
 			"google-generative-ai",
 			"google-gemini-cli",
 			"google-vertex",
+			"omp-swarm",
 		])
 		.optional(),
 	headers: z.record(z.string(), z.string()).optional(),

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -32,6 +32,15 @@ export interface ProviderValidationConfig {
 	disableStrictTools?: boolean;
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
+	/**
+	 * The provider authenticates with no credentials of its own (it is in the
+	 * registry's keyless set, e.g. the synthetic `omp` provider whose blend members
+	 * authenticate independently). When true, the `apiKey`/`oauth`-required-when-
+	 * `models[]`-defined check is relaxed: a keyless provider can declare models
+	 * (built-in blend presets) without carrying a credential. This mirrors the
+	 * `models-config` path, which already exempts `auth: "none"` providers.
+	 */
+	keyless?: boolean;
 }
 
 export function validateProviderConfiguration(
@@ -66,7 +75,7 @@ export function validateProviderConfiguration(
 		}
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
+				? !config.apiKey && !config.oauthConfigured && !config.keyless
 				: !config.apiKey && (config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,14 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
+import {
+	isClaudeModelId,
+	isDeepseekModelIdOrName,
+	isKimiModelId,
+	isMimoModelIdOrName,
+	isMinimaxM2FamilyModelId,
+	isOpenAIGptOssModelId,
+	isQwenModelId,
+} from "@oh-my-pi/pi-catalog/identity";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import {
@@ -65,6 +74,91 @@ function compactSearchText(value: string): string {
 
 function getAlphaSearchTokens(query: string): string[] {
 	return [...normalizeSearchText(query).matchAll(/[a-z]+/g)].map(match => match[0]).filter(token => token.length > 0);
+}
+
+/**
+ * Orthogonal grouping dimensions for the picker's group view. `null` is the
+ * default (provider-tab / MRU / recency) view, left untouched. The `g` keybind
+ * cycles through the non-null dimensions and back to `null`.
+ */
+type GroupDimension = "provider" | "family" | "cost-tier" | "capability";
+
+const GROUP_DIMENSIONS: ReadonlyArray<GroupDimension> = ["provider", "family", "cost-tier", "capability"];
+
+const GROUP_DIMENSION_LABEL: Record<GroupDimension, string> = {
+	provider: "Provider",
+	family: "Family",
+	"cost-tier": "Cost tier",
+	capability: "Capability",
+};
+
+/** Classify a model into a coarse family bucket via the shared identity predicates. */
+function familyGroupKey(model: Model): string {
+	const id = `${model.provider}/${model.id}`;
+	if (isClaudeModelId(id)) return "Claude";
+	if (isKimiModelId(id)) return "Kimi";
+	if (isQwenModelId(id)) return "Qwen";
+	if (isDeepseekModelIdOrName(id) || isDeepseekModelIdOrName(model.name)) return "DeepSeek";
+	if (isMimoModelIdOrName(id) || isMimoModelIdOrName(model.name)) return "MiMo";
+	if (isMinimaxM2FamilyModelId(id)) return "MiniMax";
+	if (isOpenAIGptOssModelId(id)) return "GPT-OSS";
+	if (/(^|\/)(gpt|o\d|chatgpt)/i.test(id)) return "OpenAI";
+	if (/(^|\/)gemini/i.test(id)) return "Gemini";
+	if (/(^|\/)grok/i.test(id)) return "Grok";
+	if (/(^|\/)llama/i.test(id)) return "Llama";
+	if (/(^|\/)glm/i.test(id)) return "GLM";
+	return "Other";
+}
+
+/** Bucket a model by blended ($/1M) cost into free / low / mid / high tiers. */
+function costTierGroupKey(model: Model): string {
+	const blended = (model.cost?.input ?? 0) + (model.cost?.output ?? 0);
+	if (blended <= 0) return "Free / local";
+	if (blended < 2) return "Low cost";
+	if (blended < 15) return "Mid cost";
+	return "High cost";
+}
+
+/** Bucket a model by capability: reasoning support and context-window size. */
+function capabilityGroupKey(model: Model): string {
+	const reasoning = model.reasoning || model.thinking !== undefined;
+	const context = model.contextWindow ?? 0;
+	const longContext = context >= 200_000;
+	if (reasoning && longContext) return "Reasoning + long context";
+	if (reasoning) return "Reasoning";
+	if (longContext) return "Long context";
+	return "Standard";
+}
+
+function groupKeyFor(model: Model, dimension: GroupDimension): string {
+	switch (dimension) {
+		case "provider":
+			return model.provider;
+		case "family":
+			return familyGroupKey(model);
+		case "cost-tier":
+			return costTierGroupKey(model);
+		case "capability":
+			return capabilityGroupKey(model);
+	}
+}
+
+/**
+ * Stable reorder so all items sharing a group key are contiguous, in first-seen
+ * group order (which inherits the upstream sort), preserving within-group order.
+ */
+function groupContiguously<T extends { model: Model }>(items: ReadonlyArray<T>, dimension: GroupDimension): T[] {
+	const buckets = new Map<string, T[]>();
+	for (const item of items) {
+		const key = groupKeyFor(item.model, dimension);
+		const bucket = buckets.get(key);
+		if (bucket) {
+			bucket.push(item);
+		} else {
+			buckets.set(key, [item]);
+		}
+	}
+	return Array.from(buckets.values()).flat();
 }
 
 function computeModelRank(model: Model, roles: Record<string, RoleAssignment | undefined>): number {
@@ -162,6 +256,10 @@ export class ModelSelectorComponent extends Container {
 	#canonicalModels: CanonicalModelItem[] = [];
 	#filteredCanonicalModels: CanonicalModelItem[] = [];
 	#selectedIndex: number = 0;
+	// Orthogonal group view. `null` keeps the default provider-tab/MRU/recency
+	// ordering untouched; non-null values render section headers within the
+	// already-filtered list and reorder it so each group is contiguous.
+	#groupDimension: GroupDimension | null = null;
 	#roles = {} as Record<string, RoleAssignment | undefined>;
 	#settings = null as unknown as Settings;
 	#modelRegistry = null as unknown as ModelRegistry;
@@ -836,6 +934,14 @@ export class ModelSelectorComponent extends Container {
 			this.#filteredCanonicalModels = baseCanonicalModels;
 		}
 
+		// Group view is orthogonal to the default sort: it only reorders the
+		// already-sorted/filtered list so each group is contiguous, preserving
+		// the within-group order the comparators produced.
+		if (this.#groupDimension) {
+			this.#filteredModels = groupContiguously(this.#filteredModels, this.#groupDimension);
+			this.#filteredCanonicalModels = groupContiguously(this.#filteredCanonicalModels, this.#groupDimension);
+		}
+
 		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
 		this.#selectedIndex = this.#coerceSelectedIndex(
 			Math.min(this.#selectedIndex, Math.max(0, visibleItems.length - 1)),
@@ -847,6 +953,29 @@ export class ModelSelectorComponent extends Container {
 	#applyTabFilter(): void {
 		const query = this.#searchInput.getValue();
 		this.#filterModels(query);
+	}
+
+	/**
+	 * Advance the orthogonal group view: null -> provider -> family -> cost-tier
+	 * -> capability -> null. Re-applies the current filter so the grouped
+	 * reordering and section headers refresh, pinning the highlighted item by
+	 * selector so cycling never yanks the selection.
+	 */
+	#cycleGroupDimension(): void {
+		const selectedKey = this.#getSelectedItem()?.selector;
+		const current = this.#groupDimension;
+		const currentIndex = current ? GROUP_DIMENSIONS.indexOf(current) : -1;
+		this.#groupDimension = GROUP_DIMENSIONS[currentIndex + 1] ?? null;
+		this.#applyTabFilter();
+		if (selectedKey) {
+			const visibleItems = this.#getVisibleItems();
+			const restoredIndex = visibleItems.findIndex(item => item.selector === selectedKey);
+			if (restoredIndex >= 0) {
+				this.#selectedIndex = this.#coerceSelectedIndex(restoredIndex, visibleItems);
+			}
+		}
+		this.#updateList();
+		this.#tui.requestRender();
 	}
 
 	#formatDiscoveryAge(fetchedAt: number | undefined): string | undefined {
@@ -921,6 +1050,11 @@ export class ModelSelectorComponent extends Container {
 
 		const showProvider = this.#getActiveTabId() === ALL_TAB;
 
+		const groupDimension = this.#groupDimension;
+		// Undefined seed means the first visible row always prints its section
+		// header, so a viewport scrolled into the middle of a group keeps context.
+		let lastGroupKey: string | undefined;
+
 		const rows: string[] = [];
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
@@ -928,6 +1062,14 @@ export class ModelSelectorComponent extends Container {
 			if (!item) continue;
 			const canonicalItem = isCanonicalTab ? (item as CanonicalModelItem) : undefined;
 			const providerItem = isCanonicalTab ? undefined : (item as ModelItem);
+
+			if (groupDimension) {
+				const groupKey = groupKeyFor(item.model, groupDimension);
+				if (groupKey !== lastGroupKey) {
+					rows.push(theme.fg("dim", `  ${GROUP_DIMENSION_LABEL[groupDimension]}: ${theme.bold(groupKey)}`));
+					lastGroupKey = groupKey;
+				}
+			}
 
 			const isSelected = i === this.#selectedIndex;
 			const isDisabled = this.#isItemDisabled(item);
@@ -1025,6 +1167,7 @@ export class ModelSelectorComponent extends Container {
 			);
 		}
 	}
+
 	#getThinkingLevelsForModel(model: Model): ReadonlyArray<ConfiguredThinkingLevel> {
 		return [ThinkingLevel.Inherit, ThinkingLevel.Off, AUTO_THINKING, ...getSupportedEfforts(model)];
 	}
@@ -1206,6 +1349,14 @@ export class ModelSelectorComponent extends Container {
 		// Escape or Ctrl+C - close selector
 		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
 			this.#onCancelCallback();
+			return;
+		}
+
+		// 'g' cycles the orthogonal group view. Only intercepted while the search
+		// box is empty so a 'g' typed into a query (e.g. "glm", "grok") still
+		// reaches the search input and the default view stays untouched.
+		if (keyData === "g" && this.#searchInput.getValue().length === 0) {
+			this.#cycleGroupDimension();
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,5 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { Model, SwarmSpec } from "@oh-my-pi/pi-ai";
 import {
 	isClaudeModelId,
 	isDeepseekModelIdOrName,
@@ -117,6 +117,98 @@ function costTierGroupKey(model: Model): string {
 	if (blended < 2) return "Low cost";
 	if (blended < 15) return "Mid cost";
 	return "High cost";
+}
+
+/** Blended ($/1M) cost of one member, summing input + output rates. */
+export interface MemberCostRate {
+	input: number;
+	output: number;
+}
+
+/**
+ * Resolve a member's `model` selector (a model id or `provider/id`) to its
+ * per-million-token input/output rates, or `undefined` when the member can't be
+ * resolved (unknown model, no credentials). Injected so the cost helper stays
+ * pure and unit-testable without a `ModelRegistry`.
+ */
+export type MemberCostLookup = (modelId: string) => MemberCostRate | undefined;
+
+/** Summed blend cost plus the resolution tally that produced it. */
+export interface SwarmSummedCost {
+	/** Summed $/1M input rate across the counted members. */
+	input: number;
+	/** Summed $/1M output rate across the counted members. */
+	output: number;
+	/** `input + output` — the blended $/1M figure the picker row renders. */
+	blended: number;
+	/** How many member/selector calls were counted toward the sum. */
+	counted: number;
+	/** How many of those calls resolved to a known cost (the rest contributed 0). */
+	resolved: number;
+}
+
+/**
+ * PURE helper: compute the summed (~Nx) member cost of a blended model from its
+ * {@link SwarmSpec} and a {@link MemberCostLookup}, mirroring the executor's
+ * per-strategy spend (KTD-7) so the picker can surface it up front:
+ *
+ *   - `router` ≈ ONE member + the classifier. Only one member runs per turn, but
+ *     which one is data-dependent, so the row shows the worst case: the single
+ *     most expensive candidate member plus the classifier's selector call.
+ *   - `sequence` / `draft-refine` / `moa` = Σ members. Every member runs (moa
+ *     proposers fan out, the aggregator synthesizes), so the sum is over all of
+ *     them (after `maxMembers` capping, matching `capMembers`).
+ *
+ * Members that don't resolve contribute 0 (and are tallied in `resolved`) rather
+ * than aborting, so a partially-uncredentialed blend still shows a lower-bound
+ * figure. Returns `undefined` only when the cap leaves no members to count.
+ */
+export function computeSwarmSummedCost(swarm: SwarmSpec, lookup: MemberCostLookup): SwarmSummedCost | undefined {
+	const cap = swarm.maxMembers !== undefined && swarm.maxMembers > 0 ? swarm.maxMembers : 5;
+	const members = swarm.members.slice(0, cap);
+	if (members.length === 0) {
+		return undefined;
+	}
+
+	let input = 0;
+	let output = 0;
+	let counted = 0;
+	let resolved = 0;
+
+	const count = (rate: MemberCostRate | undefined): void => {
+		counted++;
+		if (rate) {
+			input += rate.input;
+			output += rate.output;
+			resolved++;
+		}
+	};
+
+	if (swarm.strategy === "router") {
+		// One member runs per turn; surface the worst case (priciest candidate).
+		let worst: MemberCostRate | undefined;
+		let worstBlended = -1;
+		for (const member of members) {
+			const rate = lookup(member.model);
+			const blended = rate ? rate.input + rate.output : 0;
+			if (blended > worstBlended) {
+				worstBlended = blended;
+				worst = rate;
+			}
+		}
+		count(worst);
+		const selectorModel = swarm.selector?.kind === "classifier" ? swarm.selector.model : undefined;
+		if (selectorModel !== undefined) {
+			count(lookup(selectorModel));
+		}
+	} else {
+		// sequence / draft-refine / moa: every (capped) member runs → sum all.
+		for (const member of members) {
+			count(lookup(member.model));
+		}
+	}
+
+	return { input, output, blended: input + output, counted, resolved };
 }
 
 /** Bucket a model by capability: reasoning support and context-window size. */
@@ -812,6 +904,36 @@ export class ModelSelectorComponent extends Container {
 		return ` ${theme.status.disabled} context>${formatNumber(model.contextWindow ?? 0).toLowerCase()}`;
 	}
 
+	/** Index every known model's $/1M rate by `provider/id` AND bare `id`. */
+	#buildMemberCostLookup(): MemberCostLookup {
+		const rates = new Map<string, MemberCostRate>();
+		for (const model of this.#modelRegistry.getAll()) {
+			const rate: MemberCostRate = { input: model.cost?.input ?? 0, output: model.cost?.output ?? 0 };
+			rates.set(`${model.provider}/${model.id}`, rate);
+			if (!rates.has(model.id)) {
+				rates.set(model.id, rate);
+			}
+		}
+		return modelId => rates.get(modelId);
+	}
+
+	/**
+	 * Render the summed (~Nx) member-cost suffix for a blended model. Returns "" for
+	 * non-blended models and blends with no resolvable members, leaving the row
+	 * unchanged (additive contract). `lookup` is built once per `#updateList` pass.
+	 */
+	#formatSwarmCostSuffix(model: Model, lookup: MemberCostLookup): string {
+		const swarm = model.swarm;
+		if (swarm === undefined) {
+			return "";
+		}
+		const summed = computeSwarmSummedCost(swarm, lookup);
+		if (summed === undefined || summed.resolved === 0) {
+			return "";
+		}
+		return ` ${theme.fg("dim", `~$${summed.blended.toFixed(2)}/1M`)}`;
+	}
+
 	#getVisibleItems(): ReadonlyArray<ModelItem | CanonicalModelItem> {
 		return this.#isCanonicalTab() ? this.#filteredCanonicalModels : this.#filteredModels;
 	}
@@ -1056,6 +1178,8 @@ export class ModelSelectorComponent extends Container {
 		let lastGroupKey: string | undefined;
 
 		const rows: string[] = [];
+		// Built once per render pass; reused for every visible blended row's cost.
+		const memberCostLookup = this.#buildMemberCostLookup();
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = visibleItems[i];
@@ -1074,6 +1198,10 @@ export class ModelSelectorComponent extends Container {
 			const isSelected = i === this.#selectedIndex;
 			const isDisabled = this.#isItemDisabled(item);
 			const disabledSuffix = this.#formatContextLimitSuffix(item.model);
+			// Additive: blended models render their summed (~Nx) member cost so the
+			// picker shows the real per-turn spend up front. Empty for normal models,
+			// leaving their existing row formatting byte-identical.
+			const swarmCostSuffix = this.#formatSwarmCostSuffix(item.model, memberCostLookup);
 
 			// Build role badges. Solid badges are configured; outlined badges are auto-selected defaults.
 			const roleBadgeTokens: string[] = [];
@@ -1100,24 +1228,24 @@ export class ModelSelectorComponent extends Container {
 				if (isCanonicalTab) {
 					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
 					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${theme.fg("accent", item.id)}${variants}${backing}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${theme.fg("accent", item.id)}${variants}${backing}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				} else if (showProvider) {
 					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${theme.fg("accent", providerItem?.id ?? item.id)}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${providerPrefix}${theme.fg("accent", providerItem?.id ?? item.id)}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				} else {
-					line = `${prefix}${theme.fg("accent", item.id)}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${theme.fg("accent", item.id)}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				}
 			} else {
 				const prefix = "  ";
 				if (isCanonicalTab) {
 					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
 					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${item.id}${variants}${backing}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${item.id}${variants}${backing}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				} else if (showProvider) {
 					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${providerItem?.id ?? item.id}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${providerPrefix}${providerItem?.id ?? item.id}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				} else {
-					line = `${prefix}${item.id}${badgeText}${disabledSuffix}`;
+					line = `${prefix}${item.id}${badgeText}${swarmCostSuffix}${disabledSuffix}`;
 				}
 			}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8578,7 +8578,15 @@ export class AgentSession {
 		const parsedCurrent = parseRetryFallbackSelector(currentSelector);
 		if (!parsedCurrent) return undefined;
 		const currentBaseSelector = formatRetryFallbackBaseSelector(parsedCurrent);
-		for (const role of Object.keys(this.#getRetryFallbackChains())) {
+		// Consider every role that has a configured model assignment, not only
+		// those with an explicit `fallbackChains` entry: implicit canonical
+		// failover (appended in #getRetryFallbackEffectiveChain) lets a role with
+		// a multi-provider primary fail over with no hand-authored chain.
+		const roles = new Set<string>([
+			...Object.keys(this.#getRetryFallbackChains()),
+			...Object.keys(this.settings.getModelRoles()),
+		]);
+		for (const role of roles) {
 			const primarySelector = this.#getRetryFallbackPrimarySelector(role);
 			if (!primarySelector) continue;
 			if (primarySelector.raw === currentSelector) return role;
@@ -8587,7 +8595,7 @@ export class AgentSession {
 		return undefined;
 	}
 
-	#getRetryFallbackEffectiveChain(role: string): RetryFallbackSelector[] {
+	#getRetryFallbackEffectiveChain(role: string, options?: { includeCanonical?: boolean }): RetryFallbackSelector[] {
 		const primarySelector = this.#getRetryFallbackPrimarySelector(role);
 		if (!primarySelector) return [];
 		const chain = [primarySelector];
@@ -8598,11 +8606,38 @@ export class AgentSession {
 			seen.add(parsed.raw);
 			chain.push(parsed);
 		}
+		// Implicit canonical-variant failover: after the explicit user chain,
+		// append the ranked CROSS-PROVIDER siblings of the primary canonical model
+		// (bedrock/openrouter/… of the same model), ordered by `modelProviderOrder`.
+		// The explicit chain takes precedence via `seen`, so users who hand-authored
+		// a chain are unaffected; singleton-canonical models contribute nothing
+		// (`rankCanonicalVariantsFor` returns []). Same-provider variants (e.g. a
+		// dated alias of the active model) are skipped: they share the account and
+		// credentials, so they can't recover an account-level quota block and would
+		// pre-empt the existing sibling-credential wait. Only included when the
+		// caller opts in (the QUOTA_EXHAUSTED path), so transient errors with no
+		// explicit chain keep retrying the same model.
+		if (options?.includeCanonical) {
+			const primaryModel = this.#modelRegistry.find(primarySelector.provider, primarySelector.id);
+			if (primaryModel) {
+				for (const variant of this.#modelRegistry.rankCanonicalVariantsFor(primaryModel, { availableOnly: true })) {
+					if (variant.provider === primarySelector.provider) continue;
+					const parsed = parseRetryFallbackSelector(formatModelString(variant));
+					if (!parsed || seen.has(parsed.raw)) continue;
+					seen.add(parsed.raw);
+					chain.push(parsed);
+				}
+			}
+		}
 		return chain;
 	}
 
-	#findRetryFallbackCandidates(role: string, currentSelector: string): RetryFallbackSelector[] {
-		const chain = this.#getRetryFallbackEffectiveChain(role);
+	#findRetryFallbackCandidates(
+		role: string,
+		currentSelector: string,
+		options?: { includeCanonical?: boolean },
+	): RetryFallbackSelector[] {
+		const chain = this.#getRetryFallbackEffectiveChain(role, options);
 		if (chain.length <= 1) return [];
 		const parsedCurrent = parseRetryFallbackSelector(currentSelector);
 		const currentBaseSelector = parsedCurrent ? formatRetryFallbackBaseSelector(parsedCurrent) : undefined;
@@ -8659,11 +8694,16 @@ export class AgentSession {
 		});
 	}
 
-	async #tryRetryModelFallback(currentSelector: string, options?: { pinFallback?: boolean }): Promise<boolean> {
+	async #tryRetryModelFallback(
+		currentSelector: string,
+		options?: { pinFallback?: boolean; includeCanonical?: boolean },
+	): Promise<boolean> {
 		const role = this.#activeRetryFallback?.role ?? this.#resolveRetryFallbackRole(currentSelector);
 		if (!role) return false;
 
-		for (const selector of this.#findRetryFallbackCandidates(role, currentSelector)) {
+		for (const selector of this.#findRetryFallbackCandidates(role, currentSelector, {
+			includeCanonical: options?.includeCanonical,
+		})) {
 			if (this.#isRetryFallbackSelectorSuppressed(selector)) continue;
 			const candidate = this.#modelRegistry.find(selector.provider, selector.id);
 			if (!candidate) continue;
@@ -8805,6 +8845,12 @@ export class AgentSession {
 		const errorMessage = message.errorMessage || "Unknown error";
 		const staleOpenAIResponsesReplayError = this.#isStaleOpenAIResponsesReplayError(message);
 		const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
+		// QUOTA_EXHAUSTED is a long, account-level block (not a transient blip):
+		// prefer switching to a ranked canonical sibling over sleeping out the
+		// window. Transient rate-limit/error reasons keep the current backoff and
+		// only fail over along an explicit chain.
+		const quotaExhausted =
+			isUsageLimitError(errorMessage) && parseRateLimitReason(errorMessage) === "QUOTA_EXHAUSTED";
 		let delayMs = staleOpenAIResponsesReplayError
 			? 0
 			: calculateRetryBackoffDelayMs(retrySettings.baseDelayMs, this.#retryAttempt);
@@ -8867,7 +8913,10 @@ export class AgentSession {
 				if (!classifierRefusal) {
 					this.#noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
 				}
-				switchedModel = await this.#tryRetryModelFallback(currentSelector, { pinFallback: classifierRefusal });
+				switchedModel = await this.#tryRetryModelFallback(currentSelector, {
+					pinFallback: classifierRefusal,
+					includeCanonical: quotaExhausted,
+				});
 			}
 			if (switchedModel) {
 				delayMs = 0;

--- a/packages/coding-agent/src/swarm/executor.ts
+++ b/packages/coding-agent/src/swarm/executor.ts
@@ -59,6 +59,8 @@ import {
 	runParallelAggregate,
 	runRouter,
 	runSequence,
+	type SubagentLeafDeps,
+	subagentLeafDriveNode,
 	sumUsage,
 } from "./primitives";
 
@@ -72,12 +74,26 @@ export type StreamSimpleFn = (
 	options?: SimpleStreamOptions,
 ) => AssistantMessageEventStream;
 
+/**
+ * Everything the subagent-leaf needs EXCEPT the per-call `context` (which the
+ * executor injects from each blend invocation). Carried on
+ * {@link SwarmExecutorDeps.subagent}; absent when the host registered no subagent
+ * runner, in which case a `kind: "subagent"` member fails with a clear error.
+ */
+export type SwarmSubagentDeps = Omit<SubagentLeafDeps, "context">;
+
 /** Dependencies the blend executor closes over (injected by the registry). */
 export interface SwarmExecutorDeps {
 	/** Resolve a member model id to a built model (registry-backed in prod). */
 	resolveModel: SwarmModelResolver;
 	/** The transport edge for `kind: "model"` members. Defaults to ai `streamSimple`. */
 	streamSimple: StreamSimpleFn;
+	/**
+	 * The subagent-leaf edge for `kind: "subagent"` members (KTD-2: direct
+	 * `runSubprocess`). Optional — when unset, a subagent member fails fast rather
+	 * than silently downgrading to a model call.
+	 */
+	subagent?: SwarmSubagentDeps;
 }
 
 /** The API string the `omp` provider serves. */
@@ -397,6 +413,35 @@ async function runBlendMoa(
 }
 
 /**
+ * Build the per-member {@link DriveNode}: `kind: "subagent"` members go to the
+ * subagent-leaf (direct `runSubprocess`, KTD-2), everything else to the
+ * model-leaf (`streamSimple`). Both leaves close over the SAME base `context`, so
+ * every member call shares the byte-identical stable prefix and appends only the
+ * variable tail (KTD-8). A subagent member with no configured runner
+ * ({@link SwarmExecutorDeps.subagent} unset) fails fast rather than silently
+ * routing to the model edge.
+ */
+function makeDrive(deps: SwarmExecutorDeps, context: Context, options: SimpleStreamOptions | undefined): DriveNode {
+	const model = modelLeafDriveNode(deps.streamSimple, deps.resolveModel, context, options);
+	const subagentConfig = deps.subagent;
+	const subagent: DriveNode | undefined =
+		subagentConfig === undefined ? undefined : subagentLeafDriveNode({ ...subagentConfig, context });
+	return (member, input, signal) => {
+		if (member.kind === "subagent") {
+			if (subagent === undefined) {
+				return Promise.reject(
+					new Error(
+						`swarm member "${member.role}" is kind:"subagent" but no subagent runner is configured for this blend.`,
+					),
+				);
+			}
+			return subagent(member, input, signal);
+		}
+		return model(member, input, signal);
+	};
+}
+
+/**
  * Build the `omp-swarm` {@link CustomStreamSimpleFn} from explicit deps. The
  * returned function reads `model.swarm`, maps the strategy onto the matching
  * pure primitive (driven by {@link modelLeafDriveNode}), and reduces the members
@@ -439,7 +484,7 @@ function runBlend(
 		queueMicrotask(() => outer.fail(new Error(`omp-swarm model "${model.id}" has no members.`)));
 		return outer;
 	}
-	const drive = modelLeafDriveNode(deps.streamSimple, deps.resolveModel, context, options);
+	const drive = makeDrive(deps, context, options);
 	void (async () => {
 		try {
 			if (spec.strategy === "moa") {

--- a/packages/coding-agent/src/swarm/executor.ts
+++ b/packages/coding-agent/src/swarm/executor.ts
@@ -1,0 +1,510 @@
+/**
+ * The `omp-swarm` blend executor.
+ *
+ * A synthetic blended model (`api: "omp-swarm"`) is virtual: it carries a
+ * {@link SwarmSpec} on `model.swarm` and, at dispatch time, fans out across its
+ * members and reduces their streams into ONE coherent
+ * {@link AssistantMessageEventStream}. This module is the
+ * {@link CustomStreamSimpleFn} the `omp` provider registers — it is the bridge
+ * between the catalog spec and the pure blend primitives (U5).
+ *
+ * Division of labor:
+ *   - the PURE combinators in `./primitives` express each strategy over a
+ *     {@link DriveNode} without performing I/O;
+ *   - this executor wires the single effect edge (`modelLeafDriveNode`), maps the
+ *     spec's `strategy` onto the right combinator, surfaces exactly one member's
+ *     content, and reports the summed usage across every member run.
+ *
+ * Streaming contract (KTD-7): the blend emits one outer stream — `start` → the
+ * surfaced member's content events → `done` — whose `message.usage` is the sum
+ * across all members. Parallel/`moa` blends push an early `start` placeholder so
+ * the agent-loop first-event watchdog never misfires on pre-aggregation latency.
+ *
+ * Cache-prefix stability (KTD-8): every member call is constructed from the
+ * SAME base context — the shared system prompt + conversation prefix stays
+ * byte-identical and only the variable tail (a prior stage's output / the
+ * aggregator prompt) is appended as a fresh user turn. The model-leaf node
+ * passes the base context through unchanged, so native prompt caching stays
+ * effective. The combinators never rewrite the prefix.
+ *
+ * Registration: `model-registry.ts` wires this via {@link registerSwarmApi},
+ * which installs ONE instance-free global dispatcher under the `"omp-swarm"`
+ * custom-API slot. Deps are first-writer-wins: the first registry to register
+ * owns the slot until `clearCustomApis()`; later (possibly transient) registries
+ * neither rebind it (no hijack of a live blend's resolver/auth) nor break it (no
+ * poison-latch). The single global slot can serve one active owner; U9 adds
+ * per-`Model` deps binding for robust attribution when several registries are
+ * live. The executor never imports the registry; it receives a `resolveModel`
+ * closure, keeping it a pure function of its dependencies.
+ */
+
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	SwarmMember,
+	SwarmSpec,
+	Usage,
+} from "@oh-my-pi/pi-ai";
+import { getCustomApi, registerCustomApi } from "@oh-my-pi/pi-ai/api-registry";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import {
+	capMembers,
+	type DriveNode,
+	type DriveResult,
+	emitSurface,
+	modelLeafDriveNode,
+	pickSurface,
+	runParallelAggregate,
+	runRouter,
+	runSequence,
+	sumUsage,
+} from "./primitives";
+
+/** Resolve a member's `model` id (or `provider/id`) to a built {@link Model}. */
+export type SwarmModelResolver = (modelId: string) => Model;
+
+/** The `ai` streaming entry point, injected so the executor stays testable. */
+export type StreamSimpleFn = (
+	model: Model,
+	context: Context,
+	options?: SimpleStreamOptions,
+) => AssistantMessageEventStream;
+
+/** Dependencies the blend executor closes over (injected by the registry). */
+export interface SwarmExecutorDeps {
+	/** Resolve a member model id to a built model (registry-backed in prod). */
+	resolveModel: SwarmModelResolver;
+	/** The transport edge for `kind: "model"` members. Defaults to ai `streamSimple`. */
+	streamSimple: StreamSimpleFn;
+}
+
+/** The API string the `omp` provider serves. */
+export const OMP_SWARM_API = "omp-swarm" as const;
+
+/** Source id used when registering the built-in `omp` provider. */
+export const OMP_PROVIDER_SOURCE_ID = "omp-builtin";
+
+/** Provider name for synthetic blended models. */
+export const OMP_PROVIDER_NAME = "omp";
+
+/** Base URL for the (network-less) synthetic `omp` provider. */
+export const OMP_BASE_URL = "omp://";
+
+/**
+ * Extract the user's most recent prompt text from the base context. Used to feed
+ * the router selector and the moa aggregator-prompt builder. Returns the empty
+ * string when the trailing message is not a textual user turn.
+ */
+function lastUserPrompt(context: Context): string {
+	for (let i = context.messages.length - 1; i >= 0; i--) {
+		const message = context.messages[i];
+		if (message.role !== "user") continue;
+		if (typeof message.content === "string") return message.content;
+		let text = "";
+		for (const block of message.content) {
+			if (block.type === "text") text += block.text;
+		}
+		return text;
+	}
+	return "";
+}
+
+/**
+ * True when a member's run did not terminate successfully. A terminal provider
+ * `error` event RESOLVES `result()` with an error message (`stopReason: "error"`,
+ * empty content, zero usage) rather than rejecting — see `event-stream.ts`. So a
+ * failed member arrives as a fulfilled {@link DriveResult} and must be detected
+ * here by its `stopReason`, not by a rejected promise.
+ */
+function isFailedResult(result: DriveResult): boolean {
+	const reason = result.message.stopReason;
+	return reason === "error" || reason === "aborted";
+}
+
+/**
+ * Compose the aggregator's prompt for a `moa` blend from the user's question and
+ * the surviving proposals. Failed proposers (terminal `error`/`aborted`, which
+ * resolve rather than reject — see {@link isFailedResult}) are DROPPED here so
+ * the aggregator never sees an empty `### Proposal` section; their (zero) usage
+ * is still summed into the blend total elsewhere. The surviving proposals are
+ * appended as the variable tail (a fresh user turn); the stable system/
+ * conversation prefix is untouched (KTD-8).
+ *
+ * When EVERY proposal failed there is nothing to synthesize, so this throws
+ * (caught by {@link runBlend} → `outer.fail`) rather than handing the aggregator
+ * a content-free prompt — the `runParallelAggregate` "all proposers failed"
+ * guard cannot catch this case because terminal error events resolve, leaving
+ * the proposals fulfilled-but-empty.
+ */
+function buildAggregatorInput(userPrompt: string, proposals: DriveResult[]): string {
+	const surviving = proposals.filter(proposal => !isFailedResult(proposal));
+	if (surviving.length === 0) {
+		throw new Error(`all ${proposals.length} proposer(s) failed in moa blend; nothing to synthesize.`);
+	}
+	const sections = surviving.map((proposal, index) => `### Proposal ${index + 1}\n${proposal.output}`);
+	return [
+		"You are the aggregator in a mixture-of-agents blend.",
+		"Synthesize the single best answer to the user's request from the proposals below.",
+		"Do not mention the proposals or the synthesis process in your reply.",
+		"",
+		`## User request\n${userPrompt}`,
+		"",
+		`## Proposals\n${sections.join("\n\n")}`,
+	].join("\n");
+}
+
+/**
+ * Build a classifier-only context that asks for a routing verdict — NOT an
+ * answer to the user. The base conversation is discarded for the selector call
+ * (routing is a meta-decision, not part of the surfaced thread); a single
+ * developer instruction enumerates the candidate roles and a user turn carries
+ * the request to classify. Kept separate from the member contexts so it never
+ * perturbs the cache-stable prefix the members share.
+ */
+function buildSelectorContext(context: Context, members: readonly SwarmMember[], userPrompt: string): Context {
+	const roles = members.map(member => member.role).join(", ");
+	return {
+		systemPrompt: context.systemPrompt,
+		tools: [],
+		messages: [
+			{
+				role: "developer",
+				content: [
+					"You are a request router. Read the user request below and reply with EXACTLY ONE",
+					`of these role names and nothing else: ${roles}.`,
+					"Pick the role best suited to handle the request.",
+				].join(" "),
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: userPrompt, timestamp: Date.now() },
+		],
+	};
+}
+
+/**
+ * The router selector seam. `kind: "rule"` (or no selector) picks the first
+ * member deterministically. `kind: "classifier"` drives the classifier model
+ * against a routing-only context (see {@link buildSelectorContext}) and matches
+ * its text verdict to a member role (falling back to the first member when no
+ * role matches). Selection is the ONLY place a classifier call lives; the pure
+ * `runRouter` combinator never sees it.
+ */
+function makeRouterSelect(
+	spec: SwarmSpec,
+	deps: SwarmExecutorDeps,
+	context: Context,
+	baseOptions: SimpleStreamOptions | undefined,
+	selectorUsages: Usage[],
+): (members: readonly SwarmMember[], userPrompt: string, signal?: AbortSignal) => Promise<string | number> {
+	return async (members, userPrompt, signal) => {
+		const selector = spec.selector;
+		if (selector === undefined || selector.kind === "rule" || selector.model === undefined) {
+			return 0;
+		}
+		signal?.throwIfAborted();
+		const classifier = deps.resolveModel(selector.model);
+		const options: SimpleStreamOptions | undefined = signal !== undefined ? { ...baseOptions, signal } : baseOptions;
+		const selectorContext = buildSelectorContext(context, members, userPrompt);
+		const stream = deps.streamSimple(classifier, selectorContext, options);
+		const message = await stream.result();
+		// The classifier ran, so its tokens are part of the blend's cost. Sum its
+		// usage into the blend total (KTD-7) — the caller threads `selectorUsages`
+		// into `sumUsage` alongside the chosen member's usage.
+		selectorUsages.push(message.usage);
+		const verdict = messageText(message).trim().toLowerCase();
+		return matchVerdictToMember(verdict, members);
+	};
+}
+
+/**
+ * Map a classifier verdict to a member index. Matching is tiered so overlapping
+ * role names (e.g. `code` vs `coder`) never mis-route:
+ *   1. exact normalized equality (the classifier was told to emit ONE role name);
+ *   2. whole-word containment (the role appears as a standalone token in the
+ *      verdict — anchored on word boundaries, so `code` does NOT match `coder`);
+ *   3. loose substring containment (last resort for chatty verdicts).
+ * Falls back to the first member (index 0) when nothing matches. The earlier,
+ * stricter tiers win across ALL members before any looser tier is consulted, so
+ * an exact/word-boundary match on a later member beats a substring hit on an
+ * earlier one.
+ */
+function matchVerdictToMember(verdict: string, members: readonly SwarmMember[]): number {
+	const roles = members.map(member => member.role.toLowerCase());
+	const exact = roles.indexOf(verdict);
+	if (exact >= 0) return exact;
+	const word = roles.findIndex(role => role.length > 0 && wordBoundaryMatch(verdict, role));
+	if (word >= 0) return word;
+	const loose = roles.findIndex(role => role.length > 0 && verdict.includes(role));
+	return loose >= 0 ? loose : 0;
+}
+
+/**
+ * True when `role` occurs in `verdict` as a whole word (delimited by start/end of
+ * string or a non-word character), so a prefix/substring role can't steal a
+ * verdict naming a longer role (`code` must not match the verdict `coder`).
+ */
+function wordBoundaryMatch(verdict: string, role: string): boolean {
+	let from = 0;
+	for (;;) {
+		const at = verdict.indexOf(role, from);
+		if (at < 0) return false;
+		const before = at === 0 ? "" : verdict[at - 1];
+		const after = at + role.length >= verdict.length ? "" : verdict[at + role.length];
+		if (!isWordChar(before) && !isWordChar(after)) return true;
+		from = at + 1;
+	}
+}
+
+/** Word character for verdict tokenization: ASCII alphanumerics plus `_`. */
+function isWordChar(ch: string): boolean {
+	return ch.length > 0 && /[a-z0-9_]/.test(ch);
+}
+
+/** Concatenate the text content blocks of an assistant message. */
+function messageText(message: AssistantMessage): string {
+	let text = "";
+	for (const block of message.content) {
+		if (block.type === "text") text += block.text;
+	}
+	return text;
+}
+
+/**
+ * Forward the surfaced member's content events + `done` onto an outer stream that
+ * ALREADY emitted its `start` (the moa early-start path). Mirrors the body of
+ * {@link emitSurface} but omits the leading `start`, so the watchdog placeholder
+ * isn't duplicated. The surfaced `message.usage` is the summed blend total.
+ */
+function forwardSurfaceBody(outer: AssistantMessageEventStream, surface: AssistantMessage, totalUsage: Usage): void {
+	const message: AssistantMessage = { ...surface, usage: totalUsage };
+	const partial = message;
+	for (let i = 0; i < message.content.length; i++) {
+		const block = message.content[i];
+		if (block.type === "text") {
+			outer.push({ type: "text_start", contentIndex: i, partial });
+			outer.push({ type: "text_delta", contentIndex: i, delta: block.text, partial });
+			outer.push({ type: "text_end", contentIndex: i, content: block.text, partial });
+		} else if (block.type === "thinking") {
+			outer.push({ type: "thinking_start", contentIndex: i, partial });
+			outer.push({ type: "thinking_delta", contentIndex: i, delta: block.thinking, partial });
+			outer.push({ type: "thinking_end", contentIndex: i, content: block.thinking, partial });
+		} else if (block.type === "toolCall") {
+			const serialized = typeof block.arguments === "string" ? block.arguments : JSON.stringify(block.arguments);
+			outer.push({ type: "toolcall_start", contentIndex: i, partial });
+			outer.push({ type: "toolcall_delta", contentIndex: i, delta: serialized, partial });
+			outer.push({ type: "toolcall_end", contentIndex: i, toolCall: block, partial });
+		}
+	}
+	if (message.stopReason === "stop" || message.stopReason === "length" || message.stopReason === "toolUse") {
+		outer.push({ type: "done", reason: message.stopReason, message });
+		return;
+	}
+	outer.push({
+		type: "error",
+		reason: message.stopReason === "aborted" ? "aborted" : "error",
+		error: { ...message, errorMessage: message.errorMessage ?? "swarm surface error" },
+	});
+}
+
+/**
+ * A placeholder `start` partial for the moa early-start: an empty assistant
+ * message attributed to the synthetic blend. Pushing it immediately resets the
+ * agent-loop first-event watchdog before the proposers/aggregator run (KTD-7).
+ */
+function synthesizingPartial(model: Model): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: sumUsage([]),
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Run a `router` / `sequence` / `draft-refine` blend (single coherent surface,
+ * no pre-aggregation latency), surfacing one member and reporting summed usage.
+ */
+async function runBlendSurfaced(
+	outer: AssistantMessageEventStream,
+	spec: SwarmSpec,
+	members: SwarmMember[],
+	drive: DriveNode,
+	context: Context,
+	deps: SwarmExecutorDeps,
+	baseOptions: SimpleStreamOptions | undefined,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	const ordered: { member: SwarmMember; result: DriveResult }[] = [];
+	// A classifier selector runs a model whose tokens must be billed; the select
+	// seam pushes its usage here so it joins the summed total (KTD-7).
+	const selectorUsages: Usage[] = [];
+	if (spec.strategy === "router") {
+		const select = makeRouterSelect(spec, deps, context, baseOptions, selectorUsages);
+		const { chosen, result } = await runRouter(members, lastUserPrompt(context), select, drive, signal);
+		ordered.push({ member: chosen, result });
+	} else {
+		// "sequence" and "draft-refine" both pipe output → input.
+		const results = await runSequence(members, drive, signal);
+		for (let i = 0; i < members.length; i++) ordered.push({ member: members[i], result: results[i] });
+	}
+	const surface = pickSurface(spec, ordered);
+	const totalUsage = sumUsage([...selectorUsages, ...ordered.map(o => o.result.usage)]);
+	emitSurface(outer, surface.message, totalUsage);
+}
+
+/**
+ * Run a `moa` blend: emit the early `start` placeholder, fan out the proposers,
+ * synthesize with the aggregator, then forward the aggregator's content + `done`
+ * with summed usage. The aggregator is the last member; proposers are all the
+ * rest. A `surface` role/flag may override which member is surfaced.
+ */
+async function runBlendMoa(
+	outer: AssistantMessageEventStream,
+	model: Model,
+	spec: SwarmSpec,
+	members: SwarmMember[],
+	drive: DriveNode,
+	context: Context,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	if (members.length < 2) {
+		throw new Error(`moa blend "${model.id}" needs at least one proposer and an aggregator (got ${members.length})`);
+	}
+	// Early start so the first-event watchdog doesn't misfire while proposers run.
+	outer.push({ type: "start", partial: synthesizingPartial(model) });
+	const proposers = members.slice(0, -1);
+	const aggregator = members[members.length - 1];
+	const { proposals, aggregate } = await runParallelAggregate(
+		proposers,
+		aggregator,
+		lastUserPrompt(context),
+		buildAggregatorInput,
+		drive,
+		signal,
+	);
+	const ordered: { member: SwarmMember; result: DriveResult }[] = [];
+	for (let i = 0; i < proposals.length; i++) ordered.push({ member: proposers[i], result: proposals[i] });
+	ordered.push({ member: aggregator, result: aggregate });
+	const surface = pickSurface(spec, ordered);
+	const totalUsage = sumUsage([...proposals.map(p => p.usage), aggregate.usage]);
+	forwardSurfaceBody(outer, surface.message, totalUsage);
+}
+
+/**
+ * Build the `omp-swarm` {@link CustomStreamSimpleFn} from explicit deps. The
+ * returned function reads `model.swarm`, maps the strategy onto the matching
+ * pure primitive (driven by {@link modelLeafDriveNode}), and reduces the members
+ * into one outer stream. This is the test-facing seam: a test injects mock deps
+ * and registers the result directly, exercising the executor without the global
+ * registry. An absent `model.swarm` is a programming error; an `options.signal`
+ * abort is fatal.
+ */
+export function createSwarmStreamSimple(
+	deps: SwarmExecutorDeps,
+): (model: Model, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream {
+	return (model, context, options) => runBlend(model, context, options, deps);
+}
+
+/**
+ * Drive one blend to completion against an explicit {@link SwarmExecutorDeps}.
+ * Shared by {@link createSwarmStreamSimple} and the stable global dispatcher, so
+ * both paths run identical logic. Returns the single outer stream synchronously;
+ * the fan-out runs async and settles `result()` via `start`/`done` (or `fail`).
+ */
+function runBlend(
+	model: Model,
+	context: Context,
+	options: SimpleStreamOptions | undefined,
+	deps: SwarmExecutorDeps,
+): AssistantMessageEventStream {
+	const outer = new AssistantMessageEventStream();
+	const spec = model.swarm;
+	if (spec === undefined) {
+		queueMicrotask(() => outer.fail(new Error(`omp-swarm model "${model.id}" has no swarm spec; cannot blend.`)));
+		return outer;
+	}
+	const signal = options?.signal;
+	if (signal?.aborted) {
+		queueMicrotask(() => outer.fail(signal.reason ?? new Error("swarm aborted before start")));
+		return outer;
+	}
+	const members = capMembers(spec.members, spec.maxMembers);
+	if (members.length === 0) {
+		queueMicrotask(() => outer.fail(new Error(`omp-swarm model "${model.id}" has no members.`)));
+		return outer;
+	}
+	const drive = modelLeafDriveNode(deps.streamSimple, deps.resolveModel, context, options);
+	void (async () => {
+		try {
+			if (spec.strategy === "moa") {
+				await runBlendMoa(outer, model, spec, members, drive, context, signal);
+			} else {
+				await runBlendSurfaced(outer, spec, members, drive, context, deps, options, signal);
+			}
+		} catch (err) {
+			outer.fail(err);
+		}
+	})();
+	return outer;
+}
+
+// =============================================================================
+// Stable global dispatch (lifecycle-safe registration)
+// =============================================================================
+
+/**
+ * Deps of the registry that owns the process-global `omp-swarm` slot. The
+ * custom-API registry keys on the literal API string (`"omp-swarm"`), so there
+ * is exactly ONE slot and the instance-free dispatcher resolves deps from here.
+ * First-writer-wins: the first registry to register owns the slot until
+ * `clearCustomApis()` empties it; later registrations do NOT rebind (see
+ * {@link registerSwarmApi}). This deliberately rejects two worse designs — a
+ * poison-latch that permanently broke dispatch once any transient second
+ * `ModelRegistry` (sdk.ts, task/executor.ts, the CLIs) was built, and
+ * last-writer-wins, which would let a transient newer registry silently resolve
+ * an already-live blend's members and auth (a hijack). Single-active-owner fits
+ * the normal one-registry process; U9 adds per-`Model` deps binding for robust
+ * attribution when several registries are live at once.
+ */
+let activeSwarmDeps: SwarmExecutorDeps | undefined;
+
+/**
+ * The stable global `omp-swarm` dispatcher. Registered ONCE (see
+ * {@link registerSwarmApi}); it never closes over a registry instance, resolving
+ * deps from {@link activeSwarmDeps} at dispatch time.
+ */
+function dispatchSwarm(model: Model, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	if (activeSwarmDeps === undefined) {
+		const outer = new AssistantMessageEventStream();
+		queueMicrotask(() => outer.fail(new Error(`omp-swarm model "${model.id}" has no registered blend deps.`)));
+		return outer;
+	}
+	return runBlend(model, context, options, activeSwarmDeps);
+}
+
+/**
+ * Register the stable `omp-swarm` dispatcher with the custom-API registry. The
+ * registered function is instance-free. First-writer-wins: deps are bound only on
+ * the install-from-empty path, so the owning registry keeps the slot and a later
+ * (possibly transient) registry cannot rebind it — no hijack of an already-live
+ * blend's resolver/auth, and no poison-latch. The once-guard keys on live
+ * registry state ({@link getCustomApi}) so it self-heals after `clearCustomApis()`.
+ * Returns whether this call performed the install — `false` means an owner already
+ * holds the slot and deps were left untouched.
+ */
+export function registerSwarmApi(deps: SwarmExecutorDeps, sourceId: string = OMP_PROVIDER_SOURCE_ID): boolean {
+	if (getCustomApi(OMP_SWARM_API) === undefined) {
+		activeSwarmDeps = deps;
+		registerCustomApi(OMP_SWARM_API, dispatchSwarm, sourceId, (model, context, options) =>
+			dispatchSwarm(model, context, options as SimpleStreamOptions),
+		);
+		return true;
+	}
+	return false;
+}

--- a/packages/coding-agent/src/swarm/executor.ts
+++ b/packages/coding-agent/src/swarm/executor.ts
@@ -404,11 +404,15 @@ async function runBlendMoa(
 		drive,
 		signal,
 	);
-	const ordered: { member: SwarmMember; result: DriveResult }[] = [];
-	for (let i = 0; i < proposals.length; i++) ordered.push({ member: proposers[i], result: proposals[i] });
-	ordered.push({ member: aggregator, result: aggregate });
+	// Each proposal already carries its proposer (rejected proposers are omitted
+	// from `proposals`), so no index zip against `proposers` can misattribute a
+	// survivor's result to the wrong member.
+	const ordered: { member: SwarmMember; result: DriveResult }[] = [
+		...proposals,
+		{ member: aggregator, result: aggregate },
+	];
 	const surface = pickSurface(spec, ordered);
-	const totalUsage = sumUsage([...proposals.map(p => p.usage), aggregate.usage]);
+	const totalUsage = sumUsage([...proposals.map(p => p.result.usage), aggregate.usage]);
 	forwardSurfaceBody(outer, surface.message, totalUsage);
 }
 

--- a/packages/coding-agent/src/swarm/presets.ts
+++ b/packages/coding-agent/src/swarm/presets.ts
@@ -1,0 +1,117 @@
+/**
+ * Built-in `omp-swarm` blend presets (U9).
+ *
+ * Three curated, selectable synthetic models shipped under the keyless `omp`
+ * provider. Each is a {@link SwarmSpec} carried on a custom-model definition and
+ * registered programmatically via `ModelRegistry.registerProvider`, so it appears
+ * in `getAvailable()` and resolves through `resolveModelFromString` exactly like
+ * any other model:
+ *
+ *   - `omp/router-balanced` — `router`: a classifier picks one of a weak/strong
+ *     pair by request difficulty (cheap model for easy turns, frontier model for
+ *     hard ones), so most turns cost ~1× + a tiny classifier call.
+ *   - `omp/draft-refine` — `draft-refine`: a cheap model drafts, a frontier model
+ *     refines; the refiner is surfaced.
+ *   - `omp/moa-synthesis` — `moa`: homogeneous proposers (Self-MoA, KTD-6) fan out
+ *     and a best/frontier aggregator synthesizes the surfaced answer.
+ *
+ * Member model ids are explicit `provider/id` selectors that exist in the bundled
+ * catalog. They are resolved at dispatch time by the registry's `resolveModel`
+ * (canonical-equivalence + `modelProviderOrder`), so each member fails over
+ * independently — Phase-1 many-providers fallback composes for free without any
+ * per-member wiring here.
+ *
+ * Lifecycle (KTD / U9 deferred concern #2): these presets register under a
+ * DISTINCT source id ({@link OMP_PRESET_SOURCE_ID}, `"omp-presets"`) — NOT the
+ * dispatcher's `"omp-builtin"`. The `omp-swarm` custom-API dispatcher is a
+ * process-global, instance-free, first-writer-wins singleton registered under
+ * `"omp-builtin"`; if these preset models shared that source id, a
+ * `clearSourceRegistrations("omp-builtin")` would call `unregisterCustomApis` and
+ * tear the live dispatcher down. Keeping the per-registry preset PROVIDER lifecycle
+ * (`"omp-presets"`) separate from the dispatcher API lifecycle (`"omp-builtin"`)
+ * decouples the two cleanly.
+ */
+
+import type { SwarmSpec } from "@oh-my-pi/pi-catalog/types";
+import type { ProviderConfigInput } from "../config/model-registry";
+
+/** One preset model definition (matches `ProviderConfigInput.models[number]`). */
+type PresetModel = NonNullable<ProviderConfigInput["models"]>[number];
+
+/**
+ * Source id for the built-in preset PROVIDER registration. Deliberately distinct
+ * from `OMP_PROVIDER_SOURCE_ID` (`"omp-builtin"`, which owns the process-global
+ * `omp-swarm` custom-API dispatcher slot): tearing down preset provider state via
+ * `clearSourceRegistrations("omp-presets")` must NEVER unregister the dispatcher.
+ */
+export const OMP_PRESET_SOURCE_ID = "omp-presets";
+
+// Catalog member selectors (bundled `anthropic/*` ids). A weak/cheap tier, a mid
+// tier, and a frontier tier — each an explicit `provider/id` so exact resolution
+// hits before any canonical/pattern fallback, while still failing over per member.
+const WEAK_MODEL = "anthropic/claude-haiku-4-5";
+const MID_MODEL = "anthropic/claude-sonnet-4-5";
+const STRONG_MODEL = "anthropic/claude-opus-4-5";
+
+/** `router`: classify request difficulty → pick weak OR strong (cheap by default). */
+export const ROUTER_BALANCED_SPEC: SwarmSpec = {
+	strategy: "router",
+	members: [
+		{ role: "weak", model: WEAK_MODEL, kind: "model" },
+		{ role: "strong", model: STRONG_MODEL, kind: "model" },
+	],
+	selector: { kind: "classifier", model: WEAK_MODEL },
+	maxMembers: 2,
+};
+
+/** `draft-refine`: weak model drafts, strong model refines; the refiner surfaces. */
+export const DRAFT_REFINE_SPEC: SwarmSpec = {
+	strategy: "draft-refine",
+	members: [
+		{ role: "draft", model: WEAK_MODEL, kind: "model" },
+		{ role: "refine", model: STRONG_MODEL, kind: "model", surface: true },
+	],
+	surface: "refine",
+	maxMembers: 2,
+};
+
+/** `moa`: homogeneous proposers (Self-MoA, KTD-6) + best aggregator (surfaced). */
+export const MOA_SYNTHESIS_SPEC: SwarmSpec = {
+	strategy: "moa",
+	members: [
+		{ role: "proposer", model: MID_MODEL, kind: "model" },
+		{ role: "proposer", model: MID_MODEL, kind: "model" },
+		{ role: "proposer", model: MID_MODEL, kind: "model" },
+		{ role: "aggregator", model: STRONG_MODEL, kind: "model", surface: true },
+	],
+	surface: "aggregator",
+	maxMembers: 4,
+};
+
+/**
+ * Shared model-definition skeleton. The synthetic shell itself bills nothing —
+ * cost is the per-member spend, summed across members by the executor (KTD-7).
+ */
+function presetModel(id: string, name: string, swarm: SwarmSpec): PresetModel {
+	return {
+		id,
+		name,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+		swarm,
+	};
+}
+
+/**
+ * The three built-in preset model definitions, registered under the `omp`
+ * provider with `api: "omp-swarm"`. Order is stable for deterministic surfacing
+ * in the picker.
+ */
+export const OMP_PRESET_MODELS: PresetModel[] = [
+	presetModel("router-balanced", "OMP Router (balanced)", ROUTER_BALANCED_SPEC),
+	presetModel("draft-refine", "OMP Draft → Refine", DRAFT_REFINE_SPEC),
+	presetModel("moa-synthesis", "OMP Mixture-of-Agents", MOA_SYNTHESIS_SPEC),
+];

--- a/packages/coding-agent/src/swarm/primitives.ts
+++ b/packages/coding-agent/src/swarm/primitives.ts
@@ -1,0 +1,391 @@
+/**
+ * Pure blend primitives for synthetic `omp-swarm` models.
+ *
+ * These combinators express the three blend strategies (router / sequence /
+ * draft-refine / moa) over swarm members **without performing any I/O**. Each
+ * primitive is parameterized by a {@link DriveNode} callback — the single effect
+ * edge. The combinators never call `streamSimple` or `runSubprocess`; they only
+ * invoke the injected `DriveNode`, so they are deterministic and fully testable
+ * with a stub node.
+ *
+ * The model-leaf effect edge ({@link modelLeafDriveNode}) lives here too: it is
+ * the one place that touches the network (via the injected `streamSimple`). The
+ * subagent-leaf edge is added in a sibling unit and calls `runSubprocess`
+ * directly — never importing `@oh-my-pi/swarm-extension` (no cross-package cycle).
+ *
+ * Placement: `coding-agent`, NOT `ai`. Nothing in `ai` consumes these; the sole
+ * consumer is the blend executor (sibling unit) in this same package. The module
+ * depends only on `ai` event-stream + catalog types, so a later lift to `ai` is
+ * mechanical if a second consumer ever appears.
+ */
+
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	SwarmMember,
+	SwarmSpec,
+	Usage,
+} from "@oh-my-pi/pi-ai";
+import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+
+/** Default hard cap on members actually run when `swarm.maxMembers` is unset. */
+export const DEFAULT_MAX_MEMBERS = 5;
+
+/**
+ * The sentinel meaning "drive this member against the original context verbatim,
+ * with no extra user turn". It is a unique symbol (NOT the empty string) so it
+ * can never collide with a piped member output: a stage that produces empty text
+ * yields `output: ""`, which is a distinct {@link DriveInput} from this sentinel
+ * and is therefore still appended as a (possibly empty) user turn rather than
+ * silently reverting the downstream stage to the original context.
+ */
+export const ORIGINAL_INPUT: unique symbol = Symbol("swarm.ORIGINAL_INPUT");
+
+/**
+ * The input handed to a {@link DriveNode}: either the {@link ORIGINAL_INPUT}
+ * sentinel (drive against the base context) or a concrete prompt string (a
+ * piped member output, appended as a fresh user turn — even when empty).
+ */
+export type DriveInput = typeof ORIGINAL_INPUT | string;
+
+/**
+ * The result of driving a single swarm member to completion. `output` is the
+ * textual content threaded into the next member (sequence) or collected for the
+ * aggregator (moa); `message` is the full assistant message; `usage` is the
+ * member's token spend. `stream` is the live stream when the caller wants to
+ * forward content events (the surfaced member); it is omitted for buffered runs.
+ */
+export interface DriveResult {
+	/** The full assistant message produced by this member. */
+	message: AssistantMessage;
+	/** This member's token usage (summed into the blend total). */
+	usage: Usage;
+	/** The member's text output, used to feed downstream members. */
+	output: string;
+	/** Live event stream, present only when content should be forwarded. */
+	stream?: AssistantMessageEventStream;
+}
+
+/**
+ * The single effect edge: runs one member with an input prompt and resolves to
+ * its {@link DriveResult}. `kind: "model"` members get {@link modelLeafDriveNode};
+ * `kind: "subagent"` members get the subagent leaf (sibling unit). The pure
+ * combinators only ever call this callback — never the underlying transport.
+ */
+export type DriveNode = (member: SwarmMember, input: DriveInput, signal?: AbortSignal) => Promise<DriveResult>;
+
+/**
+ * Apply the `maxMembers` guardrail. Returns at most `maxMembers` members
+ * (default {@link DEFAULT_MAX_MEMBERS}), preserving order. A non-positive or
+ * absent cap falls back to the default.
+ */
+export function capMembers(members: readonly SwarmMember[], maxMembers?: number): SwarmMember[] {
+	const cap = maxMembers !== undefined && maxMembers > 0 ? maxMembers : DEFAULT_MAX_MEMBERS;
+	return members.slice(0, cap);
+}
+
+/**
+ * Sum a list of {@link Usage} records into one, recomputing the derived totals
+ * (`totalTokens` = input+output+cacheRead+cacheWrite; `cost.total` = the sum of
+ * its components) so the blend reports a single coherent usage. Mirrors the
+ * canonical formula in `packages/catalog/src/types.ts`.
+ */
+export function sumUsage(usages: readonly Usage[]): Usage {
+	const acc: Usage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	let reasoningTokens: number | undefined;
+	let premiumRequests: number | undefined;
+	for (const u of usages) {
+		acc.input += u.input;
+		acc.output += u.output;
+		acc.cacheRead += u.cacheRead;
+		acc.cacheWrite += u.cacheWrite;
+		acc.cost.input += u.cost.input;
+		acc.cost.output += u.cost.output;
+		acc.cost.cacheRead += u.cost.cacheRead;
+		acc.cost.cacheWrite += u.cost.cacheWrite;
+		if (u.reasoningTokens !== undefined) reasoningTokens = (reasoningTokens ?? 0) + u.reasoningTokens;
+		if (u.premiumRequests !== undefined) premiumRequests = (premiumRequests ?? 0) + u.premiumRequests;
+	}
+	// Recompute derived totals from components (never trust per-member totals).
+	acc.totalTokens = acc.input + acc.output + acc.cacheRead + acc.cacheWrite;
+	acc.cost.total = acc.cost.input + acc.cost.output + acc.cost.cacheRead + acc.cost.cacheWrite;
+	if (reasoningTokens !== undefined) acc.reasoningTokens = reasoningTokens;
+	if (premiumRequests !== undefined) acc.premiumRequests = premiumRequests;
+	return acc;
+}
+
+/** Concatenate the text content blocks of an assistant message into one string. */
+function messageText(message: AssistantMessage): string {
+	let text = "";
+	for (const block of message.content) {
+		if (block.type === "text") text += block.text;
+	}
+	return text;
+}
+
+/**
+ * Run members in order, piping each member's `output` into the next member's
+ * input (`sequence` / `draft-refine`). The FIRST member is driven against
+ * {@link ORIGINAL_INPUT} (it sees the user's prompt via the base context); every
+ * subsequent member receives the previous member's `output`, which the leaf
+ * appends as a fresh user turn. This passthrough is explicit here, not inferred
+ * downstream. Returns every member's {@link DriveResult} in run order; the caller
+ * surfaces the terminal member and sums usage. The combinator is pure: all
+ * effects flow through `drive`.
+ *
+ * @param members ordered stages (already resolved; cap applied by the caller).
+ * @param drive the effect edge.
+ * @param signal cooperative abort, forwarded to each `drive` call.
+ */
+export async function runSequence(
+	members: readonly SwarmMember[],
+	drive: DriveNode,
+	signal?: AbortSignal,
+): Promise<DriveResult[]> {
+	const results: DriveResult[] = [];
+	// First member sees the original prompt (ORIGINAL_INPUT); thereafter pipe.
+	// `input` is a DriveInput, so an empty piped `output` ("") stays distinct
+	// from the sentinel and is appended as a (possibly empty) user turn rather
+	// than reverting the next stage to the original context.
+	let input: DriveInput = ORIGINAL_INPUT;
+	for (const member of members) {
+		signal?.throwIfAborted();
+		const result = await drive(member, input, signal);
+		results.push(result);
+		input = result.output;
+	}
+	return results;
+}
+
+/**
+ * Pick exactly one member and run it (`router`). The `select` callback inspects
+ * the user prompt and returns the role (or index) of the winning member; the
+ * combinator resolves it against `members` and drives only that one against
+ * {@link ORIGINAL_INPUT} (the chosen member answers the user's original prompt
+ * via the base context). `select` is the selector seam — a classifier-model or
+ * static-rule call lives in the executor, not here, so this combinator stays
+ * pure.
+ *
+ * @param userPrompt the user's prompt text, passed to `select` for routing.
+ * @returns the single chosen member's {@link DriveResult} plus the resolved member.
+ * @throws if `select` returns a role/index that matches no member.
+ */
+export async function runRouter(
+	members: readonly SwarmMember[],
+	userPrompt: string,
+	select: (members: readonly SwarmMember[], userPrompt: string, signal?: AbortSignal) => Promise<string | number>,
+	drive: DriveNode,
+	signal?: AbortSignal,
+): Promise<{ chosen: SwarmMember; result: DriveResult }> {
+	signal?.throwIfAborted();
+	const choice = await select(members, userPrompt, signal);
+	const chosen = typeof choice === "number" ? members[choice] : members.find(m => m.role === choice);
+	if (chosen === undefined) {
+		throw new Error(`router selector returned no matching member for ${JSON.stringify(choice)}`);
+	}
+	const result = await drive(chosen, ORIGINAL_INPUT, signal);
+	return { chosen, result };
+}
+
+/** A {@link runParallelAggregate} run: every proposer result plus the aggregator's. */
+export interface ParallelAggregateResult {
+	/** One entry per proposer, in declaration order (failed proposers omitted). */
+	proposals: DriveResult[];
+	/** The aggregator's synthesized/voted result. */
+	aggregate: DriveResult;
+}
+
+/**
+ * Run proposer members in parallel, then synthesize/vote with the aggregator
+ * (`moa`). Every proposer is driven against {@link ORIGINAL_INPUT} (each answers
+ * the user's original prompt) concurrently; a proposer failure is tolerated (its
+ * result is dropped) as long as at least one proposal survives — matching "one
+ * voter fails → remaining outputs still reduce". The surviving proposals are
+ * handed to `buildAggregatorInput`, whose (non-empty) output drives the
+ * aggregator as a fresh user turn. An abort `signal` is fatal (propagated, not
+ * swallowed).
+ *
+ * @param proposers the fan-out members (cap applied by the caller).
+ * @param aggregator the reduce member.
+ * @param userPrompt the user's prompt, passed to `buildAggregatorInput`.
+ * @param buildAggregatorInput maps the surviving proposals → the aggregator prompt.
+ * @param drive the effect edge.
+ * @throws if every proposer fails, or on abort.
+ */
+export async function runParallelAggregate(
+	proposers: readonly SwarmMember[],
+	aggregator: SwarmMember,
+	userPrompt: string,
+	buildAggregatorInput: (userPrompt: string, proposals: DriveResult[]) => string,
+	drive: DriveNode,
+	signal?: AbortSignal,
+): Promise<ParallelAggregateResult> {
+	signal?.throwIfAborted();
+	const settled = await Promise.allSettled(proposers.map(member => drive(member, ORIGINAL_INPUT, signal)));
+	// An abort is fatal: surface it instead of degrading to a partial reduce.
+	if (signal?.aborted) signal.throwIfAborted();
+	const proposals: DriveResult[] = [];
+	let lastError: unknown;
+	for (const outcome of settled) {
+		if (outcome.status === "fulfilled") proposals.push(outcome.value);
+		else lastError = outcome.reason;
+	}
+	if (proposals.length === 0) {
+		throw new Error(
+			`all ${proposers.length} proposer(s) failed in moa blend: ${
+				lastError instanceof Error ? lastError.message : String(lastError)
+			}`,
+		);
+	}
+	const aggregatorInput = buildAggregatorInput(userPrompt, proposals);
+	const aggregate = await drive(aggregator, aggregatorInput, signal);
+	return { proposals, aggregate };
+}
+
+/**
+ * Emit the surfaced member's message as the blend's single outer stream, with
+ * `usage` overwritten to the summed total across all members run (KTD-7). The
+ * outer stream pushes `start` → the surface's content events → `done`, so
+ * `result()` settles with one coherent message. Only the surface member's
+ * content reaches the user; non-surfaced members (e.g. proposers, classifier)
+ * contribute usage but not content.
+ *
+ * @param outer the blend's single output stream (pushed into and closed here).
+ * @param surface the surfaced member's full message (its content is forwarded).
+ * @param totalUsage the summed usage across every member run.
+ */
+export function emitSurface(outer: AssistantMessageEventStream, surface: AssistantMessage, totalUsage: Usage): void {
+	// Clone so we can rewrite usage without mutating the member's own message.
+	const message: AssistantMessage = { ...surface, usage: totalUsage };
+	const partial = message;
+	outer.push({ type: "start", partial });
+	for (let i = 0; i < message.content.length; i++) {
+		const block = message.content[i];
+		if (block.type === "text") {
+			outer.push({ type: "text_start", contentIndex: i, partial });
+			outer.push({ type: "text_delta", contentIndex: i, delta: block.text, partial });
+			outer.push({ type: "text_end", contentIndex: i, content: block.text, partial });
+		} else if (block.type === "thinking") {
+			outer.push({ type: "thinking_start", contentIndex: i, partial });
+			outer.push({ type: "thinking_delta", contentIndex: i, delta: block.thinking, partial });
+			outer.push({ type: "thinking_end", contentIndex: i, content: block.thinking, partial });
+		} else if (block.type === "toolCall") {
+			const serialized = typeof block.arguments === "string" ? block.arguments : JSON.stringify(block.arguments);
+			outer.push({ type: "toolcall_start", contentIndex: i, partial });
+			outer.push({ type: "toolcall_delta", contentIndex: i, delta: serialized, partial });
+			outer.push({ type: "toolcall_end", contentIndex: i, toolCall: block, partial });
+		}
+		// RedactedThinkingContent has no event-stream representation; skip it.
+	}
+	const reason = surfaceDoneReason(message.stopReason);
+	if (reason === undefined) {
+		outer.push({
+			type: "error",
+			reason: message.stopReason === "aborted" ? "aborted" : "error",
+			error: { ...message, errorMessage: message.errorMessage ?? "swarm surface error" },
+		});
+		return;
+	}
+	outer.push({ type: "done", reason, message });
+}
+
+/** Narrow a surface message's stopReason to the terminal-success `done` reasons. */
+function surfaceDoneReason(stopReason: AssistantMessage["stopReason"]): "stop" | "length" | "toolUse" | undefined {
+	if (stopReason === "stop" || stopReason === "length" || stopReason === "toolUse") return stopReason;
+	return undefined;
+}
+
+/**
+ * Builds the per-member {@link Context} from the base context and the member's
+ * {@link DriveInput}. Injected into {@link modelLeafDriveNode} so transport
+ * execution and context-threading policy stay separable. The default
+ * ({@link appendUserInputContext}) appends a string input as a user turn and
+ * passes {@link ORIGINAL_INPUT} through unchanged.
+ */
+export type MemberContextBuilder = (context: Context, input: DriveInput) => Context;
+
+/**
+ * Default {@link MemberContextBuilder}: pipe the previous member's `output` into
+ * the next member as a fresh user turn. {@link ORIGINAL_INPUT} (the unique
+ * symbol sentinel) is the only explicit passthrough — the member sees the
+ * original context unchanged. Any string input — INCLUDING the empty string
+ * from a stage that produced no text — is appended as a user turn. Because the
+ * sentinel is a symbol, an empty piped output can never collide with it, so a
+ * downstream stage can never silently fall back to the original prompt.
+ */
+export function appendUserInputContext(context: Context, input: DriveInput): Context {
+	if (input === ORIGINAL_INPUT) return context;
+	return {
+		...context,
+		messages: [...context.messages, { role: "user", content: input, timestamp: Date.now() }],
+	};
+}
+
+/**
+ * The model-leaf effect edge: drive a `kind: "model"` member via `streamSimple`.
+ * This is the ONLY place in the blend that performs network I/O. It resolves the
+ * member's model id against the registry, builds the per-member context via the
+ * injected {@link MemberContextBuilder}, runs `streamSimple`, awaits the result,
+ * and maps it to a {@link DriveResult}. The combinators above invoke the returned
+ * `DriveNode`; they never see `streamSimple` directly.
+ *
+ * @param streamSimple the `ai` streaming entry point (injected for testability).
+ * @param resolveModel maps a member's `model` string to a built `Model`.
+ * @param context the base conversation context fed to each member call.
+ * @param baseOptions shared stream options (signal merged per-call).
+ * @param buildMemberContext context-threading strategy (defaults to
+ *   {@link appendUserInputContext}).
+ */
+export function modelLeafDriveNode(
+	streamSimple: (model: Model, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream,
+	resolveModel: (modelId: string) => Model,
+	context: Context,
+	baseOptions?: SimpleStreamOptions,
+	buildMemberContext: MemberContextBuilder = appendUserInputContext,
+): DriveNode {
+	return async (member, input, signal) => {
+		signal?.throwIfAborted();
+		const model = resolveModel(member.model);
+		const memberContext = buildMemberContext(context, input);
+		const options: SimpleStreamOptions | undefined = signal !== undefined ? { ...baseOptions, signal } : baseOptions;
+		const stream = streamSimple(model, memberContext, options);
+		const message = await stream.result();
+		return { message, usage: message.usage, output: messageText(message), stream };
+	};
+}
+
+/**
+ * Resolve the surfaced member's message from a set of completed results. Surface
+ * resolution order (KTD-7): the `swarm.surface` role, else any member flagged
+ * `surface: true`, else the strategy's terminal member (the last result).
+ *
+ * @param spec the blend spec (for `surface` role + member flags).
+ * @param ordered the members actually run, paired with their results.
+ * @returns the {@link DriveResult} to surface.
+ * @throws if `ordered` is empty.
+ */
+export function pickSurface(
+	spec: SwarmSpec,
+	ordered: readonly { member: SwarmMember; result: DriveResult }[],
+): DriveResult {
+	if (ordered.length === 0) throw new Error("pickSurface: no members were run");
+	if (spec.surface !== undefined) {
+		const byRole = ordered.find(o => o.member.role === spec.surface);
+		if (byRole !== undefined) return byRole.result;
+	}
+	const flagged = ordered.find(o => o.member.surface === true);
+	if (flagged !== undefined) return flagged.result;
+	return ordered[ordered.length - 1].result;
+}
+
+export type { AssistantMessageEvent };

--- a/packages/coding-agent/src/swarm/primitives.ts
+++ b/packages/coding-agent/src/swarm/primitives.ts
@@ -30,6 +30,8 @@ import type {
 	Usage,
 } from "@oh-my-pi/pi-ai";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import type { ExecutorOptions } from "../task/executor";
+import type { AgentDefinition, SingleResult } from "../task/types";
 
 /** Default hard cap on members actually run when `swarm.maxMembers` is unset. */
 export const DEFAULT_MAX_MEMBERS = 5;
@@ -361,6 +363,211 @@ export function modelLeafDriveNode(
 		const stream = streamSimple(model, memberContext, options);
 		const message = await stream.result();
 		return { message, usage: message.usage, output: messageText(message), stream };
+	};
+}
+
+/**
+ * The subagent runner the {@link subagentLeafDriveNode} drives. Structurally this
+ * is the in-package `runSubprocess` (`task/executor.ts`) — injected (not imported
+ * at the call site) so the leaf is testable with a mock that never spawns a real
+ * process or builds a `ModelRegistry`. KTD-2: the subagent leaf calls this
+ * directly — it NEVER imports `@oh-my-pi/swarm-extension` (no cross-package cycle),
+ * uses no global runner registry, and needs no bootstrap shim.
+ */
+export type SubagentRunner = (options: ExecutorOptions) => Promise<SingleResult>;
+
+/**
+ * Dependencies for the subagent-leaf effect edge. The base `context` supplies the
+ * stable prompt prefix (KTD-8); `input` becomes the subagent's `task` (a fresh
+ * user turn for piped members, or the original user prompt for the first/router
+ * member). `taskDepth`/`maxRecursionDepth` drive the same recursion guard
+ * `runSubprocess` honors internally: the at-cap task-tool strip is delegated to
+ * `runSubprocess` (it marks `atMaxDepth` at `childDepth >= cap` and drops `task`
+ * so the child still runs); the leaf only adds a defensive guard that refuses to
+ * spawn a member already past the cap (`childDepth > cap`, reachable solely via an
+ * explicitly-injected over-deep `taskDepth`).
+ */
+export interface SubagentLeafDeps {
+	/** The subagent runner (injected; structurally `runSubprocess`). */
+	runSubprocess: SubagentRunner;
+	/** The subagent definition each `kind: "subagent"` member runs as. */
+	agent: AgentDefinition;
+	/** Working directory handed to the subagent. */
+	cwd: string;
+	/** Base conversation context — supplies the original prompt for {@link ORIGINAL_INPUT}. */
+	context: Context;
+	/** Parent recursion depth (0 = top-level). The child runs at `taskDepth + 1`. */
+	taskDepth?: number;
+	/**
+	 * Recursion cap (mirrors `settings.get("task.maxRecursionDepth")`, default 2).
+	 * A negative value disables the guard, matching `runSubprocess`. The leaf
+	 * refuses when the child's depth would exceed this cap.
+	 */
+	maxRecursionDepth?: number;
+	/** Passthroughs forwarded verbatim so the subagent shares the parent's runtime. */
+	modelRegistry?: ExecutorOptions["modelRegistry"];
+	authStorage?: ExecutorOptions["authStorage"];
+	settings?: ExecutorOptions["settings"];
+	/**
+	 * Base spawn index for telemetry/ordering (defaults to 0). Each `drive()` call
+	 * is given a DISTINCT index — `index + n` for the nth spawn off this leaf — so
+	 * concurrent members and repeated turns never share an `ExecutorOptions.index`.
+	 */
+	index?: number;
+	/**
+	 * Allocate a registry-unique spawn id. Called once per `drive()`; the returned
+	 * id is used verbatim as {@link ExecutorOptions.id}. The process-global
+	 * `AgentRegistry` is keyed by this id, so every spawn — including same-role moa
+	 * proposers in one blend and repeated turns of the same blend — MUST get a
+	 * distinct value or registers collide (overwrite, cross-talk `setStatus`, lost
+	 * teardown). Defaults to {@link defaultSubagentIdAllocator} (`crypto.randomUUID`),
+	 * mirroring the real task tool's per-spawn `outputManager.allocate`. Inject the
+	 * session's allocator when one exists to keep ids unique across the whole session.
+	 */
+	idAllocator?: () => string;
+}
+
+/** Default recursion cap when {@link SubagentLeafDeps.maxRecursionDepth} is unset. */
+export const DEFAULT_MAX_RECURSION_DEPTH = 2;
+
+/**
+ * Default {@link SubagentLeafDeps.idAllocator}: a fresh `crypto.randomUUID` per
+ * spawn. Guarantees registry-unique ids without threading a session allocator,
+ * mirroring the real task tool's per-spawn id allocation ("to prevent artifact
+ * collisions"). Hosts with a session-scoped allocator should inject it instead.
+ */
+export function defaultSubagentIdAllocator(): string {
+	return crypto.randomUUID();
+}
+
+/**
+ * Resolve the textual `task` for a subagent member. {@link ORIGINAL_INPUT} maps to
+ * the most recent user-turn text in the base context (the subagent answers the
+ * user's original prompt); any string input (a piped member output, even empty)
+ * is used verbatim as the task. This keeps the stable prefix in the base context
+ * and threads only the variable tail (KTD-8).
+ */
+function subagentTask(context: Context, input: DriveInput): string {
+	if (input !== ORIGINAL_INPUT) return input;
+	for (let i = context.messages.length - 1; i >= 0; i--) {
+		const message = context.messages[i];
+		if (message.role !== "user") continue;
+		if (typeof message.content === "string") return message.content;
+		let text = "";
+		for (const block of message.content) {
+			if (block.type === "text") text += block.text;
+		}
+		return text;
+	}
+	return "";
+}
+
+/**
+ * Map a {@link SingleResult} (the subagent runner's output) onto a
+ * {@link DriveResult}. The subagent's `output` text threads into the next member
+ * and is wrapped in a synthesized {@link AssistantMessage} so the surface path
+ * treats a subagent member exactly like a model member. Usage falls back to a
+ * zero record when the runner reported none. A failed/aborted run maps to the
+ * matching terminal `stopReason` so the executor's `isFailedResult` check (which
+ * keys on `stopReason`) detects it — failed subagents resolve here, they do not
+ * reject (mirroring the model-leaf / event-stream contract).
+ */
+function singleResultToDriveResult(member: SwarmMember, result: SingleResult): DriveResult {
+	const usage = result.usage ?? {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	const output = result.output ?? "";
+	const stopReason: AssistantMessage["stopReason"] = result.aborted
+		? "aborted"
+		: result.error !== undefined || result.exitCode !== 0
+			? "error"
+			: "stop";
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: output === "" ? [] : [{ type: "text", text: output }],
+		api: "omp-swarm",
+		provider: "omp",
+		model: member.model,
+		usage,
+		stopReason,
+		errorMessage: result.error,
+		timestamp: Date.now(),
+	};
+	return { message, usage, output };
+}
+
+/**
+ * The subagent-leaf effect edge: drive a `kind: "subagent"` member by mapping it
+ * to an {@link ExecutorOptions} and calling the injected runner (`runSubprocess`)
+ * DIRECTLY (KTD-2 — same package, no `swarm-extension` import, no registry, no
+ * shim). The member's {@link DriveInput} becomes the subagent `task`; the base
+ * context supplies the original prompt + stable prefix. Honors `signal` (fatal —
+ * checked before and forwarded into the run).
+ *
+ * Recursion depth: the at-cap task-tool strip is `runSubprocess`'s job — it marks
+ * `atMaxDepth` at `childDepth >= cap` and drops the `task` tool while still running
+ * the child — so the leaf does NOT pre-empt that boundary. The leaf only adds a
+ * defensive guard refusing a member whose depth is already PAST the cap
+ * (`childDepth > cap`), which is reachable solely via an explicitly-injected
+ * over-deep `taskDepth` (normal recursion can't get here: a child at the cap loses
+ * its `task` tool and so can never spawn a swarm one level deeper).
+ *
+ * Identity: each `drive()` is allocated a UNIQUE id (and a distinct `index`) via
+ * {@link SubagentLeafDeps.idAllocator} (default `crypto.randomUUID`). The
+ * process-global `AgentRegistry` is keyed by id, so a constant role/index would
+ * collide for same-role moa proposers in one blend and for repeated turns of the
+ * same blend — mirroring the real task tool, which allocates a unique id per spawn.
+ *
+ * The {@link SingleResult} is mapped back to a {@link DriveResult}; the pure
+ * combinators above only ever see that result.
+ */
+export function subagentLeafDriveNode(deps: SubagentLeafDeps): DriveNode {
+	const allocateId = deps.idAllocator ?? defaultSubagentIdAllocator;
+	const baseIndex = deps.index ?? 0;
+	// Monotonic per-leaf spawn counter: distinct `index` per `drive()` so concurrent
+	// blend members and repeated turns never share an `ExecutorOptions.index`.
+	let spawnCount = 0;
+	return async (member, input, signal) => {
+		signal?.throwIfAborted();
+		const parentDepth = deps.taskDepth ?? 0;
+		const childDepth = parentDepth + 1;
+		const cap = deps.maxRecursionDepth ?? DEFAULT_MAX_RECURSION_DEPTH;
+		// A negative cap disables the guard (matching runSubprocess). This is a
+		// defensive over-deep guard ONLY: the at-cap (`childDepth >= cap`) task-tool
+		// strip is delegated to runSubprocess; the leaf refuses only when the depth is
+		// already PAST the cap (`childDepth > cap`), unreachable via normal recursion.
+		if (cap >= 0 && childDepth > cap) {
+			throw new Error(
+				`subagent blend member "${member.role}" refused: recursion depth ${childDepth} exceeds cap ${cap}`,
+			);
+		}
+		const index = baseIndex + spawnCount;
+		spawnCount += 1;
+		const task = subagentTask(deps.context, input);
+		const options: ExecutorOptions = {
+			agent: deps.agent,
+			task,
+			cwd: deps.cwd,
+			index,
+			// Registry-unique per spawn (NOT `${agent}-${role}-${index}`, which collides
+			// for same-role members / repeated turns in the process-global AgentRegistry).
+			id: allocateId(),
+			role: member.role,
+			modelOverride: member.model,
+			taskDepth: parentDepth,
+			signal,
+			modelRegistry: deps.modelRegistry,
+			authStorage: deps.authStorage,
+			settings: deps.settings,
+		};
+		const result = await deps.runSubprocess(options);
+		signal?.throwIfAborted();
+		return singleResultToDriveResult(member, result);
 	};
 }
 

--- a/packages/coding-agent/src/swarm/primitives.ts
+++ b/packages/coding-agent/src/swarm/primitives.ts
@@ -200,9 +200,21 @@ export async function runRouter(
 }
 
 /** A {@link runParallelAggregate} run: every proposer result plus the aggregator's. */
+/** A surviving proposal paired with the proposer that produced it. */
+export interface SwarmProposal {
+	member: SwarmMember;
+	result: DriveResult;
+}
+
 export interface ParallelAggregateResult {
-	/** One entry per proposer, in declaration order (failed proposers omitted). */
-	proposals: DriveResult[];
+	/**
+	 * Surviving proposals, each paired with its proposer, in declaration order
+	 * (failed proposers omitted). Pairing the member with the result here — rather
+	 * than returning a bare `DriveResult[]` zipped against the original `proposers`
+	 * by index — is what prevents a rejected proposer from misattributing a
+	 * survivor's result to the wrong member.
+	 */
+	proposals: SwarmProposal[];
 	/** The aggregator's synthesized/voted result. */
 	aggregate: DriveResult;
 }
@@ -233,10 +245,16 @@ export async function runParallelAggregate(
 	signal?: AbortSignal,
 ): Promise<ParallelAggregateResult> {
 	signal?.throwIfAborted();
-	const settled = await Promise.allSettled(proposers.map(member => drive(member, ORIGINAL_INPUT, signal)));
+	// Settle {member, result} pairs (not bare results) so a rejected proposer —
+	// dropped below — never misattributes a survivor's result to the wrong member
+	// via index zipping. (Index access would also be `| undefined` under
+	// noUncheckedIndexedAccess; carrying the member in the value avoids both.)
+	const settled = await Promise.allSettled(
+		proposers.map(async member => ({ member, result: await drive(member, ORIGINAL_INPUT, signal) })),
+	);
 	// An abort is fatal: surface it instead of degrading to a partial reduce.
 	if (signal?.aborted) signal.throwIfAborted();
-	const proposals: DriveResult[] = [];
+	const proposals: SwarmProposal[] = [];
 	let lastError: unknown;
 	for (const outcome of settled) {
 		if (outcome.status === "fulfilled") proposals.push(outcome.value);
@@ -249,7 +267,10 @@ export async function runParallelAggregate(
 			}`,
 		);
 	}
-	const aggregatorInput = buildAggregatorInput(userPrompt, proposals);
+	const aggregatorInput = buildAggregatorInput(
+		userPrompt,
+		proposals.map(p => p.result),
+	);
 	const aggregate = await drive(aggregator, aggregatorInput, signal);
 	return { proposals, aggregate };
 }

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -83,6 +83,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
 		authStorage.setRuntimeApiKey("google", "google-test-key");
+		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
 		sharedRegistry = new ModelRegistry(authStorage);
 	});
 
@@ -213,6 +214,120 @@ describe("AgentSession retry fallback", () => {
 				role: "default",
 			},
 		]);
+	});
+
+	it("fails over to a ranked canonical variant with no explicit chain, then restores the primary on cooldown", async () => {
+		// Multi-provider canonical model: claude-sonnet-4-5 is served by both
+		// anthropic and openrouter. With retry.modelFallback on and NO explicit
+		// retry.fallbackChains entry, the implicit canonical-variant chain must
+		// carry a terminal error onto the ranked next variant.
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const openrouterVariant = getBundledModel("openrouter", "anthropic/claude-sonnet-4.5");
+		if (!primaryModel || !openrouterVariant) {
+			throw new Error("Expected bundled canonical-variant test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const fallbackSucceededEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>> = [];
+		const mock = createMockModel();
+		// Flips true once the primary's quota window has elapsed so the cooldown
+		// leg actually exercises a healthy primary (not a queued generic success).
+		let primaryRecovered = false;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				const isPrimary = model.provider === primaryModel.provider && model.id === primaryModel.id;
+				if (model.provider === openrouterVariant.provider && model.id === openrouterVariant.id) {
+					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
+				} else if (isPrimary && primaryRecovered) {
+					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
+				} else {
+					// The primary's account quota is exhausted; the only cross-provider
+					// canonical sibling is the openrouter variant. "quota exceeded"
+					// classifies as QUOTA_EXHAUSTED, which gates the implicit
+					// canonical-variant failover.
+					mock.push({ throw: "quota exceeded for this account retry-after-ms=200" });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.modelFallback": true,
+			"retry.fallbackRevertPolicy": "cooldown-expiry",
+			// Intentionally NO retry.fallbackChains: failover must come purely
+			// from canonical-variant ranking.
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+			if (event.type === "retry_fallback_succeeded") {
+				fallbackSucceededEvents.push(event);
+			}
+		});
+
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		await session.prompt("Recover via canonical failover");
+		await session.waitForIdle();
+
+		// The error walks the implicit canonical chain straight to the cross-provider
+		// sibling; the primary's same-provider dated alias is intentionally skipped
+		// (it shares the exhausted account and would not recover).
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${openrouterVariant.provider}/${openrouterVariant.id}`,
+		]);
+
+		// The single hop fires the existing retry_fallback_applied event with role
+		// "default", landing on the cross-provider sibling.
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${openrouterVariant.provider}/${openrouterVariant.id}`,
+				role: "default",
+			},
+		]);
+		expect(fallbackSucceededEvents.at(-1)).toEqual({
+			type: "retry_fallback_succeeded",
+			model: `${openrouterVariant.provider}/${openrouterVariant.id}`,
+			role: "default",
+		});
+		expect(session.model?.provider).toBe(openrouterVariant.provider);
+		expect(session.model?.id).toBe(openrouterVariant.id);
+
+		// After the primary's cooldown expires and its quota recovers, the next
+		// turn restores and uses the primary directly.
+		now += 60 * 60 * 1000;
+		primaryRecovered = true;
+		requestedModels.length = 0;
+		await session.prompt("Primary should be restored after cooldown");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primaryModel.provider}/${primaryModel.id}`]);
+		expect(session.model?.provider).toBe(primaryModel.provider);
+		expect(session.model?.id).toBe(primaryModel.id);
 	});
 
 	it("falls back on structured classifier refusals and pins the fallback", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -463,6 +463,84 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("rankCanonicalVariantsFor", () => {
+		// Three custom providers all aliasing the same bundled canonical id, so the
+		// equivalence index groups them WITHOUT pulling in bundled anthropic
+		// variants (no anthropic auth is configured here).
+		function writeThreeProviderCanonical() {
+			writeRawModelsJson({
+				demo: providerConfig("https://demo.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+				proxy: providerConfig("https://proxy.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+				gateway: providerConfig("https://gateway.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+			});
+		}
+
+		test("ranks fallback siblings by configured modelProviderOrder, excluding the primary", async () => {
+			await Settings.init({
+				inMemory: true,
+				overrides: {
+					modelProviderOrder: ["demo", "proxy", "gateway"],
+				},
+			});
+			writeThreeProviderCanonical();
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const primary = registry.find("demo", "anthropic/claude-sonnet-4.5");
+			expect(primary).toBeDefined();
+
+			const ranked = registry.rankCanonicalVariantsFor(primary as Model);
+			// The primary (demo) is excluded; siblings follow modelProviderOrder.
+			expect(ranked.map(model => model.provider)).toEqual(["proxy", "gateway"]);
+		});
+
+		test("reorders the fallback chain when modelProviderOrder changes", async () => {
+			await Settings.init({
+				inMemory: true,
+				overrides: {
+					modelProviderOrder: ["gateway", "proxy", "demo"],
+				},
+			});
+			writeThreeProviderCanonical();
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const primary = registry.find("demo", "anthropic/claude-sonnet-4.5");
+			expect(primary).toBeDefined();
+
+			const ranked = registry.rankCanonicalVariantsFor(primary as Model);
+			expect(ranked.map(model => model.provider)).toEqual(["gateway", "proxy"]);
+		});
+
+		test("returns [] for a singleton-canonical model (no fallback siblings)", () => {
+			writeRawModelsJson({
+				solo: providerConfig("https://solo.example.com/v1", [{ id: "my-private-llm-v1" }]),
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const primary = registry.find("solo", "my-private-llm-v1");
+			expect(primary).toBeDefined();
+
+			// The canonical group contains only the model itself, so excluding the
+			// primary leaves an empty failover chain (no empty-chain hazard).
+			const variants = registry.getCanonicalVariants(registry.getCanonicalId(primary as Model) ?? "", {
+				availableOnly: true,
+			});
+			expect(variants.map(variant => variant.model.provider)).toEqual(["solo"]);
+			expect(registry.rankCanonicalVariantsFor(primary as Model)).toEqual([]);
+		});
+
+		test("returns [] for an unknown-canonical model (not in the equivalence index)", () => {
+			writeRawModelsJson({
+				demo: providerConfig("https://demo.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			// A model that is not registered has no canonical id at all.
+			const unknown = { provider: "ghost", id: "not-a-real-model" } as Model;
+			expect(registry.getCanonicalId(unknown)).toBeUndefined();
+			expect(registry.rankCanonicalVariantsFor(unknown)).toEqual([]);
+		});
+	});
+
 	describe("OpenRouter routed suffix fallback", () => {
 		test("find synthesizes a routed model id from the base OpenRouter metadata", () => {
 			writeRawModelsJson({

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -519,11 +519,18 @@ describe("ModelRegistry", () => {
 			const primary = registry.find("solo", "my-private-llm-v1");
 			expect(primary).toBeDefined();
 
+			// A REGISTERED-but-unaliased custom id is its OWN canonical: resolveCanonicalIdForModel
+			// falls through to the "fallback" source and returns the bare model id, so
+			// getCanonicalId() is NEVER undefined here. That is the load-bearing distinction from
+			// the unregistered-model case below (where getCanonicalId() *does* return undefined).
+			// Assert it directly so a regression in the self-fallback path fails on THIS line, not
+			// indirectly via the empty variants list.
+			const canonicalId = registry.getCanonicalId(primary as Model);
+			expect(canonicalId).toBe("my-private-llm-v1");
+
 			// The canonical group contains only the model itself, so excluding the
 			// primary leaves an empty failover chain (no empty-chain hazard).
-			const variants = registry.getCanonicalVariants(registry.getCanonicalId(primary as Model) ?? "", {
-				availableOnly: true,
-			});
+			const variants = registry.getCanonicalVariants(canonicalId ?? "", { availableOnly: true });
 			expect(variants.map(variant => variant.model.provider)).toEqual(["solo"]);
 			expect(registry.rankCanonicalVariantsFor(primary as Model)).toEqual([]);
 		});

--- a/packages/coding-agent/test/model-selector-swarm-cost.test.ts
+++ b/packages/coding-agent/test/model-selector-swarm-cost.test.ts
@@ -1,0 +1,301 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { Model, SwarmSpec } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	computeSwarmSummedCost,
+	type MemberCostLookup,
+	type MemberCostRate,
+	ModelSelectorComponent,
+} from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+/**
+ * U10 — picker cost surfacing for blended (`omp-swarm`) models.
+ *
+ * The bulk of the coverage targets the PURE helper {@link computeSwarmSummedCost}:
+ * it takes a {@link SwarmSpec} plus a cost-lookup fn and returns the summed
+ * member cost WITHOUT touching a `ModelRegistry`, so the per-strategy reduce
+ * (router ≈ 1 member + classifier; sequence/draft-refine/moa = Σ members) is
+ * exercised deterministically. A small component test then asserts the additive
+ * contract: a blended row renders the cost, a normal row is byte-identical.
+ */
+
+/** Build a lookup from a plain `{ id|provider/id -> {input, output} }` table. */
+function lookupFrom(table: Record<string, MemberCostRate>): MemberCostLookup {
+	return modelId => table[modelId];
+}
+
+describe("computeSwarmSummedCost (pure helper)", () => {
+	test("sequence sums every member's input+output rate", () => {
+		const swarm: SwarmSpec = {
+			strategy: "sequence",
+			members: [
+				{ role: "draft", model: "p/draft" },
+				{ role: "refine", model: "p/refine", surface: true },
+			],
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/draft": { input: 1, output: 4 }, "p/refine": { input: 3, output: 15 } }),
+		);
+		expect(summed).toBeDefined();
+		// input = 1 + 3 = 4; output = 4 + 15 = 19; blended = 23.
+		expect(summed?.input).toBe(4);
+		expect(summed?.output).toBe(19);
+		expect(summed?.blended).toBe(23);
+		expect(summed?.counted).toBe(2);
+		expect(summed?.resolved).toBe(2);
+	});
+
+	test("draft-refine sums every member (same reduce as sequence)", () => {
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "p/cheap" },
+				{ role: "refine", model: "p/strong", surface: true },
+			],
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/cheap": { input: 0.5, output: 2 }, "p/strong": { input: 5, output: 25 } }),
+		);
+		expect(summed?.blended).toBeCloseTo(32.5, 5);
+		expect(summed?.resolved).toBe(2);
+	});
+
+	test("moa sums all proposers AND the aggregator", () => {
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "p/mid" },
+				{ role: "proposer", model: "p/mid" },
+				{ role: "proposer", model: "p/mid" },
+				{ role: "aggregator", model: "p/strong", surface: true },
+			],
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/mid": { input: 1, output: 5 }, "p/strong": { input: 5, output: 25 } }),
+		);
+		// 3 proposers @ (1+5)=6 each = 18, plus aggregator (5+25)=30 → 48.
+		expect(summed?.blended).toBe(48);
+		expect(summed?.counted).toBe(4);
+		expect(summed?.resolved).toBe(4);
+	});
+
+	test("router counts ONE member (worst-case candidate) + the classifier", () => {
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			members: [
+				{ role: "weak", model: "p/weak" },
+				{ role: "strong", model: "p/strong" },
+			],
+			selector: { kind: "classifier", model: "p/weak" },
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/weak": { input: 1, output: 4 }, "p/strong": { input: 5, output: 20 } }),
+		);
+		// One member runs per turn → worst-case is the priciest candidate (strong,
+		// blended 25); plus the classifier (weak, blended 5) → 30. NOT the sum of
+		// both members (which would be 30 too here — so use asymmetric rates below
+		// to prove only one member is counted).
+		expect(summed?.counted).toBe(2); // 1 member + 1 classifier, NOT 3.
+		expect(summed?.blended).toBe(30);
+	});
+
+	test("router picks the most expensive member, not the first or the sum of all", () => {
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			members: [
+				{ role: "weak", model: "p/weak" },
+				{ role: "strong", model: "p/strong" },
+			],
+			// No classifier selector → rule routing, so only the member cost counts.
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/weak": { input: 1, output: 1 }, "p/strong": { input: 100, output: 100 } }),
+		);
+		// Sum-of-all would be 202; first-member would be 2; worst-case is 200.
+		expect(summed?.counted).toBe(1);
+		expect(summed?.blended).toBe(200);
+	});
+
+	test("router classifier with kind:rule contributes no classifier call", () => {
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			members: [
+				{ role: "a", model: "p/a" },
+				{ role: "b", model: "p/b" },
+			],
+			selector: { kind: "rule" },
+		};
+		const summed = computeSwarmSummedCost(
+			swarm,
+			lookupFrom({ "p/a": { input: 2, output: 2 }, "p/b": { input: 1, output: 1 } }),
+		);
+		// rule selector → no classifier model → only the worst member is counted.
+		expect(summed?.counted).toBe(1);
+		expect(summed?.blended).toBe(4);
+	});
+
+	test("maxMembers caps the members counted (mirrors capMembers)", () => {
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "p/x" },
+				{ role: "proposer", model: "p/x" },
+				{ role: "proposer", model: "p/x" },
+				{ role: "aggregator", model: "p/x", surface: true },
+			],
+			maxMembers: 2,
+		};
+		const summed = computeSwarmSummedCost(swarm, lookupFrom({ "p/x": { input: 1, output: 1 } }));
+		// Only the first 2 members survive the cap → blended 2 + 2 = 4, not 8.
+		expect(summed?.counted).toBe(2);
+		expect(summed?.blended).toBe(4);
+	});
+
+	test("unresolved members contribute 0 and are tallied separately", () => {
+		const swarm: SwarmSpec = {
+			strategy: "sequence",
+			members: [
+				{ role: "draft", model: "p/known" },
+				{ role: "refine", model: "p/unknown" },
+			],
+		};
+		const summed = computeSwarmSummedCost(swarm, lookupFrom({ "p/known": { input: 2, output: 3 } }));
+		expect(summed?.blended).toBe(5); // unknown contributes 0
+		expect(summed?.counted).toBe(2);
+		expect(summed?.resolved).toBe(1);
+	});
+
+	test("returns undefined only when the cap leaves no members", () => {
+		const swarm: SwarmSpec = { strategy: "moa", members: [{ role: "x", model: "p/x" }], maxMembers: 0 };
+		// maxMembers: 0 is treated as the default cap (5), so the single member survives.
+		const summed = computeSwarmSummedCost(swarm, lookupFrom({ "p/x": { input: 1, output: 1 } }));
+		expect(summed?.counted).toBe(1);
+
+		const empty: SwarmSpec = { strategy: "sequence", members: [] };
+		expect(computeSwarmSummedCost(empty, lookupFrom({}))).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Component-level additive contract: blended row shows cost, normal row doesn't.
+// ---------------------------------------------------------------------------
+
+function normalizeRenderedText(text: string): string {
+	return stripVTControlCharacters(text).replace(/\s+/g, " ").trim();
+}
+
+let testTheme = await getThemeByName("dark");
+
+function installTestTheme(): void {
+	if (!testTheme) {
+		throw new Error("Failed to load dark theme for ModelSelector swarm-cost tests");
+	}
+	setThemeInstance(testTheme);
+}
+
+function memberModel(provider: string, id: string, input: number, output: number): Model {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input, output, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	});
+}
+
+function blendedModel(swarm: SwarmSpec): Model {
+	return buildModel({
+		id: "draft-refine",
+		name: "OMP Draft → Refine",
+		api: "omp-swarm",
+		provider: "omp",
+		baseUrl: "omp://",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+		swarm,
+	});
+}
+
+function createScopedSelector(models: Model[], settings: Settings): ModelSelectorComponent {
+	const modelRegistry = {
+		getAll: () => models,
+		getAvailable: () => models,
+		getDiscoverableProviders: () => [],
+		getCanonicalModelSelections: () => [],
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		undefined,
+		settings,
+		modelRegistry,
+		models.map(model => ({ model })),
+		() => {},
+		() => {},
+	);
+}
+
+describe("ModelSelector blended-model cost surfacing", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("dark");
+		if (!testTheme) {
+			throw new Error("Failed to load dark theme for ModelSelector swarm-cost tests");
+		}
+	});
+
+	test("renders the summed (~Nx) cost on a blended model row", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const cheap = memberModel("omp", "cheap", 1, 4);
+		const strong = memberModel("omp", "strong", 5, 16);
+		const blend = blendedModel({
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "omp/cheap" },
+				{ role: "refine", model: "omp/strong", surface: true },
+			],
+		});
+
+		const selector = createScopedSelector([blend, cheap, strong], settings);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		// blended = (1+4) + (5+16) = 26.00; rendered as ~$26.00/1M on the blend row.
+		expect(rendered).toContain("draft-refine");
+		expect(rendered).toContain("~$26.00/1M");
+	});
+
+	test("does not add a cost suffix to a normal (non-blended) model row", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const plain = memberModel("omp", "plain-model", 2, 8);
+
+		const selector = createScopedSelector([plain], settings);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("plain-model");
+		// The /1M synthetic-cost suffix is reserved for blended rows only.
+		expect(rendered).not.toContain("/1M");
+	});
+});

--- a/packages/coding-agent/test/swarm-config-parse.test.ts
+++ b/packages/coding-agent/test/swarm-config-parse.test.ts
@@ -154,7 +154,7 @@ describe("U8 swarm config zod mirror", () => {
 				openai: {
 					api: "openai-completions" as const,
 					baseUrl: "https://api.openai.com/v1",
-					apiKey: "sk-test",
+					apiKey: "test-placeholder",
 					models: [{ id: "gpt-4o" }],
 				},
 			},

--- a/packages/coding-agent/test/swarm-config-parse.test.ts
+++ b/packages/coding-agent/test/swarm-config-parse.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { ModelsConfigSchema } from "@oh-my-pi/pi-coding-agent/config/models-config-schema";
+
+/**
+ * U8 — the zod `SwarmSpec` mirror must let a user-authored `swarm:` block and an
+ * `api: "omp-swarm"` declaration survive `ModelsConfigSchema` parsing. Zod strips
+ * unknown keys, so without the mirror the field is silently dropped before the
+ * custom-model build pipeline (KTD-4). These tests assert the field is RETAINED
+ * (not merely accepted), that the new api literal parses on both the model- and
+ * provider-level enums, that invalid blends fail parse, and that configs without
+ * a swarm block are unchanged (no contamination).
+ */
+describe("U8 swarm config zod mirror", () => {
+	const baseSwarm = {
+		strategy: "moa" as const,
+		members: [
+			{ role: "proposer", model: "anthropic/claude-opus-4", kind: "model" as const },
+			{ role: "proposer", model: "anthropic/claude-sonnet-4" },
+			{ role: "aggregator", model: "anthropic/claude-opus-4", surface: true },
+		],
+		selector: { kind: "classifier" as const, model: "openai/gpt-4o-mini" },
+		surface: "aggregator",
+		maxMembers: 3,
+		firstEventTimeoutMs: 5000,
+	};
+
+	test("a valid swarm block parses AND is retained on the model definition", () => {
+		const config = {
+			providers: {
+				omp: {
+					api: "omp-swarm" as const,
+					baseUrl: "omp://",
+					models: [{ id: "omp/moa-synthesis", swarm: baseSwarm }],
+				},
+			},
+		};
+
+		const result = ModelsConfigSchema.safeParse(config);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		const model = result.data.providers?.omp?.models?.[0];
+		expect(model).toBeDefined();
+		// The whole spec must survive byte-for-byte — proves no strip.
+		expect(model?.swarm).toEqual(baseSwarm);
+		expect(model?.swarm?.strategy).toBe("moa");
+		expect(model?.swarm?.members).toHaveLength(3);
+		expect(model?.swarm?.members[2]?.surface).toBe(true);
+		expect(model?.swarm?.selector?.kind).toBe("classifier");
+	});
+
+	test('api: "omp-swarm" is accepted on the provider-level enum', () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: { omp: { api: "omp-swarm", baseUrl: "omp://", auth: "none" } },
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.providers?.omp?.api).toBe("omp-swarm");
+		}
+	});
+
+	test('api: "omp-swarm" is accepted on the model-level enum', () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				omp: {
+					baseUrl: "omp://",
+					models: [{ id: "omp/router-balanced", api: "omp-swarm", swarm: baseSwarm }],
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.providers?.omp?.models?.[0]?.api).toBe("omp-swarm");
+		}
+	});
+
+	test("each swarm strategy literal parses", () => {
+		for (const strategy of ["router", "draft-refine", "sequence", "moa"] as const) {
+			const result = ModelsConfigSchema.safeParse({
+				providers: {
+					omp: {
+						baseUrl: "omp://",
+						models: [{ id: `omp/${strategy}`, swarm: { strategy, members: [{ role: "a", model: "x/y" }] } }],
+					},
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.providers?.omp?.models?.[0]?.swarm?.strategy).toBe(strategy);
+			}
+		}
+	});
+
+	test("an unknown strategy fails parse", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				omp: {
+					baseUrl: "omp://",
+					models: [{ id: "omp/bad", swarm: { strategy: "consensus", members: [{ role: "a", model: "x/y" }] } }],
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("an empty members array fails parse (members.min(1))", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				omp: {
+					baseUrl: "omp://",
+					models: [{ id: "omp/empty", swarm: { strategy: "moa", members: [] } }],
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("an invalid selector kind fails parse", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				omp: {
+					baseUrl: "omp://",
+					models: [
+						{
+							id: "omp/bad-selector",
+							swarm: {
+								strategy: "router",
+								members: [{ role: "a", model: "x/y" }],
+								selector: { kind: "semantic" },
+							},
+						},
+					],
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("a model missing role/model in a member fails parse", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				omp: {
+					baseUrl: "omp://",
+					models: [{ id: "omp/bad-member", swarm: { strategy: "sequence", members: [{ role: "draft" }] } }],
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("a config without swarm is unchanged (no contamination)", () => {
+		const config = {
+			providers: {
+				openai: {
+					api: "openai-completions" as const,
+					baseUrl: "https://api.openai.com/v1",
+					apiKey: "sk-test",
+					models: [{ id: "gpt-4o" }],
+				},
+			},
+		};
+
+		const result = ModelsConfigSchema.safeParse(config);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		const model = result.data.providers?.openai?.models?.[0];
+		expect(model?.id).toBe("gpt-4o");
+		// No swarm key introduced where the user authored none.
+		expect(model?.swarm).toBeUndefined();
+		expect(result.data.providers?.openai?.api).toBe("openai-completions");
+	});
+});

--- a/packages/coding-agent/test/swarm-executor.test.ts
+++ b/packages/coding-agent/test/swarm-executor.test.ts
@@ -1,0 +1,432 @@
+/**
+ * U6 — `omp-swarm` blend executor.
+ *
+ * Exercises the executor against mock member models (no network). Two seams are
+ * covered:
+ *   1. {@link createSwarmStreamSimple} with injected mock deps — the direct,
+ *      registry-free contract (the real U6 deliverable);
+ *   2. dispatch through the global custom-API registry via {@link registerSwarmApi}
+ *      + {@link getCustomApi}, proving `api: "omp-swarm"` routes to the executor.
+ *
+ * Assertions track the plan's scenarios: surfaced message + SUMMED usage; router
+ * surfaces exactly one member; draft-refine pipes draft→refiner and surfaces the
+ * refiner; moa surfaces the aggregator and sums every proposer's usage; an abort
+ * signal is fatal; and every member call shares a byte-identical cache prefix
+ * (KTD-8).
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	type AssistantMessage,
+	type Context,
+	clearCustomApis,
+	getCustomApi,
+	type Model,
+	type Usage,
+} from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel, streamMock } from "@oh-my-pi/pi-ai/providers/mock";
+import type { SwarmSpec } from "@oh-my-pi/pi-catalog/types";
+import {
+	createSwarmStreamSimple,
+	OMP_BASE_URL,
+	OMP_PROVIDER_NAME,
+	OMP_SWARM_API,
+	registerSwarmApi,
+	type SwarmExecutorDeps,
+} from "@oh-my-pi/pi-coding-agent/swarm/executor";
+
+afterEach(() => {
+	clearCustomApis();
+});
+
+/** A blend `Model` carrying the given spec. The executor only reads `swarm` + identity. */
+function blendModel(swarm: SwarmSpec, id = "omp/test-blend"): Model {
+	return {
+		id,
+		name: id,
+		api: OMP_SWARM_API,
+		provider: OMP_PROVIDER_NAME,
+		baseUrl: OMP_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 32_768,
+		compat: undefined,
+		swarm,
+	} as unknown as Model;
+}
+
+/** A base conversation context with a single user turn — the stable cache prefix. */
+function baseContext(prompt = "refactor the parser"): Context {
+	return {
+		systemPrompt: ["You are a coding agent."],
+		tools: [],
+		messages: [{ role: "user", content: prompt, timestamp: 1 }],
+	};
+}
+
+/**
+ * Build executor deps from a role→MockModel map. `resolveModel` indexes the map;
+ * `streamSimple` forwards to the mock transport. The returned `models` handle
+ * exposes every mock for call inspection.
+ */
+function mockDeps(models: Record<string, MockModel>): { deps: SwarmExecutorDeps; models: Record<string, MockModel> } {
+	const deps: SwarmExecutorDeps = {
+		resolveModel: id => {
+			const model = models[id];
+			if (!model) throw new Error(`test resolveModel: no mock for "${id}"`);
+			return model as unknown as Model;
+		},
+		streamSimple: (model, context, options) => streamMock(model, context, options),
+	};
+	return { deps, models };
+}
+
+/** Usage with explicit input/output token counts (cost recomputed by the executor's sum). */
+function usage(input: number, output: number): Partial<Usage> {
+	return {
+		input,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+/** Collect the text of an assistant message. */
+function text(message: AssistantMessage): string {
+	let out = "";
+	for (const block of message.content) {
+		if (block.type === "text") out += block.text;
+	}
+	return out;
+}
+
+describe("omp-swarm blend executor", () => {
+	it("dispatches through getCustomApi('omp-swarm') and surfaces the member message with summed usage", async () => {
+		const drafter = createMockModel({ id: "weak", responses: [{ content: ["draft answer"], usage: usage(10, 5) }] });
+		const refiner = createMockModel({
+			id: "strong",
+			responses: [{ content: ["refined answer"], usage: usage(20, 8) }],
+		});
+		const { deps } = mockDeps({ weak: drafter, strong: refiner });
+		// Register the global dispatcher (deps as fallback) and route via the registry.
+		registerSwarmApi(deps);
+		const api = getCustomApi(OMP_SWARM_API);
+		expect(api).toBeDefined();
+
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "weak" },
+				{ role: "refine", model: "strong" },
+			],
+		};
+		const message = await api!.streamSimple(blendModel(swarm), baseContext(), undefined).result();
+
+		// Surface is the terminal (refiner) member.
+		expect(text(message)).toBe("refined answer");
+		// Usage is summed across BOTH members, with derived totals recomputed.
+		expect(message.usage.input).toBe(30);
+		expect(message.usage.output).toBe(13);
+		expect(message.usage.totalTokens).toBe(43);
+	});
+
+	it("router surfaces exactly one member and leaves the others uncalled", async () => {
+		const fast = createMockModel({ id: "fast", responses: [{ content: ["fast reply"], usage: usage(5, 5) }] });
+		const slow = createMockModel({ id: "slow", responses: [{ content: ["slow reply"], usage: usage(50, 50) }] });
+		const { deps } = mockDeps({ fast, slow });
+
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			// No selector → rule default picks the first member ("fast").
+			members: [
+				{ role: "fast", model: "fast" },
+				{ role: "slow", model: "slow" },
+			],
+		};
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined).result();
+
+		expect(text(message)).toBe("fast reply");
+		// Exactly one member ran; the unrouted member was never invoked.
+		expect(fast.calls).toHaveLength(1);
+		expect(slow.calls).toHaveLength(0);
+		// Surfaced usage is the single chosen member's.
+		expect(message.usage.totalTokens).toBe(10);
+	});
+
+	it("router classifier verdict selects the matching member", async () => {
+		const codeModel = createMockModel({ id: "code", responses: [{ content: ["code answer"], usage: usage(7, 7) }] });
+		const proseModel = createMockModel({
+			id: "prose",
+			responses: [{ content: ["prose answer"], usage: usage(9, 9) }],
+		});
+		// Classifier emits the winning role verbatim.
+		const classifier = createMockModel({ id: "judge", responses: [{ content: ["prose"], usage: usage(2, 1) }] });
+		const { deps } = mockDeps({ code: codeModel, prose: proseModel, judge: classifier });
+
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			selector: { kind: "classifier", model: "judge" },
+			members: [
+				{ role: "code", model: "code" },
+				{ role: "prose", model: "prose" },
+			],
+		};
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined).result();
+
+		expect(text(message)).toBe("prose answer");
+		expect(codeModel.calls).toHaveLength(0);
+		expect(proseModel.calls).toHaveLength(1);
+		expect(classifier.calls).toHaveLength(1);
+		// Summed usage = classifier + chosen member (the classifier spends tokens too).
+		expect(message.usage.input).toBe(11);
+		expect(message.usage.output).toBe(10);
+	});
+
+	it("draft-refine pipes the draft output into the refiner as a fresh user turn", async () => {
+		const drafter = createMockModel({ id: "weak", responses: [{ content: ["DRAFT"], usage: usage(1, 1) }] });
+		const refiner = createMockModel({ id: "strong", responses: [{ content: ["FINAL"], usage: usage(1, 1) }] });
+		const { deps } = mockDeps({ weak: drafter, strong: refiner });
+
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "weak" },
+				{ role: "refine", model: "strong" },
+			],
+		};
+		await createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined).result();
+
+		// The drafter saw the original context (one user turn).
+		expect(drafter.calls[0].context.messages).toHaveLength(1);
+		// The refiner saw the original prefix PLUS the drafter's output appended.
+		const refinerMessages = refiner.calls[0].context.messages;
+		expect(refinerMessages).toHaveLength(2);
+		const appended = refinerMessages[1];
+		expect(appended.role).toBe("user");
+		expect(appended.content).toBe("DRAFT");
+	});
+
+	it("moa surfaces the aggregator and sums all proposer usage", async () => {
+		const p1 = createMockModel({ id: "p1", responses: [{ content: ["proposal one"], usage: usage(10, 10) }] });
+		const p2 = createMockModel({ id: "p2", responses: [{ content: ["proposal two"], usage: usage(10, 10) }] });
+		const agg = createMockModel({ id: "agg", responses: [{ content: ["synthesis"], usage: usage(30, 15) }] });
+		const { deps } = mockDeps({ p1, p2, agg });
+
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "p1" },
+				{ role: "proposer", model: "p2" },
+				{ role: "aggregator", model: "agg" },
+			],
+		};
+		const stream = createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined);
+
+		// moa emits an early `start` placeholder before the aggregate completes (KTD-7).
+		// Collect the full event sequence and AWAIT it so the assertions never race
+		// the stream draining (and any late stream error surfaces inside the test).
+		const events: string[] = [];
+		const collector = (async () => {
+			for await (const event of stream) events.push(event.type);
+		})();
+		const message = await stream.result();
+		await collector;
+
+		expect(text(message)).toBe("synthesis");
+		// Summed usage = both proposers + aggregator.
+		expect(message.usage.input).toBe(50);
+		expect(message.usage.output).toBe(35);
+		expect(message.usage.totalTokens).toBe(85);
+		// The aggregator received a prompt that embeds BOTH proposals.
+		const aggInput = agg.calls[0].context.messages.at(-1);
+		expect(aggInput?.role).toBe("user");
+		expect(String(aggInput?.content)).toContain("proposal one");
+		expect(String(aggInput?.content)).toContain("proposal two");
+		// First emitted event is a `start` (the synthesizing placeholder).
+		expect(events[0]).toBe("start");
+	});
+
+	it("moa drops a failed proposer from the aggregator prompt and still reduces", async () => {
+		const ok = createMockModel({ id: "ok", responses: [{ content: ["good proposal"], usage: usage(10, 10) }] });
+		// A `{ throw }` mock emits a TERMINAL error event, which RESOLVES result()
+		// with an error message (stopReason "error", empty content, zero usage) —
+		// it does NOT reject. So the failed proposer arrives as a fulfilled, empty
+		// DriveResult; the executor drops it by `stopReason`, not by a rejection.
+		const bad = createMockModel({ id: "bad", responses: [{ throw: "proposer exploded" }] });
+		const agg = createMockModel({ id: "agg", responses: [{ content: ["reduced"], usage: usage(5, 5) }] });
+		const { deps } = mockDeps({ ok, bad, agg });
+
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "ok" },
+				{ role: "proposer", model: "bad" },
+				{ role: "aggregator", model: "agg" },
+			],
+		};
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined).result();
+
+		expect(text(message)).toBe("reduced");
+		// Usage sums every member's usage; the failed proposer contributes zero, so
+		// the total is the surviving proposer (10) + aggregator (5).
+		expect(message.usage.input).toBe(15);
+		const aggPrompt = String(agg.calls[0].context.messages.at(-1)?.content);
+		// The surviving proposal is embedded.
+		expect(aggPrompt).toContain("good proposal");
+		// The failed proposer is DROPPED: exactly one numbered Proposal section is
+		// present, so the aggregator never sees an empty "### Proposal 2".
+		expect(aggPrompt).toContain("### Proposal 1");
+		expect(aggPrompt).not.toContain("### Proposal 2");
+	});
+
+	it("moa fails loudly when every proposer fails (nothing to synthesize)", async () => {
+		// Both proposers emit terminal error events (resolve-not-reject), so the
+		// primitive's allSettled drop branch never fires; the executor detects the
+		// all-failed case by stopReason and fails loud rather than feeding the
+		// aggregator a content-free prompt.
+		const bad1 = createMockModel({ id: "bad1", responses: [{ throw: "boom one" }] });
+		const bad2 = createMockModel({ id: "bad2", responses: [{ throw: "boom two" }] });
+		const agg = createMockModel({ id: "agg", responses: [{ content: ["unreachable"], usage: usage(5, 5) }] });
+		const { deps } = mockDeps({ bad1, bad2, agg });
+
+		const swarm: SwarmSpec = {
+			strategy: "moa",
+			members: [
+				{ role: "proposer", model: "bad1" },
+				{ role: "proposer", model: "bad2" },
+				{ role: "aggregator", model: "agg" },
+			],
+		};
+		const stream = createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined);
+		await expect(stream.result()).rejects.toThrow(/all 2 proposer\(s\) failed/);
+		// The aggregator never ran: there was nothing to synthesize.
+		expect(agg.calls).toHaveLength(0);
+	});
+
+	it("router classifier prefers an exact role over a prefix role on overlapping names", async () => {
+		// Roles `code` and `coder` overlap: `code` is a prefix of `coder`. A naive
+		// first-substring match would route the verdict "coder" to `code` (checked
+		// first). Exact/word-boundary matching must select `coder`.
+		const code = createMockModel({ id: "code", responses: [{ content: ["from code"], usage: usage(3, 3) }] });
+		const coder = createMockModel({ id: "coder", responses: [{ content: ["from coder"], usage: usage(4, 4) }] });
+		const classifier = createMockModel({ id: "judge", responses: [{ content: ["coder"], usage: usage(1, 1) }] });
+		const { deps } = mockDeps({ code, coder, judge: classifier });
+
+		const swarm: SwarmSpec = {
+			strategy: "router",
+			selector: { kind: "classifier", model: "judge" },
+			members: [
+				// `code` is declared FIRST so a substring-first matcher would wrongly win.
+				{ role: "code", model: "code" },
+				{ role: "coder", model: "coder" },
+			],
+		};
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), undefined).result();
+
+		expect(text(message)).toBe("from coder");
+		expect(coder.calls).toHaveLength(1);
+		expect(code.calls).toHaveLength(0);
+	});
+
+	it("each member call shares a byte-identical cache prefix (KTD-8)", async () => {
+		const drafter = createMockModel({ id: "weak", responses: [{ content: ["d"], usage: usage(1, 1) }] });
+		const refiner = createMockModel({ id: "strong", responses: [{ content: ["f"], usage: usage(1, 1) }] });
+		const { deps } = mockDeps({ weak: drafter, strong: refiner });
+
+		const context = baseContext("stable prompt");
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "weak" },
+				{ role: "refine", model: "strong" },
+			],
+		};
+		await createSwarmStreamSimple(deps)(blendModel(swarm), context, undefined).result();
+
+		const draftCtx = drafter.calls[0].context;
+		const refineCtx = refiner.calls[0].context;
+		// Same system prompt object content across every member call.
+		expect(refineCtx.systemPrompt).toEqual(draftCtx.systemPrompt);
+		expect(draftCtx.systemPrompt).toEqual(context.systemPrompt);
+		// The shared conversation prefix (everything before the variable tail) is
+		// byte-identical: the refiner's first message equals the drafter's only
+		// message; only a fresh tail turn is appended, never a rewritten prefix.
+		expect(refineCtx.messages[0]).toEqual(draftCtx.messages[0]);
+		expect(refineCtx.messages[0]).toEqual(context.messages[0]);
+		expect(refineCtx.messages).toHaveLength(2);
+	});
+
+	it("treats an abort signal as fatal", async () => {
+		const member = createMockModel({ id: "m", responses: [{ content: ["never"], usage: usage(1, 1) }] });
+		const { deps } = mockDeps({ m: member });
+		const controller = new AbortController();
+		controller.abort();
+
+		const swarm: SwarmSpec = { strategy: "sequence", members: [{ role: "only", model: "m" }] };
+		const stream = createSwarmStreamSimple(deps)(blendModel(swarm), baseContext(), { signal: controller.signal });
+
+		await expect(stream.result()).rejects.toThrow();
+		// No member ran: the abort short-circuited before dispatch.
+		expect(member.calls).toHaveLength(0);
+	});
+
+	it("fails fast when the model carries no swarm spec", async () => {
+		const { deps } = mockDeps({});
+		const notBlend = { ...blendModel({ strategy: "sequence", members: [] }) } as Model;
+		// Strip the spec to simulate a misrouted non-blend model.
+		(notBlend as { swarm?: SwarmSpec }).swarm = undefined;
+
+		const stream = createSwarmStreamSimple(deps)(notBlend, baseContext(), undefined);
+		await expect(stream.result()).rejects.toThrow(/no swarm spec/);
+	});
+
+	it("registerSwarmApi installs the dispatcher once; re-registering the SAME deps is an idempotent refresh", async () => {
+		const only = createMockModel({ id: "only", responses: [{ content: ["from owner"], usage: usage(1, 1) }] });
+		const { deps } = mockDeps({ only });
+		const firstInstall = registerSwarmApi(deps);
+		// Re-registering the IDENTICAL deps object (e.g. a cached single-owner
+		// reference) is a no-op refresh: the slot stays unambiguous.
+		const secondInstall = registerSwarmApi(deps);
+		expect(firstInstall).toBe(true);
+		// The global slot is registered exactly once.
+		expect(secondInstall).toBe(false);
+
+		const swarm: SwarmSpec = { strategy: "sequence", members: [{ role: "only", model: "only" }] };
+		const message = await getCustomApi(OMP_SWARM_API)!
+			.streamSimple(blendModel(swarm), baseContext(), undefined)
+			.result();
+		// Dispatch resolves through the single active owner.
+		expect(text(message)).toBe("from owner");
+		expect(only.calls).toHaveLength(1);
+	});
+
+	it("first-writer-wins: a SECOND distinct registry does not rebind or break the slot", async () => {
+		// The custom-API slot keys on the literal "omp-swarm" string, so it is
+		// process-global. First-writer-wins: the first registry owns the slot; a
+		// second DISTINCT registry must NOT rebind it (rebinding would hijack the
+		// live owner's member resolution + auth) and must NOT poison it (a latch
+		// would permanently break every blend after any transient second registry —
+		// sdk.ts / task/executor.ts / the CLIs all build one). Dispatch keeps
+		// resolving through the FIRST owner.
+		const first = createMockModel({ id: "first", responses: [{ content: ["from first"], usage: usage(1, 1) }] });
+		const second = createMockModel({ id: "second", responses: [{ content: ["from second"], usage: usage(1, 1) }] });
+		const firstInstall = registerSwarmApi(mockDeps({ only: first }).deps);
+		// A distinct deps object models a second live ModelRegistry in the process.
+		const secondInstall = registerSwarmApi(mockDeps({ only: second }).deps);
+		expect(firstInstall).toBe(true);
+		expect(secondInstall).toBe(false);
+
+		const swarm: SwarmSpec = { strategy: "sequence", members: [{ role: "only", model: "only" }] };
+		const message = await getCustomApi(OMP_SWARM_API)!
+			.streamSimple(blendModel(swarm), baseContext(), undefined)
+			.result();
+		// Resolves through the FIRST owner; the second registry's model never ran.
+		expect(text(message)).toBe("from first");
+		expect(first.calls).toHaveLength(1);
+		expect(second.calls).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/swarm-presets.test.ts
+++ b/packages/coding-agent/test/swarm-presets.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCustomApis, getCustomApi } from "@oh-my-pi/pi-ai";
+import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resolveModelFromString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { OMP_PROVIDER_SOURCE_ID, OMP_SWARM_API } from "@oh-my-pi/pi-coding-agent/swarm/executor";
+import {
+	DRAFT_REFINE_SPEC,
+	MOA_SYNTHESIS_SPEC,
+	OMP_PRESET_MODELS,
+	OMP_PRESET_SOURCE_ID,
+	ROUTER_BALANCED_SPEC,
+} from "@oh-my-pi/pi-coding-agent/swarm/presets";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+/**
+ * U9 — built-in `omp/*` blend presets.
+ *
+ * These tests assert the registration contract only — they CONSTRUCT a
+ * `ModelRegistry` (so the orchestrator cannot be driven here) and verify that
+ * each preset:
+ *   1. resolves via `resolveModelFromString` (against `getAvailable()` and the
+ *      registry, exercising both exact `provider/id` and canonical paths);
+ *   2. is surfaced by `getAvailable()` despite the `omp` provider being keyless
+ *      and carrying NO credential (deferred concern #1);
+ *   3. carries its declared {@link SwarmSpec} byte-for-byte through the build
+ *      pipeline (no field dropped — Sever guard);
+ *   4. registers under a DISTINCT source id so tearing down the preset PROVIDER
+ *      never tears down the `omp-swarm` custom-API dispatcher (deferred concern #2).
+ *
+ * The blend executor itself (dispatch, surfacing, usage summing, abort) is
+ * covered by swarm-executor.test.ts; this unit only proves the presets are
+ * registered, resolvable, available, and spec-carrying.
+ */
+describe("U9 built-in omp blend presets", () => {
+	let tempDir: string | undefined;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-swarm-presets-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+	});
+
+	afterEach(() => {
+		// The omp-swarm dispatcher is a process-global first-writer-wins singleton;
+		// clearing it between tests is required so the self-heal test sees an empty
+		// slot, and matches the sibling swarm-registry-threading suite convention.
+		// Guard each step so a failed beforeEach can't mask its error during cleanup.
+		clearCustomApis();
+		authStorage?.close();
+		authStorage = undefined;
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+		tempDir = undefined;
+	});
+
+	/** Build a registry, asserting the per-test auth storage initialized. */
+	function makeRegistry(): ModelRegistry {
+		if (authStorage === undefined) throw new Error("authStorage not initialized");
+		return new ModelRegistry(authStorage, modelsJsonPath);
+	}
+
+	// The three preset ids the registry ships under provider "omp", paired with the
+	// spec each must carry. Keeping this table local makes every assertion below a
+	// data-driven check against the source-of-truth presets module.
+	const PRESETS = [
+		{ id: "router-balanced", spec: ROUTER_BALANCED_SPEC, strategy: "router" as const },
+		{ id: "draft-refine", spec: DRAFT_REFINE_SPEC, strategy: "draft-refine" as const },
+		{ id: "moa-synthesis", spec: MOA_SYNTHESIS_SPEC, strategy: "moa" as const },
+	];
+
+	test("the presets module ships exactly the three planned blends with valid specs", () => {
+		// Guards the module contract itself (the spec table the registry registers).
+		expect(OMP_PRESET_MODELS.map(m => m.id).sort()).toEqual(["draft-refine", "moa-synthesis", "router-balanced"]);
+		for (const model of OMP_PRESET_MODELS) {
+			expect(model.api ?? "omp-swarm").toBeDefined();
+			expect(model.swarm).toBeDefined();
+			// Every member names a model and a role; the executor resolves these later.
+			for (const member of model.swarm?.members ?? []) {
+				expect(member.role.length).toBeGreaterThan(0);
+				expect(member.model.length).toBeGreaterThan(0);
+			}
+		}
+		// Strategy-specific shape sanity (matches the plan: router weak+strong+classifier,
+		// draft-refine two stages with a surfaced refiner, moa homogeneous proposers + best aggregator).
+		expect(ROUTER_BALANCED_SPEC.strategy).toBe("router");
+		expect(ROUTER_BALANCED_SPEC.selector?.kind).toBe("classifier");
+		expect(ROUTER_BALANCED_SPEC.selector?.model?.length).toBeGreaterThan(0);
+		expect(DRAFT_REFINE_SPEC.strategy).toBe("draft-refine");
+		expect(DRAFT_REFINE_SPEC.members.find(m => m.surface === true)?.role).toBe("refine");
+		expect(MOA_SYNTHESIS_SPEC.strategy).toBe("moa");
+		const moaProposers = MOA_SYNTHESIS_SPEC.members.filter(m => m.role === "proposer");
+		expect(moaProposers.length).toBeGreaterThanOrEqual(2);
+		// Self-MoA (KTD-6): proposers are homogeneous — all the same model.
+		expect(new Set(moaProposers.map(m => m.model)).size).toBe(1);
+		// The aggregator is the surfaced member and a DISTINCT (best) model.
+		const aggregator = MOA_SYNTHESIS_SPEC.members.find(m => m.role === "aggregator");
+		expect(aggregator?.surface).toBe(true);
+		expect(aggregator?.model).not.toBe(moaProposers[0]?.model);
+	});
+
+	test("each preset resolves via resolveModelFromString and carries its swarm spec", () => {
+		const registry = makeRegistry();
+		const available = registry.getAvailable();
+
+		for (const { id, spec, strategy } of PRESETS) {
+			// (a) exact provider/id resolution against the available set.
+			const bySelector = resolveModelFromString(`omp/${id}`, available, undefined, registry);
+			expect(bySelector, `omp/${id} should resolve`).toBeDefined();
+			expect(bySelector?.provider).toBe("omp");
+			expect(bySelector?.id).toBe(id);
+			expect(bySelector?.api).toBe("omp-swarm");
+			// (c) the spec rides through the build pipeline unchanged.
+			expect(bySelector?.swarm).toEqual(spec);
+			expect(bySelector?.swarm?.strategy).toBe(strategy);
+		}
+	});
+
+	test("every preset is surfaced by getAvailable() despite the keyless omp provider", async () => {
+		const registry = makeRegistry();
+
+		// (1) The omp provider carries no credential — keyless registration (concern #1).
+		expect(await registry.getApiKeyForProvider("omp")).toBe(kNoAuth);
+
+		// (2) Each preset is in getAvailable() with its spec, with no auth configured.
+		const available = registry.getAvailable();
+		for (const { id, spec } of PRESETS) {
+			const found = available.find(m => m.provider === "omp" && m.id === id);
+			expect(found, `omp/${id} should be available`).toBeDefined();
+			expect(found?.swarm).toEqual(spec);
+		}
+
+		// find() agrees with getAvailable().
+		for (const { id, spec } of PRESETS) {
+			const model = registry.find("omp", id);
+			expect(model).toBeDefined();
+			expect(model?.swarm).toEqual(spec);
+		}
+	});
+
+	test("presets survive a refresh('offline') cycle (runtime-overlay re-materialization)", async () => {
+		const registry = makeRegistry();
+		expect(registry.find("omp", "moa-synthesis")?.swarm).toEqual(MOA_SYNTHESIS_SPEC);
+
+		await registry.refresh("offline");
+
+		// A drop here would be the "Sever" failure mode: the runtime overlay (not the
+		// disk config) must re-materialize each preset after #reloadStaticModels().
+		for (const { id, spec } of PRESETS) {
+			const model = registry.find("omp", id);
+			expect(model, `omp/${id} should survive refresh`).toBeDefined();
+			expect(model?.swarm).toEqual(spec);
+			expect(model?.api).toBe("omp-swarm");
+		}
+		// Keyless surfacing is re-applied on reload too.
+		expect(await registry.getApiKeyForProvider("omp")).toBe(kNoAuth);
+	});
+
+	test("preset registration uses a DISTINCT source id, so tearing it down spares the dispatcher", () => {
+		const registry = makeRegistry();
+
+		// The custom-API dispatcher is live and owned by the dispatcher's source id —
+		// NOT the preset provider's source id (concern #2).
+		const dispatcher = getCustomApi(OMP_SWARM_API);
+		expect(dispatcher).toBeDefined();
+		expect(dispatcher?.sourceId).toBe(OMP_PROVIDER_SOURCE_ID);
+		expect(OMP_PRESET_SOURCE_ID).not.toBe(OMP_PROVIDER_SOURCE_ID);
+
+		// Tearing down the preset PROVIDER source must NOT unregister the dispatcher.
+		registry.clearSourceRegistrations(OMP_PRESET_SOURCE_ID);
+		expect(getCustomApi(OMP_SWARM_API), "dispatcher must survive preset teardown").toBeDefined();
+		// And the preset models are gone from the registry after their source is cleared.
+		expect(registry.find("omp", "moa-synthesis")).toBeUndefined();
+	});
+
+	test("self-heal: a re-construction re-asserts the dispatcher when its slot is empty", () => {
+		// Simulate a process where the dispatcher slot was torn down entirely.
+		const first = makeRegistry();
+		expect(getCustomApi(OMP_SWARM_API)).toBeDefined();
+		clearCustomApis();
+		expect(getCustomApi(OMP_SWARM_API)).toBeUndefined();
+
+		// A fresh registry must re-assert the dispatcher (so resolved omp/* can dispatch)
+		// and still surface the presets.
+		const second = makeRegistry();
+		expect(getCustomApi(OMP_SWARM_API), "dispatcher should self-heal on re-construction").toBeDefined();
+		expect(second.find("omp", "router-balanced")?.swarm).toEqual(ROUTER_BALANCED_SPEC);
+		// Reference `first` so it is not flagged unused; both share the process-global slot.
+		expect(first.find("omp", "router-balanced")).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/swarm-primitives.test.ts
+++ b/packages/coding-agent/test/swarm-primitives.test.ts
@@ -254,8 +254,13 @@ describe("runParallelAggregate", () => {
 			return "agg";
 		};
 		const { proposals, aggregate } = await runParallelAggregate(proposers, aggregator, "q", buildAgg, drive);
-		// Failed proposer dropped; survivors still reduce.
-		expect(proposals.map(p => p.output).sort()).toEqual(["p1", "p3"]);
+		// Failed proposer (p2) dropped; survivors still reduce, and each surviving
+		// proposal stays paired with its OWN proposer — the alignment fix: a dropped
+		// proposer must not shift p3's result onto p2's member slot.
+		expect(proposals.map(p => p.result.output).sort()).toEqual(["p1", "p3"]);
+		expect(proposals.map(p => p.member.role).sort()).toEqual(["p1", "p3"]);
+		// The stub sets result(m.role), so a correctly-aligned pair has output === role.
+		for (const p of proposals) expect(p.result.output).toBe(p.member.role);
 		expect(seenProposals.sort()).toEqual(["p1", "p3"]);
 		// `aggregate` is the aggregator member's DriveResult; the stub returns
 		// result(m.role), so its output is its role ("aggregator"). buildAgg's "agg"
@@ -294,7 +299,8 @@ describe("runParallelAggregate", () => {
 			drive,
 		);
 		expect(proposals).toHaveLength(1);
-		expect(proposals[0].output).toBe("solo");
+		expect(proposals[0]?.result.output).toBe("solo");
+		expect(proposals[0]?.member.role).toBe("solo");
 	});
 });
 

--- a/packages/coding-agent/test/swarm-primitives.test.ts
+++ b/packages/coding-agent/test/swarm-primitives.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it } from "bun:test";
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	SwarmMember,
+	SwarmSpec,
+	Usage,
+} from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import {
+	appendUserInputContext,
+	capMembers,
+	DEFAULT_MAX_MEMBERS,
+	type DriveInput,
+	type DriveNode,
+	type DriveResult,
+	emitSurface,
+	modelLeafDriveNode,
+	ORIGINAL_INPUT,
+	pickSurface,
+	runParallelAggregate,
+	runRouter,
+	runSequence,
+	sumUsage,
+} from "@oh-my-pi/pi-coding-agent/swarm/primitives";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function usage(over: Partial<Omit<Usage, "cost">> & { cost?: Partial<Usage["cost"]> } = {}): Usage {
+	const base: Usage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	const merged: Usage = { ...base, ...over, cost: { ...base.cost, ...over.cost } };
+	merged.totalTokens = merged.input + merged.output + merged.cacheRead + merged.cacheWrite;
+	merged.cost.total = merged.cost.input + merged.cost.output + merged.cost.cacheRead + merged.cost.cacheWrite;
+	return merged;
+}
+
+function assistantMessage(text: string, u: Usage = usage()): AssistantMessage {
+	return {
+		role: "assistant",
+		content: text === "" ? [] : [{ type: "text", text }],
+		api: "mock",
+		provider: "mock",
+		model: "mock",
+		usage: u,
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function result(output: string, u: Usage = usage()): DriveResult {
+	return { message: assistantMessage(output, u), usage: u, output };
+}
+
+function member(role: string, model = `model-${role}`, extra: Partial<SwarmMember> = {}): SwarmMember {
+	return { role, model, ...extra };
+}
+
+function emptyContext(): Context {
+	return { messages: [] };
+}
+
+// ── sumUsage ─────────────────────────────────────────────────────────────────
+
+describe("sumUsage", () => {
+	it("sums components and recomputes derived totals", () => {
+		const a = usage({ input: 10, output: 5, cost: { input: 0.1, output: 0.2 } });
+		const b = usage({ input: 3, output: 7, cacheRead: 2, cost: { input: 0.05, cacheRead: 0.01 } });
+		const total = sumUsage([a, b]);
+		expect(total.input).toBe(13);
+		expect(total.output).toBe(12);
+		expect(total.cacheRead).toBe(2);
+		// totalTokens recomputed from components, not trusted from inputs.
+		expect(total.totalTokens).toBe(13 + 12 + 2 + 0);
+		expect(total.cost.input).toBeCloseTo(0.15, 10);
+		expect(total.cost.output).toBeCloseTo(0.2, 10);
+		expect(total.cost.cacheRead).toBeCloseTo(0.01, 10);
+		// cost.total recomputed from cost components.
+		expect(total.cost.total).toBeCloseTo(0.15 + 0.2 + 0.01, 10);
+	});
+
+	it("returns a zeroed usage for an empty list", () => {
+		const total = sumUsage([]);
+		expect(total.totalTokens).toBe(0);
+		expect(total.cost.total).toBe(0);
+	});
+
+	it("sums optional reasoningTokens only when present", () => {
+		const withReasoning = sumUsage([usage({ reasoningTokens: 4 }), usage({ reasoningTokens: 6 })]);
+		expect(withReasoning.reasoningTokens).toBe(10);
+		const without = sumUsage([usage(), usage()]);
+		expect(without.reasoningTokens).toBeUndefined();
+	});
+});
+
+// ── capMembers ───────────────────────────────────────────────────────────────
+
+describe("capMembers", () => {
+	const five = [member("a"), member("b"), member("c"), member("d"), member("e"), member("f")];
+
+	it("defaults the cap to DEFAULT_MAX_MEMBERS", () => {
+		expect(DEFAULT_MAX_MEMBERS).toBe(5);
+		expect(capMembers(five).map(m => m.role)).toEqual(["a", "b", "c", "d", "e"]);
+	});
+
+	it("honors an explicit positive cap and preserves order", () => {
+		expect(capMembers(five, 2).map(m => m.role)).toEqual(["a", "b"]);
+	});
+
+	it("falls back to the default for a non-positive cap", () => {
+		expect(capMembers(five, 0)).toHaveLength(5);
+		expect(capMembers(five, -3)).toHaveLength(5);
+	});
+});
+
+// ── runSequence ──────────────────────────────────────────────────────────────
+
+describe("runSequence", () => {
+	it("pipes each member's output into the next member's input (i -> i+1)", async () => {
+		const seen: Array<{ role: string; input: DriveInput }> = [];
+		// Render the sentinel symbol as a readable token so outputs stay strings.
+		const render = (input: DriveInput): string => (input === ORIGINAL_INPUT ? "<orig>" : input);
+		const drive: DriveNode = async (m, input) => {
+			seen.push({ role: m.role, input });
+			return result(`${m.role}:${render(input)}`);
+		};
+		const results = await runSequence([member("draft"), member("refine")], drive);
+		// First member sees the original-prompt sentinel; second sees member 1's output.
+		expect(seen).toEqual([
+			{ role: "draft", input: ORIGINAL_INPUT },
+			{ role: "refine", input: "draft:<orig>" },
+		]);
+		expect(results).toHaveLength(2);
+		expect(results[1].output).toBe("refine:draft:<orig>");
+	});
+
+	it("returns every member result in run order", async () => {
+		const drive: DriveNode = async m => result(m.role);
+		const results = await runSequence([member("a"), member("b"), member("c")], drive);
+		expect(results.map(r => r.output)).toEqual(["a", "b", "c"]);
+	});
+
+	it("throws when aborted before driving the next member", async () => {
+		const controller = new AbortController();
+		const drive: DriveNode = async m => {
+			if (m.role === "first") controller.abort();
+			return result(m.role);
+		};
+		await expect(runSequence([member("first"), member("second")], drive, controller.signal)).rejects.toThrow();
+	});
+
+	it("drives a downstream stage with the empty piped output, not the original context", async () => {
+		// A first stage that produces NO text yields output: "". The next stage
+		// must receive that empty string as a piped DriveInput — NOT the
+		// ORIGINAL_INPUT sentinel — so it can never silently fall back to the
+		// original context. (Regression guard for the sentinel collision.)
+		const seen: Array<{ role: string; input: DriveInput; isOriginal: boolean }> = [];
+		const drive: DriveNode = async (m, input) => {
+			seen.push({ role: m.role, input, isOriginal: input === ORIGINAL_INPUT });
+			// First stage returns empty output; downstream returns its role.
+			return m.role === "draft" ? result("") : result(m.role);
+		};
+		await runSequence([member("draft"), member("refine")], drive);
+		expect(seen[0]).toMatchObject({ role: "draft", isOriginal: true });
+		// The second stage's input is the empty piped output, distinct from the sentinel.
+		expect(seen[1]).toMatchObject({ role: "refine", isOriginal: false });
+		expect(seen[1].input).toBe("");
+	});
+});
+
+// ── runRouter ────────────────────────────────────────────────────────────────
+
+describe("runRouter", () => {
+	const members = [member("weak"), member("strong")];
+
+	it("picks exactly one member by role and drives only it", async () => {
+		const driven: string[] = [];
+		const drive: DriveNode = async m => {
+			driven.push(m.role);
+			return result(m.role);
+		};
+		const { chosen, result: r } = await runRouter(members, "hard task", async () => "strong", drive);
+		expect(chosen.role).toBe("strong");
+		expect(r.output).toBe("strong");
+		// Only one member ran.
+		expect(driven).toEqual(["strong"]);
+	});
+
+	it("resolves a numeric selector choice to the member at that index", async () => {
+		const drive: DriveNode = async m => result(m.role);
+		const { chosen } = await runRouter(members, "easy", async () => 0, drive);
+		expect(chosen.role).toBe("weak");
+	});
+
+	it("drives the chosen member with the original-prompt sentinel", async () => {
+		let receivedInput: DriveInput | undefined;
+		const drive: DriveNode = async (m, input) => {
+			receivedInput = input;
+			return result(m.role);
+		};
+		await runRouter(members, "the user prompt", async () => "weak", drive);
+		expect(receivedInput).toBe(ORIGINAL_INPUT);
+	});
+
+	it("throws when the selector returns no matching member", async () => {
+		const drive: DriveNode = async m => result(m.role);
+		await expect(runRouter(members, "x", async () => "nope", drive)).rejects.toThrow(/no matching member/);
+	});
+});
+
+// ── runParallelAggregate ─────────────────────────────────────────────────────
+
+describe("runParallelAggregate", () => {
+	const proposers = [member("p1"), member("p2"), member("p3")];
+	const aggregator = member("aggregator");
+
+	it("runs all proposers then the aggregator with the synthesized input", async () => {
+		const order: string[] = [];
+		// Proposers are driven against the sentinel; render it as "" so outputs stay strings.
+		const render = (input: DriveInput): string => (input === ORIGINAL_INPUT ? "" : input);
+		const drive: DriveNode = async (m, input) => {
+			order.push(m.role);
+			return result(`${m.role}<${render(input)}>`);
+		};
+		const buildAgg = (prompt: string, proposals: DriveResult[]) =>
+			`SYNTH(${prompt})[${proposals.map(p => p.output).join(",")}]`;
+		const { proposals, aggregate } = await runParallelAggregate(proposers, aggregator, "question", buildAgg, drive);
+		expect(proposals).toHaveLength(3);
+		// Aggregator runs after every proposer.
+		expect(order.slice(0, 3).sort()).toEqual(["p1", "p2", "p3"]);
+		expect(order[3]).toBe("aggregator");
+		// Aggregator received the synthesized prompt built from proposals.
+		expect(aggregate.output).toContain("SYNTH(question)");
+		expect(aggregate.output).toContain("p1<>");
+	});
+
+	it("tolerates a failing proposer as long as one survives (remaining outputs reduce)", async () => {
+		const drive: DriveNode = async m => {
+			if (m.role === "p2") throw new Error("p2 boom");
+			return result(m.role);
+		};
+		const seenProposals: string[] = [];
+		const buildAgg = (_prompt: string, proposals: DriveResult[]) => {
+			seenProposals.push(...proposals.map(p => p.output));
+			return "agg";
+		};
+		const { proposals, aggregate } = await runParallelAggregate(proposers, aggregator, "q", buildAgg, drive);
+		// Failed proposer dropped; survivors still reduce.
+		expect(proposals.map(p => p.output).sort()).toEqual(["p1", "p3"]);
+		expect(seenProposals.sort()).toEqual(["p1", "p3"]);
+		// `aggregate` is the aggregator member's DriveResult; the stub returns
+		// result(m.role), so its output is its role ("aggregator"). buildAgg's "agg"
+		// is the aggregator's INPUT prompt (its consumption of survivors is asserted
+		// via seenProposals above), not its output.
+		expect(aggregate.output).toBe("aggregator");
+	});
+
+	it("throws when every proposer fails", async () => {
+		const drive: DriveNode = async () => {
+			throw new Error("all dead");
+		};
+		await expect(runParallelAggregate(proposers, aggregator, "q", () => "agg", drive)).rejects.toThrow(
+			/proposer\(s\) failed/,
+		);
+	});
+
+	it("aborts fatally instead of degrading to a partial reduce", async () => {
+		const controller = new AbortController();
+		const drive: DriveNode = async m => {
+			controller.abort();
+			return result(m.role);
+		};
+		await expect(
+			runParallelAggregate(proposers, aggregator, "q", () => "agg", drive, controller.signal),
+		).rejects.toThrow();
+	});
+
+	it("degenerates to passthrough with a single proposer", async () => {
+		const drive: DriveNode = async m => result(m.role);
+		const { proposals } = await runParallelAggregate(
+			[member("solo")],
+			aggregator,
+			"q",
+			(_p, ps) => ps[0].output,
+			drive,
+		);
+		expect(proposals).toHaveLength(1);
+		expect(proposals[0].output).toBe("solo");
+	});
+});
+
+// ── pickSurface ──────────────────────────────────────────────────────────────
+
+describe("pickSurface", () => {
+	const a = { member: member("draft"), result: result("draft-out") };
+	const b = { member: member("refine"), result: result("refine-out") };
+
+	it("prefers the spec.surface role", () => {
+		const spec: SwarmSpec = { strategy: "sequence", members: [], surface: "draft" };
+		expect(pickSurface(spec, [a, b]).output).toBe("draft-out");
+	});
+
+	it("falls back to a member flagged surface: true", () => {
+		const flagged = { member: member("refine", "m", { surface: true }), result: result("flagged-out") };
+		const spec: SwarmSpec = { strategy: "sequence", members: [] };
+		expect(pickSurface(spec, [a, flagged]).output).toBe("flagged-out");
+	});
+
+	it("falls back to the terminal member when nothing is flagged", () => {
+		const spec: SwarmSpec = { strategy: "sequence", members: [] };
+		expect(pickSurface(spec, [a, b]).output).toBe("refine-out");
+	});
+
+	it("throws when no members were run", () => {
+		const spec: SwarmSpec = { strategy: "sequence", members: [] };
+		expect(() => pickSurface(spec, [])).toThrow();
+	});
+});
+
+// ── emitSurface ──────────────────────────────────────────────────────────────
+
+describe("emitSurface", () => {
+	it("settles result() with the surface message and the total usage", async () => {
+		const outer = new AssistantMessageEventStream();
+		const surface = assistantMessage("final answer", usage({ output: 1 }));
+		const total = usage({ input: 100, output: 50 });
+		emitSurface(outer, surface, total);
+		const message = await outer.result();
+		// Surface content is preserved...
+		expect(message.content).toEqual([{ type: "text", text: "final answer" }]);
+		// ...but usage is overwritten with the blend total.
+		expect(message.usage.input).toBe(100);
+		expect(message.usage.output).toBe(50);
+		expect(message.usage.totalTokens).toBe(150);
+	});
+
+	it("emits start -> text events -> done in order", async () => {
+		const outer = new AssistantMessageEventStream();
+		const events: AssistantMessageEvent[] = [];
+		const collect = (async () => {
+			for await (const e of outer) events.push(e);
+		})();
+		emitSurface(outer, assistantMessage("hi", usage()), usage());
+		await outer.result();
+		await collect;
+		const types = events.map(e => e.type);
+		expect(types[0]).toBe("start");
+		expect(types).toContain("text_start");
+		expect(types).toContain("text_delta");
+		expect(types).toContain("text_end");
+		expect(types.at(-1)).toBe("done");
+	});
+
+	it("does not surface non-surface members' content (only the surface message is emitted)", async () => {
+		// The surface is one member's message; a proposer's tool-call content is
+		// never part of the surfaced message, so it cannot leak into the stream.
+		const outer = new AssistantMessageEventStream();
+		const surfaceMsg: AssistantMessage = {
+			...assistantMessage("clean surface text"),
+		};
+		emitSurface(outer, surfaceMsg, usage());
+		const message = await outer.result();
+		expect(message.content.some(b => b.type === "toolCall")).toBe(false);
+		expect(message.content).toEqual([{ type: "text", text: "clean surface text" }]);
+	});
+
+	it("emits a terminal error event when the surface stopped with an error", async () => {
+		const outer = new AssistantMessageEventStream();
+		const events: AssistantMessageEvent[] = [];
+		const collect = (async () => {
+			for await (const e of outer) events.push(e);
+		})();
+		const errored: AssistantMessage = { ...assistantMessage("partial"), stopReason: "error" };
+		emitSurface(outer, errored, usage());
+		// Per the AssistantMessageEventStream contract, an `error` event is a
+		// terminal event whose extractResult RETURNS event.error — so result()
+		// RESOLVES with the error-marked message; it does NOT reject. (This is
+		// exactly how the mock provider template settles an errored stream.)
+		const message = await outer.result();
+		await collect;
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toBeDefined();
+		// The terminal event is an `error` event carrying the error message.
+		const last = events.at(-1);
+		expect(last?.type).toBe("error");
+		if (last?.type === "error") {
+			expect(last.reason).toBe("error");
+			expect(last.error.errorMessage).toBeDefined();
+		}
+	});
+});
+
+// ── appendUserInputContext ───────────────────────────────────────────────────
+
+describe("appendUserInputContext", () => {
+	it("passes the original context through unchanged for ORIGINAL_INPUT", () => {
+		const ctx = emptyContext();
+		expect(appendUserInputContext(ctx, ORIGINAL_INPUT)).toBe(ctx);
+	});
+
+	it("always appends a non-empty input as a fresh user turn", () => {
+		const ctx: Context = { messages: [{ role: "user", content: "same", timestamp: 0 }] };
+		// Even when the input equals existing user text, it is appended (no
+		// text-equality guessing that could silently drop a piped output).
+		const next = appendUserInputContext(ctx, "same");
+		expect(next.messages).toHaveLength(2);
+		expect(next.messages[1]).toMatchObject({ role: "user", content: "same" });
+	});
+
+	it("appends an EMPTY piped output as a user turn rather than reverting to the original context", () => {
+		// The empty string is a piped output from a stage that produced no text;
+		// because ORIGINAL_INPUT is a symbol (not ""), the empty string does NOT
+		// match the passthrough sentinel and must still be appended as a turn.
+		const ctx: Context = { messages: [{ role: "user", content: "orig", timestamp: 0 }] };
+		const next = appendUserInputContext(ctx, "");
+		expect(next).not.toBe(ctx);
+		expect(next.messages).toHaveLength(2);
+		expect(next.messages[1]).toMatchObject({ role: "user", content: "" });
+	});
+
+	it("does not mutate the original context", () => {
+		const ctx: Context = { messages: [] };
+		appendUserInputContext(ctx, "piped");
+		expect(ctx.messages).toHaveLength(0);
+	});
+});
+
+// ── modelLeafDriveNode (the effect edge) ─────────────────────────────────────
+
+describe("modelLeafDriveNode", () => {
+	function fakeStream(text: string, u: Usage): AssistantMessageEventStream {
+		const stream = new AssistantMessageEventStream();
+		const msg = assistantMessage(text, u);
+		stream.push({ type: "start", partial: msg });
+		stream.push({ type: "done", reason: "stop", message: msg });
+		return stream;
+	}
+
+	it("resolves the member's model, runs streamSimple, and maps to a DriveResult", async () => {
+		const resolved: string[] = [];
+		const u = usage({ input: 7, output: 3 });
+		const streamSimple = (model: Model, _ctx: Context, _opts?: SimpleStreamOptions) => {
+			resolved.push(model.id);
+			return fakeStream("leaf output", u);
+		};
+		const resolveModel = (id: string): Model => ({ id }) as unknown as Model;
+		const drive = modelLeafDriveNode(streamSimple, resolveModel, emptyContext());
+		const r = await drive(member("worker", "provider/worker"), ORIGINAL_INPUT);
+		expect(resolved).toEqual(["provider/worker"]);
+		expect(r.output).toBe("leaf output");
+		expect(r.usage.input).toBe(7);
+		expect(r.message.content).toEqual([{ type: "text", text: "leaf output" }]);
+	});
+
+	it("builds the per-member context with the injected MemberContextBuilder", async () => {
+		let receivedCtx: Context | undefined;
+		const streamSimple = (_model: Model, ctx: Context) => {
+			receivedCtx = ctx;
+			return fakeStream("out", usage());
+		};
+		const resolveModel = (id: string): Model => ({ id }) as unknown as Model;
+		// Default builder appends a non-empty input as a user turn.
+		const drive = modelLeafDriveNode(streamSimple, resolveModel, emptyContext());
+		await drive(member("refine"), "piped draft");
+		expect(receivedCtx?.messages.at(-1)).toMatchObject({ role: "user", content: "piped draft" });
+	});
+
+	it("forwards the abort signal into the stream options", async () => {
+		let sawSignal: AbortSignal | undefined;
+		const streamSimple = (_model: Model, _ctx: Context, opts?: SimpleStreamOptions) => {
+			sawSignal = opts?.signal;
+			return fakeStream("out", usage());
+		};
+		const resolveModel = (id: string): Model => ({ id }) as unknown as Model;
+		const controller = new AbortController();
+		const drive = modelLeafDriveNode(streamSimple, resolveModel, emptyContext());
+		await drive(member("worker"), ORIGINAL_INPUT, controller.signal);
+		expect(sawSignal).toBe(controller.signal);
+	});
+
+	it("throws immediately when the signal is already aborted", async () => {
+		const streamSimple = () => fakeStream("out", usage());
+		const resolveModel = (id: string): Model => ({ id }) as unknown as Model;
+		const controller = new AbortController();
+		controller.abort();
+		const drive = modelLeafDriveNode(streamSimple, resolveModel, emptyContext());
+		await expect(drive(member("worker"), ORIGINAL_INPUT, controller.signal)).rejects.toThrow();
+	});
+});

--- a/packages/coding-agent/test/swarm-registry-threading.test.ts
+++ b/packages/coding-agent/test/swarm-registry-threading.test.ts
@@ -58,7 +58,8 @@ describe("ModelRegistry swarm threading + keyless omp", () => {
 		return {
 			// apiKey is required by validateProviderConfiguration in runtime-register
 			// mode when models are defined; the keyless surfacing is independent of it.
-			apiKey: "OMP_RUNTIME_KEY",
+			// Value is an inert non-secret placeholder (avoids tripping secret scanners).
+			apiKey: "test-placeholder",
 			api: "omp-swarm",
 			baseUrl: "omp://",
 			streamSimple,

--- a/packages/coding-agent/test/swarm-registry-threading.test.ts
+++ b/packages/coding-agent/test/swarm-registry-threading.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AssistantMessageEventStream, clearCustomApis } from "@oh-my-pi/pi-ai";
+import type { SwarmSpec } from "@oh-my-pi/pi-catalog/types";
+import { kNoAuth, ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resolveModelFromString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+/**
+ * U4 — swarm spec threaded through the runtime custom-model pipeline + keyless `omp`.
+ *
+ * Verifies the five explicit threading sites in model-registry.ts carry
+ * `Model.swarm` end to end (registerProvider → getAvailable/find → resolve),
+ * that it survives a refresh() overlay-merge cycle, that a model WITHOUT swarm
+ * stays clean (no silent injection / Sever), and that the synthetic `omp`
+ * provider is keyless so `omp/*` models surface without configured auth.
+ */
+describe("ModelRegistry swarm threading + keyless omp", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-swarm-registry-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+	});
+
+	afterEach(() => {
+		clearCustomApis();
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	// A streamSimple stub: U4 only threads metadata; it never dispatches here.
+	const streamSimple: NonNullable<ProviderConfigInput["streamSimple"]> = () =>
+		({}) as unknown as AssistantMessageEventStream;
+
+	const blendSpec: SwarmSpec = {
+		strategy: "moa",
+		members: [
+			{ role: "proposer", model: "anthropic/claude-sonnet-4-5" },
+			{ role: "proposer", model: "anthropic/claude-sonnet-4-5" },
+			{ role: "aggregator", model: "anthropic/claude-opus-4-5", surface: true },
+		],
+		surface: "aggregator",
+		maxMembers: 5,
+		firstEventTimeoutMs: 30_000,
+	};
+
+	function ompConfig(models: NonNullable<ProviderConfigInput["models"]>): ProviderConfigInput {
+		return {
+			// apiKey is required by validateProviderConfiguration in runtime-register
+			// mode when models are defined; the keyless surfacing is independent of it.
+			apiKey: "OMP_RUNTIME_KEY",
+			api: "omp-swarm",
+			baseUrl: "omp://",
+			streamSimple,
+			models,
+		};
+	}
+
+	const swarmModel: NonNullable<ProviderConfigInput["models"]>[number] = {
+		id: "moa-synthesis",
+		name: "MoA Synthesis",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+		swarm: blendSpec,
+	};
+
+	const plainModel: NonNullable<ProviderConfigInput["models"]>[number] = {
+		id: "plain-model",
+		name: "Plain Model",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8192,
+	};
+
+	test("swarm spec threads through registerProvider into find()/getAvailable()", () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider("omp", ompConfig([swarmModel]), "omp-builtin");
+
+		const model = registry.find("omp", "moa-synthesis");
+		expect(model).toBeDefined();
+		expect(model?.api).toBe("omp-swarm");
+		expect(model?.provider).toBe("omp");
+		// Deep-equal proves every site (definition → overlay → buildModel) carried
+		// the spec verbatim with no field dropped or mutated.
+		expect(model?.swarm).toEqual(blendSpec);
+
+		const available = registry.getAvailable();
+		const surfaced = available.find(m => m.provider === "omp" && m.id === "moa-synthesis");
+		expect(surfaced).toBeDefined();
+		expect(surfaced?.swarm).toEqual(blendSpec);
+	});
+
+	test("omp/* resolves via resolveModelFromString", () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider("omp", ompConfig([swarmModel]), "omp-builtin");
+
+		const resolved = resolveModelFromString("omp/moa-synthesis", registry.getAvailable());
+		expect(resolved).toBeDefined();
+		expect(resolved?.provider).toBe("omp");
+		expect(resolved?.id).toBe("moa-synthesis");
+		expect(resolved?.swarm).toEqual(blendSpec);
+	});
+
+	test("swarm spec survives refresh('offline') overlay-merge cycle", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider("omp", ompConfig([swarmModel]), "omp-builtin");
+		expect(registry.find("omp", "moa-synthesis")?.swarm).toEqual(blendSpec);
+
+		await registry.refresh("offline");
+
+		const model = registry.find("omp", "moa-synthesis");
+		expect(model).toBeDefined();
+		// The runtime overlay (not the disk config) must re-materialize swarm after
+		// #reloadStaticModels(); a drop here would be the "Sever" failure mode.
+		expect(model?.swarm).toEqual(blendSpec);
+		expect(model?.api).toBe("omp-swarm");
+	});
+
+	test("a model without swarm stays clean (no silent injection)", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider("omp", ompConfig([plainModel]), "omp-builtin");
+
+		const before = registry.find("omp", "plain-model");
+		expect(before).toBeDefined();
+		expect(before?.swarm).toBeUndefined();
+
+		await registry.refresh("offline");
+
+		const after = registry.find("omp", "plain-model");
+		expect(after).toBeDefined();
+		expect(after?.swarm).toBeUndefined();
+	});
+
+	test("omp provider is keyless: surfaces omp/* and yields no-auth sentinel without credentials", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		// Keyless is established at construction (re-applied on every #loadModels)
+		// and is independent of any configured key for the `omp` provider.
+		expect(await registry.getApiKeyForProvider("omp")).toBe(kNoAuth);
+
+		// A model object on the omp provider counts as configured purely via keyless.
+		const probe = {
+			id: "probe",
+			name: "Probe",
+			api: "omp-swarm",
+			provider: "omp",
+			baseUrl: "omp://",
+			reasoning: false,
+			input: ["text"] as ("text" | "image")[],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		} as Parameters<ModelRegistry["hasConfiguredAuth"]>[0];
+		expect(registry.hasConfiguredAuth(probe)).toBe(true);
+
+		// Keyless survives a refresh cycle (re-added in #addImplicitDiscoverableProviders).
+		await registry.refresh("offline");
+		expect(await registry.getApiKeyForProvider("omp")).toBe(kNoAuth);
+	});
+});

--- a/packages/coding-agent/test/swarm-subagent-leaf.test.ts
+++ b/packages/coding-agent/test/swarm-subagent-leaf.test.ts
@@ -1,0 +1,475 @@
+/**
+ * U7 — subagent-leaf `DriveNode` via direct `runSubprocess`.
+ *
+ * Exercises {@link subagentLeafDriveNode} and its wire-in to the blend executor
+ * with a MOCKED `runSubprocess` (injected) — so the suite runs serially with no
+ * real subprocess spawn and no `ModelRegistry` (which would hang the loader). The
+ * mock records every {@link ExecutorOptions} it receives, so the tests can assert
+ * the member → options mapping (task threading, depth, role, modelOverride) and
+ * the {@link SingleResult} → {@link DriveResult} mapping (output/usage/message).
+ *
+ * Plan scenarios: a `kind:"subagent"` member is driven and mapped to a
+ * `DriveResult`; the depth guard refuses beyond the cap; a `signal` abort
+ * propagates (fatal); the executor routes `kind:"subagent"` to the subagent leaf
+ * and `kind:"model"` to the model leaf; and a STATIC guard asserts no
+ * `coding-agent`/`ai` source imports `@oh-my-pi/swarm-extension` (KTD-2).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import type { AssistantMessage, Context, Model, SimpleStreamOptions, SwarmMember, Usage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import type { SwarmSpec } from "@oh-my-pi/pi-catalog/types";
+import {
+	createSwarmStreamSimple,
+	OMP_BASE_URL,
+	OMP_PROVIDER_NAME,
+	OMP_SWARM_API,
+	type SwarmExecutorDeps,
+} from "@oh-my-pi/pi-coding-agent/swarm/executor";
+import {
+	ORIGINAL_INPUT,
+	type SubagentLeafDeps,
+	subagentLeafDriveNode,
+} from "@oh-my-pi/pi-coding-agent/swarm/primitives";
+import type { ExecutorOptions } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function usage(input = 0, output = 0): Usage {
+	const u: Usage = {
+		input,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	return u;
+}
+
+const agent: AgentDefinition = {
+	name: "explorer",
+	description: "test agent",
+	systemPrompt: "be helpful",
+	source: "bundled",
+};
+
+function context(prompt = "do the thing"): Context {
+	return {
+		systemPrompt: ["You are a coding agent."],
+		tools: [],
+		messages: [{ role: "user", content: prompt, timestamp: 1 }],
+	};
+}
+
+/** A `SingleResult` with the fields the leaf reads; the rest are filler. */
+function singleResult(over: Partial<SingleResult>): SingleResult {
+	return {
+		index: 0,
+		id: "id",
+		agent: "explorer",
+		agentSource: "bundled",
+		task: "t",
+		exitCode: 0,
+		output: "",
+		stderr: "",
+		truncated: false,
+		durationMs: 0,
+		tokens: 0,
+		requests: 0,
+		...over,
+	};
+}
+
+/**
+ * A mock runner that records each call's {@link ExecutorOptions} and returns a
+ * queued {@link SingleResult} (or a default success). No real spawn, no registry.
+ */
+function mockRunner(results: SingleResult[] = []) {
+	const calls: ExecutorOptions[] = [];
+	let i = 0;
+	const runSubprocess = async (options: ExecutorOptions): Promise<SingleResult> => {
+		calls.push(options);
+		const result = results[i] ?? singleResult({ output: "subagent output" });
+		i += 1;
+		return result;
+	};
+	return { runSubprocess, calls };
+}
+
+function leafDeps(over: Partial<SubagentLeafDeps> = {}): SubagentLeafDeps {
+	const { runSubprocess } = mockRunner();
+	return { runSubprocess, agent, cwd: "/repo", context: context(), ...over };
+}
+
+// ── subagentLeafDriveNode ────────────────────────────────────────────────────
+
+describe("subagentLeafDriveNode", () => {
+	it("drives a subagent member and maps SingleResult → DriveResult", async () => {
+		const runner = mockRunner([singleResult({ output: "explored result", usage: usage(40, 12) })]);
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "anthropic/claude", kind: "subagent" };
+
+		const result = await node(member, ORIGINAL_INPUT);
+
+		// SingleResult.output threads into the next member and the synthesized message.
+		expect(result.output).toBe("explored result");
+		expect(result.usage.input).toBe(40);
+		expect(result.usage.output).toBe(12);
+		expect(result.message.role).toBe("assistant");
+		expect(result.message.stopReason).toBe("stop");
+		expect(result.message.content).toEqual([{ type: "text", text: "explored result" }]);
+	});
+
+	it("maps ORIGINAL_INPUT to the last user prompt and a string input to the task verbatim", async () => {
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, context: context("ORIG PROMPT") }),
+		);
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+		await node(member, "PIPED TAIL");
+
+		expect(runner.calls[0].task).toBe("ORIG PROMPT");
+		expect(runner.calls[1].task).toBe("PIPED TAIL");
+		// Identity + recursion are threaded into the options.
+		expect(runner.calls[0].agent).toBe(agent);
+		expect(runner.calls[0].role).toBe("explore");
+		expect(runner.calls[0].modelOverride).toBe("m");
+		expect(runner.calls[0].cwd).toBe("/repo");
+	});
+
+	it("forwards the parent taskDepth so the child runs one level deeper", async () => {
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess, taskDepth: 1 }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+
+		// runSubprocess receives the PARENT depth (it computes childDepth itself).
+		expect(runner.calls[0].taskDepth).toBe(1);
+	});
+
+	it("refuses to run when the child's depth would exceed the cap", async () => {
+		const runner = mockRunner();
+		// parent depth 2, cap 2 → childDepth 3 > 2 → refuse.
+		const node = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, taskDepth: 2, maxRecursionDepth: 2 }),
+		);
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await expect(node(member, ORIGINAL_INPUT)).rejects.toThrow(/recursion depth/);
+		// The guard short-circuits BEFORE the runner is touched.
+		expect(runner.calls).toHaveLength(0);
+	});
+
+	it("allows the child to run at exactly the cap", async () => {
+		const runner = mockRunner();
+		// parent depth 1, cap 2 → childDepth 2, not > 2 → allowed.
+		const node = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, taskDepth: 1, maxRecursionDepth: 2 }),
+		);
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+		expect(runner.calls).toHaveLength(1);
+	});
+
+	it("treats an aborted run as a fatal abort (signal checked before the runner)", async () => {
+		const runner = mockRunner();
+		const controller = new AbortController();
+		controller.abort();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await expect(node(member, ORIGINAL_INPUT, controller.signal)).rejects.toThrow();
+		expect(runner.calls).toHaveLength(0);
+	});
+
+	it("forwards the abort signal into the runner's ExecutorOptions", async () => {
+		const runner = mockRunner();
+		const controller = new AbortController();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT, controller.signal);
+		expect(runner.calls[0].signal).toBe(controller.signal);
+	});
+
+	it("maps a failed run to a resolved DriveResult with stopReason 'error' (not a rejection)", async () => {
+		const runner = mockRunner([singleResult({ exitCode: 1, error: "boom", output: "" })]);
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		const result = await node(member, ORIGINAL_INPUT);
+		expect(result.message.stopReason).toBe("error");
+		expect(result.message.errorMessage).toBe("boom");
+	});
+
+	it("maps an aborted run to stopReason 'aborted'", async () => {
+		const runner = mockRunner([singleResult({ exitCode: 1, aborted: true, output: "" })]);
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		const result = await node(member, ORIGINAL_INPUT);
+		expect(result.message.stopReason).toBe("aborted");
+	});
+
+	it("defaults usage to a zero record when the runner reports none", async () => {
+		const runner = mockRunner([singleResult({ output: "x", usage: undefined })]);
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		const result = await node(member, ORIGINAL_INPUT);
+		expect(result.usage.totalTokens).toBe(0);
+		expect(result.usage.cost.total).toBe(0);
+	});
+
+	it("allocates a registry-unique id (and distinct index) per spawn for two SAME-ROLE members in one blend", async () => {
+		// moa proposers commonly share a role; SwarmMember does not forbid duplicates.
+		// A constant `${agent}-${role}-${index}` id would collide in the process-global
+		// AgentRegistry (overwrite, setStatus cross-talk, lost teardown). Each spawn must
+		// get a distinct id AND a distinct index.
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const a: SwarmMember = { role: "propose", model: "m1", kind: "subagent" };
+		const b: SwarmMember = { role: "propose", model: "m2", kind: "subagent" };
+
+		await Promise.all([node(a, ORIGINAL_INPUT), node(b, ORIGINAL_INPUT)]);
+
+		expect(runner.calls).toHaveLength(2);
+		expect(runner.calls[0].id).not.toBe(runner.calls[1].id);
+		expect(runner.calls[0].index).not.toBe(runner.calls[1].index);
+	});
+
+	it("allocates distinct ids across repeated turns of the same blend (same role, stable index base)", async () => {
+		// A repeated blend re-drives the same role every turn; a deterministic id keyed on
+		// role/index would clobber the prior turn's registry ref. The per-leaf counter +
+		// allocator keep each turn unique.
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+		await node(member, ORIGINAL_INPUT);
+
+		expect(runner.calls[0].id).not.toBe(runner.calls[1].id);
+		expect(runner.calls[0].index).not.toBe(runner.calls[1].index);
+	});
+
+	it("uses an injected idAllocator verbatim for ExecutorOptions.id", async () => {
+		const ids = ["alloc-0", "alloc-1"];
+		let n = 0;
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, idAllocator: () => ids[n++] }),
+		);
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+		await node(member, ORIGINAL_INPUT);
+
+		expect(runner.calls[0].id).toBe("alloc-0");
+		expect(runner.calls[1].id).toBe("alloc-1");
+	});
+
+	it("offsets each spawn's index from the configured base index", async () => {
+		const runner = mockRunner();
+		const node = subagentLeafDriveNode(leafDeps({ runSubprocess: runner.runSubprocess, index: 10 }));
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+
+		await node(member, ORIGINAL_INPUT);
+		await node(member, ORIGINAL_INPUT);
+
+		expect(runner.calls[0].index).toBe(10);
+		expect(runner.calls[1].index).toBe(11);
+	});
+
+	it("does NOT refuse at exactly the cap (the task-tool strip is delegated to runSubprocess)", async () => {
+		// Real guard: runSubprocess marks atMaxDepth at childDepth >= cap and strips the
+		// task tool while STILL running the child. The leaf must not pre-empt that — it
+		// only refuses when the depth is already PAST the cap (childDepth > cap).
+		const runner = mockRunner();
+		// parent depth 2, cap 2 → childDepth 3 > 2 → defensive refuse.
+		const past = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, taskDepth: 2, maxRecursionDepth: 2 }),
+		);
+		const member: SwarmMember = { role: "explore", model: "m", kind: "subagent" };
+		await expect(past(member, ORIGINAL_INPUT)).rejects.toThrow(/recursion depth/);
+		expect(runner.calls).toHaveLength(0);
+
+		// parent depth 1, cap 2 → childDepth 2 == cap → leaf allows; runSubprocess strips.
+		const atCap = subagentLeafDriveNode(
+			leafDeps({ runSubprocess: runner.runSubprocess, taskDepth: 1, maxRecursionDepth: 2 }),
+		);
+		await atCap(member, ORIGINAL_INPUT);
+		expect(runner.calls).toHaveLength(1);
+	});
+});
+
+// ── executor wire-in (kind dispatch) ─────────────────────────────────────────
+
+/** A blend `Model` carrying the given spec; the executor reads only `swarm` + identity. */
+function blendModel(swarm: SwarmSpec, id = "omp/subagent-blend"): Model {
+	return {
+		id,
+		name: id,
+		api: OMP_SWARM_API,
+		provider: OMP_PROVIDER_NAME,
+		baseUrl: OMP_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 32_768,
+		compat: undefined,
+		swarm,
+	} as unknown as Model;
+}
+
+/** A model-leaf `streamSimple` that emits a fixed text message — no network, no registry. */
+function fixedModelStream(text: string, u: Usage): SwarmExecutorDeps["streamSimple"] {
+	return (model: Model, _context: Context, _options?: SimpleStreamOptions) => {
+		const stream = new AssistantMessageEventStream();
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: u,
+			stopReason: "stop",
+			timestamp: 0,
+		};
+		queueMicrotask(() => {
+			stream.push({ type: "start", partial: message });
+			stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
+}
+
+function collectText(message: AssistantMessage): string {
+	let out = "";
+	for (const block of message.content) {
+		if (block.type === "text") out += block.text;
+	}
+	return out;
+}
+
+describe("executor kind dispatch", () => {
+	it("routes kind:'subagent' members to the subagent leaf and surfaces its output", async () => {
+		const runner = mockRunner([singleResult({ output: "from subagent", usage: usage(7, 3) })]);
+		const deps: SwarmExecutorDeps = {
+			resolveModel: id => ({ id }) as unknown as Model,
+			streamSimple: fixedModelStream("from model", usage(99, 99)),
+			subagent: { runSubprocess: runner.runSubprocess, agent, cwd: "/repo" },
+		};
+		const swarm: SwarmSpec = {
+			strategy: "sequence",
+			members: [{ role: "explore", model: "m", kind: "subagent" }],
+		};
+
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), context(), undefined).result();
+
+		// Surfaced content is the subagent's output, not the model leaf's.
+		expect(collectText(message)).toBe("from subagent");
+		expect(message.usage.input).toBe(7);
+		expect(message.usage.output).toBe(3);
+		expect(runner.calls).toHaveLength(1);
+	});
+
+	for (const { label, member } of [
+		{ label: "unset kind", member: { role: "answer", model: "m" } as SwarmMember },
+		{ label: "explicit kind:'model'", member: { role: "answer", model: "m", kind: "model" } as SwarmMember },
+	]) {
+		it(`routes ${label} members to the model leaf`, async () => {
+			const runner = mockRunner();
+			const deps: SwarmExecutorDeps = {
+				resolveModel: id => ({ id }) as unknown as Model,
+				streamSimple: fixedModelStream("from model", usage(5, 5)),
+				subagent: { runSubprocess: runner.runSubprocess, agent, cwd: "/repo" },
+			};
+			const swarm: SwarmSpec = { strategy: "sequence", members: [member] };
+
+			const message = await createSwarmStreamSimple(deps)(blendModel(swarm), context(), undefined).result();
+
+			expect(collectText(message)).toBe("from model");
+			// The subagent runner was never touched for a model member.
+			expect(runner.calls).toHaveLength(0);
+		});
+	}
+
+	it("pipes a model draft into a subagent refiner (mixed-kind sequence)", async () => {
+		const runner = mockRunner([singleResult({ output: "refined", usage: usage(1, 1) })]);
+		const deps: SwarmExecutorDeps = {
+			resolveModel: id => ({ id }) as unknown as Model,
+			streamSimple: fixedModelStream("draft", usage(2, 2)),
+			subagent: { runSubprocess: runner.runSubprocess, agent, cwd: "/repo" },
+		};
+		const swarm: SwarmSpec = {
+			strategy: "draft-refine",
+			members: [
+				{ role: "draft", model: "m" },
+				{ role: "refine", model: "m2", kind: "subagent" },
+			],
+		};
+
+		const message = await createSwarmStreamSimple(deps)(blendModel(swarm), context(), undefined).result();
+
+		// Terminal (subagent) member is surfaced; usage is summed across both.
+		expect(collectText(message)).toBe("refined");
+		expect(message.usage.input).toBe(3);
+		expect(message.usage.output).toBe(3);
+		// The subagent's task is the model draft's output (the piped variable tail).
+		expect(runner.calls[0].task).toBe("draft");
+	});
+
+	it("fails fast when a subagent member has no configured runner", async () => {
+		const deps: SwarmExecutorDeps = {
+			resolveModel: id => ({ id }) as unknown as Model,
+			streamSimple: fixedModelStream("from model", usage(1, 1)),
+			// no `subagent` configured
+		};
+		const swarm: SwarmSpec = {
+			strategy: "sequence",
+			members: [{ role: "explore", model: "m", kind: "subagent" }],
+		};
+
+		await expect(createSwarmStreamSimple(deps)(blendModel(swarm), context(), undefined).result()).rejects.toThrow(
+			/no subagent runner is configured/,
+		);
+	});
+});
+
+// ── static import-direction guard (KTD-2) ────────────────────────────────────
+
+describe("import direction (KTD-2)", () => {
+	it("no coding-agent or ai source imports @oh-my-pi/swarm-extension", () => {
+		const roots = [path.resolve(import.meta.dir, "../src"), path.resolve(import.meta.dir, "../../ai/src")];
+		// Match a REAL module specifier (static `from "..."` / dynamic `import("...")` /
+		// `require("...")`), NOT a prose mention of the package name in a doc comment —
+		// the package name appears legitimately in KTD-2 comments documenting the ban.
+		const importSpecifier = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*["']@oh-my-pi\/swarm-extension(?:\/[^"']*)?["']/;
+		const offenders: string[] = [];
+		const walk = (dir: string) => {
+			for (const entry of readdirSync(dir)) {
+				const full = path.join(dir, entry);
+				const st = statSync(full);
+				if (st.isDirectory()) {
+					walk(full);
+					continue;
+				}
+				if (!/\.(ts|tsx|mts|cts)$/.test(entry)) continue;
+				const text = readFileSync(full, "utf8");
+				if (importSpecifier.test(text)) offenders.push(full);
+			}
+		};
+		for (const root of roots) walk(root);
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/swarm-extension/src/cli.ts
+++ b/packages/swarm-extension/src/cli.ts
@@ -13,7 +13,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { buildDependencyGraph, buildExecutionWaves, detectCycles } from "./swarm/dag";
 import { PipelineController } from "./swarm/pipeline";
 import { renderSwarmProgress } from "./swarm/render";
-import { parseSwarmYaml, validateSwarmDefinition } from "./swarm/schema";
+import { collectSwarmWarnings, parseSwarmYaml, validateSwarmDefinition } from "./swarm/schema";
 import { StateTracker } from "./swarm/state";
 
 const yamlPath = process.argv[2];
@@ -38,6 +38,12 @@ const errors = validateSwarmDefinition(def);
 if (errors.length > 0) {
 	console.error("Validation errors:", errors);
 	process.exit(1);
+}
+
+// Surface non-fatal advisory caveats (KTD-6 Self-MoA heterogeneous-proposer
+// warning) to stderr so the operator sees the quality trade-off; non-halting.
+for (const warning of collectSwarmWarnings(def)) {
+	console.warn(`Warning: ${warning}`);
 }
 
 // Build DAG

--- a/packages/swarm-extension/src/extension.ts
+++ b/packages/swarm-extension/src/extension.ts
@@ -16,7 +16,7 @@ import { formatDuration } from "@oh-my-pi/pi-utils";
 import { buildDependencyGraph, buildExecutionWaves, detectCycles } from "./swarm/dag";
 import { PipelineController } from "./swarm/pipeline";
 import { renderSwarmProgress } from "./swarm/render";
-import { parseSwarmYaml, type SwarmDefinition, validateSwarmDefinition } from "./swarm/schema";
+import { collectSwarmWarnings, parseSwarmYaml, type SwarmDefinition, validateSwarmDefinition } from "./swarm/schema";
 import { StateTracker } from "./swarm/state";
 
 export default function swarmExtension(pi: ExtensionAPI): void {
@@ -94,6 +94,12 @@ async function handleRun(yamlPath: string, ctx: ExtensionCommandContext, pi: Ext
 	if (validationErrors.length > 0) {
 		ctx.ui.notify(`Validation errors:\n${validationErrors.map(e => `  - ${e}`).join("\n")}`, "error");
 		return;
+	}
+
+	// 3a. Surface non-fatal advisory caveats (KTD-6 Self-MoA heterogeneous-proposer
+	// warning) so an operator sees the quality trade-off without halting the run.
+	for (const warning of collectSwarmWarnings(def)) {
+		ctx.ui.notify(warning, "warning");
 	}
 
 	// 4. Build DAG

--- a/packages/swarm-extension/src/swarm/__tests__/mixture.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/mixture.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExecutorOptions, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import * as taskExecutor from "@oh-my-pi/pi-coding-agent";
+import { buildDependencyGraph, buildExecutionWaves } from "../dag";
+import { PipelineController } from "../pipeline";
+import {
+	collectSwarmWarnings,
+	type SwarmAgent,
+	type SwarmDefinition,
+	type SwarmMode,
+	validateSwarmDefinition,
+} from "../schema";
+import { StateTracker } from "../state";
+
+// ============================================================================
+// Builders — assemble SwarmDefinition objects directly (mirrors parseSwarmYaml output)
+// ============================================================================
+
+function agent(name: string, overrides: Partial<SwarmAgent> = {}): SwarmAgent {
+	return {
+		name,
+		role: `${name}-role`,
+		task: `${name} task`,
+		reportsTo: [],
+		waitsFor: [],
+		...overrides,
+	};
+}
+
+function mixtureDef(agents: SwarmAgent[], mode: SwarmMode = "mixture", model?: string): SwarmDefinition {
+	const map = new Map<string, SwarmAgent>();
+	for (const a of agents) map.set(a.name, a);
+	return {
+		name: "test-mixture",
+		workspace: "/tmp/ws",
+		mode,
+		targetCount: 1,
+		model,
+		agents: map,
+		agentOrder: agents.map(a => a.name),
+	};
+}
+
+/** A well-formed mixture topology: N proposers + one aggregator that waits_for all of them. */
+function happyMixtureDef(proposerCount: number, opts: { proposerModel?: (i: number) => string } = {}): SwarmDefinition {
+	const proposers = Array.from({ length: proposerCount }, (_, i) =>
+		agent(`proposer${i + 1}`, opts.proposerModel ? { model: opts.proposerModel(i) } : {}),
+	);
+	const aggregator = agent("aggregator", { waitsFor: proposers.map(p => p.name) });
+	return mixtureDef([...proposers, aggregator]);
+}
+
+function mockResult(over: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "x",
+		agent: "x",
+		agentSource: "project",
+		task: "t",
+		exitCode: 0,
+		output: "ok",
+		stderr: "",
+		truncated: false,
+		durationMs: 1,
+		tokens: 0,
+		...over,
+	} as SingleResult;
+}
+
+// ============================================================================
+// Validation — mixture shares the strict fan-in shape with vote
+// ============================================================================
+
+describe("validateSwarmDefinition — mixture mode", () => {
+	it("accepts an aggregator + 2 proposers (no errors)", () => {
+		expect(validateSwarmDefinition(happyMixtureDef(2))).toEqual([]);
+	});
+
+	it("accepts an aggregator + 3 proposers (no errors)", () => {
+		expect(validateSwarmDefinition(happyMixtureDef(3))).toEqual([]);
+	});
+
+	it("rejects a missing aggregator (all agents are proposers, none waits_for)", () => {
+		const def = mixtureDef([agent("p1"), agent("p2")]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("requires an aggregator"))).toBe(true);
+	});
+
+	it("rejects more than one aggregator", () => {
+		const def = mixtureDef([
+			agent("p1"),
+			agent("p2"),
+			agent("a1", { waitsFor: ["p1", "p2"] }),
+			agent("a2", { waitsFor: ["p1", "p2"] }),
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("exactly one aggregator"))).toBe(true);
+	});
+
+	it("rejects fewer than 2 proposers", () => {
+		const def = mixtureDef([agent("p1"), agent("aggregator", { waitsFor: ["p1"] })]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("at least 2 proposer"))).toBe(true);
+	});
+
+	it("rejects an aggregator that does not wait_for every proposer", () => {
+		const def = mixtureDef([
+			agent("p1"),
+			agent("p2"),
+			agent("p3"),
+			agent("aggregator", { waitsFor: ["p1", "p2"] }), // misses p3
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("missing proposer 'p3'"))).toBe(true);
+	});
+
+	it("rejects a proposer that reports_to another proposer (would serialize wave 0)", () => {
+		const def = mixtureDef([
+			agent("p1", { reportsTo: ["p2"] }),
+			agent("p2"),
+			agent("aggregator", { waitsFor: ["p1", "p2"] }),
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("proposer 'p1' must not declare reports_to"))).toBe(true);
+	});
+
+	it("rejects an aggregator that reports_to a proposer (structural cycle)", () => {
+		const def = mixtureDef([
+			agent("p1"),
+			agent("p2"),
+			agent("aggregator", { waitsFor: ["p1", "p2"], reportsTo: ["p1"] }),
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("aggregator 'aggregator' must not declare reports_to"))).toBe(true);
+	});
+});
+
+// ============================================================================
+// Self-MoA guard (KTD-6) — heterogeneous proposers surface a non-fatal caveat
+// ============================================================================
+
+describe("collectSwarmWarnings — mixture Self-MoA guard", () => {
+	it("emits no warning when proposers are homogeneous (all default to def.model)", () => {
+		// Proposers carry no per-agent model, so they all inherit the swarm default.
+		const def = happyMixtureDef(3, { proposerModel: undefined });
+		def.model = "anthropic/claude-sonnet";
+		expect(collectSwarmWarnings(def)).toEqual([]);
+	});
+
+	it("emits no warning when proposers explicitly share one model", () => {
+		const def = happyMixtureDef(3, { proposerModel: () => "openai/gpt-x" });
+		expect(collectSwarmWarnings(def)).toEqual([]);
+	});
+
+	it("emits a heterogeneous-proposer caveat when proposers use different models", () => {
+		// Two distinct proposer models trips the Self-MoA caveat (KTD-6).
+		const def = happyMixtureDef(2, { proposerModel: i => (i === 0 ? "model-a" : "model-b") });
+		const warnings = collectSwarmWarnings(def);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("heterogeneous");
+		expect(warnings[0]).toContain("Self-MoA");
+		// The offending models are surfaced so the operator can see the mix.
+		expect(warnings[0]).toContain("model-a");
+		expect(warnings[0]).toContain("model-b");
+	});
+
+	it("excludes the aggregator from the homogeneity check (best-model aggregator is expected to differ)", () => {
+		// Proposers share one model; the aggregator runs a different (best) model.
+		// Per KTD-6 that is the recommended config and must NOT warn.
+		const def = happyMixtureDef(2, { proposerModel: () => "proposer-model" });
+		def.agents.get("aggregator")!.model = "best-aggregator-model";
+		expect(collectSwarmWarnings(def)).toEqual([]);
+	});
+
+	it("does not warn for non-mixture modes", () => {
+		const def = happyMixtureDef(2, { proposerModel: i => (i === 0 ? "model-a" : "model-b") });
+		def.mode = "vote";
+		expect(collectSwarmWarnings(def)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// DAG — mixture reuses the vote wave shape (no new DAG primitive, KTD-5)
+// ============================================================================
+
+describe("mixture mode DAG", () => {
+	it("places proposers in wave 0 and the aggregator in wave 1", () => {
+		const def = happyMixtureDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		expect(waves).toHaveLength(2);
+		expect(waves[0].sort()).toEqual(["proposer1", "proposer2", "proposer3"]);
+		expect(waves[1]).toEqual(["aggregator"]);
+	});
+
+	it("gives proposers no implicit chain (all proposers share wave 0)", () => {
+		const def = happyMixtureDef(3);
+		const deps = buildDependencyGraph(def);
+		expect(deps.get("proposer1")!.size).toBe(0);
+		expect(deps.get("proposer2")!.size).toBe(0);
+		expect(deps.get("proposer3")!.size).toBe(0);
+		expect([...deps.get("aggregator")!].sort()).toEqual(["proposer1", "proposer2", "proposer3"]);
+	});
+});
+
+// ============================================================================
+// Pipeline — the aggregator SYNTHESIZES (mixture reduce), distinct from vote JUDGE
+// ============================================================================
+
+describe("PipelineController — mixture reduce", () => {
+	let workspace: string;
+
+	beforeEach(async () => {
+		workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-mixture-test-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await fs.rm(workspace, { recursive: true, force: true });
+	});
+
+	it("fans out proposers and injects every proposal into the aggregator, instructing synthesis", async () => {
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			return mockResult({ agent: name, output: `PROPOSAL_FROM_${name}` });
+		});
+
+		const def = happyMixtureDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		expect(result.status).toBe("completed");
+		// 3 proposers + 1 aggregator = 4 subprocess invocations.
+		expect(spy).toHaveBeenCalledTimes(4);
+
+		const aggCall = spy.mock.calls.find(c => c[0].agent.name === "aggregator");
+		expect(aggCall).toBeDefined();
+		const aggPrompt = aggCall![0].agent.systemPrompt ?? "";
+		// Every proposer output reaches the aggregator's context.
+		expect(aggPrompt).toContain("PROPOSAL_FROM_proposer1");
+		expect(aggPrompt).toContain("PROPOSAL_FROM_proposer2");
+		expect(aggPrompt).toContain("PROPOSAL_FROM_proposer3");
+		// The aggregator is told to SYNTHESIZE — the mixture reduce, not vote's JUDGE.
+		expect(aggPrompt).toContain("AGGREGATOR");
+		expect(aggPrompt).toContain("SYNTHESIZE");
+		expect(aggPrompt).toContain("mixture-of-agents");
+		// Mixture must NOT prompt the vote JUDGE/consensus reduce.
+		expect(aggPrompt).not.toContain("JUDGE");
+		expect(aggPrompt.toLowerCase()).not.toContain("consensus");
+	});
+
+	it("does not inject proposals into the proposers themselves", async () => {
+		const spy = vi
+			.spyOn(taskExecutor, "runSubprocess")
+			.mockImplementation(async (opts: ExecutorOptions) =>
+				mockResult({ agent: opts.agent.name, output: `PROPOSAL_FROM_${opts.agent.name}` }),
+			);
+
+		const def = happyMixtureDef(2);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		const proposerCall = spy.mock.calls.find(c => c[0].agent.name === "proposer1");
+		expect(proposerCall).toBeDefined();
+		const proposerPrompt = proposerCall![0].agent.systemPrompt ?? "";
+		expect(proposerPrompt).not.toContain("AGGREGATOR");
+		expect(proposerPrompt).not.toContain("PROPOSAL_FROM_proposer2");
+	});
+
+	it("single proposer degenerates to a passthrough (aggregator synthesizes the one proposal)", async () => {
+		// A 1-proposer mixture is structurally valid only as a direct construction (the
+		// validator recommends >=2); here we exercise the runtime reduce to show it does
+		// not crash and the lone proposal still reaches the aggregator unchanged.
+		const def = mixtureDef([agent("p1"), agent("aggregator", { waitsFor: ["p1"] })]);
+		const spy = vi
+			.spyOn(taskExecutor, "runSubprocess")
+			.mockImplementation(async (opts: ExecutorOptions) =>
+				mockResult({ agent: opts.agent.name, output: `PROPOSAL_FROM_${opts.agent.name}` }),
+			);
+
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		expect(result.status).toBe("completed");
+		expect(spy).toHaveBeenCalledTimes(2);
+		const aggCall = spy.mock.calls.find(c => c[0].agent.name === "aggregator")!;
+		const aggPrompt = aggCall[0].agent.systemPrompt ?? "";
+		// The single proposal is present; with one proposal "synthesis" degenerates to
+		// passing the lone answer through, but the aggregator still runs the reduce.
+		expect(aggPrompt).toContain("PROPOSAL_FROM_p1");
+		expect(aggPrompt).toContain("SYNTHESIZE");
+	});
+
+	it("still synthesizes when one proposer fails (failure surfaced to the aggregator)", async () => {
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			if (name === "proposer2") {
+				return mockResult({ agent: name, exitCode: 1, output: "", error: "boom" });
+			}
+			return mockResult({ agent: name, output: `PROPOSAL_FROM_${name}` });
+		});
+
+		const def = happyMixtureDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		const aggCall = spy.mock.calls.find(c => c[0].agent.name === "aggregator")!;
+		const aggPrompt = aggCall[0].agent.systemPrompt ?? "";
+		expect(aggPrompt).toContain("PROPOSAL_FROM_proposer1");
+		expect(aggPrompt).toContain("PROPOSAL_FROM_proposer3");
+		// The failed proposer is surfaced rather than silently dropped.
+		expect(aggPrompt).toContain("proposer failed");
+		expect(result.errors.some(e => e.includes("proposer2"))).toBe(true);
+	});
+
+	it("downgrades the aggregator instruction when every proposer fails (no fabricated synthesis)", async () => {
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			if (name === "aggregator") {
+				return mockResult({ agent: name, output: "report" });
+			}
+			return mockResult({ agent: name, exitCode: 1, output: "", error: `boom-${name}` });
+		});
+
+		const def = happyMixtureDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		expect(result.status).toBe("failed");
+		const aggCall = spy.mock.calls.find(c => c[0].agent.name === "aggregator")!;
+		const aggPrompt = aggCall[0].agent.systemPrompt ?? "";
+		// All proposers failed: the aggregator must be told NOT to fabricate a synthesis.
+		expect(aggPrompt).toContain("EVERY proposer failed");
+		expect(aggPrompt).toContain("Do NOT fabricate a");
+		// And must NOT carry the synthesis instruction.
+		expect(aggPrompt).not.toContain("combines the complementary strengths");
+	});
+});

--- a/packages/swarm-extension/src/swarm/__tests__/vote.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/vote.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExecutorOptions, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import * as taskExecutor from "@oh-my-pi/pi-coding-agent";
+import { buildDependencyGraph, buildExecutionWaves, findVoteAggregator } from "../dag";
+import { PipelineController } from "../pipeline";
+import { type SwarmAgent, type SwarmDefinition, type SwarmMode, validateSwarmDefinition } from "../schema";
+import { StateTracker } from "../state";
+
+// ============================================================================
+// Builders — assemble SwarmDefinition objects directly (mirrors parseSwarmYaml output)
+// ============================================================================
+
+function agent(name: string, overrides: Partial<SwarmAgent> = {}): SwarmAgent {
+	return {
+		name,
+		role: `${name}-role`,
+		task: `${name} task`,
+		reportsTo: [],
+		waitsFor: [],
+		...overrides,
+	};
+}
+
+function voteDef(agents: SwarmAgent[], mode: SwarmMode = "vote"): SwarmDefinition {
+	const map = new Map<string, SwarmAgent>();
+	for (const a of agents) map.set(a.name, a);
+	return {
+		name: "test-vote",
+		workspace: "/tmp/ws",
+		mode,
+		targetCount: 1,
+		agents: map,
+		agentOrder: agents.map(a => a.name),
+	};
+}
+
+/** A well-formed vote topology: N voters + one judge that waits_for all of them. */
+function happyVoteDef(voterCount: number): SwarmDefinition {
+	const voters = Array.from({ length: voterCount }, (_, i) => agent(`voter${i + 1}`));
+	const judge = agent("judge", { waitsFor: voters.map(v => v.name) });
+	return voteDef([...voters, judge]);
+}
+
+function mockResult(over: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "x",
+		agent: "x",
+		agentSource: "project",
+		task: "t",
+		exitCode: 0,
+		output: "ok",
+		stderr: "",
+		truncated: false,
+		durationMs: 1,
+		tokens: 0,
+		...over,
+	} as SingleResult;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+describe("validateSwarmDefinition — vote mode", () => {
+	it("accepts a judge + 2 voters (no errors)", () => {
+		expect(validateSwarmDefinition(happyVoteDef(2))).toEqual([]);
+	});
+
+	it("accepts a judge + 3 voters (no errors)", () => {
+		expect(validateSwarmDefinition(happyVoteDef(3))).toEqual([]);
+	});
+
+	it("rejects a missing aggregator (all agents are voters, none waits_for)", () => {
+		const def = voteDef([agent("v1"), agent("v2")]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("judge/aggregator"))).toBe(true);
+	});
+
+	it("rejects more than one aggregator", () => {
+		const def = voteDef([
+			agent("v1"),
+			agent("v2"),
+			agent("j1", { waitsFor: ["v1", "v2"] }),
+			agent("j2", { waitsFor: ["v1", "v2"] }),
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("exactly one judge/aggregator"))).toBe(true);
+	});
+
+	it("rejects fewer than 2 voters", () => {
+		const def = voteDef([agent("v1"), agent("judge", { waitsFor: ["v1"] })]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("at least 2 voter"))).toBe(true);
+	});
+
+	it("rejects a judge that does not wait_for every voter", () => {
+		const def = voteDef([
+			agent("v1"),
+			agent("v2"),
+			agent("v3"),
+			agent("judge", { waitsFor: ["v1", "v2"] }), // misses v3
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("missing voter 'v3'"))).toBe(true);
+	});
+
+	it("rejects a voter that reports_to another voter (would serialize wave 0)", () => {
+		// v1 reports_to v2 → buildDependencyGraph makes v2 depend on v1, splitting the
+		// voters across waves. Validation must reject this so its waitsFor-only partition
+		// stays congruent with the dependency graph that actually gets built.
+		const def = voteDef([
+			agent("v1", { reportsTo: ["v2"] }),
+			agent("v2"),
+			agent("judge", { waitsFor: ["v1", "v2"] }),
+		]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("voter 'v1' must not declare reports_to"))).toBe(true);
+	});
+
+	it("rejects a judge that reports_to a voter (structural cycle)", () => {
+		// judge waits_for v1 AND reports_to v1 → v1 depends on judge while judge depends on
+		// v1: a cycle. Vote validation must reject it up front rather than lean on the
+		// downstream detectCycles pass that direct PipelineController callers may skip.
+		const def = voteDef([agent("v1"), agent("v2"), agent("judge", { waitsFor: ["v1", "v2"], reportsTo: ["v1"] })]);
+		const errors = validateSwarmDefinition(def);
+		expect(errors.some(e => e.includes("judge 'judge' must not declare reports_to"))).toBe(true);
+	});
+
+	it("the rejected voter-reports_to config would split voters across waves (proves the contract)", () => {
+		// Demonstrates the broken DAG the validation guards against: with reports_to present
+		// the voters no longer share wave 0.
+		const def = voteDef([
+			agent("v1", { reportsTo: ["v2"] }),
+			agent("v2"),
+			agent("judge", { waitsFor: ["v1", "v2"] }),
+		]);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		// v1 must precede v2 (v2 depends on v1 via reports_to), so they are NOT in one wave.
+		const wave0 = waves[0];
+		expect(wave0).toEqual(["v1"]);
+		expect(wave0).not.toContain("v2");
+	});
+});
+
+// ============================================================================
+// DAG — waves and aggregator detection
+// ============================================================================
+
+describe("vote mode DAG", () => {
+	it("places voters in wave 0 and the judge in wave 1", () => {
+		const def = happyVoteDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		expect(waves).toHaveLength(2);
+		expect(waves[0].sort()).toEqual(["voter1", "voter2", "voter3"]);
+		expect(waves[1]).toEqual(["judge"]);
+	});
+
+	it("gives voters no implicit chain (all voters share wave 0)", () => {
+		// Three voters declared in order; in pipeline mode they would chain into 3 waves.
+		const def = happyVoteDef(3);
+		const deps = buildDependencyGraph(def);
+		// Each voter depends on nothing; only the judge has deps.
+		expect(deps.get("voter1")!.size).toBe(0);
+		expect(deps.get("voter2")!.size).toBe(0);
+		expect(deps.get("voter3")!.size).toBe(0);
+		expect([...deps.get("judge")!].sort()).toEqual(["voter1", "voter2", "voter3"]);
+	});
+
+	it("findVoteAggregator identifies the judge for a vote definition", () => {
+		expect(findVoteAggregator(happyVoteDef(2))).toBe("judge");
+	});
+
+	it("findVoteAggregator returns null for non-vote modes", () => {
+		const def = happyVoteDef(2);
+		def.mode = "pipeline";
+		expect(findVoteAggregator(def)).toBeNull();
+	});
+});
+
+// ============================================================================
+// Pipeline — the judge receives every voter's output (reuses executeSwarmAgent)
+// ============================================================================
+
+describe("PipelineController — vote reduce", () => {
+	let workspace: string;
+
+	beforeEach(async () => {
+		workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-vote-test-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await fs.rm(workspace, { recursive: true, force: true });
+	});
+
+	it("injects all voter outputs into the judge's system prompt", async () => {
+		// Each runSubprocess call returns a distinct answer keyed by the agent name so we
+		// can assert the judge's prompt carries every voter output. runSubprocess builds
+		// the system prompt from agent.role + agent.extraContext, so injection through the
+		// derived judge agent is observable on the captured options.
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			return mockResult({ agent: name, output: `ANSWER_FROM_${name}` });
+		});
+
+		const def = happyVoteDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const controller = new PipelineController(def, waves, stateTracker);
+		const result = await controller.run({ workspace });
+
+		expect(result.status).toBe("completed");
+		// 3 voters + 1 judge = 4 subprocess invocations.
+		expect(spy).toHaveBeenCalledTimes(4);
+
+		const judgeCall = spy.mock.calls.find(c => c[0].agent.name === "judge");
+		expect(judgeCall).toBeDefined();
+		const judgePrompt = judgeCall![0].agent.systemPrompt ?? "";
+		// Every voter output is present in the judge's context.
+		expect(judgePrompt).toContain("ANSWER_FROM_voter1");
+		expect(judgePrompt).toContain("ANSWER_FROM_voter2");
+		expect(judgePrompt).toContain("ANSWER_FROM_voter3");
+		// The judge is prompted to reduce, not concatenate.
+		expect(judgePrompt).toContain("JUDGE");
+		expect(judgePrompt.toLowerCase()).toContain("consensus");
+	});
+
+	it("does not inject voter outputs into the voters themselves", async () => {
+		const spy = vi
+			.spyOn(taskExecutor, "runSubprocess")
+			.mockImplementation(async (opts: ExecutorOptions) =>
+				mockResult({ agent: opts.agent.name, output: `ANSWER_FROM_${opts.agent.name}` }),
+			);
+
+		const def = happyVoteDef(2);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		const voterCall = spy.mock.calls.find(c => c[0].agent.name === "voter1");
+		expect(voterCall).toBeDefined();
+		const voterPrompt = voterCall![0].agent.systemPrompt ?? "";
+		expect(voterPrompt).not.toContain("JUDGE");
+		expect(voterPrompt).not.toContain("ANSWER_FROM_voter2");
+	});
+
+	it("still reduces when one voter fails (failure surfaced to the judge)", async () => {
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			if (name === "voter2") {
+				return mockResult({ agent: name, exitCode: 1, output: "", error: "boom" });
+			}
+			return mockResult({ agent: name, output: `ANSWER_FROM_${name}` });
+		});
+
+		const def = happyVoteDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		// The failed voter contributes a non-zero exit, so the pipeline reports failed
+		// overall, but the judge still runs and reduces the surviving outputs.
+		expect(spy.mock.calls.some(c => c[0].agent.name === "judge")).toBe(true);
+		const judgeCall = spy.mock.calls.find(c => c[0].agent.name === "judge")!;
+		const judgePrompt = judgeCall[0].agent.systemPrompt ?? "";
+		expect(judgePrompt).toContain("ANSWER_FROM_voter1");
+		expect(judgePrompt).toContain("ANSWER_FROM_voter3");
+		// The failed voter is surfaced rather than silently dropped.
+		expect(judgePrompt).toContain("voter failed");
+		expect(result.errors.some(e => e.includes("voter2"))).toBe(true);
+	});
+
+	it("downgrades the judge instruction when every voter fails (no fabricated consensus)", async () => {
+		const spy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async (opts: ExecutorOptions) => {
+			const name = opts.agent.name;
+			if (name === "judge") {
+				return mockResult({ agent: name, output: "report" });
+			}
+			return mockResult({ agent: name, exitCode: 1, output: "", error: `boom-${name}` });
+		});
+
+		const def = happyVoteDef(3);
+		const waves = buildExecutionWaves(buildDependencyGraph(def));
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const result = await new PipelineController(def, waves, stateTracker).run({ workspace });
+
+		expect(result.status).toBe("failed");
+		const judgeCall = spy.mock.calls.find(c => c[0].agent.name === "judge")!;
+		const judgePrompt = judgeCall[0].agent.systemPrompt ?? "";
+		// All voters failed: the judge must be told NOT to fabricate a consensus.
+		expect(judgePrompt).toContain("EVERY voter failed");
+		expect(judgePrompt).toContain("Do NOT fabricate a consensus");
+		// And must NOT carry the consensus-producing instruction.
+		expect(judgePrompt).not.toContain("produce a single consolidated answer");
+	});
+});

--- a/packages/swarm-extension/src/swarm/dag.ts
+++ b/packages/swarm-extension/src/swarm/dag.ts
@@ -39,7 +39,10 @@ export function buildDependencyGraph(def: SwarmDefinition): Map<string, Set<stri
 		}
 	}
 
-	// For pipeline/sequential with no explicit deps, chain by declaration order
+	// For pipeline/sequential with no explicit deps, chain by declaration order.
+	// Vote mode is intentionally excluded: voters fan out in parallel (no implicit
+	// chain) and only the aggregator waits_for them via the explicit edges above,
+	// so buildExecutionWaves naturally places voters in wave 0, the judge in wave 1.
 	if ((def.mode === "pipeline" || def.mode === "sequential") && !hasExplicitDeps(deps)) {
 		for (let i = 1; i < def.agentOrder.length; i++) {
 			deps.get(def.agentOrder[i])!.add(def.agentOrder[i - 1]);
@@ -47,6 +50,22 @@ export function buildDependencyGraph(def: SwarmDefinition): Map<string, Set<stri
 	}
 
 	return deps;
+}
+
+/**
+ * Identify the vote-mode judge/aggregator: the single agent that waits_for the voters.
+ *
+ * Relies on the strict shape enforced by `validateSwarmDefinition` for vote mode
+ * (exactly one agent with a non-empty waits_for). Returns its name, or null if the
+ * shape does not hold (e.g. an invalid definition that skipped validation).
+ */
+export function findVoteAggregator(def: SwarmDefinition): string | null {
+	if (def.mode !== "vote") return null;
+	const aggregators: string[] = [];
+	for (const [name, agent] of def.agents) {
+		if (agent.waitsFor.length > 0) aggregators.push(name);
+	}
+	return aggregators.length === 1 ? aggregators[0] : null;
 }
 
 function hasExplicitDeps(deps: Map<string, Set<string>>): boolean {

--- a/packages/swarm-extension/src/swarm/pipeline.ts
+++ b/packages/swarm-extension/src/swarm/pipeline.ts
@@ -7,7 +7,6 @@
  * - For pipeline mode, iterations repeat the full DAG execution
  */
 import type { AgentSource, ModelRegistry, Settings, SingleResult } from "@oh-my-pi/pi-coding-agent";
-import { findVoteAggregator } from "./dag";
 import { executeSwarmAgent } from "./executor";
 import type { SwarmAgent, SwarmDefinition } from "./schema";
 import type { StateTracker } from "./state";
@@ -133,10 +132,14 @@ export class PipelineController {
 		const results = new Map<string, SingleResult>();
 		let agentIndex = 0;
 
-		// In vote mode the judge/aggregator is the final-wave agent that waits_for the
-		// voters; it must reduce their outputs. We identify it structurally (validated
-		// shape) once per iteration so the wave loop can inject the voter outputs.
-		const voteAggregator = this.#def.mode === "vote" ? findVoteAggregator(this.#def) : null;
+		// In vote and mixture modes the aggregator is the final-wave agent that
+		// waits_for the fan-out members; it must REDUCE their outputs. Both share the
+		// same DAG shape (KTD-5) and the same proposer->aggregator injection seam — they
+		// differ only in the reduce instruction (vote JUDGES the consensus; mixture
+		// SYNTHESIZES a unified answer). We identify the aggregator structurally (validated
+		// shape) once per iteration so the wave loop can inject the member outputs.
+		const reduceAggregator =
+			this.#def.mode === "vote" || this.#def.mode === "mixture" ? this.#findReduceAggregator() : null;
 
 		for (let waveIdx = 0; waveIdx < this.#waves.length; waveIdx++) {
 			const wave = this.#waves[waveIdx];
@@ -161,11 +164,13 @@ export class PipelineController {
 			const waveResults = await Promise.all(
 				wave.map(async agentName => {
 					const baseAgent = this.#def.agents.get(agentName)!;
-					// Feedback seam: when this agent is the vote judge, inject every voter's
-					// output into its context and prompt it to pick/synthesize the consensus.
-					// Reuses executeSwarmAgent unchanged by deriving an agent whose extraContext
-					// carries the voter outputs (NON-deterministic, advisory — the judge decides).
-					const agent = agentName === voteAggregator ? this.#buildJudgeAgent(baseAgent, results) : baseAgent;
+					// Feedback seam: when this agent is the vote/mixture aggregator, inject every
+					// fan-out member's output into its context and prompt it to reduce. Reuses
+					// executeSwarmAgent unchanged by deriving an agent whose extraContext carries
+					// the member outputs. The reduce instruction is mode-specific: vote JUDGES the
+					// consensus, mixture SYNTHESIZES a unified answer (both NON-deterministic,
+					// advisory — the aggregator decides).
+					const agent = agentName === reduceAggregator ? this.#buildReduceAgent(baseAgent, results) : baseAgent;
 					const currentIndex = agentIndex++;
 					try {
 						const result = await executeSwarmAgent(agent, currentIndex, {
@@ -215,6 +220,33 @@ export class PipelineController {
 	}
 
 	/**
+	 * Identify the vote/mixture aggregator structurally: the single agent that
+	 * waits_for the fan-out members. Both modes share this shape (KTD-5) and it is
+	 * enforced by validateSwarmDefinition, so the lone agent with a non-empty
+	 * waits_for is unambiguously the reducer. Returns null if the shape does not hold
+	 * (zero or multiple candidates), matching dag.ts findVoteAggregator but without
+	 * the vote-only mode gate so mixture can reuse it.
+	 */
+	#findReduceAggregator(): string | null {
+		const aggregators: string[] = [];
+		for (const [name, agent] of this.#def.agents) {
+			if (agent.waitsFor.length > 0) aggregators.push(name);
+		}
+		return aggregators.length === 1 ? aggregators[0] : null;
+	}
+
+	/**
+	 * Dispatch the reduce-agent derivation by mode: vote JUDGES the consensus,
+	 * mixture SYNTHESIZES a unified answer. Both inject the member outputs into the
+	 * aggregator's extraContext via the same seam; only the prompt instruction differs.
+	 */
+	#buildReduceAgent(agent: SwarmAgent, completed: Map<string, SingleResult>): SwarmAgent {
+		return this.#def.mode === "mixture"
+			? this.#buildSynthesizerAgent(agent, completed)
+			: this.#buildJudgeAgent(agent, completed);
+	}
+
+	/**
 	 * Derive the vote judge agent by appending the voter outputs to its extraContext
 	 * plus an instruction to pick/synthesize the consensus answer. Returns the base
 	 * agent unchanged if no voter output is available yet (defensive — under the
@@ -257,6 +289,55 @@ export class PipelineController {
 			.join("\n\n");
 
 		return { ...agent, extraContext: judgeContext };
+	}
+
+	/**
+	 * Derive the mixture-of-agents aggregator by appending every proposer's output to
+	 * its extraContext plus an instruction to SYNTHESIZE a single best answer (the
+	 * mixture reduce — distinct from vote's JUDGE/consensus reduce). Returns the base
+	 * agent unchanged if no proposer output is available yet (defensive — under the
+	 * validated mixture shape proposers always complete in an earlier wave).
+	 *
+	 * The synthesis is an LLM reduce: NON-deterministic and advisory. Unlike vote,
+	 * which picks/consolidates the consensus, the aggregator here is told to combine
+	 * the complementary strengths of the proposals into one improved answer (the
+	 * mixture-of-agents pattern, arxiv 2406.04692).
+	 */
+	#buildSynthesizerAgent(agent: SwarmAgent, completed: Map<string, SingleResult>): SwarmAgent {
+		const proposers = agent.waitsFor.filter(name => this.#def.agents.has(name));
+		const sections: string[] = [];
+		let succeededProposers = 0;
+		for (const proposer of proposers) {
+			const result = completed.get(proposer);
+			if (!result) continue;
+			const succeeded = result.exitCode === 0;
+			if (succeeded) succeededProposers++;
+			const body = succeeded ? result.output : `(proposer failed: ${result.error ?? "unknown error"})`;
+			sections.push(`### Proposer: ${proposer}\n${body}`);
+		}
+
+		if (sections.length === 0) return agent;
+
+		// When every proposer failed there is nothing to synthesize; prompting the
+		// aggregator to "synthesize" over zero real answers would invent one. Downgrade
+		// the instruction to report the failures instead. (The pipeline already marks the
+		// overall run failed because each failed proposer contributes a non-zero exit.)
+		const instruction =
+			succeededProposers === 0
+				? "You are acting as the AGGREGATOR in a mixture-of-agents swarm, but EVERY proposer " +
+					"failed to produce an answer (see the failure markers below). Do NOT fabricate a " +
+					"synthesis. Report that all proposers failed and summarize the failures."
+				: "You are acting as the AGGREGATOR in a mixture-of-agents swarm. Below are the " +
+					"independent proposed answers from each proposer to the same task. Do NOT simply " +
+					"pick one and do NOT concatenate them. SYNTHESIZE a single, improved answer that " +
+					"combines the complementary strengths of the proposals, corrects their individual " +
+					"errors, and resolves any contradictions into one coherent response.";
+
+		const synthContext = [agent.extraContext, instruction, "## Proposer outputs", sections.join("\n\n")]
+			.filter((part): part is string => Boolean(part))
+			.join("\n\n");
+
+		return { ...agent, extraContext: synthContext };
 	}
 
 	#buildProgressSnapshot(): Record<string, { status: string; iteration: number }> {

--- a/packages/swarm-extension/src/swarm/pipeline.ts
+++ b/packages/swarm-extension/src/swarm/pipeline.ts
@@ -7,8 +7,9 @@
  * - For pipeline mode, iterations repeat the full DAG execution
  */
 import type { AgentSource, ModelRegistry, Settings, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import { findVoteAggregator } from "./dag";
 import { executeSwarmAgent } from "./executor";
-import type { SwarmDefinition } from "./schema";
+import type { SwarmAgent, SwarmDefinition } from "./schema";
 import type { StateTracker } from "./state";
 
 // ============================================================================
@@ -132,6 +133,11 @@ export class PipelineController {
 		const results = new Map<string, SingleResult>();
 		let agentIndex = 0;
 
+		// In vote mode the judge/aggregator is the final-wave agent that waits_for the
+		// voters; it must reduce their outputs. We identify it structurally (validated
+		// shape) once per iteration so the wave loop can inject the voter outputs.
+		const voteAggregator = this.#def.mode === "vote" ? findVoteAggregator(this.#def) : null;
+
 		for (let waveIdx = 0; waveIdx < this.#waves.length; waveIdx++) {
 			const wave = this.#waves[waveIdx];
 
@@ -154,7 +160,12 @@ export class PipelineController {
 			// Execute all agents in wave in parallel, catching per-agent errors
 			const waveResults = await Promise.all(
 				wave.map(async agentName => {
-					const agent = this.#def.agents.get(agentName)!;
+					const baseAgent = this.#def.agents.get(agentName)!;
+					// Feedback seam: when this agent is the vote judge, inject every voter's
+					// output into its context and prompt it to pick/synthesize the consensus.
+					// Reuses executeSwarmAgent unchanged by deriving an agent whose extraContext
+					// carries the voter outputs (NON-deterministic, advisory — the judge decides).
+					const agent = agentName === voteAggregator ? this.#buildJudgeAgent(baseAgent, results) : baseAgent;
 					const currentIndex = agentIndex++;
 					try {
 						const result = await executeSwarmAgent(agent, currentIndex, {
@@ -201,6 +212,51 @@ export class PipelineController {
 		}
 
 		return results;
+	}
+
+	/**
+	 * Derive the vote judge agent by appending the voter outputs to its extraContext
+	 * plus an instruction to pick/synthesize the consensus answer. Returns the base
+	 * agent unchanged if no voter output is available yet (defensive — under the
+	 * validated vote shape voters always complete in an earlier wave).
+	 *
+	 * The judge is an LLM reduce: explicitly NON-deterministic and advisory. There is
+	 * no deterministic exact-match-majority contract in this slice (no vote_key field).
+	 */
+	#buildJudgeAgent(agent: SwarmAgent, completed: Map<string, SingleResult>): SwarmAgent {
+		const voters = agent.waitsFor.filter(name => this.#def.agents.has(name));
+		const sections: string[] = [];
+		let succeededVoters = 0;
+		for (const voter of voters) {
+			const result = completed.get(voter);
+			if (!result) continue;
+			const succeeded = result.exitCode === 0;
+			if (succeeded) succeededVoters++;
+			const body = succeeded ? result.output : `(voter failed: ${result.error ?? "unknown error"})`;
+			sections.push(`### Voter: ${voter}\n${body}`);
+		}
+
+		if (sections.length === 0) return agent;
+
+		// When every voter failed there is nothing to reach consensus over; prompting the
+		// judge to "produce a consensus" over zero real answers would invent one. Downgrade
+		// the instruction to report the failures instead. (The pipeline already marks the
+		// overall run failed because each failed voter contributes a non-zero exit.)
+		const instruction =
+			succeededVoters === 0
+				? "You are acting as the JUDGE in a majority-vote swarm, but EVERY voter failed to " +
+					"produce an answer (see the failure markers below). Do NOT fabricate a consensus. " +
+					"Report that all voters failed and summarize the failures."
+				: "You are acting as the JUDGE in a majority-vote swarm. Below are the independent " +
+					"answers from each voter to the same task. Compare them, identify the majority/consensus " +
+					"position, and produce a single consolidated answer. If voters disagree, pick the most " +
+					"strongly supported answer and briefly note the disagreement. Do not simply concatenate.";
+
+		const judgeContext = [agent.extraContext, instruction, "## Voter outputs", sections.join("\n\n")]
+			.filter((part): part is string => Boolean(part))
+			.join("\n\n");
+
+		return { ...agent, extraContext: judgeContext };
 	}
 
 	#buildProgressSnapshot(): Record<string, { status: string; iteration: number }> {

--- a/packages/swarm-extension/src/swarm/schema.ts
+++ b/packages/swarm-extension/src/swarm/schema.ts
@@ -24,7 +24,7 @@ interface RawSwarmConfig {
 // Normalized types (camelCase, defaults applied)
 // ============================================================================
 
-export type SwarmMode = "pipeline" | "parallel" | "sequential" | "vote";
+export type SwarmMode = "pipeline" | "parallel" | "sequential" | "vote" | "mixture";
 
 export interface SwarmAgent {
 	name: string;
@@ -51,7 +51,7 @@ export interface SwarmDefinition {
 // Parsing
 // ============================================================================
 
-const VALID_MODES = new Set<string>(["pipeline", "parallel", "sequential", "vote"]);
+const VALID_MODES = new Set<string>(["pipeline", "parallel", "sequential", "vote", "mixture"]);
 const VALID_SWARM_NAME = /^[a-zA-Z0-9._-]+$/;
 
 export function parseSwarmYaml(content: string): SwarmDefinition {
@@ -157,79 +157,213 @@ export function validateSwarmDefinition(def: SwarmDefinition): string[] {
 		errors.push(...validateVoteMode(def, agentNames));
 	}
 
+	if (def.mode === "mixture") {
+		errors.push(...validateMixtureMode(def, agentNames));
+	}
+
 	return errors;
 }
 
 /**
- * Vote mode requires a strict fan-in shape so the judge/aggregator is unambiguous:
- *   - exactly one aggregator (the single agent with a non-empty waits_for),
- *   - at least two voters (the remaining agents, which must have no waits_for),
- *   - the aggregator must wait_for every voter (final wave reduces all of them),
- *   - voters carry no reports_to (any reports_to among voters would inject an extra
- *     dependency edge in buildDependencyGraph and serialize the voters into separate
- *     waves, silently breaking the "voters fan out in parallel, wave 0" contract),
- *   - the aggregator carries no reports_to (reports_to makes its target depend on the
- *     aggregator; pointing it at a voter the aggregator already waits_for would form a
- *     voter<->judge cycle that vote validation must reject up front, not lean on the
- *     downstream detectCycles pass that direct PipelineController callers may skip).
+ * Non-fatal advisory warnings for a swarm definition. Kept separate from
+ * validateSwarmDefinition (whose every entry aborts the run) so a quality
+ * caveat never blocks an otherwise-valid topology. Callers surface these at
+ * "warning" severity without halting; an empty array means no caveats.
  *
- * The topology itself carries the role (KTD-5: no new DAG primitive, no new schema
- * field) — this validation is the contract that makes the shape unambiguous, so the
- * pipeline reducer can identify the aggregator structurally without heuristics. The
- * reports_to checks keep this validated partition congruent with the dependency graph
- * buildDependencyGraph actually constructs (which consumes both waits_for AND reports_to).
+ * WIRING CONTRACT (KTD-6 deliverable — must reach the operator before mixture
+ * ships): every real run path MUST invoke this AFTER validateSwarmDefinition
+ * passes and surface each returned string non-fatally —
+ *   - extension.ts /swarm run → ctx.ui.notify(msg, "warning") (non-halting),
+ *   - cli.ts → process.stderr / console.warn.
+ * Without that wiring the Self-MoA heterogeneous-proposer caveat is dead code
+ * and the −6.6pp quality regression it guards against ships silently. The
+ * wiring lands in a dedicated follow-up commit (kept out of U2's three-file
+ * atomic scope by design); do NOT leave it unwired across the milestone.
+ */
+export function collectSwarmWarnings(def: SwarmDefinition): string[] {
+	const warnings: string[] = [];
+	if (def.mode === "mixture") {
+		warnings.push(...mixtureModelWarnings(def));
+	}
+	return warnings;
+}
+
+/**
+ * KTD-6 (Self-MoA, arxiv 2502.00674): a mixture-of-agents aggregator gains the
+ * most when its proposers share ONE model (heterogeneous mixing nets −6.6pp).
+ * The aggregator should get the best available model; the proposers should be
+ * homogeneous. Mixing distinct proposer models is allowed but earns a one-line
+ * caveat so the operator knows the configuration trades quality for diversity.
+ *
+ * "Homogeneous" is judged over the EFFECTIVE proposer model — a proposer's own
+ * `model` if set, otherwise the swarm-level default `def.model`. The aggregator
+ * is excluded: it is expected to differ (best model) and is not a proposer.
+ */
+function mixtureModelWarnings(def: SwarmDefinition): string[] {
+	const aggregatorName = findFanInAggregator(def);
+	if (aggregatorName === null) return [];
+
+	const proposerModels = new Set<string>();
+	for (const [name, agent] of def.agents) {
+		if (name === aggregatorName) continue;
+		// undefined → inherits def.model; collapse to a sentinel so two proposers
+		// that both inherit the same default count as homogeneous.
+		proposerModels.add(agent.model ?? def.model ?? "<default>");
+	}
+
+	if (proposerModels.size > 1) {
+		return [
+			`mixture mode proposers use heterogeneous models [${[...proposerModels].sort().join(", ")}]; ` +
+				"Self-MoA (KTD-6) favors homogeneous proposers (same model) with the aggregator on the best model — " +
+				"heterogeneous mixing can lower quality (arxiv 2502.00674).",
+		];
+	}
+	return [];
+}
+
+/**
+ * Mixture mode shares the strict fan-in shape with vote mode: the proposers fan
+ * out in parallel (wave 0, no waits_for, no reports_to) and exactly one
+ * aggregator waits_for every proposer (final wave). The only difference is the
+ * reduce semantics at the aggregator — vote JUDGES the consensus, mixture
+ * SYNTHESIZES a unified answer — which lives in the pipeline reducer, not here.
+ * The topology validation is therefore identical, so it is delegated.
+ */
+function validateMixtureMode(def: SwarmDefinition, agentNames: Set<string>): string[] {
+	return validateFanInShape(def, agentNames, MIXTURE_VOCAB);
+}
+
+/**
+ * Vote mode requires the same strict fan-in shape, judged with vote vocabulary.
  */
 function validateVoteMode(def: SwarmDefinition, agentNames: Set<string>): string[] {
+	return validateFanInShape(def, agentNames, VOTE_VOCAB);
+}
+
+/**
+ * Per-mode message vocabulary for the shared fan-in validator. Each closure
+ * renders the exact operator-facing error string for that violation so the two
+ * modes keep their own wording (vote speaks of a "judge"/"voters", mixture of an
+ * "aggregator"/"proposers") while sharing one structural check.
+ */
+interface FanInVocab {
+	mode: SwarmMode;
+	/** No agent has a non-empty waits_for → no aggregator to reduce. */
+	missingAggregator(): string;
+	/** More than one agent has waits_for → the reducer would be ambiguous. */
+	multipleAggregators(names: string[]): string;
+	/** Fewer than the 2-member fan-in minimum. */
+	tooFewMembers(count: number): string;
+	/** The aggregator fails to wait_for one of the members. */
+	missingMemberEdge(aggregator: string, member: string): string;
+	/** A member declares reports_to, which would serialize it out of wave 0. */
+	memberReportsTo(member: string): string;
+	/** The aggregator declares reports_to, forming an aggregator<->member cycle. */
+	aggregatorReportsTo(aggregator: string): string;
+}
+
+const VOTE_VOCAB: FanInVocab = {
+	mode: "vote",
+	missingAggregator: () => "vote mode requires a judge/aggregator agent (one agent that waits_for the voters)",
+	multipleAggregators: names =>
+		`vote mode requires exactly one judge/aggregator agent, found ${names.length}: [${names.join(", ")}]`,
+	tooFewMembers: count => `vote mode requires at least 2 voter agents, found ${count}`,
+	missingMemberEdge: (aggregator, member) =>
+		`vote mode judge '${aggregator}' must wait_for every voter; missing voter '${member}'`,
+	memberReportsTo: member =>
+		`vote mode voter '${member}' must not declare reports_to; voters fan out in parallel with no implicit chain`,
+	aggregatorReportsTo: aggregator =>
+		`vote mode judge '${aggregator}' must not declare reports_to; the judge depends on voters via waits_for only`,
+};
+
+const MIXTURE_VOCAB: FanInVocab = {
+	mode: "mixture",
+	missingAggregator: () =>
+		"mixture mode requires an aggregator agent (one agent that waits_for the proposers and synthesizes their answers)",
+	multipleAggregators: names =>
+		`mixture mode requires exactly one aggregator agent, found ${names.length}: [${names.join(", ")}]`,
+	tooFewMembers: count => `mixture mode requires at least 2 proposer agents, found ${count}`,
+	missingMemberEdge: (aggregator, member) =>
+		`mixture mode aggregator '${aggregator}' must wait_for every proposer; missing proposer '${member}'`,
+	memberReportsTo: member =>
+		`mixture mode proposer '${member}' must not declare reports_to; proposers fan out in parallel with no implicit chain`,
+	aggregatorReportsTo: aggregator =>
+		`mixture mode aggregator '${aggregator}' must not declare reports_to; the aggregator depends on proposers via waits_for only`,
+};
+
+/**
+ * The strict fan-in shape shared by vote and mixture (KTD-5 — no new DAG
+ * primitive, the topology itself carries the role):
+ *   - exactly one aggregator (the single agent with a non-empty waits_for),
+ *   - at least two members (the rest, which must have no waits_for),
+ *   - the aggregator must wait_for every member (final wave reduces all of them),
+ *   - members carry no reports_to (any reports_to among members would inject an
+ *     extra dependency edge in buildDependencyGraph and serialize them into
+ *     separate waves, silently breaking the "members fan out, wave 0" contract),
+ *   - the aggregator carries no reports_to (reports_to makes its target depend on
+ *     the aggregator; pointing it at a member the aggregator already waits_for
+ *     forms a cycle this validation must reject up front, not lean on the
+ *     downstream detectCycles pass that direct PipelineController callers may skip).
+ *
+ * This validation is the contract that makes the shape unambiguous so the pipeline
+ * reducer can identify the aggregator structurally without heuristics. The
+ * reports_to checks keep the validated partition congruent with the dependency
+ * graph buildDependencyGraph constructs (which consumes waits_for AND reports_to).
+ */
+function validateFanInShape(def: SwarmDefinition, agentNames: Set<string>, vocab: FanInVocab): string[] {
 	const errors: string[] = [];
 
 	const aggregators: string[] = [];
-	const voters: string[] = [];
+	const members: string[] = [];
 	for (const [name, agent] of def.agents) {
 		if (agent.waitsFor.length > 0) {
 			aggregators.push(name);
 		} else {
-			voters.push(name);
+			members.push(name);
 		}
 	}
 
 	if (aggregators.length === 0) {
-		errors.push("vote mode requires a judge/aggregator agent (one agent that waits_for the voters)");
+		errors.push(vocab.missingAggregator());
 		return errors;
 	}
 	if (aggregators.length > 1) {
-		errors.push(
-			`vote mode requires exactly one judge/aggregator agent, found ${aggregators.length}: [${aggregators.join(", ")}]`,
-		);
+		errors.push(vocab.multipleAggregators(aggregators));
 		return errors;
 	}
 
 	const aggregatorName = aggregators[0];
-	if (voters.length < 2) {
-		errors.push(`vote mode requires at least 2 voter agents, found ${voters.length}`);
+	if (members.length < 2) {
+		errors.push(vocab.tooFewMembers(members.length));
 	}
 
 	const aggregatorDeps = new Set(def.agents.get(aggregatorName)!.waitsFor.filter(d => agentNames.has(d)));
-	for (const voter of voters) {
-		if (!aggregatorDeps.has(voter)) {
-			errors.push(`vote mode judge '${aggregatorName}' must wait_for every voter; missing voter '${voter}'`);
+	for (const member of members) {
+		if (!aggregatorDeps.has(member)) {
+			errors.push(vocab.missingMemberEdge(aggregatorName, member));
 		}
-		// Voters must fan out in parallel: reports_to adds an extra dependency edge in
-		// the graph that would serialize them out of wave 0, so the partition validation
-		// enforces here would no longer match the waves that get built.
-		if (def.agents.get(voter)!.reportsTo.length > 0) {
-			errors.push(
-				`vote mode voter '${voter}' must not declare reports_to; voters fan out in parallel with no implicit chain`,
-			);
+		if (def.agents.get(member)!.reportsTo.length > 0) {
+			errors.push(vocab.memberReportsTo(member));
 		}
 	}
 
-	// The aggregator's only edges come from waits_for. A reports_to on the judge would
-	// make its target depend on the judge while the judge waits_for that voter — a cycle.
 	if (def.agents.get(aggregatorName)!.reportsTo.length > 0) {
-		errors.push(
-			`vote mode judge '${aggregatorName}' must not declare reports_to; the judge depends on voters via waits_for only`,
-		);
+		errors.push(vocab.aggregatorReportsTo(aggregatorName));
 	}
 
 	return errors;
+}
+
+/**
+ * Identify the single fan-in aggregator (the lone agent with a non-empty
+ * waits_for) for vote/mixture definitions. Relies on the strict shape enforced by
+ * validateSwarmDefinition; returns null when the shape does not hold (e.g. an
+ * invalid definition that skipped validation, or zero/multiple candidates).
+ */
+function findFanInAggregator(def: SwarmDefinition): string | null {
+	const aggregators: string[] = [];
+	for (const [name, agent] of def.agents) {
+		if (agent.waitsFor.length > 0) aggregators.push(name);
+	}
+	return aggregators.length === 1 ? aggregators[0] : null;
 }

--- a/packages/swarm-extension/src/swarm/schema.ts
+++ b/packages/swarm-extension/src/swarm/schema.ts
@@ -24,7 +24,7 @@ interface RawSwarmConfig {
 // Normalized types (camelCase, defaults applied)
 // ============================================================================
 
-export type SwarmMode = "pipeline" | "parallel" | "sequential";
+export type SwarmMode = "pipeline" | "parallel" | "sequential" | "vote";
 
 export interface SwarmAgent {
 	name: string;
@@ -51,7 +51,7 @@ export interface SwarmDefinition {
 // Parsing
 // ============================================================================
 
-const VALID_MODES = new Set<string>(["pipeline", "parallel", "sequential"]);
+const VALID_MODES = new Set<string>(["pipeline", "parallel", "sequential", "vote"]);
 const VALID_SWARM_NAME = /^[a-zA-Z0-9._-]+$/;
 
 export function parseSwarmYaml(content: string): SwarmDefinition {
@@ -151,6 +151,84 @@ export function validateSwarmDefinition(def: SwarmDefinition): string[] {
 	}
 	if (def.mode !== "pipeline" && def.targetCount !== 1) {
 		errors.push("target_count is only supported in pipeline mode");
+	}
+
+	if (def.mode === "vote") {
+		errors.push(...validateVoteMode(def, agentNames));
+	}
+
+	return errors;
+}
+
+/**
+ * Vote mode requires a strict fan-in shape so the judge/aggregator is unambiguous:
+ *   - exactly one aggregator (the single agent with a non-empty waits_for),
+ *   - at least two voters (the remaining agents, which must have no waits_for),
+ *   - the aggregator must wait_for every voter (final wave reduces all of them),
+ *   - voters carry no reports_to (any reports_to among voters would inject an extra
+ *     dependency edge in buildDependencyGraph and serialize the voters into separate
+ *     waves, silently breaking the "voters fan out in parallel, wave 0" contract),
+ *   - the aggregator carries no reports_to (reports_to makes its target depend on the
+ *     aggregator; pointing it at a voter the aggregator already waits_for would form a
+ *     voter<->judge cycle that vote validation must reject up front, not lean on the
+ *     downstream detectCycles pass that direct PipelineController callers may skip).
+ *
+ * The topology itself carries the role (KTD-5: no new DAG primitive, no new schema
+ * field) — this validation is the contract that makes the shape unambiguous, so the
+ * pipeline reducer can identify the aggregator structurally without heuristics. The
+ * reports_to checks keep this validated partition congruent with the dependency graph
+ * buildDependencyGraph actually constructs (which consumes both waits_for AND reports_to).
+ */
+function validateVoteMode(def: SwarmDefinition, agentNames: Set<string>): string[] {
+	const errors: string[] = [];
+
+	const aggregators: string[] = [];
+	const voters: string[] = [];
+	for (const [name, agent] of def.agents) {
+		if (agent.waitsFor.length > 0) {
+			aggregators.push(name);
+		} else {
+			voters.push(name);
+		}
+	}
+
+	if (aggregators.length === 0) {
+		errors.push("vote mode requires a judge/aggregator agent (one agent that waits_for the voters)");
+		return errors;
+	}
+	if (aggregators.length > 1) {
+		errors.push(
+			`vote mode requires exactly one judge/aggregator agent, found ${aggregators.length}: [${aggregators.join(", ")}]`,
+		);
+		return errors;
+	}
+
+	const aggregatorName = aggregators[0];
+	if (voters.length < 2) {
+		errors.push(`vote mode requires at least 2 voter agents, found ${voters.length}`);
+	}
+
+	const aggregatorDeps = new Set(def.agents.get(aggregatorName)!.waitsFor.filter(d => agentNames.has(d)));
+	for (const voter of voters) {
+		if (!aggregatorDeps.has(voter)) {
+			errors.push(`vote mode judge '${aggregatorName}' must wait_for every voter; missing voter '${voter}'`);
+		}
+		// Voters must fan out in parallel: reports_to adds an extra dependency edge in
+		// the graph that would serialize them out of wave 0, so the partition validation
+		// enforces here would no longer match the waves that get built.
+		if (def.agents.get(voter)!.reportsTo.length > 0) {
+			errors.push(
+				`vote mode voter '${voter}' must not declare reports_to; voters fan out in parallel with no implicit chain`,
+			);
+		}
+	}
+
+	// The aggregator's only edges come from waits_for. A reports_to on the judge would
+	// make its target depend on the judge while the judge waits_for that voter — a cycle.
+	if (def.agents.get(aggregatorName)!.reportsTo.length > 0) {
+		errors.push(
+			`vote mode judge '${aggregatorName}' must not declare reports_to; the judge depends on voters via waits_for only`,
+		);
 	}
 
 	return errors;


### PR DESCRIPTION
Closes #2609.

One additive arc on model orchestration, in three stacked parts. **No default behavior changes** — failover rides the existing session retry loop, blends are opt-in virtual catalog entries. 17 commits, one concern each.

## What's here

### 1 — Canonical-equivalence failover + grouped picker
- `refactor(catalog)`: extract `rankCanonicalVariants` from `resolveCanonicalVariant` — byte-identical by construction (`resolveCanonicalVariant(v,p) === rankCanonicalVariants(v,p)[0]`, regression-tested).
- `feat(coding-agent)`: `ModelRegistry.rankCanonicalVariantsFor`; canonical siblings auto-append to the **existing** session retry chain after the explicit user chain (explicit wins, de-duped). Gated on the existing `retry.modelFallback` flag — **no new settings key**.
- `feat(coding-agent)`: grouped model-picker view (`g` cycles provider / family / cost-tier / capability); default provider-tab view untouched.

### 2 — Swarm patterns (extends the existing `swarm-extension`)
- `vote` mode (majority voting via judge agent) and `mixture` mode (mixture-of-agents).
- Self-MoA guard (arXiv 2502.00674) surfaced as a non-halting caveat on `/swarm run` (UI notify) and the CLI (stderr).

### 3 — Synthetic / blended models (`api: "omp-swarm"`, keyless `provider: "omp"`)
- One catalog field `Model.swarm?: SwarmSpec` threaded through the custom-model pipeline (spread-preserved through `buildModel`; explicit-list sites in `finalizeCustomModel`).
- Pure combinators (`runSequence` / `runRouter` / `runParallelAggregate`) parameterized by an injected `driveNode`; two leaves — model-leaf (recursive `streamSimple`) and subagent-leaf (reuses the existing `runSubprocess`, no new registry).
- Strategies: `router` (one member/turn, no cost multiplier — recommended default), `draft-refine` (sequential), `moa`.
- Built-in presets (`omp/router-balanced`, `omp/draft-refine`, `omp/moa-synthesis`) + user-authorable `swarm:` blocks via a zod mirror on the models config schema.
- Picker surfaces summed member cost for blends up front.

## Design notes
- **Dispatch is unchanged for the common path.** `getCustomApi(model.api)` is already consulted in `stream()`/`streamSimple()` before the apiKey gate; `"omp-swarm"` registers cleanly (it isn't a `BUILTIN_API`). A keyless `omp` model dispatches with zero switch edits.
- **One coherent message out.** `stream.result()` settles with a single `AssistantMessage` = one surface member's content + `stopReason` + **summed `Usage`**. Non-surface members are status-only; their tool-call content never enters the final message (asserted in tests). Live deltas are UI fidelity only.
- **Cache-friendly.** The dispatched prefix is held stable; only the variable tail differs across members, so provider prompt-cache hits survive blends.
- **Concurrency.** First-writer-wins global dispatcher install (set deps only from empty); `signal.aborted` is always fatal.
- **MoA proposer alignment.** Surviving proposals are returned as `{member, result}` pairs (single source of truth — no parallel array to misalign, no index access under `noUncheckedIndexedAccess`), so a rejected proposer can't shift a later survivor onto the wrong member.
- **Naming guard.** Reserves `provider:"omp"` / `api:"omp-swarm"`; never reuses the `synthetic.new` vendor namespace.

## Scope / non-goals
Deliberately cut as Excess for an in-process single-user CLI: the full ~21-pattern swarms.world catalog, a GRAPH scheduler, standalone FANOUT/AGGREGATE primitives, CONVERSE/GroupChat. Default install stays single-model + failover-only.

## Verification
- `bun run check` (typecheck + biome) green across all packages.
- Pure unit tests pass: catalog `canonical-variant-ranking`, `swarm-spec`; coding-agent `swarm-primitives` (35), `swarm-subagent-leaf` (21), `swarm-config-parse` (9), `swarm-presets`, `swarm-executor`, `model-selector-swarm-cost`, `swarm-registry-threading`; swarm-extension `vote`, `mixture`.
- Tests that import the full `ModelRegistry` hang at module-load **in my local sandbox only** (a pre-existing environment quirk, not introduced here) — they run via `cd packages/<pkg> && bun test test/<file>` serially. Flagging so CI coverage is the source of truth for those.
- Rebased onto `origin/main`; merges cleanly against current upstream `main` (feature paths are disjoint from the one intervening upstream commit).
