### PR TITLE
fix(ai): align Codex OAuth originator

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex browser login issuing credentials for the `opencode` OAuth originator while OMP requests identify as `pi`, which could make the first authenticated Codex request return 401 ([#2696](https://github.com/can1357/oh-my-pi/issues/2696)).
+
 ## [16.0.0] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/ai/src/registry/oauth/openai-codex.ts
+++ b/packages/ai/src/registry/oauth/openai-codex.ts
@@ -1,6 +1,8 @@
 /**
  * OpenAI Codex (ChatGPT OAuth) flow — browser and device-code flows.
  */
+
+import { OPENAI_HEADER_VALUES } from "@oh-my-pi/pi-catalog/wire/codex";
 import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
@@ -60,6 +62,29 @@ interface PKCE {
 	verifier: string;
 	challenge: string;
 }
+/** Builds the Codex browser OAuth URL used by browser login; exported for auth regression tests. */
+export function createOpenAICodexAuthorizationUrl(args: {
+	state: string;
+	redirectUri: string;
+	challenge: string;
+	originator?: string;
+}): string {
+	const originator = args.originator?.trim() || OPENAI_HEADER_VALUES.ORIGINATOR_CODEX;
+	const searchParams = new URLSearchParams({
+		response_type: "code",
+		client_id: CLIENT_ID,
+		redirect_uri: args.redirectUri,
+		scope: SCOPE,
+		code_challenge: args.challenge,
+		code_challenge_method: "S256",
+		state: args.state,
+		id_token_add_organizations: "true",
+		codex_cli_simplified_flow: "true",
+		originator,
+	});
+
+	return `${AUTHORIZE_URL}?${searchParams.toString()}`;
+}
 
 class OpenAICodexOAuthFlow extends OAuthCallbackFlow {
 	constructor(
@@ -79,20 +104,12 @@ class OpenAICodexOAuthFlow extends OAuthCallbackFlow {
 	}
 
 	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
-		const searchParams = new URLSearchParams({
-			response_type: "code",
-			client_id: CLIENT_ID,
-			redirect_uri: redirectUri,
-			scope: SCOPE,
-			code_challenge: this.pkce.challenge,
-			code_challenge_method: "S256",
+		const url = createOpenAICodexAuthorizationUrl({
 			state,
-			id_token_add_organizations: "true",
-			codex_cli_simplified_flow: "true",
+			redirectUri,
+			challenge: this.pkce.challenge,
 			originator: this.originator,
 		});
-
-		const url = `${AUTHORIZE_URL}?${searchParams.toString()}`;
 		return { url, instructions: "A browser window should open. Complete login to finish." };
 	}
 
@@ -153,13 +170,13 @@ async function exchangeCodeForToken(code: string, verifier: string, redirectUri:
  * Login with OpenAI Codex OAuth
  */
 export type OpenAICodexLoginOptions = OAuthController & {
-	/** Optional originator value for OpenAI Codex OAuth. Default: "opencode". */
+	/** Optional originator value for OpenAI Codex OAuth. Default matches OMP Codex request headers. */
 	originator?: string;
 };
 
 export async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promise<OAuthCredentials> {
 	const pkce = await generatePKCE();
-	const originator = options.originator?.trim() || "opencode";
+	const originator = options.originator?.trim() || OPENAI_HEADER_VALUES.ORIGINATOR_CODEX;
 	const flow = new OpenAICodexOAuthFlow(options, pkce, originator);
 
 	return flow.login();

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, it } from "bun:test";
+import { createOpenAICodexAuthorizationUrl } from "@oh-my-pi/pi-ai/oauth/openai-codex";
 import { type RequestBody, transformRequestBody } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
 import { CodexApiError, parseCodexError } from "@oh-my-pi/pi-ai/providers/openai-codex/response-handler";
 import { convertOpenAICodexResponsesTools } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import type { Tool } from "@oh-my-pi/pi-ai/types";
+import { OPENAI_HEADER_VALUES } from "@oh-my-pi/pi-catalog/wire/codex";
 import { createCodexModel } from "./helpers";
 
 const DEFAULT_PROMPT_PREFIX =
 	"You are an expert coding assistant. You help users with coding tasks by reading files, executing commands";
+
+describe("openai-codex oauth", () => {
+	it("uses the same default originator for browser login and API requests", () => {
+		const authUrl = createOpenAICodexAuthorizationUrl({
+			state: "state",
+			redirectUri: "http://localhost:1455/auth/callback",
+			challenge: "challenge",
+		});
+
+		expect(new URL(authUrl).searchParams.get("originator")).toBe(OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
+	});
+});
 
 describe("openai-codex tool schemas", () => {
 	it("adds empty properties to no-argument object parameter schemas", () => {


### PR DESCRIPTION
## Repro
A focused auth-flow probe against `loginOpenAICodex()` captured the browser OAuth URL and expected its `originator` query parameter to match the `pi` originator sent on Codex API requests: `bun --eval 'import { loginOpenAICodex } from "@oh-my-pi/pi-ai/oauth/openai-codex"; ...'`. Before the fix it printed `originator=opencode` and exited 1.

## Cause
`packages/ai/src/registry/oauth/openai-codex.ts` defaulted browser OAuth login to `originator=opencode`, while `packages/catalog/src/wire/codex.ts` defines the Codex request header originator as `pi`. That mismatch can issue credentials for a different Codex client surface before OMP sends its first authenticated request.

## Fix
- Added `createOpenAICodexAuthorizationUrl()` so the OAuth URL builder has one default originator path.
- Switched the default Codex OAuth originator to `OPENAI_HEADER_VALUES.ORIGINATOR_CODEX`.
- Added a regression test asserting browser-login URLs use the same default originator as Codex API requests.
- Added the `packages/ai` changelog entry for #2696.

## Verification
`bun test packages/ai/test/openai-codex.test.ts` passed: 11 tests, 32 assertions. `bun --cwd=packages/ai run check` passed. The repro probe now prints `originator=pi` and exits 0. Fixes #2696