### PR TITLE
Allow proxied models without auth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,6 +55,8 @@
 - Fixed settings overlay crash when scrolling past the last row in list views
 - Improved tool result formatting by correctly wrapping `<out>` blocks in dim-ink toggles
 - Fixed auto-retry after transient model-stream socket closes to replay text/thinking-only partial assistant output, including turns where incomplete tool-call arguments were dropped; completed tool calls still block retry to avoid duplicating tool execution.
+- Fixed proxied model overrides so providers with an explicit `baseUrl` override remain selectable without stored credentials while bundled provider URLs still require auth.
+
 - Fixed `omp update` reporting `EPERM: operation not permitted, unlink '<binary>.bak'` on Windows when self-replacing a standalone binary, even though the new binary had already been installed. The backed-up old executable is still the running process image and cannot be unlinked until the process exits, so the post-verify backup cleanup is now best-effort, backups use a unique per-attempt name, and stale backups are swept on the next update ([#845](https://github.com/can1357/oh-my-pi/issues/845)).
 - Fixed plan-mode `Refine plan` so the internal approval abort is hidden and the editor is ready for a follow-up prompt instead of showing `Operation aborted` ([#2971](https://github.com/can1357/oh-my-pi/issues/2971)).
 - Fixed TUI prompts beginning with shell-style variables such as `$HOME` being misrouted to Python eval; Python shortcuts now require `$ <code>` or `$$ <code>`. ([#2944](https://github.com/can1357/oh-my-pi/issues/2944))

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -208,6 +208,21 @@ function mergeByModelKey<T extends { provider: string; id: string }>(
 	return merged;
 }
 
+function modelBaseUrlOverrideKey(provider: string, id: string, baseUrl: string): string {
+	return `${provider}\u0000${id}\u0000${baseUrl}`;
+}
+
+function openRouterRoutedBaseModelId(modelId: string): string | undefined {
+	const colonIdx = modelId.lastIndexOf(":");
+	if (colonIdx === -1) return undefined;
+	const suffix = modelId
+		.slice(colonIdx + 1)
+		.trim()
+		.toLowerCase();
+	if (!suffix || suffix === "max") return undefined;
+	return modelId.slice(0, colonIdx);
+}
+
 interface BuiltInDiscoveryResult {
 	models: Model<Api>[];
 	authoritativeProviders: Set<string>;
@@ -241,6 +256,7 @@ interface CustomModelsResult {
 	models?: CustomModelOverlay[];
 	overrides?: Map<string, ProviderOverride>;
 	modelOverrides?: Map<string, Map<string, ModelOverride>>;
+	modelBaseUrlOverrides?: Set<string>;
 	keylessProviders?: Set<string>;
 	discoverableProviders?: DiscoveryProviderConfig[];
 	configuredProviders?: Set<string>;
@@ -632,6 +648,8 @@ export class ModelRegistry {
 	#canonicalIndexDirty: boolean = true;
 	#customProviderApiKeys: Map<string, string> = new Map();
 	#keylessProviders: Set<string> = new Set();
+	#baseUrlOverrideProviderUrls: Map<string, string> = new Map();
+	#modelBaseUrlOverrideKeys: Set<string> = new Set();
 	#discoverableProviders: DiscoveryProviderConfig[] = [];
 	#customModelOverlays: CustomModelOverlay[] = [];
 	#providerOverrides: Map<string, ProviderOverride> = new Map();
@@ -790,7 +808,8 @@ export class ModelRegistry {
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
 		this.#keylessProviders.clear();
-		this.#discoverableProviders = [];
+		this.#baseUrlOverrideProviderUrls.clear();
+		this.#modelBaseUrlOverrideKeys.clear();
 		// Drop config-sourced apiKeys from AuthStorage before reload; entries
 		// removed from models.yml must actually disappear from the resolver, not
 		// linger from the previous parse. The post-load setters below repopulate.
@@ -822,6 +841,7 @@ export class ModelRegistry {
 			overrides = new Map(),
 			modelOverrides = new Map(),
 			keylessProviders = new Set(),
+			modelBaseUrlOverrides = new Set(),
 			discoverableProviders = [],
 			configuredProviders = new Set(),
 			equivalence,
@@ -829,6 +849,12 @@ export class ModelRegistry {
 		} = this.#loadCustomModels();
 		this.#configError = configError;
 		this.#keylessProviders = keylessProviders;
+		this.#baseUrlOverrideProviderUrls = new Map(
+			[...overrides].flatMap(([provider, override]) =>
+				override.baseUrl === undefined ? [] : [[provider, override.baseUrl]],
+			),
+		);
+		this.#modelBaseUrlOverrideKeys = modelBaseUrlOverrides;
 		this.#discoverableProviders = discoverableProviders;
 		this.#customModelOverlays = customModels;
 		this.#providerOverrides = overrides;
@@ -1093,6 +1119,7 @@ export class ModelRegistry {
 				models: [],
 				overrides: new Map(),
 				modelOverrides: new Map(),
+				modelBaseUrlOverrides: new Set(),
 				keylessProviders: new Set(),
 				discoverableProviders: [],
 				configuredProviders: new Set(),
@@ -1104,6 +1131,7 @@ export class ModelRegistry {
 				models: [],
 				overrides: new Map(),
 				modelOverrides: new Map(),
+				modelBaseUrlOverrides: new Set(),
 				keylessProviders: new Set(),
 				discoverableProviders: [],
 				configuredProviders: new Set(),
@@ -1183,8 +1211,10 @@ export class ModelRegistry {
 			}
 		}
 
+		const parsedModels = this.#parseModels(value);
 		return {
-			models: this.#parseModels(value),
+			models: parsedModels.models,
+			modelBaseUrlOverrides: parsedModels.modelBaseUrlOverrides,
 			overrides,
 			modelOverrides: allModelOverrides,
 			keylessProviders,
@@ -1621,8 +1651,9 @@ export class ModelRegistry {
 		}
 	}
 
-	#parseModels(config: ModelsConfig): CustomModelOverlay[] {
+	#parseModels(config: ModelsConfig): { models: CustomModelOverlay[]; modelBaseUrlOverrides: Set<string> } {
 		const models: CustomModelOverlay[] = [];
+		const modelBaseUrlOverrides = new Set<string>();
 
 		for (const [providerName, providerConfig] of Object.entries(config.providers ?? {})) {
 			const modelDefs = providerConfig.models ?? [];
@@ -1648,9 +1679,12 @@ export class ModelRegistry {
 				);
 				if (!model) continue;
 				models.push(model);
+				if (modelDef.baseUrl !== undefined) {
+					modelBaseUrlOverrides.add(modelBaseUrlOverrideKey(providerName, modelDef.id, model.baseUrl));
+				}
 			}
 		}
-		return models;
+		return { models, modelBaseUrlOverrides };
 	}
 
 	/**
@@ -1671,14 +1705,14 @@ export class ModelRegistry {
 		const disabledProviders = getDisabledProviderIdsFromSettings();
 		const byProvider = new Map<string, boolean>();
 		return model => {
+			if (disabledProviders.has(model.provider)) return false;
 			let available = byProvider.get(model.provider);
 			if (available === undefined) {
-				available =
-					!disabledProviders.has(model.provider) &&
-					(this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider));
+				available = this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider);
 				byProvider.set(model.provider, available);
 			}
-			return available;
+			if (available) return true;
+			return this.#hasNoAuthBaseUrlForModel(model);
 		};
 	}
 
@@ -1819,6 +1853,7 @@ export class ModelRegistry {
 		const keyConfig = this.#customProviderApiKeys.get(model.provider);
 		return (
 			isCommandConfigValue(keyConfig) ||
+			this.#hasNoAuthBaseUrlForModel(model) ||
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasAuth(model.provider)
 		);
@@ -1849,16 +1884,49 @@ export class ModelRegistry {
 		return this.#models.find(m => m.provider === provider && m.baseUrl)?.baseUrl;
 	}
 
+	#hasNoAuthBaseUrlForModel(model: ApiKeyResolverModel): boolean {
+		if (model.baseUrl === undefined) return false;
+		const runtimeBaseUrl = this.#runtimeProviderOverrides.get(model.provider)?.baseUrl;
+		if (runtimeBaseUrl !== undefined && model.baseUrl === runtimeBaseUrl) return true;
+		const providerBaseUrl = this.#baseUrlOverrideProviderUrls.get(model.provider);
+		if (providerBaseUrl !== undefined && model.baseUrl === providerBaseUrl) return true;
+		if (this.#modelBaseUrlOverrideKeys.has(modelBaseUrlOverrideKey(model.provider, model.id, model.baseUrl))) {
+			return true;
+		}
+		if (model.provider !== "openrouter") return false;
+		const baseId = openRouterRoutedBaseModelId(model.id);
+		return (
+			baseId !== undefined &&
+			this.#modelBaseUrlOverrideKeys.has(modelBaseUrlOverrideKey(model.provider, baseId, model.baseUrl))
+		);
+	}
+
 	/**
 	 * Get API key for a model.
 	 */
-	async getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined> {
+	async #getApiKeyForModel(
+		model: ApiKeyResolverModel,
+		sessionId?: string,
+		options?: { forceRefresh?: boolean; signal?: AbortSignal },
+	): Promise<string | undefined> {
 		const commandKey = this.#resolveCommandBackedApiKey(model.provider);
 		if (commandKey.configured) return commandKey.value;
-		if (this.#keylessProviders.has(model.provider) && !this.authStorage.hasAuth(model.provider)) {
+		if (
+			(this.#hasNoAuthBaseUrlForModel(model) || this.#keylessProviders.has(model.provider)) &&
+			!this.authStorage.hasAuth(model.provider)
+		) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(model.provider, sessionId, { baseUrl: model.baseUrl, modelId: model.id });
+		return this.authStorage.getApiKey(model.provider, sessionId, {
+			baseUrl: model.baseUrl,
+			modelId: model.id,
+			forceRefresh: options?.forceRefresh,
+			signal: options?.signal,
+		});
+	}
+
+	async getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined> {
+		return this.#getApiKeyForModel(model, sessionId);
 	}
 
 	/**
@@ -1875,6 +1943,9 @@ export class ModelRegistry {
 	): Promise<string | undefined> {
 		const commandKey = this.#resolveCommandBackedApiKey(provider);
 		if (commandKey.configured) return commandKey.value;
+		// Provider-wide probes feed hosted-provider fallbacks; only explicit
+		// auth: none providers get the sentinel here. BaseUrl-only proxies are
+		// model-scoped and must not look like hosted credentials.
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
@@ -1900,11 +1971,19 @@ export class ModelRegistry {
 		if (typeof target === "string") {
 			return createApiKeyResolver(this, target, options);
 		}
-		return createApiKeyResolver(this, target.provider, {
-			...options,
-			baseUrl: target.baseUrl,
-			modelId: target.id,
-		});
+		return async ({ lastChance, error, signal }) => {
+			if (error !== undefined && lastChance) {
+				await this.authStorage.rotateSessionCredential(target.provider, options?.sessionId, {
+					error,
+					modelId: target.id,
+					signal,
+				});
+			}
+			return this.#getApiKeyForModel(target, options?.sessionId, {
+				forceRefresh: error !== undefined && !lastChance ? true : undefined,
+				signal,
+			});
+		};
 	}
 
 	async #peekApiKeyForProvider(provider: string): Promise<string | undefined> {

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -16,6 +16,7 @@ export type ProviderValidationMode = "models-config" | "runtime-register";
 export interface ProviderValidationModel {
 	id: string;
 	api?: Api;
+	baseUrl?: string;
 	contextWindow?: number;
 	supportsTools?: boolean;
 	maxTokens?: number;
@@ -62,13 +63,15 @@ export function validateProviderConfiguration(
 			}
 		}
 	} else {
-		if (!config.baseUrl) {
+		const allModelsHaveBaseUrl = mode === "models-config" && models.every(modelDef => modelDef.baseUrl !== undefined);
+		const hasBaseUrlOnlyProxy = mode === "models-config" && (config.baseUrl !== undefined || allModelsHaveBaseUrl);
+		if (!config.baseUrl && !allModelsHaveBaseUrl) {
 			throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
 		}
 		const requiresAuth =
 			mode === "runtime-register"
 				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && (config.auth ?? "apiKey") !== "none";
+				: !config.apiKey && (config.auth ?? "apiKey") !== "none" && !hasBaseUrlOnlyProxy;
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6896,19 +6896,10 @@ export class AgentSession {
 	}
 
 	async #getScopedModelsWithApiKey(): Promise<Array<{ model: Model; thinkingLevel?: ThinkingLevel }>> {
-		const apiKeysByProvider = new Map<string, string | undefined>();
 		const result: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> = [];
 
 		for (const scoped of this.#scopedModels) {
-			const provider = scoped.model.provider;
-			let apiKey: string | undefined;
-			if (apiKeysByProvider.has(provider)) {
-				apiKey = apiKeysByProvider.get(provider);
-			} else {
-				apiKey = await this.#modelRegistry.getApiKeyForProvider(provider, this.sessionId);
-				apiKeysByProvider.set(provider, apiKey);
-			}
-
+			const apiKey = await this.#modelRegistry.getApiKey(scoped.model, this.sessionId);
 			if (apiKey) {
 				result.push(scoped);
 			}

--- a/packages/coding-agent/test/agent-session-model-switch-auth.test.ts
+++ b/packages/coding-agent/test/agent-session-model-switch-auth.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
@@ -49,7 +50,14 @@ describe("AgentSession model switch auth pre-flight", () => {
 		return model;
 	}
 
-	function makeSession(initialModel: Model<Api>, roles?: Record<string, string>): AgentSession {
+	function makeSession(
+		initialModel: Model<Api>,
+		roles?: Record<string, string>,
+		options?: {
+			modelRegistry?: ModelRegistry;
+			scopedModels?: Array<{ model: Model<Api>; thinkingLevel?: undefined }>;
+		},
+	): AgentSession {
 		const settings = Settings.isolated();
 		if (roles) {
 			for (const role in roles) settings.setModelRole(role, roles[role]);
@@ -67,7 +75,8 @@ describe("AgentSession model switch auth pre-flight", () => {
 			agent,
 			sessionManager: SessionManager.inMemory(),
 			settings,
-			modelRegistry: registry,
+			modelRegistry: options?.modelRegistry ?? registry,
+			scopedModels: options?.scopedModels,
 		});
 		return session;
 	}
@@ -119,6 +128,59 @@ describe("AgentSession model switch auth pre-flight", () => {
 
 		expect(s.model?.id).toBe(to.id);
 		expect(getApiKeySpy).not.toHaveBeenCalled();
+	});
+
+	it("cycles scoped baseUrl-only proxy models with model-scoped auth", async () => {
+		const localDir = TempDir.createSync("@pi-scoped-model-proxy-");
+		const localAuthStorage = await AuthStorage.create(path.join(localDir.path(), "auth.db"));
+		try {
+			const modelsYmlPath = path.join(localDir.path(), "models.yml");
+			fs.writeFileSync(
+				modelsYmlPath,
+				`providers:
+  scoped-proxy:
+    baseUrl: https://scoped-proxy.example.com/v1
+    api: openai-completions
+    models:
+      - id: proxied-one
+        reasoning: false
+        input: [text]
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+        contextWindow: 128000
+        maxTokens: 16384
+      - id: proxied-two
+        reasoning: false
+        input: [text]
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+        contextWindow: 128000
+        maxTokens: 16384
+`,
+			);
+			const localRegistry = new ModelRegistry(localAuthStorage, modelsYmlPath);
+			const first = localRegistry.find("scoped-proxy", "proxied-one");
+			const second = localRegistry.find("scoped-proxy", "proxied-two");
+			if (!first || !second) throw new Error("Expected scoped proxy models");
+			const s = makeSession(first, undefined, {
+				modelRegistry: localRegistry,
+				scopedModels: [{ model: first }, { model: second }],
+			});
+
+			const result = await s.cycleModel();
+
+			expect(result?.model.id).toBe("proxied-two");
+			expect(s.model?.id).toBe("proxied-two");
+		} finally {
+			localAuthStorage.close();
+			localDir.removeSync();
+		}
 	});
 
 	it("rejects the switch synchronously when no credential is configured, without calling the resolver", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -3,10 +3,17 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
+import {
+	Effort,
+	type FetchImpl,
+	type Model,
+	type OpenAICompat,
+	resolveApiKeyOnce,
+	type ThinkingConfig,
+} from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
-import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { isAuthenticated, kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { Snowflake } from "@oh-my-pi/pi-utils";
@@ -540,6 +547,175 @@ describe("ModelRegistry", () => {
 			// Should have multiple built-in models, not just one
 			expect(anthropicModels.length).toBeGreaterThan(1);
 			expect(anthropicModels.some(m => m.id.includes("claude"))).toBe(true);
+		});
+
+		test("baseUrl override makes provider models available without hosted provider auth", async () => {
+			writeRawModelsJson({
+				anthropic: overrideConfig("https://my-proxy.example.com/v1"),
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const availableAnthropic = registry.getAvailable().filter(m => m.provider === "anthropic");
+
+			expect(availableAnthropic.length).toBeGreaterThan(0);
+			expect(availableAnthropic.every(m => m.baseUrl === "https://my-proxy.example.com/v1")).toBe(true);
+			await expect(registry.getApiKey(availableAnthropic[0])).resolves.toBe(kNoAuth);
+			const providerKey = await registry.getApiKeyForProvider("anthropic");
+			expect(providerKey).toBeUndefined();
+			expect(isAuthenticated(providerKey)).toBe(false);
+			await expect(
+				registry.getApiKeyForProvider("anthropic", undefined, {
+					baseUrl: availableAnthropic[0].baseUrl,
+					modelId: availableAnthropic[0].id,
+				}),
+			).resolves.toBeUndefined();
+			await expect(resolveApiKeyOnce(registry.resolver(availableAnthropic[0]))).resolves.toBe(kNoAuth);
+			await expect(resolveApiKeyOnce(registry.resolver("anthropic"))).resolves.toBeUndefined();
+		});
+
+		test("provider-level baseUrl-only custom models are available without provider auth", async () => {
+			const modelsYmlPath = path.join(tempDir, "models.yml");
+			fs.writeFileSync(
+				modelsYmlPath,
+				`providers:
+  provider-proxy:
+    baseUrl: https://provider-proxy.example.com/v1
+    api: openai-completions
+    models:
+      - id: proxied-model
+        reasoning: false
+        input: [text]
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+        contextWindow: 128000
+        maxTokens: 16384
+`,
+			);
+
+			const registry = new ModelRegistry(authStorage, modelsYmlPath);
+			const proxied = registry.find("provider-proxy", "proxied-model");
+
+			expect(registry.getError()).toBeUndefined();
+			expect(proxied?.baseUrl).toBe("https://provider-proxy.example.com/v1");
+			if (!proxied) throw new Error("Expected provider-level proxy model to load");
+			expect(registry.getAvailable()).toContain(proxied);
+			expect(registry.hasConfiguredAuth(proxied)).toBe(true);
+			await expect(registry.getApiKey(proxied)).resolves.toBe(kNoAuth);
+			const providerKey = await registry.getApiKeyForProvider("provider-proxy");
+			expect(providerKey).toBeUndefined();
+			expect(isAuthenticated(providerKey)).toBe(false);
+			await expect(
+				registry.getApiKeyForProvider("provider-proxy", undefined, {
+					baseUrl: proxied.baseUrl,
+					modelId: proxied.id,
+				}),
+			).resolves.toBeUndefined();
+			await expect(resolveApiKeyOnce(registry.resolver(proxied))).resolves.toBe(kNoAuth);
+			await expect(resolveApiKeyOnce(registry.resolver("provider-proxy"))).resolves.toBeUndefined();
+		});
+
+		test("model-level baseUrl-only models are available without provider auth", async () => {
+			writeRawModelsJson({
+				"model-proxy": {
+					api: "openai-completions",
+					models: [
+						{
+							id: "proxied-model",
+							baseUrl: "https://model-proxy.example.com/v1",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 16384,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const proxied = registry.find("model-proxy", "proxied-model");
+
+			expect(proxied?.baseUrl).toBe("https://model-proxy.example.com/v1");
+			if (!proxied) throw new Error("Expected model-level proxy model to load");
+			expect(registry.getAvailable()).toContain(proxied);
+			expect(registry.hasConfiguredAuth(proxied)).toBe(true);
+			await expect(registry.getApiKey(proxied)).resolves.toBe(kNoAuth);
+			const providerKey = await registry.getApiKeyForProvider("model-proxy");
+			expect(providerKey).toBeUndefined();
+			expect(isAuthenticated(providerKey)).toBe(false);
+			await expect(
+				registry.getApiKeyForProvider("model-proxy", undefined, {
+					baseUrl: proxied.baseUrl,
+					modelId: proxied.id,
+				}),
+			).resolves.toBeUndefined();
+			await expect(resolveApiKeyOnce(registry.resolver(proxied))).resolves.toBe(kNoAuth);
+			await expect(resolveApiKeyOnce(registry.resolver("model-proxy"))).resolves.toBeUndefined();
+		});
+
+		test("model-level baseUrl-only OpenRouter models keep no-auth for routed suffixes", async () => {
+			writeRawModelsJson({
+				openrouter: {
+					api: "openai-completions",
+					models: [
+						{
+							id: "z-ai/glm-4.7",
+							baseUrl: "https://openrouter-proxy.example.com/v1",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 16384,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const routed = registry.find("openrouter", "z-ai/glm-4.7:nitro");
+
+			expect(routed?.baseUrl).toBe("https://openrouter-proxy.example.com/v1");
+			if (!routed) throw new Error("Expected routed OpenRouter proxy model to resolve");
+			expect(registry.hasConfiguredAuth(routed)).toBe(true);
+			await expect(registry.getApiKey(routed)).resolves.toBe(kNoAuth);
+		});
+
+		test("auth none provider-level probes keep no-auth sentinel", async () => {
+			writeRawModelsJson({
+				"auth-none-proxy": {
+					baseUrl: "https://auth-none-proxy.example.com/v1",
+					api: "openai-completions",
+					auth: "none",
+					models: [
+						{
+							id: "proxied-model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 16384,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const proxied = registry.find("auth-none-proxy", "proxied-model");
+
+			expect(proxied).toBeDefined();
+			if (!proxied) throw new Error("Expected auth:none proxy model to load");
+			await expect(registry.getApiKey(proxied)).resolves.toBe(kNoAuth);
+			await expect(registry.getApiKeyForProvider("auth-none-proxy")).resolves.toBe(kNoAuth);
+			await expect(resolveApiKeyOnce(registry.resolver("auth-none-proxy"))).resolves.toBe(kNoAuth);
+		});
+
+		test("bundled provider baseUrl does not make models available without auth", () => {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+			expect(registry.getAvailable().some(m => m.provider === "aimlapi")).toBe(false);
 		});
 
 		test("overriding baseUrl changes URL on all built-in models", () => {
@@ -1577,6 +1753,7 @@ describe("ModelRegistry", () => {
 	describe("disabled provider filtering", () => {
 		test("getAvailable and getDiscoverableProviders exclude disabled providers from settings", async () => {
 			writeRawModelsJson({
+				anthropic: overrideConfig("https://my-proxy.example.com/v1"),
 				ollama: {
 					baseUrl: "http://127.0.0.1:11434/v1",
 					api: "openai-completions",
@@ -1595,14 +1772,16 @@ describe("ModelRegistry", () => {
 			await Settings.init({
 				inMemory: true,
 				overrides: {
-					disabledProviders: ["github-copilot", "ollama"],
+					disabledProviders: ["github-copilot", "ollama", "anthropic"],
 				},
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
 
 			expect(registry.getAvailable().some(model => model.provider === "github-copilot")).toBe(false);
+			expect(registry.getAvailable().some(model => model.provider === "anthropic")).toBe(false);
 			expect(registry.getDiscoverableProviders()).not.toContain("ollama");
+			expect(registry.getAvailable().some(model => model.provider === "ollama")).toBe(false);
 		});
 
 		test("refresh skips discovery probes for disabled local providers", async () => {


### PR DESCRIPTION
## Summary
- Treat provider/model entries with an explicit baseUrl as available without stored auth, while still honoring disabled providers.
- Add a regression test for baseUrl-only provider overrides appearing in getAvailable without auth.

## Verification
- bun test packages/coding-agent/test/model-registry.test.ts
- bunx biome check packages/coding-agent/src/config/model-registry.ts packages/coding-agent/test/model-registry.test.ts