### PR TITLE
fix(tui): keep overlay focus above hidden prompts

### DIFF
--- a/packages/coding-agent/src/modes/setup-wizard/wizard-overlay.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/wizard-overlay.ts
@@ -1,4 +1,12 @@
-import { type Component, matchesKey, padding, parseSgrMouse, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	matchesKey,
+	type OverlayFocusOwner,
+	padding,
+	parseSgrMouse,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { gradientLogo, PI_LOGO } from "../components/welcome";
 import { theme } from "../theme/theme";
@@ -53,7 +61,7 @@ function dissolveFrames(from: string[], to: string[], progress: number, height: 
 	return out;
 }
 
-export class SetupWizardComponent implements Component {
+export class SetupWizardComponent implements Component, OverlayFocusOwner {
 	#phase: WizardPhase = "splash";
 	#phaseStartedAt = performance.now();
 	#sceneIndex = 0;
@@ -63,6 +71,7 @@ export class SetupWizardComponent implements Component {
 	#disposed = false;
 	/** Screen row where the active scene's body began in the last rendered frame. */
 	#bodyRowStart = 0;
+	#sceneFocusTarget: Component | undefined;
 
 	constructor(
 		readonly ctx: InteractiveModeContext,
@@ -85,6 +94,11 @@ export class SetupWizardComponent implements Component {
 
 	invalidate(): void {
 		this.#activeScene?.invalidate?.();
+	}
+
+	ownsOverlayFocusTarget(component: Component): boolean {
+		if (this.#sceneFocusTarget !== component) return false;
+		return true;
 	}
 
 	handleInput(data: string): void {
@@ -260,12 +274,19 @@ export class SetupWizardComponent implements Component {
 			ctx: this.ctx,
 			requestRender: () => this.ctx.ui.requestRender(),
 			finish: (_result: SetupSceneResult) => this.#finishScene(),
-			setFocus: component => this.ctx.ui.setFocus(component),
-			restoreFocus: () => this.ctx.ui.setFocus(this),
+			setFocus: component => {
+				this.#sceneFocusTarget = component ?? undefined;
+				this.ctx.ui.setFocus(component);
+			},
+			restoreFocus: () => {
+				this.#sceneFocusTarget = undefined;
+				this.ctx.ui.setFocus(this);
+			},
 		};
 		this.#activeScene = scene.mount(host);
 		this.#phase = targetPhase;
 		this.#phaseStartedAt = performance.now();
+		this.#sceneFocusTarget = undefined;
 		this.ctx.ui.setFocus(this);
 		void this.#activeScene.onMount?.();
 		this.ctx.ui.requestRender();
@@ -288,6 +309,7 @@ export class SetupWizardComponent implements Component {
 	}
 
 	#unmountActiveScene(): void {
+		this.#sceneFocusTarget = undefined;
 		this.#activeScene?.onUnmount?.();
 		this.#activeScene?.dispose?.();
 		this.#activeScene = undefined;

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed fullscreen overlays losing keyboard focus to hidden prompt surfaces, which could make settings unresponsive while a background approval request was pending ([#2789](https://github.com/can1357/oh-my-pi/issues/2789)).
+
 ## [16.0.2] - 2026-06-16
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1171,6 +1171,11 @@ export class TUI extends Container {
 	}
 
 	setFocus(component: Component | null): void {
+		const topVisibleOverlay = this.#getTopmostVisibleOverlay();
+		if (topVisibleOverlay && component !== topVisibleOverlay.component) {
+			component = topVisibleOverlay.component;
+		}
+
 		const previousFocusedComponent = this.#focusedComponent;
 		// Clear focused flag on old component
 		if (isFocusable(previousFocusedComponent)) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -171,6 +171,12 @@ export interface Component {
 	dispose?(): void;
 }
 
+/** Lets an overlay root delegate keyboard focus to components it owns. */
+export interface OverlayFocusOwner {
+	/** Returns true when `component` is a focus target inside this overlay. */
+	ownsOverlayFocusTarget(component: Component): boolean;
+}
+
 /**
  * Component seam for append-only native-scrollback commits. A component that
  * renders a finalized prefix followed by a live/mutating suffix reports the
@@ -219,6 +225,13 @@ export interface NativeScrollbackCommittedRows {
 
 function setNativeScrollbackCommittedRows(component: Component, rows: number): void {
 	(component as Component & Partial<NativeScrollbackCommittedRows>).setNativeScrollbackCommittedRows?.(rows);
+}
+
+function isOverlayFocusTarget(owner: Component, component: Component | null): boolean {
+	if (component === owner) return true;
+	if (!component) return false;
+	const candidate = owner as Component & Partial<OverlayFocusOwner>;
+	return candidate.ownsOverlayFocusTarget?.(component) === true;
 }
 
 function getNativeScrollbackLiveRegionStart(component: Component): number | undefined {
@@ -1172,8 +1185,11 @@ export class TUI extends Container {
 
 	setFocus(component: Component | null): void {
 		const topVisibleOverlay = this.#getTopmostVisibleOverlay();
-		if (topVisibleOverlay && component !== topVisibleOverlay.component) {
-			component = topVisibleOverlay.component;
+		if (topVisibleOverlay && !isOverlayFocusTarget(topVisibleOverlay.component, component)) {
+			const currentFocus = this.#focusedComponent;
+			component = isOverlayFocusTarget(topVisibleOverlay.component, currentFocus)
+				? currentFocus
+				: topVisibleOverlay.component;
 		}
 
 		const previousFocusedComponent = this.#focusedComponent;
@@ -1218,8 +1234,8 @@ export class TUI extends Container {
 				const index = this.overlayStack.indexOf(entry);
 				if (index !== -1) {
 					this.overlayStack.splice(index, 1);
-					// Restore focus if this overlay had focus
-					if (this.#focusedComponent === component) {
+					// Restore focus if this overlay or one of its owned targets had focus
+					if (isOverlayFocusTarget(component, this.#focusedComponent)) {
 						const topVisible = this.#getTopmostVisibleOverlay();
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}
@@ -1235,8 +1251,8 @@ export class TUI extends Container {
 				entry.hidden = hidden;
 				// Update focus when hiding/showing
 				if (hidden) {
-					// If this overlay had focus, move focus to next visible or preFocus
-					if (this.#focusedComponent === component) {
+					// If this overlay or one of its owned targets had focus, move focus to next visible or preFocus
+					if (isOverlayFocusTarget(component, this.#focusedComponent)) {
 						const topVisible = this.#getTopmostVisibleOverlay();
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, type Focusable, TUI } from "@oh-my-pi/pi-tui";
+import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui/terminal";
+
+class MinimalTerminal implements Terminal {
+	columns = 80;
+	rows = 24;
+	kittyProtocolActive = false;
+	kittyEnableSequence: string | null = null;
+	appearance: TerminalAppearance | undefined;
+	#onInput: ((data: string) => void) | undefined;
+	#onResize: (() => void) | undefined;
+	output = "";
+	cursorHidden = false;
+	cursorTransitions = 0;
+
+	start(onInput: (data: string) => void, onResize: () => void): void {
+		this.#onInput = onInput;
+		this.#onResize = onResize;
+	}
+
+	stop(): void {
+		this.#onInput = undefined;
+		this.#onResize = undefined;
+	}
+
+	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
+
+	write(data: string): void {
+		this.output += data;
+		if (data.length === 0) this.output += "";
+	}
+
+	moveBy(_lines: number): void {}
+
+	hideCursor(): void {
+		this.cursorHidden = true;
+		this.cursorTransitions += 1;
+	}
+
+	showCursor(): void {
+		this.cursorHidden = false;
+		this.cursorTransitions += 1;
+	}
+
+	clearLine(): void {}
+
+	clearFromCursor(): void {}
+
+	clearScreen(): void {}
+
+	setTitle(_title: string): void {}
+
+	setProgress(_active: boolean): void {}
+
+	onAppearanceChange(_callback: (appearance: TerminalAppearance) => void): void {}
+
+	sendInput(data: string): void {
+		const onInput = this.#onInput;
+		if (onInput) onInput(data);
+	}
+
+	emitResize(): void {
+		const onResize = this.#onResize;
+		if (onResize) onResize();
+	}
+}
+
+class FocusRecorder implements Component, Focusable {
+	focused = false;
+	inputs: string[] = [];
+	lastInput = "";
+
+	constructor(readonly label: string) {}
+
+	handleInput(data: string): void {
+		this.inputs.push(data);
+		this.lastInput = data;
+	}
+
+	render(_width: number): string[] {
+		const suffix = this.focused ? "-focused" : "";
+		return [`${this.label}${suffix}`];
+	}
+}
+
+describe("TUI overlay focus", () => {
+	it("keeps keyboard focus on the visible overlay when a hidden surface requests focus", () => {
+		const terminal = new MinimalTerminal();
+		const tui = new TUI(terminal);
+		const editor = new FocusRecorder("editor");
+		const settingsOverlay = new FocusRecorder("settings");
+		const approvalPrompt = new FocusRecorder("approval");
+
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			tui.showOverlay(settingsOverlay, { fullscreen: true });
+
+			tui.setFocus(approvalPrompt);
+			terminal.sendInput("x");
+
+			expect(tui.getFocused()).toBe(settingsOverlay);
+			expect(settingsOverlay.inputs).toEqual(["x"]);
+			expect(approvalPrompt.inputs).toEqual([]);
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { type Component, type Focusable, TUI } from "@oh-my-pi/pi-tui";
+import { type Component, type Focusable, type OverlayFocusOwner, TUI } from "@oh-my-pi/pi-tui";
 import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui/terminal";
 
 class MinimalTerminal implements Terminal {
@@ -84,6 +84,15 @@ class FocusRecorder implements Component, Focusable {
 	}
 }
 
+class OwningOverlay extends FocusRecorder implements OverlayFocusOwner {
+	focusTarget: Component | undefined;
+
+	ownsOverlayFocusTarget(component: Component): boolean {
+		if (component !== this.focusTarget) return false;
+		return true;
+	}
+}
+
 describe("TUI overlay focus", () => {
 	it("keeps keyboard focus on the visible overlay when a hidden surface requests focus", () => {
 		const terminal = new MinimalTerminal();
@@ -104,6 +113,40 @@ describe("TUI overlay focus", () => {
 
 			expect(tui.getFocused()).toBe(settingsOverlay);
 			expect(settingsOverlay.inputs).toEqual(["x"]);
+			expect(approvalPrompt.inputs).toEqual([]);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("allows a visible overlay to delegate focus to an owned prompt", () => {
+		const terminal = new MinimalTerminal();
+		const tui = new TUI(terminal);
+		const editor = new FocusRecorder("editor");
+		const wizardOverlay = new OwningOverlay("wizard");
+		const authorizationCodeInput = new FocusRecorder("code");
+		const approvalPrompt = new FocusRecorder("approval");
+
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			tui.showOverlay(wizardOverlay, { fullscreen: true });
+
+			wizardOverlay.focusTarget = authorizationCodeInput;
+			tui.setFocus(authorizationCodeInput);
+			terminal.sendInput("code");
+
+			expect(tui.getFocused()).toBe(authorizationCodeInput);
+			expect(authorizationCodeInput.inputs).toEqual(["code"]);
+			expect(wizardOverlay.inputs).toEqual([]);
+
+			tui.setFocus(approvalPrompt);
+			terminal.sendInput("still-code");
+
+			expect(tui.getFocused()).toBe(authorizationCodeInput);
+			expect(authorizationCodeInput.inputs).toEqual(["code", "still-code"]);
 			expect(approvalPrompt.inputs).toEqual([]);
 		} finally {
 			tui.stop();


### PR DESCRIPTION
## Repro
With tool approval set to `always-ask`, opening `/settings` while the agent is still running can overlap a visible fullscreen settings overlay with a hidden approval prompt. The regression test reproduces the focus handoff with `bun test packages/tui/test/overlay-focus.test.ts`: the hidden approval surface calls `TUI.setFocus(...)`, then the next keypress is delivered to that hidden prompt instead of the visible overlay.

## Cause
`packages/tui/src/tui.ts` allowed any component to become `#focusedComponent` even while `overlayStack` contained a visible overlay. Approval prompts are mounted on the editor surface, not as overlays, so a background prompt could steal focus from `SettingsSelectorComponent` after `/settings` opened it via `TUI.showOverlay(...)`.

## Fix
- Clamp `TUI.setFocus(...)` to the top visible overlay whenever one exists, preserving visible overlay ownership of keyboard input.
- Add `packages/tui/test/overlay-focus.test.ts` to assert that a hidden prompt cannot receive keystrokes while a fullscreen overlay is visible.
- Add a `packages/tui/CHANGELOG.md` entry for the focus deadlock fix.

## Verification
`bun test packages/tui/test/overlay-focus.test.ts packages/tui/test/overlay-scroll.test.ts packages/tui/test/focus-menu-regression.test.ts` passed: 24 tests, 132 assertions. `bun --cwd=packages/tui run check` passed. Fixes #2789