### PR TITLE
fix(sdk): wire hookCapability pre-hooks into extension path discovery

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -40,6 +40,7 @@ import { type AsyncJob, AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
+import { type Hook, hookCapability } from "./capability/hook";
 import { bucketRules } from "./capability/rule-buckets";
 import { createApiKeyResolver } from "./config/api-key-resolver";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
@@ -717,7 +718,13 @@ export async function discoverSessionExtensionPaths(
 	if (options.disableExtensionDiscovery) {
 		return options.additionalExtensionPaths ?? [];
 	}
-	const configuredPaths = [...(options.additionalExtensionPaths ?? []), ...(settings.get("extensions") ?? [])];
+	const discoveredHooks = await loadCapability<Hook>(hookCapability.id, { cwd });
+	const hookPaths = discoveredHooks.items.filter(h => h.type === "pre").map(h => h.path);
+	const configuredPaths = [
+		...(options.additionalExtensionPaths ?? []),
+		...hookPaths,
+		...(settings.get("extensions") ?? []),
+	];
 	const disabledExtensionIds = settings.get("disabledExtensions") ?? [];
 	return discoverExtensionPaths(configuredPaths, cwd, disabledExtensionIds);
 }


### PR DESCRIPTION
## Summary

Fixes #2796.

Files placed in `~/.omp/agent/hooks/pre/` were silently ignored because `discoverSessionExtensionPaths()` only read from `additionalExtensionPaths` (CLI `--hook`/`--extension` flags) and `settings.get('extensions')`. The `hookCapability` registry — populated by the builtin discovery provider scanning `hooks/pre/` — was never consulted.

## Change

In `discoverSessionExtensionPaths()` ([sdk.ts](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/sdk.ts)), load `hookCapability` and prepend the resolved paths of all `pre`-type hooks to `configuredPaths` before passing to `discoverExtensionPaths()`.

`post` hooks are excluded — the extension runner has no post-execution hook phase.

The `disableExtensionDiscovery` early-return is unchanged: `--no-extensions` continues to suppress hook loading.

## Testing

1. Drop a `guard-test.ts` hook factory into `~/.omp/agent/hooks/pre/`
2. Start a fresh session (no `--hook` flag, no `settings.json` entry)
3. Bash tool calls are now intercepted by the hook