### PR TITLE
fix(agent): restore eager nudges after compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed post-compaction auto-continuation to reassert eager task/todo reminders without forcing the todo tool choice on the resumed turn ([#2681](https://github.com/can1357/oh-my-pi/issues/2681)).
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -313,6 +313,11 @@ export type AgentSessionEvent =
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
+type EagerPreludeOptions = {
+	allowPriorUserMessages?: boolean;
+	suppressTodoToolChoice?: boolean;
+};
+
 const UNEXPECTED_STOP_MAX_RETRIES = 3;
 const UNEXPECTED_STOP_TIMEOUT_MS = 4000;
 const EMPTY_STOP_MAX_RETRIES = 3;
@@ -2147,6 +2152,20 @@ export class AgentSession {
 
 	#scheduleAutoContinuePrompt(generation: number): void {
 		const continuePrompt = async () => {
+			const eagerTodoPrelude = this.#createEagerTodoPrelude(autoContinuePrompt, {
+				allowPriorUserMessages: true,
+				suppressTodoToolChoice: true,
+			});
+			const eagerTaskPrelude = this.#createEagerTaskPrelude(autoContinuePrompt, {
+				allowPriorUserMessages: true,
+			});
+			const prependMessages: AgentMessage[] = [];
+			if (eagerTodoPrelude) {
+				prependMessages.push(eagerTodoPrelude.message);
+			}
+			if (eagerTaskPrelude) {
+				prependMessages.push(eagerTaskPrelude);
+			}
 			await this.#promptWithMessage(
 				{
 					role: "developer",
@@ -2155,7 +2174,10 @@ export class AgentSession {
 					timestamp: Date.now(),
 				},
 				autoContinuePrompt,
-				{ skipPostPromptRecoveryWait: true },
+				{
+					prependMessages: prependMessages.length > 0 ? prependMessages : undefined,
+					skipPostPromptRecoveryWait: true,
+				},
 			);
 		};
 		this.#schedulePostPromptTask(
@@ -7314,7 +7336,10 @@ export class AgentSession {
 		};
 	}
 
