### PR TITLE
feat(coding-agent): advisor tool — pair any executor with any advisor model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in `advisor` tool (`advisor.enabled`, default off): the agent can consult a separately-paired advisor model — any provider, selected via the new `advisor` model role — for a concise second opinion on the current task. For the generic two-model strategy, pairing a `compactor` model role (a cheap, fast, long-context model via the new `compactor` role) first digests the transcript into a dense brief so an expensive or shorter-context advisor stays affordable. Both side-calls are prompt-cache-friendly (stable prompt-cache key, isolated per-call request lineage) and never block the turn on failure; `advisor.nudge` adds system-prompt guidance to consult the advisor aggressively.
+
 ## [15.13.2] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/config/model-roles.ts
+++ b/packages/coding-agent/src/config/model-roles.ts
@@ -5,7 +5,18 @@
 import { isValidThemeColor, type ThemeColor } from "../modes/theme/theme";
 import type { Settings } from "./settings";
 
-export type ModelRole = "default" | "smol" | "slow" | "vision" | "plan" | "designer" | "commit" | "title" | "task";
+export type ModelRole =
+	| "default"
+	| "smol"
+	| "slow"
+	| "vision"
+	| "plan"
+	| "designer"
+	| "commit"
+	| "title"
+	| "task"
+	| "advisor"
+	| "compactor";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -25,6 +36,8 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	commit: { tag: "COMMIT", name: "Commit", color: "dim" },
 	title: { tag: "TITLE", name: "Title", color: "dim", hidden: true },
 	task: { tag: "TASK", name: "Subtask", color: "muted" },
