### PR TITLE
fix(tool): normalize Windows drive aliases for bash paths

### DIFF
--- a/crates/brush-core-vendored/src/patterns.rs
+++ b/crates/brush-core-vendored/src/patterns.rs
@@ -24,6 +24,12 @@ impl PatternPiece {
 
 type PatternWord = Vec<PatternPiece>;
 
+fn component_string(components: &[PatternWord], index: usize) -> Option<String> {
+	components
+		.get(index)
+		.map(|component| component.iter().map(|piece| piece.as_str()).collect())
+}
+
 /// Options for filename expansion.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct FilenameExpansionOptions {
@@ -213,20 +219,44 @@ impl Pattern {
 			}
 		}
 
-		// Check if the path appears to be absolute by inspecting the first component.
+		// Check if the path appears to be absolute by inspecting the first components.
 		// On Unix, a leading `/` produces an empty first component. On Windows, a
-		// drive-letter prefix like `c:` is also recognized. The platform-specific
-		// logic lives in `sys::fs::pattern_path_root`.
-		let absolute_root = components.first().and_then(|first_component| {
-			let flattened: String = first_component.iter().map(|p| p.as_str()).collect();
-			sys::fs::pattern_path_root(&flattened)
+		// drive-letter prefix like `c:` is also recognized, and a forward-slash
+		// MSYS/WSL drive alias (`/d/...`, `/mnt/d/...`) must be translated before
+		// `read_dir()` sees the root.
+		let starts_with_forward_slash = self
+			.pieces
+			.iter()
+			.find_map(|piece| piece.as_str().as_bytes().first().copied())
+			.is_some_and(|byte| byte == b'/');
+		let first_component = component_string(&components, 0);
+		let second_component = component_string(&components, 1);
+		let third_component = component_string(&components, 2);
+		let alias_root = first_component.as_deref().and_then(|first| {
+			sys::fs::pattern_drive_alias_root(
+				starts_with_forward_slash,
+				first,
+				second_component.as_deref(),
+				third_component.as_deref(),
+			)
 		});
+		let (absolute_root, components_to_remove) =
+			if let Some((root, consumed)) = alias_root {
+				(Some(root), consumed)
+			} else {
+				(
+					first_component
+						.as_deref()
+						.and_then(sys::fs::pattern_path_root),
+					1,
+				)
+			};
 
 		let prefix_to_remove;
 		let mut paths_so_far = if let Some(root) = absolute_root {
 			prefix_to_remove = None;
-			// Skip the first component; it was consumed to determine the root.
-			components.remove(0);
+			// Skip the component(s) consumed to determine the root.
+			drop(components.drain(0..components_to_remove));
 			vec![root]
 		} else {
 			// Build a prefix to remove after glob expansion so results are
@@ -925,6 +955,38 @@ mod tests {
 			assert!(
 				p.contains(scratch_normalized.as_str()),
 				"absolute result {p:?} should contain {scratch_normalized:?}"
+			);
+		}
+
+		Ok(())
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn test_msys_drive_alias_glob_expands_from_drive_root() -> Result<()> {
+		let scratch = tempfile::tempdir()?;
+		std::fs::write(scratch.path().join("one.txt"), "")?;
+		std::fs::write(scratch.path().join("two.txt"), "")?;
+
+		let scratch_normalized = scratch.path().to_string_lossy().replace('\\', "/");
+		let Some((drive, tail)) = scratch_normalized.split_once(":/") else {
+			anyhow::bail!("expected drive-qualified temp path, got {scratch_normalized:?}");
+		};
+		let alias_pattern = format!("/{}/{}/*.txt", drive.to_ascii_lowercase(), tail);
+
+		let pattern = Pattern::from(alias_pattern.as_str()).set_extended_globbing(false);
+		let result = pattern.expand::<fn(&Path) -> bool>(
+			Path::new("/"),
+			None,
+			&FilenameExpansionOptions::default(),
+		)?;
+
+		let paths = expect_expanded(result)?;
+		assert_eq!(paths.len(), 2, "unexpected results: {paths:?}");
+		for p in &paths {
+			assert!(
+				p.contains(scratch_normalized.as_str()),
+				"alias result {p:?} should contain native scratch path {scratch_normalized:?}"
 			);
 		}
 

--- a/crates/brush-core-vendored/src/shell/fs.rs
+++ b/crates/brush-core-vendored/src/shell/fs.rs
@@ -164,7 +164,8 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
 	///
 	/// * `path` - The path to get the absolute form of.
 	pub fn absolute_path(&self, path: impl AsRef<Path>) -> PathBuf {
-		let path = path.as_ref();
+		let normalized_path = crate::sys::fs::normalize_shell_path(path.as_ref());
+		let path = normalized_path.as_ref();
 		if path.as_os_str().is_empty() || path.is_absolute() {
 			path.to_owned()
 		} else {

--- a/crates/brush-core-vendored/src/sys/fs.rs
+++ b/crates/brush-core-vendored/src/sys/fs.rs
@@ -1,5 +1,105 @@
 //! Filesystem utilities
 
+use std::{borrow::Cow, path::Path};
+#[cfg(any(windows, test))]
+use std::path::PathBuf;
+
+/// Normalizes shell-facing path aliases before std::fs sees them.
+pub fn normalize_shell_path(path: &Path) -> Cow<'_, Path> {
+	#[cfg(windows)]
+	{
+		translate_unix_drive_path(path).map_or(Cow::Borrowed(path), Cow::Owned)
+	}
+	#[cfg(not(windows))]
+	{
+		Cow::Borrowed(path)
+	}
+}
+
+#[cfg(any(windows, test))]
+fn translate_unix_drive_path(path: &Path) -> Option<PathBuf> {
+	let raw = path.to_str()?;
+	let bytes = raw.as_bytes();
+	let (drive, tail) = drive_alias_parts(bytes)?;
+
+	let mut native = String::with_capacity(3 + tail.len());
+	native.push(char::from(drive).to_ascii_uppercase());
+	native.push(':');
+	native.push('\\');
+	for &byte in tail {
+		native.push(if is_path_separator(byte) { '\\' } else { char::from(byte) });
+	}
+	Some(PathBuf::from(native))
+}
+
+#[cfg(any(windows, test))]
+fn drive_alias_parts(bytes: &[u8]) -> Option<(u8, &[u8])> {
+	if bytes.len() >= 2
+		&& is_path_separator(bytes[0])
+		&& bytes[1].is_ascii_alphabetic()
+		&& bytes.get(2).is_none_or(|byte| is_path_separator(*byte))
+	{
+		let tail = if bytes.len() > 2 { &bytes[3..] } else { &[] };
+		return Some((bytes[1], tail));
+	}
+
+	if bytes.len() >= 6
+		&& is_path_separator(bytes[0])
+		&& bytes[1..4].eq_ignore_ascii_case(b"mnt")
+		&& is_path_separator(bytes[4])
+		&& bytes[5].is_ascii_alphabetic()
+		&& bytes.get(6).is_none_or(|byte| is_path_separator(*byte))
+	{
+		let tail = if bytes.len() > 6 { &bytes[7..] } else { &[] };
+		return Some((bytes[5], tail));
+	}
+
+	None
+}
+
+#[cfg(any(windows, test))]
+const fn is_path_separator(byte: u8) -> bool {
+	byte == b'/' || byte == b'\\'
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn unix_drive_aliases_translate_to_windows_roots() {
+		assert_eq!(translate_unix_drive_path(Path::new("/c")).as_deref(), Some(Path::new("C:\\")));
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/d/project/app")).as_deref(),
+			Some(Path::new("D:\\project\\app")),
+		);
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/D/project")).as_deref(),
+			Some(Path::new("D:\\project")),
+		);
+	}
+
+	#[test]
+	fn wsl_mount_drive_aliases_translate_to_windows_roots() {
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/mnt/d/project")).as_deref(),
+			Some(Path::new("D:\\project")),
+		);
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/MNT/c")).as_deref(),
+			Some(Path::new("C:\\")),
+		);
+	}
+
+	#[test]
+	fn non_drive_absolute_paths_are_left_native() {
+		assert_eq!(translate_unix_drive_path(Path::new("/")).as_deref(), None);
+		assert_eq!(translate_unix_drive_path(Path::new("/dev/null")).as_deref(), None);
+		assert_eq!(translate_unix_drive_path(Path::new("/mnt/data")).as_deref(), None);
+		assert_eq!(translate_unix_drive_path(Path::new("relative/path")).as_deref(), None);
+	}
+}
+
 pub use super::platform::fs::*;
 
 /// Extension trait for path-related filesystem operations.

--- a/crates/brush-core-vendored/src/sys/fs.rs
+++ b/crates/brush-core-vendored/src/sys/fs.rs
@@ -35,20 +35,20 @@ fn translate_unix_drive_path(path: &Path) -> Option<PathBuf> {
 #[cfg(any(windows, test))]
 fn drive_alias_parts(bytes: &[u8]) -> Option<(u8, &[u8])> {
 	if bytes.len() >= 2
-		&& is_path_separator(bytes[0])
+		&& bytes[0] == b'/'
 		&& bytes[1].is_ascii_alphabetic()
-		&& bytes.get(2).is_none_or(|byte| is_path_separator(*byte))
+		&& bytes.get(2).is_none_or(|byte| *byte == b'/')
 	{
 		let tail = if bytes.len() > 2 { &bytes[3..] } else { &[] };
 		return Some((bytes[1], tail));
 	}
 
 	if bytes.len() >= 6
-		&& is_path_separator(bytes[0])
+		&& bytes[0] == b'/'
 		&& bytes[1..4].eq_ignore_ascii_case(b"mnt")
-		&& is_path_separator(bytes[4])
+		&& bytes[4] == b'/'
 		&& bytes[5].is_ascii_alphabetic()
-		&& bytes.get(6).is_none_or(|byte| is_path_separator(*byte))
+		&& bytes.get(6).is_none_or(|byte| *byte == b'/')
 	{
 		let tail = if bytes.len() > 6 { &bytes[7..] } else { &[] };
 		return Some((bytes[5], tail));
@@ -97,6 +97,8 @@ mod tests {
 		assert_eq!(translate_unix_drive_path(Path::new("/dev/null")).as_deref(), None);
 		assert_eq!(translate_unix_drive_path(Path::new("/mnt/data")).as_deref(), None);
 		assert_eq!(translate_unix_drive_path(Path::new("relative/path")).as_deref(), None);
+		assert_eq!(translate_unix_drive_path(Path::new("\\d\\logs")).as_deref(), None);
+		assert_eq!(translate_unix_drive_path(Path::new("\\mnt\\d\\logs")).as_deref(), None);
 	}
 }
 

--- a/crates/brush-core-vendored/src/sys/fs.rs
+++ b/crates/brush-core-vendored/src/sys/fs.rs
@@ -1,8 +1,9 @@
 //! Filesystem utilities
 
-use std::{borrow::Cow, path::Path};
-#[cfg(any(windows, test))]
-use std::path::PathBuf;
+use std::{
+	borrow::Cow,
+	path::{Path, PathBuf},
+};
 
 /// Normalizes shell-facing path aliases before std::fs sees them.
 pub fn normalize_shell_path(path: &Path) -> Cow<'_, Path> {
@@ -14,6 +15,65 @@ pub fn normalize_shell_path(path: &Path) -> Cow<'_, Path> {
 	{
 		Cow::Borrowed(path)
 	}
+}
+
+/// Returns a Windows drive root for a shell pattern that starts with an MSYS/WSL drive alias.
+pub fn pattern_drive_alias_root(
+	starts_with_forward_slash: bool,
+	first: &str,
+	second: Option<&str>,
+	third: Option<&str>,
+) -> Option<(PathBuf, usize)> {
+	#[cfg(windows)]
+	{
+		pattern_drive_alias_root_impl(starts_with_forward_slash, first, second, third)
+	}
+	#[cfg(not(windows))]
+	{
+		let _ = (starts_with_forward_slash, first, second, third);
+		None
+	}
+}
+
+#[cfg(any(windows, test))]
+fn pattern_drive_alias_root_impl(
+	starts_with_forward_slash: bool,
+	first: &str,
+	second: Option<&str>,
+	third: Option<&str>,
+) -> Option<(PathBuf, usize)> {
+	if !starts_with_forward_slash || !first.is_empty() {
+		return None;
+	}
+
+	if let Some(drive) = second
+		&& is_ascii_drive_component(drive)
+	{
+		return Some((drive_root_path(drive.as_bytes()[0]), 2));
+	}
+
+	if let (Some(mount), Some(drive)) = (second, third)
+		&& mount.eq_ignore_ascii_case("mnt")
+		&& is_ascii_drive_component(drive)
+	{
+		return Some((drive_root_path(drive.as_bytes()[0]), 3));
+	}
+
+	None
+}
+
+#[cfg(any(windows, test))]
+fn drive_root_path(drive: u8) -> PathBuf {
+	let mut root = String::with_capacity(3);
+	root.push(char::from(drive).to_ascii_uppercase());
+	root.push(':');
+	root.push('/');
+	PathBuf::from(root)
+}
+
+#[cfg(any(windows, test))]
+fn is_ascii_drive_component(value: &str) -> bool {
+	value.len() == 1 && value.as_bytes()[0].is_ascii_alphabetic()
 }
 
 #[cfg(any(windows, test))]
@@ -89,6 +149,28 @@ mod tests {
 			translate_unix_drive_path(Path::new("/MNT/c")).as_deref(),
 			Some(Path::new("C:\\")),
 		);
+	}
+
+	#[test]
+	fn pattern_drive_alias_roots_report_consumed_components() {
+		assert_eq!(
+			pattern_drive_alias_root_impl(true, "", Some("d"), Some("project")),
+			Some((PathBuf::from("D:/"), 2)),
+		);
+		assert_eq!(
+			pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("d")),
+			Some((PathBuf::from("D:/"), 3)),
+		);
+	}
+
+	#[test]
+	fn pattern_drive_alias_roots_require_forward_slash_prefix() {
+		assert_eq!(pattern_drive_alias_root_impl(false, "", Some("d"), Some("logs")), None);
+		assert_eq!(
+			pattern_drive_alias_root_impl(false, "", Some("mnt"), Some("d")),
+			None,
+		);
+		assert_eq!(pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("data")), None);
 	}
 
 	#[test]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows bash path handling so MSYS/Git-Bash drive aliases like `/d/project` and WSL-style `/mnt/d/project` normalize to native drive paths consistently across the bash tool cwd validation and brush filesystem builtins ([#2634](https://github.com/can1357/oh-my-pi/issues/2634)).
