### PR TITLE
fix(coding-agent): respect startup.quiet for startup statuses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `startup.quiet` leaving MCP and LSP startup status events visible during launch ([#2639](https://github.com/can1357/oh-my-pi/issues/2639)).
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -542,6 +542,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
+					if (this.settings.get("startup.quiet")) return;
 					this.#handleLspStartupEvent(data as LspStartupEvent);
 				}),
 			);
@@ -551,6 +552,7 @@ export class InteractiveMode implements InteractiveModeContext {
 						logger.warn("Ignoring malformed mcp:connecting event", { data });
 						return;
 					}
+					if (this.settings.get("startup.quiet")) return;
 					this.showStatus(formatMCPConnectingMessage(data.serverNames));
 				}),
 			);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1608,8 +1608,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		let startDeferredMCPDiscovery:
 			| ((liveSession: AgentSession, activation: DeferredMCPActivation) => void)
 			| undefined;
+		const startupQuiet = settings.get("startup.quiet");
 		const onMCPConnecting = (serverNames: string[]) => {
-			if (!options.hasUI || serverNames.length === 0) return;
+			if (!options.hasUI || startupQuiet || serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTING_EVENT_CHANNEL, { serverNames } satisfies McpConnectingEvent);
 		};
 		const mcpDiscoverOptions = {
@@ -2696,7 +2697,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							type: "completed",
 							servers: result.servers,
 						};
-						eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
+						if (!startupQuiet) eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
 					} catch (error) {
 						const errorMessage = error instanceof Error ? error.message : String(error);
 						logger.warn("LSP server warmup failed", { cwd, error: errorMessage });
@@ -2708,7 +2709,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							type: "failed",
 							error: errorMessage,
 						};
-						eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
+						if (!startupQuiet) eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
 					}
 				})();
 			}

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -119,4 +119,16 @@ describe("InteractiveMode LSP startup welcome banner", () => {
 		expect(findServerLine()).toContain(theme.status.enabled);
 		expect(findServerLine()).not.toContain(theme.status.pending);
 	});
+
+	it("does not render LSP startup warnings when startup.quiet is enabled", () => {
+		session.settings.set("startup.quiet", true);
+		const showWarningSpy = vi.spyOn(mode, "showWarning").mockImplementation(() => {});
+
+		eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, {
+			type: "failed",
+			error: "rust-analyzer timed out",
+		} satisfies LspStartupEvent);
+
+		expect(showWarningSpy).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-mcp-connecting.test.ts
+++ b/packages/coding-agent/test/interactive-mode-mcp-connecting.test.ts
@@ -103,6 +103,17 @@ describe("InteractiveMode MCP connecting banner", () => {
 		expect(showStatusSpy).toHaveBeenCalledWith(formatMCPConnectingMessage(serverNames));
 	});
 
+	it("does not render the mcp:connecting status when startup.quiet is enabled", () => {
+		session.settings.set("startup.quiet", true);
+		const showStatusSpy = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
+
+		eventBus.emit(MCP_CONNECTING_EVENT_CHANNEL, {
+			serverNames: ["sequential", "critic"],
+		} satisfies McpConnectingEvent);
+
+		expect(showStatusSpy).not.toHaveBeenCalled();
+	});
+
 	it("rejects a malformed mcp:connecting payload via the guard instead of letting it throw", () => {
 		const showStatusSpy = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});


### PR DESCRIPTION
## Repro
With `startup.quiet=true`, emitting `mcp:connecting` still reached `InteractiveMode.showStatus`, and emitting a failed `lsp:startup` event still reached `InteractiveMode.showWarning`. I reproduced this with `cd packages/coding-agent && bun test test/interactive-mode-mcp-connecting.test.ts test/interactive-mode-lsp-startup.test.ts`, which failed before the fix with `3 pass, 2 fail`.

## Cause
`packages/coding-agent/src/sdk.ts` emitted `MCP_CONNECTING_EVENT_CHANNEL` and `LSP_STARTUP_EVENT_CHANNEL` whenever UI was available, without checking `settings.get("startup.quiet")`; `packages/coding-agent/src/modes/interactive-mode.ts` also rendered those events without consulting the same setting.

## Fix
- Gate MCP connecting emits in `createAgentSession` when `startup.quiet` is enabled.
- Gate LSP startup completion/failure emits in `createAgentSession` when `startup.quiet` is enabled.
- Add matching `InteractiveMode` subscriber guards so externally emitted startup events stay quiet.
- Add regression coverage for both MCP connecting and LSP startup event paths.

## Verification
`cd packages/coding-agent && bun test test/interactive-mode-mcp-connecting.test.ts test/interactive-mode-lsp-startup.test.ts` passed with `5 pass, 0 fail`; `cd packages/coding-agent && bun run check` passed. Fixes #2639