### PR TITLE
feat(mcp): lazy on-demand MCP servers (lifecycle + idleTimeout)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 
 - Fixed `omp usage` hiding sibling-only limits such as Claude 7 Day (Fable) on accounts whose current report omitted that scoped bucket; the account now renders an explicit `not reported` row instead of looking like the usage refresh skipped the column.
+### Added
+
+- Opt-in per-server MCP `lifecycle: eager | lazy` plus `idleTimeout`, with global defaults `mcp.defaultLifecycle` and `mcp.defaultIdleTimeoutMs`. `lazy` servers advertise cached tools without spawning at session start, connect on first tool call (single-flight), and idle-disconnect after `idleTimeout` (never mid-call). Default remains `eager`, so existing configs are unchanged.
 
 ## [16.3.3] - 2026-07-02
 

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -49,6 +49,10 @@ export interface MCPServer {
 	};
 	/** Transport type */
 	transport?: "stdio" | "sse" | "http";
+	/** Connection lifecycle: "eager" (default) connects at session start; "lazy" connects on first tool use and idle-disconnects after idleTimeout. */
+	lifecycle?: "eager" | "lazy";
+	/** Idle-disconnect timeout in milliseconds for lazy servers. 0 disables idle disconnect. */
+	idleTimeout?: number;
 	/** Source metadata (added by loader) */
 	_source: SourceMeta;
 }

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -75,6 +75,18 @@ export const mcpCapability = defineCapability<MCPServer>({
 			return "http/sse transport requires url field";
 		}
 
+		// Validate lifecycle policy so a typo (e.g. "lazyy") surfaces as a config
+		// error instead of silently falling through every === "lazy" check as eager.
+		if (server.lifecycle !== undefined && server.lifecycle !== "eager" && server.lifecycle !== "lazy") {
+			return `Invalid lifecycle "${server.lifecycle}" (expected "eager" or "lazy")`;
+		}
+		if (
+			server.idleTimeout !== undefined &&
+			(typeof server.idleTimeout !== "number" || !Number.isFinite(server.idleTimeout) || server.idleTimeout < 0)
+		) {
+			return "idleTimeout must be a non-negative number of milliseconds";
+		}
+
 		return undefined;
 	},
 });

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -123,6 +123,16 @@
         },
         "oauth": {
           "$ref": "#/$defs/oauthConfig"
+        },
+        "lifecycle": {
+          "type": "string",
+          "enum": ["eager", "lazy"],
+          "description": "Connection lifecycle. \"eager\" (default) connects at session start; \"lazy\" connects on first tool use and disconnects after idleTimeout."
+        },
+        "idleTimeout": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Idle disconnect timeout in milliseconds for lazy servers. 0 disables idle disconnect (connect on first use, stay connected)."
         }
       }
     },

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -137,13 +137,14 @@
       }
     },
     "stdioServer": {
+      "type": "object",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["command"],
           "properties": {
             "type": {
@@ -179,13 +180,14 @@
       ]
     },
     "httpServer": {
+      "type": "object",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {
@@ -210,13 +212,14 @@
       ]
     },
     "sseServer": {
+      "type": "object",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3861,6 +3861,30 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.defaultLifecycle": {
+		type: "enum",
+		values: ["eager", "lazy"] as const,
+		default: "eager",
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Default Lifecycle",
+			description:
+				"Default connection lifecycle for MCP servers without an explicit lifecycle field. Set to lazy to connect servers on first tool use and idle-disconnect them.",
+		},
+	},
+
+	"mcp.defaultIdleTimeoutMs": {
+		type: "number",
+		default: 300000,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Idle Disconnect (ms)",
+			description: "Idle timeout in milliseconds before a lazy MCP server is disconnected. 0 disables idle disconnect.",
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Tasks
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3881,7 +3881,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "tools",
 			group: "Discovery & MCP",
 			label: "MCP Idle Disconnect (ms)",
-			description: "Idle timeout in milliseconds before a lazy MCP server is disconnected. 0 disables idle disconnect.",
+			description:
+				"Idle timeout in milliseconds before a lazy MCP server is disconnected. 0 disables idle disconnect.",
 		},
 	},
 

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -184,6 +184,8 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 					  }
 					| undefined,
 				transport: serverConfig.type as "stdio" | "sse" | "http" | undefined,
+				lifecycle: serverConfig.lifecycle as "eager" | "lazy" | undefined,
+				idleTimeout: serverConfig.idleTimeout as number | undefined,
 				_source: createSourceMeta(PROVIDER_ID, path, level),
 			});
 		}

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -48,6 +48,8 @@ interface MCPConfigFile {
 				callbackPath?: string;
 				prompt?: string;
 			};
+			lifecycle?: "eager" | "lazy";
+			idleTimeout?: number;
 		}
 	>;
 }
@@ -96,6 +98,8 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				auth: serverConfig.auth,
 				oauth: serverConfig.oauth,
 				transport: serverConfig.type,
