### PR TITLE
fix(coding-agent): list linked local plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1896,6 +1896,7 @@
 
 - Fixed plan-mode re-entry after approval reopening a fresh `local://PLAN.md` instead of the approved titled plan artifact, which could duplicate plan content and fail approval on an existing destination.
 - Fixed `read` URL reader mode aborting after a stalled Jina request instead of falling back to trafilatura/lynx/native: Jina (and Parallel extract) now have their own per-attempt sub-budget capped at 10s, the catch handler honours only real user cancellation, and the in-process native renderer is always attempted on already-loaded HTML ([#1449](https://github.com/can1357/oh-my-pi/issues/1449))
+- Fixed `omp plugin list` omitting successfully linked local plugins when the plugin runtime lockfile existed but the plugins package manifest had not been bootstrapped yet ([#2742](https://github.com/can1357/oh-my-pi/issues/2742))
 
 ## [15.5.6] - 2026-05-27
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -490,21 +490,22 @@ export class PluginManager {
 	 */
 	async list(): Promise<InstalledPlugin[]> {
 		const pkgJsonPath = getPluginsPackageJson();
-		let pkg: { dependencies?: Record<string, string> };
+		let pkg: { dependencies?: Record<string, string> } = { dependencies: {} };
 		try {
 			pkg = await Bun.file(pkgJsonPath).json();
 		} catch (err) {
-			if (isEnoent(err)) return [];
-			throw err;
+			if (!isEnoent(err)) throw err;
 		}
 
-		const deps = pkg.dependencies || {};
+		const dependencyNames = Object.keys(pkg.dependencies || {});
 		const projectOverrides = await this.#loadProjectOverrides();
 		const config = await this.#ensureConfigLoaded();
+		const pluginNames = new Set([...dependencyNames, ...Object.keys(config.plugins)]);
 		const plugins: InstalledPlugin[] = [];
 
-		for (const [name] of Object.entries(deps)) {
-			const pluginPkgPath = path.join(getPluginsNodeModules(), name, "package.json");
+		for (const name of pluginNames) {
+			const pluginDir = path.join(getPluginsNodeModules(), name);
+			const pluginPkgPath = path.join(pluginDir, "package.json");
 			let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
 			try {
 				pluginPkg = await Bun.file(pluginPkgPath).json();
@@ -528,7 +529,7 @@ export class PluginManager {
 			plugins.push({
 				name,
 				version: pluginPkg.version,
-				path: path.join(getPluginsNodeModules(), name),
+				path: pluginDir,
 				manifest,
 				enabledFeatures: projectFeatures ?? runtimeState.enabledFeatures,
 				enabled: runtimeState.enabled && !isDisabledInProject,
@@ -556,6 +557,7 @@ export class PluginManager {
 			throw new Error("package.json must have a name field");
 		}
 
+		await this.#ensurePackageJson();
 		await this.#ensurePluginsDir();
 
 		const linkPath = path.join(getPluginsNodeModules(), pkg.name);

--- a/packages/coding-agent/test/plugin-linked-list.test.ts
+++ b/packages/coding-agent/test/plugin-linked-list.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getPluginsLockfile, getPluginsPackageJson, setAgentDir } from "@oh-my-pi/pi-utils";
+import { PluginManager } from "../src/extensibility/plugins/manager";
+
+describe("PluginManager list()", () => {
+	let tempRoot: string;
+	let projectDir: string;
+	let pluginDir: string;
+	let originalAgentDir: string;
+	let originalConfigDir: string | undefined;
+
+	beforeEach(async () => {
+		originalAgentDir = getAgentDir();
+		originalConfigDir = process.env.PI_CONFIG_DIR;
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-list-"));
+		projectDir = path.join(tempRoot, "project");
+		pluginDir = path.join(tempRoot, "linked-plugin");
+
+		process.env.PI_CONFIG_DIR = path.relative(os.homedir(), tempRoot);
+		setAgentDir(path.join(tempRoot, "agent"));
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.mkdir(pluginDir, { recursive: true });
+		await Bun.write(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "ecc-linked-test",
+					version: "1.2.3",
+					omp: {
+						description: "linked plugin test fixture",
+						version: "1.2.3",
+					},
+				},
+				null,
+				2,
+			),
+		);
+	});
+
+	afterEach(async () => {
+		if (originalConfigDir === undefined) {
+			delete process.env.PI_CONFIG_DIR;
+		} else {
+			process.env.PI_CONFIG_DIR = originalConfigDir;
+		}
+		setAgentDir(originalAgentDir);
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("includes a successfully linked local plugin even before any npm dependency install state exists", async () => {
+		const manager = new PluginManager(projectDir);
+		await manager.link(pluginDir);
+
+		const pluginPkg = await Bun.file(getPluginsPackageJson()).json();
+		expect(pluginPkg).toMatchObject({
+			name: "omp-plugins",
+			private: true,
+			dependencies: {},
+		});
+
+		const runtimeConfig = await Bun.file(getPluginsLockfile()).json();
+		expect(runtimeConfig.plugins["ecc-linked-test"]).toMatchObject({
+			version: "1.2.3",
+			enabled: true,
+			enabledFeatures: null,
+		});
+
+		const plugins = await manager.list();
+		const matches = plugins.filter(plugin => plugin.name === "ecc-linked-test");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]).toMatchObject({
+			name: "ecc-linked-test",
+			version: "1.2.3",
+			enabled: true,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2742.

`omp plugin list` could report no installed plugins after a successful local `omp plugin link` because linked plugins were only tracked in `omp-plugins.lock.json`, while `PluginManager.list()` returned early when the plugins package manifest was missing and only enumerated dependency-backed installs.

## What changed

- bootstrap the plugins package manifest during `PluginManager.link()`
- make `PluginManager.list()` tolerate a missing plugins package manifest
- list plugins from the union of package dependencies and runtime lockfile entries
- add a regression test covering a local linked plugin before any dependency-backed install state exists
- add an unreleased changelog entry

## Verification

Ran locally:

```sh
bun --cwd=packages/natives run build
bun --cwd=packages/coding-agent test test/plugin-linked-list.test.ts test/plugin-command.test.ts
bun --cwd=packages/coding-agent check
```
