### PR TITLE
feat(coding-agent/modes): upgraded the workflowz keyword into a delegate-first DAG execution mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the `workflowz` hidden notice into a delegate-first DAG execution contract (certainty-before-code, skill survey, plan-agent gate, delegate-as-a-DAG with `eval` `pipeline`/`parallel`, scenario contract, evidence-bound manual QA, TDD, reviewer gate). It references only bundled agents and does not change thinking effort.
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1341,7 +1341,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			group: "Magic Keywords",
 			label: "Workflow Keyword",
-			description: "Let standalone workflowz append its hidden eval workflow notice",
+			description:
+				"Let a standalone workflowz keyword enter the delegate-first DAG execution mode (decompose and fan work over subagents as an acyclic graph; scenario contract, evidence-bound QA, reviewer gate)",
 		},
 	},
 

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -31,7 +31,7 @@ export function highlightMagicKeywords(text: string, resetTo?: string, phase?: n
 /**
  * Cheap test for "does this text contain any magic keyword as standalone prose?".
  * Short-circuits on a substring probe before paying for the markdown-aware
- * prose check, so the common "no keyword in buffer" path is just three
+ * prose check, so the common "no keyword in buffer" path is three
  * `String#indexOf`s. Used by the live editor to gate the shimmer timer.
  */
 export function hasMagicKeyword(text: string): boolean {

--- a/packages/coding-agent/src/modes/workflow.ts
+++ b/packages/coding-agent/src/modes/workflow.ts
@@ -5,32 +5,34 @@ import { keywordInProse } from "./markdown-prose";
 /**
  * "workflowz" keyword support.
  *
- * Typing the standalone word in the input editor paints it with a warm
+ * Typing the standalone keyword in the input editor paints it with a warm
  * amber→green gradient ({@link highlightWorkflow}); submitting a message that
- * mentions it appends a hidden {@link WORKFLOW_NOTICE} that steers the model to
- * author a deterministic multi-subagent workflow in eval cells (agent/parallel/
- * pipeline). Matching is whitespace-delimited and case-sensitive (lowercase
- * only) — "workflowz" triggers, but "workflowzed", "Workflowz", and
- * "workflowz.ts" never do.
+ * mentions it appends a hidden {@link WORKFLOW_NOTICE} that steers the model
+ * into a delegate-first DAG execution mode (decompose the task and fan the work
+ * over subagents as an acyclic graph) whose fan-out mechanism is the `eval`
+ * runtime (agent/parallel/pipeline). The notice does NOT change thinking
+ * effort. Matching is whitespace-delimited and case-sensitive (lowercase only)
+ * — "workflowz" triggers, but "Workflowz", "workflowzed", and "workflowz.ts"
+ * never do.
  */
 
-// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
+// Detection: the lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
 const WORKFLOW_WORD = /(?<!\S)workflowz(?!\S)/;
 
-/** Hidden system notice appended after a user message that mentions "workflowz". */
+/** Hidden system notice appended after a user message that mentions the keyword. */
 export const WORKFLOW_NOTICE: string = workflowNotice.trim();
 
 /**
- * Whether `text` contains the standalone keyword "workflowz"
- * (lowercase, whitespace-delimited) in prose — never inside a code block, inline
- * code span, or XML/HTML section.
+ * Whether `text` contains the standalone `workflowz` keyword (lowercase,
+ * whitespace-delimited) in prose — never inside a code block, inline code span,
+ * or XML/HTML section.
  */
 export function containsWorkflow(text: string): boolean {
 	return keywordInProse(text, WORKFLOW_WORD);
 }
 
 /**
- * Highlight every standalone "workflowz" in `text` for editor display
+ * Highlight every standalone `workflowz` keyword in `text` for editor display
  * with a warm amber→green gradient (hue 30..150), visually distinct from
  * ultrathink's rainbow and orchestrate's teal→violet.
  */

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -1,70 +1,37 @@
 <system-notice>
-The user's message above contains the **workflowz** keyword: drive this task as a deterministic multi-subagent workflow. Author the orchestration as Python in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+The user's message above contains the **workflowz** keyword. Drive this task as a delegate-first DAG: decompose it, fan the work over subagents as an acyclic graph, and prove every claim with evidence. This contract overrides any default tendency to do the whole task inline, to yield after one phase, or to call work done on "it should pass". It does NOT change your thinking effort — reason exactly as you otherwise would; the keyword buys discipline and fan-out, not a larger thinking budget.
 
-<when>
-Worth it when the task benefits from decomposition + parallel coverage, or from independent/adversarial cross-checking before you commit. For a quick lookup or single edit, just do it directly — don't spin up agents. Scout inline FIRST (list the files, scope the diff, find the call sites) to discover the work-list, then fan out over it — you don't need to know the shape before the *task*, only before the *fan-out*. Common shapes, each a well-scoped `eval` call you can chain across turns:
-- **Understand** — parallel readers over subsystems → structured map
-- **Design** — judge panel of N independent approaches → scored synthesis
-- **Review** — split into dimensions → find per dimension → adversarially verify each finding
-- **Research** — multi-modal sweep → deep-read the hits → synthesize
-- **Migrate** — discover sites → transform each → verify
-</when>
+## 1. Certainty before code
+Do not touch the tree until you can state the user's true intent and the shape of the change. When unsure, INVESTIGATE — `read` the files, `search` the call sites, `lsp references`/`lsp definition` the symbols, dispatch `task` `agent: explore` for an unknown subsystem — or ask one sharp question. Not-ready signals: you are guessing at requirements, you have not located the code you will change, or two readings of the request disagree. Resolve them before editing.
 
-<helpers>
-State persists across cells, so scout in one cell and fan out in the next. Every cell has:
+## 2. Survey skills first
+Before exploring or planning, enumerate the skills available this session and read the description of each one even loosely relevant to the task. State the chosen skills with a one-line reason each, then act. A skill that matches the task and goes unused is a defect.
 
-- `agent(prompt, *, agent_type="task", model=None, label=None, schema=None)` — run ONE subagent; returns its final text, or the validated object when `schema` (a JSON Schema dict) is given. With `schema` the subagent is forced to emit structured output that is validated for you — branch on the object, not on parsed prose. `agent_type` picks a discovered agent ("explore", "reviewer", "oracle", …); `label` names the artifact. Shared background goes in a `local://` file referenced from each prompt, not a parameter. Subagents are told their final text IS the return value, so they hand back raw data. `agent()` blocks until the subagent finishes; eval-spawned agents nest at most 3 deep.
-- `parallel(thunks)` — run zero-arg callables concurrently through a bounded pool, preserving input order; returns once all finish. The pool is bounded by the session's `task` concurrency — don't hand-tune it; fan out as wide as the work divides. A thunk that raises propagates — wrap risky work in `try/except` inside the thunk to keep partial results. In a loop, bind each closure's value with a default arg (`lambda d=d: …`) or every thunk captures the last one.
-- `pipeline(items, *stages)` — map items through `stages` left-to-right. There is a BARRIER between stages: ALL items clear stage N before stage N+1 begins. Each stage is a one-arg callable; stage 1 gets the original item, later stages get the previous result. Same pool width as `parallel()`.
-- `completion(prompt, *, model="default", system=None, schema=None)` — oneshot, stateless model call (no tools, no history). Tiers: "smol", "default", "slow". Cheap classification/scoring inside a fan-out.
-- `log(message)` — emit a progress line above the status tree. `phase(title)` — start a phase; the status lines that follow group under it.
-- `budget` — `budget.total` (output-token ceiling, or `None` when none is set), `budget.spent()` (tokens spent this turn — main loop + eval subagents), `budget.remaining()` (`math.inf` when total is `None`), `budget.hard` (whether it's enforced). A ceiling is set by the user: `+Nk` in their message is advisory (you self-limit via `budget.remaining()`), `+Nk!` (or Goal Mode) is hard — `agent()` refuses to spawn once spent reaches it. Gate loops on `budget.total` first, since it's `None` when the user set no budget.
+## 3. Plan-agent gate
+Any 2+-step, multi-file, unclear-scope, or architectural task: dispatch `task` `agent: plan` BEFORE writing code. Then execute in the exact wave ordering and parallel grouping it returns, running the verification it defines per task — treat its plan as the DAG; do not invent your own ordering or skip its checks. A genuinely trivial single edit may skip this gate.
 
-Everything runs INLINE and synchronously inside the eval call — no background mode, no resume, no separate progress app. Each eval call is one well-scoped fan-out; chain several across cells and turns for multi-phase work, reading each result before you decide the next phase.
-</helpers>
+## 4. Delegate as a DAG
+Substantial or parallelizable work goes through subagents; a trivial self-contained edit is yours to make inline. Discipline:
+- **Parallelize maximally.** Every set of edits with disjoint file scope ships as parallel `task` calls in one message — fan as wide as the work divides. About to dispatch exactly one subagent? Either find what runs alongside it, or make the edit yourself.
+- **Self-contained assignments.** Each `task` brief names target files (explicit paths, no globs), the change with APIs/patterns, edge cases, and observable acceptance criteria. Subagents share no context with you.
+- **Subagents skip gates.** Instruct every subagent to skip lint/format/typecheck/test; YOU run the gate once per wave across the union of changed files.
+- **Verify each wave** before launching the next; dispatch fix-up subagents on a red gate, never advance on red.
+- **Respawn, do not absorb.** Incomplete or wrong subagent output → a corrective subagent with the specific gap, never a silent self-fix.
+- **No scope creep, no scope shrink.** Never add unrequested work; never relabel unfinished work as "v1" / "MVP" / "follow-up".
+- **Wire the graph with `eval`.** Author waves as `eval` `pipeline`/`parallel` over `agent(...)`; pass an upstream node's `agent://` handle or `output` into the dependent stage's prompt so large transcripts flow by reference, not re-inlined; wrap each node in try/except so a failed node isolates to its dependent subtree while independent branches still finish. Acyclic only — a node never waits on its own descendant.
 
-<structure>
-For independent per-item chains (review → verify, fetch → extract → score), wrap the WHOLE chain in one function and run it with `parallel()` — then each item flows through its own steps without waiting on the others:
+## 5. Scenario contract
+Before writing code, define 3+ scenarios, each with a binary observable pass condition ("returns 200 + body matches schema", not "should work"), covering happy path, edge/boundary, regression (existing behavior still holds), and adversarial/abuse where relevant. These scenarios are the contract; you are not done until every one passes with captured evidence.
 
-    DIMENSIONS = [{"key": "bugs", "prompt": "…"}, {"key": "perf", "prompt": "…"}]
-    def review_and_verify(d):
-        found = agent(d["prompt"], label=f"review:{d['key']}", schema=FINDINGS_SCHEMA)
-        return parallel([lambda f=f: {**f, "verdict": agent(
-            f"Refute if you can (default refuted when unsure): {f['title']}",
-            label=f"verify:{f['file']}", schema=VERDICT_SCHEMA)} for f in found["findings"]])
-    phase("Review")
-    results = parallel([lambda d=d: review_and_verify(d) for d in DIMENSIONS])
-    confirmed = [f for group in results for f in group if f["verdict"]["is_real"]]
+## 6. Evidence-bound manual QA
+Tests alone never prove done. For each scenario, name the EXACT tool and invocation — the literal `bash` command, `curl`, `browser` action, or `eval` call — with concrete inputs and the binary observable, run it, and capture the real-surface artifact (output, screenshot, response). "Run it" / "open the page" is not a scenario. The moment a QA step spawns a resource (process, port, temp dir, browser/agent session), add a paired teardown todo and execute it before declaring done.
 
-Reach for `pipeline()` only when a stage genuinely needs ALL of the previous stage first — dedup/merge across the whole set, early-exit on zero, or "compare against the other findings" — because its inter-stage barrier makes every item wait for the slowest peer:
+## 7. TDD: RED → GREEN → SURFACE
+Every behavior change is test-first. Write the failing test, run it, confirm it fails for the RIGHT reason; write production code to GREEN; then capture the real-surface artifact. Refactors: write characterization tests pinning current behavior and keep them green throughout. Exemption whitelist (no new test required): pure formatting, comment-only edits, no-behavior dependency bumps, rename-only moves — each justified explicitly. Typed production code with no preceding failing test → stop, revert, write the test, redo.
 
-    phase("Find")
-    found = parallel([lambda d=d: agent(d["prompt"], schema=FINDINGS_SCHEMA) for d in DIMENSIONS])
-    findings = dedupe([f for r in found for f in r["findings"]])   # needs everything at once
-    phase("Verify")
-    verdicts = parallel([lambda f=f: agent(verify_prompt(f), schema=VERDICT_SCHEMA) for f in findings])
+## 8. Reviewer gate
+Trigger when ANY apply: the task touches 3+ files, is a refactor / migration / perf / security change, or the user said "rigorously" / "properly" / "deeply". Dispatch `task` `agent: reviewer` against the diff (goal + scenarios + evidence), or `task` `agent: oracle` for a deep second opinion on a hard call. Address every confirmed finding before yielding.
 
-Don't add a barrier just to flatten/map/filter — do that with plain Python between calls. Nested `parallel()` pools each cap independently, so keep total fan-out sane.
-</structure>
-
-<patterns>
-Compose the harness the task calls for:
-- **Adversarial verify** — N independent skeptics per finding, each prompted to REFUTE; keep it only if a majority survive. `votes = parallel([lambda i=i: agent(f"Refute: {claim}. refuted=true if unsure.", schema=VERDICT) for i in range(3)])`, then keep when `sum(not v["refuted"] for v in votes) ≥ 2`.
-- **Perspective-diverse verify** — give each verifier a distinct lens (correctness, security, perf, does-it-reproduce) instead of N identical refuters.
-- **Judge panel** — N attempts from different angles, scored by parallel judges; synthesize from the winner, graft the best of the rest.
-- **Loop-until-dry** — for unknown-size discovery, keep spawning finders until K consecutive rounds surface nothing new; dedup against everything SEEN, not just what was confirmed, or it never converges.
-- **Multi-modal sweep** — parallel finders each searching a different way (by-container, by-content, by-entity, by-time), each blind to the others.
-- **Completeness critic** — a final agent that asks "what's missing — modality not run, claim unverified, file unread?"; its answer is the next round.
-- **Budget/count loops** — `while len(bugs) < 10:` to hit a target, or `while budget.total and budget.remaining() > 50_000:` to scale depth to the turn budget; `log()` each round.
-- **No silent caps** — if you bound coverage (top-N, no-retry, sampling), `log()` what you dropped; silent truncation reads as "covered everything" when it didn't.
-
-Scale to the ask: "find any bugs" → a few finders, single-vote verify. "thoroughly audit / be comprehensive" → larger finder pool, 3–5-vote adversarial pass, a synthesis stage.
-</patterns>
-
-<execution>
-- Decompose the surface first; capture it in `todo` when it spans phases.
-- Prefer `schema=` for any agent whose output you branch on.
-- After a fan-out returns, YOU own correctness: read the artifacts, run the gate, verify before acting. Subagents do the legwork; they don't get the last word.
-- Keep going until the task is closed — a returned fan-out is a step, not a stopping point.
-</execution>
+## 9. Fan-out toolkit
+The delegation mechanism is the `eval` runtime (full helper reference lives in the `eval` tool description): `agent()` (one subagent; `schema=` to branch on a validated object; `return_handle` for a DAG node carrying the `agent://` handle), `parallel()` (one wave), `pipeline()` (staged waves, barrier between stages), `completion()` (cheap stateless scoring inside a fan-out), plus `budget`/`log`/`phase`. Compose the harness the task calls for — **adversarial-verify** (N skeptics per finding, each prompted to refute, keep on majority survive), **judge-panel** (N approaches scored by parallel judges, synthesize the winner), **loop-until-dry** (keep spawning finders until K rounds surface nothing new, dedup against everything seen). Scale fan-out to the ask. A returned fan-out is a step, not a stopping point — keep going until every scenario passes.
 </system-notice>

--- a/packages/coding-agent/test/modes/workflow.test.ts
+++ b/packages/coding-agent/test/modes/workflow.test.ts
@@ -8,11 +8,9 @@ beforeAll(() => {
 });
 
 describe("workflow keyword detection", () => {
-	it("matches the lowercase trigger word delimited by whitespace", () => {
+	it("matches the standalone workflowz keyword delimited by whitespace", () => {
 		expect(containsWorkflow("workflowz")).toBe(true);
 		expect(containsWorkflow("please workflowz this rollout")).toBe(true);
-		expect(containsWorkflow("design the workflowz")).toBe(true);
-		expect(containsWorkflow("run these workflowz")).toBe(true);
 	});
 
 	it("ignores old triggers, casing, inflections, punctuation-adjacent, and path-embedded forms", () => {
@@ -48,9 +46,17 @@ describe("workflow keyword highlighting", () => {
 });
 
 describe("workflow notice", () => {
-	it("is a non-empty system notice carrying the eval-fan-out contract", () => {
+	it("carries the DAG execution contract and does not change thinking effort", () => {
 		expect(WORKFLOW_NOTICE.length).toBeGreaterThan(0);
 		expect(WORKFLOW_NOTICE).toContain("**workflowz** keyword");
+		expect(WORKFLOW_NOTICE).toContain("does NOT change your thinking effort");
 		expect(WORKFLOW_NOTICE).toContain("parallel(");
+	});
+
+	it("references only bundled agents (no critic / deep_task)", () => {
+		expect(WORKFLOW_NOTICE).toContain("agent: plan");
+		expect(WORKFLOW_NOTICE).toContain("agent: reviewer");
+		expect(WORKFLOW_NOTICE).not.toContain("critic");
+		expect(WORKFLOW_NOTICE).not.toContain("deep_task");
 	});
 });


### PR DESCRIPTION
## Summary
Rewrites the `workflowz` magic keyword's hidden notice into a delegate-first DAG execution contract: decompose the task and fan the work over subagents as an acyclic graph (via the `eval` `pipeline`/`parallel` runtime with handle piping), with certainty-before-code, a skill survey, a plan-agent gate, a scenario contract, evidence-bound manual QA, TDD, and a reviewer gate. It references only bundled agents and does NOT change thinking effort.

## Tests
Detection / highlight / notice-contract regression test; `bun check` green.

Depends on #2662.
Closes #2670.