### PR TITLE
fix(tui): gate git status-line work

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Fixed startup model fallback choosing the plain OpenAI `gpt-5.5` provider before the Codex OAuth provider when both shared the same default model id, which could surface a misleading OpenAI 401 despite valid Codex credentials ([#2807](https://github.com/can1357/oh-my-pi/issues/2807)).
 - Fixed local auto-thinking classification for reasoning-capable tiny models by giving them the same safe answer budget as online reasoning classifiers, with a larger local floor for non-reasoning tiny models ([#2808](https://github.com/can1357/oh-my-pi/issues/2808)).
 
+- Fixed WSL2 TUI stutter by adding a `git.enabled` setting and skipping footer/status-line git probes when disabled or when no git-backed status segment is visible ([#2847](https://github.com/can1357/oh-my-pi/issues/2847)).
+
 ### Removed
 
 - Removed the built-in `render_mermaid` tool and its `renderMermaid.enabled` setting, so it can no longer be invoked directly

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -415,6 +415,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 	shellPath: { type: "string", default: undefined },
+	"git.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Git",
+			label: "Enable Git Integration",
+			description: "Show git branch, status, and PR information in the TUI and watch repository metadata.",
+		},
+	},
 
 	extensions: { type: "array", default: EMPTY_STRING_ARRAY },
 

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -4,6 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Component, padding, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
+import { settings } from "../../config/settings";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
@@ -58,6 +59,8 @@ export class FooterComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
+		if (!settings.get("git.enabled")) return;
+
 		void git.head
 			.resolve(getProjectDir())
 			.then(head => {
@@ -102,6 +105,7 @@ export class FooterComponent implements Component {
 	 * Returns null if not in a git repo, branch name otherwise.
 	 */
 	#getCurrentBranch(): string | null {
+		if (!settings.get("git.enabled")) return null;
 		if (this.#cachedBranch !== undefined) {
 			return this.#cachedBranch;
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -111,6 +111,9 @@ function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
 function hasPrSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return segments.includes("pr");
 }
+function hasGitBackedSegment(segments: readonly StatusLineSegmentId[]): boolean {
+	return hasGitSegment(segments) || hasPrSegment(segments);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // StatusLineComponent
@@ -176,6 +179,12 @@ export class StatusLineComponent implements Component {
 	#gitEnabled(): boolean {
 		return settings.get("git.enabled");
 	}
+	#hasGitBackedSegment(): boolean {
+		const effectiveSettings = this.#resolveSettings();
+		return (
+			hasGitBackedSegment(effectiveSettings.leftSegments) || hasGitBackedSegment(effectiveSettings.rightSegments)
+		);
+	}
 
 	/**
 	 * Re-point the status line at another session (focus proxy). Invalidate: model/context/usage all derive
@@ -193,6 +202,7 @@ export class StatusLineComponent implements Component {
 	updateSettings(settings: StatusLineSettings): void {
 		this.#settings = settings;
 		this.#effectiveSettings = undefined;
+		if (this.#onBranchChange) this.#setupGitWatcher();
 	}
 
 	getEffectiveSettingsForTest(): EffectiveStatusLineSettings {
@@ -251,7 +261,7 @@ export class StatusLineComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
-		if (!this.#gitEnabled()) {
+		if (!this.#gitEnabled() || !this.#hasGitBackedSegment()) {
 			this.#invalidateGitCaches();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -104,6 +104,13 @@ const EMPTY_MESSAGES: readonly AgentMessage[] = [];
 function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return segments.includes("context_pct") || segments.includes("context_total");
 }
+function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
+	return segments.includes("git");
+}
+
+function hasPrSegment(segments: readonly StatusLineSegmentId[]): boolean {
+	return segments.includes("pr");
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // StatusLineComponent
@@ -165,6 +172,9 @@ export class StatusLineComponent implements Component {
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 			transparent: settings.get("statusLine.transparent"),
 		};
+	}
+	#gitEnabled(): boolean {
+		return settings.get("git.enabled");
 	}
 
 	/**
@@ -241,6 +251,11 @@ export class StatusLineComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
+		if (!this.#gitEnabled()) {
+			this.#invalidateGitCaches();
+			return;
+		}
+
 		const repository = git.repo.resolveSync(getProjectDir());
 		if (!repository) return;
 
@@ -286,6 +301,8 @@ export class StatusLineComponent implements Component {
 		this.#cachedPrContext = undefined;
 	}
 	#getCurrentBranch(): string | null {
+		if (!this.#gitEnabled()) return null;
+
 		const cwd = getProjectDir();
 		if (this.#cachedBranch !== undefined && this.#cachedBranchCwd === cwd) {
 			return this.#cachedBranch;
@@ -322,6 +339,7 @@ export class StatusLineComponent implements Component {
 	}
 
 	#getGitStatus(): { staged: number; unstaged: number; untracked: number } | null {
+		if (!this.#gitEnabled()) return null;
 		if (this.#gitStatusInFlight || Date.now() - this.#gitStatusLastFetch < 1000) {
 			return this.#cachedGitStatus;
 		}
@@ -343,6 +361,8 @@ export class StatusLineComponent implements Component {
 	}
 
 	#lookupPr(): { number: number; url: string } | null {
+		if (!this.#gitEnabled()) return null;
+
 		const branch = this.#getCurrentBranch();
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 
@@ -550,6 +570,8 @@ export class StatusLineComponent implements Component {
 		width: number,
 		segmentOptions: StatusLineSettings["segmentOptions"],
 		includeContext: boolean,
+		includeGit: boolean,
+		includePr: boolean,
 	): SegmentContext {
 		const state = this.session.state;
 
@@ -587,6 +609,10 @@ export class StatusLineComponent implements Component {
 			contextPercent = collabState.contextUsage.percent ?? contextPercent;
 		}
 
+		const gitBranch = includeGit || includePr ? this.#getCurrentBranch() : null;
+		const gitStatus = includeGit ? this.#getGitStatus() : null;
+		const gitPr = includePr ? this.#lookupPr() : null;
+
 		return {
 			session: this.session,
 			focusedAgentId: this.#focusedAgentId,
@@ -603,9 +629,9 @@ export class StatusLineComponent implements Component {
 			subagentCount: this.#subagentCount,
 			sessionStartTime: this.#sessionStartTime,
 			git: {
-				branch: this.#getCurrentBranch(),
-				status: this.#getGitStatus(),
-				pr: this.#lookupPr(),
+				branch: gitBranch,
+				status: gitStatus,
+				pr: gitPr,
 			},
 			usage: this.#cachedUsage,
 		};
@@ -656,7 +682,19 @@ export class StatusLineComponent implements Component {
 		const effectiveSettings = this.#resolveSettings();
 		const includeContext =
 			hasContextSegment(effectiveSettings.leftSegments) || hasContextSegment(effectiveSettings.rightSegments);
-		const ctx = this.#buildSegmentContext(width, effectiveSettings.segmentOptions, includeContext);
+		const gitEnabled = this.#gitEnabled();
+		const includeGit =
+			gitEnabled &&
+			(hasGitSegment(effectiveSettings.leftSegments) || hasGitSegment(effectiveSettings.rightSegments));
+		const includePr =
+			gitEnabled && (hasPrSegment(effectiveSettings.leftSegments) || hasPrSegment(effectiveSettings.rightSegments));
+		const ctx = this.#buildSegmentContext(
+			width,
+			effectiveSettings.segmentOptions,
+			includeContext,
+			includeGit,
+			includePr,
+		);
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
 		// `transparent` reuses the empty-string sentinel (`\x1b[49m`) so the bar

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -380,6 +380,7 @@ export class SelectorController {
 				this.ctx.session.agent.repetitionPenalty = repetitionPenalty >= 0 ? repetitionPenalty : undefined;
 				break;
 			}
+			case "git.enabled":
 			case "statusLinePreset":
 			case "statusLine.preset":
 			case "statusLineSeparator":

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+
+let settingsState: SettingsTestState | undefined;
+
+beforeEach(async () => {
+	settingsState = beginSettingsTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterEach(() => {
+	restoreSettingsTestState(settingsState);
+	settingsState = undefined;
+});
+
+describe("selector setting side effects", () => {
+	it("refreshes the status line when git integration changes at runtime", () => {
+		const updateSettings = vi.fn();
+		const updateEditorTopBorder = vi.fn();
+		const requestRender = vi.fn();
+		const controller = new SelectorController({
+			statusLine: { updateSettings },
+			updateEditorTopBorder,
+			ui: { requestRender },
+		} as unknown as ConstructorParameters<typeof SelectorController>[0]);
+
+		Settings.instance.override("git.enabled", false);
+		controller.handleSettingChange("git.enabled", false);
+
+		expect(updateSettings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				preset: Settings.instance.get("statusLine.preset"),
+				leftSegments: Settings.instance.get("statusLine.leftSegments"),
+				rightSegments: Settings.instance.get("statusLine.rightSegments"),
+			}),
+		);
+		expect(updateEditorTopBorder).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -229,6 +229,7 @@ describe("StatusLineComponent effective settings cache", () => {
 	it("skips git probes when no git-backed segment is visible", async () => {
 		const headSpy = spyOn(git.head, "resolveSync").mockReturnValue(null);
 		const statusSpy = spyOn(git.status, "summary").mockResolvedValue({ staged: 0, unstaged: 0, untracked: 0 });
+		const repoSpy = spyOn(git.repo, "resolveSync").mockReturnValue(null);
 		try {
 			const component = makeComponent({
 				preset: "custom",
@@ -237,12 +238,17 @@ describe("StatusLineComponent effective settings cache", () => {
 				sessionAccent: false,
 			});
 
+			component.watchBranch(() => {
+				throw new Error("git watcher should not fire when no git-backed segment is visible");
+			});
 			component.getTopBorder(100);
 			await Promise.resolve();
 
+			expect(repoSpy).not.toHaveBeenCalled();
 			expect(headSpy).not.toHaveBeenCalled();
 			expect(statusSpy).not.toHaveBeenCalled();
 		} finally {
+			repoSpy.mockRestore();
 			statusSpy.mockRestore();
 			headSpy.mockRestore();
 		}

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -7,6 +7,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent, type StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { STATUS_LINE_PRESETS } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/presets";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import { setProjectDir } from "@oh-my-pi/pi-utils";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
@@ -195,5 +196,55 @@ describe("StatusLineComponent effective settings cache", () => {
 		const nextEffective = component.getEffectiveSettingsForTest();
 		expect(nextEffective).not.toBe(effective);
 		expect(component.getEffectiveSettingsForTest()).toBe(nextEffective);
+	});
+	it("skips git probes when git integration is disabled", async () => {
+		const headSpy = spyOn(git.head, "resolveSync").mockReturnValue(null);
+		const statusSpy = spyOn(git.status, "summary").mockResolvedValue({ staged: 0, unstaged: 0, untracked: 0 });
+		const repoSpy = spyOn(git.repo, "resolveSync").mockReturnValue(null);
+		try {
+			Settings.instance.override("git.enabled", false);
+			const component = makeComponent({
+				preset: "custom",
+				leftSegments: ["git", "pr"],
+				rightSegments: [],
+				sessionAccent: false,
+			});
+
+			component.watchBranch(() => {
+				throw new Error("git watcher should not fire while git integration is disabled");
+			});
+			component.getTopBorder(100);
+			await Promise.resolve();
+
+			expect(repoSpy).not.toHaveBeenCalled();
+			expect(headSpy).not.toHaveBeenCalled();
+			expect(statusSpy).not.toHaveBeenCalled();
+		} finally {
+			repoSpy.mockRestore();
+			statusSpy.mockRestore();
+			headSpy.mockRestore();
+		}
+	});
+
+	it("skips git probes when no git-backed segment is visible", async () => {
+		const headSpy = spyOn(git.head, "resolveSync").mockReturnValue(null);
+		const statusSpy = spyOn(git.status, "summary").mockResolvedValue({ staged: 0, unstaged: 0, untracked: 0 });
+		try {
+			const component = makeComponent({
+				preset: "custom",
+				leftSegments: ["pi"],
+				rightSegments: ["session_name"],
+				sessionAccent: false,
+			});
+
+			component.getTopBorder(100);
+			await Promise.resolve();
+
+			expect(headSpy).not.toHaveBeenCalled();
+			expect(statusSpy).not.toHaveBeenCalled();
+		} finally {
+			statusSpy.mockRestore();
+			headSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Repro
The issue reproduces on the current code path because `StatusLineComponent.#buildSegmentContext()` always requests git branch/status/PR data for the rendered context and `#getGitStatus()` schedules `git.status.summary(getProjectDir())`; `FooterComponent.render()` also reads the branch through `git.head.resolveSync()`. This was recorded with the repro command: `search 'setupGitWatcher|getGitStatus|getCurrentBranch|git\.status\.summary' packages/coding-agent/src/modes/components`.

## Cause
`packages/coding-agent/src/modes/components/footer.ts` and `packages/coding-agent/src/modes/components/status-line/component.ts` had no setting gate for git integration. Watcher setup, synchronous branch reads, `git status --porcelain`, and PR lookup could all remain tied to the TUI path once a repository was detected.

## Fix
- Added `git.enabled` to `packages/coding-agent/src/config/settings-schema.ts`, defaulting to `true`.
- Gated footer git watcher setup and render-time branch reads when `git.enabled` is `false`.
- Gated status-line git watcher setup, branch/status/PR lookups, and skipped git probes entirely when neither `git` nor `pr` status-line segments are visible.
- Added regression coverage proving disabled git integration and non-git status-line layouts do not call git probe helpers.

## Verification
Ran `bun test packages/coding-agent/test/status-line-settings-cache.test.ts` with 9 passing tests, then `bun run check` in `packages/coding-agent` with the package check passing. `gh_push_branch` also completed the pre-publish gate. Fixes #2847