### PR TITLE
feat(coding-agent): add command and keybind welcome tips

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -360,10 +360,9 @@ export interface AuthCredentialStore {
 	 */
 	markCredentialSuspect?(credentialId: number, opts?: { signal?: AbortSignal }): Promise<void>;
 	/**
-	 * Optional async write hook for upserting a single credential. When present,
-	 * `AuthStorage.#upsertOAuthCredential` routes through this instead of the
-	 * sync `upsertAuthCredentialForProvider`. `RemoteAuthCredentialStore` uses
-	 * it to send the upsert to the broker via `POST /v1/credential`.
+	 * Optional async write hook for upserting a single credential. Remote stores
+	 * can implement this to send single-row uploads to the broker via
+	 * `POST /v1/credential`.
 	 *
 	 * Implementations MUST update the in-memory snapshot before returning so the
 	 * post-write read path is consistent.
@@ -1505,17 +1504,6 @@ export class AuthStorage {
 		const stored = this.#store.replaceAuthCredentialsRemote
 			? await this.#store.replaceAuthCredentialsRemote(provider, deduped)
 			: this.#store.replaceAuthCredentialsForProvider(provider, deduped);
-		this.#setStoredCredentials(
-			provider,
-			stored.map(record => ({ id: record.id, credential: record.credential })),
-		);
-		this.#resetProviderAssignments(provider);
-	}
-
-	async #upsertOAuthCredential(provider: string, credential: OAuthCredential): Promise<void> {
-		const stored = this.#store.upsertAuthCredentialRemote
-			? await this.#store.upsertAuthCredentialRemote(provider, credential)
-			: this.#store.upsertAuthCredentialForProvider(provider, credential);
 		this.#setStoredCredentials(
 			provider,
 			stored.map(record => ({ id: record.id, credential: record.credential })),

--- a/packages/ai/src/registry/alibaba-coding-plan.ts
+++ b/packages/ai/src/registry/alibaba-coding-plan.ts
@@ -90,5 +90,5 @@ export const alibabaCodingPlanProvider = {
 	id: "alibaba-coding-plan",
 	name: "Alibaba Coding Plan",
 	login: (cb: OAuthLoginCallbacks) => loginAlibabaCodingPlan(cb),
-	getApiKey: (credentials) => credentials.access,
+	getApiKey: credentials => credentials.access,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -142,14 +142,14 @@ export async function getOAuthApiKey(
 		provider === "alibaba-coding-plan";
 	const apiKey = needsStructuredApiKey
 		? JSON.stringify({
-			token: creds.access,
-			enterpriseUrl: creds.enterpriseUrl,
-			projectId: creds.projectId,
-			refreshToken: creds.refresh,
-			expiresAt: creds.expires,
-			email: creds.email,
-			accountId: creds.accountId,
-		})
+				token: creds.access,
+				enterpriseUrl: creds.enterpriseUrl,
+				projectId: creds.projectId,
+				refreshToken: creds.refresh,
+				expiresAt: creds.expires,
+				email: creds.email,
+				accountId: creds.accountId,
+			})
 		: creds.access;
 	return { newCredentials: creds, apiKey };
 }

--- a/packages/ai/test/alibaba-endpoint-selection.test.ts
+++ b/packages/ai/test/alibaba-endpoint-selection.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import type { OAuthController, OAuthCredentials } from "../src/registry/oauth/types";
-import * as apiKeyValidation from "../src/registry/api-key-validation";
-import { loginAlibabaCodingPlan, alibabaCodingPlanProvider } from "../src/registry/alibaba-coding-plan";
-import { getOAuthApiKey } from "../src/registry/oauth/index";
 import type { Mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { loginAlibabaCodingPlan } from "../src/registry/alibaba-coding-plan";
+import * as apiKeyValidation from "../src/registry/api-key-validation";
+import { getOAuthApiKey } from "../src/registry/oauth/index";
+import type { OAuthController } from "../src/registry/oauth/types";
 
 describe("alibaba-coding-plan endpoint selection", () => {
 	let validateSpy: Mock<typeof apiKeyValidation.validateOpenAICompatibleApiKey>;
@@ -19,9 +19,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 1 uses international endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -48,9 +50,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 2 uses China endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "2";
 				if (prompt.message.includes("Paste your")) return "sk-cn-key";
 				return "";
@@ -77,9 +81,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 3 prompts for custom URL and uses it", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1";
 				if (prompt.message.includes("Paste your")) return "sk-custom-key";
@@ -107,7 +113,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -123,7 +129,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1///";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
@@ -140,32 +146,28 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Custom URL is required for option 3"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Custom URL is required for option 3");
 	});
 
 	it("throws error when API key is empty", async () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"API key is required"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("API key is required");
 	});
 
 	it("checks abort signal after endpoint selection", async () => {
@@ -173,7 +175,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) {
 					controller.abort();
 					return "";
@@ -183,9 +185,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 			signal: controller.signal,
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Login cancelled"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Login cancelled");
 	});
 });
 

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -538,7 +538,7 @@ describe("antigravity discovery collapsing", () => {
 	it("uses the primary daily endpoint by default", async () => {
 		const requestedUrls: string[] = [];
 		const defaultFetcher = Object.assign(
-			(input: RequestInfo | URL, _init?: RequestInit) => {
+			(input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => {
 				requestedUrls.push(String(input));
 				return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
 			},

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Expanded the welcome-screen tip pool from 23 to 102 entries — added 81 source-verified tips covering slash commands (`/goal`, `/advisor`, `/review <PR URL>`, `/mcp`, `/collab view`, `/handoff`, `/tree`, …), `omp` CLI subcommands (`omp bench`, `omp models`, `omp usage`, `omp token`, `omp worktree`, …), and default keyboard shortcuts (`ctrl+o`, `alt+up`, `shift+tab`, `ctrl+t`, `ctrl+j`, …), and removed 2 pre-existing non-command tips (`completion()` eval helper, task-isolation worktree note) to keep the pool focused on commands and keybinds. Fixed the `/plan-review` tip to qualify it as plan-mode-only, and updated `/fork` copy to describe duplicating the current session/current leaf. Each new tip was independently re-checked against current source before inclusion.
+
 ## [16.0.4] - 2026-06-17
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -3,8 +3,6 @@ You can /btw to ask a side question
 Use /tan to fork the current conversation into a background agent
 Ctrl+D can be used to exit, but with your draft saved!
 Find out which model you emotionally abuse the most with `omp stats`
-Try task isolation to create CoW worktrees
-Need a cheap nested model call? Use `completion(x...)`. Have a big batch of tasks? Ask clanker to use it!
 Spaghetti code? Try complaining with /omfg
 Did you know? Each kitty/tmux/cmux/zellij/wezterm split keeps its own session — `omp -c` resumes the right one
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
@@ -21,3 +19,84 @@ Pair up live: `/collab` shares your session through an end-to-end encrypted rela
 Press ← ← to drill into a running or finished agent and inspect its tool calls and transcript
 Hit a Codex rate limit? `/usage reset` spends a saved reset credit to immediately restore your quota
 No native tool_calling? Inference provider botches parsing them? `PI_DIALECT=glm|kimi|anthropic…` rolls it locally for them!
+Compare two models head-to-head — `omp bench opus sonnet --runs 3` reports time-to-first-token and tokens/s, averaged across the runs
+Skip the commit-message struggle — `omp commit` drafts the message and updates changelogs; add `--push` to ship it or `--dry-run` to preview first
+`omp gallery` renders every built-in tool across streaming, in-progress, success, and failure states — add `--screenshot` to capture PNGs (needs `vhs`) for bug reports
+`omp grep` runs the exact search the agent uses — preview matches and `.gitignore` handling before delegating (`-c` counts, `-f` files-only, `-C N` context)
+Tool misbehaving? `omp grievances` lists the auto-QA issues captured from your sessions — `clean --all` wipes them, `push` submits them to the backend
+`omp install ./my-ext` symlinks a local directory into your plugin set and watches it for changes; `omp install pkg@1.2.3` pulls from npm — same surface as `plugin link`/`plugin install`
+`omp models find minimax` searches provider/id/name by substring — and `omp models openai-codex` lists one provider, since any provider name doubles as a filter
+`omp plugin doctor --fix` health-checks every installed plugin and auto-repairs what it can — reach for it when extensions act weird after an update
+Curious what the agent's `read` tool actually returns? `omp read issue://123` (or a URL, `archive.zip:dir/file.ts`, even `db.sqlite:users:42`) shows the exact parsed output
+Let omp talk back — `omp say "build failed"` synthesizes speech on-device with the local TTS engine; `--out file.wav` saves it instead of playing
+Preview what the agent's web search returns before you trust it — `omp q "rust async channels" --recency week --limit 5` (alias of `omp search`)
+Re-run onboarding any time with `omp setup`; `omp setup python` checks Python reachability, `omp setup speech` installs speech models/recorder, and `--check` reports what's missing
+Need the raw credential for a provider, say to pipe into another tool? `omp token anthropic` prints it; `--force-refresh` grabs a fresh OAuth token first
+`omp usage --history --days 30` charts your usage-limit trend from hourly snapshots, and `--redact` masks account emails so you can safely share the screenshot
+Agent worktrees piling up in `~/.omp/wt`? `omp worktree` (alias `omp wt`) lists them; `omp wt clear --dry-run` previews removal, `--all` sweeps live PR checkouts too
+`/agents` opens the Agent Control Center — oversee every spawned subagent in one dashboard
+`/changelog full` prints the entire changelog — bare `/changelog` only shows the latest 3 entries
+`/context` breaks down what's eating your context window before you reach for `/compact`
+`/extensions` (alias `/status`) pops open the Extension Control Center dashboard
+`/hotkeys` lays out every default keyboard shortcut on one screen — and yes, they're all remappable
+`/jobs` tracks async background work (long bash, debug runs, task subagents) — they linger there ~5 min after finishing
+`/marketplace add <owner/repo>` then `/marketplace discover` — browse and install plugins straight from a registry
+`/mcp add <name> --url <url>` wires up an MCP server; `/mcp test <name>` pings the connection
+`/mcp smithery-search <keyword>` browses the Smithery registry and deploys a server in one shot — add `--semantic` for meaning-based matches
+`/memory mm refresh` updates the auto-mental-models bank; `/memory mm history` diffs one model's change log
+`/memory` shows the injected memory payload; `/memory clear` wipes it and refreshes the system prompt
+`/plugins enable <name@marketplace>` (or `disable`) toggles a plugin without uninstalling — `/plugins list` shows npm and marketplace installs
+`/reload-plugins` hot-reloads every plugin kind — skills, commands, hooks, tools, agents, MCP — with no restart
+`/settings` opens the settings menu; `/setup` (alias `/providers`) configures sign-in and web search providers
+`/ssh add <name> --host <host>` registers an SSH host the agent can shell into — then it shows up as a tool
+`/todo append`, `/todo start`, `/todo done` — drive the agent's checklist yourself instead of waiting on it
+`/todo edit` cracks open the agent's todos in `$EDITOR` as Markdown — round-trips cleanly
+`/tools` lists every tool the agent can see — `*` marks the active ones, `-` the disabled
+Typed a message while omp was still running? `alt+up` pulls your queued draft back into the editor to tweak or resend
+`alt+shift+p` flips plan mode on — omp explores read-only and drafts a plan before it touches your files
+`shift+tab` cycles the thinking level without retyping a magic word — dial reasoning up or down per turn
+Thinking block eating the screen? `ctrl+t` hides (or shows) it mid-stream
+Long tool output got truncated? `ctrl+o` toggles full expansion so you can read every line inline
+Leap across words instead of single chars — `alt+left` / `alt+right` hop the cursor a word at a time
+`ctrl+u` wipes back to the line start and `ctrl+k` forward to the end — emacs-style line surgery
+`ctrl+w` (or `alt+backspace`) chops the whole last word off your draft — skip the backspace mashing
+`omp --profile work` runs a fully isolated agent tree (auth, sessions, settings, memory) — `--alias` mints an `omp-work` shell shortcut
+`/advisor on` brings in a second model that reviews each turn and drops severity-tagged notes — blocker, concern, or nit
+Paste a GitHub PR URL after `/review` and it fetches the diff for a full code review — no checkout required
+Hold Space to dictate your prompt — push-to-talk STT (enable `stt.enabled` first), release to transcribe
+`/logout` opens an account picker when you've got several OAuth logins — drop just one, keep the rest
+`/dump` exports the full verbose session — system prompt, model + thinking config, tool inventory, and the whole transcript as markdown headings
+Your terminal can't send shift+enter? `ctrl+j` inserts a newline too — it's a default binding, no config needed
+`/branch` pivots the conversation — on default installs it opens the tree navigator, and in non-tree mode it lets you branch from an earlier message
+Reclaim context tokens with `/compact` — pass focus like `/compact keep the database schema` so the summary preserves what matters
+`/fork` duplicates the current session/current leaf into a new fork — use `/branch` when you need to start from an earlier message
+Provider stream got wedged but your transcript is fine? `/fresh` resets the stream state and leaves the conversation untouched
+Cap how many tokens a goal may burn with `/goal budget 50000`, or `/goal budget off` to let it run unbounded
+Set a persistent autonomous objective with `/goal set ship the migration` — the agent keeps driving toward it across turns until you `/goal drop`
+Not sure how to phrase the objective? `/guided-goal` interviews you, refines the rough idea, then flips on goal mode
+Hand the whole session off to a fresh one with `/handoff` — add focus like `/handoff focus on the test suite` to steer the handoff summary
+Turn on `/loop` and your next prompt re-submits itself after every yield — `Esc` cancels the current iteration, `/loop` again disables it
+`/new` starts a fresh session and keeps the old one; `/drop` deletes the current session and starts clean for a real blank slate
+Flip on `/plan` mode and the agent drafts a plan before it touches a single file — start it primed with `/plan refactor the auth flow`
+`/rename my-feature` titles the session so you can find it later; `/move ../other-repo` relocates it to a different working directory
+`/resume` opens the session picker so you can jump straight back into any past session without leaving the TUI
+Last agent turn failed mid-stream? `/retry` reruns it — no need to retype the prompt
+`/session info` prints the session id, title, and cwd at a glance; `/session delete` wipes the session and returns to the selector
+`/tree` opens the session tree navigator — switch branches of your conversation and jump between timelines
+`/browser visible` puts the agent's browser on screen so you can watch it click and type — plain `/browser` toggles, `/browser headless` hides it again
+`/collab status` shows the live link plus everyone connected; `/collab stop` ends the session and drops all guests
+`/collab view` shares a read-only relay link — guests watch your tool calls stream live but can't send prompts of their own
+`/export report.html` renders the whole session to a self-contained HTML file you can email or attach to a ticket
+`/fast on` rides your provider's priority tier (OpenAI service_tier=priority, Anthropic speed=fast) when you need throughput — `/fast status` to check where you stand
+Done spectating? `/leave` drops you out of a guest session cleanly — or stops hosting if the session is yours
+`/share` posts an end-to-end encrypted snapshot of your session as a link (secret gist or share server) — perfect when a teammate just needs to see where you got to, not pair live
+Prefix a message with `!` to run it straight in the shell — output streams inline and the editor border flips to bash mode as you type
+Type `#` in the prompt to fuzzy-search editor actions — copy line, copy whole prompt, undo, jump cursor — without memorizing any shortcut
+Prefix a message with `$` to run it as a Python cell in the shared kernel the agent's `eval` tool uses — `$$` runs it without spending context
+Type `:joy` (or any `:shortcode`) to pop an emoji picker — on by default, kill it with the `emojiAutocomplete` setting
+`ctrl+g` yanks your draft into `$EDITOR` — inside the plan-review overlay it edits the whole plan or your in-flight annotation instead
+`ctrl+shift+v` pastes clipboard text raw, skipping the collapse-to-`[Paste]`-marker so the full text lands verbatim in your draft
+`ctrl+v` drops a clipboard image straight into your prompt — it's auto-resized and shown as an `[Image #N]` chip the model can see
+Start typing `skill://`, `rule://`, `local://`, or `omp://` and the path fuzzy-completes from your registry as you go
+`/plan-review` reopens the plan-review overlay in plan mode — even after a restart, it tracks down your newest plan so you can edit or approve it
+Inside the plan-review overlay, `d` drops a section into your Refine feedback, `a` annotates it, and `u` undoes — Tab cycles outline → body → actions

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1060,7 +1060,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "fork",
-		description: "Create a new fork from a previous message",
+		description: "Duplicate the current session into a new fork",
 		handleTui: async (_command, runtime) => {
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleForkCommand();


### PR DESCRIPTION
## Summary

Expands the welcome-screen tip pool in `packages/coding-agent/src/modes/components/tips.txt` from **23 → 102 tips** (81 new). Rebased onto current `main`.

Scope is **commands, `omp` CLI, and keyboard shortcuts** only — settings, eval/agent-programming internals, and rendering/UX observations were drafted then deliberately trimmed as out-of-scope filler. Tips show one-per-welcome, chosen at random by `welcome.ts` (`tipsText.split("\n").map(trim).filter(len>0)`).

## What changed vs main
- **+81 new source-verified tips** — slash commands (`/goal`, `/advisor`, `/review`, `/mcp`, `/handoff`, `/tree`, …), `omp` CLI (`bench`, `models`, `usage`, `token`, `worktree`, …), and default keybinds (`ctrl+o`, `alt+up`, `shift+tab`, `ctrl+t`, `ctrl+j`, …).
- **−2 pre-existing non-command tips** removed to match the command/keybind focus: the `completion()` eval helper and the task-isolation worktree note.
- **Fixed `/plan-review`** to read "in plan mode" — it's guarded by `planModeEnabled` (`builtin-registry.ts`, `interactive-mode.ts:2776`).
- **Fixed `/fork` copy** in both the welcome tip and the built-in slash-command description: `/fork` duplicates the current session/current leaf; `/branch` is the previous-message picker.
- **Fixed `/branch` copy** to reflect the default `doubleEscapeAction: tree` behavior: on default installs it opens the tree navigator, and non-tree setups get the earlier-message branch picker.
- **Fixed `omp setup python` copy** to say it checks Python reachability; `omp setup speech` is the installer/setup flow for speech models/recorder.
- **Kept upstream's new `PI_DIALECT=…` tip** (added on main in `8443a42d2`) unchanged.
- **Fixed the latest-main merge-ref TS/lint breakage** that surfaced after rebasing: removed an unused private auth-storage helper, applied Biome fixes in the Alibaba endpoint-selection/auth files, and replaced a `RequestInfo` annotation with `Parameters<typeof fetch>[0]` in `packages/catalog/test/variant-collapse.test.ts`.

## Review comments — all addressed
- **`/plan-review` "anytime"** (@chatgpt-codex-connector, @roboomp) → **fixed** — now "reopens the plan-review overlay in plan mode".
- **`/fork` previous-message wording** (@chatgpt-codex-connector) → **fixed** — welcome tip and registry description now say it duplicates the current session/current leaf; `/branch` owns previous-message selection.
- **`/branch` default-tree behavior** (@chatgpt-codex-connector) → **fixed** — the tip now says default installs open the tree navigator, while non-tree setups get the earlier-message branch picker.
- **`omp setup python` installer wording** (@chatgpt-codex-connector) → **fixed** — it now says `python` checks reachability and `speech` installs/setup speech dependencies.
- **`agent(role=…)` invalid option** (@roboomp) → **removed** — the entire eval/agent-programming tip lane was cut by the command/keybind trim.
- **`autolearn.enabled` overclaim** (@roboomp) → **removed** — the settings tip lane was cut by the trim.

## How the tips were produced (`workflowz`)
10 parallel draft lanes (incl. two recent-features lanes) → 10 adversarial auditors (refute-by-default, each independently re-read current source) → family dedup + control-char scan. The audit caught real issues before merge, e.g. the `glm-5.2[1m]` variant doesn't exist (`dropUnusableZaiContextTierIds` filters it), and `/plan-review` is plan-mode-only.

## QA
- `bun run check:ts` passed locally on the rebased branch.
- `bun --cwd=packages/coding-agent run check` passed locally.
- Parse smoke-test replicating `welcome.ts` consumer logic: **102 tips, 0 blanks**.
- **0 control characters** (LaTeX backslash tips assembled programmatically from JSON — no tab/form-feed munging), **0 exact-duplicate lines**, **0 collisions** with main's tips.
- `welcome-tip.test.ts` tests the `renderWelcomeTip` wrapping function with a synthetic string and does not pin `tips.txt` content, so this change is safe for it.

## Files changed
- `packages/coding-agent/src/modes/components/tips.txt` — 81 new tips, 2 removed, `/plan-review`, `/fork`, `/branch`, and `omp setup python` copy fixed.
- `packages/coding-agent/src/slash-commands/builtin-registry.ts` — `/fork` description fixed to match implementation.
- `packages/coding-agent/CHANGELOG.md` — one `### Added` bullet under `[Unreleased]`.
- `packages/ai/src/auth-storage.ts`, `packages/ai/src/registry/alibaba-coding-plan.ts`, `packages/ai/src/registry/oauth/index.ts`, `packages/ai/test/alibaba-endpoint-selection.test.ts`, and `packages/catalog/test/variant-collapse.test.ts` — latest-main merge-ref check fixes.
