### PR TITLE
fix(google): avoid serializing default AUTO functionCallingConfig

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -849,9 +849,12 @@ export function buildRequest(
 		if (options.toolChoice) {
 			const choice = options.toolChoice;
 			if (typeof choice === "string") {
-				request.toolConfig = {
-					functionCallingConfig: { mode: mapToolChoice(choice) },
-				};
+				const mode = mapToolChoice(choice);
+				if (mode !== "AUTO") {
+					request.toolConfig = {
+						functionCallingConfig: { mode },
+					};
+				}
 			} else {
 				request.toolConfig = {
 					functionCallingConfig: {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -793,9 +793,12 @@ export function buildGoogleGenerateContentParams<T extends "google-generative-ai
 	if (context.tools && context.tools.length > 0 && options.toolChoice) {
 		const choice = options.toolChoice;
 		if (typeof choice === "string") {
-			config.toolConfig = {
-				functionCallingConfig: { mode: mapToolChoice(choice) },
-			};
+			const mode = mapToolChoice(choice);
+			if (mode !== "AUTO") {
+				config.toolConfig = {
+					functionCallingConfig: { mode },
+				};
+			}
 		} else {
 			// Named-tool routing — `mode: "ANY"` plus an explicit allow-list. The
 			// caller is responsible for ensuring the names exist in `context.tools`.

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -229,6 +229,42 @@ describe("Google Gemini CLI alignment", () => {
 			expect(parts.slice(3).some(p => p.text === "my instructions")).toBe(true);
 		}
 	});
+	it("omits toolConfig when toolChoice is 'auto' in buildRequest", () => {
+		const model = createModel("google-gemini-cli");
+		const toolContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			tools: [{ name: "search", description: "Search", parameters: { type: "object", properties: {} } as never }],
+		};
+		const payload = buildRequest(model, toolContext, "proj-123", { toolChoice: "auto" }, false) as {
+			request: { toolConfig?: unknown };
+		};
+		expect(payload.request.toolConfig).toBeUndefined();
+	});
+
+	it("keeps toolConfig when toolChoice is 'none' or 'any' in buildRequest", () => {
+		const model = createModel("google-gemini-cli");
+		const toolContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			tools: [{ name: "search", description: "Search", parameters: { type: "object", properties: {} } as never }],
+		};
+
+		const payloadNone = buildRequest(model, toolContext, "proj-123", { toolChoice: "none" }, false) as {
+			request: { toolConfig?: unknown };
+		};
+		expect(payloadNone.request.toolConfig).toEqual({
+			functionCallingConfig: { mode: "NONE" },
+		});
+
+		const payloadAny = buildRequest(model, toolContext, "proj-123", { toolChoice: "any" }, false) as {
+			request: { toolConfig?: unknown };
+		};
+		expect(payloadAny.request.toolConfig).toEqual({
+			functionCallingConfig: { mode: "ANY" },
+		});
+	});
+
 	it("adds anthropic-beta for Antigravity Claude reasoning models without relying on id suffix", async () => {
 		let requestHeaders: Headers | undefined;
 		const fetchMock: FetchImpl = async (_url, init) => {

--- a/packages/ai/test/google-tool-choice.test.ts
+++ b/packages/ai/test/google-tool-choice.test.ts
@@ -84,6 +84,16 @@ describe("buildGoogleGenerateContentParams toolConfig serialization (F7)", () =>
 		expect(params.config!.toolConfig).toBeUndefined();
 	});
 
+	it("emits functionCallingConfig.mode for string toolChoice 'none'", () => {
+		const params = buildGoogleGenerateContentParams(model, ctx(), {
+			apiKey: "fake",
+			toolChoice: "none",
+		});
+		expect(params.config!.toolConfig).toEqual({
+			functionCallingConfig: { mode: "NONE" },
+		});
+	});
+
 	it("clears toolConfig when no toolChoice is provided", () => {
 		const params = buildGoogleGenerateContentParams(model, ctx(), { apiKey: "fake" });
 		expect(params.config!.toolConfig).toBeUndefined();

--- a/packages/ai/test/google-tool-choice.test.ts
+++ b/packages/ai/test/google-tool-choice.test.ts
@@ -76,6 +76,14 @@ describe("buildGoogleGenerateContentParams toolConfig serialization (F7)", () =>
 		});
 	});
 
+	it("omits toolConfig when toolChoice is 'auto'", () => {
+		const params = buildGoogleGenerateContentParams(model, ctx(), {
+			apiKey: "fake",
+			toolChoice: "auto",
+		});
+		expect(params.config!.toolConfig).toBeUndefined();
+	});
+
 	it("clears toolConfig when no toolChoice is provided", () => {
 		const params = buildGoogleGenerateContentParams(model, ctx(), { apiKey: "fake" });
 		expect(params.config!.toolConfig).toBeUndefined();


### PR DESCRIPTION
Fixes #2769

### Description
When using Gemini-3 models with tools, explicitly providing `toolConfig: { functionCallingConfig: { mode: "AUTO" } }` in the API payload triggers a Google-side bug that causes the model to output raw reasoning/call JSON as plain text instead of making actual tool calls.

According to the Gemini API specifications, omitting `toolConfig` when `tools` are present defaults to `AUTO` mode. This PR avoids serializing the default `AUTO` mode, falling back to the API's native default, which effectively bypasses the bug without altering the tool choice semantics.

### Changes
- `packages/ai/src/providers/google-shared.ts`: Omit `toolConfig` serialization when string `toolChoice` maps to `AUTO`.
- `packages/ai/src/providers/google-gemini-cli.ts`: Same optimization for the CLI provider.
- Added tests in both shared and CLI provider test suites to verify that `auto` tool choice results in undefined `toolConfig` while `none`/`any` continue to be serialized correctly.

### Verification
- Ran `bun test` in `packages/ai`: All tests passed successfully.
- Verified Biome checks: `bun run check:ts` passed with zero errors.