### PR TITLE
fix(providers): normalize GLM-5.2 max reasoning effort

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed Zhipu/BigModel GLM-5.2 chat-completions requests so the internal `xhigh` effort serializes as provider-native `reasoning_effort: "max"` and tool calls opt into `tool_stream`. ([#2833](https://github.com/can1357/oh-my-pi/issues/2833))
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/ai/src/providers/openai-chat-server-schema.ts
+++ b/packages/ai/src/providers/openai-chat-server-schema.ts
@@ -225,7 +225,7 @@ export const openaiChatRequestSchema = z.object({
 	frequency_penalty: z.number().optional(),
 	logit_bias: z.record(z.string(), z.number()).optional(),
 	user: z.string().optional(),
-	reasoning_effort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).optional(),
+	reasoning_effort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
 	parallel_tool_calls: z.boolean().optional(),
 	service_tier: z.enum(["auto", "default", "flex", "scale", "priority"]).optional(),
 	metadata: z.record(z.string(), z.unknown()).optional(),

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolvePromptCacheKey } from "../auth-gateway/http";
 /**
  * Parsed inbound OpenAI chat-completions request, ready to feed into pi-ai
@@ -32,8 +33,22 @@ export type { ParsedRequest };
 
 type ReasoningEffort = NonNullable<ParsedRequest["options"]["reasoning"]>;
 
-function isReasoningEffort(value: unknown): value is ReasoningEffort {
-	return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
+	switch (value) {
+		case "minimal":
+			return Effort.Minimal;
+		case "low":
+			return Effort.Low;
+		case "medium":
+			return Effort.Medium;
+		case "high":
+			return Effort.High;
+		case "xhigh":
+		case "max":
+			return Effort.XHigh;
+		default:
+			return undefined;
+	}
 }
 
 function isServiceTier(value: unknown): value is ResolvedServiceTier {
@@ -156,8 +171,9 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	if (data.user !== undefined) options.user = data.user;
 	if (data.response_format !== undefined) options.responseFormat = data.response_format;
 	if (data.parallel_tool_calls !== undefined) options.parallelToolCalls = data.parallel_tool_calls;
-	if (data.reasoning_effort !== undefined && isReasoningEffort(data.reasoning_effort)) {
-		options.reasoning = data.reasoning_effort;
+	const reasoningEffort = normalizeReasoningEffort(data.reasoning_effort);
+	if (reasoningEffort !== undefined) {
+		options.reasoning = reasoningEffort;
 	}
 	if (data.service_tier !== undefined && isServiceTier(data.service_tier)) {
 		options.serviceTier = data.service_tier;

--- a/packages/ai/src/providers/openai-chat-wire.ts
+++ b/packages/ai/src/providers/openai-chat-wire.ts
@@ -116,7 +116,7 @@ export type Metadata = {
 };
 
 /** Constrains effort on reasoning for reasoning models. */
-export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
 
 /** JSON object response format (older JSON mode). */
 export interface ResponseFormatJSONObject {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,6 +1,6 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { toFirepassWireModelId, toFireworksWireModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
-import { isDeepseekModelIdOrName } from "@oh-my-pi/pi-catalog/identity";
+import { isDeepseekModelIdOrName, isGlm52ReasoningEffortModelId } from "@oh-my-pi/pi-catalog/identity";
 import { getSupportedEfforts, resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import type { ResolvedOpenAICompat } from "@oh-my-pi/pi-catalog/types";
@@ -367,7 +367,7 @@ export interface OpenAICompletionsOptions extends StreamOptions {
 	openrouterVariant?: string;
 }
 
-type OpenAICompletionsParams = ChatCompletionCreateParamsStreaming & {
+type OpenAICompletionsParams = Omit<ChatCompletionCreateParamsStreaming, "reasoning_effort"> & {
 	top_k?: number;
 	min_p?: number;
 	repetition_penalty?: number;
@@ -375,6 +375,8 @@ type OpenAICompletionsParams = ChatCompletionCreateParamsStreaming & {
 	enable_thinking?: boolean;
 	chat_template_kwargs?: { enable_thinking: boolean };
 	reasoning?: { effort?: string } | { enabled: false };
+	reasoning_effort?: string | null;
+	tool_stream?: boolean;
 	provider?: OpenAICompat["openRouterRouting"];
 	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
 };
@@ -1338,6 +1340,10 @@ function buildParams(
 	// `compat.alwaysSendMaxTokens` carries that detection.
 	const requestedMaxTokens =
 		options?.maxTokens ?? (compat.alwaysSendMaxTokens ? (model.maxTokens ?? OPENAI_MAX_OUTPUT_TOKENS) : undefined);
+	const modelOutputLimit =
+		compat.thinkingFormat === "zai" && isGlm52ReasoningEffortModelId(model.id)
+			? (model.maxTokens ?? OPENAI_MAX_OUTPUT_TOKENS)
+			: OPENAI_MAX_OUTPUT_TOKENS;
 	// OpenRouter fans out to upstreams whose output caps differ from the catalog
 	// value (which tracks the highest-cap provider). A max_tokens above the routed
 	// upstream's cap makes OpenRouter silently skip that provider (e.g. Cerebras
@@ -1348,7 +1354,7 @@ function buildParams(
 	const effectiveMaxTokens =
 		requestedMaxTokens === undefined || omitMaxTokensForRouting
 			? undefined
-			: Math.min(requestedMaxTokens, model.maxTokens ?? Number.POSITIVE_INFINITY, OPENAI_MAX_OUTPUT_TOKENS);
+			: Math.min(requestedMaxTokens, model.maxTokens ?? Number.POSITIVE_INFINITY, modelOutputLimit);
 
 	const requestModelId = resolveOpenAICompletionsModelId(model, options);
 	const params: OpenAICompletionsParams = {
@@ -1423,6 +1429,16 @@ function buildParams(
 		params.tools = [];
 	}
 
+	if (
+		compat.thinkingFormat === "zai" &&
+		compat.supportsReasoningEffort &&
+		isGlm52ReasoningEffortModelId(model.id) &&
+		Array.isArray(params.tools) &&
+		params.tools.length > 0
+	) {
+		params.tool_stream = true;
+	}
+
 	if (options?.toolChoice && compat.supportsToolChoice) {
 		params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
 	}
@@ -1459,12 +1475,23 @@ function buildParams(
 	}
 
 	if (supportsReasoningParams && compat.thinkingFormat === "zai" && model.reasoning) {
-		// Z.ai uses binary thinking: { type: "enabled" | "disabled" }
-		// Must explicitly disable since z.ai defaults to thinking enabled.
-		const enabled = options?.reasoning && !options?.disableReasoning;
+		// Z.AI-style hosts use binary thinking, while GLM-5.2+ also accepts
+		// `reasoning_effort` when thinking is enabled. `minimal` maps to the
+		// provider's skip-thinking path, so keep the effort field absent there.
+		const requestedEffort = options?.reasoning;
+		const mappedEffort =
+			requestedEffort === undefined
+				? undefined
+				: (compat.reasoningEffortMap?.[requestedEffort] ??
+					model.thinking?.effortMap?.[requestedEffort] ??
+					requestedEffort);
+		const enabled = mappedEffort !== undefined && mappedEffort !== "none" && !options?.disableReasoning;
 		params.thinking = { type: enabled ? "enabled" : "disabled" };
 		if (enabled && compat.thinkingKeep) {
 			params.thinking.keep = compat.thinkingKeep;
+		}
+		if (enabled && compat.supportsReasoningEffort) {
+			params.reasoning_effort = mappedEffort;
 		}
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen" && model.reasoning) {
 		// Qwen uses top-level enable_thinking: boolean

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { encodeResponse, encodeStream, parseRequest } from "@oh-my-pi/pi-ai/providers/openai-chat-server";
 import type { AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 
 function makeEventStream(events: AssistantMessageEvent[], final: AssistantMessage): AssistantMessageEventStream {
 	async function* iter() {
@@ -151,6 +152,16 @@ describe("auth-gateway openai-chat: parseRequest", () => {
 		const parsed = parseRequest({ model: "m", messages: [], max_tokens: 256 });
 		expect(parsed.options.maxOutputTokens).toBe(256);
 		expect(parsed.stream).toBe(false);
+	});
+
+	it("normalizes provider-native max reasoning effort to internal xhigh", () => {
+		const parsed = parseRequest({
+			model: "glm-5.2",
+			messages: [{ role: "user", content: "hi" }],
+			reasoning_effort: "max",
+		});
+
+		expect(parsed.options.reasoning).toBe(Effort.XHigh);
 	});
 
 	it("honours an explicit wire `name` on a tool message over back-resolution", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -78,6 +78,26 @@ function baseContext(): Context {
 	};
 }
 
+function zaiGlm52Model(): Model<"openai-completions"> {
+	return buildModel({
+		id: "glm-5.2",
+		name: "GLM-5.2",
+		api: "openai-completions",
+		provider: "zhipu-coding-plan",
+		baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+		reasoning: true,
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
 async function captureOpenAICompletionsPayload(
 	model: Model<"openai-completions">,
 	context: Context = baseContext(),
@@ -563,6 +583,56 @@ describe("openai-completions compatibility", () => {
 		const payload = await promise;
 		const chatTemplateArgs = getNestedObject(payload, "chat_template_kwargs");
 		expect(getNestedBoolean(chatTemplateArgs, "enable_thinking")).toBe(true);
+	});
+
+	it("maps GLM-5.2 xhigh to Z.AI max and enables tool streaming", async () => {
+		const model = zaiGlm52Model();
+		const readTool: Tool = {
+			name: "read",
+			description: "Read a file",
+			parameters: {
+				type: "object",
+				properties: { path: { type: "string" } },
+				required: ["path"],
+			},
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(
+			model,
+			{ ...baseContext(), tools: [readTool] },
+			{
+				apiKey: "test-key",
+				reasoning: "xhigh",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+				maxTokens: 65_536,
+			},
+		);
+		const payload = await promise;
+		const thinking = getNestedObject(payload, "thinking");
+
+		expect(Reflect.get(thinking ?? {}, "type")).toBe("enabled");
+		expect(Reflect.get(toObject(payload) ?? {}, "reasoning_effort")).toBe("max");
+		expect(Reflect.get(toObject(payload) ?? {}, "tool_stream")).toBe(true);
+		expect(Reflect.get(toObject(payload) ?? {}, "max_tokens")).toBe(65_536);
+	});
+
+	it("maps GLM-5.2 minimal reasoning to disabled Z.AI thinking", async () => {
+		const model = zaiGlm52Model();
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "minimal",
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		const thinking = getNestedObject(payload, "thinking");
+
+		expect(Reflect.get(thinking ?? {}, "type")).toBe("disabled");
+		expect(Reflect.get(toObject(payload) ?? {}, "reasoning_effort")).toBeUndefined();
 	});
 
 	it("treats finish_reason end as stop", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed GLM-5.2 catalog thinking metadata for Zhipu/BigModel so the top effort is exposed consistently and maps to provider-native `max`. ([#2833](https://github.com/can1357/oh-my-pi/issues/2833))
 ## [16.0.2] - 2026-06-16
 
 ### Fixed

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -208,9 +208,9 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 		model.maxTokens = copilotLimits.maxTokens;
 	}
 
-	// GLM Coding Plan (zai): GLM-5.2 is the selectable 1M served id; pin it
-	// so endpoint discovery or older bundled fallbacks cannot regress to 200k.
-	if (model.provider === "zai" && model.id === "glm-5.2") {
+	// GLM Coding Plan: GLM-5.2 is the selectable 1M served id; pin it so
+	// endpoint discovery or older bundled fallbacks cannot regress to 200k.
+	if ((model.provider === "zai" || model.provider === "zhipu-coding-plan") && model.id === "glm-5.2") {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 131_072;
 	}

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -12,6 +12,7 @@ import {
 	isAnthropicNamespacedModelId,
 	isClaudeModelId,
 	isDeepseekModelIdOrName,
+	isGlm52ReasoningEffortModelId,
 	isKimiK26ModelId,
 	isKimiModelId,
 	isMimoModelIdOrName,
@@ -82,6 +83,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const isCerebras = modelMatchesHost(hostModel, "cerebras");
 	const isZai = modelMatchesHost(hostModel, "zai");
 	const isZhipu = modelMatchesHost(hostModel, "zhipu");
+	const supportsZaiReasoningEffort = (isZai || isZhipu) && isGlm52ReasoningEffortModelId(spec.id);
 	const isKilo = modelMatchesHost(hostModel, "kilo");
 	const isKimiModel = isKimiModelId(spec.id);
 	const isMoonshotNative = modelMatchesHost(hostModel, "moonshotNative");
@@ -136,6 +138,8 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const useMaxTokens =
 		isMistral ||
 		isMoonshotNative ||
+		isZai ||
+		isZhipu ||
 		hostMatchesUrl(baseUrl, "chutes") ||
 		hostMatchesUrl(baseUrl, "fireworks") ||
 		isDirectDeepseekApi;
@@ -202,7 +206,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// OpenAI's reasoning-API surface.
 		supportsDeveloperRole: isOpenAIHost || isAzureHost,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
-		supportsReasoningEffort: !isGrok && !isZai && !isZhipu && !isXiaomiMimo,
+		supportsReasoningEffort: !isGrok && !isXiaomiMimo && (!(isZai || isZhipu) || supportsZaiReasoningEffort),
 		// GitHub Copilot's chat-completions endpoint rejects reasoning params wholesale.
 		supportsReasoningParams: provider !== "github-copilot",
 		reasoningEffortMap: {},

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -106,6 +106,18 @@ export function isReasoningGlmModelId(modelId: string): boolean {
 	return semverGte(glm.version, "4.5");
 }
 
+/** GLM-5.2+ coding SKUs accept `reasoning_effort` in addition to binary thinking. */
+export function isGlm52ReasoningEffortModelId(modelId: string): boolean {
+	const glm = parseGlmModel(bareModelId(modelId));
+	if (!glm || glm.vision) {
+		return false;
+	}
+	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+		return false;
+	}
+	return semverGte(glm.version, "5.2");
+}
+
 /** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */
 export function isGlmVisionModelId(modelId: string): boolean {
 	return parseGlmModel(bareModelId(modelId))?.vision === true;

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -23,6 +23,7 @@ import {
 import {
 	findThinkingVariantToken,
 	isDeepseekModelIdOrName,
+	isGlm52ReasoningEffortModelId,
 	isMinimaxM2FamilyModelId,
 	isOpenAIGptOssModelId,
 	supportsAdaptiveThinkingDisplay,
@@ -75,6 +76,14 @@ const DEEPSEEK_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 };
 const FIREWORKS_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.Minimal]: "none",
+};
+
+const ZAI_GLM_52_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
+	[Effort.Minimal]: "none",
+	[Effort.Low]: "high",
+	[Effort.Medium]: "high",
+	[Effort.High]: "high",
+	[Effort.XHigh]: "max",
 };
 
 /**
@@ -259,9 +268,17 @@ function sameEffortList(left: readonly Effort[], right: readonly Effort[]): bool
 }
 
 function getModelDefinedEfforts<TApi extends Api>(spec: ModelSpec<TApi>): readonly Effort[] | undefined {
+	if (spec.api === "openai-completions" && isZaiGlm52ReasoningEffortModel(spec)) {
+		return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
+	}
 	return spec.api === "openai-completions" && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))
 		? LOW_MEDIUM_HIGH_REASONING_EFFORTS
 		: undefined;
+}
+
+function isZaiGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	if (!isGlm52ReasoningEffortModelId(spec.id)) return false;
+	return modelMatchesHost(spec, "zai") || modelMatchesHost(spec, "zhipu");
 }
 
 function readCompatEffortMap(compat: CompatOf<Api>): EffortMap | undefined {
@@ -287,6 +304,9 @@ function inferDetectedEffortMap<TApi extends Api>(
 	}
 	if (spec.provider === "groq" && spec.id === "qwen/qwen3-32b") {
 		return GROQ_QWEN3_32B_REASONING_EFFORT_MAP;
+	}
+	if (isZaiGlm52ReasoningEffortModel(spec)) {
+		return ZAI_GLM_52_REASONING_EFFORT_MAP;
 	}
 	if (isDeepseekReasoningModel(spec)) {
 		return DEEPSEEK_REASONING_EFFORT_MAP;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -27751,8 +27751,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -27780,8 +27780,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30791,6 +30791,25 @@
 				]
 			}
 		},
+		"z-ai/glm-5.2": {
+			"id": "z-ai/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072
+		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
 			"name": "GLM 5V Turbo",
@@ -32862,6 +32881,35 @@
 				"input": 0.95,
 				"output": 4,
 				"cacheRead": 0.19,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"kimi-k2.7-code-highspeed": {
+			"id": "kimi-k2.7-code-highspeed",
+			"name": "Kimi K2.7 Code HighSpeed",
+			"api": "openai-completions",
+			"provider": "moonshot",
+			"baseUrl": "https://api.moonshot.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.9,
+				"output": 8,
+				"cacheRead": 0.38,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -60012,8 +60060,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.098,
-				"output": 0.196,
+				"input": 0.09,
+				"output": 0.18,
 				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
@@ -62075,13 +62123,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
+				"input": 0.74,
 				"output": 3.5,
-				"cacheRead": 0.16,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62397,8 +62445,8 @@
 			],
 			"cost": {
 				"input": 0.5,
-				"output": 2.5,
-				"cacheRead": 0.15,
+				"output": 2.2,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -66658,13 +66706,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.125,
+				"input": 0.13,
 				"output": 0.85,
-				"cacheRead": 0.06,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131070,
+			"maxTokens": 98304,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66938,6 +66986,34 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"z-ai/glm-5.2": {
+			"id": "z-ai/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68791,8 +68867,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 7.5,
+				"input": 1.25,
+				"output": 3.75,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -68915,7 +68991,8 @@
 					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"requiresEffort": true
 			},
 			"compat": {
 				"escapeBuiltinToolNames": true
@@ -68972,7 +69049,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 131072,
+			"maxTokens": 131071,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -68983,6 +69060,39 @@
 					"xhigh"
 				]
 			},
+			"compat": {
+				"escapeBuiltinToolNames": true
+			}
+		},
+		"umans-glm-5.2": {
+			"id": "umans-glm-5.2",
+			"name": "Umans GLM 5.2",
+			"api": "anthropic-messages",
+			"provider": "umans",
+			"baseUrl": "https://api.code.umans.ai",
+			"reasoning": true,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 405504,
+			"maxTokens": 131071,
 			"compat": {
 				"escapeBuiltinToolNames": true
 			}
@@ -69791,6 +69901,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-glm-5-2-p": {
+			"id": "e2ee-glm-5-2-p",
+			"name": "e2ee-glm-5-2-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-gpt-oss-120b-p": {
 			"id": "e2ee-gpt-oss-120b-p",
 			"name": "e2ee-gpt-oss-120b-p",
@@ -70559,24 +70691,32 @@
 		},
 		"kimi-k2-7-code": {
 			"id": "kimi-k2-7-code",
-			"name": "kimi-k2-7-code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.9,
+				"output": 4.3,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"kimi-k2-thinking": {
@@ -71985,6 +72125,35 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
+			"maxTokens": 24000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"zai-org-glm-5-2": {
+			"id": "zai-org-glm-5-2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.75,
+				"output": 5.5,
+				"cacheRead": 0.325,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 24000,
 			"thinking": {
 				"mode": "effort",
@@ -74758,6 +74927,36 @@
 				]
 			}
 		},
+		"moonshotai/kimi-k2.7-code-highspeed": {
+			"id": "moonshotai/kimi-k2.7-code-highspeed",
+			"name": "Kimi K2.7 Code High Speed",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.9,
+				"output": 8,
+				"cacheRead": 0.38,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
 			"name": "Nemotron 3 Super",
@@ -77052,6 +77251,35 @@
 			},
 			"contextWindow": 202800,
 			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"zai/glm-5.2": {
+			"id": "zai/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -84227,8 +84455,16 @@
 					"minimal",
 					"low",
 					"medium",
-					"high"
-				]
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "none",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
 			}
 		},
 		"glm-5v-turbo": {

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -477,6 +477,29 @@ describe("model thinking runtime helpers", () => {
 		);
 	});
 
+	it("maps GLM-5.2 xhigh to Z.AI provider-native max", () => {
+		const model = createModel({
+			id: "glm-5.2",
+			api: "openai-completions",
+			provider: "zhipu-coding-plan",
+			baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+			compat: { thinkingFormat: "zai" },
+		});
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			effortMap: {
+				minimal: "none",
+				low: "high",
+				medium: "high",
+				high: "high",
+				xhigh: "max",
+			},
+		});
+		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
+	});
+
 	it("derives binary-thinking fallback from resolved compat when catalog compat is partial", () => {
 		const model = createModel({
 			id: "qwen/qwen3-32b",

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -5,10 +5,9 @@ import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 /**
  * Resolver-branch coverage for the `isZhipu` path added by the
- * `zhipu-coding-plan` provider. Mirrors the shape of existing zai/cerebras
- * tests: assert the contract the provider relies on (zai thinking format,
- * disabled `reasoning_effort`, no `developer` role) so future refactors of
- * `buildOpenAICompat` cannot silently regress the BigModel SKU.
+ * `zhipu-coding-plan` provider. GLM-5.2+ additionally accepts
+ * `reasoning_effort`; older BigModel thinking SKUs keep the binary Z.AI-shaped
+ * toggle only.
  */
 
 const baseModel: Omit<ModelSpec<"openai-completions">, "provider" | "baseUrl"> = {
@@ -40,8 +39,28 @@ function zhipuByBaseUrl(): ModelSpec<"openai-completions"> {
 	};
 }
 
+function zhipuGlm52ByProvider(): ModelSpec<"openai-completions"> {
+	return {
+		...baseModel,
+		id: "glm-5.2",
+		name: "GLM-5.2",
+		provider: "zhipu-coding-plan",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+	};
+}
+
+function zhipuGlm52ByOfficialBaseUrl(): ModelSpec<"openai-completions"> {
+	return {
+		...baseModel,
+		id: "glm-5.2",
+		name: "GLM-5.2",
+		provider: "custom",
+		baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+	};
+}
+
 describe("openai-completions compat — zhipu-coding-plan branch", () => {
-	it("forces zai thinking format and disables reasoning_effort / developer role", () => {
+	it("forces zai thinking format and disables reasoning_effort before GLM-5.2", () => {
 		const compat = buildOpenAICompat(zhipuByProvider());
 
 		expect(compat.thinkingFormat).toBe("zai");
@@ -59,6 +78,19 @@ describe("openai-completions compat — zhipu-coding-plan branch", () => {
 
 		expect(compat.thinkingFormat).toBe("zai");
 		expect(compat.supportsReasoningEffort).toBe(false);
+	});
+
+	it("enables reasoning_effort for GLM-5.2 on both Zhipu route shapes", () => {
+		const codingPlanCompat = buildOpenAICompat(zhipuGlm52ByProvider());
+		const officialCompat = buildOpenAICompat(zhipuGlm52ByOfficialBaseUrl());
+
+		expect(codingPlanCompat.thinkingFormat).toBe("zai");
+		expect(codingPlanCompat.supportsReasoningEffort).toBe(true);
+		expect(officialCompat.thinkingFormat).toBe("zai");
+		expect(officialCompat.supportsReasoningEffort).toBe(true);
+		expect(officialCompat.reasoningContentField).toBe("reasoning_content");
+		expect(codingPlanCompat.maxTokensField).toBe("max_tokens");
+		expect(officialCompat.maxTokensField).toBe("max_tokens");
 	});
 
 	it("lets explicit model.compat overrides win at the resolver layer", () => {


### PR DESCRIPTION
## Repro
`bun -e "import modelsJson from './packages/catalog/src/models.json'; const model = modelsJson['zhipu-coding-plan']['glm-5.2']; console.log('thinking efforts:', model.thinking?.efforts?.join(',')); console.log('contextWindow:', model.contextWindow, 'maxTokens:', model.maxTokens); if (!model.thinking?.efforts?.includes('xhigh')) throw new Error('GLM-5.2 does not expose top xhigh/max-compatible effort');"` failed because bundled `zhipu-coding-plan/glm-5.2` exposed only `minimal,low,medium,high` even though the Z.AI and BigModel docs define provider-native top effort as `max` with `xhigh` as its compatibility alias.

## Cause
`packages/catalog/src/model-thinking.ts` treated Z.AI/Zhipu OpenAI-compatible GLM thinking as binary Z.AI-style thinking and inherited the generic four-level `reasoning_effort` surface, while `packages/catalog/src/compat/openai.ts` disabled `reasoning_effort` for every `open.bigmodel.cn` route. `packages/ai/src/providers/openai-completions.ts` therefore emitted only `thinking: { type }` for Zhipu GLM-5.2 and had no path to serialize internal `xhigh` as provider-native `reasoning_effort: "max"`.

## Fix
- Added a GLM-5.2+ family predicate and Z.AI/Zhipu effort map so `xhigh` remains the internal top level but serializes as `max`, `low`/`medium` serialize as `high`, and `minimal` disables thinking without sending `reasoning_effort`.
- Enabled `reasoning_effort` for GLM-5.2+ on both Zhipu route shapes (`https://open.bigmodel.cn/api/coding/paas/v4` and `https://open.bigmodel.cn/api/paas/v4`) while keeping older GLM thinking models binary-only.
- Updated OpenAI-compatible request serialization to send Zhipu GLM-5.2 `thinking: { type: "enabled" }` with `reasoning_effort: "max"`, and to opt streamed tool requests into `tool_stream: true`.
- Regenerated bundled catalog metadata and added changelog entries for `pi-ai` and `pi-catalog`; sampling defaults intentionally remain provider/default-temperature driven, with no unconditional `do_sample=false`.

## Verification
Reproduced the pre-fix catalog cap with the recorded `bun -e` repro. Verified the fixed bundled model with `bun -e` showing `thinking efforts: minimal,low,medium,high,xhigh`, `effortMap: {"minimal":"none","low":"high","medium":"high","high":"high","xhigh":"max"}`, `contextWindow: 1000000`, `maxTokens: 131072`, and request `reasoning_effort: max`. Ran `bun test packages/catalog/test/model-thinking.test.ts packages/catalog/test/zhipu-compat.test.ts packages/ai/test/openai-completions-compat.test.ts` (86 pass) and `bun check` (passed). Fixes #2833