### PR TITLE
Add concise tool display mode

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3253,6 +3253,22 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Tool execution
+	"tools.displayMode": {
+		type: "enum",
+		values: ["detailed", "concise"] as const,
+		default: "detailed",
+		ui: {
+			tab: "tools",
+			group: "Execution",
+			label: "Tool Display Mode",
+			description:
+				"Detailed shows normal tool arguments and results. Concise keeps collapsed noisy tool rows to name, intent, status, and minimal metadata; expand to inspect details.",
+			options: [
+				{ value: "detailed", label: "Detailed", description: "Show current detailed tool previews" },
+				{ value: "concise", label: "Concise", description: "Hide details in collapsed noisy tool rows" },
+			],
+		},
+	},
 	"tools.intentTracing": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -245,6 +245,9 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 		theme: Theme,
 		args?: Static<TParams>,
 	) => Component;
+
+	/** If true, result rendering replaces the pending call preview once a result exists. */
+	mergeCallAndResult?: boolean;
 }
 
 /** Factory function that creates a custom tool or array of tools */

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -35,6 +35,8 @@ export type { ExecOptions, ExecResult } from "../../exec/exec";
 /** Re-export for custom tools to use in execute signature */
 export type { AgentToolResult, AgentToolUpdateCallback, ToolApproval, ToolApprovalDecision, ToolTier };
 
+export type ToolDisplayMode = "detailed" | "concise";
+
 /** Pending action entry consumed by the hidden resolve tool */
 export interface CustomToolPendingAction {
 	/** Human-readable preview label shown in resolve flow */
@@ -149,6 +151,10 @@ export interface RenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (0-9, only provided during partial results) */
 	spinnerFrame?: number;
+	/** Tool display density selected for this render */
+	displayMode?: ToolDisplayMode;
+	/** Normalized tool-call intent, when available */
+	intent?: string;
 }
 
 export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -402,6 +402,10 @@ export interface ToolRenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (optional) */
 	spinnerFrame?: number;
+	/** Tool display density selected for this render */
+	displayMode?: "detailed" | "concise";
+	/** Normalized tool-call intent, when available */
+	intent?: string;
 }
 
 /** Session event for tool onSession lifecycle */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -464,6 +464,9 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 		theme: Theme,
 		args?: Static<TParams>,
 	) => Component;
+
+	/** If true, result rendering replaces the pending call preview once a result exists. */
+	mergeCallAndResult?: boolean;
 }
 
 // ============================================================================

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -39,12 +39,7 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 		}
 		if (registeredTool.definition.renderResult) {
 			this.renderResult = (result: any, options: any, theme: any, args?: any) =>
-				registeredTool.definition.renderResult!(
-					result,
-					{ expanded: options.expanded, isPartial: options.isPartial, spinnerFrame: options.spinnerFrame },
-					theme as Theme,
-					args,
-				);
+				registeredTool.definition.renderResult!(result, options, theme as Theme, args);
 		}
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -19,6 +19,7 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 	declare parameters: any;
 	declare label: string;
 	declare strict: boolean;
+	declare mergeCallAndResult?: boolean;
 
 	renderCall?: (args: any, options: any, theme: any) => any;
 	renderResult?: (result: any, options: any, theme: any, args?: any) => any;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1,5 +1,5 @@
 import type { SnapshotStore } from "@oh-my-pi/hashline";
-import { INTENT_FIELD, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type AgentTool, INTENT_FIELD } from "@oh-my-pi/pi-agent-core";
 import {
 	Box,
 	type Component,

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -781,6 +781,16 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		return !(this.#tool && (this.#tool.renderCall || this.#tool.renderResult)) && !(this.#toolName in toolRenderers);
 	}
 
+	#hidesResultDetailsInConcise(): boolean {
+		return (
+			this.#usesGenericFallback() ||
+			this.#toolName === "bash" ||
+			this.#toolName === "ssh" ||
+			this.#toolName === "eval" ||
+			this.#toolName === "web_search"
+		);
+	}
+
 	#rebuildDisplay(): void {
 		// Sync shared mutable render state for component closures
 		this.#renderState.expanded = this.#expanded;
@@ -997,7 +1007,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 		this.#imageSpacers = [];
 
