### PR TITLE
fix(providers): handle Umans Kimi output caps and web search

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `UMANS_WEBSEARCH_PROVIDER=native|exa` support for routing Umans gateway-owned web search requests.
+
+### Fixed
+
+- Fixed Anthropic-compatible Umans requests escaping client `web_search` tools so Kimi answers normally instead of returning raw gateway search results.
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Anthropic-compatible Umans requests escaping client tool names so Kimi answers normally instead of returning raw gateway search results.
+- Fixed Anthropic-compatible Umans requests escaping client tool names and forwarding gateway web search headers so Kimi answers normally instead of returning raw gateway search results.
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Anthropic-compatible Umans requests escaping client `web_search` tools so Kimi answers normally instead of returning raw gateway search results.
+- Fixed Anthropic-compatible Umans requests escaping client tool names so Kimi answers normally instead of returning raw gateway search results.
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/ai/src/providers/anthropic-client.ts
+++ b/packages/ai/src/providers/anthropic-client.ts
@@ -39,6 +39,8 @@ export interface AnthropicRequestOptions {
 	timeout?: number;
 	/** Per-request retry budget override. */
 	maxRetries?: number;
+	/** Per-request headers merged after client defaults. */
+	headers?: Record<string, string>;
 }
 
 /**
@@ -217,7 +219,7 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 		return new AnthropicApiRequest(() => this.#send(path, params, options));
 	}
 
-	#buildHeaders(): Record<string, string> {
+	#buildHeaders(requestHeaders?: Record<string, string>): Record<string, string> {
 		const opts = this.#options;
 		const defaults = opts.defaultHeaders ?? {};
 		const headers: Record<string, string> = {};
@@ -228,6 +230,7 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 			headers.Authorization = `Bearer ${opts.authToken}`;
 		}
 		Object.assign(headers, defaults);
+		Object.assign(headers, requestHeaders);
 		return headers;
 	}
 
@@ -242,7 +245,7 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 		const timeoutMs = options?.timeout ?? opts.timeout ?? DEFAULT_TIMEOUT_MS;
 		const maxRetries = Math.max(0, options?.maxRetries ?? opts.maxRetries ?? DEFAULT_MAX_RETRIES);
 		const url = `${opts.baseURL ?? "https://api.anthropic.com"}${path}`;
-		const headers = this.#buildHeaders();
+		const headers = this.#buildHeaders(options?.headers);
 		const body = JSON.stringify(params);
 
 		for (let attempt = 0; ; attempt++) {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -704,6 +704,8 @@ export function resolveAnthropicMetadataUserId(
 	return generateClaudeJsonUserId(sessionId, accountId);
 }
 const ANTHROPIC_BUILTIN_TOOL_NAMES = new Set(["web_search", "code_execution", "text_editor", "computer"]);
+const UMANS_WEBSEARCH_PROVIDER_HEADER = "X-Umans-Websearch-Provider";
+const UMANS_WEBSEARCH_TOOL_NAME = "web_search";
 export const applyClaudeToolPrefix = (name: string): string => {
 	if (!claudeToolPrefix) return name;
 	if (ANTHROPIC_BUILTIN_TOOL_NAMES.has(name.toLowerCase())) return name;
@@ -720,6 +722,73 @@ export const stripClaudeToolPrefix = (name: string): string => {
 	if (!name.toLowerCase().startsWith(claudeToolPrefix.toLowerCase())) return name;
 	return name.slice(claudeToolPrefix.length);
 };
+
+function normalizeUmansWebSearchProvider(value: string | undefined): "native" | "exa" | undefined {
+	const normalized = value?.trim().toLowerCase();
+	return normalized === "native" || normalized === "exa" ? normalized : undefined;
+}
+
+function getUmansWebSearchProvider(headers: Record<string, string> | undefined): "native" | "exa" | undefined {
+	const explicit = getHeaderCaseInsensitive(headers, UMANS_WEBSEARCH_PROVIDER_HEADER);
+	if (explicit !== undefined) return normalizeUmansWebSearchProvider(explicit);
+	return normalizeUmansWebSearchProvider($env.UMANS_WEBSEARCH_PROVIDER);
+}
+
+function isUmansAnthropicModel(model: Model<"anthropic-messages">): boolean {
+	return model.provider === "umans" || model.baseUrl.toLowerCase().includes("api.code.umans.ai");
+}
+
+function getUmansWebSearchHeader(
+	model: Model<"anthropic-messages">,
+	headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!isUmansAnthropicModel(model)) return undefined;
+	const provider = getUmansWebSearchProvider(headers);
+	return provider ? { [UMANS_WEBSEARCH_PROVIDER_HEADER]: provider } : undefined;
+}
+
+function shouldUseUmansGatewayWebSearch(name: string, enabled: boolean): boolean {
+	return enabled && name.toLowerCase() === UMANS_WEBSEARCH_TOOL_NAME;
+}
+
+function isUmansGatewayWebSearchEnabled(
+	model: Model<"anthropic-messages">,
+	headers: Record<string, string> | undefined,
+): boolean {
+	return isUmansAnthropicModel(model) && getUmansWebSearchProvider(headers) !== undefined;
+}
+
+function shouldEscapeAnthropicBuiltinToolName(
+	name: string,
+	escapeBuiltinToolNames: boolean,
+	useUmansGatewayWebSearch: boolean,
+): boolean {
+	return (
+		escapeBuiltinToolNames &&
+		ANTHROPIC_BUILTIN_TOOL_NAMES.has(name.toLowerCase()) &&
+		!shouldUseUmansGatewayWebSearch(name, useUmansGatewayWebSearch)
+	);
+}
+
+function encodeAnthropicToolName(
+	name: string,
+	isOAuthToken: boolean,
+	escapeBuiltinToolNames: boolean,
+	useUmansGatewayWebSearch = false,
+): string {
+	if (shouldUseUmansGatewayWebSearch(name, useUmansGatewayWebSearch)) return name;
+	if (shouldEscapeAnthropicBuiltinToolName(name, escapeBuiltinToolNames, useUmansGatewayWebSearch)) {
+		return `${claudeToolPrefix}${name}`;
+	}
+	return isOAuthToken ? applyClaudeToolPrefix(name) : name;
+}
+
+function decodeAnthropicToolName(name: string, isOAuthToken: boolean, escapeBuiltinToolNames: boolean): string {
+	if (isOAuthToken) return stripClaudeToolPrefix(name);
+	if (!escapeBuiltinToolNames) return name;
+	const stripped = stripClaudeToolPrefix(name);
+	return ANTHROPIC_BUILTIN_TOOL_NAMES.has(stripped.toLowerCase()) ? stripped : name;
+}
 
 const ANTHROPIC_MANY_IMAGE_THRESHOLD = 20;
 const ANTHROPIC_MANY_IMAGE_MAX_DIMENSION = 2000;
@@ -1900,9 +1969,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 								const block: Block = {
 									type: "toolCall",
 									id: event.content_block.id,
-									name: isOAuthToken
-										? stripClaudeToolPrefix(event.content_block.name)
-										: event.content_block.name,
+									name: decodeAnthropicToolName(
+										event.content_block.name,
+										isOAuthToken,
+										model.compat.escapeBuiltinToolNames,
+									),
 									arguments: event.content_block.input ?? {},
 									partialJson: "",
 									index: event.index,
@@ -2377,7 +2448,13 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		isOAuth: oauthToken,
 		extraBetas: betaFeatures,
 		stream,
-		modelHeaders: mergeHeaders(model.headers, foundryCustomHeaders, headers, dynamicHeaders),
+		modelHeaders: mergeHeaders(
+			model.headers,
+			foundryCustomHeaders,
+			getUmansWebSearchHeader(model, mergeHeaders(model.headers, headers)),
+			headers,
+			dynamicHeaders,
+		),
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
 		claudeCodeSessionId,
 		claudeCodeBetas: oauthToken
@@ -2758,6 +2835,10 @@ function buildParams(
 	});
 
 	// Pre-compute tools.
+	const useUmansGatewayWebSearch = isUmansGatewayWebSearchEnabled(
+		model,
+		mergeHeaders(model.headers, options?.headers),
+	);
 	let tools: AnthropicWireTool[] | undefined;
 	if (context.tools) {
 		tools = convertTools(
@@ -2765,6 +2846,8 @@ function buildParams(
 			isOAuthToken,
 			disableStrictTools || model.provider === "github-copilot",
 			model.compat.supportsEagerToolInputStreaming,
+			model.compat.escapeBuiltinToolNames,
+			useUmansGatewayWebSearch,
 		);
 	} else if (isOAuthToken) {
 		tools = [];
@@ -2890,10 +2973,16 @@ function buildParams(
 	if (options?.toolChoice) {
 		if (typeof options.toolChoice === "string") {
 			params.tool_choice = { type: options.toolChoice };
-		} else if (isOAuthToken && options.toolChoice.name) {
-			params.tool_choice = { ...options.toolChoice, name: applyClaudeToolPrefix(options.toolChoice.name) };
-		} else {
-			params.tool_choice = options.toolChoice;
+		} else if (options.toolChoice.name) {
+			params.tool_choice = {
+				...options.toolChoice,
+				name: encodeAnthropicToolName(
+					options.toolChoice.name,
+					isOAuthToken,
+					model.compat.escapeBuiltinToolNames,
+					useUmansGatewayWebSearch,
+				),
+			};
 		}
 		// Claude Fable/Mythos 5 reject forced tool use outright ("tool_choice forces
 		// tool use is not compatible with this model"). Downgrade any/tool → auto so the
@@ -3098,7 +3187,7 @@ export function convertAnthropicMessages(
 					blocks.push({
 						type: "tool_use",
 						id: block.id,
-						name: isOAuthToken ? applyClaudeToolPrefix(block.name) : block.name,
+						name: encodeAnthropicToolName(block.name, isOAuthToken, model.compat.escapeBuiltinToolNames),
 						// Always sanitize: the model itself can emit lone-surrogate escapes
 						// in tool-argument JSON (streamed out fine, rejected with a 400 on
 						// replay by Anthropic's strict UTF-8 validation). toWellFormedDeep
@@ -3684,6 +3773,8 @@ function convertTools(
 	isOAuthToken: boolean,
 	disableStrictTools = false,
 	supportsEagerToolInputStreaming = true,
+	escapeBuiltinToolNames = false,
+	useUmansGatewayWebSearch = false,
 ): AnthropicWireTool[] {
 	if (!tools) return [];
 	const schemaPlans = buildAnthropicToolSchemaPlans(tools, disableStrictTools);
@@ -3691,7 +3782,7 @@ function convertTools(
 	return tools.map((tool, index) => {
 		const plan = schemaPlans[index];
 		const baseTool = {
-			name: isOAuthToken ? applyClaudeToolPrefix(tool.name) : tool.name,
+			name: encodeAnthropicToolName(tool.name, isOAuthToken, escapeBuiltinToolNames, useUmansGatewayWebSearch),
 			description: tool.description || "",
 			input_schema: plan.inputSchema,
 		};

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -751,13 +751,6 @@ function shouldUseUmansGatewayWebSearch(name: string, enabled: boolean): boolean
 	return enabled && name.toLowerCase() === UMANS_WEBSEARCH_TOOL_NAME;
 }
 
-function isUmansGatewayWebSearchEnabled(
-	model: Model<"anthropic-messages">,
-	headers: Record<string, string> | undefined,
-): boolean {
-	return isUmansAnthropicModel(model) && getUmansWebSearchProvider(headers) !== undefined;
-}
-
 function encodeAnthropicToolName(
 	name: string,
 	isOAuthToken: boolean,
@@ -1631,6 +1624,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			let disableStrictTools =
 				(providerSessionState?.strictToolsDisabled ?? false) || (model.compat?.disableStrictTools ?? false);
 			let dropFastMode = providerSessionState?.fastModeDisabled ?? false;
+			const mergedCallerHeaders = mergeHeaders(model.headers, options?.headers);
+			const umansGatewayWebSearchHeader = getUmansWebSearchHeader(model, mergedCallerHeaders);
 
 			let client: AnthropicMessagesClientLike;
 			let isOAuthToken: boolean;
@@ -1692,7 +1687,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			}
 			const preparedContext = await prepareAnthropicManyImageContext(context, model.input.includes("image"));
 			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
-				let nextParams = buildParams(model, preparedContext, isOAuthToken, options, disableStrictTools);
+				let nextParams = buildParams(
+					model,
+					preparedContext,
+					isOAuthToken,
+					options,
+					disableStrictTools,
+					umansGatewayWebSearchHeader !== undefined,
+				);
 				if (disableStrictTools) {
 					dropAnthropicStrictTools(nextParams);
 				}
@@ -1770,7 +1772,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				// to zero even when no watchdog timeout is configured (the helper only
 				// pins it alongside a timeout; a client retry budget of 5 would otherwise
 				// multiply with PROVIDER_MAX_RETRIES into up to 66 wire attempts).
-				const requestOptions = { ...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs), maxRetries: 0 };
+				const requestOptions = {
+					...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs),
+					maxRetries: 0,
+					...(umansGatewayWebSearchHeader ? { headers: umansGatewayWebSearchHeader } : {}),
+				};
 				const anthropicRequest: unknown =
 					isOAuthToken && client.beta
 						? client.beta.messages.create({ ...params, stream: true }, requestOptions)
@@ -2805,6 +2811,7 @@ function buildParams(
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
 	disableStrictTools = false,
+	useUmansGatewayWebSearch = false,
 ): MessageCreateParamsStreaming {
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention, isOAuthToken);
 
@@ -2819,10 +2826,6 @@ function buildParams(
 	});
 
 	// Pre-compute tools.
-	const useUmansGatewayWebSearch = isUmansGatewayWebSearchEnabled(
-		model,
-		mergeHeaders(model.headers, options?.headers),
-	);
 	let tools: AnthropicWireTool[] | undefined;
 	if (context.tools) {
 		tools = convertTools(

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -758,18 +758,6 @@ function isUmansGatewayWebSearchEnabled(
 	return isUmansAnthropicModel(model) && getUmansWebSearchProvider(headers) !== undefined;
 }
 
-function shouldEscapeAnthropicBuiltinToolName(
-	name: string,
-	escapeBuiltinToolNames: boolean,
-	useUmansGatewayWebSearch: boolean,
-): boolean {
-	return (
-		escapeBuiltinToolNames &&
-		ANTHROPIC_BUILTIN_TOOL_NAMES.has(name.toLowerCase()) &&
-		!shouldUseUmansGatewayWebSearch(name, useUmansGatewayWebSearch)
-	);
-}
-
 function encodeAnthropicToolName(
 	name: string,
 	isOAuthToken: boolean,
@@ -777,17 +765,13 @@ function encodeAnthropicToolName(
 	useUmansGatewayWebSearch = false,
 ): string {
 	if (shouldUseUmansGatewayWebSearch(name, useUmansGatewayWebSearch)) return name;
-	if (shouldEscapeAnthropicBuiltinToolName(name, escapeBuiltinToolNames, useUmansGatewayWebSearch)) {
-		return `${claudeToolPrefix}${name}`;
-	}
+	if (escapeBuiltinToolNames) return `${claudeToolPrefix}${name}`;
 	return isOAuthToken ? applyClaudeToolPrefix(name) : name;
 }
 
 function decodeAnthropicToolName(name: string, isOAuthToken: boolean, escapeBuiltinToolNames: boolean): string {
-	if (isOAuthToken) return stripClaudeToolPrefix(name);
-	if (!escapeBuiltinToolNames) return name;
-	const stripped = stripClaudeToolPrefix(name);
-	return ANTHROPIC_BUILTIN_TOOL_NAMES.has(stripped.toLowerCase()) ? stripped : name;
+	if (isOAuthToken || escapeBuiltinToolNames) return stripClaudeToolPrefix(name);
+	return name;
 }
 
 const ANTHROPIC_MANY_IMAGE_THRESHOLD = 20;

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -58,6 +58,15 @@ const CLOUDFLARE_ANTHROPIC_MODEL: Model<"anthropic-messages"> = buildModel({
 	baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic",
 });
 
+const UMANS_ANTHROPIC_MODEL: Model<"anthropic-messages"> = buildModel({
+	...ANTHROPIC_MODEL_SPEC,
+	id: "umans-kimi-k2.7",
+	name: "Umans Kimi K2.7 Code",
+	provider: "umans",
+	baseUrl: "https://api.code.umans.ai",
+	maxTokens: 32_768,
+});
+
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
 	controller.abort();
@@ -76,6 +85,7 @@ type CaptureAnthropicOptions = {
 	toolChoice?: "auto" | "any" | "none" | { type: "tool"; name: string };
 	thinkingDisplay?: "summarized" | "omitted";
 	sessionId?: string;
+	headers?: Record<string, string>;
 };
 
 function captureAnthropicPayload(
@@ -98,6 +108,7 @@ function captureAnthropicPayload(
 		toolChoice: options?.toolChoice,
 		thinkingDisplay: options?.thinkingDisplay,
 		sessionId: options?.sessionId,
+		headers: options?.headers,
 		onPayload: payload => resolve(payload),
 	});
 	return promise;
@@ -469,6 +480,19 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(options.defaultHeaders.Authorization).toBeUndefined();
 	});
 
+	it("adds Umans gateway web search header from env", async () => {
+		await withEnv({ UMANS_WEBSEARCH_PROVIDER: "exa" }, () => {
+			const options = buildAnthropicClientOptions({
+				model: UMANS_ANTHROPIC_MODEL,
+				apiKey: "sk-umans-test",
+				stream: true,
+				hasTools: true,
+			});
+
+			expect(options.defaultHeaders["X-Umans-Websearch-Provider"]).toBe("exa");
+		});
+	});
+
 	it("forwards only prefix-matching Claude Code User-Agent values", () => {
 		const forwardedHeaders = buildAnthropicHeaders({
 			apiKey: "sk-ant-oat-test",
@@ -799,6 +823,88 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.metadata?.user_id).not.toBe("invalid-user-id");
 		expectClaudeMetadataUserId(payload.metadata?.user_id);
 	});
+	it("escapes Anthropic built-in tool names for compatible gateways", async () => {
+		const tools: Tool[] = [
+			{
+				name: "web_search",
+				description: "search the web",
+				parameters: {
+					type: "object",
+					properties: { query: { type: "string" } },
+					required: ["query"],
+				},
+			},
+			{
+				name: "read",
+				description: "read a file",
+				parameters: {
+					type: "object",
+					properties: { path: { type: "string" } },
+					required: ["path"],
+				},
+			},
+		];
+
+		const payload = (await captureAnthropicPayload(
+			UMANS_ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+				tools,
+			},
+			{ isOAuth: false, toolChoice: { type: "tool", name: "web_search" } },
+		)) as {
+			tools?: Array<{ name?: string }>;
+			tool_choice?: { type?: string; name?: string };
+		};
+
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["_web_search", "read"]);
+		expect(payload.tool_choice).toEqual({ type: "tool", name: "_web_search" });
+	});
+
+	it("leaves Umans web_search unescaped when gateway web search is selected", async () => {
+		const tools: Tool[] = [
+			{
+				name: "web_search",
+				description: "search the web",
+				parameters: {
+					type: "object",
+					properties: { query: { type: "string" } },
+					required: ["query"],
+				},
+			},
+			{
+				name: "read",
+				description: "read a file",
+				parameters: {
+					type: "object",
+					properties: { path: { type: "string" } },
+					required: ["path"],
+				},
+			},
+		];
+
+		const payload = (await captureAnthropicPayload(
+			UMANS_ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+				tools,
+			},
+			{
+				isOAuth: false,
+				headers: { "X-Umans-Websearch-Provider": "native" },
+				toolChoice: { type: "tool", name: "web_search" },
+			},
+		)) as {
+			tools?: Array<{ name?: string }>;
+			tool_choice?: { type?: string; name?: string };
+		};
+
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["web_search", "read"]);
+		expect(payload.tool_choice).toEqual({ type: "tool", name: "web_search" });
+	});
+
 	it("adds additionalProperties false to Anthropic tool object schemas", async () => {
 		const originalNestedSchema = {
 			type: "object",

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -823,7 +823,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.metadata?.user_id).not.toBe("invalid-user-id");
 		expectClaudeMetadataUserId(payload.metadata?.user_id);
 	});
-	it("escapes Anthropic built-in tool names for compatible gateways", async () => {
+	it("escapes Umans client tool names for unambiguous round-trips", async () => {
 		const tools: Tool[] = [
 			{
 				name: "web_search",
@@ -843,6 +843,15 @@ describe("Anthropic request fingerprint alignment", () => {
 					required: ["path"],
 				},
 			},
+			{
+				name: "_web_search",
+				description: "literal prefixed search",
+				parameters: {
+					type: "object",
+					properties: { query: { type: "string" } },
+					required: ["query"],
+				},
+			},
 		];
 
 		const payload = (await captureAnthropicPayload(
@@ -858,7 +867,7 @@ describe("Anthropic request fingerprint alignment", () => {
 			tool_choice?: { type?: string; name?: string };
 		};
 
-		expect(payload.tools?.map(tool => tool.name)).toEqual(["_web_search", "read"]);
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["_web_search", "_read", "__web_search"]);
 		expect(payload.tool_choice).toEqual({ type: "tool", name: "_web_search" });
 	});
 
@@ -901,7 +910,7 @@ describe("Anthropic request fingerprint alignment", () => {
 			tool_choice?: { type?: string; name?: string };
 		};
 
-		expect(payload.tools?.map(tool => tool.name)).toEqual(["web_search", "read"]);
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["web_search", "_read"]);
 		expect(payload.tool_choice).toEqual({ type: "tool", name: "web_search" });
 	});
 

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -18,6 +18,19 @@ const model: Model<"anthropic-messages"> = buildModel({
 	maxTokens: 8_192,
 });
 
+const umansModel: Model<"anthropic-messages"> = buildModel({
+	id: "umans-kimi-k2.7",
+	name: "Umans Kimi K2.7 Code",
+	api: "anthropic-messages",
+	provider: "umans",
+	baseUrl: "https://api.code.umans.ai",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 262_144,
+	maxTokens: 32_768,
+});
+
 const context: Context = {
 	messages: [{ role: "user", content: "Say hi", timestamp: Date.now() }],
 };
@@ -308,6 +321,126 @@ describe("anthropic stream envelope handling", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.responseId).toBe("msg_text_success");
 		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("decodes escaped Anthropic built-in tool names from compatible gateways", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_tool",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "tool_use", id: "tool_1", name: "_web_search", input: {} },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "input_json_delta", partial_json: '{"query":"5+54"}' },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "tool_use" },
+						usage: {
+							input_tokens: 12,
+							output_tokens: 4,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(umansModel, context, { apiKey: "sk-ant-test" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(countEvents(events, "toolcall_start")).toBe(1);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toEqual([
+			{
+				type: "toolCall",
+				id: "tool_1",
+				name: "web_search",
+				arguments: { query: "5+54" },
+			},
+		]);
+	});
+
+	it("ignores Umans gateway web search server blocks and keeps final text", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_server_search",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "server_tool_use", id: "srv_1", name: "web_search", input: { query: "5+54" } },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "content_block_start",
+						index: 1,
+						content_block: { type: "web_search_tool_result", tool_use_id: "srv_1", content: [] },
+					},
+					{ type: "content_block_stop", index: 1 },
+					{ type: "content_block_start", index: 2, content_block: { type: "text", text: "" } },
+					{ type: "content_block_delta", index: 2, delta: { type: "text_delta", text: "59" } },
+					{ type: "content_block_stop", index: 2 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "end_turn" },
+						usage: {
+							input_tokens: 12,
+							output_tokens: 4,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(umansModel, context, {
+			apiKey: "sk-ant-test",
+			headers: { "X-Umans-Websearch-Provider": "exa" },
+		});
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(countEvents(events, "toolcall_start")).toBe(0);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "59" }]);
 	});
 	it("unwraps thinking blocks that Anthropic streams with literal thinking tags", async () => {
 		const wrappedThinking =

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -383,6 +383,66 @@ describe("anthropic stream envelope handling", () => {
 		]);
 	});
 
+	it("decodes escaped literal-prefixed Umans tool names", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_literal_tool",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "tool_use", id: "tool_1", name: "__web_search", input: {} },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "input_json_delta", partial_json: '{"query":"literal"}' },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "tool_use" },
+						usage: {
+							input_tokens: 12,
+							output_tokens: 4,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(umansModel, context, { apiKey: "sk-ant-test" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(countEvents(events, "toolcall_start")).toBe(1);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toEqual([
+			{
+				type: "toolCall",
+				id: "tool_1",
+				name: "_web_search",
+				arguments: { query: "literal" },
+			},
+		]);
+	});
+
 	it("ignores Umans gateway web search server blocks and keeps final text", async () => {
 		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
 			() =>

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
 import { convertAnthropicMessages, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import { AnthropicMessages } from "@oh-my-pi/pi-ai/providers/anthropic-client";
+import {
+	AnthropicMessages,
+	type AnthropicMessagesClientLike,
+	type AnthropicRequestOptions,
+} from "@oh-my-pi/pi-ai/providers/anthropic-client";
 import type { AssistantMessageEvent, Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
@@ -501,6 +505,48 @@ describe("anthropic stream envelope handling", () => {
 		expect(countEvents(events, "toolcall_start")).toBe(0);
 		expect(result.stopReason).toBe("stop");
 		expect(result.content).toEqual([{ type: "text", text: "59" }]);
+	});
+
+	it("passes Umans gateway web search headers to custom clients", async () => {
+		type CapturedPayload = { tools?: Array<{ name?: string }> };
+		let capturedParams: CapturedPayload | undefined;
+		let capturedOptions: AnthropicRequestOptions | undefined;
+		const client: AnthropicMessagesClientLike = {
+			messages: {
+				create(params, options) {
+					capturedParams = params as CapturedPayload;
+					capturedOptions = options;
+					return createMockRequest(createTextSuccessEvents("59"));
+				},
+			},
+		};
+
+		const stream = streamAnthropic(
+			umansModel,
+			{
+				...context,
+				tools: [
+					{
+						name: "web_search",
+						description: "Search the web",
+						parameters: queryObjectSchema,
+					},
+				],
+			},
+			{
+				client,
+				headers: { "X-Umans-Websearch-Provider": "exa" },
+			},
+		);
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+
+		expect(result.content).toEqual([{ type: "text", text: "59" }]);
+		expect(capturedParams?.tools?.map(tool => tool.name)).toEqual(["web_search"]);
+		expect(capturedOptions?.headers).toEqual({ "X-Umans-Websearch-Provider": "exa" });
 	});
 	it("unwraps thinking blocks that Anthropic streams with literal thinking tags", async () => {
 		const wrappedThinking =

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Kimi output caps for Umans AI Coding Plan and Venice so discovery metadata cannot use context-sized token ceilings as request caps.
+- Marked Umans Anthropic-compatible models as client-tool escaped so cached and bundled metadata do not expose `web_search` as a provider server tool.
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kimi output caps for Umans AI Coding Plan and Venice so discovery metadata cannot use context-sized token ceilings as request caps.
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -30,7 +30,9 @@ import {
 	ANTHROPIC_CURATED_FALLBACK_MODELS,
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
+	clampKimiK27CodeMaxTokens,
 	isFireworksKimiK2ModelId,
+	isKimiK27CodeModelId,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
 	stripFireworksDeepSeekThinkingToggle,
@@ -245,21 +247,22 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 }
 
 /**
- * Fireworks-backed Kimi K2.x deployments report `max_completion_tokens: 65536`
- * over `/v1/models`, but Kimi's documented output budget on Fireworks is
- * lower (#1849). Cap them here so the post-processing pass — which also folds
- * in the `prevModelsJson` static fallback used by `firepass` — never lets a
- * stale or inflated upstream value through. The resolver applies the same
- * cap when discovery runs at runtime; this is the bundle-time safety net.
+ * Provider discovery sometimes reports context-sized Kimi output ceilings. Keep
+ * the bundled catalog at the documented/provider-safe caps so request builders
+ * that always send `max_tokens` do not over-allocate.
  */
