### PR TITLE
fix(ai): unwrap thinking envelopes in raw dumps

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed dialect transcript rendering so literal thinking envelopes are unwrapped before adding the dialect's own thinking tags, preventing nested `<thinking>` output in advisor raw dumps ([#2700](https://github.com/can1357/oh-my-pi/issues/2700)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/src/dialect/rendering.ts
+++ b/packages/ai/src/dialect/rendering.ts
@@ -157,9 +157,29 @@ export function messageContentText(
 	return text;
 }
 
+function isAsciiWhitespace(code: number): boolean {
+	return code === 9 || code === 10 || code === 11 || code === 12 || code === 13 || code === 32;
+}
+
+function unwrapDelimitedThinking(open: string, close: string, text: string): string {
+	let start = 0;
+	let end = text.length;
+	let changed = false;
+	while (true) {
+		while (start < end && isAsciiWhitespace(text.charCodeAt(start))) start++;
+		while (end > start && isAsciiWhitespace(text.charCodeAt(end - 1))) end--;
+		if (end - start < open.length + close.length) break;
+		if (!text.startsWith(open, start) || !text.startsWith(close, end - close.length)) break;
+		start += open.length;
+		end -= close.length;
+		changed = true;
+	}
+	return changed ? text.slice(start, end) : text;
+}
+
 export function renderDelimitedThinking(open: string, close: string, text: string): string {
 	if (!text) return "";
-	return `${open}\n${text}\n${close}`;
+	return `${open}\n${unwrapDelimitedThinking(open, close, text)}\n${close}`;
 }
 
 export function chatMlTurn(role: "assistant" | "system" | "tool" | "user", body: string): string {

--- a/packages/ai/src/dialect/rendering.ts
+++ b/packages/ai/src/dialect/rendering.ts
@@ -161,20 +161,55 @@ function isAsciiWhitespace(code: number): boolean {
 	return code === 9 || code === 10 || code === 11 || code === 12 || code === 13 || code === 32;
 }
 
-function unwrapDelimitedThinking(open: string, close: string, text: string): string {
-	let start = 0;
-	let end = text.length;
-	let changed = false;
-	while (true) {
-		while (start < end && isAsciiWhitespace(text.charCodeAt(start))) start++;
-		while (end > start && isAsciiWhitespace(text.charCodeAt(end - 1))) end--;
-		if (end - start < open.length + close.length) break;
-		if (!text.startsWith(open, start) || !text.startsWith(close, end - close.length)) break;
-		start += open.length;
-		end -= close.length;
-		changed = true;
+function trimAsciiStart(text: string, start: number, end: number): number {
+	let cursor = start;
+	while (cursor < end && isAsciiWhitespace(text.charCodeAt(cursor))) cursor++;
+	return cursor;
+}
+
+function trimAsciiEnd(text: string, start: number, end: number): number {
+	let cursor = end;
+	while (cursor > start && isAsciiWhitespace(text.charCodeAt(cursor - 1))) cursor--;
+	return cursor;
+}
+
+function findDelimitedThinkingClose(open: string, close: string, text: string, start: number, end: number): number {
+	let depth = 1;
+	let cursor = start;
+	while (cursor < end) {
+		const nextClose = text.indexOf(close, cursor);
+		if (nextClose < 0 || nextClose >= end) return -1;
+		const nextOpen = text.indexOf(open, cursor);
+		if (nextOpen >= 0 && nextOpen < nextClose) {
+			depth++;
+			cursor = nextOpen + open.length;
+			continue;
+		}
+		depth--;
+		if (depth === 0) return nextClose;
+		cursor = nextClose + close.length;
 	}
-	return changed ? text.slice(start, end) : text;
+	return -1;
+}
+
+function unwrapDelimitedThinking(open: string, close: string, text: string): string {
+	const end = trimAsciiEnd(text, 0, text.length);
+	let cursor = trimAsciiStart(text, 0, end);
+	if (cursor >= end || !text.startsWith(open, cursor)) return text;
+
+	const segments: string[] = [];
+	while (cursor < end) {
+		if (!text.startsWith(open, cursor)) return text;
+		const innerStart = cursor + open.length;
+		const innerEnd = findDelimitedThinkingClose(open, close, text, innerStart, end);
+		if (innerEnd < 0) return text;
+
+		const trimmedInnerEnd = trimAsciiEnd(text, innerStart, innerEnd);
+		const trimmedInnerStart = trimAsciiStart(text, innerStart, trimmedInnerEnd);
+		segments.push(unwrapDelimitedThinking(open, close, text.slice(trimmedInnerStart, trimmedInnerEnd)));
+		cursor = trimAsciiStart(text, innerEnd + close.length, end);
+	}
+	return segments.join("\n");
 }
 
 export function renderDelimitedThinking(open: string, close: string, text: string): string {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/advisor dump raw` so Opus 4.5 thinking content that already includes literal `<thinking>` tags is not rendered with nested thinking tags ([#2700](https://github.com/can1357/oh-my-pi/issues/2700)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { createAdvisorMessageCard } from "../../modes/components/advisor-message";
 import { getThemeByName } from "../../modes/theme/theme";
+import { formatSessionDumpText } from "../../session/session-dump-format";
 import { formatSessionHistoryMarkdown } from "../../session/session-history-format";
 import { YieldQueue } from "../../session/yield-queue";
 import {
@@ -581,6 +582,28 @@ describe("advisor", () => {
 			const card = createAdvisorMessageCard({ notes: [{ note, severity: "concern" }] }, () => false, uiTheme);
 			const text = strip(card.render(30));
 			expect(text).toContain("truncated.");
+		});
+	});
+	describe("formatSessionDumpText raw thinking", () => {
+		it("does not nest literal thinking envelopes", () => {
+			const md = formatSessionDumpText({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "thinking",
+								thinking: "<thinking>\nCheck logs before accepting container health.\n</thinking>",
+							},
+						],
+						timestamp: Date.now(),
+					} as AgentMessage,
+				],
+				thinkingLevel: "high",
+			});
+
+			expect(md).toContain("Assistant: <thinking>\nCheck logs before accepting container health.\n</thinking>");
+			expect(md).not.toContain("<thinking>\n<thinking>");
 		});
 	});
 });

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -605,5 +605,26 @@ describe("advisor", () => {
 			expect(md).toContain("Assistant: <thinking>\nCheck logs before accepting container health.\n</thinking>");
 			expect(md).not.toContain("<thinking>\n<thinking>");
 		});
+
+		it("unwraps sibling literal thinking envelopes independently", () => {
+			const md = formatSessionDumpText({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "<thinking>\nfirst\n</thinking>" },
+							{ type: "toolCall", id: "tc-1", name: "read", arguments: { path: "file.ts" } },
+							{ type: "thinking", thinking: "<thinking>\nsecond\n</thinking>" },
+						],
+						timestamp: Date.now(),
+					} as AgentMessage,
+				],
+				tools: [{ name: "read", description: "Read a file", parameters: { type: "object" } }],
+				thinkingLevel: "high",
+			});
+
+			expect(md).toContain("Assistant: <thinking>\nfirst\nsecond\n</thinking>");
+			expect(md).not.toContain("first\n</thinking>\n<thinking>\nsecond");
+		});
 	});
 });


### PR DESCRIPTION
## Repro
`/advisor dump raw` serializes the advisor agent transcript with `formatSessionDumpText`. Reproduced the nested output with `bun --cwd packages/coding-agent -e 'import { formatSessionDumpText } from "./src/session/session-dump-format"; const text = formatSessionDumpText({ messages: [{ role: "assistant", content: [{ type: "thinking", thinking: "<thinking>\nCheck logs before accepting container health.\n</thinking>" }], timestamp: 1 }], thinkingLevel: "high" }); console.log(text);'`, which previously printed `Assistant: <thinking>\n<thinking>...`.

## Cause
`packages/coding-agent/src/session/session-dump-format.ts` delegates raw transcript rendering to the selected dialect via `definition.renderTranscript(convertToLlm(...))`. Anthropic/XML-style dialects render every `thinking` block by adding their own `<thinking>...</thinking>` delimiters in `packages/ai/src/dialect/rendering.ts`; if provider output was already stored with literal thinking tags, the raw advisor dump added a second envelope.

## Fix
- Unwrap matching literal thinking envelopes inside `renderDelimitedThinking` before adding the dialect delimiter.
- Preserve ordinary unwrapped thinking text unchanged.
- Add advisor raw dump regression coverage for literal `<thinking>` input.
- Add changelog entries for `packages/ai` and `packages/coding-agent`.

## Verification
`bun --cwd packages/coding-agent test src/advisor/__tests__/advisor.test.ts` passed. `bun --cwd packages/ai test test/anthropic-stream-envelope.test.ts` passed. `bun --cwd=packages/ai run check` passed. `bun --cwd=packages/coding-agent run check` passed. Manual repro now prints one `<thinking>` envelope. Fixes #2700