### PR TITLE
fix(providers): omit google cli auto tool config

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Gemini CLI and Antigravity tool calls with `toolChoice: "auto"` serializing an explicit `toolConfig` AUTO mode, which can cause Gemini-3 models to leak raw planning JSON instead of executing tools. ([#2830](https://github.com/can1357/oh-my-pi/issues/2830))
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -849,9 +849,12 @@ export function buildRequest(
 		if (options.toolChoice) {
 			const choice = options.toolChoice;
 			if (typeof choice === "string") {
-				request.toolConfig = {
-					functionCallingConfig: { mode: mapToolChoice(choice) },
-				};
+				const mode = mapToolChoice(choice);
+				if (mode !== "AUTO") {
+					request.toolConfig = {
+						functionCallingConfig: { mode },
+					};
+				}
 			} else {
 				request.toolConfig = {
 					functionCallingConfig: {

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -171,6 +171,37 @@ describe("Google Gemini CLI alignment", () => {
 		expect(payload.userAgent).toBe("antigravity");
 		expect(payload.requestId).toMatch(/^agent-/);
 	});
+	it("omits AUTO toolConfig for Google Gemini CLI tool calls", () => {
+		for (const provider of ["google-gemini-cli", "google-antigravity"] as const) {
+			const model = createModel(provider);
+			const context: Context = {
+				messages: [{ role: "user", content: "inspect repo", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "read_file",
+						description: "Read a file",
+						parameters: {
+							type: "object",
+							properties: { path: { type: "string" } },
+							required: ["path"],
+						} as TJsonSchema,
+					},
+				],
+			};
+			const payload = buildRequest(
+				model,
+				context,
+				"proj-123",
+				{ toolChoice: "auto" },
+				provider === "google-antigravity",
+			) as {
+				request: { tools?: unknown; toolConfig?: unknown };
+			};
+
+			expect(payload.request.tools).toBeDefined();
+			expect(payload.request.toolConfig).toBeUndefined();
+		}
+	});
 
 	it("strips patternProperties when antigravity rewrites tools to legacy parameters", () => {
 		const model = createModel("google-antigravity");


### PR DESCRIPTION
## Repro
Added a focused regression that builds `google-gemini-cli` and `google-antigravity` requests with tools plus `toolChoice: "auto"`; before the fix, `bun --cwd=packages/ai test test/google-gemini-cli-alignment.test.ts -t "omits AUTO toolConfig"` failed because `request.toolConfig.functionCallingConfig.mode` was serialized as `"AUTO"`.

## Cause
`packages/ai/src/providers/google-gemini-cli.ts` had an independent `buildRequest` tool-choice path that always assigned `request.toolConfig` for string tool choices, unlike `buildGoogleGenerateContentParams` in `packages/ai/src/providers/google-shared.ts`, so the Gemini CLI and Antigravity providers still sent the explicit Google-side AUTO mode.

## Fix
- Changed `buildRequest` to map string tool choices once and omit `request.toolConfig` when the mapped mode is `"AUTO"`.
- Kept non-AUTO string choices and named-tool object choices serialized as before.
- Added regression coverage for both `google-gemini-cli` and `google-antigravity` provider identities.
- Added the `packages/ai` changelog entry for #2830.

## Verification
Reproduced before the fix with `bun --cwd=packages/ai test test/google-gemini-cli-alignment.test.ts -t "omits AUTO toolConfig"` failing on a received `mode: "AUTO"`; after the fix, `bun --cwd=packages/ai test test/google-gemini-cli-alignment.test.ts test/google-tool-choice.test.ts` passed with 24 tests, and `bun --cwd=packages/ai run check` passed. Fixes #2830