### PR TITLE
feat(settings): sync v15.13 feature surfaces and close YAML/UI gaps

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -41,6 +41,7 @@ app.history.search: []
 | `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |
 | `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste from the clipboard (image preferred, text fallback) |
 | `app.stt.toggle`            | Unbound (hold `Space`)                 | Toggle speech-to-text. By default there is no key chord — hold the space bar to record (push-to-talk) and release to transcribe; bind a chord here for a press-to-toggle alternative |
+| `tui.input.newLine`        | `Shift+Enter`, `Ctrl+J`               | Insert a newline without submitting          |
 
 On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. When the clipboard holds no image, `app.clipboard.pasteImage` pastes the clipboard text instead, so hosts that deliver only this chord (VS Code's integrated terminal when configured to forward `Ctrl+V`, Windows clipboard history via `Win+V`) work for both payload kinds. Windows Terminal also swallows `Ctrl+Enter`, so the follow-up shortcut also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -345,6 +345,7 @@ A value of `-1` means "use the provider/model default" — `omp` does not send t
 | `presencePenalty` | number | `-1` | Presence penalty. |
 | `repetitionPenalty` | number | `-1` | Repetition penalty. |
 | `serviceTier` | enum | `none` | `none`, `auto`, `default`, `flex`, `scale`, `priority`, `openai-only`, `claude-only`. |
+| `fastModeScope` | enum | `both` | `both`, `openai`, `claude`. Which providers `/fast on` and the fast-mode toggle target; `openai`/`claude` scope priority to one provider family. |
 | `personality` | enum | `default` | `default`, `friendly`, `pragmatic`, `none`. |
 
 ### Retry and fallback
@@ -397,6 +398,21 @@ tools:
 | `tools.artifactTailLines` | number | `500` | Max tail lines kept inline on spill. |
 
 Individual built-in tools are toggled by their own keys, e.g. `bash.enabled`, `eval.py`, `eval.js`, `find.enabled`, `search.enabled`, `fetch.enabled`, `browser.enabled`, `astEdit.enabled`, `astGrep.enabled`, `web_search.enabled`, `inspect_image.enabled`, `renderMermaid.enabled`.
+
+### Tasks and todos
+
+```yaml
+task:
+  eager: default       # default, preferred, always
+
+todo:
+  eager: default       # default, preferred, always
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `task.eager` | enum | `default` | `default`, `preferred`, `always`. How strongly to push delegating work to subagents. |
+| `todo.eager` | enum | `default` | `default`, `preferred`, `always`. How strongly to push automatic todo-list creation after the first message. |
 
 ### Shell, eval, and LSP
 

--- a/docs/tools/irc.md
+++ b/docs/tools/irc.md
@@ -31,7 +31,7 @@
 ## Outputs
 - Single-shot `AgentToolResult`; no streaming updates.
 - `content` is one text block:
-  - `list`: `No other agents.` or `<n> peer(s):` bullets — `id [displayName · kind · status]` plus unread count, parent, and last-activity age; a footer notes that parked agents are revived automatically when messaged.
+  - `list`: `No other agents.` or `<n> peer(s):` bullets — `id [displayName · kind · status]` plus current activity (the peer's task), unread count, parent, and last-activity age; a footer notes that parked agents are revived automatically when messaged.
   - `send`: per-recipient delivery receipts (`injected` / `woken` / `revived` / `failed — <error>`); with `await: true`, the reply body or a clean no-reply timeout note.
   - `wait`: the consumed message as `[<msgId>] <from>: <body>` (with a reply-to tag), or `No message within <duration>.`
   - `inbox`: `Inbox empty.` or `<n> message(s):` bullets.
@@ -40,7 +40,7 @@
 ## Flow
 1. `IrcTool.createIf` constructs the tool only when `isIrcEnabled` passes and the session has both an `AgentRegistry` and `getAgentId`. There is no `irc.enabled` setting: availability is derived — true for every subagent (`taskDepth > 0`; a parent always exists) and for any session that can still spawn subagents through the task tool. Only a top-level session with task spawning unavailable has no peers, hence no irc.
 2. `execute` resolves the registry and sender id; missing either returns a text error result instead of throwing.
-3. `op: "list"`: `registry.list()` minus self and minus `aborted` agents — `parked` peers ARE listed. Each row includes the unread count from `IrcBus.unreadCount(...)` and last activity.
+3. `op: "list"`: `registry.list()` minus self and minus `aborted` agents — `parked` peers ARE listed. Each row includes the peer activity (`ref.activity`, its current task), unread count from `IrcBus.unreadCount(...)`, and last activity.
 4. `op: "send"` validates `to`/`message`, rejects self-sends, and rejects `await` with `to: "all"`.
 5. Target resolution: broadcasts fan out to `registry.listVisibleTo(senderId)` (live peers only — `running`/`idle`; reviving every parked agent on a broadcast would be a stampede). Direct sends go through the bus unfiltered, so a parked recipient is revived.
 6. `IrcBus.send(...)` is fire-and-forget — it never blocks on the recipient generating anything. Delivery by recipient status:
@@ -54,7 +54,7 @@
 10. Timeouts resolve as `params.timeoutMs ?? irc.timeoutMs`, normalized: `0` disables the timeout, negative/non-finite values fall back to the default `120_000`, positive values are truncated and clamped to ≥ 1 ms.
 
 ## Modes / Variants
-- `list`: enumerate peers with status (`running`/`idle`/`parked`), unread counts, and last activity.
+- `list`: enumerate peers with status (`running`/`idle`/`parked`), current activity, unread counts, and last activity.
 - `send` direct: one exact peer id; wakes idle peers, revives parked ones.
 - `send` broadcast: `to: "all"` to every live peer; parked peers are skipped.
 - `send` + `await: true`: round-trip convenience — send, then wait for the next message from that peer. Marks the send `expectsReply`, enabling the busy-recipient auto-reply path when async execution is disabled.

--- a/docs/tools/learn.md
+++ b/docs/tools/learn.md
@@ -1,0 +1,102 @@
+# learn
+
+> Capture a reusable lesson into long-term memory, and optionally create or update a managed skill in the same call.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/learn.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/learn.md`
+- Managed-skill collaborators:
+  - `packages/coding-agent/src/autolearn/managed-skills.ts` — validates names, writes managed `SKILL.md` files, enforces size and symlink safety.
+  - `packages/coding-agent/src/extensibility/skills.ts` — detects authored skills that would shadow a managed skill name.
+- Memory collaborators:
+  - `packages/coding-agent/src/mnemopi/state.ts` — scoped Mnemopi retention path.
+  - `packages/coding-agent/src/memory-backend/local-backend.ts` — local file-backed lesson storage.
+  - `packages/coding-agent/src/hindsight/state.ts` — Hindsight queued retention path.
+
+## Inputs
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `memory` | `string` | Yes | Durable, self-contained lesson to remember. Include what, when, and why so a future session understands it without this conversation. |
+| `context` | `string` | No | Optional source context for the lesson. Stored with the lesson when the active backend supports it. |
+| `skill` | `object` | No | Also create or enhance a managed skill in the same call. Use only when the lesson is a repeatable procedure worth codifying. |
+| `skill.action` | `"create" \| "update"` | Yes, when `skill` is present | Create a new managed skill or update an existing one. |
+| `skill.name` | `string` | Yes, when `skill` is present | Kebab-case skill name. It is normalized to lowercase and must use only lowercase letters, digits, and hyphens, 1-64 chars, starting with a letter or digit. |
+| `skill.description` | `string` | Yes, when `skill` is present | One-line description of when to use the skill. It drives discovery, so make it specific. |
+| `skill.body` | `string` | Yes, when `skill` is present | `SKILL.md` body in Markdown. Do not include frontmatter; generated frontmatter uses `skill.name` and `skill.description`. |
+
+## Outputs
+Returns a single-shot tool result.
+
+When only the lesson is captured:
+- `content[0].type = "text"`
+- `content[0].text = "Lesson stored."` for Mnemopi or local memory.
+- `content[0].text = "Lesson queued for retention."` for Hindsight.
+- `details = { skill: null }`
+
+When a managed skill is also written:
+- `content[0].text = "Lesson stored. Created managed skill \"<name>\"."` or `"Lesson stored. Updated managed skill \"<name>\"."`
+- Hindsight uses `"Lesson queued for retention. ..."` instead of `"Lesson stored. ..."`.
+- `details = { skill: "<name>" }`
+
+When `skill.action = "create"` targets a name already claimed by a user-authored skill:
+- the lesson has already been stored or queued;
+- `content[0].text` explains that the managed skill was not created because managed skills cannot override authored skills;
+- `isError = true`;
+- `details = { skill: null, shadowed: true }`.
+
+## Flow
+1. `LearnTool.createIf(...)` exposes the tool only when `autolearn.enabled` is true and `memory.backend` is one of `"hindsight"`, `"mnemopi"`, or `"local"`.
+2. `execute(...)` reads the active memory backend.
+3. If the backend is `mnemopi`:
+   - it reads `session.getMnemopiSessionState()` and throws if the backend was not started;
+   - it calls `state.rememberScoped(...)` with source `coding-agent-learn`, importance `0.8`, bank scope, extraction enabled, `veracity = "tool"`, and `memoryType = "fact"`;
+   - it throws if Mnemopi does not return a memory id.
+4. If the backend is `local`:
+   - it calls `localBackend.save(...)` with source `coding-agent-learn`, importance `0.8`, the current agent directory, and cwd;
+   - it throws if the sanitized lesson stores zero entries.
+5. If the backend is `hindsight`:
+   - it reads `session.getHindsightSessionState()` and throws if the backend was not started;
+   - it calls `state.enqueueRetain(memory, context)` and reports the lesson as queued.
+6. If `skill` is present:
+   - a `create` request first checks whether an authored skill already claims the normalized name;
+   - if the name is not shadowed, it writes the managed skill through `writeManagedSkill(...)`;
+   - write failures are surfaced after the memory operation, so the error message states that the lesson was stored or queued but the managed skill could not be written.
+
+## Modes / Variants
+- Memory-only mode records a reusable lesson without changing managed skills.
+- Memory-plus-skill mode records the lesson and creates or updates an isolated managed skill.
+- Managed skills are stored under `~/.omp/agent/managed-skills` and surface like normal skills in future sessions.
+- Managed skills never touch user-authored skills and cannot override a user-authored skill with the same name.
+- Capture sparingly and specifically: one strong reusable lesson is preferred over several vague lessons.
+
+## Side Effects
+- Memory
+  - Mnemopi: stores a scoped fact in the configured Mnemopi bank.
+  - Local: appends to the local backend's learned-memory store.
+  - Hindsight: queues a retention request for the backend.
+- Filesystem
+  - When `skill` is present, creates or overwrites `~/.omp/agent/managed-skills/<name>/SKILL.md`.
+- Approval
+  - Uses write approval when `skill` is present or when `memory.backend = "local"`; otherwise uses read approval.
+
+## Limits & Caps
+- Tool availability is gated by `autolearn.enabled`.
+- Tool availability also requires `memory.backend` to be `"hindsight"`, `"mnemopi"`, or `"local"`.
+- Managed skill names must match lowercase kebab-case: lowercase letters, digits, and hyphens, 1-64 chars, starting with a letter or digit.
+- Managed skill content is capped at 64,000 UTF-8 bytes for the generated frontmatter plus body.
+- `skill.action` supports only `"create"` and `"update"`; deletion uses `manage_skill`.
+
+## Errors
+- Throws `Mnemopi backend is not initialised for this session.` when `memory.backend == "mnemopi"` but no Mnemopi state exists.
+- Throws `Mnemopi did not store the lesson (no memory id returned).` when scoped Mnemopi retention returns no id.
+- Throws `Lesson was empty after sanitization; nothing stored.` when local storage rejects the sanitized lesson.
+- Throws `Hindsight backend is not initialised for this session.` when `memory.backend == "hindsight"` but no Hindsight state exists.
+- Returns an error result, after storing or queueing the lesson, when creating a managed skill whose name is already claimed by an authored skill.
+- Throws `Lesson stored, but the managed skill could not be written: <reason>` or `Lesson queued for retention, but the managed skill could not be written: <reason>` when managed-skill writing fails.
+- Managed-skill write failures include invalid names, empty descriptions, empty bodies, existing skills on `create`, missing skills on `update`, symlink safety failures, and the 64,000-byte size cap.
+
+## Notes
+- Use `learn` after solving something whose insight will pay off again: a non-obvious fix, a project convention, or a workflow that worked.
+- Use the optional `skill` object only for repeatable procedures worth codifying as a skill, not for ordinary facts.
+- The managed-skill `body` is the Markdown content below frontmatter; frontmatter is generated automatically from `name` and `description`.

--- a/docs/tools/manage-skill.md
+++ b/docs/tools/manage-skill.md
@@ -1,0 +1,96 @@
+# manage_skill
+
+> Create, update, or delete an isolated managed skill for the auto-learn feature.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/manage-skill.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/manage-skill.md`
+- Managed-skill collaborators:
+  - `packages/coding-agent/src/autolearn/managed-skills.ts` — validates names, writes and deletes managed `SKILL.md` files, enforces size and symlink safety.
+  - `packages/coding-agent/src/extensibility/skills.ts` — detects authored skills that would shadow a managed skill name.
+
+## Inputs
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `action` | `"create" \| "update" \| "delete"` | Yes | Operation to perform. `create` fails if the managed skill already exists; `update` fails if it does not exist; `delete` removes an existing managed skill. |
+| `name` | `string` | Yes | Kebab-case skill name. It is normalized to lowercase and must use only lowercase letters, digits, and hyphens, 1-64 chars, starting with a letter or digit. |
+| `description` | `string` | Required for `create` and `update` | One-line description of when to use the skill. It drives discovery, so make it specific. Not used for `delete`. |
+| `body` | `string` | Required for `create` and `update` | `SKILL.md` body in Markdown. Do not include frontmatter; generated frontmatter uses `name` and `description`. Not used for `delete`. |
+
+## Outputs
+Returns a single-shot tool result.
+
+When a skill is created:
+- `content[0].type = "text"`
+- `content[0].text = "Created managed skill \"<name>\" (managed-skills/<name>/SKILL.md)."`
+- `details = { action: "create", name: "<name>" }`
+
+When a skill is updated:
+- `content[0].text = "Updated managed skill \"<name>\" (managed-skills/<name>/SKILL.md)."`
+- `details = { action: "update", name: "<name>" }`
+
+When a skill is deleted:
+- `content[0].text = "Deleted managed skill \"<name>\"."`
+- `details = { action: "delete", name: "<name>" }`
+
+When `action = "create"` targets a name already claimed by a user-authored skill:
+- `content[0].text` explains that managed skills cannot override authored skills;
+- `isError = true`;
+- `details = { action: "create", name: "<name>", shadowed: true }`.
+
+## Flow
+1. `ManageSkillTool.createIf(...)` exposes the tool only when `autolearn.enabled` is true.
+2. The tool is backend-independent: it does not require an active memory backend.
+3. For `action = "delete"`:
+   - `execute(...)` calls `deleteManagedSkill(name)`;
+   - the helper normalizes and validates the name, checks the managed-skills root, refuses symlinked skill directories, and removes `~/.omp/agent/managed-skills/<name>`.
+4. For `action = "create"` or `"update"`:
+   - schema refinement requires both `description` and `body`;
+   - `create` checks whether an authored skill already claims the normalized name and returns an error result if so;
+   - `writeManagedSkill(...)` normalizes the name, sanitizes the description, trims the body, generates frontmatter, checks the byte cap, and writes `~/.omp/agent/managed-skills/<name>/SKILL.md`.
+5. `create` uses atomic file creation and fails if the managed skill already exists.
+6. `update` requires an existing plain managed `SKILL.md` and refuses symlinks or unsafe hard-linked files before overwriting.
+
+## Modes / Variants
+- `create` adds a new managed skill and fails if it already exists.
+- `update` overwrites the generated frontmatter and body for an existing managed skill.
+- `delete` removes an existing managed skill directory.
+- Managed skills are stored under `~/.omp/agent/managed-skills` and surface like normal skills in future sessions.
+- Managed skills are for repeatable procedures worth codifying: setup sequences, debugging recipes, and project-specific workflows.
+- Managed skills never edit user-authored skills and cannot override a user-authored skill with the same name.
+
+## Side Effects
+- Filesystem
+  - `create` writes `~/.omp/agent/managed-skills/<name>/SKILL.md`.
+  - `update` overwrites `~/.omp/agent/managed-skills/<name>/SKILL.md`.
+  - `delete` removes `~/.omp/agent/managed-skills/<name>`.
+- Approval
+  - Always uses write approval.
+- Memory
+  - None. Use `learn` when a lesson should also be stored in long-term memory.
+
+## Limits & Caps
+- Tool availability is gated by `autolearn.enabled`.
+- Managed skill names must match lowercase kebab-case: lowercase letters, digits, and hyphens, 1-64 chars, starting with a letter or digit.
+- `description` must sanitize to a non-empty single line for `create` and `update`.
+- `body` must be non-empty after trimming for `create` and `update`.
+- Managed skill content is capped at 64,000 UTF-8 bytes for the generated frontmatter plus body.
+- The generated file is always named `SKILL.md`; callers provide only the body, not frontmatter.
+
+## Errors
+- Schema validation rejects `create` and `update` calls that omit `description` or `body` with `"create" and "update" require both "description" and "body".`
+- Throws `Invalid skill name "<raw>". Use lowercase letters, digits, and hyphens (1-64 chars, starting with a letter or digit).` for invalid names.
+- Returns an error result when creating a managed skill whose name is already claimed by an authored skill.
+- Throws `Managed skill "<name>" needs a non-empty description.` when the sanitized description is empty.
+- Throws `Managed skill "<name>" needs a non-empty body.` when the trimmed body is empty.
+- Throws `Managed skill is <bytes> bytes; the limit is 64000. Trim the body or description.` when the generated file exceeds the cap.
+- Throws `Managed skill "<name>" already exists. Use action "update" to change it.` on duplicate `create`.
+- Throws `Managed skill "<name>" does not exist. Use action "create" to add it.` on missing `update`.
+- Throws `Managed skill "<name>" does not exist.` on missing `delete`.
+- Throws symlink or hard-link safety errors when the managed-skills root, skill directory, or `SKILL.md` is unsafe to mutate.
+
+## Notes
+- `name` is the discovery key; choose a specific kebab-case name that will not collide with authored skills.
+- `description` is discovery-facing. It should state when to use the skill, not merely what the skill is called.
+- `body` should contain the reusable procedure in Markdown and must not include frontmatter.

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -26,7 +26,7 @@
 
 ## Inputs
 
-The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ id?, description?, assignment, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
+The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ id?, description?, role?, assignment, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
 
 - **Batch shape** (`task.batch` on): `{ agent, context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `isolated` is per item.
 - **Flat shape** (`task.batch` off): `{ agent, ...item }` — exactly one spawn per call. Shared background goes into a `local://` file (e.g. `local://ctx.md`) that each assignment references; subagents share the parent's `local://` root.
@@ -38,6 +38,7 @@ The wire schema is shape-swapped by `task.batch` (default on). One unit of work 
 | `tasks` | `array` | Yes (batch) | One task item per subagent. Provided ids must be unique within the call (case-insensitive). Rejected when `task.batch` is off. |
 | `id` | `string` | No | Stable agent id, schema max length 48. Defaults to a generated AdjectiveNoun name. Uniquified per session by `AgentOutputManager`. Item field in batch shape, top-level in flat shape. |
 | `description` | `string` | No | UI label only; the subagent never sees it. Item field in batch shape, top-level in flat shape. |
+| `role` | `string` | No | Specialist role/expertise this subagent embodies; shapes its system-prompt identity/persona and roster display name. Schema max length 256. Item field in batch shape, top-level in flat shape. |
 | `assignment` | `string` | Yes | The work — complete, self-contained instructions. Empty-after-trim is rejected. Item field in batch shape, top-level in flat shape. |
 | `isolated` | `boolean` | No | Run in an isolated workspace and return patches. Exists only when `task.isolation.mode` is not `none`; per item in batch shape, top-level in flat shape. Isolated agents are torn down at completion — not revivable. |
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- Surfaced previously config-file-only settings in the `/settings` panel: Auto Retry (`retry.enabled`), the Skills master toggle (`skills.enabled`), Speech Language (`stt.language`), Shell Path (`shellPath`), SearXNG Categories and Language, Auto-Continue After Compaction (`compaction.autoContinue`), Remote Compaction Endpoint (`compaction.remoteEndpoint`, shown when Remote Compaction is enabled), and the Hindsight recall/retain knobs — recall budget, bank mission, retain mission, and retain context (shown when the Hindsight backend is active).
+- Added status-line indicators for speech vocalization (`speech.enabled`) and auto-learn (`autolearn.enabled`), rendered after the model name with theme-aware speaker/brain glyphs (unicode/nerd-font/ascii).
+- Documented the `Ctrl+J` newline shortcut in the in-app hotkeys reference and `docs/keybindings.md`.
+
+### Changed
+
+- Consolidated the speech settings into Interaction → Speech and gated dependent rows: Speech Vocalization Mode/Voice appear only when Speech Vocalization is on, Local TTS Voice hides under the xAI TTS provider, and Local TTS Model stays while the local provider or vocalization is active.
+- Mnemopi remote-LLM fields (base URL / API key / model) now appear only in remote LLM mode, and the embedding endpoint fields (model / URL / key) only when embeddings are enabled.
+- Exa search sub-tools (search, researcher, websets) are now hidden when the Exa master toggle is off.
+- Removed the redundant `mcp.discoveryMode` settings-panel row, which duplicated `tools.discoveryMode`; the config key is still honored for existing configs.
+
+### Fixed
+
+- `/fast` help now notes that `fastModeScope` controls the target provider family (both / OpenAI / Claude), and `/guided-goal` help now describes the short guided interview that produces a goal.
+- Synced tool docs: added the per-item `role` parameter to `docs/tools/task.md`, the work-aware `activity` field to `docs/tools/irc.md` (and the model-facing prompt), and added the missing `docs/tools/learn.md` and `docs/tools/manage-skill.md` references.
+- Added `docs/settings.md` catalog entries for `fastModeScope`, `task.eager`, and `todo.eager`.
+
 ## [15.13.1] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -380,7 +380,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Keep the display from idle-sleeping while a session is open (caffeinate -d)",
 		},
 	},
