### PR TITLE
feat(terminal): report working directory via OSC 7 / OSC 9;9

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Report the working directory to the host terminal on session start and `/move` via OSC 7 (`file://`), plus OSC 9;9 when running under Windows Terminal, so new tabs/panes — and Windows Terminal's persisted-layout restore — open in the session's current directory instead of the profile default. OSC 9;9 is gated on `WT_SESSION` because OSC 9 is iTerm2's notification sequence.
+- Report the working directory to the host terminal on session start and `/move` via OSC 7 (`file://`), plus OSC 9;9 when running under Windows Terminal, so new tabs/panes — and Windows Terminal's persisted-layout restore — open in the session's current directory instead of the profile default. OSC 9;9 is gated on `WT_SESSION` because OSC 9 is iTerm2's notification sequence; under WSL (where `WT_SESSION` is inherited but `cwd` is a POSIX path) it is translated to a Windows path via `wslpath -w`, and omitted when no Windows path is available so layout restore never lands in the wrong directory.
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Report the working directory to the host terminal on session start and `/move` via OSC 7 (`file://`), plus OSC 9;9 when running under Windows Terminal, so new tabs/panes — and Windows Terminal's persisted-layout restore — open in the session's current directory instead of the profile default. OSC 9;9 is gated on `WT_SESSION` because OSC 9 is iTerm2's notification sequence.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -1,7 +1,10 @@
 /**
  * Generate session titles using a smol, fast model.
  */
