### PR TITLE
fix(tui): reduce loader repaint flicker

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed animated working-message loader frames repainting at 30fps on terminals without synchronized-output support, which could cause visible flicker during normal prompt rendering ([#2771](https://github.com/can1357/oh-my-pi/issues/2771)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -57,12 +57,15 @@ export class Loader extends Text {
 		this.#intervalId = setInterval(() => {
 			const now = performance.now();
 			const elapsed = now - this.#lastSpinnerTick;
-			if (elapsed >= SPINNER_ADVANCE_MS) {
+			const shouldAdvanceSpinner = elapsed >= SPINNER_ADVANCE_MS;
+			if (shouldAdvanceSpinner) {
 				const steps = Math.floor(elapsed / SPINNER_ADVANCE_MS);
 				this.#currentFrame = (this.#currentFrame + steps) % this.#frames.length;
 				this.#lastSpinnerTick += steps * SPINNER_ADVANCE_MS;
 			}
-			this.#updateDisplay();
+			if (shouldAdvanceSpinner || this.#ui?.synchronizedOutput === true) {
+				this.#updateDisplay();
+			}
 		}, intervalMs);
 	}
 

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -92,7 +92,7 @@ describe("Loader component", () => {
 	it("requests render when animated message bytes change between spinner frames", () => {
 		vi.useFakeTimers();
 		setSystemTime(new Date(1_000));
-		const ui = { requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { synchronizedOutput: true, requestComponentRender: vi.fn() } as unknown as TUI;
 		const colorMessage = ((text: string) => `${text}-${Date.now()}`) as LoaderMessageColorFn & { animated: true };
 		colorMessage.animated = true;
 		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0"]);
@@ -102,6 +102,26 @@ describe("Loader component", () => {
 		vi.advanceTimersByTime(34);
 		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
 		expect(loader.render(40).join("\n")).toContain("0 Checking-");
+
+		loader.stop();
+	});
+
+	it("holds animated message-only frames when synchronized output is unavailable", () => {
+		vi.useFakeTimers();
+		setSystemTime(new Date(1_000));
+		const ui = { synchronizedOutput: false, requestComponentRender: vi.fn() } as unknown as TUI;
+		const colorMessage = ((text: string) => `${text}-${Date.now()}`) as LoaderMessageColorFn & { animated: true };
+		colorMessage.animated = true;
+		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0", "1"]);
+
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(34);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(67);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(loader.render(40).join("\n")).toContain("1 Checking-");
 
 		loader.stop();
 	});


### PR DESCRIPTION
## Repro
The working-message loader can animate its message at 30fps while `TUI.synchronizedOutput` is false, so unsupported terminals receive visible intermediate paints during normal prompt rendering. Reproduced with `bun -e "$REPRO_SCRIPT"`, which showed render requests increasing from 1 to 2 after 34ms with `synchronizedOutput=false`.

## Cause
`packages/tui/src/components/loader.ts` treated `LoaderMessageColorFn.animated` as a fixed 30fps repaint cadence and called `#updateDisplay()` on every timer tick even when DEC 2026 synchronized output was unavailable, so message-only shimmer frames reached terminals without frame batching.

## Fix
- Gate animated message-only loader repaints on `TUI.synchronizedOutput` while preserving spinner-frame updates.
- Keep synchronized terminals on the existing 30fps animated-message path.
- Add a regression test covering the non-synchronized path and update the TUI changelog.

## Verification
`bun --cwd=packages/tui run check && bun test packages/tui/test/loader.test.ts` passed. The repro script now keeps render requests at 1 after 34ms with `synchronizedOutput=false`. Fixes #2771