-	shellPath: { type: "string", default: undefined },
+	shellPath: {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "shell",
+			group: "Bash",
+			label: "Shell Path",
+			description: "Path to the shell binary used for bash command execution (default: system shell)",
+		},
+	},
 
 	extensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
@@ -1036,7 +1045,16 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Retries
-	"retry.enabled": { type: "boolean", default: true },
+	"retry.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Auto Retry",
+			description: "Automatically retry transient API errors before failing the request",
+		},
+	},
 
 	"retry.maxRetries": {
 		type: "number",
@@ -1448,6 +1466,12 @@ export const SETTINGS_SCHEMA = {
 	"stt.language": {
 		type: "string",
 		default: "en",
+		ui: {
+			tab: "interaction",
+			group: "Speech",
+			label: "Speech Language",
+			description: "Language hint for speech-to-text transcription (e.g. en, es, de)",
+		},
 	},
 
 	"stt.modelName": {
@@ -1600,9 +1624,28 @@ export const SETTINGS_SCHEMA = {
 
 	"compaction.keepRecentTokens": { type: "number", default: 20000 },
 
-	"compaction.autoContinue": { type: "boolean", default: true },
+	"compaction.autoContinue": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "context",
+			group: "Compaction",
+			label: "Auto-Continue After Compaction",
+			description: "Automatically continue the turn after a compaction completes",
+		},
+	},
 
-	"compaction.remoteEndpoint": { type: "string", default: undefined },
+	"compaction.remoteEndpoint": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "context",
+			group: "Compaction",
+			label: "Remote Compaction Endpoint",
+			description: "Endpoint URL for remote compaction; used when Remote Compaction is enabled",
+			condition: "compactionRemoteActive",
+		},
+	},
 
 	// Idle compaction
 	"compaction.idleEnabled": {
@@ -2071,7 +2114,7 @@ export const SETTINGS_SCHEMA = {
 			label: "Mnemopi Embedding Model",
 			description:
 				"Advanced: explicit embedding model id that overrides the variant. Leave empty to use mnemopi.embeddingVariant.",
-			condition: "mnemopiActive",
+			condition: "mnemopiEmbeddingsActive",
 		},
 	},
 	"mnemopi.embeddingApiUrl": {
@@ -2082,7 +2125,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Mnemopi",
 			label: "Mnemopi Embedding API URL",
 			description: "Optional OpenAI-compatible embedding endpoint passed to Mnemopi",
-			condition: "mnemopiActive",
+			condition: "mnemopiEmbeddingsActive",
 		},
 	},
 	"mnemopi.embeddingApiKey": {
@@ -2093,7 +2136,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Mnemopi",
 			label: "Mnemopi Embedding API Key",
 			description: "Optional embedding API key passed to Mnemopi",
-			condition: "mnemopiActive",
+			condition: "mnemopiEmbeddingsActive",
 		},
 	},
 	"mnemopi.llmMode": {
@@ -2121,7 +2164,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Mnemopi",
 			label: "Mnemopi LLM Base URL",
 			description: "Optional OpenAI-compatible LLM endpoint for Mnemopi remote mode",
-			condition: "mnemopiActive",
+			condition: "mnemopiRemoteLlm",
 		},
 	},
 	"mnemopi.llmApiKey": {
@@ -2132,7 +2175,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Mnemopi",
 			label: "Mnemopi LLM API Key",
 			description: "Optional LLM API key for Mnemopi remote mode",
-			condition: "mnemopiActive",
+			condition: "mnemopiRemoteLlm",
 		},
 	},
 	"mnemopi.llmModel": {
@@ -2143,7 +2186,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Mnemopi",
 			label: "Mnemopi LLM Model",
 			description: "Optional LLM model name for Mnemopi remote mode",
-			condition: "mnemopiActive",
+			condition: "mnemopiRemoteLlm",
 		},
 	},
 	"mnemopi.retainEveryNTurns": { type: "number", default: 4 },
