### PR TITLE
feat: mouse click + wheel in the /copy picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Mouse support in the `/copy` picker: it now opens fullscreen (alternate screen) so the terminal reports mouse, letting you left-click a block to copy it and scroll the wheel to move the selection. Keyboard navigation is unchanged. Added an `app.clipboard.copy` keybinding (default `Alt+Shift+Y`) to open the picker.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -36,6 +36,7 @@ interface AppKeybindings {
 	"app.clipboard.pasteTextRaw": true;
 	"app.clipboard.copyLine": true;
 	"app.clipboard.copyPrompt": true;
+	"app.clipboard.copy": true;
 	"app.agents.hub": true;
 	"app.session.new": true;
 	"app.session.tree": true;
@@ -150,6 +151,10 @@ export const KEYBINDINGS = {
 	"app.clipboard.copyPrompt": {
 		defaultKeys: "alt+shift+c",
 		description: "Copy prompt",
+	},
+	"app.clipboard.copy": {
+		defaultKeys: "alt+shift+y",
+		description: "Open copy picker",
 	},
 	"app.session.new": {
 		defaultKeys: [],

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -1,4 +1,13 @@
-import { type Component, matchesKey, padding, Text, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	matchesKey,
+	padding,
+	parseSgrMouse,
+	type SgrMouseEvent,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
 import { replaceTabs } from "../../tools/render-utils";
 import { highlightCode, theme } from "../theme/theme";
 import type { CopyTarget } from "../utils/copy-targets";
@@ -54,6 +63,9 @@ export class CopySelectorComponent implements Component {
 	#roots: CopyTarget[];
 	#cursorId: string;
 	#treeRows = MIN_TREE_ROWS;
+	// Per-render hit map: 0-based screen row -> flattened node index. Rebuilt by
+	// every #renderTree call so a click row resolves to the node painted there.
+	#rowToFlatIndex = new Map<number, number>();
 	// Reused across renders to wrap preview content to the pane width.
 	#previewText = new Text("", 0, 0);
 
@@ -81,6 +93,11 @@ export class CopySelectorComponent implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// SGR mouse reports arrive while the fullscreen overlay holds the alt
+		// screen. Parse failures fall through to keyboard handling (plan-review
+		// pattern), so a malformed partial never gets dropped silently.
+		if (keyData.startsWith("\x1b[<") && this.#handleMouse(keyData)) return;
+
 		if (matchesSelectCancel(keyData)) {
 			this.callbacks.onCancel();
 			return;
@@ -107,10 +124,45 @@ export class CopySelectorComponent implements Component {
 		}
 	}
 
+	/**
+	 * Hit-test an SGR mouse report against the last render. Wheel moves the
+	 * selection one row per notch (clamped, no wrap); a left click on a tree row
+	 * selects that node and copies it when it carries content (the Enter path);
+	 * motion/release and non-left buttons are consumed as no-ops. Returns false
+	 * only when `data` is not an SGR report, so the caller falls back to keys.
+	 */
+	#handleMouse(data: string): boolean {
+		const event: SgrMouseEvent | null = parseSgrMouse(data);
+		if (!event) return false;
+		const flat = this.#flatten();
+		if (flat.length === 0) return true;
+		if (event.wheel !== null) {
+			const idx = Math.max(
+				0,
+				flat.findIndex(n => n.target.id === this.#cursorId),
+			);
+			const next = Math.min(flat.length - 1, Math.max(0, idx + event.wheel));
+			this.#cursorId = flat[next]!.target.id;
+			return true;
+		}
+		if (event.release || event.motion) return true;
+		if (!event.leftClick) return true;
+		const flatIdx = this.#rowToFlatIndex.get(event.row);
+		if (flatIdx === undefined) return true;
+		const node = flat[flatIdx];
+		if (!node) return true;
+		this.#cursorId = node.target.id;
+		if (node.target.content !== undefined) this.callbacks.onPick(node.target);
+		return true;
+	}
+
 	#renderTree(width: number, flat: FlatNode[], cursorIdx: number, rows: number): string[] {
 		const inner = Math.max(0, width - 4);
 		const start = Math.max(0, Math.min(cursorIdx - Math.floor(rows / 2), Math.max(0, flat.length - rows)));
 		const out: string[] = [];
+		// Rebuild the click map for this frame. Tree rows paint starting at screen
+		// row 1 (row 0 is the top border), so row r maps to screen row 1 + r.
+		this.#rowToFlatIndex.clear();
 		for (let r = 0; r < rows; r++) {
 			const i = start + r;
 			const node = flat[i];
@@ -118,6 +170,7 @@ export class CopySelectorComponent implements Component {
 				out.push(row("", width));
 				continue;
 			}
+			this.#rowToFlatIndex.set(1 + r, i);
 			const target = node.target;
 			const isSelected = i === cursorIdx;
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -339,6 +339,9 @@ export class InputController {
 		for (const key of this.ctx.keybindings.getKeys("app.clipboard.copyLine")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyCurrentLine());
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.clipboard.copy")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showCopySelector());
+		}
 		const hubKeys = new Set([
 			...this.ctx.keybindings.getKeys("app.agents.hub"),
 			...this.ctx.keybindings.getKeys("app.session.observe"),

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -662,6 +662,10 @@ export class SelectorController {
 			width: "100%",
 			maxHeight: "100%",
 			margin: 0,
+			// Fullscreen mounts the picker on the alternate screen, which is what
+			// enables SGR mouse tracking (tui #wantsAltScreen) so block rows can be
+			// clicked. Without this flag no mouse reports reach the component.
+			fullscreen: true,
 		});
 		this.ctx.ui.setFocus(selector);
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -132,4 +132,64 @@ describe("CopySelectorComponent", () => {
 
 		expect(onCancel).toHaveBeenCalledTimes(1);
 	});
+
+	// Mouse: the fullscreen overlay enables SGR tracking. Wire row is 1-based and
+	// parseSgrMouse converts to 0-based; the top border is screen row 0, so the
+	// first tree row (msg:1) is screen row 1 == wire row 2.
+	it("copies the block under a left click", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		render(component); // builds the per-row hit map
+		component.handleInput("\x1b[<0;4;3M"); // wire row 3 -> screen row 2 -> Block 1
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick.mock.calls[0]![0].content).toBe("BLOCK0");
+	});
+
+	it("moves the selection with the wheel and clamps at the top", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		render(component);
+		component.handleInput("\x1b[<65;4;2M"); // wheel down -> Block 1
+		expect(render(component)).toContain("alpha()");
+		component.handleInput("\x1b[<64;4;2M"); // wheel up -> msg:1
+		component.handleInput("\x1b[<64;4;2M"); // already at top, clamps (no wrap)
+		component.handleInput(ENTER);
+		expect(onPick.mock.calls.at(-1)![0].content).toBe("FULL_MESSAGE");
+	});
+
+	it("ignores a click outside the tree rows", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		render(component);
+		component.handleInput("\x1b[<0;4;1M"); // wire row 1 -> screen row 0 (top border)
+		component.handleInput("\x1b[<0;4;39M"); // far below the tree
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("does not copy a node that carries no content", () => {
+		const onPick = vi.fn();
+		const roots: CopyTarget[] = [
+			{
+				id: "group",
+				label: "Group",
+				preview: "",
+				children: [{ id: "leaf", label: "Leaf", preview: "x", content: "LEAF", copyMessage: "c" }],
+			},
+		];
+		const component = new CopySelectorComponent(roots, { onPick, onCancel: vi.fn() });
+		render(component);
+		component.handleInput("\x1b[<0;4;2M"); // screen row 1 -> the contentless group
+		expect(onPick).not.toHaveBeenCalled();
+		component.handleInput("\x1b[<0;4;3M"); // screen row 2 -> the leaf
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick.mock.calls[0]![0].content).toBe("LEAF");
+	});
+
+	it("falls through on a non-SGR-mouse sequence without copying", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		render(component);
+		expect(() => component.handleInput("\x1b[<garbage")).not.toThrow();
+		expect(onPick).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## What

Make the existing `/copy` picker mouse-driven: open it with a keybinding and **left-click a block to copy it** (or scroll the wheel to move the selection). Keyboard navigation is unchanged.

## Why

`/copy` already extracts conversation blocks (messages, code blocks, quote blocks, shell/eval commands, handoff) and copies the selected one to the clipboard — but it was keyboard-only. This adds the obvious mouse affordance.

## How

- **`selector-controller.ts#showCopySelector`**: mount the picker with `fullscreen: true`. This is the linchpin — `tui #wantsAltScreen()` only emits `MOUSE_TRACKING_ON` for fullscreen (alt-screen) overlays, so without this flag no SGR mouse reports reach the component. `CopySelectorComponent.render` already sizes to the full terminal height, so fullscreen is the natural fit (matches `showSettingsSelector`).
- **`copy-selector.ts`**: add a per-render `#rowToFlatIndex` map (screen row → flat node index, rebuilt each `render`) and `#handleMouse` via `parseSgrMouse`, routed at the top of `handleInput` with the plan-review boolean guard (`startsWith("\x1b[<") && #handleMouse(...)`). Left-click selects + copies the node when it carries content (the Enter path); wheel moves the cursor one row per notch with clamping; motion/release/other buttons are consumed as no-ops.
- **`config/keybindings.ts` + `input-controller.ts`**: add an `app.clipboard.copy` action (default `Alt+Shift+Y`, unreserved, sits beside `copyLine`/`copyPrompt`) wired to `showCopySelector()`.

## Non-goals

- No click-to-copy on the live transcript — that would require enabling mouse tracking on the main screen, which breaks the terminal's native text selection. The picker is the deliberate surface for this.

## Tests

Extended `test/modes/components/copy-selector.test.ts` with mouse coverage: left-click copies the clicked block, wheel moves + clamps, clicks outside the tree are no-ops, a contentless node is not copied (defensive guard), and a non-SGR sequence falls through without copying.

```
bun test test/modes/components/copy-selector.test.ts   # 10 pass
bun run check:types                                     # clean
biome check <changed files>                             # clean
```
