### PR TITLE
feat(coding-agent): add startup splash setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -47,6 +47,14 @@ omp config reset steeringMode   # restore a key to its schema default
 omp config path                 # print the active agent directory
 ```
 
+For users who want the full first-run animation on normal launches, set `startup.showSplash`:
+
+```bash
+omp config set startup.showSplash true
+```
+
+This only controls the startup splash animation. It does not rerun setup or change setup state, and `startup.quiet: true` still suppresses all startup chrome including the splash.
+
 ### Subcommands
 
 | Command | Effect |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `startup.showSplash` (default `false`) to show the full setup splash animation on normal interactive startup while `startup.quiet` still suppresses startup chrome. ([#2880](https://github.com/can1357/oh-my-pi/issues/2880))
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1336,6 +1336,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"startup.showSplash": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Startup & Updates",
+			label: "Show Startup Splash",
+			description:
+				"Show the full animated setup splash on normal interactive startup without rerunning setup. Quiet Startup still suppresses it.",
+		},
+	},
+
 	"startup.setupWizard": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -68,6 +68,7 @@ import type { AuthStorage } from "./session/auth-storage";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
 import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
+import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
@@ -89,19 +90,6 @@ type RunRpcMode = (
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
 	eventBus?: EventBus,
 ) => Promise<never>;
-
-function maybeShowStartupSplash(options: {
-	isInteractive: boolean;
-	resuming: boolean;
-	quiet: boolean;
-	version: string;
-}): void {
-	if (!options.isInteractive) return;
-	if (options.resuming || options.quiet) return;
-	if ($env.PI_TIMING) return;
-	if (!process.stdin.isTTY || !process.stdout.isTTY) return;
-	//process.stdout.write(`${chalk.dim(`omp ${options.version}`)}\n${chalk.dim("Initializing session…")}\n`);
-}
 
 export function writeStartupNotice(parsedArgs: Pick<Args, "mode">, text: string): void {
 	(parsedArgs.mode === "json" ? process.stderr : process.stdout).write(text);
@@ -391,6 +379,7 @@ async function runInteractiveMode(
 	mcpManager: MCPManager | undefined,
 	resuming: boolean,
 	forceSetupWizard: boolean,
+	showStartupSplash: boolean,
 	eventBus?: EventBus,
 	initialMessage?: string,
 	initialImages?: ImageContent[],
@@ -411,10 +400,13 @@ async function runInteractiveMode(
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
 	// their TUI/OAuth/search/theme deps) is heavy, yet the common case only needs
 	// to know whether the stored setup version is current. Lazy-load the wizard
-	// barrel only when setup is stale or forced; otherwise skip it entirely.
+	// barrel only when setup is stale, forced, or the explicit startup splash
+	// setting needs the shared setup splash renderer.
 	const storedSetupVersion = settings.get("setupVersion");
 	const setupWizard =
-		forceSetupWizard || storedSetupVersion < CURRENT_SETUP_VERSION ? await import("./modes/setup-wizard") : undefined;
+		forceSetupWizard || storedSetupVersion < CURRENT_SETUP_VERSION || showStartupSplash
+			? await import("./modes/setup-wizard")
+			: undefined;
 	const setupScenes = setupWizard
 		? await setupWizard.selectSetupScenes(storedSetupVersion, setupWizard.ALL_SCENES, mode, {
 				resuming,
@@ -423,11 +415,16 @@ async function runInteractiveMode(
 				force: forceSetupWizard,
 			})
 		: [];
+	const playStartupSplash = showStartupSplash && setupScenes.length === 0;
 
 	await mode.init({
-		suppressWelcomeIntro: resuming || setupScenes.length > 0,
+		suppressWelcomeIntro: resuming || setupScenes.length > 0 || playStartupSplash,
 		clearInitialTerminalHistory: true,
 	});
+
+	if (setupWizard && playStartupSplash) {
+		await setupWizard.runStartupSplash(mode);
+	}
 
 	if (setupWizard && setupScenes.length > 0) {
 		await setupWizard.runSetupWizard(mode, setupScenes);
@@ -1261,11 +1258,14 @@ export async function runRootCommand(
 			stdinContent: pipedInput,
 		});
 
-		maybeShowStartupSplash({
+		const showStartupSplash = shouldShowStartupSplash({
+			configured: settingsInstance.get("startup.showSplash"),
 			isInteractive,
 			resuming: Boolean(parsedArgs.continue || parsedArgs.resume || parsedArgs.fork),
 			quiet: settingsInstance.get("startup.quiet"),
-			version: VERSION,
+			timing: Boolean($env.PI_TIMING),
+			stdinIsTTY: process.stdin.isTTY,
+			stdoutIsTTY: process.stdout.isTTY,
 		});
 
 		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager } = await createSession({
@@ -1357,6 +1357,7 @@ export async function runRootCommand(
 				mcpManager,
 				Boolean(parsedArgs.continue || parsedArgs.resume || parsedArgs.fork),
 				deps.forceSetupWizard === true,
+				showStartupSplash,
 				eventBus,
 				initialMessage,
 				initialImages,

--- a/packages/coding-agent/src/modes/setup-wizard/index.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/index.ts
@@ -9,6 +9,7 @@ import { SetupWizardComponent } from "./wizard-overlay";
 
 export type { SetupScene, SetupSceneController, SetupSceneHost, SetupSceneResult } from "./scenes/types";
 
+export { runStartupSplash } from "./startup-splash";
 export { CURRENT_SETUP_VERSION };
 
 export const ALL_SCENES = [

--- a/packages/coding-agent/src/modes/setup-wizard/startup-splash.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/startup-splash.ts
@@ -1,0 +1,107 @@
+import { type Component, matchesKey, type OverlayFocusOwner } from "@oh-my-pi/pi-tui";
+import type { InteractiveModeContext } from "../types";
+import { renderSetupSplash, SETUP_SPLASH_MS, SETUP_TICK_MS } from "./scenes/splash";
+
+export interface RunStartupSplashOptions {
+	readonly durationMs?: number;
+	readonly tickMs?: number;
+	readonly now?: () => number;
+}
+
+class StartupSplashComponent implements Component, OverlayFocusOwner {
+	#phaseStartedAt = 0;
+	#timer: NodeJS.Timeout | undefined;
+	#done = Promise.withResolvers<void>();
+	#disposed = false;
+	readonly #durationMs: number;
+	readonly #tickMs: number;
+	readonly #now: () => number;
+
+	constructor(
+		readonly ctx: InteractiveModeContext,
+		options: RunStartupSplashOptions = {},
+	) {
+		this.#durationMs = options.durationMs ?? SETUP_SPLASH_MS;
+		this.#tickMs = options.tickMs ?? SETUP_TICK_MS;
+		this.#now = options.now ?? (() => performance.now());
+	}
+
+	run(): Promise<void> {
+		this.#phaseStartedAt = this.#now();
+		this.#startTimer();
+		this.ctx.ui.requestRender();
+		return this.#done.promise;
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+		this.#stopTimer();
+	}
+
+	ownsOverlayFocusTarget(component: Component): boolean {
+		return component === this;
+	}
+
+	handleInput(data: string): void {
+		if (
+			matchesKey(data, "enter") ||
+			matchesKey(data, "return") ||
+			matchesKey(data, "space") ||
+			matchesKey(data, "escape")
+		) {
+			this.#complete();
+		}
+	}
+
+	render(width: number): readonly string[] {
+		const elapsedMs = Math.min(this.#durationMs, Math.max(0, this.#now() - this.#phaseStartedAt));
+		return renderSetupSplash(Math.max(1, width), Math.max(1, this.ctx.ui.terminal.rows), elapsedMs);
+	}
+
+	#startTimer(): void {
+		if (this.#timer) return;
+		this.#timer = setInterval(() => {
+			if (this.#disposed) return;
+			const elapsed = this.#now() - this.#phaseStartedAt;
+			if (elapsed >= this.#durationMs) {
+				this.#complete();
+				return;
+			}
+			this.ctx.ui.requestRender();
+		}, this.#tickMs);
+	}
+
+	#stopTimer(): void {
+		if (!this.#timer) return;
+		clearInterval(this.#timer);
+		this.#timer = undefined;
+	}
+
+	#complete(): void {
+		if (this.#disposed) return;
+		this.#stopTimer();
+		this.#done.resolve();
+	}
+}
+
+export async function runStartupSplash(
+	ctx: InteractiveModeContext,
+	options: RunStartupSplashOptions = {},
+): Promise<void> {
+	const component = new StartupSplashComponent(ctx, options);
+	const overlay = ctx.ui.showOverlay(component, {
+		width: "100%",
+		maxHeight: "100%",
+		anchor: "top-left",
+		margin: 0,
+		fullscreen: true,
+	});
+	try {
+		ctx.ui.setFocus(component);
+		await component.run();
+	} finally {
+		component.dispose();
+		ctx.ui.setFocus(component);
+		overlay.hide();
+	}
+}

--- a/packages/coding-agent/src/startup-splash.ts
+++ b/packages/coding-agent/src/startup-splash.ts
@@ -1,0 +1,17 @@
+export interface StartupSplashDecisionOptions {
+	readonly configured: boolean;
+	readonly isInteractive: boolean;
+	readonly resuming: boolean;
+	readonly quiet: boolean;
+	readonly timing: boolean;
+	readonly stdinIsTTY: boolean | undefined;
+	readonly stdoutIsTTY: boolean | undefined;
+}
+
+export function shouldShowStartupSplash(options: StartupSplashDecisionOptions): boolean {
+	if (!options.configured) return false;
+	if (!options.isInteractive) return false;
+	if (options.resuming || options.quiet) return false;
+	if (options.timing) return false;
+	return options.stdinIsTTY === true && options.stdoutIsTTY === true;
+}

--- a/packages/coding-agent/src/startup-splash.ts
+++ b/packages/coding-agent/src/startup-splash.ts
@@ -1,3 +1,4 @@
+/** Inputs used to decide whether the optional startup splash may run for this process. */
 export interface StartupSplashDecisionOptions {
 	readonly configured: boolean;
 	readonly isInteractive: boolean;
@@ -8,6 +9,7 @@ export interface StartupSplashDecisionOptions {
 	readonly stdoutIsTTY: boolean | undefined;
 }
 
+/** Returns true only for explicitly enabled, normal interactive TTY startup. */
 export function shouldShowStartupSplash(options: StartupSplashDecisionOptions): boolean {
 	if (!options.configured) return false;
 	if (!options.isInteractive) return false;

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -66,6 +66,12 @@ describe("Settings", () => {
 			expect(settings.get("tui.maxInlineImages")).toBe(8);
 		});
 
+		it("keeps the normal startup splash disabled by default", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("startup.showSplash")).toBe(false);
+			expect(getDefault("startup.showSplash")).toBe(false);
+		});
+
 		it("exposes all tool calling mode options", () => {
 			const values = getEnumValues("tools.format");
 			expect(values).toEqual([

--- a/packages/coding-agent/test/startup-splash.test.ts
+++ b/packages/coding-agent/test/startup-splash.test.ts
@@ -1,0 +1,67 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { runStartupSplash } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/startup-splash";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { shouldShowStartupSplash } from "@oh-my-pi/pi-coding-agent/startup-splash";
+import type { Component } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+describe("startup splash", () => {
+	it("requires the explicit setting and normal interactive TTY startup", () => {
+		const base = {
+			configured: true,
+			isInteractive: true,
+			resuming: false,
+			quiet: false,
+			timing: false,
+			stdinIsTTY: true,
+			stdoutIsTTY: true,
+		};
+
+		expect(shouldShowStartupSplash(base)).toBe(true);
+		expect(shouldShowStartupSplash({ ...base, configured: false })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, isInteractive: false })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, resuming: true })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, quiet: true })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, timing: true })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, stdinIsTTY: false })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, stdoutIsTTY: false })).toBe(false);
+	});
+
+	it("shows and hides a fullscreen setup-splash overlay", async () => {
+		let hidden = false;
+		let renderRequests = 0;
+		let focused: Component | undefined;
+		let overlayComponent: Component | undefined;
+
+		const ctx = {
+			ui: {
+				terminal: { rows: 8 },
+				showOverlay: (component: Component) => {
+					overlayComponent = component;
+					return {
+						hide: () => {
+							hidden = true;
+						},
+					};
+				},
+				setFocus: (component: Component) => {
+					focused = component;
+				},
+				requestRender: () => {
+					renderRequests += 1;
+				},
+			},
+		} as unknown as InteractiveModeContext;
+
+		await runStartupSplash(ctx, { durationMs: 0, tickMs: 1, now: () => 0 });
+
+		expect(hidden).toBe(true);
+		expect(renderRequests).toBeGreaterThan(0);
+		expect(focused).toBe(overlayComponent);
+		expect(overlayComponent?.render(32)).toHaveLength(8);
+	});
+});

--- a/packages/coding-agent/test/startup-splash.test.ts
+++ b/packages/coding-agent/test/startup-splash.test.ts
@@ -32,19 +32,24 @@ describe("startup splash", () => {
 	});
 
 	it("shows and hides a fullscreen setup-splash overlay", async () => {
+		const preSplashEditor: Component = { render: () => [] };
 		let hidden = false;
 		let renderRequests = 0;
-		let focused: Component | undefined;
+		let focused: Component | undefined = preSplashEditor;
 		let overlayComponent: Component | undefined;
-
 		const ctx = {
 			ui: {
 				terminal: { rows: 8 },
 				showOverlay: (component: Component) => {
 					overlayComponent = component;
+					const preFocus = focused;
+					focused = component;
 					return {
 						hide: () => {
 							hidden = true;
+							if (focused === component) {
+								focused = preFocus;
+							}
 						},
 					};
 				},
@@ -61,7 +66,7 @@ describe("startup splash", () => {
 
 		expect(hidden).toBe(true);
 		expect(renderRequests).toBeGreaterThan(0);
-		expect(focused).toBe(overlayComponent);
+		expect(focused).toBe(preSplashEditor);
 		expect(overlayComponent?.render(32)).toHaveLength(8);
 	});
 });


### PR DESCRIPTION
Fixes #2880

## Summary
- Add `startup.showSplash` as a default-off setting in Startup & Updates
- Show the existing setup splash animation on normal interactive startup when enabled
- Keep `startup.quiet`, resume/fork/continue, non-TTY, and `PI_TIMING` paths suppressed
- Document the config command and add focused regressions

## Tests
- bun --cwd=packages/coding-agent test test/startup-splash.test.ts test/settings-manager.test.ts
- bun --cwd=packages/coding-agent run check