### PR TITLE
fix(tui): handle VS Code keypad digit input

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -606,13 +606,11 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 			if let Some(text_codepoint) = keypad_operator_text_codepoint(parsed_codepoint) {
 				parsed_codepoint = text_codepoint;
 				parsed_base = None;
-			} else if p.modifier & MOD_NUM_LOCK != 0 {
-				if actual_mod == 0
-					&& let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed_codepoint)
-				{
+			} else if actual_mod == 0 {
+				if let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed_codepoint) {
 					parsed_codepoint = text_codepoint;
 					parsed_base = None;
-				} else {
+				} else if p.modifier & MOD_NUM_LOCK != 0 {
 					if let Some(mapped) = map_keypad_nav(parsed_codepoint) {
 						parsed_codepoint = mapped;
 					}
@@ -674,7 +672,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 		}
 
 		if modifier == 0 {
-			return bytes == b" " || kitty_matches(CP_SPACE, 0);
+			return bytes == b" " || kitty_matches(CP_SPACE, 0) || mok_matches(CP_SPACE, 0);
 		}
 		return kitty_matches(CP_SPACE, modifier) || mok_matches(CP_SPACE, modifier);
 	}
@@ -695,7 +693,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 
 		// plain tab (treat LF/CR elsewhere)
 		if modifier == 0 {
-			return bytes == b"\t" || kitty_matches(CP_TAB, 0);
+			return bytes == b"\t" || kitty_matches(CP_TAB, 0) || mok_matches(CP_TAB, 0);
 		}
 
 		// ctrl+tab etc are only distinguishable in enhanced modes (CSI-u /
@@ -716,7 +714,9 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 				|| bytes == b"\n"
 				|| bytes == b"\x1bOM"
 				|| kitty_matches(CP_ENTER, 0)
-				|| kitty_matches(CP_KP_ENTER, 0);
+				|| kitty_matches(CP_KP_ENTER, 0)
+				|| mok_matches(CP_ENTER, 0)
+				|| mok_matches(CP_KP_ENTER, 0);
 		}
 
 		// modified enter is only reliably representable when encoded (CSI-u /
@@ -738,7 +738,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 		}
 
 		if modifier == 0 {
-			return bytes == b"\x7f" || bytes == b"\x08" || kitty_matches(CP_BACKSPACE, 0);
+			return bytes == b"\x7f" || bytes == b"\x08" || kitty_matches(CP_BACKSPACE, 0) || mok_matches(CP_BACKSPACE, 0);
 		}
 
 		return kitty_matches(CP_BACKSPACE, modifier) || mok_matches(CP_BACKSPACE, modifier);
@@ -1408,8 +1408,7 @@ fn format_kitty_key(parsed: &ParsedKittySequence) -> Option<Cow<'static, str>> {
 		{
 			return Some(Cow::Borrowed(key_name));
 		}
