### PR TITLE
fix(prompting): load applicable skills before work

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed default prompts to instruct the agent to read applicable `skill://<name>` content before starting work, so discovered skills influence broad task requests like frontend generation ([#2829](https://github.com/can1357/oh-my-pi/issues/2829)).
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -117,6 +117,8 @@ ENV
 
 # Skills & Rules
 {{#if skills.length}}
+Skills are specialized knowledge. Scan descriptions for your task domain.
+If a skill applies, you MUST read `skill://<name>` before proceeding.
 <skills>
 {{#each skills}}
 - {{name}}: {{description}}

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -86,6 +86,31 @@ describe("system prompt tool inventory", () => {
 		expect(text).not.toContain("- Read: `read`");
 	});
 
+	it("tells the agent to read matching skills before work", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [
+				{
+					name: "frontend-design",
+					description: "Frontend UI workflow",
+					filePath: path.join(tempDir, "SKILL.md"),
+					baseDir: tempDir,
+					source: "test",
+				},
+			],
+			rules: [],
+			toolNames: ["read"],
+			tools: TOOLS,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+		});
+		const text = systemPrompt.join("\n\n");
+
+		expect(text).toContain("Skills are specialized knowledge. Scan descriptions for your task domain.");
+		expect(text).toContain("If a skill applies, you MUST read `skill://<name>` before proceeding.");
+		expect(text).toContain("- frontend-design: Frontend UI workflow");
+	});
+
 	it("places the inventory at the bottom of the TOOLS section (after I/O and Exploration)", async () => {
 		const text = await render({ nativeTools: true, repeatToolDescriptions: false });
 		const inventoryIdx = text.indexOf("# Inventory");


### PR DESCRIPTION
## Repro
A default prompt with a discovered frontend skill listed the skill but had no invocation guidance. Repro command: `bun --eval 'const text = await Bun.file("packages/coding-agent/src/prompts/system/system-prompt.md").text(); const skillsBlock = text.slice(text.indexOf("# Skills & Rules"), text.indexOf("{{#if alwaysApplyRules.length}}")); console.log(skillsBlock.trim()); const hasDirective = skillsBlock.includes("If a skill applies") || skillsBlock.includes("MUST read"); console.log(hasDirective ? "skill directive present" : "skill directive missing"); process.exit(hasDirective ? 0 : 1);'` exited 1 before the fix with `skill directive missing`.

## Cause
`packages/coding-agent/src/prompts/system/system-prompt.md` rendered discovered skills only as a passive `<skills>` list. Unlike `custom-system-prompt.md`, the default prompt did not tell the agent to scan descriptions or read `skill://<name>` before acting on matching task domains.

## Fix
- Added default prompt guidance to scan skill descriptions and read applicable `skill://<name>` content before work.
- Added a rendered-prompt regression test with a `frontend-design` skill to lock the behavior.
- Added an unreleased changelog entry for the prompt fix.

## Verification
Ran `bun test packages/coding-agent/test/system-prompt-inventory.test.ts` (5 pass), `bun --cwd=packages/coding-agent run check` (passed), and the repro command now exits 0 with `skill directive present`. Fixes #2829