### PR TITLE
fix: align tool cache paths with XDG dirs

### DIFF
--- a/packages/coding-agent/src/tools/report-tool-issue.ts
+++ b/packages/coding-agent/src/tools/report-tool-issue.ts
@@ -20,10 +20,9 @@
  * never blocked on the network and never throws.
  */
 import { Database } from "bun:sqlite";
-import path from "node:path";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { FetchImpl } from "@oh-my-pi/pi-ai";
-import { $env, $flag, getAgentDir, getInstallId, logger, VERSION } from "@oh-my-pi/pi-utils";
+import { $env, $flag, getAutoQaDbDir, getInstallId, logger, VERSION } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
 import type { Settings } from "..";
 import type { ToolSession } from "./index";
@@ -184,10 +183,6 @@ export async function resolveAutoQaConsent(settings: Settings | undefined): Prom
 	return consentInFlight;
 }
 
-export function getAutoQaDbPath(): string {
-	return path.join(getAgentDir(), "autoqa.db");
-}
-
 let cachedDb: Database | null = null;
 
 /**
@@ -205,7 +200,7 @@ let cachedDb: Database | null = null;
 export function openAutoQaDb(): Database | null {
 	if (cachedDb) return cachedDb;
 	try {
-		const db = new Database(getAutoQaDbPath());
+		const db = new Database(getAutoQaDbDir());
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
 		db.run("PRAGMA busy_timeout = 5000");
 		db.run(`

--- a/packages/coding-agent/src/web/scrapers/docs-rs.ts
+++ b/packages/coding-agent/src/web/scrapers/docs-rs.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { gunzipSync } from "node:zlib";
-import { getAgentDir, isEnoent, logger, ptree, tryParseJson } from "@oh-my-pi/pi-utils";
+import { getDocsRsCacheDir, isEnoent, logger, ptree, tryParseJson } from "@oh-my-pi/pi-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
 import type { RenderResult, SpecialHandler } from "./types";
 import { buildResult, MAX_BYTES } from "./types";
@@ -276,7 +276,6 @@ function findItemInModule(mod_: RustdocItem, name: string, index: Record<string,
 	return null;
 }
 
-const DOCS_RS_CACHE_ROOT = "webcache";
 const DOCS_RS_CACHE_FILENAME = "rustdoc.json";
 
 function sanitizeCacheSegment(value: string): string {
@@ -291,7 +290,7 @@ function getDocsRsCacheVersionSegment(version: string, now = new Date()): string
 function getDocsRsCachePath(target: DocsRsTarget, now = new Date()): string {
 	const crate = sanitizeCacheSegment(target.crateName);
 	const version = getDocsRsCacheVersionSegment(target.version, now);
-	return path.join(getAgentDir(), DOCS_RS_CACHE_ROOT, `docsrs_${crate}_${version}`, DOCS_RS_CACHE_FILENAME);
+	return path.join(getDocsRsCacheDir(), `docsrs_${crate}_${version}`, DOCS_RS_CACHE_FILENAME);
 }
 
 async function readCachedRustdocCrate(

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -556,6 +556,15 @@ export function getPuppeteerDir(): string {
 	return dirs.rootSubdir("puppeteer", "cache");
 }
 
+/** Get DOCS_RS cache directory () */
+export function getDocsRsCacheDir(): string {
+	return dirs.rootSubdir("webcache", "cache");
+}
+
+/**Get AutoQa db directory */
+export function getAutoQaDbDir(): string {
+	return dirs.rootSubdir("autoqa.db", "data");
+}
 /**
  * Stable 7-character hex digest of an absolute filesystem path.
  *


### PR DESCRIPTION
   ## What
   - Move the docs.rs rustdoc JSON cache path behind an XDG-aware pi-utils helper.
   - Move the AutoQA SQLite database path behind an XDG-aware pi-utils helper.
   - Update coding-agent call sites to use the centralized helpers instead of hard-coding `getAgentDir()` joins.
   ## Why
   These paths are local tool data/cache locations and should follow the repository’s XDG directory resolver instead of manually joining paths under the agent directory.

   The docs.rs rustdoc JSON cache is non-essential cached data, so it now resolves through the cache category. The AutoQA database resolves through the data category.

   ## Testing

   - Ran `bun check`.
   ---

   - [x] `bun check` passes
   - [x] Tested locally
   - [ ] CHANGELOG updated (if user-facing)