### PR TITLE
fix(mnemopi): cap sleep consolidation episodes

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1512,17 +1512,6 @@ export class AuthStorage {
 		this.#resetProviderAssignments(provider);
 	}
 
-	async #upsertOAuthCredential(provider: string, credential: OAuthCredential): Promise<void> {
-		const stored = this.#store.upsertAuthCredentialRemote
-			? await this.#store.upsertAuthCredentialRemote(provider, credential)
-			: this.#store.upsertAuthCredentialForProvider(provider, credential);
-		this.#setStoredCredentials(
-			provider,
-			stored.map(record => ({ id: record.id, credential: record.credential })),
-		);
-		this.#resetProviderAssignments(provider);
-	}
-
 	/**
 	 * List stored credential rows, optionally filtered by provider.
 	 */

--- a/packages/ai/src/registry/alibaba-coding-plan.ts
+++ b/packages/ai/src/registry/alibaba-coding-plan.ts
@@ -90,5 +90,5 @@ export const alibabaCodingPlanProvider = {
 	id: "alibaba-coding-plan",
 	name: "Alibaba Coding Plan",
 	login: (cb: OAuthLoginCallbacks) => loginAlibabaCodingPlan(cb),
-	getApiKey: (credentials) => credentials.access,
+	getApiKey: credentials => credentials.access,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -142,14 +142,14 @@ export async function getOAuthApiKey(
 		provider === "alibaba-coding-plan";
 	const apiKey = needsStructuredApiKey
 		? JSON.stringify({
-			token: creds.access,
-			enterpriseUrl: creds.enterpriseUrl,
-			projectId: creds.projectId,
-			refreshToken: creds.refresh,
-			expiresAt: creds.expires,
-			email: creds.email,
-			accountId: creds.accountId,
-		})
+				token: creds.access,
+				enterpriseUrl: creds.enterpriseUrl,
+				projectId: creds.projectId,
+				refreshToken: creds.refresh,
+				expiresAt: creds.expires,
+				email: creds.email,
+				accountId: creds.accountId,
+			})
 		: creds.access;
 	return { newCredentials: creds, apiKey };
 }