@@ -2212,8 +2255,29 @@ export const SETTINGS_SCHEMA = {
 			condition: "hindsightActive",
 		},
 	},
-	"hindsight.bankMission": { type: "string", default: undefined },
-	"hindsight.retainMission": { type: "string", default: undefined },
+	"hindsight.bankMission": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			group: "Hindsight",
+			label: "Hindsight Bank Mission",
+			description:
+				"Reflect mission for the Hindsight bank; guides mental-model and reflection generation. Blank uses the server default",
+			condition: "hindsightActive",
+		},
+	},
+	"hindsight.retainMission": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			group: "Hindsight",
+			label: "Hindsight Retain Mission",
+			description: "Retain mission for the Hindsight bank; guides what gets retained",
+			condition: "hindsightActive",
+		},
+	},
 
 	"hindsight.autoRecall": {
 		type: "boolean",
@@ -2260,12 +2324,34 @@ export const SETTINGS_SCHEMA = {
 	},
 	"hindsight.retainEveryNTurns": { type: "number", default: 3 },
 	"hindsight.retainOverlapTurns": { type: "number", default: 2 },
-	"hindsight.retainContext": { type: "string", default: "omp" },
+	"hindsight.retainContext": {
+		type: "string",
+		default: "omp",
+		ui: {
+			tab: "memory",
+			group: "Hindsight",
+			label: "Hindsight Retain Context",
+			description: "Context label attached to retained memories (default: omp)",
+			condition: "hindsightActive",
+		},
+	},
 
 	"hindsight.recallBudget": {
 		type: "enum",
 		values: ["low", "mid", "high"] as const,
 		default: "mid",
+		ui: {
+			tab: "memory",
+			group: "Hindsight",
+			label: "Hindsight Recall Budget",
+			description: "How much memory to pull on recall",
+			options: [
+				{ value: "low", label: "Low", description: "Fewer memories, less context" },
+				{ value: "mid", label: "Mid", description: "Balanced (default)" },
+				{ value: "high", label: "High", description: "More memories, more context" },
+			],
+			condition: "hindsightActive",
+		},
 	},
 	"hindsight.recallMaxTokens": { type: "number", default: 1024 },
 	"hindsight.recallContextTurns": { type: "number", default: 1 },
@@ -3016,8 +3102,8 @@ export const SETTINGS_SCHEMA = {
 		type: "boolean",
 		default: false,
 		ui: {
-			tab: "tools",
-			group: "Available Tools",
+			tab: "interaction",
+			group: "Speech",
 			label: "Speech Generation",
 			description: "Enable the tts tool for on-device (Kokoro) or xAI Grok Voice speech-file synthesis",
 		},
@@ -3305,12 +3391,6 @@ export const SETTINGS_SCHEMA = {
 	"mcp.discoveryMode": {
 		type: "boolean",
 		default: false,
-		ui: {
-			tab: "tools",
-			group: "Discovery & MCP",
-			label: "MCP Tool Discovery",
-			description: "Hide MCP tools by default and expose them through a tool discovery tool",
-		},
 	},
 
 	"mcp.discoveryDefaultServers": {
@@ -3648,7 +3728,16 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Skills
-	"skills.enabled": { type: "boolean", default: true },
+	"skills.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tasks",
+			group: "Commands & Skills",
+			label: "Skills",
+			description: "Master toggle for loading skills (skill files, /skill commands, and skill tools)",
+		},
+	},
 
 	"skills.enableSkillCommands": {
 		type: "boolean",
@@ -3791,8 +3880,8 @@ export const SETTINGS_SCHEMA = {
 		values: ["auto", "local", "xai"] as const,
 		default: "auto",
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Text-to-Speech Provider",
 			description: "Backend for the tts tool: local on-device neural TTS (Kokoro-82M) or xAI Grok Voice",
 			options: [
@@ -3815,11 +3904,12 @@ export const SETTINGS_SCHEMA = {
 		values: TTS_LOCAL_MODEL_VALUES,
 		default: DEFAULT_TTS_LOCAL_MODEL_KEY,
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Local TTS Model",
 			description: "On-device neural TTS model (Kokoro-82M) used by the local TTS backend",
 			options: TTS_LOCAL_MODEL_OPTIONS,
+			condition: "localTtsModelActive",
 		},
 	},
 	"tts.localVoice": {
@@ -3827,19 +3917,20 @@ export const SETTINGS_SCHEMA = {
 		values: TTS_LOCAL_VOICE_VALUES,
 		default: DEFAULT_TTS_VOICE,
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Local TTS Voice",
 			description: "Kokoro voice used by the local TTS backend (American/British, female/male)",
 			options: TTS_LOCAL_VOICE_OPTIONS,
+			condition: "localTtsActive",
 		},
 	},
 	"speech.enabled": {
 		type: "boolean",
 		default: false,
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Speech Vocalization",
 			description: "Speak the assistant's output aloud through the speakers as it streams",
 		},
@@ -3849,8 +3940,8 @@ export const SETTINGS_SCHEMA = {
 		values: ["all", "assistant", "yield"] as const,
 		default: "assistant",
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Speech Vocalization Mode",
 			description:
 				"What to speak: all = assistant messages + thinking; assistant = messages only; yield = only the final message at turn end",
@@ -3859,6 +3950,7 @@ export const SETTINGS_SCHEMA = {
 				{ value: "assistant", label: "Assistant messages" },
 				{ value: "yield", label: "Final message only" },
 			],
+			condition: "speechEnabled",
 		},
 	},
 	"speech.voice": {
@@ -3866,11 +3958,12 @@ export const SETTINGS_SCHEMA = {
 		values: TTS_LOCAL_VOICE_VALUES,
 		default: DEFAULT_TTS_VOICE,
 		ui: {
-			tab: "providers",
-			group: "Services",
+			tab: "interaction",
+			group: "Speech",
 			label: "Speech Vocalization Voice",
 			description: "Kokoro voice used when speaking the assistant's output aloud",
 			options: TTS_LOCAL_VOICE_OPTIONS,
+			condition: "speechEnabled",
 		},
 	},
 	"providers.tinyModel": {
@@ -4096,6 +4189,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Services",
 			label: "Exa Search",
 			description: "Enable Exa basic search, deep search, code search, and crawl tools",
+			condition: "exaEnabled",
 		},
 	},
 
@@ -4107,6 +4201,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Services",
 			label: "Exa Researcher",
 			description: "Enable the Exa researcher tool for AI-powered deep research",
+			condition: "exaEnabled",
 		},
 	},
 
@@ -4118,6 +4213,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Services",
 			label: "Exa Websets",
 			description: "Enable Exa webset management and enrichment tools",
+			condition: "exaEnabled",
 		},
 	},
 
