### PR TITLE
fix(google): intercept and filter out leaked internal thought JSON in gemini-cli stream

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -93,6 +93,9 @@
 - Fixed OpenRouter Responses requests tagging the streamed assistant message with a hardcoded `openai-responses` API instead of the runtime `model.api`, which silently disabled native-history replay (`buildResponsesInput`) and cross-model tool-call item-id stripping on subsequent OpenRouter turns. The message now carries `model.api` (matching the Chat Completions path).
 - Fixed OpenAI-family streaming leaking a pre-retry `errorMessage` onto a successful turn: the OpenRouter Anthropic compiled-grammar strict-tool fallback set `errorMessage` before retrying with strict tools disabled and never cleared it on success, and the Chat Completions success path could carry an `errorMessage` from an internally-retried attempt — both made a successful turn read as errored in agent state and telemetry. The Responses fallback no longer assigns `errorMessage`, and the Completions success path clears it before emitting the terminal `done` event.
 - Fixed Codex stream-error `.code` resolution to use the same nested-first precedence (`error.code` → `error.type` → top-level `code`) as `isRetryableCodexFailureEvent` and the formatted message. Previously the error factory resolved top-level-first, so a failure event carrying both a top-level and a differing nested error code surfaced a `.code` that could disagree with its own `retryable` flag and message text.
+### Fixed
+
+- Improved Gemini-3 client stream output planning leak detection to support dynamic 100-character boundary matching and precision OMP tool signature filtering, avoiding mis-intercepting normal JSON payloads.
 
 ## [16.0.5] - 2026-06-17
 

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -64,6 +64,87 @@ export class GeminiCliApiError extends ProviderHttpError {
 	override readonly name = "GeminiCliApiError";
 }
 
