### PR TITLE
fix(coding-agent): expand local auto-thinking classifier budget

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local auto-thinking classification for reasoning-capable tiny models by giving them the same safe answer budget as online reasoning classifiers, with a larger local floor for non-reasoning tiny models ([#2808](https://github.com/can1357/oh-my-pi/issues/2808)).
+
 ## [16.0.2] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -22,7 +22,11 @@ import type { Settings } from "../config/settings";
 import difficultySystemPrompt from "../prompts/system/auto-thinking-difficulty.md" with { type: "text" };
 import difficultyLocalPrompt from "../prompts/system/auto-thinking-difficulty-local.md" with { type: "text" };
 import { clampAutoThinkingEffort } from "../thinking";
-import { isTinyMemoryLocalModelKey, ONLINE_AUTO_THINKING_MODEL_KEY } from "../tiny/models";
+import {
+	isTinyMemoryLocalModelKey,
+	isTinyMemoryReasoningModelKey,
+	ONLINE_AUTO_THINKING_MODEL_KEY,
+} from "../tiny/models";
 import { tinyModelClient } from "../tiny/title-client";
 
 const DIFFICULTY_SYSTEM_PROMPT = prompt.render(difficultySystemPrompt);
@@ -31,8 +35,10 @@ const DIFFICULTY_SYSTEM_PROMPT = prompt.render(difficultySystemPrompt);
 const MAX_INPUT_CHARS = 6000;
 const HEAD_CHARS = 4000;
 const TAIL_CHARS = 2000;
-/** The answer is a single word; keep budgets tiny for non-reasoning backends. */
+/** The online answer is a single word; keep budgets tiny for non-reasoning backends. */
 const ANSWER_MAX_TOKENS = 8;
+/** Local classifiers occasionally need more room for chat-template boilerplate. */
+const LOCAL_ANSWER_MAX_TOKENS = 16;
 /**
  * Reasoning backends ignore `disableReasoning` on some providers, so reserve
  * enough output room for the keyword to still land after unavoidable thinking.
@@ -107,9 +113,12 @@ async function classifyLocal(input: string, modelKey: string, deps: ClassifyDiff
 	if (!isTinyMemoryLocalModelKey(modelKey)) {
 		throw new Error(`auto-thinking: unsupported local classifier model: ${modelKey}`);
 	}
+	const maxTokens = isTinyMemoryReasoningModelKey(modelKey)
+		? Math.max(LOCAL_ANSWER_MAX_TOKENS, REASONING_SAFE_MAX_TOKENS)
+		: LOCAL_ANSWER_MAX_TOKENS;
 	const builtPrompt = prompt.render(difficultyLocalPrompt, { prompt: input });
 	const text = await tinyModelClient.complete(modelKey, builtPrompt, {
-		maxTokens: ANSWER_MAX_TOKENS,
+		maxTokens,
 		signal: deps.signal,
 	});
 	if (!text) {

--- a/packages/coding-agent/src/tiny/models.ts
+++ b/packages/coding-agent/src/tiny/models.ts
@@ -10,6 +10,8 @@ export interface TinyTitleLocalModelSpec {
 	label: string;
 	description: string;
 	contextNote: string;
+	/** Model family emits hidden reasoning unless the chat template disables it. */
+	reasoning?: boolean;
 }
 
 export const TINY_TITLE_LOCAL_MODELS = [
@@ -28,6 +30,7 @@ export const TINY_TITLE_LOCAL_MODELS = [
 		label: "Qwen3 0.6B",
 		description: "Most robust local option; slower first load, about 500 MB cached.",
 		contextNote: "Use when title quality matters more than local startup cost.",
+		reasoning: true,
 	},
 	{
 		key: "gemma-270m",
@@ -122,6 +125,7 @@ export const TINY_MEMORY_LOCAL_MODELS = [
 		description:
 			"Recommended; most disciplined extraction (ignores chit-chat), good consolidation, about 1.1 GB cached.",
 		contextNote: "Best single-model pick for memory from the local experiment.",
+		reasoning: true,
 	},
 	{
 		key: "gemma-3-1b",
@@ -194,6 +198,12 @@ export function getTinyMemoryModelSpec(key: TinyMemoryLocalModelKey): (typeof TI
 	const spec = TINY_MEMORY_LOCAL_MODELS.find(model => model.key === key);
 	if (!spec) throw new Error(`Unknown tiny memory model: ${key}`);
 	return spec;
+}
+
+/** Return whether a memory local model may emit reasoning tokens before answers. */
+export function isTinyMemoryReasoningModelKey(key: TinyMemoryLocalModelKey): boolean {
+	const spec = getTinyMemoryModelSpec(key);
+	return "reasoning" in spec && spec.reasoning === true;
 }
 
 /** Any local model key (title or memory), used by the shared inference worker. */

--- a/packages/coding-agent/src/tiny/worker.ts
+++ b/packages/coding-agent/src/tiny/worker.ts
@@ -31,7 +31,8 @@ const TITLE_PREFILL = "<title>";
 const TITLE_CLOSE = "</title>";
 const TITLE_MAX_NEW_TOKENS = 20;
 const STOP_DECODE_WINDOW_TOKENS = 32;
-const MEMORY_COMPLETION_MAX_NEW_TOKENS = 256;
+const MEMORY_COMPLETION_DEFAULT_MAX_NEW_TOKENS = 256;
+const COMPLETION_MAX_NEW_TOKENS = 1024;
 const TINY_TITLE_SYSTEM_PROMPT = prompt.render(tinyTitleSystemPrompt);
 const TRANSFORMERS_PACKAGE = "@huggingface/transformers";
 const COMPILED_TRANSFORMERS_VERSION = process.env.PI_TINY_TRANSFORMERS_VERSION;
@@ -426,8 +427,8 @@ async function generateCompletion(
 ): Promise<string | null> {
 	const generator = await loadPipeline(modelKey, transport, requestId);
 	const text = buildCompletionPrompt(generator, promptText);
-	const requested = maxTokens ?? MEMORY_COMPLETION_MAX_NEW_TOKENS;
-	const maxNewTokens = Math.min(Math.max(1, requested), MEMORY_COMPLETION_MAX_NEW_TOKENS);
+	const requested = maxTokens ?? MEMORY_COMPLETION_DEFAULT_MAX_NEW_TOKENS;
+	const maxNewTokens = Math.min(Math.max(1, requested), COMPLETION_MAX_NEW_TOKENS);
 	const output = (await generator(text, {
 		max_new_tokens: maxNewTokens,
 		do_sample: false,

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -1,16 +1,61 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { Effort } from "@oh-my-pi/pi-ai";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { parseDifficultyBucket, parseDifficultyLevel } from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
+import {
+	classifyDifficulty,
+	parseDifficultyBucket,
+	parseDifficultyLevel,
+} from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
 	AUTO_THINKING,
 	clampAutoThinkingEffort,
 	parseConfiguredThinkingLevel,
 	parseThinkingLevel,
 } from "@oh-my-pi/pi-coding-agent/thinking";
+import type { TinyMemoryLocalModelKey } from "@oh-my-pi/pi-coding-agent/tiny/models";
+import { tinyModelClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("auto thinking classifier helpers", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	interface LocalClassifierFixture {
+		settings: Settings;
+		registry: ModelRegistry;
+		model: Model;
+		cleanup: () => void;
+	}
+
+	async function createLocalClassifierFixture(
+		autoThinkingModel: TinyMemoryLocalModelKey,
+	): Promise<LocalClassifierFixture> {
+		const tempDir = TempDir.createSync("@pi-auto-thinking-classifier-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const model = getBundledModel("anthropic", "claude-sonnet-4-6");
+		if (!model) {
+			authStorage.close();
+			tempDir.removeSync();
+			throw new Error("Expected bundled Claude Sonnet 4.6 model");
+		}
+
+		return {
+			settings: Settings.isolated({ "providers.autoThinkingModel": autoThinkingModel }),
+			registry: new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml")),
+			model,
+			cleanup: () => {
+				authStorage.close();
+				tempDir.removeSync();
+			},
+		};
+	}
+
 	it("parses configured thinking without widening provider-facing thinking selectors", () => {
 		expect(parseConfiguredThinkingLevel(AUTO_THINKING)).toBe(AUTO_THINKING);
 		expect(parseConfiguredThinkingLevel(Effort.High)).toBe(Effort.High);
@@ -32,6 +77,50 @@ describe("auto thinking classifier helpers", () => {
 		expect(parseDifficultyBucket("moderate")).toBe(Effort.High);
 		expect(parseDifficultyBucket("hard")).toBe(Effort.XHigh);
 		expect(parseDifficultyBucket("medium")).toBeUndefined();
+	});
+
+	it("expands the local reasoning classifier budget", async () => {
+		let maxTokens: number | undefined;
+		const fixture = await createLocalClassifierFixture("qwen3-1.7b");
+		vi.spyOn(tinyModelClient, "complete").mockImplementation(async (_modelKey, _prompt, options) => {
+			maxTokens = options?.maxTokens;
+			return "moderate";
+		});
+
+		try {
+			const effort = await classifyDifficulty("fix the local classifier token budget", {
+				settings: fixture.settings,
+				registry: fixture.registry,
+				model: fixture.model,
+			});
+
+			expect(effort).toBe(Effort.High);
+			expect(maxTokens).toBe(1024);
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	it("uses a larger local non-reasoning classifier floor", async () => {
+		let maxTokens: number | undefined;
+		const fixture = await createLocalClassifierFixture("qwen2.5-1.5b");
+		vi.spyOn(tinyModelClient, "complete").mockImplementation(async (_modelKey, _prompt, options) => {
+			maxTokens = options?.maxTokens;
+			return "moderate";
+		});
+
+		try {
+			const effort = await classifyDifficulty("rename a local helper", {
+				settings: fixture.settings,
+				registry: fixture.registry,
+				model: fixture.model,
+			});
+
+			expect(effort).toBe(Effort.High);
+			expect(maxTokens).toBe(16);
+		} finally {
+			fixture.cleanup();
+		}
 	});
 
 	it("clamps auto effort to model support while never resolving below low", () => {


### PR DESCRIPTION
## Repro
`providers.autoThinkingModel=qwen3-1.7b` on the local auto-thinking path called `tinyModelClient.complete()` with `maxTokens: 8`; a focused repro stubbed the tiny client to return no text at that budget and reproduced `auto-thinking: local classification returned no output`.

## Cause
`packages/coding-agent/src/auto-thinking/classifier.ts` mirrored the online classifier parser but not its reasoning-safe output budget: `classifyOnline()` expands reasoning models to `REASONING_SAFE_MAX_TOKENS`, while `classifyLocal()` always passed `ANSWER_MAX_TOKENS`. The tiny worker also clamped all explicit completion requests to the memory default cap, so larger local classifier budgets could not pass through.

## Fix
- Mark Qwen3 tiny models as reasoning-capable in `packages/coding-agent/src/tiny/models.ts`.
- Give local auto-thinking classifiers a 16-token non-reasoning floor and a 1024-token reasoning-safe budget.
- Raise the tiny completion explicit-request cap so classifier calls can use the reasoning-safe budget without changing the default memory completion budget.
- Add regression tests for `qwen3-1.7b` and `qwen2.5-1.5b` local classifier budgets.

## Verification
`bun test packages/coding-agent/test/auto-thinking-classifier.test.ts` passed with 6 tests; `bun run check` passed in `packages/coding-agent`; the repro script now reports `captured maxTokens=1024` and `effort=high`. Fixes #2808