### PR TITLE
fix(mnemopi): guard regex extraction for large transcripts

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1512,17 +1512,6 @@ export class AuthStorage {
 		this.#resetProviderAssignments(provider);
 	}
 
-	async #upsertOAuthCredential(provider: string, credential: OAuthCredential): Promise<void> {
-		const stored = this.#store.upsertAuthCredentialRemote
-			? await this.#store.upsertAuthCredentialRemote(provider, credential)
-			: this.#store.upsertAuthCredentialForProvider(provider, credential);
-		this.#setStoredCredentials(
-			provider,
-			stored.map(record => ({ id: record.id, credential: record.credential })),
-		);
-		this.#resetProviderAssignments(provider);
-	}
-
 	/**
 	 * List stored credential rows, optionally filtered by provider.
 	 */

--- a/packages/ai/src/registry/alibaba-coding-plan.ts
+++ b/packages/ai/src/registry/alibaba-coding-plan.ts
@@ -90,5 +90,5 @@ export const alibabaCodingPlanProvider = {
 	id: "alibaba-coding-plan",
 	name: "Alibaba Coding Plan",
 	login: (cb: OAuthLoginCallbacks) => loginAlibabaCodingPlan(cb),
-	getApiKey: (credentials) => credentials.access,
+	getApiKey: credentials => credentials.access,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -142,14 +142,14 @@ export async function getOAuthApiKey(
 		provider === "alibaba-coding-plan";
 	const apiKey = needsStructuredApiKey
 		? JSON.stringify({
-			token: creds.access,
-			enterpriseUrl: creds.enterpriseUrl,
-			projectId: creds.projectId,
-			refreshToken: creds.refresh,
-			expiresAt: creds.expires,
-			email: creds.email,
-			accountId: creds.accountId,
-		})
+				token: creds.access,
+				enterpriseUrl: creds.enterpriseUrl,
+				projectId: creds.projectId,
+				refreshToken: creds.refresh,
+				expiresAt: creds.expires,
+				email: creds.email,
+				accountId: creds.accountId,
+			})
 		: creds.access;
 	return { newCredentials: creds, apiKey };
 }

