### PR TITLE
fix(coding-agent): accept max thinking alias

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Accepted `max` as an alias for the top thinking level (`xhigh`) in selectors and `--thinking`, so DeepSeek V4 Pro can be selected with its provider-facing maximum effort ([#2727](https://github.com/can1357/oh-my-pi/issues/2727)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -563,10 +563,16 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 	} as ModelSpec<Api>);
 }
 
-function normalizeSuppressedSelector(selector: string): string {
+function normalizeSuppressedSelector(
+	selector: string,
+	hasLiveModel?: (provider: string, id: string) => boolean,
+): string {
 	const trimmed = selector.trim();
 	if (!trimmed) return trimmed;
-	const parsed = parseModelString(trimmed);
+	const parsed = parseModelString(trimmed, {
+		allowMaxAlias: true,
+		isLiteralModelId: (provider, id) => hasLiveModel?.(provider, id) === true,
+	});
 	if (!parsed) return trimmed;
 	// Retired effort-tier variant ids normalize to their collapsed logical id
 	// so persisted suppressions keyed by raw member ids still bind.
@@ -2155,14 +2161,20 @@ export class ModelRegistry {
 	 * Suppress a specific model selector (e.g., "provider/id") until a specific timestamp.
 	 */
 	suppressSelector(selector: string, untilMs: number): void {
-		this.#suppressedSelectors.set(normalizeSuppressedSelector(selector), untilMs);
+		this.#suppressedSelectors.set(
+			normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined),
+			untilMs,
+		);
 	}
 
 	/**
 	 * Check if a model selector is currently suppressed due to rate limits.
 	 */
 	isSelectorSuppressed(selector: string): boolean {
-		const normalizedSelector = normalizeSuppressedSelector(selector);
+		const normalizedSelector = normalizeSuppressedSelector(
+			selector,
+			(provider, id) => this.find(provider, id) !== undefined,
+		);
 		const suppressedUntil = this.#suppressedSelectors.get(normalizedSelector);
 		if (!suppressedUntil) return false;
 		if (suppressedUntil <= Date.now()) {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -56,6 +56,10 @@ export interface ScopedModel {
 interface ThinkingSuffixOptions {
 	allowMaxAlias?: boolean;
 }
+
+interface ModelStringParseOptions extends ThinkingSuffixOptions {
+	isLiteralModelId?: (provider: string, id: string) => boolean;
+}
 const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxAlias: true };
 
 function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ThinkingLevel | undefined {
@@ -138,14 +142,24 @@ function resolveGlobScopePattern(
  */
 export function parseModelString(
 	modelStr: string,
+	options?: ModelStringParseOptions,
 ): { provider: string; id: string; thinkingLevel?: ThinkingLevel } | undefined {
 	const slashIdx = modelStr.indexOf("/");
 	if (slashIdx <= 0) return undefined;
 	const id = modelStr.slice(slashIdx + 1);
 	const provider = modelStr.slice(0, slashIdx);
-	// Strip valid thinking level suffix (e.g., "claude-sonnet-4-6:high" -> id "claude-sonnet-4-6", thinkingLevel "high")
-	const { base, level } = splitThinkingSuffix(id);
-	return level ? { provider, id: base, thinkingLevel: level } : { provider, id };
+	// Strip strict thinking level suffixes first (e.g. "claude-sonnet-4-6:high" -> id "claude-sonnet-4-6", thinkingLevel "high").
+	const strict = splitThinkingSuffix(id);
+	if (strict.level) return { provider, id: strict.base, thinkingLevel: strict.level };
+	// `max` is a provider-facing alias for xhigh, but real model IDs can end in
+	// `:max`. Context-aware callers pass a literal lookup so those models win.
+	const maxAlias = splitThinkingSuffix(id, -1, options);
+	if (maxAlias.level) {
+		return options?.isLiteralModelId?.(provider, id) === true
+			? { provider, id }
+			: { provider, id: maxAlias.base, thinkingLevel: maxAlias.level };
+	}
+	return { provider, id };
 }
 
 /**
@@ -948,10 +962,15 @@ export function resolveModelFromString(
 	matchPreferences?: ModelMatchPreferences,
 	modelRegistry?: CanonicalModelRegistry,
 ): Model<Api> | undefined {
-	const parsed = parseModelString(value);
+	const exact = available.find(model => `${model.provider}/${model.id}` === value);
+	if (exact) return exact;
+	const parsed = parseModelString(value, {
+		...MAX_THINKING_SUFFIX_OPTIONS,
+		isLiteralModelId: (provider, id) => available.some(model => model.provider === provider && model.id === id),
+	});
 	if (parsed) {
-		const exact = available.find(model => model.provider === parsed.provider && model.id === parsed.id);
-		if (exact) return exact;
+		const parsedExact = available.find(model => model.provider === parsed.provider && model.id === parsed.id);
+		if (parsedExact) return parsedExact;
 	}
 	return parseModelPattern(value, available, matchPreferences, { modelRegistry }).model;
 }

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -53,6 +53,16 @@ export interface ScopedModel {
 	explicitThinkingLevel: boolean;
 }
 
+interface ThinkingSuffixOptions {
+	allowMaxAlias?: boolean;
+}
+
+function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ThinkingLevel | undefined {
+	const level = parseThinkingLevel(value);
+	if (level !== undefined) return level;
+	return options?.allowMaxAlias === true && value === "max" ? ThinkingLevel.XHigh : undefined;
+}
+
 /**
  * Split a trailing `:<level>` thinking selector off a model pattern.
  *
@@ -62,10 +72,14 @@ export interface ScopedModel {
  * role-alias callers pass `PREFIX_MODEL_ROLE.length` so the base is at least
  * as long as the `pi/` prefix.
  */
-function splitThinkingSuffix(pattern: string, minColonIndex = -1): { base: string; level?: ThinkingLevel } {
+function splitThinkingSuffix(
+	pattern: string,
+	minColonIndex = -1,
+	options?: ThinkingSuffixOptions,
+): { base: string; level?: ThinkingLevel } {
 	const colonIdx = pattern.lastIndexOf(":");
 	if (colonIdx <= minColonIndex) return { base: pattern };
-	const level = parseThinkingLevel(pattern.slice(colonIdx + 1));
+	const level = parseThinkingSuffix(pattern.slice(colonIdx + 1), options);
 	return level ? { base: pattern.slice(0, colonIdx), level } : { base: pattern };
 }
 
@@ -574,8 +588,10 @@ function parseModelPatternWithContext(
 		return { model: exactMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
-	// No match - try stripping a valid thinking suffix and recursing
-	const { base, level } = splitThinkingSuffix(pattern);
+	// No match - try stripping a valid thinking suffix and recursing.
+	// `max` is accepted only after the full pattern failed, so literal model IDs
+	// ending in `:max` keep winning over the alias.
+	const { base, level } = splitThinkingSuffix(pattern, -1, { allowMaxAlias: true });
 	if (level) {
 		const result = parseModelPatternWithContext(base, availableModels, context, options);
 		if (result.model) {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -56,6 +56,7 @@ export interface ScopedModel {
 interface ThinkingSuffixOptions {
 	allowMaxAlias?: boolean;
 }
+const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxAlias: true };
 
 function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ThinkingLevel | undefined {
 	const level = parseThinkingLevel(value);
@@ -81,6 +82,54 @@ function splitThinkingSuffix(
 	if (colonIdx <= minColonIndex) return { base: pattern };
 	const level = parseThinkingSuffix(pattern.slice(colonIdx + 1), options);
 	return level ? { base: pattern.slice(0, colonIdx), level } : { base: pattern };
+}
+
+function hasExactModelPattern(pattern: string, availableModels: readonly Model<Api>[]): boolean {
+	const normalized = pattern.toLowerCase();
+	return availableModels.some(
+		model => model.id.toLowerCase() === normalized || `${model.provider}/${model.id}`.toLowerCase() === normalized,
+	);
+}
+
+function matchingGlobModels(pattern: string, availableModels: readonly Model<Api>[]): Model<Api>[] {
+	const glob = new Bun.Glob(pattern.toLowerCase());
+	return availableModels.filter(model => {
+		const fullId = `${model.provider}/${model.id}`;
+		return glob.match(fullId.toLowerCase()) || glob.match(model.id.toLowerCase());
+	});
+}
+
+function resolveGlobScopePattern(
+	pattern: string,
+	availableModels: readonly Model<Api>[],
+): { models: Model<Api>[]; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } {
+	const strictSuffix = splitThinkingSuffix(pattern);
+	if (strictSuffix.level !== undefined) {
+		return {
+			models: matchingGlobModels(strictSuffix.base, availableModels),
+			thinkingLevel: strictSuffix.level,
+			explicitThinkingLevel: true,
+		};
+	}
+
+	const maxSuffix = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
+	if (maxSuffix.level !== undefined) {
+		const literalMatches = matchingGlobModels(pattern, availableModels);
+		if (literalMatches.length > 0) {
+			return { models: literalMatches, thinkingLevel: undefined, explicitThinkingLevel: false };
+		}
+		return {
+			models: matchingGlobModels(maxSuffix.base, availableModels),
+			thinkingLevel: maxSuffix.level,
+			explicitThinkingLevel: true,
+		};
+	}
+
+	return {
+		models: matchingGlobModels(pattern, availableModels),
+		thinkingLevel: undefined,
+		explicitThinkingLevel: false,
+	};
 }
 
 /**
@@ -591,7 +640,7 @@ function parseModelPatternWithContext(
 	// No match - try stripping a valid thinking suffix and recursing.
 	// `max` is accepted only after the full pattern failed, so literal model IDs
 	// ending in `:max` keep winning over the alias.
-	const { base, level } = splitThinkingSuffix(pattern, -1, { allowMaxAlias: true });
+	const { base, level } = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
 	if (level) {
 		const result = parseModelPatternWithContext(base, availableModels, context, options);
 		if (result.model) {
@@ -695,7 +744,11 @@ function resolveDefaultInheritedPatterns(
 
 	const resolved: string[] = [];
 	for (const pattern of normalizeModelPatternList(configuredDefault)) {
-		const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(pattern, PREFIX_MODEL_ROLE.length);
+		const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
+			pattern,
+			PREFIX_MODEL_ROLE.length,
+			MAX_THINKING_SUFFIX_OPTIONS,
+		);
 		const aliasRole = getModelRoleAlias(aliasCandidate);
 		if (aliasRole === role) {
 			// Self-alias (e.g. modelRoles.default = "pi/smol") would loop back to the
@@ -730,7 +783,11 @@ function resolveConfiguredRolePattern(
 	const normalized = value.trim();
 	if (!normalized) return undefined;
 
-	const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(normalized, PREFIX_MODEL_ROLE.length);
+	const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
+		normalized,
+		PREFIX_MODEL_ROLE.length,
+		MAX_THINKING_SUFFIX_OPTIONS,
+	);
 	const role = getModelRoleAlias(aliasCandidate);
 	if (!role) return [normalized];
 	if (visited.has(role)) return undefined;
@@ -865,7 +922,11 @@ export function extractExplicitThinkingSelector(
 	let current = normalized;
 	while (!visited.has(current)) {
 		visited.add(current);
-		const thinkingSelector = splitThinkingSuffix(current, PREFIX_MODEL_ROLE.length).level;
+		const thinkingSelector = splitThinkingSuffix(
+			current,
+			PREFIX_MODEL_ROLE.length,
+			MAX_THINKING_SUFFIX_OPTIONS,
+		).level;
 		if (thinkingSelector) {
 			return thinkingSelector;
 		}
@@ -1030,7 +1091,10 @@ function resolveExactCanonicalScopePattern(
 	modelRegistry: Pick<ModelRegistry, "getCanonicalVariants">,
 	availableModels: Model<Api>[],
 ): { models: Model<Api>[]; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } | undefined {
-	const { base: canonicalId, level: thinkingLevel } = splitThinkingSuffix(pattern);
+	if (pattern.endsWith(":max") && hasExactModelPattern(pattern, availableModels)) {
+		return undefined;
+	}
+	const { base: canonicalId, level: thinkingLevel } = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
 	const explicitThinkingLevel = thinkingLevel !== undefined;
 
 	const variants = modelRegistry
@@ -1076,17 +1140,13 @@ export async function resolveModelScope(
 	for (const pattern of patterns) {
 		// Check if pattern contains glob characters
 		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
-			// Extract optional thinking level suffix (e.g., "provider/*:high")
-			const { base: globPattern, level: thinkingLevel } = splitThinkingSuffix(pattern);
-			const explicitThinkingLevel = thinkingLevel !== undefined;
-
-			// Match against "provider/modelId" format OR just model ID
-			// This allows "*sonnet*" to match without requiring "anthropic/*sonnet*"
-			const matchingModels = availableModels.filter(m => {
-				const fullId = `${m.provider}/${m.id}`;
-				const glob = new Bun.Glob(globPattern.toLowerCase());
-				return glob.match(fullId.toLowerCase()) || glob.match(m.id.toLowerCase());
-			});
+			// Extract optional thinking level suffix (e.g., "provider/*:high") only
+			// after literal `:max` globs had a chance to match real model IDs.
+			const {
+				models: matchingModels,
+				thinkingLevel,
+				explicitThinkingLevel,
+			} = resolveGlobScopePattern(pattern, availableModels);
 
 			if (matchingModels.length === 0) {
 				logger.warn(`No models match pattern "${pattern}"`);
@@ -1191,13 +1251,8 @@ export function filterAvailableModelsByEnabledPatterns(
 
 	for (const pattern of patterns) {
 		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
-			const { base: globPattern } = splitThinkingSuffix(pattern);
-			const glob = new Bun.Glob(globPattern.toLowerCase());
-			for (const model of available) {
-				const fullId = `${model.provider}/${model.id}`.toLowerCase();
-				if (glob.match(fullId) || glob.match(model.id.toLowerCase())) {
-					addAllowed(model);
-				}
+			for (const model of resolveGlobScopePattern(pattern, available).models) {
+				addAllowed(model);
 			}
 			continue;
 		}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -924,9 +924,19 @@ export function resolveModelRoleValue(
 	return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning };
 }
 
+interface ExplicitThinkingSelectorOptions {
+	isLiteralModelId?: (provider: string, id: string) => boolean;
+}
+
+function isLiteralModelSelector(value: string, options?: ExplicitThinkingSelectorOptions): boolean {
+	const parsed = parseModelString(value);
+	return parsed !== undefined && options?.isLiteralModelId?.(parsed.provider, parsed.id) === true;
+}
+
 export function extractExplicitThinkingSelector(
 	value: string | undefined,
 	settings?: Settings,
+	options?: ExplicitThinkingSelectorOptions,
 ): ThinkingLevel | undefined {
 	if (!value) return undefined;
 	const normalized = value.trim();
@@ -936,13 +946,13 @@ export function extractExplicitThinkingSelector(
 	let current = normalized;
 	while (!visited.has(current)) {
 		visited.add(current);
-		const thinkingSelector = splitThinkingSuffix(
-			current,
-			PREFIX_MODEL_ROLE.length,
-			MAX_THINKING_SUFFIX_OPTIONS,
-		).level;
-		if (thinkingSelector) {
-			return thinkingSelector;
+		const strictSelector = splitThinkingSuffix(current, PREFIX_MODEL_ROLE.length).level;
+		if (strictSelector) {
+			return strictSelector;
+		}
+		const maxSelector = splitThinkingSuffix(current, PREFIX_MODEL_ROLE.length, MAX_THINKING_SUFFIX_OPTIONS).level;
+		if (maxSelector && (current.startsWith(PREFIX_MODEL_ROLE) || !isLiteralModelSelector(current, options))) {
+			return maxSelector;
 		}
 		const expanded = expandRoleAlias(current, settings).trim();
 		if (!expanded || expanded === current) break;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -820,7 +820,7 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: [...THINKING_EFFORTS, AUTO_THINKING],
+		values: [...THINKING_EFFORTS, AUTO_THINKING, "max"],
 		default: "high",
 		ui: {
 			tab: "model",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -69,7 +69,7 @@ import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
 import { initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
-import { AUTO_THINKING } from "./thinking";
+import { AUTO_THINKING, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import {
 	getChangelogPath,
@@ -853,7 +853,7 @@ async function buildSessionOptions(
 	if (scopedModels.length > 0) {
 		// `auto` is a session-level concept only; per-scoped-model (Ctrl+P) thinking
 		// overrides stay concrete, so coerce the auto default to "unset" here.
-		const defaultThinkingLevelSetting = activeSettings.get("defaultThinkingLevel");
+		const defaultThinkingLevelSetting = parseConfiguredThinkingLevel(activeSettings.get("defaultThinkingLevel"));
 		const defaultThinkingLevel =
 			defaultThinkingLevelSetting === AUTO_THINKING ? undefined : defaultThinkingLevelSetting;
 		options.scopedModels = scopedModels.map(scopedModel => ({

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1245,12 +1245,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			? getRestorableSessionModels(existingSession.models, sessionManager.getLastModelChangeRole())
 			: [];
 	let restoredSessionModelIndex = -1;
+	let restoredSessionThinkingLevel: ThinkingLevel | undefined;
 	if (!hasExplicitModel && !model && sessionModelStrings.length > 0) {
 		logger.time("restoreSessionModel", () => {
 			let failedSessionModel: string | undefined;
 			for (let i = 0; i < sessionModelStrings.length; i++) {
 				const sessionModelStr = sessionModelStrings[i];
-				const parsedModel = parseModelString(sessionModelStr);
+				const parsedModel = parseModelString(sessionModelStr, {
+					allowMaxAlias: true,
+					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+				});
 				if (!parsedModel) {
 					failedSessionModel ??= sessionModelStr;
 					continue;
@@ -1260,6 +1264,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (restoredModel && hasModelAuth(restoredModel)) {
 					model = restoredModel;
 					restoredSessionModelIndex = i;
+					restoredSessionThinkingLevel = parsedModel.thinkingLevel;
 					break;
 				}
 				failedSessionModel ??= sessionModelStr;
@@ -1284,14 +1289,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const taskDepth = options.taskDepth ?? 0;
 
 	// Resolves the session/agent thinking level using the same precedence we
-	// apply at startup: explicit option → persisted session entry → default
-	// role's explicit selector → selected model's defaultLevel → global
-	// settings default. Run again after extension role reclaim so the final
-	// model's own defaults aren't masked by an earlier fallback model's.
+	// apply at startup: explicit option → persisted session entry → restored
+	// model selector suffix → default role's explicit selector → selected
+	// model's defaultLevel → global settings default. Run again after extension
+	// role reclaim so the final model's own defaults aren't masked by an earlier
+	// fallback model's.
 	const pickInitialThinkingLevel = (selectedModel: Model | undefined): ConfiguredThinkingLevel | undefined => {
 		let level = options.thinkingLevel;
 		if (level === undefined && hasExistingSession && hasThinkingEntry) {
 			level = parseThinkingLevel(existingSession.thinkingLevel);
+		}
+		if (level === undefined && !hasThinkingEntry && restoredSessionThinkingLevel !== undefined) {
+			level = restoredSessionThinkingLevel;
 		}
 		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
 			level = defaultRoleSpec.thinkingLevel;
@@ -1884,13 +1893,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (!hasExplicitModel && sessionRetryLimit > 0) {
 			for (let i = 0; i < sessionRetryLimit; i++) {
 				const sessionModelStr = sessionModelStrings[i];
-				const parsedModel = parseModelString(sessionModelStr);
+				const parsedModel = parseModelString(sessionModelStr, {
+					allowMaxAlias: true,
+					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+				});
 				if (!parsedModel) continue;
 				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
 				if (restoredModel && hasModelAuth(restoredModel)) {
 					model = restoredModel;
 					modelFallbackMessage = undefined;
 					restoredSessionModelIndex = i;
+					restoredSessionThinkingLevel = parsedModel.thinkingLevel;
 					// Recompute thinking-level from scratch against the reclaimed
 					// model: any value derived from the earlier fallback model's
 					// `thinking.defaultLevel` must not become sticky.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -148,6 +148,7 @@ import { AgentOutputManager } from "./task/output-manager";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
+	parseConfiguredThinkingLevel,
 	parseThinkingLevel,
 	resolveProvisionalAutoLevel,
 	resolveThinkingLevelForModel,
@@ -1299,7 +1300,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			level = selectedModel.thinking.defaultLevel;
 		}
 		if (level === undefined) {
-			level = settings.get("defaultThinkingLevel");
+			level = parseConfiguredThinkingLevel(settings.get("defaultThinkingLevel"));
 		}
 		return level;
 	};

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -627,10 +627,16 @@ interface ActiveRetryFallbackState {
 	pinned: boolean;
 }
 
-function parseRetryFallbackSelector(selector: string): RetryFallbackSelector | undefined {
+function parseRetryFallbackSelector(
+	selector: string,
+	modelLookup?: { find(provider: string, id: string): Model | undefined },
+): RetryFallbackSelector | undefined {
 	const trimmed = selector.trim();
 	if (!trimmed) return undefined;
-	const parsed = parseModelString(trimmed);
+	const parsed = parseModelString(trimmed, {
+		allowMaxAlias: true,
+		isLiteralModelId: (provider, id) => modelLookup?.find(provider, id) !== undefined,
+	});
 	if (!parsed) return undefined;
 	return {
 		raw: trimmed,
@@ -8272,7 +8278,11 @@ export class AgentSession {
 		const configuredTarget = currentModel.contextPromotionTarget?.trim();
 		if (!configuredTarget) return undefined;
 
-		const parsed = parseModelString(configuredTarget);
+		const parsed = parseModelString(configuredTarget, {
+			allowMaxAlias: true,
+			isLiteralModelId: (provider, id) =>
+				availableModels.some(model => model.provider === provider && model.id === id),
+		});
 		if (parsed) {
 			const explicitModel = availableModels.find(m => m.provider === parsed.provider && m.id === parsed.id);
 			if (explicitModel) return explicitModel;
@@ -9249,7 +9259,7 @@ export class AgentSession {
 					this.configWarnings.push(msg);
 					continue;
 				}
-				const parsed = parseRetryFallbackSelector(selectorStr);
+				const parsed = parseRetryFallbackSelector(selectorStr, this.#modelRegistry);
 				if (!parsed) {
 					const msg = `Invalid fallback selector format in role '${role}': ${selectorStr}`;
 					logger.warn(msg);
@@ -9272,7 +9282,7 @@ export class AgentSession {
 
 	#getRetryFallbackPrimarySelector(role: string): RetryFallbackSelector | undefined {
 		const configuredSelector = this.settings.getModelRole(role);
-		return configuredSelector ? parseRetryFallbackSelector(configuredSelector) : undefined;
+		return configuredSelector ? parseRetryFallbackSelector(configuredSelector, this.#modelRegistry) : undefined;
 	}
 
 	#clearActiveRetryFallback(): void {
@@ -9293,7 +9303,7 @@ export class AgentSession {
 	}
 
 	#resolveRetryFallbackRole(currentSelector: string): string | undefined {
-		const parsedCurrent = parseRetryFallbackSelector(currentSelector);
+		const parsedCurrent = parseRetryFallbackSelector(currentSelector, this.#modelRegistry);
 		if (!parsedCurrent) return undefined;
 		const currentBaseSelector = formatRetryFallbackBaseSelector(parsedCurrent);
 		for (const role of Object.keys(this.#getRetryFallbackChains())) {
@@ -9311,7 +9321,7 @@ export class AgentSession {
 		const chain = [primarySelector];
 		const seen = new Set<string>([primarySelector.raw]);
 		for (const selector of this.#getRetryFallbackChains()[role] ?? []) {
-			const parsed = parseRetryFallbackSelector(selector);
+			const parsed = parseRetryFallbackSelector(selector, this.#modelRegistry);
 			if (!parsed || seen.has(parsed.raw)) continue;
 			seen.add(parsed.raw);
 			chain.push(parsed);
@@ -9322,7 +9332,7 @@ export class AgentSession {
 	#findRetryFallbackCandidates(role: string, currentSelector: string): RetryFallbackSelector[] {
 		const chain = this.#getRetryFallbackEffectiveChain(role);
 		if (chain.length <= 1) return [];
-		const parsedCurrent = parseRetryFallbackSelector(currentSelector);
+		const parsedCurrent = parseRetryFallbackSelector(currentSelector, this.#modelRegistry);
 		const currentBaseSelector = parsedCurrent ? formatRetryFallbackBaseSelector(parsedCurrent) : undefined;
 		const exactIndex = chain.findIndex(selector => selector.raw === currentSelector);
 		if (exactIndex >= 0) return chain.slice(exactIndex + 1);
@@ -9404,7 +9414,7 @@ export class AgentSession {
 			originalThinkingLevel,
 			lastAppliedFallbackThinkingLevel,
 		} = this.#activeRetryFallback;
-		const originalSelector = parseRetryFallbackSelector(originalSelectorRaw);
+		const originalSelector = parseRetryFallbackSelector(originalSelectorRaw, this.#modelRegistry);
 		if (!originalSelector) {
 			this.#clearActiveRetryFallback();
 			return;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8271,7 +8271,9 @@ export class AgentSession {
 		const existingRoleValue = this.settings.getModelRole(role);
 		if (!existingRoleValue) return modelKey;
 
-		const thinkingLevel = extractExplicitThinkingSelector(existingRoleValue, this.settings);
+		const thinkingLevel = extractExplicitThinkingSelector(existingRoleValue, this.settings, {
+			isLiteralModelId: (provider, id) => this.#modelRegistry.find(provider, id) !== undefined,
+		});
 		return formatModelSelectorValue(modelKey, thinkingLevel);
 	}
 	#resolveContextPromotionConfiguredTarget(currentModel: Model, availableModels: Model[]): Model | undefined {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -230,6 +230,7 @@ import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
 	clampAutoThinkingEffort,
+	parseConfiguredThinkingLevel,
 	resolveProvisionalAutoLevel,
 	resolveThinkingLevelForModel,
 	shouldDisableReasoning,
@@ -10455,7 +10456,7 @@ export class AgentSession {
 			const hasServiceTierEntry = this.sessionManager
 				.getBranch()
 				.some(entry => entry.type === "service_tier_change");
-			const defaultThinkingLevel = this.settings.get("defaultThinkingLevel");
+			const defaultThinkingLevel = parseConfiguredThinkingLevel(this.settings.get("defaultThinkingLevel"));
 			const configuredServiceTier = this.settings.get("serviceTier");
 			// Session log entries store only concrete levels. When `auto` has resolved
 			// for a turn, the persisted context may already carry that concrete level

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -53,7 +53,6 @@ const THINKING_LEVEL_BY_SELECTOR: Readonly<Record<string, ThinkingLevel>> = {
 	[ThinkingLevel.Medium]: ThinkingLevel.Medium,
 	[ThinkingLevel.High]: ThinkingLevel.High,
 	[ThinkingLevel.XHigh]: ThinkingLevel.XHigh,
-	max: ThinkingLevel.XHigh,
 };
 
 /**
@@ -141,6 +140,7 @@ const AUTO_THINKING_METADATA: ConfiguredThinkingLevelMetadata = {
  */
 export function parseConfiguredThinkingLevel(value: string | null | undefined): ConfiguredThinkingLevel | undefined {
 	if (value === AUTO_THINKING) return AUTO_THINKING;
+	if (value === "max") return ThinkingLevel.XHigh;
 	return parseThinkingLevel(value);
 }
 

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -32,26 +32,42 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 	[ThinkingLevel.High]: { value: ThinkingLevel.High, label: "high", description: "Deep reasoning (~16k tokens)" },
 	[ThinkingLevel.XHigh]: {
 		value: ThinkingLevel.XHigh,
-		label: "xhigh",
+		label: "max",
 		description: "Maximum reasoning (~32k tokens)",
 	},
 };
 
-const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS]);
-const EFFORT_LEVELS = new Set<string>(THINKING_EFFORTS);
+const EFFORT_BY_SELECTOR: Readonly<Record<string, Effort>> = {
+	[Effort.Minimal]: Effort.Minimal,
+	[Effort.Low]: Effort.Low,
+	[Effort.Medium]: Effort.Medium,
+	[Effort.High]: Effort.High,
+	[Effort.XHigh]: Effort.XHigh,
+	max: Effort.XHigh,
+};
+const THINKING_LEVEL_BY_SELECTOR: Readonly<Record<string, ThinkingLevel>> = {
+	[ThinkingLevel.Inherit]: ThinkingLevel.Inherit,
+	[ThinkingLevel.Off]: ThinkingLevel.Off,
+	[ThinkingLevel.Minimal]: ThinkingLevel.Minimal,
+	[ThinkingLevel.Low]: ThinkingLevel.Low,
+	[ThinkingLevel.Medium]: ThinkingLevel.Medium,
+	[ThinkingLevel.High]: ThinkingLevel.High,
+	[ThinkingLevel.XHigh]: ThinkingLevel.XHigh,
+	max: ThinkingLevel.XHigh,
+};
 
 /**
  * Parses a provider-facing effort value.
  */
 export function parseEffort(value: string | null | undefined): Effort | undefined {
-	return value !== undefined && value !== null && EFFORT_LEVELS.has(value) ? (value as Effort) : undefined;
+	return value === undefined || value === null ? undefined : EFFORT_BY_SELECTOR[value];
 }
 
 /**
  * Parses an agent-local thinking selector.
  */
 export function parseThinkingLevel(value: string | null | undefined): ThinkingLevel | undefined {
-	return value !== undefined && value !== null && THINKING_LEVELS.has(value) ? (value as ThinkingLevel) : undefined;
+	return value === undefined || value === null ? undefined : THINKING_LEVEL_BY_SELECTOR[value];
 }
 
 /**

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -55,18 +55,22 @@ const THINKING_LEVEL_BY_SELECTOR: Readonly<Record<string, ThinkingLevel>> = {
 	[ThinkingLevel.XHigh]: ThinkingLevel.XHigh,
 };
 
+function getOwnSelector<T>(selectors: Readonly<Record<string, T>>, value: string | null | undefined): T | undefined {
+	return value === undefined || value === null || !Object.hasOwn(selectors, value) ? undefined : selectors[value];
+}
+
 /**
  * Parses a provider-facing effort value.
  */
 export function parseEffort(value: string | null | undefined): Effort | undefined {
-	return value === undefined || value === null ? undefined : EFFORT_BY_SELECTOR[value];
+	return getOwnSelector(EFFORT_BY_SELECTOR, value);
 }
 
 /**
  * Parses an agent-local thinking selector.
  */
 export function parseThinkingLevel(value: string | null | undefined): ThinkingLevel | undefined {
-	return value === undefined || value === null ? undefined : THINKING_LEVEL_BY_SELECTOR[value];
+	return getOwnSelector(THINKING_LEVEL_BY_SELECTOR, value);
 }
 
 /**

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1235,6 +1235,10 @@ describe("AgentSession retry fallback", () => {
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o")).toBe(true);
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:low")).toBe(true);
 
+		modelRegistry.suppressSelector("openai/gpt-4o:max", future);
+		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:xhigh")).toBe(true);
+		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:max")).toBe(true);
+
 		await modelRegistry.refresh("offline");
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o")).toBe(false);
 	});

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -3,7 +3,6 @@ import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { parseDifficultyBucket, parseDifficultyLevel } from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
-import { parseModelString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import {
 	AUTO_THINKING,
 	clampAutoThinkingEffort,
@@ -44,14 +43,9 @@ describe("auto thinking classifier helpers", () => {
 		expect(clampAutoThinkingEffort(model, Effort.Minimal)).toBe(Effort.Low);
 	});
 
-	it("accepts max as the top thinking selector alias", () => {
+	it("accepts max as the top configured thinking alias", () => {
 		expect(parseEffort("max")).toBe(Effort.XHigh);
-		expect(parseThinkingLevel("max")).toBe(ThinkingLevel.XHigh);
+		expect(parseThinkingLevel("max")).toBeUndefined();
 		expect(parseConfiguredThinkingLevel("max")).toBe(ThinkingLevel.XHigh);
-		expect(parseModelString("deepseek/deepseek-v4-pro:max")).toEqual({
-			provider: "deepseek",
-			id: "deepseek-v4-pro",
-			thinkingLevel: ThinkingLevel.XHigh,
-		});
 	});
 });

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -3,10 +3,12 @@ import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { parseDifficultyBucket, parseDifficultyLevel } from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
+import { parseModelString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import {
 	AUTO_THINKING,
 	clampAutoThinkingEffort,
 	parseConfiguredThinkingLevel,
+	parseEffort,
 	parseThinkingLevel,
 } from "@oh-my-pi/pi-coding-agent/thinking";
 
@@ -40,5 +42,16 @@ describe("auto thinking classifier helpers", () => {
 
 		expect(clampAutoThinkingEffort(model, Effort.XHigh)).toBe(Effort.High);
 		expect(clampAutoThinkingEffort(model, Effort.Minimal)).toBe(Effort.Low);
+	});
+
+	it("accepts max as the top thinking selector alias", () => {
+		expect(parseEffort("max")).toBe(Effort.XHigh);
+		expect(parseThinkingLevel("max")).toBe(ThinkingLevel.XHigh);
+		expect(parseConfiguredThinkingLevel("max")).toBe(ThinkingLevel.XHigh);
+		expect(parseModelString("deepseek/deepseek-v4-pro:max")).toEqual({
+			provider: "deepseek",
+			id: "deepseek-v4-pro",
+			thinkingLevel: ThinkingLevel.XHigh,
+		});
 	});
 });

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -48,4 +48,12 @@ describe("auto thinking classifier helpers", () => {
 		expect(parseThinkingLevel("max")).toBeUndefined();
 		expect(parseConfiguredThinkingLevel("max")).toBe(ThinkingLevel.XHigh);
 	});
+
+	it("rejects inherited object keys as thinking selectors", () => {
+		for (const selector of ["toString", "constructor", "__proto__"]) {
+			expect(parseEffort(selector)).toBeUndefined();
+			expect(parseThinkingLevel(selector)).toBeUndefined();
+			expect(parseConfiguredThinkingLevel(selector)).toBeUndefined();
+		}
+	});
 });

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -107,4 +107,18 @@ describe("config CLI schema coverage", () => {
 			value: 600,
 		});
 	});
+
+	it("accepts max as a persisted default thinking level", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await runConfigCommand({ action: "set", key: "defaultThinkingLevel", value: "max", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "defaultThinkingLevel", flags: { json: true } });
+
+		const payload = logSpy.mock.calls.at(-1)?.[0];
+		expect(typeof payload).toBe("string");
+		const parsed = JSON.parse(String(payload)) as { key: string; value: unknown; type: string };
+		expect(parsed.key).toBe("defaultThinkingLevel");
+		expect(parsed.type).toBe("enum");
+		expect(parsed.value).toBe("max");
+	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -96,6 +96,37 @@ const mockOpenRouterModels: Model<Api>[] = [
 	}),
 ];
 
+const mockMaxSuffixModels: Model<Api>[] = [
+	buildModel({
+		id: "coding-router",
+		name: "NanoGPT Coding Router",
+		api: "openai-completions",
+		provider: "nanogpt",
+		baseUrl: "https://nano-gpt.com/api/v1",
+		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+		},
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
+	buildModel({
+		id: "coding-router:max",
+		name: "NanoGPT Coding Router Max",
+		api: "openai-completions",
+		provider: "nanogpt",
+		baseUrl: "https://nano-gpt.com/api/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
+];
+
 const mockProviderOverlapModels: Model<"anthropic-messages">[] = [
 	buildModel({
 		id: "kimi-k2.5",
@@ -287,6 +318,21 @@ describe("parseModelPattern", () => {
 				expect(result.thinkingLevel).toBe(level);
 				expect(result.warning).toBeUndefined();
 			}
+		});
+		test("max aliases the highest thinking level after the literal pattern misses", () => {
+			const result = parseModelPattern("gpt-5.3-codex:max", allModels);
+			expect(result.model?.id).toBe("gpt-5.3-codex");
+			expect(result.thinkingLevel).toBe(Effort.XHigh);
+			expect(result.explicitThinkingLevel).toBe(true);
+			expect(result.warning).toBeUndefined();
+		});
+
+		test("literal model ids ending in max win over the thinking alias", () => {
+			const result = parseModelPattern("nanogpt/coding-router:max", mockMaxSuffixModels);
+			expect(result.model?.id).toBe("coding-router:max");
+			expect(result.thinkingLevel).toBeUndefined();
+			expect(result.explicitThinkingLevel).toBe(false);
+			expect(result.warning).toBeUndefined();
 		});
 	});
 
@@ -856,6 +902,19 @@ describe("resolveModelScope", () => {
 			"github-copilot/anthropic/claude-sonnet-4.5",
 		]);
 	});
+	test("preserves literal :max in scoped-model globs", async () => {
+		const registry = {
+			getAvailable: () => mockMaxSuffixModels,
+			getCanonicalVariants: (_id: string, _opts?: unknown): CanonicalModelVariant[] => [],
+		};
+
+		const scoped = await resolveModelScope(["nanogpt/*:max"], registry);
+
+		expect(scoped).toHaveLength(1);
+		expect(scoped[0].model.id).toBe("coding-router:max");
+		expect(scoped[0].thinkingLevel).toBeUndefined();
+		expect(scoped[0].explicitThinkingLevel).toBe(false);
+	});
 });
 
 describe("parseModelString", () => {
@@ -1084,6 +1143,11 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
 		expect(result).toHaveLength(1);
 		expect(result[0].provider).toBe("anthropic");
+	});
+	test("preserves literal :max in enabledModels globs", () => {
+		const result = filterAvailableModelsByEnabledPatterns(mockMaxSuffixModels, ["nanogpt/*:max"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("coding-router:max");
 	});
 
 	test("evaluates glob patterns against bare model id", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1006,6 +1006,19 @@ describe("parseModelString", () => {
 			});
 		});
 
+		test("extracts max when explicitly enabled for provider id selectors", () => {
+			const result = parseModelString("deepseek/deepseek-v4-pro:max", { allowMaxAlias: true });
+			expect(result).toEqual({ provider: "deepseek", id: "deepseek-v4-pro", thinkingLevel: Effort.XHigh });
+		});
+
+		test("preserves literal max model ids when the caller can prove they exist", () => {
+			const result = parseModelString("nanogpt/coding-router:max", {
+				allowMaxAlias: true,
+				isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:max",
+			});
+			expect(result).toEqual({ provider: "nanogpt", id: "coding-router:max" });
+		});
+
 		test("does not extract thinking level from model ID with invalid suffix", () => {
 			const result = parseModelString("openrouter/openai/gpt-4o:extended");
 			// :extended is not a valid thinking level, so it stays as part of the ID
@@ -1017,6 +1030,20 @@ describe("parseModelString", () => {
 			// Empty string is not a valid thinking level, so colon stays as part of ID
 			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:" });
 		});
+	});
+});
+
+describe("resolveModelFromString", () => {
+	test("applies max as a provider model selector alias after literal lookup misses", () => {
+		const result = resolveModelFromString("nanogpt/coding-router:max", [mockMaxSuffixModels[0]]);
+		expect(result?.provider).toBe("nanogpt");
+		expect(result?.id).toBe("coding-router");
+	});
+
+	test("preserves literal max provider model ids before alias parsing", () => {
+		const result = resolveModelFromString("nanogpt/coding-router:max", mockMaxSuffixModels);
+		expect(result?.provider).toBe("nanogpt");
+		expect(result?.id).toBe("coding-router:max");
 	});
 });
 

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1020,6 +1020,10 @@ describe("parseModelString", () => {
 			expect(result).toEqual({ provider: "nanogpt", id: "coding-router:max" });
 		});
 
+		test("does not strip inherited object keys as thinking suffixes", () => {
+			const result = parseModelString("anthropic/claude-sonnet-4-5:constructor");
+			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:constructor" });
+		});
 		test("does not extract thinking level from model ID with invalid suffix", () => {
 			const result = parseModelString("openrouter/openai/gpt-4o:extended");
 			// :extended is not a valid thinking level, so it stays as part of the ID

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -502,6 +502,19 @@ describe("resolveModelRoleValue", () => {
 		expect(result.explicitThinkingLevel).toBe(true);
 	});
 
+	test("resolves pi/<role>:max by expanding role alias before parsing thinking", () => {
+		const settings = {
+			getModelRole: (role: string) => (role === "smol" ? "openai-codex/gpt-5.3-codex" : undefined),
+		} as NonNullable<Parameters<typeof resolveModelRoleValue>[2]>["settings"];
+
+		const result = resolveModelRoleValue("pi/smol:max", allModels, { settings });
+
+		expect(result.model?.provider).toBe("openai-codex");
+		expect(result.model?.id).toBe("gpt-5.3-codex");
+		expect(result.thinkingLevel).toBe(Effort.XHigh);
+		expect(result.explicitThinkingLevel).toBe(true);
+	});
+
 	test("resolves pi/default through configured default role alias", () => {
 		const settings = {
 			getModelRole: (role: string) => (role === "default" ? "openrouter/qwen/qwen3-coder:exacto" : undefined),
@@ -902,6 +915,36 @@ describe("resolveModelScope", () => {
 			"github-copilot/anthropic/claude-sonnet-4.5",
 		]);
 	});
+
+	test("expands exact canonical ids with max thinking aliases", async () => {
+		const scoped = await resolveModelScope(["claude-sonnet-4-5:max"], {
+			getAvailable: () => canonicalVariantModels,
+			getCanonicalVariants: (canonicalId: string, options?: { candidates?: Model<"anthropic-messages">[] }) =>
+				canonicalRegistry.getCanonicalVariants!(canonicalId, options),
+		} as unknown as Parameters<typeof resolveModelScope>[1]);
+
+		expect(scoped).toHaveLength(2);
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`).sort()).toEqual([
+			"anthropic/claude-sonnet-4-5",
+			"github-copilot/anthropic/claude-sonnet-4.5",
+		]);
+		expect(scoped.map(entry => entry.thinkingLevel)).toEqual([Effort.High, Effort.High]);
+		expect(scoped.every(entry => entry.explicitThinkingLevel)).toBe(true);
+	});
+
+	test("applies max thinking aliases to glob scopes when no literal max ids match", async () => {
+		const registry = {
+			getAvailable: () => mockCodexOverlapModels,
+			getCanonicalVariants: (_id: string, _opts?: unknown): CanonicalModelVariant[] => [],
+		};
+
+		const scoped = await resolveModelScope(["openai-codex/*:max"], registry);
+
+		expect(scoped).toHaveLength(2);
+		expect(scoped.map(entry => entry.thinkingLevel)).toEqual([Effort.XHigh, Effort.XHigh]);
+		expect(scoped.every(entry => entry.explicitThinkingLevel)).toBe(true);
+	});
+
 	test("preserves literal :max in scoped-model globs", async () => {
 		const registry = {
 			getAvailable: () => mockMaxSuffixModels,
@@ -1112,6 +1155,22 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], canonicalRegistry);
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("expands canonical enabledModels entries with max thinking aliases", () => {
+		const registry = {
+			getCanonicalVariants: (canonicalId: string, options?: { candidates?: Model<"anthropic-messages">[] }) =>
+				canonicalRegistry.getCanonicalVariants!(canonicalId, options),
+		};
+		const result = filterAvailableModelsByEnabledPatterns(
+			canonicalVariantModels,
+			["claude-sonnet-4-5:max"],
+			registry,
+		);
+		expect(result.map(model => `${model.provider}/${model.id}`).sort()).toEqual([
+			"anthropic/claude-sonnet-4-5",
+			"github-copilot/anthropic/claude-sonnet-4.5",
+		]);
 	});
 
 	test("strips :thinkingLevel suffix before matching", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -4,6 +4,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { CanonicalModelVariant } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import {
 	expandRoleAlias,
+	extractExplicitThinkingSelector,
 	filterAvailableModelsByEnabledPatterns,
 	parseModelPattern,
 	parseModelString,
@@ -1060,6 +1061,31 @@ describe("expandRoleAlias", () => {
 		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
 
 		expect(expandRoleAlias("pi/vision", settings)).toBe("pi/vision");
+	});
+});
+
+describe("extractExplicitThinkingSelector", () => {
+	test("does not carry max from literal role model ids", () => {
+		const result = extractExplicitThinkingSelector("nanogpt/coding-router:max", undefined, {
+			isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:max",
+		});
+		expect(result).toBeUndefined();
+	});
+
+	test("treats max as an explicit selector when the model id is not literal", () => {
+		const result = extractExplicitThinkingSelector("nanogpt/coding-router:max", undefined, {
+			isLiteralModelId: () => false,
+		});
+		expect(result).toBe(Effort.XHigh);
+	});
+
+	test("treats max on pi role aliases as an explicit selector before expansion", () => {
+		const settings = Settings.isolated();
+		settings.setModelRole("smol", "nanogpt/coding-router:max");
+		const result = extractExplicitThinkingSelector("pi/smol:max", settings, {
+			isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:max",
+		});
+		expect(result).toBe(Effort.XHigh);
 	});
 });
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -297,7 +297,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
-	test("restores role model from extension provider after startup resume", async () => {
+	test("restores role model max selector from extension provider after startup resume", async () => {
 		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!defaultModel) {
 			throw new Error("Expected bundled anthropic default model");
@@ -326,7 +326,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 					id: "smol-model",
 					parentId: "default-model",
 					timestamp,
-					model: "runtime-provider/runtime-model",
+					model: "runtime-provider/runtime-reasoning-model:max",
 					role: "smol",
 				},
 			]
@@ -355,7 +355,8 @@ describe("createAgentSession deferred model pattern resolution", () => {
 
 		try {
 			expect(session.model?.provider).toBe("runtime-provider");
-			expect(session.model?.id).toBe("runtime-model");
+			expect(session.model?.id).toBe("runtime-reasoning-model");
+			expect(session.thinkingLevel).toBe(Effort.XHigh);
 		} finally {
 			await session.dispose();
 			authStorage.close();

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -117,6 +118,19 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(session.model?.provider).toBe("runtime-provider");
 		expect(session.model?.id).toBe("runtime-reasoning-model");
 		expect(session.thinkingLevel).toBe("off");
+	});
+
+	test("normalizes max default thinking level from settings", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: "max" });
+
+		const { session } = await createAgentSession({
+			...(await buildSessionOptions("runtime-provider/runtime-reasoning-model")),
+			settings,
+		});
+
+		expect(session.model?.provider).toBe("runtime-provider");
+		expect(session.model?.id).toBe("runtime-reasoning-model");
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
 	});
 
 	test("selects the settings default model without synchronously validating auth", async () => {


### PR DESCRIPTION
## Repro
`deepseek/deepseek-v4-pro` advertises the top supported thinking effort as canonical `xhigh`, but `:max` was not parsed as a thinking suffix: `bun -e 'import { getBundledModel } from "@oh-my-pi/pi-catalog/models"; import { parseThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking"; import { parseModelString } from "@oh-my-pi/pi-coding-agent/config/model-resolver"; const model=getBundledModel("deepseek","deepseek-v4-pro"); console.log(JSON.stringify({model: !!model, efforts: model?.thinking?.efforts, max: parseThinkingLevel("max") ?? null, xhigh: parseThinkingLevel("xhigh") ?? null, selector: parseModelString("deepseek/deepseek-v4-pro:max")}, null, 2));'` previously returned `max: null` and kept `:max` in the model id.

## Cause
`packages/coding-agent/src/thinking.ts` only accepted the canonical `THINKING_EFFORTS` values, where the highest internal effort is named `xhigh`; `packages/coding-agent/src/config/model-resolver.ts` therefore treated `deepseek/deepseek-v4-pro:max` as a literal model id suffix instead of a top-effort selector.

## Fix
- Map `max` to canonical `xhigh` in both provider-facing effort parsing and agent-local thinking selector parsing.
- Display the top thinking selector as `max` while retaining the stored `xhigh` value.
- Add a regression test covering `--thinking` parsing, configured thinking parsing, and `deepseek/deepseek-v4-pro:max` model-string parsing.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/auto-thinking-classifier.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. The repro command now returns `max: "xhigh"` and strips `:max` to `id: "deepseek-v4-pro"`. Fixes #2727