### PR TITLE
fix(auth): route GitHub Copilot Business endpoint

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed Antigravity model streaming and usage fetch paths to retry on transient `429`/`5xx` errors by failing over to the alternate endpoint before surfacing an error
 - Fixed Antigravity endpoint tracking to prefer a previously successful endpoint in `auto` mode for subsequent requests
 - Fixed Antigravity and Gemini CLI model requests failing with an opaque error when Google requires account verification. Cloud Code Assist `403 VALIDATION_REQUIRED` responses now surface the `validation_url` and the signed-in account email when available, so users see an actionable account-verification message instead of the raw API error body.
+- Fixed GitHub Copilot OAuth for Business seats by storing the login-discovered API endpoint and routing model enablement plus chat requests to that endpoint. ([#2876](https://github.com/can1357/oh-my-pi/issues/2876))
 
 ## [16.0.4] - 2026-06-17
 

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -21,6 +21,7 @@ import { usageReportSchema } from "../usage";
 /** Real OAuth credential (broker-side) — refresh token is the actual upstream value. */
 export const oauthCredentialSchema = z
 	.object({
+		apiEndpoint: z.string().optional(),
 		type: z.literal("oauth"),
 		refresh: z
 			.string()

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1971,6 +1971,7 @@ export class AuthStorage {
 			projectId: next.projectId,
 			email: next.email,
 			enterpriseUrl: next.enterpriseUrl,
+			apiEndpoint: next.apiEndpoint,
 		});
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -191,6 +191,7 @@ export type CompletionProbeCredential =
 			projectId?: string;
 			email?: string;
 			enterpriseUrl?: string;
+			apiEndpoint?: string;
 	  };
 
 /**
@@ -638,6 +639,7 @@ export interface OAuthAccess {
 	email?: string;
 	projectId?: string;
 	enterpriseUrl?: string;
+	apiEndpoint?: string;
 }
 
 export interface OAuthAccessFailure {
@@ -646,6 +648,7 @@ export interface OAuthAccessFailure {
 	email?: string;
 	projectId?: string;
 	enterpriseUrl?: string;
+	apiEndpoint?: string;
 	error: string;
 }
 
@@ -1803,6 +1806,7 @@ export class AuthStorage {
 			projectId: credential.projectId,
 			email: credential.email,
 			enterpriseUrl: credential.enterpriseUrl,
+			apiEndpoint: credential.apiEndpoint,
 		};
 	}
 
@@ -1881,6 +1885,7 @@ export class AuthStorage {
 			projectId: credential.projectId,
 			email: credential.email,
 			enterpriseUrl: credential.enterpriseUrl,
+			apiEndpoint: credential.apiEndpoint,
 		};
 	}
 
@@ -1904,6 +1909,7 @@ export class AuthStorage {
 			projectId: credential.projectId,
 			email: credential.email,
 			enterpriseUrl: credential.enterpriseUrl,
+			apiEndpoint: credential.apiEndpoint,
 		};
 	}
 
@@ -1917,6 +1923,7 @@ export class AuthStorage {
 			projectId: refreshed.projectId ?? credential.projectId,
 			email: refreshed.email ?? credential.email,
 			enterpriseUrl: refreshed.enterpriseUrl ?? credential.enterpriseUrl,
+			apiEndpoint: refreshed.apiEndpoint ?? credential.apiEndpoint,
 		};
 	}
 
@@ -3384,6 +3391,7 @@ export class AuthStorage {
 				email: result.newCredentials.email ?? selection.credential.email,
 				projectId: result.newCredentials.projectId ?? selection.credential.projectId,
 				enterpriseUrl: result.newCredentials.enterpriseUrl ?? selection.credential.enterpriseUrl,
+				apiEndpoint: result.newCredentials.apiEndpoint ?? selection.credential.apiEndpoint,
 			};
 			this.#replaceCredentialAt(provider, selection.index, updated);
 			if ((checkUsage && !allowBlocked) || requiresProModel) {
@@ -3510,6 +3518,7 @@ export class AuthStorage {
 					return JSON.stringify({
 						token: oauthSelection.credential.access,
 						enterpriseUrl: oauthSelection.credential.enterpriseUrl,
+						apiEndpoint: oauthSelection.credential.apiEndpoint,
 					});
 				}
 				return oauthSelection.credential.access;
@@ -3607,6 +3616,7 @@ export class AuthStorage {
 			email: credential.email,
 			projectId: credential.projectId,
 			enterpriseUrl: credential.enterpriseUrl,
+			apiEndpoint: credential.apiEndpoint,
 		};
 	}
 
@@ -4067,6 +4077,7 @@ export class AuthStorage {
 				email: refreshed.email ?? target.credential.email,
 				projectId: refreshed.projectId ?? target.credential.projectId,
 				enterpriseUrl: refreshed.enterpriseUrl ?? target.credential.enterpriseUrl,
+				apiEndpoint: refreshed.apiEndpoint ?? target.credential.apiEndpoint,
 			};
 			this.#replaceCredentialAt(provider, index, updated);
 			return {

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -16,7 +16,8 @@ export function resolveGitHubCopilotBaseUrl(
 	apiKey: string | undefined,
 ): string | undefined {
 	if (!apiKey) return baseUrl;
-	const { enterpriseUrl } = parseGitHubCopilotApiKey(apiKey);
+	const { enterpriseUrl, apiEndpoint } = parseGitHubCopilotApiKey(apiKey);
+	if (apiEndpoint && (!baseUrl || baseUrl.includes("githubcopilot.com"))) return apiEndpoint;
 	if (!enterpriseUrl) return baseUrl;
 	if (baseUrl && !baseUrl.includes("githubcopilot.com")) return baseUrl;
 	return getGitHubCopilotBaseUrl(enterpriseUrl);

--- a/packages/ai/src/registry/github-copilot.ts
+++ b/packages/ai/src/registry/github-copilot.ts
@@ -17,6 +17,6 @@ export const githubCopilotProvider = {
 	refreshToken: async (credentials: OAuthCredentials) => {
 		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
 		const { refreshGitHubCopilotToken } = await import("./oauth/github-copilot");
-		return refreshGitHubCopilotToken(credentials.refresh, credentials.enterpriseUrl);
+		return refreshGitHubCopilotToken(credentials.refresh, credentials.enterpriseUrl, credentials.apiEndpoint);
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -8,6 +8,7 @@ import {
 	getGitHubCopilotBaseUrl,
 	isPublicGitHubHost,
 	normalizeDomain,
+	normalizeGitHubCopilotApiEndpoint,
 	normalizeGitHubCopilotEnterpriseDomain,
 	OPENCODE_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
@@ -203,13 +204,39 @@ const FAR_FUTURE_MS = Date.now() + 10 * 365.25 * 24 * 60 * 60 * 1000;
  * Refresh GitHub Copilot token.
  * With the opencode OAuth flow, the GitHub token is used directly — no JWT exchange needed.
  */
-export function refreshGitHubCopilotToken(refreshToken: string, enterpriseDomain?: string): OAuthCredentials {
+export function refreshGitHubCopilotToken(
+	refreshToken: string,
+	enterpriseDomain?: string,
+	apiEndpoint?: string,
+): OAuthCredentials {
 	return {
 		refresh: refreshToken,
 		access: refreshToken,
 		expires: FAR_FUTURE_MS,
 		enterpriseUrl: enterpriseDomain,
+		apiEndpoint,
 	};
+}
+
+async function discoverGitHubCopilotApiEndpoint(token: string, fetchImpl: FetchImpl): Promise<string | undefined> {
+	try {
+		const data = await fetchJson(
+			"https://api.github.com/copilot_internal/user",
+			{
+				headers: {
+					Accept: "application/json",
+					Authorization: `token ${token}`,
+					...OPENCODE_HEADERS,
+				},
+			},
+			fetchImpl,
+		);
+		if (!data || typeof data !== "object") return undefined;
+		const endpoints = (data as { endpoints?: { api?: unknown } }).endpoints;
+		return typeof endpoints?.api === "string" ? normalizeGitHubCopilotApiEndpoint(endpoints.api) : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 /**
@@ -220,9 +247,10 @@ async function enableGitHubCopilotModel(
 	token: string,
 	modelId: string,
 	fetchImpl: FetchImpl,
-	enterpriseDomain?: string,
+	enterpriseDomain: string | undefined,
+	apiEndpoint: string | undefined,
 ): Promise<boolean> {
-	const baseUrl = getGitHubCopilotBaseUrl(enterpriseDomain);
+	const baseUrl = apiEndpoint ?? getGitHubCopilotBaseUrl(enterpriseDomain);
 	const url = `${baseUrl}/models/${modelId}/policy`;
 
 	try {
@@ -250,6 +278,7 @@ async function enableGitHubCopilotModel(
 async function enableAllGitHubCopilotModels(
 	token: string,
 	enterpriseDomain: string | undefined,
+	apiEndpoint: string | undefined,
 	fetchImpl: FetchImpl,
 	onProgress?: (model: string, success: boolean) => void,
 ): Promise<void> {
@@ -261,7 +290,7 @@ async function enableAllGitHubCopilotModels(
 		const batch = wireModelIds.slice(i, i + BATCH_SIZE);
 		await Promise.all(
 			batch.map(async modelId => {
-				const success = await enableGitHubCopilotModel(token, modelId, fetchImpl, enterpriseDomain);
+				const success = await enableGitHubCopilotModel(token, modelId, fetchImpl, enterpriseDomain, apiEndpoint);
 				onProgress?.(modelId, success);
 			}),
 		);
@@ -311,16 +340,19 @@ export async function loginGitHubCopilot(options: GitHubCopilotLoginOptions): Pr
 		options.pollIntervalScaleMs,
 	);
 
+	const apiEndpoint = await discoverGitHubCopilotApiEndpoint(githubAccessToken, fetchImpl);
+
 	// With opencode OAuth, the GitHub token is used directly for all API requests
 	const credentials: OAuthCredentials = {
 		refresh: githubAccessToken,
 		access: githubAccessToken,
 		expires: FAR_FUTURE_MS,
 		enterpriseUrl: enterpriseDomain ?? undefined,
+		apiEndpoint,
 	};
 
 	// Enable all models after successful login
 	options.onProgress?.("Enabling models...");
-	await enableAllGitHubCopilotModels(githubAccessToken, enterpriseDomain ?? undefined, fetchImpl);
+	await enableAllGitHubCopilotModels(githubAccessToken, enterpriseDomain ?? undefined, apiEndpoint, fetchImpl);
 	return credentials;
 }

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -142,6 +142,7 @@ export async function getOAuthApiKey(
 		provider === "alibaba-coding-plan";
 	const apiKey = needsStructuredApiKey
 		? JSON.stringify({
+				apiEndpoint: creds.apiEndpoint,
 				token: creds.access,
 				enterpriseUrl: creds.enterpriseUrl,
 				projectId: creds.projectId,

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -9,6 +9,7 @@ export type OAuthCredentials = {
 	projectId?: string;
 	email?: string;
 	accountId?: string;
+	apiEndpoint?: string;
 };
 
 export type OAuthProvider = OAuthProviderUnion;

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -210,6 +210,7 @@ export interface UsageCredential {
 	email?: string;
 	enterpriseUrl?: string;
 	metadata?: Record<string, unknown>;
+	apiEndpoint?: string;
 }
 
 /** Parameters provided to a usage fetcher. */

--- a/packages/ai/test/auth-storage-check-credentials.test.ts
+++ b/packages/ai/test/auth-storage-check-credentials.test.ts
@@ -30,6 +30,7 @@ import {
 	REMOTE_REFRESH_SENTINEL,
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai/auth-storage";
+import type { UsageProvider } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 
 function oauthRow(id: number, email: string, opts?: { expired?: boolean }): StoredAuthCredential {
@@ -303,6 +304,65 @@ describe("AuthStorage.checkCredentials", () => {
 			}
 			expect(result.completion).toEqual({ ok: true, modelId: "test-probe-model", latencyMs: 42 });
 			expect(result.ok).toBe(true); // usage probe independently succeeded
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("persists Copilot API endpoint after usage refresh", async () => {
+		const apiEndpoint = "https://api.business.githubcopilot.com";
+		const row: StoredAuthCredential = {
+			id: 8,
+			provider: "github-copilot",
+			credential: {
+				type: "oauth",
+				access: "oat-business",
+				refresh: "refresh-business",
+				expires: Date.now() - 60_000,
+				accountId: "account-business",
+				email: "business@example.com",
+				apiEndpoint,
+			},
+			disabledCause: null,
+		};
+		const refreshSpy = vi.fn<NonNullable<AuthCredentialStore["refreshOAuthCredential"]>>().mockResolvedValue({
+			access: "oat-business-refreshed",
+			refresh: "refresh-business-refreshed",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-business",
+			email: "business@example.com",
+		});
+		const store = makeStore([row], refreshSpy);
+		const updatedCredentials: AuthCredential[] = [];
+		vi.spyOn(store, "updateAuthCredential").mockImplementation((_id, credential) => {
+			updatedCredentials.push(credential);
+		});
+		const usageProvider: UsageProvider = {
+			id: "github-copilot",
+			async fetchUsage(params) {
+				expect(params.credential.apiEndpoint).toBe(apiEndpoint);
+				return {
+					provider: "github-copilot",
+					fetchedAt: Date.now(),
+					limits: [],
+					metadata: {},
+				};
+			},
+		};
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "github-copilot" ? usageProvider : undefined),
+		});
+		await storage.reload();
+
+		try {
+			const [result] = await storage.checkCredentials();
+			expect(refreshSpy).toHaveBeenCalledTimes(1);
+			expect(result.ok).toBe(true);
+			expect(updatedCredentials).toHaveLength(1);
+			const updated = updatedCredentials[0];
+			expect(updated?.type).toBe("oauth");
+			if (updated?.type !== "oauth") throw new Error("expected OAuth credential update");
+			expect(updated.apiEndpoint).toBe(apiEndpoint);
 		} finally {
 			storage.close();
 		}

--- a/packages/ai/test/github-copilot-login.test.ts
+++ b/packages/ai/test/github-copilot-login.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { getOAuthApiKey } from "@oh-my-pi/pi-ai/registry/oauth";
 import { loginGitHubCopilot } from "@oh-my-pi/pi-ai/registry/oauth/github-copilot";
 
 const FAST_POLL_OPTIONS = { pollIntervalFloorMs: 0, pollIntervalScaleMs: 1 } as const;
@@ -69,6 +70,67 @@ describe("loginGitHubCopilot", () => {
 		expect(credentials.expires).toBeGreaterThan(Date.now());
 		expect(credentials.enterpriseUrl).toBeUndefined();
 		expect(pollCount).toBeGreaterThanOrEqual(1);
+	});
+
+	it("stores business API endpoint and enables models against it", async () => {
+		const policyUrls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://github.com/login/device/code") {
+				return new Response(JSON.stringify(deviceCodeResponse()), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://github.com/login/oauth/access_token") {
+				return new Response(JSON.stringify(accessTokenResponse()), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://api.github.com/copilot_internal/user") {
+				return new Response(
+					JSON.stringify({
+						copilot_plan: "business",
+						endpoints: { api: "https://api.business.githubcopilot.com/" },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url.includes("/models/") && url.includes("/policy")) {
+				policyUrls.push(url);
+				return modelPolicyOk();
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		});
+
+		const credentials = await loginGitHubCopilot({
+			...FAST_POLL_OPTIONS,
+			fetch: fetchMock as unknown as typeof fetch,
+			onAuth: vi.fn(),
+			onPrompt: mockOnPrompt(""),
+		});
+
+		expect(credentials.apiEndpoint).toBe("https://api.business.githubcopilot.com");
+		expect(policyUrls.length).toBeGreaterThan(0);
+		expect(policyUrls.every(url => url.startsWith("https://api.business.githubcopilot.com/models/"))).toBe(true);
+	});
+
+	it("serializes business API endpoint into structured api keys", async () => {
+		const result = await getOAuthApiKey("github-copilot", {
+			"github-copilot": {
+				access: "ghu_test",
+				refresh: "ghu_test",
+				expires: Date.now() + 60_000,
+				apiEndpoint: "https://api.business.githubcopilot.com",
+			},
+		});
+
+		expect(result).not.toBeNull();
+		expect(JSON.parse(result!.apiKey)).toMatchObject({
+			token: "ghu_test",
+			apiEndpoint: "https://api.business.githubcopilot.com",
+		});
 	});
 
 	it("enterprise domain", async () => {

--- a/packages/ai/test/github-copilot-openai-base-url.test.ts
+++ b/packages/ai/test/github-copilot-openai-base-url.test.ts
@@ -39,6 +39,10 @@ function createUnauthorizedResponse(): Response {
 
 const testToken = "ghu_test_copilot_token";
 const enterpriseApiKey = JSON.stringify({ token: testToken, enterpriseUrl: "ghe.example.com" });
+const businessApiKey = JSON.stringify({
+	token: testToken,
+	apiEndpoint: "https://api.business.githubcopilot.com",
+});
 
 describe("GitHub Copilot OpenAI transport base URL", () => {
 	it("uses model baseUrl for chat completions", async () => {
@@ -95,6 +99,26 @@ describe("GitHub Copilot OpenAI transport base URL", () => {
 		expect(requestedAuthHeaders[0]).toBe(`Bearer ${testToken}`);
 	});
 
+	it("routes structured business credentials to the business chat completions host", async () => {
+		const requestedUrls: string[] = [];
+		const requestedAuthHeaders: Array<string | null> = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			requestedUrls.push(getRequestUrl(input));
+			requestedAuthHeaders.push(getRequestHeader(input, init, "Authorization"));
+			return createUnauthorizedResponse();
+		});
+
+		const model = getBundledModel("github-copilot", "gpt-4o") as Model<"openai-completions">;
+		const result = await streamOpenAICompletions(model, testContext, {
+			apiKey: businessApiKey,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(requestedUrls[0]).toBe("https://api.business.githubcopilot.com/chat/completions");
+		expect(requestedAuthHeaders[0]).toBe(`Bearer ${testToken}`);
+	});
+
 	it("routes structured enterprise credentials to the enterprise responses host", async () => {
 		const requestedUrls: string[] = [];
 		const requestedAuthHeaders: Array<string | null> = [];
@@ -112,6 +136,26 @@ describe("GitHub Copilot OpenAI transport base URL", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(requestedUrls[0]).toBe("https://copilot-api.ghe.example.com/responses");
+		expect(requestedAuthHeaders[0]).toBe(`Bearer ${testToken}`);
+	});
+
+	it("routes structured business credentials to the business responses host", async () => {
+		const requestedUrls: string[] = [];
+		const requestedAuthHeaders: Array<string | null> = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			requestedUrls.push(getRequestUrl(input));
+			requestedAuthHeaders.push(getRequestHeader(input, init, "Authorization"));
+			return createUnauthorizedResponse();
+		});
+
+		const model = getBundledModel("github-copilot", "gpt-5-mini") as Model<"openai-responses">;
+		const result = await streamOpenAIResponses(model, testContext, {
+			apiKey: businessApiKey,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(requestedUrls[0]).toBe("https://api.business.githubcopilot.com/responses");
 		expect(requestedAuthHeaders[0]).toBe(`Bearer ${testToken}`);
 	});
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Routed google-antigravity default baseUrl to the stable primary daily endpoint in the catalog generator and all fallback snapshots, resolving connection drops on heavy queries.
+- Fixed GitHub Copilot dynamic discovery to honor plan-specific API endpoints stored in structured OAuth credentials. ([#2876](https://github.com/can1357/oh-my-pi/issues/2876))
 
 ## [16.0.4] - 2026-06-17
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2808,9 +2808,11 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 	const parsedApiKey = rawApiKey ? parseGitHubCopilotApiKey(rawApiKey) : undefined;
 	const apiKey = parsedApiKey?.accessToken;
 	const baseUrl =
-		parsedApiKey?.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
-			? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
-			: configuredBaseUrl;
+		parsedApiKey?.apiEndpoint && configuredBaseUrl.includes("githubcopilot.com")
+			? parsedApiKey.apiEndpoint
+			: parsedApiKey?.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
+				? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
+				: configuredBaseUrl;
 	const providerRefs = createBundledReferenceMap<Api>("github-copilot");
 	const resolveReference = createReferenceResolver(providerRefs);
 	return {

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -30,11 +30,13 @@ export const COPILOT_API_HEADERS = {
 type GitHubCopilotApiKeyPayload = {
 	token?: unknown;
 	enterpriseUrl?: unknown;
+	apiEndpoint?: unknown;
 };
 
 export type ParsedGitHubCopilotApiKey = {
 	accessToken: string;
 	enterpriseUrl?: string;
+	apiEndpoint?: string;
 };
 
 const PUBLIC_GITHUB_HOSTS = new Set(["api.github.com", "github.com", "www.github.com"]);
@@ -51,6 +53,18 @@ export function normalizeGitHubCopilotEnterpriseDomain(input: string | undefined
 	return normalized;
 }
 
+export function normalizeGitHubCopilotApiEndpoint(input: string | undefined): string | undefined {
+	const trimmed = input?.trim();
+	if (!trimmed?.startsWith("https://")) return undefined;
+	try {
+		const url = new URL(trimmed);
+		if (url.protocol !== "https:" || !url.hostname) return undefined;
+		return trimmed.replace(/\/+$/, "");
+	} catch {
+		return undefined;
+	}
+}
+
 export function parseGitHubCopilotApiKey(apiKeyRaw: string): ParsedGitHubCopilotApiKey {
 	try {
 		const parsed = JSON.parse(apiKeyRaw) as GitHubCopilotApiKeyPayload;
@@ -60,6 +74,10 @@ export function parseGitHubCopilotApiKey(apiKeyRaw: string): ParsedGitHubCopilot
 				enterpriseUrl:
 					typeof parsed.enterpriseUrl === "string"
 						? normalizeGitHubCopilotEnterpriseDomain(parsed.enterpriseUrl)
+						: undefined,
+				apiEndpoint:
+					typeof parsed.apiEndpoint === "string"
+						? normalizeGitHubCopilotApiEndpoint(parsed.apiEndpoint)
 						: undefined,
 			};
 		}

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -81,6 +81,20 @@ describe("github copilot model limits mapping", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("unwraps structured OAuth keys for discovery and routes business discovery to the business host", async () => {
+		const structuredApiKey = JSON.stringify({
+			token: "ghu_test_copilot_token",
+			apiEndpoint: "https://api.business.githubcopilot.com",
+		});
+		const { fetchMock } = await discoverCopilotModels(
+			{ data: [] },
+			structuredApiKey,
+			"https://api.business.githubcopilot.com",
+			"ghu_test_copilot_token",
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("uses max_context_window_tokens as context window when Copilot reports a prompt budget", async () => {
 		const { models, fetchMock } = await discoverCopilotModels({
 			data: [

--- a/packages/catalog/test/github-copilot-wire.test.ts
+++ b/packages/catalog/test/github-copilot-wire.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	getGitHubCopilotBaseUrl,
+	normalizeGitHubCopilotApiEndpoint,
 	normalizeGitHubCopilotEnterpriseDomain,
 	parseGitHubCopilotApiKey,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
@@ -18,14 +19,26 @@ describe("GitHub Copilot OAuth helpers", () => {
 		expect(getGitHubCopilotBaseUrl("copilot-api.ghe.example.com")).toBe("https://copilot-api.ghe.example.com");
 	});
 
+	it("normalizes Copilot API endpoints", () => {
+		expect(normalizeGitHubCopilotApiEndpoint("https://api.business.githubcopilot.com/")).toBe(
+			"https://api.business.githubcopilot.com",
+		);
+		expect(normalizeGitHubCopilotApiEndpoint("http://api.business.githubcopilot.com")).toBeUndefined();
+	});
+
 	it("parses structured Copilot api keys", () => {
 		expect(
 			parseGitHubCopilotApiKey(
-				JSON.stringify({ token: "ghu_test_token", enterpriseUrl: "https://ghe.example.com" }),
+				JSON.stringify({
+					token: "ghu_test_token",
+					enterpriseUrl: "https://ghe.example.com",
+					apiEndpoint: "https://api.business.githubcopilot.com/",
+				}),
 			),
 		).toEqual({
 			accessToken: "ghu_test_token",
 			enterpriseUrl: "ghe.example.com",
+			apiEndpoint: "https://api.business.githubcopilot.com",
 		});
 	});
 });


### PR DESCRIPTION
## Repro
A structured GitHub Copilot credential with `apiEndpoint: "https://api.business.githubcopilot.com"` still routed through the bundled `https://api.githubcopilot.com` host before this fix. Reproduced with: `bun --cwd packages/ai -e 'import { resolveGitHubCopilotBaseUrl } from "./src/providers/github-copilot-headers.ts"; const key = JSON.stringify({ token: "ghu_test", apiEndpoint: "https://api.business.githubcopilot.com" }); const resolved = resolveGitHubCopilotBaseUrl("https://api.githubcopilot.com", key); if (resolved !== "https://api.business.githubcopilot.com") { console.error(`expected business endpoint, got ${resolved}`); process.exit(1); } console.log(resolved);'`.

## Cause
`packages/catalog/src/wire/github-copilot.ts` parsed only `token` and `enterpriseUrl`, while `packages/ai/src/providers/github-copilot-headers.ts` only rerouted GitHub Copilot requests for GHE `enterpriseUrl`. Business seats on github.com have no GHE domain, so the login-discovered `endpoints.api` value was never stored or serialized and every request fell back to the bundled `https://api.githubcopilot.com` base URL.

## Fix
- Discover `copilot_internal/user.endpoints.api` during `loginGitHubCopilot`, normalize it, store it on `OAuthCredentials`, preserve it through refresh/broker/usage/probe credential paths, and use it for login-time model policy enablement.
- Serialize and parse `apiEndpoint` in structured GitHub Copilot API keys, then prefer it over the generic bundled Copilot host while preserving explicit non-Copilot custom base URLs.
- Route GitHub Copilot dynamic model discovery through the stored plan-specific endpoint and add regression coverage for Business endpoint discovery, serialization, chat completions, Responses, and model discovery.

## Verification
Passed: `bun test packages/catalog/test/github-copilot-wire.test.ts packages/catalog/test/github-copilot-model-limits.test.ts packages/ai/test/github-copilot-login.test.ts packages/ai/test/github-copilot-openai-base-url.test.ts` (41 pass); `bun run --cwd packages/catalog check && bun run --cwd packages/ai check`; `gh_push_branch` pre-publish gate. Fixes #2876