### PR TITLE
refactor(python): dedup single-owner definitions and drop a stale private reach-in

### DIFF
--- a/python/omp-rpc/src/omp_rpc/client.py
+++ b/python/omp-rpc/src/omp_rpc/client.py
@@ -1186,13 +1186,6 @@ class RpcClient:
         process = self._require_process()
         self._write_json(process, payload)
 
-    def _normalize_host_tool_result(self, result: object) -> JsonObject:
-        if isinstance(result, str):
-            return {"content": [{"type": "text", "text": result}]}
-        if isinstance(result, Mapping):
-            return cast(JsonObject, dict(result))
-        raise RpcError("Host tool handlers must return a string or a result mapping")
-
     def _handle_host_tool_call(self, payload: JsonObject) -> None:
         request_id = payload.get("id")
         tool_name = payload.get("toolName")
@@ -1274,7 +1267,7 @@ class RpcClient:
                     {
                         "type": "host_tool_result",
                         "id": request_id,
-                        "result": self._normalize_host_tool_result(result),
+                        "result": tool.normalize_result(result),
                     }
                 )
             except Exception as exc:

--- a/python/omp-rpc/src/omp_rpc/client.py
+++ b/python/omp-rpc/src/omp_rpc/client.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar, cast
 from .host_tools import HostTool, HostToolContext
 from .host_uris import HostUri, HostUriContext, normalize_read_result
 from .protocol import (
+    _TODO_STATUS_VALUES,
     AgentStartEvent,
     AgentEndEvent,
     AgentMessage,
@@ -110,7 +111,6 @@ THistoryItem = TypeVar("THistoryItem")
 
 _ASYNC_COMMANDS = frozenset({"prompt", "abort_and_prompt"})
 _DEFAULT_ERROR_HISTORY_LIMIT = 128
-_TODO_STATUS_VALUES = frozenset({"pending", "in_progress", "completed", "abandoned"})
 
 
 def _process_group_id(process: subprocess.Popen[Any]) -> int | None:

--- a/python/robomp/src/cli.py
+++ b/python/robomp/src/cli.py
@@ -9,7 +9,7 @@ import sys
 import click
 import uvicorn
 
-from robomp.config import Settings, get_settings
+from robomp.config import Settings, get_settings, require_proxy_mode
 from robomp.db import INACTIVE_EVENT_STATES, get_database
 from robomp.logging_config import configure_logging
 from robomp.manual_triage import (
@@ -33,22 +33,8 @@ def _settings_or_die() -> Settings:
         sys.exit(2)
 
 
-def _require_proxy_mode(cfg: Settings) -> tuple[str, bytes]:
-    if cfg.github_token is not None:
-        raise SystemExit(
-            "robomp orchestrator refuses to start with GITHUB_TOKEN set in env. "
-            "The PAT must live only in the gh-proxy container."
-        )
-    if cfg.gh_proxy_url is None or cfg.gh_proxy_hmac_key is None:
-        raise SystemExit(
-            "robomp orchestrator requires ROBOMP_GH_PROXY_URL and "
-            "ROBOMP_GH_PROXY_HMAC_KEY (run gh-proxy in a sibling container)."
-        )
-    return cfg.gh_proxy_url, cfg.gh_proxy_hmac_key.get_secret_value().encode("utf-8")
-
-
 def _build_github(cfg: Settings) -> GitHubProxyClient:
-    base_url, key = _require_proxy_mode(cfg)
+    base_url, key = require_proxy_mode(cfg)
     return GitHubProxyClient(base_url=base_url, hmac_key=key)
 
 

--- a/python/robomp/src/config.py
+++ b/python/robomp/src/config.py
@@ -363,6 +363,20 @@ def reset_settings_cache() -> None:
     get_settings.cache_clear()
 
 
+def require_proxy_mode(cfg: Settings) -> tuple[str, bytes]:
+    if cfg.github_token is not None:
+        raise SystemExit(
+            "robomp orchestrator refuses to start with GITHUB_TOKEN set in env. "
+            "The PAT must live only in the gh-proxy container."
+        )
+    if cfg.gh_proxy_url is None or cfg.gh_proxy_hmac_key is None:
+        raise SystemExit(
+            "robomp orchestrator requires ROBOMP_GH_PROXY_URL and "
+            "ROBOMP_GH_PROXY_HMAC_KEY (run gh-proxy in a sibling container)."
+        )
+    return cfg.gh_proxy_url, cfg.gh_proxy_hmac_key.get_secret_value().encode("utf-8")
+
+
 class _ProxyEnvLoader(BaseSettings):
     """Minimal env loader for `python -m robomp.proxy serve`.
 

--- a/python/robomp/src/server.py
+++ b/python/robomp/src/server.py
@@ -16,7 +16,7 @@ from fastapi.staticfiles import StaticFiles
 
 from robomp import github_events
 from robomp.autoclose import AutocloseScheduler
-from robomp.config import Settings, get_settings
+from robomp.config import Settings, get_settings, require_proxy_mode
 from robomp.dashboard import render_index, static_dir, tail_jsonl
 from robomp.db import (
     INACTIVE_EVENT_STATES,
@@ -214,22 +214,8 @@ def _issue_browse_payload(
     }
 
 
-def _require_proxy_mode(cfg: Settings) -> tuple[str, bytes]:
-    if cfg.github_token is not None:
-        raise SystemExit(
-            "robomp orchestrator refuses to start with GITHUB_TOKEN set in env. "
-            "The PAT must live only in the gh-proxy container."
-        )
-    if cfg.gh_proxy_url is None or cfg.gh_proxy_hmac_key is None:
-        raise SystemExit(
-            "robomp orchestrator requires ROBOMP_GH_PROXY_URL and "
-            "ROBOMP_GH_PROXY_HMAC_KEY (run gh-proxy in a sibling container)."
-        )
-    return cfg.gh_proxy_url, cfg.gh_proxy_hmac_key.get_secret_value().encode("utf-8")
-
-
 def _build_orchestrator(cfg: Settings) -> tuple[GitHubBackend, ProxyGitTransport]:
-    base_url, key = _require_proxy_mode(cfg)
+    base_url, key = require_proxy_mode(cfg)
     github = GitHubProxyClient(base_url=base_url, hmac_key=key)
     transport = ProxyGitTransport(base_url=base_url, hmac_key=key)
     return github, transport

--- a/python/robomp/src/worker.py
+++ b/python/robomp/src/worker.py
@@ -551,23 +551,8 @@ def _run_rpc_blocking(
         # out from under us, which makes `prompt_and_wait` raise an `RpcError`
         # we'll let propagate. The `with` exit calls `client.stop()` again, but
         # it's idempotent.
-        #
-        # NOTE: omp_rpc.RpcClient.stop() has a bug where it sets `_stopping=True`
-        # before the stdout reader loop notices the closed pipe, so the reader's
-        # `if not self._stopping` guard skips `_mark_closed()` entirely.
-        # `_wait_for_agent_end` then blocks on `_event_condition` until the hard
-        # timeout because `_closed_error` is never set. We work around it here
-        # by calling `_mark_closed()` ourselves after stop returns — this is
-        # idempotent (it no-ops when `_closed_error` is already set).
         def _cancel_hook() -> None:
-            try:
-                client.stop()
-            finally:
-                # Private API, but the only way to unblock `_wait_for_agent_end`
-                # without waiting for the request timeout. Idempotent.
-                client._mark_closed(  # noqa: SLF001
-                    RpcProcessExitError("cancelled by operator")
-                )
+            client.stop()
 
         if bindings.abort is not None:
             bindings.abort.stop = _cancel_hook

--- a/python/robomp/tests/test_worker.py
+++ b/python/robomp/tests/test_worker.py
@@ -27,7 +27,6 @@ class _FakeRpcClient:
         self.set_todos_calls: list[list[dict]] = []
         self.get_todos_calls = 0
         self.stop_calls = 0
-        self.mark_closed_calls: list[BaseException] = []
         _FakeRpcClient.instances.append(self)
 
     def __enter__(self):
@@ -47,9 +46,6 @@ class _FakeRpcClient:
 
     def stop(self) -> None:
         self.stop_calls += 1
-
-    def _mark_closed(self, error: BaseException) -> None:
-        self.mark_closed_calls.append(error)
 
     def set_todos(self, phases):
         self.set_todos_calls.append(phases)
@@ -518,23 +514,13 @@ async def test_run_rpc_hard_timeout_stops_client_and_fails(
 
     fake = _FakeRpcClient.instances[0]
     assert fake.stop_calls == 1
-    # `_cancel_hook` (used by both manual cancel and hard timeout) MUST also call
-    # `_mark_closed` to unblock `_wait_for_agent_end` — `stop()` alone leaves
-    # `_closed_error` unset (omp_rpc bug), so the worker would hang otherwise.
-    assert len(fake.mark_closed_calls) == 1
-    from omp_rpc import RpcProcessExitError
-
-    assert isinstance(fake.mark_closed_calls[0], RpcProcessExitError)
 
 
 @pytest.mark.asyncio
-async def test_run_rpc_cancel_hook_stops_and_marks_closed(
+async def test_run_rpc_cancel_hook_stops_client(
     tmp_path: Path, settings: Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The cancel hook registered with `register_cancel_hook` must call both
-    `client.stop()` AND `client._mark_closed()`. The latter is the workaround for
-    an upstream omp_rpc bug where `stop()` does not set `_closed_error`, leaving
-    `_wait_for_agent_end` blocked until timeout."""
+    """The cancel hook must call client.stop(); the real RpcClient.stop() sets _closed_error to unblock _wait_for_agent_end."""
     captured: list = []
     monkeypatch.setattr("robomp.worker.register_cancel_hook", lambda hook: captured.append(hook))
     monkeypatch.setattr("robomp.worker.unregister_cancel_hook", lambda: None)
@@ -558,11 +544,6 @@ async def test_run_rpc_cancel_hook_stops_and_marks_closed(
     pre_stop = fake.stop_calls
     hook()  # Simulate the API/worker firing the cancel
     assert fake.stop_calls == pre_stop + 1
-    assert len(fake.mark_closed_calls) == 1
-    from omp_rpc import RpcProcessExitError
-
-    assert isinstance(fake.mark_closed_calls[0], RpcProcessExitError)
-    assert "cancelled by operator" in str(fake.mark_closed_calls[0])
 
 
 class _ClassifiedRow:


### PR DESCRIPTION
## What

Four small, behavior-preserving cleanups across the Python packages (`omp-rpc`, `robomp`). Each restores a single owner for a contract that had drifted into a duplicate (or a stale private reach-in), with no change to observable behavior. One atomic commit per concern.

| Commit | Change |
|---|---|
| `refactor(omp-rpc): imported _TODO_STATUS_VALUES from protocol owner` | `client.py` redefined the todo-status frozenset that `protocol.py` already owns and uses for todo parsing. Import the owner; the two sets were byte-identical. |
| `refactor(omp-rpc): normalized host-tool results via HostTool.normalize_result` | `client._normalize_host_tool_result` duplicated `HostTool.normalize_result`. Route the single call site through the tool's own normalizer (already in closure scope) and delete the private copy. |
| `refactor(robomp): centralized require_proxy_mode in config` | `_require_proxy_mode` was defined byte-identically in `cli.py` and `server.py`. Move it to `config.py` (beside `Settings` and the other settings helpers) as the single owner; both entrypoints import it. |
| `refactor(robomp): drove RpcClient teardown through public stop()` | The cancel hook reached into `RpcClient._mark_closed()` to work around a bug where `stop()` left `_closed_error` unset. `stop()` now sets it itself (idempotently), so the manual reach-in was already a no-op — removed; `robomp` now drives teardown only through the public `stop()`. |

Net: **+23 / −78** lines across six files. No new abstractions, no public-API changes.

## Why

Each duplicate is a maintenance hazard — a future edit to one copy silently diverges from the other. After this change every one of these contracts has exactly one owner, and `robomp` talks to `RpcClient` only through its public surface.

### Behavior notes
- **Host-tool normalize:** both implementations map `str -> {"content":[{"type":"text","text":...}]}` and `mapping -> dict(...)` identically. The only divergence is the error text on a contract-violating return type (neither str nor mapping); no test asserts that string.
- **`_mark_closed` removal:** `stop()` already calls `_mark_closed(RpcProcessExitError("RPC process stopped"))` in its `finally`, and `_mark_closed` is idempotent (early-returns when `_closed_error` is set). Because the hook calls `stop()` first, the manual call was already shadowed in production. The two `worker` cancel/hard-timeout tests are updated to assert the public `stop()` contract.

## Verification
- `ruff check` (lint rules) clean on all six touched files.
- `omp-rpc`: 53 passed. `robomp`: 470 passed, 4 skipped (pre-existing env-gated integration skips).

## Note (intentionally out of scope)
There is no Python lint/test job in CI. `ruff format --check` reports two **pre-existing** unformatted files — `omp_rpc/protocol.py` (untouched by this PR) and one block in `worker.py` outside the edited region — under both ruff 0.13 and 0.15. That format debt predates this PR; it is left for a separate `style:` sweep to keep this change single-concern.
