### PR TITLE
fix(ai): surface empty Ollama length completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible Ollama completions that return empty `finish_reason:length` after filling `num_ctx` so they surface an actionable context-window error instead of an empty length stop. ([#2774](https://github.com/can1357/oh-my-pi/issues/2774))
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1162,6 +1162,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				output.stopReason = "toolUse";
 			}
 
+			if (output.stopReason === "length" && !hasVisibleCompletionContent(output)) {
+				output.stopReason = "error";
+				output.errorMessage = emptyLengthCompletionMessage(model);
+			}
 			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
 			if (firstEventTimeoutError) {
 				throw firstEventTimeoutError;
@@ -2194,6 +2198,23 @@ function shouldRetryWithoutStrictTools(
 	return /wrong_api_format|mixed values for 'strict'|tool[s]?\b.*strict|\bstrict\b.*tool|tool parameters? schema|invalid schema for function/i.test(
 		messageParts,
 	);
+}
+
+const NON_WHITESPACE_RE = /\S/;
+
+function hasVisibleCompletionContent(message: AssistantMessage): boolean {
+	for (const block of message.content) {
+		if (block.type === "toolCall") return true;
+		if (block.type === "text" && NON_WHITESPACE_RE.test(block.text)) return true;
+	}
+	return false;
+}
+
+function emptyLengthCompletionMessage(model: Model<"openai-completions">): string {
+	if (model.provider === "ollama") {
+		return "Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.";
+	}
+	return "Model returned no content before hitting the length limit; increase the context window/output budget or shorten the prompt.";
 }
 
 function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | string): {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1162,7 +1162,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				output.stopReason = "toolUse";
 			}
 
-			if (model.provider === "ollama" && output.stopReason === "length" && !hasVisibleCompletionContent(output)) {
+			if (model.provider === "ollama" && output.stopReason === "length" && !hasCompletionContent(output)) {
 				output.stopReason = "error";
 				output.errorMessage = EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE;
 			}
@@ -2202,10 +2202,11 @@ function shouldRetryWithoutStrictTools(
 
 const NON_WHITESPACE_RE = /\S/;
 
-function hasVisibleCompletionContent(message: AssistantMessage): boolean {
+function hasCompletionContent(message: AssistantMessage): boolean {
 	for (const block of message.content) {
 		if (block.type === "toolCall") return true;
 		if (block.type === "text" && NON_WHITESPACE_RE.test(block.text)) return true;
+		if (block.type === "thinking" && NON_WHITESPACE_RE.test(block.thinking)) return true;
 	}
 	return false;
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1162,9 +1162,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				output.stopReason = "toolUse";
 			}
 
-			if (output.stopReason === "length" && !hasVisibleCompletionContent(output)) {
+			if (model.provider === "ollama" && output.stopReason === "length" && !hasVisibleCompletionContent(output)) {
 				output.stopReason = "error";
-				output.errorMessage = emptyLengthCompletionMessage(model);
+				output.errorMessage = EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE;
 			}
 			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
 			if (firstEventTimeoutError) {
@@ -2210,12 +2210,8 @@ function hasVisibleCompletionContent(message: AssistantMessage): boolean {
 	return false;
 }
 
-function emptyLengthCompletionMessage(model: Model<"openai-completions">): string {
-	if (model.provider === "ollama") {
-		return "Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.";
-	}
-	return "Model returned no content before hitting the length limit; increase the context window/output budget or shorten the prompt.";
-}
+const EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE =
+	"Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.";
 
 function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | string): {
 	stopReason: StopReason;

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -23,7 +23,8 @@ import type { AssistantMessage } from "../types";
  * - HTTP 413 variants: "Payload Too Large" / "Request Entity Too Large"
  * - z.ai / GLM: Returns finish_reason: "model_context_window_exceeded" mapped to error message
  * - z.ai: Does NOT error, accepts overflow silently - handled via usage.input > contextWindow
- * - Ollama: Silently truncates input - not detectable via error message
+ * - Ollama OpenAI-compatible: "prompt filled the context window" after empty finish_reason:length
+ * - Ollama native: Silently truncates input - not detectable via error message
  */
 const OVERFLOW_PATTERNS = [
 	/prompt is too long/i, // Anthropic
@@ -51,6 +52,7 @@ const OVERFLOW_PATTERNS = [
 	/entity too large/i, // Generic HTTP 413 variant
 	/\b413\b.*\b(request|payload|entity)\b.*\btoo large\b/i, // "413 Request Entity Too Large" variants
 	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+	/prompt filled the context window/i, // Ollama OpenAI-compatible empty length completion
 ];
 /**
  * Check if an assistant message represents a context overflow error.
@@ -78,11 +80,12 @@ const OVERFLOW_PATTERNS = [
  * - Kimi For Coding: "exceeded model token limit: X (requested: Y)"
  * - Anthropic 413: "request_too_large" (request body exceeds size limit)
  * - HTTP 413: "Payload Too Large" / "Request Entity Too Large"
+ * - Ollama OpenAI-compatible: "prompt filled the context window"
  *
  * **Unreliable detection:**
  * - z.ai: Sometimes accepts overflow silently (detectable via usage.input > contextWindow),
  *   sometimes returns rate limit errors. Pass contextWindow param to detect silent overflow.
- * - Ollama: Silently truncates input without error. Cannot be detected via this function.
+ * - Ollama native: Silently truncates input without error. Cannot be detected via this function.
  *   The response will have usage.input < expected, but we don't know the expected value.
  *
  * ## Custom Providers

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -595,6 +595,50 @@ describe("openai-completions compatibility", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.content[0]).toMatchObject({ type: "text", text: "done" });
 	});
+	it("surfaces empty Ollama length completions as context-window errors", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "ollama" as Model["provider"],
+			id: "local-12b",
+			baseUrl: "http://ollama.invalid/v1",
+		} as ModelSpec<"openai-completions">);
+		const fetchMock = createMockFetch([
+			{
+				id: "chatcmpl-empty-length",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: "length" }],
+				usage: {
+					prompt_tokens: 8191,
+					completion_tokens: 1,
+					total_tokens: 8192,
+				},
+			},
+			"[DONE]",
+		]);
+
+		const stream = streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		});
+		const resultPromise = stream.result();
+		const eventTypes: string[] = [];
+		for await (const event of stream) {
+			eventTypes.push(event.type);
+		}
+		const result = await resultPromise;
+
+		expect(result.stopReason).toBe("error");
+		expect(eventTypes).toContain("error");
+		expect(result.errorMessage).toBe(
+			"Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.",
+		);
+		expect(result.content).toEqual([]);
+		expect(result.usage.input).toBe(8191);
+		expect(result.usage.output).toBe(1);
+	});
 
 	it("injects compat.extraBody into OpenAI payload", async () => {
 		const model: Model<"openai-completions"> = buildModel({

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -78,6 +78,16 @@ function baseContext(): Context {
 	};
 }
 
+function localOllamaCompletionsModel(): Model<"openai-completions"> {
+	return buildModel({
+		...gpt4oMiniSpec,
+		api: "openai-completions",
+		provider: "ollama" as Model["provider"],
+		id: "local-12b",
+		baseUrl: "http://ollama.invalid/v1",
+	} as ModelSpec<"openai-completions">);
+}
+
 async function captureOpenAICompletionsPayload(
 	model: Model<"openai-completions">,
 	context: Context = baseContext(),
@@ -596,13 +606,7 @@ describe("openai-completions compatibility", () => {
 		expect(result.content[0]).toMatchObject({ type: "text", text: "done" });
 	});
 	it("surfaces empty Ollama length completions as context-window errors", async () => {
-		const model: Model<"openai-completions"> = buildModel({
-			...gpt4oMiniSpec,
-			api: "openai-completions",
-			provider: "ollama" as Model["provider"],
-			id: "local-12b",
-			baseUrl: "http://ollama.invalid/v1",
-		} as ModelSpec<"openai-completions">);
+		const model = localOllamaCompletionsModel();
 		const fetchMock = createMockFetch([
 			{
 				id: "chatcmpl-empty-length",
@@ -638,6 +642,45 @@ describe("openai-completions compatibility", () => {
 		expect(result.content).toEqual([]);
 		expect(result.usage.input).toBe(8191);
 		expect(result.usage.output).toBe(1);
+	});
+	it("preserves reasoning-only Ollama length completions for recovery", async () => {
+		const model = localOllamaCompletionsModel();
+		const fetchMock = createMockFetch([
+			{
+				id: "chatcmpl-reasoning-length",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { role: "assistant", reasoning_content: "still thinking" } }],
+			},
+			{
+				id: "chatcmpl-reasoning-length",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "length" }],
+			},
+			"[DONE]",
+		]);
+
+		const stream = streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		});
+		const resultPromise = stream.result();
+		const eventTypes: string[] = [];
+		for await (const event of stream) {
+			eventTypes.push(event.type);
+		}
+		const result = await resultPromise;
+
+		expect(result.stopReason).toBe("length");
+		expect(eventTypes).toContain("done");
+		expect(eventTypes).not.toContain("error");
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "still thinking", thinkingSignature: "reasoning_content" },
+		]);
 	});
 	it("preserves empty non-Ollama length completions for recovery", async () => {
 		const model: Model<"openai-completions"> = buildModel({

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -639,6 +639,40 @@ describe("openai-completions compatibility", () => {
 		expect(result.usage.input).toBe(8191);
 		expect(result.usage.output).toBe(1);
 	});
+	it("preserves empty non-Ollama length completions for recovery", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "custom" as Model["provider"],
+			baseUrl: "https://gateway.example/v1",
+		} as ModelSpec<"openai-completions">);
+		const fetchMock = createMockFetch([
+			{
+				id: "chatcmpl-empty-length",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: "length" }],
+			},
+			"[DONE]",
+		]);
+
+		const stream = streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		});
+		const resultPromise = stream.result();
+		const eventTypes: string[] = [];
+		for await (const event of stream) {
+			eventTypes.push(event.type);
+		}
+		const result = await resultPromise;
+
+		expect(result.stopReason).toBe("length");
+		expect(eventTypes).toContain("done");
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.content).toEqual([]);
+	});
 
 	it("injects compat.extraBody into OpenAI payload", async () => {
 		const model: Model<"openai-completions"> = buildModel({

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -33,6 +33,12 @@ describe("isContextOverflow - model_context_window_exceeded", () => {
 		const message = createErrorMessage("model_context_window_exceeded");
 		expect(isContextOverflow(message)).toBe(true);
 	});
+	it("detects empty Ollama length completion guidance", () => {
+		const message = createErrorMessage(
+			"Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.",
+		);
+		expect(isContextOverflow(message)).toBe(true);
+	});
 });
 
 describe("isContextOverflow - HTTP 413 variants", () => {


### PR DESCRIPTION
## Repro
A synthetic Ollama OpenAI-compatible `/v1/chat/completions` SSE stream with `content:""`, `finish_reason:"length"`, and usage `{ prompt_tokens: 8191, completion_tokens: 1 }` previously resolved from `streamOpenAICompletions` as `stopReason:"length"` with `content: []`, leaving the coding-agent no visible output.

## Cause
`packages/ai/src/providers/openai-completions.ts` mapped `finish_reason:"length"` to `stopReason:"length"` unconditionally. Empty length completions were therefore delivered as successful terminal messages instead of provider errors, so the coding-agent empty-stop path could burn retries and only warn-log after the retry cap.

## Fix
- Detect `stopReason:"length"` messages with no visible text and no tool calls before the OpenAI-compatible provider emits the terminal event.
- Convert the Ollama case to an `error` terminal event with actionable `num_ctx` guidance.
- Added regression coverage for the empty Ollama length SSE path and updated the `packages/ai` changelog.

## Verification
Ran `bun test test/openai-completions-compat.test.ts && bun run check` from `packages/ai`: 54 tests passed and package check passed. Also reran the synthetic Ollama SSE repro and observed `eventTypes:["start","error"]`, `stopReason:"error"`, and `Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.` Fixes #2774