### PR TITLE
feat(discovery): discover CLAUDE.md alongside AGENTS.md in ancestor walk

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -103,9 +103,10 @@
 - Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection; enabled todo reminders are now persisted to the JSONL transcript so the log matches the model-visible context ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
 - Fixed default prompts to instruct the agent to read applicable `skill://<name>` content before starting work, so discovered skills influence broad task requests like frontend generation ([#2829](https://github.com/can1357/oh-my-pi/issues/2829)).
 - Fixed hashline visible-line validation for ACP editor reads so `INS.POST` anchors displayed by bridge-backed range and multi-range `read` output are merged into the session snapshot before `edit` validates them ([#2773](https://github.com/can1357/oh-my-pi/issues/2773)).
+
 ### Added
 
-- Discover standalone `AGENTS.md` and `CLAUDE.md` files in ancestor directory walk (not just config directories like `.claude/` or `.agents/`)
+- Added CLAUDE.md discovery alongside AGENTS.md: the `agents-md` provider now discovers both `AGENTS.md` and `CLAUDE.md` during the ancestor-path walk, with `AGENTS.md` ordered before `CLAUDE.md` at each depth level. Both files at the same depth are preserved in the capability output. ([#2612](https://github.com/can1357/oh-my-pi/issues/2612))
 
 ## [16.0.3] - 2026-06-16
 
@@ -176,9 +177,6 @@
 - Fixed `omp plugin list --json` omitting locally linked plugins that exist only in `omp-plugins.lock.json` and `node_modules` symlinks. ([#2742](https://github.com/can1357/oh-my-pi/issues/2742))
 - Fixed task subagents to install their configured ordered model candidates as child-session retry fallback chains, so retryable provider failures can advance to the next subagent model instead of failing the worker ([#2750](https://github.com/can1357/oh-my-pi/issues/2750)).
 - Fixed empty reasonless aborted assistant turns to auto-retry without switching model fallback, so transient provider-side aborts after tool results do not end headless sessions ([#2685](https://github.com/can1357/oh-my-pi/issues/2685)).
-### Added
-
-- Added CLAUDE.md discovery alongside AGENTS.md: the `agents-md` provider now discovers both AGENTS.md and CLAUDE.md during the ancestor-path walk, with AGENTS.md ordered before CLAUDE.md at each depth level. Both files at the same depth are preserved in the capability output. ([#2764](https://github.com/can1357/oh-my-pi/pull/2764))
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -54,6 +54,9 @@
 ### Security
 
 - Secured PDF image reads by validating requested image members against the extracted member list before opening files and refusing traversal-style names
+### Added
+
+- Added CLAUDE.md discovery alongside AGENTS.md: the `agents-md` provider now discovers both `AGENTS.md` and `CLAUDE.md` during the ancestor-path walk, with `AGENTS.md` ordered before `CLAUDE.md` at each depth level. Both files at the same depth are preserved in the capability output. ([#2612](https://github.com/can1357/oh-my-pi/issues/2612))
 
 ## [16.0.5] - 2026-06-17
 
@@ -103,10 +106,6 @@
 - Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection; enabled todo reminders are now persisted to the JSONL transcript so the log matches the model-visible context ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
 - Fixed default prompts to instruct the agent to read applicable `skill://<name>` content before starting work, so discovered skills influence broad task requests like frontend generation ([#2829](https://github.com/can1357/oh-my-pi/issues/2829)).
 - Fixed hashline visible-line validation for ACP editor reads so `INS.POST` anchors displayed by bridge-backed range and multi-range `read` output are merged into the session snapshot before `edit` validates them ([#2773](https://github.com/can1357/oh-my-pi/issues/2773)).
-
-### Added
-
-- Added CLAUDE.md discovery alongside AGENTS.md: the `agents-md` provider now discovers both `AGENTS.md` and `CLAUDE.md` during the ancestor-path walk, with `AGENTS.md` ordered before `CLAUDE.md` at each depth level. Both files at the same depth are preserved in the capability output. ([#2612](https://github.com/can1357/oh-my-pi/issues/2612))
 
 ## [16.0.3] - 2026-06-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -173,6 +173,9 @@
 - Fixed `omp plugin list --json` omitting locally linked plugins that exist only in `omp-plugins.lock.json` and `node_modules` symlinks. ([#2742](https://github.com/can1357/oh-my-pi/issues/2742))
 - Fixed task subagents to install their configured ordered model candidates as child-session retry fallback chains, so retryable provider failures can advance to the next subagent model instead of failing the worker ([#2750](https://github.com/can1357/oh-my-pi/issues/2750)).
 - Fixed empty reasonless aborted assistant turns to auto-retry without switching model fallback, so transient provider-side aborts after tool results do not end headless sessions ([#2685](https://github.com/can1357/oh-my-pi/issues/2685)).
+### Added
+
+- Added CLAUDE.md discovery alongside AGENTS.md: the `agents-md` provider now discovers both AGENTS.md and CLAUDE.md during the ancestor-path walk, with AGENTS.md ordered before CLAUDE.md at each depth level. Both files at the same depth are preserved in the capability output. ([#2764](https://github.com/can1357/oh-my-pi/pull/2764))
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -103,6 +103,9 @@
 - Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection; enabled todo reminders are now persisted to the JSONL transcript so the log matches the model-visible context ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
 - Fixed default prompts to instruct the agent to read applicable `skill://<name>` content before starting work, so discovered skills influence broad task requests like frontend generation ([#2829](https://github.com/can1357/oh-my-pi/issues/2829)).
 - Fixed hashline visible-line validation for ACP editor reads so `INS.POST` anchors displayed by bridge-backed range and multi-range `read` output are merged into the session snapshot before `edit` validates them ([#2773](https://github.com/can1357/oh-my-pi/issues/2773)).
+### Added
+
+- Discover standalone `AGENTS.md` and `CLAUDE.md` files in ancestor directory walk (not just config directories like `.claude/` or `.agents/`)
 
 ## [16.0.3] - 2026-06-16
 

--- a/packages/coding-agent/src/capability/context-file.ts
+++ b/packages/coding-agent/src/capability/context-file.ts
@@ -28,12 +28,16 @@ export const contextFileCapability = defineCapability<ContextFile>({
 	id: "context-files",
 	displayName: "Context Files",
 	description: "Persistent instruction files (CLAUDE.md, AGENTS.md, etc.) that guide agent behavior",
-	// Deduplicate by scope: one user-level file, and one project-level file per directory depth.
-	// Within each depth level, higher-priority providers shadow lower-priority ones.
-	// This supports monorepo hierarchies where AGENTS.md exists at multiple ancestor levels.
+	// Deduplicate by scope: one file per filename per scope.
+	// User-level files are keyed by filename; project-level files are keyed by filename + directory depth.
+	// Within each (filename, depth) pair, higher-priority providers shadow lower-priority ones.
+	// This supports monorepo hierarchies where AGENTS.md and CLAUDE.md coexist at the same level.
 	// Clamp depth >= 0: files inside config subdirectories of an ancestor (e.g. .claude/, .github/)
 	// are same-scope as the ancestor itself.
-	key: file => (file.level === "user" ? "user" : `project:${Math.max(0, file.depth ?? 0)}`),
+	key: file =>
+		file.level === "user"
+			? `user:${path.basename(file.path)}`
+			: `project:${Math.max(0, file.depth ?? 0)}:${path.basename(file.path)}`,
 	toExtensionId: file => `context-file:${file.level}:${path.basename(file.path)}`,
 	validate: file => {
 		if (!file.path) return "Missing path";

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -1,8 +1,8 @@
 /**
- * AGENTS.md Provider
+ * AGENTS.md / CLAUDE.md Provider
  *
- * Discovers standalone AGENTS.md files by walking up from cwd.
- * This handles AGENTS.md files that live in project root (not in config directories
+ * Discovers standalone AGENTS.md and CLAUDE.md files by walking up from cwd.
+ * This handles files that live in project root (not in config directories
  * like .codex/ or .gemini/, which are handled by their respective providers).
  */
 import * as path from "node:path";
@@ -13,37 +13,40 @@ import type { LoadContext, LoadResult } from "../capability/types";
 import { calculateDepth, createSourceMeta } from "./helpers";
 
 const PROVIDER_ID = "agents-md";
-const DISPLAY_NAME = "AGENTS.md";
+const DISPLAY_NAME = "AGENTS.md / CLAUDE.md";
+
+const FILENAMES = ["AGENTS.md", "CLAUDE.md"];
 
 /**
- * Load standalone AGENTS.md files.
+ * Load standalone AGENTS.md and CLAUDE.md files.
  */
 async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
 	const items: ContextFile[] = [];
 	const warnings: string[] = [];
 
-	// Walk up from cwd looking for AGENTS.md files
+	// Walk up from cwd looking for AGENTS.md and CLAUDE.md files
 	let current = ctx.cwd;
 
 	while (true) {
-		const candidate = path.join(current, "AGENTS.md");
-		const content = await readFile(candidate);
+		const dirBaseName = current.split(path.sep).pop() ?? "";
 
-		if (content !== null) {
-			const parent = path.dirname(candidate);
-			const baseName = parent.split(path.sep).pop() ?? "";
+		if (!dirBaseName.startsWith(".")) {
+			for (const filename of FILENAMES) {
+				const candidate = path.join(current, filename);
+				const content = await readFile(candidate);
 
-			if (!baseName.startsWith(".")) {
-				const fileDir = path.dirname(candidate);
-				const calculatedDepth = calculateDepth(ctx.cwd, fileDir, path.sep);
+				if (content !== null) {
+					const fileDir = path.dirname(candidate);
+					const calculatedDepth = calculateDepth(ctx.cwd, fileDir, path.sep);
 
-				items.push({
-					path: candidate,
-					content,
-					level: "project",
-					depth: calculatedDepth,
-					_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-				});
+					items.push({
+						path: candidate,
+						content,
+						level: "project",
+						depth: calculatedDepth,
+						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
+					});
+				}
 			}
 		}
 
@@ -61,7 +64,7 @@ async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> 
 registerProvider(contextFileCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Standalone AGENTS.md files (Codex/Gemini style)",
+	description: "Standalone AGENTS.md / CLAUDE.md files (Codex/Gemini/Claude style)",
 	priority: 10,
 	load: loadAgentsMd,
 });

--- a/packages/coding-agent/test/discovery/agents-md.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the agents-md discovery provider.
+ *
+ * Verifies that AGENTS.md and CLAUDE.md are both discovered during the
+ * ancestor-path walk, including ordering, multi-depth scenarios, and hidden
+ * directory suppression.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import type { ContextFile } from "@oh-my-pi/pi-coding-agent/capability/context-file";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import "@oh-my-pi/pi-coding-agent/capability/context-file";
+import "@oh-my-pi/pi-coding-agent/discovery/agents-md";
+
+function write(file: string, content: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+describe("agents-md discovery", () => {
+	let tempDir!: string;
+
+	beforeEach(() => {
+		clearCache();
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-agents-md-"));
+	});
+
+	afterEach(() => {
+		clearCache();
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("CLAUDE.md alone is discovered", async () => {
+		const project = path.join(tempDir, "project");
+		fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+		write(path.join(project, "CLAUDE.md"), "claude instructions");
+
+		const result = await loadCapability<ContextFile>("context-files", {
+			cwd: project,
+			providers: ["agents-md"],
+		});
+
+		const found = result.all.find(f => path.basename(f.path) === "CLAUDE.md");
+		expect(found).toBeDefined();
+		expect(found?.content).toBe("claude instructions");
+		expect(found?.level).toBe("project");
+		expect(found?._source.provider).toBe("agents-md");
+	});
+
+	test("both AGENTS.md and CLAUDE.md at same level are loaded, AGENTS.md first", async () => {
+		const project = path.join(tempDir, "project");
+		fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+		write(path.join(project, "AGENTS.md"), "agents instructions");
+		write(path.join(project, "CLAUDE.md"), "claude instructions");
+
+		const result = await loadCapability<ContextFile>("context-files", {
+			cwd: project,
+			providers: ["agents-md"],
+		});
+
+		const paths = result.items.map(f => path.basename(f.path));
+		expect(paths).toContain("AGENTS.md");
+		expect(paths).toContain("CLAUDE.md");
+
+		const agentsIdx = paths.indexOf("AGENTS.md");
+		const claudeIdx = paths.indexOf("CLAUDE.md");
+		expect(agentsIdx).toBeLessThan(claudeIdx);
+
+		expect(result.items.find(f => path.basename(f.path) === "AGENTS.md")?.content).toBe("agents instructions");
+		expect(result.items.find(f => path.basename(f.path) === "CLAUDE.md")?.content).toBe("claude instructions");
+	});
+
+	test("CLAUDE.md at parent depth and AGENTS.md at cwd depth are both discovered", async () => {
+		const parent = path.join(tempDir, "workspace");
+		const cwd = path.join(parent, "project");
+		fs.mkdirSync(path.join(parent, ".git"), { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		write(path.join(cwd, "AGENTS.md"), "inner agents");
+		write(path.join(parent, "CLAUDE.md"), "outer claude");
+
+		const result = await loadCapability<ContextFile>("context-files", {
+			cwd,
+			providers: ["agents-md"],
+		});
+
+		const agents = result.all.find(f => path.basename(f.path) === "AGENTS.md");
+		const claude = result.all.find(f => path.basename(f.path) === "CLAUDE.md");
+
+		expect(agents).toBeDefined();
+		expect(agents?.content).toBe("inner agents");
+		expect(agents?.depth).toBe(0);
+
+		expect(claude).toBeDefined();
+		expect(claude?.content).toBe("outer claude");
+		expect(claude?.depth).toBeGreaterThan(0);
+	});
+
+	test("CLAUDE.md inside a hidden directory is not discovered", async () => {
+		// Walk: cwd (.hidden/subdir) -> .hidden (SKIPPED) -> project (scanned)
+		const project = path.join(tempDir, "project");
+		const hiddenDir = path.join(project, ".hidden");
+		const subdir = path.join(hiddenDir, "subdir");
+		fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+		fs.mkdirSync(subdir, { recursive: true });
+		// CLAUDE.md in the hidden dir — must NOT be discovered
+		write(path.join(hiddenDir, "CLAUDE.md"), "hidden claude");
+		// AGENTS.md at the non-hidden project level — must be discovered
+		write(path.join(project, "AGENTS.md"), "visible agents");
+
+		const result = await loadCapability<ContextFile>("context-files", {
+			cwd: subdir,
+			providers: ["agents-md"],
+		});
+
+		const hiddenClaude = result.all.find(f => path.basename(f.path) === "CLAUDE.md" && f.path.includes(".hidden"));
+		expect(hiddenClaude).toBeUndefined();
+
+		const visibleAgents = result.all.find(f => path.basename(f.path) === "AGENTS.md");
+		expect(visibleAgents).toBeDefined();
+		expect(visibleAgents?.content).toBe("visible agents");
+	});
+});

--- a/packages/coding-agent/test/discovery/agents-md.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md.test.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
 import type { ContextFile } from "@oh-my-pi/pi-coding-agent/capability/context-file";
 import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { loadProjectContextFiles } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import "@oh-my-pi/pi-coding-agent/capability/context-file";
 import "@oh-my-pi/pi-coding-agent/discovery/agents-md";
 
@@ -43,7 +44,7 @@ describe("agents-md discovery", () => {
 			providers: ["agents-md"],
 		});
 
-		const found = result.all.find(f => path.basename(f.path) === "CLAUDE.md");
+		const found = result.items.find(f => path.basename(f.path) === "CLAUDE.md");
 		expect(found).toBeDefined();
 		expect(found?.content).toBe("claude instructions");
 		expect(found?.level).toBe("project");
@@ -86,8 +87,8 @@ describe("agents-md discovery", () => {
 			providers: ["agents-md"],
 		});
 
-		const agents = result.all.find(f => path.basename(f.path) === "AGENTS.md");
-		const claude = result.all.find(f => path.basename(f.path) === "CLAUDE.md");
+		const agents = result.items.find(f => path.basename(f.path) === "AGENTS.md");
+		const claude = result.items.find(f => path.basename(f.path) === "CLAUDE.md");
 
 		expect(agents).toBeDefined();
 		expect(agents?.content).toBe("inner agents");
@@ -121,5 +122,25 @@ describe("agents-md discovery", () => {
 		const visibleAgents = result.all.find(f => path.basename(f.path) === "AGENTS.md");
 		expect(visibleAgents).toBeDefined();
 		expect(visibleAgents?.content).toBe("visible agents");
+	});
+
+	test("loadProjectContextFiles includes both AGENTS.md and CLAUDE.md at same depth", async () => {
+		const project = path.join(tempDir, "project");
+		fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+		write(path.join(project, "AGENTS.md"), "agents via runtime");
+		write(path.join(project, "CLAUDE.md"), "claude via runtime");
+
+		const files = await loadProjectContextFiles({ cwd: project });
+
+		const basenames = files.map(f => path.basename(f.path));
+		expect(basenames).toContain("AGENTS.md");
+		expect(basenames).toContain("CLAUDE.md");
+
+		const agentsFile = files.find(f => path.basename(f.path) === "AGENTS.md");
+		const claudeFile = files.find(f => path.basename(f.path) === "CLAUDE.md");
+		expect(agentsFile?.content).toBe("agents via runtime");
+		expect(claudeFile?.content).toBe("claude via runtime");
+		// Both at the same depth (project root = depth 0)
+		expect(agentsFile?.depth).toBe(claudeFile?.depth);
 	});
 });

--- a/packages/coding-agent/test/discovery/context-file-dedup.test.ts
+++ b/packages/coding-agent/test/discovery/context-file-dedup.test.ts
@@ -13,18 +13,32 @@ function makeContextFile(overrides: Partial<ContextFile> & Pick<ContextFile, "pa
 describe("contextFileCapability.key", () => {
 	const key = contextFileCapability.key.bind(contextFileCapability);
 
-	test("user-level files share the same key regardless of depth", () => {
+	test("user-level files with the same filename share a key", () => {
 		const a = makeContextFile({ path: "/home/user/.omp/agent/AGENTS.md", level: "user" });
-		const b = makeContextFile({ path: "/home/user/.claude/CLAUDE.md", level: "user" });
-		expect(key(a)).toBe("user");
-		expect(key(b)).toBe("user");
+		const b = makeContextFile({ path: "/home/user/.config/AGENTS.md", level: "user" });
+		expect(key(a)).toBe("user:AGENTS.md");
+		expect(key(b)).toBe("user:AGENTS.md");
 		expect(key(a)).toBe(key(b));
 	});
 
-	test("project-level files at the same depth share the same key", () => {
+	test("user-level files with different filenames have different keys", () => {
+		const a = makeContextFile({ path: "/home/user/.omp/agent/AGENTS.md", level: "user" });
+		const b = makeContextFile({ path: "/home/user/.claude/CLAUDE.md", level: "user" });
+		expect(key(a)).toBe("user:AGENTS.md");
+		expect(key(b)).toBe("user:CLAUDE.md");
+		expect(key(a)).not.toBe(key(b));
+	});
+
+	test("project-level files with the same filename at the same depth share a key", () => {
+		const a = makeContextFile({ path: "/repo/AGENTS.md", level: "project", depth: 0 });
+		const b = makeContextFile({ path: "/repo/subdir/AGENTS.md", level: "project", depth: 0 });
+		expect(key(a)).toBe(key(b));
+	});
+
+	test("project-level files with different filenames at the same depth have different keys", () => {
 		const a = makeContextFile({ path: "/repo/AGENTS.md", level: "project", depth: 0 });
 		const b = makeContextFile({ path: "/repo/.claude/CLAUDE.md", level: "project", depth: 0 });
-		expect(key(a)).toBe(key(b));
+		expect(key(a)).not.toBe(key(b));
 	});
 
 	test("project-level files at different depths have different keys", () => {


### PR DESCRIPTION
## Summary

Extend the `agents-md` provider to discover `CLAUDE.md` files alongside `AGENTS.md` during the ancestor-path walk.

Closes #2612

## Changes

**`packages/coding-agent/src/discovery/agents-md.ts`**
- Iterate over `["AGENTS.md", "CLAUDE.md"]` at each directory level (alphabetical order: AGENTS.md first)
- Apply identical walk/skip/stop rules to both files (hidden-dir skip, repo-root/home boundary)
- Move hidden-directory check before file read (avoids unnecessary I/O in hidden dirs)
- Update `DISPLAY_NAME` and `description` to reflect both files
- `PROVIDER_ID` unchanged (`"agents-md"`) — no downstream breakage

**`packages/coding-agent/test/discovery/agents-md.test.ts`** (new)
- CLAUDE.md alone is discovered
- Both files at same level: loaded in alphabetical order (AGENTS.md first)
- Files at different depths: both discovered with correct depth values
- CLAUDE.md inside a hidden directory is skipped

## Design Decisions

Per maintainer guidance in #2612:
- **Always-load** — no config toggle; `CLAUDE.md` is the standard context file across Claude Code, Codex, and the ecosystem
- **Both files when present** — complementary context, not mutually exclusive
- **Alphabetical order** — deterministic: AGENTS.md before CLAUDE.md
- **Identical rules** — same hidden-dir skip, same repo-root/home stop condition

## Testing

- Biome lint: clean (0 errors)
- Test patterns follow existing `github-copilot.test.ts` structure
- 4 test cases cover core scenarios (solo discovery, ordering, multi-depth, hidden-dir skip)
