### PR TITLE
fix(stats): prevent dashboard overflow

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stats dashboard overflow by letting summary cards reflow at usable widths and keeping dense request tables contained inside their cards.
+
 ## [15.13.3] - 2026-06-15
 
 ### Changed

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed stats dashboard overflow by letting summary cards reflow at usable widths and keeping dense request tables contained inside their cards.
+- Fixed stats dashboard overflow by compacting large summary-card values (full precision preserved in the hover tooltip) and keeping dense request tables contained inside their cards.
 
 ## [15.13.3] - 2026-06-15
 

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -116,7 +116,7 @@ export default function App() {
 							<LoadingState label="Loading overview..." />
 						)}
 
-						<div className="grid lg:grid-cols-2 gap-6">
+						<div className="grid 2xl:grid-cols-2 gap-6">
 							<RequestList
 								title="Recent Requests"
 								requests={recentRequests.slice(0, 10)}

--- a/packages/stats/src/client/components/Header.tsx
+++ b/packages/stats/src/client/components/Header.tsx
@@ -24,7 +24,7 @@ interface HeaderProps {
 
 export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onTimeRangeChange }: HeaderProps) {
 	return (
-		<header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-6 mb-8 border-b border-[var(--border-subtle)]">
+		<header className="flex flex-col xl:flex-row xl:items-center justify-between gap-4 pb-6 mb-8 border-b border-[var(--border-subtle)]">
 			<div className="flex items-center gap-3">
 				<div className="w-10 h-10 rounded-[var(--radius-md)] bg-gradient-to-br from-[var(--accent-pink)] to-[var(--accent-cyan)] flex items-center justify-center shadow-lg">
 					<Activity className="w-5 h-5 text-white" />
@@ -35,8 +35,8 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 				</div>
 			</div>
 
-			<div className="flex items-center gap-3">
-				<div className="flex bg-[var(--bg-surface)] rounded-[var(--radius-md)] p-1 border border-[var(--border-subtle)]">
+			<div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center xl:w-auto">
+				<div className="flex max-w-full overflow-x-auto bg-[var(--bg-surface)] rounded-[var(--radius-md)] p-1 border border-[var(--border-subtle)]">
 					{tabs.map(tab => (
 						<button
 							key={tab}
@@ -48,7 +48,7 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 						</button>
 					))}
 				</div>
-				<div className="flex bg-[var(--bg-surface)] rounded-[var(--radius-md)] p-1 border border-[var(--border-subtle)]">
+				<div className="flex max-w-full overflow-x-auto bg-[var(--bg-surface)] rounded-[var(--radius-md)] p-1 border border-[var(--border-subtle)]">
 					{timeRanges.map(range => (
 						<button
 							key={range.value}
@@ -62,7 +62,7 @@ export function Header({ activeTab, onTabChange, onSync, syncing, timeRange, onT
 					))}
 				</div>
 
-				<button type="button" onClick={onSync} disabled={syncing} className="btn btn-primary">
+				<button type="button" onClick={onSync} disabled={syncing} className="btn btn-primary shrink-0">
 					<RefreshCw size={16} className={syncing ? "spin" : ""} />
 					{syncing ? "Syncing..." : "Sync"}
 				</button>

--- a/packages/stats/src/client/components/RequestList.tsx
+++ b/packages/stats/src/client/components/RequestList.tsx
@@ -15,7 +15,15 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
 			</div>
 			<div className="overflow-auto flex-1">
-				<table className="w-full">
+				<table className="w-full min-w-[560px] table-fixed">
+					<colgroup>
+						<col className="w-[28%]" />
+						<col className="w-[16%]" />
+						<col className="w-[17%]" />
+						<col className="w-[15%]" />
+						<col className="w-[15%]" />
+						<col className="w-[9%]" />
+					</colgroup>
 					<thead className="bg-[var(--bg-elevated)] sticky top-0 z-10">
 						<tr>
 							<th className="text-left py-3 px-4 table-header">Model</th>
@@ -33,9 +41,13 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 								onClick={() => onSelect(req)}
 								className="table-row cursor-pointer border-b border-[var(--border-subtle)] last:border-b-0"
 							>
-								<td className="py-3 px-4">
-									<div className="font-medium text-[var(--text-primary)] text-sm">{req.model}</div>
-									<div className="text-xs text-[var(--text-muted)]">{req.provider}</div>
+								<td className="py-3 px-4 min-w-0">
+									<div className="font-medium text-[var(--text-primary)] text-sm leading-snug break-words">
+										{req.model}
+									</div>
+									<div className="text-xs text-[var(--text-muted)] truncate" title={req.provider}>
+										{req.provider}
+									</div>
 								</td>
 								<td className="py-3 px-4 text-sm text-[var(--text-secondary)]">
 									{formatDistanceToNow(req.timestamp, { addSuffix: true })}

--- a/packages/stats/src/client/components/RequestList.tsx
+++ b/packages/stats/src/client/components/RequestList.tsx
@@ -8,6 +8,13 @@ interface RequestListProps {
 	title: string;
 }
 
+const requestCostFormatter = new Intl.NumberFormat(undefined, {
+	currency: "USD",
+	maximumFractionDigits: 4,
+	minimumFractionDigits: 4,
+	style: "currency",
+});
+
 export function RequestList({ requests, onSelect, title }: RequestListProps) {
 	return (
 		<div className="surface overflow-hidden flex flex-col h-full">
@@ -15,14 +22,14 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 				<h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
 			</div>
 			<div className="overflow-auto flex-1">
-				<table className="w-full min-w-[560px] table-fixed">
+				<table className="w-full min-w-[720px] table-fixed">
 					<colgroup>
-						<col className="w-[28%]" />
-						<col className="w-[16%]" />
+						<col className="w-[29%]" />
 						<col className="w-[17%]" />
 						<col className="w-[15%]" />
 						<col className="w-[15%]" />
-						<col className="w-[9%]" />
+						<col className="w-[13%]" />
+						<col className="w-[11%]" />
 					</colgroup>
 					<thead className="bg-[var(--bg-elevated)] sticky top-0 z-10">
 						<tr>
@@ -35,41 +42,56 @@ export function RequestList({ requests, onSelect, title }: RequestListProps) {
 						</tr>
 					</thead>
 					<tbody>
-						{requests.map(req => (
-							<tr
-								key={`${req.sessionFile}-${req.entryId}`}
-								onClick={() => onSelect(req)}
-								className="table-row cursor-pointer border-b border-[var(--border-subtle)] last:border-b-0"
-							>
-								<td className="py-3 px-4 min-w-0">
-									<div className="font-medium text-[var(--text-primary)] text-sm leading-snug break-words">
-										{req.model}
-									</div>
-									<div className="text-xs text-[var(--text-muted)] truncate" title={req.provider}>
-										{req.provider}
-									</div>
-								</td>
-								<td className="py-3 px-4 text-sm text-[var(--text-secondary)]">
-									{formatDistanceToNow(req.timestamp, { addSuffix: true })}
-								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
-									{req.usage.totalTokens.toLocaleString()}
-								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
-									${req.usage.cost.total.toFixed(4)}
-								</td>
-								<td className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono">
-									{req.duration ? `${(req.duration / 1000).toFixed(1)}s` : "-"}
-								</td>
-								<td className="py-3 px-4 text-center">
-									{req.errorMessage ? (
-										<XCircle size={16} className="text-[var(--accent-red)] mx-auto" />
-									) : (
-										<CheckCircle2 size={16} className="text-[var(--accent-green)] mx-auto" />
-									)}
-								</td>
-							</tr>
-						))}
+						{requests.map(req => {
+							const timeAgo = formatDistanceToNow(req.timestamp, { addSuffix: true });
+							const tokens = req.usage.totalTokens.toLocaleString();
+							const cost = requestCostFormatter.format(req.usage.cost.total);
+							const duration = req.duration ? `${(req.duration / 1000).toFixed(1)}s` : "-";
+							return (
+								<tr
+									key={`${req.sessionFile}-${req.entryId}`}
+									onClick={() => onSelect(req)}
+									className="table-row cursor-pointer border-b border-[var(--border-subtle)] last:border-b-0"
+								>
+									<td className="py-3 px-4 min-w-0">
+										<div className="font-medium text-[var(--text-primary)] text-sm leading-snug break-words">
+											{req.model}
+										</div>
+										<div className="text-xs text-[var(--text-muted)] truncate" title={req.provider}>
+											{req.provider}
+										</div>
+									</td>
+									<td className="py-3 px-4 text-sm text-[var(--text-secondary)]" title={timeAgo}>
+										<div className="truncate">{timeAgo}</div>
+									</td>
+									<td
+										className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono"
+										title={tokens}
+									>
+										<div className="truncate">{tokens}</div>
+									</td>
+									<td
+										className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono"
+										title={cost}
+									>
+										<div className="truncate">{cost}</div>
+									</td>
+									<td
+										className="py-3 px-4 text-right text-sm text-[var(--text-secondary)] font-mono"
+										title={duration}
+									>
+										<div className="truncate">{duration}</div>
+									</td>
+									<td className="py-3 px-4 text-center">
+										{req.errorMessage ? (
+											<XCircle size={16} className="text-[var(--accent-red)] mx-auto" />
+										) : (
+											<CheckCircle2 size={16} className="text-[var(--accent-green)] mx-auto" />
+										)}
+									</td>
+								</tr>
+							);
+						})}
 						{requests.length === 0 && (
 							<tr>
 								<td colSpan={6} className="py-12 text-center text-[var(--text-muted)] text-sm">

--- a/packages/stats/src/client/components/StatsGrid.tsx
+++ b/packages/stats/src/client/components/StatsGrid.tsx
@@ -10,6 +10,20 @@ const compactNumberFormatter = new Intl.NumberFormat(undefined, {
 	maximumFractionDigits: 1,
 });
 
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+	currency: "USD",
+	maximumFractionDigits: 2,
+	minimumFractionDigits: 2,
+	style: "currency",
+});
+
+const preciseCurrencyFormatter = new Intl.NumberFormat(undefined, {
+	currency: "USD",
+	maximumFractionDigits: 4,
+	minimumFractionDigits: 4,
+	style: "currency",
+});
+
 function formatCompactNumber(value: number): string {
 	return compactNumberFormatter.format(value);
 }
@@ -18,33 +32,53 @@ function formatExactNumber(value: number): string {
 	return value.toLocaleString();
 }
 
+function formatCurrency(value: number): string {
+	return currencyFormatter.format(value);
+}
+
+function formatPreciseCurrency(value: number): string {
+	return preciseCurrencyFormatter.format(value);
+}
+
+interface StatCardConfig {
+	key: string;
+	title: string;
+	icon: typeof Server;
+	color: string;
+	getValue: (stats: AggregatedStats) => string;
+	getTitle?: (stats: AggregatedStats) => string;
+	getDetail: (stats: AggregatedStats) => string;
+}
+
 const totalPromptCompletionTokens = (stats: AggregatedStats) => stats.totalInputTokens + stats.totalOutputTokens;
 
-const statConfig = [
+const statConfig: StatCardConfig[] = [
 	{
 		key: "requests",
 		title: "Total Requests",
 		icon: Server,
 		color: "var(--accent-violet)",
-		getValue: (s: AggregatedStats) => s.totalRequests.toLocaleString(),
+		getValue: (s: AggregatedStats) => formatCompactNumber(s.totalRequests),
+		getTitle: (s: AggregatedStats) => formatExactNumber(s.totalRequests),
 		getDetail: (s: AggregatedStats) =>
-			`${s.successfulRequests.toLocaleString()} success · ${s.failedRequests.toLocaleString()} errors`,
+			`${formatCompactNumber(s.successfulRequests)} success · ${formatCompactNumber(s.failedRequests)} errors`,
 	},
 	{
 		key: "cost",
 		title: "Total Cost",
 		icon: Activity,
 		color: "var(--accent-pink)",
-		getValue: (s: AggregatedStats) => `$${s.totalCost.toFixed(2)}`,
+		getValue: (s: AggregatedStats) => formatCurrency(s.totalCost),
 		getDetail: (s: AggregatedStats) =>
-			s.totalRequests > 0 ? `$${(s.totalCost / s.totalRequests).toFixed(4)} avg/req` : "-",
+			s.totalRequests > 0 ? `${formatPreciseCurrency(s.totalCost / s.totalRequests)} avg/req` : "-",
 	},
 	{
 		key: "premiumRequests",
 		title: "Premium Reqs",
 		icon: Star,
 		color: "var(--accent-amber)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalPremiumRequests),
+		getValue: (s: AggregatedStats) => formatCompactNumber(s.totalPremiumRequests),
+		getTitle: (s: AggregatedStats) => formatExactNumber(s.totalPremiumRequests),
 		getDetail: (s: AggregatedStats) =>
 			s.totalRequests > 0 ? `${((s.totalPremiumRequests / s.totalRequests) * 100).toFixed(1)}% of requests` : "-",
 	},
@@ -61,10 +95,11 @@ const statConfig = [
 		title: "Input Tokens",
 		icon: Download,
 		color: "var(--accent-violet)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalInputTokens),
+		getValue: (s: AggregatedStats) => formatCompactNumber(s.totalInputTokens),
+		getTitle: (s: AggregatedStats) => formatExactNumber(s.totalInputTokens),
 		getDetail: (s: AggregatedStats) =>
 			totalPromptCompletionTokens(s) > 0
-				? `${((s.totalInputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				? `${((s.totalInputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of tokens`
 				: "-",
 	},
 	{
@@ -72,10 +107,11 @@ const statConfig = [
 		title: "Output Tokens",
 		icon: Upload,
 		color: "var(--accent-pink)",
-		getValue: (s: AggregatedStats) => formatExactNumber(s.totalOutputTokens),
+		getValue: (s: AggregatedStats) => formatCompactNumber(s.totalOutputTokens),
+		getTitle: (s: AggregatedStats) => formatExactNumber(s.totalOutputTokens),
 		getDetail: (s: AggregatedStats) =>
 			totalPromptCompletionTokens(s) > 0
-				? `${((s.totalOutputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				? `${((s.totalOutputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of tokens`
 				: "-",
 	},
 	{
@@ -92,8 +128,7 @@ const statConfig = [
 		icon: BarChart3,
 		color: "var(--accent-green)",
 		getValue: (s: AggregatedStats) => s.avgTokensPerSecond?.toFixed(1) ?? "-",
-		getDetail: (s: AggregatedStats) =>
-			`${formatCompactNumber(totalPromptCompletionTokens(s))} total prompt+completion`,
+		getDetail: (s: AggregatedStats) => `${formatCompactNumber(totalPromptCompletionTokens(s))} tokens total`,
 	},
 	{
 		key: "ttft",
@@ -107,15 +142,20 @@ const statConfig = [
 
 export function StatsGrid({ stats }: StatsGridProps) {
 	return (
-		<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-9 gap-4 mb-8">
+		<div className="grid [grid-template-columns:repeat(auto-fit,minmax(210px,1fr))] gap-4 mb-8">
 			{statConfig.map(stat => {
 				const Icon = stat.icon;
+				const value = stat.getValue(stats);
+				const title = stat.getTitle?.(stats) ?? value;
+				const detail = stat.getDetail(stats);
 				return (
-					<div key={stat.key} className="stat-card group">
-						<div className="flex items-center justify-between mb-3">
-							<span className="text-sm font-medium text-[var(--text-secondary)]">{stat.title}</span>
+					<div key={stat.key} className="stat-card group min-w-0">
+						<div className="flex items-center justify-between gap-3 mb-3">
+							<span className="min-w-0 truncate text-sm font-medium text-[var(--text-secondary)]">
+								{stat.title}
+							</span>
 							<div
-								className="p-2 rounded-[var(--radius-sm)] transition-colors"
+								className="shrink-0 p-2 rounded-[var(--radius-sm)] transition-colors"
 								style={{ backgroundColor: `${stat.color}15` }}
 							>
 								<Icon
@@ -125,8 +165,15 @@ export function StatsGrid({ stats }: StatsGridProps) {
 								/>
 							</div>
 						</div>
-						<div className="text-2xl font-bold text-[var(--text-primary)] mb-1">{stat.getValue(stats)}</div>
-						<div className="text-xs text-[var(--text-muted)] truncate">{stat.getDetail(stats)}</div>
+						<div
+							className="truncate text-2xl font-bold tracking-tight tabular-nums text-[var(--text-primary)] mb-1"
+							title={title}
+						>
+							{value}
+						</div>
+						<div className="text-xs leading-snug text-[var(--text-muted)]" title={detail}>
+							{detail}
+						</div>
 					</div>
 				);
 			})}

--- a/packages/stats/src/client/components/StatsGrid.tsx
+++ b/packages/stats/src/client/components/StatsGrid.tsx
@@ -24,6 +24,13 @@ const preciseCurrencyFormatter = new Intl.NumberFormat(undefined, {
 	style: "currency",
 });
 
+const compactCurrencyFormatter = new Intl.NumberFormat(undefined, {
+	currency: "USD",
+	maximumFractionDigits: 1,
+	notation: "compact",
+	style: "currency",
+});
+
 function formatCompactNumber(value: number): string {
 	return compactNumberFormatter.format(value);
 }
@@ -38,6 +45,10 @@ function formatCurrency(value: number): string {
 
 function formatPreciseCurrency(value: number): string {
 	return preciseCurrencyFormatter.format(value);
+}
+
+function formatCompactCurrency(value: number): string {
+	return compactCurrencyFormatter.format(value);
 }
 
 interface StatCardConfig {
@@ -68,7 +79,8 @@ const statConfig: StatCardConfig[] = [
 		title: "Total Cost",
 		icon: Activity,
 		color: "var(--accent-pink)",
-		getValue: (s: AggregatedStats) => formatCurrency(s.totalCost),
+		getValue: (s: AggregatedStats) => formatCompactCurrency(s.totalCost),
+		getTitle: (s: AggregatedStats) => formatCurrency(s.totalCost),
 		getDetail: (s: AggregatedStats) =>
 			s.totalRequests > 0 ? `${formatPreciseCurrency(s.totalCost / s.totalRequests)} avg/req` : "-",
 	},
@@ -142,7 +154,7 @@ const statConfig: StatCardConfig[] = [
 
 export function StatsGrid({ stats }: StatsGridProps) {
 	return (
-		<div className="grid [grid-template-columns:repeat(auto-fit,minmax(210px,1fr))] gap-4 mb-8">
+		<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-9 gap-4 mb-8">
 			{statConfig.map(stat => {
 				const Icon = stat.icon;
 				const value = stat.getValue(stats);


### PR DESCRIPTION
> **Superseded.** The stats dashboard was rebuilt on `main` (routes/ + ui/ + data/ architecture),
> which already prevents the card and request-table overflow this PR targeted and renders small
> nonzero costs correctly. Closing - there is no longer a surface to patch. Details below for record.

## Summary
- keep the overview stat cards in their existing responsive grid (all nine in a row on wide screens) and stop them overflowing by hardening each card: `min-width: 0`, value truncation, and a non-shrinking icon
- compact large card values (request counts, token totals, total cost) so they fit the cell, with the exact figure preserved in the hover `title` tooltip
- constrain dense request tables with fixed columns and scoped horizontal scrolling so they scroll inside their card instead of widening the page
- keep long per-row request values (relative time, tokens, cost, duration) inside their cells by truncating each with the exact figure in a hover `title` tooltip, and format per-row cost with a shared locale-aware currency formatter
- let the header controls wrap/scroll at smaller widths instead of widening the page
- defer the lower two-up content grid to the `2xl` breakpoint so each panel has room before going side by side
- add an Unreleased changelog entry for the stats package
- address Copilot/Codex review feedback on currency formatting, exact compact-value tooltips, and duplicate card getter calls

## Verification
- `bun --cwd=packages/stats run check`
- `bun --cwd=packages/stats run build`
- browser smoke with representative high-volume stats at 1600, 1366, 1200, 900, and 390 px: no page-level overflow and no stat-card overflow

## Before / After

Captured from a clean client build of this branch vs `main`. The dataset is **synthetic** - fabricated model names, providers, token counts, and costs generated into an isolated throwaway config dir, no real usage data - chosen to push the numbers into the billions/tens-of-thousands range that triggers the overflow. These are full-page captures, so any horizontal overflow shows up as extra image width.

| Viewport | Before (`main`) | After (this PR) |
|---|---|---|
| 1600 px (desktop) | ![before 1600](https://omp-pr.wolfie.gg/before-1600.png) | ![after 1600](https://omp-pr.wolfie.gg/after-1600-v2.png) |
| 1366 px | ![before 1366](https://omp-pr.wolfie.gg/before-1366.png) | ![after 1366](https://omp-pr.wolfie.gg/after-1366-v2.png) |
| 1200 px | ![before 1200](https://omp-pr.wolfie.gg/before-1200.png) | ![after 1200](https://omp-pr.wolfie.gg/after-1200-v2.png) |
| 900 px (tablet) | ![before 900](https://omp-pr.wolfie.gg/before-900.png) | ![after 900](https://omp-pr.wolfie.gg/after-900-v2.png) |
| 390 px (phone) | ![before 390](https://omp-pr.wolfie.gg/before-390.png) | ![after 390](https://omp-pr.wolfie.gg/after-390-v2.png) |

Before: the nine stat cards sit in one row, the raw comma-separated token counts and cost blow past their cells, and the request tables widen the whole page (visible as horizontal overflow on the 900 px and 390 px shots). After: the cards stay in that same row on wide screens, each large value renders compact (`19.9B`, `$324.3K`) with the exact figure in the hover tooltip, every card truncates instead of pushing the grid wider, and the tables keep a minimum width while scrolling inside their own card.

## Notes
The request tables intentionally keep a minimum width on phone-sized viewports and scroll inside their card. That preserves dense columns without causing body overflow.