--- a/packages/ai/test/alibaba-endpoint-selection.test.ts
+++ b/packages/ai/test/alibaba-endpoint-selection.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import type { OAuthController, OAuthCredentials } from "../src/registry/oauth/types";
-import * as apiKeyValidation from "../src/registry/api-key-validation";
-import { loginAlibabaCodingPlan, alibabaCodingPlanProvider } from "../src/registry/alibaba-coding-plan";
-import { getOAuthApiKey } from "../src/registry/oauth/index";
 import type { Mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { loginAlibabaCodingPlan } from "../src/registry/alibaba-coding-plan";
+import * as apiKeyValidation from "../src/registry/api-key-validation";
+import { getOAuthApiKey } from "../src/registry/oauth/index";
+import type { OAuthController } from "../src/registry/oauth/types";
 
 describe("alibaba-coding-plan endpoint selection", () => {
 	let validateSpy: Mock<typeof apiKeyValidation.validateOpenAICompatibleApiKey>;
@@ -19,9 +19,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 1 uses international endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -48,9 +50,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 2 uses China endpoint and auth URL", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "2";
 				if (prompt.message.includes("Paste your")) return "sk-cn-key";
 				return "";
@@ -77,9 +81,11 @@ describe("alibaba-coding-plan endpoint selection", () => {
 	it("option 3 prompts for custom URL and uses it", async () => {
 		let capturedAuth: { url: string; instructions?: string } | undefined;
 		const options: OAuthController = {
-			onAuth: (info) => { capturedAuth = info; },
+			onAuth: info => {
+				capturedAuth = info;
+			},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1";
 				if (prompt.message.includes("Paste your")) return "sk-custom-key";
@@ -107,7 +113,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
 				return "";
@@ -123,7 +129,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "https://my-proxy.com/v1///";
 				if (prompt.message.includes("Paste your")) return "sk-test-key";
@@ -140,32 +146,28 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "3";
 				if (prompt.message.includes("custom base URL")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Custom URL is required for option 3"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Custom URL is required for option 3");
 	});
 
 	it("throws error when API key is empty", async () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) return "1";
 				if (prompt.message.includes("Paste your")) return "";
 				return "";
 			},
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"API key is required"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("API key is required");
 	});
 
 	it("checks abort signal after endpoint selection", async () => {
@@ -173,7 +175,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		const options: OAuthController = {
 			onAuth: () => {},
 			onProgress: () => {},
-			onPrompt: async (prompt) => {
+			onPrompt: async prompt => {
 				if (prompt.message.includes("Select Alibaba")) {
 					controller.abort();
 					return "";
@@ -183,9 +185,7 @@ describe("alibaba-coding-plan endpoint selection", () => {
 			signal: controller.signal,
 		};
 
-		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow(
-			"Login cancelled"
-		);
+		await expect(loginAlibabaCodingPlan(options)).rejects.toThrow("Login cancelled");
 	});
 });
 

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -538,7 +538,7 @@ describe("antigravity discovery collapsing", () => {
 	it("uses the primary daily endpoint by default", async () => {
 		const requestedUrls: string[] = [];
 		const defaultFetcher = Object.assign(
-			(input: RequestInfo | URL, _init?: RequestInit) => {
+			(input: string | URL | Request, _init?: RequestInit) => {
 				requestedUrls.push(String(input));
 				return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
 			},

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Skipped regex-only entity and pattern fact extraction for oversized raw transcripts so progress/log noise cannot flood MEMORIA with junk facts. ([#2868](https://github.com/can1357/oh-my-pi/issues/2868))
+
 ## [15.13.1] - 2026-06-15
 
 ### Added

--- a/packages/mnemopi/src/core/beam/consolidate.ts
+++ b/packages/mnemopi/src/core/beam/consolidate.ts
@@ -1,6 +1,7 @@
 import type { SQLQueryBindings } from "bun:sqlite";
 import { generateId, stableMemoryId } from "../../util/ids";
 import { aaakEncode } from "../aaak";
+import { REGEX_EXTRACTION_MAX_INPUT_CHARS } from "../entities";
 import { EpisodicGraph } from "../episodic-graph";
 import { heuristicExtractFacts } from "../extraction";
 import { clampVeracity } from "../veracity-consolidation";
@@ -57,6 +58,7 @@ const TIER2_DAYS = envInt("MNEMOPI_TIER2_DAYS", 30);
 const TIER3_DAYS = envInt("MNEMOPI_TIER3_DAYS", 180);
 const DEGRADE_BATCH_SIZE = envInt("MNEMOPI_DEGRADE_BATCH", 100);
 const TIER3_MAX_CHARS = envInt("MNEMOPI_TIER3_MAX_CHARS", 300);
+const PATTERN_FACT_EXTRACTION_MAX_INPUT_CHARS = REGEX_EXTRACTION_MAX_INPUT_CHARS;
 
 function isoNow(): string {
 	return new Date().toISOString();
@@ -440,6 +442,7 @@ export function extractAndStoreFacts(
 		decision: 0,
 	};
 	const text = String(content ?? "");
+	if (text.length > PATTERN_FACT_EXTRACTION_MAX_INPUT_CHARS) return counts;
 	for (const match of text.matchAll(
 		/(\d+(?:[.,]\d+)?)\s*(ms|sec|seconds?|minutes?|hours?|days?|weeks?|months?|%|KB|MB|GB|TB|rows?|columns?|roles?|features?|bugs?|commits?|cards?|users?|items?|tests?|APIs?|endpoints?|sprints?|tickets?)\b/gi,
 	)) {

--- a/packages/mnemopi/src/core/entities.ts
+++ b/packages/mnemopi/src/core/entities.ts
@@ -118,6 +118,9 @@ const ENTITY_EXTRACTION_STOP_WORD_VALUES = [
 ] as const;
 
 export const ENTITY_EXTRACTION_STOP_WORDS: ReadonlySet<string> = new Set(ENTITY_EXTRACTION_STOP_WORD_VALUES);
+/** Maximum raw text size for regex-only entity extraction. */
+export const REGEX_EXTRACTION_MAX_INPUT_CHARS = 50_000;
+
 const ENTITY_PATTERNS: readonly RegExp[] = [
 	/@(\w{2,30})/g,
 	/#(\w{2,30})/g,
@@ -192,6 +195,7 @@ function isPureNumber(entity: string): boolean {
 
 export function extractEntitiesRegex(text: string): string[] {
 	if (typeof text !== "string" || text.length === 0) return [];
+	if (text.length > REGEX_EXTRACTION_MAX_INPUT_CHARS) return [];
 
 	const entities = new Set<string>();
 	for (const sourcePattern of ENTITY_PATTERNS) {

--- a/packages/mnemopi/test/beam-consolidate-unit.test.ts
+++ b/packages/mnemopi/test/beam-consolidate-unit.test.ts
@@ -14,6 +14,7 @@ import {
 	sleepAllSessions,
 } from "@oh-my-pi/pi-mnemopi/core/beam/consolidate";
 import type { BeamMemoryState } from "@oh-my-pi/pi-mnemopi/core/beam/types";
+import { REGEX_EXTRACTION_MAX_INPUT_CHARS } from "@oh-my-pi/pi-mnemopi/core/entities";
 import { closeQuietly, openDatabase } from "@oh-my-pi/pi-mnemopi/db";
 
 function state(sessionId = "s1"): BeamMemoryState {
@@ -255,5 +256,25 @@ describe("beam consolidation free functions", () => {
 			count: number;
 		};
 		expect(facts.count).toBeGreaterThanOrEqual(4);
+	});
+
+	it("skips pattern fact extraction for oversized raw transcripts", () => {
+		const beam = trackedState();
+		const line = "progress boot done 615014ms downloading gapps its@66% priv-app files done 221MB version 1.2.3\n";
+		const text = line.repeat(Math.ceil((REGEX_EXTRACTION_MAX_INPUT_CHARS + 1) / line.length));
+		const counts = extractAndStoreFacts(beam, text, 7, "large-transcript");
+
+		expect(counts).toEqual({
+			metric: 0,
+			date: 0,
+			version: 0,
+			entity: 0,
+			sequence: 0,
+			timeline: 0,
+			negation: 0,
+			decision: 0,
+		});
+		const facts = beam.db.query("SELECT COUNT(*) AS count FROM memoria_facts").get() as { count: number };
+		expect(facts.count).toBe(0);
 	});
 });

--- a/packages/mnemopi/test/entities.test.ts
+++ b/packages/mnemopi/test/entities.test.ts
@@ -4,6 +4,7 @@ import {
 	extractEntitiesRegex,
 	findSimilarEntities,
 	levenshteinDistance,
+	REGEX_EXTRACTION_MAX_INPUT_CHARS,
 	similarity,
 } from "@oh-my-pi/pi-mnemopi/core/entities";
 
@@ -45,6 +46,12 @@ describe("entity utilities", () => {
 		expect(extractEntitiesRegex("the quick brown fox jumps")).toEqual([]);
 		expect(extractEntitiesRegex("The Quick Brown Fox 123 1,234")).toEqual(["Brown", "Fox", "Quick"]);
 		expect(extractEntitiesRegex("I visited New York with Abdias yesterday.")).toEqual(["Abdias", "New York"]);
+	});
+
+	it("skips regex extraction for oversized raw transcripts", () => {
+		const text = "Project Alpha progress ".repeat(Math.ceil((REGEX_EXTRACTION_MAX_INPUT_CHARS + 1) / 23));
+
+		expect(extractEntitiesRegex(text)).toEqual([]);
 	});
 
 	it("finds similar entities above threshold sorted by score", () => {


### PR DESCRIPTION
## Repro
A large progress/log transcript still went through MEMORIA's regex-only pattern passes. Reproduced with `bun --cwd packages/mnemopi -e 'import { BeamMemory } from "@oh-my-pi/pi-mnemopi/core/beam"; import { extractAndStoreFacts } from "@oh-my-pi/pi-mnemopi/core/beam/consolidate"; const beam = new BeamMemory({ dbPath: ":memory:", sessionId: "repro" }); try { const line = "progress boot done 615014ms downloading gapps its@66% priv-app files done 221MB version 1.2.3\n"; const text = line.repeat(1200); const counts = extractAndStoreFacts(beam, text, 0, "large-transcript"); const rows = beam.db.query("SELECT fact_type, COUNT(*) AS count FROM memoria_facts GROUP BY fact_type ORDER BY count DESC").all(); console.log(JSON.stringify({ chars: text.length, counts, rows }, null, 2)); } finally { beam.close(); }'`, which produced 1,200 `version` rows and 10 `metric` rows before the fix.

## Cause
`packages/mnemopi/src/core/entities.ts#extractEntitiesRegex` scanned the full raw input with `ENTITY_PATTERNS`, and `packages/mnemopi/src/core/beam/consolidate.ts#extractAndStoreFacts` scanned the full raw input for metrics, dates, versions, heuristic facts, and KG relations. Neither path had a raw-text cap, so multi-megabyte transcripts created thousands of regex artifacts before any semantic relevance check.

## Fix
- Added `REGEX_EXTRACTION_MAX_INPUT_CHARS` and early-returned `extractEntitiesRegex` for oversized raw text.
- Reused the same cap in `extractAndStoreFacts` so MEMORIA pattern fact extraction skips oversized transcripts instead of writing junk `memoria_facts` rows.
- Added regression coverage for both the entity extractor and MEMORIA pattern fact path, plus an Unreleased changelog entry.
- Replaced an unavailable `RequestInfo` alias in a catalog test with the concrete fetch input union so the repo check gate completes on this branch.

## Verification
`bun --cwd packages/mnemopi -e ...` now returns zero pattern facts for the 112,800-character repro; `bun test --parallel test/entities.test.ts test/beam-consolidate-unit.test.ts` passed; `bun run check` passed in `packages/mnemopi`; `bun run check` passed in `packages/catalog`; pre-publish `bun check` passed during `gh_push_branch`. Fixes #2868