### PR TITLE
fix(hashline): drop duplicated JSX boundary echoes

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-repaired duplicated JSX/XML closing boundary lines at the end of single-line replacement expansions. ([#2705](https://github.com/can1357/oh-my-pi/issues/2705))
+
 ## [16.0.1] - 2026-06-15
 
 ### Fixed

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -132,9 +132,44 @@ export const STRUCTURAL_CLOSER_RE = /^\s*[)\]}]+[;,]?\s*$/;
 
 /** A JSX/XML closing boundary that carries structure but no bracket tokens. */
 const JSX_CLOSER_RE = /^\s*(?:<\/>|<\/[A-Za-z][\w.:-]*>|\/>)\s*[;,]?\s*$/;
+const JSX_NAMED_CLOSER_RE = /^\s*<\/([A-Za-z][\w.:-]*)>\s*[;,]?\s*$/;
+const JSX_FRAGMENT_CLOSER_RE = /^\s*<\/>\s*[;,]?\s*$/;
+const JSX_TAG_RE = /<>|<\/>|<\/?([A-Za-z][\w.:-]*)\b[^>]*>/g;
 
 function isStructuralCloserLine(text: string): boolean {
 	return STRUCTURAL_CLOSER_RE.test(text) || JSX_CLOSER_RE.test(text);
+}
+
+function jsxCloserName(text: string): string | undefined {
+	if (JSX_FRAGMENT_CLOSER_RE.test(text)) return "";
+	const match = JSX_NAMED_CLOSER_RE.exec(text);
+	return match?.[1];
+}
+
+function payloadHasJsxOpenerForEcho(payloadPrefix: readonly string[], echoLines: readonly string[]): boolean {
+	const openTags: string[] = [];
+	for (const line of payloadPrefix) {
+		JSX_TAG_RE.lastIndex = 0;
+		let match = JSX_TAG_RE.exec(line);
+		while (match !== null) {
+			const raw = match[0];
+			if (raw === "<>") {
+				openTags.push("");
+			} else if (raw === "</>") {
+				if (openTags[openTags.length - 1] === "") openTags.pop();
+			} else if (raw.startsWith("</")) {
+				if (openTags[openTags.length - 1] === match[1]) openTags.pop();
+			} else if (!raw.endsWith("/>")) {
+				openTags.push(match[1]);
+			}
+			match = JSX_TAG_RE.exec(line);
+		}
+	}
+	for (const line of echoLines) {
+		const name = jsxCloserName(line);
+		if (name !== undefined && openTags.includes(name)) return true;
+	}
+	return false;
 }
 
 interface DelimiterBalance {
@@ -480,8 +515,10 @@ function findOneSidedBoundaryEcho(
 	const echoLines =
 		side === "leading" ? group.payload.slice(0, count) : group.payload.slice(group.payload.length - count);
 	if (!balanceIsZero(computeDelimiterBalance(echoLines))) return undefined;
-	if (group.deleteIndices.length <= 1 && (side !== "trailing" || !echoLines.every(isStructuralCloserLine))) {
-		return undefined;
+	if (group.deleteIndices.length <= 1) {
+		if (side !== "trailing" || !echoLines.every(isStructuralCloserLine)) return undefined;
+		const payloadPrefix = group.payload.slice(0, group.payload.length - count);
+		if (payloadHasJsxOpenerForEcho(payloadPrefix, echoLines)) return undefined;
 	}
 	return { side, count };
 }

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -134,7 +134,7 @@ export const STRUCTURAL_CLOSER_RE = /^\s*[)\]}]+[;,]?\s*$/;
 const JSX_CLOSER_RE = /^\s*(?:<\/>|<\/[A-Za-z][\w.:-]*>|\/>)\s*[;,]?\s*$/;
 const JSX_NAMED_CLOSER_RE = /^\s*<\/([A-Za-z][\w.:-]*)>\s*[;,]?\s*$/;
 const JSX_FRAGMENT_CLOSER_RE = /^\s*<\/>\s*[;,]?\s*$/;
