### PR TITLE
fix(tool): resolve pasted image attachments in inspect_image

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed `inspect_image` resolving pasted image labels such as `Image #1`, `[Image #1, WxH]`, and `attachment://1` against current chat attachments instead of falling back to `<cwd>/Image #1` ([#2787](https://github.com/can1357/oh-my-pi/issues/2787)).
+
 ## [16.0.2] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/prompts/tools/inspect-image.md
+++ b/packages/coding-agent/src/prompts/tools/inspect-image.md
@@ -2,7 +2,7 @@ Inspects an image file with a vision-capable model and returns compact text anal
 
 <instruction>
 - Use this for image understanding tasks (OCR, UI/screenshot debugging, scene/object questions)
-- Provide `path` to the local image file
+- Provide `path` as a local image file path, `Image #N` attachment label, or `attachment://N` URI
 - Write a specific `question`:
   - what to inspect
   - constraints (for example: "quote visible text verbatim", "only report confirmed findings")

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1511,6 +1511,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),
 			getActiveModelString,
 			getActiveModel: () => agent?.state.model ?? model,
+			getImageAttachments: () => session?.getImageAttachments() ?? [],
 			getPlanModeState: () => session?.getPlanModeState(),
 			getPlanReferencePath: () => session?.getPlanReferencePath() ?? "local://PLAN.md",
 			getGoalModeState: () => session?.getGoalModeState(),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4605,7 +4605,9 @@ export class AgentSession {
 	getImageAttachments(): { label: string; uri: string; image: ImageContent }[] {
 		for (let i = this.agent.state.messages.length - 1; i >= 0; i--) {
 			const message = this.agent.state.messages[i];
-			if (!message || !("content" in message) || !Array.isArray(message.content)) continue;
+			if (!message || (message.role !== "user" && message.role !== "developer") || !Array.isArray(message.content)) {
+				continue;
+			}
 			const images = message.content.filter((part): part is ImageContent => part.type === "image");
 			if (images.length === 0) continue;
 			return images.map((image, index) => ({

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4601,6 +4601,22 @@ export class AgentSession {
 		return this.agent.state.messages;
 	}
 
+	/** Latest image attachments addressable by tools as `Image #N` or `attachment://N`. */
+	getImageAttachments(): { label: string; uri: string; image: ImageContent }[] {
+		for (let i = this.agent.state.messages.length - 1; i >= 0; i--) {
+			const message = this.agent.state.messages[i];
+			if (!message || !("content" in message) || !Array.isArray(message.content)) continue;
+			const images = message.content.filter((part): part is ImageContent => part.type === "image");
+			if (images.length === 0) continue;
+			return images.map((image, index) => ({
+				label: `Image #${index + 1}`,
+				uri: `attachment://${index + 1}`,
+				image,
+			}));
+		}
+		return [];
+	}
+
 	buildDisplaySessionContext(): SessionContext {
 		return deobfuscateSessionContext(this.sessionManager.buildSessionContext(), this.#obfuscator);
 	}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { InMemorySnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { FetchImpl, Model, ToolChoice } from "@oh-my-pi/pi-ai";
+import type { FetchImpl, ImageContent, Model, ToolChoice } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { AsyncJobManager } from "../async/job-manager";
 import type { Rule } from "../capability/rule";
@@ -113,6 +113,13 @@ export type ContextFileEntry = {
 	path: string;
 	content: string;
 	depth?: number;
+};
+
+/** Image attachment handle exposed to tools for user-facing labels such as `Image #1`. */
+export type ImageAttachmentEntry = {
+	label: string;
+	uri: string;
+	image: ImageContent;
 };
 
 export type {
@@ -355,6 +362,8 @@ export interface ToolSession {
 	/** Get the active OpenTelemetry config so subagent dispatch can forward
 	 *  the parent's tracer/hooks with the subagent's own identity stamped. */
 	getTelemetry?: () => AgentTelemetryConfig | undefined;
+	/** Return image attachments visible to tools for resolving labels such as `Image #1`. */
+	getImageAttachments?: () => ImageAttachmentEntry[];
 }
 
 export type ToolFactory = (session: ToolSession) => Tool | null | Promise<Tool | null>;

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -1,6 +1,6 @@
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import { instrumentedCompleteSimple, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
-import { type Api, completeSimple, type Model, type ToolExample } from "@oh-my-pi/pi-ai";
+import { type Api, completeSimple, type ImageContent, type Model, type ToolExample } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
 import { extractTextContent } from "../commit/utils";
@@ -11,6 +11,7 @@ import inspectImageSystemPromptTemplate from "../prompts/tools/inspect-image-sys
 import {
 	ImageInputTooLargeError,
 	type LoadedImageInput,
+	loadImageAttachmentInput,
 	loadImageInput,
 	MAX_IMAGE_INPUT_BYTES,
 	webpExclusionForModel,
@@ -20,12 +21,61 @@ import { ToolError } from "./tool-errors";
 
 const inspectImageSchema = z
 	.object({
-		path: z.string().describe("image path"),
+		path: z.string().describe("image file path, Image #N label, or attachment://N URI"),
 		question: z.string().describe("question about image"),
 	})
 	.strict();
 
 export type InspectImageParams = z.infer<typeof inspectImageSchema>;
+
+interface ImageAttachmentReference {
+	index: number;
+}
+
+const IMAGE_ATTACHMENT_REFERENCE_REGEX =
+	/^\s*(?:\[?Image #([1-9]\d*)(?:,[^\]\n]*)?\]?|(?:attachment|image):\/\/([1-9]\d*))\s*$/i;
+
+function parseImageAttachmentReference(path: string): ImageAttachmentReference | null {
+	const match = IMAGE_ATTACHMENT_REFERENCE_REGEX.exec(path);
+	if (!match) return null;
+	const rawIndex = match[1] ?? match[2];
+	if (!rawIndex) return null;
+	return { index: Number(rawIndex) };
+}
+
+function formatAvailableImageAttachments(attachments: readonly { label: string; uri: string }[]): string {
+	if (attachments.length === 0) return "none";
+	return attachments.map(attachment => `${attachment.label} -> ${attachment.uri}`).join(", ");
+}
+
+async function loadAttachmentReferenceInput(options: {
+	path: string;
+	reference: ImageAttachmentReference;
+	attachments: readonly { label: string; uri: string; image: ImageContent }[];
+	autoResize: boolean;
+	excludeWebP: boolean | undefined;
+}): Promise<LoadedImageInput | null> {
+	const attachment = options.attachments[options.reference.index - 1];
+	if (!attachment) {
+		const available = formatAvailableImageAttachments(options.attachments);
+		if (options.attachments.length === 0) {
+			throw new ToolError(
+				`No image attachments are available in this turn. path="${options.path}" must be a readable file path or attachment URI.`,
+			);
+		}
+		throw new ToolError(
+			`Could not resolve image attachment '${options.path}'. Available image attachments: ${available}. Pass an attachment URI or a readable filesystem path.`,
+		);
+	}
+	return loadImageAttachmentInput({
+		image: attachment.image,
+		label: attachment.label,
+		uri: attachment.uri,
+		autoResize: options.autoResize,
+		maxBytes: MAX_IMAGE_INPUT_BYTES,
+		excludeWebP: options.excludeWebP,
+	});
+}
 
 export interface InspectImageToolDetails {
 	model: string;
@@ -130,14 +180,27 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 		}
 
 		let imageInput: LoadedImageInput | null;
+		const autoResize = this.session.settings.get("images.autoResize");
+		const excludeWebP = webpExclusionForModel(model);
+		const attachmentReference = parseImageAttachmentReference(params.path);
 		try {
-			imageInput = await loadImageInput({
-				path: params.path,
-				cwd: this.session.cwd,
-				autoResize: this.session.settings.get("images.autoResize"),
-				maxBytes: MAX_IMAGE_INPUT_BYTES,
-				excludeWebP: webpExclusionForModel(model),
-			});
+			if (attachmentReference) {
+				imageInput = await loadAttachmentReferenceInput({
+					path: params.path,
+					reference: attachmentReference,
+					attachments: this.session.getImageAttachments?.() ?? [],
+					autoResize,
+					excludeWebP,
+				});
+			} else {
+				imageInput = await loadImageInput({
+					path: params.path,
+					cwd: this.session.cwd,
+					autoResize,
+					maxBytes: MAX_IMAGE_INPUT_BYTES,
+					excludeWebP,
+				});
+			}
 		} catch (error) {
 			if (error instanceof ImageInputTooLargeError) {
 				throw new ToolError(error.message);

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -38,6 +38,17 @@ export interface LoadImageInputOptions {
 	excludeWebP?: boolean;
 }
 
+/** Options for loading an in-memory chat image attachment as a vision-model input. */
+export interface LoadImageAttachmentInputOptions {
+	image: ImageContent;
+	label: string;
+	uri: string;
+	autoResize: boolean;
+	maxBytes?: number;
+	/** Force non-WebP output (e.g. for Ollama). Leave unset to honor `OMP_NO_WEBP`. */
+	excludeWebP?: boolean;
+}
+
 export interface LoadedImageInput {
 	resolvedPath: string;
 	mimeType: string;
@@ -154,6 +165,53 @@ export async function loadImageInput(options: LoadImageInputOptions): Promise<Lo
 
 	return {
 		resolvedPath,
+		mimeType: outputMimeType,
+		data: outputData,
+		textNote,
+		dimensionNote,
+		bytes: outputBytes,
+	};
+}
+
+/** Loads a chat attachment image through the same size and encoder policy as file-backed image inputs. */
+export async function loadImageAttachmentInput(
+	options: LoadImageAttachmentInputOptions,
+): Promise<LoadedImageInput | null> {
+	const maxBytes = options.maxBytes ?? MAX_IMAGE_INPUT_BYTES;
+	if (!SUPPORTED_INPUT_IMAGE_MIME_TYPES.has(options.image.mimeType)) {
+		return null;
+	}
+
+	const inputBytes = Buffer.byteLength(options.image.data, "base64");
+	if (inputBytes > maxBytes) {
+		throw new ImageInputTooLargeError(inputBytes, maxBytes);
+	}
+
+	let outputData = options.image.data;
+	let outputMimeType = options.image.mimeType;
+	let outputBytes = inputBytes;
+	let dimensionNote: string | undefined;
+
+	const shouldReencodeWebP = options.excludeWebP === true && options.image.mimeType === "image/webp";
+	if (options.autoResize || shouldReencodeWebP) {
+		try {
+			const resized = await resizeImage(options.image, { excludeWebP: options.excludeWebP });
+			outputData = resized.data;
+			outputMimeType = resized.mimeType;
+			outputBytes = resized.buffer.byteLength;
+			dimensionNote = formatDimensionNote(resized);
+		} catch {
+			// keep original image when resize fails
+		}
+	}
+
+	let textNote = `Read image attachment ${options.label} [${outputMimeType}]`;
+	if (dimensionNote) {
+		textNote += `\n${dimensionNote}`;
+	}
+
+	return {
+		resolvedPath: options.uri,
 		mimeType: outputMimeType,
 		data: outputData,
 		textNote,

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -4,6 +4,7 @@ import {
 	type Api,
 	type Context,
 	clearCustomApis,
+	type ImageContent,
 	type Message,
 	type Model,
 	type ModelSpec,
@@ -113,6 +114,34 @@ describe("AgentSession message pipeline", () => {
 		expect(queued.steering).toBe(true);
 		expect(queued.content).toEqual([{ type: "text", text: "raw <steer> &" }]);
 		session.clearQueue();
+	});
+
+	it("resolves image attachments from submitted messages, not tool-result images", () => {
+		const userImage: ImageContent = { type: "image", data: "user-image", mimeType: "image/png" };
+		const toolImage: ImageContent = { type: "image", data: "tool-image", mimeType: "image/png" };
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+		});
+		sessions.push(session);
+
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "inspect this" }, userImage],
+			timestamp: Date.now(),
+		});
+		session.agent.appendMessage({
+			role: "toolResult",
+			toolCallId: "eval-1",
+			toolName: "eval",
+			content: [{ type: "text", text: "plot output" }, toolImage],
+			timestamp: Date.now(),
+			isError: false,
+		});
+
+		expect(session.getImageAttachments()).toEqual([{ label: "Image #1", uri: "attachment://1", image: userImage }]);
 	});
 
 	it("keeps stored steering text raw while pre-LLM conversion wraps it", async () => {

--- a/packages/coding-agent/test/tools/inspect-image.test.ts
+++ b/packages/coding-agent/test/tools/inspect-image.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { completeSimple, ImageContent, Model } from "@oh-my-pi/pi-ai";
+import { AuthStorage, type completeSimple, type ImageContent, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { InspectImageTool } from "@oh-my-pi/pi-coding-agent/tools/inspect-image";
 import { inspectImageToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/inspect-image-renderer";
@@ -225,6 +228,51 @@ describe("InspectImageTool", () => {
 			/Available image attachments: Image #1 -> attachment:\/\/1/,
 		);
 		expect(stub.calls).toHaveLength(0);
+	});
+
+	it("wires createAgentSession tool sessions to live image attachments", async () => {
+		const image: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const authStorage = await AuthStorage.create(path.join(testDir, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const settings = Settings.isolated({ "compaction.enabled": false, "inspect_image.enabled": true });
+		settings.setModelRole("vision", `${visionModel.provider}/${visionModel.id}`);
+
+		try {
+			const { session } = await createAgentSession({
+				cwd: testDir,
+				agentDir: testDir,
+				sessionManager: SessionManager.inMemory(testDir),
+				settings,
+				model: visionModel,
+				modelRegistry,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["inspect_image"],
+			});
+			try {
+				session.agent.appendMessage({
+					role: "user",
+					content: [{ type: "text", text: "inspect this" }, image],
+					timestamp: Date.now(),
+				});
+
+				const tool = session.getToolByName("inspect_image");
+				expect(tool).toBeDefined();
+				const wiredToolSession = (tool as unknown as { session?: ToolSession }).session;
+				expect(wiredToolSession?.getImageAttachments?.()).toEqual([
+					{ label: "Image #1", uri: "attachment://1", image },
+				]);
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			authStorage.close();
+		}
 	});
 
 	it("sends question text unchanged", async () => {

--- a/packages/coding-agent/test/tools/inspect-image.test.ts
+++ b/packages/coding-agent/test/tools/inspect-image.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { completeSimple, Model } from "@oh-my-pi/pi-ai";
+import type { completeSimple, ImageContent, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -38,6 +38,7 @@ interface CreateSessionOptions {
 	availableModels?: Model<"openai-responses">[];
 	activeModel?: Model<"openai-responses">;
 	configureVisionRole?: boolean;
+	imageAttachments?: { label: string; uri: string; image: ImageContent }[];
 }
 
 interface CompleteSimpleStub {
@@ -58,7 +59,7 @@ function createSession(
 		settings.setModelRole("vision", `${model.provider}/${model.id}`);
 	}
 
-	return {
+	const session: ToolSession = {
 		cwd,
 		hasUI: false,
 		getSessionFile: () => null,
@@ -74,6 +75,10 @@ function createSession(
 			resolver: () => async () => apiKey,
 		} as unknown as NonNullable<ToolSession["modelRegistry"]>,
 	};
+	if (options.imageAttachments) {
+		session.getImageAttachments = () => options.imageAttachments ?? [];
+	}
+	return session;
 }
 
 function createCompleteSimpleSuccessStub(text: string): CompleteSimpleStub {
@@ -145,6 +150,81 @@ describe("InspectImageTool", () => {
 		const contentParts = (Array.isArray(content) ? content : []) as Array<{ type: string; text?: string }>;
 		expect(contentParts[0]?.type).toBe("image");
 		expect(contentParts[1]).toEqual({ type: "text", text: "Extract visible UI labels." });
+	});
+
+	it("resolves pasted image labels from current attachments without using cwd", async () => {
+		const image: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const stub = createCompleteSimpleSuccessStub("Attached image inspected");
+		const missingCwd = path.join(testDir, "missing-cwd");
+		const tool = new InspectImageTool(
+			createSession(missingCwd, visionModel, "test-key", Settings.isolated(), {
+				imageAttachments: [{ label: "Image #1", uri: "attachment://1", image }],
+			}),
+			stub.fn,
+		);
+
+		const result = await tool.execute("call-attachment-label", {
+			path: "Image #1",
+			question: "Describe the pasted image.",
+		});
+
+		expect(result.details?.imagePath).toBe("attachment://1");
+		expect(stub.calls).toHaveLength(1);
+		const request = stub.calls[0]?.[1] as { messages?: Array<{ content?: unknown }> } | undefined;
+		const attachmentContent = request?.messages?.[0]?.content;
+		const attachmentParts = (Array.isArray(attachmentContent) ? attachmentContent : []) as Array<{
+			type: string;
+			data?: string;
+		}>;
+		expect(attachmentParts[0]).toMatchObject({ type: "image", data: TINY_PNG_BASE64 });
+	});
+
+	it("resolves bracketed labels and attachment URIs deterministically", async () => {
+		const first: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const second: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const attachments = [
+			{ label: "Image #1", uri: "attachment://1", image: first },
+			{ label: "Image #2", uri: "attachment://2", image: second },
+		];
+
+		const bracketStub = createCompleteSimpleSuccessStub("First");
+		const bracketTool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", Settings.isolated(), { imageAttachments: attachments }),
+			bracketStub.fn,
+		);
+		const bracketResult = await bracketTool.execute("call-bracket-label", {
+			path: "[Image #1, 1568x784]",
+			question: "Describe the first attachment.",
+		});
+
+		const uriStub = createCompleteSimpleSuccessStub("Second");
+		const uriTool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", Settings.isolated(), { imageAttachments: attachments }),
+			uriStub.fn,
+		);
+		const uriResult = await uriTool.execute("call-uri-label", {
+			path: "attachment://2",
+			question: "Describe the second attachment.",
+		});
+
+		expect(bracketResult.details?.imagePath).toBe("attachment://1");
+		expect(uriResult.details?.imagePath).toBe("attachment://2");
+	});
+
+	it("reports attachment-aware errors for missing image labels", async () => {
+		const image: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const stub = createCompleteSimpleForbiddenStub();
+		const tool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", Settings.isolated(), {
+				imageAttachments: [{ label: "Image #1", uri: "attachment://1", image }],
+			}),
+			stub.fn,
+		);
+
+		await expect(tool.execute("call-missing-label", { path: "Image #2", question: "Describe it." })).rejects.toThrow(
+			/Available image attachments: Image #1 -> attachment:\/\/1/,
+		);
+		expect(stub.calls).toHaveLength(0);
 	});
 
 	it("sends question text unchanged", async () => {


### PR DESCRIPTION
## Repro
`inspect_image(path="Image #1")` reproduced the reported failure by entering `loadImageInput()` and attempting to open `<cwd>/Image #1`, which raised raw `ENOENT` before any vision request was made.

## Cause
`packages/coding-agent/src/tools/inspect-image.ts` accepted only file paths and always called `loadImageInput()` with `params.path`; the active `AgentSession` had normalized chat images in message content, but `ToolSession` exposed no attachment table for tools to resolve `Image #N` or `attachment://N` labels.

## Fix
- Added `ToolSession.getImageAttachments()` and implemented it in `AgentSession` from the latest message containing image content.
- Taught `inspect_image` to resolve `Image #N`, `[Image #N, WxH]`, `attachment://N`, and `image://N` before file-path loading.
- Added in-memory attachment loading through the existing image size/resize/WebP policy.
- Updated the inspect-image prompt, changelog, and regression tests for cwd-independent labels, multiple images, URIs, and attachment-aware errors.

## Verification
Ran `bun test test/tools/inspect-image.test.ts` and `bun run check` in `packages/coding-agent`; both passed. Fixes #2787