### PR TITLE
test(plugins): isolate discovery test from real ~/.omp on all platforms

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The `plugin-extensions-discovery` test suite no longer writes fixtures into — and `rm -rf`s the `node_modules` of — the developer's real `~/.omp/plugins`. Its `XDG_DATA_HOME` isolation was a no-op on Windows (XDG is gated to Linux/macOS) and was bypassed in XDG-migrated Linux/macOS environments, so a local run could delete installed plugins. The suite now isolates the whole config root via an `os.homedir()` mock plus cleared `XDG_*` vars, with a pre-write guard that fails if resolution escapes the temp home ([#2721](https://github.com/can1357/oh-my-pi/issues/2721)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,20 +10,36 @@ const currentPiExtensionsPath = Bun.resolveSync("@oh-my-pi/pi-coding-agent/exten
 
 describe("plugin extension discovery", () => {
 	let projectDir: TempDir;
-	let tempXdgDataHome = "";
-	let originalXdgDataHome: string | undefined;
+	let tempHome = "";
 	const originalAgentDir = getAgentDir();
+	const xdgVars = ["XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"] as const;
+	const originalXdg = new Map<string, string | undefined>();
 
 	beforeEach(() => {
 		projectDir = TempDir.createSync("@pi-plugin-ext-");
-		originalXdgDataHome = process.env.XDG_DATA_HOME;
-		tempXdgDataHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plugin-data-"));
-		fs.mkdirSync(path.join(tempXdgDataHome, "omp"), { recursive: true });
-		process.env.XDG_DATA_HOME = tempXdgDataHome;
-		// Rebuild path caches after changing XDG env so plugin discovery resolves into the temp root.
-		setAgentDir(originalAgentDir);
+		// Redirect the whole config root to an isolated temp home so plugin discovery
+		// resolves into `<tempHome>/.omp/plugins` on every platform. Two things are needed:
+		//  - mock os.homedir() so configRoot = `<tempHome>/.omp` (the previous
+		//    XDG_DATA_HOME redirect was a no-op on Windows, where these tests then wrote
+		//    into and rm'd the developer's real `~/.omp/plugins`);
+		//  - clear the XDG_* vars, because on Linux/macOS the resolver prefers
+		//    `$XDG_DATA_HOME/omp` over the home config root when that dir exists, so an
+		//    XDG-migrated environment would otherwise still resolve the real plugins dir.
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plugin-home-"));
+		for (const key of xdgVars) {
+			originalXdg.set(key, process.env[key]);
+			delete process.env[key];
+		}
+		spyOn(os, "homedir").mockReturnValue(tempHome);
+		setAgentDir(path.join(tempHome, ".omp", "agent"));
 
 		const pluginsDir = getPluginsDir();
+		// Safety gate: never write fixtures outside the temp home. This is the exact
+		// failure mode being fixed — a resolver/mock regression that resolves to the real
+		// ~/.omp must fail loudly here instead of clobbering the developer's plugins.
+		if (!pluginsDir.startsWith(tempHome + path.sep)) {
+			throw new Error(`plugin isolation failed: getPluginsDir() resolved outside the temp home: ${pluginsDir}`);
+		}
 		const pluginDir = path.join(pluginsDir, "node_modules", "@demo", "plugin");
 		fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
 		fs.writeFileSync(
@@ -58,13 +74,14 @@ describe("plugin extension discovery", () => {
 
 	afterEach(() => {
 		projectDir.removeSync();
-		fs.rmSync(tempXdgDataHome, { recursive: true, force: true });
-		if (originalXdgDataHome === undefined) {
-			delete process.env.XDG_DATA_HOME;
-		} else {
-			process.env.XDG_DATA_HOME = originalXdgDataHome;
+		spyOn(os, "homedir").mockRestore();
+		for (const [key, value] of originalXdg) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
 		}
+		originalXdg.clear();
 		setAgentDir(originalAgentDir);
+		fs.rmSync(tempHome, { recursive: true, force: true });
 	});
 
 	it("loads installed plugin extensions declared in package.json", async () => {


### PR DESCRIPTION
## Problem

`plugin-extensions-discovery.test.ts` isolates the plugins directory by redirecting `XDG_DATA_HOME` to a temp dir + `setAgentDir(originalAgentDir)`. But XDG redirection is gated to Linux/macOS in `packages/utils/src/dirs.ts`:

```ts
if ((process.platform === "linux" || process.platform === "darwin") && isDefault) {
  // xdgData = resolveIf("XDG_DATA_HOME")
}
```

On **Windows** the redirect is a no-op, so `getPluginsDir()` resolves to the real `os.homedir()/.omp/plugins`. The suite then **writes fixtures into** and **`fs.rmSync(node_modules, { recursive: true, force: true })`s** the developer's real plugins directory — wiping installed plugins. Green on Linux CI, silently destructive on Windows local. (Observed first-hand: a full run deleted an `omp plugin install`ed package and left phantom fixture deps in real `~/.omp/plugins/package.json`.)

The sibling plugin tests (`plugin-install-validation`/`-git`/`-local`/`plugin-config`) isolate via `vi.spyOn(piUtils, "getPluginsDir")`, but that can't intercept the discovery path: `extensibility/plugins/loader.ts` imports `getPluginsNodeModules`/`getPluginsPackageJson`/`getPluginsLockfile` as destructured named imports, so spying the namespace object is a no-op. Hence the XDG workaround — which only covers Linux/macOS.

## Fix

Adopt the cross-platform `os.homedir()` mock already used by `autolearn-*.test.ts`: redirect the config root to a temp home and `setAgentDir(<tempHome>/.omp/agent)` to rebuild the resolver. `configRoot = os.homedir()/.omp` then resolves under the temp home on **every** platform, so `getPluginsDir()` and its derivatives are isolated regardless of import binding. Test-only — no production change.

## Verification

- `sha256sum ~/.omp/plugins/package.json` is **identical before and after** a full suite run on Windows (previously it was rewritten/emptied).
- `bun test plugin-extensions-discovery.test.ts` → **9 pass / 0 fail**; biome + `tsgo` typecheck clean.

Fixes #2721.
