### PR TITLE
fix(openai-responses): quarantine invalid tool schemas instead of failing the whole turn (#2652)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A single MCP tool whose input schema can't be emitted as a valid strict tool schema for the active provider no longer fails the whole turn with HTTP 400. `convertTools` (openai-responses) now validates each tool's emitted parameter schema for `enum`/`const`-vs-`type` contradictions that pass structural JSON-Schema validation but the provider rejects — e.g. a non-null `enum` on a `type: "null"` node, or an `enum` on an `array` node — and quarantines just the offending tool with a `logger.warn` naming the tool and schema path, keeping every other tool usable. Adds `findStrictToolSchemaViolation` to `@oh-my-pi/pi-ai/utils/schema` ([#2652](https://github.com/can1357/oh-my-pi/issues/2652))
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -34,7 +34,13 @@ import {
 import { postOpenAIStream } from "../utils/openai-http";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
-import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
+import {
+	adaptSchemaForStrict,
+	findStrictToolSchemaViolation,
+	NO_STRICT,
+	sanitizeSchemaForOpenAIResponses,
+	toolWireSchema,
+} from "../utils/schema";
 import { mapToOpenAIResponsesToolChoice, type OpenAIResponsesToolChoice } from "../utils/tool-choice";
 import {
 	buildCopilotDynamicHeaders,
@@ -661,7 +667,8 @@ function getOpenAIResponsesRoutingSessionId(
 	return normalizeOpenAIResponsesPromptCacheKey(options?.sessionId);
 }
 
-function buildParams(
+/** @internal Exported for tests. */
+export function buildParams(
 	model: Model<"openai-responses">,
 	context: Context,
 	options: OpenAIResponsesOptions | undefined,
@@ -714,7 +721,21 @@ function buildParams(
 	if (context.tools) {
 		params.tools = convertTools(context.tools, model.compat.supportsStrictMode, model);
 		if (options?.toolChoice) {
-			params.tool_choice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, context.tools, model);
+			// Map tool_choice against the tools that survived quarantine, not the
+			// original list: a forced choice for a dropped tool — or "required" when
+			// every tool was dropped — would otherwise send a tool_choice with no
+			// matching tool, which the provider rejects just like the bad schema did (#2652).
+			const emittedNames = new Set(
+				params.tools.map(t => (t as { name?: string }).name).filter((n): n is string => n !== undefined),
+			);
+			const survivingTools =
+				params.tools.length === context.tools.length
+					? context.tools
+					: context.tools.filter(t => emittedNames.has(t.customWireName ?? t.name));
+			const toolChoice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, survivingTools, model);
+			if (toolChoice !== undefined && params.tools.length > 0) {
+				params.tool_choice = toolChoice;
+			}
 		}
 		// The apply_patch spec §1 marks only `apply_patch` itself as
 		// `supports_parallel_tool_calls = false`. OpenAI's Responses API
@@ -861,11 +882,20 @@ export function mapOpenAIResponsesToolChoiceForTools(
 }
 
 /** @internal Exported for tests. */
-export function convertTools(tools: Tool[], strictMode: boolean, model: Model<"openai-responses">): OpenAITool[] {
+export function convertTools(
+	tools: Tool[],
+	strictMode: boolean,
+	model: Model<"openai-responses">,
+	onQuarantine: (toolName: string, schemaPath: string) => void = (toolName, schemaPath) =>
+		logger.warn(
+			`Tool "${toolName}" omitted from the openai-responses request: its parameter schema is invalid for this provider at ${schemaPath} (an enum/const value cannot match its declared type). Other tools are unaffected.`,
+		),
+): OpenAITool[] {
 	const allowFreeform = supportsFreeformApplyPatch(model);
-	return tools.map(tool => {
+	const out: OpenAITool[] = [];
+	for (const tool of tools) {
 		if (allowFreeform && tool.customFormat) {
-			return {
+			out.push({
 				type: "custom",
 				// Tool advertises its wire-level name (e.g. `apply_patch`) — the
 				// agent-loop dispatcher will match incoming calls by either the
@@ -877,18 +907,29 @@ export function convertTools(tools: Tool[], strictMode: boolean, model: Model<"o
 					syntax: tool.customFormat.syntax,
 					definition: compactGrammarDefinition(tool.customFormat.syntax, tool.customFormat.definition),
 				},
-			} as unknown as OpenAITool;
+			} as unknown as OpenAITool);
+			continue;
 		}
 		const strict = !NO_STRICT && strictMode && tool.strict !== false;
 		const baseParameters = toolWireSchema(tool);
 		const responseParameters = sanitizeSchemaForOpenAIResponses(baseParameters);
 		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(responseParameters, strict);
-		return {
+		// Quarantine a tool whose emitted schema carries a provider-rejecting
+		// enum/const-vs-type contradiction: dropping just that tool keeps the rest
+		// of the request valid instead of letting one bad MCP schema 400 the whole
+		// turn (#2652). Other tools and built-ins are unaffected.
+		const violation = findStrictToolSchemaViolation(parameters);
+		if (violation) {
+			onQuarantine(tool.name, violation);
+			continue;
+		}
+		out.push({
 			type: "function",
 			name: tool.name,
 			description: tool.description || "",
 			parameters,
 			...(effectiveStrict && { strict: true }),
-		} as OpenAITool;
-	});
+		} as OpenAITool);
+	}
+	return out;
 }

--- a/packages/ai/src/utils/schema/index.ts
+++ b/packages/ai/src/utils/schema/index.ts
@@ -8,6 +8,7 @@ export * from "./json-schema-validator";
 export * from "./meta-validator";
 export * from "./normalize";
 export * from "./spill";
+export * from "./strict-tool-validation";
 export * from "./types";
 export * from "./typescript";
 export * from "./wire";

--- a/packages/ai/src/utils/schema/strict-tool-validation.ts
+++ b/packages/ai/src/utils/schema/strict-tool-validation.ts
@@ -1,0 +1,117 @@
+/**
+ * Detects tool-parameter schemas that pass structural JSON-Schema validation
+ * (so {@link isValidJsonSchema} accepts them) yet make OpenAI-style providers
+ * reject the whole request with HTTP 400 — namely an `enum`/`const` whose
+ * value(s) cannot satisfy the node's declared `type`. MCP servers emit these
+ * when a nullable/array branch is built incorrectly (e.g. a non-null `enum`
+ * copied onto a `type: "null"` branch, or an `enum` placed on an `array`
+ * schema instead of its `items`). One such tool 400s the entire turn, so
+ * callers quarantine just the offending tool. See issue #2652.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+const SCHEMA_TYPE_NAMES: Record<string, true> = {
+	string: true,
+	number: true,
+	integer: true,
+	boolean: true,
+	object: true,
+	array: true,
+	null: true,
+};
+
+function jsonValueMatchesType(value: unknown, type: string): boolean {
+	switch (type) {
+		case "string":
+			return typeof value === "string";
+		case "number":
+			return typeof value === "number";
+		case "integer":
+			return typeof value === "number" && Number.isInteger(value);
+		case "boolean":
+			return typeof value === "boolean";
+		case "null":
+			return value === null;
+		case "object":
+			return typeof value === "object" && value !== null && !Array.isArray(value);
+		case "array":
+			return Array.isArray(value);
+		default:
+			// Unknown type keyword — don't flag (forward compatibility).
+			return true;
+	}
+}
+
+function declaredTypes(node: JsonRecord): string[] {
+	const t = node.type;
+	if (typeof t === "string") return t in SCHEMA_TYPE_NAMES ? [t] : [];
+	if (Array.isArray(t)) return t.filter((x): x is string => typeof x === "string" && x in SCHEMA_TYPE_NAMES);
+	return [];
+}
+
+const CHILD_MAP_KEYS = ["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"] as const;
+const CHILD_SCHEMA_KEYS = [
+	"items",
+	"contains",
+	"not",
+	"if",
+	"then",
+	"else",
+	"propertyNames",
+	"additionalProperties",
+	"unevaluatedProperties",
+	"unevaluatedItems",
+] as const;
+const CHILD_ARRAY_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
+
+/**
+ * Walk a tool parameter schema for OpenAI-strict `enum`/`const`-vs-`type`
+ * contradictions. Returns a JSON-pointer-ish path to the first offending node,
+ * or `null` when the schema is safe to emit.
+ */
+export function findStrictToolSchemaViolation(schema: unknown, path = "#"): string | null {
+	if (Array.isArray(schema)) {
+		for (let i = 0; i < schema.length; i++) {
+			const hit = findStrictToolSchemaViolation(schema[i], `${path}/${i}`);
+			if (hit) return hit;
+		}
+		return null;
+	}
+	if (typeof schema !== "object" || schema === null) return null;
+	const node = schema as JsonRecord;
+
+	const types = declaredTypes(node);
+	if (types.length > 0) {
+		if (Array.isArray(node.enum) && node.enum.some(v => !types.some(t => jsonValueMatchesType(v, t)))) {
+			return `${path}/enum`;
+		}
+		if ("const" in node && !types.some(t => jsonValueMatchesType(node.const, t))) {
+			return `${path}/const`;
+		}
+	}
+
+	for (const key of CHILD_MAP_KEYS) {
+		const sub = node[key];
+		if (sub && typeof sub === "object" && !Array.isArray(sub)) {
+			for (const k of Object.keys(sub as JsonRecord)) {
+				const hit = findStrictToolSchemaViolation((sub as JsonRecord)[k], `${path}/${key}/${k}`);
+				if (hit) return hit;
+			}
+		}
+	}
+	for (const key of CHILD_SCHEMA_KEYS) {
+		if (key in node) {
+			const hit = findStrictToolSchemaViolation(node[key], `${path}/${key}`);
+			if (hit) return hit;
+		}
+	}
+	for (const key of CHILD_ARRAY_KEYS) {
+		const arr = node[key];
+		if (Array.isArray(arr)) {
+			const hit = findStrictToolSchemaViolation(arr, `${path}/${key}`);
+			if (hit) return hit;
+		}
+	}
+	return null;
+}

--- a/packages/ai/test/openai-responses-tool-quarantine.test.ts
+++ b/packages/ai/test/openai-responses-tool-quarantine.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { buildParams, convertTools } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Context, Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
+import { findStrictToolSchemaViolation } from "@oh-my-pi/pi-ai/utils/schema";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { z } from "zod/v4";
+
+function makeModel(): Model<"openai-responses"> {
+	return buildModel({
+		id: "gpt-5",
+		name: "GPT-5",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	} as ModelSpec<"openai-responses">);
+}
+
+describe("findStrictToolSchemaViolation (#2652)", () => {
+	test("flags a non-null enum on a null-typed node (nullable-enum shape)", () => {
+		expect(findStrictToolSchemaViolation({ enum: ["A", "B"], type: "null" })).toBe("#/enum");
+	});
+
+	test("flags an enum on an array-typed node (enum-on-array shape)", () => {
+		expect(findStrictToolSchemaViolation({ enum: [0, 1, 2], items: { type: "integer" }, type: "array" })).toBe(
+			"#/enum",
+		);
+	});
+
+	test("flags a const incompatible with its type (anyOf/const shape) with its path", () => {
+		const schema = { anyOf: [{ const: 5, type: "string" }, { type: "null" }] };
+		expect(findStrictToolSchemaViolation(schema)).toBe("#/anyOf/0/const");
+	});
+
+	test("reports the nested path to the offending node", () => {
+		const schema = {
+			type: "object",
+			properties: { tag: { enum: ["x"], type: "null" } },
+			required: ["tag"],
+		};
+		expect(findStrictToolSchemaViolation(schema)).toBe("#/properties/tag/enum");
+	});
+
+	test("accepts valid enum/const/type combinations, including nullable unions", () => {
+		expect(findStrictToolSchemaViolation({ enum: ["a", "b"], type: "string" })).toBeNull();
+		expect(findStrictToolSchemaViolation({ enum: ["a", null], type: ["string", "null"] })).toBeNull();
+		expect(findStrictToolSchemaViolation({ const: 5, type: "integer" })).toBeNull();
+		// An enum belongs on the array's items, which is valid.
+		expect(findStrictToolSchemaViolation({ type: "array", items: { enum: [1, 2], type: "integer" } })).toBeNull();
+		// enum without a declared type cannot contradict anything.
+		expect(findStrictToolSchemaViolation({ enum: ["x"] })).toBeNull();
+	});
+});
+
+const badTool: Tool = {
+	name: "mcp__server__bad",
+	description: "an MCP tool with an invalid nullable-enum schema",
+	parameters: {
+		type: "object",
+		properties: { choice: { enum: ["A", "B"], type: "null" } },
+		required: ["choice"],
+		additionalProperties: false,
+	} as unknown as Tool["parameters"],
+};
+const goodTool: Tool = {
+	name: "read_file",
+	description: "read a file",
+	parameters: z.object({ path: z.string() }),
+};
+
+describe("convertTools quarantine (#2652)", () => {
+	test("drops only the tool with the provider-rejecting schema, keeping the rest", () => {
+		const out = convertTools([goodTool, badTool], true, makeModel()) as Array<{ name: string }>;
+		const names = out.map(t => t.name);
+		expect(names).toContain("read_file");
+		expect(names).not.toContain("mcp__server__bad");
+		expect(out).toHaveLength(1);
+	});
+
+	test("emits every tool when all schemas are valid", () => {
+		expect(convertTools([goodTool], true, makeModel())).toHaveLength(1);
+	});
+
+	test("reports the hidden tool name and the offending schema path", () => {
+		const dropped: Array<{ name: string; path: string }> = [];
+		convertTools([badTool], true, makeModel(), (name, path) => dropped.push({ name, path }));
+		expect(dropped).toEqual([{ name: "mcp__server__bad", path: "#/properties/choice/enum" }]);
+	});
+});
+
+describe("buildParams tool_choice reconciliation (#2652)", () => {
+	function ctx(tools: Tool[]): Context {
+		return { systemPrompt: [], messages: [], tools } as unknown as Context;
+	}
+
+	test("drops a forced tool_choice when the selected tool was quarantined", () => {
+		const { params } = buildParams(
+			makeModel(),
+			ctx([goodTool, badTool]),
+			{ toolChoice: { type: "tool", name: "mcp__server__bad" } },
+			undefined,
+		);
+		expect((params.tools as Array<{ name: string }>).map(t => t.name)).toEqual(["read_file"]);
+		expect(params.tool_choice).toBeUndefined();
+	});
+
+	test("drops a 'required' tool_choice when every tool was quarantined", () => {
+		const { params } = buildParams(makeModel(), ctx([badTool]), { toolChoice: "required" }, undefined);
+		expect(params.tools).toHaveLength(0);
+		expect(params.tool_choice).toBeUndefined();
+	});
+
+	test("keeps tool_choice for a surviving forced tool", () => {
+		const { params } = buildParams(
+			makeModel(),
+			ctx([goodTool, badTool]),
+			{ toolChoice: { type: "tool", name: "read_file" } },
+			undefined,
+		);
+		expect(params.tool_choice).toEqual({ type: "function", name: "read_file" });
+	});
+});


### PR DESCRIPTION
Fixes #2652.

## Problem
When an enabled MCP server exposes a tool whose input schema can't be emitted as a valid strict tool schema for the active provider, OMP sends it anyway and the provider rejects the **entire** request with HTTP 400 — so the assistant can't respond at all. roboomp reproduced this in the OpenAI Responses path: `convertTools()` still emits both example invalid shapes (`{enum:[…], type:"null"}` and an `enum` on an `array` node) alongside valid tools.

The reason they slip through: these schemas are *structurally* valid JSON Schema, so `isValidJsonSchema` (the existing meta-validator) accepts them. The contradiction is **semantic** — an `enum`/`const` value that can't satisfy the node's declared `type` — which the provider enforces but the structural validator doesn't.

## Fix
Implements the issue's suggested approach (validate the emitted schema → drop only the invalid tool → warn → continue):

- **`findStrictToolSchemaViolation(schema)`** (new, `@oh-my-pi/pi-ai/utils/schema`) — walks a tool's parameter schema and returns a JSON-pointer-ish path to the first `enum`/`const`-vs-`type` contradiction, or `null` when safe. Recurses through `properties`/`items`/`anyOf`/`$defs`/etc. Conservative: only flags values that provably can't match the declared type (nullable unions like `{enum:["a",null], type:["string","null"]}` pass).
- **`convertTools` (openai-responses)** — after building each tool's wire schema, quarantines a tool with a violation: drops just that tool, `logger.warn`s with the tool name + schema path, and continues with the rest. Valid tools and built-ins are unaffected.

Quarantine (not rewrite) keeps the blast radius minimal on this hot path — a provably-contradictory tool is dropped, valid schemas are never mutated.

## Acceptance criteria
- ✅ Invalid MCP tool schemas no longer cause provider HTTP 400 (the bad tool is omitted).
- ✅ Other MCP and built-in tools remain usable.
- ✅ A `logger.warn` surfaces which tool was hidden and the offending schema path.
- ✅ Regression coverage: nullable-enum, enum-on-array, anyOf/const, nested-path reporting, valid-combination negatives, and the `convertTools` quarantine (one bad tool dropped while a sibling survives).

## Tests
`packages/ai/test/openai-responses-tool-quarantine.test.ts` — 7 tests, all green. Existing `convertTools` tests (`apply-patch-freeform.test.ts`, 25) still pass; `tsgo`/`biome` clean for the touched package.

## Notes
- Scoped to the openai-responses path (the reported `github-copilot/openai-responses` case). `findStrictToolSchemaViolation` is exported and provider-agnostic, so the other strict providers (`openai-completions`, `openai-codex-responses`, the anthropic strict candidate) can adopt the same guard in a follow-up if desired.
- This validates the *emitted* schema (post `sanitizeSchemaForOpenAIResponses` + `adaptSchemaForStrict`), so it also catches contradictions those steps don't normalize away.
