### PR TITLE
fix(plugins): resolve directory extension manifest entries one level deep

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Installed plugins whose `extensions` manifest entry points at a directory of sub-extensions (the standard pi `extensions/<name>/index.ts` layout, e.g. `pi.extensions: ["./extensions"]`) are no longer rejected at install (`declared extension entry not found on disk`) or silently dropped at load. The plugin manifest resolver now resolves a directory the same way as the configured-directory (`-e`) extension loader: the directory's own `package.json` `omp`/`pi` `extensions` (authoritative — a missing declared entry is reported instead of falling back to a decoy `index`), then a direct `index.{ts,js,mjs,cjs}`, then a one-level scan of sub-extensions ([#2713](https://github.com/can1357/oh-my-pi/issues/2713)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -143,29 +143,161 @@ export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {
 // Path Resolution
 // =============================================================================
 
-const MANIFEST_ENTRY_INDEX_NAMES = ["index.ts", "index.js", "index.mjs", "index.cjs"];
+const MANIFEST_ENTRY_MODULE_EXTENSIONS = [".ts", ".js", ".mjs", ".cjs"];
+const MANIFEST_ENTRY_INDEX_NAMES = MANIFEST_ENTRY_MODULE_EXTENSIONS.map(ext => `index${ext}`);
+
+/** `.d.ts` / `.d.mts` / `.d.cts` TypeScript declaration files — never loadable as modules. */
+const DECLARATION_FILE_RE = /\.d\.[mc]?ts$/;
+
+/** A loadable module file: a .ts/.js/.mjs/.cjs that is not a declaration file. */
+function isModuleFile(name: string): boolean {
+	return MANIFEST_ENTRY_MODULE_EXTENSIONS.includes(path.extname(name)) && !DECLARATION_FILE_RE.test(name);
+}
+
+/** First `index.{ts,js,mjs,cjs}` inside `dir`, or null when none exists. */
+function findDirectoryIndex(dir: string): string | null {
+	for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
+		const candidate = path.join(dir, name);
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+interface DeclaredManifestEntries {
+	/** True when the directory's package.json declares a non-empty `omp`/`pi` `extensions` array. */
+	declared: boolean;
+	/** Resolved, existing module files for the declared entries (may be empty when declared files are missing). */
+	files: string[];
+}
 
 /**
- * Resolve a plugin manifest entry to a concrete loadable file path. Returns the
- * file path itself when the entry points at a file, the matching index file when
- * the entry points at a directory containing index.{ts,js,mjs,cjs}, and null
- * when no entry exists at the joined path.
+ * Read the extension entries declared by `dir`'s own package.json `omp`/`pi`
+ * manifest. `declared` distinguishes "a manifest explicitly lists extensions"
+ * (authoritative — callers must not fall back to index/scan, so a missing
+ * declared file surfaces as a missing entry instead of silently loading a stale
+ * index) from "no manifest / no extensions field" (callers fall back to
+ * convention). Mirrors the manifest branch of the configured-directory (`-e`)
+ * scanner: a declared entry that is a file resolves to itself; one that is a
+ * directory resolves to its direct index.{ts,js,mjs,cjs}.
  */
-function resolveManifestEntryFile(joined: string): string | null {
+function readDeclaredManifestEntries(dir: string): DeclaredManifestEntries {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(path.join(dir, "package.json"), "utf8");
+	} catch {
+		return { declared: false, files: [] };
+	}
+	let pkg: { omp?: { extensions?: unknown }; pi?: { extensions?: unknown } };
+	try {
+		pkg = JSON.parse(raw) as { omp?: { extensions?: unknown }; pi?: { extensions?: unknown } };
+	} catch {
+		return { declared: false, files: [] };
+	}
+	const declared = (pkg.omp ?? pkg.pi)?.extensions;
+	if (!Array.isArray(declared) || declared.length === 0) {
+		return { declared: false, files: [] };
+	}
+	const files: string[] = [];
+	for (const entry of declared) {
+		if (typeof entry !== "string") continue;
+		const candidate = path.resolve(dir, entry);
+		let candidateStats: fs.Stats;
+		try {
+			candidateStats = fs.statSync(candidate);
+		} catch {
+			continue;
+		}
+		if (candidateStats.isDirectory()) {
+			const index = findDirectoryIndex(candidate);
+			if (index) files.push(index);
+		} else {
+			files.push(candidate);
+		}
+	}
+	return { declared: true, files };
+}
+
+/**
+ * Resolve a directory to its loadable extension module files, mirroring the
+ * configured-directory (`-e`) scanner in extensions/loader.ts:
+ *   1. the directory's own package.json `omp`/`pi` `extensions` entries —
+ *      authoritative: a manifest that lists extensions suppresses the index/scan
+ *      fallback, so a missing declared file is reported rather than silently
+ *      replaced by a decoy index
+ *   2. a direct index.{ts,js,mjs,cjs}
+ *   3. one level of children: each direct *.{ts,js,mjs,cjs} file plus each
+ *      sub-directory resolved by the same precedence (manifest, then index)
+ */
+function resolveDirectoryEntries(dir: string): string[] {
+	const manifest = readDeclaredManifestEntries(dir);
+	if (manifest.declared) return manifest.files;
+
+	const directIndex = findDirectoryIndex(dir);
+	if (directIndex) return [directIndex];
+
+	let children: string[];
+	try {
+		children = fs.readdirSync(dir);
+	} catch {
+		return [];
+	}
+	const resolved: string[] = [];
+	for (const child of children.sort()) {
+		const childPath = path.join(dir, child);
+		let childStats: fs.Stats;
+		try {
+			// statSync follows symlinks, matching the configured-dir loader.
+			childStats = fs.statSync(childPath);
+		} catch {
+			continue;
+		}
+		if (childStats.isDirectory()) {
+			const childManifest = readDeclaredManifestEntries(childPath);
+			if (childManifest.declared) {
+				resolved.push(...childManifest.files);
+			} else {
+				const index = findDirectoryIndex(childPath);
+				if (index) resolved.push(index);
+			}
+		} else if (isModuleFile(child)) {
+			resolved.push(childPath);
+		}
+	}
+	return resolved;
+}
+
+/**
+ * Resolve a plugin manifest entry to the loadable module files it names:
+ * - a file entry → that file
+ * - a directory:
+ *   - when `expandDirectory` (the `extensions` key), resolved by
+ *     {@link resolveDirectoryEntries} — its own package.json `omp`/`pi`
+ *     `extensions`, then a direct index, then a one-level scan of
+ *     sub-extensions — matching the pi `extensions/<name>/index.ts` convention
+ *     and OMP's configured-directory (`-e`) extension loader
+ *   - otherwise (tools/hooks/commands) only a direct index.{ts,js,mjs,cjs}.
+ *     The sub-extension scan and the `omp`/`pi` `extensions` manifest are
+ *     extensions-specific and must not hijack a non-extension directory entry
+ *     (e.g. a `tools: "."` entry must still resolve `./index.ts`).
+ *
+ * Returns an empty array when nothing loadable exists at `joined`, letting
+ * callers flag a missing entry instead of silently dropping it.
+ */
+function resolveManifestEntryFiles(joined: string, expandDirectory: boolean): string[] {
 	let stats: fs.Stats;
 	try {
 		stats = fs.statSync(joined);
 	} catch {
-		return null;
+		return [];
 	}
-	if (stats.isDirectory()) {
-		for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
-			const candidate = path.join(joined, name);
-			if (fs.existsSync(candidate)) return candidate;
-		}
-		return null;
+	if (!stats.isDirectory()) {
+		return [joined];
 	}
-	return joined;
+	if (expandDirectory) {
+		return resolveDirectoryEntries(joined);
+	}
+	const index = findDirectoryIndex(joined);
+	return index ? [index] : [];
 }
 
 /**
@@ -196,16 +328,17 @@ export function resolvePluginManifestEntries(
 	const declared: Array<{ entry: string; resolvedPath: string | null }> = [];
 	const manifest = plugin.manifest;
 
-	const resolveEntry = (entry: string): { entry: string; resolvedPath: string | null } => ({
-		entry,
-		resolvedPath: resolveManifestEntryFile(path.join(plugin.path, entry)),
-	});
+	const expandDirectory = key === "extensions";
+	const resolveEntry = (entry: string): Array<{ entry: string; resolvedPath: string | null }> => {
+		const files = resolveManifestEntryFiles(path.join(plugin.path, entry), expandDirectory);
+		return files.length > 0 ? files.map(resolvedPath => ({ entry, resolvedPath })) : [{ entry, resolvedPath: null }];
+	};
 
 	const base = manifest[key];
 	if (base) {
 		const entries = Array.isArray(base) ? base : [base];
 		for (const entry of entries) {
-			declared.push(resolveEntry(entry));
+			declared.push(...resolveEntry(entry));
 		}
 	}
 
@@ -215,7 +348,7 @@ export function resolvePluginManifestEntries(
 			if (!enabledSet.has(featName)) continue;
 			if (feat[key]) {
 				for (const entry of feat[key]) {
-					declared.push(resolveEntry(entry));
+					declared.push(...resolveEntry(entry));
 				}
 			}
 		}
@@ -225,7 +358,7 @@ export function resolvePluginManifestEntries(
 			if (!feat.default) continue;
 			if (feat[key]) {
 				for (const entry of feat[key]) {
-					declared.push(resolveEntry(entry));
+					declared.push(...resolveEntry(entry));
 				}
 			}
 		}

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -534,4 +534,199 @@ describe("plugin extension discovery", () => {
 		expect(extension).toBeDefined();
 		expect(extension?.commands.has("dir-entry-ext")).toBe(true);
 	});
+
+	it("loads installed plugin extensions whose manifest entry points at a directory of sub-extensions", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "subdir-entry-plugin");
+		const extensionDir = path.join(pluginDir, "extensions", "feature");
+		const extensionPath = path.join(extensionDir, "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(extensionDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"subdir-entry-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "subdir-entry-plugin",
+				version: "1.0.0",
+				pi: {
+					// Directory entry with no direct index — the loader must scan one
+					// level and pick up `extensions/<name>/index.ts` (pi package layout).
+					extensions: ["./extensions"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("subdir-entry-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+		const pluginError = result.errors.find(err => err.path.includes("subdir-entry-plugin"));
+
+		expect(pluginError).toBeUndefined();
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("subdir-entry-ext")).toBe(true);
+	});
+
+	it("resolves a sub-extension directory via its own package.json manifest over a decoy index", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "nested-manifest-plugin");
+		const featureDir = path.join(pluginDir, "extensions", "feature");
+		const realEntry = path.join(featureDir, "dist", "real-ext.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.dirname(realEntry), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"nested-manifest-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "nested-manifest-plugin",
+				version: "1.0.0",
+				pi: { extensions: ["./extensions"] },
+			}),
+		);
+		// Child package declares its real entry via its own manifest; the index.ts
+		// is a decoy that must NOT win (manifest takes precedence, like the -e scanner).
+		fs.writeFileSync(
+			path.join(featureDir, "package.json"),
+			JSON.stringify({ name: "feature-ext", version: "1.0.0", omp: { extensions: ["./dist/real-ext.ts"] } }),
+		);
+		fs.writeFileSync(
+			realEntry,
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("nested-manifest-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(featureDir, "index.ts"),
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("decoy-index-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === realEntry);
+		const decoy = result.extensions.find(ext => ext.commands.has("decoy-index-ext"));
+		const pluginError = result.errors.find(err => err.path.includes("nested-manifest-plugin"));
+
+		expect(pluginError).toBeUndefined();
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("nested-manifest-ext")).toBe(true);
+		expect(decoy).toBeUndefined();
+	});
+
+	it("does not fall back to a decoy index when a sub-extension manifest declares a missing entry", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "missing-decl-plugin");
+		const featureDir = path.join(pluginDir, "extensions", "feature");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(featureDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"missing-decl-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "missing-decl-plugin",
+				version: "1.0.0",
+				pi: { extensions: ["./extensions"] },
+			}),
+		);
+		// The child manifest is authoritative: it declares ./dist/real-ext.ts, which does
+		// not exist (e.g. unbuilt). The leftover index.ts must NOT be loaded as a fallback.
+		fs.writeFileSync(
+			path.join(featureDir, "package.json"),
+			JSON.stringify({ name: "feature-ext", version: "1.0.0", omp: { extensions: ["./dist/real-ext.ts"] } }),
+		);
+		fs.writeFileSync(
+			path.join(featureDir, "index.ts"),
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("decoy-index-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const decoy = result.extensions.find(ext => ext.commands.has("decoy-index-ext"));
+
+		expect(decoy).toBeUndefined();
+	});
+
+	it("skips .d.ts declaration files when scanning a flat extensions directory", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "dts-plugin");
+		const extensionsDir = path.join(pluginDir, "extensions");
+		const moduleEntry = path.join(extensionsDir, "ext.js");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"dts-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "dts-plugin",
+				version: "1.0.0",
+				omp: { extensions: ["./extensions"] },
+			}),
+		);
+		fs.writeFileSync(
+			moduleEntry,
+			["export default function(pi) {", '\tpi.registerCommand("dts-ext", { handler: async () => {} });', "}"].join(
+				"\n",
+			),
+		);
+		// A sibling declaration file must be ignored — importing it would fail.
+		fs.writeFileSync(path.join(extensionsDir, "ext.d.ts"), "export default function (pi: unknown): void;\n");
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === moduleEntry);
+		const declaration = result.extensions.find(ext => ext.path.endsWith("ext.d.ts"));
+
+		expect(result.errors).toHaveLength(0);
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("dts-ext")).toBe(true);
+		expect(declaration).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/plugin-manifest-paths.test.ts
+++ b/packages/coding-agent/test/plugin-manifest-paths.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	resolvePluginExtensionPaths,
+	resolvePluginToolPaths,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/loader";
+import type { InstalledPlugin, PluginManifest } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
+
+function makePlugin(pluginPath: string, manifest: PluginManifest): InstalledPlugin {
+	return {
+		name: "fixture-plugin",
+		version: "1.0.0",
+		path: pluginPath,
+		manifest,
+		enabledFeatures: null,
+		enabled: true,
+	};
+}
+
+describe("plugin manifest path resolution", () => {
+	it("resolves a directory tools entry to its index, not the omp.extensions modules", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-manifest-paths-"));
+		try {
+			// The package declares both extensions and a directory-based tool entry.
+			// `omp.extensions` and the sub-extension scan are extensions-specific and
+			// must not hijack the `tools: "."` directory entry (regression: the shared
+			// directory resolver returned the extension module for every key).
+			fs.writeFileSync(
+				path.join(dir, "package.json"),
+				JSON.stringify({ name: "fixture-plugin", version: "1.0.0", omp: { extensions: ["./ext.ts"], tools: "." } }),
+			);
+			fs.writeFileSync(path.join(dir, "index.ts"), "export default {};");
+			fs.writeFileSync(path.join(dir, "ext.ts"), "export default function () {};");
+			const plugin = makePlugin(dir, {
+				name: "fixture-plugin",
+				version: "1.0.0",
+				extensions: ["./ext.ts"],
+				tools: ".",
+			});
+
+			expect(resolvePluginToolPaths(plugin)).toEqual([path.join(dir, "index.ts")]);
+			expect(resolvePluginExtensionPaths(plugin)).toEqual([path.join(dir, "ext.ts")]);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Installing a pi package whose `extensions` manifest entry points at a **directory of sub-extensions** (the standard pi layout `extensions/<name>/index.ts`) fails:

```bash
omp plugin install @zosmaai/pi-llm-wiki
# ✘ Failed to install: Plugin @zosmaai/pi-llm-wiki extension validation failed:
# ./extensions: declared extension entry not found on disk
```

The package uses the canonical pi manifest (`"pi": { "extensions": ["./extensions"] }`) with its entry one level below at `extensions/llm-wiki/index.ts` — per the [pi package spec](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/packages.md#package-structure), `extensions/` is a convention directory holding one sub-directory per extension.

## Root cause

`resolveManifestEntryFile` in `extensibility/plugins/loader.ts` resolved a directory entry only to a **direct** `index.{ts,js,mjs,cjs}`; with none present it returned `null`. Both consumers then failed:

- `PluginManager.#validateInstalledExtensions` → `"<entry>: declared extension entry not found on disk"`, aborting install.
- `resolvePluginExtensionPaths` → `[]` at runtime, silently dropping the extension.

This diverged from OMP's own `-e` / `extensions:` configured-directory loader, which already scans one level for `*/index.{ts,js}` (see `docs/extension-loading.md`).

## Fix

`resolveManifestEntryFile` → `resolveManifestEntryFiles` (returns `string[]`):

- file entry → that file
- directory with a direct `index.{ts,js,mjs,cjs}` → that index (unchanged)
- directory **without** a direct index → one level of children: each sub-directory's `index.{ts,js,mjs,cjs}` plus each direct `*.{ts,js,mjs,cjs}` file

`resolvePluginManifestEntries` spreads the resolved files, preserving the missing-entry contract (an entry resolving to zero files still yields one `null` record, so install validation still reports it). `statSync` follows symlinks to match the configured-directory loader.

## Verification

- `omp plugin install @zosmaai/pi-llm-wiki` now succeeds; the extension loads with **0 errors** and registers all 14 `wiki_*` tools + its `wiki-model`/`wiki-trajectories` commands (verified via `discoverAndLoadExtensions`).
- New regression test: `plugin-extensions-discovery.test.ts` → "loads installed plugin extensions whose manifest entry points at a directory of sub-extensions".
- `bun test plugin-extensions-discovery.test.ts plugin-install-validation.test.ts` → 14 pass / 0 fail. Existing "directory with direct index" and "missing entry" cases still pass (semantics preserved).

Closes the install path called out in #2166; relates to #433, #441.


Fixes #2713.
