### PR TITLE
feat(memory): add runtime status/search/save commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/memory status`, `/memory search <query>`, and `/memory save <text>` plus complete `ctx.memory` runtime wiring for extension contexts, so users and extensions can inspect, search, and explicitly retain memories through the configured backend.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -195,8 +195,27 @@ const noOpUIContext: ExtensionUIContext = {
 	setToolsExpanded: () => {},
 };
 
+export const noOpMemoryContext: MemoryRuntimeContext = {
+	async status() {
+		return {
+			backend: "off",
+			active: false,
+			writable: false,
+			searchable: false,
+			message: "No active memory context.",
+		};
+	},
+	async search(query: string) {
+		return { backend: "off", query, count: 0, items: [], message: "No active memory context." };
+	},
+	async save() {
+		return { backend: "off", stored: 0, message: "No active memory context." };
+	},
+};
+
 export class ExtensionRunner {
 	#uiContext: ExtensionUIContext;
+	#memoryContext: MemoryRuntimeContext = noOpMemoryContext;
 	#errorListeners: Set<ExtensionErrorListener> = new Set();
 	#getModel: () => Model | undefined = () => undefined;
 	#isIdleFn: () => boolean = () => true;
@@ -264,6 +283,7 @@ export class ExtensionRunner {
 		this.#hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.#shutdownHandler = contextActions.shutdown;
 		this.#getSystemPromptFn = contextActions.getSystemPrompt;
+		this.#memoryContext = contextActions.memory ?? noOpMemoryContext;
 
 		// Command context actions (optional, only for interactive mode)
 		if (commandContextActions) {
@@ -495,6 +515,7 @@ export class ExtensionRunner {
 		const getModel = this.#getModel;
 		return {
 			ui: this.#uiContext,
+			memory: this.#getMemoryFn?.() ?? this.#memoryContext,
 			getContextUsage: () => this.#getContextUsageFn(),
 			compact: instructionsOrOptions => this.#compactFn(instructionsOrOptions),
 			hasUI: this.hasUI(),
@@ -510,7 +531,6 @@ export class ExtensionRunner {
 			hasPendingMessages: () => this.#hasPendingMessagesFn(),
 			shutdown: () => this.#shutdownHandler(),
 			getSystemPrompt: () => this.#getSystemPromptFn(),
-			memory: this.#getMemoryFn?.(),
 		};
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -150,7 +150,6 @@ export interface ExtensionUIDialogOptions {
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
 
 export type WidgetPlacement = "aboveEditor" | "belowEditor";
-
 export interface ExtensionWidgetOptions {
 	placement?: WidgetPlacement;
 }
@@ -349,6 +348,7 @@ export interface ExtensionContext {
 	shutdown(): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string[];
+
 	/** Structured memory runtime for status/search/save across the configured backend. */
 	memory?: MemoryRuntimeContext;
 }
@@ -1310,9 +1310,9 @@ export interface ExtensionActions {
 	setSessionName: (name: string) => Promise<void>;
 }
 
-/** Actions for ExtensionContext (ctx.* in event handlers). */
 export interface ExtensionContextActions {
 	getModel: () => Model | undefined;
+	memory?: MemoryRuntimeContext;
 	isIdle: () => boolean;
 	abort: () => void;
 	hasPendingMessages: () => boolean;
@@ -1322,7 +1322,6 @@ export interface ExtensionContextActions {
 	getSystemPrompt: () => string[];
 }
 
-/** Actions for ExtensionCommandContext (ctx.* in command handlers). */
 export interface ExtensionCommandContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	waitForIdle: () => Promise<void>;
@@ -1336,7 +1335,6 @@ export interface ExtensionCommandContextActions {
 	switchSession: (sessionPath: string) => Promise<{ cancelled: boolean }>;
 	reload: () => Promise<void>;
 }
-
 /** Full runtime = state + actions. */
 export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {}
 

--- a/packages/coding-agent/src/hindsight/backend.ts
+++ b/packages/coding-agent/src/hindsight/backend.ts
@@ -10,7 +10,13 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
 import { onHindsightScopeChanged, type Settings } from "../config/settings";
-import type { MemoryBackend, MemoryBackendStartOptions } from "../memory-backend/types";
+import type {
+	MemoryBackend,
+	MemoryBackendSaveInput,
+	MemoryBackendSearchItem,
+	MemoryBackendStartOptions,
+	MemoryBackendStatus,
+} from "../memory-backend/types";
 import type { AgentSession } from "../session/agent-session";
 import { type BankScope, computeBankScope } from "./bank";
 import { createHindsightClient } from "./client";
@@ -131,6 +137,82 @@ export const hindsightBackend: MemoryBackend = {
 		await primary.forceRetainCurrentSession();
 	},
 
+	async status({ session }): Promise<MemoryBackendStatus> {
+		const state = session?.getHindsightSessionState();
+		const primary = state?.aliasOf ?? state;
+		if (!primary) {
+			return {
+				backend: "hindsight",
+				active: false,
+				writable: false,
+				searchable: false,
+				message: "Hindsight backend is configured but not initialised for this session.",
+			};
+		}
+		return {
+			backend: "hindsight",
+			active: true,
+			writable: true,
+			searchable: true,
+			scope: primary.config.scoping,
+			retainBank: primary.bankId,
+			recallBanks: [primary.bankId],
+			lastRecall: Boolean(primary.lastRecallSnippet),
+		};
+	},
+
+	async search({ session }, query, options) {
+		const state = session?.getHindsightSessionState();
+		const primary = state?.aliasOf ?? state;
+		if (!primary) {
+			return {
+				backend: "hindsight",
+				query,
+				count: 0,
+				items: [],
+				message: "Hindsight backend is not initialised for this session.",
+			};
+		}
+		if (options?.signal?.aborted) {
+			return { backend: "hindsight", query, count: 0, items: [], message: "Search aborted." };
+		}
+		const response = await primary.client.recall(primary.bankId, query, {
+			budget: primary.config.recallBudget,
+			maxTokens: primary.config.recallMaxTokens,
+			types: primary.config.recallTypes.length > 0 ? primary.config.recallTypes : undefined,
+			tags: primary.recallTags,
+			tagsMatch: primary.recallTagsMatch,
+		});
+		const limit = clampLimit(options?.limit);
+		const items: MemoryBackendSearchItem[] = (response.results ?? []).slice(0, limit).map(result => ({
+			id: result.id,
+			content: result.text,
+			source: typeof result.type === "string" ? result.type : undefined,
+			timestamp: typeof result.mentioned_at === "string" ? result.mentioned_at : undefined,
+		}));
+		return { backend: "hindsight", query, count: items.length, items };
+	},
+
+	async save({ session }, input: MemoryBackendSaveInput) {
+		const state = session?.getHindsightSessionState();
+		const primary = state?.aliasOf ?? state;
+		if (!primary) {
+			return {
+				backend: "hindsight",
+				stored: 0,
+				message: "Hindsight backend is not initialised for this session.",
+			};
+		}
+		const content = input.content.trim();
+		if (!content) return { backend: "hindsight", stored: 0, message: "Memory content is empty." };
+		primary.enqueueRetain(content, input.context ?? input.source ?? "memory.save");
+		return {
+			backend: "hindsight",
+			stored: 1,
+			queued: true,
+			message: "Memory queued for Hindsight retention.",
+		};
+	},
 	async preCompactionContext(
 		messages: AgentMessage[],
 		settings: Settings,
@@ -321,6 +403,11 @@ function bankScopesEqual(
 		stringArraysEqual(scope.recallTags, state.recallTags) &&
 		scope.recallTagsMatch === state.recallTagsMatch
 	);
+}
+
+function clampLimit(limit: number | undefined): number {
+	if (!Number.isFinite(limit)) return 10;
+	return Math.max(1, Math.min(50, Math.trunc(limit ?? 10)));
 }
 
 /** Reduce arbitrary AgentMessages into the Hindsight flat-text shape. */

--- a/packages/coding-agent/src/memory-backend/runtime.ts
+++ b/packages/coding-agent/src/memory-backend/runtime.ts
@@ -52,9 +52,15 @@ export function createMemoryRuntimeContext(context: MemoryBackendOperationContex
 export function createSessionMemoryRuntimeContext(
 	session: AgentSession,
 	agentDir: string,
-	cwd: string,
+	cwd: string | (() => string),
 ): MemoryRuntimeContext {
-	return createMemoryRuntimeContext({ agentDir, cwd, session });
+	const createForCurrentCwd = () =>
+		createMemoryRuntimeContext({ agentDir, cwd: typeof cwd === "function" ? cwd() : cwd, session });
+	return {
+		status: () => createForCurrentCwd().status(),
+		search: (query, options) => createForCurrentCwd().search(query, options),
+		save: input => createForCurrentCwd().save(input),
+	};
 }
 
 function unavailableSearch(backend: MemoryBackendId, query: string, message: string) {

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -180,7 +180,6 @@ export const mnemopiBackend: MemoryBackend = {
 				message: "Mnemopi backend is not initialised for this session.",
 			};
 		}
-
 		const { targets, owned } = createStatsTargets(agentDir, session);
 		try {
 			if (targets.length === 0) {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -58,6 +58,7 @@ import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
+import { createSessionMemoryRuntimeContext } from "../../memory-backend/runtime";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
 import { type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
@@ -2095,6 +2096,11 @@ export class AcpAgent implements Agent {
 				},
 			},
 			{
+				memory: createSessionMemoryRuntimeContext(
+					record.session,
+					record.session.settings.getAgentDir(),
+					record.session.sessionManager.getCwd(),
+				),
 				getModel: () => record.session.model,
 				isIdle: () => !record.session.isStreaming,
 				abort: () => {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -25,7 +25,12 @@ import {
 	seedAlreadyExists,
 	summarizeMentalModel,
 } from "../../hindsight";
-import { resolveMemoryBackend } from "../../memory-backend";
+import {
+	type MemoryBackendSaveResult,
+	type MemoryBackendSearchResult,
+	type MemoryBackendStatus,
+	resolveMemoryBackend,
+} from "../../memory-backend";
 import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BorderedLoader } from "../../modes/components/bordered-loader";
 import { DynamicBorder } from "../../modes/components/dynamic-border";
@@ -43,7 +48,7 @@ import { formatShakeSummary, type ShakeMode, type ShakeResult } from "../../sess
 import { limitMatchesActiveAccount } from "../../slash-commands/helpers/active-oauth-account";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
-import { replaceTabs } from "../../tools/render-utils";
+import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
@@ -57,6 +62,67 @@ function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown:
 	block.addChild(new Markdown(markdown.trim(), 1, 1, getMarkdownTheme()));
 	block.addChild(new DynamicBorder());
 	ctx.present(block);
+}
+
+function renderMemoryStatusMarkdown(status: MemoryBackendStatus): string {
+	const lines = [
+		"# Memory Status",
+		"",
+		`- Backend: ${status.backend}`,
+		`- Active: ${status.active ? "yes" : "no"}`,
+		`- Searchable: ${status.searchable ? "yes" : "no"}`,
+		`- Writable: ${status.writable ? "yes" : "no"}`,
+	];
+	if (status.scope) lines.push(`- Scope: ${status.scope}`);
+	if (status.retainBank) lines.push(`- Retain bank: ${status.retainBank}`);
+	if (status.recallBanks?.length) lines.push(`- Recall banks: ${status.recallBanks.join(", ")}`);
+	if (status.workingCount !== undefined) lines.push(`- Working memories: ${status.workingCount}`);
+	if (status.episodicCount !== undefined) lines.push(`- Episodic memories: ${status.episodicCount}`);
+	if (status.tripleCount !== undefined) lines.push(`- Triples: ${status.tripleCount}`);
+	if (status.lastMemory) lines.push(`- Last memory: ${sanitizeMemorySearchContent(status.lastMemory)}`);
+	if (status.lastRecall !== undefined) lines.push(`- Last recall injected: ${status.lastRecall ? "yes" : "no"}`);
+	if (status.database) lines.push(`- Database: ${status.database}`);
+	if (status.message) lines.push("", status.message);
+	if (status.error) lines.push("", `Error: ${status.error}`);
+	return lines.join("\n");
+}
+
+function parseMemoryAction(input: string): { action: string; argument: string } {
+	const trimmed = input.trimStart();
+	if (!trimmed) return { action: "view", argument: "" };
+	const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(trimmed);
+	if (!match) return { action: "view", argument: "" };
+	return { action: match[1]?.toLowerCase() ?? "view", argument: match[2] ?? "" };
+}
+
+function sanitizeMemorySearchContent(content: string): string {
+	return truncateToWidth(replaceTabs(content.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")), 160);
+}
+
+function renderMemorySearchMarkdown(result: MemoryBackendSearchResult): string {
+	if (result.message) return result.message;
+	if (result.items.length === 0) return `No memories found for: ${result.query}`;
+	const lines = [
+		`# Memory Search`,
+		"",
+		`Found ${result.count} ${result.count === 1 ? "memory" : "memories"} for: ${result.query}`,
+		"",
+	];
+	for (const item of result.items) {
+		const id = item.id ? ` (id: ${item.id})` : "";
+		const source = item.source ? ` [${item.source}]` : "";
+		const timestamp = item.timestamp ? ` (${item.timestamp.slice(0, 10)})` : "";
+		const score = typeof item.score === "number" ? ` score=${item.score.toFixed(3)}` : "";
+		lines.push(`- ${sanitizeMemorySearchContent(item.content)}${id}${source}${timestamp}${score}`);
+	}
+	return lines.join("\n");
+}
+
+function renderMemorySaveMarkdown(result: MemoryBackendSaveResult): string {
+	if (result.stored <= 0) return result.message ?? "No memory stored.";
+	const queued = result.queued ? " queued" : " stored";
+	const ids = result.ids?.length ? ` (${result.ids.join(", ")})` : "";
+	return `${result.stored} ${result.stored === 1 ? "memory" : "memories"}${queued}${ids}.${result.message ? ` ${result.message}` : ""}`;
 }
 
 export class CommandController {
@@ -498,15 +564,16 @@ export class CommandController {
 	}
 
 	async handleMemoryCommand(text: string): Promise<void> {
-		const argumentText = text.slice(7).trim();
-		const action = argumentText.split(/\s+/, 1)[0]?.toLowerCase() || "view";
+		const memoryText = text.slice(7);
+		const { action, argument } = parseMemoryAction(memoryText);
 		const agentDir = this.ctx.settings.getAgentDir();
 		const backend = await resolveMemoryBackend(this.ctx.settings);
+		const memoryContext = { agentDir, cwd: this.ctx.sessionManager.getCwd(), session: this.ctx.session };
 
 		if (action === "view") {
 			const payload = await backend.buildDeveloperInstructions(agentDir, this.ctx.settings, this.ctx.session);
 			if (!payload) {
-				this.ctx.showWarning("Memory payload is empty (memory backend off, disabled, or no memory available).");
+				this.ctx.showWarning("Memory payload is empty.");
 				return;
 			}
 			const block = new TranscriptBlock();
@@ -519,11 +586,65 @@ export class CommandController {
 			return;
 		}
 
+		if (action === "status") {
+			try {
+				const status = await backend.status?.(memoryContext);
+				if (!status) {
+					this.ctx.showWarning(`Memory status is not available for the ${backend.id} backend.`);
+					return;
+				}
+				showMarkdownPanel(this.ctx, "Memory Status", renderMemoryStatusMarkdown(status));
+			} catch (error) {
+				this.ctx.showError(`Memory status failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+			return;
+		}
+
+		if (action === "search") {
+			if (!argument) {
+				this.ctx.showError("Usage: /memory search <query>");
+				return;
+			}
+			try {
+				const result = await backend.search?.(memoryContext, argument, { limit: 10 });
+				if (!result) {
+					this.ctx.showWarning(`Memory search is not available for the ${backend.id} backend.`);
+					return;
+				}
+				showMarkdownPanel(this.ctx, "Memory Search", renderMemorySearchMarkdown(result));
+			} catch (error) {
+				this.ctx.showError(`Memory search failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+			return;
+		}
+
+		if (action === "save") {
+			if (!argument) {
+				this.ctx.showError("Usage: /memory save <memory text>");
+				return;
+			}
+			try {
+				const result = await backend.save?.(memoryContext, {
+					content: argument,
+					source: "slash-memory-save",
+					context: "/memory save",
+				});
+				if (!result) {
+					this.ctx.showWarning(`Memory save is not available for the ${backend.id} backend.`);
+					return;
+				}
+				this.ctx.showStatus(renderMemorySaveMarkdown(result));
+			} catch (error) {
+				this.ctx.showError(`Memory save failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+			return;
+		}
+
 		if (action === "reset" || action === "clear") {
 			try {
 				await backend.clear(agentDir, this.ctx.sessionManager.getCwd(), this.ctx.session);
 				await this.ctx.session.refreshBaseSystemPrompt();
-				this.ctx.showStatus("Memory data cleared and system prompt refreshed.");
+				this.ctx.showStatus("Memory cleared.");
 			} catch (error) {
 				this.ctx.showError(`Memory clear failed: ${error instanceof Error ? error.message : String(error)}`);
 			}
@@ -556,11 +677,11 @@ export class CommandController {
 		}
 
 		if (action === "mm") {
-			await this.#handleMentalModelsSubcommand(argumentText);
+			await this.#handleMentalModelsSubcommand(memoryText.trim());
 			return;
 		}
 
-		this.ctx.showError("Usage: /memory <view|stats|diagnose|clear|reset|enqueue|rebuild|mm ...>");
+		this.ctx.showError("Usage: /memory <view|status|search|save|stats|diagnose|clear|reset|enqueue|rebuild|mm ...>");
 	}
 
 	async #handleMentalModelsSubcommand(argumentText: string): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../extensibility/extensions";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
 import { createExtensionModelQuery } from "../../extensibility/extensions/model-api";
+import { createSessionMemoryRuntimeContext } from "../../memory-backend/runtime";
 import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
 import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/components/hook-selector";
@@ -122,6 +123,11 @@ export class ExtensionUiController {
 			setSessionName: name => this.#updateSessionName(name),
 		};
 		const contextActions: ExtensionContextActions = {
+			memory: createSessionMemoryRuntimeContext(
+				this.ctx.session,
+				this.ctx.settings.getAgentDir(),
+				this.ctx.sessionManager.getCwd(),
+			),
 			getModel: () => this.ctx.session.model,
 			isIdle: () => !this.ctx.session.isStreaming,
 			abort: () => this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL }),
@@ -358,6 +364,11 @@ export class ExtensionUiController {
 			setSessionName: name => this.#updateSessionName(name),
 		};
 		const contextActions: ExtensionContextActions = {
+			memory: createSessionMemoryRuntimeContext(
+				this.ctx.session,
+				this.ctx.settings.getAgentDir(),
+				this.ctx.sessionManager.getCwd(),
+			),
 			getModel: () => this.ctx.session.model,
 			isIdle: () => !this.ctx.session.isStreaming,
 			abort: () => this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL }),
@@ -486,6 +497,11 @@ export class ExtensionUiController {
 				try {
 					await registeredTool.definition.onSession(event, {
 						ui: uiContext,
+						memory: createSessionMemoryRuntimeContext(
+							this.ctx.session,
+							this.ctx.settings.getAgentDir(),
+							this.ctx.sessionManager.getCwd(),
+						),
 						getContextUsage: () => this.ctx.session.getContextUsage(),
 						compact: instructionsOrOptions => this.#compactSession(instructionsOrOptions),
 						hasUI: true,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1988,7 +1988,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			cwd,
 			sessionManager,
 			modelRegistry,
-			() => (hasSession ? createSessionMemoryRuntimeContext(session, agentDir, cwd) : undefined),
+			() =>
+				hasSession
+					? createSessionMemoryRuntimeContext(session, agentDir, () => sessionManager.getCwd())
+					: undefined,
 			settings,
 		);
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -184,6 +184,7 @@ import type {
 	TurnStartEvent,
 } from "../extensibility/extensions";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
+import { noOpMemoryContext } from "../extensibility/extensions/runner";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import type { HookCommandContext } from "../extensibility/hooks/types";
@@ -5435,6 +5436,7 @@ export class AgentSession {
 		return {
 			ui: noOpUIContext,
 			hasUI: false,
+			memory: noOpMemoryContext,
 			cwd: this.sessionManager.getCwd(),
 			sessionManager: this.sessionManager,
 			modelRegistry: this.#modelRegistry,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -23,11 +23,17 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
-import { resolveMemoryBackend } from "../memory-backend";
+import {
+	type MemoryBackendSaveResult,
+	type MemoryBackendSearchResult,
+	type MemoryBackendStatus,
+	resolveMemoryBackend,
+} from "../memory-backend";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { replaceTabs, truncateToWidth } from "../tools/render-utils";
 import { urlHyperlinkAlways } from "../tui";
 import { getChangelogPath, parseChangelog } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
@@ -1400,6 +1406,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		acpInputHint: "<subcommand>",
 		subcommands: [
 			{ name: "view", description: "Show current memory injection payload" },
+			{ name: "status", description: "Show structured memory backend status" },
+			{ name: "search", description: "Search memory explicitly" },
+			{ name: "save", description: "Save a memory from command text" },
 			{ name: "stats", description: "Show memory backend statistics" },
 			{ name: "diagnose", description: "Run memory backend diagnostics" },
 			{ name: "clear", description: "Clear persisted memory data and artifacts" },
@@ -1419,9 +1428,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		],
 		allowArgs: true,
 		handle: async (command, runtime) => {
-			const verb = (command.args.trim().split(/\s+/)[0] ?? "").toLowerCase() || "view";
+			const { action, argument } = parseMemoryAction(command.args);
 			const backend = await resolveMemoryBackend(runtime.settings);
-			switch (verb) {
+			const context = { agentDir: runtime.settings.getAgentDir(), cwd: runtime.cwd, session: runtime.session };
+			switch (action) {
 				case "view": {
 					const payload = await backend.buildDeveloperInstructions(
 						runtime.settings.getAgentDir(),
@@ -1429,6 +1439,39 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime.session,
 					);
 					await runtime.output(payload || "Memory payload is empty.");
+					return commandConsumed();
+				}
+				case "status": {
+					const status = await backend.status?.(context);
+					await runtime.output(
+						status
+							? renderMemoryStatusMarkdown(status)
+							: `Memory status is not available for the ${backend.id} backend.`,
+					);
+					return commandConsumed();
+				}
+				case "search": {
+					if (!argument) return usage("Usage: /memory search <query>", runtime);
+					const result = await backend.search?.(context, argument, { limit: 10 });
+					await runtime.output(
+						result
+							? renderMemorySearchMarkdown(result)
+							: `Memory search is not available for the ${backend.id} backend.`,
+					);
+					return commandConsumed();
+				}
+				case "save": {
+					if (!argument) return usage("Usage: /memory save <memory text>", runtime);
+					const result = await backend.save?.(context, {
+						content: argument,
+						source: "slash-memory-save",
+						context: `/${command.name} save`,
+					});
+					await runtime.output(
+						result
+							? renderMemorySaveMarkdown(result)
+							: `Memory save is not available for the ${backend.id} backend.`,
+					);
 					return commandConsumed();
 				}
 				case "clear":
@@ -1446,9 +1489,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				}
 				case "stats":
 				case "diagnose": {
-					const hook = verb === "stats" ? backend.stats : backend.diagnose;
+					const hook = action === "stats" ? backend.stats : backend.diagnose;
 					const payload = await hook?.(runtime.settings.getAgentDir(), runtime.cwd, runtime.session);
-					await runtime.output(payload ?? `Memory ${verb} is not available for the ${backend.id} backend.`);
+					await runtime.output(payload ?? `Memory ${action} is not available for the ${backend.id} backend.`);
 					return commandConsumed();
 				}
 				case "mm":
@@ -1457,7 +1500,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime,
 					);
 				default:
-					return usage("Usage: /memory <view|stats|diagnose|clear|reset|enqueue|rebuild>", runtime);
+					return usage(
+						"Usage: /memory <view|status|search|save|stats|diagnose|clear|reset|enqueue|rebuild>",
+						runtime,
+					);
 			}
 		},
 		handleTui: async (command, runtime) => {
@@ -2299,6 +2345,67 @@ export async function executeBuiltinSlashCommand(
 		return true;
 	}
 	return false;
+}
+
+function parseMemoryAction(input: string): { action: string; argument: string } {
+	const trimmed = input.trimStart();
+	if (!trimmed) return { action: "view", argument: "" };
+	const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(trimmed);
+	if (!match) return { action: "view", argument: "" };
+	return { action: match[1]?.toLowerCase() ?? "view", argument: match[2] ?? "" };
+}
+
+function sanitizeMemorySearchContent(content: string): string {
+	return truncateToWidth(replaceTabs(content.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")), 160);
+}
+
+function renderMemoryStatusMarkdown(status: MemoryBackendStatus): string {
+	const lines = [
+		"# Memory Status",
+		"",
+		`- Backend: ${status.backend}`,
+		`- Active: ${status.active ? "yes" : "no"}`,
+		`- Searchable: ${status.searchable ? "yes" : "no"}`,
+		`- Writable: ${status.writable ? "yes" : "no"}`,
+	];
+	if (status.scope) lines.push(`- Scope: ${status.scope}`);
+	if (status.retainBank) lines.push(`- Retain bank: ${status.retainBank}`);
+	if (status.recallBanks?.length) lines.push(`- Recall banks: ${status.recallBanks.join(", ")}`);
+	if (status.workingCount !== undefined) lines.push(`- Working memories: ${status.workingCount}`);
+	if (status.episodicCount !== undefined) lines.push(`- Episodic memories: ${status.episodicCount}`);
+	if (status.tripleCount !== undefined) lines.push(`- Triples: ${status.tripleCount}`);
+	if (status.lastMemory) lines.push(`- Last memory: ${sanitizeMemorySearchContent(status.lastMemory)}`);
+	if (status.lastRecall !== undefined) lines.push(`- Last recall injected: ${status.lastRecall ? "yes" : "no"}`);
+	if (status.database) lines.push(`- Database: ${status.database}`);
+	if (status.message) lines.push("", status.message);
+	if (status.error) lines.push("", `Error: ${status.error}`);
+	return lines.join("\n");
+}
+
+function renderMemorySearchMarkdown(result: MemoryBackendSearchResult): string {
+	if (result.message) return result.message;
+	if (result.items.length === 0) return `No memories found for: ${result.query}`;
+	const lines = [
+		`# Memory Search`,
+		"",
+		`Found ${result.count} ${result.count === 1 ? "memory" : "memories"} for: ${result.query}`,
+		"",
+	];
+	for (const item of result.items) {
+		const id = item.id ? ` (id: ${item.id})` : "";
+		const source = item.source ? ` [${item.source}]` : "";
+		const timestamp = item.timestamp ? ` (${item.timestamp.slice(0, 10)})` : "";
+		const score = typeof item.score === "number" ? ` score=${item.score.toFixed(3)}` : "";
+		lines.push(`- ${sanitizeMemorySearchContent(item.content)}${id}${source}${timestamp}${score}`);
+	}
+	return lines.join("\n");
+}
+
+function renderMemorySaveMarkdown(result: MemoryBackendSaveResult): string {
+	if (result.stored <= 0) return result.message ?? "No memory stored.";
+	const queued = result.queued ? " queued" : " stored";
+	const ids = result.ids?.length ? ` (${result.ids.join(", ")})` : "";
+	return `${result.stored} ${result.stored === 1 ? "memory" : "memories"}${queued}${ids}.${result.message ? ` ${result.message}` : ""}`;
 }
 
 /** Look up a unified spec by name or alias. Used by the ACP dispatcher. */

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -24,6 +24,7 @@ import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { callTool } from "../mcp/client";
 import type { MCPManager } from "../mcp/manager";
+import { createSessionMemoryRuntimeContext } from "../memory-backend/runtime";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
@@ -2046,6 +2047,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						},
 					},
 					{
+						memory: createSessionMemoryRuntimeContext(
+							session,
+							session.settings.getAgentDir(),
+							session.sessionManager.getCwd(),
+						),
 						getModel: () => session.model,
 						isIdle: () => !session.isStreaming,
 						abort: () => session.abort({ reason: USER_INTERRUPT_LABEL }),

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -574,6 +574,13 @@ describe("wave 3 commands", () => {
 	});
 
 	// /memory
+	it("/memory with no args defaults to view", async () => {
+		const { output, runtime } = createRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/memory", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toBe("Memory payload is empty.");
+	});
+
 	it("/memory unknown: returns usage message", async () => {
 		const { output, runtime } = createRuntime();
 		const result = await executeAcpBuiltinSlashCommand("/memory unknownverb", runtime);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -843,6 +843,85 @@ describe("ExtensionRunner", () => {
 			});
 			delete globalState.__ompMemoryStatus;
 		});
+
+		it("falls back to a no-op memory runtime when no memory source is wired", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.on("session_start", async (_event, ctx) => {
+						globalThis.__ompMemoryFallback = {
+							status: await ctx.memory.status(),
+							search: await ctx.memory.search("test"),
+							save: await ctx.memory.save("hello"),
+						};
+					});
+				}
+			`;
+			const explicitExtensionPath = path.join(tempDir.path(), "memory-fallback.ts");
+			fs.writeFileSync(explicitExtensionPath, extCode);
+			const globalState = globalThis as typeof globalThis & { __ompMemoryFallback?: unknown };
+			delete globalState.__ompMemoryFallback;
+
+			const result = await loadTestExtensions([explicitExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.initialize(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					appendEntry: () => {},
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: async () => {},
+					getCommands: () => [],
+					setModel: async () => false,
+					getThinkingLevel: () => undefined,
+					setThinkingLevel: () => {},
+					getSessionName: () => undefined,
+					setSessionName: async () => {},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: async () => {},
+					getSystemPrompt: () => [],
+				},
+			);
+
+			await runner.emit({ type: "session_start" });
+
+			expect(globalState.__ompMemoryFallback).toEqual({
+				status: {
+					backend: "off",
+					active: false,
+					writable: false,
+					searchable: false,
+					message: "No active memory context.",
+				},
+				search: {
+					backend: "off",
+					query: "test",
+					count: 0,
+					items: [],
+					message: "No active memory context.",
+				},
+				save: {
+					backend: "off",
+					stored: 0,
+					message: "No active memory context.",
+				},
+			});
+			delete globalState.__ompMemoryFallback;
+		});
 	});
 
 	describe("session name API", () => {

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -911,3 +911,124 @@ describe("hindsightBackend retain queue flush on session teardown", () => {
 		expect(retainBatchSpy).not.toHaveBeenCalled();
 	});
 });
+
+describe("hindsightBackend status/search/save", () => {
+	beforeEach(() => {
+		resetSettingsForTest();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("status reports inactive when the session has no Hindsight state", async () => {
+		const session = makeFakeSession({ sessionId: "s-status-uninit" });
+		const result = await hindsightBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
+		expect(result).toEqual({
+			backend: "hindsight",
+			active: false,
+			writable: false,
+			searchable: false,
+			message: "Hindsight backend is configured but not initialised for this session.",
+		});
+	});
+
+	it("status reflects the active bank after start", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+		const session = makeFakeSession({ sessionId: "s-status-active", settings });
+
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const result = await hindsightBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
+		expect(result).toMatchObject({
+			backend: "hindsight",
+			active: true,
+			writable: true,
+			searchable: true,
+			scope: settings.get("hindsight.scoping"),
+			retainBank: expect.any(String),
+			recallBanks: [expect.any(String)],
+		});
+	});
+
+	it("save queues content and reports it as queued", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+		const session = makeFakeSession({ sessionId: "s-save", settings });
+
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const result = await hindsightBackend.save!(
+			{ agentDir: "/tmp", cwd: "/tmp", session: session as never },
+			{ content: "user prefers dark mode", context: "preferences" },
+		);
+		expect(result).toEqual({
+			backend: "hindsight",
+			stored: 1,
+			queued: true,
+			message: "Memory queued for Hindsight retention.",
+		});
+	});
+
+	it("search maps recall results without inventing extra fields", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+		vi.spyOn(HindsightApi.prototype, "recall").mockResolvedValue({
+			results: [
+				{
+					id: "m1",
+					text: "user prefers dark mode",
+					type: "fact",
+					mentioned_at: "2026-01-15T00:00:00Z",
+				},
+			],
+		} as never);
+		const session = makeFakeSession({ sessionId: "s-search", settings });
+
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const result = await hindsightBackend.search!(
+			{ agentDir: "/tmp", cwd: "/tmp", session: session as never },
+			"dark mode",
+		);
+		expect(result).toMatchObject({
+			backend: "hindsight",
+			query: "dark mode",
+			count: 1,
+		});
+		expect(result.items[0]).toEqual({
+			id: "m1",
+			content: "user prefers dark mode",
+			source: "fact",
+			timestamp: "2026-01-15T00:00:00Z",
+		});
+	});
+});

--- a/packages/coding-agent/test/memory-backend-resolve.test.ts
+++ b/packages/coding-agent/test/memory-backend-resolve.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createMemoryRuntimeContext, resolveMemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend";
+import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
+import {
+	createMemoryRuntimeContext,
+	createSessionMemoryRuntimeContext,
+	resolveMemoryBackend,
+} from "@oh-my-pi/pi-coding-agent/memory-backend";
 
 describe("resolveMemoryBackend", () => {
 	beforeEach(() => {
@@ -47,5 +55,27 @@ describe("resolveMemoryBackend", () => {
 			backend: "local",
 			count: 0,
 		});
+	});
+
+	it("recomputes session cwd for each runtime memory operation", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-memory-runtime-"));
+		let cwd = "/tmp/project-a";
+		const memory = createSessionMemoryRuntimeContext({ settings } as never, agentDir, () => cwd);
+
+		try {
+			await memory.save("first lesson");
+			cwd = "/tmp/project-b";
+			await memory.save("second lesson");
+
+			const first = await Bun.file(path.join(getMemoryRoot(agentDir, "/tmp/project-a"), "learned.md")).text();
+			const second = await Bun.file(path.join(getMemoryRoot(agentDir, "/tmp/project-b"), "learned.md")).text();
+			expect(first).toContain("first lesson");
+			expect(first).not.toContain("second lesson");
+			expect(second).toContain("second lesson");
+			expect(second).not.toContain("first lesson");
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/repro-issue-1020-ctx-shutdown.test.ts
+++ b/packages/coding-agent/test/repro-issue-1020-ctx-shutdown.test.ts
@@ -38,6 +38,8 @@ describe("issue #1020 - ctx.shutdown() in interactive mode", () => {
 				// other session fields are only touched lazily by other actions; we
 				// only invoke `shutdown`, so leave them out.
 			},
+			settings: { getAgentDir: () => "/tmp" },
+			sessionManager: { getCwd: () => "/tmp" },
 		} as unknown as InteractiveModeContext;
 
 		const controller = new ExtensionUiController(ctxStub);
@@ -82,6 +84,8 @@ describe("issue #1020 - ctx.shutdown() in interactive mode", () => {
 			setEditorComponent: () => {},
 			toolOutputExpanded: false,
 			setToolsExpanded: () => {},
+			settings: { getAgentDir: () => "/tmp" },
+			sessionManager: { getCwd: () => "/tmp" },
 		} as unknown as InteractiveModeContext;
 
 		const controller = new ExtensionUiController(ctxStub);

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -49,6 +49,8 @@ function createMockSession(
 		for (const listener of listeners) listener(event);
 	};
 
+	const settings = Settings.isolated();
+
 	const session = {
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
@@ -56,7 +58,10 @@ function createMockSession(
 		extensionRunner: undefined,
 		sessionManager: {
 			appendSessionInit: () => {},
+			getCwd: () => "/tmp/project",
+			getSessionName: () => undefined,
 		},
+		settings,
 		getActiveToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {


### PR DESCRIPTION
## Summary
- add `/memory status`, `/memory search <query>`, and `/memory save <text>` to expose the structured memory runtime from slash commands
- wire `ctx.memory` into extension contexts across interactive, ACP, task, and UI runner paths
- add Hindsight backend `status`, `search`, and `save` support, with no-op fallback memory context for contexts without an active session

## Scope
- intentionally excludes `/memory parse`, `/memory list`, delete/update APIs, and schema migrations

## Testing
- `bun --cwd=packages/coding-agent test test/extensions-runner.test.ts test/hindsight-backend.test.ts test/repro-issue-2600-shutdown-timeout.test.ts test/repro-issue-1020-ctx-shutdown.test.ts test/sdk-credential-disabled-bridge.test.ts test/acp-builtins.test.ts test/modes/controllers/tan-command-controller.test.ts`
- `bun run --cwd packages/coding-agent check`