+				lifecycle: serverConfig.lifecycle,
+				idleTimeout: serverConfig.idleTimeout,
 				_source: source,
 			};
 

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -35,7 +35,7 @@ export interface LoadMCPConfigsResult {
 /**
  * Convert canonical MCPServer to legacy MCPServerConfig.
  */
-function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
+export function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	// Determine transport type
 	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
 	const shared = {

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -43,6 +43,8 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 		timeout: server.timeout,
 		auth: server.auth,
 		oauth: server.oauth,
+		lifecycle: server.lifecycle,
+		idleTimeout: server.idleTimeout,
 	};
 
 	if (transport === "stdio") {

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -10,6 +10,7 @@ import type { AuthStorage } from "../session/auth-storage";
 import { type MCPLoadResult, MCPManager } from "./manager";
 import type { McpConnectionStatusEvent } from "./startup-events";
 import { MCPToolCache } from "./tool-cache";
+import type { MCPLifecycle } from "./types";
 
 /** Result from loading MCP tools */
 export interface MCPToolsLoadResult {
@@ -39,6 +40,8 @@ export interface MCPToolsLoadOptions {
 	cacheStorage?: AgentStorage | null;
 	/** Auth storage used to resolve OAuth credentials before initial MCP connect */
 	authStorage?: AuthStorage;
+	/** Default lifecycle + idle timeout for servers without an explicit `lifecycle`. */
+	lifecycleDefaults?: { lifecycle: MCPLifecycle; idleTimeoutMs: number };
 }
 
 async function resolveToolCache(storage: AgentStorage | null | undefined): Promise<MCPToolCache | null> {
@@ -64,6 +67,9 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 	const manager = new MCPManager(cwd, toolCache);
 	if (options?.authStorage) {
 		manager.setAuthStorage(options.authStorage);
+	}
+	if (options?.lifecycleDefaults) {
+		manager.setLifecycleDefaults(options.lifecycleDefaults.lifecycle, options.lifecycleDefaults.idleTimeoutMs);
 	}
 
 	let result: MCPLoadResult;

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -34,11 +34,12 @@ import {
 } from "./oauth-credentials";
 import { type MCPStoredOAuthCredential, refreshMCPOAuthToken } from "./oauth-flow";
 import type { McpConnectionStatusEvent } from "./startup-events";
-import type { MCPToolDetails } from "./tool-bridge";
+import type { MCPActivityHooks, MCPToolDetails } from "./tool-bridge";
 import { DeferredMCPTool, MCPTool } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
 import type {
 	MCPGetPromptResult,
+	MCPLifecycle,
 	MCPPrompt,
 	MCPRequestOptions,
 	MCPResource,
@@ -207,11 +208,196 @@ export class MCPManager {
 	#reconnectHistory = new Map<string, number[]>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
+	/** Default lifecycle applied to servers without an explicit `lifecycle`. */
+	#defaultLifecycle: MCPLifecycle = "eager";
+	/** Default idle-disconnect timeout (ms) for lazy servers without an explicit `idleTimeout`. */
+	#defaultIdleTimeoutMs = 300_000;
+	/** In-flight tool-call refcount per server; guards lazy idle-disconnect. */
+	#activeCalls = new Map<string, number>();
+	/** Timestamp (ms) of the last tool-call activity per server. */
+	#lastActivityAt = new Map<string, number>();
+	/** Pending idle-disconnect timers per lazy server. */
+	#idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	constructor(
 		private cwd: string,
 		private toolCache: MCPToolCache | null = null,
 	) {}
+
+	/**
+	 * Set the default lifecycle and idle-disconnect timeout for servers that do
+	 * not specify their own. Wired from settings (`mcp.defaultLifecycle`,
+	 * `mcp.defaultIdleTimeoutMs`) before servers are connected.
+	 */
+	setLifecycleDefaults(defaultLifecycle: MCPLifecycle, defaultIdleTimeoutMs: number): void {
+		this.#defaultLifecycle = defaultLifecycle;
+		this.#defaultIdleTimeoutMs =
+			Number.isFinite(defaultIdleTimeoutMs) && defaultIdleTimeoutMs >= 0 ? defaultIdleTimeoutMs : 300_000;
+	}
+
+	/** Effective lifecycle for a server config (per-server overrides the default). */
+	#effectiveLifecycle(config: MCPServerConfig | undefined): MCPLifecycle {
+		return config?.lifecycle ?? this.#defaultLifecycle;
+	}
+
+	/** Effective idle-disconnect timeout (ms) for a server config. */
+	#effectiveIdleTimeout(config: MCPServerConfig | undefined): number {
+		return config?.idleTimeout ?? this.#defaultIdleTimeoutMs;
+	}
+
+	/** Activity hooks handed to a server's tools so the manager can refcount calls. */
+	#activityHooks(name: string): MCPActivityHooks {
+		return {
+			begin: () => this.#beginCall(name),
+			end: () => this.#endCall(name),
+		};
+	}
+
+	/** Mark a tool call started: bump the refcount and cancel any pending idle reap. */
+	#beginCall(name: string): void {
+		this.#activeCalls.set(name, (this.#activeCalls.get(name) ?? 0) + 1);
+		this.#lastActivityAt.set(name, Date.now());
+		const timer = this.#idleTimers.get(name);
+		if (timer) {
+			clearTimeout(timer);
+			this.#idleTimers.delete(name);
+		}
+	}
+
+	/** Mark a tool call finished: drop the refcount and (re)arm the idle reaper. */
+	#endCall(name: string): void {
+		const next = (this.#activeCalls.get(name) ?? 1) - 1;
+		if (next <= 0) {
+			this.#activeCalls.delete(name);
+		} else {
+			this.#activeCalls.set(name, next);
+		}
+		this.#lastActivityAt.set(name, Date.now());
+		this.#scheduleIdleCheck(name);
+	}
+
+	/**
+	 * Arm an idle-disconnect timer for a lazy server with idle work remaining.
+	 * No-op for eager servers, disabled idle timeouts (`idleTimeout <= 0`), or a
+	 * server with an in-flight call (a later `#endCall` reschedules). The timer
+	 * is `unref`'d so it never keeps the process alive.
+	 */
+	#scheduleIdleCheck(name: string): void {
+		const existing = this.#idleTimers.get(name);
+		if (existing) {
+			clearTimeout(existing);
+			this.#idleTimers.delete(name);
+		}
+		const config = this.#connections.get(name)?.config ?? this.#serverConfigs.get(name);
+		if (this.#effectiveLifecycle(config) !== "lazy") return;
+		const idleTimeout = this.#effectiveIdleTimeout(config);
+		if (!(idleTimeout > 0)) return;
+		if ((this.#activeCalls.get(name) ?? 0) > 0) return;
+		const timer = setTimeout(() => {
+			void this.#maybeIdleDisconnect(name);
+		}, idleTimeout);
+		timer.unref?.();
+		this.#idleTimers.set(name, timer);
+	}
+
+	/** Drop all idle/activity tracking for a server (called on disconnect). */
+	#clearIdleState(name: string): void {
+		const timer = this.#idleTimers.get(name);
+		if (timer) clearTimeout(timer);
+		this.#idleTimers.delete(name);
+		this.#activeCalls.delete(name);
+		this.#lastActivityAt.delete(name);
+	}
+
+	/**
+	 * Idle-disconnect a lazy server: close its transport (terminating any stdio
+	 * child) and re-register its tools as {@link DeferredMCPTool} so the next
+	 * call lazily reconnects. Re-checks the idle preconditions to avoid racing a
+	 * call that started after the timer was armed.
+	 */
+	async #maybeIdleDisconnect(name: string): Promise<void> {
+		this.#idleTimers.delete(name);
+		const connection = this.#connections.get(name);
+		if (!connection) return;
+		if ((this.#activeCalls.get(name) ?? 0) > 0) return;
+		const config = connection.config ?? this.#serverConfigs.get(name);
+		if (this.#effectiveLifecycle(config) !== "lazy") return;
+		const idleTimeout = this.#effectiveIdleTimeout(config);
+		if (!(idleTimeout > 0)) return;
+		if (Date.now() - (this.#lastActivityAt.get(name) ?? 0) < idleTimeout) {
+			// Activity landed after the timer was armed; re-arm instead of reaping.
+			this.#scheduleIdleCheck(name);
+			return;
+		}
+
+		// Tool definitions to re-advertise. Prefer the live connection's cached
+		// list; fall back to the persistent tool cache. If neither is available we
+		// keep the server connected rather than strip live tools from the registry.
+		let defs = connection.tools ?? null;
+		if (!defs && this.toolCache && config) {
+			defs = await this.toolCache.get(name, config);
+		}
+		if (!defs) return;
+
+		// Detach onClose first so the close() below does not trigger a reconnect.
+		connection.transport.onClose = undefined;
+		const subscribedUris = this.#subscribedResources.get(name);
+		if (subscribedUris && subscribedUris.size > 0) {
+			void unsubscribeFromResources(connection, Array.from(subscribedUris)).catch(() => {});
+		}
+		this.#subscribedResources.delete(name);
+		const hadPrompts = (connection.prompts?.length ?? 0) > 0;
+		await disconnectServer(connection);
+		this.#connections.delete(name);
+		this.#activeCalls.delete(name);
+
+		// Re-register as deferred tools that lazily reconnect on next use.
+		const source = this.#sources.get(name) ?? connection._source;
+		const reconnect = () => this.reconnectServer(name);
+		const onActivity = this.#activityHooks(name);
+		const deferred = DeferredMCPTool.fromTools(
+			name,
+			defs,
+			() => this.#ensureLazyConnection(name),
+			source,
+			reconnect,
+			onActivity,
+		);
+		this.#replaceServerTools(name, deferred);
+		this.#onToolsChanged?.(this.#tools);
+		if (hadPrompts) this.#onPromptsChanged?.(name);
+		logger.debug("MCP server idle-disconnected", { path: `mcp:${name}`, idleTimeoutMs: idleTimeout });
+	}
+
+	/**
+	 * Connect a lazy server on demand, single-flighting concurrent first calls
+	 * through `#pendingConnections`. Used as the `getConnection` callback for a
+	 * lazy server's {@link DeferredMCPTool}s.
+	 */
+	async #ensureLazyConnection(name: string): Promise<MCPServerConnection> {
+		const existing = this.#connections.get(name);
+		if (existing) return existing;
+		const pending = this.#pendingConnections.get(name);
+		if (pending) return pending;
+		const reconnecting = this.#pendingReconnections.get(name);
+		if (reconnecting) {
+			const result = await reconnecting;
+			if (result) return result;
+		}
+		const config = this.#serverConfigs.get(name);
+		if (!config) throw new Error(`MCP server not connected: ${name}`);
+		const source = this.#sources.get(name);
+		const epoch = this.#epoch;
+		const attempt = this.#connectAndWireServer(name, config, source, epoch);
+		this.#pendingConnections.set(name, attempt);
+		try {
+			return await attempt;
+		} finally {
+			if (this.#pendingConnections.get(name) === attempt) {
+				this.#pendingConnections.delete(name);
+			}
+		}
+	}
 
 	/**
 	 * Set a callback to receive all server notifications.
@@ -401,6 +587,30 @@ export class MCPManager {
 			// and falls back to cached/deferred tools.
 			this.#serverConfigs.set(name, config);
 
+			// Lazy servers do not connect at startup. Advertise cached tools as
+			// DeferredMCPTool (which lazily connects on first use); on a cold cache
+			// fall through to a one-time eager connect this session to populate it.
+			if (this.#effectiveLifecycle(config) === "lazy") {
+				const cached = this.toolCache ? await this.toolCache.get(name, config) : null;
+				if (cached && cached.length > 0) {
+					const source = this.#sources.get(name) ?? sources[name];
+					const reconnect = () => this.reconnectServer(name);
+					const onActivity = this.#activityHooks(name);
+					allTools.push(
+						...DeferredMCPTool.fromTools(
+							name,
+							cached,
+							() => this.#ensureLazyConnection(name),
+							source,
+							reconnect,
+							onActivity,
+						),
+					);
+					continue;
+				}
+				// Cold cache: fall through to the eager connect below to populate it.
+			}
+
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
 				const resolvedConfig = await this.#resolveAuthConfig(config);
@@ -475,13 +685,14 @@ export class MCPManager {
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
 					this.#pendingToolLoads.delete(name);
 					const reconnect = () => this.reconnectServer(name);
-					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+					const customTools = MCPTool.fromTools(connection, serverTools, reconnect, this.#activityHooks(name));
 					this.#replaceServerTools(name, customTools);
 					this.#onToolsChanged?.(this.#tools);
 					void this.toolCache?.set(name, config, serverTools);
 
 					onStatus?.({ type: "connected", serverName: name });
 					await this.#loadServerResourcesAndPrompts(name, connection);
+					this.#scheduleIdleCheck(name);
 				})
 				.catch(error => {
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
@@ -537,7 +748,7 @@ export class MCPManager {
 					const { connection, serverTools } = value;
 					connectedServers.add(name);
 					const reconnect = () => this.reconnectServer(name);
-					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect));
+					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect, this.#activityHooks(name)));
 				} else if (task.tracked.status === "rejected") {
 					const message =
 						task.tracked.reason instanceof Error ? task.tracked.reason.message : String(task.tracked.reason);
@@ -549,7 +760,14 @@ export class MCPManager {
 						const source = this.#sources.get(name);
 						const reconnect = () => this.reconnectServer(name);
 						allTools.push(
-							...DeferredMCPTool.fromTools(name, cached, () => this.waitForConnection(name), source, reconnect),
+							...DeferredMCPTool.fromTools(
+								name,
+								cached,
+								() => this.waitForConnection(name),
+								source,
+								reconnect,
+								this.#activityHooks(name),
+							),
 						);
 					}
 				}
@@ -745,6 +963,7 @@ export class MCPManager {
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
 		this.#reconnectHistory.delete(name);
+		this.#clearIdleState(name);
 
 		const connection = this.#connections.get(name);
 
@@ -794,6 +1013,12 @@ export class MCPManager {
 		this.#tools = [];
 		this.#subscribedResources.clear();
 		this.#reconnectHistory.clear();
+		for (const timer of this.#idleTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.#idleTimers.clear();
+		this.#activeCalls.clear();
+		this.#lastActivityAt.clear();
 	}
 
 	/**
@@ -982,11 +1207,12 @@ export class MCPManager {
 		try {
 			const serverTools = await listTools(connection);
 			const reconnect = () => this.reconnectServer(name);
-			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+			const customTools = MCPTool.fromTools(connection, serverTools, reconnect, this.#activityHooks(name));
 			void this.toolCache?.set(name, config, serverTools);
 			this.#replaceServerTools(name, customTools);
 			this.#onToolsChanged?.(this.#tools);
 			void this.#loadServerResourcesAndPrompts(name, connection);
+			this.#scheduleIdleCheck(name);
 			return connection;
 		} catch (error) {
 			// Clean up the connection to avoid zombie transports
@@ -1039,7 +1265,7 @@ export class MCPManager {
 		// Reload tools
 		const serverTools = await listTools(connection);
 		const reconnect = () => this.reconnectServer(name);
-		const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+		const customTools = MCPTool.fromTools(connection, serverTools, reconnect, this.#activityHooks(name));
 		void this.toolCache?.set(name, connection.config, serverTools);
 
 		// Replace tools from this server

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -383,15 +383,31 @@ export class MCPManager {
 		if (reconnecting) {
 			const result = await reconnecting;
 			if (result) return result;
+			// A failed in-flight reconnection just settled; another caller may have
+			// already established or queued a connection — reuse it before spawning.
+			const settled = this.#connections.get(name);
+			if (settled) return settled;
+			const queued = this.#pendingConnections.get(name);
+			if (queued) return queued;
 		}
 		const config = this.#serverConfigs.get(name);
 		if (!config) throw new Error(`MCP server not connected: ${name}`);
+		// Respect the crash-burst breaker on the on-demand path too, so a down
+		// lazy server stops spawning a subprocess per tool call once it trips.
+		if (this.#reconnectBreakerOpen(name)) {
+			throw new Error(`MCP server "${name}" is suspended after repeated connection failures`);
+		}
 		const source = this.#sources.get(name);
 		const epoch = this.#epoch;
 		const attempt = this.#connectAndWireServer(name, config, source, epoch);
 		this.#pendingConnections.set(name, attempt);
 		try {
 			return await attempt;
+		} catch (error) {
+			// Record the failed on-demand connect so the breaker governs the lazy
+			// path; once tripped, the pre-check above short-circuits later calls.
+			this.#tripReconnectBreaker(name);
+			throw error;
 		} finally {
 			if (this.#pendingConnections.get(name) === attempt) {
 				this.#pendingConnections.delete(name);
@@ -1090,6 +1106,18 @@ export class MCPManager {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Whether the crash-burst breaker is currently open for a server, WITHOUT
+	 * recording an attempt. Use for a pre-flight check (e.g. the on-demand lazy
+	 * connect) so a tripped breaker short-circuits before spawning;
+	 * {@link #tripReconnectBreaker} both records an attempt and reports the state.
+	 */
+	#reconnectBreakerOpen(name: string): boolean {
+		const now = Date.now();
+		const recent = (this.#reconnectHistory.get(name) ?? []).filter(ts => now - ts < RECONNECT_BURST_WINDOW_MS);
+		return recent.length > RECONNECT_BURST_LIMIT;
 	}
 
 	async #doReconnect(name: string): Promise<MCPServerConnection | null> {

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -217,7 +217,7 @@ export class MCPManager {
 	/** Timestamp (ms) of the last tool-call activity per server. */
 	#lastActivityAt = new Map<string, number>();
 	/** Pending idle-disconnect timers per lazy server. */
-	#idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	#idleTimers = new Map<string, Timer>();
 
 	constructor(
 		private cwd: string,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -25,6 +25,12 @@ import type { MCPContent, MCPServerConnection, MCPToolCallParams, MCPToolCallRes
 /** Reconnect callback: tears down stale connection, returns new one or null. */
 export type MCPReconnect = () => Promise<MCPServerConnection | null>;
 
+/** Hooks the manager uses to refcount in-flight tool calls for idle-disconnect. */
+export interface MCPActivityHooks {
+	begin(): void;
+	end(): void;
+}
+
 /**
  * Network-level and stale-session errors that warrant a reconnect + single retry.
  * Conservative: only catches errors where the server is likely alive but the
@@ -283,14 +289,20 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mergeCallAndResult = true;
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
-	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
-		return tools.map(tool => new MCPTool(connection, tool, reconnect));
+	static fromTools(
+		connection: MCPServerConnection,
+		tools: MCPToolDefinition[],
+		reconnect?: MCPReconnect,
+		onActivity?: MCPActivityHooks,
+	): MCPTool[] {
+		return tools.map(tool => new MCPTool(connection, tool, reconnect, onActivity));
 	}
 
 	constructor(
 		private connection: MCPServerConnection,
 		private readonly tool: MCPToolDefinition,
 		private readonly reconnect?: MCPReconnect,
+		private readonly onActivity?: MCPActivityHooks,
 	) {
 		this.name = createMCPToolName(connection.name, tool.name);
 		this.label = `${connection.name}/${tool.name}`;
@@ -320,34 +332,39 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const provider = this.connection._source?.provider;
 		const providerName = this.connection._source?.providerName;
 
+		this.onActivity?.begin();
 		try {
-			const result = await callTool(this.connection, this.tool.name, args, { signal });
-			return buildResult(result, this.connection.name, this.tool.name, provider, providerName);
-		} catch (error) {
-			rethrowIfAborted(error, signal);
-			if (this.reconnect && isRetriableConnectionError(error)) {
-				const newConn = await reconnectWithAbort(this.reconnect, signal);
-				if (newConn) {
-					// Rebind so subsequent calls on this instance use the fresh connection
-					this.connection = newConn;
-					const retryProvider = newConn._source?.provider ?? provider;
-					const retryProviderName = newConn._source?.providerName ?? providerName;
-					try {
-						const result = await callTool(newConn, this.tool.name, args, { signal });
-						return buildResult(result, newConn.name, this.tool.name, retryProvider, retryProviderName);
-					} catch (retryError) {
-						rethrowIfAborted(retryError, signal);
-						return buildErrorResult(
-							retryError,
-							this.connection.name,
-							this.tool.name,
-							retryProvider,
-							retryProviderName,
-						);
+			try {
+				const result = await callTool(this.connection, this.tool.name, args, { signal });
+				return buildResult(result, this.connection.name, this.tool.name, provider, providerName);
+			} catch (error) {
+				rethrowIfAborted(error, signal);
+				if (this.reconnect && isRetriableConnectionError(error)) {
+					const newConn = await reconnectWithAbort(this.reconnect, signal);
+					if (newConn) {
+						// Rebind so subsequent calls on this instance use the fresh connection
+						this.connection = newConn;
+						const retryProvider = newConn._source?.provider ?? provider;
+						const retryProviderName = newConn._source?.providerName ?? providerName;
+						try {
+							const result = await callTool(newConn, this.tool.name, args, { signal });
+							return buildResult(result, newConn.name, this.tool.name, retryProvider, retryProviderName);
+						} catch (retryError) {
+							rethrowIfAborted(retryError, signal);
+							return buildErrorResult(
+								retryError,
+								this.connection.name,
+								this.tool.name,
+								retryProvider,
+								retryProviderName,
+							);
+						}
 					}
 				}
+				return buildErrorResult(error, this.connection.name, this.tool.name, provider, providerName);
 			}
-			return buildErrorResult(error, this.connection.name, this.tool.name, provider, providerName);
+		} finally {
+			this.onActivity?.end();
 		}
 	}
 }
@@ -378,8 +395,9 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		getConnection: () => Promise<MCPServerConnection>,
 		source?: SourceMeta,
 		reconnect?: MCPReconnect,
+		onActivity?: MCPActivityHooks,
 	): DeferredMCPTool[] {
-		return tools.map(tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect));
+		return tools.map(tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect, onActivity));
 	}
 
 	constructor(
@@ -388,6 +406,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		private readonly getConnection: () => Promise<MCPServerConnection>,
 		source?: SourceMeta,
 		private readonly reconnect?: MCPReconnect,
+		private readonly onActivity?: MCPActivityHooks,
 	) {
 		this.name = createMCPToolName(serverName, tool.name);
 		this.label = `${serverName}/${tool.name}`;
@@ -419,66 +438,71 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const provider = this.#fallbackProvider;
 		const providerName = this.#fallbackProviderName;
 
+		this.onActivity?.begin();
 		try {
-			const connection = await untilAborted(signal, () => this.getConnection());
-			throwIfAborted(signal);
 			try {
-				const result = await callTool(connection, this.tool.name, args, { signal });
-				return buildResult(
-					result,
-					this.serverName,
-					this.tool.name,
-					connection._source?.provider ?? provider,
-					connection._source?.providerName ?? providerName,
-				);
-			} catch (callError) {
-				rethrowIfAborted(callError, signal);
-				if (this.reconnect && isRetriableConnectionError(callError)) {
+				const connection = await untilAborted(signal, () => this.getConnection());
+				throwIfAborted(signal);
+				try {
+					const result = await callTool(connection, this.tool.name, args, { signal });
+					return buildResult(
+						result,
+						this.serverName,
+						this.tool.name,
+						connection._source?.provider ?? provider,
+						connection._source?.providerName ?? providerName,
+					);
+				} catch (callError) {
+					rethrowIfAborted(callError, signal);
+					if (this.reconnect && isRetriableConnectionError(callError)) {
+						const newConn = await reconnectWithAbort(this.reconnect, signal);
+						if (newConn) {
+							const retryProvider = newConn._source?.provider ?? provider;
+							const retryProviderName = newConn._source?.providerName ?? providerName;
+							try {
+								const result = await callTool(newConn, this.tool.name, args, { signal });
+								return buildResult(result, this.serverName, this.tool.name, retryProvider, retryProviderName);
+							} catch (retryError) {
+								rethrowIfAborted(retryError, signal);
+								return buildErrorResult(
+									retryError,
+									this.serverName,
+									this.tool.name,
+									retryProvider,
+									retryProviderName,
+								);
+							}
+						}
+					}
+					return buildErrorResult(callError, this.serverName, this.tool.name, provider, providerName);
+				}
+			} catch (connError) {
+				// getConnection() failed — server never connected or connection lost.
+				// This is always worth a reconnect attempt for deferred tools, since the
+				// error ("MCP server not connected") isn't a network error from callTool.
+				rethrowIfAborted(connError, signal);
+				if (this.reconnect) {
 					const newConn = await reconnectWithAbort(this.reconnect, signal);
 					if (newConn) {
-						const retryProvider = newConn._source?.provider ?? provider;
-						const retryProviderName = newConn._source?.providerName ?? providerName;
 						try {
 							const result = await callTool(newConn, this.tool.name, args, { signal });
-							return buildResult(result, this.serverName, this.tool.name, retryProvider, retryProviderName);
-						} catch (retryError) {
-							rethrowIfAborted(retryError, signal);
-							return buildErrorResult(
-								retryError,
+							return buildResult(
+								result,
 								this.serverName,
 								this.tool.name,
-								retryProvider,
-								retryProviderName,
+								newConn._source?.provider ?? provider,
+								newConn._source?.providerName ?? providerName,
 							);
+						} catch (retryError) {
+							rethrowIfAborted(retryError, signal);
+							return buildErrorResult(retryError, this.serverName, this.tool.name, provider, providerName);
 						}
 					}
 				}
-				return buildErrorResult(callError, this.serverName, this.tool.name, provider, providerName);
+				return buildErrorResult(connError, this.serverName, this.tool.name, provider, providerName);
 			}
-		} catch (connError) {
-			// getConnection() failed — server never connected or connection lost.
-			// This is always worth a reconnect attempt for deferred tools, since the
-			// error ("MCP server not connected") isn't a network error from callTool.
-			rethrowIfAborted(connError, signal);
-			if (this.reconnect) {
-				const newConn = await reconnectWithAbort(this.reconnect, signal);
-				if (newConn) {
-					try {
-						const result = await callTool(newConn, this.tool.name, args, { signal });
-						return buildResult(
-							result,
-							this.serverName,
-							this.tool.name,
-							newConn._source?.provider ?? provider,
-							newConn._source?.providerName ?? providerName,
-						);
-					} catch (retryError) {
-						rethrowIfAborted(retryError, signal);
-						return buildErrorResult(retryError, this.serverName, this.tool.name, provider, providerName);
-					}
-				}
-			}
-			return buildErrorResult(connError, this.serverName, this.tool.name, provider, providerName);
+		} finally {
+			this.onActivity?.end();
 		}
 	}
 }

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -59,6 +59,9 @@ export interface MCPAuthConfig {
 	resource?: string;
 }
 
+/** Connection lifecycle for an MCP server. */
+export type MCPLifecycle = "lazy" | "eager";
+
 /** Base server config with shared options */
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
@@ -77,6 +80,10 @@ interface MCPServerConfigBase {
 		/** `prompt` param for the authorization request (default "consent"; "" to omit) */
 		prompt?: string;
 	};
+	/** Connection lifecycle: "eager" (default) connects at session start; "lazy" connects on first tool use and idle-disconnects after idleTimeout. */
+	lifecycle?: MCPLifecycle;
+	/** Idle-disconnect timeout in milliseconds for lazy servers. 0 disables idle disconnect. */
+	idleTimeout?: number;
 }
 
 /** Stdio server configuration */

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1681,6 +1681,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const cacheStorage = settings.getStorage();
 				mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
 				mcpManager.setAuthStorage(authStorage);
+				mcpManager.setLifecycleDefaults(
+					settings.get("mcp.defaultLifecycle"),
+					settings.get("mcp.defaultIdleTimeoutMs"),
+				);
 				toolSession.mcpManager = mcpManager;
 
 				if (settings.get("mcp.notifications")) {
@@ -1761,6 +1765,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					...mcpDiscoverOptions,
 					cacheStorage: settings.getStorage(),
 					authStorage,
+					lifecycleDefaults: {
+						lifecycle: settings.get("mcp.defaultLifecycle"),
+						idleTimeoutMs: settings.get("mcp.defaultIdleTimeoutMs"),
+					},
 				});
 				mcpManager = mcpResult.manager;
 				toolSession.mcpManager = mcpManager;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1682,7 +1682,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
 				mcpManager.setAuthStorage(authStorage);
 				mcpManager.setLifecycleDefaults(
-					settings.get("mcp.defaultLifecycle"),
+					settings.get("mcp.defaultLifecycle") === "lazy" ? "lazy" : "eager",
 					settings.get("mcp.defaultIdleTimeoutMs"),
 				);
 				toolSession.mcpManager = mcpManager;
@@ -1766,7 +1766,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					cacheStorage: settings.getStorage(),
 					authStorage,
 					lifecycleDefaults: {
-						lifecycle: settings.get("mcp.defaultLifecycle"),
+						lifecycle: settings.get("mcp.defaultLifecycle") === "lazy" ? "lazy" : "eager",
 						idleTimeoutMs: settings.get("mcp.defaultIdleTimeoutMs"),
 					},
 				});

--- a/packages/coding-agent/test/fixtures/lazy-lifecycle-mcp.ts
+++ b/packages/coding-agent/test/fixtures/lazy-lifecycle-mcp.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a configurable stdio MCP server for the lifecycle tests. It
+ * advertises a single tool and answers tool calls, and is driven entirely by
+ * environment variables so one fixture covers every scenario:
+ *
+ *   MCP_SPAWN_LOG       append `spawn <pid>` to this file on startup, so a test
+ *                       can assert whether (and how many times) a lazy server
+ *                       was actually spawned.
+ *   MCP_CRASH_BEFORE_INIT="1"  exit(1) before speaking MCP, so the connect fails.
+ *   MCP_CALL_DELAY_MS   delay each `tools/call` response by this many ms, used to
+ *                       hold a call in-flight across an idle window.
+ *
+ * Speaks newline-delimited JSON-RPC 2.0 (the wire format of `StdioTransport`),
+ * same shape as `many-tools-mcp.ts`. Exported constants are imported by tests;
+ * the server only starts when run as the entry module (`import.meta.main`).
+ */
+import * as fs from "node:fs";
+import * as readline from "node:readline";
+
+/** Name of the single tool the fixture advertises. */
+export const LAZY_TOOL_NAME = "ping";
+
+type JsonRpcRequest = {
+	jsonrpc: "2.0";
+	id?: string | number;
+	method: string;
+	params?: Record<string, unknown>;
+};
+
+function buildResult(method: string): Record<string, unknown> {
+	switch (method) {
+		case "initialize":
+			return {
+				protocolVersion: "2025-03-26",
+				serverInfo: { name: "lazy-lifecycle-fixture", version: "1.0.0" },
+				capabilities: { tools: {} },
+			};
+		case "tools/list":
+			return {
+				tools: [
+					{
+						name: LAZY_TOOL_NAME,
+						description: "Lazy fixture tool",
+						inputSchema: { type: "object", properties: {}, additionalProperties: false },
+					},
+				],
+			};
+		case "tools/call":
+			return { content: [{ type: "text", text: "pong" }] };
+		default:
+			return {};
+	}
+}
+
+function startServer(): void {
+	const spawnLog = process.env.MCP_SPAWN_LOG;
+	if (spawnLog) {
+		fs.appendFileSync(spawnLog, `spawn ${process.pid}\n`);
+	}
+	if (process.env.MCP_CRASH_BEFORE_INIT === "1") {
+		// Exit before speaking MCP so the connect attempt fails.
+		process.exit(1);
+	}
+	const callDelayMs = Number(process.env.MCP_CALL_DELAY_MS ?? "0") || 0;
+
+	const rl = readline.createInterface({ input: process.stdin });
+	rl.on("line", line => {
+		void (async () => {
+			const trimmed = line.trim();
+			if (trimmed.length === 0) return;
+			let msg: JsonRpcRequest;
+			try {
+				msg = JSON.parse(trimmed) as JsonRpcRequest;
+			} catch {
+				return;
+			}
+			// Notifications (no `id`) get no response.
+			if (msg.id === undefined || msg.id === null) return;
+			if (msg.method === "tools/call" && callDelayMs > 0) {
+				await Bun.sleep(callDelayMs);
+			}
+			const response = { jsonrpc: "2.0" as const, id: msg.id, result: buildResult(msg.method) };
+			process.stdout.write(`${JSON.stringify(response)}\n`);
+		})();
+	});
+	rl.on("close", () => process.exit(0));
+}
+
+if (import.meta.main) {
+	startServer();
+}

--- a/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
@@ -9,7 +9,15 @@ import * as path from "node:path";
 import type { MCPServer } from "../src/capability/mcp";
 import { convertToLegacyConfig } from "../src/mcp/config";
 import { MCPManager } from "../src/mcp/manager";
-import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, TOOL_DEF, waitFor } from "./mcp-lifecycle-harness";
+import {
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	spawnCount,
+	TOOL_DEF,
+	waitFor,
+} from "./mcp-lifecycle-harness";
 
 describe("MCP lifecycle precedence: per-server overrides the default", () => {
 	let workDir: string;

--- a/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
@@ -6,6 +6,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { MCPServer } from "../src/capability/mcp";
+import { convertToLegacyConfig } from "../src/mcp/config";
 import { MCPManager } from "../src/mcp/manager";
 import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, TOOL_DEF, waitFor } from "./mcp-lifecycle-harness";
 
@@ -53,4 +55,68 @@ describe("MCP lifecycle precedence: per-server overrides the default", () => {
 			await manager.disconnectAll();
 		}
 	}, 15_000);
+});
+
+describe("convertToLegacyConfig threads lifecycle + idleTimeout", () => {
+	it("carries both fields onto a stdio legacy config", () => {
+		const legacy = convertToLegacyConfig({
+			name: "s",
+			command: "cmd",
+			lifecycle: "lazy",
+			idleTimeout: 1000,
+		} as unknown as MCPServer);
+		expect(legacy.type).toBe("stdio");
+		expect(legacy.lifecycle).toBe("lazy");
+		expect(legacy.idleTimeout).toBe(1000);
+	});
+
+	it("carries both fields onto an http legacy config", () => {
+		const legacy = convertToLegacyConfig({
+			name: "h",
+			transport: "http",
+			url: "https://example.test/mcp",
+			lifecycle: "eager",
+			idleTimeout: 0,
+		} as unknown as MCPServer);
+		expect(legacy.type).toBe("http");
+		expect(legacy.lifecycle).toBe("eager");
+		// idleTimeout 0 ("never reap") must survive, not be dropped as falsy.
+		expect(legacy.idleTimeout).toBe(0);
+	});
+
+	it("carries both fields onto an sse legacy config", () => {
+		const legacy = convertToLegacyConfig({
+			name: "e",
+			transport: "sse",
+			url: "https://example.test/sse",
+			lifecycle: "lazy",
+			idleTimeout: 5000,
+		} as unknown as MCPServer);
+		expect(legacy.type).toBe("sse");
+		expect(legacy.lifecycle).toBe("lazy");
+		expect(legacy.idleTimeout).toBe(5000);
+	});
+
+	it("leaves both fields undefined when the canonical server omits them", () => {
+		const legacy = convertToLegacyConfig({ name: "s", command: "cmd" } as unknown as MCPServer);
+		expect(legacy.lifecycle).toBeUndefined();
+		expect(legacy.idleTimeout).toBeUndefined();
+	});
+});
+
+describe("mcp-schema.json constrains lifecycle", () => {
+	const schema = JSON.parse(
+		fs.readFileSync(path.join(import.meta.dir, "..", "src", "config", "mcp-schema.json"), "utf8"),
+	);
+	const props = schema.$defs.serverBase.properties;
+
+	it("accepts only eager and lazy for lifecycle (rejects other values)", () => {
+		expect(props.lifecycle.enum).toEqual(["eager", "lazy"]);
+		expect(props.lifecycle.enum).not.toContain("keep-alive");
+	});
+
+	it("declares idleTimeout as a non-negative number", () => {
+		expect(props.idleTimeout.type).toBe("number");
+		expect(props.idleTimeout.minimum).toBe(0);
+	});
 });

