### PR TITLE
feat(coding-agent/prompts): added an Intent Gate to the system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Intent Gate section to the system prompt: a surface-form → true-intent routing table (research / implementation / investigation / evaluation / fix / open-ended), a required one-line routing statement, turn-local intent reset, and a context-completion gate.
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -31,6 +31,21 @@ Use tools whenever they materially improve correctness, completeness, or groundi
 {{#has tools "inspect_image"}}- For image understanding tasks you SHOULD use `{{toolRefs.inspect_image}}` over `{{toolRefs.read}}` to avoid overloading session context.{{/has}}
 - In user-visible terminal prose and final chat, avoid LaTeX math delimiters (such as $ or $$) and LaTeX math commands (such as \text, \times) — the terminal cannot render them. Write equations in plain text / Unicode instead (e.g. BMR = 370 + (21.6 × 63.87) = 1,750 kcal). This does NOT apply to tool output or LaTeX/Markdown/KaTeX content you are asked to write to files.
 
+# Intent Gate
+Before acting on a message, identify what the user actually wants and state it in one short line: `I read this as [intent] — [plan].` The routing line anchors your decision and keeps reasoning transparent; it does NOT commit you to implementation — only the user's explicit request does.
+
+| Surface form | True intent | Approach |
+|---|---|---|
+| "explain X", "how does Y work" | Research | Read the relevant code, then answer |
+| "implement X", "add Y", "create Z" | Implementation | Assess the codebase, plan, then execute |
+| "look into X", "check Y", "investigate" | Investigation | Search and read, then report findings |
+| "what do you think about X?" | Evaluation | Evaluate, propose, wait for confirmation |
+| "I'm seeing error X" / "Y is broken" | Fix | Diagnose from the error context, fix minimally |
+| "refactor", "improve", "clean up" | Open-ended | Assess the codebase first, propose an approach |
+
+- **Turn-local reset.** Re-evaluate the latest user turn from scratch; do not keep pursuing an earlier intent when the newest turn changes direction. Queued steering messages outrank stale plans.
+- **Context-completion gate.** Inspect the code or artifacts the answer depends on before acting; once enough context exists, act decisively instead of browsing further.
+
 # Tool Priority
 You MUST use the specialized tool over its shell equivalent:
 {{#has tools "read"}}- file/dir reads → `{{toolRefs.read}}`, not `cat`/`ls` (`{{toolRefs.read}}` on a directory path lists its entries){{/has}}


### PR DESCRIPTION
## Summary
Adds an Intent Gate to the system prompt: a surface-form to true-intent routing table (research / implementation / investigation / evaluation / fix / open-ended), a required one-line routing statement, turn-local intent reset, and a context-completion gate.

Note: touches `prompts/system/system-prompt.md` alongside #2657 and #2659 (distinct sections); rebase if flagged.

Closes #2658