+
+import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { type Api, type AssistantMessage, completeSimple, type Model, type Tool } from "@oh-my-pi/pi-ai";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
@@ -397,6 +400,45 @@ export function setTerminalTitle(title: string): void {
 
 export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
 	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
+	setTerminalWorkingDirectory(cwd);
+}
+
+/**
+ * Build the OSC escape(s) that report `cwd` to the host terminal so new
+ * tabs/panes — and Windows Terminal's persisted-layout restore — reuse it.
+ *
+ * - OSC 7 (`file://host/path`) is the cross-platform standard, honored by the
+ *   xterm/VTE family and recent Windows Terminal builds.
+ * - OSC 9;9 (`"<native path>"`) is the ConEmu / Windows Terminal convention and
+ *   the only form stable Windows Terminal understands. It is gated on
+ *   `WT_SESSION` because OSC 9 is iTerm2's notification sequence — emitting it
+ *   unconditionally would spam notifications there.
+ *
+ * Returns "" when no cwd is given.
+ */
+export function buildCwdReportSequence(
+	cwd: string | undefined,
+	opts?: { hostname?: string; wtSession?: boolean },
+): string {
+	if (!cwd) return "";
+	const resolved = path.resolve(cwd);
+	const host = opts?.hostname ?? os.hostname();
+	let seq = `\x1b]7;file://${host}${pathToFileURL(resolved).pathname}\x1b\\`;
+	const wtSession = opts?.wtSession ?? Boolean(Bun.env.WT_SESSION);
+	// Windows paths cannot contain `"`, so the quoted form needs no escaping.
+	if (wtSession) seq += `\x1b]9;9;"${resolved}"\x1b\\`;
+	return seq;
+}
+
+/**
+ * Report the working directory to the host terminal via
+ * {@link buildCwdReportSequence}. No-op when stdout is not a TTY (print/RPC
+ * modes, pipes) — matching {@link setTerminalTitle}.
+ */
+export function setTerminalWorkingDirectory(cwd: string | undefined): void {
+	if (!process.stdout.isTTY) return;
+	const seq = buildCwdReportSequence(cwd);
+	if (seq) process.stdout.write(seq);
 }
 
 /**

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -412,22 +412,46 @@ export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: s
  * - OSC 9;9 (`"<native path>"`) is the ConEmu / Windows Terminal convention and
  *   the only form stable Windows Terminal understands. It is gated on
  *   `WT_SESSION` because OSC 9 is iTerm2's notification sequence — emitting it
- *   unconditionally would spam notifications there.
+ *   unconditionally would spam notifications there. The payload must be a
+ *   *Windows* path: native on Win32, and `wslpath -w`-translated under WSL
+ *   (where `WT_SESSION` is inherited but `cwd` is a POSIX path Windows Terminal
+ *   can't restore into). When no Windows path is available it is omitted — OSC 7
+ *   already covers the cross-platform case, and a raw POSIX path would send the
+ *   layout restore to the wrong directory.
  *
  * Returns "" when no cwd is given.
  */
 export function buildCwdReportSequence(
 	cwd: string | undefined,
-	opts?: { hostname?: string; wtSession?: boolean },
+	opts?: { hostname?: string; wtSession?: boolean; osc99Path?: (resolved: string) => string | undefined },
 ): string {
 	if (!cwd) return "";
 	const resolved = path.resolve(cwd);
 	const host = opts?.hostname ?? os.hostname();
 	let seq = `\x1b]7;file://${host}${pathToFileURL(resolved).pathname}\x1b\\`;
 	const wtSession = opts?.wtSession ?? Boolean(Bun.env.WT_SESSION);
-	// Windows paths cannot contain `"`, so the quoted form needs no escaping.
-	if (wtSession) seq += `\x1b]9;9;"${resolved}"\x1b\\`;
+	if (wtSession) {
+		const native = (opts?.osc99Path ?? resolveOsc99WindowsPath)(resolved);
+		// A Windows path can't contain `"`, but a translated/edge value might —
+		// dropping it beats emitting an unescaped payload that truncates the OSC.
+		if (native && !native.includes('"')) seq += `\x1b]9;9;"${native}"\x1b\\`;
+	}
 	return seq;
+}
+
+/**
+ * Resolve the OSC 9;9 native-path payload for {@link buildCwdReportSequence}.
+ * Win32 reports the resolved path verbatim; WSL translates it to its Windows
+ * form via `wslpath -w` (omitting OSC 9;9 if interop is unavailable); any other
+ * host has no Windows path to report.
+ */
+function resolveOsc99WindowsPath(resolved: string): string | undefined {
+	if (process.platform === "win32") return resolved;
+	if (process.platform !== "linux" || !(Bun.env.WSL_DISTRO_NAME || Bun.env.WSL_INTEROP)) return undefined;
+	const result = Bun.spawnSync(["wslpath", "-w", resolved], { stdout: "pipe", stderr: "pipe", windowsHide: true });
+	if (result.exitCode !== 0) return undefined;
+	const win = new TextDecoder().decode(result.stdout).trim();
+	return win.length > 0 ? win : undefined;
 }
 
 /**

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -434,6 +434,13 @@ export function buildCwdReportSequence(
  * Report the working directory to the host terminal via
  * {@link buildCwdReportSequence}. No-op when stdout is not a TTY (print/RPC
  * modes, pipes) — matching {@link setTerminalTitle}.
+ *
+ * Like the OSC 0 title write, this is gated only by TTY, NOT by `--no-title`
+ * (`PI_NO_TITLE`): that flag disables AI title *auto-generation* only (see its
+ * description and the single gate in `input-controller.ts`), and the terminal
+ * title is still asserted under it. Suppressing cwd on `--no-title` would be
+ * inconsistent — title written, cwd withheld. The rpc/acp/protocol modes that
+ * also set `PI_NO_TITLE` are already silenced here by the non-TTY check.
  */
 export function setTerminalWorkingDirectory(cwd: string | undefined): void {
 	if (!process.stdout.isTTY) return;

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import { buildCwdReportSequence, generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import { logger } from "@oh-my-pi/pi-utils";
 
 function getModelOrThrow(id: string): Model<Api> {
@@ -455,5 +455,36 @@ describe("title generator", () => {
 		await generateSessionTitle("Some message", registry, currentSettings);
 		expect(mockComplete).toHaveBeenCalled();
 		expect(mockComplete.mock.calls[0]?.[0]).toBe(smolModel);
+	});
+});
+
+describe("buildCwdReportSequence", () => {
+	const ST = "\x1b\\";
+	const absPath = process.platform === "win32" ? "C:\\tmp\\a b" : "/tmp/a b";
+	// OSC 7 percent-encodes the path; Windows drive paths keep the literal colon.
+	const expectedOsc7Path = process.platform === "win32" ? "/C:/tmp/a%20b" : "/tmp/a%20b";
+
+	it("returns an empty string when no cwd is provided", () => {
+		expect(buildCwdReportSequence(undefined)).toBe("");
+		expect(buildCwdReportSequence("")).toBe("");
+	});
+
+	it("always emits an ST-terminated OSC 7 file:// sequence with the host authority", () => {
+		const seq = buildCwdReportSequence(absPath, { hostname: "myhost", wtSession: false });
+		expect(seq).toBe(`\x1b]7;file://myhost${expectedOsc7Path}${ST}`);
+	});
+
+	it("omits OSC 9;9 unless WT_SESSION is signalled (OSC 9 is iTerm2's notification)", () => {
+		expect(buildCwdReportSequence(absPath, { hostname: "h", wtSession: false })).not.toContain("]9;9;");
+	});
+
+	it("appends a quoted, unencoded OSC 9;9 native path under Windows Terminal", () => {
+		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true });
+		// OSC 7 still present and percent-encoded...
+		expect(seq).toContain(`\x1b]7;file://h${expectedOsc7Path}${ST}`);
+		// ...followed by OSC 9;9 carrying the resolved native path verbatim, quoted.
+		expect(seq.endsWith(`\x1b]9;9;"${absPath}"${ST}`)).toBe(true);
+		// The native form keeps the literal space, not %20.
+		expect(seq).toContain(`"${absPath}"`);
 	});
 });

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -478,13 +478,39 @@ describe("buildCwdReportSequence", () => {
 		expect(buildCwdReportSequence(absPath, { hostname: "h", wtSession: false })).not.toContain("]9;9;");
 	});
 