+
 ## [15.13.2] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -143,6 +143,37 @@ export function expandPath(filePath: string): string {
 	const normalized = stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(filePath)));
 	return expandTilde(normalized);
 }
+
+function isAsciiDriveLetter(value: string): boolean {
+	if (value.length !== 1) return false;
+	const code = value.charCodeAt(0);
+	return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function windowsDriveAliasPath(filePath: string): string | undefined {
+	const normalizedSeparators = filePath.replace(/\\/g, "/");
+	const parts = normalizedSeparators.split("/");
+	if (parts[0] !== "") return undefined;
+
+	let drive: string | undefined;
+	let tailStart = 2;
+	if (parts.length >= 2 && isAsciiDriveLetter(parts[1] ?? "")) {
+		drive = parts[1]!.toUpperCase();
+	} else if (parts.length >= 3 && (parts[1] ?? "").toLowerCase() === "mnt" && isAsciiDriveLetter(parts[2] ?? "")) {
+		drive = parts[2]!.toUpperCase();
+		tailStart = 3;
+	}
+	if (!drive) return undefined;
+
+	const tail = parts.slice(tailStart).filter(Boolean).join("\\");
+	return tail ? `${drive}:\\${tail}` : `${drive}:\\`;
+}
+
+export function normalizeWindowsDriveAliasPath(filePath: string, platform: NodeJS.Platform = process.platform): string {
+	if (platform !== "win32") return filePath;
+	return windowsDriveAliasPath(filePath) ?? filePath;
+}
+
 /**
  * Inclusive line range describing one selector segment (e.g. `50-100`,
  * `301-`, or `50+10`). `endLine` is `undefined` for open-ended ranges.
@@ -353,7 +384,7 @@ export function isInternalUrlPath(filePath: string): boolean {
  */
 export function resolveToCwd(filePath: string, cwd: string): string {
 	const normalized = normalizeLocalScheme(filePath);
-	const expanded = expandPath(normalized);
+	const expanded = normalizeWindowsDriveAliasPath(expandPath(normalized));
 	const expandedAndNormalized = normalizeLocalScheme(expanded);
 
 	assertNotInternalUrl(expandedAndNormalized, normalized);

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -151,8 +151,8 @@ function isAsciiDriveLetter(value: string): boolean {
 }
 
 function windowsDriveAliasPath(filePath: string): string | undefined {
-	const normalizedSeparators = filePath.replace(/\\/g, "/");
-	const parts = normalizedSeparators.split("/");
+	if (!filePath.startsWith("/")) return undefined;
+	const parts = filePath.split("/");
 	if (parts[0] !== "") return undefined;
 
 	let drive: string | undefined;

--- a/packages/coding-agent/test/tools/windows-drive-alias.test.ts
+++ b/packages/coding-agent/test/tools/windows-drive-alias.test.ts
@@ -18,5 +18,7 @@ describe("Windows drive alias paths", () => {
 		expect(normalizeWindowsDriveAliasPath("/dev/null", "win32")).toBe("/dev/null");
 		expect(normalizeWindowsDriveAliasPath("/mnt/data", "win32")).toBe("/mnt/data");
 		expect(normalizeWindowsDriveAliasPath("/d/project", "linux")).toBe("/d/project");
+		expect(normalizeWindowsDriveAliasPath("\\d\\logs", "win32")).toBe("\\d\\logs");
+		expect(normalizeWindowsDriveAliasPath("\\mnt\\d\\logs", "win32")).toBe("\\mnt\\d\\logs");
 	});
 });

--- a/packages/coding-agent/test/tools/windows-drive-alias.test.ts
+++ b/packages/coding-agent/test/tools/windows-drive-alias.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeWindowsDriveAliasPath } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
+
+describe("Windows drive alias paths", () => {
+	it("maps MSYS drive roots to native Windows paths", () => {
+		expect(normalizeWindowsDriveAliasPath("/c", "win32")).toBe("C:\\");
+		expect(normalizeWindowsDriveAliasPath("/d/project/app", "win32")).toBe("D:\\project\\app");
+		expect(normalizeWindowsDriveAliasPath("/D/project", "win32")).toBe("D:\\project");
+	});
+
+	it("maps WSL mount roots to native Windows paths", () => {
+		expect(normalizeWindowsDriveAliasPath("/mnt/d/project", "win32")).toBe("D:\\project");
+		expect(normalizeWindowsDriveAliasPath("/MNT/c", "win32")).toBe("C:\\");
+	});
+
+	it("leaves non-drive absolute paths and non-Windows platforms unchanged", () => {
+		expect(normalizeWindowsDriveAliasPath("/", "win32")).toBe("/");
+		expect(normalizeWindowsDriveAliasPath("/dev/null", "win32")).toBe("/dev/null");
+		expect(normalizeWindowsDriveAliasPath("/mnt/data", "win32")).toBe("/mnt/data");
+		expect(normalizeWindowsDriveAliasPath("/d/project", "linux")).toBe("/d/project");
+	});
+});