-function applyFireworksKimiMaxTokensCap(models: readonly ModelSpec[]): ModelSpec[] {
+function applyKimiMaxTokensCap(models: readonly ModelSpec[]): ModelSpec[] {
 	const FIREWORKS_KIMI_PROVIDERS = new Set(["fireworks", "firepass"]);
 	return models.map(model => {
-		if (!FIREWORKS_KIMI_PROVIDERS.has(model.provider)) return model;
-		if (!isFireworksKimiK2ModelId(model.id)) return model;
-		const capped = clampFireworksKimiMaxTokens(model.id, model.maxTokens);
-		if (capped === model.maxTokens) return model;
-		return { ...model, maxTokens: capped };
+		if (FIREWORKS_KIMI_PROVIDERS.has(model.provider) && isFireworksKimiK2ModelId(model.id)) {
+			const capped = clampFireworksKimiMaxTokens(model.id, model.maxTokens);
+			return capped === model.maxTokens ? model : { ...model, maxTokens: capped };
+		}
+		if (model.provider === "venice" && isKimiK27CodeModelId(model.id)) {
+			const capped = clampKimiK27CodeMaxTokens(model.id, model.maxTokens);
+			return capped === model.maxTokens ? model : { ...model, maxTokens: capped };
+		}
+		return model;
 	});
 }
 
@@ -418,20 +421,31 @@ async function fetchCodexDiscoveryModels(): Promise<ModelSpec<"openai-codex-resp
 }
 
 async function generateModels() {
-	// Fetch models from dynamic sources
+	// Fetch models from dynamic sources.
 	const modelsDevModels = await loadModelsDevData();
-	const catalogProviderModels = (
-		await Promise.all(
-			PROVIDER_DESCRIPTORS.filter(
-				descriptor => isCatalogDescriptor(descriptor) && !DISCOVERY_ONLY_PROVIDERS.has(descriptor.providerId),
-			).map(descriptor => fetchProviderModelsFromCatalog(descriptor as CatalogProviderDescriptor)),
-		)
-	).flat();
+	const catalogProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
+		(descriptor): descriptor is CatalogProviderDescriptor =>
+			isCatalogDescriptor(descriptor) && !DISCOVERY_ONLY_PROVIDERS.has(descriptor.providerId),
+	);
+	const catalogProviderModelBatches = await Promise.all(
+		catalogProviderDescriptors.map(async descriptor => ({
+			descriptor,
+			models: await fetchProviderModelsFromCatalog(descriptor),
+		})),
+	);
+	const authoritativeCatalogProviders = new Set(
+		catalogProviderModelBatches
+			.filter(batch => batch.descriptor.dynamicModelsAuthoritative === true && batch.models.length > 0)
+			.map(batch => batch.descriptor.providerId),
+	);
+	const catalogProviderModels = catalogProviderModelBatches.flatMap(batch => batch.models);
+	const bundledModelsDevModels = modelsDevModels.filter(model => !authoritativeCatalogProviders.has(model.provider));
 	// getGitLabDuoModels returns built models; project back to spec stage for the bundle.
 	const gitLabDuoModels = getGitLabDuoModels().map(model => toModelSpec(model));
