### PR TITLE
fix(ai): preserve Cursor MCP tool-call args when completion frame omits oversized params

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor (`cursor-agent` API) dropping the `task` tool's `tasks` array on multi-subagent dispatches when the `tool_call_completed` frame's structured `McpArgs` map omits oversized parameters. Streamed args are now merged with the decoded completion map without downgrading structured values to their string fallback, and cumulative `args_text_delta` snapshots emit append-only deltas instead of being concatenated.
+
 ## [15.13.1] - 2026-06-15
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1829,6 +1829,55 @@ function decodeMcpArgsMap(args?: Record<string, Uint8Array>): Record<string, unk
 	}
 	return decoded;
 }
+/**
+ * Accumulates Cursor `args_text_delta` frames into the running tool-arg JSON buffer.
+ *
+ * `PartialToolCallUpdate.args_text_delta` is documented as "Aggregated args text so
+ * far", i.e. each frame MAY carry the full cumulative snapshot rather than an
+ * increment. Blindly concatenating cumulative snapshots corrupts the JSON once a
+ * call spans more than one frame (large args), which then parses to a truncated
+ * prefix that silently drops trailing parameters. Detect cumulative snapshots
+ * without treating prefix-shaped incremental fragments as duplicates:
+ *   - incoming extends prev -> cumulative snapshot, supersede
+ *   - incoming equals prev  -> duplicate snapshot, keep prev
+ *   - otherwise            -> true incremental fragment, append
+ */
+export function accumulateArgsText(prev: string, incoming: string): string {
+	if (!incoming) return prev;
+	if (!prev) return incoming;
+	if (incoming === prev) return prev;
+	if (incoming.startsWith(prev)) return incoming;
+	return prev + incoming;
+}
+
+/**
+ * Merges args decoded from `tool_call_completed` with args recovered from the
+ * streamed `args_text_delta` text. The completion frame is authoritative for
+ * scalars, but Cursor omits large parameters from the structured map (and
+ * `decodeMcpArgValue` falls back to raw text when a `Value` fails to parse), so a
+ * blind overwrite drops or downgrades big params like `task`'s `tasks` array —
+ * surfacing as a Zod "expected array, received undefined". Use the streamed parse
+ * as the base and overlay decoded values, but never let the completion frame
+ * remove a key or downgrade a structured value to a string.
+ */
+export function mergeCompletedMcpArgs(
+	streamed: Record<string, unknown>,
+	decoded: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+	if (!decoded || Object.keys(decoded).length === 0) return streamed;
+	const merged: Record<string, unknown> = { ...streamed };
+	for (const [key, value] of Object.entries(decoded)) {
+		if (value === undefined) continue;
+		// Skip prototype-polluting keys: decoded args are model/provider-controlled, and a
+		// `merged["__proto__"] = …` bracket-assign rewrites the arguments object's prototype.
+		if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+		const current = merged[key];
+		// Don't downgrade a structured streamed value to a string/primitive fallback.
+		if (current !== null && typeof current === "object" && typeof value !== "object") continue;
+		merged[key] = value;
+	}
+	return merged;
+}
 
 function decodeMcpCall(args: {
 	name: string;
@@ -1940,7 +1989,7 @@ function buildMcpErrorResult(error: string) {
 	});
 }
 