--- a/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-config-convert.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Contract: lifecycle resolution precedence is per-server > manager default. A
+ * server with an explicit `lifecycle` ignores `mcp.defaultLifecycle`; a server
+ * without one inherits the default.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, TOOL_DEF, waitFor } from "./mcp-lifecycle-harness";
+
+describe("MCP lifecycle precedence: per-server overrides the default", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("an explicit eager server connects even when the default is lazy", async () => {
+		const spawnLog = path.join(workDir, "explicit-eager.log");
+		const manager = new MCPManager(workDir, inMemoryToolCache());
+		manager.setLifecycleDefaults("lazy", 300_000);
+		const config = lazyConfig({ lifecycle: "eager", spawnLog });
+		try {
+			await manager.connectServers({ srv: config }, {});
+			// Per-server "eager" wins over the "lazy" default.
+			expect(await waitFor(() => manager.getConnectionStatus("srv") === "connected")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(1);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("a server without a lifecycle inherits the lazy default (no startup spawn)", async () => {
+		const spawnLog = path.join(workDir, "default-lazy.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ spawnLog }); // no per-server lifecycle
+		await cache.set("srv", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		manager.setLifecycleDefaults("lazy", 300_000);
+		try {
+			await manager.connectServers({ srv: config }, {});
+			// Inherited lazy → advertised from cache, not spawned.
+			expect(manager.getConnectionStatus("srv")).toBe("disconnected");
+			expect(hasServerTool(manager, "srv")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(0);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-eager-unchanged.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-eager-unchanged.test.ts
@@ -6,7 +6,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { MCPManager } from "../src/mcp/manager";
-import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, waitFor } from "./mcp-lifecycle-harness";
+import {
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	spawnCount,
+	waitFor,
+} from "./mcp-lifecycle-harness";
 
 describe("MCP eager lifecycle: connects at startup", () => {
 	let workDir: string;

--- a/packages/coding-agent/test/mcp-lifecycle-eager-unchanged.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-eager-unchanged.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Contract: `lifecycle: "eager"` (and the absent-with-default-"eager" case)
+ * preserve today's behavior — the server is connected (spawned) at startup.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, waitFor } from "./mcp-lifecycle-harness";
+
+describe("MCP eager lifecycle: connects at startup", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("spawns an explicit eager server at startup", async () => {
+		const spawnLog = path.join(workDir, "eager.log");
+		const manager = new MCPManager(workDir, inMemoryToolCache());
+		const config = lazyConfig({ lifecycle: "eager", spawnLog });
+		try {
+			await manager.connectServers({ srv: config }, {});
+			expect(await waitFor(() => manager.getConnectionStatus("srv") === "connected")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(1);
+			expect(hasServerTool(manager, "srv")).toBe(true);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("treats an absent lifecycle as eager (default) and spawns at startup", async () => {
+		const spawnLog = path.join(workDir, "default.log");
+		// No setLifecycleDefaults call → manager default lifecycle is "eager".
+		const manager = new MCPManager(workDir, inMemoryToolCache());
+		const config = lazyConfig({ spawnLog });
+		try {
+			await manager.connectServers({ srv: config }, {});
+			expect(await waitFor(() => manager.getConnectionStatus("srv") === "connected")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(1);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-harness.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-harness.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared helpers for the MCP lifecycle (lazy/eager + idleTimeout) test suites.
+ *
+ * NOT a test file — the `.ts` (not `.test.ts`) suffix keeps the bun runner from
+ * executing it. Imported by the `mcp-lifecycle-*.test.ts` suites so each can
+ * stay focused on one contract.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { CustomToolResult } from "../src/extensibility/custom-tools/types";
+import type { MCPManager } from "../src/mcp/manager";
+import type { MCPToolDetails } from "../src/mcp/tool-bridge";
+import { MCPToolCache } from "../src/mcp/tool-cache";
+import type { MCPStdioServerConfig, MCPToolDefinition } from "../src/mcp/types";
+import type { AgentStorage } from "../src/session/agent-storage";
+import { LAZY_TOOL_NAME } from "./fixtures/lazy-lifecycle-mcp";
+
+export { LAZY_TOOL_NAME };
+export const FIXTURE = path.join(import.meta.dir, "fixtures", "lazy-lifecycle-mcp.ts");
+export const BUN = process.execPath;
+
+/** Single tool definition matching what the fixture advertises. */
+export const TOOL_DEF: MCPToolDefinition = {
+	name: LAZY_TOOL_NAME,
+	description: "Lazy fixture tool",
+	inputSchema: { type: "object", properties: {}, additionalProperties: false },
+};
+
+export function makeWorkDir(prefix = "omp-mcp-lifecycle-"): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Minimal in-memory MCPToolCache backed by a Map (getCache/setCache only). */
+export function inMemoryToolCache(): MCPToolCache {
+	const store = new Map<string, string>();
+	const storage = {
+		getCache: (key: string) => store.get(key) ?? null,
+		setCache: (key: string, value: string) => {
+			store.set(key, value);
+		},
+	} as unknown as AgentStorage;
+	return new MCPToolCache(storage);
+}
+
+export interface LazyConfigOptions {
+	lifecycle?: "lazy" | "eager";
+	idleTimeout?: number;
+	/** File the fixture appends a `spawn` line to on each startup. */
+	spawnLog?: string;
+	/** Make the fixture exit before `initialize` so the connect fails. */
+	crashBeforeInit?: boolean;
+	/** Delay each `tools/call` response by this many ms (hold a call in-flight). */
+	callDelayMs?: number;
+}
+
+export function lazyConfig(options: LazyConfigOptions = {}): MCPStdioServerConfig {
+	const env: Record<string, string> = {};
+	if (options.spawnLog) env.MCP_SPAWN_LOG = options.spawnLog;
+	if (options.crashBeforeInit) env.MCP_CRASH_BEFORE_INIT = "1";
+	if (options.callDelayMs) env.MCP_CALL_DELAY_MS = String(options.callDelayMs);
+
+	const config: MCPStdioServerConfig = { type: "stdio", command: BUN, args: [FIXTURE] };
+	if (options.lifecycle) config.lifecycle = options.lifecycle;
+	if (options.idleTimeout !== undefined) config.idleTimeout = options.idleTimeout;
+	if (Object.keys(env).length > 0) config.env = env;
+	return config;
+}
+
+/**
+ * Genuine integration wait: lifecycle transitions (connect, idle-disconnect)
+ * run fire-and-forget against a REAL MCP subprocess and expose no awaitable
+ * signal; fake timers cannot drive a child process. Poll a predicate with a
+ * generous ceiling, returning as soon as it holds.
+ */
+export async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 10_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await predicate()) return true;
+		if (Date.now() >= deadline) return false;
+		await Bun.sleep(20);
+	}
+}
+
+/** Count the `spawn` lines a fixture appended to its spawn log (0 if never spawned). */
+export function spawnCount(spawnLog: string): number {
+	if (!fs.existsSync(spawnLog)) return 0;
+	return fs
+		.readFileSync(spawnLog, "utf8")
+		.split("\n")
+		.filter(line => line.startsWith("spawn")).length;
+}
+
+/** Find a server's registered tool and invoke it through the agent tool interface. */
+export async function executeServerTool(
+	manager: MCPManager,
+	serverName: string,
+	args: Record<string, unknown> = {},
+): Promise<CustomToolResult<MCPToolDetails>> {
+	const tool = manager.getTools().find(t => (t as unknown as { mcpServerName?: string }).mcpServerName === serverName);
+	if (!tool) throw new Error(`No tool registered for MCP server "${serverName}"`);
+	return tool.execute("call-1", args, undefined, {} as Parameters<typeof tool.execute>[3], undefined) as Promise<
+		CustomToolResult<MCPToolDetails>
+	>;
+}
+
+/** True when a server has a tool registered in the manager. */
+export function hasServerTool(manager: MCPManager, serverName: string): boolean {
+	return manager.getTools().some(t => (t as unknown as { mcpServerName?: string }).mcpServerName === serverName);
+}
+
+/** Extract the joined text content of a tool result. */
+export function resultText(result: CustomToolResult<MCPToolDetails>): string {
+	return result.content
+		.map(part => (part.type === "text" ? part.text : ""))
+		.join("")
+		.trim();
+}

--- a/packages/coding-agent/test/mcp-lifecycle-idle-reap.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-idle-reap.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Contract: after a lazy server goes idle past `idleTimeout`, the manager
+ * disconnects it (terminating the subprocess) but keeps its tools registered as
+ * deferred placeholders, so the next call transparently re-spawns it.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import {
+	executeServerTool,
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	resultText,
+	spawnCount,
+	waitFor,
+} from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: idle disconnect and re-spawn", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("idle-disconnects after the timeout and re-spawns on the next call", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", idleTimeout: 150, spawnLog });
+		await cache.set("lazy", config, [{ name: "ping", inputSchema: { type: "object" } }]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: config }, {});
+			expect(resultText(await executeServerTool(manager, "lazy"))).toBe("pong");
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+			expect(spawnCount(spawnLog)).toBe(1);
+
+			// Idle reaper fires ~150ms after the call completes.
+			expect(await waitFor(() => manager.getConnectionStatus("lazy") === "disconnected")).toBe(true);
+			// Tools survive the reap as deferred placeholders.
+			expect(hasServerTool(manager, "lazy")).toBe(true);
+
+			// Next call transparently re-spawns the server.
+			expect(resultText(await executeServerTool(manager, "lazy"))).toBe("pong");
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+			expect(spawnCount(spawnLog)).toBe(2);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 20_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-idle-refcount.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-idle-refcount.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Contract: the idle reaper never disconnects a lazy server while a tool call
+ * is in flight. An in-flight call holds the per-server refcount, so the idle
+ * timer is not armed until the call finishes — the connection survives an
+ * elapsed `idleTimeout` mid-call.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import {
+	executeServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	resultText,
+	TOOL_DEF,
+	waitFor,
+} from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: no idle disconnect mid-call", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("keeps the connection alive across an elapsed idleTimeout while a call runs", async () => {
+		const cache = inMemoryToolCache();
+		// idleTimeout (100ms) is far shorter than the call (600ms): a naive reaper
+		// would fire mid-call.
+		const config = lazyConfig({ lifecycle: "lazy", idleTimeout: 100, callDelayMs: 600 });
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: config }, {});
+
+			// Start a slow call but do not await it yet.
+			const callPromise = executeServerTool(manager, "lazy");
+			expect(await waitFor(() => manager.getConnectionStatus("lazy") === "connected")).toBe(true);
+
+			// Genuine integration wait: let the idle window (100ms) elapse WHILE the
+			// 600ms call is still in flight. Fake timers cannot drive the real
+			// subprocess call, so a real delay is the only way to exercise this.
+			await Bun.sleep(300);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+
+			expect(resultText(await callPromise)).toBe("pong");
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 20_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-idle-refcount.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-idle-refcount.test.ts
@@ -6,7 +6,6 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
-import * as path from "node:path";
 import { MCPManager } from "../src/mcp/manager";
 import {
 	executeServerTool,

--- a/packages/coding-agent/test/mcp-lifecycle-idle-zero-disabled.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-idle-zero-disabled.test.ts
@@ -35,6 +35,7 @@ describe("MCP lazy lifecycle: idleTimeout 0 disables reaping", () => {
 
 		const manager = new MCPManager(workDir, cache);
 		try {
+			await manager.connectServers({ lazy: config }, {});
 			expect(resultText(await executeServerTool(manager, "lazy"))).toBe("pong");
 			expect(manager.getConnectionStatus("lazy")).toBe("connected");
 

--- a/packages/coding-agent/test/mcp-lifecycle-idle-zero-disabled.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-idle-zero-disabled.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Contract: `idleTimeout: 0` disables idle disconnect. A lazy server connects on
+ * first use and then stays connected — it is never reaped.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import {
+	executeServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	resultText,
+	spawnCount,
+	TOOL_DEF,
+} from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: idleTimeout 0 disables reaping", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("connects on first use then never idle-disconnects", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", idleTimeout: 0, spawnLog });
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			expect(resultText(await executeServerTool(manager, "lazy"))).toBe("pong");
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+
+			// Genuine integration wait: idleTimeout 0 must arm no reaper, so let real
+			// wall-clock pass and confirm the connection is still up. Fake timers
+			// cannot stand in for "no timer was scheduled at all".
+			await Bun.sleep(300);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+			expect(spawnCount(spawnLog)).toBe(1);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-keepalive-alias.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-keepalive-alias.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Contract: `keep-alive` was deliberately dropped — only `lazy` and `eager`
+ * exist. Any non-"lazy" lifecycle value (including a legacy "keep-alive") is
+ * treated as eager and connects at startup. Pins the "no keep-alive code path"
+ * decision so a future reader does not reintroduce it.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import { inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, waitFor } from "./mcp-lifecycle-harness";
+
+describe("MCP lifecycle: legacy keep-alive is treated as eager", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("connects a 'keep-alive' server at startup, like eager", async () => {
+		const spawnLog = path.join(workDir, "keepalive.log");
+		const config = lazyConfig({ spawnLog });
+		// Force a value outside the supported union; only "lazy" defers.
+		(config as unknown as { lifecycle: string }).lifecycle = "keep-alive";
+
+		const manager = new MCPManager(workDir, inMemoryToolCache());
+		try {
+			await manager.connectServers({ srv: config }, {});
+			expect(await waitFor(() => manager.getConnectionStatus("srv") === "connected")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(1);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-coldcache.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-coldcache.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Contract: a lazy server with a COLD cache (no known tools) connects once at
+ * startup to populate the cache and advertise its real tools. A later session
+ * reading the now-warm cache must connect lazily (no startup spawn).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, waitFor } from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: cold cache populates once", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("connects once on a cold cache, then a warm-cache session does not spawn", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", spawnLog });
+
+		const first = new MCPManager(workDir, cache);
+		try {
+			await first.connectServers({ lazy: config }, {});
+			// Cold cache → fall through to a one-time connect this session.
+			expect(await waitFor(() => first.getConnectionStatus("lazy") === "connected")).toBe(true);
+			expect(spawnCount(spawnLog)).toBe(1);
+			expect(hasServerTool(first, "lazy")).toBe(true);
+			// Cache is populated for the next session.
+			expect(await waitFor(async () => (await cache.get("lazy", config)) !== null)).toBe(true);
+		} finally {
+			await first.disconnectAll();
+		}
+
+		// Second session over the now-warm cache must advertise from cache only.
+		const second = new MCPManager(workDir, cache);
+		try {
+			await second.connectServers({ lazy: config }, {});
+			expect(second.getConnectionStatus("lazy")).toBe("disconnected");
+			expect(hasServerTool(second, "lazy")).toBe(true);
+			// No additional spawn — still just the one from the cold-cache session.
+			expect(spawnCount(spawnLog)).toBe(1);
+		} finally {
+			await second.disconnectAll();
+		}
+	}, 20_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-coldcache.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-coldcache.test.ts
@@ -7,7 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { MCPManager } from "../src/mcp/manager";
-import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, waitFor } from "./mcp-lifecycle-harness";
+import {
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	spawnCount,
+	waitFor,
+} from "./mcp-lifecycle-harness";
 
 describe("MCP lazy lifecycle: cold cache populates once", () => {
 	let workDir: string;

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-connect-failure.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-connect-failure.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Contract: when a lazy server fails to connect on demand, the failure surfaces
+ * as a tool ERROR result, not a thrown exception — the session stays usable.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import { MCPManager } from "../src/mcp/manager";
+import { executeServerTool, hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, TOOL_DEF } from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: on-demand connect failure", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("returns an error result (does not throw) when the lazy connect fails", async () => {
+		const cache = inMemoryToolCache();
+		// Cache makes the tool discoverable; the server crashes before `initialize`
+		// so every connect attempt fails.
+		const config = lazyConfig({ lifecycle: "lazy", crashBeforeInit: true });
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: config }, {});
+
+			const result = await executeServerTool(manager, "lazy");
+			expect(result.isError).toBe(true);
+
+			// The manager survives a failed lazy connect and stays usable.
+			expect(hasServerTool(manager, "lazy")).toBe(true);
+		} finally {
+			await manager.disconnectAll();
+		}
+		// Generous: the on-demand connect failure walks the reconnect backoff
+		// (0.5s + 1s + 2s + 4s) before surfacing the error result.
+	}, 30_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-connect-failure.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-connect-failure.test.ts
@@ -5,7 +5,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import { MCPManager } from "../src/mcp/manager";
-import { executeServerTool, hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, TOOL_DEF } from "./mcp-lifecycle-harness";
+import {
+	executeServerTool,
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	TOOL_DEF,
+} from "./mcp-lifecycle-harness";
 
 describe("MCP lazy lifecycle: on-demand connect failure", () => {
 	let workDir: string;

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-firstcall-connect.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-firstcall-connect.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Contract: executing a warm-cache lazy server's DeferredMCPTool connects the
+ * server on demand (exactly one spawn) and returns the live tool result.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import {
+	executeServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	resultText,
+	spawnCount,
+	TOOL_DEF,
+} from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: first call connects on demand", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("spawns once on the first tool call and returns the result", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", spawnLog });
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: config }, {});
+			// Not connected, not spawned yet.
+			expect(manager.getConnectionStatus("lazy")).toBe("disconnected");
+			expect(spawnCount(spawnLog)).toBe(0);
+
+			const result = await executeServerTool(manager, "lazy");
+
+			expect(result.isError).toBeFalsy();
+			expect(resultText(result)).toBe("pong");
+			expect(spawnCount(spawnLog)).toBe(1);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-nospawn.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-nospawn.test.ts
@@ -7,7 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { MCPManager } from "../src/mcp/manager";
-import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, TOOL_DEF } from "./mcp-lifecycle-harness";
+import {
+	hasServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	spawnCount,
+	TOOL_DEF,
+} from "./mcp-lifecycle-harness";
 
 describe("MCP lazy lifecycle: warm cache does not spawn", () => {
 	let workDir: string;

--- a/packages/coding-agent/test/mcp-lifecycle-lazy-nospawn.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-lazy-nospawn.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Contract: a lazy server with a WARM tool cache advertises its tools as
+ * DeferredMCPTool placeholders WITHOUT spawning the subprocess at startup.
+ * This is the memory win — the whole point of `lifecycle: "lazy"`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import { hasServerTool, inMemoryToolCache, lazyConfig, makeWorkDir, spawnCount, TOOL_DEF } from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: warm cache does not spawn", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("advertises cached tools as deferred and never spawns the server", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", spawnLog });
+		// Seed the cache so the server's tools are known without connecting.
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			const result = await manager.connectServers({ lazy: config }, {});
+
+			expect(manager.getConnectionStatus("lazy")).toBe("disconnected");
+			expect(hasServerTool(manager, "lazy")).toBe(true);
+			expect(result.tools.length).toBeGreaterThan(0);
+			expect(result.connectedServers).not.toContain("lazy");
+			// The subprocess was never started.
+			expect(spawnCount(spawnLog)).toBe(0);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-lifecycle-single-flight.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-single-flight.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Contract: concurrent first calls to the same lazy server share ONE connect
+ * (single-flight via #pendingConnections) — the subprocess is spawned once.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import {
+	executeServerTool,
+	inMemoryToolCache,
+	lazyConfig,
+	makeWorkDir,
+	resultText,
+	spawnCount,
+	TOOL_DEF,
+} from "./mcp-lifecycle-harness";
+
+describe("MCP lazy lifecycle: concurrent first calls single-flight", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = makeWorkDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("spawns the server exactly once for two concurrent calls", async () => {
+		const spawnLog = path.join(workDir, "spawns.log");
+		const cache = inMemoryToolCache();
+		const config = lazyConfig({ lifecycle: "lazy", spawnLog });
+		await cache.set("lazy", config, [TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: config }, {});
+
+			const [first, second] = await Promise.all([
+				executeServerTool(manager, "lazy"),
+				executeServerTool(manager, "lazy"),
+			]);
+
+			expect(resultText(first)).toBe("pong");
+			expect(resultText(second)).toBe("pong");
+			// Both calls resolved through a single connect.
+			expect(spawnCount(spawnLog)).toBe(1);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});


### PR DESCRIPTION
## Summary
Adds an **opt-in** per-server MCP `lifecycle: lazy | eager` plus `idleTimeout`, so stdio MCP servers no longer all spawn eagerly at session start.

Today `MCPManager.connectServers` builds a connect promise for every enabled server in parallel (`mcp/manager.ts:347-470`); stdio spawns synchronously inside connect (`mcp/transports/stdio.ts:313-335`). The 250ms `STARTUP_TIMEOUT_MS` race only decides live-vs-cached tool surfacing — it does not gate the spawn. With several stdio servers and multiple concurrent sessions this is a large, mostly-idle process/RAM footprint (measured: ~13 sessions × 6 servers ≈ 4 GB RSS).

## Behavior
- `lifecycle: "eager"` (default) — **exactly today's behavior**.
- `lifecycle: "lazy"` — advertise tools from `MCPToolCache` as `DeferredMCPTool`; connect on first tool call via a single-flight `#ensureLazyConnection` (gated by the existing crash-burst breaker); disconnect after `idleTimeout` of inactivity (active-call refcount; never mid-call) and re-arm as deferred.
- `idleTimeout` (ms, default 300000, `0`=never) + global `mcp.defaultLifecycle` (default `"eager"`) / `mcp.defaultIdleTimeoutMs`. Precedence: per-server → setting → `"eager"`.

**Backward compatibility: zero change on merge** — with `lifecycle` absent and the default `eager`, every existing config behaves byte-for-byte as today. `keep-alive` intentionally omitted from v1 (`eager` already auto-restarts via `onClose → reconnectServer`).

## Edge cases handled
Cold cache (first run connects once to populate, then lazy); concurrent first-calls (single-flight, one spawn); idle-vs-in-flight (refcount, unref()'d reaper); auth/secret re-resolution on reconnect; tool-list drift self-heals on connect; HTTP/SSE lifecycle = defer handshake/SSE stream.

11 `bun test` files cover no-spawn (warm cache), cold-cache, first-call connect, single-flight, idle-reap, idle-refcount, idleTimeout:0, eager-unchanged, connect-failure, and config round-trip.

Two related, independent fixes submitted separately (resource-templates `-32601`; disconnect-on-dispose orphans).

---
*Note: developed against current source and reviewed; the full `bun test`/`tsgo` suite was not run in my contributor environment (memory-constrained) — CI should verify. Happy to adjust.*
