### PR TITLE
fix(catalog): route google-antigravity default baseUrl to primary daily endpoint

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Routed google-antigravity default baseUrl to the stable primary daily endpoint in the catalog generator and all fallback snapshots, resolving connection drops on heavy queries.
+
 ## [16.0.4] - 2026-06-17
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -14,7 +14,7 @@ import { AuthStorage, type OAuthAccess, SqliteAuthCredentialStore } from "@oh-my
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/oauth/types";
 import { getGitLabDuoModels } from "@oh-my-pi/pi-ai/providers/gitlab-duo";
 import { $env } from "@oh-my-pi/pi-utils";
-import { fetchAntigravityDiscoveryModels } from "../src/discovery/antigravity";
+import { ANTIGRAVITY_PRIMARY_ENDPOINT, fetchAntigravityDiscoveryModels } from "../src/discovery/antigravity";
 import { fetchCodexModels } from "../src/discovery/codex";
 import { createModelManager } from "../src/model-manager";
 import prevModelsJson from "../src/models.json" with { type: "json" };
@@ -323,7 +323,16 @@ function dropXiaomiAudioOnlyIds(models: readonly ModelSpec[]): ModelSpec[] {
 	});
 }
 
-const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+function normalizeAntigravityEndpoint(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		if (model.provider === "google-antigravity" && model.baseUrl) {
+			return { ...model, baseUrl: ANTIGRAVITY_PRIMARY_ENDPOINT };
+		}
+		return model;
+	});
+}
+
+const ANTIGRAVITY_ENDPOINT = ANTIGRAVITY_PRIMARY_ENDPOINT;
 
 async function getOAuthAccessFromStorage(provider: OAuthProvider): Promise<OAuthAccess | null> {
 	try {
@@ -522,6 +531,7 @@ async function generateModels() {
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);
 	allModels = dropXiaomiAudioOnlyIds(allModels);
+	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and
 	// price/promo tags are model-extrinsic — strip them from the bundle.

--- a/packages/catalog/src/discovery/antigravity.ts
+++ b/packages/catalog/src/discovery/antigravity.ts
@@ -4,10 +4,9 @@ import { toPositiveNumber } from "../utils";
 import { ANTIGRAVITY_VARIANT_COLLAPSE_TABLE, collapseEffortVariants } from "../variant-collapse";
 import { getAntigravityUserAgent } from "../wire/gemini-headers";
 
-const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [
-	"https://daily-cloudcode-pa.googleapis.com",
-	"https://daily-cloudcode-pa.sandbox.googleapis.com",
-] as const;
+export const ANTIGRAVITY_PRIMARY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
+export const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [ANTIGRAVITY_PRIMARY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17726,7 +17726,7 @@
 			"name": "Claude Opus 4.5",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17762,7 +17762,7 @@
 			"name": "Claude Opus 4.6",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17798,7 +17798,7 @@
 			"name": "Claude Sonnet 4.5",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17835,7 +17835,7 @@
 			"name": "Claude Sonnet 4.6",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17872,7 +17872,7 @@
 			"name": "Gemini 2.5 Flash",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17908,7 +17908,7 @@
 			"name": "Gemini 2.5 Pro",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17938,7 +17938,7 @@
 			"name": "Gemini 3 Flash",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -17968,7 +17968,7 @@
 			"name": "Gemini 3 Pro",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -18002,7 +18002,7 @@
 			"name": "Gemini 3.1 Pro Preview",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -18036,7 +18036,7 @@
 			"name": "GPT OSS 120B",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
 			"reasoning": true,
 			"input": [
 				"text"

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -3,7 +3,10 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { fetchAntigravityDiscoveryModels } from "@oh-my-pi/pi-catalog/discovery/antigravity";
+import {
+	ANTIGRAVITY_PRIMARY_ENDPOINT,
+	fetchAntigravityDiscoveryModels,
+} from "@oh-my-pi/pi-catalog/discovery/antigravity";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
@@ -530,5 +533,24 @@ describe("antigravity discovery collapsing", () => {
 		expect(flash?.baseUrl).toBe("https://cca.test");
 		expect(flash?.requestModelId).toBe("gemini-3.5-flash-extra-low");
 		expect(flash?.thinking?.effortRouting?.off).toBe("gemini-3.5-flash-extra-low");
+	});
+
+	it("uses the primary daily endpoint by default", async () => {
+		const requestedUrls: string[] = [];
+		const defaultFetcher = Object.assign(
+			(input: RequestInfo | URL, _init?: RequestInit) => {
+				requestedUrls.push(String(input));
+				return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const models = await fetchAntigravityDiscoveryModels({
+			token: "t",
+			fetcher: defaultFetcher,
+		});
+
+		expect(requestedUrls[0]).toContain(ANTIGRAVITY_PRIMARY_ENDPOINT);
+		expect(models?.[0]?.baseUrl).toBe(ANTIGRAVITY_PRIMARY_ENDPOINT);
 	});
 });


### PR DESCRIPTION
### Problem
The default `baseUrl` for `google-antigravity` models in `models.json` was hardcoded to the unstable developer sandbox endpoint (`https://daily-cloudcode-pa.sandbox.googleapis.com`). Under heavy reasoning queries, this sandbox server frequently drops connections mid-stream.

### Solution
- Updated the generator `generate-models.ts` to use `ANTIGRAVITY_PRIMARY_ENDPOINT` (`https://daily-cloudcode-pa.googleapis.com`) as the default endpoint.
- Exported and reused endpoint constants in `antigravity.ts` to keep discovery endpoints DRY.
- Regenerated `models.json` and added a regression test to ensure that the primary daily endpoint is used by default.

Note: This is a clean, up-to-date alternative to #2419 with all merge conflicts resolved.