### PR TITLE
fix(coding-agent): Claude plugin skills should not appear as slash commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Claude Code plugin skills no longer register as bare `/<name>` slash commands; they surface only as skills (reachable via the `/skill:<name>` command or a `skill://` URL). Reverses the bare-slash mirroring added in #2415.
+
 ## [15.13.2] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -124,43 +124,6 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	}
 	return { items, warnings };
 }
-async function loadSkillSlashCommands(ctx: LoadContext, root: ClaudePluginRoot): Promise<LoadResult<SlashCommand>> {
-	const { dir: skillsDir, warning } = await resolvePluginDir(root, ["skills"], "skills");
-	const warnings: string[] = warning ? [warning] : [];
-	const skillsResult = await scanSkillsFromDir(ctx, {
-		dir: skillsDir,
-		providerId: PROVIDER_ID,
-		level: root.scope,
-	});
-	warnings.push(...(skillsResult.warnings ?? []));
-
-	const commands = await Promise.all(
-		skillsResult.items.map(async skill => {
-			const content = await readFile(skill.path);
-			if (content === null) {
-				warnings.push(`Failed to read skill slash command: ${skill.path}`);
-				return null;
-			}
-			// Slash command name MUST come from the skill directory basename, not
-			// frontmatter `name`: `expandSlashCommand` splits the command at the first
-			// whitespace, so a display name like "Understand Anything" would never match
-			// `/understand`. The documented layout is `skills/<name>/SKILL.md` → `/<name>`.
-			const command: SlashCommand = {
-				name: path.basename(path.dirname(skill.path)),
-				path: skill.path,
-				content,
-				level: skill.level,
-				_source: skill._source,
-			};
-			return command;
-		}),
-	);
-
-	return {
-		items: commands.filter((command): command is SlashCommand => command !== null),
-		warnings,
-	};
-}
 
 // =============================================================================
 // Slash Commands
@@ -189,16 +152,14 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 					};
 				},
 			});
-			const skillCommandResult = await loadSkillSlashCommands(ctx, root);
-			return { commandResult, skillCommandResult, warning };
+			return { commandResult, warning };
 		}),
 	);
 
-	for (const { commandResult, skillCommandResult, warning } of results) {
+	for (const { commandResult, warning } of results) {
 		if (warning) warnings.push(warning);
-		items.push(...commandResult.items, ...skillCommandResult.items);
+		items.push(...commandResult.items);
 		if (commandResult.warnings) warnings.push(...commandResult.warnings);
-		if (skillCommandResult.warnings) warnings.push(...skillCommandResult.warnings);
 	}
 
 	return { items, warnings };

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -9,7 +9,7 @@ import {
 	listClaudePluginRoots,
 	parseClaudePluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
-import { expandSlashCommand, loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
+import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
@@ -356,11 +356,12 @@ describe("listClaudePluginRoots", () => {
 		expect(found).toBeDefined();
 		expect(found?.path).toContain(path.join(".claude", "skills", "manifest-skill", "SKILL.md"));
 	});
-	test("exposes plugin skills as bare slash commands", async () => {
+	test("does not expose plugin skills as bare slash commands", async () => {
 		const pluginsDir = path.join(tempDir, ".omp", "plugins");
 		const pluginPath = path.join(tempDir, ".omp", "plugins", "cache", "plugins", "understand-anything");
 		await fs.mkdir(pluginsDir, { recursive: true });
 		await fs.mkdir(path.join(pluginPath, "skills", "understand"), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "commands"), { recursive: true });
 
 		const registry = {
 			version: 2,
@@ -382,14 +383,16 @@ describe("listClaudePluginRoots", () => {
 			path.join(pluginPath, "skills", "understand", "SKILL.md"),
 			"---\nname: understand\ndescription: Build an understanding graph\n---\nAnalyze the project.\n",
 		);
+		await fs.writeFile(path.join(pluginPath, "commands", "explain.md"), "Explain the project.\n");
 
 		const commands = await loadSlashCommands({ cwd: tempDir });
-		const found = commands.find(command => command.name === "understand");
+		expect(commands.find(command => command.name === "understand-anything:explain")).toBeDefined();
+		expect(commands.find(command => command.name === "understand")).toBeUndefined();
 
-		expect(found?.description).toBe("Build an understanding graph");
-		expect(expandSlashCommand("/understand --language zh", commands)).toContain("Analyze the project.");
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		expect(skills.all.find(skill => skill.name === "understand")).toBeDefined();
 	});
-	test("uses skill directory basename when frontmatter name contains spaces", async () => {
+	test("does not expose skill directory basename when frontmatter name contains spaces", async () => {
 		const pluginsDir = path.join(tempDir, ".omp", "plugins");
 		const pluginPath = path.join(tempDir, ".omp", "plugins", "cache", "plugins", "display-name-skill");
 		await fs.mkdir(pluginsDir, { recursive: true });
@@ -417,12 +420,11 @@ describe("listClaudePluginRoots", () => {
 		);
 
 		const commands = await loadSlashCommands({ cwd: tempDir });
-		// Skill is registered by directory basename so `/understand` resolves,
-		// even though the frontmatter `name` is the multi-word display label.
-		const found = commands.find(command => command.name === "understand");
-		expect(found?.description).toBe("Build an understanding graph");
+		expect(commands.find(command => command.name === "understand")).toBeUndefined();
 		expect(commands.find(command => command.name === "Understand Anything")).toBeUndefined();
-		expect(expandSlashCommand("/understand", commands)).toContain("Analyze the project.");
+
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		expect(skills.all.find(skill => skill.name === "Understand Anything")).toBeDefined();
 	});
 
 	test("reads slash commands directory from plugin manifest slash-commands field", async () => {


### PR DESCRIPTION
Closes #2645 — removes the plugin skill-as-bare-slash-command mirroring (reverts #2415); skills surface only as skills.