### PR TITLE
feat: add DuckDuckGo web search provider (keyless fallback)

### DIFF
--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -94,6 +94,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.searxng,
 		load: async () => new (await import("./providers/searxng")).SearXNGProvider(),
 	},
+	duckduckgo: {
+		id: "duckduckgo",
+		label: SEARCH_PROVIDER_LABELS.duckduckgo,
+		load: async () => new (await import("./providers/duckduckgo")).DuckDuckGoProvider(),
+	},
 };
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -1,0 +1,129 @@
+/**
+ * DuckDuckGo Web Search Provider
+ *
+ * Zero-config fallback that scrapes DuckDuckGo's HTML endpoint.
+ * No API key required. Always available as the last-resort provider.
+ */
+import { parseHTML } from "linkedom";
+import type { SearchResponse, SearchSource } from "../types";
+import { SearchProviderError } from "../types";
+import { clampNumResults } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+
+const DDG_HTML_URL = "https://html.duckduckgo.com/html/";
+const DEFAULT_NUM_RESULTS = 10;
+const MAX_NUM_RESULTS = 25;
+const USER_AGENT =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+interface DdgRawResult {
+	title: string;
+	url: string;
+	snippet?: string;
+}
+
+/** Extract the real URL from a DDG redirect link. */
+function extractUrl(href: string): string | undefined {
+	// DDG wraps results in //duckduckgo.com/l/?uddg=<encoded_url>&rut=...
+	try {
+		// Handle protocol-relative URLs
+		const absolute = href.startsWith("//") ? `https:${href}` : href;
+		const parsed = new URL(absolute);
+		const uddg = parsed.searchParams.get("uddg");
+		if (uddg) return uddg;
+	} catch {
+		// Not a redirect link — fall through to the raw-href check below.
+	}
+	if (href.startsWith("http")) return href;
+	return undefined;
+}
+
+/** Strip HTML tags from a string. */
+function stripHtml(html: string): string {
+	return html.replace(/<[^>]*>/g, "").trim();
+}
+
+/** Fetch and parse DuckDuckGo HTML search results. */
+async function fetchDdgResults(query: string, numResults: number, signal?: AbortSignal): Promise<DdgRawResult[]> {
+	const body = new URLSearchParams({ q: query });
+
+	const response = await fetch(DDG_HTML_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			"User-Agent": USER_AGENT,
+		},
+		body: body.toString(),
+		signal,
+	});
+
+	if (!response.ok) {
+		throw new SearchProviderError("duckduckgo", `DuckDuckGo returned HTTP ${response.status}`, response.status);
+	}
+
+	const html = await response.text();
+	const { document } = parseHTML(html);
+	const results: DdgRawResult[] = [];
+
+	const resultElements = document.querySelectorAll(".result");
+	for (const el of resultElements) {
+		if (results.length >= numResults) break;
+
+		const linkEl = el.querySelector("a.result__a");
+		if (!linkEl) continue;
+
+		const href = linkEl.getAttribute("href");
+		if (!href) continue;
+
+		const url = extractUrl(href);
+		if (!url) continue;
+
+		const title = stripHtml(linkEl.innerHTML || "").replace(/\s+/g, " ") || url;
+		const snippetEl = el.querySelector("a.result__snippet, .result__snippet");
+		const snippet = snippetEl ? stripHtml(snippetEl.innerHTML || "").replace(/\s+/g, " ") : undefined;
+
+		results.push({ title, url, snippet });
+	}
+
+	return results;
+}
+
+/** Execute DuckDuckGo web search. */
+export async function searchDuckDuckGo(params: {
+	query: string;
+	num_results?: number;
+	signal?: AbortSignal;
+}): Promise<SearchResponse> {
+	const numResults = clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	const raw = await fetchDdgResults(params.query, numResults, params.signal);
+
+	const sources: SearchSource[] = raw.map(r => ({
+		title: r.title,
+		url: r.url,
+		snippet: r.snippet,
+	}));
+
+	return {
+		provider: "duckduckgo",
+		sources,
+	};
+}
+
+/** Search provider for DuckDuckGo (zero-config fallback). */
+export class DuckDuckGoProvider extends SearchProvider {
+	readonly id = "duckduckgo";
+	readonly label = "DuckDuckGo";
+
+	isAvailable(): boolean {
+		return true; // Always available — no API key needed
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchDuckDuckGo({
+			query: params.query,
+			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
+		});
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -19,6 +19,7 @@ export const SEARCH_PROVIDER_ORDER = [
 	"kagi",
 	"synthetic",
 	"searxng",
+	"duckduckgo",
 ] as const;
 
 /** Supported web search providers */
@@ -62,6 +63,7 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
+	{ value: "duckduckgo", label: "DuckDuckGo", description: "Free, no API key required (HTML scraping)" },
 ] as const;
 
 export const SEARCH_PROVIDER_LABELS: Record<SearchProviderId, string> = {
@@ -79,6 +81,7 @@ export const SEARCH_PROVIDER_LABELS: Record<SearchProviderId, string> = {
 	kagi: "Kagi",
 	synthetic: "Synthetic",
 	searxng: "SearXNG",
+	duckduckgo: "DuckDuckGo",
 };
 
 export function isSearchProviderId(value: string): value is SearchProviderId {


### PR DESCRIPTION
## What

Adds a `duckduckgo` web search provider that scrapes the `html.duckduckgo.com/html/` endpoint via `linkedom`. It is the only `web_search` provider that needs no API key and no self-hosted instance, so it serves as a zero-config fallback.

It is registered **last** in `SEARCH_PROVIDER_ORDER`, so the auto provider chain only falls through to it after all configured (keyed) providers are exhausted. `isAvailable()` returns `true` unconditionally.

## Why

Out of the box `web_search` requires either an API key (Tavily, Brave, Perplexity, Exa, Kagi, ...) or a self-hosted SearXNG. A user with no key configured gets nothing. A keyless DuckDuckGo fallback makes `web_search` work with zero setup.

## Notes / caveats

- **Best-effort**: it parses DuckDuckGo's HTML results page, so it depends on their current markup and may need maintenance if DDG changes their layout. It is intentionally the lowest-priority provider.
- Result URLs are extracted from DDG's `//duckduckgo.com/l/?uddg=` redirect wrapper and decoded to the real target.
- `numResults` is clamped (default 10, max 25) via the shared `clampNumResults` helper; non-OK responses throw `SearchProviderError("duckduckgo", ...)`.
- Provider-only: this PR does **not** add any result-summarization machinery; it returns sources like every other provider.

## Files
- `packages/coding-agent/src/web/search/providers/duckduckgo.ts` -- the provider
- `packages/coding-agent/src/web/search/types.ts` -- register in `SEARCH_PROVIDER_ORDER` / `_OPTIONS` / `_LABELS`
- `packages/coding-agent/src/web/search/provider.ts` -- lazy `PROVIDER_META` entry