### PR TITLE
feat(coding-agent): validate managed skills + support bundled references/scripts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Managed skills (`manage_skill`, `learn`) now validate against the Agent Skills standard (reserved-word name check, description capped at 1024 chars) and can bundle reference/script files: both tools accept an optional `files` array written under the skill directory (relative paths only, traversal- and symlink-safe, count- and byte-capped), readable on demand via `skill://<name>/<path>`.
+
 ## [15.13.2] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/autolearn/managed-skills.ts
+++ b/packages/coding-agent/src/autolearn/managed-skills.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
+import { validateRelativePath } from "../internal-urls/path-safety";
 
 /** Provider id stamped on discovered managed skills (distinguishes them from authored). */
 export const MANAGED_SKILLS_PROVIDER_ID = "omp-managed";
@@ -19,7 +20,11 @@ export const MANAGED_SKILLS_PROVIDER_ID = "omp-managed";
 /** Hard cap on a managed SKILL.md body to keep generated skills bounded. */
 export const MAX_MANAGED_SKILL_BYTES = 64_000;
 
+/** Hard cap on bundled reference/script files per managed skill. */
+export const MAX_MANAGED_SKILL_FILES = 32;
+
 const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const SKILL_NAME_RESERVED_PATTERN = /anthropic|claude/;
 
 /** Resolve the isolated managed-skills directory (`~/.omp/agent/managed-skills`). */
 export function getManagedSkillsDir(agentDir: string = getAgentDir()): string {
@@ -38,6 +43,9 @@ export function sanitizeSkillName(raw: string): string {
 			`Invalid skill name "${raw}". Use lowercase letters, digits, and hyphens (1-64 chars, starting with a letter or digit).`,
 		);
 	}
+	if (SKILL_NAME_RESERVED_PATTERN.test(name)) {
+		throw new Error('Skill name must not contain reserved words "anthropic" or "claude".');
+	}
 	return name;
 }
 