+	advisor: { tag: "ADVISOR", name: "Advisor", color: "accent" },
+	compactor: { tag: "COMPACTOR", name: "Compactor", color: "muted" },
 };
 
 export const MODEL_ROLE_IDS: ModelRole[] = [
@@ -37,6 +50,8 @@ export const MODEL_ROLE_IDS: ModelRole[] = [
 	"commit",
 	"title",
 	"task",
+	"advisor",
+	"compactor",
 ];
 
 export type RoleInfo = ModelRoleInfo;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -106,7 +106,7 @@ export const TAB_METADATA: Record<SettingTab, { label: string; icon: `tab.${stri
  */
 export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 	appearance: ["Theme", "Status Line", "Display", "Images"],
-	model: ["Thinking", "Sampling", "Prompt", "Retry & Fallback"],
+	model: ["Thinking", "Sampling", "Prompt", "Retry & Fallback", "Advisor"],
 	interaction: [
 		"Input",
 		"Approvals",
@@ -1954,6 +1954,32 @@ export const SETTINGS_SCHEMA = {
 			label: "Auto-Learn (experimental)",
 			description:
 				"After the agent stops, nudge it to capture lessons to memory and create/enhance isolated managed skills",
+		},
+	},
+	// Advisor (experimental): expose the model-invoked `advisor` tool. Opt-in only
+	// (default off). The advisor model is paired via the "Advisor" model role, so
+	// it surfaces in the standard model selector with no separate config key.
+	"advisor.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Tool (experimental)",
+			description:
+				'Expose the `advisor` tool so the agent can consult a separately-paired advisor model for a second opinion. Choose which model answers via the "Advisor" role in the model selector (/model).',
+		},
+	},
+	"advisor.nudge": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Nudge",
+			description:
+				"When on, the system prompt urges the agent to consult the advisor aggressively — at hard forks, when stuck, and before committing to a direction. Off = the advisor is available but called at the agent's discretion.",
+			condition: "advisorActive",
 		},
 	},
 	"autolearn.autoContinue": {

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -97,6 +97,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	advisorActive: () => {
+		try {
+			return Settings.instance.get("advisor.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
 	autoThinkingActive: () => {
 		try {
 			return Settings.instance.get("defaultThinkingLevel") === "auto";

--- a/packages/coding-agent/src/prompts/system/advisor-nudge.md
+++ b/packages/coding-agent/src/prompts/system/advisor-nudge.md
@@ -1,0 +1,10 @@
+## Advisor
+
+An `advisor` tool is available: it consults a more capable paired model that reads the conversation and returns a concise second opinion. Use it AGGRESSIVELY, not as a last resort.
+
+Consult the advisor:
+- At any hard fork — an architectural choice, an ambiguous requirement, two viable designs.
+- When stuck — a bug that survived one fix attempt, an approach that is not converging.
+- Before committing to a direction that is expensive to reverse — a schema, a public API, a migration.
+
+The advisor steers; you implement. Treat its guidance as input, not orders — weigh it, then decide. A short consult before a big commit is cheaper than redoing the work.

--- a/packages/coding-agent/src/prompts/tools/advisor-compactor.md
+++ b/packages/coding-agent/src/prompts/tools/advisor-compactor.md
@@ -1,0 +1,9 @@
+You are a compaction model preparing a coding-agent conversation for a separate advisor model.
+
+Read the conversation above and produce a DENSE, FAITHFUL brief — not advice. Capture:
+
+- The task or objective and any hard constraints.
+- What has been tried and the current state: key files, errors, decisions already made.
+- The open question or decision the agent faces right now.
+
+Preserve specifics — file paths, identifiers, error text, numbers. Drop chatter, restated boilerplate, and tool plumbing. Be compact but lossless on anything an advisor would need to give a sound second opinion. Output only the brief: no preamble, no advice.

--- a/packages/coding-agent/src/prompts/tools/advisor-system.md
+++ b/packages/coding-agent/src/prompts/tools/advisor-system.md
@@ -1,0 +1,9 @@
+You are a strategic advisor to a coding agent (the executor). You have been given the session — either its full transcript or a compacted `<conversation_brief>` of it — plus the executor's current question.
+
+Return a concise plan or course-correction — at most ~700 words. Name three things:
+
+- The key decision the executor faces right now.
+- The approach you would take, and why.
+- The failure mode most likely to bite, and how to avoid it.
+
+Do NOT write the full solution or large code blocks — the executor implements; you steer. If the executor is already on a sound path, say so briefly and sharpen it rather than inventing objections. No preamble, no restating the task back.

--- a/packages/coding-agent/src/prompts/tools/advisor.md
+++ b/packages/coding-agent/src/prompts/tools/advisor.md
@@ -1,0 +1,7 @@
+Consult a separately-paired advisor model for a concise strategic second opinion on the current task.
+
+The advisor reads the full conversation and returns a short plan or course-correction — the key decision, the approach it would take, and the failure mode to avoid. It does NOT write the solution; you remain the executor.
+
+Reach for it at a genuine fork: an architectural choice, a stubborn bug after a failed attempt, or before committing to a direction that is expensive to reverse. Pass `focus` to ask a specific question; omit it for general guidance on where things stand.
+
+The advisor model is configured separately (the `advisor` model role) and may be a more capable model from any provider. When a `compactor` model role is also paired, a cheaper long-context model first digests the conversation into a brief that the advisor reviews — so an expensive or shorter-context advisor stays affordable. If no advisor is paired, or the call fails, the tool returns a note and the turn continues — a missing second opinion never blocks you.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -101,6 +101,7 @@ import {
 import { MCP_CONNECTING_EVENT_CHANNEL, type McpConnectingEvent } from "./mcp/startup-events";
 import { createSessionMemoryRuntimeContext, resolveMemoryBackend } from "./memory-backend";
 import type { MnemopiSessionState } from "./mnemopi/state";
+import advisorNudgePrompt from "./prompts/system/advisor-nudge.md" with { type: "text" };
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import lateDiagnosticTemplate from "./prompts/tools/lsp-late-diagnostic.md" with { type: "text" };
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
@@ -1492,6 +1493,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getMnemopiSessionState: () => session?.getMnemopiSessionState(),
+			getAgentSession: () => session,
 			getAgentId: () => resolvedAgentId,
 			getToolByName: name => session?.getToolByName(name),
 			agentRegistry,
@@ -2145,6 +2147,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const appendParts: string[] = [];
 			if (memoryInstructions) appendParts.push(memoryInstructions);
 			if (autoLearnInstructions) appendParts.push(autoLearnInstructions);
+			// Advisor nudge: only when enabled (opt-in), the user turned the nudge on, AND the tool is
+			// active for this agent. The `advisor.enabled` conjunct stops a stale nudge value from firing
+			// against a same-named custom tool while the feature is off.
+			if (settings.get("advisor.nudge") && settings.get("advisor.enabled") && toolNames.includes("advisor"))
+				appendParts.push(advisorNudgePrompt);
 			let appendPrompt: string | undefined = appendParts.length > 0 ? appendParts.join("\n\n") : undefined;
 			if (serverInstructions && serverInstructions.size > 0) {
 				const parts: string[] = [];

--- a/packages/coding-agent/src/tools/advisor.ts
+++ b/packages/coding-agent/src/tools/advisor.ts
@@ -1,0 +1,225 @@
+import {
+	type AgentTool,
+	type AgentToolResult,
+	instrumentedCompleteSimple,
+	resolveTelemetry,
+} from "@oh-my-pi/pi-agent-core";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { z } from "zod/v4";
+import { extractTextContent } from "../commit/utils";
+import { formatModelString } from "../config/model-resolver";
+import advisorDescription from "../prompts/tools/advisor.md" with { type: "text" };
+import advisorCompactorPrompt from "../prompts/tools/advisor-compactor.md" with { type: "text" };
+import advisorSystemPrompt from "../prompts/tools/advisor-system.md" with { type: "text" };
+import type { AgentSession } from "../session/agent-session";
+import { toReasoningEffort } from "../thinking";
+import type { ToolSession } from ".";
+
+const advisorSchema = z.object({
+	focus: z
+		.string()
+		.describe("optional specific question for the advisor; omit for general guidance on the current task")
+		.optional(),
+});
+
+export type AdvisorParams = z.infer<typeof advisorSchema>;
+
+const DEFAULT_ASK =
+	"Advise on the current task: the key decision, the approach you would take, and the failure mode to avoid.";
+
+function advisorError(text: string): AgentToolResult {
+	return { content: [{ type: "text", text }], isError: true, details: { advisor: null } };
+}
+
+/**
+ * Model-invoked "advisor" tool: consults a separately-paired advisor model that
+ * returns a concise plan / course-correction. The advisor model is resolved from
+ * the `advisor` model role, so any provider can be paired with any executor
+ * (unlike a vendor-native advisor that fixes the executor/advisor pair). Opt-in
+ * via `advisor.enabled` (default off).
+ *
+ * Generic two-model strategy: when a `compactor` model role is also paired, a
+ * cheap, fast, long-context model first digests the full transcript into a dense
+ * brief, and the advisor reviews the brief — so a high-IQ but expensive or
+ * shorter-context advisor stays affordable and in-budget. With no compactor the
+ * advisor reads the transcript directly.
+ *
+ * Cache discipline mirrors {@link AgentSession.runEphemeralTurn} for BOTH side
+ * calls: a stable `promptCacheKey` (the session id) lets repeated consults reuse
+ * the growing-transcript prefix, while a unique per-call `sessionId` keeps each
+ * side request's provider lineage separate so the executor's own prompt cache is
+ * never disturbed.
+ */
+export class AdvisorTool implements AgentTool<typeof advisorSchema> {
+	readonly name = "advisor";
+	readonly approval = "read" as const;
+	readonly label = "Advisor";
+	readonly description = advisorDescription;
+	readonly parameters = advisorSchema;
+	readonly strict = true;
+	readonly loadMode = "essential" as const;
+	readonly summary = "Consult a paired advisor model for a second opinion on the current task";
+
+	constructor(private readonly session: ToolSession) {}
+
+	static createIf(session: ToolSession): AdvisorTool | null {
+		return session.settings.get("advisor.enabled") ? new AdvisorTool(session) : null;
+	}
+
+	async execute(_id: string, params: AdvisorParams, signal?: AbortSignal): Promise<AgentToolResult> {
+		const agentSession = this.session.getAgentSession?.();
+		if (!agentSession) {
+			return advisorError("Advisor is unavailable in this context.");
+		}
+
+		const { model, thinkingLevel } = agentSession.resolveRoleModelWithThinking("advisor");
+		if (!model) {
+			// No silent fallback to the executor model — that would defeat the pairing.
+			return advisorError(
+				'No advisor model configured. Pair one via the "Advisor" model role (run /model and assign the Advisor role).',
+			);
+		}
+
+		const apiKey = await agentSession.modelRegistry.getApiKey(model, agentSession.sessionId);
+		if (!apiKey) {
+			return advisorError(
+				`No API key for ${model.provider}/${model.id}; configure credentials or choose another advisor model.`,
+			);
+		}
+
+		const ask = params.focus?.trim() || DEFAULT_ASK;
+		const cacheSessionId = agentSession.sessionId;
+
+		try {
+			const transcript = await agentSession.convertMessagesToLlm(agentSession.messages, signal);
+			// First stage (optional): compact the transcript with the paired `compactor` model.
+			const brief = await this.#compact(agentSession, transcript, cacheSessionId, _id, signal);
+			const advisorMessages: Message[] = brief
+				? [
+						{
+							role: "user",
+							content: [
+								{ type: "text", text: `<conversation_brief>\n${brief}\n</conversation_brief>\n\n${ask}` },
+							],
+							timestamp: Date.now(),
+						},
+					]
+				: [...transcript, { role: "user", content: [{ type: "text", text: ask }], timestamp: Date.now() }];
+
+			const response = await instrumentedCompleteSimple(
+				model,
+				{ systemPrompt: [advisorSystemPrompt], messages: advisorMessages, tools: [] },
+				agentSession.prepareSimpleStreamOptions(
+					{
+						apiKey: agentSession.modelRegistry.resolver(model, cacheSessionId),
+						signal,
+						reasoning: toReasoningEffort(thinkingLevel),
+						promptCacheKey: cacheSessionId,
+						sessionId: `${cacheSessionId}:advisor:${_id}`,
+					},
+					model.provider,
+				),
+				{ telemetry: resolveTelemetry(agentSession.agent.telemetry, cacheSessionId), oneshotKind: "advisor" },
+			);
+
+			if (response.stopReason === "error") {
+				return advisorError(`Advisor request failed: ${response.errorMessage ?? "unknown error"}.`);
+			}
+			if (response.stopReason === "aborted") {
+				return advisorError("Advisor request was aborted.");
+			}
+
+			const advice = extractTextContent(response).trim();
+			if (!advice) {
+				return advisorError("Advisor returned no guidance.");
+			}
+
+			return {
+				content: [{ type: "text", text: advice }],
+				details: { advisor: formatModelString(model), compacted: brief !== null },
+			};
+		} catch (err) {
+			// Transport / resolver failures (advisor OR compactor) reject rather than resolving with a
+			// stopReason. Keep the same graceful contract regardless of caller — the eval JS tool bridge
+			// invokes execute() directly, without the agent loop's tool try/catch.
+			return advisorError(`Advisor request failed: ${err instanceof Error ? err.message : String(err)}.`);
+		}
+	}
+
+	/**
+	 * Optional first stage of the generic advisor strategy. When a `compactor`
+	 * model role is paired, a cheap, fast, long-context model digests the full
+	 * transcript into a dense brief for the advisor. Returns `null` when no
+	 * compactor is configured (the advisor then reads the transcript directly);
+	 * throws when a configured compactor fails, so the caller surfaces a graceful
+	 * advisorError rather than dumping the full transcript into a possibly
+	 * shorter-context advisor.
+	 *
+	 * Cache discipline matches the advisor call: a stable `promptCacheKey` lets
+	 * repeated consults reuse the compactor's growing-transcript prefix, while a
+	 * unique per-call `sessionId` keeps its provider lineage separate.
+	 */
+	async #compact(
+		agentSession: AgentSession,
+		transcript: Message[],
+		cacheSessionId: string,
+		callId: string,
+		signal: AbortSignal | undefined,
+	): Promise<string | null> {
+		const { model, thinkingLevel } = agentSession.resolveRoleModelWithThinking("compactor");
+		if (!model) {
+			// Discriminate "no compactor configured" (direct mode) from "configured but
+			// unresolvable". A paired-but-unavailable compactor must NOT silently dump the
+			// full transcript into a possibly short-context advisor — surface it instead.
+			if (this.session.settings.getModelRole("compactor")) {
+				throw new Error(
+					"Paired compactor model is unavailable; configure credentials or reassign the compactor model role.",
+				);
+			}
+			return null;
+		}
+
+		const apiKey = await agentSession.modelRegistry.getApiKey(model, cacheSessionId);
+		if (!apiKey) {
+			throw new Error(`No API key for the paired compactor ${model.provider}/${model.id}.`);
+		}
+
+		const response = await instrumentedCompleteSimple(
+			model,
+			{
+				systemPrompt: [advisorCompactorPrompt],
+				messages: [
+					...transcript,
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Compact the conversation above into a dense brief for an advisor." },
+						],
+						timestamp: Date.now(),
+					},
+				],
+				tools: [],
+			},
+			agentSession.prepareSimpleStreamOptions(
+				{
+					apiKey: agentSession.modelRegistry.resolver(model, cacheSessionId),
+					signal,
+					reasoning: toReasoningEffort(thinkingLevel),
+					promptCacheKey: cacheSessionId,
+					sessionId: `${cacheSessionId}:advisor-compact:${callId}`,
+				},
+				model.provider,
+			),
+			{ telemetry: resolveTelemetry(agentSession.agent.telemetry, cacheSessionId), oneshotKind: "advisor_compact" },
+		);
+
+		if (response.stopReason === "error" || response.stopReason === "aborted") {
+			throw new Error(response.errorMessage ?? "compactor request failed");
+		}
+		const brief = extractTextContent(response).trim();
+		if (!brief) {
+			throw new Error("compactor returned an empty brief");
+		}
+		return brief;
+	}
+}

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -30,6 +30,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"reflect",
 	"learn",
 	"manage_skill",
+	"advisor",
 ] as const;
 
 export type BuiltinToolName = (typeof BUILTIN_TOOL_NAMES)[number];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -19,6 +19,7 @@ import type { MCPManager } from "../mcp";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import type { PlanModeState } from "../plan-mode/state";
 import type { AgentRegistry } from "../registry/agent-registry";
+import type { AgentSession } from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
@@ -32,6 +33,7 @@ import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../tool-disc
 import type { EventBus } from "../utils/event-bus";
 import { WebSearchTool } from "../web/search";
 import type { WorkspaceTree } from "../workspace-tree";
+import { AdvisorTool } from "./advisor";
 import { AskTool } from "./ask";
 import { AstEditTool } from "./ast-edit";
 import { AstGrepTool } from "./ast-grep";
@@ -72,6 +74,7 @@ export * from "../lsp";
 export * from "../session/streaming-output";
 export * from "../task";
 export * from "../web/search";
+export * from "./advisor";
 export * from "./ask";
 export * from "./ast-edit";
 export * from "./ast-grep";
@@ -213,6 +216,8 @@ export interface ToolSession {
 	getHindsightSessionState?: () => HindsightSessionState | undefined;
 	/** Get Mnemopi runtime state for this agent session. */
 	getMnemopiSessionState?: () => MnemopiSessionState | undefined;
+	/** Get the full agent session for model-pairing side requests (e.g. the advisor tool). */
+	getAgentSession?: () => AgentSession;
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "Main", "AuthLoader"). */
 	getAgentId?: () => string | null;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
@@ -446,6 +451,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
 	manage_skill: ManageSkillTool.createIf,
+	advisor: AdvisorTool.createIf,
 };
 
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
@@ -582,6 +588,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 				["hindsight", "mnemopi", "local"].includes(session.settings.get("memory.backend") ?? "")
 			);
 		}
+		if (name === "advisor") return session.settings.get("advisor.enabled");
 		if (name === "task") {
 			return canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0);
 		}

--- a/packages/coding-agent/test/tools/advisor.test.ts
+++ b/packages/coding-agent/test/tools/advisor.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as core from "@oh-my-pi/pi-agent-core";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { AdvisorTool } from "@oh-my-pi/pi-coding-agent/tools";
+
+const advisorModel = { provider: "openai", id: "gpt-x" } as unknown as Model<Api>;
+const compactorModel = { provider: "google", id: "flash-lc" } as unknown as Model<Api>;
+
+function adviceResponse(text: string) {
+	return { stopReason: "end_turn", content: [{ type: "text", text }] };
+}
+
+interface SessionOpts {
+	model?: Model<Api>;
+	compactor?: Model<Api>;
+	roles?: string[];
+}
+
+/** Minimal AgentSession exposing only the surface the advisor tool reaches. */
+function createAgentSession(opts: SessionOpts = {}): AgentSession {
+	const model = "model" in opts ? opts.model : advisorModel;
+	const roles = opts.roles ?? [];
+	return {
+		resolveRoleModelWithThinking(role: string) {
+			roles.push(role);
+			if (role === "compactor") return { model: opts.compactor, explicitThinkingLevel: false };
+			return { model, explicitThinkingLevel: false };
+		},
+		modelRegistry: {
+			getApiKey: async () => "test-key",
+			resolver: (m: Model<Api>) => `${m.provider}/${m.id}:key`,
+		},
+		sessionId: "session-1",
+		agent: { telemetry: undefined },
+		messages: [],
+		convertMessagesToLlm: async () => [],
+		// Identity: keep the options the tool built so the test can assert on them.
+		prepareSimpleStreamOptions: (options: unknown) => options,
+	} as unknown as AgentSession;
+}
+
+function createToolSession(agentSession?: AgentSession, opts: { compactorRole?: string } = {}): ToolSession {
+	return {
+		settings: { get: () => true, getModelRole: () => opts.compactorRole },
+		getAgentSession: () => agentSession,
+	} as unknown as ToolSession;
+}
+
+describe("advisor tool", () => {
+	afterEach(() => {
+		(core.instrumentedCompleteSimple as { mockRestore?: () => void }).mockRestore?.();
+	});
+
+	it("is opt-in: createIf returns null unless advisor.enabled", () => {
+		const off = { settings: { get: () => false } } as unknown as ToolSession;
+		const on = { settings: { get: () => true } } as unknown as ToolSession;
+		expect(AdvisorTool.createIf(off)).toBeNull();
+		expect(AdvisorTool.createIf(on)).toBeInstanceOf(AdvisorTool);
+	});
+
+	it("errors (no throw) when no advisor model is paired", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple");
+		const session = createAgentSession({ model: undefined });
+		const result = await new AdvisorTool(createToolSession(session)).execute("call-1", {});
+		expect(result.isError).toBe(true);
+		expect(result.content[0]).toMatchObject({ type: "text" });
+		expect((result.content[0] as { text: string }).text).toContain("Advisor");
+		expect(complete).not.toHaveBeenCalled();
+	});
+
+	it("errors (no throw) when used without an agent session", async () => {
+		const result = await new AdvisorTool(createToolSession(undefined)).execute("call-1", {});
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain("unavailable");
+	});
+
+	it("surfaces an advisor request failure as a tool error rather than throwing", async () => {
+		spyOn(core, "instrumentedCompleteSimple").mockResolvedValue({
+			stopReason: "error",
+			errorMessage: "upstream 500",
+		} as never);
+		const result = await new AdvisorTool(createToolSession(createAgentSession())).execute("call-1", {});
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain("upstream 500");
+	});
+
+	it("contains a thrown (rejected) advisor completion instead of failing the turn", async () => {
+		spyOn(core, "instrumentedCompleteSimple").mockRejectedValue(new Error("ECONNRESET"));
+		const result = await new AdvisorTool(createToolSession(createAgentSession())).execute("call-1", {});
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain("ECONNRESET");
+	});
+
+	it("routes to the advisor role with a stable cache key and unique request lineage", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
+			adviceResponse("Pick approach B; the failure mode is N+1 queries.") as never,
+		);
+		const roles: string[] = [];
+		const session = createAgentSession({ roles });
+		const result = await new AdvisorTool(createToolSession(session)).execute("call-42", {});
+
+		expect(roles).toContain("advisor");
+		const streamOptions = complete.mock.calls[0]?.[2] as { promptCacheKey?: string; sessionId?: string };
+		expect(streamOptions.promptCacheKey).toBe("session-1");
+		expect(streamOptions.sessionId).toBe("session-1:advisor:call-42");
+		expect(streamOptions.sessionId).not.toBe(streamOptions.promptCacheKey);
+
+		expect(result.isError).toBeUndefined();
+		expect((result.content[0] as { text: string }).text).toContain("approach B");
+		expect(result.details).toMatchObject({ advisor: "openai/gpt-x" });
+	});
+
+	it("compacts with the paired compactor, then briefs the advisor (both cache-friendly)", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple")
+			.mockResolvedValueOnce(
+				adviceResponse("BRIEF: task is to add caching; open decision is eviction policy.") as never,
+			)
+			.mockResolvedValueOnce(adviceResponse("Use approach B; failure mode is N+1.") as never);
+		const session = createAgentSession({ compactor: compactorModel });
+
+		const result = await new AdvisorTool(createToolSession(session)).execute("call-7", {});
+
+		expect(complete.mock.calls).toHaveLength(2);
+		// First call: the compactor digests the transcript on its own request lineage.
+		expect(complete.mock.calls[0]?.[0]).toBe(compactorModel);
+		const compactOptions = complete.mock.calls[0]?.[2] as { promptCacheKey?: string; sessionId?: string };
+		expect(compactOptions.promptCacheKey).toBe("session-1");
+		expect(compactOptions.sessionId).toBe("session-1:advisor-compact:call-7");
+		// Second call: the advisor reviews the brief, not the raw transcript.
+		expect(complete.mock.calls[1]?.[0]).toBe(advisorModel);
+		const advisorContext = complete.mock.calls[1]?.[1] as { messages: { content: { text: string }[] }[] };
+		expect(advisorContext.messages).toHaveLength(1);
+		expect(advisorContext.messages[0]?.content[0]?.text).toContain("<conversation_brief>");
+		expect(advisorContext.messages[0]?.content[0]?.text).toContain("eviction policy");
+		expect(result.details).toMatchObject({ advisor: "openai/gpt-x", compacted: true });
+	});
+
+	it("errors when a compactor is paired but unavailable, instead of dumping the transcript", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple");
+		// Advisor resolves, but the paired `compactor` role string is set yet resolves to no model.
+		const session = createAgentSession({ compactor: undefined });
+		const result = await new AdvisorTool(createToolSession(session, { compactorRole: "google/flash-lc" })).execute(
+			"call-9",
+			{},
+		);
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain("compactor");
+		expect(complete).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Closes #2641 — adds the opt-in `advisor` tool (cross-provider pairable) with an optional cheap/long-context `compactor` stage; both side-calls are prompt-cache-friendly. See the issue for full acceptance criteria.