### PR TITLE
fix: exclude cacheRead cost from status-line accumulation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the status-line `cost` segment inflating far beyond actual API billing. `cacheRead` cost (full cached context re-read every turn) was accumulated across turns, producing N×context_size cost inflation — the same pattern already fixed for token totals. The cost segment now sums `input + output + cacheWrite` costs, matching the `token_total` segment behavior. Cache-read cost data is still preserved in the full `UsageStatistics` ledger for programmatic access. ([#2475](https://github.com/can1357/oh-my-pi/issues/2475))
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -96,7 +96,7 @@ function addUsage(target: UsageStatistics, usage: Usage | undefined): void {
 	target.cacheRead += usage.cacheRead;
 	target.cacheWrite += usage.cacheWrite;
 	target.premiumRequests += usage.premiumRequests ?? 0;
-	target.cost += usage.cost.total;
+	target.cost += usage.cost.input + usage.cost.output + usage.cost.cacheWrite;
 }
 
 function isAssistantEntry(entry: SessionEntry): boolean {


### PR DESCRIPTION
The status-line `cost` segment inflates far beyond actual API billing because `cacheRead` cost (full cached context size re-read every turn) is accumulated across all turns, producing N×context_size cost inflation.

This is the same pattern already fixed for `token_total` in #2475 — that segment was changed to show `input + output + cacheWrite` tokens, but the cost path was overlooked.

**Change**: In `addUsage` (`session-manager.ts:99`), sum `usage.cost.input + usage.cost.output + usage.cost.cacheWrite` instead of `usage.cost.total` (which includes cacheRead).

Cache-read cost data is still preserved in the full `UsageStatistics` ledger for programmatic access — only the displayed accumulation is sanitized.

**Repro**: Every turn adds ~$0.03 in cacheRead cost (100K Sonnet 4 context). A 50-turn session shows ~$1.50 of phantom cacheRead cost on top of ~$1.88 real cost = **79% inflation**. More turns or larger contexts push it past 200%.