### PR TITLE
fix(ai): deep-merge fragmented object-shaped tool-call args in OpenAI chat-completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible chat-completions object-arg streams replacing fragmented `tasks` arrays mid-stream; nested objects and arrays are now deep-merged across streamed argument fragments instead of the latest fragment overwriting earlier keys.
+
 ## [15.13.1] - 2026-06-15
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -103,6 +103,59 @@ function normalizeMistralToolId(id: string, isMistral: boolean): string {
 	}
 	return normalized;
 }
+
+function sameJsonValue(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) return true;
+	try {
+		return JSON.stringify(left) === JSON.stringify(right);
+	} catch {
+		return false;
+	}
+}
+
+function arrayStartsWith(candidate: readonly unknown[], prefix: readonly unknown[]): boolean {
+	if (candidate.length < prefix.length) return false;
+	for (let i = 0; i < prefix.length; i += 1) {
+		if (!sameJsonValue(candidate[i], prefix[i])) return false;
+	}
+	return true;
+}
+
+function mergeOpenAIObjectToolArgValue(prev: unknown, value: unknown): unknown {
+	if (typeof prev === "string" && typeof value === "string") {
+		return value.startsWith(prev) ? value : prev + value;
+	}
+	if (Array.isArray(prev) && Array.isArray(value)) {
+		return arrayStartsWith(value, prev) ? value : [...prev, ...value];
+	}
+	if (
+		prev !== null &&
+		value !== null &&
+		typeof prev === "object" &&
+		typeof value === "object" &&
+		!Array.isArray(prev) &&
+		!Array.isArray(value)
+	) {
+		return mergeOpenAIObjectToolArgs(prev as Record<string, unknown>, value as Record<string, unknown>);
+	}
+	return value;
+}
+
+export function mergeOpenAIObjectToolArgs(
+	prev: Record<string, unknown> | undefined,
+	next: Record<string, unknown>,
+): Record<string, unknown> {
+	const merged: Record<string, unknown> = prev ? { ...prev } : {};
+	for (const [key, value] of Object.entries(next)) {
+		// Skip prototype-polluting keys: tool args are model/provider-controlled, and a
+		// `merged["__proto__"] = …` bracket-assign rewrites the arguments object's prototype
+		// instead of storing a data property. `Object.hasOwn` avoids the same walk via `in`.
+		if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+		merged[key] = Object.hasOwn(merged, key) ? mergeOpenAIObjectToolArgValue(merged[key], value) : value;
+	}
+	return merged;
+}
+
 // Direct DeepSeek model ids on NanoGPT are routed via the default tools-capable
 // path. We deliberately do NOT append `:tools` here: with `:tools`, NanoGPT
 // performs server-side tool-call parsing on the upstream DeepSeek stream and
@@ -987,10 +1040,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 								// OpenAI JSON-string contract. Most chunks carry the complete object in one delta,
 								// but cannot rely on that: replacing per-chunk drops earlier keys (and earlier
 								// string content for the same key) when the host fragments the args across deltas.
-								// Shallow-merge into the accumulated object; for shared string keys, detect
-								// cumulative-vs-delta semantics with `startsWith` so we neither duplicate cumulative
-								// payloads nor lose delta fragments. Degenerates to the previous "last wins"
-								// behaviour for the common single-chunk shape (no prior value to merge with).
+								// Deep-merge into the accumulated object; for shared string keys, detect
+								// cumulative-vs-delta semantics with `startsWith`, and for array keys preserve
+								// cumulative snapshots while appending true fragments. This avoids losing nested
+								// keys or earlier `tasks` array elements when a host fragments object args.
 								//
 								// `delta` stays empty here: emitting `JSON.stringify(rawArgs)` per chunk feeds
 								// downstream concat-based accumulators (proxy.ts, openai-chat-server,
@@ -1003,15 +1056,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 									!Array.isArray(block.partialArgs)
 										? (block.partialArgs as Record<string, unknown>)
 										: undefined;
-								const merged: Record<string, unknown> = prev ? { ...prev } : {};
-								for (const [key, value] of Object.entries(rawArgs)) {
-									const prevValue = merged[key];
-									if (typeof prevValue === "string" && typeof value === "string") {
-										merged[key] = value.startsWith(prevValue) ? value : prevValue + value;
-									} else {
-										merged[key] = value;
-									}
-								}
+								const merged = mergeOpenAIObjectToolArgs(prev, rawArgs);
 								block.partialArgs = merged;
 								block.arguments = merged;
 							}

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	applyOpenRouterRoutingVariant,
 	convertMessages,
