### PR TITLE
fix(ai): strip OpenAI Responses regex lookarounds

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses/Codex tool schema normalization stripping provider-rejected regex lookaround patterns from MCP tool parameter schemas. ([#2784](https://github.com/can1357/oh-my-pi/issues/2784))
+
 ## [16.0.2] - 2026-06-16
 
 ### Added

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1000,8 +1000,10 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 
 		const child = value[key];
 		let next: unknown = child;
-		if (OPENAI_RESPONSES_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
-			next = normalizeOpenAIResponsesSchemaMap(child, cache);
+		if (key === "patternProperties" && isJsonObject(child)) {
+			next = normalizeOpenAIResponsesSchemaMap(child, cache, true);
+		} else if (OPENAI_RESPONSES_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+			next = normalizeOpenAIResponsesSchemaMap(child, cache, false);
 		} else if (OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
 			next = normalizeOpenAIResponsesSchemaArray(child, cache);
 		} else if (OPENAI_RESPONSES_SCHEMA_VALUE_KEYS.has(key) && isJsonObject(child)) {
@@ -1056,11 +1058,19 @@ function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<Js
 	return changed ? output : value;
 }
 
-function normalizeOpenAIResponsesSchemaMap(schemaMap: JsonObject, cache: WeakMap<JsonObject, JsonObject>): JsonObject {
+function normalizeOpenAIResponsesSchemaMap(
+	schemaMap: JsonObject,
+	cache: WeakMap<JsonObject, JsonObject>,
+	stripUnsupportedRegexKeys: boolean,
+): JsonObject {
 	let changed = false;
 	const output: JsonObject = {};
 	for (const key in schemaMap) {
 		if (!Object.hasOwn(schemaMap, key)) continue;
+		if (stripUnsupportedRegexKeys && hasOpenAIUnsupportedRegexLookaround(key)) {
+			changed = true;
+			continue;
+		}
 		const child = schemaMap[key];
 		const next = normalizeOpenAIResponsesSchemaNode(child, cache);
 		if (next !== child) changed = true;

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -937,6 +937,7 @@ export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject
  */
 export const normalizeSchemaForOpenAIResponses: (schema: JsonObject) => JsonObject = sanitizeSchemaForOpenAIResponses;
 const OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS = new Set(["=", "!", "<=", "<!"]);
+const OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK = ".*";
 
 function hasOpenAIUnsupportedRegexLookaround(pattern: string): boolean {
 	let groupStart = pattern.indexOf("(?");
@@ -1067,16 +1068,30 @@ function normalizeOpenAIResponsesSchemaMap(
 	const output: JsonObject = {};
 	for (const key in schemaMap) {
 		if (!Object.hasOwn(schemaMap, key)) continue;
-		if (stripUnsupportedRegexKeys && hasOpenAIUnsupportedRegexLookaround(key)) {
-			changed = true;
-			continue;
-		}
 		const child = schemaMap[key];
 		const next = normalizeOpenAIResponsesSchemaNode(child, cache);
 		if (next !== child) changed = true;
+		if (stripUnsupportedRegexKeys && hasOpenAIUnsupportedRegexLookaround(key)) {
+			changed = true;
+			appendOpenAIResponsesFallbackPatternProperty(output, next);
+			continue;
+		}
 		output[key] = next;
 	}
 	return changed ? output : schemaMap;
+}
+
+function appendOpenAIResponsesFallbackPatternProperty(output: JsonObject, schema: unknown): void {
+	const existing = output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK];
+	if (existing === undefined) {
+		output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = schema;
+		return;
+	}
+	if (isJsonObject(existing) && Array.isArray(existing.anyOf) && Object.keys(existing).length === 1) {
+		existing.anyOf = [...existing.anyOf, schema];
+		return;
+	}
+	output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = { anyOf: [existing, schema] };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -936,6 +936,22 @@ export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject
  * `normalizeSchemaFor*` dispatcher naming used elsewhere in this module.
  */
 export const normalizeSchemaForOpenAIResponses: (schema: JsonObject) => JsonObject = sanitizeSchemaForOpenAIResponses;
+const OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS = new Set(["=", "!", "<=", "<!"]);
+
+function hasOpenAIUnsupportedRegexLookaround(pattern: string): boolean {
+	let groupStart = pattern.indexOf("(?");
+	while (groupStart !== -1) {
+		let escapes = 0;
+		for (let i = groupStart - 1; i >= 0 && pattern[i] === "\\"; i--) escapes++;
+		if (escapes % 2 === 0) {
+			const operator =
+				pattern[groupStart + 2] === "<" ? pattern.slice(groupStart + 2, groupStart + 4) : pattern[groupStart + 2];
+			if (OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS.has(operator)) return true;
+		}
+		groupStart = pattern.indexOf("(?", groupStart + 2);
+	}
+	return false;
+}
 
 function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonObject, JsonObject>): unknown {
 	if (!isJsonObject(value)) return value;
@@ -970,6 +986,14 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 		// still preserved verbatim so callers can see the original payload
 		// instead of having it silently disappear.
 		if (key === "oneOf" && Array.isArray(value.oneOf)) {
+			changed = true;
+			continue;
+		}
+		if (
+			key === "pattern" &&
+			typeof value.pattern === "string" &&
+			hasOpenAIUnsupportedRegexLookaround(value.pattern)
+		) {
 			changed = true;
 			continue;
 		}

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -953,7 +953,7 @@ function hasOpenAIUnsupportedRegexLookaround(pattern: string): boolean {
 	return false;
 }
 
-function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonObject, JsonObject>): unknown {
+function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonObject, unknown>): unknown {
 	if (!isJsonObject(value)) return value;
 
 	// `{}` (empty JSON Schema) ≡ `true` (JSON Schema draft 2020-12 §4.3.1).
@@ -1034,7 +1034,7 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 	// the seeded partial and set `changed = true` for that node, so a node
 	// that finishes with `changed === false` is provably non-cyclic and
 	// referentially equal to its input.
-	const result = changed ? output : value;
+	const result = changed ? (isJsonObjectEmpty(output) ? true : output) : value;
 	cache.set(value, result);
 	return result;
 }
@@ -1048,7 +1048,7 @@ function declaresObjectType(type: unknown): boolean {
 	return false;
 }
 
-function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<JsonObject, JsonObject>): unknown[] {
+function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<JsonObject, unknown>): unknown[] {
 	let changed = false;
 	const output = value.map(item => {
 		const next = normalizeOpenAIResponsesSchemaNode(item, cache);
@@ -1060,7 +1060,7 @@ function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<Js
 
 function normalizeOpenAIResponsesSchemaMap(
 	schemaMap: JsonObject,
-	cache: WeakMap<JsonObject, JsonObject>,
+	cache: WeakMap<JsonObject, unknown>,
 	stripUnsupportedRegexKeys: boolean,
 ): JsonObject {
 	let changed = false;

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -69,6 +69,36 @@ describe("openai-codex tool schemas", () => {
 			},
 		});
 	});
+	it("strips MCP regex lookaround patternProperties from function parameters", () => {
+		const tools: Tool[] = [
+			{
+				name: "read_dynamic_values",
+				description: "Read dynamic values",
+				parameters: {
+					type: "object",
+					patternProperties: {
+						"^(?!secret_)": { type: "string" },
+						"^public_": { type: "string" },
+					},
+				},
+			},
+		];
+
+		const converted = convertOpenAICodexResponsesTools(tools, createCodexModel("gpt-5.5"));
+
+		expect(converted[0]).toEqual({
+			type: "function",
+			name: "read_dynamic_values",
+			description: "Read dynamic values",
+			parameters: {
+				type: "object",
+				patternProperties: {
+					"^public_": { type: "string" },
+				},
+				properties: {},
+			},
+		});
+	});
 });
 
 describe("openai-codex request transformer", () => {

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -82,6 +82,7 @@ describe("openai-codex tool schemas", () => {
 						"^(?!secret_)": { type: "string" },
 						"^public_": { type: "string" },
 					},
+					additionalProperties: false,
 				},
 			},
 		];
@@ -95,8 +96,10 @@ describe("openai-codex tool schemas", () => {
 			parameters: {
 				type: "object",
 				patternProperties: {
+					".*": { type: "string" },
 					"^public_": { type: "string" },
 				},
+				additionalProperties: false,
 				properties: {},
 			},
 		});

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -41,6 +41,34 @@ describe("openai-codex tool schemas", () => {
 			parameters: { type: "object", properties: {} },
 		});
 	});
+	it("strips MCP regex lookaround patterns from function parameters", () => {
+		const tools: Tool[] = [
+			{
+				name: "get_design_context",
+				description: "Get Figma design context",
+				parameters: {
+					type: "object",
+					properties: {
+						fileKey: { type: "string", pattern: "^(?!undefined$|null$)" },
+					},
+				},
+			},
+		];
+
+		const converted = convertOpenAICodexResponsesTools(tools, createCodexModel("gpt-5.5"));
+
+		expect(converted[0]).toEqual({
+			type: "function",
+			name: "get_design_context",
+			description: "Get Figma design context",
+			parameters: {
+				type: "object",
+				properties: {
+					fileKey: { type: "string" },
+				},
+			},
+		});
+	});
 });
 
 describe("openai-codex request transformer", () => {

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -51,6 +51,7 @@ describe("openai-codex tool schemas", () => {
 					properties: {
 						fileKey: { type: "string", pattern: "^(?!undefined$|null$)" },
 					},
+					propertyNames: { pattern: "^(?!undefined$|null$)" },
 				},
 			},
 		];
@@ -66,6 +67,7 @@ describe("openai-codex tool schemas", () => {
 				properties: {
 					fileKey: { type: "string" },
 				},
+				propertyNames: true,
 			},
 		});
 	});

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -527,6 +527,13 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				ending: { type: "string", pattern: "(?<=/)node$" },
 				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
 				literal: { type: "string", pattern: "\\(?!literal" },
