### PR TITLE
feat: configurable Bedrock User-Agent header

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -283,6 +283,11 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 				requestHeaders = { ...baseHeaders, ...signed };
 			}
 
+			const bedrockUserAgent = $env.BEDROCK_USER_AGENT;
+			if (bedrockUserAgent) {
+				requestHeaders["user-agent"] = bedrockUserAgent;
+			}
+
 			// Bun's native fetch ceiling is disabled below (`timeout: false`) so
 			// configurable watchdogs govern slow-prefill streams (issue #2422).
 			// Direct callers that bypass `register-builtins` (which installs the

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4217,6 +4217,16 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
+	"providers.bedrockUserAgent": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Bedrock User Agent",
+			description: "Custom User-Agent header for AWS Bedrock requests (e.g. claude-cli/2.1.112 (external, cli))",
+		},
+	},
 
 	// Exa
 	"exa.enabled": {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1182,6 +1182,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		setPreferredImageProvider(imageProvider);
 	}
 
+	const bedrockUserAgent = settings.get("providers.bedrockUserAgent");
+	if (bedrockUserAgent) {
+		Bun.env.BEDROCK_USER_AGENT = bedrockUserAgent;
+	}
+
 	const sessionManager =
 		options.sessionManager ??
 		logger.time("sessionManager", () =>


### PR DESCRIPTION
## What

Adds a configurable User-Agent header for Amazon Bedrock requests, settable via:
- env var `BEDROCK_USER_AGENT`, or
- setting `providers.bedrockUserAgent` (Providers tab -> Services), which is mapped onto the env var at startup.

When set, the value is injected as the `user-agent` request header on the Bedrock `fetch` POST, after both the SigV4 and bearer auth branches build their headers.

## Why

The Bedrock provider constructs its request headers directly and has no `modelHeaders` plumbing (that mechanism is Anthropic-provider-only). There is currently no way to override the User-Agent on Bedrock calls. Enterprise deployments that front Bedrock with a gateway/proxy frequently route, throttle, or audit by User-Agent, so a configurable value is needed to integrate with them.

## Notes

- The header is applied *after* the auth headers are built and is intentionally not part of the SigV4 canonical request. AWS SigV4 does not sign `user-agent`, so injecting it post-signing is correct and does not break request signing.
- No-op when unset: the default `""` leaves the provider's existing behavior untouched.

## Files
- `packages/ai/src/providers/amazon-bedrock.ts` -- inject `user-agent` from `$env.BEDROCK_USER_AGENT`
- `packages/coding-agent/src/config/settings-schema.ts` -- `providers.bedrockUserAgent` setting
- `packages/coding-agent/src/sdk.ts` -- map the setting onto the env var at startup