### PR TITLE
fix(tui): preserve scrollback while editing

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed xterm-compatible terminals scrolling the native viewport to the bottom on prompt-editor keypresses by disabling `?1010`/`?1011` while the TUI owns the TTY and restoring the prior set modes on exit ([#2732](https://github.com/can1357/oh-my-pi/issues/2732)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -375,6 +375,20 @@ function parseOsc99KeyValues(section: string): Map<string, string> {
 	}
 	return values;
 }
+const XTERM_SCROLL_TO_BOTTOM_MODES = [1010, 1011] as const;
+
+function isXtermScrollToBottomMode(mode: number): boolean {
+	return mode === 1010 || mode === 1011;
+}
+
+function isPrivateModeSet(status: string): boolean {
+	return status === "1" || status === "3";
+}
+
+function isPrivateModeSupported(status: string): boolean {
+	return status !== "0" && status !== "4";
+}
+
 /**
  * Real terminal using process.stdin/stdout
  */
@@ -397,6 +411,7 @@ export class ProcessTerminal implements Terminal {
 	};
 
 	#windowsVTInputRestore?: () => void;
+	#xtermScrollToBottomRestoreModes = new Set<number>();
 	#appearanceCallbacks: Array<(appearance: TerminalAppearance) => void> = [];
 	#appearance: TerminalAppearance | undefined;
 	#osc11Pending = false;
