### PR TITLE
fix(coding-agent): isolate plugin discovery tests on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plugin extension discovery tests on Windows so fixture installs resolve under a temp home instead of writing to and deleting the real `~/.omp/plugins` ([#2721](https://github.com/can1357/oh-my-pi/issues/2721)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,20 +10,30 @@ const currentPiExtensionsPath = Bun.resolveSync("@oh-my-pi/pi-coding-agent/exten
 
 describe("plugin extension discovery", () => {
 	let projectDir: TempDir;
-	let tempXdgDataHome = "";
+	let tempHome = "";
 	let originalXdgDataHome: string | undefined;
+	let originalXdgStateHome: string | undefined;
+	let originalXdgCacheHome: string | undefined;
 	const originalAgentDir = getAgentDir();
 
 	beforeEach(() => {
 		projectDir = TempDir.createSync("@pi-plugin-ext-");
 		originalXdgDataHome = process.env.XDG_DATA_HOME;
-		tempXdgDataHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plugin-data-"));
-		fs.mkdirSync(path.join(tempXdgDataHome, "omp"), { recursive: true });
-		process.env.XDG_DATA_HOME = tempXdgDataHome;
-		// Rebuild path caches after changing XDG env so plugin discovery resolves into the temp root.
-		setAgentDir(originalAgentDir);
+		originalXdgStateHome = process.env.XDG_STATE_HOME;
+		originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+		delete process.env.XDG_DATA_HOME;
+		delete process.env.XDG_STATE_HOME;
+		delete process.env.XDG_CACHE_HOME;
+
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plugin-home-"));
+		spyOn(os, "homedir").mockReturnValue(tempHome);
+		setAgentDir(path.join(tempHome, ".omp", "agent"));
 
 		const pluginsDir = getPluginsDir();
+		const relativePluginsDir = path.relative(tempHome, pluginsDir);
+		if (relativePluginsDir.startsWith("..") || path.isAbsolute(relativePluginsDir)) {
+			throw new Error(`Plugin discovery test resolved outside temp home: ${pluginsDir}`);
+		}
 		const pluginDir = path.join(pluginsDir, "node_modules", "@demo", "plugin");
 		fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
 		fs.writeFileSync(
@@ -58,13 +68,24 @@ describe("plugin extension discovery", () => {
 
 	afterEach(() => {
 		projectDir.removeSync();
-		fs.rmSync(tempXdgDataHome, { recursive: true, force: true });
+		spyOn(os, "homedir").mockRestore();
 		if (originalXdgDataHome === undefined) {
 			delete process.env.XDG_DATA_HOME;
 		} else {
 			process.env.XDG_DATA_HOME = originalXdgDataHome;
 		}
+		if (originalXdgStateHome === undefined) {
+			delete process.env.XDG_STATE_HOME;
+		} else {
+			process.env.XDG_STATE_HOME = originalXdgStateHome;
+		}
+		if (originalXdgCacheHome === undefined) {
+			delete process.env.XDG_CACHE_HOME;
+		} else {
+			process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+		}
 		setAgentDir(originalAgentDir);
+		fs.rmSync(tempHome, { recursive: true, force: true });
 	});
 
 	it("loads installed plugin extensions declared in package.json", async () => {


### PR DESCRIPTION
## Repro
Simulated Windows with `process.platform = "win32"`, a mocked home, and `XDG_DATA_HOME` pointing at a temp XDG root; after `setAgentDir(originalAgentDir)`, `getPluginsDir()` resolved to `<home>/.omp/plugins` instead of the XDG temp root, and a test-style `fs.rmSync(path.join(getPluginsDir(), "node_modules"), { recursive: true, force: true })` removed a sentinel installed plugin.

## Cause
`packages/coding-agent/test/plugin-extensions-discovery.test.ts` isolated fixtures by setting `XDG_DATA_HOME`, but `packages/utils/src/dirs.ts` only applies XDG roots on Linux/macOS. On Windows the no-arg plugin path helpers used by `packages/coding-agent/src/extensibility/plugins/loader.ts` resolve from `os.homedir()/.omp`, so the discovery test wrote fixtures and removed `node_modules` under the real plugin directory.

## Fix
- Mock `os.homedir()` to a per-test temp home in `plugin-extensions-discovery.test.ts` and rebuild the directory resolver with `setAgentDir(<tempHome>/.omp/agent)`.
- Clear and restore ambient XDG env vars around the test so Linux/macOS runners also use the same temp-home root instead of the developer or CI XDG root.
- Add a pre-write guard that fails before fixture writes if `getPluginsDir()` resolves outside the temp home.
- Document the Windows test isolation fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/plugin-extensions-discovery.test.ts` passes: 9 tests, 27 assertions. Manual Windows-platform simulation after the fix reports `pluginsDir` under the mocked temp home and not under ambient XDG. `gh_push_branch` pre-publish gate completed successfully before publishing. Fixes #2721