### PR TITLE
feat(ast): add Emacs Lisp tree-sitter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "tree-sitter-dart",
  "tree-sitter-diff",
  "tree-sitter-dockerfile-updated",
+ "tree-sitter-elisp",
  "tree-sitter-elixir",
  "tree-sitter-erlang",
  "tree-sitter-go",
@@ -3526,6 +3527,16 @@ checksum = "5e61eb704364be179ab9be89e2891c8e77c0041eca5891a5c04164a21f6df7a0"
 dependencies = [
  "cc",
  "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-elisp"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2e9a6ab3cebf24ca41cdc1f985549b9b33f7ef25c19ac7d18e53a4ee24da09"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,6 +317,7 @@ tree-sitter-dart = "0.2"
 tree-sitter-diff = "0.1"
 tree-sitter-dockerfile = { version = "0.2.0", package = "tree-sitter-dockerfile-updated" }
 tree-sitter-elixir = "0.3"
+tree-sitter-elisp = "1.6.1"
 tree-sitter-erlang = "0.16.0"
 tree-sitter-go = "0.25"
 tree-sitter-graphql = "0.1.0"

--- a/crates/pi-ast/Cargo.toml
+++ b/crates/pi-ast/Cargo.toml
@@ -29,6 +29,7 @@ tree-sitter-css.workspace = true
 tree-sitter-diff.workspace = true
 tree-sitter-dockerfile.workspace = true
 tree-sitter-elixir.workspace = true
+tree-sitter-elisp.workspace = true
 tree-sitter-erlang.workspace = true
 tree-sitter-go.workspace = true
 tree-sitter-graphql.workspace = true

--- a/crates/pi-ast/src/block.rs
+++ b/crates/pi-ast/src/block.rs
@@ -417,6 +417,11 @@ mod tests {
 		let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n";
 		assert_eq!(resolve(code, "init.el", 1), Some(BlockRange { start_line: 1, end_line: 3 }));
 	}
+	#[test]
+	fn resolves_emacs_lisp_dot_emacs_block() {
+		let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n";
+		assert_eq!(resolve(code, ".emacs", 1), Some(BlockRange { start_line: 1, end_line: 3 }));
+	}
 
 	#[test]
 	fn resolves_emacs_lisp_macro_style_list_block() {

--- a/crates/pi-ast/src/block.rs
+++ b/crates/pi-ast/src/block.rs
@@ -412,6 +412,78 @@ mod tests {
 		assert_eq!(resolve(code, "g.swift", 3), Some(BlockRange { start_line: 3, end_line: 5 }));
 	}
 
+	#[test]
+	fn resolves_emacs_lisp_defun_block() {
+		let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n";
+		assert_eq!(resolve(code, "init.el", 1), Some(BlockRange { start_line: 1, end_line: 3 }));
+	}
+
+	#[test]
+	fn resolves_emacs_lisp_macro_style_list_block() {
+		let code = "(ert-deftest ogent-zen-test ()\n  \"Doc.\"\n  (should t))\n";
+		assert_eq!(
+			resolve(code, "test/ogent-zen-tests.el", 1),
+			Some(BlockRange { start_line: 1, end_line: 3 })
+		);
+	}
+
+	#[test]
+	fn emacs_lisp_closing_paren_resolves_to_nothing() {
+		let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name)\n)\n";
+		assert_eq!(resolve(code, "init.el", 4), None);
+	}
+
+	#[test]
+	fn emacs_lisp_visible_opener_surfaces_closer() {
+		let code = "(defun greet (name)\n  \"Doc.\"\n  (let ((message (format \"Hello %s\" \
+		            name)))\n    (message \"%s\" message))\n)\n";
+		assert_eq!(boundaries(code, "init.el", &[(1, 1)]), Some(vec![5]));
+	}
+
+	#[test]
+	fn emacs_lisp_top_level_macro_forms_resolve_as_single_sexprs() {
+		let cases = [
+			(
+				"use-package",
+				"(use-package magit\n  :commands (magit-status)\n  :config\n  (setq \
+				 magit-save-repository-buffers nil))\n",
+				4,
+			),
+			(
+				"with-eval-after-load",
+				"(with-eval-after-load 'org\n  (setq org-startup-indented t)\n  (add-hook \
+				 'org-mode-hook #'visual-line-mode))\n",
+				3,
+			),
+			(
+				"pcase",
+				"(pcase major-mode\n  ('emacs-lisp-mode\n   (message \"elisp\"))\n  (_\n   (message \
+				 \"other\")))\n",
+				5,
+			),
+		];
+
+		for (name, code, end_line) in cases {
+			assert_eq!(
+				resolve(code, "init.el", 1),
+				Some(BlockRange { start_line: 1, end_line }),
+				"{name}"
+			);
+		}
+	}
+
+	#[test]
+	fn resolves_emacs_lisp_explicit_language_block() {
+		let result = block_range_at(BlockRangeOptions {
+			code: "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n".to_string(),
+			lang: Some("emacs-lisp".to_string()),
+			path: None,
+			line: 1,
+		})
+		.expect("block resolution succeeds");
+		assert_eq!(result, Some(BlockRange { start_line: 1, end_line: 3 }));
+	}
+
 	fn boundaries(code: &str, path: &str, ranges: &[(u32, u32)]) -> Option<Vec<u32>> {
 		enclosing_block_boundaries(EnclosingBoundaryOptions {
 			code:   code.to_string(),

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -631,6 +631,9 @@ fn from_extension(path: &Path) -> Option<SupportLang> {
 	{
 		return Some(SupportLang::Dockerfile);
 	}
+	if name == ".emacs" {
+		return Some(SupportLang::EmacsLisp);
+	}
 
 	// Extensionless shell rc/profile files. `Path::extension` returns `None`
 	// for both bare (`zshrc`) and dotfile (`.zshrc`) forms, so they would

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -166,6 +166,7 @@ impl_lang!(Diff, language_diff);
 impl_lang!(Xml, language_xml);
 impl_lang!(Regex, language_regex);
 impl_lang!(Dart, language_dart);
+impl_lang!(EmacsLisp, language_elisp);
 
 // ── Html (custom implementation with injection support) ──────────────────
 
@@ -278,6 +279,7 @@ pub enum SupportLang {
 	Css,
 	Diff,
 	Dockerfile,
+	EmacsLisp,
 	Elixir,
 	Erlang,
 	Go,
@@ -335,11 +337,11 @@ impl SupportLang {
 	pub const fn all_langs() -> &'static [Self] {
 		use SupportLang::*;
 		&[
-			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, Elixir, Erlang,
-			Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia, Kotlin, Lua,
-			Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python, R, Regex,
-			Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx, TypeScript,
-			Verilog, Vue, Xml, Yaml, Zig,
+			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, EmacsLisp,
+			Elixir, Erlang, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia,
+			Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python,
+			R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx,
+			TypeScript, Verilog, Vue, Xml, Yaml, Zig,
 		]
 	}
 
@@ -358,6 +360,7 @@ impl SupportLang {
 			Self::Css => "css",
 			Self::Diff => "diff",
 			Self::Dockerfile => "dockerfile",
+			Self::EmacsLisp => "emacs-lisp",
 			Self::Elixir => "elixir",
 			Self::Erlang => "erlang",
 			Self::Go => "go",
@@ -443,6 +446,7 @@ macro_rules! execute_lang_method {
 			S::Css => Css.$method($($pname,)*),
 			S::Diff => Diff.$method($($pname,)*),
 			S::Dockerfile => Dockerfile.$method($($pname,)*),
+			S::EmacsLisp => EmacsLisp.$method($($pname,)*),
 			S::Elixir => Elixir.$method($($pname,)*),
 			S::Erlang => Erlang.$method($($pname,)*),
 			S::Go => Go.$method($($pname,)*),
@@ -557,6 +561,7 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		Css => &["css", "scss"],
 		Diff => &["diff", "patch"],
 		Dockerfile => &["dockerfile"],
+		EmacsLisp => &["el"],
 		Elixir => &["ex", "exs"],
 		Erlang => &["erl", "hrl"],
 		Go => &["go"],
@@ -693,6 +698,10 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "docker"         => SupportLang::Dockerfile,
 "dockerfile"     => SupportLang::Dockerfile,
 "containerfile"  => SupportLang::Dockerfile,
+"emacs-lisp"     => SupportLang::EmacsLisp,
+"emacslisp"      => SupportLang::EmacsLisp,
+"elisp"          => SupportLang::EmacsLisp,
+"el"             => SupportLang::EmacsLisp,
 "elixir"         => SupportLang::Elixir,
 "ex"             => SupportLang::Elixir,
 "exs"            => SupportLang::Elixir,

--- a/crates/pi-ast/src/language/parsers.rs
+++ b/crates/pi-ast/src/language/parsers.rs
@@ -38,6 +38,9 @@ pub fn language_dockerfile() -> TSLanguage {
 pub fn language_elixir() -> TSLanguage {
 	tree_sitter_elixir::LANGUAGE.into()
 }
+pub fn language_elisp() -> TSLanguage {
+	tree_sitter_elisp::LANGUAGE.into()
+}
 pub fn language_erlang() -> TSLanguage {
 	tree_sitter_erlang::LANGUAGE.into()
 }

--- a/crates/pi-ast/src/summary.rs
+++ b/crates/pi-ast/src/summary.rs
@@ -407,6 +407,7 @@ fn is_comment_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Kotlin => kind == "block_comment",
 		SupportLang::Scala => kind == "block_comment",
 		SupportLang::Lua => kind == "comment",
+		SupportLang::EmacsLisp => kind == "comment",
 		_ => false,
 	}
 }
@@ -655,6 +656,17 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "list" | "map_expr"
 				| "tuple"
 		),
+		SupportLang::EmacsLisp => matches!(
+			kind,
+			"function_definition"
+				| "macro_definition"
+				| "special_form"
+				| "list" | "vector"
+				| "hash_table"
+				| "bytecode"
+				| "string_text_properties"
+				| "string"
+		),
 		SupportLang::Clojure => {
 			matches!(kind, "list_lit" | "map_lit" | "vec_lit" | "set_lit" | "str_lit")
 		},
@@ -764,6 +776,7 @@ fn is_groupable_kind(language: SupportLang, kind: &str) -> bool {
 		| SupportLang::Lua
 		| SupportLang::Elixir
 		| SupportLang::Erlang
+		| SupportLang::EmacsLisp
 		| SupportLang::Clojure
 		| SupportLang::Sql
 		| SupportLang::Zig
@@ -966,6 +979,29 @@ mod tests {
 				.unwrap_or_default()
 				.contains("return")
 		);
+	}
+
+	#[test]
+	fn summarizes_emacs_lisp_defun_body() {
+		let code = "(defun greet (name)\n  \"Doc.\"\n  (let ((message (format \"Hello %s\" \
+		            name)))\n    (message \"%s\" message)\n    message)\n)\n";
+		let result = summarize(code, "fixture.el");
+
+		assert!(result.parsed);
+		assert!(result.elided);
+		assert_eq!(result.language.as_deref(), Some("emacs-lisp"));
+		assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+	}
+
+	#[test]
+	fn summarizes_emacs_lisp_special_form() {
+		let code =
+			"(let ((count 0))\n  (setq count (1+ count))\n  (setq count (1+ count))\n  count\n)\n";
+		let result = summarize(code, "fixture.el");
+
+		assert!(result.parsed);
+		assert!(result.elided);
+		assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
 	}
 
 	#[test]

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -1175,6 +1175,9 @@ mod tests {
 		assert_eq!(resolve_supported_lang("cpp").ok(), Some(SupportLang::Cpp));
 		assert_eq!(resolve_supported_lang("tla").ok(), Some(SupportLang::Tlaplus));
 		assert_eq!(resolve_supported_lang("pluscal").ok(), Some(SupportLang::Tlaplus));
+		assert_eq!(resolve_supported_lang("emacs-lisp").ok(), Some(SupportLang::EmacsLisp));
+		assert_eq!(resolve_supported_lang("elisp").ok(), Some(SupportLang::EmacsLisp));
+		assert_eq!(resolve_supported_lang("el").ok(), Some(SupportLang::EmacsLisp));
 		assert!(resolve_supported_lang("brainfuck").is_err());
 	}
 

--- a/crates/pi-natives/src/highlight.rs
+++ b/crates/pi-natives/src/highlight.rs
@@ -182,6 +182,7 @@ const LANG_ALIASES: &[(&[&str], &str)] = &[
 	(&["r"], "R"),
 	(&["scala"], "Scala"),
 	(&["clj", "clojure"], "Clojure"),
+	(&["el", "elisp", "emacs-lisp", "emacslisp"], "Lisp"),
 	(&["ex", "exs", "elixir"], "Ruby"),
 	(&["erl", "erlang"], "Erlang"),
 	(&["hs", "haskell"], "Haskell"),

--- a/docs/tools/ast-grep.md
+++ b/docs/tools/ast-grep.md
@@ -30,7 +30,7 @@ Pattern grammar and language support exposed to the model:
 - Metavariable names must be uppercase and must stand for whole AST nodes, not partial tokens or string fragments.
 - Reusing the same metavariable requires identical code at each occurrence.
 - Patterns must parse as one valid AST node for the inferred target language.
-- Supported canonical languages come from `SupportLang::all_langs()` in `crates/pi-ast/src/language/mod.rs`: `astro`, `bash`, `c`, `cmake`, `cpp`, `csharp`, `dart`, `clojure`, `css`, `diff`, `dockerfile`, `elixir`, `erlang`, `go`, `graphql`, `haskell`, `hcl`, `html`, `ini`, `java`, `javascript`, `json`, `just`, `julia`, `kotlin`, `lua`, `make`, `markdown`, `nix`, `objc`, `ocaml`, `odin`, `perl`, `php`, `powershell`, `protobuf`, `python`, `r`, `regex`, `ruby`, `rust`, `scala`, `solidity`, `sql`, `starlark`, `svelte`, `swift`, `toml`, `tlaplus`, `tsx`, `typescript`, `verilog`, `vue`, `xml`, `yaml`, `zig`.
+- Supported canonical languages come from `SupportLang::all_langs()` in `crates/pi-ast/src/language/mod.rs`: `astro`, `bash`, `c`, `cmake`, `cpp`, `csharp`, `dart`, `clojure`, `css`, `diff`, `dockerfile`, `emacs-lisp`, `elixir`, `erlang`, `go`, `graphql`, `haskell`, `hcl`, `html`, `ini`, `java`, `javascript`, `json`, `just`, `julia`, `kotlin`, `lua`, `make`, `markdown`, `nix`, `objc`, `ocaml`, `odin`, `perl`, `php`, `powershell`, `protobuf`, `python`, `r`, `regex`, `ruby`, `rust`, `scala`, `solidity`, `sql`, `starlark`, `svelte`, `swift`, `toml`, `tlaplus`, `tsx`, `typescript`, `verilog`, `vue`, `xml`, `yaml`, `zig`.
 
 ## Outputs
 - Single-shot tool result.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed edit-tool block operations on Emacs Lisp files: `.el` and `.emacs` paths now resolve top-level forms for `SWAP.BLK`, `DEL.BLK`, and `INS.BLK.POST` instead of reporting an unsupported-language block-resolution error.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes
@@ -110,9 +114,6 @@
 - Ctrl+C now works like Escape in selector components, so mashing Ctrl+C will eventually close the program ([#400](https://github.com/badlogic/pi-mono/pull/400) by [@mitsuhiko](https://github.com/mitsuhiko))
 - External editor (Ctrl-G) now shows full pasted content instead of `[paste #N ...]` placeholders ([#444](https://github.com/badlogic/pi-mono/pull/444) by [@aliou](https://github.com/aliou))
 - Subagent example README referenced incorrect filename `subagent.ts` instead of `index.ts` ([#427](https://github.com/badlogic/pi-mono/pull/427) by [@Whamp](https://github.com/Whamp))
-### Fixed
-
-- Fixed edit-tool block operations on Emacs Lisp files: `.el` paths now resolve top-level forms for `SWAP.BLK`, `DEL.BLK`, and `INS.BLK.POST` instead of reporting an unsupported-language block-resolution error.
 
 ## [16.0.0] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -110,6 +110,9 @@
 - Ctrl+C now works like Escape in selector components, so mashing Ctrl+C will eventually close the program ([#400](https://github.com/badlogic/pi-mono/pull/400) by [@mitsuhiko](https://github.com/mitsuhiko))
 - External editor (Ctrl-G) now shows full pasted content instead of `[paste #N ...]` placeholders ([#444](https://github.com/badlogic/pi-mono/pull/444) by [@aliou](https://github.com/aliou))
 - Subagent example README referenced incorrect filename `subagent.ts` instead of `index.ts` ([#427](https://github.com/badlogic/pi-mono/pull/427) by [@Whamp](https://github.com/Whamp))
+### Fixed
+
+- Fixed edit-tool block operations on Emacs Lisp files: `.el` paths now resolve top-level forms for `SWAP.BLK`, `DEL.BLK`, and `INS.BLK.POST` instead of reporting an unsupported-language block-resolution error.
 
 ## [16.0.0] - 2026-06-15
 

--- a/packages/coding-agent/src/utils/lang-from-path.ts
+++ b/packages/coding-agent/src/utils/lang-from-path.ts
@@ -210,6 +210,7 @@ export function getLanguageFromPath(filePath: string): string | undefined {
 	if (baseName === "dockerfile" || baseName.startsWith("dockerfile.") || baseName === "containerfile") {
 		return "dockerfile";
 	}
+	if (baseName === ".emacs") return "emacs-lisp";
 	if (baseName === "justfile") return "just";
 	if (baseName === "cmakelists.txt") return "cmake";
 
@@ -223,6 +224,9 @@ export function detectLanguageId(filePath: string): string {
 	const baseName = path.basename(filePath).toLowerCase();
 	if (baseName === "dockerfile" || baseName.startsWith("dockerfile.") || baseName === "containerfile") {
 		return "dockerfile";
+	}
+	if (baseName === ".emacs") {
+		return "emacs-lisp";
 	}
 	if (baseName === "makefile" || baseName === "gnumakefile") {
 		return "makefile";

--- a/packages/coding-agent/src/utils/lang-from-path.ts
+++ b/packages/coding-agent/src/utils/lang-from-path.ts
@@ -66,6 +66,7 @@ const EXTENSION_LANG: Record<string, readonly [string, string]> = {
 	cljc: ["clojure", "clojure"],
 	cljs: ["clojure", "clojure"],
 	edn: ["clojure", "clojure"],
+	el: ["emacs-lisp", "emacs-lisp"],
 
 	// .NET
 	cs: ["csharp", "csharp"],

--- a/packages/coding-agent/test/core/block-replace.test.ts
+++ b/packages/coding-agent/test/core/block-replace.test.ts
@@ -124,6 +124,19 @@ describe("SWAP.BLK — native tree-sitter resolution end-to-end", () => {
 			expect(text).toContain("INS.BLK.POST 1 → resolved lines 1-3 (3 lines); body lands after line 3");
 		});
 	});
+	it("inserts after an extensionless .emacs top-level form", async () => {
+		await withTempDir(async tempDir => {
+			const session = makeSession(tempDir);
+			const { filePath, header } = await seedFile(tempDir, session, ".emacs", ELISP_SOURCE);
+			const input = `${header}\nINS.BLK.POST 1:\n+\n+(message "loaded")`;
+
+			await executeHashlineSingle(executeOptions(tempDir, input, session));
+
+			expect(await Bun.file(filePath).text()).toBe(
+				["(ert-deftest ogent-zen-test ()", '  "Doc."', "  (should t))", "", '(message "loaded")', ""].join("\n"),
+			);
+		});
+	});
 
 	it("reports the diff for a resolved block edit", async () => {
 		await withTempDir(async tempDir => {

--- a/packages/coding-agent/test/core/block-replace.test.ts
+++ b/packages/coding-agent/test/core/block-replace.test.ts
@@ -62,6 +62,7 @@ async function seedFile(
 }
 
 const TS_SOURCE = "function x() {\n  if (y) {\n  }\n}\n";
+const ELISP_SOURCE = ["(ert-deftest ogent-zen-test ()", '  "Doc."', "  (should t))", ""].join("\n");
 
 describe("SWAP.BLK — native tree-sitter resolution end-to-end", () => {
 	it("resolves the inner `if` block (line 2) and replaces its full span", async () => {
@@ -97,6 +98,30 @@ describe("SWAP.BLK — native tree-sitter resolution end-to-end", () => {
 			await executeHashlineSingle(executeOptions(tempDir, input, session));
 
 			expect(await Bun.file(filePath).text()).toBe("function x() {\n}\n");
+		});
+	});
+
+	it("inserts after an Emacs Lisp top-level macro-style form", async () => {
+		await withTempDir(async tempDir => {
+			const session = makeSession(tempDir);
+			const { filePath, header } = await seedFile(tempDir, session, "ogent-zen-tests.el", ELISP_SOURCE);
+			const input = `${header}\nINS.BLK.POST 1:\n+\n+(ert-deftest ogent-zen-second-test ()\n+  (should-not nil))`;
+
+			const result = await executeHashlineSingle(executeOptions(tempDir, input, session));
+			const text = result.content.map(part => (part.type === "text" ? part.text : "")).join("\n");
+
+			expect(await Bun.file(filePath).text()).toBe(
+				[
+					"(ert-deftest ogent-zen-test ()",
+					'  "Doc."',
+					"  (should t))",
+					"",
+					"(ert-deftest ogent-zen-second-test ()",
+					"  (should-not nil))",
+					"",
+				].join("\n"),
+			);
+			expect(text).toContain("INS.BLK.POST 1 → resolved lines 1-3 (3 lines); body lands after line 3");
 		});
 	});
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -39,6 +39,7 @@ import { clampTimeout } from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
 import * as piUtils from "@oh-my-pi/pi-utils";
 import { sanitizeText, TempDir } from "@oh-my-pi/pi-utils";
 import DEFAULTS from "../../src/lsp/defaults.json" with { type: "json" };
+import { getLanguageFromPath } from "../../src/utils/lang-from-path";
 
 interface RpcMessage {
 	jsonrpc?: string;
@@ -851,6 +852,10 @@ describe("lsp regressions", () => {
 		} finally {
 			tempDir.removeSync();
 		}
+	});
+	it("detects extensionless .emacs files for UI and LSP language ids", () => {
+		expect(getLanguageFromPath("/Users/example/.emacs")).toBe("emacs-lisp");
+		expect(detectLanguageId("/Users/example/.emacs")).toBe("emacs-lisp");
 	});
 
 	it("loads config-only marketplace LSP servers from Claude plugin cache", async () => {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Emacs Lisp (`.el`, `.emacs`, `emacs-lisp`/`elisp`) support to native tree-sitter language inference, enabling astGrep/astEdit, summarizeCode, and blockRangeAt on Emacs Lisp source.
+
 ## [16.0.1] - 2026-06-15
 
 ### Fixed
@@ -9,9 +13,6 @@
 - Fixed shipped Linux native addons failing to load with `version 'GLIBC_2.39' not found` on distributions older than Ubuntu 24.04. After native builds moved onto the Ubuntu 24.04 (glibc 2.39) self-hosted runner, the x64 addon was a plain host build that linked the runner's glibc and the arm64 cross-build floated up to GLIBC_2.30; the `linux-x64` (baseline + modern) and `linux-arm64` addons are now built through `cargo-zigbuild` against a pinned glibc 2.17 floor, restoring portability to any glibc ≥ 2.17 (CentOS 7 / Ubuntu 14.04 era).
 - Fixed Linux native builds hard-failing when `RUSTC_WRAPPER=sccache` points at an unavailable shared cache backend. The native build script now retries the `napi` build once without the sccache wrapper after a cache-storage startup failure, so install smoke tests and local fallback builds can proceed while preserving the cached fast path when the backend is healthy.
 - Fixed shell cancellation cleanup failing to reap child processes inside containers whose guest kernel was built without `CONFIG_PROC_CHILDREN` (e.g. some Kata/microVM guests): the Linux descendant walk relied solely on `/proc/<pid>/task/<tid>/children`, which does not exist there, so `children()` / `live_descendants()` returned empty and termination waves never reached the children. It now falls back to scanning `/proc` and grouping by parent pid (the primitive the macOS path already uses) when no `children` file is readable, keeping the cheap per-task fast path on kernels that support it.
-### Added
-
-- Added Emacs Lisp (`.el`, `emacs-lisp`/`elisp`) support to native tree-sitter language inference, enabling astGrep/astEdit, summarizeCode, and blockRangeAt on Emacs Lisp source.
 
 ## [15.13.1] - 2026-06-15
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Fixed shipped Linux native addons failing to load with `version 'GLIBC_2.39' not found` on distributions older than Ubuntu 24.04. After native builds moved onto the Ubuntu 24.04 (glibc 2.39) self-hosted runner, the x64 addon was a plain host build that linked the runner's glibc and the arm64 cross-build floated up to GLIBC_2.30; the `linux-x64` (baseline + modern) and `linux-arm64` addons are now built through `cargo-zigbuild` against a pinned glibc 2.17 floor, restoring portability to any glibc ≥ 2.17 (CentOS 7 / Ubuntu 14.04 era).
 - Fixed Linux native builds hard-failing when `RUSTC_WRAPPER=sccache` points at an unavailable shared cache backend. The native build script now retries the `napi` build once without the sccache wrapper after a cache-storage startup failure, so install smoke tests and local fallback builds can proceed while preserving the cached fast path when the backend is healthy.
 - Fixed shell cancellation cleanup failing to reap child processes inside containers whose guest kernel was built without `CONFIG_PROC_CHILDREN` (e.g. some Kata/microVM guests): the Linux descendant walk relied solely on `/proc/<pid>/task/<tid>/children`, which does not exist there, so `children()` / `live_descendants()` returned empty and termination waves never reached the children. It now falls back to scanning `/proc` and grouping by parent pid (the primitive the macOS path already uses) when no `children` file is readable, keeping the cheap per-task fast path on kernels that support it.
+### Added
+
+- Added Emacs Lisp (`.el`, `emacs-lisp`/`elisp`) support to native tree-sitter language inference, enabling astGrep/astEdit, summarizeCode, and blockRangeAt on Emacs Lisp source.
 
 ## [15.13.1] - 2026-06-15
 

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -125,15 +125,17 @@ describe("pi-natives", () => {
 		});
 
 		it("summarizes Emacs Lisp function bodies through native inference", () => {
-			const result = summarizeCode({
-				path: "fixture.el",
-				code: '(defun greet (name)\n  "Doc."\n  (let ((message (format "Hello %s" name)))\n    (message "%s" message)\n    message)\n)\n',
-			});
+			for (const path of ["fixture.el", ".emacs"]) {
+				const result = summarizeCode({
+					path,
+					code: '(defun greet (name)\n  "Doc."\n  (let ((message (format "Hello %s" name)))\n    (message "%s" message)\n    message)\n)\n',
+				});
 
-			expect(result.parsed).toBe(true);
-			expect(result.elided).toBe(true);
-			expect(result.language).toBe("emacs-lisp");
-			expect(result.segments.map(segment => segment.kind)).toEqual(["kept", "elided", "kept"]);
+				expect(result.parsed).toBe(true);
+				expect(result.elided).toBe(true);
+				expect(result.language).toBe("emacs-lisp");
+				expect(result.segments.map(segment => segment.kind)).toEqual(["kept", "elided", "kept"]);
+			}
 		});
 
 		it("summarizes multiline literals and block comments", () => {

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -4,7 +4,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	AstMatchStrictness,
+	astEdit,
 	astMatch,
+	blockRangeAt,
 	executeShell,
 	FileType,
 	fuzzyFind,
@@ -20,6 +22,7 @@ import {
 	PtySession,
 	parseKey,
 	summarizeCode,
+	supportsLanguage,
 	truncateToWidth,
 	visibleWidth,
 	wrapTextWithAnsi,
@@ -121,6 +124,18 @@ describe("pi-natives", () => {
 			expect(python.segments.at(-1)?.text).toContain("return");
 		});
 
+		it("summarizes Emacs Lisp function bodies through native inference", () => {
+			const result = summarizeCode({
+				path: "fixture.el",
+				code: '(defun greet (name)\n  "Doc."\n  (let ((message (format "Hello %s" name)))\n    (message "%s" message)\n    message)\n)\n',
+			});
+
+			expect(result.parsed).toBe(true);
+			expect(result.elided).toBe(true);
+			expect(result.language).toBe("emacs-lisp");
+			expect(result.segments.map(segment => segment.kind)).toEqual(["kept", "elided", "kept"]);
+		});
+
 		it("summarizes multiline literals and block comments", () => {
 			const result = summarizeCode({
 				path: "fixture.ts",
@@ -152,6 +167,36 @@ describe("pi-natives", () => {
 			expect(summarizeCode({ path: "fixture.ts", code, minBodyLines: 3 }).elided).toBe(true);
 		});
 	});
+
+	describe("blockRangeAt", () => {
+		it("resolves Emacs Lisp macro-style top-level forms", () => {
+			const range = blockRangeAt({
+				path: "init.el",
+				code: '(ert-deftest ogent-zen-test ()\n  "Doc."\n  (should t))\n',
+				line: 1,
+			});
+
+			expect(range).toEqual({ startLine: 1, endLine: 3 });
+		});
+
+		it("does not resolve a bare Emacs Lisp closing paren as a block", () => {
+			const range = blockRangeAt({
+				path: "init.el",
+				code: '(defun greet (name)\n  "Doc."\n  (message "Hello %s" name)\n)\n',
+				line: 4,
+			});
+
+			expect(range).toBeNull();
+		});
+	});
+
+	describe("highlight aliases", () => {
+		it("recognizes Emacs Lisp aliases", () => {
+			expect(supportsLanguage("emacs-lisp")).toBe(true);
+			expect(supportsLanguage("elisp")).toBe(true);
+		});
+	});
+
 	describe("keys", () => {
 		it("matches Ghostty's super+alt Backspace Kitty wire", () => {
 			const ghosttyOptionBackspace = "\x1b[127;11u";
@@ -704,6 +749,38 @@ describe("pi-natives", () => {
 			});
 			expect(same.totalMatches).toBe(1);
 			expect(diff.totalMatches).toBe(0);
+		});
+
+		it("matches Emacs Lisp patterns with public aliases and metavariables", async () => {
+			const match = await astMatch({
+				source: ["(defun greet (name)", '  (message "Hello %s" name)', ")"].join("\n"),
+				lang: "emacs-lisp",
+				patterns: ["(defun $NAME $$$BODY)"],
+				includeMeta: true,
+			});
+
+			expect(match.parseErrors).toBeUndefined();
+			expect(match.totalMatches).toBe(1);
+			expect(match.matches[0]?.metaVariables?.NAME).toBe("greet");
+		});
+
+		it("rewrites Emacs Lisp source with astEdit aliases", async () => {
+			const filePath = path.join(testDir, "emacs-ast-edit.el");
+			await fs.writeFile(filePath, '(defun greet (name)\n  (message "Hello %s" name))\n');
+
+			const result = await astEdit({
+				path: filePath,
+				lang: "elisp",
+				rewrites: {
+					"(message $FORMAT $ARG)": "(format-message $FORMAT $ARG)",
+				},
+				dryRun: false,
+			});
+
+			expect(result.applied).toBe(true);
+			expect(result.parseErrors).toBeUndefined();
+			expect(result.totalReplacements).toBe(1);
+			expect(await Bun.file(filePath).text()).toBe('(defun greet (name)\n  (format-message "Hello %s" name))\n');
 		});
 
 		it("reports parse errors for incomplete source without throwing", async () => {


### PR DESCRIPTION
## What

Adds Emacs Lisp support to the shared native AST language registry.

- Registers `tree-sitter-elisp` in `pi-ast`.
- Adds canonical language support for `emacs-lisp`.
- Adds `.el`, `elisp`, `emacslisp`, and `emacs-lisp` inference aliases.
- Enables Emacs Lisp parsing for `blockRangeAt`, `summarizeCode`, native AST matching/editing, and syntax-highlighting aliases.
- Covers edit-tool block operations on top-level Emacs Lisp forms, including `defun`, ERT tests, `use-package`, `with-eval-after-load`, and `pcase`.
- Updates ast-grep docs and package changelogs.

## Why

`.el` files previously failed native block resolution as an unsupported language, so edit-tool block operations such as `SWAP.BLK`, `DEL.BLK`, and `INS.BLK.POST` could not operate on Emacs Lisp top-level forms.

This makes Emacs Lisp files behave like other tree-sitter-backed languages across native parsing, summaries, AST tools, and coding-agent block edits.

## Testing

- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test -p pi-ast --lib emacs_lisp`
- `cargo test -p pi-ast --lib swift`
- `cargo test -p pi-natives --lib resolves_supported_language_aliases`
- `cargo clippy -p pi-ast -p pi-natives -- -D warnings`
- `CC=/usr/bin/cc CXX=/usr/bin/c++ CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/usr/bin/cc bun --cwd=packages/natives run build`
- `bun test packages/natives/test/native.test.ts packages/coding-agent/test/core/block-replace.test.ts`
- `bun run ci:check:full`
- `git diff --check`
- `ubs $(git diff --name-only origin/main)`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
