### PR TITLE
fix(cli): resolve plugin extension directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plugin `pi.extensions: ["./extensions"]` manifest entries to load one-level extension directory children such as `extensions/<name>/index.ts` instead of failing install validation or silently skipping them at runtime ([#2713](https://github.com/can1357/oh-my-pi/issues/2713)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -146,7 +146,10 @@ export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {
 const MANIFEST_ENTRY_INDEX_NAMES = ["index.ts", "index.js", "index.mjs", "index.cjs"];
 
 function isManifestEntryFile(name: string): boolean {
-	return name.endsWith(".ts") || name.endsWith(".js") || name.endsWith(".mjs") || name.endsWith(".cjs");
+	return (
+		!name.endsWith(".d.ts") &&
+		(name.endsWith(".ts") || name.endsWith(".js") || name.endsWith(".mjs") || name.endsWith(".cjs"))
+	);
 }
 
 function resolveManifestEntryIndex(dir: string): string | null {

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -145,27 +145,70 @@ export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {
 
 const MANIFEST_ENTRY_INDEX_NAMES = ["index.ts", "index.js", "index.mjs", "index.cjs"];
 
+function isManifestEntryFile(name: string): boolean {
+	return name.endsWith(".ts") || name.endsWith(".js") || name.endsWith(".mjs") || name.endsWith(".cjs");
+}
+
+function resolveManifestEntryIndex(dir: string): string | null {
+	for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
+		const candidate = path.join(dir, name);
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+function resolveExtensionDirectoryEntries(dir: string): string[] {
+	const resolved: string[] = [];
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return resolved;
+	}
+
+	entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+	for (const entry of entries) {
+		const candidate = path.join(dir, entry.name);
+		let stats: fs.Stats | null = null;
+		try {
+			stats = entry.isSymbolicLink() ? fs.statSync(candidate) : null;
+		} catch {
+			continue;
+		}
+		const isFile = entry.isFile() || stats?.isFile() === true;
+		if (isFile && isManifestEntryFile(entry.name)) {
+			resolved.push(candidate);
+			continue;
+		}
+		const isDirectory = entry.isDirectory() || stats?.isDirectory() === true;
+		if (!isDirectory) continue;
+		const index = resolveManifestEntryIndex(candidate);
+		if (index) resolved.push(index);
+	}
+
+	return resolved;
+}
+
 /**
- * Resolve a plugin manifest entry to a concrete loadable file path. Returns the
+ * Resolve a plugin manifest entry to concrete loadable file paths. Returns the
  * file path itself when the entry points at a file, the matching index file when
- * the entry points at a directory containing index.{ts,js,mjs,cjs}, and null
- * when no entry exists at the joined path.
+ * the entry points at a directory containing index.{ts,js,mjs,cjs}, extension
+ * children when an extension-directory entry contains no direct index, and an
+ * empty array when no entry exists at the joined path.
  */
-function resolveManifestEntryFile(joined: string): string | null {
+function resolveManifestEntryFiles(joined: string, key: "tools" | "hooks" | "commands" | "extensions"): string[] {
 	let stats: fs.Stats;
 	try {
 		stats = fs.statSync(joined);
 	} catch {
-		return null;
+		return [];
 	}
 	if (stats.isDirectory()) {
-		for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
-			const candidate = path.join(joined, name);
-			if (fs.existsSync(candidate)) return candidate;
-		}
-		return null;
+		const index = resolveManifestEntryIndex(joined);
+		if (index) return [index];
+		return key === "extensions" ? resolveExtensionDirectoryEntries(joined) : [];
 	}
-	return joined;
+	return [joined];
 }
 
 /**
@@ -175,15 +218,15 @@ function resolveManifestEntryFile(joined: string): string | null {
 function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "commands" | "extensions"): string[] {
 	const resolved: string[] = [];
 	for (const entry of resolvePluginManifestEntries(plugin, key)) {
-		if (entry.resolvedPath) {
-			resolved.push(entry.resolvedPath);
+		if (entry.resolvedPaths.length > 0) {
+			resolved.push(...entry.resolvedPaths);
 		}
 	}
 	return resolved;
 }
 
 /**
- * Declared manifest entries paired with their resolved file path. Returns one
+ * Declared manifest entries paired with their resolved file paths. Returns one
  * record per declared entry — base entries first, then enabled-feature entries
  * — so callers (e.g. install-time validation) can detect manifest entries that
  * point at missing files instead of silently skipping them like
@@ -192,13 +235,13 @@ function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "c
 export function resolvePluginManifestEntries(
 	plugin: InstalledPlugin,
 	key: "tools" | "hooks" | "commands" | "extensions",
-): Array<{ entry: string; resolvedPath: string | null }> {
-	const declared: Array<{ entry: string; resolvedPath: string | null }> = [];
+): Array<{ entry: string; resolvedPaths: string[] }> {
+	const declared: Array<{ entry: string; resolvedPaths: string[] }> = [];
 	const manifest = plugin.manifest;
 
-	const resolveEntry = (entry: string): { entry: string; resolvedPath: string | null } => ({
+	const resolveEntry = (entry: string): { entry: string; resolvedPaths: string[] } => ({
 		entry,
-		resolvedPath: resolveManifestEntryFile(path.join(plugin.path, entry)),
+		resolvedPaths: resolveManifestEntryFiles(path.join(plugin.path, entry), key),
 	});
 
 	const base = manifest[key];

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -259,11 +259,11 @@ export class PluginManager {
 
 		const errors: string[] = [];
 		const loadable: string[] = [];
-		for (const { entry, resolvedPath } of declaredEntries) {
-			if (resolvedPath === null) {
+		for (const { entry, resolvedPaths } of declaredEntries) {
+			if (resolvedPaths.length === 0) {
 				errors.push(`${entry}: declared extension entry not found on disk`);
 			} else {
-				loadable.push(resolvedPath);
+				loadable.push(...resolvedPaths);
 			}
 		}
 

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -108,6 +108,7 @@ describe("plugin extension discovery", () => {
 				}
 			`,
 		);
+		fs.writeFileSync(path.join(pluginDir, "extensions", "direct.d.ts"), "export interface IgnoredDeclaration {}\n");
 
 		const result = await discoverAndLoadExtensions([], projectDir.path());
 		const directExtension = result.extensions.find(ext => ext.path === directExtensionPath);

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -76,6 +76,48 @@ describe("plugin extension discovery", () => {
 		expect(extension?.commands.has("plugin-ext")).toBe(true);
 	});
 
+	it("loads installed pi plugin extension directories with one-level children", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "@demo", "plugin");
+		const directExtensionPath = path.join(pluginDir, "extensions", "direct.ts");
+		const nestedExtensionPath = path.join(pluginDir, "extensions", "llm-wiki", "index.ts");
+		fs.mkdirSync(path.dirname(nestedExtensionPath), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "@demo/plugin",
+				version: "1.0.0",
+				pi: {
+					extensions: ["./extensions"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			directExtensionPath,
+			`
+				export default function(pi) {
+					pi.registerCommand("direct-pi-ext", { handler: async () => {} });
+				}
+			`,
+		);
+		fs.writeFileSync(
+			nestedExtensionPath,
+			`
+				export default function(pi) {
+					pi.registerCommand("nested-pi-ext", { handler: async () => {} });
+				}
+			`,
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const directExtension = result.extensions.find(ext => ext.path === directExtensionPath);
+		const nestedExtension = result.extensions.find(ext => ext.path === nestedExtensionPath);
+
+		expect(result.errors).toHaveLength(0);
+		expect(directExtension?.commands.has("direct-pi-ext")).toBe(true);
+		expect(nestedExtension?.commands.has("nested-pi-ext")).toBe(true);
+	});
+
 	it("loads installed legacy Pi plugin extensions from Windows drive-letter paths", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "legacy-pi-plugin");

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -98,6 +98,14 @@ describe("PluginManager.install load validation", () => {
 					path.join(installedDir, "extensions", "wiki", "index.ts"),
 					'export default function(pi) { pi.registerCommand("wiki-ext", { handler: async () => {} }); }\n',
 				);
+				await Bun.write(
+					path.join(installedDir, "extensions", "direct.js"),
+					'export default function(pi) { pi.registerCommand("direct-ext", { handler: async () => {} }); }\n',
+				);
+				await Bun.write(
+					path.join(installedDir, "extensions", "direct.d.ts"),
+					"export interface IgnoredDeclaration {}\n",
+				);
 			})();
 
 			return {

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -67,6 +67,55 @@ describe("PluginManager.install load validation", () => {
 		await fs.rm(tmpRoot, { recursive: true, force: true });
 	});
 
+	test("accepts an install whose pi extension entry is a directory of sub-extensions", async () => {
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			expect(cmd).toEqual(["bun", "install", "directory-plugin"]);
+
+			const prepare = (async () => {
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{ name: "omp-plugins", private: true, dependencies: { "directory-plugin": "1.0.0" } },
+						null,
+						2,
+					),
+				);
+				const installedDir = path.join(pluginsNodeModules, "directory-plugin");
+				await fs.mkdir(path.join(installedDir, "extensions", "wiki"), { recursive: true });
+				await Bun.write(
+					path.join(installedDir, "package.json"),
+					JSON.stringify(
+						{
+							name: "directory-plugin",
+							version: "1.0.0",
+							pi: { extensions: ["./extensions"] },
+						},
+						null,
+						2,
+					),
+				);
+				await Bun.write(
+					path.join(installedDir, "extensions", "wiki", "index.ts"),
+					'export default function(pi) { pi.registerCommand("wiki-ext", { handler: async () => {} }); }\n',
+				);
+			})();
+
+			return {
+				pid: 1,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		await expect(new PluginManager(tmpRoot).install("directory-plugin")).resolves.toMatchObject({
+			name: "directory-plugin",
+			version: "1.0.0",
+		});
+		const lock = await Bun.file(path.join(tmpRoot, "omp-plugins.lock.json")).json();
+		expect(lock.plugins["directory-plugin"]).toEqual({ version: "1.0.0", enabledFeatures: null, enabled: true });
+	});
+
 	test("rejects an install whose extension entry cannot resolve its dependencies", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
 			expect(cmd).toEqual(["bun", "install", "broken-plugin"]);


### PR DESCRIPTION
## Repro
A plugin manifest that declares `pi.extensions: ["./extensions"]` while storing the loadable extension at `extensions/llm-wiki/index.ts` resolves to no installed extension paths. Reproduced with `bun --eval 'import { resolvePluginExtensionPaths, resolvePluginManifestEntries } from "./packages/coding-agent/src/extensibility/plugins/loader.ts"; /* creates extensions/llm-wiki/index.ts and resolves pi.extensions: ["./extensions"] */'`, which returned `resolvedPaths: []` before the fix.

## Cause
`packages/coding-agent/src/extensibility/plugins/loader.ts` resolved manifest directory entries only as a direct `index.{ts,js,mjs,cjs}` file. When `PluginManager.#validateInstalledExtensions` in `packages/coding-agent/src/extensibility/plugins/manager.ts` validated `./extensions`, the shared resolver returned no path, so install validation failed and runtime discovery skipped the nested extension.

## Fix
- Changed plugin manifest resolution to return multiple files for extension-directory entries.
- Added one-level scanning for direct extension files and child directories with `index.{ts,js,mjs,cjs}` when an extension manifest directory has no direct index.
- Updated install validation to validate every resolved child entry.
- Added install-time and runtime discovery regression coverage for `pi.extensions: ["./extensions"]`.

## Verification
`bun test packages/coding-agent/test/plugin-extensions-discovery.test.ts packages/coding-agent/test/plugin-install-validation.test.ts` passed: 15 tests, 57 assertions. `bun --cwd=packages/coding-agent run check` passed. Fixes #2713