-	// Combine models (models.dev has priority)
+	// Combine models. models.dev has priority unless a provider's successful endpoint
+	// discovery is authoritative; those endpoint snapshots replace models.dev rows.
 	let allModels = applyGlobalModelsDevFallback(
-		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels],
+		[...bundledModelsDevModels, ...catalogProviderModels, ...gitLabDuoModels],
 		modelsDevModels,
 	);
 
@@ -471,19 +485,16 @@ async function generateModels() {
 		}
 	}
 
-	const modelsDevAuthoritativeProviders = new Set<string>();
+	const modelsDevSnapshotExcludedProviders = new Set<string>();
 	for (const model of modelsDevModels) {
 		if (model.provider === "google-vertex") {
-			modelsDevAuthoritativeProviders.add(model.provider);
+			modelsDevSnapshotExcludedProviders.add(model.provider);
 		}
 	}
-	if (catalogProviderModels.some(model => model.provider === "aimlapi")) {
-		modelsDevAuthoritativeProviders.add("aimlapi");
-	}
 	// Merge previous models.json entries as fallback for provider/model pairs not
-	// fetched dynamically. Providers that models.dev covers authoritatively keep
-	// the upstream list exactly, so retired entries from the previous snapshot do
-	// not reappear during regeneration.
+	// fetched dynamically. Providers covered by authoritative endpoint discovery
+	// or authoritative models.dev sources keep that upstream list exactly, so
+	// retired entries from the previous snapshot do not reappear during regeneration.
 	// Discovery-only providers (local inference servers) — never bundle static models.
 	const fetchedKeys = new Set(allModels.map(model => `${model.provider}/${model.id}`));
 
