### PR TITLE
docs(coding-agent): refresh workflowz notice with advisor + provenance patterns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Refreshed the hidden `workflowz` orchestration notice with two patterns: an "Advisor consult" (consult the `advisor` tool at a hard fork before committing) and "Provenance-rich context" (brief each subagent on which files/commits and what "done" means via a `local://` brief).
+
 ## [15.13.2] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -57,6 +57,8 @@ Compose the harness the task calls for:
 - **Completeness critic** — a final agent that asks "what's missing — modality not run, claim unverified, file unread?"; its answer is the next round.
 - **Budget/count loops** — `while len(bugs) < 10:` to hit a target, or `while budget.total and budget.remaining() > 50_000:` to scale depth to the turn budget; `log()` each round.
 - **No silent caps** — if you bound coverage (top-N, no-retry, sampling), `log()` what you dropped; silent truncation reads as "covered everything" when it didn't.
+- **Advisor consult** — at a hard fork or when stuck, if the `advisor` tool is enabled, consult it for a second opinion from a more-capable paired model before committing to a direction; cheaper than a full judge panel for a single decision.
+- **Provenance-rich context** — hand each subagent which files/commits to touch, why, and what "done" looks like via a `local://` brief; never assume a subagent shares your context.
 
 Scale to the ask: "find any bugs" → a few finders, single-vote verify. "thoroughly audit / be comprehensive" → larger finder pool, 3–5-vote adversarial pass, a synthesis stage.
 </patterns>


### PR DESCRIPTION
Closes #2642 — adds Advisor-consult and provenance-rich-context patterns to the workflowz orchestration notice.

Depends on #2646.