### PR TITLE
fix(coding-agent): route MuPDF warnings to logger

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed PDF reads leaking recoverable MuPDF WASM warnings into the terminal TUI by routing MuPDF output through the file logger before `markit-ai` loads it ([#2766](https://github.com/can1357/oh-my-pi/issues/2766)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/markit.ts
+++ b/packages/coding-agent/src/utils/markit.ts
@@ -1,4 +1,4 @@
-import { untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Markit, StreamInfo } from "markit-ai";
 import { ToolAbortError } from "../tools/tool-errors";
 
@@ -7,6 +7,29 @@ export interface MarkitConversionResult {
 	ok: boolean;
 	error?: string;
 }
+
+interface MuPdfWasmModuleConfig {
+	print?: (...values: unknown[]) => void;
+	printErr?: (...values: unknown[]) => void;
+}
+
+declare global {
+	var $libmupdf_wasm_Module: MuPdfWasmModuleConfig | undefined;
+}
+
+function logMuPdfWasmOutput(stream: "stdout" | "stderr", values: unknown[]): void {
+	const message = values.length === 1 && typeof values[0] === "string" ? values[0] : values.map(String).join(" ");
+	logger.debug("mupdf wasm output", { stream, message });
+}
+
+function installMuPdfWasmLogger(): void {
+	const moduleConfig = globalThis.$libmupdf_wasm_Module ?? {};
+	moduleConfig.print = (...values) => logMuPdfWasmOutput("stdout", values);
+	moduleConfig.printErr = (...values) => logMuPdfWasmOutput("stderr", values);
+	globalThis.$libmupdf_wasm_Module = moduleConfig;
+}
+
+installMuPdfWasmLogger();
 
 let markit: () => Markit | Promise<Markit> = async () => {
 	const promise = import("markit-ai").then(({ Markit }) => {

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { convertBufferWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
+import { logger } from "@oh-my-pi/pi-utils";
+
+function warningPdf(): Uint8Array {
+	const objects: string[] = [];
+	function add(body: string): void {
+		objects.push(body);
+	}
+
+	const pageText = "/P <</MCID 0>> BDC\nBT /F1 24 Tf 72 720 Td (Tagged PDF repro text) Tj ET\nEMC\n";
+	add("<< /Type /Catalog /Pages 2 0 R /MarkInfo << /Marked true >> /StructTreeRoot 8 0 R >>");
+	add("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+	add(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R /StructParents 0 /Annots [9 0 R] >>",
+	);
+	add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+	add(`<< /Length ${pageText.length} >>\nstream\n${pageText}endstream`);
+	add("<< /Nums [0 [7 0 R]] >>");
+	add("<< /Type /StructElem /S /P /P 8 0 R /Pg 3 0 R /K 99 >>");
+	add("<< /Type /StructTreeRoot /K [7 0 R] /ParentTree 6 0 R /ParentTreeNextKey 1 >>");
+	add("<< /Type /Annot /Subtype /Screen /Rect [72 650 200 700] /T (movie) >>");
+
+	let pdf = "%PDF-1.7\n";
+	const offsets = [0];
+	for (let i = 0; i < objects.length; i++) {
+		offsets.push(Buffer.byteLength(pdf));
+		pdf += `${i + 1} 0 obj\n${objects[i]}\nendobj\n`;
+	}
+
+	const xref = Buffer.byteLength(pdf);
+	pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+	for (let i = 1; i < offsets.length; i++) {
+		pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+	}
+	pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+
+	return new TextEncoder().encode(pdf);
+}
+
+describe("markit MuPDF warnings", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("routes recoverable PDF warnings to the file logger", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
+
+		const result = await convertBufferWithMarkit(warningPdf(), ".pdf");
+
+		expect(result.ok).toBe(true);
+		expect(result.content).toContain("Tagged PDF repro text");
+		expect(consoleError).not.toHaveBeenCalled();
+		expect(
+			debug.mock.calls.some(([message, metadata]) => {
+				if (message !== "mupdf wasm output" || typeof metadata !== "object" || metadata === null) return false;
+				if (!("stream" in metadata) || metadata.stream !== "stderr") return false;
+				return "message" in metadata && String(metadata.message).includes("Screen annotations");
+			}),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
A minimal tagged PDF containing a `Screen` annotation reproduces the leak: `bun .wt/repro-pdf.js && bun .wt/repro-markit.js` returned `ok: true` with extracted `Tagged PDF repro text`, while pre-fix MuPDF sent 5 recoverable warnings through `console.error`, including `unsupported error: cannot create appearance stream for Screen annotations`.

## Cause
`packages/coding-agent/src/utils/markit.ts` lazily imports `markit-ai`; the PDF converter then imports `mupdf`, whose WASM loader reads `globalThis.$libmupdf_wasm_Module` once and defaults `printErr` to `console.error` when no hook is installed. Those recoverable parser warnings bypass the TUI renderer and write directly to the terminal fd.

## Fix
- Installed MuPDF WASM `print` and `printErr` hooks in `markit.ts` before the lazy `markit-ai` import can load `mupdf`.
- Routed MuPDF output to `logger.debug` with the stream and message so warnings stay in the file log instead of the terminal.
- Added a regression test that converts a tagged PDF with a `Screen` annotation and asserts conversion succeeds without calling `console.error`.
- Added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts` passed. `bun --cwd=packages/coding-agent test test/utils/markit-mupdf-warnings.test.ts && bun --cwd=packages/coding-agent run check:types` passed. `bun --cwd=packages/coding-agent run check` passed. Fixes #2766