### PR TITLE
feat(coding-agent): improve update UX

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added in-band `/update` and `/restart` TUI commands, reusable update-flow helpers, update changelog printing, installed-version markers, and stale running-session warnings for issue #2712.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -35,6 +35,8 @@ export interface Args {
 	hideThinking?: boolean;
 	continue?: boolean;
 	resume?: string | true;
+	showChangelogOnResume?: boolean;
+	changelogOnResumePath?: string;
 	help?: boolean;
 	version?: boolean;
 	mode?: Mode;
@@ -184,6 +186,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.alias = arg.slice("--alias=".length);
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
+		} else if (arg === "--show-changelog-on-resume") {
+			result.showChangelogOnResume = true;
 		} else if (arg === "--no-session") {
 			result.noSession = true;
 		} else if (arg === "--no-tools") {

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -132,6 +132,9 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--provider-session-id": (result, value) => {
 		result.providerSessionId = value;
 	},
+	"--changelog-on-resume-path": (result, value) => {
+		result.changelogOnResumePath = value;
+	},
 	"--session-dir": (result, value) => {
 		result.sessionDir = value;
 	},
@@ -255,6 +258,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--version",
 	"--allow-home",
 	"--continue",
+	"--show-changelog-on-resume",
 	"--no-session",
 	"--no-tools",
 	"--no-lsp",

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -8,10 +8,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
-import { $which, APP_NAME, isEnoent, VERSION } from "@oh-my-pi/pi-utils";
+import { $which, APP_NAME, getLastInstalledVersionPath, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { theme } from "../modes/theme/theme";
+import {
+	formatChangelogMarkdown,
+	getEntriesInVersionRange,
+	parseChangelogContent,
+	writeLastChangelogVersion,
+} from "../utils/changelog";
 
 const REPO = "can1357/oh-my-pi";
 const PACKAGE = "@oh-my-pi/pi-coding-agent";
@@ -57,9 +63,10 @@ function currentNativeTag(): string {
 	return `${process.platform}-${process.arch}`;
 }
 
-interface ReleaseInfo {
+export interface ReleaseInfo {
 	tag: string;
 	version: string;
+	tarball?: string;
 }
 
 /** Result from running the installed binary and parsing its reported version. */
@@ -193,7 +200,42 @@ interface UpdateMethodResolutionOptions {
 	miseDataDir?: string;
 }
 
-type UpdateTarget = { method: "brew" } | { method: "mise" } | { method: "bun" } | { method: "binary"; path: string };
+export type UpdateTarget =
+	| { method: "brew" }
+	| { method: "mise" }
+	| { method: "bun" }
+	| { method: "binary"; path: string };
+
+export interface UpdateFlowOptions {
+	force: boolean;
+	check: boolean;
+	showChangelog: boolean;
+	currentVersion?: string;
+}
+
+export interface UpdateFlowOutput {
+	log(message: string): void | Promise<void>;
+	error(message: string): void | Promise<void>;
+}
+
+export type UpdateFlowResult =
+	| { kind: "no-update"; currentVersion: string; latestVersion: string }
+	| { kind: "update-available"; currentVersion: string; latestVersion: string; checkOnly: true }
+	| { kind: "updated"; previousVersion: string; version: string; forced: boolean; changelogPrinted: boolean };
+
+export interface UpdateFlowDependencies {
+	getLatestRelease?: () => Promise<ReleaseInfo>;
+	resolveUpdateTarget?: () => Promise<UpdateTarget>;
+	installUpdate?: (
+		target: UpdateTarget,
+		expectedVersion: string,
+		force: boolean,
+		output: UpdateFlowOutput,
+	) => Promise<void>;
+	loadReleaseChangelog?: (release: ReleaseInfo) => Promise<string | undefined>;
+	writeInstalledVersion?: (version: string) => Promise<void>;
+	writeSeenChangelogVersion?: (version: string) => Promise<void>;
+}
 
 function resolveUpdateMethod(
 	ompPath: string,
@@ -244,13 +286,14 @@ async function getLatestRelease(): Promise<ReleaseInfo> {
 		throw new Error(`Failed to fetch release info: ${response.statusText}`);
 	}
 
-	const data = (await response.json()) as { version: string };
+	const data = (await response.json()) as { version: string; dist?: { tarball?: string } };
 	const version = data.version;
 	const tag = `v${version}`;
 
 	return {
 		tag,
 		version,
+		tarball: data.dist?.tarball,
 	};
 }
 
@@ -260,16 +303,20 @@ async function getLatestRelease(): Promise<ReleaseInfo> {
  * - 0 if a == b
  * - positive if a > b
  */
-function compareVersions(a: string, b: string): number {
-	const pa = a.split(".").map(Number);
-	const pb = b.split(".").map(Number);
+export function compareSemver(a: string, b: string): number {
+	try {
+		return Bun.semver.order(a, b);
+	} catch {
+		const pa = a.split(".").map(Number);
+		const pb = b.split(".").map(Number);
 
-	for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-		const na = pa[i] || 0;
-		const nb = pb[i] || 0;
-		if (na !== nb) return na - nb;
+		for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+			const na = pa[i] || 0;
+			const nb = pb[i] || 0;
+			if (na !== nb) return na - nb;
+		}
+		return 0;
 	}
-	return 0;
 }
 
 /**
@@ -338,8 +385,8 @@ async function verifyInstalledVersion(expectedVersion: string): Promise<Installe
 	}
 }
 
-function printVerifiedVersion(expectedVersion: string): void {
-	console.log(chalk.green(`\n${theme.status.success} Updated to ${expectedVersion}`));
+async function printVerifiedVersion(expectedVersion: string, output: UpdateFlowOutput): Promise<void> {
+	await output.log(chalk.green(`\n${theme.status.success} Updated to ${expectedVersion}`));
 }
 
 function formatVerificationFailure(result: InstalledVersionVerification, expectedVersion: string): string {
@@ -352,14 +399,16 @@ function formatVerificationFailure(result: InstalledVersionVerification, expecte
 /**
  * Print post-update verification result.
  */
-async function printVerification(expectedVersion: string): Promise<void> {
+async function printVerification(expectedVersion: string, output: UpdateFlowOutput): Promise<void> {
 	const result = await verifyInstalledVersion(expectedVersion);
 	if (result.ok) {
-		printVerifiedVersion(expectedVersion);
+		await printVerifiedVersion(expectedVersion, output);
 		return;
 	}
-	console.log(chalk.yellow(`\nWarning: ${formatVerificationFailure(result, expectedVersion)}`));
-	console.log(chalk.yellow(`You may need to reinstall: curl -fsSL https://omp.sh/install | sh`));
+	const failure = formatVerificationFailure(result, expectedVersion);
+	await output.error(chalk.yellow(`\nWarning: ${failure}`));
+	await output.error(chalk.yellow(`You may need to reinstall: curl -fsSL https://omp.sh/install | sh`));
+	throw new Error(failure);
 }
 
 async function unlinkIfExists(filePath: string): Promise<void> {
@@ -461,64 +510,64 @@ export function buildMiseForceInstallArgs(expectedVersion: string): string[] {
 /**
  * Update via bun package manager.
  */
-async function updateViaBun(expectedVersion: string): Promise<void> {
-	console.log(chalk.dim("Updating via bun..."));
+async function updateViaBun(expectedVersion: string, output: UpdateFlowOutput): Promise<void> {
+	await output.log(chalk.dim("Updating via bun..."));
 	const args = buildBunInstallArgs(expectedVersion);
-	const result = await $`bun ${args}`.nothrow();
+	const result = await $`bun ${args}`.quiet().nothrow();
 	if (result.exitCode !== 0) {
 		throw new Error(`bun install failed with exit code ${result.exitCode}`);
 	}
 
-	await printVerification(expectedVersion);
+	await printVerification(expectedVersion, output);
 }
 
-async function updateViaHomebrew(expectedVersion: string, force: boolean): Promise<void> {
-	console.log(chalk.dim("Updating Homebrew formulae..."));
-	const update = await $`brew update`.nothrow();
+async function updateViaHomebrew(expectedVersion: string, force: boolean, output: UpdateFlowOutput): Promise<void> {
+	await output.log(chalk.dim("Updating Homebrew formulae..."));
+	const update = await $`brew update`.quiet().nothrow();
 	if (update.exitCode !== 0) {
 		throw new Error(`brew update failed with exit code ${update.exitCode}`);
 	}
 
-	console.log(chalk.dim("Updating via Homebrew..."));
+	await output.log(chalk.dim("Updating via Homebrew..."));
 	const args = buildHomebrewUpdateArgs(force);
-	const result = await $`brew ${args}`.nothrow();
+	const result = await $`brew ${args}`.quiet().nothrow();
 	if (result.exitCode !== 0) {
 		throw new Error(`brew ${args[0]} failed with exit code ${result.exitCode}`);
 	}
 
-	await printVerification(expectedVersion);
+	await printVerification(expectedVersion, output);
 }
 
-async function updateViaMise(expectedVersion: string, force: boolean): Promise<void> {
-	console.log(chalk.dim("Updating via mise..."));
+async function updateViaMise(expectedVersion: string, force: boolean, output: UpdateFlowOutput): Promise<void> {
+	await output.log(chalk.dim("Updating via mise..."));
 	const args = buildMiseUpgradeArgs();
-	const result = await $`mise ${args}`.nothrow();
+	const result = await $`mise ${args}`.quiet().nothrow();
 	if (result.exitCode !== 0) {
 		throw new Error(`mise upgrade failed with exit code ${result.exitCode}`);
 	}
 
 	if (force) {
 		const forceArgs = buildMiseForceInstallArgs(expectedVersion);
-		const forceResult = await $`mise ${forceArgs}`.nothrow();
+		const forceResult = await $`mise ${forceArgs}`.quiet().nothrow();
 		if (forceResult.exitCode !== 0) {
 			throw new Error(`mise install --force failed with exit code ${forceResult.exitCode}`);
 		}
 	}
 
-	await printVerification(expectedVersion);
+	await printVerification(expectedVersion, output);
 }
 
 /**
  * Download a release binary to a target path, replacing an existing file.
  */
-async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
+async function updateViaBinaryAt(targetPath: string, expectedVersion: string, output: UpdateFlowOutput): Promise<void> {
 	const binaryName = getBinaryName();
 	const tag = `v${expectedVersion}`;
 	const url = `https://github.com/${REPO}/releases/download/${tag}/${binaryName}`;
 
 	const tempPath = `${targetPath}.new`;
 	const backupPath = `${targetPath}.bak`;
-	console.log(chalk.dim(`Downloading ${binaryName}…`));
+	await output.log(chalk.dim(`Downloading ${binaryName}…`));
 
 	const response = await fetch(url, { redirect: "follow" });
 	if (!response.ok || !response.body) {
@@ -527,7 +576,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 	const fileStream = fs.createWriteStream(tempPath, { mode: 0o755 });
 	await pipeline(response.body, fileStream);
 
-	console.log(chalk.dim("Installing update..."));
+	await output.log(chalk.dim("Installing update..."));
 	await replaceBinaryForUpdate({
 		targetPath,
 		tempPath,
@@ -535,57 +584,161 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 		expectedVersion,
 		verifyInstalledVersion,
 	});
-	printVerifiedVersion(expectedVersion);
-	console.log(chalk.dim(`Restart ${APP_NAME} to use the new version`));
+	await printVerifiedVersion(expectedVersion, output);
+	await output.log(chalk.dim(`Restart ${APP_NAME} to use the new version`));
+}
+
+async function loadReleaseChangelog(release: ReleaseInfo): Promise<string | undefined> {
+	if (!release.tarball) return undefined;
+
+	try {
+		const response = await fetch(release.tarball, { signal: AbortSignal.timeout(15_000) });
+		if (!response.ok || !response.body) return undefined;
+
+		const archive = new Bun.Archive(new Uint8Array(await response.arrayBuffer()));
+		const files = await archive.files();
+		return (await files.get("package/CHANGELOG.md")?.text()) ?? (await files.get("CHANGELOG.md")?.text());
+	} catch {
+		return undefined;
+	}
+}
+
+export async function readLastInstalledVersion(agentDir?: string): Promise<string | undefined> {
+	try {
+		const value = (await Bun.file(getLastInstalledVersionPath(agentDir)).text()).trim();
+		return value || undefined;
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.warn("Failed to read last-installed-version marker", { error: String(error) });
+		}
+		return undefined;
+	}
+}
+
+export async function writeLastInstalledVersion(version: string, agentDir?: string): Promise<void> {
+	try {
+		await Bun.write(getLastInstalledVersionPath(agentDir), version);
+	} catch (error) {
+		logger.warn("Failed to persist last-installed-version marker", { error: String(error) });
+	}
+}
+
+export async function getOutdatedProcessInfo(
+	currentVersion: string = VERSION,
+	agentDir?: string,
+): Promise<{ currentVersion: string; installedVersion: string } | undefined> {
+	const installedVersion = await readLastInstalledVersion(agentDir);
+	if (installedVersion && compareSemver(installedVersion, currentVersion) > 0) {
+		return { currentVersion, installedVersion };
+	}
+	return undefined;
+}
+
+/**
+ * Run the update command.
+ */
+async function installUpdateForTarget(
+	target: UpdateTarget,
+	expectedVersion: string,
+	force: boolean,
+	output: UpdateFlowOutput,
+): Promise<void> {
+	if (target.method === "brew") {
+		await updateViaHomebrew(expectedVersion, force, output);
+	} else if (target.method === "mise") {
+		await updateViaMise(expectedVersion, force, output);
+	} else if (target.method === "bun") {
+		await updateViaBun(expectedVersion, output);
+	} else {
+		await updateViaBinaryAt(target.path, expectedVersion, output);
+	}
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export async function runUpdateFlow(
+	options: UpdateFlowOptions,
+	output: UpdateFlowOutput,
+	deps: UpdateFlowDependencies = {},
+): Promise<UpdateFlowResult> {
+	const currentVersion = options.currentVersion ?? VERSION;
+	await output.log(chalk.dim(`Current version: ${currentVersion}`));
+
+	let release: ReleaseInfo;
+	try {
+		release = await (deps.getLatestRelease ?? getLatestRelease)();
+	} catch (err) {
+		throw new Error(`Failed to check for updates: ${errorMessage(err)}`);
+	}
+
+	const comparison = compareSemver(release.version, currentVersion);
+
+	if (comparison <= 0 && !options.force) {
+		await output.log(chalk.green(`${theme.status.success} Already up to date`));
+		return { kind: "no-update", currentVersion, latestVersion: release.version };
+	}
+
+	if (comparison > 0) {
+		await output.log(chalk.cyan(`New version available: ${release.version}`));
+		if (options.check) {
+			return { kind: "update-available", currentVersion, latestVersion: release.version, checkOnly: true };
+		}
+	} else if (options.check) {
+		return { kind: "no-update", currentVersion, latestVersion: release.version };
+	} else {
+		await output.log(chalk.yellow(`Forcing reinstall of ${release.version}`));
+	}
+
+	try {
+		const target = await (deps.resolveUpdateTarget ?? resolveUpdateTarget)();
+		await (deps.installUpdate ?? installUpdateForTarget)(target, release.version, options.force, output);
+		await (deps.writeInstalledVersion ?? writeLastInstalledVersion)(release.version);
+	} catch (err) {
+		throw new Error(`Update failed: ${errorMessage(err)}`);
+	}
+
+	let changelogPrinted = false;
+	if (options.showChangelog && comparison > 0) {
+		try {
+			const changelogContent = await (deps.loadReleaseChangelog ?? loadReleaseChangelog)(release);
+			if (changelogContent) {
+				const entries = parseChangelogContent(changelogContent);
+				const entriesToShow = getEntriesInVersionRange(entries, currentVersion, release.version);
+				const changelogMarkdown = formatChangelogMarkdown(entriesToShow, { reverse: true });
+				if (changelogMarkdown) {
+					await output.log(`\nWhat's new:\n\n${changelogMarkdown}`);
+					changelogPrinted = true;
+					await (deps.writeSeenChangelogVersion ?? writeLastChangelogVersion)(release.version);
+				}
+			}
+		} catch {
+			// Changelog loading is best-effort and must never fail an update.
+		}
+	}
+
+	return {
+		kind: "updated",
+		previousVersion: currentVersion,
+		version: release.version,
+		forced: options.force,
+		changelogPrinted,
+	};
 }
 
 /**
  * Run the update command.
  */
 export async function runUpdateCommand(opts: { force: boolean; check: boolean }): Promise<void> {
-	console.log(chalk.dim(`Current version: ${VERSION}`));
-
-	// Check for updates
-	let release: ReleaseInfo;
+	const consoleOutput: UpdateFlowOutput = {
+		log: message => console.log(message),
+		error: message => console.log(message),
+	};
 	try {
-		release = await getLatestRelease();
+		await runUpdateFlow({ force: opts.force, check: opts.check, showChangelog: true }, consoleOutput);
 	} catch (err) {
-		console.error(chalk.red(`Failed to check for updates: ${err}`));
-		process.exit(1);
-	}
-
-	const comparison = compareVersions(release.version, VERSION);
-
-	if (comparison <= 0 && !opts.force) {
-		console.log(chalk.green(`${theme.status.success} Already up to date`));
-		return;
-	}
-
-	if (comparison > 0) {
-		console.log(chalk.cyan(`New version available: ${release.version}`));
-	} else {
-		console.log(chalk.yellow(`Forcing reinstall of ${release.version}`));
-	}
-
-	if (opts.check) {
-		// Just check, don't install
-		return;
-	}
-
-	// Choose update method based on the prioritized omp binary in PATH
-	try {
-		const target = await resolveUpdateTarget();
-		if (target.method === "brew") {
-			await updateViaHomebrew(release.version, opts.force);
-		} else if (target.method === "mise") {
-			await updateViaMise(release.version, opts.force);
-		} else if (target.method === "bun") {
-			await updateViaBun(release.version);
-		} else {
-			await updateViaBinaryAt(target.path, release.version);
-		}
-	} catch (err) {
-		console.error(chalk.red(`Update failed: ${err}`));
+		console.error(chalk.red(errorMessage(err)));
 		process.exit(1);
 	}
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -6,6 +6,7 @@
  */
 import * as fsSync from "node:fs";
 import * as os from "node:os";
+import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
@@ -375,6 +376,71 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 	};
 }
 
+export function buildRestartLaunchArgs(parsed: Args, baseCwd: string = getProjectDir()): string[] {
+	const args: string[] = [];
+	const pushString = (flag: string, value: string | undefined) => {
+		if (value) args.push(flag, value);
+	};
+	const expandHome = (value: string): string => {
+		if (value === "~") return os.homedir();
+		if (value.startsWith("~/") || value.startsWith("~\\")) return path.join(os.homedir(), value.slice(2));
+		return value;
+	};
+	const resolveFromProjectDir = (value: string): string => {
+		const expanded = expandHome(value);
+		return path.isAbsolute(expanded) ? expanded : path.resolve(baseCwd, expanded);
+	};
+	const resolvePromptArg = (value: string | undefined): string | undefined => {
+		if (!value || value.includes("\n")) return value;
+		const expanded = expandHome(value);
+		const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(baseCwd, expanded);
+		if (expanded !== value || fsSync.existsSync(resolved)) return resolved;
+		return value;
+	};
+	const pushResolvedStrings = (flag: string, values: string[] | undefined) => {
+		for (const value of values ?? []) {
+			args.push(flag, resolveFromProjectDir(value));
+		}
+	};
+
+	pushResolvedStrings("--config", parsed.config);
+	pushString("--plan", parsed.plan);
+	pushString("--provider-session-id", parsed.providerSessionId);
+	if (parsed.models && parsed.models.length > 0) args.push("--models", parsed.models.join(","));
+	pushString("--api-key", parsed.apiKey);
+	pushString("--smol", parsed.smol);
+	pushString("--slow", parsed.slow);
+	if (parsed.noTools) args.push("--no-tools");
+	if (parsed.tools && parsed.tools.length > 0) args.push("--tools", parsed.tools.join(","));
+	if (parsed.noLsp) args.push("--no-lsp");
+	if (parsed.noPty) args.push("--no-pty");
+	pushResolvedStrings("--extension", parsed.extensions);
+	pushResolvedStrings("--hook", parsed.hooks);
+	pushResolvedStrings("--plugin-dir", parsed.pluginDirs);
+	if (parsed.noExtensions) args.push("--no-extensions");
+	if (parsed.noSkills) args.push("--no-skills");
+	if (parsed.skills && parsed.skills.length > 0) args.push("--skills", parsed.skills.join(","));
+	if (parsed.noRules) args.push("--no-rules");
+	if (parsed.noTitle) args.push("--no-title");
+	if (parsed.autoApprove) args.push("--auto-approve");
+	pushString("--approval-mode", parsed.approvalMode);
+	pushString("--system-prompt", resolvePromptArg(parsed.systemPrompt));
+	pushString("--append-system-prompt", resolvePromptArg(parsed.appendSystemPrompt));
+	for (const [name, value] of parsed.unknownFlags) {
+		if (value === true) {
+			args.push(`--${name}`);
+		} else if (typeof value === "string") {
+			if (value.startsWith("-")) {
+				args.push(`--${name}=${value}`);
+			} else {
+				args.push(`--${name}`, value);
+			}
+		}
+	}
+
+	return args;
+}
+
 async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
@@ -392,6 +458,7 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	titleSystemPrompt?: string,
 	joinLink?: string,
+	restartLaunchArgs: string[] = [],
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -402,6 +469,7 @@ async function runInteractiveMode(
 		mcpManager,
 		eventBus,
 		titleSystemPrompt,
+		restartLaunchArgs,
 	);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
@@ -576,8 +644,27 @@ async function moveMissingCwdSessionIfNeeded(
 	return { status: "moved", manager };
 }
 
+function isRestartChangelogHandoffPath(value: string): boolean {
+	const dir = path.resolve(path.dirname(value));
+	const tmpDir = path.resolve(os.tmpdir());
+	return path.dirname(dir) === tmpDir && path.basename(dir).startsWith("omp-update-changelog-");
+}
+
 async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
-	if (parsed.continue || parsed.resume) {
+	if (parsed.changelogOnResumePath) {
+		try {
+			const changelog = (await fsSync.promises.readFile(parsed.changelogOnResumePath, "utf8")).trim();
+			return changelog || undefined;
+		} catch (error) {
+			logger.warn("Failed to load update changelog handoff", { error: String(error) });
+		} finally {
+			if (isRestartChangelogHandoffPath(parsed.changelogOnResumePath)) {
+				await fsSync.promises.rm(path.dirname(parsed.changelogOnResumePath), { recursive: true, force: true });
+			}
+		}
+	}
+
+	if (parsed.continue || (parsed.resume && !parsed.showChangelogOnResume)) {
 		return undefined;
 	}
 
@@ -991,6 +1078,7 @@ export async function runRootCommand(
 	}
 
 	let cwd = getProjectDir();
+	const startupCwd = cwd;
 	const settingsInstance =
 		deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
 	if (parsedArgs.approvalMode) {
@@ -1333,6 +1421,7 @@ export async function runRootCommand(
 				initialImages,
 				titleSystemPrompt,
 				parsedArgs.join,
+				buildRestartLaunchArgs(initialArgs, startupCwd),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -44,7 +44,7 @@ import { limitMatchesActiveAccount } from "../../slash-commands/helpers/active-o
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs } from "../../tools/render-utils";
-import { getChangelogPath, parseChangelog } from "../../utils/changelog";
+import { formatChangelogMarkdown, getChangelogPath, parseChangelog } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
@@ -452,10 +452,7 @@ export class CommandController {
 		const entriesToShow = showFull ? allEntries : allEntries.slice(0, 3);
 		const changelogMarkdown =
 			entriesToShow.length > 0
-				? [...entriesToShow]
-						.reverse()
-						.map(e => e.content)
-						.join("\n\n")
+				? formatChangelogMarkdown(entriesToShow, { reverse: true })
 				: "No changelog entries found.";
 		const title = showFull ? "Full Changelog" : "Recent Changes";
 		const hint = showFull

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my-pi/pi-tui";
 import { $env, isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { getOutdatedProcessInfo } from "../../cli/update-cli";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
@@ -85,6 +86,21 @@ export class InputController {
 	// Sequential index for `local://attachment-N` references created by the large-paste local-file
 	// action. Seeded from 0 and bumped past any existing attachment files in #attachPasteAsFile.
 	#attachmentCounter = 0;
+	#outdatedVersionWarningShownFor: string | undefined;
+
+	async #warnIfProcessIsOutdated(): Promise<void> {
+		try {
+			const info = await getOutdatedProcessInfo();
+			if (info && info.installedVersion !== this.#outdatedVersionWarningShownFor) {
+				this.#outdatedVersionWarningShownFor = info.installedVersion;
+				this.ctx.showWarning(
+					`OMP was updated from v${info.currentVersion} to v${info.installedVersion}. Run /restart to resume this session on the new version.`,
+				);
+			}
+		} catch {
+			// Stale-version checks must never block prompt submission.
+		}
+	}
 
 	#showTinyTitleDownloadProgress(modelKey: string): void {
 		if (!isTinyTitleLocalModelKey(modelKey)) return;
@@ -603,6 +619,8 @@ export class InputController {
 				}
 			}
 
+			await this.#warnIfProcessIsOutdated();
+
 			// While loop mode is on, every user-typed prompt becomes the new loop
 			// prompt that auto-resubmits after each yield.
 			if (this.ctx.loopModeEnabled) {
@@ -939,6 +957,9 @@ export class InputController {
 		// the queued entry is later re-parsed into a skill invocation is a
 		// separate concern owned by the compaction-resume path.
 		if (this.ctx.session.isCompacting) {
+			if (!text.startsWith("/")) {
+				await this.#warnIfProcessIsOutdated();
+			}
 			const images = this.ctx.pendingImages.length > 0 ? [...this.ctx.pendingImages] : undefined;
 			this.ctx.queueCompactionMessage(text, "followUp", images);
 			return;
@@ -960,6 +981,8 @@ export class InputController {
 		if (await this.#invokeSkillCommand(text, "followUp")) {
 			return;
 		}
+
+		await this.#warnIfProcessIsOutdated();
 
 		// Forward any pending clipboard-pasted images alongside the queued text;
 		// otherwise the follow-up would drop the image (mirrors the Enter/steer path).

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3,6 +3,7 @@
  * Handles TUI rendering and user interaction, delegating business logic to AgentSession.
  */
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import {
 	type Agent,
@@ -36,6 +37,7 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import {
+	$which,
 	APP_NAME,
 	adjustHsv,
 	formatNumber,
@@ -47,6 +49,7 @@ import {
 	prompt,
 	setProjectDir,
 } from "@oh-my-pi/pi-utils";
+import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import chalk from "chalk";
 import { reset as resetCapabilities } from "../capability";
 import type { CollabGuestLink } from "../collab/guest";
@@ -451,6 +454,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#cleanupUnsubscribe?: () => void;
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
+	readonly #restartLaunchArgs: string[];
 	#planModePreviousTools: string[] | undefined;
 	#goalModePreviousTools: string[] | undefined;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
@@ -533,6 +537,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		mcpManager?: MCPManager,
 		eventBus?: EventBus,
 		titleSystemPrompt?: string,
+		restartLaunchArgs: string[] = [],
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -546,6 +551,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.mcpManager = mcpManager;
 		this.#eventBus = eventBus;
 		this.titleSystemPrompt = titleSystemPrompt;
+		this.#restartLaunchArgs = restartLaunchArgs;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -3011,16 +3017,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async shutdown(): Promise<void> {
-		if (this.#isShuttingDown) return;
-		this.#isShuttingDown = true;
-
-		// Snapshot the editor before any teardown empties it. Persisting the draft
-		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
-		// already cleared so saveDraft("") just removes any stale sidecar.
-		const draftText = this.editor.getText();
-
-		// Flush pending session writes before shutdown
+	async #prepareForProcessExit(draftText: string): Promise<void> {
+		// Flush pending session writes before shutdown/restart
 		await this.sessionManager.flush();
 		try {
 			await this.sessionManager.saveDraft(draftText);
@@ -3043,6 +3041,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.ui.terminal.drainInput(1000);
 		popTerminalTitle();
 		this.stop();
+	}
+
+	async shutdown(): Promise<void> {
+		if (this.#isShuttingDown) return;
+		this.#isShuttingDown = true;
+
+		// Snapshot the editor before any teardown empties it. Persisting the draft
+		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
+		// already cleared so saveDraft("") just removes any stale sidecar.
+		const draftText = this.editor.getText();
+		await this.#prepareForProcessExit(draftText);
 
 		// Print resumption hint if this is a persisted session
 		const sessionId = this.sessionManager.getSessionId();
@@ -3052,6 +3061,87 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		await postmortem.quit(0);
+	}
+
+	async #writeRestartChangelog(markdown: string): Promise<string> {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-update-changelog-"));
+		const file = path.join(dir, "CHANGELOG.md");
+		await Bun.write(file, markdown);
+		return file;
+	}
+
+	async restartCurrentSession(options: { showChangelog?: boolean; changelogMarkdown?: string } = {}): Promise<void> {
+		if (this.#isShuttingDown) return;
+		if (
+			this.session.isStreaming ||
+			this.session.isCompacting ||
+			this.session.isBashRunning ||
+			this.session.isEvalRunning
+		) {
+			this.showWarning("Wait for current work to finish before restarting.");
+			return;
+		}
+
+		const sessionFile = this.sessionManager.getSessionFile();
+		const sessionId = this.sessionManager.getSessionId();
+		if (!sessionFile || !sessionId) {
+			this.showWarning("Cannot restart an in-memory session. Start omp again manually.");
+			return;
+		}
+
+		const ompPath = $which(APP_NAME);
+		if (!ompPath) {
+			this.showWarning(
+				`Cannot restart because ${APP_NAME} is not on PATH. Run ${APP_NAME} --resume ${sessionId} manually.`,
+			);
+			return;
+		}
+
+		this.#isShuttingDown = true;
+		const profile = getActiveProfile();
+		const cwdArgs = ["--cwd", getProjectDir()];
+		const profileArgs = profile ? ["--profile", profile] : [];
+		const changelogArgs = options.changelogMarkdown
+			? ["--changelog-on-resume-path", await this.#writeRestartChangelog(options.changelogMarkdown)]
+			: options.showChangelog
+				? ["--show-changelog-on-resume"]
+				: [];
+		const restartCmd = [
+			ompPath,
+			...profileArgs,
+			...cwdArgs,
+			"--resume",
+			sessionFile,
+			...changelogArgs,
+			...this.#restartLaunchArgs,
+		];
+		const fallbackCommand = [APP_NAME, ...restartCmd.slice(1)]
+			.map(arg => (/[\s"'\\]/.test(arg) ? JSON.stringify(arg) : arg))
+			.join(" ");
+		const draftText = this.editor.getText();
+		let teardownComplete = false;
+		try {
+			await this.#prepareForProcessExit(draftText);
+			teardownComplete = true;
+			const child = Bun.spawn({
+				cmd: restartCmd,
+				stdin: "inherit",
+				stdout: "inherit",
+				stderr: "inherit",
+				env: process.env,
+			});
+			const exitCode = await child.exited;
+			await postmortem.quit(exitCode ?? 0);
+		} catch (error) {
+			const message = `Restart failed: ${error instanceof Error ? error.message : String(error)}. Run ${fallbackCommand} manually.`;
+			if (!teardownComplete) {
+				this.#isShuttingDown = false;
+				this.showError(message);
+				return;
+			}
+			process.stderr.write(`\n${chalk.red(message)}\n`);
+			await postmortem.quit(1);
+		}
 	}
 
 	async checkShutdownRequested(): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -186,6 +186,7 @@ export interface InteractiveModeContext {
 	init(options?: InteractiveModeInitOptions): Promise<void>;
 	playWelcomeIntro(): void;
 	shutdown(): Promise<void>;
+	restartCurrentSession(options?: { showChangelog?: boolean; changelogMarkdown?: string }): Promise<void>;
 	checkShutdownRequested(): Promise<void>;
 
 	// Extension UI integration

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,8 +3,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { setNextRequestDebugPath } from "@oh-my-pi/pi-ai/utils/request-debug";
-import type { AutocompleteItem } from "@oh-my-pi/pi-tui";
+import { type AutocompleteItem, Markdown, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { APP_NAME, setProjectDir } from "@oh-my-pi/pi-utils";
+import * as updateCli from "../cli/update-cli";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
 import type { SettingPath, SettingValue } from "../config/settings";
@@ -24,12 +25,14 @@ import {
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
 import { resolveMemoryBackend } from "../memory-backend";
-import { theme } from "../modes/theme/theme";
+import { DynamicBorder } from "../modes/components/dynamic-border";
+import { TranscriptBlock } from "../modes/components/transcript-container";
+import { getMarkdownTheme, theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { urlHyperlinkAlways } from "../tui";
-import { getChangelogPath, parseChangelog } from "../utils/changelog";
+import { formatChangelogMarkdown, getChangelogPath, parseChangelog } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
 import { createMarketplaceManager } from "./helpers/marketplace-manager";
@@ -55,6 +58,18 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+function showUpdateChangelog(ctx: InteractiveModeContext, message: string): string {
+	const changelog = message.replace(/^\nWhat's new:\n\n/, "").trim();
+	const block = new TranscriptBlock();
+	block.addChild(new DynamicBorder());
+	block.addChild(new Text(theme.fg("accent", "What's new"), 1, 0));
+	block.addChild(new Spacer(1));
+	block.addChild(new Markdown(changelog, 1, 1, getMarkdownTheme()));
+	block.addChild(new DynamicBorder());
+	ctx.present(block);
+	return changelog;
+}
 
 function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
@@ -978,12 +993,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				await runtime.output("No changelog entries found.");
 				return commandConsumed();
 			}
-			await runtime.output(
-				[...entriesToShow]
-					.reverse()
-					.map(entry => entry.content)
-					.join("\n\n"),
-			);
+			await runtime.output(formatChangelogMarkdown(entriesToShow, { reverse: true }));
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
@@ -1538,6 +1548,77 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		name: "exit",
 		description: "Exit the application",
 		handleTui: shutdownHandlerTui,
+	},
+	{
+		name: "restart",
+		description: "Restart OMP and resume this session",
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.restartCurrentSession();
+		},
+	},
+	{
+		name: "update",
+		description: "Check for and install OMP updates",
+		inlineHint: "[--check] [--force]",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			let check = false;
+			let force = false;
+			for (const token of command.args.split(/\s+/).filter(Boolean)) {
+				if (token === "--check" || token === "-c") {
+					check = true;
+				} else if (token === "--force" || token === "-f") {
+					force = true;
+				} else {
+					runtime.ctx.showStatus("Usage: /update [--check] [--force]");
+					runtime.ctx.editor.setText("");
+					return;
+				}
+			}
+
+			if (
+				!check &&
+				(runtime.ctx.session.isStreaming ||
+					runtime.ctx.session.isCompacting ||
+					runtime.ctx.session.isBashRunning ||
+					runtime.ctx.session.isEvalRunning)
+			) {
+				runtime.ctx.showStatus("Wait for current work to finish before updating.");
+				return;
+			}
+
+			let updateChangelogMarkdown: string | undefined;
+
+			try {
+				const result = await updateCli.runUpdateFlow(
+					{ force, check, showChangelog: !check },
+					{
+						log: message => {
+							if (message.startsWith("\nWhat's new:\n\n")) {
+								updateChangelogMarkdown = showUpdateChangelog(runtime.ctx, message);
+							} else {
+								runtime.ctx.showStatus(message);
+							}
+						},
+						error: message => runtime.ctx.showWarning(message),
+					},
+				);
+				if (result.kind === "updated") {
+					runtime.ctx.editor.setText("");
+					runtime.ctx.showStatus(`Restarting OMP to use v${result.version}...`);
+					await runtime.ctx.restartCurrentSession({
+						showChangelog: !result.changelogPrinted || !updateChangelogMarkdown,
+						changelogMarkdown: result.changelogPrinted ? updateChangelogMarkdown : undefined,
+					});
+					return;
+				}
+				runtime.ctx.editor.setText("");
+			} catch (error) {
+				runtime.ctx.showError(errorMessage(error));
+				runtime.ctx.editor.setText("");
+			}
+		},
 	},
 	{
 		name: "marketplace",

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -21,53 +21,7 @@ export async function parseChangelog(changelogPath: string | undefined): Promise
 		return [];
 	}
 	try {
-		const content = await Bun.file(changelogPath).text();
-		const lines = content.split("\n");
-		const entries: ChangelogEntry[] = [];
-
-		let currentLines: string[] = [];
-		let currentVersion: { major: number; minor: number; patch: number } | null = null;
-
-		for (const line of lines) {
-			// Check if this is a version header (## [x.y.z] ...)
-			if (line.startsWith("## ")) {
-				// Save previous entry if exists
-				if (currentVersion && currentLines.length > 0) {
-					entries.push({
-						...currentVersion,
-						content: currentLines.join("\n").trim(),
-					});
-				}
-
-				// Try to parse version from this line
-				const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
-				if (versionMatch) {
-					currentVersion = {
-						major: Number.parseInt(versionMatch[1], 10),
-						minor: Number.parseInt(versionMatch[2], 10),
-						patch: Number.parseInt(versionMatch[3], 10),
-					};
-					currentLines = [line];
-				} else {
-					// Reset if we can't parse version
-					currentVersion = null;
-					currentLines = [];
-				}
-			} else if (currentVersion) {
-				// Collect lines for current version
-				currentLines.push(line);
-			}
-		}
-
-		// Save last entry
-		if (currentVersion && currentLines.length > 0) {
-			entries.push({
-				...currentVersion,
-				content: currentLines.join("\n").trim(),
-			});
-		}
-
-		return entries;
+		return parseChangelogContent(await Bun.file(changelogPath).text());
 	} catch (error) {
 		if (isEnoent(error)) {
 			return [];
@@ -77,29 +31,103 @@ export async function parseChangelog(changelogPath: string | undefined): Promise
 	}
 }
 
+export function parseChangelogContent(content: string): ChangelogEntry[] {
+	const lines = content.split("\n");
+	const entries: ChangelogEntry[] = [];
+
+	let currentLines: string[] = [];
+	let currentVersion: { major: number; minor: number; patch: number } | null = null;
+
+	for (const line of lines) {
+		// Check if this is a version header (## [x.y.z] ...)
+		if (line.startsWith("## ")) {
+			// Save previous entry if exists
+			if (currentVersion && currentLines.length > 0) {
+				entries.push({
+					...currentVersion,
+					content: currentLines.join("\n").trim(),
+				});
+			}
+
+			// Try to parse version from this line
+			const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
+			if (versionMatch) {
+				currentVersion = {
+					major: Number.parseInt(versionMatch[1], 10),
+					minor: Number.parseInt(versionMatch[2], 10),
+					patch: Number.parseInt(versionMatch[3], 10),
+				};
+				currentLines = [line];
+			} else {
+				// Reset if we can't parse version
+				currentVersion = null;
+				currentLines = [];
+			}
+		} else if (currentVersion) {
+			// Collect lines for current version
+			currentLines.push(line);
+		}
+	}
+
+	// Save last entry
+	if (currentVersion && currentLines.length > 0) {
+		entries.push({
+			...currentVersion,
+			content: currentLines.join("\n").trim(),
+		});
+	}
+
+	return entries;
+}
+
+export function changelogEntryVersion(entry: ChangelogEntry): string {
+	return `${entry.major}.${entry.minor}.${entry.patch}`;
+}
+
+function compareVersionStrings(a: string, b: string): number {
+	try {
+		return Bun.semver.order(a, b);
+	} catch {
+		const pa = a.split(".").map(Number);
+		const pb = b.split(".").map(Number);
+
+		for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+			const na = pa[i] || 0;
+			const nb = pb[i] || 0;
+			if (na !== nb) return na - nb;
+		}
+		return 0;
+	}
+}
+
 /**
  * Compare versions. Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
  */
 export function compareVersions(v1: ChangelogEntry, v2: ChangelogEntry): number {
-	if (v1.major !== v2.major) return v1.major - v2.major;
-	if (v1.minor !== v2.minor) return v1.minor - v2.minor;
-	return v1.patch - v2.patch;
+	return compareVersionStrings(changelogEntryVersion(v1), changelogEntryVersion(v2));
+}
+
+export function getEntriesInVersionRange(
+	entries: ChangelogEntry[],
+	fromExclusive: string,
+	toInclusive: string,
+): ChangelogEntry[] {
+	return entries.filter(entry => {
+		const version = changelogEntryVersion(entry);
+		return compareVersionStrings(version, fromExclusive) > 0 && compareVersionStrings(version, toInclusive) <= 0;
+	});
+}
+
+export function formatChangelogMarkdown(entries: ChangelogEntry[], options?: { reverse?: boolean }): string {
+	const orderedEntries = options?.reverse ? [...entries].reverse() : entries;
+	return orderedEntries.map(entry => entry.content).join("\n\n");
 }
 
 /**
  * Get entries newer than lastVersion
  */
 export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): ChangelogEntry[] {
-	// Parse lastVersion
-	const parts = lastVersion.split(".").map(Number);
-	const last: ChangelogEntry = {
-		major: parts[0] || 0,
-		minor: parts[1] || 0,
-		patch: parts[2] || 0,
-		content: "",
-	};
-
-	return entries.filter(entry => compareVersions(entry, last) > 0);
+	return entries.filter(entry => compareVersionStrings(changelogEntryVersion(entry), lastVersion) > 0);
 }
 
 // Re-export getChangelogPath from paths.ts for convenience

--- a/packages/coding-agent/test/restart-launch-args.test.ts
+++ b/packages/coding-agent/test/restart-launch-args.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { buildRestartLaunchArgs } from "@oh-my-pi/pi-coding-agent/main";
+import { getProjectDir } from "@oh-my-pi/pi-utils";
+
+describe("buildRestartLaunchArgs", () => {
+	it("does not preserve launch cwd guards because restart uses the current project dir", () => {
+		const parsed = parseArgs(["--cwd", "/work/project", "--allow-home"]);
+
+		expect(buildRestartLaunchArgs(parsed)).toEqual([]);
+	});
+
+	it("resolves config overlays against the startup project dir", () => {
+		const parsed = parseArgs(["--config", "config.local.yaml"]);
+
+		expect(buildRestartLaunchArgs(parsed, "/startup/project")).toEqual([
+			"--config",
+			path.resolve("/startup/project", "config.local.yaml"),
+		]);
+	});
+
+	it("expands tilde before resolving restart path inputs", () => {
+		const parsed = parseArgs(["--config=~/omp.yml", "--extension=~/plugin.ts"]);
+
+		expect(buildRestartLaunchArgs(parsed)).toEqual([
+			"--config",
+			path.join(os.homedir(), "omp.yml"),
+			"--extension",
+			path.join(os.homedir(), "plugin.ts"),
+		]);
+	});
+
+	it("resolves existing prompt files without rewriting literal prompts", () => {
+		const parsed = parseArgs(["--system-prompt", "package.json", "--append-system-prompt", "literal prompt text"]);
+
+		expect(buildRestartLaunchArgs(parsed, getProjectDir())).toEqual([
+			"--system-prompt",
+			path.resolve(getProjectDir(), "package.json"),
+			"--append-system-prompt",
+			"literal prompt text",
+		]);
+	});
+	it("preserves extension-aware flags without replaying initial messages", () => {
+		const parsed = parseArgs(
+			["--extension", "plan-mode.ts", "--plan", "review diff", "--workspace", "team-a"],
+			new Map([
+				["plan", { type: "boolean" }],
+				["workspace", { type: "string" }],
+			]),
+		);
+
+		expect(parsed.plan).toBeUndefined();
+		expect(parsed.messages).toEqual(["review diff"]);
+		expect(buildRestartLaunchArgs(parsed)).toEqual([
+			"--extension",
+			path.resolve(getProjectDir(), "plan-mode.ts"),
+			"--plan",
+			"--workspace",
+			"team-a",
+		]);
+	});
+
+	it("preserves equals form for dashed extension flag values", () => {
+		const parsed = parseArgs(["--target=--staging"], new Map([["target", { type: "string" }]]));
+
+		expect(buildRestartLaunchArgs(parsed)).toEqual(["--target=--staging"]);
+	});
+
+	it("treats changelog handoff path as a built-in string flag", () => {
+		const parsed = parseArgs(["--changelog-on-resume-path", "--notes", "--profile", "work"]);
+
+		expect(parsed.changelogOnResumePath).toBe("--notes");
+		expect(parsed.profile).toBe("work");
+	});
+
+	it("preserves tool, approval, scoped model, and extension launch restrictions", () => {
+		const parsed = parseArgs([
+			"--no-tools",
+			"--tools",
+			"read,bash",
+			"--models",
+			"anthropic/claude-sonnet-4-5,openai/gpt-5",
+			"--approval-mode",
+			"always-ask",
+			"--no-extensions",
+			"--no-skills",
+			"--no-rules",
+		]);
+
+		expect(buildRestartLaunchArgs(parsed)).toEqual([
+			"--models",
+			"anthropic/claude-sonnet-4-5,openai/gpt-5",
+			"--no-tools",
+			"--tools",
+			"read,bash",
+			"--no-extensions",
+			"--no-skills",
+			"--no-rules",
+			"--approval-mode",
+			"always-ask",
+		]);
+	});
+
+	it("omits session-state model and thinking flags so resume restores current session state", () => {
+		const parsed = parseArgs([
+			"--provider",
+			"anthropic",
+			"--model",
+			"claude-sonnet-4-5",
+			"--thinking",
+			"high",
+			"--hide-thinking",
+		]);
+
+		expect(buildRestartLaunchArgs(parsed)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/update.test.ts
+++ b/packages/coding-agent/test/slash-commands/update.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as updateCli from "@oh-my-pi/pi-coding-agent/cli/update-cli";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntimeHarness(sessionState: Partial<InteractiveModeContext["session"]> = {}) {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const showWarning = vi.fn();
+	const showError = vi.fn();
+	const present = vi.fn();
+	const restartCurrentSession = vi.fn(async () => {});
+	return {
+		setText,
+		showStatus,
+		showWarning,
+		showError,
+		present,
+		restartCurrentSession,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				session: {
+					isStreaming: false,
+					isCompacting: false,
+					isBashRunning: false,
+					isEvalRunning: false,
+					...sessionState,
+				} as unknown as InteractiveModeContext["session"],
+				showStatus,
+				showWarning,
+				showError,
+				present,
+				restartCurrentSession,
+			} as unknown as InteractiveModeContext,
+		},
+	};
+}
+
+beforeAll(async () => {
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("Expected dark theme");
+	setThemeInstance(theme);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("/update slash command", () => {
+	it("checks for updates without restarting", async () => {
+		const harness = createRuntimeHarness();
+		const runUpdateFlow = vi.spyOn(updateCli, "runUpdateFlow").mockResolvedValue({
+			kind: "update-available",
+			currentVersion: "15.13.0",
+			latestVersion: "15.13.2",
+			checkOnly: true,
+		});
+
+		expect(await executeBuiltinSlashCommand("/update --check", harness.runtime)).toBe(true);
+
+		expect(runUpdateFlow).toHaveBeenCalledWith(
+			{ force: false, check: true, showChangelog: false },
+			expect.objectContaining({ log: expect.any(Function), error: expect.any(Function) }),
+		);
+		expect(harness.restartCurrentSession).not.toHaveBeenCalled();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("restarts after a successful update", async () => {
+		const harness = createRuntimeHarness();
+		vi.spyOn(updateCli, "runUpdateFlow").mockResolvedValue({
+			kind: "updated",
+			previousVersion: "15.13.0",
+			version: "15.13.2",
+			forced: false,
+			changelogPrinted: false,
+		});
+
+		expect(await executeBuiltinSlashCommand("/update", harness.runtime)).toBe(true);
+
+		expect(updateCli.runUpdateFlow).toHaveBeenCalledWith(
+			{ force: false, check: false, showChangelog: true },
+			expect.objectContaining({ log: expect.any(Function), error: expect.any(Function) }),
+		);
+
+		expect(harness.showStatus).toHaveBeenCalledWith("Restarting OMP to use v15.13.2...");
+		expect(harness.restartCurrentSession).toHaveBeenCalledWith({ showChangelog: true });
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("falls back to resumed changelog when update result says notes printed but none were captured", async () => {
+		const harness = createRuntimeHarness();
+		vi.spyOn(updateCli, "runUpdateFlow").mockResolvedValue({
+			kind: "updated",
+			previousVersion: "15.13.0",
+			version: "15.13.2",
+			forced: false,
+			changelogPrinted: true,
+		});
+
+		expect(await executeBuiltinSlashCommand("/update", harness.runtime)).toBe(true);
+
+		expect(harness.restartCurrentSession).toHaveBeenCalledWith({ showChangelog: true, changelogMarkdown: undefined });
+	});
+
+	it("presents release notes without coalescing them into status", async () => {
+		const harness = createRuntimeHarness();
+		vi.spyOn(updateCli, "runUpdateFlow").mockImplementation(async (_options, output) => {
+			await output.log("Current version: 15.13.0");
+			await output.log("\nWhat's new:\n\n## [15.13.2]\n\n- Update UX");
+			return {
+				kind: "updated",
+				previousVersion: "15.13.0",
+				version: "15.13.2",
+				forced: false,
+				changelogPrinted: true,
+			};
+		});
+
+		expect(await executeBuiltinSlashCommand("/update", harness.runtime)).toBe(true);
+
+		expect(harness.showStatus).toHaveBeenCalledWith("Current version: 15.13.0");
+		expect(harness.showStatus).not.toHaveBeenCalledWith(expect.stringContaining("What's new:"));
+		expect(harness.present).toHaveBeenCalledTimes(1);
+		expect(harness.restartCurrentSession).toHaveBeenCalledWith({
+			showChangelog: false,
+			changelogMarkdown: "## [15.13.2]\n\n- Update UX",
+		});
+	});
+
+	it("rejects unknown update flags without running the update flow", async () => {
+		const harness = createRuntimeHarness();
+		const runUpdateFlow = vi.spyOn(updateCli, "runUpdateFlow").mockResolvedValue({
+			kind: "no-update",
+			currentVersion: "15.13.2",
+			latestVersion: "15.13.2",
+		});
+
+		expect(await executeBuiltinSlashCommand("/update --bogus", harness.runtime)).toBe(true);
+
+		expect(harness.showStatus).toHaveBeenCalledWith("Usage: /update [--check] [--force]");
+		expect(runUpdateFlow).not.toHaveBeenCalled();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("refuses install while work is running and keeps the typed command", async () => {
+		const harness = createRuntimeHarness({ isStreaming: true } as Partial<InteractiveModeContext["session"]>);
+		const runUpdateFlow = vi.spyOn(updateCli, "runUpdateFlow").mockResolvedValue({
+			kind: "updated",
+			previousVersion: "15.13.0",
+			version: "15.13.2",
+			forced: false,
+			changelogPrinted: false,
+		});
+
+		expect(await executeBuiltinSlashCommand("/update", harness.runtime)).toBe(true);
+
+		expect(harness.showStatus).toHaveBeenCalledWith("Wait for current work to finish before updating.");
+		expect(runUpdateFlow).not.toHaveBeenCalled();
+		expect(harness.setText).not.toHaveBeenCalled();
+	});
+});
+
+describe("/restart slash command", () => {
+	it("restarts the current session and clears the editor", async () => {
+		const harness = createRuntimeHarness();
+
+		expect(await executeBuiltinSlashCommand("/restart", harness.runtime)).toBe(true);
+
+		expect(harness.restartCurrentSession).toHaveBeenCalledTimes(1);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -7,9 +7,14 @@ import {
 	buildHomebrewUpdateArgs,
 	buildMiseForceInstallArgs,
 	buildMiseUpgradeArgs,
+	getOutdatedProcessInfo,
+	readLastInstalledVersion,
 	replaceBinaryForUpdate,
 	resolveUpdateMethodForTest,
+	runUpdateFlow,
+	writeLastInstalledVersion,
 } from "@oh-my-pi/pi-coding-agent/cli/update-cli";
+import { getEntriesInVersionRange, parseChangelogContent } from "@oh-my-pi/pi-coding-agent/utils/changelog";
 
 const tempDirs: string[] = [];
 
@@ -20,6 +25,7 @@ async function makeTempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 describe("update-cli install target detection", () => {
@@ -179,5 +185,158 @@ describe("update-cli binary replacement", () => {
 		expect(await Bun.file(targetPath).text()).toBe("new binary");
 		expect(await Bun.file(tempPath).exists()).toBe(false);
 		expect(await Bun.file(backupPath).exists()).toBe(false);
+	});
+});
+
+describe("update-cli changelog helpers", () => {
+	it("selects only changelog entries newer than the running version and not newer than the installed release", () => {
+		const entries = parseChangelogContent(
+			[
+				"## [15.14.0]",
+				"- Future",
+				"",
+				"## [15.13.2]",
+				"- Patch two",
+				"",
+				"## [15.13.1]",
+				"- Patch one",
+				"",
+				"## [15.13.0]",
+				"- Baseline",
+			].join("\n"),
+		);
+
+		const selected = getEntriesInVersionRange(entries, "15.13.0", "15.13.2");
+
+		expect(selected.map(entry => `${entry.major}.${entry.minor}.${entry.patch}`)).toEqual(["15.13.2", "15.13.1"]);
+	});
+});
+
+describe("runUpdateFlow", () => {
+	it("prints release notes for the installed range and records update markers", async () => {
+		const messages: string[] = [];
+		const installedVersions: string[] = [];
+		const seenChangelogVersions: string[] = [];
+
+		const result = await runUpdateFlow(
+			{ force: false, check: false, showChangelog: true, currentVersion: "15.13.0" },
+			{
+				log: message => {
+					messages.push(message);
+				},
+				error: message => {
+					messages.push(message);
+				},
+			},
+			{
+				getLatestRelease: async () => ({ version: "15.13.2", tag: "v15.13.2", tarball: "fixture" }),
+				resolveUpdateTarget: async () => ({ method: "binary", path: "/tmp/omp" }),
+				installUpdate: vi.fn(async () => {}),
+				loadReleaseChangelog: async () =>
+					[
+						"## [15.14.0]",
+						"- Future",
+						"",
+						"## [15.13.2]",
+						"- Patch two",
+						"",
+						"## [15.13.1]",
+						"- Patch one",
+						"",
+						"## [15.13.0]",
+						"- Baseline",
+					].join("\n"),
+				writeInstalledVersion: async version => {
+					installedVersions.push(version);
+				},
+				writeSeenChangelogVersion: async version => {
+					seenChangelogVersions.push(version);
+				},
+			},
+		);
+
+		const output = messages.join("\n");
+		expect(result).toEqual({
+			kind: "updated",
+			previousVersion: "15.13.0",
+			version: "15.13.2",
+			forced: false,
+			changelogPrinted: true,
+		});
+		expect(output).toContain("What's new:");
+		expect(output).toContain("## [15.13.1]");
+		expect(output).toContain("## [15.13.2]");
+		expect(output).not.toContain("## [15.13.0]");
+		expect(output).not.toContain("## [15.14.0]");
+		expect(installedVersions).toEqual(["15.13.2"]);
+		expect(seenChangelogVersions).toEqual(["15.13.2"]);
+	});
+
+	it("does not install when check is combined with force", async () => {
+		const installUpdate = vi.fn(async () => {});
+		const messages: string[] = [];
+
+		const result = await runUpdateFlow(
+			{ force: true, check: true, showChangelog: true, currentVersion: "15.13.2" },
+			{
+				log: message => {
+					messages.push(message);
+				},
+				error: () => {},
+			},
+			{
+				getLatestRelease: async () => ({ version: "15.13.2", tag: "v15.13.2" }),
+				resolveUpdateTarget: async () => ({ method: "binary", path: "/tmp/omp" }),
+				installUpdate,
+			},
+		);
+
+		expect(result).toEqual({ kind: "no-update", currentVersion: "15.13.2", latestVersion: "15.13.2" });
+		expect(installUpdate).not.toHaveBeenCalled();
+		expect(messages.join("\n")).not.toContain("Forcing reinstall");
+	});
+
+	it("does not write the installed-version marker when installation fails", async () => {
+		const writeInstalledVersion = vi.fn(async () => {});
+
+		await expect(
+			runUpdateFlow(
+				{ force: false, check: false, showChangelog: true, currentVersion: "15.13.0" },
+				{ log: () => {}, error: () => {} },
+				{
+					getLatestRelease: async () => ({ version: "15.13.2", tag: "v15.13.2", tarball: "fixture" }),
+					resolveUpdateTarget: async () => ({ method: "binary", path: "/tmp/omp" }),
+					installUpdate: async () => {
+						throw new Error("installer exploded");
+					},
+					writeInstalledVersion,
+				},
+			),
+		).rejects.toThrow("Update failed: installer exploded");
+		expect(writeInstalledVersion).not.toHaveBeenCalled();
+	});
+});
+
+describe("update-cli installed-version marker", () => {
+	it("reads and writes the installed version marker in an agent dir", async () => {
+		const dir = await makeTempDir();
+
+		expect(await readLastInstalledVersion(dir)).toBeUndefined();
+		await writeLastInstalledVersion("15.13.2", dir);
+
+		expect(await readLastInstalledVersion(dir)).toBe("15.13.2");
+	});
+
+	it("reports outdated process info only when the installed marker is newer", async () => {
+		const dir = await makeTempDir();
+
+		await writeLastInstalledVersion("15.13.2", dir);
+
+		expect(await getOutdatedProcessInfo("15.13.1", dir)).toEqual({
+			currentVersion: "15.13.1",
+			installedVersion: "15.13.2",
+		});
+		expect(await getOutdatedProcessInfo("15.13.2", dir)).toBeUndefined();
+		expect(await getOutdatedProcessInfo("15.13.3", dir)).toBeUndefined();
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `getLastInstalledVersionPath()` for the update flow's global installed-version marker.
+
 ## [15.13.3] - 2026-06-15
 
 ### Added

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -664,6 +664,24 @@ export function getLastChangelogVersionPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "last-changelog-version", "state");
 }
 
+function getDefaultProfileLastInstalledVersionPath(): string {
+	const defaultDirs = new DirResolver({
+		agentDirOverride: resolvePreProfileAgentDir(
+			undefined,
+			process.env.PI_CODING_AGENT_DIR,
+			readPiProfileFromEnvSafe(),
+		),
+	});
+	return defaultDirs.agentSubdir(undefined, "last-installed-version", "state");
+}
+
+/** Get the global last successfully installed omp version marker (~/.omp/agent/last-installed-version). */
+export function getLastInstalledVersionPath(agentDir?: string): string {
+	return agentDir
+		? dirs.agentSubdir(agentDir, "last-installed-version", "state")
+		: getDefaultProfileLastInstalledVersionPath();
+}
+
 /** Get the path to history.db (SQLite database for session history). */
 export function getHistoryDbPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "history.db", "data");

--- a/packages/utils/test/profiles.test.ts
+++ b/packages/utils/test/profiles.test.ts
@@ -10,6 +10,7 @@ import {
 	getAgentDir,
 	getConfigAgentDirName,
 	getConfigRootDir,
+	getLastInstalledVersionPath,
 	getPythonGatewayDir,
 	getSessionsDir,
 	getStatsDbPath,
@@ -129,6 +130,15 @@ describe("profile directories", () => {
 		expect(getAgentDbPath()).toBe(path.join(agent, "agent.db"));
 		expect(getSessionsDir()).toBe(path.join(agent, "sessions"));
 		expect(getStatsDbPath()).toBe(path.join(root, "stats.db"));
+	});
+
+	it("keeps installed-version marker global across named profiles", () => {
+		const root = path.join(os.homedir(), configDir);
+		const marker = path.join(root, "agent", "last-installed-version");
+
+		expect(getLastInstalledVersionPath()).toBe(marker);
+		setProfile("work");
+		expect(getLastInstalledVersionPath()).toBe(marker);
 	});
 
 	it("treats the default profile as regular mode", () => {


### PR DESCRIPTION
## Summary

OMP updates are now understandable and recoverable from both CLI and TUI flows. `omp update` reuses a non-exiting update engine and prints the relevant release notes after a verified install, while the TUI gains `/update` and `/restart` commands so a running session can check/install updates and resume on the newly installed binary.

Closes #2712.

## What changed

- Refactored update handling into exported `runUpdateFlow()` APIs that return structured results instead of exiting, with CLI-only exit behavior preserved in `runUpdateCommand()`.
- Added release changelog loading from npm tarballs, version-range filtering, and shared changelog formatting so only entries newer than the running version and not newer than the installed release are shown.
- Added a separate `last-installed-version` marker and stale-process warning so old TUI processes can tell users to run `/restart` after an update succeeds elsewhere.
- Added TUI-only `/update [--check] [--force]` and `/restart` commands; restart uses the PATH-resolved `omp --resume <sessionFile>` path rather than attempting an in-process reload.
- Hardened the flow so failed post-install verification does not advance the installed marker, best-effort changelog loading times out, and restart failures report a manual resume fallback.

## Testing

- `bun test packages/coding-agent/test/update-cli.test.ts packages/coding-agent/test/slash-commands/update.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/utils run check`
- Marker smoke via `writeLastInstalledVersion()` / `getOutdatedProcessInfo()` with a throwaway agent dir.

Manual interactive TUI smoke was attempted from this Windows harness, but stdin could not provide a usable TTY for command feeding. The user-visible `/update`, `/restart`, and busy-state behavior is covered by focused slash-command tests.

## Post-Deploy Monitoring & Validation

No additional production monitoring required: this is local CLI/TUI update behavior. Validation signal is user reports around `omp update`, `/update`, `/restart`, and stale-session warning output after release.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GitHub_Copilot_GPT_5.5_%281M%29](https://img.shields.io/badge/GitHub_Copilot_GPT_5.5_%281M%29-000000)