@@ -495,7 +506,8 @@ async function generateModels() {
 			if (
 				!fetchedKeys.has(`${model.provider}/${model.id}`) &&
 				!DISCOVERY_ONLY_PROVIDERS.has(model.provider) &&
-				!modelsDevAuthoritativeProviders.has(model.provider)
+				!authoritativeCatalogProviders.has(model.provider) &&
+				!modelsDevSnapshotExcludedProviders.has(model.provider)
 			) {
 				allModels.push(model);
 			}
@@ -505,7 +517,7 @@ async function generateModels() {
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
-	allModels = applyFireworksKimiMaxTokensCap(allModels);
+	allModels = applyKimiMaxTokensCap(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);
@@ -534,8 +546,8 @@ async function generateModels() {
 		if (!providers[model.provider]) {
 			providers[model.provider] = {};
 		}
-		// Use model ID as key to automatically deduplicate
-		// Only add if not already present (models.dev takes priority over endpoint discovery)
+		// Use model ID as key to deduplicate the ordered sources assembled above.
+		// Earlier sources win.
 		if (!providers[model.provider][model.id]) {
 			providers[model.provider][model.id] = model;
 		}

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -67,6 +67,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		// arguments (#2005). Known non-signing hosts (Z.AI, DeepSeek) are also
 		// preserved for compatibility.
 		replayUnsignedThinking: isZai || modelMatchesHost(spec, "deepseekFamily") || (spec.reasoning && !official),
+		escapeBuiltinToolNames: modelMatchesHost(spec, "umans"),
 	};
 	applyCompatOverrides(compat, spec.compat);
 	return compat;

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -42,6 +42,7 @@ export const KNOWN_HOSTS = {
 	zhipu: { providers: ["zhipu-coding-plan"], urlMarkers: ["open.bigmodel.cn"] },
 	kilo: { providers: ["kilo"], urlMarkers: ["api.kilo.ai"] },
 	alibabaDashscope: { providers: ["alibaba-coding-plan"], urlMarkers: ["dashscope"] },
+	umans: { providers: ["umans"], urlMarkers: ["api.code.umans.ai"] },
 	xiaomi: { providers: ["xiaomi"], providerPrefixes: ["xiaomi-token-plan-"], urlMarkers: ["xiaomimimo.com"] },
 	xai: { providers: ["xai"], urlMarkers: ["api.x.ai"] },
 	mistral: { providers: ["mistral"], urlMarkers: ["mistral.ai"] },

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -65932,13 +65932,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.063,
-				"output": 0.21,
-				"cacheRead": 0.020999999999999998,
+				"input": 0.06599999999999999,
+				"output": 0.26,
+				"cacheRead": 0.029,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 64000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68916,6 +68916,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		},
 		"umans-flash": {
@@ -68946,6 +68949,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		},
 		"umans-glm-5.1": {
@@ -68976,6 +68982,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		},
 		"umans-kimi-k2.6": {
@@ -69006,6 +69015,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		},
 		"umans-kimi-k2.7": {
@@ -69037,6 +69049,9 @@
 					"xhigh"
 				],
 				"requiresEffort": true
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		},
 		"umans-qwen3.6-35b-a3b": {
@@ -69067,6 +69082,9 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"escapeBuiltinToolNames": true
 			}
 		}
 	},