-const JSX_TAG_RE = /<>|<\/>|<\/?([A-Za-z][\w.:-]*)\b[^>]*>/g;
+const JSX_TAG_RE = /<>|<\/>|<\/?([A-Za-z][\w.:-]*)\b[\s\S]*?>/g;
 
 function isStructuralCloserLine(text: string): boolean {
 	return STRUCTURAL_CLOSER_RE.test(text) || JSX_CLOSER_RE.test(text);
@@ -146,24 +146,27 @@ function jsxCloserName(text: string): string | undefined {
 	return match?.[1];
 }
 
+function isSelfClosingJsxTag(text: string): boolean {
+	return /\/>\s*$/.test(text);
+}
+
 function payloadHasJsxOpenerForEcho(payloadPrefix: readonly string[], echoLines: readonly string[]): boolean {
 	const openTags: string[] = [];
-	for (const line of payloadPrefix) {
-		JSX_TAG_RE.lastIndex = 0;
-		let match = JSX_TAG_RE.exec(line);
-		while (match !== null) {
-			const raw = match[0];
-			if (raw === "<>") {
-				openTags.push("");
-			} else if (raw === "</>") {
-				if (openTags[openTags.length - 1] === "") openTags.pop();
-			} else if (raw.startsWith("</")) {
-				if (openTags[openTags.length - 1] === match[1]) openTags.pop();
-			} else if (!raw.endsWith("/>")) {
-				openTags.push(match[1]);
-			}
-			match = JSX_TAG_RE.exec(line);
+	const payloadText = payloadPrefix.join("\n");
+	JSX_TAG_RE.lastIndex = 0;
+	let match = JSX_TAG_RE.exec(payloadText);
+	while (match !== null) {
+		const raw = match[0];
+		if (raw === "<>") {
+			openTags.push("");
+		} else if (raw === "</>") {
+			if (openTags[openTags.length - 1] === "") openTags.pop();
+		} else if (raw.startsWith("</")) {
+			if (openTags[openTags.length - 1] === match[1]) openTags.pop();
+		} else if (!isSelfClosingJsxTag(raw)) {
+			openTags.push(match[1]);
 		}
+		match = JSX_TAG_RE.exec(payloadText);
 	}
 	for (const line of echoLines) {
 		const name = jsxCloserName(line);

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -134,7 +134,6 @@ export const STRUCTURAL_CLOSER_RE = /^\s*[)\]}]+[;,]?\s*$/;
 const JSX_CLOSER_RE = /^\s*(?:<\/>|<\/[A-Za-z][\w.:-]*>|\/>)\s*[;,]?\s*$/;
 const JSX_NAMED_CLOSER_RE = /^\s*<\/([A-Za-z][\w.:-]*)>\s*[;,]?\s*$/;
 const JSX_FRAGMENT_CLOSER_RE = /^\s*<\/>\s*[;,]?\s*$/;
-const JSX_TAG_RE = /<>|<\/>|<\/?([A-Za-z][\w.:-]*)\b[\s\S]*?>/g;
 
 function isStructuralCloserLine(text: string): boolean {
 	return STRUCTURAL_CLOSER_RE.test(text) || JSX_CLOSER_RE.test(text);
@@ -146,27 +145,79 @@ function jsxCloserName(text: string): string | undefined {
 	return match?.[1];
 }
 
-function isSelfClosingJsxTag(text: string): boolean {
-	return /\/>\s*$/.test(text);
+interface JsxPayloadTag {
+	readonly name: string;
+	readonly closing: boolean;
+	readonly selfClosing: boolean;
+}
+
+function isJsxTagStart(text: string, index: number): boolean {
+	const next = text[index + 1];
+	return next === ">" || next === "/" || (next >= "A" && next <= "Z") || (next >= "a" && next <= "z");
+}
+
+function findJsxTagEnd(text: string, start: number): number {
+	let quote: string | undefined;
+	let braces = 0;
+	for (let i = start + 1; i < text.length; i++) {
+		const ch = text[i];
+		if (quote) {
+			if (ch === "\\" && i + 1 < text.length) {
+				i++;
+			} else if (ch === quote) {
+				quote = undefined;
+			}
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+		} else if (ch === "{") {
+			braces++;
+		} else if (ch === "}" && braces > 0) {
+			braces--;
+		} else if (ch === ">" && braces === 0) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+function parseJsxPayloadTag(raw: string): JsxPayloadTag | undefined {
+	if (raw === "<>") return { name: "", closing: false, selfClosing: false };
+	if (raw === "</>") return { name: "", closing: true, selfClosing: false };
+	const closing = raw.startsWith("</");
+	const nameStart = closing ? 2 : 1;
+	let nameEnd = nameStart;
+	while (nameEnd < raw.length && /[\w.:-]/.test(raw[nameEnd])) nameEnd++;
+	if (nameEnd === nameStart) return undefined;
+	return {
+		name: raw.slice(nameStart, nameEnd),
+		closing,
+		selfClosing: !closing && /\/>\s*$/.test(raw),
+	};
+}
+
+function readJsxPayloadTags(text: string): JsxPayloadTag[] {
+	const tags: JsxPayloadTag[] = [];
+	for (let start = text.indexOf("<"); start >= 0; start = text.indexOf("<", start + 1)) {
+		if (!isJsxTagStart(text, start)) continue;
+		const end = findJsxTagEnd(text, start);
+		if (end < 0) break;
+		const tag = parseJsxPayloadTag(text.slice(start, end + 1));
+		if (tag) tags.push(tag);
+		start = end;
+	}
+	return tags;
 }
 
 function payloadHasJsxOpenerForEcho(payloadPrefix: readonly string[], echoLines: readonly string[]): boolean {
 	const openTags: string[] = [];
-	const payloadText = payloadPrefix.join("\n");
-	JSX_TAG_RE.lastIndex = 0;
-	let match = JSX_TAG_RE.exec(payloadText);
-	while (match !== null) {
-		const raw = match[0];
-		if (raw === "<>") {
-			openTags.push("");
-		} else if (raw === "</>") {
-			if (openTags[openTags.length - 1] === "") openTags.pop();
-		} else if (raw.startsWith("</")) {
-			if (openTags[openTags.length - 1] === match[1]) openTags.pop();
-		} else if (!isSelfClosingJsxTag(raw)) {
-			openTags.push(match[1]);
+	for (const tag of readJsxPayloadTags(payloadPrefix.join("\n"))) {
+		if (tag.closing) {
+			if (openTags[openTags.length - 1] === tag.name) openTags.pop();
+		} else if (!tag.selfClosing) {
+			openTags.push(tag.name);
 		}
-		match = JSX_TAG_RE.exec(payloadText);
 	}
 	for (const line of echoLines) {
 		const name = jsxCloserName(line);

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -130,6 +130,13 @@ function bucketAnchorEditsByLine(edits: IndexedEdit[]): Map<number, IndexedEdit[
 /** A line that is nothing but closing delimiters: `}`, `)`, `];`, `})`, `},`. */
 export const STRUCTURAL_CLOSER_RE = /^\s*[)\]}]+[;,]?\s*$/;
 
+/** A JSX/XML closing boundary that carries structure but no bracket tokens. */
+const JSX_CLOSER_RE = /^\s*(?:<\/>|<\/[A-Za-z][\w.:-]*>|\/>)\s*[;,]?\s*$/;
+
+function isStructuralCloserLine(text: string): boolean {
+	return STRUCTURAL_CLOSER_RE.test(text) || JSX_CLOSER_RE.test(text);
+}
+
 interface DelimiterBalance {
 	paren: number;
 	bracket: number;
@@ -452,19 +459,18 @@ function describeBoundaryRepair(group: ReplacementGroup, action: string): string
  * are handled by {@link findBoundaryEcho}; delimiter-imbalanced one-sided echoes
  * by {@link findDuplicateSuffix}/{@link findDuplicatePrefix}.
  *
- * Scoped to multi-line ranges (a construct rewrite) on purpose: a single-line
- * `replace N.=N` expanding into several lines is an *expansion* where every
- * payload line is intentional new content, so a payload line that happens to
- * equal a neighbor stays — only a genuine block rewrite retypes a boundary
- * keeper by mistake. The dropped lines must be delimiter-neutral so removing the
- * duplicate keeps the already-balanced result balanced, and must not consume the
- * whole payload.
+ * Scoped broadly for multi-line ranges (a construct rewrite) because retouched
+ * neutral keepers are usually boundary mistakes there. Single-line expansions
+ * are riskier — ordinary duplicated statements may be intentional — so they are
+ * only repaired when the duplicated edge is a structural closer line that
+ * carries no delimiter-balance signal itself, such as a JSX `</section>` close.
+ * The dropped lines must keep the already-balanced result balanced, and must
+ * not consume the whole payload.
  */
 function findOneSidedBoundaryEcho(
 	group: ReplacementGroup,
 	fileLines: readonly string[],
 ): { side: "leading" | "trailing"; count: number } | undefined {
-	if (group.deleteIndices.length <= 1) return undefined;
 	const leading = countDuplicateLeadingBoundaryLines(group, fileLines);
 	const trailing = countDuplicateTrailingBoundaryLines(group, fileLines);
 	if (leading > 0 === trailing > 0) return undefined;
@@ -474,6 +480,9 @@ function findOneSidedBoundaryEcho(
 	const echoLines =
 		side === "leading" ? group.payload.slice(0, count) : group.payload.slice(group.payload.length - count);
 	if (!balanceIsZero(computeDelimiterBalance(echoLines))) return undefined;
+	if (group.deleteIndices.length <= 1 && (side !== "trailing" || !echoLines.every(isStructuralCloserLine))) {
+		return undefined;
+	}
 	return { side, count };
 }
 

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -301,6 +301,28 @@ describe("boundary-balance repair", () => {
 		expect(warnings).toHaveLength(0);
 	});
 
+	it("preserves a nested JSX closer when the opener spans payload lines", () => {
+		const file = ["const view = (", '<section className="outer">', "old text", "</section>", ");"].join("\n");
+		const diff = ["SWAP 3.=3:", "+<section", '+  className="inner"', "+>", "+new text", "+</section>"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(
+			[
+				"const view = (",
+				'<section className="outer">',
+				"<section",
+				'  className="inner"',
+				">",
+				"new text",
+				"</section>",
+				"</section>",
+				");",
+			].join("\n"),
+		);
+		expect(text.split("\n").filter(line => line.trim() === "</section>")).toHaveLength(2);
+		expect(warnings).toHaveLength(0);
+	});
+
 	// Mirror direction: the payload restates the keeper that survives just above
 	// the multi-line range (range one line low instead of one short).
 	it("drops a one-sided leading keeper echo in a multi-line rewrite", () => {

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -281,6 +281,26 @@ describe("boundary-balance repair", () => {
 		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
 	});
 
+	it("preserves a nested JSX closer that matches the surviving parent closer", () => {
+		const file = ["const view = (", '<section className="outer">', "old text", "</section>", ");"].join("\n");
+		const diff = ["SWAP 3.=3:", "+<section>", "+new text", "+</section>"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(
+			[
+				"const view = (",
+				'<section className="outer">',
+				"<section>",
+				"new text",
+				"</section>",
+				"</section>",
+				");",
+			].join("\n"),
+		);
+		expect(text.split("\n").filter(line => line.trim() === "</section>")).toHaveLength(2);
+		expect(warnings).toHaveLength(0);
+	});
+
 	// Mirror direction: the payload restates the keeper that survives just above
 	// the multi-line range (range one line low instead of one short).
 	it("drops a one-sided leading keeper echo in a multi-line rewrite", () => {

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -271,6 +271,16 @@ describe("boundary-balance repair", () => {
 		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
 	});
 
+	it("drops a one-sided JSX closer echo in a single-line expansion", () => {
+		const file = ["const view = (", "  <section>", "    <Old />", "  </section>", ");"].join("\n");
+		const diff = ["SWAP 3.=3:", "+    <New />", "+  </section>"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(["const view = (", "  <section>", "    <New />", "  </section>", ");"].join("\n"));
+		expect(text.split("\n").filter(line => line === "  </section>")).toHaveLength(1);
+		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+	});
+
 	// Mirror direction: the payload restates the keeper that survives just above
 	// the multi-line range (range one line low instead of one short).
 	it("drops a one-sided leading keeper echo in a multi-line rewrite", () => {

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -281,6 +281,16 @@ describe("boundary-balance repair", () => {
 		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
 	});
 
+	it("drops a JSX closer echo after a self-closing tag with a greater-than prop expression", () => {
+		const file = ["const view = (", "<Foo>", "old text", "</Foo>", ");"].join("\n");
+		const diff = ["SWAP 3.=3:", "+<Foo value={a > b} />", "+</Foo>"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(["const view = (", "<Foo>", "<Foo value={a > b} />", "</Foo>", ");"].join("\n"));
+		expect(text.split("\n").filter(line => line === "</Foo>")).toHaveLength(1);
+		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+	});
+
 	it("preserves a nested JSX closer that matches the surviving parent closer", () => {
 		const file = ["const view = (", '<section className="outer">', "old text", "</section>", ");"].join("\n");
 		const diff = ["SWAP 3.=3:", "+<section>", "+new text", "+</section>"].join("\n");


### PR DESCRIPTION
## Repro
A single-line `SWAP 3.=3` replacement that changes a JSX child and retypes the surviving closing tag below the range leaves the closer duplicated. Reproduced with: `bun -e 'import { applyEdits, parsePatch } from "@oh-my-pi/hashline"; const file=["const view = (","  <section>","    <Old />","  </section>",");"].join("\n"); const diff=["SWAP 3.=3:","+    <New />","+  </section>"].join("\n"); const result=applyEdits(file, parsePatch(diff).edits); console.log(result.text); console.log(JSON.stringify(result.warnings));'`.

## Cause
`packages/hashline/src/apply.ts` only let delimiter-balance repair handle single-line replacement expansions; `findOneSidedBoundaryEcho` deliberately limited delimiter-neutral one-sided echo repair to multi-line ranges. JSX/XML closing tags such as `</section>` carry structural block-boundary meaning but no `()[]{}` delimiter balance, so the repair saw a balanced single-line expansion and preserved the duplicated closer.

## Fix
- Added JSX/XML structural closer detection alongside delimiter-only closers.
- Allowed single-line replacement expansions to drop a one-sided trailing echo only when the duplicated edge is structural closer content, preserving ordinary statement duplicates.
- Added a regression test covering the `SWAP 3.=3` JSX closer echo.
- Added a hashline changelog entry for #2705.

## Verification
`bun --cwd=packages/hashline test && bun --cwd=packages/hashline run check` passed. Manual repro now emits one `</section>` plus the boundary-echo repair warning. Fixes #2705