### PR TITLE
feat(coding-agent/eval): added return_handle to agent() for DAG handle piping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the `eval` `agent()` helper to accept `return_handle` (Python) / `returnHandle` (JS): instead of bare text it returns a DAG node dict `{ text, output, handle, id, agent }` whose `handle` is the spawned agent's recoverable `agent://<id>` URI, so a downstream `pipeline`/`parallel` stage can wire a large transcript by reference instead of re-inlining it. The default path is unchanged (bare text, or the parsed object under `schema`).
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/eval/__tests__/prelude-agent.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/prelude-agent.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import * as vm from "node:vm";
+import { JAVASCRIPT_PRELUDE_SOURCE } from "../js/shared/prelude";
+
+/**
+ * The eval `agent()` helper grows a `returnHandle` option that turns its bare
+ * text result into a DAG node dict carrying the spawned agent's recoverable
+ * `agent://<id>` handle, so a downstream `pipeline`/`parallel` stage can wire
+ * the transcript by reference instead of re-inlining it. These lock the node
+ * shape, backward compatibility of the default path, the schema interaction,
+ * and the no-`details` fallback (the helper must never throw).
+ *
+ * The prelude source is executed verbatim in a throwaway VM context with only
+ * the host bridge (`__omp_call_tool__`) stubbed — no worker, no kernel — so the
+ * test runs against the real shipped helper, not a re-implementation.
+ */
+function loadPrelude(callTool: (name: string, args: unknown) => Promise<unknown>): Record<string, unknown> {
+	const sandbox: Record<string, unknown> = { __omp_call_tool__: callTool };
+	vm.createContext(sandbox);
+	vm.runInContext(JAVASCRIPT_PRELUDE_SOURCE, sandbox);
+	return sandbox;
+}
+
+type AgentHelper = (prompt: string, opts?: Record<string, unknown>) => Promise<unknown>;
+
+describe("eval js agent() returnHandle", () => {
+	it("returns a DAG node carrying the agent:// handle when returnHandle is set", async () => {
+		let seenName: string | undefined;
+		const sandbox = loadPrelude(async name => {
+			seenName = name;
+			return { text: "hello world", details: { agent: "task", id: "abc123", model: "m", structured: false } };
+		});
+		const node = await (sandbox.agent as AgentHelper)("say hi", { returnHandle: true });
+		expect(seenName).toBe("__agent__");
+		expect(node).toEqual({
+			text: "hello world",
+			output: "hello world",
+			handle: "agent://abc123",
+			id: "abc123",
+			agent: "task",
+		});
+	});
+
+	it("returns bare text by default (backward compatible)", async () => {
+		const sandbox = loadPrelude(async () => ({
+			text: "hello world",
+			details: { agent: "task", id: "abc123", structured: false },
+		}));
+		const out = await (sandbox.agent as AgentHelper)("say hi");
+		expect(out).toBe("hello world");
+	});
+
+	it("carries the parsed object under data when schema and returnHandle combine", async () => {
+		const payload = JSON.stringify({ k: 1 });
+		const sandbox = loadPrelude(async () => ({
+			text: payload,
+			details: { agent: "task", id: "id-9", structured: true },
+		}));
+		const node = (await (sandbox.agent as AgentHelper)("emit", {
+			schema: { type: "object" },
+			returnHandle: true,
+		})) as Record<string, unknown>;
+		expect(node.handle).toBe("agent://id-9");
+		expect(node.data).toEqual({ k: 1 });
+		expect(node.text).toBe(payload);
+	});
+
+	it("falls back to a null handle without throwing when the bridge omits details", async () => {
+		const sandbox = loadPrelude(async () => ({ text: "lonely" }));
+		const node = await (sandbox.agent as AgentHelper)("x", { returnHandle: true });
+		expect(node).toEqual({ text: "lonely", output: "lonely", handle: null, id: null, agent: null });
+	});
+});

--- a/packages/coding-agent/src/eval/js/shared/prelude.txt
+++ b/packages/coding-agent/src/eval/js/shared/prelude.txt
@@ -117,10 +117,19 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 	};
 
 	const agent = async (prompt, opts, ...rest) => {
-		const o = optionsArg("agent", opts, rest, ["agentType", "model", "label", "schema"], "{ agentType, model, label, schema }");
-		const res = await globalThis.__omp_call_tool__("__agent__", { prompt, ...o });
+		const o = optionsArg("agent", opts, rest, ["agentType", "model", "label", "schema"], "{ agentType, model, label, schema, returnHandle }");
+		const { returnHandle, ...callArgs } = o;
+		const res = await globalThis.__omp_call_tool__("__agent__", { prompt, ...callArgs });
 		const text = res && typeof res === "object" ? res.text : res;
-		return hasOwn(o, "schema") ? JSON.parse(text) : text;
+		const parsed = hasOwn(callArgs, "schema") ? JSON.parse(text) : text;
+		if (!returnHandle) return parsed;
+		const details = res && typeof res === "object" ? res.details : undefined;
+		if (!details || typeof details !== "object" || details.id == null) {
+			return { text, output: text, handle: null, id: null, agent: null };
+		}
+		const node = { text, output: text, handle: `agent://${details.id}`, id: details.id, agent: details.agent ?? null };
+		if (hasOwn(callArgs, "schema")) node.data = parsed;
+		return node;
 	};
 
 	// Pool ceiling mirrors the task tool's `task.maxConcurrency` setting so an

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -519,7 +519,7 @@ if "__omp_prelude_loaded__" not in globals():
         text = res.get("text") if isinstance(res, dict) else res
         return json.loads(text) if schema is not None else text
 
