### PR TITLE
fix(ai): unwrap Anthropic thinking envelopes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- Fixed Anthropic thinking summaries that arrive wrapped in literal `<thinking>` tags so advisor/raw transcript dumps do not render nested thinking tags ([#2695](https://github.com/can1357/oh-my-pi/issues/2695)).
 - Fixed Gemini, Gemma, Kimi, and Pi in-band scanners to respect `parseThinking: false`, leaving private reasoning markers in visible text when parsing is disabled
 - Fixed thinking-channel parsing for streaming Gemini, Gemma, Kimi, and Pi outputs so split or partial `<thinking>` blocks no longer leak into visible replies
 - Fixed in-band thinking finalization and Kimi stream-healing interactions so leaked `<think>` blocks are preserved when structured tool calls are present, not duplicated when explicit reasoning is present, and closed on stream flush.

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1462,6 +1462,19 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	return isRetryableError(error);
 }
 
+const THINKING_ENVELOPE_OPEN = "<thinking>";
+const THINKING_ENVELOPE_CLOSE = "</thinking>";
+
+function unwrapAnthropicThinkingEnvelope(text: string): string {
+	let current = text.trim();
+	let changed = false;
+	while (current.startsWith(THINKING_ENVELOPE_OPEN) && current.endsWith(THINKING_ENVELOPE_CLOSE)) {
+		current = current.slice(THINKING_ENVELOPE_OPEN.length, current.length - THINKING_ENVELOPE_CLOSE.length).trim();
+		changed = true;
+	}
+	return changed ? current : text;
+}
+
 function createEmptyUsage(premiumRequests?: number): Usage {
 	return {
 		input: 0,
@@ -1668,6 +1681,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				if (block.type === "text") {
 					stream.push({ type: "text_end", contentIndex, content: block.text, partial: output });
 				} else if (block.type === "thinking") {
+					block.thinking = unwrapAnthropicThinkingEnvelope(block.thinking);
 					stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
 				} else if (block.type === "toolCall") {
 					const finalJson =

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1467,10 +1467,12 @@ const THINKING_ENVELOPE_CLOSE = "</thinking>";
 
 function unwrapAnthropicThinkingEnvelope(text: string): string | undefined {
 	let current = text.trim();
+	let stripped = false;
 	while (current.startsWith(THINKING_ENVELOPE_OPEN) && current.endsWith(THINKING_ENVELOPE_CLOSE)) {
 		current = current.slice(THINKING_ENVELOPE_OPEN.length, current.length - THINKING_ENVELOPE_CLOSE.length).trim();
+		stripped = true;
 	}
-	return current === text ? undefined : current;
+	return stripped ? current : undefined;
 }
 
 function createEmptyUsage(premiumRequests?: number): Usage {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1465,14 +1465,12 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 const THINKING_ENVELOPE_OPEN = "<thinking>";
 const THINKING_ENVELOPE_CLOSE = "</thinking>";
 
-function unwrapAnthropicThinkingEnvelope(text: string): string {
+function unwrapAnthropicThinkingEnvelope(text: string): string | undefined {
 	let current = text.trim();
-	let changed = false;
 	while (current.startsWith(THINKING_ENVELOPE_OPEN) && current.endsWith(THINKING_ENVELOPE_CLOSE)) {
 		current = current.slice(THINKING_ENVELOPE_OPEN.length, current.length - THINKING_ENVELOPE_CLOSE.length).trim();
-		changed = true;
 	}
-	return changed ? current : text;
+	return current === text ? undefined : current;
 }
 
 function createEmptyUsage(premiumRequests?: number): Usage {
@@ -1681,7 +1679,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				if (block.type === "text") {
 					stream.push({ type: "text_end", contentIndex, content: block.text, partial: output });
 				} else if (block.type === "thinking") {
-					block.thinking = unwrapAnthropicThinkingEnvelope(block.thinking);
+					const unwrappedThinking = unwrapAnthropicThinkingEnvelope(block.thinking);
+					if (unwrappedThinking !== undefined) {
+						block.thinking = unwrappedThinking;
+						block.thinkingSignature = undefined;
+					}
 					stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
 				} else if (block.type === "toolCall") {
 					const finalJson =

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -349,6 +349,42 @@ describe("anthropic stream envelope handling", () => {
 			{ type: "text", text: "Check logs before accepting container health." },
 		]);
 	});
+	it("preserves signed thinking bytes when no literal thinking envelope is present", async () => {
+		const signedThinking = "\nCheck logs before accepting container health.\n";
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() => createMockRequest(createThinkingSuccessEvents(signedThinking)) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		for await (const _ of stream) {
+			// drain stream
+		}
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toHaveLength(1);
+		const block = result.content[0];
+		expect(block?.type).toBe("thinking");
+		if (block?.type !== "thinking") {
+			throw new Error("Expected signed thinking content");
+		}
+		expect(block.thinking).toBe(signedThinking);
+		expect(block.thinkingSignature).toBe("sig_thinking");
+
+		const replayParams = convertAnthropicMessages(
+			[
+				{ role: "user", content: "Say hi", timestamp: 1 },
+				result,
+				{ role: "user", content: "follow up", timestamp: 2 },
+			],
+			model,
+			false,
+		);
+		const replayAssistant = replayParams.find(param => param.role === "assistant");
+		expect(replayAssistant?.content).toEqual([
+			{ type: "thinking", thinking: signedThinking, signature: "sig_thinking" },
+		]);
+	});
 
 	it("drops replayed closed blocks after a duplicate message_start instead of duplicating content", async () => {
 		const events: MockAnthropicEvent[] = [

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
-import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { convertAnthropicMessages, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import { AnthropicMessages } from "@oh-my-pi/pi-ai/providers/anthropic-client";
 import type { AssistantMessageEvent, Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -326,12 +326,27 @@ describe("anthropic stream envelope handling", () => {
 		expect(countEvents(events, "thinking_start")).toBe(1);
 		expect(countEvents(events, "thinking_end")).toBe(1);
 		expect(result.stopReason).toBe("stop");
-		expect(result.content).toEqual([
-			{
-				type: "thinking",
-				thinking: "Check logs before accepting container health.",
-				thinkingSignature: "sig_thinking",
-			},
+		expect(result.content).toHaveLength(1);
+		const block = result.content[0];
+		expect(block?.type).toBe("thinking");
+		if (block?.type !== "thinking") {
+			throw new Error("Expected thinking content after wrapped thinking stream");
+		}
+		expect(block.thinking).toBe("Check logs before accepting container health.");
+		expect(block.thinkingSignature).toBeUndefined();
+
+		const replayParams = convertAnthropicMessages(
+			[
+				{ role: "user", content: "Say hi", timestamp: 1 },
+				result,
+				{ role: "user", content: "follow up", timestamp: 2 },
+			],
+			model,
+			false,
+		);
+		const replayAssistant = replayParams.find(param => param.role === "assistant");
+		expect(replayAssistant?.content).toEqual([
+			{ type: "text", text: "Check logs before accepting container health." },
 		]);
 	});
 

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -175,6 +175,37 @@ function createTextSuccessEvents(
 	}
 	return events;
 }
+function createThinkingSuccessEvents(thinking: string): MockAnthropicEvent[] {
+	return [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_thinking_success",
+				usage: {
+					input_tokens: 12,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking } },
+		{ type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig_thinking" } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: {
+				input_tokens: 12,
+				output_tokens: 4,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		},
+		{ type: "message_stop" },
+	];
+}
 
 function createTextSuccessEventsWithPreamble(text: string, preambleEvents: MockAnthropicEvent[]): MockAnthropicEvent[] {
 	return [...preambleEvents, ...createTextSuccessEvents(text)];
@@ -277,6 +308,31 @@ describe("anthropic stream envelope handling", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.responseId).toBe("msg_text_success");
 		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+	it("unwraps thinking blocks that Anthropic streams with literal thinking tags", async () => {
+		const wrappedThinking =
+			"<thinking>\n<thinking>\nCheck logs before accepting container health.\n</thinking></thinking>";
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() => createMockRequest(createThinkingSuccessEvents(wrappedThinking)) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(countEvents(events, "thinking_start")).toBe(1);
+		expect(countEvents(events, "thinking_end")).toBe(1);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([
+			{
+				type: "thinking",
+				thinking: "Check logs before accepting container health.",
+				thinkingSignature: "sig_thinking",
+			},
+		]);
 	});
 
 	it("drops replayed closed blocks after a duplicate message_start instead of duplicating content", async () => {


### PR DESCRIPTION
## Repro
A focused Anthropic stream test reproduced the leak with a `thinking_delta` payload containing nested literal `<thinking>...</thinking>` wrappers; before the fix, `bun test packages/ai/test/anthropic-stream-envelope.test.ts -t "unwraps thinking blocks"` stored those wrappers inside the parsed `thinking` field, which made `/advisor dump raw` render nested thinking tags.

## Cause
`packages/ai/src/providers/anthropic.ts` appended `thinking_delta` text verbatim and finalized `ThinkingContent` without normalizing Anthropic summaries. When Opus 4.5 high-effort summaries arrived already wrapped in literal thinking tags, `packages/ai/src/dialect/anthropic.ts` added its normal transcript wrapper around an already-wrapped `thinking` block.

## Fix
- Added Anthropic thinking-envelope unwrapping before `thinking_end` finalization in `streamAnthropic`.
- Added a regression stream fixture for nested literal `<thinking>` wrappers.
- Added an `@oh-my-pi/pi-ai` changelog entry for #2695.

## Verification
- `bun test packages/ai/test/anthropic-stream-envelope.test.ts -t "unwraps thinking blocks"` failed before the fix and passes after it.
- `bun test packages/ai/test/anthropic-stream-envelope.test.ts` passed: 21 tests, 128 assertions.
- `bun --cwd=packages/ai run check` passed.

Fixes #2695