### PR TITLE
fix(coding-agent): stream tool downloads to avoid Bun.write(Response) hang

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed transcript scrollback stability on terminals with eager erase risk so completed assistant messages remain stable while new streaming lines are rendering
 - Fixed Hindsight retain (and the shared mnemopi/Hindsight recall paths) framing assistant turns whose only content was punctuation/whitespace — most commonly the lone `.` some providers emit for tool-call-only or thinking-only turns — into `[role: assistant]\n.\n[assistant:end]` blocks that polluted the bank, wasted retain tokens, and degraded recall. `prepareRetentionTranscript`, `extractMessages`, and `flattenMessagesForRecall` now require at least one letter or digit per message via a shared `hasSubstantiveContent` predicate ([#1806](https://github.com/can1357/oh-my-pi/issues/1806)).
 - Fixed `/resume` rendering forked child sessions without a fork tag, making them indistinguishable from their parent when titles match ([#1792](https://github.com/can1357/oh-my-pi/issues/1792)).
+- Fixed on-demand tool downloads (and `read` on YouTube URLs) hanging: stream the download to disk instead of `Bun.write(dest, response)`, which deadlocks on a streaming body in Bun 1.3.14 ([oven-sh/bun#30594](https://github.com/oven-sh/bun/pull/30594)).
 
 ## [16.1.10] - 2026-06-21
 

--- a/packages/coding-agent/src/utils/tools-manager.test.ts
+++ b/packages/coding-agent/src/utils/tools-manager.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { downloadFile } from "./tools-manager";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+// A chunked streaming body. `Bun.write(dest, response)` deadlocks on a body like
+// this (oven-sh/bun#30594) — many small chunks are enough; no timers needed — so
+// this test hangs (and fails on the suite timeout) against the old code and
+// passes against the streamed `pipeline` write.
+function streamingResponse(chunks: number, chunkSize: number): Response {
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (let i = 0; i < chunks; i++) controller.enqueue(new Uint8Array(chunkSize));
+			controller.close();
+		},
+	});
+	return new Response(body, { status: 200 });
+}
+
+test("downloadFile streams a chunked response body to disk without deadlocking", async () => {
+	const chunks = 300;
+	const chunkSize = 64 * 1024;
+	globalThis.fetch = (async () => streamingResponse(chunks, chunkSize)) as unknown as typeof fetch;
+	const dest = path.join(os.tmpdir(), `omp-dl-${process.pid}-${Math.random().toString(36).slice(2)}`);
+	try {
+		await downloadFile("https://example.test/asset", dest);
+		expect(fs.statSync(dest).size).toBe(chunks * chunkSize);
+	} finally {
+		fs.rmSync(dest, { force: true });
+	}
+}, 10_000);

--- a/packages/coding-agent/src/utils/tools-manager.test.ts
+++ b/packages/coding-agent/src/utils/tools-manager.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { downloadFile } from "./tools-manager";
+import { __internalsForTesting } from "./tools-manager";
 
-const realFetch = globalThis.fetch;
+const { downloadFile } = __internalsForTesting;
+
 afterEach(() => {
-	globalThis.fetch = realFetch;
+	vi.restoreAllMocks();
 });
 
 // A chunked streaming body. `Bun.write(dest, response)` deadlocks on a body like
@@ -26,7 +27,7 @@ function streamingResponse(chunks: number, chunkSize: number): Response {
 test("downloadFile streams a chunked response body to disk without deadlocking", async () => {
 	const chunks = 300;
 	const chunkSize = 64 * 1024;
-	globalThis.fetch = (async () => streamingResponse(chunks, chunkSize)) as unknown as typeof fetch;
+	vi.spyOn(globalThis, "fetch").mockResolvedValue(streamingResponse(chunks, chunkSize));
 	const dest = path.join(os.tmpdir(), `omp-dl-${process.pid}-${Math.random().toString(36).slice(2)}`);
 	try {
 		await downloadFile("https://example.test/asset", dest);

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -156,7 +156,7 @@ async function getLatestVersion(repo: string, signal?: AbortSignal): Promise<str
 }
 
 // Download a file from URL
-export async function downloadFile(url: string, dest: string, signal?: AbortSignal): Promise<void> {
+async function downloadFile(url: string, dest: string, signal?: AbortSignal): Promise<void> {
 	let response: Response;
 	try {
 		response = await fetch(url, {
@@ -176,6 +176,13 @@ export async function downloadFile(url: string, dest: string, signal?: AbortSign
 	// Stream to disk — Bun.write(dest, response) deadlocks on a streaming body (oven-sh/bun#30594).
 	await pipeline(response.body, fs.createWriteStream(dest));
 }
+
+/**
+ * Test-only handle for the internal download helper. NOT part of the public
+ * API; exposed so the regression test can drive the streaming write without
+ * re-exporting `downloadFile` through the package's `./utils/*` entry.
+ */
+export const __internalsForTesting = { downloadFile };
 
 // Download and install a tool
 async function downloadTool(tool: ToolName, signal?: AbortSignal): Promise<string> {

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pipeline } from "node:stream/promises";
 import { $which, APP_NAME, getToolsDir, logger, ptree, TempDir } from "@oh-my-pi/pi-utils";
 import { extractArchive } from "./zip";
 
@@ -155,7 +156,7 @@ async function getLatestVersion(repo: string, signal?: AbortSignal): Promise<str
 }
 
 // Download a file from URL
-async function downloadFile(url: string, dest: string, signal?: AbortSignal): Promise<void> {
+export async function downloadFile(url: string, dest: string, signal?: AbortSignal): Promise<void> {
 	let response: Response;
 	try {
 		response = await fetch(url, {
@@ -172,7 +173,8 @@ async function downloadFile(url: string, dest: string, signal?: AbortSignal): Pr
 	} else if (!response.body) {
 		throw new Error("No response body");
 	}
-	await Bun.write(dest, response);
+	// Stream to disk — Bun.write(dest, response) deadlocks on a streaming body (oven-sh/bun#30594).
+	await pipeline(response.body, fs.createWriteStream(dest));
 }
 
 // Download and install a tool


### PR DESCRIPTION
## What

`downloadFile()` in `packages/coding-agent/src/utils/tools-manager.ts` wrote the HTTP response to disk with `await Bun.write(dest, response)`. Handing a **streaming fetch `Response`** to `Bun.write` intermittently deadlocks on Bun 1.3.14, so on-demand tool-binary downloads (`yt-dlp`, `sd`, `sg`, `ffmpeg`) — and therefore `read` on a YouTube URL, which fetches `yt-dlp` via `ensureTool` — hang forever.

Fix (one line): stream `response.body` to `fs.createWriteStream(dest)` via `node:stream/promises` `pipeline` — constant memory, backpressure, and it lets the existing `ptree.combineSignals(signal, TOOL_DOWNLOAD_TIMEOUT_MS)` actually bound the transfer. This matches the existing pattern already used in `cli/update-cli.ts`.

## Why

Fixes #3369.

Known, still-open upstream Bun bug, present on the shipped Bun `1.3.14`: [oven-sh/bun#30594](https://github.com/oven-sh/bun/pull/30594) (and [#13237](https://github.com/oven-sh/bun/issues/13237), [#15796](https://github.com/oven-sh/bun/issues/15796), [#17459](https://github.com/oven-sh/bun/issues/17459)). The documented workaround is to not hand a streaming `Response` to `Bun.write`.

Repro before the fix: `read https://www.youtube.com/shorts/<id>` (any YouTube URL) hangs indefinitely because `ensureTool("yt-dlp") → downloadTool → downloadFile` deadlocks inside `Bun.write`.

## Testing

Built the repo Docker image (`pi-runtime`, Bun 1.3.14) and ran in-container:
- `tsgo --noEmit` (coding-agent): 0 errors; `biome check`: clean.
- E2E against the real GitHub release CDN: patched `pipeline` streaming downloaded **8/8** (36 MB each) and `ensureTool("yt-dlp")` **2/2** (real ~38 MB binary); the old `Bun.write(dest, response)` hung **6/6** in the same runtime.

---

- [x] `bun check` passes (biome + tsgo on the changed package)
- [x] Tested locally (containerized build + e2e)
- [x] CHANGELOG updated