@@ -48,7 +56,7 @@ export function sanitizeSkillName(raw: string): string {
  * (e.g. hand-placed) must not render unescaped into the system prompt.
  */
 export function isValidManagedSkillName(name: string): boolean {
-	return SKILL_NAME_PATTERN.test(name);
+	return SKILL_NAME_PATTERN.test(name) && !SKILL_NAME_RESERVED_PATTERN.test(name);
 }
 
 /**
@@ -86,6 +94,7 @@ export interface WriteManagedSkillInput {
 	name: string;
 	description: string;
 	body: string;
+	files?: ReadonlyArray<{ path: string; content: string }>;
 }
 
 /**
@@ -126,25 +135,155 @@ async function assertManagedRootSafe(): Promise<void> {
 
 const UPDATE_FILE_OPEN_FLAGS = fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
 
-function assertManagedSkillFileSafeForUpdate(name: string, fileStat: Stats): void {
+function assertManagedSkillFileSafeForUpdate(name: string, fileStat: Stats, relativePath = "SKILL.md"): void {
 	if (!fileStat.isFile()) {
-		throw new Error(`Managed skill "${name}" SKILL.md is not a regular file; refusing to overwrite it.`);
+		throw new Error(`Managed skill "${name}" ${relativePath} is not a regular file; refusing to overwrite it.`);
 	}
 	if (fileStat.nlink > 1) {
 		throw new Error(
-			`Managed skill "${name}" SKILL.md has ${fileStat.nlink} hard links; refusing to overwrite a file that may be user-authored elsewhere.`,
+			`Managed skill "${name}" ${relativePath} has ${fileStat.nlink} hard links; refusing to overwrite a file that may be user-authored elsewhere.`,
 		);
 	}
 }
 
-async function openManagedSkillFileForUpdate(name: string, file: string) {
+async function openManagedSkillFileForUpdate(name: string, file: string, relativePath = "SKILL.md") {
 	try {
 		return await fs.open(file, UPDATE_FILE_OPEN_FLAGS);
 	} catch (err) {
 		if ((err as { code?: string }).code === "ELOOP") {
-			throw new Error(`Managed skill "${name}" SKILL.md is a symlink; refusing to overwrite it.`);
+			throw new Error(`Managed skill "${name}" ${relativePath} is a symlink; refusing to overwrite it.`);
 		}
 		throw err;
+	}
+}
+
+interface PreparedManagedSkillFile {
+	relativePath: string;
+	targetPath: string;
+	content: string;
+}
+
+function prepareManagedSkillFiles(
+	name: string,
+	dir: string,
+	files: ReadonlyArray<{ path: string; content: string }> | undefined,
+): PreparedManagedSkillFile[] {
+	if (!files?.length) return [];
+	if (files.length > MAX_MANAGED_SKILL_FILES) {
+		throw new Error(`Managed skill "${name}" has ${files.length} files; the limit is ${MAX_MANAGED_SKILL_FILES}.`);
+	}
+
+	const seen = new Set<string>();
+	return files.map(file => {
+		try {
+			validateRelativePath(file.path);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			throw new Error(`Managed skill "${name}" file path "${file.path}" is invalid: ${reason}`);
+		}
+
+		const relativePath = path.normalize(file.path);
+		if (!relativePath || relativePath === ".") {
+			throw new Error(`Managed skill "${name}" file path must name a file.`);
+		}
+		if (relativePath.toLowerCase() === "skill.md") {
+			throw new Error(`Managed skill "${name}" file path "SKILL.md" is reserved for the skill manifest.`);
+		}
+		if (seen.has(relativePath)) {
+			throw new Error(`Managed skill "${name}" includes duplicate bundled file "${relativePath}".`);
+		}
+		seen.add(relativePath);
+
+		const targetPath = path.join(dir, relativePath);
+		const resolvedTarget = path.resolve(targetPath);
+		const resolvedDir = path.resolve(dir);
+		if (!resolvedTarget.startsWith(resolvedDir + path.sep) && resolvedTarget !== resolvedDir) {
+			throw new Error(`Managed skill "${name}" file path "${file.path}" escapes the skill directory.`);
+		}
+
+		const bytes = Buffer.byteLength(file.content, "utf8");
+		if (bytes > MAX_MANAGED_SKILL_BYTES) {
+			throw new Error(
+				`Managed skill "${name}" file "${relativePath}" is ${bytes} bytes; the per-file limit is ${MAX_MANAGED_SKILL_BYTES}.`,
+			);
+		}
+
+		return { relativePath, targetPath, content: file.content };
+	});
+}
+
+async function ensureManagedSkillParentDirsSafe(name: string, dir: string, relativePath: string): Promise<void> {
+	const parts = relativePath.split(path.sep).slice(0, -1);
+	let current = dir;
+	for (const part of parts) {
+		if (!part || part === ".") continue;
+		current = path.join(current, part);
+		let stat = await fs.lstat(current).catch(err => {
+			if (isEnoent(err)) return null;
+			throw err;
+		});
+		if (stat === null) {
+			try {
+				await fs.mkdir(current);
+			} catch (err) {
+				if ((err as { code?: string }).code !== "EEXIST") throw err;
+			}
+			stat = await fs.lstat(current);
+		}
+		if (stat.isSymbolicLink()) {
+			throw new Error(`Managed skill "${name}" parent directory for "${relativePath}" is a symlink.`);
+		}
+		if (!stat.isDirectory()) {
+			throw new Error(`Managed skill "${name}" parent for "${relativePath}" is not a directory.`);
+		}
+	}
+}
+
+async function writeManagedSkillBundledFile(
+	name: string,
+	dir: string,
+	file: PreparedManagedSkillFile,
+	action: "create" | "update",
+): Promise<void> {
+	await ensureManagedSkillParentDirsSafe(name, dir, file.relativePath);
+	if (action === "create") {
+		try {
+			await fs.writeFile(file.targetPath, file.content, { flag: "wx" });
+		} catch (err) {
+			if ((err as { code?: string }).code === "EEXIST") {
+				throw new Error(`Managed skill "${name}" file "${file.relativePath}" already exists.`);
+			}
+			throw err;
+		}
+		return;
+	}
+
+	const fileStat = await fs.lstat(file.targetPath).catch(err => {
+		if (isEnoent(err)) return null;
+		throw err;
+	});
+	if (fileStat === null) {
+		try {
+			await fs.writeFile(file.targetPath, file.content, { flag: "wx" });
+			return;
+		} catch (err) {
+			if ((err as { code?: string }).code !== "EEXIST") throw err;
+		}
+	}
+
+	const latestStat = fileStat ?? (await fs.lstat(file.targetPath));
+	if (latestStat.isSymbolicLink()) {
+		throw new Error(`Managed skill "${name}" ${file.relativePath} is a symlink; refusing to overwrite it.`);
+	}
+	assertManagedSkillFileSafeForUpdate(name, latestStat, file.relativePath);
+	const handle = await openManagedSkillFileForUpdate(name, file.targetPath, file.relativePath);
+	try {
+		const openStat = await handle.stat();
+		assertManagedSkillFileSafeForUpdate(name, openStat, file.relativePath);
+		await handle.truncate(0);
+		await handle.writeFile(file.content);
+	} finally {
+		await handle.close();
 	}
 }
 
@@ -152,6 +291,11 @@ async function openManagedSkillFileForUpdate(name: string, file: string) {
 export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<{ path: string }> {
 	const name = sanitizeSkillName(input.name);
 	const description = sanitizeManagedDescription(input.description);
+	if (description.length > 1024) {
+		throw new Error(
+			`Managed skill "${name}" description is ${description.length} characters; Agent-Skills descriptions are limited to 1024 characters.`,
+		);
+	}
 	const body = input.body.trim();
 	// Reject empty content: an all-whitespace/control description sanitizes to ""
 	// and the `requireDescription` discovery scan then silently drops the skill,
@@ -175,6 +319,7 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 		await assertManagedRootSafe();
 		const dir = path.join(getManagedSkillsDir(), name);
 		const file = path.join(dir, "SKILL.md");
+		const bundledFiles = prepareManagedSkillFiles(name, dir, input.files);
 		// Reject a symlinked skill directory: an intermediate symlink would let the
 		// write escape the isolated managed root. lstat does not follow the final
 		// component, so a symlinked `dir` is caught here.
@@ -185,6 +330,19 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 		if (dirStat?.isSymbolicLink()) {
 			throw new Error(
 				`Managed skill "${name}" resolves through a symlink; refusing to write outside the managed directory.`,
+			);
+		}
+		if (input.action === "create" && bundledFiles.length > 0) {
+			await Promise.all(
+				bundledFiles.map(async bundledFile => {
+					const existing = await fs.lstat(bundledFile.targetPath).catch(err => {
+						if (isEnoent(err)) return null;
+						throw err;
+					});
+					if (existing !== null) {
+						throw new Error(`Managed skill "${name}" file "${bundledFile.relativePath}" already exists.`);
+					}
+				}),
 			);
 		}
 		if (input.action === "create") {
@@ -198,6 +356,9 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 					throw new Error(`Managed skill "${name}" already exists. Use action "update" to change it.`);
 				}
 				throw err;
+			}
+			for (const bundledFile of bundledFiles) {
+				await writeManagedSkillBundledFile(name, dir, bundledFile, "create");
 			}
 			return { path: file };
 		}
@@ -224,6 +385,9 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 			await handle.writeFile(content);
 		} finally {
 			await handle.close();
+		}
+		for (const bundledFile of bundledFiles) {
+			await writeManagedSkillBundledFile(name, dir, bundledFile, "update");
 		}
 		return { path: file };
 	});

--- a/packages/coding-agent/src/internal-urls/path-safety.ts
+++ b/packages/coding-agent/src/internal-urls/path-safety.ts
@@ -1,0 +1,20 @@
+import * as path from "node:path";
+
+/**
+ * Validate that a relative path is safe (no traversal, no absolute paths).
+ *
+ * Leaf utility shared by the skill://, local://, memory://, and vault:// protocol
+ * handlers and by managed-skill bundled-file writes. Kept dependency-free (only
+ * `node:path`) so importers never drag the skill-discovery graph into a
+ * module-initialization cycle.
+ */
+export function validateRelativePath(relativePath: string): void {
+	if (path.isAbsolute(relativePath)) {
+		throw new Error("Absolute paths are not allowed in skill:// URLs");
+	}
+
+	const normalized = path.normalize(relativePath);
+	if (normalized.startsWith("..") || normalized.includes("/../") || normalized.includes("/..")) {
+		throw new Error("Path traversal (..) is not allowed in skill:// URLs");
+	}
+}

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -9,6 +9,7 @@
  */
 import * as path from "node:path";
 import { getActiveSkills } from "../extensibility/skills";
+import { validateRelativePath } from "./path-safety";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
 
 function getContentType(filePath: string): InternalResource["contentType"] {
@@ -17,19 +18,10 @@ function getContentType(filePath: string): InternalResource["contentType"] {
 	return "text/plain";
 }
 
-/**
- * Validate that a path is safe (no traversal, no absolute paths).
- */
-export function validateRelativePath(relativePath: string): void {
-	if (path.isAbsolute(relativePath)) {
-		throw new Error("Absolute paths are not allowed in skill:// URLs");
-	}
-
-	const normalized = path.normalize(relativePath);
-	if (normalized.startsWith("..") || normalized.includes("/../") || normalized.includes("/..")) {
-		throw new Error("Path traversal (..) is not allowed in skill:// URLs");
-	}
-}
+// Re-exported from ./path-safety (a dependency-free leaf) so the local://, memory://, and
+// vault:// handlers can keep importing it from here. managed-skills imports the leaf directly
+// to avoid a module-init cycle through this handler's skill-discovery imports.
+export { validateRelativePath };
 
 /**
  * Handler for skill:// URLs.

--- a/packages/coding-agent/src/prompts/tools/learn.md
+++ b/packages/coding-agent/src/prompts/tools/learn.md
@@ -4,4 +4,6 @@ Use after solving something whose insight will pay off again: a non-obvious fix,
 
 Provide the optional `skill` object when the lesson is a repeatable *procedure* worth codifying as a `SKILL.md` (not just a fact). Managed skills are written to an isolated directory (`~/.omp/agent/managed-skills`) and are surfaced like normal skills next session. They NEVER touch user-authored skills. `body` is the SKILL.md content in markdown — do not include frontmatter; it is generated from `name` and `description`. Use `action: "update"` to enhance an existing managed skill.
 
+Within `skill`, optional `files` can bundle supporting references or scripts under the skill directory. Paths must be relative (no absolute paths or `..`); place executables under `scripts/`, and put longer markdown references in files like `REFERENCE.md` so they can be loaded on demand with `skill://<name>/<path>`. On update, only listed files are overwritten or added; unlisted files are kept.
+
 Capture sparingly and specifically. One strong, reusable lesson beats several vague ones.

--- a/packages/coding-agent/src/prompts/tools/manage-skill.md
+++ b/packages/coding-agent/src/prompts/tools/manage-skill.md
@@ -7,3 +7,5 @@ Managed skills are for repeatable procedures worth codifying: a setup sequence, 
 - `action: "delete"` — requires `name`. Fails if the skill does not exist.
 
 `name` is kebab-case (lowercase letters, digits, hyphens). `description` is a single line stating when to use the skill — it drives discovery, so make it specific. `body` is the SKILL.md content in markdown; do not include frontmatter (it is generated from `name` and `description`).
+
+Optional `files` may bundle reference or script files under the skill directory. Paths must be relative (no absolute paths or `..`); use `scripts/` for executables and `.md` files such as `REFERENCE.md` for longer material loaded on demand via `skill://<name>/<path>`. On update, only listed files are overwritten or added; unlisted existing files remain.

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -15,6 +15,7 @@ const learnSchema = z.object({
 			name: z.string().describe("kebab-case skill name"),
 			description: z.string().describe("one-line description of when to use the skill"),
 			body: z.string().describe("the SKILL.md body in markdown (no frontmatter)"),
+			files: z.array(z.object({ path: z.string(), content: z.string() })).optional(),
 		})
 		.describe("also create or enhance a managed skill in the same call")
 		.optional(),

--- a/packages/coding-agent/src/tools/manage-skill.ts
+++ b/packages/coding-agent/src/tools/manage-skill.ts
@@ -23,6 +23,7 @@ const manageSkillSchema = z
 			.string()
 			.describe("the SKILL.md body in markdown, no frontmatter (required for create/update)")
 			.optional(),
+		files: z.array(z.object({ path: z.string(), content: z.string() })).optional(),
 	})
 	// Enforce the action/field contract at validation time rather than only in
 	// execute. Kept as a cross-field refine (not a discriminated union) so the
@@ -93,6 +94,7 @@ export class ManageSkillTool implements AgentTool<typeof manageSkillSchema> {
 			name: params.name,
 			description: params.description,
 			body: params.body,
+			files: params.files,
 		});
 		const relativePath = path.relative(getManagedSkillsDir(), skillPath);
 		const verb = params.action === "create" ? "Created" : "Updated";

--- a/packages/coding-agent/test/autolearn-managed-skills.test.ts
+++ b/packages/coding-agent/test/autolearn-managed-skills.test.ts
@@ -31,6 +31,7 @@ describe("managed-skills primitives", () => {
 	});
 
 	const skillFile = (name: string) => path.join(getManagedSkillsDir(), name, "SKILL.md");
+	const skillPath = (name: string, relativePath: string) => path.join(getManagedSkillsDir(), name, relativePath);
 
 	describe("sanitizeSkillName", () => {
 		it("rejects traversal, slashes, and empty names", () => {
@@ -42,6 +43,11 @@ describe("managed-skills primitives", () => {
 
 		it("normalizes and accepts a valid kebab name", () => {
 			expect(sanitizeSkillName("  Demo-Skill ")).toBe("demo-skill");
+		});
+
+		it("rejects names containing reserved Agent-Skills vendor words", () => {
+			expect(() => sanitizeSkillName("claude-helper")).toThrow(/reserved/);
+			expect(() => sanitizeSkillName("anthropic-helper")).toThrow(/reserved/);
 		});
 	});
 
@@ -66,6 +72,66 @@ describe("managed-skills primitives", () => {
 			await expect(
 				writeManagedSkill({ action: "create", name: "foo", description: "x", body: "y" }),
 			).rejects.toThrow(/already exists/);
+		});
+
+		it("rejects a create name containing reserved Agent-Skills vendor words", async () => {
+			await expect(
+				writeManagedSkill({ action: "create", name: "claude-helper", description: "d", body: "b" }),
+			).rejects.toThrow(/reserved/);
+		});
+
+		it("writes bundled reference and script files under the skill directory", async () => {
+			await writeManagedSkill({
+				action: "create",
+				name: "bundle",
+				description: "When bundled files help.",
+				body: "# Bundle\nUse the reference.",
+				files: [
+					{ path: "REFERENCE.md", content: "# Reference\nDetails" },
+					{ path: "scripts/run.sh", content: "#!/bin/sh\nprintf '%s\\n' ok\n" },
+				],
+			});
+
+			expect(await Bun.file(skillFile("bundle")).exists()).toBe(true);
+			expect(await Bun.file(skillPath("bundle", "REFERENCE.md")).text()).toBe("# Reference\nDetails");
+			expect(await Bun.file(skillPath("bundle", "scripts/run.sh")).text()).toBe("#!/bin/sh\nprintf '%s\\n' ok\n");
+		});
+
+		it("rejects bundled traversal and absolute paths", async () => {
+			await expect(
+				writeManagedSkill({
+					action: "create",
+					name: "bad-ref",
+					description: "d",
+					body: "b",
+					files: [{ path: "../escape.md", content: "nope" }],
+				}),
+			).rejects.toThrow(/traversal|invalid/i);
+			expect(await Bun.file(path.join(getManagedSkillsDir(), "escape.md")).exists()).toBe(false);
+
+			await expect(
+				writeManagedSkill({
+					action: "create",
+					name: "abs-ref",
+					description: "d",
+					body: "b",
+					files: [{ path: path.join(tempHome, "escape.md"), content: "nope" }],
+				}),
+			).rejects.toThrow(/absolute|invalid/i);
+			expect(await Bun.file(path.join(tempHome, "escape.md")).exists()).toBe(false);
+		});
+
+		it("rejects a bundled file that clobbers the SKILL.md manifest case-insensitively", async () => {
+			await expect(
+				writeManagedSkill({
+					action: "create",
+					name: "caseclash",
+					description: "d",
+					body: "b",
+					files: [{ path: "skill.md", content: "nope" }],
+				}),
+			).rejects.toThrow(/reserved/i);
+			expect(await Bun.file(skillPath("caseclash", "skill.md")).exists()).toBe(false);
 		});
 
 		it("update overwrites the body; update of a missing skill throws", async () => {
@@ -103,6 +169,13 @@ describe("managed-skills primitives", () => {
 			const description = "b".repeat(500); // body + description + frontmatter exceeds it
 			await expect(writeManagedSkill({ action: "create", name: "fin", description, body })).rejects.toThrow(/bytes/);
 			expect(await Bun.file(skillFile("fin")).exists()).toBe(false);
+		});
+
+		it("rejects descriptions over the Agent-Skills 1024 character limit", async () => {
+			await expect(
+				writeManagedSkill({ action: "create", name: "longdesc", description: "d".repeat(1025), body: "b" }),
+			).rejects.toThrow(/1024/);
+			expect(await Bun.file(skillFile("longdesc")).exists()).toBe(false);
 		});
 
 		it("neutralizes prompt-injection metacharacters in the persisted description", async () => {


### PR DESCRIPTION
Closes #2644 — Agent-Skills-standard validation plus bundled reference/script files under the skill directory, with traversal- and symlink-safety.