### PR TITLE
fix(tui): restore cursor after inline image placement

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Coalesced byte-adjacent SGR sequences in emitted lines into a single `CSI … m`. The component tree styles each span as `<set>text<reset>`, so adjacent spans emit runs of back-to-back SGR sequences (e.g. a `CSI 39 m` fg-reset immediately followed by the next span's `CSI 38;2;r;g;b m`); merging the run is behavior-preserving because SGR parameters apply left-to-right regardless of framing. On a real transcript this drops ~30-40% of all SGR sequences, cutting the per-frame byte volume and SGR-dispatch count a slow terminal engine (e.g. xterm.js/WebGL under a large viewport) must process. Each emitted sequence is capped at 16 parameter tokens so a long adjacent run is split across several valid CSIs instead of overflowing a terminal's parameter buffer (xterm.js caps at 32 and silently truncates, corrupting colors). A run is never extended past a parameter list that ends in an incomplete semicolon-form extended color (`38/48/58;2` missing a channel or `;5` missing the index), so a following code can't be absorbed as the missing component. Disable with `PI_NO_SGR_COALESCE=1`.
 
+### Fixed
+
+- Fixed direct inline-image placements leaving the cursor inside the reserved image block, which let following chat rows overwrite the middle of rendered screenshots ([#2863](https://github.com/can1357/oh-my-pi/issues/2863)).
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -27,6 +27,8 @@ export interface ImageOptions {
 
 const EMPTY_IDS: readonly number[] = [];
 const EMPTY_TRANSMITS: readonly string[] = [];
+const SAVE_CURSOR = "\x1b7";
+const RESTORE_CURSOR = "\x1b8";
 // Direct placements reserve height with leading zero-width rows. Keep them
 // non-plain so transcript blank-edge trimming does not collapse image-only blocks.
 const RESERVED_IMAGE_ROW = "\x1b[0m";
@@ -349,16 +351,18 @@ export class Image implements Component {
 			} else if (result) {
 				// Direct placement: return `rows` lines so TUI accounts for image
 				// height. First (rows-1) lines are empty (TUI clears them); the last
-				// moves the cursor back up, emits the image sequence, then restores the
-				// cursor so the renderer's next CRLF starts below the reserved block.
+				// saves the final-row cursor, moves up to the image origin, emits the
+				// image sequence, then restores the final-row cursor. Save/restore is
+				// required because CUU clamps at the viewport top when leading rows are
+				// clipped away.
 				lines = [];
 				for (let i = 0; i < result.rows - 1; i++) {
 					lines.push(RESERVED_IMAGE_ROW);
 				}
 				const cursorRows = result.rows - 1;
 				const moveUp = cursorRows > 0 ? `\x1b[${cursorRows}A` : "";
-				const moveDown = cursorRows > 0 ? `\x1b[${cursorRows}B` : "";
-				lines.push(moveUp + (result.sequence ?? "") + moveDown);
+				const placement = moveUp + (result.sequence ?? "");
+				lines.push(cursorRows > 0 ? SAVE_CURSOR + placement + RESTORE_CURSOR : placement);
 			} else {
 				lines = this.#fallbackLines();
 			}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -349,13 +349,16 @@ export class Image implements Component {
 			} else if (result) {
 				// Direct placement: return `rows` lines so TUI accounts for image
 				// height. First (rows-1) lines are empty (TUI clears them); the last
-				// moves the cursor back up, then emits the image sequence.
+				// moves the cursor back up, emits the image sequence, then restores the
+				// cursor so the renderer's next CRLF starts below the reserved block.
 				lines = [];
 				for (let i = 0; i < result.rows - 1; i++) {
 					lines.push(RESERVED_IMAGE_ROW);
 				}
-				const moveUp = result.rows > 1 ? `\x1b[${result.rows - 1}A` : "";
-				lines.push(moveUp + (result.sequence ?? ""));
+				const cursorRows = result.rows - 1;
+				const moveUp = cursorRows > 0 ? `\x1b[${cursorRows}A` : "";
+				const moveDown = cursorRows > 0 ? `\x1b[${cursorRows}B` : "";
+				lines.push(moveUp + (result.sequence ?? "") + moveDown);
 			} else {
 				lines = this.#fallbackLines();
 			}

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -544,7 +544,7 @@ export function encodeKitty(
 		imageId?: number;
 	} = {},
 ): string {
-	const params: string[] = ["a=T", "f=100", "q=2"];
+	const params: string[] = ["a=T", "f=100", "q=2", "C=1"];
 	if (options.columns) params.push(`c=${options.columns}`);
 	if (options.rows) params.push(`r=${options.rows}`);
 	if (options.imageId) params.push(`i=${options.imageId}`);
@@ -563,10 +563,12 @@ export function encodeKittyTransmit(base64Data: string, imageId: number): string
 }
 
 /**
- * Display a previously transmitted image (`a=p`) at the cursor. Carrying a
- * stable `placementId` (`p=`) means re-emitting the sequence on a repaint
- * *replaces* the existing placement (moving/resizing it without flicker) rather
- * than stacking a duplicate.
+ * Display a previously transmitted image (`a=p`) at the cursor. `C=1` keeps
+ * the terminal cursor anchored at the placement origin so the renderer's
+ * explicit cursor movement remains the only row accounting. Carrying a stable
+ * `placementId` (`p=`) means re-emitting the sequence on a repaint *replaces*
+ * the existing placement (moving/resizing it without flicker) rather than
+ * stacking a duplicate.
  */
 export function encodeKittyPlacement(options: {
 	imageId: number;
@@ -574,7 +576,7 @@ export function encodeKittyPlacement(options: {
 	columns?: number;
 	rows?: number;
 }): string {
-	const params: string[] = ["a=p", "q=2", `i=${options.imageId}`];
+	const params: string[] = ["a=p", "q=2", "C=1", `i=${options.imageId}`];
 	if (options.placementId) params.push(`p=${options.placementId}`);
 	if (options.columns) params.push(`c=${options.columns}`);
 	if (options.rows) params.push(`r=${options.rows}`);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -532,7 +532,7 @@ describe("kitty transmit / placement encoding", () => {
 
 	it("encodeKittyPlacement displays a transmitted image by id with a stable placement id", () => {
 		const seq = encodeKittyPlacement({ imageId: 9, placementId: 9, columns: 3, rows: 2 });
-		expect(seq).toBe("\x1b_Ga=p,q=2,i=9,p=9,c=3,r=2\x1b\\");
+		expect(seq).toBe("\x1b_Ga=p,q=2,C=1,i=9,p=9,c=3,r=2\x1b\\");
 		expect(seq).not.toContain(BASE64_ONE_PIXEL_PNG);
 	});
 });

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -117,7 +117,7 @@ describe("terminal image rendering", () => {
 		expect((result?.sequence ?? "").startsWith("\x1bP")).toBe(true);
 	});
 
-	it("Image component forwards maxHeightCells to terminal rendering", () => {
+	it("Image component restores direct-placement cursor with save/restore", () => {
 		terminal.imageProtocol = ImageProtocol.Kitty;
 		const image = new Image(
 			BASE64_DUMMY,
@@ -131,11 +131,13 @@ describe("terminal image rendering", () => {
 
 		expect(lines[0]).toBe("\x1b[0m");
 		expect(lines).toHaveLength(2);
-		expect(lines[1]).toContain("\x1b[1A");
-		expect(lines[1]).toContain("C=1");
-		expect(lines[1]).toContain("c=2");
-		expect(lines[1]).toContain("r=2");
-		expect(lines[1]?.endsWith("\x1b[1B")).toBe(true);
+		const clippedTopLine = lines[1] ?? "";
+		expect(clippedTopLine.startsWith("\x1b7\x1b[1A")).toBe(true);
+		expect(clippedTopLine).toContain("C=1");
+		expect(clippedTopLine).toContain("c=2");
+		expect(clippedTopLine).toContain("r=2");
+		expect(clippedTopLine).not.toContain("\x1b[1B");
+		expect(clippedTopLine.endsWith("\x1b8")).toBe(true);
 	});
 });
 

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -20,7 +20,7 @@ const SQUARE_DIMENSIONS = { widthPx: 100, heightPx: 100 };
 const BASE64_ONE_PIXEL_PNG =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
-function parseKittyParam(sequence: string, key: "c" | "r"): number | null {
+function parseKittyParam(sequence: string, key: "c" | "r" | "C"): number | null {
 	const match = sequence.match(new RegExp(`${key}=(\\d+)`));
 	if (!match) return null;
 	return Number.parseInt(match[1], 10);
@@ -57,6 +57,17 @@ describe("terminal image rendering", () => {
 		expect(result?.rows).toBe(2);
 		expect(parseKittyParam(result?.sequence ?? "", "c")).toBe(2);
 		expect(parseKittyParam(result?.sequence ?? "", "r")).toBe(2);
+	});
+
+	it("anchors Kitty display commands before renderer-managed cursor movement", () => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		const result = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, {
+			maxWidthCells: 10,
+			maxHeightCells: 2,
+		});
+
+		expect(result).not.toBeNull();
+		expect(parseKittyParam(result?.sequence ?? "", "C")).toBe(1);
 	});
 
 	it("uses intrinsic image size when no bounds are provided", () => {
@@ -121,6 +132,7 @@ describe("terminal image rendering", () => {
 		expect(lines[0]).toBe("\x1b[0m");
 		expect(lines).toHaveLength(2);
 		expect(lines[1]).toContain("\x1b[1A");
+		expect(lines[1]).toContain("C=1");
 		expect(lines[1]).toContain("c=2");
 		expect(lines[1]).toContain("r=2");
 		expect(lines[1]?.endsWith("\x1b[1B")).toBe(true);

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -123,6 +123,7 @@ describe("terminal image rendering", () => {
 		expect(lines[1]).toContain("\x1b[1A");
 		expect(lines[1]).toContain("c=2");
 		expect(lines[1]).toContain("r=2");
+		expect(lines[1]?.endsWith("\x1b[1B")).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Repro
Direct inline-image placement reserves the expected image rows, moves the cursor up to emit the graphics sequence, and then leaves the cursor inside that reserved block. Reproduced with `bun --eval "$REPRO"`, which showed a 3-row image ending with the graphics sequence instead of a cursor restore and exited 1.

## Cause
`packages/tui/src/components/image.ts` built direct-placement image blocks by returning reserved rows followed by `CSI n A` plus the image sequence on the last row. `TUI` then appended the next row with `CRLF`, so following chat content began inside the reserved image area and could overwrite the middle of screenshots.

## Fix
- Restored the cursor back down after direct inline-image placement sequences so subsequent rows start below the reserved block.
- Updated `packages/tui/test/image-render.test.ts` to assert image placement rows end by restoring the cursor.
- Added an Unreleased `packages/tui/CHANGELOG.md` entry for the screenshot rendering fix.

## Verification
`bun test test/image-render.test.ts` in `packages/tui` passed: 7 pass, 0 fail. `bun run check` in `packages/tui` passed. The repro command now reports `restoresCursor: true` and exits 0. Skipped pre-publish `bun check`: it fails on `main` in unrelated `packages/catalog/test/variant-collapse.test.ts` with `Cannot find name 'RequestInfo'`, verified in a detached `origin/main` worktree via `bun run check` in `packages/catalog`. Fixes #2863