### PR TITLE
fix(tool): default Windows bash children to UTF-8

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows bash-tool child processes defaulting interpreter pipe I/O to the ANSI codepage by adding UTF-8 encoding defaults when the inherited environment is unset ([#2701](https://github.com/can1357/oh-my-pi/issues/2701)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -11,7 +11,7 @@ import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
-import { NON_INTERACTIVE_ENV } from "./non-interactive-env";
+import { buildNonInteractiveEnv } from "./non-interactive-env";
 
 export interface BashExecutorOptions {
 	cwd?: string;
@@ -184,7 +184,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 
 	const commandCwd = await resolveShellCwd(options?.cwd);
-	const commandEnv = options?.env ? { ...NON_INTERACTIVE_ENV, ...options.env } : NON_INTERACTIVE_ENV;
+	const commandEnv = buildNonInteractiveEnv(options?.env);
 
 	// Apply command prefix if configured
 	const prefixedCommand = prefix ? `${prefix} ${command}` : command;

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -47,12 +47,16 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	CLOUDSDK_CORE_DISABLE_PROMPTS: "1",
 };
 
-const WINDOWS_UTF8_ENV_DEFAULTS: Readonly<Record<string, string>> = {
-	PYTHONIOENCODING: "utf-8",
-	PYTHONUTF8: "1",
-	LANG: "C.UTF-8",
-	LC_ALL: "C.UTF-8",
-};
+const WINDOWS_UTF8_ENV_DEFAULT_GROUPS: ReadonlyArray<ReadonlyArray<readonly [key: string, value: string]>> = [
+	[
+		["PYTHONIOENCODING", "utf-8"],
+		["PYTHONUTF8", "1"],
+	],
+	[
+		["LANG", "C.UTF-8"],
+		["LC_ALL", "C.UTF-8"],
+	],
+];
 
 function hasEnvValue(
 	env: Record<string, string | undefined> | undefined,
@@ -70,6 +74,17 @@ function hasEnvValue(
 	return false;
 }
 
+function hasEnvGroupValue(
+	env: Record<string, string | undefined> | undefined,
+	group: ReadonlyArray<readonly [key: string, value: string]>,
+	platform: NodeJS.Platform,
+): boolean {
+	for (const [key] of group) {
+		if (hasEnvValue(env, key, platform)) return true;
+	}
+	return false;
+}
+
 /** Builds the per-command environment for non-interactive child processes. */
 export function buildNonInteractiveEnv(
 	overrides?: Record<string, string>,
@@ -81,8 +96,11 @@ export function buildNonInteractiveEnv(
 	}
 
 	const env: Record<string, string> = { ...NON_INTERACTIVE_ENV };
-	for (const [key, value] of Object.entries(WINDOWS_UTF8_ENV_DEFAULTS)) {
-		if (!hasEnvValue(baseEnv, key, platform) && !hasEnvValue(overrides, key, platform)) {
+	for (const group of WINDOWS_UTF8_ENV_DEFAULT_GROUPS) {
+		if (hasEnvGroupValue(baseEnv, group, platform) || hasEnvGroupValue(overrides, group, platform)) {
+			continue;
+		}
+		for (const [key, value] of group) {
 			env[key] = value;
 		}
 	}

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -74,11 +74,22 @@ function hasEnvValue(
 	return false;
 }
 
+function hasLocaleEnvValue(env: Record<string, string | undefined> | undefined, platform: NodeJS.Platform): boolean {
+	if (!env) return false;
+	for (const [key, value] of Object.entries(env)) {
+		if (value === undefined) continue;
+		const normalizedKey = platform === "win32" ? key.toUpperCase() : key;
+		if (normalizedKey === "LANG" || normalizedKey.startsWith("LC_")) return true;
+	}
+	return false;
+}
+
 function hasEnvGroupValue(
 	env: Record<string, string | undefined> | undefined,
 	group: ReadonlyArray<readonly [key: string, value: string]>,
 	platform: NodeJS.Platform,
 ): boolean {
+	if (group.some(([key]) => key === "LC_ALL") && hasLocaleEnvValue(env, platform)) return true;
 	for (const [key] of group) {
 		if (hasEnvValue(env, key, platform)) return true;
 	}

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -46,3 +46,45 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	COMPOSER_NO_INTERACTION: "1",
 	CLOUDSDK_CORE_DISABLE_PROMPTS: "1",
 };
+
+const WINDOWS_UTF8_ENV_DEFAULTS: Readonly<Record<string, string>> = {
+	PYTHONIOENCODING: "utf-8",
+	PYTHONUTF8: "1",
+	LANG: "C.UTF-8",
+	LC_ALL: "C.UTF-8",
+};
+
+function hasEnvValue(
+	env: Record<string, string | undefined> | undefined,
+	key: string,
+	platform: NodeJS.Platform,
+): boolean {
+	if (!env) return false;
+	if (platform !== "win32") return env[key] !== undefined;
+
+	for (const [existingKey, value] of Object.entries(env)) {
+		if (value !== undefined && existingKey.toLowerCase() === key.toLowerCase()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/** Builds the per-command environment for non-interactive child processes. */
+export function buildNonInteractiveEnv(
+	overrides?: Record<string, string>,
+	baseEnv: Record<string, string | undefined> = Bun.env,
+	platform: NodeJS.Platform = process.platform,
+): Record<string, string> {
+	if (platform !== "win32") {
+		return overrides ? { ...NON_INTERACTIVE_ENV, ...overrides } : NON_INTERACTIVE_ENV;
+	}
+
+	const env: Record<string, string> = { ...NON_INTERACTIVE_ENV };
+	for (const [key, value] of Object.entries(WINDOWS_UTF8_ENV_DEFAULTS)) {
+		if (!hasEnvValue(baseEnv, key, platform) && !hasEnvValue(overrides, key, platform)) {
+			env[key] = value;
+		}
+	}
+	return overrides ? { ...env, ...overrides } : env;
+}

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -11,12 +11,17 @@ describe("buildNonInteractiveEnv", () => {
 		expect(env.LC_ALL).toBe("C.UTF-8");
 	});
 
-	it("preserves inherited and per-command Windows encoding overrides", () => {
-		const env = buildNonInteractiveEnv(
-			{ PYTHONUTF8: "0", LC_ALL: "en_US.UTF-8" },
-			{ pythonioencoding: "cp1252", LANG: "de_DE.UTF-8" },
-			"win32",
-		);
+	it("preserves inherited Windows encoding groups as user-owned", () => {
+		const env = buildNonInteractiveEnv(undefined, { PYTHONUTF8: "0", LANG: "de_DE.UTF-8" }, "win32");
+
+		expect(env.PYTHONIOENCODING).toBeUndefined();
+		expect(env.PYTHONUTF8).toBeUndefined();
+		expect(env.LANG).toBeUndefined();
+		expect(env.LC_ALL).toBeUndefined();
+	});
+
+	it("preserves per-command Windows encoding groups as user-owned", () => {
+		const env = buildNonInteractiveEnv({ PYTHONUTF8: "0", LC_ALL: "en_US.UTF-8" }, {}, "win32");
 
 		expect(env.PYTHONIOENCODING).toBeUndefined();
 		expect(env.PYTHONUTF8).toBe("0");

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -29,6 +29,13 @@ describe("buildNonInteractiveEnv", () => {
 		expect(env.LC_ALL).toBe("en_US.UTF-8");
 	});
 
+	it("preserves inherited Windows LC category locales as user-owned", () => {
+		const env = buildNonInteractiveEnv(undefined, { LC_CTYPE: "en_US.UTF-8" }, "win32");
+
+		expect(env.LANG).toBeUndefined();
+		expect(env.LC_ALL).toBeUndefined();
+	});
+
 	it("does not force UTF-8 encoding defaults on non-Windows platforms", () => {
 		const env = buildNonInteractiveEnv(undefined, {}, "linux");
 

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { buildNonInteractiveEnv } from "@oh-my-pi/pi-coding-agent/exec/non-interactive-env";
+
+describe("buildNonInteractiveEnv", () => {
+	it("defaults Windows child-process encoding to UTF-8 when inherited env is unset", () => {
+		const env = buildNonInteractiveEnv(undefined, {}, "win32");
+
+		expect(env.PYTHONIOENCODING).toBe("utf-8");
+		expect(env.PYTHONUTF8).toBe("1");
+		expect(env.LANG).toBe("C.UTF-8");
+		expect(env.LC_ALL).toBe("C.UTF-8");
+	});
+
+	it("preserves inherited and per-command Windows encoding overrides", () => {
+		const env = buildNonInteractiveEnv(
+			{ PYTHONUTF8: "0", LC_ALL: "en_US.UTF-8" },
+			{ pythonioencoding: "cp1252", LANG: "de_DE.UTF-8" },
+			"win32",
+		);
+
+		expect(env.PYTHONIOENCODING).toBeUndefined();
+		expect(env.PYTHONUTF8).toBe("0");
+		expect(env.LANG).toBeUndefined();
+		expect(env.LC_ALL).toBe("en_US.UTF-8");
+	});
+
+	it("does not force UTF-8 encoding defaults on non-Windows platforms", () => {
+		const env = buildNonInteractiveEnv(undefined, {}, "linux");
+
+		expect(env.PYTHONIOENCODING).toBeUndefined();
+		expect(env.PYTHONUTF8).toBeUndefined();
+		expect(env.LANG).toBeUndefined();
+		expect(env.LC_ALL).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
On the reported native Windows path, `python -c "print('Привет мир — ✓')"` fails under the bash tool because the child stdout pipe inherits no UTF-8 encoding defaults. I reproduced the code-path defect before the fix with `bun --cwd packages/coding-agent -e "import { NON_INTERACTIVE_ENV } from './src/exec/non-interactive-env.ts'; const keys = ['PYTHONIOENCODING','PYTHONUTF8','LANG','LC_ALL']; for (const key of keys) console.log(key + '=' + (NON_INTERACTIVE_ENV[key] ?? '<unset>')); process.exit(keys.some(key => NON_INTERACTIVE_ENV[key] === undefined) ? 1 : 0);"`, which printed all four keys as `<unset>` and exited 1.

## Cause
`packages/coding-agent/src/exec/bash-executor.ts` built every non-interactive bash command environment from `NON_INTERACTIVE_ENV` in `packages/coding-agent/src/exec/non-interactive-env.ts`. That constant set `PYTHONUNBUFFERED=1` but no `PYTHONIOENCODING`, `PYTHONUTF8`, `LANG`, or `LC_ALL`, so native Windows pipe-based child processes could derive stdout encoding from the ANSI codepage instead of UTF-8.

## Fix
- Added `buildNonInteractiveEnv()` to apply Windows-only UTF-8 defaults when neither the inherited process env nor per-command env already define encoding or locale values.
- Switched `executeBash()` to use the builder for child command env construction.
- Added regression tests for missing Windows UTF-8 defaults, inherited/per-command overrides, and non-Windows behavior.
- Added a coding-agent changelog entry for #2701.

## Verification
`bun run test test/non-interactive-env.test.ts` passed in `packages/coding-agent`; `bun run check` passed in `packages/coding-agent`; post-fix probe `buildNonInteractiveEnv(undefined, {}, 'win32')` printed `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`, `LANG=C.UTF-8`, and `LC_ALL=C.UTF-8`. Fixes #2701