### PR TITLE
fix(ai): disable DeepSeek V4 reasoning for tool calls

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed direct DeepSeek V4 tool requests to suppress reasoning payload fields when tools are present, so advisor-style calls can reach the tool-capable backend instead of spending output on text. ([#2690](https://github.com/can1357/oh-my-pi/issues/2690))
+
 ## [16.0.0] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1239,7 +1239,9 @@ function buildParams(
 		compat.disableReasoningOnForcedToolChoice &&
 		compat.supportsForcedToolChoice &&
 		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
-	if (compat.whenThinking && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
+	if (reasoningDisabledForRequest && compat.whenReasoningDisabled) {
+		compat = compat.whenReasoningDisabled; // precomputed at model build — pointer swap, no allocation
+	} else if (compat.whenThinking && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
 		compat = compat.whenThinking; // precomputed at model build — pointer swap, no allocation
 	}
 	const messages = convertMessages(model, context, compat);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1231,8 +1231,10 @@ function buildParams(
 	toolStrictModeOverride?: ToolStrictModeOverride,
 ): { params: OpenAICompletionsParams; toolStrictMode: AppliedToolStrictMode; strictToolsApplied: boolean } {
 	let compat = model.compat;
+	const disableReasoningForTools = compat.disableReasoningWhenToolsPresent && (context.tools?.length ?? 0) > 0;
+	const reasoningDisabledForRequest = Boolean(options?.disableReasoning) || disableReasoningForTools;
 	const thinkingEnabledForRequest =
-		Boolean(options?.reasoning) && !options?.disableReasoning && Boolean(model.reasoning);
+		Boolean(options?.reasoning) && !reasoningDisabledForRequest && Boolean(model.reasoning);
 	const forcedToolChoiceSuppressesThinking =
 		compat.disableReasoningOnForcedToolChoice &&
 		compat.supportsForcedToolChoice &&
@@ -1372,17 +1374,16 @@ function buildParams(
 	if (supportsReasoningParams && compat.thinkingFormat === "zai" && model.reasoning) {
 		// Z.ai uses binary thinking: { type: "enabled" | "disabled" }
 		// Must explicitly disable since z.ai defaults to thinking enabled.
-		const enabled = options?.reasoning && !options?.disableReasoning;
+		const enabled = options?.reasoning && !reasoningDisabledForRequest;
 		params.thinking = { type: enabled ? "enabled" : "disabled" };
 		if (enabled && compat.thinkingKeep) {
 			params.thinking.keep = compat.thinkingKeep;
 		}
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen" && model.reasoning) {
-		// Qwen uses top-level enable_thinking: boolean
-		params.enable_thinking = !!options?.reasoning && !options?.disableReasoning;
+		params.enable_thinking = !!options?.reasoning && !reasoningDisabledForRequest;
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		params.chat_template_kwargs = {
-			enable_thinking: !!options?.reasoning && !options?.disableReasoning,
+			enable_thinking: !!options?.reasoning && !reasoningDisabledForRequest,
 		};
 	} else if (supportsReasoningParams && compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
@@ -1392,7 +1393,7 @@ function buildParams(
 		const openRouterParams = params as typeof params & {
 			reasoning?: { effort?: string } | { enabled: false };
 		};
-		if (options?.disableReasoning) {
+		if (reasoningDisabledForRequest) {
 			openRouterParams.reasoning = { enabled: false };
 		} else if (options?.reasoning) {
 			openRouterParams.reasoning = {
@@ -1405,7 +1406,7 @@ function buildParams(
 	} else if (
 		supportsReasoningParams &&
 		options?.reasoning &&
-		!options?.disableReasoning &&
+		!reasoningDisabledForRequest &&
 		model.reasoning &&
 		compat.supportsReasoningEffort
 	) {
@@ -1469,6 +1470,11 @@ function buildParams(
 
 	if (compat.extraBody) {
 		Object.assign(params, compat.extraBody);
+		if (reasoningDisabledForRequest) {
+			delete params.thinking;
+			delete params.enable_thinking;
+			delete params.chat_template_kwargs;
+		}
 		if (model.provider === "fireworks" && params.reasoning_effort !== undefined) {
 			// Fireworks rejects simultaneous DeepSeek-style `thinking` toggles and
 			// OpenAI-style `reasoning_effort`; the effort field carries the user's level.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1476,6 +1476,7 @@ function buildParams(
 			delete params.thinking;
 			delete params.enable_thinking;
 			delete params.chat_template_kwargs;
+			delete params.reasoning_effort;
 		}
 		if (model.provider === "fireworks" && params.reasoning_effort !== undefined) {
 			// Fireworks rejects simultaneous DeepSeek-style `thinking` toggles and

--- a/packages/ai/test/issue-1207-repro.test.ts
+++ b/packages/ai/test/issue-1207-repro.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
-import type { Context, Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessage, Context, Message, Model, ModelSpec, Tool, Usage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { z } from "zod/v4";
@@ -11,9 +11,21 @@ const echoTool: Tool = {
 	parameters: z.object({ text: z.string() }),
 };
 
-function contextWithTools(tools: Tool[] = [echoTool]): Context {
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function contextWithTools(
+	tools: Tool[] = [echoTool],
+	messages: Message[] = [{ role: "user", content: "call tool", timestamp: Date.now() }],
+): Context {
 	return {
-		messages: [{ role: "user", content: "call tool", timestamp: Date.now() }],
+		messages,
 		tools,
 	};
 }
@@ -27,10 +39,10 @@ function abortedSignal(): AbortSignal {
 async function capturePayload(
 	model: Model<"openai-completions">,
 	tools?: Tool[],
-	options: { disableReasoning?: boolean } = {},
+	options: { disableReasoning?: boolean; messages?: Message[] } = {},
 ): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
-	streamOpenAICompletions(model, contextWithTools(tools), {
+	streamOpenAICompletions(model, contextWithTools(tools, options.messages), {
 		apiKey: "test-key",
 		signal: abortedSignal(),
 		reasoning: "minimal",
@@ -56,6 +68,26 @@ function customDeepseekFlash(): Model<"openai-completions"> {
 			reasoningEffortMap: { xhigh: "max" },
 		},
 	} as ModelSpec<"openai-completions">);
+}
+
+function assistantToolCall(model: Model<"openai-completions">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "call_echo",
+				name: "echo",
+				arguments: { text: "inspect" },
+			},
+		],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
 }
 
 describe("issue #1207 / #2690 — DeepSeek V4 reasoning with tools", () => {
@@ -98,6 +130,31 @@ describe("issue #1207 / #2690 — DeepSeek V4 reasoning with tools", () => {
 		expect(body.thinking).toBeUndefined();
 		expect(body.max_tokens).toBe(123);
 		expect(body.max_completion_tokens).toBeUndefined();
+	});
+
+	it("omits reasoning_content replay when direct DeepSeek tools disable reasoning", async () => {
+		const model = customDeepseekFlash();
+		const body = await capturePayload(model, [echoTool], {
+			messages: [
+				assistantToolCall(model),
+				{
+					role: "toolResult",
+					toolCallId: "call_echo",
+					toolName: "echo",
+					content: [{ type: "text", text: "done" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		});
+		const messages = body.messages as Array<Record<string, unknown>>;
+		const assistant = messages.find(message => message.role === "assistant");
+
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
+		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.thinking).toBeUndefined();
 	});
 
 	it("honors explicit disableReasoning by suppressing the direct DeepSeek thinking toggle", async () => {

--- a/packages/ai/test/issue-1207-repro.test.ts
+++ b/packages/ai/test/issue-1207-repro.test.ts
@@ -24,12 +24,17 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-async function capturePayload(model: Model<"openai-completions">, tools?: Tool[]): Promise<Record<string, unknown>> {
+async function capturePayload(
+	model: Model<"openai-completions">,
+	tools?: Tool[],
+	options: { disableReasoning?: boolean } = {},
+): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
 	streamOpenAICompletions(model, contextWithTools(tools), {
 		apiKey: "test-key",
 		signal: abortedSignal(),
 		reasoning: "minimal",
+		disableReasoning: options.disableReasoning,
 		toolChoice: "auto",
 		maxTokens: 123,
 		onPayload: payload => resolve(payload),
@@ -53,12 +58,13 @@ function customDeepseekFlash(): Model<"openai-completions"> {
 	} as ModelSpec<"openai-completions">);
 }
 
-describe("issue #1207 — DeepSeek V4 keeps reasoning with tools", () => {
+describe("issue #1207 / #2690 — DeepSeek V4 reasoning with tools", () => {
 	it("detects the documented direct DeepSeek V4 compat shape", () => {
 		const model = getBundledModel("deepseek", "deepseek-v4-flash") as Model<"openai-completions">;
 		const compat = model.compat;
 
 		expect(compat.supportsToolChoice).toBe(false);
+		expect(compat.disableReasoningWhenToolsPresent).toBe(true);
 		expect(compat.maxTokensField).toBe("max_tokens");
 		expect(compat.extraBody).toEqual({ thinking: { type: "enabled" } });
 		expect(model.thinking?.effortMap).toMatchObject({
@@ -74,6 +80,7 @@ describe("issue #1207 — DeepSeek V4 keeps reasoning with tools", () => {
 		const model = customDeepseekFlash();
 
 		expect(model.compat.supportsToolChoice).toBe(false);
+		expect(model.compat.disableReasoningWhenToolsPresent).toBe(true);
 		expect(model.thinking?.effortMap).toMatchObject({
 			minimal: "high",
 			low: "high",
@@ -82,15 +89,24 @@ describe("issue #1207 — DeepSeek V4 keeps reasoning with tools", () => {
 		});
 	});
 
-	it("omits tool_choice but preserves documented reasoning when tools are present", async () => {
+	it("omits tool_choice and disables reasoning when direct DeepSeek tools are present", async () => {
 		const body = await capturePayload(customDeepseekFlash());
 
 		expect(body.tools).toBeDefined();
 		expect(body.tool_choice).toBeUndefined();
-		expect(body.reasoning_effort).toBe("high");
-		expect(body.thinking).toEqual({ type: "enabled" });
+		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.thinking).toBeUndefined();
 		expect(body.max_tokens).toBe(123);
 		expect(body.max_completion_tokens).toBeUndefined();
+	});
+
+	it("honors explicit disableReasoning by suppressing the direct DeepSeek thinking toggle", async () => {
+		const body = await capturePayload(customDeepseekFlash(), [], { disableReasoning: true });
+
+		expect(body.tools).toBeUndefined();
+		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.thinking).toBeUndefined();
+		expect(body.max_tokens).toBe(123);
 	});
 
 	it("does not mix Fireworks DeepSeek effort with the native thinking toggle", async () => {

--- a/packages/ai/test/issue-1207-repro.test.ts
+++ b/packages/ai/test/issue-1207-repro.test.ts
@@ -39,13 +39,13 @@ function abortedSignal(): AbortSignal {
 async function capturePayload(
 	model: Model<"openai-completions">,
 	tools?: Tool[],
-	options: { disableReasoning?: boolean; messages?: Message[] } = {},
+	options: { disableReasoning?: boolean; messages?: Message[]; sendReasoning?: boolean } = {},
 ): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
 	streamOpenAICompletions(model, contextWithTools(tools, options.messages), {
 		apiKey: "test-key",
 		signal: abortedSignal(),
-		reasoning: "minimal",
+		reasoning: options.sendReasoning === false ? undefined : "minimal",
 		disableReasoning: options.disableReasoning,
 		toolChoice: "auto",
 		maxTokens: 123,
@@ -130,6 +130,17 @@ describe("issue #1207 / #2690 — DeepSeek V4 reasoning with tools", () => {
 		expect(body.thinking).toBeUndefined();
 		expect(body.max_tokens).toBe(123);
 		expect(body.max_completion_tokens).toBeUndefined();
+	});
+
+	it("omits fallback reasoning_effort when disabled direct DeepSeek tools have no explicit reasoning", async () => {
+		const body = await capturePayload(customDeepseekFlash(), [echoTool], {
+			disableReasoning: true,
+			sendReasoning: false,
+		});
+
+		expect(body.tools).toBeDefined();
+		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.thinking).toBeUndefined();
 	});
 
 	it("omits reasoning_content replay when direct DeepSeek tools disable reasoning", async () => {

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -35,6 +35,7 @@ const compat: ResolvedOpenAICompat = {
 	supportsToolChoice: true,
 	supportsForcedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
+	disableReasoningWhenToolsPresent: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",
 	requiresToolResultName: false,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -137,6 +137,7 @@ describe("openai-completions compatibility", () => {
 			supportsToolChoice: true,
 			supportsForcedToolChoice: true,
 			disableReasoningOnForcedToolChoice: false,
+			disableReasoningWhenToolsPresent: false,
 			disableReasoningOnToolChoice: false,
 			maxTokensField: "max_completion_tokens",
 			requiresToolResultName: false,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -24,6 +24,7 @@ const compat: ResolvedOpenAICompat = {
 	supportsToolChoice: true,
 	supportsForcedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
+	disableReasoningWhenToolsPresent: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",
 	requiresToolResultName: false,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed direct DeepSeek V4 OpenAI-compatible metadata to flag tool-bearing requests as reasoning-disabled, matching the provider backend split used by advisor tool calls. ([#2690](https://github.com/can1357/oh-my-pi/issues/2690))
+
 ## [16.0.0] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -280,12 +280,24 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 
 	applyCompatOverrides(compat, spec.compat);
 
+	const whenReasoningDisabledPolicy =
+		spec.compat?.whenReasoningDisabled ??
+		(compat.disableReasoningWhenToolsPresent ? { requiresReasoningContentForToolCalls: false } : undefined);
+	let whenReasoningDisabled: ResolvedOpenAICompat | undefined;
+	if (whenReasoningDisabledPolicy) {
+		whenReasoningDisabled = { ...compat };
+		applyCompatOverrides(whenReasoningDisabled, whenReasoningDisabledPolicy);
+	}
+
 	const whenThinkingPolicy =
 		spec.compat?.whenThinking ?? (isOpenCodeProvider && spec.reasoning ? OPENCODE_WHEN_THINKING : undefined);
 	if (whenThinkingPolicy) {
 		const variant: ResolvedOpenAICompat = { ...compat };
 		applyCompatOverrides(variant, whenThinkingPolicy);
 		compat.whenThinking = variant;
+	}
+	if (whenReasoningDisabled) {
+		compat.whenReasoningDisabled = whenReasoningDisabled;
 	}
 
 	return compat;

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -215,6 +215,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// before the final answer.
 		alwaysSendMaxTokens: isKimiModel,
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel,
+		disableReasoningWhenToolsPresent: isDirectDeepseekReasoning,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
 		supportsForcedToolChoice: true,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -27697,6 +27697,7 @@
 				"supportsUsageInStreaming": true,
 				"alwaysSendMaxTokens": false,
 				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningWhenToolsPresent": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
 				"supportsForcedToolChoice": true,
@@ -60012,8 +60013,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.18,
+				"input": 0.098,
+				"output": 0.196,
 				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -254,7 +254,13 @@ export interface OpenAICompat {
 	 * alternate view as `compat.whenThinking`; handlers pointer-swap, never
 	 * spread. Default: auto-detected (OpenCode gateways, #1071/#1484).
 	 */
-	whenThinking?: Partial<Omit<OpenAICompat, "whenThinking">>;
+	whenThinking?: Partial<Omit<OpenAICompat, "whenThinking" | "whenReasoningDisabled">>;
+	/**
+	 * Compat deltas applied when a request explicitly suppresses reasoning.
+	 * Use this to disable thinking-mode history replay fields alongside
+	 * top-level reasoning params. Default: auto-detected (direct DeepSeek tools).
+	 */
+	whenReasoningDisabled?: Partial<Omit<OpenAICompat, "whenThinking" | "whenReasoningDisabled">>;
 }
 
 /**
@@ -366,6 +372,7 @@ export type ResolvedOpenAICompat = Required<
 		| "strictResponsesPairing"
 		| "requiresJuiceZeroHack"
 		| "whenThinking"
+		| "whenReasoningDisabled"
 	>
 > & {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
@@ -381,6 +388,8 @@ export type ResolvedOpenAICompat = Required<
 	isVercelGatewayHost: boolean;
 	/** Complete alternate view for thinking-engaged requests; swap pointers, never spread. */
 	whenThinking?: ResolvedOpenAICompat;
+	/** Complete alternate view for reasoning-disabled requests; swap pointers, never spread. */
+	whenReasoningDisabled?: ResolvedOpenAICompat;
 };
 
 /** Fully-resolved Responses-API compat view (same contract as `ResolvedOpenAICompat`). */

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -207,6 +207,13 @@ export interface OpenAICompat {
 	 * Default: auto-detected (DeepSeek reasoning models).
 	 */
 	disableReasoningOnToolChoice?: boolean;
+	/**
+	 * Drop reasoning fields for any request that advertises tools. Use for
+	 * providers/models that route reasoning requests to a backend that cannot
+	 * call tools even when the transport accepts the `tools` array.
+	 * Default: auto-detected (direct DeepSeek reasoning models).
+	 */
+	disableReasoningWhenToolsPresent?: boolean;
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */


### PR DESCRIPTION
## Repro
An advisor-style DeepSeek V4 Flash request with the `advise` tool reproduced the failure payload locally: `tools` was present while the request also sent `reasoning_effort: "high"` and `thinking: { type: "enabled" }`, which routes direct DeepSeek V4 Flash away from the tool-capable path. Command: `bun --eval "$REPRO"`.

## Cause
`packages/ai/src/providers/openai-completions.ts` only honored DeepSeek reasoning suppression when `tool_choice` survived into the OpenAI-compatible payload. Direct DeepSeek V4 marks `supportsToolChoice: false`, so advisor requests kept `tools` but dropped `tool_choice`, then `compat.extraBody` re-added `thinking: { type: "enabled" }`.

## Fix
- Added `disableReasoningWhenToolsPresent` to OpenAI-compatible catalog metadata and enabled it for direct DeepSeek reasoning models in `packages/catalog/src/compat/openai.ts`.
- Applied that flag in `buildParams()` so tool-bearing direct DeepSeek V4 requests suppress `reasoning_effort`, OpenRouter `reasoning`, and DeepSeek-native `thinking` payload fields.
- Updated DeepSeek regression coverage in `packages/ai/test/issue-1207-repro.test.ts` and refreshed affected compat fixtures/changelogs.

## Verification
`bun test packages/ai/test/issue-1207-repro.test.ts` passed. `bun test packages/ai/test/issue-1207-repro.test.ts packages/ai/test/openai-completions-compat.test.ts packages/ai/test/openai-completions-tool-result-images.test.ts packages/ai/test/issue-967-vision-guard.test.ts` passed. `bun check` passed. The post-fix repro payload keeps `tools` and omits both `reasoning_effort` and `thinking`. Fixes #2690