### PR TITLE
fix(rpc): honor todo setting opt-outs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection; enabled todo reminders are now persisted to the JSONL transcript so the log matches the model-visible context ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
+
 ## [16.0.3] - 2026-06-16
 
 ### Added
@@ -42,8 +46,6 @@
 - Fixed `hooks/pre/*.ts` and `hooks/post/*.ts` files discovered through `hookCapability` being registered in discovery but never loaded into the extension runner, so their `tool_call` handlers now run without a manual `settings.json` `extensions` entry ([#2796](https://github.com/can1357/oh-my-pi/issues/2796)).
 - Fixed startup model fallback choosing the plain OpenAI `gpt-5.5` provider before the Codex OAuth provider when both shared the same default model id, which could surface a misleading OpenAI 401 despite valid Codex credentials ([#2807](https://github.com/can1357/oh-my-pi/issues/2807)).
 - Fixed local auto-thinking classification for reasoning-capable tiny models by giving them the same safe answer budget as online reasoning classifiers, with a larger local floor for non-reasoning tiny models ([#2808](https://github.com/can1357/oh-my-pi/issues/2808)).
-
-- Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
 
 ### Removed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Fixed startup model fallback choosing the plain OpenAI `gpt-5.5` provider before the Codex OAuth provider when both shared the same default model id, which could surface a misleading OpenAI 401 despite valid Codex credentials ([#2807](https://github.com/can1357/oh-my-pi/issues/2807)).
 - Fixed local auto-thinking classification for reasoning-capable tiny models by giving them the same safe answer budget as online reasoning classifiers, with a larger local floor for non-reasoning tiny models ([#2808](https://github.com/can1357/oh-my-pi/issues/2808)).
 
+- Fixed RPC/ACP startup forcing todo settings back to host defaults, so project-level `todo.enabled`, `todo.reminders`, and `todo.eager` opt-outs now suppress protocol-mode todo prompt injection ([#2824](https://github.com/can1357/oh-my-pi/issues/2824)).
+
 ### Removed
 
 - Removed the built-in `render_mermaid` tool and its `renderMermaid.enabled` setting, so it can no longer be invoked directly

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -124,11 +124,9 @@ async function checkForNewVersion(currentVersion: string): Promise<string | unde
 	}
 }
 
+// Todo settings are caller-controlled in protocol modes. Do not host-default them:
+// embedders need project-level opt-outs for reminder/prelude prompt injection.
 const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
-	"todo.enabled",
-	"todo.reminders",
-	"todo.reminders.max",
-	"todo.eager",
 	"task.isolation.mode",
 	"task.isolation.merge",
 	"task.isolation.commits",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8164,14 +8164,17 @@ export class AgentSession {
 			maxAttempts: remindersMax,
 		});
 
-		this.#todoReminderAwaitingProgress = true;
-		// Inject reminder and continue the conversation
-		this.agent.appendMessage({
+		const reminderMessage: Message = {
 			role: "developer",
 			content: [{ type: "text", text: reminder }],
 			attribution: "agent",
 			timestamp: Date.now(),
-		});
+		};
+
+		this.#todoReminderAwaitingProgress = true;
+		// Inject reminder and persist it so the JSONL transcript matches model context.
+		this.agent.appendMessage(reminderMessage);
+		this.sessionManager.appendMessage(reminderMessage);
 		this.#scheduleAgentContinue({ generation: this.#promptGeneration });
 	}
 

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -317,6 +317,81 @@ describe("ACP lazy startup", () => {
 			});
 		}
 	});
+
+	it("honors explicit todo settings for protocol hosts", async () => {
+		const { runRootCommand } = await import("@oh-my-pi/pi-coding-agent/main");
+
+		type ObservedTodoSettings = {
+			enabled: boolean;
+			reminders: boolean;
+			eager: "default" | "preferred" | "always";
+		};
+
+		const runProtocolStartup = async (mode: "rpc" | "rpc-ui" | "acp"): Promise<ObservedTodoSettings> => {
+			using tempDir = TempDir.createSync("@omp-protocol-todo-settings-");
+			const cwd = tempDir.path();
+			const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+			const settings = Settings.isolated({
+				"todo.enabled": false,
+				"todo.reminders": false,
+				"todo.eager": "always",
+			});
+			let observed: ObservedTodoSettings | undefined;
+			const stopMessage = "stop test protocol todo settings";
+			const observe = () => {
+				observed = {
+					enabled: settings.get("todo.enabled"),
+					reminders: settings.get("todo.reminders"),
+					eager: settings.get("todo.eager"),
+				};
+				throw new Error(stopMessage);
+			};
+
+			try {
+				await runRootCommand(
+					{
+						mode,
+						messages: [],
+						fileArgs: [],
+						unknownFlags: new Map(),
+						unrecognizedFlags: [],
+						noSkills: true,
+						noRules: true,
+						noTools: true,
+						noLsp: true,
+						noExtensions: true,
+						sessionDir: cwd,
+					},
+					[],
+					{
+						discoverAuthStorage: async () => authStorage,
+						settings,
+						createAgentSession: async () => observe(),
+						runAcpMode: async () => observe(),
+					},
+				);
+			} catch (error) {
+				if (!(error instanceof Error) || error.message !== stopMessage) {
+					throw error;
+				}
+			} finally {
+				authStorage.close();
+			}
+
+			if (!observed) {
+				throw new Error("Expected protocol mode to start");
+			}
+			return observed;
+		};
+
+		for (const mode of ["rpc", "rpc-ui", "acp"] as const) {
+			await expect(runProtocolStartup(mode)).resolves.toEqual({
+				enabled: false,
+				reminders: false,
+				eager: "always",
+			});
+		}
+	});
 	it("answers initialize before creating the first AgentSession", async () => {
 		const clientToAgent = new TransformStream();
 		const agentToClient = new TransformStream();

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -153,11 +153,22 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("baseline: a single text-only stop fires reminder 1/3", async () => {
+	it("baseline: a single text-only stop fires reminder 1/3 and records it in the transcript", async () => {
 		vi.spyOn(session.agent, "continue").mockResolvedValue();
 		emitTextOnlyStop();
 		await withTimeout(firstReminderPromise, 1000, "todo_reminder never fired");
 		expect(reminderAttempts).toEqual([1]);
+
+		const reminderEntry = sessionManager.getBranch().find(entry => {
+			if (entry.type !== "message" || entry.message.role !== "developer") return false;
+			const { content } = entry.message;
+			if (!Array.isArray(content)) return false;
+			return content.some(
+				(item): item is TextContent =>
+					item.type === "text" && item.text.includes("You stopped with 2 incomplete todo item(s):"),
+			);
+		});
+		expect(reminderEntry?.type).toBe("message");
 	});
 
 	it("fires exactly one reminder per user pause when the agent only acknowledges", async () => {


### PR DESCRIPTION
## Repro
An RPC startup harness with `Settings.isolated({ "todo.reminders": false })` observed `todo.reminders` as a truthy object after protocol defaults were applied: `bun -e "$REPRO"` printed `todo.reminders after RPC startup: [object Object]` and exited 1.

## Cause
`packages/coding-agent/src/main.ts` included `todo.enabled`, `todo.reminders`, `todo.reminders.max`, and `todo.eager` in `HOST_DEFAULTED_SETTING_PATHS`, so RPC/ACP startup overwrote caller/project todo settings. The `todo.reminders.max` runtime override also occupied the same nested settings path as the `todo.reminders` boolean, leaving reminder checks with a truthy object instead of the explicit `false` opt-out.

## Fix
- Removed todo settings from protocol host-default overrides so RPC/ACP sessions honor caller/project todo settings.
- Added startup coverage in `packages/coding-agent/test/acp-lazy-startup.test.ts` for `rpc`, `rpc-ui`, and `acp` preserving `todo.enabled`, `todo.reminders`, and `todo.eager`.
- Added the coding-agent changelog entry for #2824.

## Verification
`bun test packages/coding-agent/test/acp-lazy-startup.test.ts -t "todo settings"` passed. `bun test packages/coding-agent/test/acp-lazy-startup.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. Fixes #2824