-		if (this.#result && !(this.#usesGenericFallback() && this.#conciseCollapsed())) {
+		if (this.#result && !(this.#hidesResultDetailsInConcise() && this.#conciseCollapsed())) {
 			const imageBlocks = this.#getAllImageBlocks();
 
 			for (let i = 0; i < imageBlocks.length; i++) {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1,5 +1,5 @@
 import type { SnapshotStore } from "@oh-my-pi/hashline";
-import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { INTENT_FIELD, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import {
 	Box,
 	type Component,
@@ -15,6 +15,7 @@ import {
 	type TUI,
 } from "@oh-my-pi/pi-tui";
 import { getProjectDir, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { settings } from "../../config/settings";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { Theme } from "../../modes/theme/theme";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
@@ -129,6 +130,7 @@ export interface ToolExecutionOptions {
 	/** Live-region probe used to settle detached task progress once the block
 	 * leaves the repaintable transcript region. */
 	liveRegion?: TranscriptLiveRegionProbe;
+	initialIntent?: string;
 }
 
 export interface ToolExecutionHandle {
@@ -182,6 +184,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
 	#snapshots?: SnapshotStore;
+	#initialIntent?: string;
 	#isPartial = true;
 	#resultVersion = 0;
 	#lastDisplayKey: string | undefined;
@@ -245,6 +248,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		spinnerFrame?: number;
 		expanded: boolean;
 		isPartial: boolean;
+		displayMode?: "detailed" | "concise";
+		intent?: string;
 		renderContext?: Record<string, unknown>;
 	} = {
 		expanded: false,
@@ -268,6 +273,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#editAllowFuzzy = options.editAllowFuzzy;
 		this.#snapshots = options.snapshots;
 		this.#liveRegion = options.liveRegion;
+		this.#initialIntent = this.#normalizeIntent(options.initialIntent);
 		this.#tool = tool;
 		this.#ui = ui;
 		this.#cwd = cwd;
@@ -306,6 +312,14 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#displayInputVersion++;
 		this.#updateSpinnerAnimation();
 		this.#editDiffInFlight = this.#runPreviewDiff();
+		this.#updateDisplay();
+	}
+
+	updateIntent(intent: unknown): void {
+		const normalized = this.#normalizeIntent(intent);
+		if (!normalized || normalized === this.#initialIntent) return;
+		this.#initialIntent = normalized;
+		this.#displayInputVersion++;
 		this.#updateDisplay();
 	}
 
@@ -705,7 +719,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// TUI startup, so a result rendered before it lands must re-shape once it
 		// does (it gates Image children vs text fallback in #rebuildDisplay); keyed
 		// here for the same reason markdown.ts keys its render cache on it.
-		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozen}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
+		const displayMode = this.#toolDisplayMode();
+		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozen}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}|${displayMode}`;
 		if (key === this.#lastDisplayKey && this.#displayBuilt) return;
 		this.#lastDisplayKey = key;
 
@@ -723,11 +738,56 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		return `${o.maxWidthCells}:${o.maxHeightCells ?? "-"}`;
 	}
 
+	#toolDisplayMode(): "detailed" | "concise" {
+		try {
+			return settings.get("tools.displayMode");
+		} catch (err) {
+			if (err instanceof Error && err.message.includes("Settings not initialized")) {
+				return "detailed";
+			}
+			throw err;
+		}
+	}
+
+	#normalizeIntent(value: unknown): string | undefined {
+		if (typeof value !== "string") return undefined;
+		const intent = value.replace(/\s+/g, " ").trim();
+		if (!intent) return undefined;
+		return intent.length > 80 ? `${intent.slice(0, 79)}…` : intent;
+	}
+
+	#toolIntent(): string | undefined {
+		if (this.#initialIntent) return this.#initialIntent;
+		if (!this.#args || typeof this.#args !== "object") return undefined;
+		const args = this.#args as Record<string, unknown>;
+		const explicitIntent = this.#normalizeIntent(args[INTENT_FIELD]);
+		if (explicitIntent) return explicitIntent;
+
+		const deriveIntent = this.#tool?.intent;
+		if (typeof deriveIntent !== "function") return undefined;
+		try {
+			return this.#normalizeIntent(deriveIntent(this.#args as never));
+		} catch (err) {
+			logger.warn("Tool intent derivation failed", { tool: this.#toolName, error: String(err) });
+			return undefined;
+		}
+	}
+
+	#conciseCollapsed(): boolean {
+		return this.#renderState.displayMode === "concise" && !this.#expanded;
+	}
+
+	#usesGenericFallback(): boolean {
+		return !(this.#tool && (this.#tool.renderCall || this.#tool.renderResult)) && !(this.#toolName in toolRenderers);
+	}
+
 	#rebuildDisplay(): void {
 		// Sync shared mutable render state for component closures
 		this.#renderState.expanded = this.#expanded;
 		this.#renderState.isPartial = this.#isPartial;
 		this.#renderState.spinnerFrame = this.#spinnerFrame;
+		this.#renderState.displayMode = this.#toolDisplayMode();
+		this.#renderState.intent = this.#toolIntent();
 
 		// Non-self-framing tools (custom/extension renderers and the generic
 		// fallback) get a padded, state-tinted block — built-ins that draw their
@@ -937,7 +997,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 		this.#imageSpacers = [];
 
-		if (this.#result) {
+		if (this.#result && !(this.#usesGenericFallback() && this.#conciseCollapsed())) {
 			const imageBlocks = this.#getAllImageBlocks();
 
 			for (let i = 0; i < imageBlocks.length; i++) {
@@ -1080,6 +1140,19 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		const lines: string[] = [];
 		const icon = this.#isPartial ? "pending" : this.#result?.isError ? "error" : "done";
 		lines.push(renderStatusLine({ icon, title: this.#toolLabel }, theme));
+
+		const conciseCollapsed = this.#conciseCollapsed();
+		if (conciseCollapsed) {
+			const intent = this.#toolIntent();
+			if (intent) {
+				lines.push(` ${theme.fg("dim", theme.tree.branch)} ${theme.fg("dim", intent)}`);
+			}
+			if (this.#result?.isError) {
+				lines.push(` ${theme.fg("dim", theme.tree.branch)} ${theme.fg("error", "Failed")}`);
+			}
+			lines.push(` ${theme.fg("dim", theme.tree.last)} ${formatExpandHint(theme, false, true)}`);
+			return lines.join("\n");
+		}
 
 		const argsObject = this.#args && typeof this.#args === "object" ? (this.#args as Record<string, unknown>) : null;
 		if (!this.#expanded && argsObject && Object.keys(argsObject).length > 0) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -556,6 +556,7 @@ export class EventController {
 							showImages: settings.get("terminal.showImages"),
 							editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 							editAllowFuzzy: settings.get("edit.fuzzyMatch"),
+							initialIntent: content.intent,
 						},
 						tool,
 						this.ctx.ui,
@@ -570,6 +571,7 @@ export class EventController {
 					const component = this.ctx.pendingTools.get(content.id);
 					if (component) {
 						component.updateArgs(renderArgs, content.id);
+						if (component instanceof ToolExecutionComponent) component.updateIntent(content.intent);
 						this.#toolArgsReveal.bind(content.id, component);
 					}
 				}
@@ -715,6 +717,7 @@ export class EventController {
 					editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 					editAllowFuzzy: settings.get("edit.fuzzyMatch"),
 					liveRegion: this.ctx.chatContainer,
+					initialIntent: event.intent,
 				},
 				tool,
 				this.ctx.ui,
@@ -725,6 +728,9 @@ export class EventController {
 			this.ctx.chatContainer.addChild(component);
 			this.ctx.pendingTools.set(event.toolCallId, component);
 			this.ctx.ui.requestRender();
+		} else {
+			const component = this.ctx.pendingTools.get(event.toolCallId);
+			if (component instanceof ToolExecutionComponent) component.updateIntent(event.intent);
 		}
 	}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -906,11 +906,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		renderCall: tool.renderCall,
 		renderResult: tool.renderResult
 			? (result, options, theme): Component => {
-					const component = tool.renderResult?.(
-						result,
-						{ expanded: options.expanded, isPartial: options.isPartial, spinnerFrame: options.spinnerFrame },
-						theme,
-					);
+					const component = tool.renderResult?.(result, options, theme);
 					// Return empty component if undefined to match Component type requirement
 					return component ?? ({ render: () => [] } as unknown as Component);
 				}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -903,6 +903,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>
 			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx), signal),
 		onSession: tool.onSession ? (event, ctx) => tool.onSession?.(event, createCustomToolContext(ctx)) : undefined,
+		mergeCallAndResult: tool.mergeCallAndResult,
 		renderCall: tool.renderCall,
 		renderResult: tool.renderResult
 			? (result, options, theme): Component => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -906,8 +906,8 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		mergeCallAndResult: tool.mergeCallAndResult,
 		renderCall: tool.renderCall,
 		renderResult: tool.renderResult
-			? (result, options, theme): Component => {
-					const component = tool.renderResult?.(result, options, theme);
+			? (result, options, theme, args): Component => {
+					const component = tool.renderResult?.(result, options, theme, args);
 					// Return empty component if undefined to match Component type requirement
 					return component ?? ({ render: () => [] } as unknown as Component);
 				}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1228,13 +1228,15 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 				config.showHeader === false
 					? undefined
 					: renderStatusLine({ icon: "pending", title: config.resolveTitle(args, options) }, uiTheme);
+			const conciseHeader =
+				header ?? renderStatusLine({ icon: "pending", title: config.resolveTitle(args, options) }, uiTheme);
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
 				render: (width: number): readonly string[] => {
 					const expanded = options.expanded;
 					return outputBlock.render(
 						{
-							header,
+							header: isConciseCollapsed(options, expanded) ? conciseHeader : header,
 							state: "pending",
 							sections: [
 								{
@@ -1284,6 +1286,20 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 									},
 							uiTheme,
 						);
+			const conciseHeader =
+				header ??
+				renderStatusLine(
+					success
+						? {
+								iconOverride: uiTheme.styledSymbol("tool.bash", "accent"),
+								title: config.resolveTitle(args, options),
+							}
+						: {
+								icon: isPartial ? "pending" : "error",
+								title: config.resolveTitle(args, options),
+							},
+					uiTheme,
+				);
 			const details = result.details;
 			const outputBlock = new CachedOutputBlock();
 
@@ -1315,7 +1331,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					if (isConciseCollapsed(options, expanded)) {
 						return outputBlock.render(
 							{
-								header,
+								header: conciseHeader,
 								state: isPartial ? "pending" : isError ? "error" : "success",
 								sections: [
 									{

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -31,7 +31,13 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { capPreviewLines, formatExpandHint, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
+import {
+	capPreviewLines,
+	formatExpandHint,
+	formatToolWorkingDirectory,
+	previewWindowRows,
+	replaceTabs,
+} from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -1170,10 +1176,7 @@ function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode">, e
 	return options.displayMode === "concise" && expanded !== true;
 }
 
-function formatConciseShellLines(
-	uiTheme: Theme,
-	options: { intent?: string; metadata?: readonly string[] },
-): string[] {
+function formatConciseShellLines(uiTheme: Theme, options: { intent?: string; metadata?: readonly string[] }): string[] {
 	const lines: string[] = [];
 	const append = (text: string) => {
 		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", text)}`);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -31,7 +31,7 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { capPreviewLines, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
+import { capPreviewLines, formatExpandHint, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -1166,27 +1166,85 @@ function toBashRenderArgs<TArgs>(args: TArgs | undefined, config: ShellRendererC
 	};
 }
 
+function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode">, expanded: boolean | undefined): boolean {
+	return options.displayMode === "concise" && expanded !== true;
+}
+
+function formatConciseShellLines(
+	uiTheme: Theme,
+	options: { intent?: string; metadata?: readonly string[] },
+): string[] {
+	const lines: string[] = [];
+	const append = (text: string) => {
+		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", text)}`);
+	};
+	if (options.intent) append(options.intent);
+	for (const item of options.metadata ?? []) {
+		if (item) append(item);
+	}
+	lines.push(`${uiTheme.fg("dim", uiTheme.tree.last)} ${formatExpandHint(uiTheme, false, true)}`);
+	return lines;
+}
+
+function formatBashConciseMetadata(details: BashToolDetails | undefined, isError: boolean): string[] {
+	const statsParts: string[] = [];
+	if (typeof details?.exitCode === "number") {
+		statsParts.push(`Exit: ${details.exitCode}`);
+	} else if (isError) {
+		statsParts.push("Failed");
+	}
+	if (details?.wallTimeMs !== undefined) {
+		statsParts.push(`Wall: ${formatWallTimeSeconds(details.wallTimeMs)}s`);
+	}
+	const timeoutSeconds = details?.timeoutSeconds;
+	if (typeof timeoutSeconds === "number") {
+		const requested = details?.requestedTimeoutSeconds;
+		statsParts.push(
+			requested !== undefined && requested !== timeoutSeconds
+				? `Timeout: ${timeoutSeconds}s (requested ${requested}s clamped)`
+				: `Timeout: ${timeoutSeconds}s`,
+		);
+	}
+	const artifactId = details?.meta?.truncation?.artifactId;
+	if (artifactId) {
+		statsParts.push(`Artifact: ${artifactId}`);
+	}
+	if (details?.async) {
+		statsParts.push(`Job: ${details.async.jobId} (${details.async.state})`);
+	}
+	return statsParts.length > 0 ? [statsParts.join(" | ")] : [];
+}
+
 export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 	return {
 		renderCall(args: TArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 			const renderArgs = toBashRenderArgs(args, config);
-			const cmdLines = formatBashCommandLines(renderArgs, uiTheme);
+			let cmdLines: string[] | undefined;
+			const getCmdLines = () => (cmdLines ??= formatBashCommandLines(renderArgs, uiTheme));
 			const header =
 				config.showHeader === false
 					? undefined
 					: renderStatusLine({ icon: "pending", title: config.resolveTitle(args, options) }, uiTheme);
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
-				render: (width: number): readonly string[] =>
-					outputBlock.render(
+				render: (width: number): readonly string[] => {
+					const expanded = options.expanded;
+					return outputBlock.render(
 						{
 							header,
 							state: "pending",
-							sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: options.expanded }) }],
+							sections: [
+								{
+									lines: isConciseCollapsed(options, expanded)
+										? formatConciseShellLines(uiTheme, { intent: options.intent })
+										: capPreviewLines(getCmdLines(), uiTheme, { expanded }),
+								},
+							],
 							width,
 						},
 						uiTheme,
-					),
+					);
+				},
 				invalidate: () => {
 					outputBlock.invalidate();
 				},
@@ -1250,12 +1308,31 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					const expanded = renderContext?.expanded ?? options.expanded;
 					const previewLines = renderContext?.previewLines ?? BASH_DEFAULT_PREVIEW_LINES;
 
+					const isPartial = options.isPartial === true;
+					if (isConciseCollapsed(options, expanded)) {
+						return outputBlock.render(
+							{
+								header,
+								state: isPartial ? "pending" : isError ? "error" : "success",
+								sections: [
+									{
+										lines: formatConciseShellLines(uiTheme, {
+											intent: options.intent,
+											metadata: formatBashConciseMetadata(details, isError),
+										}),
+									},
+								],
+								width,
+							},
+							uiTheme,
+						);
+					}
+
 					// Get output from context (preferred) or fall back to result content.
 					// Strip the LLM-facing notice appended by wrappedExecute so we don't
 					// double-print it alongside the styled warning line below.
 					const rawOutput = renderContext?.output ?? result.content?.find(c => c.type === "text")?.text ?? "";
 
-					const isPartial = options.isPartial === true;
 					const previewWindow = previewWindowRows();
 
 					if (

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -126,10 +126,7 @@ function formatConciseEvalMetadata(
 	return languageLabel ? [languageLabel] : [];
 }
 
-function formatConciseEvalLines(
-	uiTheme: Theme,
-	options: { intent?: string; metadata?: readonly string[] },
-): string[] {
+function formatConciseEvalLines(uiTheme: Theme, options: { intent?: string; metadata?: readonly string[] }): string[] {
 	const lines: string[] = [];
 	const append = (text: string) => {
 		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", text)}`);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -17,7 +17,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
-import { markFramedBlockComponent, renderCodeCell } from "../tui";
+import { CachedOutputBlock, markFramedBlockComponent, renderCodeCell, renderStatusLine } from "../tui";
 import {
 	JSON_TREE_MAX_DEPTH_COLLAPSED,
 	JSON_TREE_MAX_DEPTH_EXPANDED,
@@ -30,7 +30,9 @@ import {
 import { formatStyledTruncationWarning, stripOutputNotice } from "./output-meta";
 import {
 	formatBadge,
+	formatCount,
 	formatDuration,
+	formatExpandHint,
 	formatStatusIcon,
 	formatTitle,
 	previewWindowRows,
@@ -87,6 +89,82 @@ function getRenderCells(args: EvalRenderArgs | undefined): EvalRenderCell[] {
 		});
 	}
 	return out;
+}
+
+function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode">, expanded: boolean | undefined): boolean {
+	return options.displayMode === "concise" && expanded !== true;
+}
+
+function formatEvalLanguageLabel(languages: readonly EvalLanguage[]): string | undefined {
+	if (languages.length === 0) return undefined;
+	if (languages.length === 1) return languages[0] === "js" ? "JavaScript" : "Python";
+	return "Python, JavaScript";
+}
+
+function collectEvalLanguages(cells: readonly { language?: EvalLanguage }[], fallback?: EvalLanguage): EvalLanguage[] {
+	let hasPython = fallback === "python";
+	let hasJs = fallback === "js";
+	for (const cell of cells) {
+		if (cell.language === "js") hasJs = true;
+		else if (cell.language === "python") hasPython = true;
+	}
+	const languages: EvalLanguage[] = [];
+	if (hasPython) languages.push("python");
+	if (hasJs) languages.push("js");
+	return languages;
+}
+
+function formatConciseEvalMetadata(
+	cellCount: number | undefined,
+	languages: readonly EvalLanguage[],
+): readonly string[] {
+	const languageLabel = formatEvalLanguageLabel(languages);
+	if (cellCount !== undefined) {
+		const cellLabel = formatCount("cell", cellCount);
+		return [languageLabel ? `${cellLabel} · ${languageLabel}` : cellLabel];
+	}
+	return languageLabel ? [languageLabel] : [];
+}
+
+function formatConciseEvalLines(
+	uiTheme: Theme,
+	options: { intent?: string; metadata?: readonly string[] },
+): string[] {
+	const lines: string[] = [];
+	const append = (text: string) => {
+		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", text)}`);
+	};
+	if (options.intent) append(options.intent);
+	for (const item of options.metadata ?? []) {
+		if (item) append(item);
+	}
+	lines.push(`${uiTheme.fg("dim", uiTheme.tree.last)} ${formatExpandHint(uiTheme, false, true)}`);
+	return lines;
+}
+
+function renderConciseEvalBlock(
+	header: string,
+	state: "pending" | "success" | "error",
+	uiTheme: Theme,
+	options: { intent?: string; metadata?: readonly string[] },
+): Component {
+	const outputBlock = new CachedOutputBlock();
+	return markFramedBlockComponent({
+		render(width: number): readonly string[] {
+			return outputBlock.render(
+				{
+					header,
+					state,
+					sections: [{ lines: formatConciseEvalLines(uiTheme, options) }],
+					width,
+				},
+				uiTheme,
+			);
+		},
+		invalidate() {
+			outputBlock.invalidate();
+		},
+	});
 }
 
 type AgentEventStatus = "pending" | "running" | "completed" | "failed" | "aborted";
@@ -484,6 +562,14 @@ export const evalToolRenderer = {
 	renderCall(args: EvalRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const cells = getRenderCells(args);
 
+		if (isConciseCollapsed(options, options.expanded)) {
+			const header = renderStatusLine({ icon: "pending", title: "Eval" }, uiTheme);
+			return renderConciseEvalBlock(header, "pending", uiTheme, {
+				intent: options.intent,
+				metadata: formatConciseEvalMetadata(cells.length, collectEvalLanguages(cells)),
+			});
+		}
+
 		if (cells.length === 0) {
 			const promptSym = uiTheme.fg("accent", ">>>");
 			const text = formatTitle(`${promptSym} …`, uiTheme);
@@ -535,12 +621,42 @@ export const evalToolRenderer = {
 	},
 
 	renderResult(
-		result: { content: Array<{ type: string; text?: string }>; details?: EvalToolDetails },
+		result: {
+			content: Array<{ type: string; text?: string }>;
+			details?: EvalToolDetails;
+			isError?: boolean;
+		},
 		options: RenderResultOptions & { renderContext?: EvalRenderContext },
 		uiTheme: Theme,
-		_args?: EvalRenderArgs,
+		args?: EvalRenderArgs,
 	): Component {
 		const details = result.details;
+		const resultExpanded = options.renderContext?.expanded ?? options.expanded;
+		if (isConciseCollapsed(options, resultExpanded)) {
+			const cellResults = details?.cells ?? [];
+			const renderCells = cellResults.length > 0 ? [] : getRenderCells(args);
+			const cellCount = cellResults.length > 0 ? cellResults.length : renderCells.length || undefined;
+			const isError =
+				result.isError === true || details?.isError === true || cellResults.some(cell => cell.status === "error");
+			const header = renderStatusLine(
+				options.isPartial
+					? { icon: "pending", title: "Eval" }
+					: isError
+						? { icon: "error", title: "Eval" }
+						: { iconOverride: uiTheme.styledSymbol("tool.eval", "accent"), title: "Eval" },
+				uiTheme,
+			);
+			const languages =
+				details?.languages && details.languages.length > 0
+					? details.languages
+					: cellResults.length > 0
+						? collectEvalLanguages(cellResults, details?.language)
+						: collectEvalLanguages(renderCells, details?.language);
+			return renderConciseEvalBlock(header, options.isPartial ? "pending" : isError ? "error" : "success", uiTheme, {
+				intent: options.intent,
+				metadata: [...(isError ? ["Failed"] : []), ...formatConciseEvalMetadata(cellCount, languages)],
+			});
+		}
 
 		const rawOutput =
 			options.renderContext?.output ?? (result.content?.find(c => c.type === "text")?.text ?? "").trimEnd();

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -18,7 +18,7 @@ import { CachedOutputBlock, markFramedBlockComponent } from "../tui/output-block
 import type { ToolSession } from ".";
 import { truncateForPrompt } from "./approval";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
-import { capPreviewLines, replaceTabs } from "./render-utils";
+import { capPreviewLines, formatExpandHint, replaceTabs } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -253,24 +253,46 @@ function formatSshCommandLines(command: string, uiTheme: Theme): string[] {
 	return rawLines.map((line, i) => (i === 0 ? `${prefix}${line}` : line));
 }
 
+function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode">, expanded: boolean | undefined): boolean {
+	return options.displayMode === "concise" && expanded !== true;
+}
+
+function formatConciseSshLines(uiTheme: Theme, intent?: string): string[] {
+	const lines: string[] = [];
+	if (intent) {
+		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", intent)}`);
+	}
+	lines.push(`${uiTheme.fg("dim", uiTheme.tree.last)} ${formatExpandHint(uiTheme, false, true)}`);
+	return lines;
+}
+
 export const sshToolRenderer = {
 	renderCall(args: SshRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const host = args.host || "…";
 		const command = args.command ?? "";
 		const header = renderStatusLine({ icon: "pending", title: "SSH", description: `[${host}]` }, uiTheme);
-		const cmdLines = formatSshCommandLines(command, uiTheme);
+		let cmdLines: string[] | undefined;
+		const getCmdLines = () => (cmdLines ??= formatSshCommandLines(command, uiTheme));
 		const outputBlock = new CachedOutputBlock();
 		return markFramedBlockComponent({
-			render: (width: number): readonly string[] =>
-				outputBlock.render(
+			render: (width: number): readonly string[] => {
+				const expanded = _options.expanded;
+				return outputBlock.render(
 					{
 						header,
 						state: "pending",
-						sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: _options.expanded }) }],
+						sections: [
+							{
+								lines: isConciseCollapsed(_options, expanded)
+									? formatConciseSshLines(uiTheme, _options.intent)
+									: capPreviewLines(getCmdLines(), uiTheme, { expanded }),
+							},
+						],
 						width,
 					},
 					uiTheme,
-				),
+				);
+			},
 			invalidate: () => {
 				outputBlock.invalidate();
 			},
@@ -281,6 +303,7 @@ export const sshToolRenderer = {
 		result: {
 			content: Array<{ type: string; text?: string }>;
 			details?: SSHToolDetails;
+			isError?: boolean;
 		},
 		options: RenderResultOptions & { renderContext?: SshRenderContext },
 		uiTheme: Theme,
@@ -293,16 +316,34 @@ export const sshToolRenderer = {
 			{ iconOverride: uiTheme.styledSymbol("tool.ssh", "accent"), title: "SSH", description: `[${host}]` },
 			uiTheme,
 		);
-		const cmdLines = formatSshCommandLines(command, uiTheme);
-		const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
+		let cmdLines: string[] | undefined;
+		let textContent: string | undefined;
+		const getCmdLines = () => (cmdLines ??= formatSshCommandLines(command, uiTheme));
 		const outputBlock = new CachedOutputBlock();
 
 		return markFramedBlockComponent({
 			render: (width: number): readonly string[] => {
 				// REACTIVE: read mutable options at render time
 				const { expanded, renderContext } = options;
+				const isPartial = options.isPartial === true;
+				const isError = result.isError === true;
+				if (isConciseCollapsed(options, expanded)) {
+					return outputBlock.render(
+						{
+							header,
+							state: isPartial ? "pending" : isError ? "error" : "success",
+							sections: [{ lines: formatConciseSshLines(uiTheme, options.intent) }],
+							width,
+						},
+						uiTheme,
+					);
+				}
+
 				// Strip LLM-facing notice so we don't echo it next to the styled warning.
-				const output = stripOutputNotice(textContent, details?.meta).trimEnd();
+				const output = stripOutputNotice(
+					(textContent ??= result.content?.find(c => c.type === "text")?.text ?? ""),
+					details?.meta,
+				).trimEnd();
 				const outputLines: string[] = [];
 
 				if (output) {
@@ -347,7 +388,7 @@ export const sshToolRenderer = {
 							{
 								// Viewport-sized tail window in every state — streaming and final
 								// render identically; only ctrl+o uncaps.
-								lines: capPreviewLines(cmdLines, uiTheme, { expanded }),
+								lines: capPreviewLines(getCmdLines(), uiTheme, { expanded }),
 							},
 							{ label: uiTheme.fg("toolTitle", "Output"), lines: outputLines },
 						],

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -257,10 +257,13 @@ function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode">, e
 	return options.displayMode === "concise" && expanded !== true;
 }
 
-function formatConciseSshLines(uiTheme: Theme, intent?: string): string[] {
+function formatConciseSshLines(uiTheme: Theme, intent: string | undefined, isError: boolean): string[] {
 	const lines: string[] = [];
 	if (intent) {
 		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", intent)}`);
+	}
+	if (isError) {
+		lines.push(`${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("error", "Failed")}`);
 	}
 	lines.push(`${uiTheme.fg("dim", uiTheme.tree.last)} ${formatExpandHint(uiTheme, false, true)}`);
 	return lines;
@@ -284,7 +287,7 @@ export const sshToolRenderer = {
 						sections: [
 							{
 								lines: isConciseCollapsed(_options, expanded)
-									? formatConciseSshLines(uiTheme, _options.intent)
+									? formatConciseSshLines(uiTheme, _options.intent, false)
 									: capPreviewLines(getCmdLines(), uiTheme, { expanded }),
 							},
 						],
@@ -328,11 +331,18 @@ export const sshToolRenderer = {
 				const isPartial = options.isPartial === true;
 				const isError = result.isError === true;
 				if (isConciseCollapsed(options, expanded)) {
+					const conciseHeader =
+						isPartial || isError
+							? renderStatusLine(
+									{ icon: isPartial ? "pending" : "error", title: "SSH", description: `[${host}]` },
+									uiTheme,
+								)
+							: header;
 					return outputBlock.render(
 						{
-							header,
+							header: conciseHeader,
 							state: isPartial ? "pending" : isError ? "error" : "success",
-							sections: [{ lines: formatConciseSshLines(uiTheme, options.intent) }],
+							sections: [{ lines: formatConciseSshLines(uiTheme, options.intent, isError) }],
 							width,
 						},
 						uiTheme,

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -340,10 +340,8 @@ export const sshToolRenderer = {
 				}
 
 				// Strip LLM-facing notice so we don't echo it next to the styled warning.
-				const output = stripOutputNotice(
-					(textContent ??= result.content?.find(c => c.type === "text")?.text ?? ""),
-					details?.meta,
-				).trimEnd();
+				textContent ??= result.content?.find(c => c.type === "text")?.text ?? "";
+				const output = stripOutputNotice(textContent, details?.meta).trimEnd();
 				const outputLines: string[] = [];
 
 				if (output) {

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -294,6 +294,7 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	renderResult(result, options: RenderResultOptions, theme: Theme, args) {
 		return renderSearchResult(result, options, theme, args);
 	},
+	mergeCallAndResult: true,
 };
 
 export function getSearchTools(): CustomTool<any, any>[] {

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -26,6 +26,60 @@ import type { SearchResponse } from "./types";
 
 const MAX_COLLAPSED_ITEMS = PREVIEW_LIMITS.COLLAPSED_ITEMS;
 
+function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode" | "expanded">): boolean {
+	return options.displayMode === "concise" && options.expanded !== true;
+}
+
+function formatConciseSearchLines(
+	theme: Theme,
+	options: { intent?: string; metadata?: readonly string[] },
+): string[] {
+	const lines: string[] = [];
+	const append = (text: string) => {
+		lines.push(`${theme.fg("dim", theme.tree.branch)} ${theme.fg("dim", text)}`);
+	};
+	if (options.intent) append(options.intent);
+	for (const item of options.metadata ?? []) {
+		if (item) append(item);
+	}
+	lines.push(`${theme.fg("dim", theme.tree.last)} ${formatExpandHint(theme, false, true)}`);
+	return lines;
+}
+
+function renderConciseSearchPanel(
+	header: string,
+	state: "pending" | "success" | "warning" | "error",
+	theme: Theme,
+	options: { intent?: string; metadata?: readonly string[] },
+): Component {
+	const outputBlock = new CachedOutputBlock();
+	return markFramedBlockComponent({
+		render(width: number): readonly string[] {
+			return outputBlock.render(
+				{
+					header,
+					state,
+					sections: [{ lines: formatConciseSearchLines(theme, options) }],
+					width,
+				},
+				theme,
+			);
+		},
+		invalidate() {
+			outputBlock.invalidate();
+		},
+	});
+}
+
+function getProviderLabel(provider: SearchResponse["provider"] | undefined): string | undefined {
+	if (!provider) return undefined;
+	return provider !== "none" ? getSearchProviderLabel(provider) : "None";
+}
+
+function getErrorProviderLabel(provider: SearchResponse["provider"] | undefined): string | undefined {
+	return provider && provider !== "none" ? getSearchProviderLabel(provider) : undefined;
+}
+
 function renderFallbackText(contentText: string, expanded: boolean, theme: Theme): Component {
 	const lines = contentText.split("\n").filter(line => line.trim());
 	const maxLines = expanded ? lines.length : 6;
@@ -76,7 +130,11 @@ function renderSearchErrorPanel(message: string, providerLabel: string | undefin
 
 /** Render web search result with tree-based layout */
 export function renderSearchResult(
-	result: { content: Array<{ type: string; text?: string }>; details?: SearchRenderDetails },
+	result: {
+		content: Array<{ type: string; text?: string }>;
+		details?: SearchRenderDetails;
+		isError?: boolean;
+	},
 	options: RenderResultOptions,
 	theme: Theme,
 	args?: {
@@ -85,17 +143,52 @@ export function renderSearchResult(
 	},
 ): Component {
 	const details = result.details;
+	const response = details?.response;
+
+	if (isConciseCollapsed(options)) {
+		const sources = response && Array.isArray(response.sources) ? response.sources : undefined;
+		const sourceCount = sources?.length;
+		const providerLabel = getProviderLabel(response?.provider);
+		const isError = result.isError === true || details?.error !== undefined;
+		const state: "pending" | "success" | "warning" | "error" = isError
+			? "error"
+			: options.isPartial
+				? "pending"
+				: sourceCount !== undefined && sourceCount > 0
+					? "success"
+					: "warning";
+		const header = renderStatusLine(
+			state === "success"
+				? {
+						iconOverride: theme.styledSymbol("tool.webSearch", "accent"),
+						title: "Web Search",
+						description: providerLabel,
+						meta: sourceCount !== undefined ? [formatCount("source", sourceCount)] : undefined,
+					}
+				: {
+						icon: state,
+						title: "Web Search",
+						description: providerLabel,
+						meta: sourceCount !== undefined ? [formatCount("source", sourceCount)] : undefined,
+					},
+			theme,
+		);
+		return renderConciseSearchPanel(header, state, theme, {
+			intent: options.intent,
+			metadata: [
+				...(isError ? ["Failed"] : []),
+				...(providerLabel ? [] : ["Provider: pending"]),
+				...(sourceCount === undefined ? ["Sources: pending"] : []),
+			],
+		});
+	}
 
 	// Handle error case as a framed panel, matching the success layout.
 	if (details?.error) {
-		const errorProvider = details.response?.provider;
-		const errorProviderLabel =
-			errorProvider && errorProvider !== "none" ? getSearchProviderLabel(errorProvider) : undefined;
-		return renderSearchErrorPanel(details.error, errorProviderLabel, theme);
+		return renderSearchErrorPanel(details.error, getErrorProviderLabel(response?.provider), theme);
 	}
 
 	const rawText = result.content?.find(block => block.type === "text")?.text?.trim() ?? "";
-	const response = details?.response;
 	if (!response) {
 		return renderFallbackText(rawText, options.expanded, theme);
 	}
@@ -111,7 +204,7 @@ export function renderSearchResult(
 	const answerText = typeof response.answer === "string" ? response.answer.trim() : "";
 	const contentText = answerText || rawText;
 
-	const providerLabel = provider !== "none" ? getSearchProviderLabel(provider) : "None";
+	const providerLabel = getProviderLabel(provider) ?? "None";
 	const queryPreview = args?.query
 		? truncateToWidth(args.query, 80)
 		: searchQueries[0]
@@ -247,9 +340,16 @@ export function renderSearchResult(
 /** Render web search call (query preview) */
 export function renderSearchCall(
 	args: { query?: string; [key: string]: unknown },
-	_options: RenderResultOptions,
+	options: RenderResultOptions,
 	theme: Theme,
 ): Component {
+	if (isConciseCollapsed(options)) {
+		const header = renderStatusLine({ icon: "pending", title: "Web Search" }, theme);
+		return renderConciseSearchPanel(header, "pending", theme, {
+			intent: options.intent,
+			metadata: ["Provider: pending", "Sources: pending"],
+		});
+	}
 	const query = truncateToWidth(args.query ?? "", 80);
 	const text = renderStatusLine({ icon: "pending", title: "Web Search", description: query }, theme);
 	return new Text(text, 0, 0);

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -30,10 +30,7 @@ function isConciseCollapsed(options: Pick<RenderResultOptions, "displayMode" | "
 	return options.displayMode === "concise" && options.expanded !== true;
 }
 
-function formatConciseSearchLines(
-	theme: Theme,
-	options: { intent?: string; metadata?: readonly string[] },
-): string[] {
+function formatConciseSearchLines(theme: Theme, options: { intent?: string; metadata?: readonly string[] }): string[] {
 	const lines: string[] = [];
 	const append = (text: string) => {
 		lines.push(`${theme.fg("dim", theme.tree.branch)} ${theme.fg("dim", text)}`);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -84,6 +84,12 @@ describe("Settings", () => {
 				"gemma",
 			]);
 		});
+
+		it("exposes concise tool display mode options", () => {
+			expect(getDefault("tools.displayMode")).toBe("detailed");
+			expect(getEnumValues("tools.displayMode")).toEqual(["detailed", "concise"]);
+			expect(Settings.isolated({ "tools.displayMode": "concise" }).get("tools.displayMode")).toBe("concise");
+		});
 	});
 
 	describe("get()", () => {

--- a/packages/coding-agent/test/tools/tool-display-mode.test.ts
+++ b/packages/coding-agent/test/tools/tool-display-mode.test.ts
@@ -118,6 +118,19 @@ describe("concise tool display mode", () => {
 		expect(collapsed).not.toContain("SSH_COMMAND_SECRET");
 		expect(collapsed).not.toContain("SSH_OUTPUT_SECRET");
 
+		const failedCollapsed = clean(
+			sshToolRenderer
+				.renderResult(
+					{ ...result, isError: true },
+					{ expanded: false, isPartial: false, displayMode: "concise", intent: "Running hidden remote" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(failedCollapsed).toContain("Failed");
+		expect(failedCollapsed).not.toContain("SSH_OUTPUT_SECRET");
 		const expanded = clean(
 			sshToolRenderer
 				.renderResult(

--- a/packages/coding-agent/test/tools/tool-display-mode.test.ts
+++ b/packages/coding-agent/test/tools/tool-display-mode.test.ts
@@ -260,5 +260,10 @@ describe("concise tool display mode", () => {
 		expect(customToolCollapsed).not.toContain("Sources: pending");
 		expect(customToolCollapsed).not.toContain("WEB_QUERY_SECRET");
 		expect(customToolCollapsed).not.toContain("WEB_ANSWER_SECRET");
+
+		component.setExpanded(true);
+		const customToolExpanded = clean(component.render(120));
+		expect(customToolExpanded).toContain("WEB_QUERY_SECRET");
+		expect(customToolExpanded).toContain("WEB_ANSWER_SECRET");
 	});
 });

--- a/packages/coding-agent/test/tools/tool-display-mode.test.ts
+++ b/packages/coding-agent/test/tools/tool-display-mode.test.ts
@@ -6,6 +6,7 @@ import { getThemeByName, initTheme, setThemeInstance, type Theme } from "@oh-my-
 import { bashToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/bash";
 import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval-render";
 import { sshToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/ssh";
+import { webSearchCustomTool } from "@oh-my-pi/pi-coding-agent/web/search";
 import { renderSearchResult, type SearchRenderDetails } from "@oh-my-pi/pi-coding-agent/web/search/render";
 import type { SearchResponse } from "@oh-my-pi/pi-coding-agent/web/search/types";
 import type { TUI } from "@oh-my-pi/pi-tui";
@@ -197,7 +198,7 @@ describe("concise tool display mode", () => {
 		expect(expanded).toContain("EVAL_OUTPUT_SECRET");
 	});
 
-	it("keeps web search concise when collapsed and reveals query/answer/sources when expanded", () => {
+	it("keeps web search concise when collapsed and reveals query/answer/sources when expanded", async () => {
 		const response: SearchResponse = {
 			provider: "perplexity",
 			answer: "WEB_ANSWER_SECRET",
@@ -238,5 +239,26 @@ describe("concise tool display mode", () => {
 		expect(expanded).toContain("WEB_QUERY_SECRET");
 		expect(expanded).toContain("WEB_ANSWER_SECRET");
 		expect(expanded).toContain("WEB_SOURCE_TITLE_SECRET");
+
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: process.cwd(), overrides: { "tools.displayMode": "concise" } });
+		const ui = { requestRender() {} } as unknown as TUI;
+		const component = new ToolExecutionComponent(
+			"web_search",
+			{ _i: "Searching hidden web", query: "WEB_QUERY_SECRET" },
+			{},
+			webSearchCustomTool as never,
+			ui,
+			process.cwd(),
+		);
+		component.updateResult(result, false);
+
+		const customToolCollapsed = clean(component.render(120));
+		expect(customToolCollapsed).toContain("Web Search");
+		expect(customToolCollapsed).toContain("2 sources");
+		expect(customToolCollapsed).not.toContain("Provider: pending");
+		expect(customToolCollapsed).not.toContain("Sources: pending");
+		expect(customToolCollapsed).not.toContain("WEB_QUERY_SECRET");
+		expect(customToolCollapsed).not.toContain("WEB_ANSWER_SECRET");
 	});
 });

--- a/packages/coding-agent/test/tools/tool-display-mode.test.ts
+++ b/packages/coding-agent/test/tools/tool-display-mode.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { getThemeByName, initTheme, setThemeInstance, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { bashToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/bash";
+import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval-render";
+import { sshToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/ssh";
+import { renderSearchResult, type SearchRenderDetails } from "@oh-my-pi/pi-coding-agent/web/search/render";
+import type { SearchResponse } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+function clean(lines: readonly string[]): string {
+	return stripVTControlCharacters(lines.join("\n"));
+}
+
+describe("concise tool display mode", () => {
+	let theme: Theme;
+
+	beforeAll(async () => {
+		await initTheme();
+		theme = (await getThemeByName("dark"))!;
+		expect(theme).toBeDefined();
+		setThemeInstance(theme);
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
+	it("keeps generic fallback concise when collapsed and reveals details when expanded", async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: process.cwd(), overrides: { "tools.displayMode": "concise" } });
+		const ui = { requestRender() {} } as unknown as TUI;
+		const component = new ToolExecutionComponent(
+			"generic_tool",
+			{ _i: "Checking generic result", secretArg: "ARG_SECRET" },
+			{},
+			undefined,
+			ui,
+			process.cwd(),
+		);
+
+		component.updateResult({ content: [{ type: "text", text: '{"secret":"OUTPUT_SECRET"}' }] }, false);
+		const collapsed = clean(component.render(120));
+
+		expect(collapsed).toContain("generic_tool");
+		expect(collapsed).toContain("Checking generic result");
+		expect(collapsed).toMatch(/expand/i);
+		expect(collapsed).not.toContain("ARG_SECRET");
+		expect(collapsed).not.toContain("OUTPUT_SECRET");
+
+		component.setExpanded(true);
+		const expanded = clean(component.render(120));
+
+		expect(expanded).toContain("ARG_SECRET");
+		expect(expanded).toContain("OUTPUT_SECRET");
+	});
+
+	it("keeps bash concise when collapsed and reveals command/output when expanded", () => {
+		const args = { command: "printf BASH_COMMAND_SECRET" };
+		const result = {
+			content: [{ type: "text", text: "BASH_OUTPUT_SECRET" }],
+			details: { exitCode: 7 },
+			isError: true,
+		};
+
+		const collapsed = clean(
+			bashToolRenderer
+				.renderResult(
+					result,
+					{ expanded: false, isPartial: false, displayMode: "concise", intent: "Running hidden bash" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(collapsed).toContain("Running hidden bash");
+		expect(collapsed).toContain("Exit: 7");
+		expect(collapsed).toMatch(/expand/i);
+		expect(collapsed).not.toContain("BASH_COMMAND_SECRET");
+		expect(collapsed).not.toContain("BASH_OUTPUT_SECRET");
+
+		const expanded = clean(
+			bashToolRenderer
+				.renderResult(
+					result,
+					{ expanded: true, isPartial: false, displayMode: "concise", intent: "Running hidden bash" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(expanded).toContain("BASH_COMMAND_SECRET");
+		expect(expanded).toContain("BASH_OUTPUT_SECRET");
+	});
+
+	it("keeps ssh concise when collapsed and reveals command/output when expanded", () => {
+		const args = { host: "secret-host.example", command: "cat SSH_COMMAND_SECRET" };
+		const result = { content: [{ type: "text", text: "SSH_OUTPUT_SECRET" }] };
+
+		const collapsed = clean(
+			sshToolRenderer
+				.renderResult(
+					result,
+					{ expanded: false, isPartial: false, displayMode: "concise", intent: "Running hidden remote" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(collapsed).toContain("SSH");
+		expect(collapsed).toContain("secret-host.example");
+		expect(collapsed).toContain("Running hidden remote");
+		expect(collapsed).not.toContain("SSH_COMMAND_SECRET");
+		expect(collapsed).not.toContain("SSH_OUTPUT_SECRET");
+
+		const expanded = clean(
+			sshToolRenderer
+				.renderResult(
+					result,
+					{ expanded: true, isPartial: false, displayMode: "concise", intent: "Running hidden remote" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(expanded).toContain("SSH_COMMAND_SECRET");
+		expect(expanded).toContain("SSH_OUTPUT_SECRET");
+	});
+
+	it("keeps eval concise when collapsed and reveals code/output when expanded", () => {
+		const result = {
+			content: [{ type: "text", text: "EVAL_OUTPUT_SECRET" }],
+			details: {
+				language: "python" as const,
+				languages: ["python" as const],
+				cells: [
+					{
+						index: 0,
+						code: "print('EVAL_CODE_SECRET')",
+						language: "python" as const,
+						output: "EVAL_OUTPUT_SECRET",
+						status: "complete" as const,
+						statusEvents: [],
+					},
+				],
+			},
+		};
+		const args = { cells: [{ language: "py" as const, code: "print('EVAL_CODE_SECRET')" }] };
+
+		const collapsed = clean(
+			evalToolRenderer
+				.renderResult(
+					result,
+					{ expanded: false, isPartial: false, displayMode: "concise", intent: "Running hidden cells" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(collapsed).toContain("Eval");
+		expect(collapsed).toContain("Running hidden cells");
+		expect(collapsed).not.toContain("EVAL_CODE_SECRET");
+		expect(collapsed).not.toContain("EVAL_OUTPUT_SECRET");
+
+		const expanded = clean(
+			evalToolRenderer
+				.renderResult(
+					result,
+					{ expanded: true, isPartial: false, displayMode: "concise", intent: "Running hidden cells" },
+					theme,
+					args,
+				)
+				.render(120),
+		);
+
+		expect(expanded).toContain("EVAL_CODE_SECRET");
+		expect(expanded).toContain("EVAL_OUTPUT_SECRET");
+	});
+
+	it("keeps web search concise when collapsed and reveals query/answer/sources when expanded", () => {
+		const response: SearchResponse = {
+			provider: "perplexity",
+			answer: "WEB_ANSWER_SECRET",
+			sources: [
+				{ title: "WEB_SOURCE_TITLE_SECRET", url: "https://example.com/secret", snippet: "hidden snippet" },
+				{ title: "Second hidden source", url: "https://example.com/second", snippet: "second snippet" },
+			],
+		};
+		const details: SearchRenderDetails = { response };
+		const result = { content: [{ type: "text", text: "WEB_ANSWER_SECRET" }], details };
+		const args = { query: "WEB_QUERY_SECRET" };
+
+		const collapsed = clean(
+			renderSearchResult(
+				result,
+				{ expanded: false, isPartial: false, displayMode: "concise", intent: "Searching hidden web" },
+				theme,
+				args,
+			).render(120),
+		);
+
+		expect(collapsed).toContain("Web Search");
+		expect(collapsed).toContain("2 sources");
+		expect(collapsed).toContain("Searching hidden web");
+		expect(collapsed).not.toContain("WEB_QUERY_SECRET");
+		expect(collapsed).not.toContain("WEB_ANSWER_SECRET");
+		expect(collapsed).not.toContain("WEB_SOURCE_TITLE_SECRET");
+
+		const expanded = clean(
+			renderSearchResult(
+				result,
+				{ expanded: true, isPartial: false, displayMode: "concise", intent: "Searching hidden web" },
+				theme,
+				args,
+			).render(120),
+		);
+
+		expect(expanded).toContain("WEB_QUERY_SECRET");
+		expect(expanded).toContain("WEB_ANSWER_SECRET");
+		expect(expanded).toContain("WEB_SOURCE_TITLE_SECRET");
+	});
+});


### PR DESCRIPTION
## What

- Adds opt-in `tools.displayMode: detailed | concise` with default `detailed`.
- Threads concise display mode and normalized intent through built-in, SDK custom, and extension tool renderers.
- Hides collapsed command/code/query/output/image details for generic fallback, bash, ssh, eval, and web_search while preserving full details on expand.

## Why

Fixes #2785. Existing output caps and artifact spill settings reduce volume, but cannot hide command bodies, eval code, web-search answers, source/query details, or rendered result bodies while retaining steerable status information.

## Testing

- [x] `bun test packages/coding-agent/test/settings-manager.test.ts --test-name-pattern "concise tool display"`
- [x] `bun test packages/coding-agent/test/tools/tool-display-mode.test.ts`
- [x] `bun test packages/coding-agent/test/tools/eval-code-preview.test.ts`
- [x] `bun test packages/coding-agent/test/tools/ssh-render.test.ts`
- [x] `bun test packages/coding-agent/test/web/search/render.test.ts`
- [x] `bun test packages/coding-agent/test/tool-execution-args.test.ts`
- [x] `bun --cwd=packages/coding-agent run check`
- [x] `CI=0 bun check` (TS-only branch; local nested `.worktrees/` checkout makes `CI=1` Rust cargo discovery resolve the parent workspace)