+				"^(?!property-name)": { type: "string" },
+			},
+			patternProperties: {
+				"^(?!secret_)": { type: "string" },
+				"(?<=/)node$": { type: "string" },
+				"^x-": { type: "object" },
+				"\\(?!literal": { type: "string" },
 			},
 		};
 
@@ -537,6 +544,11 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				ending: { type: "string" },
 				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
 				literal: { type: "string", pattern: "\\(?!literal" },
+				"^(?!property-name)": { type: "string" },
+			},
+			patternProperties: {
+				"^x-": { type: "object", properties: {} },
+				"\\(?!literal": { type: "string" },
 			},
 		});
 	});

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -550,6 +550,7 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				"^(?!property-name)": { type: "string" },
 			},
 			patternProperties: {
+				".*": { anyOf: [{ type: "string" }, { type: "string" }] },
 				"^x-": { type: "object", properties: {} },
 				"\\(?!literal": { type: "string" },
 			},

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -519,6 +519,28 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 		});
 	});
 
+	it("strips regex lookaround patterns unsupported by OpenAI Responses", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				fileKey: { type: "string", pattern: "^(?!undefined$|null$)" },
+				ending: { type: "string", pattern: "(?<=/)node$" },
+				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
+				literal: { type: "string", pattern: "\\(?!literal" },
+			},
+		};
+
+		expect(sanitizeSchemaForOpenAIResponses(schema)).toEqual({
+			type: "object",
+			properties: {
+				fileKey: { type: "string" },
+				ending: { type: "string" },
+				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
+				literal: { type: "string", pattern: "\\(?!literal" },
+			},
+		});
+	});
+
 	it("preserves non-array oneOf payloads verbatim instead of dropping them", () => {
 		const malformed = { type: "object", oneOf: { type: "object" } } as unknown as Record<string, unknown>;
 

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -527,6 +527,7 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				ending: { type: "string", pattern: "(?<=/)node$" },
 				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
 				literal: { type: "string", pattern: "\\(?!literal" },
+				patternOnly: { pattern: "^(?!bad$)" },
 				"^(?!property-name)": { type: "string" },
 			},
 			patternProperties: {
@@ -535,6 +536,7 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				"^x-": { type: "object" },
 				"\\(?!literal": { type: "string" },
 			},
+			propertyNames: { pattern: "^(?!invalid$)" },
 		};
 
 		expect(sanitizeSchemaForOpenAIResponses(schema)).toEqual({
@@ -544,12 +546,14 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 				ending: { type: "string" },
 				slug: { type: "string", pattern: "^[a-z0-9_-]+$" },
 				literal: { type: "string", pattern: "\\(?!literal" },
+				patternOnly: true,
 				"^(?!property-name)": { type: "string" },
 			},
 			patternProperties: {
 				"^x-": { type: "object", properties: {} },
 				"\\(?!literal": { type: "string" },
 			},
+			propertyNames: true,
 		});
 	});
 