-	it("appends a quoted, unencoded OSC 9;9 native path under Windows Terminal", () => {
-		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true });
+	it("appends a quoted Windows OSC 9;9 path under Windows Terminal", () => {
+		// Inject the native-path resolver so the emission is deterministic across
+		// platforms (the default resolver is Win32-native / `wslpath -w` under WSL).
+		const winPath = "C:\\proj\\a b";
+		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true, osc99Path: () => winPath });
 		// OSC 7 still present and percent-encoded...
 		expect(seq).toContain(`\x1b]7;file://h${expectedOsc7Path}${ST}`);
-		// ...followed by OSC 9;9 carrying the resolved native path verbatim, quoted.
-		expect(seq.endsWith(`\x1b]9;9;"${absPath}"${ST}`)).toBe(true);
-		// The native form keeps the literal space, not %20.
-		expect(seq).toContain(`"${absPath}"`);
+		// ...followed by OSC 9;9 carrying the Windows path verbatim, quoted, with
+		// the literal space (not %20).
+		expect(seq.endsWith(`\x1b]9;9;"${winPath}"${ST}`)).toBe(true);
+	});
+
+	it("omits OSC 9;9 when no Windows path is available (WSL without interop, or a POSIX host)", () => {
+		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true, osc99Path: () => undefined });
+		expect(seq).toContain("\x1b]7;file://h");
+		expect(seq).not.toContain("]9;9;");
+	});
+
+	it("drops OSC 9;9 rather than emit a path containing a double quote", () => {
+		// A real Windows path can't contain `"`, but a translated WSL path or edge
+		// value might — emitting it unescaped would truncate the OSC payload.
+		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true, osc99Path: () => 'C:\\a"b' });
+		expect(seq).not.toContain("]9;9;");
+	});
+
+	it("reports the native resolved path on Windows via the default resolver", () => {
+		const seq = buildCwdReportSequence(absPath, { hostname: "h", wtSession: true });
+		if (process.platform === "win32") {
+			// Win32: resolved path is already Windows-shaped, emitted verbatim.
+			expect(seq.endsWith(`\x1b]9;9;"${absPath}"${ST}`)).toBe(true);
+		} else {
+			// A non-WSL POSIX host has no Windows path to report.
+			expect(seq).not.toContain("]9;9;");
+		}
 	});
 });


### PR DESCRIPTION
Closes #2717.

## What

omp set the terminal title but never reported its **working directory**, so `/move` didn't propagate to the terminal and new tabs/panes/duplicates (and Windows Terminal's persisted-layout restore) opened in the profile's `startingDirectory` instead of the session's cwd.

This wires cwd reporting into `setSessionTerminalTitle` — the single chokepoint already invoked on session start, `/move`, and session switch/fork/branch — via a new `setTerminalWorkingDirectory(cwd)`:

- **OSC 7** (`file://host/path`, encoded via `pathToFileURL`) — emitted always; the cross-platform standard.
- **OSC 9;9** (quoted native path) — emitted **only when `WT_SESSION` is set**, because OSC 9 is iTerm2's notification sequence and an unconditional emit would spam notifications there.

Both are out-of-band and ignored where unsupported; the emitter is a no-op when stdout is not a TTY (matching `setTerminalTitle`).

## Why a single helper + chokepoint

`setSessionTerminalTitle(name, cwd)` already receives the cwd and fires on every directory-affecting transition, so reporting cwd there covers start / `/move` / resume / fork / branch / collab-guest in one place with no new call sites.

## Tests

`buildCwdReportSequence` is a pure builder unit-tested in `test/title-generator.test.ts`:
- ST-terminated OSC 7 with host authority and percent-encoding (`%20`),
- Windows drive paths keep the literal `:`,
- OSC 9;9 gated on `WT_SESSION` and carrying the unencoded quoted native path,
- empty cwd → empty string.

`bun test packages/coding-agent/test/title-generator.test.ts` → 20 pass. `tsgo --noEmit` clean.

## Notes

- This does **not** move the parent shell's prompt cwd (a child process can't chdir its parent — that needs a shell wrapper); it reports cwd to the *terminal* so tab/pane/duplicate/restore follow.