### PR DESCRIPTION
## Repro
On the current branch, the tool-layer path resolver leaves MSYS drive aliases unchanged: `bun --print 'import { resolveToCwd } from "@oh-my-pi/pi-coding-agent/tools/path-utils"; resolveToCwd("/d/project", "D:/project")'` prints `/d/project`, so bash `cwd` validation reaches `fs.stat` with the wrong Windows path. The same missing normalization exists in brush filesystem resolution used by `cd` and stat-backed builtins.

## Cause
`packages/coding-agent/src/tools/path-utils.ts` only expanded `~` and then trusted platform absolute-path detection, which does not translate `/d/...` or `/mnt/d/...` before cwd validation. In brush, `crates/brush-core-vendored/src/shell/fs.rs` passed shell paths directly into `std::fs::metadata`/`OpenOptions`; only glob pattern expansion had Windows drive-root awareness, so `ls` and `cd` disagreed.

## Fix
- Normalize `/c/...`, `/d/...`, and `/mnt/<drive>/...` aliases to native Windows drive paths before coding-agent tool path resolution.
- Add a brush-core shell path normalization hook used by `absolute_path`, covering `cd`, redirects, and stat-style builtins that resolve through the shell.
- Add focused TypeScript and Rust regression tests for MSYS and WSL drive aliases while leaving `/`, `/dev/null`, and non-Windows platforms unchanged.
- Add the coding-agent changelog entry for the Windows bash path fix.

## Verification
`bun test packages/coding-agent/test/tools/windows-drive-alias.test.ts packages/coding-agent/test/tools/root-path-alias.test.ts` passed. `cargo test --manifest-path crates/brush-core-vendored/Cargo.toml sys::fs::tests` passed. `cargo check -p pi-shell` passed. `bun check` passed. I also attempted `cargo test -p pi-shell`; it currently fails in two embedded-session tests with exit 143 on this Linux runner after 797/799 tests pass. Fixes #2634