@@ -518,13 +533,17 @@ export class ProcessTerminal implements Terminal {
 		// Probe DEC private-mode support via DECRQM. 2026 (synchronized output)
 		// gates the renderer's begin/end markers; 2048 (in-band resize) is enabled
 		// only after the terminal confirms support; 2031 (appearance change
-		// notifications) stops the OSC 11 poll once confirmed, since push
-		// notifications make polling redundant. Each probe rides the shared DA1
-		// sentinel FIFO, so a terminal that ignores DECRQM still resolves (as
-		// unsupported) when the DA1 reply arrives.
+		// notifications) stops the OSC 11 poll once confirmed. Xterm ?1010/?1011
+		// are disabled while OMP owns the TTY so typing in the editor does not
+		// force a reader scrolled into native history back to the tail. Each probe
+		// rides the shared DA1 sentinel, so terminals that ignore DECRQM resolve as
+		// unsupported when the DA1 reply arrives.
 		this.#queryPrivateMode(2026);
 		this.#queryPrivateMode(2048);
 		this.#queryPrivateMode(2031);
+		for (const mode of XTERM_SCROLL_TO_BOTTOM_MODES) {
+			this.#queryPrivateMode(mode);
+		}
 	}
 
 	/**
@@ -709,11 +728,10 @@ export class ProcessTerminal implements Terminal {
 			// DECRPM private-mode report. Resolves the matching probe by mode; the
 			// owner stays in the FIFO and is drained by its DA1 sentinel (a no-op
 			// once resolved). Per DECRPM, status 0 = unrecognized, 1/2 =
-			// set/reset, 3 = permanently set, and 4 = permanently reset. Only
-			// settable or permanently-set modes are useful for features we enable.
+			// set/reset, 3 = permanently set, and 4 = permanently reset.
 			const decrpmMatch = sequence.match(decrpmResponsePattern);
 			if (decrpmMatch) {
-				this.#resolvePrivateMode(parseInt(decrpmMatch[1]!, 10), decrpmMatch[2] !== "0" && decrpmMatch[2] !== "4");
+				this.#handlePrivateModeReport(parseInt(decrpmMatch[1]!, 10), decrpmMatch[2]!);
 				return;
 			}
 
@@ -1021,6 +1039,13 @@ export class ProcessTerminal implements Terminal {
 		this.#safeWrite(`\x1b[?${mode}$p\x1b[c`);
 	}
 
+	#handlePrivateModeReport(mode: number, status: string): void {
+		this.#resolvePrivateMode(mode, isPrivateModeSupported(status));
+		if (isXtermScrollToBottomMode(mode) && isPrivateModeSet(status)) {
+			this.#disableXtermScrollToBottomMode(mode);
+		}
+	}
+
 	/**
 	 * Record DECRQM support for a private mode (idempotent — first result wins)
 	 * and notify subscribers. Enables DEC 2048 in-band resize when 2048 resolves
@@ -1040,6 +1065,12 @@ export class ProcessTerminal implements Terminal {
 		}
 		if (mode === 2048 && supported) this.#enableInBandResize();
 		if (mode === 2031 && supported) this.#stopOsc11Poll();
+	}
+
+	#disableXtermScrollToBottomMode(mode: number): void {
+		if (this.#xtermScrollToBottomRestoreModes.has(mode) || this.#dead) return;
+		this.#xtermScrollToBottomRestoreModes.add(mode);
+		this.#safeWrite(`\x1b[?${mode}l`);
 	}
 
 	/**
@@ -1170,7 +1201,12 @@ export class ProcessTerminal implements Terminal {
 		// Disable Mode 2031 appearance change notifications
 		this.#safeWrite("\x1b[?2031l");
 
-		// Disable DEC 2048 in-band resize notifications if we enabled them.
+		// Restore xterm scroll-to-bottom modes that were set before startup.
+		for (const mode of this.#xtermScrollToBottomRestoreModes) {
+			this.#safeWrite(`\x1b[?${mode}h`);
+		}
+		this.#xtermScrollToBottomRestoreModes.clear();
+
 		if (this.#inBandResizeActive) {
 			this.#safeWrite("\x1b[?2048l");
 			this.#inBandResizeActive = false;
@@ -1193,6 +1229,7 @@ export class ProcessTerminal implements Terminal {
 		this.#da1SentinelOwners.length = 0;
 		this.#privateModeCallbacks = [];
 		this.#privateModeSupport.clear();
+		this.#xtermScrollToBottomRestoreModes.clear();
 		this.#reportedColumns = undefined;
 		this.#reportedRows = undefined;
 

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -389,9 +389,12 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		expect(writes.some(w => w.includes("\x1b[>31u"))).toBe(false);
 		expect(writes).toContain("\x1b[?u\x1b[c");
 
-		// Five DA1 sentinels are in flight at startup: keyboard probe, OSC 11, and
-		// the DECRQM probes for DEC 2026, 2048, and 2031 (each rides the shared
-		// FIFO). Consume them in send-order and verify none leaks to the input handler.
+		// Seven DA1 sentinels are in flight at startup: keyboard probe, OSC 11, and
+		// the DECRQM probes for DEC 2026, 2048, 2031, 1010, and 1011 (each rides the
+		// shared FIFO). Consume them in send-order and verify none leaks to the input
+		// handler.
+		process.stdin.emit("data", "\x1b[?1;2c");
+		process.stdin.emit("data", "\x1b[?1;2c");
 		process.stdin.emit("data", "\x1b[?1;2c");
 		process.stdin.emit("data", "\x1b[?1;2c");
 		process.stdin.emit("data", "\x1b[?1;2c");
@@ -399,8 +402,7 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		process.stdin.emit("data", "\x1b[?1;2c");
 		expect(received).toEqual([]);
 
-		// A sixth stray DA1 has no owner and must reach the input handler — it is
-		// no longer ours to swallow.
+		// An eighth stray DA1 has no owner and must reach the input handler — it is
 		process.stdin.emit("data", "\x1b[?1;2c");
 		expect(received).toEqual(["\x1b[?1;2c"]);
 
@@ -486,11 +488,13 @@ describe("ProcessTerminal DECRQM + in-band resize (DEC 2026/2048)", () => {
 		return { terminal, writes, received, reports, resizeCount: () => resizeCount };
 	}
 
-	it("queries DECRQM for DEC 2026, 2048, and 2031 at startup", () => {
+	it("queries DECRQM for DEC 2026, 2048, 2031, and xterm scroll-to-bottom modes at startup", () => {
 		const { terminal, writes } = setup();
 		expect(writes.some(w => w.includes("\x1b[?2026$p"))).toBe(true);
 		expect(writes.some(w => w.includes("\x1b[?2048$p"))).toBe(true);
 		expect(writes.some(w => w.includes("\x1b[?2031$p"))).toBe(true);
+		expect(writes.some(w => w.includes("\x1b[?1010$p"))).toBe(true);
+		expect(writes.some(w => w.includes("\x1b[?1011$p"))).toBe(true);
 		terminal.stop();
 	});
 
@@ -531,6 +535,36 @@ describe("ProcessTerminal DECRQM + in-band resize (DEC 2026/2048)", () => {
 		expect(writes).toContain("\x1b[?2048h");
 		terminal.stop();
 		expect(writes).toContain("\x1b[?2048l");
+	});
+
+	it("disables xterm scroll-to-bottom modes while active and restores them on stop", () => {
+		const { terminal, writes, reports } = setup();
+		process.stdin.emit("data", "\x1b[?1010;1$y");
+		process.stdin.emit("data", "\x1b[?1011;3$y");
+		expect(reports).toContainEqual({ mode: 1010, supported: true });
+		expect(reports).toContainEqual({ mode: 1011, supported: true });
+		expect(writes).toContain("\x1b[?1010l");
+		expect(writes).toContain("\x1b[?1011l");
+
+		terminal.stop();
+
+		expect(writes).toContain("\x1b[?1010h");
+		expect(writes).toContain("\x1b[?1011h");
+	});
+
+	it("leaves already-reset xterm scroll-to-bottom modes unchanged", () => {
+		const { terminal, writes, reports } = setup();
+		process.stdin.emit("data", "\x1b[?1010;2$y");
+		process.stdin.emit("data", "\x1b[?1011;4$y");
+		expect(reports).toContainEqual({ mode: 1010, supported: true });
+		expect(reports).toContainEqual({ mode: 1011, supported: false });
+		expect(writes).not.toContain("\x1b[?1010l");
+		expect(writes).not.toContain("\x1b[?1011l");
+
+		terminal.stop();
+
+		expect(writes).not.toContain("\x1b[?1010h");
+		expect(writes).not.toContain("\x1b[?1011h");
 	});
 
 	it("does not enable DEC 2048 when reported unsupported", () => {


### PR DESCRIPTION
## Repro
A mocked TTY reported xterm private modes `?1010` and `?1011` as set, then `ProcessTerminal` was started and fed those DECRPM replies. Before the fix, the startup writes never disabled either mode, leaving compatible terminals free to scroll the native viewport to the tail on output or keypress while the prompt editor was active. Repro command: `bun -e 'import { ProcessTerminal } from "./packages/tui/src/terminal.ts"; /* mocked TTY */ ... emit DECRPM set reports for ?1010 and ?1011; assert startup writes disable both modes'` exited 1 with `reproduced: xterm scroll-to-bottom modes stayed enabled while OMP was active`.

## Cause
`packages/tui/src/terminal.ts` only probed DEC private modes `2026`, `2048`, and `2031`. It never queried xterm scroll-to-bottom modes `1010`/`1011`, so terminals that default those modes on kept snapping users back to the bottom when OMP repainted the editor or received keypresses.

## Fix
- Query xterm private modes `1010` and `1011` during `ProcessTerminal.start()` alongside the existing DECRQM probes.
- When DECRPM reports either mode set, reset it for the lifetime of the TUI and remember it for restoration.
- Restore only the modes that were originally set during `ProcessTerminal.stop()`.
- Add regression coverage for querying, disabling/restoring set modes, and leaving already-reset modes unchanged.

## Verification
`bun test packages/tui/test/terminal-appearance.test.ts` passed: 35 tests, 110 assertions. `bun check` passed for the workspace. `gh_push_branch` pre-publish gate passed and pushed `farm/1c10fabf/preserve-scroll-while-editing`. Fixes #2732