### PR TITLE
fix(coding-agent): open isolated subagent sessions in worktree cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed isolated task subagents with persisted transcripts resolving file tools against the parent repository instead of the isolated worktree, which made `rcopy` patch capture report no changes after tool-based edits.
+
 ## [15.13.1] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1522,15 +1522,17 @@ export class SessionManager {
 	/**
 	 * Open a specific session file.
 	 * @param sessionDir Optional dir for /new or /branch; defaults to the file's parent.
+	 * @param options.initialCwd Cwd to use when the file is empty or missing.
 	 */
 	static async open(
 		filePath: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
+		options?: { initialCwd?: string },
 	): Promise<SessionManager> {
 		const loaded = await loadEntriesFromFile(filePath, storage);
 		const header = loaded.find(entry => entry.type === "session") as SessionHeader | undefined;
-		const cwd = header?.cwd ?? getProjectDir();
+		const cwd = header?.cwd ?? options?.initialCwd ?? getProjectDir();
 		const dir = sessionDir ?? path.dirname(path.resolve(filePath));
 		const manager = new SessionManager(cwd, dir, true, storage);
 		await manager.setSessionFile(filePath);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1829,9 +1829,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? resolvedThinkingLevel
 				: (thinkingLevel ?? resolvedThinkingLevel);
 
+			const effectiveCwd = worktree ?? cwd;
 			const sessionManager = sessionFile
-				? await awaitAbortable(SessionManager.open(sessionFile))
-				: SessionManager.inMemory(worktree ?? cwd);
+				? await awaitAbortable(SessionManager.open(sessionFile, undefined, undefined, { initialCwd: effectiveCwd }))
+				: SessionManager.inMemory(effectiveCwd);
 			if (options.parentArtifactManager) {
 				sessionManager.adoptArtifactManager(options.parentArtifactManager);
 			}

--- a/packages/coding-agent/test/task/subagent-lsp.test.ts
+++ b/packages/coding-agent/test/task/subagent-lsp.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -93,6 +96,7 @@ function createSession(
 		isolationMode?: "none" | "auto";
 		parentEnableLsp?: boolean;
 		planMode?: PlanModeState;
+		sessionFile?: string | null;
 		taskEnableLsp?: boolean;
 	} = {},
 ): ToolSession {
@@ -112,7 +116,7 @@ function createSession(
 			"task.isolation.mode": options.isolationMode ?? "none",
 			...(options.taskEnableLsp !== undefined ? { "task.enableLsp": options.taskEnableLsp } : {}),
 		}),
-		getSessionFile: () => null,
+		getSessionFile: () => options.sessionFile ?? null,
 		getSessionSpawns: () => "*",
 		modelRegistry,
 		getPlanModeState: () => options.planMode,
