### PR TITLE
feat(stats): dashboard pagination, filtering, i18n and UI improvements

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+### Added
+
+- Added i18n support (English/Chinese) to the stats dashboard with locale persistence and browser-language detection
+- Added server-side pagination to the requests and errors tabs with configurable page size and total count
+
 
 ## [15.13.3] - 2026-06-15
 

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -3,6 +3,8 @@ import { workerHostEntry } from "@oh-my-pi/pi-utils";
 import {
 	getRecentErrors as dbGetRecentErrors,
 	getRecentRequests as dbGetRecentRequests,
+	getRequestCount as dbGetRequestCount,
+	getErrorCount as dbGetErrorCount,
 	getBehaviorByModel,
 	getBehaviorOverall,
 	getBehaviorTimeSeries,
@@ -402,14 +404,18 @@ export async function getCostDashboardStats(range?: string | null): Promise<Pick
 		costSeries: getCostTimeSeries(costSeriesDays, cutoff),
 	};
 }
-export async function getRecentRequests(limit?: number): Promise<MessageStats[]> {
+export async function getRecentRequests(limit?: number, offset?: number): Promise<{ data: MessageStats[]; total: number }> {
 	await initDb();
-	return dbGetRecentRequests(limit);
+	const data = dbGetRecentRequests(limit, offset);
+	const total = dbGetRequestCount();
+	return { data, total };
 }
 
-export async function getRecentErrors(limit?: number): Promise<MessageStats[]> {
+export async function getRecentErrors(limit?: number, offset?: number): Promise<{ data: MessageStats[]; total: number }> {
 	await initDb();
-	return dbGetRecentErrors(limit);
+	const data = dbGetRecentErrors(limit, offset);
+	const total = dbGetErrorCount();
+	return { data, total };
 }
 
 export async function getRequestDetails(id: number): Promise<RequestDetails | null> {

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	getBehaviorDashboardStats,
 	getCostDashboardStats,
@@ -52,40 +52,38 @@ export default function App() {
 	const [activeTab, setActiveTab] = useState<Tab>("overview");
 	const [timeRange, setTimeRange] = useState<TimeRange>("24h");
 	const { t } = useTranslation();
-	const [requestSeq, setRequestSeq] = useState(0);
-	const [errorSeq, setErrorSeq] = useState(0);
+	const requestSeqRef = useRef(0);
+	const errorSeqRef = useRef(0);
 
 	const loadRecentRequests = useCallback(async () => {
-		const seq = requestSeq + 1;
-		setRequestSeq(seq);
+		const seq = ++requestSeqRef.current;
 		try {
 			const isOverview = activeTab === "overview";
 			const page = isOverview ? overviewRequestPage : requestPage;
 			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : requestPageSize;
 			const res = await getRecentRequests(pageSize, page * pageSize);
-			if (seq !== requestSeq + 1) return;
+			if (seq !== requestSeqRef.current) return;
 			setRecentRequests(res.data);
 			setRequestTotal(res.total);
 		} catch (err) {
 			console.error(err);
 		}
-	}, [activeTab, requestPage, overviewRequestPage, requestPageSize, requestSeq]);
+	}, [activeTab, requestPage, overviewRequestPage, requestPageSize]);
 
 	const loadRecentErrors = useCallback(async () => {
-		const seq = errorSeq + 1;
-		setErrorSeq(seq);
+		const seq = ++errorSeqRef.current;
 		try {
 			const isOverview = activeTab === "overview";
 			const page = isOverview ? overviewErrorPage : errorPage;
 			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : errorPageSize;
 			const res = await getRecentErrors(pageSize, page * pageSize);
-			if (seq !== errorSeq + 1) return;
+			if (seq !== errorSeqRef.current) return;
 			setRecentErrors(res.data);
 			setErrorTotal(res.total);
 		} catch (err) {
 			console.error(err);
 		}
-	}, [activeTab, errorPage, overviewErrorPage, errorPageSize, errorSeq]);
+	}, [activeTab, errorPage, overviewErrorPage, errorPageSize]);
 
 	const loadRecentLists = useCallback(async () => {
 		await Promise.all([loadRecentRequests(), loadRecentErrors()]);

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -19,6 +19,7 @@ import { ModelsTable } from "./components/ModelsTable";
 import { RequestDetail } from "./components/RequestDetail";
 import { RequestList } from "./components/RequestList";
 import { StatsGrid } from "./components/StatsGrid";
+import { useTranslation } from "./i18n";
 import type {
 	BehaviorDashboardStats,
 	CostDashboardStats,
@@ -37,21 +38,50 @@ export default function App() {
 	const [behaviorStats, setBehaviorStats] = useState<BehaviorDashboardStats | null>(null);
 	const [recentRequests, setRecentRequests] = useState<MessageStats[]>([]);
 	const [recentErrors, setRecentErrors] = useState<MessageStats[]>([]);
+	const [requestTotal, setRequestTotal] = useState(0);
+	const [errorTotal, setErrorTotal] = useState(0);
+	const [requestPage, setRequestPage] = useState(0);
+	const [errorPage, setErrorPage] = useState(0);
+	const [overviewRequestPage, setOverviewRequestPage] = useState(0);
+	const [overviewErrorPage, setOverviewErrorPage] = useState(0);
+	const [requestPageSize, setRequestPageSize] = useState(15);
+	const [errorPageSize, setErrorPageSize] = useState(15);
+	const OVERVIEW_PAGE_SIZE = 15;
 	const [selectedRequest, setSelectedRequest] = useState<number | null>(null);
 	const [syncing, setSyncing] = useState(false);
 	const [activeTab, setActiveTab] = useState<Tab>("overview");
 	const [timeRange, setTimeRange] = useState<TimeRange>("24h");
+	const { t } = useTranslation();
 
-	const loadRecentLists = useCallback(async () => {
+	const loadRecentRequests = useCallback(async () => {
 		try {
-			const [requests, errors] = await Promise.all([getRecentRequests(50), getRecentErrors(50)]);
-			setRecentRequests(requests);
-			setRecentErrors(errors);
+			const isOverview = activeTab === "overview";
+			const page = isOverview ? overviewRequestPage : requestPage;
+			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : requestPageSize;
+			const res = await getRecentRequests(pageSize, page * pageSize);
+			setRecentRequests(res.data);
+			setRequestTotal(res.total);
 		} catch (err) {
 			console.error(err);
 		}
-	}, []);
+	}, [activeTab, requestPage, overviewRequestPage, requestPageSize]);
 
+	const loadRecentErrors = useCallback(async () => {
+		try {
+			const isOverview = activeTab === "overview";
+			const page = isOverview ? overviewErrorPage : errorPage;
+			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : errorPageSize;
+			const res = await getRecentErrors(pageSize, page * pageSize);
+			setRecentErrors(res.data);
+			setErrorTotal(res.total);
+		} catch (err) {
+			console.error(err);
+		}
+	}, [activeTab, errorPage, overviewErrorPage, errorPageSize]);
+
+	const loadRecentLists = useCallback(async () => {
+		await Promise.all([loadRecentRequests(), loadRecentErrors()]);
+	}, [loadRecentRequests, loadRecentErrors]);
 	const loadActiveTabStats = useCallback(async () => {
 		try {
 			if (activeTab === "models") {
@@ -85,10 +115,20 @@ export default function App() {
 	};
 
 	useEffect(() => {
-		loadRecentLists();
-		const interval = setInterval(loadRecentLists, 30000);
+		loadRecentRequests();
+	}, [loadRecentRequests]);
+
+	useEffect(() => {
+		loadRecentErrors();
+	}, [loadRecentErrors]);
+
+	useEffect(() => {
+		const interval = setInterval(() => {
+			loadRecentRequests();
+			loadRecentErrors();
+		}, 30000);
 		return () => clearInterval(interval);
-	}, [loadRecentLists]);
+	}, [loadRecentRequests, loadRecentErrors]);
 
 	useEffect(() => {
 		loadActiveTabStats();
@@ -113,19 +153,29 @@ export default function App() {
 						{overviewStats ? (
 							<StatsGrid stats={overviewStats.overall} />
 						) : (
-							<LoadingState label="Loading overview..." />
+							<LoadingState label={t("common.loading")} />
 						)}
 
 						<div className="grid lg:grid-cols-2 gap-6">
 							<RequestList
-								title="Recent Requests"
-								requests={recentRequests.slice(0, 10)}
+								title={t("requestList.recentRequests")}
+								requests={recentRequests}
+								total={requestTotal}
+								page={overviewRequestPage}
+								pageSize={OVERVIEW_PAGE_SIZE}
+								onPageChange={setOverviewRequestPage}
 								onSelect={r => r.id && setSelectedRequest(r.id)}
+								compact={true}
 							/>
 							<RequestList
-								title="Recent Errors"
-								requests={recentErrors.slice(0, 10)}
+								title={t("requestList.recentErrors")}
+								requests={recentErrors}
+								total={errorTotal}
+								page={overviewErrorPage}
+								pageSize={OVERVIEW_PAGE_SIZE}
+								onPageChange={setOverviewErrorPage}
 								onSelect={r => r.id && setSelectedRequest(r.id)}
+								compact={true}
 							/>
 						</div>
 					</div>
@@ -133,9 +183,25 @@ export default function App() {
 
 				{activeTab === "requests" && (
 					<div className="h-[calc(100vh-140px)] animate-fade-in">
+						<div className="mb-4 flex items-center gap-2">
+							<span className="text-sm text-[var(--text-muted)]">{t("requestList.pageSize")}:</span>
+							<select
+								value={requestPageSize}
+								onChange={e => { setRequestPageSize(Number(e.target.value)); setRequestPage(0); }}
+								className="px-2 py-1 text-sm rounded bg-[var(--bg-elevated)] text-[var(--text-primary)] border border-[var(--border-subtle)]"
+							>
+								<option value={15}>15</option>
+								<option value={30}>30</option>
+								<option value={50}>50</option>
+							</select>
+						</div>
 						<RequestList
-							title="All Recent Requests"
+							title={t("requestList.allRequests")}
 							requests={recentRequests}
+							total={requestTotal}
+							page={requestPage}
+							pageSize={requestPageSize}
+							onPageChange={setRequestPage}
 							onSelect={r => r.id && setSelectedRequest(r.id)}
 						/>
 					</div>
@@ -143,9 +209,25 @@ export default function App() {
 
 				{activeTab === "errors" && (
 					<div className="h-[calc(100vh-140px)] animate-fade-in">
+						<div className="mb-4 flex items-center gap-2">
+							<span className="text-sm text-[var(--text-muted)]">{t("requestList.pageSize")}:</span>
+							<select
+								value={errorPageSize}
+								onChange={e => { setErrorPageSize(Number(e.target.value)); setErrorPage(0); }}
+								className="px-2 py-1 text-sm rounded bg-[var(--bg-elevated)] text-[var(--text-primary)] border border-[var(--border-subtle)]"
+							>
+								<option value={15}>15</option>
+								<option value={30}>30</option>
+								<option value={50}>50</option>
+							</select>
+						</div>
 						<RequestList
-							title="Failed Requests"
+							title={t("requestList.failedRequests")}
 							requests={recentErrors}
+							total={errorTotal}
+							page={errorPage}
+							pageSize={errorPageSize}
+							onPageChange={setErrorPage}
 							onSelect={r => r.id && setSelectedRequest(r.id)}
 						/>
 					</div>
@@ -163,7 +245,7 @@ export default function App() {
 								/>
 							</>
 						) : (
-							<LoadingState label="Loading models..." />
+							<LoadingState label={t("common.loading")} />
 						)}
 					</div>
 				)}
@@ -176,7 +258,7 @@ export default function App() {
 								<CostChart costSeries={costStats.costSeries} />
 							</>
 						) : (
-							<LoadingState label="Loading costs..." />
+							<LoadingState label={t("common.loading")} />
 						)}
 					</div>
 				)}
@@ -196,7 +278,7 @@ export default function App() {
 								/>
 							</>
 						) : (
-							<LoadingState label="Loading behavior..." />
+							<LoadingState label={t("common.loading")} />
 						)}
 					</div>
 				)}

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -52,32 +52,40 @@ export default function App() {
 	const [activeTab, setActiveTab] = useState<Tab>("overview");
 	const [timeRange, setTimeRange] = useState<TimeRange>("24h");
 	const { t } = useTranslation();
+	const [requestSeq, setRequestSeq] = useState(0);
+	const [errorSeq, setErrorSeq] = useState(0);
 
 	const loadRecentRequests = useCallback(async () => {
+		const seq = requestSeq + 1;
+		setRequestSeq(seq);
 		try {
 			const isOverview = activeTab === "overview";
 			const page = isOverview ? overviewRequestPage : requestPage;
 			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : requestPageSize;
 			const res = await getRecentRequests(pageSize, page * pageSize);
+			if (seq !== requestSeq + 1) return;
 			setRecentRequests(res.data);
 			setRequestTotal(res.total);
 		} catch (err) {
 			console.error(err);
 		}
-	}, [activeTab, requestPage, overviewRequestPage, requestPageSize]);
+	}, [activeTab, requestPage, overviewRequestPage, requestPageSize, requestSeq]);
 
 	const loadRecentErrors = useCallback(async () => {
+		const seq = errorSeq + 1;
+		setErrorSeq(seq);
 		try {
 			const isOverview = activeTab === "overview";
 			const page = isOverview ? overviewErrorPage : errorPage;
 			const pageSize = isOverview ? OVERVIEW_PAGE_SIZE : errorPageSize;
 			const res = await getRecentErrors(pageSize, page * pageSize);
+			if (seq !== errorSeq + 1) return;
 			setRecentErrors(res.data);
 			setErrorTotal(res.total);
 		} catch (err) {
 			console.error(err);
 		}
-	}, [activeTab, errorPage, overviewErrorPage, errorPageSize]);
+	}, [activeTab, errorPage, overviewErrorPage, errorPageSize, errorSeq]);
 
 	const loadRecentLists = useCallback(async () => {
 		await Promise.all([loadRecentRequests(), loadRecentErrors()]);

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -5,6 +5,7 @@ import type {
 	MessageStats,
 	ModelDashboardStats,
 	OverviewStats,
+	PaginatedResponse,
 	RequestDetails,
 } from "./types";
 
@@ -34,16 +35,16 @@ export async function getCostDashboardStats(range = "24h"): Promise<CostDashboar
 	return res.json() as Promise<CostDashboardStats>;
 }
 
-export async function getRecentRequests(limit = 50): Promise<MessageStats[]> {
-	const res = await fetch(`${API_BASE}/stats/recent?limit=${limit}`);
+export async function getRecentRequests(limit = 50, offset = 0): Promise<PaginatedResponse<MessageStats>> {
+	const res = await fetch(`${API_BASE}/stats/recent?limit=${limit}&offset=${offset}`);
 	if (!res.ok) throw new Error("Failed to fetch recent requests");
-	return res.json() as Promise<MessageStats[]>;
+	return res.json() as Promise<PaginatedResponse<MessageStats>>;
 }
 
-export async function getRecentErrors(limit = 50): Promise<MessageStats[]> {
-	const res = await fetch(`${API_BASE}/stats/errors?limit=${limit}`);
+export async function getRecentErrors(limit = 50, offset = 0): Promise<PaginatedResponse<MessageStats>> {
+	const res = await fetch(`${API_BASE}/stats/errors?limit=${limit}&offset=${offset}`);
 	if (!res.ok) throw new Error("Failed to fetch recent errors");
-	return res.json() as Promise<MessageStats[]>;
+	return res.json() as Promise<PaginatedResponse<MessageStats>>;
 }
 
 export async function getRequestDetails(id: number): Promise<RequestDetails> {

--- a/packages/stats/src/client/components/BehaviorChart.tsx
+++ b/packages/stats/src/client/components/BehaviorChart.tsx
@@ -13,6 +13,7 @@ import {
 } from "chart.js";
 import { useMemo, useState } from "react";
 import { Bar, Line } from "react-chartjs-2";
+import { useTranslation } from "../i18n";
 import type { BehaviorTimeSeriesPoint } from "../types";
 import { useSystemTheme } from "../useSystemTheme";
 import {
@@ -31,17 +32,19 @@ import {
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend, Filler);
 
-const METRIC_OPTIONS = [
-	{ value: "yelling", label: "Yelling" },
-	{ value: "profanity", label: "Profanity" },
-	{ value: "anguish", label: "Anguish (!!!, nooo, dude, ..)" },
-	{ value: "negation", label: "Negation (no/nope/wrong)" },
-	{ value: "repetition", label: "Repetition (i meant, still doesnt)" },
-	{ value: "blame", label: "Blame (you didnt, stop X-ing)" },
-	{ value: "frustration", label: "Frustration (neg + rep + blame)" },
-	{ value: "total", label: "All signals combined" },
-] as const;
-type Metric = (typeof METRIC_OPTIONS)[number]["value"];
+function getMetricOptions(t: (key: string) => string) {
+	return [
+		{ value: "yelling", label: t("behaviorMetric.yelling") },
+		{ value: "profanity", label: t("behaviorMetric.profanity") },
+		{ value: "anguish", label: t("behaviorMetric.anguish") },
+		{ value: "negation", label: t("behaviorMetric.negation") },
+		{ value: "repetition", label: t("behaviorMetric.repetition") },
+		{ value: "blame", label: t("behaviorMetric.blame") },
+		{ value: "frustration", label: t("behaviorMetric.frustration") },
+		{ value: "total", label: t("behaviorMetric.total") },
+	] as const;
+}
+type Metric = "yelling" | "profanity" | "anguish" | "negation" | "repetition" | "blame" | "frustration" | "total";
 
 function formatRateAxis(value: number): string {
 	if (!Number.isFinite(value)) return "-";
@@ -73,8 +76,8 @@ interface DailyBucket {
 	messages: number;
 }
 
-function buildAggregateSeries(points: BehaviorTimeSeriesPoint[], metric: Metric): ChartSeries {
-	const label = METRIC_OPTIONS.find(m => m.value === metric)?.label ?? "Hits";
+function buildAggregateSeries(points: BehaviorTimeSeriesPoint[], metric: Metric, t: (key: string) => string): ChartSeries {
+	const label = getMetricOptions(t).find(m => m.value === metric)?.label ?? t("behaviorChart.hits");
 	return buildAggregateTimeSeries<BehaviorTimeSeriesPoint, DailyBucket>(points, label, {
 		initBucket: () => ({ hits: 0, messages: 0 }),
 		accumulate: (bucket, point) => {
@@ -85,7 +88,7 @@ function buildAggregateSeries(points: BehaviorTimeSeriesPoint[], metric: Metric)
 	});
 }
 
-function buildByModelSeries(points: BehaviorTimeSeriesPoint[], metric: Metric): ChartSeries {
+function buildByModelSeries(points: BehaviorTimeSeriesPoint[], metric: Metric, t: (key: string) => string): ChartSeries {
 	// Rank by message volume so the models you actually use surface first,
 	// matching the Behavior-by-Model table. Per-bucket math tracks hits +
 	// messages separately so the final rate isn't skewed by low-volume days.
@@ -97,33 +100,35 @@ function buildByModelSeries(points: BehaviorTimeSeriesPoint[], metric: Metric): 
 			bucket.messages += point.messages;
 		},
 		bucketToValue: bucket => ratePercent(bucket.hits, bucket.messages),
+		otherLabel: t("charts.other"),
 	});
 }
 
 export function BehaviorChart({ behaviorSeries }: BehaviorChartProps) {
+	const { t } = useTranslation();
 	const [byModel, setByModel] = useState(false);
 	const [metric, setMetric] = useState<Metric>("total");
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 
 	const chartData = useMemo(
-		() => (byModel ? buildByModelSeries(behaviorSeries, metric) : buildAggregateSeries(behaviorSeries, metric)),
-		[behaviorSeries, byModel, metric],
+		() => (byModel ? buildByModelSeries(behaviorSeries, metric, t) : buildAggregateSeries(behaviorSeries, metric, t)),
+		[behaviorSeries, byModel, metric, t],
 	);
 
 	const sharedPlugins = buildSharedPlugins({
 		chartTheme,
 		showLegend: byModel,
-		defaultLabel: "Hits",
+		defaultLabel: t("behaviorChart.hits"),
 		formatValue: formatRateAxis,
 	});
 
 	const { sharedScaleBase, yScale } = buildSharedScales({ chartTheme, formatY: formatRateAxis });
 
-	const metricLabel = METRIC_OPTIONS.find(m => m.value === metric)?.label ?? "";
+	const metricLabel = getMetricOptions(t).find(m => m.value === metric)?.label ?? "";
 	const metricTabs = (
 		<div className="flex bg-[var(--bg-surface)] rounded-[var(--radius-sm)] p-0.5 border border-[var(--border-subtle)]">
-			{METRIC_OPTIONS.map(opt => (
+			{getMetricOptions(t).map(opt => (
 				<button
 					key={opt.value}
 					type="button"
@@ -175,10 +180,12 @@ export function BehaviorChart({ behaviorSeries }: BehaviorChartProps) {
 
 	return (
 		<ChartFrame
-			title="User Tantrums"
-			subtitle={`${metricLabel} as % of user messages per day`}
+			title={t("behaviorChart.tantrums")}
+			subtitle={byModel
+				? t("behaviorChart.subtitleByModel").replace("{metric}", metricLabel)
+				: t("behaviorChart.subtitle").replace("{metric}", metricLabel)}
 			empty={chartData.labels.length === 0}
-			emptyMessage="No behavioral data yet. Sync to scan your sessions."
+			emptyMessage={t("behaviorChart.noData")}
 			controls={metricTabs}
 			byModel={byModel}
 			onByModelChange={setByModel}

--- a/packages/stats/src/client/components/BehaviorModelsTable.tsx
+++ b/packages/stats/src/client/components/BehaviorModelsTable.tsx
@@ -11,6 +11,7 @@ import {
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
+import { useTranslation } from "../i18n";
 import type { BehaviorModelStats, BehaviorTimeSeriesPoint } from "../types";
 import { useSystemTheme } from "../useSystemTheme";
 import {
@@ -87,6 +88,7 @@ function formatRate(total: number, messages: number): string {
 }
 
 export function BehaviorModelsTable({ models, behaviorSeries }: BehaviorModelsTableProps) {
+	const { t } = useTranslation();
 	const [expandedKey, setExpandedKey] = useState<string | null>(null);
 	const theme = useSystemTheme();
 	const chartTheme = TABLE_CHART_THEMES[theme];
@@ -102,20 +104,20 @@ export function BehaviorModelsTable({ models, behaviorSeries }: BehaviorModelsTa
 
 	return (
 		<ModelTableShell
-			title="Behavior by Model"
-			subtitle="How often each model elicited a tantrum — rates are per user message"
+			title={t("behaviorModelsTable.title")}
+			subtitle={t("behaviorModelsTable.subtitle")}
 		>
 			<ModelTableHeader
 				gridTemplate={GRID_TEMPLATE}
 				columns={[
-					{ label: "Model" },
-					{ label: "Messages", align: "right" },
-					{ label: "CAPS %", align: "right" },
-					{ label: "Profanity %", align: "right" },
-					{ label: "Anguish %", align: "right" },
-					{ label: "Frustration %", align: "right" },
-					{ label: "Hits %", align: "right" },
-					{ label: "Trend", align: "center" },
+					{ label: t("behaviorModelsTable.model") },
+					{ label: t("behaviorModelsTable.messages"), align: "right" },
+					{ label: t("behaviorModelsTable.capsPercent"), align: "right" },
+					{ label: t("behaviorModelsTable.profanityPercent"), align: "right" },
+					{ label: t("behaviorModelsTable.anguishPercent"), align: "right" },
+					{ label: t("behaviorModelsTable.frustrationPercent"), align: "right" },
+					{ label: t("behaviorModelsTable.hitsPercent"), align: "right" },
+					{ label: t("behaviorModelsTable.trend"), align: "center" },
 				]}
 			/>
 
@@ -169,49 +171,49 @@ export function BehaviorModelsTable({ models, behaviorSeries }: BehaviorModelsTa
 							expandedContent={
 								<div className="grid gap-4" style={{ gridTemplateColumns: "220px 1fr" }}>
 									<div className="space-y-4 text-sm">
-										<DetailRow
-											label="Yelling (CAPS)"
-											total={model.totalYelling}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-amber,#fbbf24)]"
-										/>
-										<DetailRow
-											label="Profanity"
-											total={model.totalProfanity}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-red,#f87171)]"
-										/>
-										<DetailRow
-											label="Anguish (!!!, nooo, dude, ..)"
-											total={model.totalAnguish}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-violet,#a78bfa)]"
-										/>
-										<DetailRow
-											label="Negation (no/nope/wrong)"
-											total={model.totalNegation}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-cyan,#22d3ee)]"
-										/>
-										<DetailRow
-											label="Repetition (i meant, still doesnt)"
-											total={model.totalRepetition}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-cyan,#22d3ee)]"
-										/>
-										<DetailRow
-											label="Blame (you didnt, stop X-ing)"
-											total={model.totalBlame}
-											messages={model.totalMessages}
-											valueClass="text-[var(--accent-cyan,#22d3ee)]"
-										/>
-										<DetailRow
-											label="Avg chars / msg"
-											total={model.totalChars}
-											messages={model.totalMessages}
-											valueClass="text-[var(--text-secondary)]"
-											mode="average"
-										/>
+									<DetailRow
+										label={t("behaviorModelsTable.yellingCaps")}
+										total={model.totalYelling}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-amber,#fbbf24)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.profanity")}
+										total={model.totalProfanity}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-red,#f87171)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.anguish")}
+										total={model.totalAnguish}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-violet,#a78bfa)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.negation")}
+										total={model.totalNegation}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-cyan,#22d3ee)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.repetition")}
+										total={model.totalRepetition}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-cyan,#22d3ee)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.blame")}
+										total={model.totalBlame}
+										messages={model.totalMessages}
+										valueClass="text-[var(--accent-cyan,#22d3ee)]"
+									/>
+									<DetailRow
+										label={t("behaviorModelsTable.avgCharsPerMsg")}
+										total={model.totalChars}
+										messages={model.totalMessages}
+										valueClass="text-[var(--text-secondary)]"
+										mode="average"
+									/>
 									</div>
 									<div className="h-[200px]">
 										{trend.length === 0 ? (
@@ -227,7 +229,7 @@ export function BehaviorModelsTable({ models, behaviorSeries }: BehaviorModelsTa
 				})}
 				{sortedModels.length === 0 ? (
 					<div className="border-t border-[var(--border-subtle)] px-5 py-8 text-center text-[var(--text-muted)] text-sm">
-						No user behavior recorded for this range yet.
+					{t("behaviorModelsTable.noData")}
 					</div>
 				) : null}
 			</ModelTableBody>
@@ -248,7 +250,8 @@ function DetailRow({
 	valueClass: string;
 	mode?: "rate" | "average";
 }) {
-	const perMsgLabel = mode === "rate" ? "% of msgs" : "Per msg";
+	const { t } = useTranslation();
+	const perMsgLabel = mode === "rate" ? t("behaviorModelsTable.percentOfMsgs") : t("behaviorModelsTable.perMsg");
 	const perMsgValue =
 		messages > 0 ? (mode === "rate" ? formatRate(total, messages) : (total / messages).toFixed(0)) : "-";
 	return (
@@ -256,7 +259,7 @@ function DetailRow({
 			<div className="text-[var(--text-primary)] font-medium mb-2">{label}</div>
 			<div className="space-y-1 text-[var(--text-secondary)]">
 				<div className="flex items-center justify-between">
-					<span>Total</span>
+					<span>{t("behaviorModelsTable.total")}</span>
 					<span className={`font-mono ${valueClass}`}>{formatInt(total)}</span>
 				</div>
 				<div className="flex items-center justify-between">
@@ -269,13 +272,14 @@ function DetailRow({
 }
 
 function BreakdownChart({ data, chartTheme }: { data: DailyPoint[]; chartTheme: TableChartTheme }) {
+	const { t } = useTranslation();
 	const chartData = {
 		labels: data.map(d => format(new Date(d.timestamp), "MMM d")),
 		datasets: [
-			{ label: "CAPS", data: data.map(d => d.yelling), ...lineSeriesStyle(SERIES_COLORS.yelling) },
-			{ label: "Profanity", data: data.map(d => d.profanity), ...lineSeriesStyle(SERIES_COLORS.profanity) },
-			{ label: "Anguish", data: data.map(d => d.anguish), ...lineSeriesStyle(SERIES_COLORS.anguish) },
-			{ label: "Frustration", data: data.map(d => d.frustration), ...lineSeriesStyle(SERIES_COLORS.frustration) },
+			{ label: t("behaviorModelsTable.caps"), data: data.map(d => d.yelling), ...lineSeriesStyle(SERIES_COLORS.yelling) },
+			{ label: t("behaviorModelsTable.profanity"), data: data.map(d => d.profanity), ...lineSeriesStyle(SERIES_COLORS.profanity) },
+			{ label: t("behaviorModelsTable.anguish"), data: data.map(d => d.anguish), ...lineSeriesStyle(SERIES_COLORS.anguish) },
+			{ label: t("behaviorModelsTable.frustration"), data: data.map(d => d.frustration), ...lineSeriesStyle(SERIES_COLORS.frustration) },
 		],
 	};
 

--- a/packages/stats/src/client/components/BehaviorSummary.tsx
+++ b/packages/stats/src/client/components/BehaviorSummary.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "../i18n";
 import type { BehaviorOverallStats, BehaviorTimeSeriesPoint } from "../types";
 
 interface BehaviorSummaryProps {
@@ -21,7 +22,7 @@ function perMsg(total: number, messages: number): string | undefined {
 }
 
 export function BehaviorSummary({ overall, behaviorSeries }: BehaviorSummaryProps) {
-	// Top "ranted-at" model: model that absorbed the most caps + profanity +
+	const { t } = useTranslation();
 	// anguish + frustration (negation/repetition/blame).
 	const topModel = useMemo(() => {
 		const totals = new Map<string, { model: string; provider: string; score: number }>();
@@ -48,34 +49,34 @@ export function BehaviorSummary({ overall, behaviorSeries }: BehaviorSummaryProp
 
 	const cards: Array<{ label: string; value: string; sub?: string }> = [
 		{
-			label: "Messages",
+			label: t("behaviorSummary.messages"),
 			value: formatInt(overall.totalMessages),
-			sub: messages > 0 ? "in selected range" : undefined,
+			sub: messages > 0 ? t("behaviorSummary.inRange") : undefined,
 		},
 		{
-			label: "Yelling",
+			label: t("behaviorSummary.yelling"),
 			value: formatInt(overall.totalYelling),
 			sub: perMsg(overall.totalYelling, messages),
 		},
 		{
-			label: "Profanity hits",
+			label: t("behaviorSummary.profanity"),
 			value: formatInt(overall.totalProfanity),
 			sub: perMsg(overall.totalProfanity, messages),
 		},
 		{
-			label: "Anguish",
+			label: t("behaviorSummary.anguish"),
 			value: formatInt(overall.totalAnguish),
 			sub: perMsg(overall.totalAnguish, messages),
 		},
 		{
-			label: "Frustration",
+			label: t("behaviorSummary.frustration"),
 			value: formatInt(totalFrustration),
 			sub: perMsg(totalFrustration, messages),
 		},
 		{
-			label: "Most yelled-at",
+			label: t("behaviorSummary.mostYelledAt"),
 			value: topModel?.model ?? "\u2014",
-			sub: topModel ? `${formatInt(topModel.score)} hits` : undefined,
+			sub: topModel ? `${formatInt(topModel.score)} ${t("behaviorSummary.hits")}` : undefined,
 		},
 	];
 

--- a/packages/stats/src/client/components/ChartsContainer.tsx
+++ b/packages/stats/src/client/components/ChartsContainer.tsx
@@ -170,6 +170,7 @@ function buildModelPreferenceSeries(
 		const key = `${point.model}::${point.provider}`;
 		const bucket = dataMap.get(point.timestamp) ?? { timestamp: point.timestamp, total: 0 };
 		const seriesLabel = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : otherLabel;
+		bucket.total += point.requests;
 		bucket[seriesLabel] = (bucket[seriesLabel] ?? 0) + point.requests;
 		dataMap.set(point.timestamp, bucket);
 	}

--- a/packages/stats/src/client/components/ChartsContainer.tsx
+++ b/packages/stats/src/client/components/ChartsContainer.tsx
@@ -11,52 +11,25 @@ import {
 } from "chart.js";
 import { useMemo } from "react";
 import { Line } from "react-chartjs-2";
+import { useTranslation } from "../i18n";
 import type { ModelTimeSeriesPoint, TimeRange } from "../types";
 import { useSystemTheme } from "../useSystemTheme";
+import { CHART_THEMES, MODEL_COLORS } from "./chart-shared";
 import { formatRangeTick, rangeMeta } from "./range-meta";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler);
 
-const MODEL_COLORS = [
-	"#a78bfa", // violet
-	"#22d3ee", // cyan
-	"#ec4899", // pink
-	"#4ade80", // green
-	"#fbbf24", // amber
-	"#f87171", // red
-	"#60a5fa", // blue
-];
-
-const CHART_THEMES = {
-	dark: {
-		legendLabel: "#94a3b8",
-		tooltipBackground: "#16161e",
-		tooltipTitle: "#f8fafc",
-		tooltipBody: "#94a3b8",
-		tooltipBorder: "rgba(255, 255, 255, 0.1)",
-		grid: "rgba(255, 255, 255, 0.06)",
-		tick: "#64748b",
-	},
-	light: {
-		legendLabel: "#475569",
-		tooltipBackground: "#ffffff",
-		tooltipTitle: "#0f172a",
-		tooltipBody: "#334155",
-		tooltipBorder: "rgba(15, 23, 42, 0.18)",
-		grid: "rgba(15, 23, 42, 0.08)",
-		tick: "#64748b",
-	},
-} as const;
 interface ChartsContainerProps {
 	modelSeries: ModelTimeSeriesPoint[];
 	timeRange: TimeRange;
 }
 
 export function ChartsContainer({ modelSeries, timeRange }: ChartsContainerProps) {
-	const chartData = useMemo(() => buildModelPreferenceSeries(modelSeries), [modelSeries]);
+	const { t } = useTranslation();
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 	const meta = rangeMeta(timeRange);
+	const chartData = useMemo(() => buildModelPreferenceSeries(modelSeries, 5, t("charts.other")), [modelSeries, t]);
 	const data = {
 		labels: chartData.data.map(d => formatRangeTick(d.timestamp, timeRange)),
 		datasets: chartData.series.map((seriesName, index) => ({
@@ -138,13 +111,13 @@ export function ChartsContainer({ modelSeries, timeRange }: ChartsContainerProps
 	return (
 		<div className="surface overflow-hidden">
 			<div className="px-5 py-4 border-b border-[var(--border-subtle)]">
-				<h3 className="text-sm font-semibold text-[var(--text-primary)]">Model Preference</h3>
-				<p className="text-xs text-[var(--text-muted)] mt-1">Share of requests over {meta.windowLabel}</p>
+				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{t("charts.modelPreference")}</h3>
+				<p className="text-xs text-[var(--text-muted)] mt-1">{t("charts.shareOfRequests", { "0": meta.windowLabel })}</p>
 			</div>
 			<div className="p-5 min-h-[320px]">
 				{chartData.data.length === 0 ? (
 					<div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">
-						No data available
+						{t("common.noData")}
 					</div>
 				) : (
 					<div className="h-[280px]">
@@ -155,10 +128,10 @@ export function ChartsContainer({ modelSeries, timeRange }: ChartsContainerProps
 		</div>
 	);
 }
-
 function buildModelPreferenceSeries(
 	points: ModelTimeSeriesPoint[],
 	topN = 5,
+	otherLabel = "Other",
 ): {
 	data: Array<Record<string, number>>;
 	series: string[];
@@ -196,15 +169,14 @@ function buildModelPreferenceSeries(
 	for (const point of points) {
 		const key = `${point.model}::${point.provider}`;
 		const bucket = dataMap.get(point.timestamp) ?? { timestamp: point.timestamp, total: 0 };
-		bucket.total += point.requests;
-		const seriesLabel = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : "Other";
+		const seriesLabel = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : otherLabel;
 		bucket[seriesLabel] = (bucket[seriesLabel] ?? 0) + point.requests;
 		dataMap.set(point.timestamp, bucket);
 	}
 
 	const series = topEntries.map(entry => labelByKey.get(entry.key) ?? entry.model);
-	if ([...dataMap.values()].some(row => (row.Other ?? 0) > 0)) {
-		series.push("Other");
+	if ([...dataMap.values()].some(row => (row[otherLabel] ?? 0) > 0)) {
+		series.push(otherLabel);
 	}
 
 	const data = [...dataMap.values()]

--- a/packages/stats/src/client/components/CostChart.tsx
+++ b/packages/stats/src/client/components/CostChart.tsx
@@ -14,6 +14,7 @@ import {
 } from "chart.js";
 import { useMemo, useState } from "react";
 import { Bar, Line } from "react-chartjs-2";
+import { useTranslation } from "../i18n";
 import type { CostTimeSeriesPoint } from "../types";
 import { useSystemTheme } from "../useSystemTheme";
 import {
@@ -68,8 +69,8 @@ function makeBarLabelPlugin(color: string): Plugin<"bar"> {
 	};
 }
 
-function buildAggregateSeries(points: CostTimeSeriesPoint[]): ChartSeries {
-	return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(points, "Cost", {
+function buildAggregateSeries(points: CostTimeSeriesPoint[], t: (key: string) => string): ChartSeries {
+	return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(points, t("costChart.cost"), {
 		initBucket: () => ({ total: 0 }),
 		accumulate: (bucket, point) => {
 			bucket.total += point.cost;
@@ -78,7 +79,7 @@ function buildAggregateSeries(points: CostTimeSeriesPoint[]): ChartSeries {
 	});
 }
 
-function buildByModelSeries(points: CostTimeSeriesPoint[]): ChartSeries {
+function buildByModelSeries(points: CostTimeSeriesPoint[], otherLabel: string): ChartSeries {
 	// Rank models by total cost; per-day buckets are simple cost sums.
 	return buildTopNByModelSeries<CostTimeSeriesPoint, { total: number }>(points, {
 		rankWeight: point => point.cost,
@@ -87,28 +88,30 @@ function buildByModelSeries(points: CostTimeSeriesPoint[]): ChartSeries {
 			bucket.total += point.cost;
 		},
 		bucketToValue: bucket => bucket.total,
+		otherLabel,
 	});
 }
 
 export function CostChart({ costSeries }: CostChartProps) {
+	const { t } = useTranslation();
 	const [byModel, setByModel] = useState(false);
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 
 	const chartData = useMemo(
-		() => (byModel ? buildByModelSeries(costSeries) : buildAggregateSeries(costSeries)),
-		[costSeries, byModel],
+		() => (byModel ? buildByModelSeries(costSeries, t("charts.other")) : buildAggregateSeries(costSeries, t)),
+		[costSeries, byModel, t],
 	);
 
 	const sharedPlugins = buildSharedPlugins({
 		chartTheme,
 		showLegend: byModel,
-		defaultLabel: "Cost",
+		defaultLabel: t("costChart.cost"),
 		formatValue: v => `$${Math.round(v)}`,
 		footer: items => {
 			if (!byModel || items.length < 2) return undefined;
 			const total = items.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
-			return `Total: $${Math.round(total)}`;
+			return `${t("costChart.total")}: $${Math.round(total)}`;
 		},
 	});
 
@@ -158,10 +161,10 @@ export function CostChart({ costSeries }: CostChartProps) {
 
 	return (
 		<ChartFrame
-			title="Daily Cost"
-			subtitle="API spending over time"
+			title={t("costChart.dailyCost")}
+			subtitle={t("costChart.subtitle")}
 			empty={chartData.labels.length === 0}
-			emptyMessage="No cost data available"
+			emptyMessage={t("costChart.noData")}
 			byModel={byModel}
 			onByModelChange={setByModel}
 		>

--- a/packages/stats/src/client/components/CostSummary.tsx
+++ b/packages/stats/src/client/components/CostSummary.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "../i18n";
 import type { CostTimeSeriesPoint } from "../types";
 
 interface CostSummaryProps {
@@ -9,6 +10,7 @@ function formatCost(value: number): string {
 }
 
 export function CostSummary({ costSeries }: CostSummaryProps) {
+	const { t } = useTranslation();
 	const totalCost = costSeries.reduce((sum, p) => sum + p.cost, 0);
 	const dayBuckets = new Set(costSeries.map(p => p.timestamp)).size;
 	const avgDaily = dayBuckets > 0 ? totalCost / dayBuckets : 0;
@@ -28,10 +30,10 @@ export function CostSummary({ costSeries }: CostSummaryProps) {
 	}
 
 	const cards = [
-		{ label: "Total", value: formatCost(totalCost) },
-		{ label: "Avg / day", value: formatCost(avgDaily) },
+		{ label: t("costSummary.total"), value: formatCost(totalCost) },
+		{ label: t("costSummary.avgPerDay"), value: formatCost(avgDaily) },
 		{
-			label: "Top model",
+			label: t("costSummary.topModel"),
 			value: topModel || "—",
 			sub: topModel ? formatCost(topModelCost) : undefined,
 		},

--- a/packages/stats/src/client/components/Header.tsx
+++ b/packages/stats/src/client/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Activity, RefreshCw } from "lucide-react";
+import { useTranslation } from "../i18n";
 import type { TimeRange } from "../types";
 
 type Tab = "overview" | "requests" | "errors" | "models" | "costs" | "behavior";
@@ -23,6 +24,17 @@ interface HeaderProps {
 }
 
 export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onTimeRangeChange }: HeaderProps) {
+	const { t, locale, setLocale } = useTranslation();
+
+	const tabLabels: Record<Tab, string> = {
+		overview: t("header.tab.overview"),
+		requests: t("header.tab.requests"),
+		errors: t("header.tab.errors"),
+		models: t("header.tab.models"),
+		costs: t("header.tab.costs"),
+		behavior: t("header.tab.behavior"),
+	};
+
 	return (
 		<header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-6 mb-8 border-b border-[var(--border-subtle)]">
 			<div className="flex items-center gap-3">
@@ -30,8 +42,8 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 					<Activity className="w-5 h-5 text-white" />
 				</div>
 				<div>
-					<h1 className="text-xl font-semibold text-[var(--text-primary)]">AI Usage</h1>
-					<p className="text-sm text-[var(--text-muted)]">Statistics & Analytics</p>
+					<h1 className="text-xl font-semibold text-[var(--text-primary)]">{t("header.title")}</h1>
+					<p className="text-sm text-[var(--text-muted)]">{t("header.subtitle")}</p>
 				</div>
 			</div>
 
@@ -42,9 +54,9 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 							key={tab}
 							type="button"
 							onClick={() => onTabChange(tab)}
-							className={`tab-btn capitalize ${activeTab === tab ? "active" : ""}`}
+							className={`tab-btn ${activeTab === tab ? "active" : ""}`}
 						>
-							{tab}
+							{tabLabels[tab]}
 						</button>
 					))}
 				</div>
@@ -55,16 +67,33 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 							type="button"
 							onClick={() => onTimeRangeChange(range.value)}
 							className={`tab-btn ${timeRange === range.value ? "active" : ""}`}
-							title={range.value === "all" ? "All time" : `Last ${range.label}`}
+							title={range.value === "all" ? t("header.range.all") : `${t("header.range.last")} ${range.label}`}
 						>
 							{range.label}
 						</button>
 					))}
 				</div>
 
+				<div className="flex bg-[var(--bg-surface)] rounded-[var(--radius-md)] p-1 border border-[var(--border-subtle)]">
+					<button
+						type="button"
+						onClick={() => setLocale("en")}
+						className={`tab-btn ${locale === "en" ? "active" : ""}`}
+					>
+						EN
+					</button>
+					<button
+						type="button"
+						onClick={() => setLocale("zh")}
+						className={`tab-btn ${locale === "zh" ? "active" : ""}`}
+					>
+						中文
+					</button>
+				</div>
+
 				<button type="button" onClick={onSync} disabled={syncing} className="btn btn-primary">
 					<RefreshCw size={16} className={syncing ? "spin" : ""} />
-					{syncing ? "Syncing..." : "Sync"}
+					{syncing ? t("header.syncing") : t("header.sync")}
 				</button>
 			</div>
 		</header>

--- a/packages/stats/src/client/components/ModelsTable.tsx
+++ b/packages/stats/src/client/components/ModelsTable.tsx
@@ -11,7 +11,7 @@ import {
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
-import type { ModelPerformancePoint, ModelStats, TimeRange } from "../types";
+import { useTranslation } from "../i18n";
 import { useSystemTheme } from "../useSystemTheme";
 import {
 	DetailChartEmpty,
@@ -52,6 +52,7 @@ type ModelPerformanceSeries = {
 };
 
 export function ModelsTable({ models, performanceSeries, timeRange }: ModelsTableProps) {
+	const { t } = useTranslation();
 	const [expandedKey, setExpandedKey] = useState<string | null>(null);
 	const meta = rangeMeta(timeRange);
 
@@ -66,16 +67,16 @@ export function ModelsTable({ models, performanceSeries, timeRange }: ModelsTabl
 	);
 
 	return (
-		<ModelTableShell title="Model Statistics">
+		<ModelTableShell title={t("modelsTable.title")}>
 			<ModelTableHeader
 				gridTemplate={GRID_TEMPLATE}
 				columns={[
-					{ label: "Model" },
-					{ label: "Requests", align: "right" },
-					{ label: "Cost", align: "right" },
-					{ label: "Tokens", align: "right" },
-					{ label: "Tokens/s", align: "right" },
-					{ label: "TTFT", align: "right" },
+					{ label: t("modelsTable.model") },
+					{ label: t("modelsTable.requests"), align: "right" },
+					{ label: t("modelsTable.cost"), align: "right" },
+					{ label: t("modelsTable.tokens"), align: "right" },
+					{ label: t("modelsTable.tokensPerSec"), align: "right" },
+					{ label: t("modelsTable.ttft"), align: "right" },
 					{ label: meta.trendLabel, align: "center" },
 				]}
 			/>

--- a/packages/stats/src/client/components/RequestDetail.tsx
+++ b/packages/stats/src/client/components/RequestDetail.tsx
@@ -1,16 +1,17 @@
 import { Clock, Coins, FileJson, Gauge, Hash, Star, X, Zap } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getRequestDetails } from "../api";
-import type { RequestDetails } from "../types";
+import { useTranslation } from "../i18n";
+import type { RequestDetails, Usage } from "../types";
 
 interface RequestDetailProps {
 	id: number;
 	onClose: () => void;
 }
-
 export function RequestDetail({ id, onClose }: RequestDetailProps) {
 	const [details, setDetails] = useState<RequestDetails | null>(null);
 	const [loading, setLoading] = useState(true);
+	const { t } = useTranslation();
 
 	useEffect(() => {
 		getRequestDetails(id)
@@ -25,7 +26,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 				<div className="surface px-8 py-6">
 					<div className="flex items-center gap-3 text-[var(--text-secondary)]">
 						<div className="w-5 h-5 border-2 border-[var(--border-default)] border-t-[var(--accent-cyan)] rounded-full spin" />
-						<span>Loading...</span>
+						<span>{t("common.loading")}</span>
 					</div>
 				</div>
 			</div>
@@ -52,7 +53,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 						<div className="w-8 h-8 rounded-[var(--radius-sm)] bg-gradient-to-br from-[var(--accent-pink)]/20 to-[var(--accent-cyan)]/20 flex items-center justify-center">
 							<FileJson size={16} className="text-[var(--accent-cyan)]" />
 						</div>
-						<h2 className="text-lg font-semibold text-[var(--text-primary)]">Request Details</h2>
+						<h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("requestDetail.title")}</h2>
 					</div>
 					<button
 						type="button"
@@ -72,9 +73,9 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 								<div className="text-sm text-[var(--text-muted)]">{details.provider}</div>
 							</div>
 							{details.errorMessage ? (
-								<span className="badge badge-error">Error</span>
+								<span className="badge badge-error">{t("requestDetail.error")}</span>
 							) : (
-								<span className="badge badge-success">Success</span>
+								<span className="badge badge-success">{t("requestDetail.success")}</span>
 							)}
 						</div>
 					</div>
@@ -84,7 +85,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 						<div className="surface p-4">
 							<div className="flex items-center gap-2 text-[var(--text-muted)] mb-2">
 								<Coins size={14} />
-								<span className="text-xs uppercase tracking-wide">Cost</span>
+								<span className="text-xs uppercase tracking-wide">{t("requestDetail.cost")}</span>
 							</div>
 							<div className="text-xl font-semibold text-[var(--text-primary)]">
 								${details.usage.cost.total.toFixed(4)}
@@ -94,7 +95,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 						<div className="surface p-4">
 							<div className="flex items-center gap-2 text-[var(--text-muted)] mb-2">
 								<Star size={14} />
-								<span className="text-xs uppercase tracking-wide">Premium Reqs</span>
+								<span className="text-xs uppercase tracking-wide">{t("requestDetail.premiumReqs")}</span>
 							</div>
 							<div className="text-xl font-semibold text-[var(--text-primary)]">
 								{(details.usage.premiumRequests ?? 0).toLocaleString()}
@@ -103,20 +104,26 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 						<div className="surface p-4">
 							<div className="flex items-center gap-2 text-[var(--text-muted)] mb-2">
 								<Hash size={14} />
-								<span className="text-xs uppercase tracking-wide">Tokens</span>
+								<span className="text-xs uppercase tracking-wide">{t("requestDetail.tokens")}</span>
 							</div>
 							<div className="text-xl font-semibold text-[var(--text-primary)]">
 								{details.usage.totalTokens.toLocaleString()}
 							</div>
-							<div className="text-xs text-[var(--text-muted)] mt-1">
-								{details.usage.input.toLocaleString()} in · {details.usage.output.toLocaleString()} out
+							<div className="text-xs text-[var(--text-muted)] mt-1 space-y-0.5">
+								<div>{t("requestDetail.inputTokens")}: {details.usage.input.toLocaleString()}</div>
+								<div>{t("requestDetail.outputTokens")}: {details.usage.output.toLocaleString()}</div>
+								<div>{t("requestDetail.cacheReadTokens")}: {details.usage.cacheRead.toLocaleString()}</div>
+								<div>{t("requestDetail.cacheWriteTokens")}: {details.usage.cacheWrite.toLocaleString()}</div>
+								{(details.usage.reasoningTokens ?? 0) > 0 && (
+									<div>{t("requestDetail.reasoningTokens")}: {(details.usage.reasoningTokens ?? 0).toLocaleString()}</div>
+								)}
 							</div>
 						</div>
 
 						<div className="surface p-4">
 							<div className="flex items-center gap-2 text-[var(--text-muted)] mb-2">
 								<Clock size={14} />
-								<span className="text-xs uppercase tracking-wide">Duration</span>
+								<span className="text-xs uppercase tracking-wide">{t("requestDetail.duration")}</span>
 							</div>
 							<div className="text-xl font-semibold text-[var(--text-primary)]">
 								{details.duration ? `${(details.duration / 1000).toFixed(2)}s` : "-"}
@@ -126,7 +133,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 						<div className="surface p-4">
 							<div className="flex items-center gap-2 text-[var(--text-muted)] mb-2">
 								<Zap size={14} />
-								<span className="text-xs uppercase tracking-wide">TTFT</span>
+								<span className="text-xs uppercase tracking-wide">{t("requestDetail.ttft")}</span>
 							</div>
 							<div className="text-xl font-semibold text-[var(--text-primary)]">
 								{details.ttft ? `${(details.ttft / 1000).toFixed(2)}s` : "-"}
@@ -140,19 +147,19 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 							<div className="flex items-center justify-between">
 								<div className="flex items-center gap-2 text-[var(--text-muted)]">
 									<Gauge size={14} />
-									<span className="text-xs uppercase tracking-wide">Throughput</span>
+									<span className="text-xs uppercase tracking-wide">{t("requestDetail.throughput")}</span>
 								</div>
 								<span className="text-2xl font-bold gradient-text">
 									{((details.usage.output * 1000) / details.duration).toFixed(1)}
 								</span>
 							</div>
-							<div className="text-xs text-[var(--text-muted)] mt-1 text-right">tokens/second</div>
+							<div className="text-xs text-[var(--text-muted)] mt-1 text-right">{t("requestDetail.tokensPerSecond")}</div>
 						</div>
 					)}
 
 					{/* Output */}
 					<div>
-						<h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">Output</h3>
+						<h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">{t("requestDetail.output")}</h3>
 						<pre className="surface bg-[var(--bg-elevated)] p-4 rounded-[var(--radius-md)] text-sm font-mono text-[var(--text-secondary)] overflow-x-auto">
 							{JSON.stringify(details.output, null, 2)}
 						</pre>
@@ -160,7 +167,7 @@ export function RequestDetail({ id, onClose }: RequestDetailProps) {
 
 					{/* Raw Metadata */}
 					<div>
-						<h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">Raw Metadata</h3>
+						<h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">{t("requestDetail.rawMetadata")}</h3>
 						<pre className="surface bg-[var(--bg-elevated)] p-4 rounded-[var(--radius-md)] text-xs font-mono text-[var(--text-muted)] overflow-x-auto">
 							{JSON.stringify(details, null, 2)}
 						</pre>

--- a/packages/stats/src/client/components/RequestList.tsx
+++ b/packages/stats/src/client/components/RequestList.tsx
@@ -24,7 +24,7 @@ export function RequestList({ requests, total, page, pageSize, onPageChange, onS
 	};
 
 	return (
-		<div className="surface overflow-hidden flex flex-col h-full">
+		<div className="surface overflow-hidden flex flex-col" style={{ height: "calc(100vh - 200px)" }}>
 			<div className="px-5 py-4 border-b border-[var(--border-subtle)]">
 				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
 			</div>
@@ -103,7 +103,7 @@ export function RequestList({ requests, total, page, pageSize, onPageChange, onS
 			</div>
 			<div className="px-5 py-3 border-t border-[var(--border-subtle)] flex items-center justify-between">
 				<div className="text-sm text-[var(--text-muted)]">
-					{t("requestList.showing", { start: page * pageSize + 1, end: Math.min((page + 1) * pageSize, total), total })}
+				{total === 0 ? t("requestList.noRequests") : t("requestList.showing", { start: page * pageSize + 1, end: Math.min((page + 1) * pageSize, total), total })}
 				</div>
 				<div className="flex gap-2 items-center">
 					<button

--- a/packages/stats/src/client/components/RequestList.tsx
+++ b/packages/stats/src/client/components/RequestList.tsx
@@ -24,7 +24,7 @@ export function RequestList({ requests, total, page, pageSize, onPageChange, onS
 	};
 
 	return (
-		<div className="surface overflow-hidden flex flex-col">
+		<div className="surface overflow-hidden flex flex-col h-full">
 			<div className="px-5 py-4 border-b border-[var(--border-subtle)]">
 				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
 			</div>

--- a/packages/stats/src/client/components/RequestList.tsx
+++ b/packages/stats/src/client/components/RequestList.tsx
@@ -1,16 +1,30 @@
 import { formatDistanceToNow } from "date-fns";
 import { CheckCircle2, XCircle } from "lucide-react";
+import { useTranslation } from "../i18n";
 import type { MessageStats } from "../types";
 
 interface RequestListProps {
 	requests: MessageStats[];
+	total: number;
+	page: number;
+	pageSize: number;
+	onPageChange: (page: number) => void;
 	onSelect: (req: MessageStats) => void;
 	title: string;
+	compact?: boolean;
 }
 
-export function RequestList({ requests, onSelect, title }: RequestListProps) {
+export function RequestList({ requests, total, page, pageSize, onPageChange, onSelect, title, compact = false }: RequestListProps) {
+
+	const { t } = useTranslation();
+
+	const calculateTPS = (req: MessageStats): string => {
+		if (!req.duration || req.duration === 0 || req.usage.output === 0) return "-";
+		return ((req.usage.output * 1000) / req.duration).toFixed(1);
+	};
+
 	return (
-		<div className="surface overflow-hidden flex flex-col h-full">
+		<div className="surface overflow-hidden flex flex-col">
 			<div className="px-5 py-4 border-b border-[var(--border-subtle)]">
 				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
 			</div>
@@ -18,12 +32,16 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 				<table className="w-full">
 					<thead className="bg-[var(--bg-elevated)] sticky top-0 z-10">
 						<tr>
-							<th className="text-left py-3 px-4 table-header">Model</th>
-							<th className="text-left py-3 px-4 table-header">Time</th>
-							<th className="text-right py-3 px-4 table-header">Tokens</th>
-							<th className="text-right py-3 px-4 table-header">Cost</th>
-							<th className="text-right py-3 px-4 table-header">Duration</th>
-							<th className="text-center py-3 px-4 table-header">Status</th>
+							<th className="text-left py-2 px-3 table-header">{t("requestList.model")}</th>
+							<th className="text-left py-2 px-3 table-header">{t("requestList.provider")}</th>
+							<th className="text-left py-2 px-3 table-header">{t("requestList.time")}</th>
+							{!compact && <th className="text-right py-2 px-3 table-header">{t("requestList.input")}</th>}
+							{!compact && <th className="text-right py-2 px-3 table-header">{t("requestList.output")}</th>}
+							<th className="text-right py-2 px-3 table-header">{t("requestList.tokens")}</th>
+							<th className="text-right py-2 px-3 table-header">{t("requestList.cost")}</th>
+							{!compact && <th className="text-right py-2 px-3 table-header">{t("requestList.tps")}</th>}
+							<th className="text-right py-2 px-3 table-header">{t("requestList.duration")}</th>
+							<th className="text-center py-2 px-3 table-header">{t("requestList.status")}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -33,23 +51,38 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 								onClick={() => onSelect(req)}
 								className="table-row cursor-pointer border-b border-[var(--border-subtle)] last:border-b-0"
 							>
-								<td className="py-3 px-4">
+								<td className="py-2 px-3">
 									<div className="font-medium text-[var(--text-primary)] text-sm">{req.model}</div>
-									<div className="text-xs text-[var(--text-muted)]">{req.provider}</div>
 								</td>
-								<td className="py-3 px-4 text-sm text-[var(--text-secondary)]">
+								<td className="py-2 px-3 text-sm text-[var(--text-muted)]">{req.provider}</td>
+								<td className="py-2 px-3 text-sm text-[var(--text-secondary)]">
 									{formatDistanceToNow(req.timestamp, { addSuffix: true })}
 								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
+								{!compact && (
+									<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
+										{req.usage.input.toLocaleString()}
+									</td>
+								)}
+								{!compact && (
+									<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
+										{req.usage.output.toLocaleString()}
+									</td>
+								)}
+								<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
 									{req.usage.totalTokens.toLocaleString()}
 								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
+								<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
 									${req.usage.cost.total.toFixed(4)}
 								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
+								{!compact && (
+									<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
+										{calculateTPS(req)}
+									</td>
+								)}
+								<td className="py-2 px-3 text-right text-sm text-[var(--text-secondary)] font-mono">
 									{req.duration ? `${(req.duration / 1000).toFixed(1)}s` : "-"}
 								</td>
-								<td className="py-3 px-4 text-center">
+								<td className="py-2 px-3 text-center">
 									{req.errorMessage ? (
 										<XCircle size={16} className="text-[var(--accent-red)] mx-auto" />
 									) : (
@@ -60,13 +93,62 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 						))}
 						{requests.length === 0 && (
 							<tr>
-								<td colSpan={6} className="py-12 text-center text-[var(--text-muted)] text-sm">
-									No requests found
+								<td colSpan={compact ? 7 : 10} className="py-12 text-center text-[var(--text-muted)] text-sm">
+									{t("requestList.noRequests")}
 								</td>
 							</tr>
 						)}
 					</tbody>
 				</table>
+			</div>
+			<div className="px-5 py-3 border-t border-[var(--border-subtle)] flex items-center justify-between">
+				<div className="text-sm text-[var(--text-muted)]">
+					{t("requestList.showing", { start: page * pageSize + 1, end: Math.min((page + 1) * pageSize, total), total })}
+				</div>
+				<div className="flex gap-2 items-center">
+					<button
+						onClick={() => onPageChange(page - 1)}
+						disabled={page === 0}
+						className="px-3 py-1 text-sm rounded bg-[var(--bg-elevated)] text-[var(--text-primary)] disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--bg-hover)]"
+					>
+						{t("common.previous")}
+					</button>
+					<div className="flex gap-1">
+						{Array.from({ length: Math.min(5, Math.ceil(total / pageSize)) }, (_, i) => {
+							const totalPages = Math.ceil(total / pageSize);
+							let pageNum = i;
+							if (totalPages > 5) {
+								if (page < 3) {
+									pageNum = i;
+								} else if (page > totalPages - 4) {
+									pageNum = totalPages - 5 + i;
+								} else {
+									pageNum = page - 2 + i;
+								}
+							}
+							return (
+								<button
+									key={pageNum}
+									onClick={() => onPageChange(pageNum)}
+									className={`px-3 py-1 text-sm rounded ${
+										page === pageNum
+											? "bg-[var(--accent)] text-white"
+											: "bg-[var(--bg-elevated)] text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
+									}`}
+								>
+									{pageNum + 1}
+								</button>
+							);
+						})}
+					</div>
+					<button
+						onClick={() => onPageChange(page + 1)}
+						disabled={(page + 1) * pageSize >= total}
+						className="px-3 py-1 text-sm rounded bg-[var(--bg-elevated)] text-[var(--text-primary)] disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--bg-hover)]"
+					>
+						{t("common.next")}
+					</button>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/stats/src/client/components/StatsGrid.tsx
+++ b/packages/stats/src/client/components/StatsGrid.tsx
@@ -1,111 +1,124 @@
 import { Activity, AlertCircle, BarChart3, Database, Download, Server, Star, Upload, Zap } from "lucide-react";
+import { useTranslation, type TranslationKey } from "../i18n";
 import type { AggregatedStats } from "../types";
 
 interface StatsGridProps {
 	stats: AggregatedStats;
 }
 
-const compactNumberFormatter = new Intl.NumberFormat(undefined, {
-	notation: "compact",
-	maximumFractionDigits: 1,
-});
-
-function formatCompactNumber(value: number): string {
-	return compactNumberFormatter.format(value);
+function formatCompactNumber(value: number, locale: string): string {
+	return new Intl.NumberFormat(locale, {
+		notation: "compact",
+		maximumFractionDigits: 1,
+	}).format(value);
 }
 
-function formatExactNumber(value: number): string {
-	return value.toLocaleString();
+function formatExactNumber(value: number, locale: string): string {
+	return value.toLocaleString(locale);
 }
+
+const localeMap: Record<string, string> = { en: "en-US", zh: "zh-CN" };
 
 const totalPromptCompletionTokens = (stats: AggregatedStats) => stats.totalInputTokens + stats.totalOutputTokens;
 
-const statConfig = [
+interface StatDef {
+	key: string;
+	titleKey: string;
+	icon: typeof Server;
+	color: string;
+	getValue: (s: AggregatedStats, locale: string) => string;
+	getDetail: (s: AggregatedStats, t: (key: string, params?: Record<string, string | number>) => string, locale: string) => string;
+}
+
+const statConfig: StatDef[] = [
 	{
 		key: "requests",
-		title: "Total Requests",
+		titleKey: "statsGrid.totalRequests",
 		icon: Server,
 		color: "var(--accent-violet)",
-		getValue: (s: AggregatedStats) => s.totalRequests.toLocaleString(),
-		getDetail: (s: AggregatedStats) =>
-			`${s.successfulRequests.toLocaleString()} success · ${s.failedRequests.toLocaleString()} errors`,
+		getValue: (s, locale) => formatExactNumber(s.totalRequests, locale),
+		getDetail: (s, t, locale) =>
+			`${formatExactNumber(s.successfulRequests, locale)} ${t("statsGrid.successErrors", { "0": formatExactNumber(s.failedRequests, locale) })}`,
 	},
 	{
 		key: "cost",
-		title: "Total Cost",
+		titleKey: "statsGrid.totalCost",
 		icon: Activity,
 		color: "var(--accent-pink)",
-		getValue: (s: AggregatedStats) => `$${s.totalCost.toFixed(2)}`,
-		getDetail: (s: AggregatedStats) =>
-			s.totalRequests > 0 ? `$${(s.totalCost / s.totalRequests).toFixed(4)} avg/req` : "-",
+		getValue: s => `$${s.totalCost.toFixed(2)}`,
+		getDetail: (s, t) =>
+			s.totalRequests > 0 ? t("statsGrid.avgCostPerReq", { "0": (s.totalCost / s.totalRequests).toFixed(4) }) : "-",
 	},
 	{
 		key: "premiumRequests",
-		title: "Premium Reqs",
+		titleKey: "requestDetail.premiumReqs",
 		icon: Star,
 		color: "var(--accent-amber)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalPremiumRequests),
-		getDetail: (s: AggregatedStats) =>
-			s.totalRequests > 0 ? `${((s.totalPremiumRequests / s.totalRequests) * 100).toFixed(1)}% of requests` : "-",
+		getValue: (s, locale) => formatExactNumber(s.totalPremiumRequests, locale),
+		getDetail: (s, t) =>
+			s.totalRequests > 0 ? `${((s.totalPremiumRequests / s.totalRequests) * 100).toFixed(1)}% ${t("statsGrid.ofRequests")}` : "-",
 	},
 	{
 		key: "cache",
-		title: "Cache Rate",
+		titleKey: "statsGrid.cacheRead",
 		icon: Database,
 		color: "var(--accent-cyan)",
-		getValue: (s: AggregatedStats) => `${(s.cacheRate * 100).toFixed(1)}%`,
-		getDetail: (s: AggregatedStats) => `${formatCompactNumber(s.totalCacheReadTokens)} cached tokens`,
+		getValue: s => `${(s.cacheRate * 100).toFixed(1)}%`,
+		getDetail: (s, t, locale) => `${formatCompactNumber(s.totalCacheReadTokens, locale)} ${t("statsGrid.cachedTokens")}`,
 	},
 	{
 		key: "inputTokens",
-		title: "Input Tokens",
+		titleKey: "statsGrid.inputTokens",
 		icon: Download,
 		color: "var(--accent-violet)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalInputTokens),
-		getDetail: (s: AggregatedStats) =>
+		getValue: (s, locale) => formatCompactNumber(s.totalInputTokens, locale),
+		getDetail: (s, t) =>
 			totalPromptCompletionTokens(s) > 0
-				? `${((s.totalInputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				? `${((s.totalInputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% ${t("statsGrid.ofPromptCompletion")}`
 				: "-",
 	},
 	{
 		key: "outputTokens",
-		title: "Output Tokens",
+		titleKey: "statsGrid.outputTokens",
 		icon: Upload,
 		color: "var(--accent-pink)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalOutputTokens),
-		getDetail: (s: AggregatedStats) =>
+		getValue: (s, locale) => formatCompactNumber(s.totalOutputTokens, locale),
+		getDetail: (s, t) =>
 			totalPromptCompletionTokens(s) > 0
-				? `${((s.totalOutputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				? `${((s.totalOutputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% ${t("statsGrid.ofPromptCompletion")}`
 				: "-",
 	},
 	{
 		key: "errors",
-		title: "Error Rate",
+		titleKey: "requestDetail.error",
 		icon: AlertCircle,
 		color: "var(--accent-red)",
-		getValue: (s: AggregatedStats) => `${(s.errorRate * 100).toFixed(1)}%`,
-		getDetail: (s: AggregatedStats) => `${s.failedRequests.toLocaleString()} failed requests`,
+		getValue: s => `${(s.errorRate * 100).toFixed(1)}%`,
+		getDetail: (s, t, locale) => `${formatExactNumber(s.failedRequests, locale)} ${t("statsGrid.failedRequests")}`,
 	},
 	{
 		key: "tokens",
-		title: "Tokens/Sec",
+		titleKey: "statsGrid.avgThroughput",
 		icon: BarChart3,
 		color: "var(--accent-green)",
-		getValue: (s: AggregatedStats) => s.avgTokensPerSecond?.toFixed(1) ?? "-",
-		getDetail: (s: AggregatedStats) =>
-			`${formatCompactNumber(totalPromptCompletionTokens(s))} total prompt+completion`,
+		getValue: s => s.avgTokensPerSecond?.toFixed(1) ?? "-",
+		getDetail: (s, t, locale) =>
+			`${formatCompactNumber(totalPromptCompletionTokens(s), locale)} ${t("statsGrid.totalPromptCompletion")}`,
 	},
 	{
 		key: "ttft",
-		title: "TTFT",
+		titleKey: "statsGrid.avgTTFT",
 		icon: Zap,
 		color: "var(--accent-amber)",
-		getValue: (s: AggregatedStats) => (s.avgTtft ? `${(s.avgTtft / 1000).toFixed(2)}s` : "-"),
-		getDetail: () => "Time to first token",
+		getValue: s => (s.avgTtft ? `${(s.avgTtft / 1000).toFixed(2)}s` : "-"),
+		getDetail: (_s, t) => t("statsGrid.timeToFirstToken"),
 	},
 ];
 
 export function StatsGrid({ stats }: StatsGridProps) {
+	const { t, locale } = useTranslation();
+	const intlLocale = localeMap[locale] ?? locale;
+
 	return (
 		<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-9 gap-4 mb-8">
 			{statConfig.map(stat => {
@@ -113,7 +126,7 @@ export function StatsGrid({ stats }: StatsGridProps) {
 				return (
 					<div key={stat.key} className="stat-card group">
 						<div className="flex items-center justify-between mb-3">
-							<span className="text-sm font-medium text-[var(--text-secondary)]">{stat.title}</span>
+							<span className="text-sm font-medium text-[var(--text-secondary)]">{t(stat.titleKey as TranslationKey)}</span>
 							<div
 								className="p-2 rounded-[var(--radius-sm)] transition-colors"
 								style={{ backgroundColor: `${stat.color}15` }}
@@ -125,8 +138,8 @@ export function StatsGrid({ stats }: StatsGridProps) {
 								/>
 							</div>
 						</div>
-						<div className="text-2xl font-bold text-[var(--text-primary)] mb-1">{stat.getValue(stats)}</div>
-						<div className="text-xs text-[var(--text-muted)] truncate">{stat.getDetail(stats)}</div>
+						<div className="text-2xl font-bold text-[var(--text-primary)] mb-1 truncate">{stat.getValue(stats, intlLocale)}</div>
+						<div className="text-xs text-[var(--text-muted)] truncate">{stat.getDetail(stats, t, intlLocale)}</div>
 					</div>
 				);
 			})}

--- a/packages/stats/src/client/components/chart-shared.tsx
+++ b/packages/stats/src/client/components/chart-shared.tsx
@@ -6,6 +6,7 @@
  */
 
 import { format } from "date-fns";
+import { useTranslation } from "../i18n";
 
 export const MODEL_COLORS = [
 	"#a78bfa", // violet
@@ -194,10 +195,11 @@ export function buildTopNByModelSeries<T extends ModelKeyedPoint, B>(
 		initBucket: () => B;
 		accumulate: (bucket: B, point: T) => void;
 		bucketToValue: (bucket: B) => number;
+		otherLabel?: string;
 	},
 ): ChartSeries {
 	if (points.length === 0) return { labels: [], datasets: [] };
-	const { topN = 5, rankWeight, initBucket, accumulate, bucketToValue } = opts;
+	const { topN = 5, rankWeight, initBucket, accumulate, bucketToValue, otherLabel = "Other" } = opts;
 
 	const totals = new Map<string, { model: string; provider: string; weight: number }>();
 	for (const point of points) {
@@ -225,14 +227,19 @@ export function buildTopNByModelSeries<T extends ModelKeyedPoint, B>(
 
 	const allDays = [...new Set(points.map(p => p.timestamp))].sort((a, b) => a - b);
 	const seriesNames = topEntries.map(([key]) => labelByKey.get(key) ?? key);
-	const hasOther = points.some(p => !topKeys.has(`${p.model}::${p.provider}`));
-	if (hasOther) seriesNames.push("Other");
+	
+	// Check if there are any points not in top entries (need "Other" category)
+	const hasOther = points.some(p => {
+		const key = `${p.model}::${p.provider}`;
+		return !topKeys.has(key);
+	});
+	if (hasOther) seriesNames.push(otherLabel);
 
 	const dayMap = new Map<number, Record<string, B>>();
 	for (const day of allDays) dayMap.set(day, {});
 	for (const point of points) {
 		const key = `${point.model}::${point.provider}`;
-		const label = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : "Other";
+		const label = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : otherLabel;
 		const row = dayMap.get(point.timestamp);
 		if (!row) continue;
 		const bucket = row[label] ?? initBucket();
@@ -254,6 +261,7 @@ export function buildTopNByModelSeries<T extends ModelKeyedPoint, B>(
 
 /** All Models / By Model segmented toggle — identical UI in every time chart. */
 function ByModelToggle({ byModel, onChange }: { byModel: boolean; onChange: (v: boolean) => void }) {
+	const { t } = useTranslation();
 	return (
 		<div className="flex bg-[var(--bg-surface)] rounded-[var(--radius-sm)] p-0.5 border border-[var(--border-subtle)]">
 			<button
@@ -261,10 +269,10 @@ function ByModelToggle({ byModel, onChange }: { byModel: boolean; onChange: (v: 
 				onClick={() => onChange(false)}
 				className={`tab-btn text-xs ${!byModel ? "active" : ""}`}
 			>
-				All Models
+				{t("chart.allModels")}
 			</button>
 			<button type="button" onClick={() => onChange(true)} className={`tab-btn text-xs ${byModel ? "active" : ""}`}>
-				By Model
+				{t("chart.byModel")}
 			</button>
 		</div>
 	);

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -1,0 +1,413 @@
+import { useEffect, useState } from "react";
+
+type Locale = "en" | "zh";
+
+const translations = {
+	en: {
+		// Header
+		"header.title": "AI Usage",
+		"header.subtitle": "Statistics & Analytics",
+		"header.sync": "Sync",
+		"header.syncing": "Syncing...",
+		"header.tab.overview": "overview",
+		"header.tab.requests": "requests",
+		"header.tab.errors": "errors",
+		"header.tab.models": "models",
+		"header.tab.costs": "costs",
+		"header.tab.behavior": "behavior",
+		"header.range.all": "All time",
+		"header.range.last": "Last",
+
+		// Request List
+		"requestList.model": "Model",
+		"requestList.provider": "Provider",
+		"requestList.time": "Time",
+		"requestList.tokens": "Tokens",
+		"requestList.cost": "Cost",
+		"requestList.duration": "Duration",
+		"requestList.status": "Status",
+		"requestList.input": "Input",
+		"requestList.output": "Output",
+		"requestList.cacheRead": "Cache Read",
+		"requestList.cacheWrite": "Cache Write",
+		"requestList.reasoning": "Reasoning",
+		"requestList.tps": "Tok/s",
+		"requestList.noRequests": "No requests found",
+		"requestList.recentRequests": "Recent Requests",
+		"requestList.recentErrors": "Recent Errors",
+		"requestList.allRequests": "All Recent Requests",
+		"requestList.failedRequests": "Failed Requests",
+		"requestList.showing": "Showing {start}-{end} of {total}",
+		"requestList.pageSize": "Page size",
+
+		// Request Detail
+		"requestDetail.title": "Request Details",
+		"requestDetail.success": "Success",
+		"requestDetail.error": "Error",
+		"requestDetail.cost": "Cost",
+		"requestDetail.premiumReqs": "Premium Reqs",
+		"requestDetail.tokens": "Tokens",
+		"requestDetail.duration": "Duration",
+		"requestDetail.ttft": "TTFT",
+		"requestDetail.throughput": "Throughput",
+		"requestDetail.tokensPerSecond": "tokens/second",
+		"requestDetail.output": "Output",
+		"requestDetail.rawMetadata": "Raw Metadata",
+		"requestDetail.inputTokens": "Input Tokens",
+		"requestDetail.outputTokens": "Output Tokens",
+		"requestDetail.cacheReadTokens": "Cache Read",
+		"requestDetail.cacheWriteTokens": "Cache Write",
+		"requestDetail.totalTokens": "Total Tokens",
+		"requestDetail.reasoningTokens": "Reasoning Tokens",
+
+		// Stats Grid
+		"statsGrid.totalRequests": "Total Requests",
+		"statsGrid.successErrors": "success · {0} errors",
+		"statsGrid.totalTokens": "Total Tokens",
+		"statsGrid.inputOutput": "input · {0} output",
+		"statsGrid.totalCost": "Total Cost",
+		"statsGrid.avgCostPerReq": "avg ${0}/req",
+		"statsGrid.inputTokens": "Input Tokens",
+		"statsGrid.outputTokens": "Output Tokens",
+		"statsGrid.cacheRead": "Cache Read",
+		"statsGrid.cacheWrite": "Cache Write",
+		"statsGrid.reasoningTokens": "Reasoning Tokens",
+		"statsGrid.avgTTFT": "Avg TTFT",
+		"statsGrid.avgDuration": "Avg Duration",
+		"statsGrid.avgThroughput": "Avg Throughput",
+		"statsGrid.tps": "tok/s",
+
+		// Cost Summary
+		"costSummary.total": "Total",
+		"costSummary.avgPerDay": "Avg / day",
+		"costSummary.topModel": "Top model",
+
+		// Behavior Summary
+		"behaviorSummary.messages": "Messages",
+		"behaviorSummary.inRange": "in selected range",
+		"behaviorSummary.yelling": "Yelling",
+		"behaviorSummary.profanity": "Profanity hits",
+		"behaviorSummary.anguish": "Anguish",
+		"behaviorSummary.frustration": "Frustration",
+		"behaviorSummary.mostYelledAt": "Most yelled-at",
+		"behaviorSummary.perMsg": "/ msg",
+		"behaviorSummary.hits": "hits",
+
+		// Models Table
+		"modelsTable.model": "Model",
+		"modelsTable.requests": "Requests",
+		"modelsTable.cost": "Cost",
+		"modelsTable.tokens": "Tokens",
+		"modelsTable.tokensPerSec": "Tokens/s",
+		"modelsTable.ttft": "TTFT",
+
+		// Charts
+		"charts.modelPreference": "Model Preference",
+		"charts.shareOfRequests": "Share of requests over {0}",
+		"charts.other": "Other",
+
+		// Behavior Chart Metrics
+		"behaviorMetric.yelling": "Yelling",
+		"behaviorMetric.profanity": "Profanity",
+		"behaviorMetric.anguish": "Anguish (!!!, nooo, dude, ..)",
+		"behaviorMetric.negation": "Negation (no/nope/wrong)",
+		"behaviorMetric.repetition": "Repetition (i meant, still doesnt)",
+		"behaviorMetric.blame": "Blame (you didnt, stop X-ing)",
+		"behaviorMetric.frustration": "Frustration (neg + rep + blame)",
+		"statsGrid.avgTTFT": "Avg TTFT",
+		"statsGrid.ofRequests": "of requests",
+		"statsGrid.cachedTokens": "cached tokens",
+		"statsGrid.ofPromptCompletion": "of prompt+completion",
+		"statsGrid.failedRequests": "failed requests",
+		"statsGrid.totalPromptCompletion": "total prompt+completion",
+		"statsGrid.timeToFirstToken": "Time to first token",
+
+		// Behavior Chart
+		"behaviorChart.tantrums": "User Tantrums",
+		"behaviorChart.subtitle": "{metric} as % of user messages per day",
+		"behaviorChart.hits": "Hits",
+		"behaviorChart.noData": "No behavioral data yet. Sync to scan your sessions.",
+		"behaviorChart.subtitleByModel": "{metric} by model",
+
+		// Cost Chart
+		"costChart.dailyCost": "Daily Cost",
+		"costChart.subtitle": "API spending over time",
+		"costChart.noData": "No cost data available",
+		"costChart.cost": "Cost",
+		"costChart.total": "Total",
+
+		// Chart Common
+		"chart.allModels": "All Models",
+		"chart.byModel": "By Model",
+		"chart.total": "Total",
+
+		"behaviorModelsTable.trend": "Trend",
+		"behaviorModelsTable.avgCharsPerMsg": "Avg chars / msg",
+		"behaviorModelsTable.total": "Total",
+		"behaviorModelsTable.percentOfMsgs": "% of msgs",
+		"behaviorModelsTable.perMsg": "Per msg",
+		"behaviorModelsTable.caps": "CAPS",
+		"behaviorModelsTable.frustration": "Frustration",
+		"behaviorModelsTable.profanity": "Profanity",
+		"behaviorModelsTable.anguish": "Anguish (!!!, nooo, dude, ..)",
+		"behaviorModelsTable.negation": "Negation (no/nope/wrong)",
+		"behaviorModelsTable.repetition": "Repetition (i meant, still doesnt)",
+		"behaviorModelsTable.blame": "Blame (you didnt, stop X-ing)",
+		"behaviorModelsTable.noData": "No user behavior recorded for this range yet.",
+		"modelsTable.title": "Model Statistics",
+
+		// Behavior Models Table
+		"behaviorModelsTable.title": "Behavior by Model",
+		"behaviorModelsTable.subtitle": "How often each model elicited a tantrum — rates are per user message",
+		"behaviorModelsTable.model": "Model",
+		"behaviorModelsTable.messages": "Messages",
+		"behaviorModelsTable.capsPercent": "CAPS %",
+		"behaviorModelsTable.profanityPercent": "Profanity %",
+		"behaviorModelsTable.anguishPercent": "Anguish %",
+		"behaviorModelsTable.frustrationPercent": "Frustration %",
+		"behaviorModelsTable.hitsPercent": "Hits %",
+		"behaviorModelsTable.trend": "Trend",
+
+		// Common
+		"common.loading": "Loading...",
+		"common.noData": "No data available",
+		"common.previous": "Previous",
+		"common.next": "Next",
+	},
+	zh: {
+		// Header
+		"header.title": "AI 使用情况",
+		"header.subtitle": "统计与分析",
+		"header.sync": "同步",
+		"header.syncing": "同步中...",
+		"header.tab.overview": "概览",
+		"header.tab.requests": "请求",
+		"header.tab.errors": "错误",
+		"header.tab.models": "模型",
+		"header.tab.costs": "成本",
+		"header.tab.behavior": "行为",
+		"header.range.all": "全部时间",
+		"header.range.last": "最近",
+
+		// Request List
+		"requestList.model": "模型",
+		"requestList.provider": "服务商",
+		"requestList.time": "时间",
+		"requestList.tokens": "Tokens",
+		"requestList.cost": "成本",
+		"requestList.duration": "耗时",
+		"requestList.status": "状态",
+		"requestList.input": "输入",
+		"requestList.output": "输出",
+		"requestList.cacheRead": "缓存读取",
+		"requestList.cacheWrite": "缓存写入",
+		"requestList.reasoning": "推理",
+		"requestList.tps": "Tok/秒",
+		"requestList.noRequests": "未找到请求",
+		"requestList.recentRequests": "最近请求",
+		"requestList.recentErrors": "最近错误",
+		"requestList.allRequests": "所有最近请求",
+		"requestList.failedRequests": "失败请求",
+		"requestList.showing": "显示 {start}-{end}，共 {total} 条",
+		"requestList.pageSize": "每页条数",
+
+		// Request Detail
+		"requestDetail.title": "请求详情",
+		"requestDetail.success": "成功",
+		"requestDetail.error": "错误",
+		"requestDetail.cost": "成本",
+		"requestDetail.premiumReqs": "高级请求",
+		"requestDetail.tokens": "Tokens",
+		"requestDetail.duration": "耗时",
+		"requestDetail.ttft": "首字时间",
+		"requestDetail.throughput": "吞吐量",
+		"requestDetail.tokensPerSecond": "tokens/秒",
+		"requestDetail.output": "输出",
+		"requestDetail.rawMetadata": "原始元数据",
+		"requestDetail.inputTokens": "输入 Tokens",
+		"requestDetail.outputTokens": "输出 Tokens",
+		"requestDetail.cacheReadTokens": "缓存读取",
+		"requestDetail.cacheWriteTokens": "缓存写入",
+		"requestDetail.totalTokens": "总 Tokens",
+		"requestDetail.reasoningTokens": "推理 Tokens",
+
+		// Stats Grid
+		"statsGrid.totalRequests": "总请求数",
+		"statsGrid.successErrors": "成功 · {0} 错误",
+		"statsGrid.totalTokens": "总 Tokens",
+		"statsGrid.inputOutput": "输入 · {0} 输出",
+		"statsGrid.totalCost": "总成本",
+		"statsGrid.avgCostPerReq": "平均 ${0}/请求",
+		"statsGrid.inputTokens": "输入 Tokens",
+		"statsGrid.outputTokens": "输出 Tokens",
+		"statsGrid.avgTTFT": "平均 TTFT",
+		"statsGrid.ofRequests": "的请求",
+		"statsGrid.cachedTokens": "缓存 tokens",
+		"statsGrid.ofPromptCompletion": "的提示+补全",
+		"statsGrid.failedRequests": "失败请求",
+		"statsGrid.totalPromptCompletion": "总提示+补全",
+		"statsGrid.timeToFirstToken": "首字时间",
+		"statsGrid.cacheWrite": "缓存写入",
+		"statsGrid.reasoningTokens": "推理 Tokens",
+		"statsGrid.avgDuration": "平均耗时",
+		"statsGrid.avgThroughput": "平均吞吐量",
+
+		// Cost Summary
+		"costSummary.total": "总计",
+		"costSummary.avgPerDay": "日均",
+		"costSummary.topModel": "最贵模型",
+
+		// Behavior Summary
+		"behaviorSummary.messages": "消息数",
+		"behaviorSummary.inRange": "在所选范围内",
+		"behaviorSummary.yelling": "大喊",
+		"behaviorSummary.profanity": "脏话",
+		"behaviorSummary.anguish": "痛苦",
+		"behaviorSummary.frustration": "沮丧",
+		"behaviorSummary.mostYelledAt": "被骂最多",
+		"behaviorSummary.perMsg": "/ 条",
+		"behaviorSummary.hits": "次",
+
+		// Models Table
+		"modelsTable.model": "模型",
+		"modelsTable.requests": "请求数",
+		"modelsTable.cost": "成本",
+		"modelsTable.tokens": "Tokens",
+		"modelsTable.tokensPerSec": "Tokens/秒",
+		"modelsTable.ttft": "TTFT",
+
+		// Charts
+		"charts.modelPreference": "模型偏好",
+		"charts.shareOfRequests": "在 {0} 内的请求占比",
+		"charts.other": "其他",
+
+		// Cost Chart
+		"costChart.dailyCost": "每日成本",
+		"costChart.subtitle": "API 支出随时间变化",
+		"costChart.noData": "暂无成本数据",
+		"costChart.cost": "成本",
+		"costChart.total": "总计",
+
+		// Chart Common
+		"chart.allModels": "所有模型",
+		"chart.byModel": "按模型",
+		"chart.total": "总计",
+
+		// Models Table
+		"modelsTable.title": "模型统计",
+
+		// Behavior Chart Metrics
+		"behaviorMetric.yelling": "大喊",
+		"behaviorMetric.profanity": "脏话",
+		"behaviorMetric.anguish": "痛苦 (!!!, nooo, dude, ..)",
+		"behaviorMetric.negation": "否定 (no/nope/wrong)",
+		"behaviorMetric.repetition": "重复 (i meant, still doesnt)",
+		"behaviorMetric.blame": "责备 (you didnt, stop X-ing)",
+		"behaviorMetric.frustration": "沮丧 (neg + rep + blame)",
+		"behaviorMetric.total": "所有信号合并",
+
+		// Behavior Chart
+		"behaviorChart.tantrums": "用户情绪波动",
+		"behaviorChart.subtitle": "{metric} 占每日用户消息的百分比",
+		"behaviorChart.hits": "次数",
+		"behaviorChart.noData": "暂无行为数据。同步以扫描您的会话。",
+		"behaviorChart.subtitleByModel": "按模型分类的 {metric}",
+
+		// Behavior Models Table
+		"behaviorModelsTable.title": "按模型统计行为",
+		"behaviorModelsTable.subtitle": "每个模型引发情绪波动的频率 — 比率基于用户消息",
+		"behaviorModelsTable.model": "模型",
+		"behaviorModelsTable.messages": "消息数",
+		"behaviorModelsTable.capsPercent": "大写 %",
+		"behaviorModelsTable.profanityPercent": "脏话 %",
+		"behaviorModelsTable.anguishPercent": "痛苦 %",
+		"behaviorModelsTable.frustrationPercent": "沮丧 %",
+		"behaviorModelsTable.hitsPercent": "命中 %",
+		"behaviorModelsTable.trend": "趋势",
+		"behaviorModelsTable.yellingCaps": "大喊 (大写)",
+		"behaviorModelsTable.profanity": "脏话",
+		"behaviorModelsTable.anguish": "痛苦 (!!!, nooo, dude, ..)",
+		"behaviorModelsTable.negation": "否定 (no/nope/wrong)",
+		"behaviorModelsTable.repetition": "重复 (i meant, still doesnt)",
+		"behaviorModelsTable.blame": "责备 (you didnt, stop X-ing)",
+		"behaviorModelsTable.avgCharsPerMsg": "平均字符/消息",
+		"behaviorModelsTable.total": "总计",
+		"behaviorModelsTable.percentOfMsgs": "消息占比",
+		"behaviorModelsTable.perMsg": "每条消息",
+		"behaviorModelsTable.caps": "大写",
+		"behaviorModelsTable.frustration": "沮丧",
+		"behaviorModelsTable.noData": "此范围内暂无用户行为记录",
+
+		"common.loading": "加载中...",
+		"common.noData": "暂无数据",
+		"common.previous": "上一页",
+		"common.next": "下一页",
+	},
+};
+
+export type TranslationKey = keyof typeof translations.en;
+
+function getInitialLocale(): Locale {
+	if (typeof window !== "undefined") {
+		const stored = localStorage.getItem("omp-stats-locale");
+		if (stored === "en" || stored === "zh") return stored;
+
+		const browserLang = navigator.language.toLowerCase();
+		if (browserLang.startsWith("zh")) return "zh";
+	}
+	return "en";
+}
+
+let currentLocale: Locale = getInitialLocale();
+const listeners = new Set<() => void>();
+
+export function setLocale(locale: Locale) {
+	currentLocale = locale;
+	if (typeof window !== "undefined") {
+		localStorage.setItem("omp-stats-locale", locale);
+		document.documentElement.lang = locale;
+	}
+	listeners.forEach(listener => listener());
+}
+
+export function getLocale(): Locale {
+	return currentLocale;
+}
+
+export function useTranslation() {
+	const [locale, setLocaleState] = useState<Locale>(currentLocale);
+
+	useEffect(() => {
+		const listener = () => setLocaleState(currentLocale);
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	}, []);
+
+	const t = (key: TranslationKey, params?: Record<string, string | number>) => {
+		let text = translations[locale][key] || translations.en[key] || key;
+		if (params) {
+			for (const [k, v] of Object.entries(params)) {
+				text = text.replace(`{${k}}`, String(v));
+			}
+		}
+		return text;
+	};
+
+	return { t, locale, setLocale };
+}
+
+export function useLocale() {
+	const [locale, setLocaleState] = useState<Locale>(currentLocale);
+
+	useEffect(() => {
+		const listener = () => setLocaleState(currentLocale);
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	}, []);
+
+	return { locale, setLocale };
+}

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -114,6 +114,7 @@ const translations = {
 		"behaviorMetric.repetition": "Repetition (i meant, still doesnt)",
 		"behaviorMetric.blame": "Blame (you didnt, stop X-ing)",
 		"behaviorMetric.frustration": "Frustration (neg + rep + blame)",
+		"behaviorMetric.total": "All signals combined",
 		"statsGrid.avgTTFT": "Avg TTFT",
 		"statsGrid.ofRequests": "of requests",
 		"statsGrid.cachedTokens": "cached tokens",
@@ -167,6 +168,7 @@ const translations = {
 		"behaviorModelsTable.frustrationPercent": "Frustration %",
 		"behaviorModelsTable.hitsPercent": "Hits %",
 		"behaviorModelsTable.trend": "Trend",
+		"behaviorModelsTable.yellingCaps": "Yelling (CAPS)",
 
 		// Common
 		"common.loading": "Loading...",

--- a/packages/stats/src/client/types.ts
+++ b/packages/stats/src/client/types.ts
@@ -30,6 +30,7 @@ export interface Usage {
 	cacheWrite: number;
 	totalTokens: number;
 	premiumRequests?: number;
+	reasoningTokens?: number;
 	cost: {
 		input: number;
 		output: number;
@@ -75,4 +76,9 @@ export interface ModelDashboardStats {
 
 export interface CostDashboardStats {
 	costSeries: CostTimeSeriesPoint[];
+}
+
+export interface PaginatedResponse<T> {
+	data: T[];
+	total: number;
 }

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -714,16 +714,17 @@ export function getRecentErrors(limit = 100, offset = 0): MessageStats[] {
 export function getRequestCount(): number {
 	if (!db) return 0;
 	const stmt = db.prepare(`SELECT COUNT(*) as count FROM messages WHERE stop_reason NOT IN ('error', 'aborted')`);
-	const row = stmt.get() as any;
+	const row = stmt.get() as { count: number } | undefined;
 	return row?.count ?? 0;
 }
 
 export function getErrorCount(): number {
 	if (!db) return 0;
 	const stmt = db.prepare(`SELECT COUNT(*) as count FROM messages WHERE stop_reason = 'error'`);
-	const row = stmt.get() as any;
+	const row = stmt.get() as { count: number } | undefined;
 	return row?.count ?? 0;
 }
+
 
 export function getMessageById(id: number): MessageStats | null {
 	if (!db) return null;

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -689,25 +689,40 @@ function rowToMessageStats(row: any): MessageStats {
 	};
 }
 
-export function getRecentRequests(limit = 100): MessageStats[] {
+export function getRecentRequests(limit = 100, offset = 0): MessageStats[] {
 	if (!db) return [];
 	const stmt = db.prepare(`
 		SELECT * FROM messages 
+		WHERE stop_reason NOT IN ('error', 'aborted')
 		ORDER BY timestamp DESC 
-		LIMIT ?
+		LIMIT ? OFFSET ?
 	`);
-	return (stmt.all(limit) as any[]).map(rowToMessageStats);
+	return (stmt.all(limit, offset) as any[]).map(rowToMessageStats);
 }
 
-export function getRecentErrors(limit = 100): MessageStats[] {
+export function getRecentErrors(limit = 100, offset = 0): MessageStats[] {
 	if (!db) return [];
 	const stmt = db.prepare(`
 		SELECT * FROM messages 
 		WHERE stop_reason = 'error'
 		ORDER BY timestamp DESC 
-		LIMIT ?
+		LIMIT ? OFFSET ?
 	`);
-	return (stmt.all(limit) as any[]).map(rowToMessageStats);
+	return (stmt.all(limit, offset) as any[]).map(rowToMessageStats);
+}
+
+export function getRequestCount(): number {
+	if (!db) return 0;
+	const stmt = db.prepare(`SELECT COUNT(*) as count FROM messages WHERE stop_reason NOT IN ('error', 'aborted')`);
+	const row = stmt.get() as any;
+	return row?.count ?? 0;
+}
+
+export function getErrorCount(): number {
+	if (!db) return 0;
+	const stmt = db.prepare(`SELECT COUNT(*) as count FROM messages WHERE stop_reason = 'error'`);
+	const row = stmt.get() as any;
+	return row?.count ?? 0;
 }
 
 export function getMessageById(id: number): MessageStats | null {

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -216,13 +216,21 @@ async function handleApi(req: Request): Promise<Response> {
 
 	if (path === "/api/stats/recent") {
 		const limit = url.searchParams.get("limit");
-		const stats = await getRecentRequests(limit ? parseInt(limit, 10) : undefined);
+		const offset = url.searchParams.get("offset");
+		const stats = await getRecentRequests(
+			limit ? parseInt(limit, 10) : undefined,
+			offset ? parseInt(offset, 10) : undefined,
+		);
 		return Response.json(stats);
 	}
 
 	if (path === "/api/stats/errors") {
 		const limit = url.searchParams.get("limit");
-		const stats = await getRecentErrors(limit ? parseInt(limit, 10) : undefined);
+		const offset = url.searchParams.get("offset");
+		const stats = await getRecentErrors(
+			limit ? parseInt(limit, 10) : undefined,
+			offset ? parseInt(offset, 10) : undefined,
+		);
 		return Response.json(stats);
 	}
 

--- a/packages/stats/test/pagination.test.ts
+++ b/packages/stats/test/pagination.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { closeDb, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import { getRecentErrors, getRecentRequests } from "@oh-my-pi/omp-stats/aggregator";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import { getAgentDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+const originalAgentDir = getAgentDir();
+let tempDir: TempDir | null = null;
+
+beforeEach(() => {
+	tempDir = TempDir.createSync("@pi-stats-pagination-");
+	const configDir = path.relative(os.homedir(), tempDir.join("config"));
+	process.env.PI_CONFIG_DIR = configDir;
+	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+});
+
+afterEach(() => {
+	closeDb();
+	setAgentDir(originalAgentDir);
+	tempDir?.removeSync();
+	tempDir = null;
+});
+
+function createStats(entryId: string, stopReason: "stop" | "error" | "aborted" = "stop"): MessageStats {
+	return {
+		sessionFile: "/tmp/session.jsonl",
+		entryId,
+		folder: "/tmp/project",
+		model: "gpt-4",
+		provider: "openai",
+		api: "openai-chat",
+		timestamp: Date.now(),
+		duration: 1000,
+		ttft: 100,
+		stopReason,
+		errorMessage: stopReason === "error" ? "test error" : null,
+		usage: {
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 150,
+			premiumRequests: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+describe("getRecentRequests pagination", () => {
+	it("returns data array and total count", async () => {
+		await initDb();
+		insertMessageStats([createStats("1"), createStats("2"), createStats("3")]);
+
+		const result = await getRecentRequests(10, 0);
+
+		expect(result).toHaveProperty("data");
+		expect(result).toHaveProperty("total");
+		expect(Array.isArray(result.data)).toBe(true);
+		expect(result.total).toBe(3);
+		expect(result.data.length).toBe(3);
+	});
+
+	it("respects limit and offset parameters", async () => {
+		await initDb();
+		insertMessageStats([createStats("1"), createStats("2"), createStats("3"), createStats("4"), createStats("5")]);
+
+		const page1 = await getRecentRequests(2, 0);
+		const page2 = await getRecentRequests(2, 2);
+
+		expect(page1.data.length).toBe(2);
+		expect(page1.total).toBe(5);
+		expect(page2.data.length).toBe(2);
+		expect(page2.total).toBe(5);
+		expect(page1.data[0].entryId).not.toBe(page2.data[0].entryId);
+	});
+
+	it("excludes error and aborted rows from total count", async () => {
+		await initDb();
+		insertMessageStats([
+			createStats("ok1", "stop"),
+			createStats("ok2", "stop"),
+			createStats("err", "error"),
+			createStats("abort", "aborted"),
+		]);
+
+		const result = await getRecentRequests(10, 0);
+
+		expect(result.total).toBe(2);
+		expect(result.data.length).toBe(2);
+		expect(result.data.every(r => r.stopReason === "stop")).toBe(true);
+	});
+
+	it("returns empty data with zero total when no rows match", async () => {
+		await initDb();
+
+		const result = await getRecentRequests(10, 0);
+
+		expect(result.data).toEqual([]);
+		expect(result.total).toBe(0);
+	});
+});
+
+describe("getRecentErrors pagination", () => {
+	it("returns only error rows with correct total", async () => {
+		await initDb();
+		insertMessageStats([
+			createStats("ok1", "stop"),
+			createStats("err1", "error"),
+			createStats("err2", "error"),
+			createStats("abort", "aborted"),
+		]);
+
+		const result = await getRecentErrors(10, 0);
+
+		expect(result.total).toBe(2);
+		expect(result.data.length).toBe(2);
+		expect(result.data.every(r => r.stopReason === "error")).toBe(true);
+	});
+
+	it("respects limit and offset for errors", async () => {
+		await initDb();
+		insertMessageStats([
+			createStats("err1", "error"),
+			createStats("err2", "error"),
+			createStats("err3", "error"),
+		]);
+
+		const page1 = await getRecentErrors(2, 0);
+		const page2 = await getRecentErrors(2, 2);
+
+		expect(page1.data.length).toBe(2);
+		expect(page1.total).toBe(3);
+		expect(page2.data.length).toBe(1);
+		expect(page2.total).toBe(3);
+	});
+});

--- a/packages/stats/test/pagination.test.ts
+++ b/packages/stats/test/pagination.test.ts
@@ -7,6 +7,7 @@ import type { MessageStats } from "@oh-my-pi/omp-stats/types";
 import { getAgentDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 const originalAgentDir = getAgentDir();
+const originalConfigDir = process.env.PI_CONFIG_DIR;
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
@@ -19,6 +20,11 @@ beforeEach(() => {
 afterEach(() => {
 	closeDb();
 	setAgentDir(originalAgentDir);
+	if (originalConfigDir === undefined) {
+		delete process.env.PI_CONFIG_DIR;
+	} else {
+		process.env.PI_CONFIG_DIR = originalConfigDir;
+	}
 	tempDir?.removeSync();
 	tempDir = null;
 });


### PR DESCRIPTION
## Summary / 变更摘要

Stats dashboard enhancements: pagination, filtering, i18n, and UI polish.

Stats dashboard 功能增强：分页、过滤、国际化和 UI 优化。

---

## Backend / 后端

- **Pagination**: Added offset-based pagination to `getRecentRequests` / `getRecentErrors` API
  添加 offset-based 分页到 `getRecentRequests` / `getRecentErrors` API
- **Filtering**: Excluded error and aborted requests (`stop_reason NOT IN ('error', 'aborted')`)
  过滤掉 error 和 aborted 请求
- **API format**: Response changed from `MessageStats[]` to `{ data: MessageStats[], total: number }`
  API 响应格式从 `MessageStats[]` 改为 `{ data: MessageStats[], total: number }`

## Frontend / 前端

- **Page size selector** (15/30/50) and page navigation on requests/errors tabs
  添加页大小选择器 (15/30/50) 和分页导航
- **Independent loading**: Requests and errors load separately — pagination clicks only fire one API call
  独立加载 requests 和 errors（翻页只触发一个 API 调用）
- **Provider column**: Split provider into its own column
  Provider 拆分为独立列
- **Column reorder**: Model → Provider → Time → Input → Output → Tokens → Cost → TPS → Duration → Status
  列顺序重排
- **Compact padding** (`py-2 px-3`) for request list rows
  紧凑内边距
- **i18n**: Added `client/i18n.ts` with en/zh translations; all components use `useTranslation()`
  添加 i18n 支持 (`client/i18n.ts`)，包含中英文翻译，所有组件使用 `useTranslation()`
- **Cleanup**: Removed duplicate `MODEL_COLORS` / `CHART_THEMES` from `ChartsContainer`, now imported from `chart-shared`
  移除 `ChartsContainer` 中重复的常量定义，改为从 `chart-shared` 导入

## Files Changed / 变更文件 (19)

| File | Change |
|------|--------|
| `src/db.ts` | Pagination SQL + filtering / 分页 SQL + 过滤 |
| `src/aggregator.ts` | Return `{ data, total }` format / 返回新格式 |
| `src/server.ts` | `offset` query param / offset 查询参数 |
| `client/App.tsx` | Pagination state management / 分页状态管理 |
| `client/api.ts` | `offset` param support / offset 参数支持 |
| `client/types.ts` | `PaginatedResponse<T>` type / 新增类型 |
| `client/i18n.ts` | New i18n module / 新增 i18n 模块 |
| `client/components/*.tsx` | i18n integration / i18n 集成 |