### PR TITLE
fix(google): omit AUTO toolConfig in google-gemini-cli provider

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -849,9 +849,12 @@ export function buildRequest(
 		if (options.toolChoice) {
 			const choice = options.toolChoice;
 			if (typeof choice === "string") {
-				request.toolConfig = {
-					functionCallingConfig: { mode: mapToolChoice(choice) },
-				};
+				const mode = mapToolChoice(choice);
+				if (mode !== "AUTO") {
+					request.toolConfig = {
+						functionCallingConfig: { mode },
+					};
+				}
 			} else {
 				request.toolConfig = {
 					functionCallingConfig: {


### PR DESCRIPTION
Fixes #2830

### Description
The shared-layer fix (#2782) omitted `toolConfig` for `AUTO` mode in `google-shared.ts`, but the `google-gemini-cli`/`google-antigravity` provider has its own independent `buildRequest` function in `google-gemini-cli.ts` that still serializes explicit `toolConfig.functionCallingConfig.mode: "AUTO"` when `toolChoice` is `"auto"`. This triggers the Gemini-3 upstream bug where the model leaks raw internal planning JSON instead of executing tool calls.

### Changes
- `packages/ai/src/providers/google-gemini-cli.ts`: Wrap the `toolConfig` assignment in a guard that skips serialization when `mapToolChoice(choice)` returns `"AUTO"`, matching the pattern from #2782.

### Verification
- Same logical fix as the reviewed-and-approved #2782, applied to the missing provider path.
- `bun test` in `packages/ai` passes.