@@ -236,6 +240,30 @@ describe("subagent LSP availability", () => {
 
 		expect(getOptions()?.cwd).toBe("/tmp/isolated-subagent");
 		expect(getOptions()?.enableLsp).toBe(false);
+	});
+
+	it("opens isolated persisted subagent sessions with the worktree cwd", async () => {
+		mockAgents({
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Use normal tools.",
+			source: "bundled",
+			tools: ["write"],
+		});
+		mockIsolation();
+		const { getOptions } = mockCreateAgentSession();
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolated-session-cwd-"));
+		try {
+			const parentSessionFile = path.join(tempDir, "parent.jsonl");
+			const tool = await TaskTool.create(createSession({ isolationMode: "auto", sessionFile: parentSessionFile }));
+			await tool.execute("tool-call", { ...TEST_TASK, isolated: true });
+
+			const sessionManager = getOptions()?.sessionManager as { getCwd?: () => string } | undefined;
+			expect(getOptions()?.cwd).toBe("/tmp/isolated-subagent");
+			expect(sessionManager?.getCwd?.()).toBe("/tmp/isolated-subagent");
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("applies plan-mode subagent tools, preserves read-only agent tools, and honors task.enableLsp", async () => {


### PR DESCRIPTION
## What

Fixed isolated task subagents with persisted JSONL sessions so their built-in
file tools resolve paths against the isolated worktree cwd instead of the parent
repository cwd.

This change updates the session-opening path used by isolated task execution:

- `SessionManager.open()` now accepts an optional `initialCwd`.
- `initialCwd` is used only when the target session file is empty or missing and
  therefore has no persisted session header yet.
- Existing resumes still prefer the cwd stored in the session header, preserving
  the current cross-project resume behavior.
- Isolated task execution now passes `worktree ?? cwd` as that `initialCwd` when
  opening the persisted subagent JSONL.
- The regression test now asserts the important invariant directly: a persisted
  isolated subagent session exposes the isolated worktree via
  `sessionManager.getCwd()`.

## Why

`rcopy` isolation was creating and using the isolated worktree correctly for the
subagent process-level cwd. A probe from the failing session showed subagents
running under paths like:

```text
~/.omp/wt/<agentId>-<repoHash>/merged
```

However, the actual file-tool writes did not participate in isolated patch
capture. The first symptom was confusing:

- subagents reported successful file writes;
- task merge summaries said `No changes to apply.`;
- `<agentId>.patch` artifacts were empty;
- in the original repro, parent-repo files appeared without any patch being
  applied.

The relevant code path split cwd ownership in two places:

1. `TaskTool` creates the isolated worktree and calls `runSubprocess()` with
   `worktree: isolationDir`.
2. `runSubprocess()` passes `cwd: worktree ?? cwd` into `createAgentSession()`.
3. But built-in tools do not resolve paths from `CreateAgentSessionOptions.cwd`.
   They resolve through `ToolSession.cwd`.
4. `ToolSession.cwd` is backed by `sessionManager.getCwd()`.
5. For persisted subagents, `runSubprocess()` opened the JSONL with
   `SessionManager.open(sessionFile)`.
6. Fresh subagent JSONL files have no header yet, so `SessionManager.open()` fell
   back to `getProjectDir()`.

That meant the prompt and some setup paths knew about the isolated worktree, but
file tools saw the parent/global project cwd through the session manager. Patch
capture then inspected the isolated worktree, found no git-visible delta, wrote
an empty patch artifact, and correctly reported `No changes to apply.`.

This is why the fix is intentionally at the persisted-session boundary rather
than in the file tools. The file tools were already using the right abstraction:
`sessionManager.getCwd()` is the session cwd. The bug was that new isolated
subagent sessions were initialized with the wrong cwd before their first header
was written.

The manual follow-up test also distinguished this root cause from a separate
untracked-file setup issue. A first retest created new arbitrary root files in an
AUR repository. Those writes stayed inside the isolated worktree after this fix,
but patch capture still produced empty patches because the files were not
visible to:

```text
git ls-files --others --exclude-standard
```

That was not the original cwd bug: the parent repository did not receive direct
writes. A second retest edited existing tracked files (`PKGBUILD` and
`.SRCINFO`), and those changes were captured and merged through non-empty patch
artifacts.

## Testing

Automated verification:

- `bun test packages/coding-agent/test/task/subagent-lsp.test.ts`
  - includes the new regression case for persisted isolated subagent cwd;
  - the test would fail before this fix because `sessionManager.getCwd()` would
    remain the parent/default project cwd instead of the isolated worktree.
- `bun --cwd=packages/coding-agent run check`
  - runs the coding-agent package checks, including type checking and Biome.

Manual patched-binary validation in a separate git repository:

- tested in a separate private git repository with a patched OMP binary;
- `task.isolation.mode=rcopy`;
- `task.isolation.merge=patch`;
- spawned two isolated subagents in one task batch;
- both subagents had `isolated: true`;
- both used normal file tools, not shell redirection or git commands;
- each subagent edited a different tracked file;
- parent marker search found no matches before merge;
- both merge summaries reported `Applied patches: yes`;
- both patch artifacts were non-empty and targeted the expected tracked files;
- parent repo contained both marker edits after merge;
- subagent JSONL cwd values were isolated worktrees under `~/.omp/wt/.../merged`;
- cleanup removed both marker edits.

This validates the intended end-to-end behavior: file-tool edits made by
persisted isolated subagents are captured in the isolated worktree, emitted as
patch artifacts, and merged back to the parent repository by patch mode.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
