### PR TITLE
fix(collab-web): preserve transcript soft line breaks

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved assistant soft line breaks in the collab web transcript Markdown renderer so tree-shaped prose no longer collapses into one paragraph.
+
 ## [15.13.1] - 2026-06-15
 
 ### Added

--- a/packages/collab-web/src/components/transcript/Markdown.tsx
+++ b/packages/collab-web/src/components/transcript/Markdown.tsx
@@ -33,6 +33,7 @@ const md = new Marked({
 			return `<a href="${escapeHtml(url)}"${titleAttr} target="_blank" rel="noopener">${inner}</a>`;
 		},
 	},
+	breaks: true,
 });
 
 export const Markdown = memo(function Markdown({ text }: { text: string }): ReactNode {

--- a/packages/collab-web/test/markdown.test.tsx
+++ b/packages/collab-web/test/markdown.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Markdown } from "../src/components/transcript/Markdown";
+
+function renderMarkdown(text: string): string {
+	return renderToStaticMarkup(<Markdown text={text} />);
+}
+
+describe("Transcript Markdown", () => {
+	it("preserves assistant soft line breaks for tree-shaped prose", () => {
+		const html = renderMarkdown("요청 요지\n├── 현재 collab guest는 텍스트 prompt는 보낼 수 있음\n└── 빠진 것은 guest → host 방향의 이미지 업로드/첨부 입력 경로임");
+
+		expect(html).toContain("요청 요지<br>");
+		expect(html).toContain("있음<br>");
+		expect(html).toContain("├── 현재 collab guest는");
+		expect(html).toContain("└── 빠진 것은 guest → host 방향");
+	});
+
+	it("continues escaping raw HTML", () => {
+		const html = renderMarkdown("safe\n<img src=x onerror=alert(1)>");
+
+		expect(html).toContain("safe<br>");
+		expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+		expect(html).not.toContain("<img src=x");
+	});
+});


### PR DESCRIPTION
## Problem

The collab web transcript renders assistant text through Markdown. Markdown treats a single newline inside a paragraph as a soft break, so tree-shaped prose such as:

```
요청 요지
├── item
└── item
```

collapsed into one visual paragraph in browser guests.

## Fix

- Enable hard rendering of Markdown soft line breaks in the collab web transcript renderer.
- Add a regression test for tree-shaped Korean prose.
- Keep the existing raw HTML escaping contract covered by test.
- Add a collab-web changelog entry.

## Verification

```
bun --cwd=packages/collab-web test
# 32 pass, 0 fail, 94 expect() calls

bun --cwd=packages/collab-web check
# bun check: passed
# root biome: ok

bun --cwd=packages/collab-web run build
# Bundled 101 modules
```
