### PR TITLE
fix(minimax): add MiniMax tool-call dialect

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Changed `AgentOptions.getApiKey` and `AgentLoopConfig.getApiKey` to receive the active `Model` and return an API key or `ApiKeyResolver`, so credential routing stays model-scoped and retry context is no longer exposed through the agent-core API
 
+### Fixed
+
+- Fixed `PI_DIALECT=minimax` being ignored by the owned tool-calling env selector. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
+
 ## [16.0.1] - 2026-06-15
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -113,6 +113,7 @@ function resolveOwnedDialectFromEnv(value: string | undefined): Dialect | undefi
 		case "qwen3":
 		case "gemini":
 		case "gemma":
+		case "minimax":
 			return value;
 		default:
 			return undefined;

--- a/packages/agent/test/prompt-tools-loop.test.ts
+++ b/packages/agent/test/prompt-tools-loop.test.ts
@@ -146,9 +146,9 @@ describe("agentLoop with owned in-band tool calls", () => {
 		expect(resultsText).toContain("echoed:hi");
 	});
 
-	it("uses PI_DIALECT when config.dialect is unset", async () => {
+	it("uses PI_DIALECT=minimax when config.dialect is unset", async () => {
 		const before = Bun.env.PI_DIALECT;
-		Bun.env.PI_DIALECT = "hermes";
+		Bun.env.PI_DIALECT = "minimax";
 		try {
 			const echoArgs: Array<{ msg: string }> = [];
 			const toolSchema = z.object({ msg: z.string().describe("message to echo") });
@@ -168,7 +168,11 @@ describe("agentLoop with owned in-band tool calls", () => {
 				responses: [
 					context => {
 						captured.push(context);
-						return { content: ['<tool_call>\n{"name":"echo","arguments":{"msg":"from env"}}\n</tool_call>'] };
+						return {
+							content: [
+								'<minimax:tool_call>\n<invoke name="echo"><parameter name="msg">from env</parameter></invoke>\n</minimax:tool_call>',
+							],
+						};
 					},
 					context => {
 						captured.push(context);
@@ -184,7 +188,7 @@ describe("agentLoop with owned in-band tool calls", () => {
 
 			expect(echoArgs).toEqual([{ msg: "from env" }]);
 			expect(captured[0].tools).toBeUndefined();
-			expect((captured[0].systemPrompt ?? []).join("\n")).toContain('"name":"function_name","arguments"');
+			expect((captured[0].systemPrompt ?? []).join("\n")).toContain("<minimax:tool_call>");
 		} finally {
 			if (before === undefined) delete Bun.env.PI_DIALECT;
 			else Bun.env.PI_DIALECT = before;

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Fixed Zhipu/BigModel GLM-5.2 chat-completions requests so internal `xhigh` effort serializes as provider-native `reasoning_effort: "max"` and tool calls opt into `tool_stream`. ([#2833](https://github.com/can1357/oh-my-pi/issues/2833))
 - Fixed Google Gemini CLI and Antigravity tool calls with `toolChoice: "auto"` serializing an explicit `toolConfig` AUTO mode, which can cause Gemini-3 models to leak raw planning JSON instead of executing tools. ([#2830](https://github.com/can1357/oh-my-pi/issues/2830))
 
+### Fixed
+
+- Fixed MiniMax M3 in-band tool calls by adding a MiniMax dialect that parses `<minimax:tool_call>` wrappers instead of falling back to generic XML. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/ai/src/dialect/anthropic.ts
+++ b/packages/ai/src/dialect/anthropic.ts
@@ -21,7 +21,7 @@ import type {
 const MAX_PARTIAL_TAG_LENGTH = 256;
 const MAX_PARAMETER_VALUE_LENGTH = 1_000_000;
 
-const WRAPPER_TAGS: Record<string, true> = { function_calls: true, tool_calls: true };
+const WRAPPER_TAGS: Readonly<Record<string, true>> = { function_calls: true, tool_calls: true };
 const THINKING_TAGS: Record<string, true> = { thinking: true, think: true, scratchpad: true };
 const BASE_TAG_PREFIXES = [
 	"<function_calls",
@@ -41,7 +41,7 @@ const BASE_TAG_PREFIXES = [
 	"<antml:parameter",
 	"</antml:parameter",
 ] as const;
-const THINKING_TAG_PREFIXES = [
+export const ANTHROPIC_THINKING_TAG_PREFIXES = [
 	"<thinking",
 	"</thinking",
 	"<think",
@@ -56,6 +56,11 @@ const THINKING_TAG_PREFIXES = [
 	"</antml:scratchpad",
 ] as const;
 
+export interface AnthropicInbandScannerConfig {
+	readonly wrapperTags?: Readonly<Record<string, true>>;
+	readonly baseTagPrefixes?: readonly string[];
+	readonly allTagPrefixes?: readonly string[];
+}
 type ScannerState = "outside" | "section" | "invoke" | "parameter" | "thinking";
 type ReturnState = "outside" | "section";
 
@@ -88,10 +93,16 @@ export class AnthropicInbandScanner implements InbandScanner {
 	#thinking = "";
 	#thinkingTag = "";
 	#thinkingClosePrefixes: readonly string[] = [];
+	readonly #wrapperTags: Readonly<Record<string, true>>;
+	readonly #baseTagPrefixes: readonly string[];
+	readonly #allTagPrefixes: readonly string[];
 	readonly #stringArgs: (toolName: string) => ReadonlySet<string>;
 	readonly #parseThinking: boolean;
 
-	constructor(options: InbandScannerOptions = {}) {
+	constructor(options: InbandScannerOptions = {}, config: AnthropicInbandScannerConfig = {}) {
+		this.#wrapperTags = config.wrapperTags ?? WRAPPER_TAGS;
+		this.#baseTagPrefixes = config.baseTagPrefixes ?? BASE_TAG_PREFIXES;
+		this.#allTagPrefixes = config.allTagPrefixes ?? ALL_TAG_PREFIXES;
 		this.#stringArgs = options.stringArgs ?? buildStringArgsResolver(options.tools);
 		this.#parseThinking = options.parseThinking === true;
 	}
@@ -154,7 +165,7 @@ export class AnthropicInbandScanner implements InbandScanner {
 			return true;
 		}
 
-		if (!tag.closing && WRAPPER_TAGS[tag.localName] === true) {
+		if (!tag.closing && this.#wrapperTags[tag.localName] === true) {
 			this.#buffer = this.#buffer.slice(tag.raw.length);
 			this.#state = "section";
 			return true;
@@ -169,7 +180,7 @@ export class AnthropicInbandScanner implements InbandScanner {
 			this.#startThinking(tag, "outside", events);
 			return true;
 		}
-		if (tag.closing && WRAPPER_TAGS[tag.localName] === true) {
+		if (tag.closing && this.#wrapperTags[tag.localName] === true) {
 			this.#buffer = this.#buffer.slice(tag.raw.length);
 			return true;
 		}
@@ -198,7 +209,7 @@ export class AnthropicInbandScanner implements InbandScanner {
 		}
 
 		this.#buffer = this.#buffer.slice(tag.raw.length);
-		if (tag.closing && WRAPPER_TAGS[tag.localName] === true) {
+		if (tag.closing && this.#wrapperTags[tag.localName] === true) {
 			this.#state = "outside";
 			return true;
 		}
@@ -461,7 +472,7 @@ export class AnthropicInbandScanner implements InbandScanner {
 	}
 
 	#relevantPrefixes(): readonly string[] {
-		return this.#parseThinking ? ALL_TAG_PREFIXES : BASE_TAG_PREFIXES;
+		return this.#parseThinking ? this.#allTagPrefixes : this.#baseTagPrefixes;
 	}
 
 	#emitText(text: string, events: InbandScanEvent[]): void {
@@ -469,7 +480,7 @@ export class AnthropicInbandScanner implements InbandScanner {
 	}
 }
 
-const ALL_TAG_PREFIXES = [...BASE_TAG_PREFIXES, ...THINKING_TAG_PREFIXES] as const;
+const ALL_TAG_PREFIXES = [...BASE_TAG_PREFIXES, ...ANTHROPIC_THINKING_TAG_PREFIXES] as const;
 
 function parseTag(raw: string): ParsedTag | undefined {
 	const match = /^<\s*(\/?)\s*(?:(?<prefix>[A-Za-z_][\w.-]*):)?(?<localName>[A-Za-z_][\w.-]*)(?<attrs>[^>]*)>$/s.exec(

--- a/packages/ai/src/dialect/factory.ts
+++ b/packages/ai/src/dialect/factory.ts
@@ -6,6 +6,7 @@ import glmDefinition from "./glm";
 import harmonyDefinition from "./harmony";
 import hermesDefinition from "./hermes";
 import kimiDefinition from "./kimi";
+import minimaxDefinition from "./minimax";
 import piDefinition from "./pi";
 import qwen3Definition from "./qwen3";
 import type { Dialect, DialectDefinition, InbandScanner, InbandScannerOptions } from "./types";
@@ -18,6 +19,7 @@ const DIALECT_DEFINITIONS: Record<Dialect, DialectDefinition> = {
 	xml: xmlDefinition,
 	anthropic: anthropicDefinition,
 	deepseek: deepseekDefinition,
+	minimax: minimaxDefinition,
 	harmony: harmonyDefinition,
 	pi: piDefinition,
 	qwen3: qwen3Definition,

--- a/packages/ai/src/dialect/minimax.md
+++ b/packages/ai/src/dialect/minimax.md
@@ -1,0 +1,31 @@
+## Format guide
+
+A call is a `<minimax:tool_call>` block wrapping one or more `<invoke>` blocks, each holding `<parameter>` children:
+
+```text
+<minimax:tool_call>
+<invoke name="tool_name"><parameter name="arg_name">arg value</parameter></invoke>
+</minimax:tool_call>
+```
+
+Results arrive later in a `<function_results>` block, one `<result>` per call (failures use `<error>` with `<stderr>` in place of `<result>` with `<stdout>`):
+
+```text
+<function_results>
+<result>
+<tool_name>tool_name</tool_name>
+<stdout>verbatim tool result</stdout>
+</result>
+</function_results>
+```
+
+## Rules
+
+- `name` MUST match a listed function.
+- String/scalar parameters: exact text, spaces preserved. Lists/objects: JSON.
+- Multiple calls: multiple `<invoke>` blocks in one `<minimax:tool_call>`.
+- You MAY write visible text before the calls.
+- NEVER emit `tool_calls` JSON.
+- NEVER use `<function_calls>` or the legacy `<tool_name>`/`<parameters>` call syntax.
+- Read each `<result>`/`<error>` in call order. NEVER emit `<function_results>` yourself.
+- After emitting your tool calls, YOU MUST EMIT THE STOP SEQUENCE AND HALT.

--- a/packages/ai/src/dialect/minimax.ts
+++ b/packages/ai/src/dialect/minimax.ts
@@ -1,0 +1,93 @@
+import type { Message, ToolCall } from "../types";
+import {
+	ANTHROPIC_THINKING_TAG_PREFIXES,
+	AnthropicInbandScanner,
+	type AnthropicInbandScannerConfig,
+} from "./anthropic";
+import { buildArgShapes, type ToolArgShape } from "./coercion";
+import dialectPrompt from "./minimax.md" with { type: "text" };
+import {
+	escapeXmlAttr,
+	escapeXmlText,
+	renderDelimitedThinking,
+	renderLegacyTextTranscript,
+	stringifyJson,
+} from "./rendering";
+import type { DialectDefinition, DialectRenderOptions, DialectToolResult } from "./types";
+
+const MINIMAX_WRAPPER_TAGS: Readonly<Record<string, true>> = { tool_call: true };
+const MINIMAX_BASE_TAG_PREFIXES = [
+	"<minimax:tool_call",
+	"</minimax:tool_call",
+	"<invoke",
+	"</invoke",
+	"<parameter",
+	"</parameter",
+] as const;
+const MINIMAX_ALL_TAG_PREFIXES = [...MINIMAX_BASE_TAG_PREFIXES, ...ANTHROPIC_THINKING_TAG_PREFIXES] as const;
+const MINIMAX_SCANNER_CONFIG: AnthropicInbandScannerConfig = {
+	wrapperTags: MINIMAX_WRAPPER_TAGS,
+	baseTagPrefixes: MINIMAX_BASE_TAG_PREFIXES,
+	allTagPrefixes: MINIMAX_ALL_TAG_PREFIXES,
+};
+
+function renderToolCall(call: ToolCall, options: DialectRenderOptions = {}): string {
+	return renderInvoke(call, buildArgShapes(options.tools).get(call.name));
+}
+
+function renderAssistantToolCalls(calls: readonly ToolCall[], options: DialectRenderOptions = {}): string {
+	if (calls.length === 0) return "";
+	return `<minimax:tool_call>\n${renderInvokes(calls, options.tools ?? [])}\n</minimax:tool_call>`;
+}
+
+function renderToolResults(results: readonly DialectToolResult[]): string {
+	const body = results
+		.map(result => {
+			const tag = result.isError ? "error" : "result";
+			const streamTag = result.isError ? "stderr" : "stdout";
+			return `<${tag}>\n<tool_name>${escapeXmlText(result.name)}</tool_name>\n<${streamTag}>${result.text}</${streamTag}>\n</${tag}>`;
+		})
+		.join("\n");
+	return `<function_results>\n${body}\n</function_results>`;
+}
+
+function renderThinking(text: string): string {
+	return renderDelimitedThinking("<thinking>", "</thinking>", text);
+}
+
+function renderTranscript(messages: readonly Message[], options: DialectRenderOptions = {}): string {
+	return renderLegacyTextTranscript(messages, options, {
+		renderThinking,
+		renderCalls: renderAssistantToolCalls,
+		renderResults: renderToolResults,
+	});
+}
+
+function renderInvoke(call: ToolCall, shape: ToolArgShape | undefined): string {
+	let body = `<invoke name="${escapeXmlAttr(call.name)}">`;
+	for (const key in call.arguments) {
+		const value = call.arguments[key];
+		const isString = shape?.stringArgs.has(key) === true;
+		const rendered = isString && typeof value === "string" ? value : stringifyJson(value);
+		body += `<parameter name="${escapeXmlAttr(key)}">${rendered}</parameter>`;
+	}
+	return `${body}</invoke>`;
+}
+
+function renderInvokes(calls: readonly ToolCall[], tools: NonNullable<DialectRenderOptions["tools"]>): string {
+	const shapes = buildArgShapes(tools);
+	return calls.map(call => renderInvoke(call, shapes.get(call.name))).join("\n");
+}
+
+const definition: DialectDefinition = {
+	dialect: "minimax",
+	prompt: dialectPrompt,
+	createScanner: options => new AnthropicInbandScanner(options, MINIMAX_SCANNER_CONFIG),
+	renderToolCall,
+	renderAssistantToolCalls,
+	renderToolResults,
+	renderThinking,
+	renderTranscript,
+};
+
+export default definition;

--- a/packages/ai/src/dialect/minimax.ts
+++ b/packages/ai/src/dialect/minimax.ts
@@ -19,6 +19,8 @@ const MINIMAX_WRAPPER_TAGS: Readonly<Record<string, true>> = { tool_call: true }
 const MINIMAX_BASE_TAG_PREFIXES = [
 	"<minimax:tool_call",
 	"</minimax:tool_call",
+	"<tool_call",
+	"</tool_call",
 	"<invoke",
 	"</invoke",
 	"<parameter",

--- a/packages/ai/src/dialect/owned-stream.ts
+++ b/packages/ai/src/dialect/owned-stream.ts
@@ -16,6 +16,7 @@ const RESPONSE_OPEN_TOKENS: Record<Dialect, readonly string[]> = {
 	kimi: ["<|im_system|>"],
 	xml: ["<tool_response>"],
 	anthropic: ["<function_results>", "<tool_response>"],
+	minimax: ["<function_results>", "<tool_response>"],
 	deepseek: ["<｜tool▁outputs▁begin｜>", "<｜tool▁output▁begin｜>"],
 	harmony: ["<|start|>functions."],
 	pi: ["<tool_response>"],

--- a/packages/ai/test/inband-tools.test.ts
+++ b/packages/ai/test/inband-tools.test.ts
@@ -38,6 +38,7 @@ const DIALECTS: readonly Dialect[] = [
 	"kimi",
 	"xml",
 	"anthropic",
+	"minimax",
 	"deepseek",
 	"harmony",
 	"pi",
@@ -144,6 +145,11 @@ describe("in-band tool dialects", () => {
 			'<invoke name="read"><parameter name="path" string="true">src/a.ts</parameter></invoke>',
 		);
 		expectRawBlock(
+			"minimax",
+			'<minimax:tool_call>\n<invoke name="read"><parameter name="path" string="true">src/a.ts</parameter></invoke>\n</minimax:tool_call>',
+			'<invoke name="read"><parameter name="path" string="true">src/a.ts</parameter></invoke>',
+		);
+		expectRawBlock(
 			"harmony",
 			'<|start|>assistant<|channel|>commentary to=functions.read<|message|>{"path":"src/a.ts"}<|call|>',
 			'<|start|>assistant<|channel|>commentary to=functions.read<|message|>{"path":"src/a.ts"}<|call|>',
@@ -161,6 +167,19 @@ describe("in-band tool dialects", () => {
 		const call = parsed.content.find((block): block is ToolCall => block.type === "toolCall");
 
 		expect(call?.rawBlock).toBe(raw);
+	});
+
+	it("parses MiniMax tool-call wrapper arguments without mangling parameter names", () => {
+		const raw =
+			'<minimax:tool_call>\n<invoke name="read">\n<parameter name="path" string="true">src/a.ts</parameter>\n<parameter name="count" string="false">2</parameter>\n</invoke>\n</minimax:tool_call>';
+		const parsed = parseInbandToolMessage(assistant([{ type: "text", text: raw }]), "minimax", TOOLS);
+		const calls = parsed.content.filter((block): block is ToolCall => block.type === "toolCall");
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("read");
+		expect(calls[0]?.arguments).toEqual({ path: "src/a.ts", count: 2 });
+		expect(calls[0]?.arguments).not.toHaveProperty('parameter name="path"');
+		expect(calls[0]?.arguments).not.toHaveProperty('parameter name="count"');
 	});
 
 	it("stops before hallucinated Anthropic function results", () => {
@@ -201,6 +220,9 @@ describe("in-band tool dialects", () => {
 			"<|start|>functions.read to=assistant<|channel|>commentary<|message|>FILE<|end|>",
 		);
 		expect(getDialectDefinition("anthropic").renderToolResults([resultBlock])).toBe(
+			"<function_results>\n<result>\n<tool_name>read</tool_name>\n<stdout>FILE</stdout>\n</result>\n</function_results>",
+		);
+		expect(getDialectDefinition("minimax").renderToolResults([resultBlock])).toBe(
 			"<function_results>\n<result>\n<tool_name>read</tool_name>\n<stdout>FILE</stdout>\n</result>\n</function_results>",
 		);
 		expect(getDialectDefinition("qwen3").renderToolResults([resultBlock])).toBe(

--- a/packages/ai/test/inband-tools.test.ts
+++ b/packages/ai/test/inband-tools.test.ts
@@ -182,6 +182,22 @@ describe("in-band tool dialects", () => {
 		expect(calls[0]?.arguments).not.toHaveProperty('parameter name="count"');
 	});
 
+	it("buffers unprefixed MiniMax wrappers across streaming tag splits", () => {
+		const raw =
+			'<tool_call>\n<invoke name="read">\n<parameter name="path" string="true">src/a.ts</parameter>\n<parameter name="count" string="false">2</parameter>\n</invoke>\n</tool_call>';
+		const events = feedText("minimax", raw);
+		const calls = toolEnds(events);
+		const visibleText = events
+			.filter((event): event is Extract<InbandScanEvent, { type: "text" }> => event.type === "text")
+			.map(event => event.text)
+			.join("");
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("read");
+		expect(calls[0]?.arguments).toEqual({ path: "src/a.ts", count: 2 });
+		expect(visibleText).toBe("");
+	});
+
 	it("stops before hallucinated Anthropic function results", () => {
 		const parsed = parseInbandToolMessage(
 			assistant([

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - Fixed GLM-5.2 catalog thinking metadata for Zhipu/BigModel so the top effort is exposed as `xhigh` and maps to provider-native `max`. ([#2833](https://github.com/can1357/oh-my-pi/issues/2833))
 
+### Fixed
+
+- Fixed MiniMax M3 dialect selection so MiniMax-family OpenAI-compatible models use the MiniMax tool-call dialect instead of generic XML. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
+
 ## [16.0.2] - 2026-06-16
 
 ### Fixed

--- a/packages/catalog/src/identity/dialect.ts
+++ b/packages/catalog/src/identity/dialect.ts
@@ -11,7 +11,8 @@ export type Dialect =
 	| "pi"
 	| "qwen3"
 	| "gemini"
-	| "gemma";
+	| "gemma"
+	| "minimax";
 
 export const FALLBACK_DIALECT: Dialect = "xml";
 
@@ -31,6 +32,8 @@ export function preferredDialect(modelId: string): Dialect {
 			return "qwen3";
 		case "deepseek":
 			return "deepseek";
+		case "minimax":
+			return "minimax";
 		case "openai":
 		case "gpt-oss":
 			return "harmony";

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -73,6 +73,13 @@ export function isMinimaxM2FamilyModelId(modelId: string): boolean {
 	return /(?:^|[/.-])m2\d*(?:[.-]\d+)?(?:[-.:_]|$)/i.test(lower);
 }
 
+/** MiniMax M3 family ids in bundled/default and aggregator namespace forms. */
+export function isMinimaxM3FamilyModelId(modelId: string): boolean {
+	const lower = modelId.toLowerCase();
+	if (!lower.includes("minimax")) return false;
+	return /(?:^|[/._-])(?:minimax[/._-])?m3(?:[-.:_]|$)/i.test(lower);
+}
+
 /**
  * OpenAI gpt-oss family (`gpt-oss-20b`, `gpt-oss-120b`, `gpt-oss:120b`,
  * `vendor/gpt-oss-…`). The Harmony reasoning format only accepts
@@ -139,7 +146,7 @@ export function modelFamilyToken(modelId: string): string {
 	if (isOpenAIModelId(modelId)) return "openai";
 	if (isKimiModelId(modelId)) return "kimi";
 	if (isQwenModelId(modelId)) return "qwen";
-	if (isMinimaxM2FamilyModelId(modelId)) return "minimax";
+	if (isMinimaxM2FamilyModelId(modelId) || isMinimaxM3FamilyModelId(modelId)) return "minimax";
 	if (isOpenAIGptOssModelId(modelId)) return "gpt-oss";
 	if (isDeepseekModelIdOrName(modelId)) return "deepseek";
 	if (isMimoModelIdOrName(modelId)) return "mimo";

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -5,6 +5,7 @@ import {
 	isKimiK26ModelId,
 	isKimiModelId,
 	isMinimaxM2FamilyModelId,
+	isMinimaxM3FamilyModelId,
 	isOpenAIGptOssModelId,
 	isReasoningGlmModelId,
 	modelFamilyToken,
@@ -90,6 +91,21 @@ describe("isMinimaxM2FamilyModelId", () => {
 		// Lone "m2" string with no MiniMax context does not match.
 		expect(isMinimaxM2FamilyModelId("kimi-m2")).toBe(false);
 		expect(isMinimaxM2FamilyModelId("gpt-oss-120b")).toBe(false);
+	});
+});
+
+describe("isMinimaxM3FamilyModelId", () => {
+	test("matches MiniMax M3 ids without broadening the M2 effort predicate", () => {
+		expect(isMinimaxM3FamilyModelId("MiniMax-M3")).toBe(true);
+		expect(isMinimaxM3FamilyModelId("minimax-m3")).toBe(true);
+		expect(isMinimaxM3FamilyModelId("minimax/minimax-m3")).toBe(true);
+		expect(isMinimaxM3FamilyModelId("minimax-m3-free")).toBe(true);
+		expect(isMinimaxM3FamilyModelId("minimax/m3")).toBe(true);
+
+		expect(isMinimaxM3FamilyModelId("MiniMax-M2.7")).toBe(false);
+		expect(isMinimaxM3FamilyModelId("MiniMax-Text-01")).toBe(false);
+		expect(isMinimaxM3FamilyModelId("minimax-music")).toBe(false);
+		expect(isMinimaxM3FamilyModelId("kimi-m3")).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/preferred-dialect.test.ts
+++ b/packages/catalog/test/preferred-dialect.test.ts
@@ -14,6 +14,8 @@ describe("preferredDialect", () => {
 		expect(preferredDialect("gemini-3.5-flash")).toBe("gemini");
 		expect(preferredDialect("gemma-3-27b-it")).toBe("gemma");
 		expect(preferredDialect("google/gemma-4-E2B-it")).toBe("gemma");
+		expect(preferredDialect("MiniMax-M3")).toBe("minimax");
+		expect(preferredDialect("minimax/minimax-m3")).toBe("minimax");
 		expect(preferredDialect("unclassified-model-id")).toBe(FALLBACK_DIALECT);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,10 @@
 - Fixed default prompts to instruct the agent to read applicable `skill://<name>` content before starting work, so discovered skills influence broad task requests like frontend generation ([#2829](https://github.com/can1357/oh-my-pi/issues/2829)).
 - Fixed hashline visible-line validation for ACP editor reads so `INS.POST` anchors displayed by bridge-backed range and multi-range `read` output are merged into the session snapshot before `edit` validates them ([#2773](https://github.com/can1357/oh-my-pi/issues/2773)).
 
+### Fixed
+
+- Fixed the `tools.format` setting schema so `minimax` can be selected as an owned tool-calling dialect. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ### Fixed
 
-- Fixed the `tools.format` setting schema so `minimax` can be selected as an owned tool-calling dialect. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
+- Fixed the `tools.format` setting schema so `minimax` can be selected as an owned tool-calling dialect, and taught auto mode to route tool-less MiniMax-family models to the MiniMax owned dialect. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
 
 ## [16.0.3] - 2026-06-16
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1791,6 +1791,7 @@ export const SETTINGS_SCHEMA = {
 			"qwen3",
 			"gemini",
 			"gemma",
+			"minimax",
 		] as const,
 		default: "auto",
 		ui: {
@@ -1817,6 +1818,7 @@ export const SETTINGS_SCHEMA = {
 				{ value: "qwen3", label: "Qwen3", description: "Use the Qwen3 owned dialect." },
 				{ value: "gemini", label: "Gemini", description: "Use the Gemini owned dialect." },
 				{ value: "gemma", label: "Gemma", description: "Use the Gemma owned dialect." },
+				{ value: "minimax", label: "MiniMax", description: "Use the MiniMax owned dialect." },
 			],
 		},
 	},

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -17,6 +17,7 @@ import {
 	streamSimple,
 } from "@oh-my-pi/pi-ai";
 import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
+import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import {
 	getOpenAICodexTransportDetails,
 	prewarmOpenAICodexResponses,
@@ -566,10 +567,13 @@ export type DialectFormat = "auto" | "native" | Dialect;
 
 export function resolveDialect(
 	format: DialectFormat,
-	model: Pick<Model, "supportsTools"> | undefined,
+	model: (Pick<Model, "supportsTools"> & Partial<Pick<Model, "id">>) | undefined,
 ): Dialect | undefined {
 	if (format === "native") return undefined;
-	if (format === "auto") return model?.supportsTools === false ? "glm" : undefined;
+	if (format === "auto") {
+		if (model?.supportsTools !== false) return undefined;
+		return model.id ? preferredDialect(model.id) : "glm";
+	}
 	return format;
 }
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -17,7 +17,7 @@ import {
 	streamSimple,
 } from "@oh-my-pi/pi-ai";
 import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
-import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
+import { FALLBACK_DIALECT, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import {
 	getOpenAICodexTransportDetails,
 	prewarmOpenAICodexResponses,
@@ -572,7 +572,9 @@ export function resolveDialect(
 	if (format === "native") return undefined;
 	if (format === "auto") {
 		if (model?.supportsTools !== false) return undefined;
-		return model.id ? preferredDialect(model.id) : "glm";
+		if (!model.id) return "glm";
+		const preferred = preferredDialect(model.id);
+		return preferred === FALLBACK_DIALECT ? "glm" : preferred;
 	}
 	return format;
 }

--- a/packages/coding-agent/test/sdk-dialect.test.ts
+++ b/packages/coding-agent/test/sdk-dialect.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { resolveDialect } from "@oh-my-pi/pi-coding-agent/sdk";
 
 describe("resolveDialect", () => {
-	it("uses GLM in auto mode only for models known not to support native tools", () => {
+	it("uses preferred owned dialects in auto mode for models without native tools", () => {
+		expect(resolveDialect("auto", { id: "MiniMax-M3", supportsTools: false })).toBe("minimax");
+		expect(resolveDialect("auto", { id: "qwen3-coder-plus", supportsTools: false })).toBe("qwen3");
 		expect(resolveDialect("auto", { supportsTools: false })).toBe("glm");
 		expect(resolveDialect("auto", { supportsTools: true })).toBeUndefined();
 		expect(resolveDialect("auto", {})).toBeUndefined();

--- a/packages/coding-agent/test/sdk-dialect.test.ts
+++ b/packages/coding-agent/test/sdk-dialect.test.ts
@@ -12,5 +12,6 @@ describe("resolveDialect", () => {
 	it("keeps native unset and passes explicit in-band dialects through", () => {
 		expect(resolveDialect("native", { supportsTools: false })).toBeUndefined();
 		expect(resolveDialect("qwen3", undefined)).toBe("qwen3");
+		expect(resolveDialect("minimax", undefined)).toBe("minimax");
 	});
 });

--- a/packages/coding-agent/test/sdk-dialect.test.ts
+++ b/packages/coding-agent/test/sdk-dialect.test.ts
@@ -5,6 +5,7 @@ describe("resolveDialect", () => {
 	it("uses preferred owned dialects in auto mode for models without native tools", () => {
 		expect(resolveDialect("auto", { id: "MiniMax-M3", supportsTools: false })).toBe("minimax");
 		expect(resolveDialect("auto", { id: "qwen3-coder-plus", supportsTools: false })).toBe("qwen3");
+		expect(resolveDialect("auto", { id: "unclassified-model-id", supportsTools: false })).toBe("glm");
 		expect(resolveDialect("auto", { supportsTools: false })).toBe("glm");
 		expect(resolveDialect("auto", { supportsTools: true })).toBeUndefined();
 		expect(resolveDialect("auto", {})).toBeUndefined();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -82,6 +82,7 @@ describe("Settings", () => {
 				"qwen3",
 				"gemini",
 				"gemma",
+				"minimax",
 			]);
 		});
 	});


### PR DESCRIPTION
Fixes #2759

## Summary
- Add a MiniMax in-band dialect for `<minimax:tool_call>` wrappers
- Route MiniMax M2/M3 family ids to the MiniMax dialect instead of generic XML
- Keep Anthropic invoke/parameter parsing reusable via scanner config
- Add parser, raw-block, result-rendering, family, and preferred-dialect regressions

## Tests
- bun --cwd=packages/catalog test test/preferred-dialect.test.ts test/identity-family.test.ts
- bun --cwd=packages/ai test test/inband-tools.test.ts
- bun --cwd=packages/catalog run check
- bun --cwd=packages/ai run check
- bun --cwd=packages/coding-agent run check