### PR TITLE
fix(cli): switch /model through session selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Fixed `/model` in the TUI to open the active-session model switcher instead of the role-assignment picker ([#2846](https://github.com/can1357/oh-my-pi/issues/2846)).
 - Fixed Whisper STT cache detection to require both encoder and decoder `.onnx` files, so partial model downloads now trigger a proper foreground download instead of being treated as fully cached
 - Fixed same-process `JsRuntime` cleanup so disposing an older inline/direct runtime no longer deletes a newer runtime's JS helper globals; inactive cmux/direct runtimes now re-activate their globals before sequential use while overlapping cross-runtime runs fail explicitly.
 - Fixed magic-keyword steering notices (`ultrathink-notice`, `orchestrate-notice`, `workflow-notice`) to be prepended before the related user message so they influence that same turn

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -308,7 +308,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "model",
 		aliases: ["models"],
-		description: "Select model (opens selector UI)",
+		description: "Switch model for this session",
 		acpDescription: "Show current model selection",
 		handle: async (command, runtime) => {
 			if (command.args) {
@@ -341,7 +341,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return commandConsumed();
 		},
 		handleTui: (_command, runtime) => {
-			runtime.ctx.showModelSelector();
+			runtime.ctx.showModelSelector({ temporaryOnly: true });
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -17,6 +17,18 @@ function createRuntime() {
 	};
 }
 
+describe("/model slash command", () => {
+	it("opens the temporary model selector for the active session", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/model", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showModelSelector).toHaveBeenCalledWith({ temporaryOnly: true });
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});
+
 describe("/switch slash command", () => {
 	it("opens the temporary model selector (mirrors alt+p)", async () => {
 		const harness = createRuntime();


### PR DESCRIPTION
## Repro
Starting OMP and running `/model` should switch the active session model. The focused repro ran `executeBuiltinSlashCommand("/model", { ctx })` with a TUI context spy and expected `showModelSelector({ temporaryOnly: true })`; before the fix it printed `{}` and exited 1 because `/model` opened the role-assignment selector.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` handled TUI `/model` with `runtime.ctx.showModelSelector()` while `/switch` and Alt+P used `showModelSelector({ temporaryOnly: true })`. The missing flag sent users into the role-assignment picker, whose next menu step does not change the active session model.

## Fix
- Route TUI `/model` through `showModelSelector({ temporaryOnly: true })`.
- Update the `/model` command description to match session model switching.
- Add `packages/coding-agent/test/slash-commands/switch.test.ts` coverage for `/model` opening the active-session selector.
- Add the coding-agent changelog entry for #2846.

## Verification
`bun run fix` passed. `bun test packages/coding-agent/test/slash-commands/switch.test.ts` passed with 2 tests / 6 assertions. The focused repro now prints `{"temporaryOnly":true}` and exits 0. Fixes #2846