### PR TITLE
fix(ai): route prefixed Responses tool deltas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed OpenAI Responses-compatible streams from Ollama/local hosts dropping arguments for parallel tool calls whose deltas use `fc_<call_id>` item ids, which left earlier `ast_grep` calls with `{}` and failed validation. ([#2715](https://github.com/can1357/oh-my-pi/issues/2715))
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -497,6 +497,7 @@ export async function processResponsesStream<TApi extends Api>(
 	// most recently added parallel call.
 	const openItemsByOutputIndex = new Map<number, StreamingItem>();
 	const openItemsByItemId = new Map<string, StreamingItem>();
+	const openItemsByPrefixedCallId = new Map<string, StreamingItem>();
 	let lastOpenItem: StreamingItem | null = null;
 	const openItemsInOrder: StreamingItem[] = [];
 
@@ -518,7 +519,7 @@ export async function processResponsesStream<TApi extends Api>(
 			prefixedAlternateItemKey !== itemId &&
 			prefixedAlternateItemKey !== alternateItemKey
 		) {
-			openItemsByItemId.set(prefixedAlternateItemKey, entry);
+			openItemsByPrefixedCallId.set(prefixedAlternateItemKey, entry);
 		}
 		openItemsInOrder.push(entry);
 		lastOpenItem = entry;
@@ -537,11 +538,29 @@ export async function processResponsesStream<TApi extends Api>(
 	};
 	const hasOpenItemKey = (event: { output_index?: number; item_id?: string }): boolean =>
 		typeof event.output_index === "number" || event.item_id !== undefined;
+	const lookupOpenToolCallAlias = (
+		event: { output_index?: number; item_id?: string },
+		type: "function_call" | "custom_tool_call",
+	): StreamingItem | undefined => {
+		if (typeof event.output_index === "number") return lookupOpenItem(event);
+		if (event.item_id) {
+			// Prefixed call-id aliases share the same wire namespace as real call ids.
+			// Argument/input events can use the prefixed form, while final
+			// output_item.done events below use exact call ids; keep aliases in a
+			// separate map so a real `call_id: "fc_x"` cannot overwrite the alias
+			// for `call_id: "x"`.
+			const alias = openItemsByPrefixedCallId.get(event.item_id);
+			if (alias?.item.type === type) return alias;
+			const exact = openItemsByItemId.get(event.item_id);
+			if (exact) return exact;
+		}
+		return lookupOpenItem(event);
+	};
 	const lookupOpenFunctionCallItem = (event: {
 		output_index?: number;
 		item_id?: string;
 	}): StreamingItem | undefined => {
-		if (hasOpenItemKey(event)) return lookupOpenItem(event);
+		if (hasOpenItemKey(event)) return lookupOpenToolCallAlias(event, "function_call");
 		for (const candidate of openItemsInOrder) {
 			if (
 				candidate.item.type === "function_call" &&
@@ -566,9 +585,10 @@ export async function processResponsesStream<TApi extends Api>(
 		if (
 			prefixedAlternateItemKey &&
 			prefixedAlternateItemKey !== itemId &&
-			prefixedAlternateItemKey !== alternateItemKey
+			prefixedAlternateItemKey !== alternateItemKey &&
+			openItemsByPrefixedCallId.get(prefixedAlternateItemKey) === entry
 		) {
-			openItemsByItemId.delete(prefixedAlternateItemKey);
+			openItemsByPrefixedCallId.delete(prefixedAlternateItemKey);
 		}
 		if (entry) {
 			const index = openItemsInOrder.indexOf(entry);
@@ -769,7 +789,7 @@ export async function processResponsesStream<TApi extends Api>(
 				delete (block as { lastParseLen?: number }).lastParseLen;
 			}
 		} else if (event.type === "response.custom_tool_call_input.delta") {
-			const entry = lookupOpenItem(event);
+			const entry = lookupOpenToolCallAlias(event, "custom_tool_call");
 			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
 				const block = entry.block;
 				block.partialJson += event.delta;
@@ -782,7 +802,7 @@ export async function processResponsesStream<TApi extends Api>(
 				});
 			}
 		} else if (event.type === "response.custom_tool_call_input.done") {
-			const entry = lookupOpenItem(event);
+			const entry = lookupOpenToolCallAlias(event, "custom_tool_call");
 			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
 				entry.block.partialJson = event.input;
 				entry.block.arguments = { input: event.input };

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -501,7 +501,7 @@ export async function processResponsesStream<TApi extends Api>(
 	const openItemsInOrder: StreamingItem[] = [];
 
 	const prefixedFunctionCallItemKey = (callId: string | undefined): string | undefined =>
-		callId && !callId.startsWith("fc_") ? `fc_${callId}` : undefined;
+		callId ? `fc_${callId}` : undefined;
 
 	const registerOpenItem = (
 		outputIndex: number | undefined,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -490,26 +490,36 @@ export async function processResponsesStream<TApi extends Api>(
 	// function_call deltas interleaved, and a singleton `current` reference would
 	// fold them into the wrong block and drop arguments on every call but the last.
 	//
-	// llama.cpp's `to_json_oaicompat_resp` (issue #2015) compounds this: `output_item.added`
-	// for function_call/custom_tool_call carries `item.call_id` but no `item.id` and no
-	// `output_index`, while the matching `function_call_arguments.delta` carries
-	// `item_id = "fc_<call_id>"`. Registering function-call items by `call_id` as a
-	// secondary key lets the delta lookup find the right block on hosts that emit one
-	// identifier but not the other.
+	// OpenAI-compatible hosts can compound this by omitting `item.id` and
+	// `output_index` on `output_item.added` while routing later argument deltas to
+	// either the bare `call_id` or a synthesized `fc_<call_id>` item id. Register
+	// both keys so each delta reaches its own block instead of falling back to the
+	// most recently added parallel call.
 	const openItemsByOutputIndex = new Map<number, StreamingItem>();
 	const openItemsByItemId = new Map<string, StreamingItem>();
 	let lastOpenItem: StreamingItem | null = null;
 	const openItemsInOrder: StreamingItem[] = [];
+
+	const prefixedFunctionCallItemKey = (callId: string | undefined): string | undefined =>
+		callId && !callId.startsWith("fc_") ? `fc_${callId}` : undefined;
 
 	const registerOpenItem = (
 		outputIndex: number | undefined,
 		itemId: string | undefined,
 		entry: StreamingItem,
 		alternateItemKey?: string,
+		prefixedAlternateItemKey?: string,
 	): void => {
 		if (typeof outputIndex === "number") openItemsByOutputIndex.set(outputIndex, entry);
 		if (itemId) openItemsByItemId.set(itemId, entry);
 		if (alternateItemKey && alternateItemKey !== itemId) openItemsByItemId.set(alternateItemKey, entry);
+		if (
+			prefixedAlternateItemKey &&
+			prefixedAlternateItemKey !== itemId &&
+			prefixedAlternateItemKey !== alternateItemKey
+		) {
+			openItemsByItemId.set(prefixedAlternateItemKey, entry);
+		}
 		openItemsInOrder.push(entry);
 		lastOpenItem = entry;
 	};
@@ -548,10 +558,18 @@ export async function processResponsesStream<TApi extends Api>(
 		itemId: string | undefined,
 		entry: StreamingItem | undefined,
 		alternateItemKey?: string,
+		prefixedAlternateItemKey?: string,
 	): void => {
 		if (typeof outputIndex === "number") openItemsByOutputIndex.delete(outputIndex);
 		if (itemId) openItemsByItemId.delete(itemId);
 		if (alternateItemKey && alternateItemKey !== itemId) openItemsByItemId.delete(alternateItemKey);
+		if (
+			prefixedAlternateItemKey &&
+			prefixedAlternateItemKey !== itemId &&
+			prefixedAlternateItemKey !== alternateItemKey
+		) {
+			openItemsByItemId.delete(prefixedAlternateItemKey);
+		}
 		if (entry) {
 			const index = openItemsInOrder.indexOf(entry);
 			if (index >= 0) openItemsInOrder.splice(index, 1);
@@ -591,7 +609,13 @@ export async function processResponsesStream<TApi extends Api>(
 					partialJson: item.arguments || "",
 				};
 				output.content.push(block);
-				registerOpenItem(event.output_index, item.id, { item, block }, item.call_id);
+				registerOpenItem(
+					event.output_index,
+					item.id,
+					{ item, block },
+					item.call_id,
+					prefixedFunctionCallItemKey(item.call_id),
+				);
 				stream.push({ type: "toolcall_start", contentIndex: contentIndexOf(block), partial: output });
 			} else if (item.type === "custom_tool_call") {
 				const block: StreamingToolCallBlock = {
@@ -609,7 +633,13 @@ export async function processResponsesStream<TApi extends Api>(
 					partialJson: item.input ?? "",
 				};
 				output.content.push(block);
-				registerOpenItem(event.output_index, item.id, { item, block }, item.call_id);
+				registerOpenItem(
+					event.output_index,
+					item.id,
+					{ item, block },
+					item.call_id,
+					prefixedFunctionCallItemKey(item.call_id),
+				);
 				stream.push({ type: "toolcall_start", contentIndex: contentIndexOf(block), partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
@@ -842,7 +872,7 @@ export async function processResponsesStream<TApi extends Api>(
 					output.content.push(toolCall);
 					contentIndex = output.content.length - 1;
 				}
-				closeOpenItem(event.output_index, item.id, entry, item.call_id);
+				closeOpenItem(event.output_index, item.id, entry, item.call_id, prefixedFunctionCallItemKey(item.call_id));
 				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			} else if (item.type === "custom_tool_call") {
 				const block = entry?.block.type === "toolCall" ? entry.block : undefined;
@@ -866,7 +896,7 @@ export async function processResponsesStream<TApi extends Api>(
 					output.content.push(toolCall);
 					contentIndex = output.content.length - 1;
 				}
-				closeOpenItem(event.output_index, item.id, entry, item.call_id);
+				closeOpenItem(event.output_index, item.id, entry, item.call_id, prefixedFunctionCallItemKey(item.call_id));
 				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			}
 		} else if (event.type === "response.completed" || event.type === "response.incomplete") {

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -354,26 +354,26 @@ describe("processResponsesStream: parallel function_call items", () => {
 			makeStream([
 				{
 					type: "response.output_item.added",
-					item: { type: "function_call", call_id: "call_a", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "x", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.added",
-					item: { type: "function_call", call_id: "fc_b", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "fc_x", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.added",
 					item: { type: "function_call", call_id: "call_c", name: "ast_grep", arguments: "" },
 				},
-				{ type: "response.function_call_arguments.delta", item_id: "fc_call_a", delta: argsA },
-				{ type: "response.function_call_arguments.delta", item_id: "fc_fc_b", delta: argsB },
+				{ type: "response.function_call_arguments.delta", item_id: "fc_x", delta: argsA },
+				{ type: "response.function_call_arguments.delta", item_id: "fc_fc_x", delta: argsB },
 				{ type: "response.function_call_arguments.delta", item_id: "fc_call_c", delta: argsC },
 				{
 					type: "response.output_item.done",
-					item: { type: "function_call", call_id: "call_a", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "x", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.done",
-					item: { type: "function_call", call_id: "fc_b", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "fc_x", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.done",
@@ -400,11 +400,11 @@ describe("processResponsesStream: parallel function_call items", () => {
 		}>;
 		expect(ends).toHaveLength(3);
 		const byCallId = new Map(ends.map(e => [e.toolCall.id.split("|")[0], e]));
-		expect(byCallId.get("call_a")?.toolCall.arguments).toEqual({
+		expect(byCallId.get("x")?.toolCall.arguments).toEqual({
 			pat: "console.log($$$)",
 			paths: ["src/**/*.ts"],
 		});
-		expect(byCallId.get("fc_b")?.toolCall.arguments).toEqual({
+		expect(byCallId.get("fc_x")?.toolCall.arguments).toEqual({
 			pat: "logger.$_($$$ARGS)",
 			paths: ["src/**/*.ts"],
 		});
@@ -412,8 +412,8 @@ describe("processResponsesStream: parallel function_call items", () => {
 			pat: "processItems",
 			paths: ["src/worker.ts"],
 		});
-		expect(byCallId.get("call_a")?.contentIndex).toBe(0);
-		expect(byCallId.get("fc_b")?.contentIndex).toBe(1);
+		expect(byCallId.get("x")?.contentIndex).toBe(0);
+		expect(byCallId.get("fc_x")?.contentIndex).toBe(1);
 		expect(byCallId.get("call_c")?.contentIndex).toBe(2);
 	});
 });

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -336,4 +336,83 @@ describe("processResponsesStream: parallel function_call items", () => {
 		expect(byCallId.get("fc_b")?.contentIndex).toBe(1);
 		expect(byCallId.get("fc_c")?.contentIndex).toBe(2);
 	});
+	test("routes Ollama Responses deltas whose item_id prefixes the call_id", async () => {
+		// Ollama's OpenAI-compatible Responses stream can add parallel calls with
+		// only `call_id`, then send argument deltas with `item_id = fc_<call_id>`.
+		// If the parser only indexes the bare call_id, every delta falls back to the
+		// most recently added call and earlier ast_grep calls execute with `{}`.
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		const argsA = JSON.stringify({ pat: "console.log($$$)", paths: ["src/**/*.ts"] });
+		const argsB = JSON.stringify({ pat: "logger.$_($$$ARGS)", paths: ["src/**/*.ts"] });
+		const argsC = JSON.stringify({ pat: "processItems", paths: ["src/worker.ts"] });
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					item: { type: "function_call", call_id: "call_a", name: "ast_grep", arguments: "" },
+				},
+				{
+					type: "response.output_item.added",
+					item: { type: "function_call", call_id: "call_b", name: "ast_grep", arguments: "" },
+				},
+				{
+					type: "response.output_item.added",
+					item: { type: "function_call", call_id: "call_c", name: "ast_grep", arguments: "" },
+				},
+				{ type: "response.function_call_arguments.delta", item_id: "fc_call_a", delta: argsA },
+				{ type: "response.function_call_arguments.delta", item_id: "fc_call_b", delta: argsB },
+				{ type: "response.function_call_arguments.delta", item_id: "fc_call_c", delta: argsC },
+				{
+					type: "response.output_item.done",
+					item: { type: "function_call", call_id: "call_a", name: "ast_grep", arguments: "" },
+				},
+				{
+					type: "response.output_item.done",
+					item: { type: "function_call", call_id: "call_b", name: "ast_grep", arguments: "" },
+				},
+				{
+					type: "response.output_item.done",
+					item: { type: "function_call", call_id: "call_c", name: "ast_grep", arguments: "" },
+				},
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		expect(output.content).toHaveLength(3);
+		const [a, b, c] = output.content;
+		if (a?.type !== "toolCall" || b?.type !== "toolCall" || c?.type !== "toolCall") {
+			throw new Error("expected toolCalls");
+		}
+		expect(a.arguments).toEqual({ pat: "console.log($$$)", paths: ["src/**/*.ts"] });
+		expect(b.arguments).toEqual({ pat: "logger.$_($$$ARGS)", paths: ["src/**/*.ts"] });
+		expect(c.arguments).toEqual({ pat: "processItems", paths: ["src/worker.ts"] });
+
+		const ends = emitted.filter(e => e.type === "toolcall_end") as Array<{
+			toolCall: { id: string; arguments: Record<string, unknown> };
+			contentIndex: number;
+		}>;
+		expect(ends).toHaveLength(3);
+		const byCallId = new Map(ends.map(e => [e.toolCall.id.split("|")[0], e]));
+		expect(byCallId.get("call_a")?.toolCall.arguments).toEqual({
+			pat: "console.log($$$)",
+			paths: ["src/**/*.ts"],
+		});
+		expect(byCallId.get("call_b")?.toolCall.arguments).toEqual({
+			pat: "logger.$_($$$ARGS)",
+			paths: ["src/**/*.ts"],
+		});
+		expect(byCallId.get("call_c")?.toolCall.arguments).toEqual({
+			pat: "processItems",
+			paths: ["src/worker.ts"],
+		});
+		expect(byCallId.get("call_a")?.contentIndex).toBe(0);
+		expect(byCallId.get("call_b")?.contentIndex).toBe(1);
+		expect(byCallId.get("call_c")?.contentIndex).toBe(2);
+	});
 });

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -338,7 +338,8 @@ describe("processResponsesStream: parallel function_call items", () => {
 	});
 	test("routes Ollama Responses deltas whose item_id prefixes the call_id", async () => {
 		// Ollama's OpenAI-compatible Responses stream can add parallel calls with
-		// only `call_id`, then send argument deltas with `item_id = fc_<call_id>`.
+		// only `call_id`, then send argument deltas with `item_id = fc_<call_id>`
+		// even when `call_id` already starts with `fc_`.
 		// If the parser only indexes the bare call_id, every delta falls back to the
 		// most recently added call and earlier ast_grep calls execute with `{}`.
 		const output = makeOutput();
@@ -357,14 +358,14 @@ describe("processResponsesStream: parallel function_call items", () => {
 				},
 				{
 					type: "response.output_item.added",
-					item: { type: "function_call", call_id: "call_b", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "fc_b", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.added",
 					item: { type: "function_call", call_id: "call_c", name: "ast_grep", arguments: "" },
 				},
 				{ type: "response.function_call_arguments.delta", item_id: "fc_call_a", delta: argsA },
-				{ type: "response.function_call_arguments.delta", item_id: "fc_call_b", delta: argsB },
+				{ type: "response.function_call_arguments.delta", item_id: "fc_fc_b", delta: argsB },
 				{ type: "response.function_call_arguments.delta", item_id: "fc_call_c", delta: argsC },
 				{
 					type: "response.output_item.done",
@@ -372,7 +373,7 @@ describe("processResponsesStream: parallel function_call items", () => {
 				},
 				{
 					type: "response.output_item.done",
-					item: { type: "function_call", call_id: "call_b", name: "ast_grep", arguments: "" },
+					item: { type: "function_call", call_id: "fc_b", name: "ast_grep", arguments: "" },
 				},
 				{
 					type: "response.output_item.done",
@@ -403,7 +404,7 @@ describe("processResponsesStream: parallel function_call items", () => {
 			pat: "console.log($$$)",
 			paths: ["src/**/*.ts"],
 		});
-		expect(byCallId.get("call_b")?.toolCall.arguments).toEqual({
+		expect(byCallId.get("fc_b")?.toolCall.arguments).toEqual({
 			pat: "logger.$_($$$ARGS)",
 			paths: ["src/**/*.ts"],
 		});
@@ -412,7 +413,7 @@ describe("processResponsesStream: parallel function_call items", () => {
 			paths: ["src/worker.ts"],
 		});
 		expect(byCallId.get("call_a")?.contentIndex).toBe(0);
-		expect(byCallId.get("call_b")?.contentIndex).toBe(1);
+		expect(byCallId.get("fc_b")?.contentIndex).toBe(1);
 		expect(byCallId.get("call_c")?.contentIndex).toBe(2);
 	});
 });


### PR DESCRIPTION
## Repro
Parallel `ast_grep` calls over an Ollama/local OpenAI Responses-compatible stream can be added with bare `call_id` values while their argument deltas are addressed to `fc_<call_id>`. Reproduced with `bun --cwd=packages/ai test test/openai-responses-parallel-tool-calls.test.ts --test-name-pattern "Ollama Responses"`, which left the first call arguments as `{}` before the fix.

## Cause
`processResponsesStream` in `packages/ai/src/providers/openai-responses-shared.ts` registered open `function_call` and `custom_tool_call` items by `output_index`, `item.id`, and bare `item.call_id` only. When Ollama/local omitted `item.id`/`output_index` and sent deltas with `item_id = fc_<call_id>`, lookup missed the intended item and fell back to the most recently added parallel call, so earlier tool calls finalized without `pat`/`paths`.

## Fix
- Register Responses tool-call stream items under both bare `call_id` and synthesized `fc_<call_id>` lookup keys.
- Remove both aliases when the item closes.
- Add a regression case covering three parallel `ast_grep` calls with prefixed delta item ids.
- Add the `pi-ai` changelog entry for the bug.

## Verification
`bun --cwd=packages/ai test test/openai-responses-parallel-tool-calls.test.ts` passed with 5 tests and 45 assertions. `bun --cwd=packages/ai run check` passed. `gh_push_branch` pre-publish gate passed. Fixes #2715