--- a/packages/ai/test/alibaba-endpoint-selection.test.ts
+++ b/packages/ai/test/alibaba-endpoint-selection.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import type { OAuthController, OAuthCredentials } from "../src/registry/oauth/types";
-import * as apiKeyValidation from "../src/registry/api-key-validation";
-import { loginAlibabaCodingPlan, alibabaCodingPlanProvider } from "../src/registry/alibaba-coding-plan";
-import { getOAuthApiKey } from "../src/registry/oauth/index";
 import type { Mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { loginAlibabaCodingPlan } from "../src/registry/alibaba-coding-plan";
+import * as apiKeyValidation from "../src/registry/api-key-validation";
+import { getOAuthApiKey } from "../src/registry/oauth/index";
+import type { OAuthController } from "../src/registry/oauth/types";
 
 describe("alibaba-coding-plan endpoint selection", () => {
 	let validateSpy: Mock<typeof apiKeyValidation.validateOpenAICompatibleApiKey>;
@@ -19,9 +19,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 1 uses international endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -48,9 +50,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 2 uses China endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "2";
 				if (prompt.message.includes("Paste your")) return "sk-cn-key";
 				return "";
@@ -77,9 +81,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 3 prompts for custom URL and uses it", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1";
 				if (prompt.message.includes("Paste your")) return "sk-custom-key";
@@ -107,7 +113,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -123,7 +129,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1///";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
@@ -140,32 +146,28 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Custom URL is required for option 3"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Custom URL is required for option 3");
 	});
 
 	it("throws error when API key is empty", async () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"API key is required"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("API key is required");
 	});
 
 	it("checks abort signal after endpoint selection", async () => {
@@ -173,7 +175,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) {
 					controller.abort();
 					return "";
@@ -183,9 +185,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 			signal: controller.signal,
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Login cancelled"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Login cancelled");
 	});
 });
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped `sleep_consolidation` episodic rows at `maxEpisodeChars` (default 100KB, `MNEMOPI_MAX_EPISODE_CHARS`) so raw session transcripts cannot be stored and extracted as multi-megabyte episodes. ([#2869](https://github.com/can1357/oh-my-pi/issues/2869))
+
 ## [15.13.1] - 2026-06-15
 
 ### Added

--- a/packages/mnemopi/src/config.ts
+++ b/packages/mnemopi/src/config.ts
@@ -126,6 +126,10 @@ export function episodicRecallLimit(env: Env = process.env): number {
 	return envInt("MNEMOPI_EP_LIMIT", 50000, env);
 }
 
+export function maxEpisodeChars(env: Env = process.env): number {
+	return Math.max(1, envInt("MNEMOPI_MAX_EPISODE_CHARS", 100000, env));
+}
+
 export function sleepBatchSize(env: Env = process.env): number {
 	return envInt("MNEMOPI_SLEEP_BATCH", 5000, env);
 }

--- a/packages/mnemopi/src/core/beam/consolidate.ts
+++ b/packages/mnemopi/src/core/beam/consolidate.ts
@@ -57,6 +57,62 @@ const TIER2_DAYS = envInt("MNEMOPI_TIER2_DAYS", 30);
 const TIER3_DAYS = envInt("MNEMOPI_TIER3_DAYS", 180);
 const DEGRADE_BATCH_SIZE = envInt("MNEMOPI_DEGRADE_BATCH", 100);
 const TIER3_MAX_CHARS = envInt("MNEMOPI_TIER3_MAX_CHARS", 300);
+const DEFAULT_MAX_EPISODE_CHARS = 100_000;
+const SLEEP_SUMMARY_SEPARATOR = " | ";
+const SLEEP_TRUNCATION_MARKER = "\n[... sleep_consolidation episode truncated by maxEpisodeChars ...]";
+
+type SleepSummary = {
+	summary: string;
+	originalChars: number;
+	truncated: boolean;
+	maxChars: number;
+};
+
+function normalizedMaxEpisodeChars(beam: BeamMemoryState): number {
+	const configured = Math.trunc(beam.config?.maxEpisodeChars ?? DEFAULT_MAX_EPISODE_CHARS);
+	return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_MAX_EPISODE_CHARS;
+}
+
+function markTruncated(content: string, maxChars: number): string {
+	if (maxChars <= 0) return "";
+	if (maxChars <= SLEEP_TRUNCATION_MARKER.length) return content.slice(0, maxChars);
+	const bodyChars = maxChars - SLEEP_TRUNCATION_MARKER.length;
+	return `${content.slice(0, bodyChars).trimEnd()}${SLEEP_TRUNCATION_MARKER}`;
+}
+
+function buildSleepSummary(beam: BeamMemoryState, source: string, items: readonly Row[]): SleepSummary {
+	const maxChars = normalizedMaxEpisodeChars(beam);
+	const prefix = `[${source}] `;
+	const joinedLimit = Math.max(0, maxChars - prefix.length);
+	let joined = "";
+	let originalChars = 0;
+	let clipped = false;
+	for (let index = 0; index < items.length; index++) {
+		const content = rowValue(items[index] ?? {}, "content") ?? "";
+		const separator = index === 0 ? "" : SLEEP_SUMMARY_SEPARATOR;
+		originalChars += separator.length + content.length;
+		if (joined.length >= joinedLimit) {
+			if (separator.length + content.length > 0) clipped = true;
+			continue;
+		}
+		const next = `${separator}${content}`;
+		const remaining = joinedLimit - joined.length;
+		if (next.length <= remaining) {
+			joined += next;
+			continue;
+		}
+		joined += next.slice(0, remaining);
+		clipped = true;
+	}
+	const uncapped = `${prefix}${aaakEncode(joined)}`;
+	const truncated = clipped || uncapped.length > maxChars;
+	return {
+		summary: truncated ? markTruncated(uncapped, maxChars) : uncapped,
+		originalChars,
+		truncated,
+		maxChars,
+	};
+}
 
 function isoNow(): string {
 	return new Date().toISOString();
@@ -878,7 +934,6 @@ export function sleep(beam: BeamMemoryState, dryRun = false): SleepResult {
 	const consolidatedIds: string[] = [];
 	let summariesCreated = 0;
 	for (const [source, items] of grouped) {
-		const lines = items.map(item => rowValue(item, "content") ?? "");
 		const ids = items.map(item => rowValue(item, "id")).filter((id): id is string => id !== null);
 		let scope = "session";
 		let validUntil: string | null = null;
@@ -887,13 +942,20 @@ export function sleep(beam: BeamMemoryState, dryRun = false): SleepResult {
 			const itemValidUntil = rowValue(item, "valid_until");
 			if (itemValidUntil && (validUntil === null || itemValidUntil < validUntil)) validUntil = itemValidUntil;
 		}
-		const summary = `[${source}] ${aaakEncode(lines.join(" | "))}`;
+		const sleepSummary = buildSleepSummary(beam, source, items);
+		const metadata: Metadata = { original_count: items.length, source, llm_used: false };
+		if (sleepSummary.truncated) {
+			metadata.truncated = true;
+			metadata.original_chars = sleepSummary.originalChars;
+			metadata.max_chars = sleepSummary.maxChars;
+		}
+		const summary = sleepSummary.summary;
 		if (!dryRun) {
 			consolidateToEpisodic(beam, summary, ids, "sleep_consolidation", 0.6, {
 				scope,
 				validUntil,
 				veracity: aggregateEpisodicVeracity(items.map(item => rowValue(item, "veracity") ?? "unknown")),
-				metadata: { original_count: items.length, source, llm_used: false },
+				metadata,
 			});
 		}
 		consolidatedIds.push(...ids);

--- a/packages/mnemopi/src/core/beam/consolidate.ts
+++ b/packages/mnemopi/src/core/beam/consolidate.ts
@@ -67,6 +67,10 @@ type SleepSummary = {
 	truncated: boolean;
 	maxChars: number;
 };
+type SleepChunk = {
+	items: Row[];
+	originalChars: number;
+};
 
 function normalizedMaxEpisodeChars(beam: BeamMemoryState): number {
 	const configured = Math.trunc(beam.config?.maxEpisodeChars ?? DEFAULT_MAX_EPISODE_CHARS);
@@ -80,35 +84,38 @@ function markTruncated(content: string, maxChars: number): string {
 	return `${content.slice(0, bodyChars).trimEnd()}${SLEEP_TRUNCATION_MARKER}`;
 }
 
-function buildSleepSummary(beam: BeamMemoryState, source: string, items: readonly Row[]): SleepSummary {
+function splitSleepItems(beam: BeamMemoryState, source: string, items: readonly Row[]): SleepChunk[] {
+	const maxChars = normalizedMaxEpisodeChars(beam);
+	const prefixChars = `[${source}] `.length;
+	const joinedLimit = Math.max(0, maxChars - prefixChars);
+	const chunks: SleepChunk[] = [];
+	let current: Row[] = [];
+	let currentChars = 0;
+
+	for (const item of items) {
+		const contentChars = (rowValue(item, "content") ?? "").length;
+		const separatorChars = current.length === 0 ? 0 : SLEEP_SUMMARY_SEPARATOR.length;
+		if (current.length > 0 && currentChars + separatorChars + contentChars > joinedLimit) {
+			chunks.push({ items: current, originalChars: currentChars });
+			current = [];
+			currentChars = 0;
+		}
+		current.push(item);
+		currentChars += (current.length === 1 ? 0 : SLEEP_SUMMARY_SEPARATOR.length) + contentChars;
+	}
+	if (current.length > 0) chunks.push({ items: current, originalChars: currentChars });
+	return chunks;
+}
+
+function buildSleepSummary(beam: BeamMemoryState, source: string, chunk: SleepChunk): SleepSummary {
 	const maxChars = normalizedMaxEpisodeChars(beam);
 	const prefix = `[${source}] `;
-	const joinedLimit = Math.max(0, maxChars - prefix.length);
-	let joined = "";
-	let originalChars = 0;
-	let clipped = false;
-	for (let index = 0; index < items.length; index++) {
-		const content = rowValue(items[index] ?? {}, "content") ?? "";
-		const separator = index === 0 ? "" : SLEEP_SUMMARY_SEPARATOR;
-		originalChars += separator.length + content.length;
-		if (joined.length >= joinedLimit) {
-			if (separator.length + content.length > 0) clipped = true;
-			continue;
-		}
-		const next = `${separator}${content}`;
-		const remaining = joinedLimit - joined.length;
-		if (next.length <= remaining) {
-			joined += next;
-			continue;
-		}
-		joined += next.slice(0, remaining);
-		clipped = true;
-	}
+	const joined = chunk.items.map(item => rowValue(item, "content") ?? "").join(SLEEP_SUMMARY_SEPARATOR);
 	const uncapped = `${prefix}${aaakEncode(joined)}`;
-	const truncated = clipped || uncapped.length > maxChars;
+	const truncated = uncapped.length > maxChars;
 	return {
 		summary: truncated ? markTruncated(uncapped, maxChars) : uncapped,
-		originalChars,
+		originalChars: chunk.originalChars,
 		truncated,
 		maxChars,
 	};
@@ -934,32 +941,34 @@ export function sleep(beam: BeamMemoryState, dryRun = false): SleepResult {
 	const consolidatedIds: string[] = [];
 	let summariesCreated = 0;
 	for (const [source, items] of grouped) {
-		const ids = items.map(item => rowValue(item, "id")).filter((id): id is string => id !== null);
-		let scope = "session";
-		let validUntil: string | null = null;
-		for (const item of items) {
-			if (rowValue(item, "scope") === "global") scope = "global";
-			const itemValidUntil = rowValue(item, "valid_until");
-			if (itemValidUntil && (validUntil === null || itemValidUntil < validUntil)) validUntil = itemValidUntil;
+		for (const chunk of splitSleepItems(beam, source, items)) {
+			const ids = chunk.items.map(item => rowValue(item, "id")).filter((id): id is string => id !== null);
+			let scope = "session";
+			let validUntil: string | null = null;
+			for (const item of chunk.items) {
+				if (rowValue(item, "scope") === "global") scope = "global";
+				const itemValidUntil = rowValue(item, "valid_until");
+				if (itemValidUntil && (validUntil === null || itemValidUntil < validUntil)) validUntil = itemValidUntil;
+			}
+			const sleepSummary = buildSleepSummary(beam, source, chunk);
+			const metadata: Metadata = { original_count: chunk.items.length, source, llm_used: false };
+			if (sleepSummary.truncated) {
+				metadata.truncated = true;
+				metadata.original_chars = sleepSummary.originalChars;
+				metadata.max_chars = sleepSummary.maxChars;
+			}
+			const summary = sleepSummary.summary;
+			if (!dryRun) {
+				consolidateToEpisodic(beam, summary, ids, "sleep_consolidation", 0.6, {
+					scope,
+					validUntil,
+					veracity: aggregateEpisodicVeracity(chunk.items.map(item => rowValue(item, "veracity") ?? "unknown")),
+					metadata,
+				});
+			}
+			consolidatedIds.push(...ids);
+			summariesCreated++;
 		}
-		const sleepSummary = buildSleepSummary(beam, source, items);
-		const metadata: Metadata = { original_count: items.length, source, llm_used: false };
-		if (sleepSummary.truncated) {
-			metadata.truncated = true;
-			metadata.original_chars = sleepSummary.originalChars;
-			metadata.max_chars = sleepSummary.maxChars;
-		}
-		const summary = sleepSummary.summary;
-		if (!dryRun) {
-			consolidateToEpisodic(beam, summary, ids, "sleep_consolidation", 0.6, {
-				scope,
-				validUntil,
-				veracity: aggregateEpisodicVeracity(items.map(item => rowValue(item, "veracity") ?? "unknown")),
-				metadata,
-			});
-		}
-		consolidatedIds.push(...ids);
-		summariesCreated++;
 	}
 	if (!dryRun) {
 		beam.db.run(

--- a/packages/mnemopi/src/core/beam/index.ts
+++ b/packages/mnemopi/src/core/beam/index.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
-import { ftsWeight, importanceWeight, vectorWeight } from "../../config";
+import { ftsWeight, importanceWeight, maxEpisodeChars, vectorWeight } from "../../config";
 import { closeQuietly, openDatabase } from "../../db";
 import { AnnotationStore } from "../annotations";
 import { EpisodicGraph } from "../episodic-graph";
@@ -68,6 +68,7 @@ const DEFAULT_CONFIG: BeamConfig = {
 	importanceWeight: 0.2,
 	useCloud: false,
 	localLlmEnabled: false,
+	maxEpisodeChars: 100_000,
 };
 
 function normalizeConfig(options: BeamMemoryOptions): BeamConfig {
@@ -82,6 +83,7 @@ function normalizeConfig(options: BeamMemoryOptions): BeamConfig {
 		importanceWeight: configured.importanceWeight ?? importanceWeight(),
 		useCloud,
 		localLlmEnabled: configured.localLlmEnabled ?? DEFAULT_CONFIG.localLlmEnabled,
+		maxEpisodeChars: configured.maxEpisodeChars ?? maxEpisodeChars(),
 	};
 }
 function autoMigrateAnnotations(db: Database, dbPath: string | undefined): void {

--- a/packages/mnemopi/src/core/beam/types.ts
+++ b/packages/mnemopi/src/core/beam/types.ts
@@ -53,6 +53,7 @@ export interface BeamConfig {
 	importanceWeight: number;
 	useCloud: boolean;
 	localLlmEnabled: boolean;
+	maxEpisodeChars: number;
 }
 
 export interface BeamMemoryOptions {

--- a/packages/mnemopi/test/beam-consolidate-unit.test.ts
+++ b/packages/mnemopi/test/beam-consolidate-unit.test.ts
@@ -43,6 +43,7 @@ function state(sessionId = "s1"): BeamMemoryState {
 			importanceWeight: 0.2,
 			useCloud: false,
 			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
 		},
 	};
 }
@@ -160,6 +161,36 @@ describe("beam consolidation free functions", () => {
 			count: 1,
 		});
 		expect(getConsolidationLog(beam, 1)[0]?.items_consolidated).toBe(2);
+	});
+	it("sleep caps oversized episodes before extraction and embedding", () => {
+		const beam = trackedState();
+		beam.config.maxEpisodeChars = 512;
+		const transcript = "[role: user] progress output with noisy tool transcript ".repeat(40);
+		insertWorking(beam.db, "wm-big", "s1", transcript, "conversation");
+
+		const result = sleep(beam, false);
+		const row = beam.db
+			.query(
+				`SELECT content, length(content) AS chars, json_extract(metadata_json, '$.truncated') AS truncated,
+				 json_extract(metadata_json, '$.original_chars') AS original_chars,
+				 json_extract(metadata_json, '$.max_chars') AS max_chars
+				 FROM episodic_memory WHERE source = 'sleep_consolidation'`,
+			)
+			.get() as {
+			content: string;
+			chars: number;
+			truncated: number;
+			original_chars: number;
+			max_chars: number;
+		} | null;
+
+		expect(result.status).toBe("consolidated");
+		expect(row).not.toBeNull();
+		expect(row?.chars).toBeLessThanOrEqual(512);
+		expect(row?.content.includes("sleep_consolidation episode truncated")).toBe(true);
+		expect(row?.truncated).toBe(1);
+		expect(row?.original_chars).toBeGreaterThan(512);
+		expect(row?.max_chars).toBe(512);
 	});
 
 	it("sleepAllSessions consolidates eligible rows outside the caller session", () => {

--- a/packages/mnemopi/test/beam-consolidate-unit.test.ts
+++ b/packages/mnemopi/test/beam-consolidate-unit.test.ts
@@ -192,6 +192,25 @@ describe("beam consolidation free functions", () => {
 		expect(row?.original_chars).toBeGreaterThan(512);
 		expect(row?.max_chars).toBe(512);
 	});
+	it("sleep splits capped source groups without dropping row ids", () => {
+		const beam = trackedState();
+		beam.config.maxEpisodeChars = 100;
+		insertWorking(beam.db, "wm-one", "s1", `first ${"a".repeat(70)}`, "conversation");
+		insertWorking(beam.db, "wm-two", "s1", `second ${"b".repeat(70)}`, "conversation");
+		insertWorking(beam.db, "wm-three", "s1", `third ${"c".repeat(70)}`, "conversation");
+
+		const result = sleep(beam, false);
+		const rows = beam.db
+			.query("SELECT summary_of, length(content) AS chars FROM episodic_memory WHERE source = 'sleep_consolidation'")
+			.all() as { summary_of: string; chars: number }[];
+
+		expect(result.status).toBe("consolidated");
+		expect(result.items_consolidated).toBe(3);
+		expect(result.summaries_created).toBe(3);
+		expect(rows).toHaveLength(3);
+		expect(rows.every(row => row.chars <= 100)).toBe(true);
+		expect(rows.map(row => row.summary_of).sort()).toEqual(["wm-one", "wm-three", "wm-two"]);
+	});
 
 	it("sleepAllSessions consolidates eligible rows outside the caller session", () => {
 		const beam = trackedState("maintenance");

--- a/packages/mnemopi/test/beam-recall-unit.test.ts
+++ b/packages/mnemopi/test/beam-recall-unit.test.ts
@@ -33,6 +33,7 @@ function makeBeam(): TestBeam {
 			importanceWeight: 0.2,
 			useCloud: false,
 			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
 		},
 		close() {
 			db.close();

--- a/packages/mnemopi/test/beam-store.test.ts
+++ b/packages/mnemopi/test/beam-store.test.ts
@@ -54,6 +54,7 @@ function makeState(sessionId = "session-a", events: BeamEvent[] = []): BeamMemor
 			importanceWeight: 0.2,
 			useCloud: false,
 			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
 		},
 	};
 	states.push(state);

--- a/packages/mnemopi/test/orchestrator.test.ts
+++ b/packages/mnemopi/test/orchestrator.test.ts
@@ -36,6 +36,7 @@ function fakeBeam(): FakeBeam {
 			importanceWeight: 0.2,
 			useCloud: false,
 			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
 		},
 		linearCalls: 0,
 		enhancedCalls: 0,

--- a/packages/mnemopi/test/polyphonic-recall.test.ts
+++ b/packages/mnemopi/test/polyphonic-recall.test.ts
@@ -32,6 +32,7 @@ function makeBeam(): BeamMemoryState {
 			importanceWeight: 0.2,
 			useCloud: false,
 			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
 		},
 	};
 }


### PR DESCRIPTION
## Repro
A single old `working_memory` row containing a 460,000-character transcript reproduced the oversized storage path: `bun -e 'import { initBeam } from "@oh-my-pi/pi-mnemopi/core/beam"; import { sleep } from "@oh-my-pi/pi-mnemopi/core/beam/consolidate"; import { openDatabase, closeQuietly } from "@oh-my-pi/pi-mnemopi/db"; ...'` wrote one `episodic_memory` row with `source='sleep_consolidation'` and `length(content)=460014` before the fix.

## Cause
`packages/mnemopi/src/core/beam/consolidate.ts` built sleep summaries with `aaakEncode(lines.join(" | "))` and passed the full result directly to `consolidateToEpisodic()`. That meant extraction, episodic graph ingest, and embedding scheduling all consumed the uncapped transcript-sized row.

## Fix
- Added `maxEpisodeChars` to the beam config, defaulting to 100KB and configurable through `MNEMOPI_MAX_EPISODE_CHARS`.
- Capped `sleep_consolidation` summaries before `consolidateToEpisodic()` and tagged truncated rows with `truncated`, `original_chars`, and `max_chars` metadata.
- Added regression coverage for an oversized transcript consolidating to a capped episodic row.
- Added a mnemopi changelog entry for #2869.

## Verification
Ran `bun test packages/mnemopi/test/beam-consolidate-unit.test.ts` (9 pass), `bun --cwd=packages/mnemopi run check` (passed), and the repro script again, which now stores `length(content)=100000` with truncation metadata. `bun check` fails on `main` for unrelated `packages/catalog/test/variant-collapse.test.ts(541,12): Cannot find name 'RequestInfo'`; skipped the pre-publish gate after verifying the same failure in `.wt/main-check` at `origin/main`. Fixes #2869