### PR TITLE
fix(tui): detect CMUX as multiplexer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed CMUX sessions being treated as direct terminals during resize/reset because they do not set `TMUX`/`STY`/`ZELLIJ` and may run with `TERM=dumb`; the renderer now treats CMUX workspace/surface env markers as multiplexer signals and preserves pane scrollback instead of emitting ED3 (`CSI 3 J`).
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -370,11 +370,15 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
-	// TMUX/STY/ZELLIJ are the authoritative signals, but they can be stripped while
-	// TERM survives (`sudo` without -E, `su`, env-sanitizing launchers/ssh). Fall back to
-	// the TERM prefix like every sibling multiplexer check (terminal-capabilities.ts) so a
-	// resize never emits ED3 into a tmux/screen pane and wipes its scrollback history.
+	// TMUX/STY/ZELLIJ/CMUX workspace+surface ids are authoritative session
+	// signals. TERM can also survive when those are stripped (`sudo` without -E,
+	// `su`, env-sanitizing launchers/ssh), so keep the TERM prefix fallback aligned
+	// with sibling multiplexer checks (terminal-capabilities.ts). Misclassifying a
+	// multiplexer as a direct terminal lets resize/reset paths emit ED3 (`CSI 3 J`)
+	// and wipe pane scrollback. Do not use CMUX_SOCKET_PATH here: it is a CLI socket
+	// override and can be set outside a CMUX terminal.
 	if (Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ) return true;
+	if (Bun.env.CMUX_WORKSPACE_ID || Bun.env.CMUX_SURFACE_ID) return true;
 	const term = Bun.env.TERM?.toLowerCase() ?? "";
 	return term.startsWith("tmux") || term.startsWith("screen");
 }

--- a/packages/tui/test/issue-2088-repro.test.ts
+++ b/packages/tui/test/issue-2088-repro.test.ts
@@ -97,16 +97,33 @@ function visible(term: VirtualTerminal): string[] {
 	return term.getViewport().map(line => line.trimEnd());
 }
 
-const TMUX_ENV: Record<string, string | undefined> = { TMUX: "1", STY: undefined, ZELLIJ: undefined };
+const MULTIPLEXER_ENV_KEYS = [
+	"TMUX",
+	"STY",
+	"ZELLIJ",
+	"CMUX_WORKSPACE_ID",
+	"CMUX_SURFACE_ID",
+	"CMUX_PANEL_ID",
+	"CMUX_TAB_ID",
+	"CMUX_SOCKET_PATH",
+];
+const NO_MULTIPLEXER_ENV: Record<string, string | undefined> = Object.fromEntries(
+	MULTIPLEXER_ENV_KEYS.map(key => [key, undefined]),
+);
+const TMUX_ENV: Record<string, string | undefined> = { ...NO_MULTIPLEXER_ENV, TMUX: "1" };
+const CMUX_ENV_CASES: Array<[string, Record<string, string | undefined>]> = [
+	["CMUX_WORKSPACE_ID", { ...NO_MULTIPLEXER_ENV, TERM: "dumb", CMUX_WORKSPACE_ID: "workspace:cmux-2088" }],
+	["CMUX_SURFACE_ID", { ...NO_MULTIPLEXER_ENV, TERM: "dumb", CMUX_SURFACE_ID: "surface:cmux-2088" }],
+];
+const CMUX_SOCKET_ONLY_ENV: Record<string, string | undefined> = {
+	...NO_MULTIPLEXER_ENV,
+	TERM: "xterm-256color",
+	CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+};
 // Pin TERM to a non-multiplexer value: `isMultiplexerSession()` falls back to
 // the TERM prefix, so leaving the host's TERM (which may be `tmux-*`/`screen-*`
 // under CI-in-tmux) would misclassify this "direct terminal" case.
-const NO_MULTIPLEXER_ENV: Record<string, string | undefined> = {
-	TMUX: undefined,
-	STY: undefined,
-	ZELLIJ: undefined,
-	TERM: "xterm-256color",
-};
+NO_MULTIPLEXER_ENV.TERM = "xterm-256color";
 
 describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 	let monotonicNow = 0;
@@ -335,15 +352,14 @@ describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 	});
 });
 
-// Regression for tmux auto-detection: `isMultiplexerSession()` gates the
+// Regression for multiplexer auto-detection: `isMultiplexerSession()` gates the
 // renderer's resize behavior. It previously checked only TMUX/STY/ZELLIJ, while
