### PR TITLE
fix(markit): route MuPDF WASM warnings to the logger instead of the TUI

### DIFF
--- a/packages/coding-agent/src/utils/markit.ts
+++ b/packages/coding-agent/src/utils/markit.ts
@@ -1,6 +1,12 @@
 import { untilAborted } from "@oh-my-pi/pi-utils";
 import type { Markit, StreamInfo } from "markit-ai";
 import { ToolAbortError } from "../tools/tool-errors";
+import { installMupdfQuietHook } from "./mupdf-quiet";
+
+// MuPDF (pulled in transitively via markit-ai for PDF/document extraction)
+// writes its WASM warnings to console.error, which corrupts the TUI. Route
+// them to the file logger before markit-ai (and thus mupdf) first loads below.
+installMupdfQuietHook();
 
 export interface MarkitConversionResult {
 	content: string;

--- a/packages/coding-agent/src/utils/mupdf-quiet.ts
+++ b/packages/coding-agent/src/utils/mupdf-quiet.ts
@@ -1,0 +1,34 @@
+import { logger } from "@oh-my-pi/pi-utils";
+
+/**
+ * Global key the `mupdf` WASM loader reads for its Emscripten module options
+ * (mupdf/dist/mupdf.js: `await libmupdf_wasm(globalThis["$libmupdf_wasm_Module"])`).
+ * Emscripten honours `print`/`printErr` from this object; both default to
+ * `console.log`/`console.error`, which corrupt the TUI when MuPDF emits
+ * recoverable-format warnings during PDF text extraction.
+ */
+export const MUPDF_MODULE_GLOBAL = "$libmupdf_wasm_Module";
+
+const INSTALLED = "__ompMupdfQuiet";
+
+/**
+ * Route MuPDF's WASM stdout/stderr to the file logger instead of the console so
+ * warnings like "format error: No common ancestor in structure tree" never reach
+ * the terminal. Idempotent. Must run before `mupdf` is first imported — Emscripten
+ * reads the options object once at instantiation.
+ */
+export function installMupdfQuietHook(): void {
+	const g = globalThis as Record<string, unknown>;
+	const current = g[MUPDF_MODULE_GLOBAL];
+	const prev = current && typeof current === "object" ? (current as Record<string, unknown>) : null;
+	if (prev?.[INSTALLED]) return;
+	const sink = (text: string): void => {
+		logger.debug(`[mupdf] ${text}`);
+	};
+	g[MUPDF_MODULE_GLOBAL] = {
+		...(prev ?? {}),
+		print: sink,
+		printErr: sink,
+		[INSTALLED]: true,
+	};
+}

--- a/packages/coding-agent/test/utils/mupdf-quiet.test.ts
+++ b/packages/coding-agent/test/utils/mupdf-quiet.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression: MuPDF WASM warnings (e.g. "format error: No common ancestor in
+ * structure tree") must not leak to the console/TUI during PDF conversion. The
+ * fix routes Emscripten print/printErr to the file logger via a global module
+ * hook installed before `mupdf` is first imported.
+ */
+import { describe, expect, it, vi } from "bun:test";
+import { logger } from "@oh-my-pi/pi-utils";
+// Side-effect import: loading markit.ts (the sole markit-ai importer) must
+// install the hook at module load, before mupdf is ever imported. A static
+// side-effect import is the rule-compliant way to assert that wiring.
+import "@oh-my-pi/pi-coding-agent/utils/markit";
+import { installMupdfQuietHook, MUPDF_MODULE_GLOBAL } from "@oh-my-pi/pi-coding-agent/utils/mupdf-quiet";
+
+type ModuleConfig = { print?: (t: string) => void; printErr?: (t: string) => void; [k: string]: unknown };
+const cfg = (): ModuleConfig | undefined =>
+	(globalThis as Record<string, unknown>)[MUPDF_MODULE_GLOBAL] as ModuleConfig | undefined;
+
+describe("mupdf quiet hook", () => {
+	it("is installed at module load when markit.ts is imported", () => {
+		expect(cfg()?.__ompMupdfQuiet).toBe(true);
+		expect(typeof cfg()?.printErr).toBe("function");
+	});
+
+	it("routes print and printErr to logger.debug, never the console/TUI", () => {
+		const g = globalThis as Record<string, unknown>;
+		const saved = g[MUPDF_MODULE_GLOBAL];
+		delete g[MUPDF_MODULE_GLOBAL];
+		const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const cerr = vi.spyOn(console, "error").mockImplementation(() => {});
+		const clog = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			installMupdfQuietHook();
+			cfg()?.printErr?.("format error: No common ancestor in structure tree");
+			cfg()?.print?.("warning: structure tree broken, assume tree is missing");
+			expect(debug).toHaveBeenCalledTimes(2);
+			expect(debug.mock.calls[0]?.[0]).toContain("No common ancestor");
+			expect(cerr).not.toHaveBeenCalled();
+			expect(clog).not.toHaveBeenCalled();
+		} finally {
+			vi.restoreAllMocks();
+			g[MUPDF_MODULE_GLOBAL] = saved;
+		}
+	});
+
+	it("is idempotent and preserves pre-existing module config keys", () => {
+		const g = globalThis as Record<string, unknown>;
+		const saved = g[MUPDF_MODULE_GLOBAL];
+		g[MUPDF_MODULE_GLOBAL] = { locateFile: (f: string) => f, custom: 42 };
+		try {
+			installMupdfQuietHook();
+			const first = cfg();
+			expect(first?.custom).toBe(42);
+			expect(typeof first?.locateFile).toBe("function");
+			expect(typeof first?.printErr).toBe("function");
+			installMupdfQuietHook();
+			expect(cfg()).toBe(first); // sentinel short-circuits, no re-clobber
+		} finally {
+			g[MUPDF_MODULE_GLOBAL] = saved;
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Reading a PDF in the TUI prints MuPDF warnings over the frame:

```
format error: No common ancestor in structure tree
warning: structure tree broken, assume tree is missing
unsupported error: cannot create appearance stream for Screen annotations
```

`markit-ai` lazily loads the `mupdf` WASM package for PDF text extraction; MuPDF's Emscripten build sends `printErr` to `console.error`, which Bun writes directly to the terminal fd, corrupting the TUI. (Reproduced: 172 messages on `console.error`, 0 on `console.log`.)

## Fix

`mupdf`'s loader reads `globalThis["$libmupdf_wasm_Module"]` once at first import and honours its `print`/`printErr`. New `src/utils/mupdf-quiet.ts` installs a hook routing both to `logger.debug` (file-only transport → TUI-safe); `markit.ts` (the sole `markit-ai` importer) calls it at module load, before mupdf can load. The hook is idempotent and merges rather than clobbers any pre-existing module config.

## Tests

`test/utils/mupdf-quiet.test.ts` (3 cases): the hook is installed when `markit.ts` is imported; `print`/`printErr` route to `logger.debug` and never touch `console.*`; idempotent and preserves existing config keys.

```
bun test test/utils/mupdf-quiet.test.ts   # 3 pass
bun run check                              # biome + tsgo clean
```

Closes #2766
