### PR TITLE
fix(cli): list linked local plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -84,6 +84,7 @@
 
 ### Fixed
 
+- Fixed `omp plugin list --json` omitting locally linked plugins that exist only in `omp-plugins.lock.json` and `node_modules` symlinks. ([#2742](https://github.com/can1357/oh-my-pi/issues/2742))
 - Fixed the advisor auto-resuming a run after the user deliberately interrupts it (Esc, or a cancel from collab/ACP/RPC/SDK/extension). A user interrupt now suppresses advisor `concern`/`blocker` auto-resume until the user next resumes (a typed message, `.`/`c` continue, or a steer/follow-up); the concern is still recorded as a visible, persisted advisor card — including one already steered into the run or arriving mid-abort — so it re-enters context on resume instead of being discarded. Natural yields are unchanged: the advisor can still steer and resume a stalled run.
 - Fixed `/advisor on|off` not being session-local by overriding the setting instead of modifying global configuration, and fixed changes not updating the TUI status line immediately.
 - Fixed `plan.defaultOnStartup` setting schema configuration missing the required `ui.group` property.

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -205,6 +205,17 @@ export class PluginManager {
 		}
 	}
 
+	#collectInstalledNames(deps: Record<string, string>, config: PluginRuntimeConfig): Set<string> {
+		const installedNames = new Set<string>();
+		for (const name of Object.keys(deps)) {
+			installedNames.add(name);
+		}
+		for (const name of Object.keys(config.plugins)) {
+			installedNames.add(name);
+		}
+		return installedNames;
+	}
+
 	async #snapshotInstalledPackage(actualName: string | undefined): Promise<PluginPackageSnapshot | null> {
 		if (!actualName) {
 			return null;
@@ -501,13 +512,7 @@ export class PluginManager {
 		const projectOverrides = await this.#loadProjectOverrides();
 		const config = await this.#ensureConfigLoaded();
 		const plugins: InstalledPlugin[] = [];
-		const installedNames = new Set<string>();
-		for (const name of Object.keys(deps)) {
-			installedNames.add(name);
-		}
-		for (const name of Object.keys(config.plugins)) {
-			installedNames.add(name);
-		}
+		const installedNames = this.#collectInstalledNames(deps, config);
 
 		for (const name of installedNames) {
 			const pluginPath = path.join(getPluginsNodeModules(), name);
@@ -750,15 +755,14 @@ export class PluginManager {
 			message: hasNodeModules ? "Found" : "Missing (run npm install in plugins dir)",
 		});
 
-		if (!hasPkgJson) {
-			return checks;
-		}
 		const deps = pkg.dependencies || {};
 		const config = await this.#ensureConfigLoaded();
+		const installedNames = this.#collectInstalledNames(deps, config);
 
-		for (const [name] of Object.entries(deps)) {
+		for (const name of installedNames) {
 			const pluginPath = path.join(nodeModulesPath, name);
 			const pluginPkgPath = path.join(pluginPath, "package.json");
+			const fromDependencies = name in deps;
 
 			let pluginPkg: { version: string; description?: string; omp?: PluginManifest; pi?: PluginManifest };
 			try {
@@ -766,13 +770,23 @@ export class PluginManager {
 			} catch (err) {
 				if (isEnoent(err)) {
 					if (!fs.existsSync(pluginPath)) {
-						const fixed = options.fix ? await this.#fixMissingPlugin() : false;
-						checks.push({
-							name: `plugin:${name}`,
-							status: "error",
-							message: "Missing from node_modules",
-							fixed,
-						});
+						if (fromDependencies) {
+							const fixed = options.fix ? await this.#fixMissingPlugin() : false;
+							checks.push({
+								name: `plugin:${name}`,
+								status: "error",
+								message: "Missing from node_modules",
+								fixed,
+							});
+						} else {
+							const fixed = options.fix ? await this.#removeOrphanedConfig(name) : false;
+							checks.push({
+								name: `orphan:${name}`,
+								status: "warning",
+								message: "Plugin in config but not installed",
+								fixed,
+							});
+						}
 					} else {
 						checks.push({
 							name: `plugin:${name}`,
@@ -847,19 +861,6 @@ export class PluginManager {
 						});
 					}
 				}
-			}
-		}
-
-		// Check for orphaned runtime config entries
-		for (const name of Object.keys(config.plugins)) {
-			if (!(name in deps)) {
-				const fixed = options.fix ? await this.#removeOrphanedConfig(name) : false;
-				checks.push({
-					name: `orphan:${name}`,
-					status: "warning",
-					message: "Plugin in config but not installed",
-					fixed,
-				});
 			}
 		}
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -490,21 +490,28 @@ export class PluginManager {
 	 */
 	async list(): Promise<InstalledPlugin[]> {
 		const pkgJsonPath = getPluginsPackageJson();
-		let pkg: { dependencies?: Record<string, string> };
+		let deps: Record<string, string> = {};
 		try {
-			pkg = await Bun.file(pkgJsonPath).json();
+			const pkg: { dependencies?: Record<string, string> } = await Bun.file(pkgJsonPath).json();
+			deps = pkg.dependencies ?? {};
 		} catch (err) {
-			if (isEnoent(err)) return [];
-			throw err;
+			if (!isEnoent(err)) throw err;
 		}
 
-		const deps = pkg.dependencies || {};
 		const projectOverrides = await this.#loadProjectOverrides();
 		const config = await this.#ensureConfigLoaded();
 		const plugins: InstalledPlugin[] = [];
+		const installedNames = new Set<string>();
+		for (const name of Object.keys(deps)) {
+			installedNames.add(name);
+		}
+		for (const name of Object.keys(config.plugins)) {
+			installedNames.add(name);
+		}
 
-		for (const [name] of Object.entries(deps)) {
-			const pluginPkgPath = path.join(getPluginsNodeModules(), name, "package.json");
+		for (const name of installedNames) {
+			const pluginPath = path.join(getPluginsNodeModules(), name);
+			const pluginPkgPath = path.join(pluginPath, "package.json");
 			let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
 			try {
 				pluginPkg = await Bun.file(pluginPkgPath).json();
@@ -521,14 +528,13 @@ export class PluginManager {
 				enabled: true,
 			};
 
-			// Apply project overrides
 			const isDisabledInProject = projectOverrides.disabled?.includes(name) ?? false;
 			const projectFeatures = projectOverrides.features?.[name];
 
 			plugins.push({
 				name,
 				version: pluginPkg.version,
-				path: path.join(getPluginsNodeModules(), name),
+				path: pluginPath,
 				manifest,
 				enabledFeatures: projectFeatures ?? runtimeState.enabledFeatures,
 				enabled: runtimeState.enabled && !isDisabledInProject,

--- a/packages/coding-agent/test/plugin-install-local.test.ts
+++ b/packages/coding-agent/test/plugin-install-local.test.ts
@@ -31,6 +31,20 @@ const FAKE_INSTALLED: InstalledPlugin = {
 	enabled: true,
 };
 
+async function createLocalPlugin(root: string): Promise<string> {
+	const localPlugin = path.join(root, "kimi-datasource");
+	await fs.mkdir(localPlugin, { recursive: true });
+	await Bun.write(
+		path.join(localPlugin, "package.json"),
+		JSON.stringify({
+			name: "kimi-datasource",
+			version: "1.0.0",
+			omp: { extensions: ["./src/extension.ts"] },
+		}),
+	);
+	return localPlugin;
+}
+
 describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 	let tmpRoot: string;
 
@@ -113,16 +127,7 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 		// (no spies on PluginManager.link), and verify the resulting symlink
 		// + lockfile entry. Pins the contract that local-path installs
 		// symlink rather than copy-install, matching `omp plugin link`.
-		const localPlugin = path.join(tmpRoot, "kimi-datasource");
-		await fs.mkdir(localPlugin, { recursive: true });
-		await Bun.write(
-			path.join(localPlugin, "package.json"),
-			JSON.stringify({
-				name: "kimi-datasource",
-				version: "1.0.0",
-				omp: { extensions: ["./src/extension.ts"] },
-			}),
-		);
+		const localPlugin = await createLocalPlugin(tmpRoot);
 
 		await runPluginCommand({ action: "install", args: [localPlugin], flags: { json: true } });
 
@@ -139,16 +144,7 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 		});
 	});
 	test("list --json includes linked local plugin without package dependencies", async () => {
-		const localPlugin = path.join(tmpRoot, "kimi-datasource");
-		await fs.mkdir(localPlugin, { recursive: true });
-		await Bun.write(
-			path.join(localPlugin, "package.json"),
-			JSON.stringify({
-				name: "kimi-datasource",
-				version: "1.0.0",
-				omp: { extensions: ["./src/extension.ts"] },
-			}),
-		);
+		const localPlugin = await createLocalPlugin(tmpRoot);
 		const output: string[] = [];
 		spyOn(console, "log").mockImplementation(message => {
 			output.push(String(message));
@@ -161,5 +157,26 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 
 		const listed = JSON.parse(output.join("\n")) as { npm: InstalledPlugin[] };
 		expect(listed.npm.map(plugin => plugin.name)).toContain("kimi-datasource");
+	});
+
+	test("doctor --fix preserves linked local plugin state without package dependencies", async () => {
+		await Bun.write(
+			path.join(tmpRoot, "plugins", "package.json"),
+			JSON.stringify({ name: "omp-plugins", private: true, dependencies: {} }),
+		);
+		const localPlugin = await createLocalPlugin(tmpRoot);
+		const manager = new PluginManager(tmpRoot);
+
+		await manager.link(localPlugin);
+		const checks = await manager.doctor({ fix: true });
+
+		expect(checks.find(check => check.name === "orphan:kimi-datasource")).toBeUndefined();
+		const lock = await Bun.file(path.join(tmpRoot, "omp-plugins.lock.json")).json();
+		expect(lock.plugins["kimi-datasource"]).toEqual({
+			version: "1.0.0",
+			enabledFeatures: null,
+			enabled: true,
+		});
+		expect((await manager.list()).map(plugin => plugin.name)).toContain("kimi-datasource");
 	});
 });

--- a/packages/coding-agent/test/plugin-install-local.test.ts
+++ b/packages/coding-agent/test/plugin-install-local.test.ts
@@ -138,4 +138,28 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 			enabled: true,
 		});
 	});
+	test("list --json includes linked local plugin without package dependencies", async () => {
+		const localPlugin = path.join(tmpRoot, "kimi-datasource");
+		await fs.mkdir(localPlugin, { recursive: true });
+		await Bun.write(
+			path.join(localPlugin, "package.json"),
+			JSON.stringify({
+				name: "kimi-datasource",
+				version: "1.0.0",
+				omp: { extensions: ["./src/extension.ts"] },
+			}),
+		);
+		const output: string[] = [];
+		spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		spyOn(MarketplaceManager.prototype, "listInstalledPlugins").mockResolvedValue([]);
+
+		await runPluginCommand({ action: "link", args: [localPlugin], flags: { json: true } });
+		output.length = 0;
+		await runPluginCommand({ action: "list", args: [], flags: { json: true } });
+
+		const listed = JSON.parse(output.join("\n")) as { npm: InstalledPlugin[] };
+		expect(listed.npm.map(plugin => plugin.name)).toContain("kimi-datasource");
+	});
 });


### PR DESCRIPTION
## Repro
A focused regression test links a valid local plugin directory and then runs `omp plugin list --json` through `runPluginCommand`; before the fix, the JSON list returned `npm: []` even though the link wrote the plugin state. Command: `bun test test/plugin-install-local.test.ts`.

## Cause
`PluginManager.list()` in `packages/coding-agent/src/extensibility/plugins/manager.ts` only enumerated `plugins/package.json#dependencies`. `PluginManager.link()` creates a `node_modules/<name>` symlink and writes `omp-plugins.lock.json`, but it does not add a dependency entry, so linked plugins were never considered by the list path.

## Fix
- Build the list input from the union of `plugins/package.json#dependencies` and `omp-plugins.lock.json#plugins`.
- Keep missing package directories skipped so stale lockfile entries do not crash listing.
- Add CLI-level regression coverage for `plugin link` followed by `plugin list --json`.
- Add a coding-agent changelog entry.

## Verification
`bun test test/plugin-install-local.test.ts` passed with 9 tests. `bun run check` passed in `packages/coding-agent`. `gh_push_branch` pre-publish checks passed before pushing. Fixes #2742