-	#createEagerTodoPrelude(promptText: string): { message: AgentMessage; toolChoice?: ToolChoice } | undefined {
+	#createEagerTodoPrelude(
+		promptText: string,
+		options: EagerPreludeOptions = {},
+	): { message: AgentMessage; toolChoice?: ToolChoice } | undefined {
 		const mode = this.settings.get("todo.eager");
 		const todosEnabled = this.settings.get("todo.enabled");
 		if (mode === "default" || !todosEnabled) {
@@ -7328,11 +7353,11 @@ export class AgentSession {
 			return undefined;
 		}
 
-		// Only inject on the first user message of the conversation. Subsequent user
-		// turns must not receive the eager todo reminder — they often correct, clarify,
-		// or redirect the prior task, and forcing a brand-new todo list there is wrong.
+		// Normally only inject on the first user message of the conversation. Auto
+		// compaction can summarize that oldest hidden reminder away, so the resume
+		// hook may re-assert it once on the synthetic continuation turn.
 		const hasPriorUserMessage = this.agent.state.messages.some(m => m.role === "user");
-		if (hasPriorUserMessage) {
+		if (hasPriorUserMessage && !options.allowPriorUserMessages) {
 			return undefined;
 		}
 
@@ -7361,8 +7386,9 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		// `preferred` suggests a todo list (reminder only); `always` also forces the
-		// `todo` tool on the first turn — the previous boolean-on behavior.
-		if (mode === "preferred") {
+		// `todo` tool on the first turn. Post-compaction auto-continuation suppresses
+		// that forced choice so it cannot override the in-flight action being resumed.
+		if (mode === "preferred" || options.suppressTodoToolChoice) {
 			return { message };
 		}
 		const todoToolChoice = buildNamedToolChoice("todo", this.model);
@@ -7380,7 +7406,7 @@ export class AgentSession {
 		return { message, toolChoice: todoToolChoice };
 	}
 
-	#createEagerTaskPrelude(promptText: string): AgentMessage | undefined {
+	#createEagerTaskPrelude(promptText: string, options: EagerPreludeOptions = {}): AgentMessage | undefined {
 		if (this.settings.get("task.eager") !== "always") return undefined;
 		// Main agent only: subagents keep `task` active (the parent only filters `todo`),
 		// so a salient delegate-reminder there would amplify nested fan-out. Gate on the
@@ -7388,7 +7414,7 @@ export class AgentSession {
 		// still gets the reminder.
 		if (this.#agentKind === "sub") return undefined;
 		if (this.#planModeState?.enabled) return undefined;
-		if (this.agent.state.messages.some(m => m.role === "user")) return undefined;
+		if (!options.allowPriorUserMessages && this.agent.state.messages.some(m => m.role === "user")) return undefined;
 		const trimmed = promptText.trimEnd();
 		if (trimmed.endsWith("?") || trimmed.endsWith("!")) return undefined;
 		if (!this.getActiveToolNames().includes("task")) return undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2152,11 +2152,12 @@ export class AgentSession {
 
 	#scheduleAutoContinuePrompt(generation: number): void {
 		const continuePrompt = async () => {
-			const eagerTodoPrelude = this.#createEagerTodoPrelude(autoContinuePrompt, {
+			const eagerPreludePromptText = this.#getLatestUserPromptText() ?? autoContinuePrompt;
+			const eagerTodoPrelude = this.#createEagerTodoPrelude(eagerPreludePromptText, {
 				allowPriorUserMessages: true,
 				suppressTodoToolChoice: true,
 			});
-			const eagerTaskPrelude = this.#createEagerTaskPrelude(autoContinuePrompt, {
+			const eagerTaskPrelude = this.#createEagerTaskPrelude(eagerPreludePromptText, {
 				allowPriorUserMessages: true,
 			});
 			const prependMessages: AgentMessage[] = [];
@@ -7334,6 +7335,24 @@ export class AgentSession {
 			toolRefs: { task: wireName("task"), todo: wireName("todo") },
 			taskBatch: this.settings.get("task.batch"),
 		};
+	}
+
+	#getLatestUserPromptText(): string | undefined {
+		const branchEntries = this.sessionManager.getBranch();
+		for (let index = branchEntries.length - 1; index >= 0; index--) {
+			const entry = branchEntries[index];
+			if (entry?.type !== "message" || entry.message.role !== "user") continue;
+			const text = this.#extractUserMessageText(entry.message.content);
+			if (text) return text;
+		}
+
+		for (let index = this.agent.state.messages.length - 1; index >= 0; index--) {
+			const message = this.agent.state.messages[index];
+			if (message?.role !== "user") continue;
+			const text = this.#extractUserMessageText(message.content);
+			if (text) return text;
+		}
+		return undefined;
 	}
 
 	#createEagerTodoPrelude(

--- a/packages/coding-agent/test/agent-session-eager-task.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-task.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { TextContent } from "@oh-my-pi/pi-ai";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -11,7 +12,7 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TodoTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { TempDir, withTimeout } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
@@ -61,6 +62,40 @@ function getMessageText(message: AgentMessage): string {
 		.join("\n");
 }
 
+function createHighUsageAssistantMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "Done." }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: 190000,
+			output: 1000,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 191000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+async function triggerAutoCompaction(session: AgentSession): Promise<void> {
+	const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+	session.subscribe(event => {
+		if (event.type === "auto_compaction_end") onCompactionDone();
+	});
+
+	const assistantMessage = createHighUsageAssistantMessage();
+	session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+	session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+
+	await withTimeout(compactionDone, 1000, "Auto-compaction timed out");
+	await withTimeout(session.waitForIdle(), 1000, "Auto-continuation timed out");
+}
+
 describe("AgentSession eager task prelude", () => {
 	let tempDir: TempDir;
 	const harnesses: Harness[] = [];
@@ -77,6 +112,7 @@ describe("AgentSession eager task prelude", () => {
 		}
 		harnesses.length = 0;
 		tempDir.removeSync();
+		vi.restoreAllMocks();
 	});
 
 	async function createHarness(
@@ -298,6 +334,36 @@ describe("AgentSession eager task prelude", () => {
 		expect(texts.at(-1)).toBe("refactor the parser across modules");
 		// the task reminder is the second prelude (after the todo reminder)
 		expect(texts.findIndex(text => text.includes("delegation is enabled"))).toBe(1);
+	});
+
+	it("reasserts eager reminders once on post-compaction auto-continuation without forcing todo", async () => {
+		vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "compacted",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		const { session, observedCalls } = await createHarness({
+			"compaction.enabled": true,
+			"compaction.keepRecentTokens": 1,
+			"todo.enabled": true,
+			"todo.eager": "always",
+			"todo.reminders": false,
+		});
+
+		await session.prompt("refactor the parser across modules");
+		expect(observedCalls[0]?.toolChoice).toBe("todo");
+
+		observedCalls.length = 0;
+		await triggerAutoCompaction(session);
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		const reminderTexts = observedCalls[0]?.messageTexts ?? [];
+		expect(reminderTexts.some(text => text.includes("You MUST call"))).toBe(true);
+		expect(reminderTexts.some(text => text.includes("delegation is enabled"))).toBe(true);
+		expect(reminderTexts.at(-1)).toContain("Resume work");
 	});
 
 	it("omits batch-call guidance from the eager task reminder when task.batch is disabled", async () => {

--- a/packages/coding-agent/test/agent-session-eager-task.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-task.test.ts
@@ -96,6 +96,16 @@ async function triggerAutoCompaction(session: AgentSession): Promise<void> {
 	await withTimeout(session.waitForIdle(), 1000, "Auto-continuation timed out");
 }
 
+function stubCompaction(): void {
+	vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+		summary: "compacted",
+		shortSummary: undefined,
+		firstKeptEntryId: preparation.firstKeptEntryId,
+		tokensBefore: preparation.tokensBefore,
+		details: {},
+	}));
+}
+
 describe("AgentSession eager task prelude", () => {
 	let tempDir: TempDir;
 	const harnesses: Harness[] = [];
@@ -337,13 +347,7 @@ describe("AgentSession eager task prelude", () => {
 	});
 
 	it("reasserts eager reminders once on post-compaction auto-continuation without forcing todo", async () => {
-		vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
-			summary: "compacted",
-			shortSummary: undefined,
-			firstKeptEntryId: preparation.firstKeptEntryId,
-			tokensBefore: preparation.tokensBefore,
-			details: {},
-		}));
+		stubCompaction();
 		const { session, observedCalls } = await createHarness({
 			"compaction.enabled": true,
 			"compaction.keepRecentTokens": 1,
@@ -363,6 +367,30 @@ describe("AgentSession eager task prelude", () => {
 		const reminderTexts = observedCalls[0]?.messageTexts ?? [];
 		expect(reminderTexts.some(text => text.includes("You MUST call"))).toBe(true);
 		expect(reminderTexts.some(text => text.includes("delegation is enabled"))).toBe(true);
+		expect(reminderTexts.at(-1)).toContain("Resume work");
+	});
+
+	it("preserves the latest user prompt punctuation gate on post-compaction auto-continuation", async () => {
+		stubCompaction();
+		const { session, observedCalls } = await createHarness({
+			"compaction.enabled": true,
+			"compaction.keepRecentTokens": 1,
+			"todo.enabled": true,
+			"todo.eager": "always",
+			"todo.reminders": false,
+		});
+
+		await session.prompt("should I refactor the parser?");
+		expect(observedCalls[0]?.messageRoles).toEqual(["user"]);
+
+		observedCalls.length = 0;
+		await triggerAutoCompaction(session);
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		const reminderTexts = observedCalls[0]?.messageTexts ?? [];
+		expect(reminderTexts.some(text => text.includes("You MUST call"))).toBe(false);
+		expect(reminderTexts.some(text => text.includes("delegation is enabled"))).toBe(false);
 		expect(reminderTexts.at(-1)).toContain("Resume work");
 	});
 


### PR DESCRIPTION
## Repro
A focused regression test in `packages/coding-agent/test/agent-session-eager-task.test.ts` triggers threshold auto-compaction, waits for the scheduled auto-continuation turn, and asserts that the resumed model call contains both eager todo and eager task reminders. Before the fix, `bun --cwd=packages/coding-agent test test/agent-session-eager-task.test.ts --test-name-pattern "post-compaction"` failed because the resumed turn had no eager todo reminder.

## Cause
`AgentSession.#scheduleAutoContinuePrompt` in `packages/coding-agent/src/session/agent-session.ts` resumed after successful auto-compaction by calling `#promptWithMessage` with only `autoContinuePrompt`. The eager reminder builders were only reached from normal user prompts and rejected any session with a prior user message, so once compaction summarized away the first-turn hidden preludes, the auto-continuation path never reinserted them.

## Fix
- Added an eager-prelude options path that lets the auto-continuation hook bypass only the prior-user-message gate while preserving mode, main-agent, plan-mode, surviving-todo, punctuation, and active-tool gates.
- Prepended eligible eager todo/task reminders from `#scheduleAutoContinuePrompt` on the resumed turn.
- Suppressed eager todo tool-choice forcing on post-compaction auto-continuation so `todo.eager: always` remains a reminder there and cannot override the in-flight resumed action.
- Added a regression test covering post-compaction auto-continuation with both eager settings enabled.
- Added a coding-agent changelog entry.

## Verification
`bun --cwd=packages/coding-agent test test/agent-session-eager-task.test.ts test/agent-session-eager-todo.test.ts` passed: 19 tests, 85 assertions. `bun --cwd=packages/coding-agent run check:types` passed. `gh_push_branch` pre-publish gate passed. Fixes #2681