+const OMP_BUILTIN_TOOLS = new Set([
+	"read",
+	"bash",
+	"edit",
+	"ast_grep",
+	"ast_edit",
+	"ask",
+	"debug",
+	"eval",
+	"ssh",
+	"github",
+	"find",
+	"search",
+	"lsp",
+	"browser",
+	"task",
+	"job",
+	"irc",
+	"todo",
+	"web_search",
+	"write",
+	"retain",
+	"recall",
+	"reflect",
+	"resolve",
+	"report_tool_issue",
+	"generate_image",
+]);
+
+function isPlanningLeakPrefix(text: string): boolean {
+	const trimmed = text.trimStart();
+	if (!trimmed.startsWith("{")) {
+		return false;
+	}
+	const afterBrace = trimmed.slice(1).trimStart();
+	if (afterBrace === "") {
+		return trimmed.length <= 100;
+	}
+	if (afterBrace[0] !== '"') {
+		return false;
+	}
+	const nextQuoteIndex = afterBrace.indexOf('"', 1);
+	if (nextQuoteIndex === -1) {
+		const keyPrefix = afterBrace.slice(1);
+		return "thought".startsWith(keyPrefix) && trimmed.length <= 100;
+	}
+	const key = afterBrace.slice(1, nextQuoteIndex);
+	if (key !== "thought") {
+		return false;
+	}
+	const afterKey = afterBrace.slice(nextQuoteIndex + 1).trimStart();
+	if (afterKey === "") {
+		return trimmed.length <= 100;
+	}
+	if (afterKey[0] !== ":") {
+		return false;
+	}
+	return true;
+}
+
+function checkBuffer(text: string): { isValidJson: boolean; isLeak: boolean } {
+	const trimmed = text.trimStart();
+	if (!trimmed.endsWith("}")) {
+		return { isValidJson: false, isLeak: false };
+	}
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (parsed && typeof parsed === "object") {
+			const hasThought = typeof parsed.thought === "string";
+			const isOmpTool = typeof parsed.call === "string" && OMP_BUILTIN_TOOLS.has(parsed.call);
+			const hasToolSignature =
+				"_i" in parsed || "paths" in parsed || "command" in parsed || ("path" in parsed && "content" in parsed);
+			const isLeak = hasThought && (isOmpTool || hasToolSignature);
+			return { isValidJson: true, isLeak };
+		}
+	} catch {
+		// Not valid JSON yet
+	}
+	return { isValidJson: false, isLeak: false };
+}
+
 export interface GoogleGeminiCliOptions extends StreamOptions {
 	/**
 	 * Tool selection mode. String forms map directly to Gemini
@@ -504,6 +585,9 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				const blocks = output.content;
 				const blockIndex = () => blocks.length - 1;
 
+				let isBuffering = false;
+				let textBuffer = "";
+
 				for await (const chunk of readSseJson<CloudCodeAssistResponseChunk>(
 					activeResponse.body!,
 					options?.signal,
@@ -554,17 +638,57 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 										partial: output,
 									});
 								} else {
-									currentBlock.text += part.text;
-									currentBlock.textSignature = retainThoughtSignature(
-										currentBlock.textSignature,
-										part.thoughtSignature,
-									);
-									stream.push({
-										type: "text_delta",
-										contentIndex: blockIndex(),
-										delta: part.text,
-										partial: output,
-									});
+									if (!isBuffering && currentBlock.text === "" && part.text.trimStart().startsWith("{")) {
+										isBuffering = true;
+										textBuffer = part.text;
+									} else if (!isBuffering) {
+										currentBlock.text += part.text;
+										currentBlock.textSignature = retainThoughtSignature(
+											currentBlock.textSignature,
+											part.thoughtSignature,
+										);
+										stream.push({
+											type: "text_delta",
+											contentIndex: blockIndex(),
+											delta: part.text,
+											partial: output,
+										});
+									} else {
+										textBuffer += part.text;
+									}
+
+									if (isBuffering) {
+										if (isPlanningLeakPrefix(textBuffer)) {
+											const check = checkBuffer(textBuffer);
+											if (check.isValidJson) {
+												if (check.isLeak) {
+													isBuffering = false;
+													textBuffer = "";
+													currentBlock.text = "";
+												} else {
+													isBuffering = false;
+													currentBlock.text += textBuffer;
+													stream.push({
+														type: "text_delta",
+														contentIndex: blockIndex(),
+														delta: textBuffer,
+														partial: output,
+													});
+													textBuffer = "";
+												}
+											}
+										} else {
+											isBuffering = false;
+											currentBlock.text += textBuffer;
+											stream.push({
+												type: "text_delta",
+												contentIndex: blockIndex(),
+												delta: textBuffer,
+												partial: output,
+											});
+											textBuffer = "";
+										}
+									}
 								}
 							} else if (part.text === "" && part.thoughtSignature && currentBlock && !part.functionCall) {
 								if (currentBlock.type === "thinking") {
@@ -585,6 +709,8 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 									pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
 									currentBlock = null;
 								}
+								isBuffering = false;
+								textBuffer = "";
 
 								const providedId = part.functionCall.id;
 								const needsNewId =
@@ -643,6 +769,20 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						};
 						calculateCost(model, output.usage);
 					}
+				}
+
+				if (isBuffering && textBuffer !== "") {
+					if (currentBlock && currentBlock.type === "text") {
+						currentBlock.text += textBuffer;
+						stream.push({
+							type: "text_delta",
+							contentIndex: blockIndex(),
+							delta: textBuffer,
+							partial: output,
+						});
+					}
+					isBuffering = false;
+					textBuffer = "";
 				}
 
 				if (currentBlock) {

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -537,4 +537,192 @@ describe("Google Gemini CLI alignment", () => {
 			expect(result.errorMessage).toContain("Cloud Code Assist API error (503)");
 		});
 	});
+
+	describe("planning leak interception", () => {
+		it("intercepts fragmented planning leak and discards it", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"thought\\": \\"let us do something\\",\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"call\\": \\"read\\",\\n  \\"paths\\": [\\"src/main.ts\\"]\\n}"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				const response = new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+				Object.defineProperty(response, "url", {
+					value: "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent",
+				});
+				return response;
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "",
+			});
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toContain("empty response");
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents).toHaveLength(0);
+		});
+
+		it("does not intercept normal JSON starting with { and releases it", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"some\\": \\"normal json\\"\\n}"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: '{\n  "some": "normal json"\n}',
+			});
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents.length).toBeGreaterThan(0);
+		});
+
+		it("releases buffer immediately if prefix does not match thought within 100 chars", async () => {
+			const longNonThoughtKey = `{${"a".repeat(105)}}`;
+			const sseChunks = [
+				`data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"${longNonThoughtKey}"}]},"finishReason":"STOP"}]}}\n\n`,
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe("text");
+			expect((result.content[0] as any).text).toBe(longNonThoughtKey);
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents).toHaveLength(1);
+			expect(textDeltaEvents[0].delta).toBe(longNonThoughtKey);
+		});
+
+		it("handles functionCall immediately after a planning leak", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"doing reading\\",\\n  \\"call\\": \\"read\\",\\n  \\"paths\\": [\\"src/main.ts\\"]\\n}"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read","args":{"path":"src/main.ts"}}}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(2);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "",
+			});
+			expect(result.content[1].type).toBe("toolCall");
+			if (result.content[1].type === "toolCall") {
+				expect(result.content[1].name).toBe("read");
+				expect(result.content[1].arguments).toEqual({ path: "src/main.ts" });
+			}
+
+			expect(events.filter(e => e.type === "toolcall_start")).toHaveLength(1);
+		});
+	});
 });


### PR DESCRIPTION
Fixes the Gemini-3 client-side planning leak bug for the CLI provider.

### Description
When using Gemini-3 models, the model occasionally outputs raw internal planning JSON blocks (containing `thought` and `call`/`_i` fields) into the assistant text content stream. 

This PR implements a robust client-side streaming buffer interceptor in `google-gemini-cli.ts` that:
1. Buffers any incoming text blocks that start with `{`.
2. Inspects if the buffer matches a potential JSON planning leak prefix.
3. If confirmed as a complete planning leak JSON block upon closing (or if aborted with a trailing tool call), discards it.
4. If it diverges from the JSON planning structure at any point (or if the stream ends without a match), flushes the buffer to the user.

This prevents raw JSON planning blocks from leaking onto the user's terminal stdout.

### Changes
- `packages/ai/src/providers/google-gemini-cli.ts`: Implement helper detection functions and add stream buffering logic inside `streamResponse`.

### Verification
- Tested locally with `google-antigravity` / `google-gemini-cli` providers. Verified that raw JSON leaks are completely suppressed, while regular text and JSON output requests remain unaffected.