-function processInteractionUpdate(
+export function processInteractionUpdate(
 	update: any,
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
@@ -2035,19 +2084,22 @@ function processInteractionUpdate(
 	} else if (updateCase === "toolCallDelta" || updateCase === "partialToolCall") {
 		if (state.currentToolCall?.kind === "mcp") {
 			const delta = update.message.value.argsTextDelta || "";
-			state.currentToolCall.partialJson = `${state.currentToolCall.partialJson ?? ""}${delta}`;
+			const prevPartialJson = state.currentToolCall.partialJson ?? "";
+			state.currentToolCall.partialJson = accumulateArgsText(prevPartialJson, delta);
 			state.currentToolCall.arguments = parseStreamingJson(state.currentToolCall.partialJson ?? "");
+			const emittedDelta = state.currentToolCall.partialJson.startsWith(prevPartialJson)
+				? state.currentToolCall.partialJson.slice(prevPartialJson.length)
+				: delta;
 			const idx = output.content.indexOf(state.currentToolCall);
-			stream.push({ type: "toolcall_delta", contentIndex: idx, delta, partial: output });
+			stream.push({ type: "toolcall_delta", contentIndex: idx, delta: emittedDelta, partial: output });
 		}
 	} else if (updateCase === "toolCallCompleted") {
 		if (state.currentToolCall) {
 			const toolCall = update.message.value.toolCall;
 			if (state.currentToolCall.kind === "mcp") {
+				const streamed = parseStreamingJson<Record<string, unknown>>(state.currentToolCall.partialJson ?? "");
 				const decodedArgs = decodeMcpArgsMap(toolCall?.mcpToolCall?.args?.args);
-				if (decodedArgs) {
-					state.currentToolCall.arguments = decodedArgs;
-				}
+				state.currentToolCall.arguments = mergeCompletedMcpArgs(streamed, decodedArgs);
 			} else if (state.currentToolCall.kind === "todo" && toolCall) {
 				const todoArgs = buildTodoArgs(toolCall);
 				if (todoArgs) {

--- a/packages/ai/test/cursor-mcp-args.test.ts
+++ b/packages/ai/test/cursor-mcp-args.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "bun:test";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { ValueSchema } from "@bufbuild/protobuf/wkt";
+import { accumulateArgsText, mergeCompletedMcpArgs, processInteractionUpdate } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai/types";
+
+// Encode a value the way Cursor sends an MCP arg value: a protobuf Value wrapping a
+// string. decodeMcpArgValue runs fromBinary -> toJson -> parseToolArgsJson(string).
+const encodeArg = (s: string): Uint8Array =>
+	toBinary(ValueSchema, create(ValueSchema, { kind: { case: "stringValue", value: s } }));
+
+function makeState() {
+	let toolCall: unknown = null;
+	return {
+		currentTextBlock: null,
+		currentThinkingBlock: null,
+		get currentToolCall() {
+			return toolCall;
+		},
+		firstTokenTime: undefined,
+		setTextBlock() {},
+		setThinkingBlock() {},
+		setToolCall(t: unknown) {
+			toolCall = t;
+		},
+		setFirstTokenTime() {},
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "cursor-composer-2.5",
+		content: [],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+describe("accumulateArgsText", () => {
+	it("supersedes with cumulative snapshots", () => {
+		expect(accumulateArgsText('{"a":', '{"a":1}')).toBe('{"a":1}');
+	});
+
+	it("appends true incremental fragments", () => {
+		expect(accumulateArgsText('{"a"', ":1}")).toBe('{"a":1}');
+	});
+
+	it("ignores duplicate snapshots", () => {
+		expect(accumulateArgsText('{"a":1}', '{"a":1}')).toBe('{"a":1}');
+	});
+
+	it("appends prefix-shaped incremental fragments", () => {
+		expect(accumulateArgsText('{"tasks":[{"assignment":"A"},', '{"assignment":"B"}]}')).toBe(
+			'{"tasks":[{"assignment":"A"},{"assignment":"B"}]}',
+		);
+	});
+});
+
+describe("mergeCompletedMcpArgs", () => {
+	it("keeps streamed keys the completion map omits", () => {
+		expect(mergeCompletedMcpArgs({ agent: "explore", tasks: [{ assignment: "x" }] }, { agent: "explore" })).toEqual({
+			agent: "explore",
+			tasks: [{ assignment: "x" }],
+		});
+	});
+
+	it("does not downgrade a structured value to a string fallback", () => {
+		expect(mergeCompletedMcpArgs({ tasks: [{ assignment: "x" }] }, { tasks: "[{trunc" })).toEqual({
+			tasks: [{ assignment: "x" }],
+		});
+	});
+
+	it("returns streamed when decoded is empty/undefined", () => {
+		expect(mergeCompletedMcpArgs({ agent: "explore" }, undefined)).toEqual({ agent: "explore" });
+		expect(mergeCompletedMcpArgs({ agent: "explore" }, {})).toEqual({ agent: "explore" });
+	});
+
+	it("does not pollute Object.prototype via a decoded __proto__ key", () => {
+		// JSON.parse keeps `__proto__` as an own data property, mirroring how a decoded
+		// provider map could carry the key; the merge must not route it through the setter.
+		const hostile = JSON.parse('{"__proto__":{"polluted":true},"agent":"explore"}') as Record<string, unknown>;
+		const merged = mergeCompletedMcpArgs({ tasks: [{ assignment: "x" }] }, hostile);
+		expect((merged as Record<string, unknown>).polluted).toBeUndefined();
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+		expect(merged).toEqual({ tasks: [{ assignment: "x" }], agent: "explore" });
+	});
+});
+
+describe("processInteractionUpdate — large MCP (task) tool call", () => {
+	it("preserves a streamed `tasks` array the completion frame omits", () => {
+		const output = makeOutput();
+		const state = makeState();
+		const events: Array<{ type: string; delta?: string }> = [];
+		const stream = {
+			push(event: { type: string; delta?: string }) {
+				events.push(event);
+			},
+			end() {},
+		};
+		const usageState = { sawTokenDelta: false };
+		const run = (update: unknown) =>
+			processInteractionUpdate(update as never, output, stream as never, state as never, usageState as never);
+
+		run({
+			message: {
+				case: "toolCallStarted",
+				value: {
+					callId: "c1",
+					toolCall: { mcpToolCall: { args: { toolCallId: "c1", name: "task" } } },
+				},
+			},
+		});
+
+		const full = '{"agent":"explore","context":"shared ctx","tasks":[{"assignment":"A"},{"assignment":"B"}]}';
+		// Two cumulative snapshots (large call spanning frames).
+		run({ message: { case: "partialToolCall", value: { argsTextDelta: full.slice(0, 30) } } });
+		run({ message: { case: "partialToolCall", value: { argsTextDelta: full } } });
+
+		// Completion frame carries only the scalars; `tasks` exceeded Cursor's structured-map budget.
+		run({
+			message: {
+				case: "toolCallCompleted",
+				value: {
+					callId: "c1",
+					toolCall: {
+						mcpToolCall: {
+							args: { args: { agent: encodeArg("explore"), context: encodeArg("shared ctx") } },
+						},
+					},
+				},
+			},
+		});
+
+		const call = output.content.find(b => b.type === "toolCall") as
+			| { name: string; arguments: Record<string, unknown> }
+			| undefined;
+		expect(call).toBeDefined();
+		expect(call?.name).toBe("task");
+		expect(Array.isArray(call?.arguments.tasks)).toBe(true);
+		expect(call?.arguments.tasks).toHaveLength(2);
+		expect(call?.arguments.agent).toBe("explore");
+		expect(call?.arguments.context).toBe("shared ctx");
+		expect(events.filter(event => event.type === "toolcall_delta").map(event => event.delta)).toEqual([
+			full.slice(0, 30),
+			full.slice(30),
+		]);
+	});
+
+	it("preserves the streamed `tasks` array when the completion frame downgrades it to a string", () => {
+		const output = makeOutput();
+		const state = makeState();
+		const stream = { push() {}, end() {} };
+		const usageState = { sawTokenDelta: false };
+		const run = (update: unknown) =>
+			processInteractionUpdate(update as never, output, stream as never, state as never, usageState as never);
+
+		run({
+			message: {
+				case: "toolCallStarted",
+				value: { callId: "c2", toolCall: { mcpToolCall: { args: { toolCallId: "c2", name: "task" } } } },
+			},
+		});
+		const full = '{"agent":"explore","tasks":[{"assignment":"A"},{"assignment":"B"}]}';
+		run({ message: { case: "partialToolCall", value: { argsTextDelta: full } } });
+		// `tasks` decodes to a truncated raw string (decodeMcpArgValue's TextDecoder fallback);
+		// the merge must keep the streamed array rather than downgrade it to that string.
+		run({
+			message: {
+				case: "toolCallCompleted",
+				value: {
+					callId: "c2",
+					toolCall: {
+						mcpToolCall: { args: { args: { agent: encodeArg("explore"), tasks: encodeArg("[{trunc") } } },
+					},
+				},
+			},
+		});
+
+		const call = output.content.find(b => b.type === "toolCall") as
+			| { arguments: Record<string, unknown> }
+			| undefined;
+		expect(Array.isArray(call?.arguments.tasks)).toBe(true);
+		expect(call?.arguments.tasks).toHaveLength(2);
+		expect(call?.arguments.agent).toBe("explore");
+	});
+});


### PR DESCRIPTION
Closes #2615

### What

Fixes the Cursor provider (`cursor-agent` API) dropping large tool-call arguments — most visibly the `task` tool's `tasks` array on multi-subagent dispatches, which surfaced as `tasks: Invalid input: expected array, received undefined`.

### Why

In `processInteractionUpdate` (`packages/ai/src/providers/cursor.ts`):

- `args_text_delta` events are **cumulative** snapshots but were concatenated, garbling the JSON.
- `tool_call_completed` **overwrote** the streamed args with the decoded structured `McpArgs` map, which omits oversized parameters — replacing or string-downgrading large arguments captured during streaming.

### How

- `accumulateArgsText(prev, incoming)`: append-only accumulation that detects cumulative vs incremental snapshots and emits only the newly added delta.
- `mergeCompletedMcpArgs(streamed, decoded)`: merges the completion map into streamed args — authoritative for scalars it carries, but never drops omitted keys or downgrades a structured value to its string fallback. Guards dangerous keys (`__proto__`/`constructor`/`prototype`).

### Tests

`packages/ai/test/cursor-mcp-args.test.ts`: helper unit tests (cumulative-snapshot, prefix-fragment, key-omission, structured-downgrade, `__proto__`) plus an integration test driving `processInteractionUpdate` and asserting the streamed `tasks` array survives a completion frame that omits/downgrades it.

`bun check` green; targeted `bun test` green.
