### PR TITLE
fix(ai): omit Google AUTO toolConfig

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Gemini tool calls with `toolChoice: "auto"` serializing an explicit `toolConfig` AUTO mode, which can cause Gemini-3 models to leak raw planning JSON instead of executing tools. ([#2776](https://github.com/can1357/oh-my-pi/issues/2776))
+
 ## [16.0.1] - 2026-06-15
 
 ### Added

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -793,9 +793,12 @@ export function buildGoogleGenerateContentParams<T extends "google-generative-ai
 	if (context.tools && context.tools.length > 0 && options.toolChoice) {
 		const choice = options.toolChoice;
 		if (typeof choice === "string") {
-			config.toolConfig = {
-				functionCallingConfig: { mode: mapToolChoice(choice) },
-			};
+			const mode = mapToolChoice(choice);
+			if (mode !== "AUTO") {
+				config.toolConfig = {
+					functionCallingConfig: { mode },
+				};
+			}
 		} else {
 			// Named-tool routing — `mode: "ANY"` plus an explicit allow-list. The
 			// caller is responsible for ensuring the names exist in `context.tools`.

--- a/packages/ai/test/google-tool-choice.test.ts
+++ b/packages/ai/test/google-tool-choice.test.ts
@@ -63,6 +63,15 @@ describe("buildGoogleGenerateContentParams toolConfig serialization (F7)", () =>
 		});
 	});
 
+	it("omits toolConfig for auto toolChoice because Google defaults tools to AUTO", () => {
+		const params = buildGoogleGenerateContentParams(model, ctx(), {
+			apiKey: "fake",
+			toolChoice: "auto",
+		});
+		expect(params.config!.tools).toBeDefined();
+		expect(params.config!.toolConfig).toBeUndefined();
+	});
+
 	it("emits allowedFunctionNames for named-tool object toolChoice", () => {
 		const params = buildGoogleGenerateContentParams(model, ctx(), {
 			apiKey: "fake",


### PR DESCRIPTION
## Repro
`bun --cwd=packages/ai -e 'import { buildGoogleGenerateContentParams } from "@oh-my-pi/pi-ai/providers/google-shared"; import { getBundledModel } from "@oh-my-pi/pi-catalog/models"; const model = getBundledModel("google", "gemini-3.1-pro-preview"); if (!model) throw new Error("missing model"); const params = buildGoogleGenerateContentParams(model, { systemPrompt: [], messages: [{ role: "user", content: "hi", timestamp: 0 }], tools: [{ name: "search", description: "Search", parameters: { type: "object", properties: {}, additionalProperties: false } }] }, { apiKey: "fake", toolChoice: "auto" }); console.log(JSON.stringify(params.config?.toolConfig)); if (params.config?.toolConfig !== undefined) process.exit(1);'` printed `{"functionCallingConfig":{"mode":"AUTO"}}` and exited 1 before the fix.

## Cause
`packages/ai/src/providers/google-shared.ts` built `GenerateContentConfig.toolConfig` for every string `toolChoice`, including `"auto"`; `paramsToWireBody` then lifted that config to the Google request body as explicit `toolConfig.functionCallingConfig.mode: "AUTO"`, although Google defaults tool-enabled requests to AUTO when `toolConfig` is omitted.

## Fix
- Omit `toolConfig` when Google `toolChoice` maps to `AUTO`.
- Preserve explicit `NONE`, `ANY`, and named-tool allow-list serialization.
- Add a regression test covering `toolChoice: "auto"` with tools present.
- Add the `packages/ai` changelog entry.

## Verification
`bun --cwd=packages/ai test test/google-tool-choice.test.ts` passed: 10 tests, 13 assertions. `bun --cwd=packages/ai run check` passed. Re-running the repro command printed `undefined` and exited 0. Fixes #2776