-// every sibling multiplexer check (terminal-capabilities.ts) also falls back to
-// the TERM prefix. When TMUX is stripped but TERM survives (`sudo` without -E,
-// `su`, env-sanitizing launchers/ssh), the engine misclassified tmux as a direct
-// terminal and emitted ED3 (CSI 3 J) on resize — which wipes tmux pane history
-// (verified against tmux 3.6a: a 20-line pane drops to its 6 on-screen rows
-// after ED3), so scrollback only reappeared after a full rerender.
-describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped", () => {
+// sibling checks also fall back to TERM prefixes and CMUX exposes its own session
+// env markers. When a multiplexer was missed, the engine misclassified the pane
+// as a direct terminal and emitted ED3 (CSI 3 J) on resize — which wipes pane
+// history (verified against tmux 3.6a: a 20-line pane drops to its 6 on-screen
+// rows after ED3), so scrollback only reappeared after a full rerender.
+describe("multiplexer detection gates ED3 on resize", () => {
 	let monotonicNow = 0;
 
 	beforeEach(() => {
@@ -364,8 +380,8 @@ describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped", (
 	// tmux/screen panes whose authoritative env signal was stripped but whose
 	// TERM still names the multiplexer — the case previously misclassified.
 	const strippedMuxTerms: Array<[string, Record<string, string | undefined>]> = [
-		["tmux-256color", { TERM: "tmux-256color", TMUX: undefined, STY: undefined, ZELLIJ: undefined }],
-		["screen-256color", { TERM: "screen-256color", TMUX: undefined, STY: undefined, ZELLIJ: undefined }],
+		["tmux-256color", { ...NO_MULTIPLEXER_ENV, TERM: "tmux-256color" }],
+		["screen-256color", { ...NO_MULTIPLEXER_ENV, TERM: "screen-256color" }],
 	];
 
 	for (const [label, env] of strippedMuxTerms) {
@@ -405,6 +421,59 @@ describe("multiplexer detection: TERM prefix gates ED3 when TMUX is stripped", (
 		});
 	}
 
+	for (const [label, env] of CMUX_ENV_CASES) {
+		it(`debounces resize and emits no ED3 when ${label} marks CMUX with TERM=dumb`, async () => {
+			await withEnvPatch(env, async () => {
+				const term = new VirtualTerminal(40, 10, 1000);
+				const tui = new TUI(term);
+				tui.addChild(new MutableLinesComponent(Array.from({ length: 20 }, (_v, i) => `line-${i}`)));
+
+				try {
+					tui.start();
+					await settle(term);
+
+					const baselineRedraws = tui.fullRedraws;
+					const writes = captureWrites(term);
+
+					term.resize(80, 10);
+					await Bun.sleep(10);
+					expect(writes.length).toBe(0);
+					expect(tui.fullRedraws).toBe(baselineRedraws);
+
+					await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+					await settle(term);
+					const out = writes.join("");
+					expect(out.length).toBeGreaterThan(0);
+					expect(out).not.toContain(ED3);
+					expect(tui.fullRedraws - baselineRedraws).toBe(1);
+					expect(visible(term)).toEqual(Array.from({ length: 10 }, (_v, i) => `line-${i + 10}`));
+				} finally {
+					tui.stop();
+				}
+			});
+		});
+	}
+
+	it("does not treat CMUX_SOCKET_PATH alone as a multiplexer session marker", async () => {
+		await withEnvPatch(CMUX_SOCKET_ONLY_ENV, async () => {
+			const term = new VirtualTerminal(40, 10, 1000);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(Array.from({ length: 20 }, (_v, i) => `line-${i}`)));
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const writes = captureWrites(term);
+				term.resize(80, 10);
+				await settleResize(term);
+				const out = writes.join("");
+				expect(out).toContain(ED3);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
 	it("still clears native scrollback (ED3) on a genuine direct-terminal resize", async () => {
 		await withEnvPatch(NO_MULTIPLEXER_ENV, async () => {
 			const term = new VirtualTerminal(40, 10, 1000);


### PR DESCRIPTION
## Summary

- Treat CMUX workspace/surface env markers as multiplexer session evidence in `packages/tui/src/tui.ts`.
- Preserve CMUX pane scrollback during resize/reset by routing CMUX through the existing multiplexer path that avoids ED3 (`CSI 3 J`).
- Add regression coverage for `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, TERM-only tmux/screen fallback with CMUX env cleared, socket-only false positive protection, and the direct-terminal ED3 control.

## Why

CMUX terminals auto-set workspace/surface ids but do not set `TMUX`/`STY`/`ZELLIJ`, and may run with `TERM=dumb`. Without CMUX-specific detection, the renderer can classify a CMUX pane as a direct terminal and emit ED3 during resize/reset, wiping scrollback.

`CMUX_SOCKET_PATH` is intentionally not used as a session marker because it is a CLI socket override and can be set outside a CMUX terminal.

## Validation

Run from `/Volumes/Dev/oh-my-pi-cmux-scrollback-fix` on macOS arm64 with Bun 1.3.14:

```sh
bun --cwd=packages/tui run check
bun test packages/tui/test/issue-2088-repro.test.ts
env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID -u CMUX_PANEL_ID -u CMUX_TAB_ID -u CMUX_SOCKET_PATH bun --cwd=packages/tui run test
```

Observed:

- `bun --cwd=packages/tui run check` passed.
- Targeted regression: `12 pass`, `0 fail`, `49 expect() calls`.
- Full TUI suite with inherited CMUX env cleared: `916 pass`, `3 skip`, `0 fail`, `3851 expect() calls`.

Note: with inherited CMUX env left in the test process, pre-existing direct-terminal tests can fail because they predate CMUX env clearing. The targeted regression test now explicitly clears CMUX markers for non-CMUX cases.