### PR TITLE
fix(coding-agent): skip Windows ssh key mode validation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the ssh tool rejecting valid Windows identity files before invoking OpenSSH by skipping Unix mode-bit key validation on native Windows ([#2850](https://github.com/can1357/oh-my-pi/issues/2850)).
+
 ## [16.0.4] - 2026-06-17
 
 ### Fixed

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -65,8 +65,8 @@ async function deleteHostInfoFromDisk(hostName: string): Promise<void> {
 	}
 }
 
-async function validateKeyPermissions(keyPath?: string): Promise<void> {
-	if (!keyPath) return;
+async function validateKeyPermissions(keyPath?: string, platform: SshPlatform = process.platform): Promise<void> {
+	if (!keyPath || platform === "win32") return;
 	let stats: fs.Stats;
 	try {
 		stats = await fs.promises.stat(keyPath);
@@ -402,7 +402,7 @@ export async function buildRemoteCommand(
 	command: string,
 	options?: SSHArgsOptions,
 ): Promise<string[]> {
-	await validateKeyPermissions(host.keyPath);
+	await validateKeyPermissions(host.keyPath, options?.platform);
 	return [...buildCommonArgs(host, options), buildSshTarget(host.username, host.host), command];
 }
 

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -66,7 +66,7 @@ async function deleteHostInfoFromDisk(hostName: string): Promise<void> {
 }
 
 async function validateKeyPermissions(keyPath?: string, platform: SshPlatform = process.platform): Promise<void> {
-	if (!keyPath || platform === "win32") return;
+	if (!keyPath) return;
 	let stats: fs.Stats;
 	try {
 		stats = await fs.promises.stat(keyPath);
@@ -79,6 +79,7 @@ async function validateKeyPermissions(keyPath?: string, platform: SshPlatform = 
 	if (!stats.isFile()) {
 		throw new Error(`SSH key is not a file: ${keyPath}`);
 	}
+	if (platform === "win32") return;
 	const mode = stats.mode & 0o777;
 	if ((mode & 0o077) !== 0) {
 		throw new Error(`SSH key permissions must be 600 or stricter: ${keyPath}`);

--- a/packages/coding-agent/test/ssh/connection-manager.test.ts
+++ b/packages/coding-agent/test/ssh/connection-manager.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as connectionManager from "@oh-my-pi/pi-coding-agent/ssh/connection-manager";
+
+async function withLooseKey<T>(run: (keyPath: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ssh-key-"));
+	const keyPath = path.join(dir, "id_ed25519");
+	await Bun.write(keyPath, "dummy-key");
+	await fs.chmod(keyPath, 0o666);
+	try {
+		return await run(keyPath);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
 
 describe("buildRemoteCommand", () => {
 	it("includes -n and OpenSSH ControlMaster options on Unix-like platforms", async () => {
@@ -35,6 +50,41 @@ describe("buildRemoteCommand", () => {
 		expect(args).toContain("BatchMode=yes");
 		expect(args.at(-2)).toBe("192.168.3.146");
 		expect(args.at(-1)).toBe("ls -la");
+	});
+
+	it("skips Unix mode-bit key validation for Windows args", async () => {
+		await withLooseKey(async keyPath => {
+			const args = await connectionManager.buildRemoteCommand(
+				{
+					name: "host",
+					host: "192.168.3.146",
+					keyPath,
+				},
+				"ls -la",
+				{ platform: "win32" },
+			);
+
+			expect(args).toContain("-i");
+			expect(args).toContain(keyPath);
+			expect(args.at(-2)).toBe("192.168.3.146");
+			expect(args.at(-1)).toBe("ls -la");
+		});
+	});
+
+	it("rejects group/world-readable identity files on Unix-like platforms", async () => {
+		await withLooseKey(async keyPath => {
+			await expect(
+				connectionManager.buildRemoteCommand(
+					{
+						name: "host",
+						host: "192.168.3.146",
+						keyPath,
+					},
+					"ls -la",
+					{ platform: "linux" },
+				),
+			).rejects.toThrow("SSH key permissions must be 600 or stricter");
+		});
 	});
 });
 

--- a/packages/coding-agent/test/ssh/connection-manager.test.ts
+++ b/packages/coding-agent/test/ssh/connection-manager.test.ts
@@ -71,6 +71,45 @@ describe("buildRemoteCommand", () => {
 		});
 	});
 
+	it("still rejects missing identity files on Windows args", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ssh-key-"));
+		const keyPath = path.join(dir, "missing_id_ed25519");
+		try {
+			await expect(
+				connectionManager.buildRemoteCommand(
+					{
+						name: "host",
+						host: "192.168.3.146",
+						keyPath,
+					},
+					"ls -la",
+					{ platform: "win32" },
+				),
+			).rejects.toThrow("SSH key not found");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("still rejects directory identity paths on Windows args", async () => {
+		const keyPath = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ssh-key-"));
+		try {
+			await expect(
+				connectionManager.buildRemoteCommand(
+					{
+						name: "host",
+						host: "192.168.3.146",
+						keyPath,
+					},
+					"ls -la",
+					{ platform: "win32" },
+				),
+			).rejects.toThrow("SSH key is not a file");
+		} finally {
+			await fs.rm(keyPath, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects group/world-readable identity files on Unix-like platforms", async () => {
 		await withLooseKey(async keyPath => {
 			await expect(


### PR DESCRIPTION
## Repro
The ssh command builder rejects Windows-style identity-file mode bits before invoking OpenSSH. I reproduced the gate with `bun -e 'import { mkdtemp, chmod, rm } from "node:fs/promises"; import * as os from "node:os"; import * as path from "node:path"; import { buildRemoteCommand } from "@oh-my-pi/pi-coding-agent/ssh/connection-manager"; const dir = await mkdtemp(path.join(os.tmpdir(), "omp-ssh-key-")); const key = path.join(dir, "id_ed25519"); await Bun.write(key, "dummy-key"); await chmod(key, 0o666); try { await buildRemoteCommand({ name: "win", host: "example.test", keyPath: key }, "true", { platform: "win32" }); console.log("unexpected success"); process.exitCode = 1; } catch (err) { console.log(String(err instanceof Error ? err.message : err)); } finally { await rm(dir, { recursive: true, force: true }); }'`, which threw `SSH key permissions must be 600 or stricter` for the same low mode bits reported on Windows.

## Cause
`packages/coding-agent/src/ssh/connection-manager.ts` always called `validateKeyPermissions()` from `buildRemoteCommand()` and `ensureConnection()`. That helper masked `fs.Stats.mode` with `0o777` and rejected group/world-readable bits, but Windows `fs.Stats.mode` does not represent ACL-enforced private key access the same way Unix mode bits do.

## Fix
- Skip ssh identity-file permission validation when the target platform is `win32`.
- Thread the existing `buildRemoteCommand()` platform option into the validator so Windows argument construction follows the runtime behavior.
- Add regression coverage for permissive Windows low mode bits and for preserved Unix rejection.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/ssh/connection-manager.test.ts` passed: 6 tests, 19 assertions. `bun --cwd=packages/coding-agent run check` passed. Fixes #2850