-    def agent(prompt, *, agent_type="task", model=None, label=None, schema=None):
+    def agent(prompt, *, agent_type="task", model=None, label=None, schema=None, return_handle=False):
         """Run a subagent and return its final output.
 
         `agent_type` selects the subagent definition (default "task"). Pass
@@ -527,6 +527,15 @@ if "__omp_prelude_loaded__" not in globals():
         id, and `schema` to request structured JSON output; when `schema` is
         supplied the parsed object is returned. Share background by writing a
         local:// file and referencing it in the prompt.
+
+        Set `return_handle=True` to receive a DAG node dict instead of bare
+        text: ``{"text", "output", "handle", "id", "agent"}`` where ``handle``
+        is the spawned agent's recoverable ``agent://<id>`` URI. A downstream
+        ``pipeline``/``parallel`` stage embeds that ``handle`` (or ``output``)
+        in its prompt so a large transcript flows through the graph by
+        reference, never re-inlined. When ``schema`` is also set the parsed
+        object lands under ``"data"``. If the bridge returns no recoverable id
+        the node still resolves with ``handle=None`` — the helper never throws.
         """
         args = {"prompt": prompt}
         if agent_type is not None:
@@ -539,7 +548,22 @@ if "__omp_prelude_loaded__" not in globals():
             args["schema"] = schema
         res = _bridge_call("__agent__", args)
         text = res.get("text") if isinstance(res, dict) else res
-        return json.loads(text) if schema is not None else text
+        parsed = json.loads(text) if schema is not None else text
+        if not return_handle:
+            return parsed
+        details = res.get("details") if isinstance(res, dict) else None
+        if not isinstance(details, dict) or details.get("id") is None:
+            return {"text": text, "output": text, "handle": None, "id": None, "agent": None}
+        node = {
+            "text": text,
+            "output": text,
+            "handle": f"agent://{details['id']}",
+            "id": details["id"],
+            "agent": details.get("agent"),
+        }
+        if schema is not None:
+            node["data"] = parsed
+        return node
 
     def _concurrency_limit():
         """Worker-pool ceiling from the host ``task.maxConcurrency`` setting.

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -41,9 +41,9 @@ tool.<name>(args) → unknown
     Invoke any session tool; `args` is its parameter object.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot stateless completion (no history, no tools). `model` tier: "smol" (fast) | "default" (session model) | "slow" (most capable). JSON-Schema `schema` forces structured output, returns parsed object.
-{{#if spawns}}agent(prompt, agent_type?="task", model?=None, label?=None, schema?=None) → str | dict
-    Run a subagent, return its final output. `agent_type`/`agentType` picks another discovered agent; `schema` as in completion(). Share background via `local://` files referenced in the prompt.
-{{#if js}}    JS: options are ONE trailing object — agent(prompt, { agentType, schema }).
+{{#if spawns}}agent(prompt, agent_type?="task", model?=None, label?=None, schema?=None, return_handle?=False) → str | dict
+    Run a subagent, return its final output. `agent_type`/`agentType` picks another discovered agent; `schema` as in completion(). Share background via `local://` files referenced in the prompt. `return_handle`/`returnHandle` → a DAG node dict { text, output, handle: "agent://<id>", id, agent } (parsed object under `data` when `schema` set) so a downstream stage references the transcript by handle instead of re-inlining it.
+{{#if js}}    JS: options are ONE trailing object — agent(prompt, { agentType, schema, returnHandle }).
 {{/if}}
 {{/if}}
 parallel(thunks) → list
@@ -58,3 +58,13 @@ budget → per-turn token budget
     {{#if py}}`budget.total` (ceiling or None), `budget.spent()`, `budget.remaining()` (math.inf when no ceiling), `budget.hard` (bool).{{/if}}{{#if js}}`await budget.total()` (ceiling or null), `await budget.spent()`, `await budget.remaining()` (Infinity when no ceiling), `await budget.hard()`.{{/if}} Ceiling comes from a `+Nk` directive (advisory) or `+Nk!`/Goal Mode (hard — `agent()` refuses to spawn past it); otherwise None/null, spend still tracked across the turn.
 ```
 </prelude>
+{{#if spawns}}
+<dag>
+Build a dependency graph by piping handles through the stage helpers — ephemeral, in-session, acyclic waves:
+- **Name nodes.** Capture each `agent(..., {{#if py}}return_handle=True{{/if}}{{#if js}}{ returnHandle: true }{{/if}})` result; it carries `handle` (`agent://<id>`) + `output`.
+- **Wire edges by reference.** Embed an upstream node's `handle` or `output` in the dependent stage's prompt so a large transcript flows by reference, never re-inlined. For bulk artifacts, `write("local://<name>.md", …)` and pass the URI.
+- **`pipeline(items, *stages)` = staged waves** with a barrier between stages (every item clears stage N before any enters stage N+1) — the linear spine of a DAG. **`parallel(thunks)` = one wave** of independent nodes.
+- **Isolate failure.** A raising node re-raises the lowest-index error and aborts its wave; wrap each risky node in try/except so a failed node degrades only its dependent subtree while independent branches still finish.
+- **Acyclic only.** A node never waits on its own descendant; cycles are an authoring bug, not a supported pattern.
+</dag>
+{{/if}}


### PR DESCRIPTION
## Summary
Adds an optional `return_handle` (Python) / `returnHandle` (JS) flag to the `eval` `agent()` helper. Instead of bare text it returns a DAG node dict `{ text, output, handle, id, agent }` whose `handle` is the spawned agent's recoverable URI, so a downstream `pipeline`/`parallel` stage can wire a large transcript by reference rather than re-inlining it. The default path is unchanged (bare text, or the parsed object under `schema`).

## Tests
VM-level prelude regression test for the node shape, the schema interaction, and the no-details fallback; `bun check` green.

Closes #2654