-		if parsed.modifier & MOD_NUM_LOCK != 0
-			&& let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed.codepoint)
+		if let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed.codepoint)
 			&& let Some(key_name) = format_key_name(text_codepoint)
 		{
 			return Some(Cow::Borrowed(key_name));
@@ -1608,10 +1607,23 @@ mod tests {
 	}
 
 	#[test]
-	fn num_lock_keypad_digits_stay_text() {
-		assert_eq!(parse_key_inner(b"\x1b[57400;129u", true).as_deref(), Some("1"));
-		assert!(matches_key_inner(b"\x1b[57400;129u", "1", true));
-		assert!(!matches_key_inner(b"\x1b[57400;129u", "end", true));
+	fn modify_other_keys_named_keys_stay_normalized() {
+		assert!(matches_key_inner(b"\x1b[27;1;32~", "space", true));
+		assert!(matches_key_inner(b"\x1b[27;1;127~", "backspace", true));
+		assert_eq!(parse_key_inner(b"\x1b[27;1;32~", true).as_deref(), Some("space"));
+		assert_eq!(parse_key_inner(b"\x1b[27;1;127~", true).as_deref(), Some("backspace"));
+	}
+
+	#[test]
+	fn keypad_digits_stay_text_with_or_without_num_lock_modifier() {
+		for bytes in [b"\x1b[57400u".as_slice(), b"\x1b[57400;129u".as_slice()] {
+			assert_eq!(parse_key_inner(bytes, true).as_deref(), Some("1"));
+			assert!(matches_key_inner(bytes, "1", true));
+			assert!(!matches_key_inner(bytes, "end", true));
+		}
+		assert_eq!(parse_key_inner(b"\x1b[57404u", true).as_deref(), Some("5"));
+		assert!(matches_key_inner(b"\x1b[57404u", "5", true));
+		assert!(!matches_key_inner(b"\x1b[57404u", "clear", true));
 	}
 
 	#[test]

--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -1618,15 +1618,22 @@ mod tests {
 	}
 
 	#[test]
-	fn keypad_digits_stay_text_with_or_without_num_lock_modifier() {
-		for bytes in [b"\x1b[57400u".as_slice(), b"\x1b[57400;129u".as_slice()] {
-			assert_eq!(parse_key_inner(bytes, true).as_deref(), Some("1"));
-			assert!(matches_key_inner(bytes, "1", true));
-			assert!(!matches_key_inner(bytes, "end", true));
-		}
-		assert_eq!(parse_key_inner(b"\x1b[57404u", true).as_deref(), Some("5"));
-		assert!(matches_key_inner(b"\x1b[57404u", "5", true));
-		assert!(!matches_key_inner(b"\x1b[57404u", "clear", true));
+	fn num_lock_keypad_digits_stay_text() {
+		let bytes = b"\x1b[57400;129u";
+		assert_eq!(parse_key_inner(bytes, true).as_deref(), Some("1"));
+		assert!(matches_key_inner(bytes, "1", true));
+		assert!(!matches_key_inner(bytes, "end", true));
+	}
+
+	#[test]
+	fn bare_keypad_digits_stay_navigation_without_num_lock_modifier() {
+		assert_eq!(parse_key_inner(b"\x1b[57400u", true).as_deref(), Some("end"));
+		assert!(matches_key_inner(b"\x1b[57400u", "end", true));
+		assert!(!matches_key_inner(b"\x1b[57400u", "1", true));
+
+		assert_eq!(parse_key_inner(b"\x1b[57404u", true).as_deref(), Some("clear"));
+		assert!(matches_key_inner(b"\x1b[57404u", "clear", true));
+		assert!(!matches_key_inner(b"\x1b[57404u", "5", true));
 	}
 
 	#[test]

--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -607,10 +607,12 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 				parsed_codepoint = text_codepoint;
 				parsed_base = None;
 			} else if actual_mod == 0 {
-				if let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed_codepoint) {
-					parsed_codepoint = text_codepoint;
-					parsed_base = None;
-				} else if p.modifier & MOD_NUM_LOCK != 0 {
+				if p.modifier & MOD_NUM_LOCK != 0 {
+					if let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed_codepoint) {
+						parsed_codepoint = text_codepoint;
+						parsed_base = None;
+					}
+				} else {
 					if let Some(mapped) = map_keypad_nav(parsed_codepoint) {
 						parsed_codepoint = mapped;
 					}
@@ -1408,7 +1410,8 @@ fn format_kitty_key(parsed: &ParsedKittySequence) -> Option<Cow<'static, str>> {
 		{
 			return Some(Cow::Borrowed(key_name));
 		}
-		if let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed.codepoint)
+		if parsed.modifier & MOD_NUM_LOCK != 0
+			&& let Some(text_codepoint) = keypad_num_lock_text_codepoint(parsed.codepoint)
 			&& let Some(key_name) = format_key_name(text_codepoint)
 		{
 			return Some(Cow::Borrowed(key_name));

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed VS Code integrated terminal keypad digit CSI-u input being handled as navigation instead of text.
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -53,6 +53,10 @@ function matchesRawBackspace(data: string, expectedModifier: number): boolean {
 
 export { isWindowsTerminalSession, matchesRawBackspace };
 
+function isVSCodeIntegratedTerminal(): boolean {
+	return process.env.TERM_PROGRAM === "vscode";
+}
+
 // =============================================================================
 // Global Kitty Protocol State
 // =============================================================================
@@ -302,6 +306,7 @@ const KITTY_MOD_SHIFT = 1;
 const KITTY_MOD_ALT = 2;
 const KITTY_MOD_CTRL = 4;
 const KITTY_MOD_SUPER = 8;
+const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
@@ -420,7 +425,7 @@ function decodeKittyPrintable(data: string): string | undefined {
 	const keypadOperatorText = KITTY_KEYPAD_OPERATOR_TEXT[codepoint];
 	if (keypadOperatorText) return keypadOperatorText;
 
-	if (effectiveMod === 0) {
+	if (effectiveMod === 0 && ((modifier & KITTY_MOD_NUM_LOCK) !== 0 || isVSCodeIntegratedTerminal())) {
 		const numpadText = KITTY_NUMPAD_TEXT[codepoint];
 		if (numpadText) return numpadText;
 	}
@@ -512,7 +517,9 @@ function decodeKeypadDigitKey(data: string): string | undefined {
 	const modValue = match[4] ? Number.parseInt(match[4], 10) : 1;
 	const modifier = Number.isFinite(modValue) ? modValue - 1 : 0;
 	const effectiveMod = modifier & ~KITTY_LOCK_MASK;
+	const hasNumLock = (modifier & KITTY_MOD_NUM_LOCK) !== 0;
 	if (effectiveMod !== 0) return undefined;
+	if (!hasNumLock && !isVSCodeIntegratedTerminal()) return undefined;
 	return KITTY_NUMPAD_TEXT[codepoint];
 }
 

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -302,7 +302,6 @@ const KITTY_MOD_SHIFT = 1;
 const KITTY_MOD_ALT = 2;
 const KITTY_MOD_CTRL = 4;
 const KITTY_MOD_SUPER = 8;
-const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
@@ -409,7 +408,7 @@ function decodeKittyPrintable(data: string): string | undefined {
 			.split(":")
 			.filter(Boolean)
 			.map(value => Number.parseInt(value, 10))
-			.filter(value => Number.isFinite(value) && value >= 32);
+			.filter(value => Number.isFinite(value) && value >= 32 && value !== 127);
 		if (codepoints.length > 0) {
 			try {
 				return String.fromCodePoint(...codepoints);
@@ -421,7 +420,7 @@ function decodeKittyPrintable(data: string): string | undefined {
 	const keypadOperatorText = KITTY_KEYPAD_OPERATOR_TEXT[codepoint];
 	if (keypadOperatorText) return keypadOperatorText;
 
-	if (effectiveMod === 0 && modifier & KITTY_MOD_NUM_LOCK) {
+	if (effectiveMod === 0) {
 		const numpadText = KITTY_NUMPAD_TEXT[codepoint];
 		if (numpadText) return numpadText;
 	}
@@ -435,7 +434,7 @@ function decodeKittyPrintable(data: string): string | undefined {
 		return undefined;
 	}
 
-	if (!Number.isFinite(effectiveCodepoint) || effectiveCodepoint < 32) return undefined;
+	if (!Number.isFinite(effectiveCodepoint) || effectiveCodepoint < 32 || effectiveCodepoint === 127) return undefined;
 
 	try {
 		return String.fromCodePoint(effectiveCodepoint);
@@ -486,7 +485,7 @@ function decodeModifyOtherKeysPrintable(data: string): string | undefined {
 	if (!parsed) return undefined;
 	const modifier = parsed.modifier & ~KITTY_LOCK_MASK;
 	if ((modifier & ~KITTY_MOD_SHIFT) !== 0) return undefined;
-	if (!Number.isFinite(parsed.codepoint) || parsed.codepoint < 32) return undefined;
+	if (!Number.isFinite(parsed.codepoint) || parsed.codepoint < 32 || parsed.codepoint === 127) return undefined;
 	try {
 		return String.fromCodePoint(parsed.codepoint);
 	} catch {
@@ -502,6 +501,45 @@ function decodeModifyOtherKeysPrintable(data: string): string | undefined {
  */
 export function decodePrintableKey(data: string): string | undefined {
 	return decodeKittyPrintable(data) ?? decodeModifyOtherKeysPrintable(data);
+}
+
+function decodeKeypadDigitKey(data: string): string | undefined {
+	const match = data.match(KITTY_CSI_U_PATTERN);
+	if (!match) return undefined;
+	if (match[5] === "3") return undefined;
+	const codepoint = Number.parseInt(match[1] ?? "", 10);
+	if (!Number.isFinite(codepoint)) return undefined;
+	const modValue = match[4] ? Number.parseInt(match[4], 10) : 1;
+	const modifier = Number.isFinite(modValue) ? modValue - 1 : 0;
+	const effectiveMod = modifier & ~KITTY_LOCK_MASK;
+	if (effectiveMod !== 0) return undefined;
+	return KITTY_NUMPAD_TEXT[codepoint];
+}
+
+function decodeEncodedNamedKey(data: string): string | undefined {
+	const kittyMatch = data.match(KITTY_CSI_U_PATTERN);
+	if (kittyMatch) {
+		if (kittyMatch[5] === "3") return undefined;
+		const codepoint = Number.parseInt(kittyMatch[1] ?? "", 10);
+		if (!Number.isFinite(codepoint)) return undefined;
+		const modValue = kittyMatch[4] ? Number.parseInt(kittyMatch[4], 10) : 1;
+		const modifier = Number.isFinite(modValue) ? modValue - 1 : 0;
+		if ((modifier & ~KITTY_LOCK_MASK) !== 0) return undefined;
+		if (codepoint === 32) return "space";
+		if (codepoint === 127) return "backspace";
+		if (codepoint === 9) return "tab";
+		if (codepoint === 13 || codepoint === 57414) return "enter";
+		return undefined;
+	}
+
+	const modifyOtherKeys = parseModifyOtherKeysSequence(data);
+	if (!modifyOtherKeys) return undefined;
+	if ((modifyOtherKeys.modifier & ~KITTY_LOCK_MASK) !== 0) return undefined;
+	if (modifyOtherKeys.codepoint === 32) return "space";
+	if (modifyOtherKeys.codepoint === 127) return "backspace";
+	if (modifyOtherKeys.codepoint === 9) return "tab";
+	if (modifyOtherKeys.codepoint === 13 || modifyOtherKeys.codepoint === 57414) return "enter";
+	return undefined;
 }
 
 /**
@@ -521,6 +559,10 @@ export function decodePrintableKey(data: string): string | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
+	const keypadDigit = decodeKeypadDigitKey(data);
+	if (keypadDigit !== undefined) return keyId === keypadDigit;
+	const encodedNamedKey = decodeEncodedNamedKey(data);
+	if (encodedNamedKey !== undefined && keyId === encodedNamedKey) return true;
 	return matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
@@ -533,5 +575,5 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
-	return parseKeyNative(data, kittyProtocolActive) ?? undefined;
+	return decodeKeypadDigitKey(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -419,13 +419,14 @@ describe("Editor component", () => {
 			expect(text).toBe("Hello äöü 😀");
 		});
 
-		it("inserts NumLock keypad digits instead of treating them as navigation", () => {
+		it("inserts keypad digits instead of treating them as navigation", () => {
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.handleInput("a");
+			editor.handleInput("\x1b[57400u");
 			editor.handleInput("\x1b[57400;129u");
 
-			expect(editor.getText()).toBe("a1");
+			expect(editor.getText()).toBe("a11");
 		});
 
 		it("inserts a newline for Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -9,9 +9,25 @@ import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
 import { setDefaultTabWidth } from "@oh-my-pi/pi-utils";
 import { defaultEditorTheme } from "./test-themes";
 
+const originalTermProgram = process.env.TERM_PROGRAM;
+
+function setVSCodeTerminal(active: boolean): void {
+	if (active) {
+		process.env.TERM_PROGRAM = "vscode";
+	} else {
+		process.env.TERM_PROGRAM = "kitty";
+	}
+}
+
 describe("Editor component", () => {
 	afterEach(() => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+		if (originalTermProgram === undefined) {
+			delete process.env.TERM_PROGRAM;
+		} else {
+			process.env.TERM_PROGRAM = originalTermProgram;
+		}
+		setKittyProtocolActive(false);
 	});
 
 	describe("Prompt history navigation", () => {
@@ -419,14 +435,35 @@ describe("Editor component", () => {
 			expect(text).toBe("Hello äöü 😀");
 		});
 
-		it("inserts keypad digits instead of treating them as navigation", () => {
+		it("inserts bare keypad digits instead of navigation in VS Code", () => {
+			setVSCodeTerminal(true);
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.handleInput("a");
 			editor.handleInput("\x1b[57400u");
+
+			expect(editor.getText()).toBe("a1");
+		});
+
+		it("keeps bare keypad digits as navigation outside VS Code", () => {
+			setVSCodeTerminal(false);
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("abc");
+			editor.handleInput("\x1b[57400u");
+			editor.handleInput("x");
+
+			expect(editor.getText()).toBe("abcx");
+		});
+
+		it("inserts NumLock keypad digits in every terminal", () => {
+			setVSCodeTerminal(false);
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("a");
 			editor.handleInput("\x1b[57400;129u");
 
-			expect(editor.getText()).toBe("a11");
+			expect(editor.getText()).toBe("a1");
 		});
 
 		it("inserts a newline for Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -133,12 +133,14 @@ describe("Input component", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("inserts NumLock keypad digits from Kitty CSI-u input", () => {
+	it("inserts keypad digits from Kitty CSI-u input with or without NumLock modifier", () => {
 		setKittyProtocolActive(true);
 		const input = setupAtEnd("a");
 
+		input.handleInput("\x1b[57407u");
 		input.handleInput("\x1b[57407;129u");
-		expect(input.getValue()).toBe("a8");
+		input.handleInput("\x1b[57404u");
+		expect(input.getValue()).toBe("a885");
 
 		setKittyProtocolActive(false);
 	});

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { CURSOR_MARKER } from "@oh-my-pi/pi-tui";
 import { Input } from "@oh-my-pi/pi-tui/components/input";
 import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
 import { getIndentation } from "@oh-my-pi/pi-utils";
+
+const originalTermProgram = process.env.TERM_PROGRAM;
+
+function setVSCodeTerminal(active: boolean): void {
+	if (active) {
+		process.env.TERM_PROGRAM = "vscode";
+	} else {
+		process.env.TERM_PROGRAM = "kitty";
+	}
+}
+
+afterEach(() => {
+	if (originalTermProgram === undefined) {
+		delete process.env.TERM_PROGRAM;
+	} else {
+		process.env.TERM_PROGRAM = originalTermProgram;
+	}
+	setKittyProtocolActive(false);
+});
 
 function renderedWidth(input: Input, width: number): number {
 	const [line] = input.render(width);
@@ -133,16 +152,23 @@ describe("Input component", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("inserts keypad digits from Kitty CSI-u input with or without NumLock modifier", () => {
+	it("inserts bare keypad digits from Kitty CSI-u input only in VS Code", () => {
 		setKittyProtocolActive(true);
+		setVSCodeTerminal(true);
 		const input = setupAtEnd("a");
 
 		input.handleInput("\x1b[57407u");
-		input.handleInput("\x1b[57407;129u");
 		input.handleInput("\x1b[57404u");
-		expect(input.getValue()).toBe("a885");
+		expect(input.getValue()).toBe("a85");
+	});
 
-		setKittyProtocolActive(false);
+	it("inserts NumLock keypad digits from Kitty CSI-u input in every terminal", () => {
+		setKittyProtocolActive(true);
+		setVSCodeTerminal(false);
+		const input = setupAtEnd("a");
+
+		input.handleInput("\x1b[57407;129u");
+		expect(input.getValue()).toBe("a8");
 	});
 
 	it("inserts keypad operators from Kitty CSI-u input", () => {

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -1,5 +1,24 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { extractPrintableText, matchesKey, parseKey, setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
+
+const originalTermProgram = process.env.TERM_PROGRAM;
+
+function setVSCodeTerminal(active: boolean): void {
+	if (active) {
+		process.env.TERM_PROGRAM = "vscode";
+	} else {
+		process.env.TERM_PROGRAM = "kitty";
+	}
+}
+
+afterEach(() => {
+	if (originalTermProgram === undefined) {
+		delete process.env.TERM_PROGRAM;
+	} else {
+		process.env.TERM_PROGRAM = originalTermProgram;
+	}
+	setKittyProtocolActive(false);
+});
 
 describe("matchesKey", () => {
 	it("matches ctrl+letter sequences", () => {
@@ -68,15 +87,26 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("keeps keypad digits as text with or without NumLock modifier", () => {
+	it("keeps bare keypad digits as text only in VS Code", () => {
 		setKittyProtocolActive(true);
-		for (const data of ["\x1b[57400u", "\x1b[57400;129u"]) {
-			expect(matchesKey(data, "1")).toBe(true);
-			expect(matchesKey(data, "end")).toBe(false);
-		}
+		setVSCodeTerminal(true);
+		expect(matchesKey("\x1b[57400u", "1")).toBe(true);
+		expect(matchesKey("\x1b[57400u", "end")).toBe(false);
 		expect(matchesKey("\x1b[57404u", "5")).toBe(true);
 		expect(matchesKey("\x1b[57404u", "clear")).toBe(false);
-		setKittyProtocolActive(false);
+
+		setVSCodeTerminal(false);
+		expect(matchesKey("\x1b[57400u", "1")).toBe(false);
+		expect(matchesKey("\x1b[57400u", "end")).toBe(true);
+		expect(matchesKey("\x1b[57404u", "5")).toBe(false);
+		expect(matchesKey("\x1b[57404u", "clear")).toBe(true);
+	});
+
+	it("keeps NumLock keypad digits as text in every terminal", () => {
+		setKittyProtocolActive(true);
+		setVSCodeTerminal(false);
+		expect(matchesKey("\x1b[57400;129u", "1")).toBe(true);
+		expect(matchesKey("\x1b[57400;129u", "end")).toBe(false);
 	});
 
 	it("matches keypad operators as their printable symbols", () => {
@@ -139,12 +169,21 @@ describe("parseKey", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("parses keypad digits as digits with or without NumLock modifier", () => {
+	it("parses bare keypad digits as digits only in VS Code", () => {
 		setKittyProtocolActive(true);
+		setVSCodeTerminal(true);
 		expect(parseKey("\x1b[57400u")).toBe("1");
-		expect(parseKey("\x1b[57400;129u")).toBe("1");
 		expect(parseKey("\x1b[57404u")).toBe("5");
-		setKittyProtocolActive(false);
+
+		setVSCodeTerminal(false);
+		expect(parseKey("\x1b[57400u")).toBe("end");
+		expect(parseKey("\x1b[57404u")).toBe("clear");
+	});
+
+	it("parses NumLock keypad digits as digits in every terminal", () => {
+		setKittyProtocolActive(true);
+		setVSCodeTerminal(false);
+		expect(parseKey("\x1b[57400;129u")).toBe("1");
 	});
 
 	it("parses keypad operators as printable keys", () => {
@@ -170,10 +209,19 @@ describe("parseKey", () => {
 });
 
 describe("extractPrintableText", () => {
-	it("extracts keypad digits from Kitty CSI-u sequences", () => {
+	it("extracts bare keypad digits from Kitty CSI-u sequences only in VS Code", () => {
+		setVSCodeTerminal(true);
 		expect(extractPrintableText("\x1b[57407u")).toBe("8");
-		expect(extractPrintableText("\x1b[57407;129u")).toBe("8");
 		expect(extractPrintableText("\x1b[57404u")).toBe("5");
+
+		setVSCodeTerminal(false);
+		expect(extractPrintableText("\x1b[57407u")).toBeUndefined();
+		expect(extractPrintableText("\x1b[57404u")).toBeUndefined();
+	});
+
+	it("extracts NumLock keypad digits from Kitty CSI-u sequences in every terminal", () => {
+		setVSCodeTerminal(false);
+		expect(extractPrintableText("\x1b[57407;129u")).toBe("8");
 	});
 
 	it("extracts keypad operators from Kitty CSI-u sequences", () => {

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -57,10 +57,25 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("keeps NumLock keypad digits as text instead of navigation keys", () => {
+	it("keeps encoded named keys on the native normalized path", () => {
 		setKittyProtocolActive(true);
-		expect(matchesKey("\x1b[57400;129u", "1")).toBe(true);
-		expect(matchesKey("\x1b[57400;129u", "end")).toBe(false);
+		expect(matchesKey("\x1b[32u", "space")).toBe(true);
+		expect(matchesKey("\x1b[27;1;32~", "space")).toBe(true);
+		expect(matchesKey("\x1b[27;1;127~", "backspace")).toBe(true);
+		expect(parseKey("\x1b[32u")).toBe("space");
+		expect(parseKey("\x1b[27;1;32~")).toBe("space");
+		expect(parseKey("\x1b[27;1;127~")).toBe("backspace");
+		setKittyProtocolActive(false);
+	});
+
+	it("keeps keypad digits as text with or without NumLock modifier", () => {
+		setKittyProtocolActive(true);
+		for (const data of ["\x1b[57400u", "\x1b[57400;129u"]) {
+			expect(matchesKey(data, "1")).toBe(true);
+			expect(matchesKey(data, "end")).toBe(false);
+		}
+		expect(matchesKey("\x1b[57404u", "5")).toBe(true);
+		expect(matchesKey("\x1b[57404u", "clear")).toBe(false);
 		setKittyProtocolActive(false);
 	});
 
@@ -124,9 +139,11 @@ describe("parseKey", () => {
 		setKittyProtocolActive(false);
 	});
 
-	it("parses NumLock keypad digits as digits", () => {
+	it("parses keypad digits as digits with or without NumLock modifier", () => {
 		setKittyProtocolActive(true);
+		expect(parseKey("\x1b[57400u")).toBe("1");
 		expect(parseKey("\x1b[57400;129u")).toBe("1");
+		expect(parseKey("\x1b[57404u")).toBe("5");
 		setKittyProtocolActive(false);
 	});
 
@@ -153,8 +170,10 @@ describe("parseKey", () => {
 });
 
 describe("extractPrintableText", () => {
-	it("extracts NumLock keypad digits from Kitty CSI-u sequences", () => {
+	it("extracts keypad digits from Kitty CSI-u sequences", () => {
+		expect(extractPrintableText("\x1b[57407u")).toBe("8");
 		expect(extractPrintableText("\x1b[57407;129u")).toBe("8");
+		expect(extractPrintableText("\x1b[57404u")).toBe("5");
 	});
 
 	it("extracts keypad operators from Kitty CSI-u sequences", () => {


### PR DESCRIPTION
## What

Treat Kitty CSI-u keypad digit sequences without a NumLock modifier as printable keypad digits instead of navigation keys.

## Why

VS Code integrated terminal emits keypad digit PUA CSI-u codes such as `\x1b[57400u` when NumLock is enabled, but does not include the Kitty NumLock modifier bit. The TUI previously interpreted those sequences as navigation keys, so numpad digit input failed in VS Code while external terminals that emit ASCII digits worked.

## Testing

- `bun --cwd=packages/tui test test/keys.test.ts test/input.test.ts test/editor.test.ts`
- `bun --cwd=packages/tui run check`
- `packages/coding-agent/dist/omp.exe --smoke-test`
- `bun run check` attempted, but the Rust check could not run because `cargo` is not installed in this environment.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
