### PR TITLE
fix(providers): preserve OpenRouter upstream routing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter `@upstream` routing selectors whose upstream slug also appears in the model id, so `openrouter/...@deepseek:high` keeps `openRouterRouting.only` instead of being consumed by provider-scoped fuzzy matching ([#2708](https://github.com/can1357/oh-my-pi/issues/2708)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -481,6 +481,10 @@ function matchModel(
 			// The prefix is not a known provider in this candidate set, so treat the
 			// slash as part of the raw model ID and continue with generic matching.
 		} else {
+			// Let the routing fallback apply `@upstream` before fuzzy matching can consume the slug.
+			if (splitUpstreamRouting(modelId)) {
+				return undefined;
+			}
 			const scored = providerModels
 				.map(model => ({ model, match: fuzzyMatch(modelId, model.id) }))
 				.filter(entry => entry.match.matches);

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -94,6 +94,18 @@ const mockOpenRouterModels: Model<Api>[] = [
 		contextWindow: 128000,
 		maxTokens: 8192,
 	}),
+	buildModel({
+		id: "deepseek/deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
 ];
 
 const mockProviderOverlapModels: Model<"anthropic-messages">[] = [
@@ -957,6 +969,14 @@ describe("provider routing selector (@upstream)", () => {
 		expect(result.model?.id).toBe("z-ai/glm-4.7");
 		expect(result.thinkingLevel).toBe(Effort.High);
 		expect(openRouterOnly(result.model)).toEqual(["cerebras"]);
+	});
+
+	test("preserves @upstream when the slug also matches model tokens", () => {
+		const result = parseModelPattern("openrouter/deepseek/deepseek-v4-pro@deepseek:high", allModels);
+		expect(result.model?.id).toBe("deepseek/deepseek-v4-pro");
+		expect(result.thinkingLevel).toBe(Effort.High);
+		expect(result.upstream).toBe("deepseek");
+		expect(openRouterOnly(result.model)).toEqual(["deepseek"]);
 	});
 
 	test("routes Vercel AI Gateway models via vercelGatewayRouting", () => {


### PR DESCRIPTION
## Repro
`parseModelPattern("openrouter/deepseek/deepseek-v4-pro@deepseek:high", ...)` reproduced the issue: before the fix it returned the OpenRouter model and `thinkingLevel: "high"`, but no `upstream` and no `compat.openRouterRouting`, so runtime OpenRouter requests could still route to arbitrary upstream providers.

## Cause
`packages/coding-agent/src/config/model-resolver.ts` let `matchModel()` run provider-scoped fuzzy matching on `modelId` before `parseModelPattern()` reached the existing `splitUpstreamRouting()` fallback. When the upstream slug duplicated a model token like `deepseek`, `fuzzyMatch()` accepted `deepseek/deepseek-v4-pro@deepseek` as `deepseek/deepseek-v4-pro` and returned the unrouted model.

## Fix
- Skip provider-scoped fuzzy matching when the provider-qualified model id contains a valid trailing `@upstream` selector, allowing the routing fallback to resolve and apply it.
- Added `deepseek/deepseek-v4-pro` OpenRouter resolver coverage for `openrouter/deepseek/deepseek-v4-pro@deepseek:high`.
- Added a coding-agent changelog entry for the OpenRouter routing fix.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts --test-name-pattern "provider routing selector"` passed: 8 tests. `bun test packages/coding-agent/test/model-resolver.test.ts` passed: 87 tests. Manual repro after the fix returned `upstream: "deepseek"` and `routing: {"only":["deepseek"]}`. Fixes #2708