+	mergeOpenAIObjectToolArgs,
 	streamOpenAICompletions,
 } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type {
@@ -120,6 +121,128 @@ function getLastTextPart(content: unknown): object | undefined {
 	}
 	return undefined;
 }
+
+describe("mergeOpenAIObjectToolArgs", () => {
+	it("preserves nested keys and appends fragmented task arrays", () => {
+		const merged = mergeOpenAIObjectToolArgs(
+			{ context: "shared", tasks: [{ assignment: "A" }], metadata: { first: true } },
+			{ tasks: [{ assignment: "B" }], metadata: { second: true } },
+		);
+		expect(merged).toEqual({
+			context: "shared",
+			tasks: [{ assignment: "A" }, { assignment: "B" }],
+			metadata: { first: true, second: true },
+		});
+	});
+
+	it("uses cumulative array snapshots without duplicating prior elements", () => {
+		const merged = mergeOpenAIObjectToolArgs(
+			{ tasks: [{ assignment: "A" }] },
+			{ tasks: [{ assignment: "A" }, { assignment: "B" }] },
+		);
+		expect(merged).toEqual({ tasks: [{ assignment: "A" }, { assignment: "B" }] });
+	});
+
+	it("does not pollute Object.prototype via a streamed __proto__ key", () => {
+		// JSON.parse keeps `__proto__` as an own data property (an object literal would
+		// instead invoke the prototype setter), matching how a provider's bytes arrive.
+		const hostile = JSON.parse('{"__proto__":{"polluted":true},"agent":"explore"}') as Record<string, unknown>;
+		const merged = mergeOpenAIObjectToolArgs({ tasks: [{ assignment: "A" }] }, hostile);
+		expect((merged as Record<string, unknown>).polluted).toBeUndefined();
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+		expect(merged).toEqual({ tasks: [{ assignment: "A" }], agent: "explore" });
+	});
+});
+
+describe("openai-completions object-shaped tool args (streaming)", () => {
+	it("preserves earlier object-arg keys when a host fragments arguments across deltas", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+		} as ModelSpec<"openai-completions">);
+		// MiniMax-style host: `function.arguments` arrives as an OBJECT, fragmented across
+		// two deltas. Pre-fix the second delta replaced the first, dropping agent/context and
+		// the first metadata key. The merge must keep omitted keys, deep-merge nested objects,
+		// and treat the cumulative `tasks` snapshot as a supersede (not an append-dup).
+		const fetchMock = createMockFetch([
+			{
+				id: "c1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_task",
+									function: {
+										name: "task",
+										arguments: {
+											agent: "explore",
+											context: "ctx",
+											tasks: [{ assignment: "A" }],
+											metadata: { first: true },
+										},
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+			{
+				id: "c1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									function: {
+										arguments: {
+											tasks: [{ assignment: "A" }, { assignment: "B" }],
+											metadata: { second: true },
+										},
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+			{
+				id: "c1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+		const toolCall = result.content.find(block => block.type === "toolCall");
+		if (toolCall?.type !== "toolCall") throw new Error("expected a finalized toolCall block");
+		expect(toolCall.name).toBe("task");
+		expect(toolCall.arguments).toEqual({
+			agent: "explore",
+			context: "ctx",
+			tasks: [{ assignment: "A" }, { assignment: "B" }],
+			metadata: { first: true, second: true },
+		});
+	});
+});
 
 describe("openai-completions compatibility", () => {
 	it("serializes assistant text content as a plain string", () => {


### PR DESCRIPTION
Closes #2617

### What

Fixes OpenAI-compatible chat-completions streams dropping fragmented **object-shaped** tool-call arguments — e.g. the `task` tool's `tasks` array, which surfaced as `tasks: Invalid input: expected array, received undefined`.

### Why

In `packages/ai/src/providers/openai-completions.ts`, the object-arg merge branch replaced earlier keys with the latest streamed fragment. A later fragment carrying a subset of keys (or a partial array) overwrote the accumulated value, dropping keys/elements it didn't repeat.

### How

`mergeOpenAIObjectToolArgs` deep-merges nested objects and arrays across fragments:

- objects merge key-by-key (`Object.hasOwn`, skipping `__proto__`/`constructor`/`prototype`);
- arrays detect cumulative-vs-delta shape via prefix checks (`arrayStartsWith`) and extend rather than replace.

### Tests

`packages/ai/test/openai-completions-compat.test.ts`: a direct helper test, an SSE-level streaming test (`streamOpenAICompletions` with fragmented object args, asserting `tasks`/`metadata`/`agent`/`context` survive across deltas with `finish_reason: "tool_calls"`), and a `__proto__`-no-pollution regression.

`bun check` green; targeted `bun test` green.