### PR DESCRIPTION
## Repro
OpenAI/Codex Responses tool schema sanitization preserved an MCP parameter pattern containing regex lookaround: `bun -e 'import { sanitizeSchemaForOpenAIResponses } from "./packages/ai/src/utils/schema"; const schema = { type: "object", properties: { fileKey: { type: "string", pattern: "^(?!undefined$|null$)" } } }; const sanitized = sanitizeSchemaForOpenAIResponses(schema); console.log(JSON.stringify(sanitized)); process.exit(sanitized.properties.fileKey.pattern === "^(?!undefined$|null$)" ? 1 : 0);'` printed the pattern and exited 1 before the fix.

## Cause
`packages/ai/src/utils/schema/normalize.ts` `sanitizeSchemaForOpenAIResponses()` normalized schema-valued positions for OpenAI Responses constraints, but copied every `pattern` keyword verbatim. `packages/ai/src/providers/openai-codex-responses.ts` `convertOpenAICodexResponsesTools()` uses that sanitizer before sending Codex function parameters, so Figma MCP schemas with `^(?!undefined$|null$)` reached the provider unchanged.

## Fix
- Added OpenAI Responses schema normalization that drops unescaped lookahead/lookbehind `pattern` values while preserving ordinary regex patterns and escaped literal text.
- Added direct sanitizer coverage for negative lookahead, lookbehind, ordinary patterns, and escaped literal `(?` text.
- Added Codex tool conversion coverage for the reported Figma-style `fileKey` parameter schema.
- Added the `packages/ai` changelog entry for #2784.

## Verification
`bun test packages/ai/test/schema-normalization.test.ts packages/ai/test/openai-codex.test.ts` passed: 68 tests, 129 expectations. `bun --cwd=packages/ai run check` passed. The repro command now prints `{"type":"object","properties":{"fileKey":{"type":"string"}}}` and exits 0. Fixes #2784