@@ -4151,11 +4247,23 @@ export const SETTINGS_SCHEMA = {
 	"searxng.categories": {
 		type: "string",
 		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "SearXNG Categories",
+			description: "Comma-separated SearXNG categories to search (e.g. general,news)",
+		},
 	},
 
 	"searxng.language": {
 		type: "string",
 		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "SearXNG Language",
+			description: "Search language code passed to SearXNG (e.g. en)",
+		},
 	},
 
 	"commit.mapReduceEnabled": { type: "boolean", default: true },

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -74,7 +74,7 @@ export type SettingDef = BooleanSettingDef | EnumSettingDef | SubmenuSettingDef 
 // Condition Functions
 // ═══════════════════════════════════════════════════════════════════════════
 
-const CONDITIONS: Record<string, () => boolean> = {
+export const CONDITIONS: Record<string, () => boolean> = {
 	hasImageProtocol: () => !!TERMINAL.imageProtocol,
 	hindsightActive: () => {
 		try {
@@ -100,6 +100,61 @@ const CONDITIONS: Record<string, () => boolean> = {
 	autoThinkingActive: () => {
 		try {
 			return Settings.instance.get("defaultThinkingLevel") === "auto";
+		} catch {
+			return false;
+		}
+	},
+	speechEnabled: () => {
+		try {
+			return Settings.instance.get("speech.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
+	localTtsActive: () => {
+		try {
+			return Settings.instance.get("providers.tts") !== "xai";
+		} catch {
+			return false;
+		}
+	},
+	localTtsModelActive: () => {
+		try {
+			return Settings.instance.get("providers.tts") !== "xai" || Settings.instance.get("speech.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
+	mnemopiRemoteLlm: () => {
+		try {
+			return (
+				Settings.instance.get("memory.backend") === "mnemopi" &&
+				Settings.instance.get("mnemopi.llmMode") === "remote"
+			);
+		} catch {
+			return false;
+		}
+	},
+	mnemopiEmbeddingsActive: () => {
+		try {
+			return (
+				Settings.instance.get("memory.backend") === "mnemopi" &&
+				Settings.instance.get("mnemopi.noEmbeddings") !== true
+			);
+		} catch {
+			return false;
+		}
+	},
+	exaEnabled: () => {
+		try {
+			return Settings.instance.get("exa.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
+	compactionRemoteActive: () => {
+		try {
+			return Settings.instance.get("compaction.remoteEnabled") === true;
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -91,6 +91,12 @@ const modelSegment: StatusLineSegment = {
 		if (ctx.session.isFastModeActive() && theme.icon.fast) {
 			content += ` ${theme.icon.fast}`;
 		}
+		if (ctx.session.settings.get("speech.enabled") && theme.icon.speak) {
+			content += ` ${theme.icon.speak}`;
+		}
+		if (ctx.session.settings.get("autolearn.enabled") && theme.icon.learn) {
+			content += ` ${theme.icon.learn}`;
+		}
 
 		// Add thinking level with dot separator
 		if (opts.showThinkingLevel !== false && state.model?.thinking) {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -133,6 +133,8 @@ export type SymbolKey =
 	| "icon.mic"
 	// Compaction divider
 	| "icon.camera"
+	| "icon.speak"
+	| "icon.learn"
 	// Thinking Levels
 	| "thinking.minimal"
 	| "thinking.low"
@@ -332,6 +334,8 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.mic": "🎤",
 	// Compaction divider
 	"icon.camera": "📷",
+	"icon.speak": "🔊",
+	"icon.learn": "🧠",
 	// Thinking levels
 	"thinking.minimal": "◔ min",
 	"thinking.low": "◑ low",
@@ -617,6 +621,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.mic": "\uf130",
 	// Compaction divider - fa-camera-retro
 	"icon.camera": "\uf083",
+	"icon.speak": "\uf028",
+	"icon.learn": "\uf5dc",
 	// Thinking Levels - emoji labels
 	// pick: 🤨 min | alt:  min  min
 	"thinking.minimal": "\u{F0E7} min",
@@ -832,6 +838,8 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.mic": "MIC",
 	// Compaction divider
 	"icon.camera": "[o]",
+	"icon.speak": "TTS",
+	"icon.learn": "AL",
 	// Thinking Levels
 	"thinking.minimal": "[min]",
 	"thinking.low": "[low]",
@@ -1798,6 +1806,8 @@ export class Theme {
 			extensionInstruction: this.#symbols["icon.extensionInstruction"],
 			mic: this.#symbols["icon.mic"],
 			camera: this.#symbols["icon.camera"],
+			speak: this.#symbols["icon.speak"],
+			learn: this.#symbols["icon.learn"],
 		};
 	}
 

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -22,7 +22,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Enter` | Send message |",
-		"| `Shift+Enter` / `Alt+Enter` | New line |",
+		"| `Shift+Enter` / `Ctrl+J` / `Alt+Enter` | New line |",
 		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
 		"| `Ctrl+U` | Delete to start of line |",
 		"| `Ctrl+K` | Delete to end of line |",

--- a/packages/coding-agent/src/prompts/tools/irc.md
+++ b/packages/coding-agent/src/prompts/tools/irc.md
@@ -2,7 +2,7 @@ Sends short text messages to other agents in this process and receives theirs.
 
 <instruction>
 - Main agent is `Main`; subagents reuse their task id (`AuthLoader`, or `AuthLoader-2` when the name repeats).
-- `op: "list"` — peers with status (`running` | `idle` | `parked`), unread count, parent, last activity. Use when unsure who exists.
+- `op: "list"` — peers with status (`running` | `idle` | `parked`), activity (current task), unread count, parent, last activity. Use when unsure who exists.
 - `op: "send"` — fire-and-forget `message` to `to` (peer id, or `"all"` to broadcast to live peers). Returns per-recipient receipts immediately; NEVER waits for the recipient to act. Outcomes: `injected` (mid-turn; folded in at next step boundary), `woken` (idle peer started a turn), `revived` (parked peer brought back and woken), `failed`.
 - Messaging an `idle`/`parked` peer is how you wake it — there is no separate revive call.
 - `send` + `await: true` — round-trip: send, then block until that peer's next message (or timeout). Invalid with `to: "all"`.
@@ -38,7 +38,7 @@ Applies to sending and replying.
 - `send`: per-recipient receipts; with `await: true`, also the reply (or timeout notice).
 - `wait`: the consumed message, or a clean timeout notice.
 - `inbox`: pending messages, oldest first.
-- `list`: peers with status, unread count, parent, last activity.
+- `list`: peers with status, activity (current task), unread count, parent, last activity.
 </output>
 
 <examples>

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -286,7 +286,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "guided-goal",
-		description: "Interview and refine a goal before enabling goal mode",
+		description: "Run a short guided interview on the plan/slow model to produce and enable a goal",
 		inlineHint: "[rough objective]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
@@ -355,7 +355,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "fast",
-		description: "Toggle priority service tier (OpenAI service_tier=priority, Anthropic speed=fast)",
+		description: "Toggle priority service tier; fastModeScope controls target family (both/OpenAI/Claude)",
 		acpDescription: "Toggle fast mode",
 		acpInputHint: "[on|off|status]",
 		subcommands: [

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -5,11 +5,12 @@ import {
 	type SettingTab,
 	TAB_GROUPS,
 } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
-import { getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
+import { CONDITIONS, getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
 
 interface UiShape {
 	tab: SettingTab;
 	group?: string;
+	condition?: string;
 }
 
 describe("settings layout", () => {
@@ -47,5 +48,18 @@ describe("settings layout", () => {
 			const expected = TAB_GROUPS[tab].filter(group => grouped.includes(group));
 			expect(grouped).toEqual(expected);
 		}
+	});
+
+	it("every ui.condition resolves to a CONDITIONS predicate", () => {
+		const unknown: string[] = [];
+		for (const path in SETTINGS_SCHEMA) {
+			const ui = (SETTINGS_SCHEMA[path as keyof typeof SETTINGS_SCHEMA] as { ui?: UiShape }).ui;
+			const condition = ui?.condition;
+			if (!condition) continue;
+			if (typeof CONDITIONS[condition] !== "function") {
+				unknown.push(`${path}: condition "${condition}" has no CONDITIONS predicate`);
+			}
+		}
+		expect(unknown).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

Brings the settings panel, slash help, and docs back in sync with the features merged in v15.13.x, and closes the YAML/UI gaps found while auditing the settings schema.

Closes #2621.

## Settings panel
- Consolidate all speech settings under **Interaction → Speech** and gate dependent rows: vocalization Mode/Voice on `speech.enabled`; Local TTS Voice off under the xAI provider; Local TTS Model on a local-or-vocalization predicate.
- Gate mnemopi remote-LLM fields to remote mode and embedding-endpoint fields to embeddings-enabled; gate exa sub-tools on the `exa.enabled` master.
- Drop the redundant `mcp.discoveryMode` panel row (subsumed by `tools.discoveryMode`); the config key is still honored for back-compat.
- Surface previously config-only settings, each gated on its master where applicable: `retry.enabled`, `skills.enabled`, `stt.language`, `shellPath`, `searxng.categories`/`searxng.language`, `compaction.autoContinue`, `compaction.remoteEndpoint`, and the Hindsight recall/retain knobs (`recallBudget`, `bankMission`, `retainMission`, `retainContext`).

## TUI
- Speech (`speech.enabled`) and auto-learn (`autolearn.enabled`) status-line indicators after the model name, across the unicode / nerd-font / ascii symbol presets.

## Help & docs
- `/fast` help notes `fastModeScope` controls the target provider family; `/guided-goal` help describes the guided interview.
- Document the `Ctrl+J` newline shortcut (in-app hotkeys + `docs/keybindings.md`).
- Sync tool docs: `role` param in `task.md`, `activity` field in `irc.md` (and the model prompt), new `learn`/`manage-skill` tool docs, and `fastModeScope`/`task.eager`/`todo.eager` in `docs/settings.md`.

## Deliberately out of scope
- `memories.enabled` stays config-only — it is a legacy back-compat migration flag explicitly superseded by `memory.backend` (already in the panel).
- The seven per-source `skills.enable*` toggles and the granular per-backend number knobs stay config-only.

## Tests
- New `settings-layout` test asserts every `ui.condition` resolves to a real `CONDITIONS` predicate (guards the silent-typo gating failure mode where a bad name disables gating and the row always shows).
- `bun run check:ts` green across all workspaces; `settings-layout` (3/3) and `tool-discovery` (49/49, incl. `mcp.discoveryMode` back-compat) pass.
