### PR TITLE
fix(coding-agent): prioritize focused subagent Esc

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### Fixed
 
+- Fixed Esc in a focused subagent view canceling the main session's context compaction, handoff generation, or auto-retry instead of returning to the main session; the view-maintenance abort now defers to the focused-return while `/btw` and `/omfg` side panels keep their Esc precedence ([#2819](https://github.com/can1357/oh-my-pi/issues/2819)).
 - Fixed legacy plugin validation for extensions that import `defineTool`, `StringEnum`, frontmatter helpers, `SettingsManager`, `createCodingTools`, or the bare `typebox` package through the hosted Pi compatibility shims ([#2858](https://github.com/can1357/oh-my-pi/issues/2858)).
 - Fixed edit seen-line guard mismatch assertion message formatting to report the actual state instead of generic failure notices
 - Fixed hashline edit mode rendering in the TUI when `setIgnoreTight` triggers synchronous display rebuilds in the constructor before `#editMode` is assigned, which previously caused the tool envelope target path to display as `…` instead of the parsed hashline filename.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -184,12 +184,12 @@ export class InputController {
 			// → /compact → auto end → manual finally), leaving Esc wired to a
 			// stale no-op closure until restart.
 			//
-			// Skip these aborts while a subagent is focused: that view's status
-			// promises "Esc returns to main", so it must not cancel the main
-			// session's maintenance. The focused branch below returns to main
-			// instead (#2819). Side panels (/btw, /omfg) and the loop/collab
-			// handlers between here and there keep their existing precedence.
-			if (!this.ctx.focusedAgentId) {
+			// Skip only main-session aborts while a subagent is focused: that
+			// view's status promises "Esc returns to main". If `viewSession` has
+			// been retargeted to the focused subagent, the visible subagent
+			// maintenance still owns its advertised "(esc to cancel)" handler.
+			const focusedViewOwnsMaintenance = this.ctx.focusedAgentId && viewSession !== this.ctx.session;
+			if (!this.ctx.focusedAgentId || focusedViewOwnsMaintenance) {
 				let aborted = false;
 				if (viewSession.isCompacting) {
 					try {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -175,6 +175,7 @@ export class InputController {
 			});
 		}
 		this.ctx.editor.onEscape = () => {
+			const viewSession = this.ctx.viewSession;
 			// Active context maintenance owns Esc: auto/manual compaction,
 			// handoff generation, and auto-retry backoff all advertise
 			// "(esc to cancel)". Dispatch on live session state instead of
@@ -182,27 +183,34 @@ export class InputController {
 			// to clobber the single saved-handler slot (auto-compaction start
 			// → /compact → auto end → manual finally), leaving Esc wired to a
 			// stale no-op closure until restart.
-			const viewSession = this.ctx.viewSession;
-			let aborted = false;
-			if (viewSession.isCompacting) {
-				try {
-					viewSession.abortCompaction();
-				} catch {}
-				aborted = true;
+			//
+			// Skip these aborts while a subagent is focused: that view's status
+			// promises "Esc returns to main", so it must not cancel the main
+			// session's maintenance. The focused branch below returns to main
+			// instead (#2819). Side panels (/btw, /omfg) and the loop/collab
+			// handlers between here and there keep their existing precedence.
+			if (!this.ctx.focusedAgentId) {
+				let aborted = false;
+				if (viewSession.isCompacting) {
+					try {
+						viewSession.abortCompaction();
+					} catch {}
+					aborted = true;
+				}
+				if (viewSession.isGeneratingHandoff) {
+					try {
+						viewSession.abortHandoff();
+					} catch {}
+					aborted = true;
+				}
+				if (viewSession.isRetrying) {
+					try {
+						viewSession.abortRetry();
+					} catch {}
+					aborted = true;
+				}
+				if (aborted) return;
 			}
-			if (viewSession.isGeneratingHandoff) {
-				try {
-					viewSession.abortHandoff();
-				} catch {}
-				aborted = true;
-			}
-			if (viewSession.isRetrying) {
-				try {
-					viewSession.abortRetry();
-				} catch {}
-				aborted = true;
-			}
-			if (aborted) return;
 
 			if (this.ctx.loopModeEnabled) {
 				this.ctx.pauseLoop();

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -433,12 +433,16 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
-	it("returns a focused subagent view to main without aborting active context maintenance (#2819)", () => {
+	it("returns a focused subagent view to main without aborting main-session maintenance (#2819)", () => {
 		const { ctx, editor, spies } = createContext();
 		Object.defineProperty(ctx, "focusedAgentId", { value: "Worker", configurable: true });
+		ctx.viewSession = ctx.session as unknown as InteractiveModeContext["viewSession"];
 		(ctx.viewSession as { isCompacting: boolean }).isCompacting = true;
 		(ctx.viewSession as { isGeneratingHandoff: boolean }).isGeneratingHandoff = true;
 		(ctx.viewSession as { isRetrying: boolean }).isRetrying = true;
+		(ctx.viewSession as { abortCompaction: Spy }).abortCompaction = vi.fn();
+		(ctx.viewSession as { abortHandoff: Spy }).abortHandoff = spies.abortHandoff;
+		(ctx.viewSession as { abortRetry: Spy }).abortRetry = vi.fn();
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
@@ -448,6 +452,20 @@ describe("InputController escape behavior", () => {
 		expect(ctx.viewSession.abortCompaction as unknown as Spy).not.toHaveBeenCalled();
 		expect(spies.abortHandoff).not.toHaveBeenCalled();
 		expect(ctx.viewSession.abortRetry as unknown as Spy).not.toHaveBeenCalled();
+	});
+
+	it("cancels focused subagent maintenance before returning to main", () => {
+		const { ctx, editor, spies } = createContext();
+		Object.defineProperty(ctx, "focusedAgentId", { value: "Worker", configurable: true });
+		(ctx.viewSession as { isCompacting: boolean }).isCompacting = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(ctx.viewSession.abortCompaction as unknown as Spy).toHaveBeenCalledTimes(1);
+		expect(ctx.unfocusSession).not.toHaveBeenCalled();
+		expect(spies.abortHandoff).not.toHaveBeenCalled();
 	});
 
 	it("lets an active /btw panel keep Esc precedence over a focused subagent view", () => {

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -433,6 +433,49 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
+	it("returns a focused subagent view to main without aborting active context maintenance (#2819)", () => {
+		const { ctx, editor, spies } = createContext();
+		Object.defineProperty(ctx, "focusedAgentId", { value: "Worker", configurable: true });
+		(ctx.viewSession as { isCompacting: boolean }).isCompacting = true;
+		(ctx.viewSession as { isGeneratingHandoff: boolean }).isGeneratingHandoff = true;
+		(ctx.viewSession as { isRetrying: boolean }).isRetrying = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(ctx.unfocusSession).toHaveBeenCalledTimes(1);
+		expect(ctx.viewSession.abortCompaction as unknown as Spy).not.toHaveBeenCalled();
+		expect(spies.abortHandoff).not.toHaveBeenCalled();
+		expect(ctx.viewSession.abortRetry as unknown as Spy).not.toHaveBeenCalled();
+	});
+
+	it("lets an active /btw panel keep Esc precedence over a focused subagent view", () => {
+		const { ctx, editor, spies } = createContext();
+		Object.defineProperty(ctx, "focusedAgentId", { value: "Worker", configurable: true });
+		spies.hasActiveBtw.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.handleBtwEscape).toHaveBeenCalledTimes(1);
+		expect(ctx.unfocusSession).not.toHaveBeenCalled();
+	});
+
+	it("lets an active /omfg panel keep Esc precedence over a focused subagent view", () => {
+		const { ctx, editor, spies } = createContext();
+		Object.defineProperty(ctx, "focusedAgentId", { value: "Worker", configurable: true });
+		spies.hasActiveOmfg.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.handleOmfgEscape).toHaveBeenCalledTimes(1);
+		expect(ctx.unfocusSession).not.toHaveBeenCalled();
+	});
+
 	it("routes a focused double-← through the global input listener like Esc", () => {
 		const now = vi.spyOn(Date, "now");
 		const { ctx, inputListeners } = createContext();


### PR DESCRIPTION
## Summary
- Return focused subagent views to main before context-maintenance abort paths handle Esc
- Preserve focused draft-clearing behavior and main-view maintenance cancellation
- Add regression coverage for active compaction, handoff generation, and retry flags

Fixes #2819.

## Verification
- bun test packages/coding-agent/test/input-controller-escape.test.ts --filter "returns focused subagent view to main without aborting active view maintenance"
- bun test packages/coding-agent/test/input-controller-escape.test.ts
- bun --cwd=packages/coding-agent run check