@@ -72310,7 +72328,8 @@
 				"supportsForcedToolChoice": true,
 				"supportsSamplingParams": true,
 				"requiresToolResultId": false,
-				"replayUnsignedThinking": false
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false
 			}
 		},
 		"alibaba/qwen3-max-preview": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -60012,8 +60012,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.18,
+				"input": 0.098,
+				"output": 0.196,
 				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
@@ -65288,7 +65288,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -65311,12 +65311,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 2.34,
+				"input": 0.385,
+				"output": 2.4499999999999997,
 				"cacheRead": 0.195,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -68906,7 +68906,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -68936,7 +68936,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -68950,7 +68950,7 @@
 		},
 		"umans-glm-5.1": {
 			"id": "umans-glm-5.1",
-			"name": "GLM 5.1",
+			"name": "Umans GLM 5.1",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -68965,7 +68965,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 202752,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
@@ -68980,7 +68980,7 @@
 		},
 		"umans-kimi-k2.6": {
 			"id": "umans-kimi-k2.6",
-			"name": "Kimi K2.6",
+			"name": "Umans Kimi K2.6",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -68996,7 +68996,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -69010,7 +69010,7 @@
 		},
 		"umans-kimi-k2.7": {
 			"id": "umans-kimi-k2.7",
-			"name": "Kimi K2.7 Code",
+			"name": "Umans Kimi K2.7 Code",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -69026,7 +69026,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -69041,7 +69041,7 @@
 		},
 		"umans-qwen3.6-35b-a3b": {
 			"id": "umans-qwen3.6-35b-a3b",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Umans Qwen3.6 35B A3B",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -69057,7 +69057,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -70537,6 +70537,28 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"kimi-k2-7-code": {
+			"id": "kimi-k2-7-code",
+			"name": "kimi-k2-7-code",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32768,
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"kimi-k2-thinking": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -658,6 +658,7 @@ function mapUmansModelInfo(
 		api: "anthropic-messages",
 		provider: "umans",
 		baseUrl,
+		compat: { ...reference?.compat, escapeBuiltinToolNames: true },
 		reasoning: thinking !== undefined,
 		...(thinking ? { thinking } : {}),
 		input: umansSupportsVision(capabilities.supports_vision) ? ["text", "image"] : ["text"],

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -664,7 +664,10 @@ function mapUmansModelInfo(
 		...(supportsTools === false ? { supportsTools: false } : {}),
 		cost: reference?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: toPositiveNumber(capabilities.context_window, reference?.contextWindow ?? null),
-		maxTokens: toPositiveNumber(capabilities.max_completion_tokens, reference?.maxTokens ?? null),
+		maxTokens: toPositiveNumber(
+			capabilities.recommended_max_tokens,
+			toPositiveNumber(capabilities.max_completion_tokens, reference?.maxTokens ?? null),
+		),
 	};
 }
 
@@ -1230,6 +1233,23 @@ export function clampFireworksKimiMaxTokens(modelId: string, candidate: number |
 export function clampFireworksKimiMaxTokens(modelId: string, candidate: number | null): number | null {
 	if (candidate === null) return null;
 	return isFireworksKimiK2ModelId(modelId) ? Math.min(candidate, FIREWORKS_KIMI_MAX_TOKENS) : candidate;
+}
+
+/**
+ * Kimi K2.7 Code's documented recommended output budget. Some provider
+ * discovery rows report the context-sized `max_completion_tokens` instead.
+ */
+export const KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS = 32_768;
+
+export function isKimiK27CodeModelId(modelId: string): boolean {
+	return /(?:^|\/)kimi[-._]?k2(?:[._-]?|p)7[-._]?code$/i.test(modelId);
+}
+
+export function clampKimiK27CodeMaxTokens(modelId: string, candidate: number): number;
+export function clampKimiK27CodeMaxTokens(modelId: string, candidate: number | null): number | null;
+export function clampKimiK27CodeMaxTokens(modelId: string, candidate: number | null): number | null {
+	if (candidate === null) return null;
+	return isKimiK27CodeModelId(modelId) ? Math.min(candidate, KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS) : candidate;
 }
 
 /**
@@ -2276,6 +2296,7 @@ export function veniceModelManagerOptions(
 					const model = mapWithBundledReference(entry, defaults, reference);
 					return {
 						...model,
+						maxTokens: clampKimiK27CodeMaxTokens(defaults.id, model.maxTokens),
 						compat: { ...model.compat, supportsUsageInStreaming: false },
 					};
 				},
@@ -3544,7 +3565,12 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 	// --- Synthetic ---
 	openAiCompletionsDescriptor("synthetic", "synthetic", "https://api.synthetic.new/openai/v1"),
 	// --- Venice AI ---
-	openAiCompletionsDescriptor("venice", "venice", "https://api.venice.ai/api/v1"),
+	openAiCompletionsDescriptor("venice", "venice", "https://api.venice.ai/api/v1", {
+		transformModel: model => {
+			const maxTokens = clampKimiK27CodeMaxTokens(model.id, model.maxTokens);
+			return maxTokens === model.maxTokens ? model : { ...model, maxTokens };
+		},
+	}),
 	// --- Ollama Cloud ---
 	simpleModelsDevDescriptor("ollama-cloud", "ollama-cloud", "ollama-chat", "https://ollama.com"),
 	// --- Xiaomi Token Plan ---

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -311,6 +311,13 @@ export interface AnthropicCompat {
 	 * Default: auto-detected from provider/baseUrl and `model.reasoning`.
 	 */
 	replayUnsignedThinking?: boolean;
+	/**
+	 * Prefix Anthropic built-in tool names (`web_search`, `code_execution`, ...)
+	 * when they are ordinary client tools. Some Anthropic-compatible gateways
+	 * intercept those exact names as server tools and return raw search/result
+	 * blocks instead of normal `tool_use` calls.
+	 */
+	escapeBuiltinToolNames?: boolean;
 }
 
 /**

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -19,6 +19,9 @@ interface BundledModel {
 		defaultLevel?: string;
 		requiresEffort?: boolean;
 	};
+	compat?: {
+		escapeBuiltinToolNames?: boolean;
+	};
 }
 
 describe("umans provider catalog", () => {
@@ -75,6 +78,7 @@ describe("umans provider catalog", () => {
 			contextWindow: 262_144,
 			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium" },
+			compat: { escapeBuiltinToolNames: true },
 		});
 		const mandatoryReasoningModel = models?.find(item => item.id === "umans-kimi-k2.7");
 		expect(mandatoryReasoningModel).toMatchObject({
@@ -82,6 +86,7 @@ describe("umans provider catalog", () => {
 			reasoning: true,
 			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium", requiresEffort: true },
+			compat: { escapeBuiltinToolNames: true },
 		});
 	});
 
@@ -141,6 +146,7 @@ describe("umans provider catalog", () => {
 			input: ["text", "image"],
 			contextWindow: 262_144,
 			maxTokens: 32_768,
+			compat: { escapeBuiltinToolNames: true },
 		});
 	});
 
@@ -150,6 +156,7 @@ describe("umans provider catalog", () => {
 
 		expect(model).toBeDefined();
 		expect(model.maxTokens).toBe(32_768);
+		expect(model.compat?.escapeBuiltinToolNames).toBe(true);
 		expect(model.thinking).toMatchObject({
 			requiresEffort: true,
 		});

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -33,6 +33,7 @@ describe("umans provider catalog", () => {
 						capabilities: {
 							context_window: 262_144,
 							max_completion_tokens: 262_144,
+							recommended_max_tokens: 32_768,
 							supports_vision: true,
 							supports_tools: true,
 							reasoning: { supported: true, can_disable: true, default_level: "medium" },
@@ -43,6 +44,7 @@ describe("umans provider catalog", () => {
 						capabilities: {
 							context_window: 262_144,
 							max_completion_tokens: 262_144,
+							recommended_max_tokens: 32_768,
 							supports_vision: true,
 							supports_tools: true,
 							reasoning: { supported: true, can_disable: false, default_level: "medium" },
@@ -71,13 +73,14 @@ describe("umans provider catalog", () => {
 			reasoning: true,
 			input: ["text", "image"],
 			contextWindow: 262_144,
-			maxTokens: 262_144,
+			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium" },
 		});
 		const mandatoryReasoningModel = models?.find(item => item.id === "umans-kimi-k2.7");
 		expect(mandatoryReasoningModel).toMatchObject({
 			id: "umans-kimi-k2.7",
 			reasoning: true,
+			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium", requiresEffort: true },
 		});
 	});
@@ -137,7 +140,7 @@ describe("umans provider catalog", () => {
 			reasoning: true,
 			input: ["text", "image"],
 			contextWindow: 262_144,
-			maxTokens: 262_144,
+			maxTokens: 32_768,
 		});
 	});
 
@@ -146,6 +149,7 @@ describe("umans provider catalog", () => {
 		const model = providers.umans?.["umans-kimi-k2.7"];
 
 		expect(model).toBeDefined();
+		expect(model.maxTokens).toBe(32_768);
 		expect(model.thinking).toMatchObject({
 			requiresEffort: true,
 		});

--- a/packages/catalog/test/venice-provider.test.ts
+++ b/packages/catalog/test/venice-provider.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import {
+	KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS,
+	veniceModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+describe("Venice provider catalog", () => {
+	it("bundles Kimi K2.7 Code with its recommended output cap", () => {
+		const model = getBundledModel("venice", "kimi-k2-7-code");
+
+		expect(model).toBeDefined();
+		expect(model.maxTokens).toBe(KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS);
+	});
+
+	it("caps Kimi K2.7 Code during runtime discovery", async () => {
+		const requestedUrls: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			requestedUrls.push(input instanceof Request ? input.url : String(input));
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "kimi-k2-7-code",
+							name: "kimi-k2-7-code",
+							context_length: 256_000,
+							max_completion_tokens: 262_144,
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const options = veniceModelManagerOptions({ apiKey: "venice-test-key", fetch: fetchImpl });
+		const models = await options.fetchDynamicModels?.();
+		const model = models?.find(candidate => candidate.id === "kimi-k2-7-code");
+
+		expect(requestedUrls).toEqual(["https://api.venice.ai/api/v1/models"]);
+		expect(model).toBeDefined();
+		expect(model?.maxTokens).toBe(KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `UMANS_WEBSEARCH_PROVIDER` environment variable to CLI help for Umans gateway web search backend selection.
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -280,6 +280,7 @@ export function getExtraHelpText(): string {
   MISTRAL_API_KEY            - Mistral models
   ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
   UMANS_AI_CODING_PLAN_API_KEY - Umans AI Coding Plan models
+  UMANS_WEBSEARCH_PROVIDER    - Umans gateway web search backend (native or exa)
   MINIMAX_API_KEY            - MiniMax models
   OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
   CURSOR_ACCESS_TOKEN        - Cursor AI models


### PR DESCRIPTION
## Summary
- Use Umans `recommended_max_tokens` for catalog maxTokens instead of the full context-sized `max_completion_tokens`
- Cap Venice Kimi K2.7 Code to its recommended output budget in bundled and runtime discovery metadata
- Let successful authoritative endpoint discovery override models.dev and previous-snapshot rows during catalog generation
- Escape Umans client-side tools by default so Kimi does not return raw gateway search results for normal prompts
- Add `UMANS_WEBSEARCH_PROVIDER=native|exa` to opt into Umans gateway-owned web search while keeping tool names on the wire
- Forward the Umans gateway web search header on per-request options so custom Anthropic clients stay aligned with the encoded tool names
- Regenerate Kimi bundled model metadata and add regression coverage

## Verification
- `bun test packages/catalog/test/umans-provider.test.ts packages/ai/test/anthropic-alignment.test.ts packages/ai/test/anthropic-stream-envelope.test.ts packages/catalog/test/venice-provider.test.ts`
- `bun test packages/ai/test/anthropic-stream-envelope.test.ts packages/ai/test/anthropic-alignment.test.ts`
- `omp-dev --model umans/umans-kimi-k2.7 --thinking xhigh --print "whats 5+54"`
- `UMANS_WEBSEARCH_PROVIDER=native omp-dev --model umans/umans-kimi-k2.7 --thinking high --print "Use web_search to search the official Umans code docs. Answer with only the two Umans web search backend names."`
- `UMANS_WEBSEARCH_PROVIDER=exa omp-dev --model umans/umans-kimi-k2.7 --thinking minimal --print "Use web_search to search for https://app.umans.ai/offers/code/docs web search backends. Then answer exactly: native, exa"`
- `bun --filter @oh-my-pi/pi-ai check && bun --filter @oh-my-pi/pi-catalog check && bun --filter @oh-my-pi/pi-coding-agent check`
- `bun --filter @oh-my-pi/pi-ai check`
- `omp-dev --smoke-test`

Note: full `bun check` passes TypeScript/Biome for changed packages but fails locally in unrelated Windows Rust `pi-natives` dead-code/clippy warnings (`crash_handler.rs`, `ps.rs`).