### PR TITLE
feat(stats): add i18n support for dashboard UI

### DIFF
--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -19,10 +19,10 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
-import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { type Component, Container, Image, ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 beforeAll(() => {
 	initTheme();
@@ -171,8 +171,10 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 		},
 		addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) =>
 			helpers.addMessageToChat(message, options),
-		renderSessionContext: (context: SessionContext, options?: { updateFooter?: boolean; populateHistory?: boolean }) =>
-			helpers.renderSessionContext(context, options),
+		renderSessionContext: (
+			context: SessionContext,
+			options?: { updateFooter?: boolean; populateHistory?: boolean },
+		) => helpers.renderSessionContext(context, options),
 		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
 	helpers = new UiHelpers(ctx);
@@ -277,7 +279,9 @@ describe("UiHelpers.renderInitialMessages — image replay", () => {
 			isError: false,
 			timestamp: 2,
 		});
-		session.appendMessage(assistantToolCall("eval-reopened", "eval", { cells: [{ language: "py", code: "display(image)" }] }));
+		session.appendMessage(
+			assistantToolCall("eval-reopened", "eval", { cells: [{ language: "py", code: "display(image)" }] }),
+		);
 		session.appendMessage({
 			role: "toolResult",
 			toolCallId: "eval-reopened",

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- New Projects view summarizing usage, cost, and reliability per project folder (backed by the existing `/api/stats/folders` endpoint).
+- System-aware light/dark theme toggle — follows the OS by default, and an explicit choice persists across reloads.
 - Added i18n (internationalization) support for the stats dashboard UI with English and Chinese translations. Language preference persists in localStorage and auto-detects browser language.
 
 ### Changed

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Added
 
-- New Projects view summarizing usage, cost, and reliability per project folder (backed by the existing `/api/stats/folders` endpoint).
-- System-aware light/dark theme toggle — follows the OS by default, and an explicit choice persists across reloads.
+- Added i18n (internationalization) support for the stats dashboard UI with English and Chinese translations. Language preference persists in localStorage and auto-detects browser language.
 
 ### Changed
 

--- a/packages/stats/src/client/app/AppLayout.tsx
+++ b/packages/stats/src/client/app/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { useTranslation } from "../i18n";
 import type { TimeRange } from "../types";
 import { NavRail } from "./NavRail";
 import type { DashboardSection } from "./routes";
@@ -27,6 +28,7 @@ export function AppLayout({
 	onSyncComplete,
 	children,
 }: AppLayoutProps) {
+	const { t } = useTranslation();
 	const [menuOpen, setMenuOpen] = useState(false);
 
 	const handleSectionChange = (section: DashboardSection) => {
@@ -47,18 +49,18 @@ export function AppLayout({
 						onClick={e => e.stopPropagation()}
 						role="dialog"
 						aria-modal="true"
-						aria-label="Navigation menu"
+						aria-label={t("nav.menu")}
 					>
 						<div className="stats-mobile-drawer-header">
 							<div className="stats-logo-container">
 								<span className="stats-logo-text">OH MY PI</span>
-								<span className="stats-logo-subtext">Observability</span>
+								<span className="stats-logo-subtext">{t("nav.observability")}</span>
 							</div>
 							<button
 								type="button"
 								onClick={() => setMenuOpen(false)}
 								className="stats-drawer-close-btn"
-								aria-label="Close navigation menu"
+								aria-label={t("nav.closeMenu")}
 							>
 								<X size={18} />
 							</button>

--- a/packages/stats/src/client/app/NavRail.tsx
+++ b/packages/stats/src/client/app/NavRail.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "../i18n";
-import { getRoutes, type DashboardSection } from "./routes";
+import { type DashboardSection, getRoutes } from "./routes";
 
 export interface NavRailProps {
 	activeSection: DashboardSection;

--- a/packages/stats/src/client/app/NavRail.tsx
+++ b/packages/stats/src/client/app/NavRail.tsx
@@ -1,4 +1,5 @@
-import { type DashboardSection, routes } from "./routes";
+import { useTranslation } from "../i18n";
+import { getRoutes, type DashboardSection } from "./routes";
 
 export interface NavRailProps {
 	activeSection: DashboardSection;
@@ -7,12 +8,15 @@ export interface NavRailProps {
 }
 
 export function NavRail({ activeSection, onSectionChange, className = "" }: NavRailProps) {
+	const { t } = useTranslation();
+	const routes = getRoutes(t);
+
 	return (
 		<aside className={`stats-nav-rail ${className}`}>
 			<div className="stats-nav-rail-header">
 				<div className="stats-logo-container">
 					<span className="stats-logo-text">OH MY PI</span>
-					<span className="stats-logo-subtext">Observability</span>
+					<span className="stats-logo-subtext">{t("nav.observability")}</span>
 				</div>
 			</div>
 
@@ -37,7 +41,7 @@ export function NavRail({ activeSection, onSectionChange, className = "" }: NavR
 			</nav>
 
 			<div className="stats-nav-rail-footer">
-				<span className="stats-version-tag">OMP Stats v1.0.0</span>
+				<span className="stats-version-tag">{t("nav.version", { version: "1.0.0" })}</span>
 			</div>
 		</aside>
 	);

--- a/packages/stats/src/client/app/RangeControl.tsx
+++ b/packages/stats/src/client/app/RangeControl.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "../i18n";
 import type { TimeRange } from "../types";
 
 export interface RangeControlProps {
@@ -6,31 +7,27 @@ export interface RangeControlProps {
 	className?: string;
 }
 
-const RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
-	{ value: "1h", label: "1h" },
-	{ value: "24h", label: "24h" },
-	{ value: "7d", label: "7d" },
-	{ value: "30d", label: "30d" },
-	{ value: "90d", label: "90d" },
-	{ value: "all", label: "All" },
-];
+const RANGE_VALUES: TimeRange[] = ["1h", "24h", "7d", "30d", "90d", "all"];
 
 export function RangeControl({ value, onChange, className = "" }: RangeControlProps) {
+	const { t } = useTranslation();
+
 	return (
-		<div className={`stats-range-control ${className}`} role="radiogroup" aria-label="Select time range">
-			{RANGE_OPTIONS.map(opt => {
-				const isActive = opt.value === value;
+		<div className={`stats-range-control ${className}`} role="radiogroup" aria-label={t("rangeControl.selectRange")}>
+			{RANGE_VALUES.map(rangeValue => {
+				const isActive = rangeValue === value;
+				const label = rangeValue === "all" ? t("rangeControl.all") : rangeValue;
 				return (
 					<button
-						key={opt.value}
+						key={rangeValue}
 						type="button"
 						role="radio"
 						aria-checked={isActive}
 						data-active={isActive ? "true" : "false"}
 						className="stats-range-control-btn"
-						onClick={() => onChange(opt.value)}
+						onClick={() => onChange(rangeValue)}
 					>
-						{opt.label}
+						{label}
 					</button>
 				);
 			})}

--- a/packages/stats/src/client/app/SyncButton.tsx
+++ b/packages/stats/src/client/app/SyncButton.tsx
@@ -1,6 +1,7 @@
 import { RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { sync } from "../api";
+import { useTranslation } from "../i18n";
 
 export interface SyncButtonProps {
 	onSyncStart?: () => void;
@@ -13,6 +14,7 @@ export interface SyncButtonProps {
 }
 
 export function SyncButton({ onSyncStart, onSyncComplete, className = "" }: SyncButtonProps) {
+	const { t } = useTranslation();
 	const [syncing, setSyncing] = useState(false);
 	const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
@@ -34,7 +36,7 @@ export function SyncButton({ onSyncStart, onSyncComplete, className = "" }: Sync
 			};
 			setStatus({
 				type: "success",
-				message: `Synced: ${result.processed} new request${result.processed === 1 ? "" : "s"} found.`,
+				message: t("sync.synced", { count: result.processed }),
 			});
 			if (onSyncComplete) {
 				onSyncComplete({ success: true, data: result });
@@ -43,7 +45,7 @@ export function SyncButton({ onSyncStart, onSyncComplete, className = "" }: Sync
 			const errorMessage = err instanceof Error ? err.message : String(err);
 			setStatus({
 				type: "error",
-				message: `Sync failed: ${errorMessage}`,
+				message: t("sync.failed", { error: errorMessage }),
 			});
 			if (onSyncComplete) {
 				onSyncComplete({ success: false, error: errorMessage });
@@ -68,7 +70,7 @@ export function SyncButton({ onSyncStart, onSyncComplete, className = "" }: Sync
 				aria-busy={syncing}
 			>
 				<RefreshCw size={14} className={`stats-sync-icon ${syncing ? "stats-spin" : ""}`} />
-				{syncing ? "Syncing..." : "Sync DB"}
+				{syncing ? t("sync.syncing") : t("sync.syncDb")}
 			</button>
 		</div>
 	);

--- a/packages/stats/src/client/app/ThemeToggle.tsx
+++ b/packages/stats/src/client/app/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import { type LucideIcon, Monitor, Moon, Sun } from "lucide-react";
+import { useTranslation } from "../i18n";
 import { type ThemePreference, useThemePreference } from "../useSystemTheme";
 
 const NEXT_PREFERENCE: Record<ThemePreference, ThemePreference> = {
@@ -13,23 +14,21 @@ const PREFERENCE_ICON: Record<ThemePreference, LucideIcon> = {
 	dark: Moon,
 };
 
-const PREFERENCE_LABEL: Record<ThemePreference, string> = {
-	system: "System theme",
-	light: "Light theme",
-	dark: "Dark theme",
-};
-
 export function ThemeToggle() {
+	const { t } = useTranslation();
 	const { preference, setPreference } = useThemePreference();
 	const Icon = PREFERENCE_ICON[preference];
+
+	const labelKey = `theme.${preference}` as const;
+	const label = t(labelKey);
 
 	return (
 		<button
 			type="button"
 			className="stats-theme-toggle"
 			onClick={() => setPreference(NEXT_PREFERENCE[preference])}
-			aria-label={`${PREFERENCE_LABEL[preference]} (click to switch)`}
-			title={`${PREFERENCE_LABEL[preference]} — click to switch`}
+			aria-label={t("theme.switchHint", { theme: label })}
+			title={t("theme.switchHint", { theme: label })}
 		>
 			<Icon size={16} />
 		</button>

--- a/packages/stats/src/client/app/ThemeToggle.tsx
+++ b/packages/stats/src/client/app/ThemeToggle.tsx
@@ -27,6 +27,7 @@ export function ThemeToggle() {
 		<button
 			type="button"
 			className="stats-theme-toggle"
+			onClick={() => setPreference(nextPreference)}
 			aria-label={t("theme.switchHint", { theme: nextLabel })}
 			title={t("theme.switchHint", { theme: nextLabel })}
 		>

--- a/packages/stats/src/client/app/ThemeToggle.tsx
+++ b/packages/stats/src/client/app/ThemeToggle.tsx
@@ -19,16 +19,16 @@ export function ThemeToggle() {
 	const { preference, setPreference } = useThemePreference();
 	const Icon = PREFERENCE_ICON[preference];
 
-	const labelKey = `theme.${preference}` as const;
-	const label = t(labelKey);
+	const nextPreference = NEXT_PREFERENCE[preference];
+	const nextLabelKey = `theme.${nextPreference}` as const;
+	const nextLabel = t(nextLabelKey);
 
 	return (
 		<button
 			type="button"
 			className="stats-theme-toggle"
-			onClick={() => setPreference(NEXT_PREFERENCE[preference])}
-			aria-label={t("theme.switchHint", { theme: label })}
-			title={t("theme.switchHint", { theme: label })}
+			aria-label={t("theme.switchHint", { theme: nextLabel })}
+			title={t("theme.switchHint", { theme: nextLabel })}
 		>
 			<Icon size={16} />
 		</button>

--- a/packages/stats/src/client/app/TopBar.tsx
+++ b/packages/stats/src/client/app/TopBar.tsx
@@ -69,7 +69,7 @@ export function TopBar({
 
 				<select
 					value={getLocale()}
-					onChange={(e) => setLocale(e.target.value as "en" | "zh")}
+					onChange={e => setLocale(e.target.value as "en" | "zh")}
 					className="stats-language-select"
 					aria-label={t("topBar.languageToggle")}
 					title={t("topBar.languageToggle")}

--- a/packages/stats/src/client/app/TopBar.tsx
+++ b/packages/stats/src/client/app/TopBar.tsx
@@ -1,8 +1,9 @@
 import { Menu } from "lucide-react";
+import { getLocale, setLocale, useTranslation } from "../i18n";
 import type { TimeRange } from "../types";
 import { RangeControl } from "./RangeControl";
 import type { DashboardSection } from "./routes";
-import { routes } from "./routes";
+import { getRoutes } from "./routes";
 import { SyncButton } from "./SyncButton";
 import { ThemeToggle } from "./ThemeToggle";
 
@@ -27,13 +28,15 @@ export function TopBar({
 	onMenuToggle,
 	className = "",
 }: TopBarProps) {
+	const { t } = useTranslation();
+	const routes = getRoutes(t);
 	const currentRoute = routes.find(r => r.id === activeSection);
-	const title = currentRoute?.label || "Observability";
+	const title = currentRoute?.label || t("topBar.observability");
 
 	const formatLastUpdated = (time: number | null) => {
-		if (!time) return "Not updated";
+		if (!time) return t("topBar.notUpdated");
 		const date = new Date(time);
-		return `Updated ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}`;
+		return `${t("topBar.updated")} ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}`;
 	};
 
 	return (
@@ -44,7 +47,7 @@ export function TopBar({
 						type="button"
 						onClick={onMenuToggle}
 						className="stats-mobile-menu-btn"
-						aria-label="Open navigation menu"
+						aria-label={t("topBar.openMenu")}
 					>
 						<Menu size={20} />
 					</button>
@@ -63,6 +66,17 @@ export function TopBar({
 				</div>
 
 				<RangeControl value={range} onChange={onRangeChange} />
+
+				<select
+					value={getLocale()}
+					onChange={(e) => setLocale(e.target.value as "en" | "zh")}
+					className="stats-language-select"
+					aria-label={t("topBar.languageToggle")}
+					title={t("topBar.languageToggle")}
+				>
+					<option value="en">English</option>
+					<option value="zh">中文</option>
+				</select>
 
 				<ThemeToggle />
 

--- a/packages/stats/src/client/app/TopBar.tsx
+++ b/packages/stats/src/client/app/TopBar.tsx
@@ -36,7 +36,8 @@ export function TopBar({
 	const formatLastUpdated = (time: number | null) => {
 		if (!time) return t("topBar.notUpdated");
 		const date = new Date(time);
-		return `${t("topBar.updated")} ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}`;
+		const timeStr = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+		return t("topBar.updated", { time: timeStr });
 	};
 
 	return (

--- a/packages/stats/src/client/app/routes.ts
+++ b/packages/stats/src/client/app/routes.ts
@@ -1,5 +1,6 @@
 import { Activity, AlertCircle, Coins, Cpu, Folder, LayoutDashboard, Smile } from "lucide-react";
 import type React from "react";
+import type { TranslationFn } from "../i18n";
 
 export type DashboardSection = "overview" | "requests" | "errors" | "models" | "costs" | "behavior" | "projects";
 
@@ -10,41 +11,43 @@ export interface DashboardRoute {
 	icon: React.ComponentType<{ size?: number; className?: string }>;
 }
 
-export const routes: DashboardRoute[] = [
-	{
-		id: "overview",
-		label: "Overview",
-		icon: LayoutDashboard,
-	},
-	{
-		id: "requests",
-		label: "Requests",
-		icon: Activity,
-	},
-	{
-		id: "errors",
-		label: "Errors",
-		icon: AlertCircle,
-	},
-	{
-		id: "models",
-		label: "Models",
-		icon: Cpu,
-	},
-	{
-		id: "costs",
-		label: "Costs",
-		icon: Coins,
-	},
-	{
-		id: "behavior",
-		label: "Behavior",
-		shortLabel: "Behavior",
-		icon: Smile,
-	},
-	{
-		id: "projects",
-		label: "Projects",
-		icon: Folder,
-	},
-];
+export function getRoutes(t: TranslationFn): DashboardRoute[] {
+	return [
+		{
+			id: "overview",
+			label: t("nav.section.overview"),
+			icon: LayoutDashboard,
+		},
+		{
+			id: "requests",
+			label: t("nav.section.requests"),
+			icon: Activity,
+		},
+		{
+			id: "errors",
+			label: t("nav.section.errors"),
+			icon: AlertCircle,
+		},
+		{
+			id: "models",
+			label: t("nav.section.models"),
+			icon: Cpu,
+		},
+		{
+			id: "costs",
+			label: t("nav.section.costs"),
+			icon: Coins,
+		},
+		{
+			id: "behavior",
+			label: t("nav.section.behavior"),
+			shortLabel: t("nav.section.behavior"),
+			icon: Smile,
+		},
+		{
+			id: "projects",
+			label: t("nav.section.projects"),
+			icon: Folder,
+		},
+	];
+}

--- a/packages/stats/src/client/components/models-table-shared.tsx
+++ b/packages/stats/src/client/components/models-table-shared.tsx
@@ -6,6 +6,7 @@
  */
 
 import { format } from "date-fns";
+import { useTranslation } from "../i18n";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Line } from "react-chartjs-2";
 import type { ChartTheme } from "./chart-shared";
@@ -250,6 +251,8 @@ export function TrendEmpty() {
 }
 
 /** Placeholder shown in the expanded detail-chart slot when data is missing. */
-export function DetailChartEmpty({ message = "No data available" }: { message?: string }) {
-	return <div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">{message}</div>;
+export function DetailChartEmpty({ message }: { message?: string }) {
+	const { t } = useTranslation();
+	const displayMessage = message ?? t("common.noData");
+	return <div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">{displayMessage}</div>;
 }

--- a/packages/stats/src/client/components/models-table-shared.tsx
+++ b/packages/stats/src/client/components/models-table-shared.tsx
@@ -6,9 +6,9 @@
  */
 
 import { format } from "date-fns";
-import { useTranslation } from "../i18n";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Line } from "react-chartjs-2";
+import { useTranslation } from "../i18n";
 import type { ChartTheme } from "./chart-shared";
 
 // Detail-table charts share the exact OMP chart chrome as the timeline charts;
@@ -254,5 +254,7 @@ export function TrendEmpty() {
 export function DetailChartEmpty({ message }: { message?: string }) {
 	const { t } = useTranslation();
 	const displayMessage = message ?? t("common.noData");
-	return <div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">{displayMessage}</div>;
+	return (
+		<div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">{displayMessage}</div>
+	);
 }

--- a/packages/stats/src/client/components/range-meta.ts
+++ b/packages/stats/src/client/components/range-meta.ts
@@ -5,6 +5,7 @@
  */
 
 import { format } from "date-fns";
+import type { TranslationFn } from "../i18n";
 import type { TimeRange } from "../types";
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -24,50 +25,74 @@ export interface RangeMeta {
 	tickFormat: string;
 }
 
-const RANGE_META: Record<TimeRange, RangeMeta> = {
+const RANGE_META_BASE: Record<TimeRange, Omit<RangeMeta, "windowLabel">> = {
 	"1h": {
-		windowLabel: "the last hour",
 		trendLabel: "1h Trend",
 		bucketMs: FIVE_MIN_MS,
 		bucketCount: 12,
 		tickFormat: "HH:mm",
 	},
 	"24h": {
-		windowLabel: "the last 24 hours",
 		trendLabel: "24h Trend",
 		bucketMs: HOUR_MS,
 		bucketCount: 24,
 		tickFormat: "HH:mm",
 	},
 	"7d": {
-		windowLabel: "the last 7 days",
 		trendLabel: "7d Trend",
 		bucketMs: DAY_MS,
 		bucketCount: 7,
 		tickFormat: "MMM d",
 	},
 	"30d": {
-		windowLabel: "the last 30 days",
 		trendLabel: "30d Trend",
 		bucketMs: DAY_MS,
 		bucketCount: 30,
 		tickFormat: "MMM d",
 	},
 	"90d": {
-		windowLabel: "the last 90 days",
 		trendLabel: "90d Trend",
 		bucketMs: DAY_MS,
 		bucketCount: 90,
 		tickFormat: "MMM d",
 	},
-	all: { windowLabel: "all time", trendLabel: "Trend", bucketMs: DAY_MS, bucketCount: 0, tickFormat: "MMM d" },
+	all: { trendLabel: "Trend", bucketMs: DAY_MS, bucketCount: 0, tickFormat: "MMM d" },
 };
 
-export function rangeMeta(range: TimeRange): RangeMeta {
-	return RANGE_META[range];
+const WINDOW_LABEL_KEY: Record<TimeRange, string> = {
+	"1h": "range.lastHour",
+	"24h": "range.last24h",
+	"7d": "range.last7d",
+	"30d": "range.last30d",
+	"90d": "range.last90d",
+	all: "range.all",
+};
+
+export interface RangeBucketMeta {
+	/** Bucket size matching the server query for this range. */
+	bucketMs: number;
+	/** Number of buckets the server is expected to return for this range. */
+	bucketCount: number;
 }
 
-/** Format a bucket timestamp using the active range's tick format. */
+/** Get bucketing metadata without translation - for data processing functions. */
+export function rangeBucketMeta(range: TimeRange): RangeBucketMeta {
+	const base = RANGE_META_BASE[range];
+	return {
+		bucketMs: base.bucketMs,
+		bucketCount: base.bucketCount,
+	};
+}
+
+export function rangeMeta(range: TimeRange, t: TranslationFn): RangeMeta {
+	const base = RANGE_META_BASE[range];
+	return {
+		...base,
+		windowLabel: t(WINDOW_LABEL_KEY[range]),
+	};
+}
+
+/** Format a timestamp using the range's tick format. */
 export function formatRangeTick(timestamp: number, range: TimeRange): string {
-	return format(new Date(timestamp), RANGE_META[range].tickFormat);
+	return format(new Date(timestamp), RANGE_META_BASE[range].tickFormat);
 }

--- a/packages/stats/src/client/components/range-meta.ts
+++ b/packages/stats/src/client/components/range-meta.ts
@@ -65,7 +65,7 @@ const WINDOW_LABEL_KEY: Record<TimeRange, string> = {
 	"7d": "range.last7d",
 	"30d": "range.last30d",
 	"90d": "range.last90d",
-	all: "range.all",
+	all: "range.allTime",
 };
 
 export interface RangeBucketMeta {

--- a/packages/stats/src/client/components/range-meta.ts
+++ b/packages/stats/src/client/components/range-meta.ts
@@ -89,6 +89,7 @@ export function rangeMeta(range: TimeRange, t: TranslationFn): RangeMeta {
 	return {
 		...base,
 		windowLabel: t(WINDOW_LABEL_KEY[range]),
+		trendLabel: t(`trend.${range}`),
 	};
 }
 

--- a/packages/stats/src/client/data/formatters.ts
+++ b/packages/stats/src/client/data/formatters.ts
@@ -1,11 +1,14 @@
 import { formatDistanceToNow } from "date-fns";
+import { zhCN } from "date-fns/locale";
+import type { Locale } from "../i18n";
 
 export function formatInteger(value: number): string {
 	return value.toLocaleString();
 }
 
-export function formatCompact(value: number): string {
-	return value.toLocaleString(undefined, { notation: "compact" });
+export function formatCompact(value: number, locale: "en" | "zh" = "en"): string {
+	const displayLocale = locale === "zh" ? "zh-CN" : "en-US";
+	return value.toLocaleString(displayLocale, { notation: "compact" });
 }
 
 export function formatCost(value: number, digits?: number): string {
@@ -33,6 +36,9 @@ export function formatTokensPerSecond(value: number | null): string {
 	return value.toFixed(1);
 }
 
-export function formatRelativeTime(timestamp: number): string {
-	return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+export function formatRelativeTime(timestamp: number, locale: Locale = "en"): string {
+	return formatDistanceToNow(new Date(timestamp), {
+		addSuffix: true,
+		locale: locale === "zh" ? zhCN : undefined,
+	});
 }

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -1,4 +1,4 @@
-import { rangeMeta } from "../components/range-meta";
+import { rangeBucketMeta } from "../components/range-meta";
 import type {
 	BehaviorOverallStats,
 	BehaviorTimeSeriesPoint,
@@ -78,7 +78,7 @@ export function buildModelPerformanceLookup(
 ): Map<string, ModelPerformanceSeries> {
 	if (points.length === 0) return new Map();
 
-	const meta = rangeMeta(range);
+	const meta = rangeBucketMeta(range);
 	const bucketMs = meta.bucketMs;
 	const bucketCount = meta.bucketCount;
 

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -347,10 +347,13 @@ const translations: Record<Locale, Record<string, string>> = {
 		"nav.menu.open": "打开导航菜单",
 		"nav.menu.close": "关闭导航菜单",
 		"nav.menu.title": "导航菜单",
+		"nav.observability": "可观测性",
 
 		// Top bar
 		"topBar.notUpdated": "未更新",
 		"topBar.updated": "已更新 {time}",
+		"topBar.languageToggle": "切换语言",
+		"topBar.openMenu": "打开菜单",
 
 		// Time ranges
 		"range.all": "全部",
@@ -375,6 +378,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"theme.system": "系统主题",
 		"theme.light": "浅色主题",
 		"theme.dark": "深色主题",
+		"theme.switchHint": "切换到{theme}",
 
 		// Metrics
 		"metric.totalCost": "总成本",
@@ -432,6 +436,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"requests.title": "所有最近请求",
 		"requests.subtitle": "OMP 处理的最多50个最近请求",
 		"requests.noRequests": "未找到最近请求",
+		"requests.status.failed": "失败",
 		"requests.status.success": "成功",
 		"requests.column.time": "时间",
 		"requests.column.model": "模型",
@@ -452,6 +457,9 @@ const translations: Record<Locale, Record<string, string>> = {
 		"errors.column.tokens": "Tokens",
 		"errors.column.cost": "成本",
 		"errors.column.errorMessage": "错误信息",
+		"errors.status.failed": "失败",
+		"errors.unknownError": "未知错误",
+		"errors.noFailures": "无最近失败",
 
 		// Models route
 		"models.preference": "模型偏好",

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -125,7 +125,6 @@ const translations: Record<Locale, Record<string, string>> = {
 		"requests.column.model": "Model",
 		"requests.column.status": "Status",
 		"requests.column.tokens": "Tokens",
-		"requests.column.tokens": "Tokens",
 		"requests.column.inputOutput": "Input/Output",
 		"requests.column.cache": "Cache R/W",
 		"requests.column.tokensPerSec": "Tokens/s",

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -13,7 +13,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		// Navigation
 		"nav.title": "OH MY PI",
 		"nav.subtitle": "Observability",
-		"nav.version": "OMP Stats v1.0.0",
+		"nav.version": "OMP Stats v{version}",
 		"nav.section.overview": "Overview",
 		"nav.section.requests": "Requests",
 		"nav.section.errors": "Errors",
@@ -43,6 +43,14 @@ const translations: Record<Locale, Record<string, string>> = {
 		"range.last30d": "the last 30 days",
 		"range.last90d": "the last 90 days",
 
+		// Trend labels (for table columns)
+		"trend.1h": "1h Trend",
+		"trend.24h": "24h Trend",
+		"trend.7d": "7d Trend",
+		"trend.30d": "30d Trend",
+		"trend.90d": "90d Trend",
+		"trend.all": "Trend",
+
 		// Range control
 		"rangeControl.all": "All",
 		"rangeControl.selectRange": "Select time range",
@@ -51,7 +59,6 @@ const translations: Record<Locale, Record<string, string>> = {
 		// Sync button
 		"sync.syncing": "Syncing...",
 		"sync.syncDb": "Sync DB",
-		"sync.db": "Sync DB",
 		"sync.synced": "Synced {count} requests",
 		"sync.success": "Synced: {count} new request{plural} found.",
 		"sync.failed": "Sync failed: {error}",
@@ -101,17 +108,11 @@ const translations: Record<Locale, Record<string, string>> = {
 		"overview.throughput": "System Throughput",
 		"overview.throughput.title": "System Throughput",
 		"overview.throughput.subtitle": "Request volume and errors over time",
-		"overview.throughputSub": "Request volume and errors over time",
-		"overview.feed": "Operational Feed",
 		"overview.feed.title": "Operational Feed",
 		"overview.feed.subtitle": "Real-time request log",
-		"overview.feedSub": "Real-time request log",
-		"overview.preview": "Recent Requests Preview",
 		"overview.preview.title": "Recent Requests Preview",
 		"overview.preview.subtitle": "Latest transactions processed by the proxy",
-		"overview.previewSub": "Latest transactions processed by the proxy",
 		"overview.viewAll": "View All Requests",
-		"overview.noRequests": "No recent requests found",
 		"overview.noRecentRequests": "No recent requests found",
 		"overview.noTimeSeries": "No time-series data available",
 		"overview.chart.requests": "Requests",
@@ -148,8 +149,6 @@ const translations: Record<Locale, Record<string, string>> = {
 
 		// Models route
 		"models.preference": "Model Preference",
-		"models.preferenceSub": "Share of requests over {window}",
-		"models.share.title": "Model Share",
 		"models.noData": "No data available",
 		"models.statistics": "Model Statistics",
 		"models.requests": "Requests",
@@ -201,7 +200,6 @@ const translations: Record<Locale, Record<string, string>> = {
 		"behavior.userMessages": "User Messages",
 		"behavior.inRange": "in range",
 		"behavior.asPercentOfMessages": "as % of messages",
-		"behavior.yelling": "Yelling (CAPS)",
 		"behavior.yellingCaps": "Yelling (CAPS)",
 		"behavior.profanityHits": "Profanity Hits",
 		"behavior.anguishSignals": "Anguish Signals",
@@ -233,16 +231,15 @@ const translations: Record<Locale, Record<string, string>> = {
 		"behavior.allCombined": "All signals combined",
 		"behavior.model": "Model",
 		"behavior.messagesCol": "Messages",
-		"behavior.capsPercent": "CAPS %",
-		"behavior.profanityPercent": "Profanity %",
+		"behavior.percentOfMsgs": "% of msgs",
+		"behavior.perMsg": "Per msg",
+		"behavior.perMsgSuffix": "/ msg",
 		"behavior.anguishPercent": "Anguish %",
 		"behavior.frustrationPercent": "Frustration %",
 		"behavior.hitsPercent": "Hits %",
 		"behavior.trend": "Trend",
 		"behavior.avgCharsPerMsg": "Avg chars / msg",
 		"behavior.total": "Total",
-		"behavior.percentOfMsgs": "% of msgs",
-		"behavior.perMsg": "Per msg",
 		"behavior.detailTotal": "Total",
 		"behavior.detailPerMsg": "Per msg",
 		"behavior.detailRate": "Rate",
@@ -336,7 +333,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		// Navigation
 		"nav.title": "OH MY PI",
 		"nav.subtitle": "可观测性",
-		"nav.version": "OMP Stats v1.0.0",
+		"nav.version": "OMP Stats v{version}",
 		"nav.section.overview": "概览",
 		"nav.section.requests": "请求",
 		"nav.section.errors": "错误",
@@ -351,13 +348,6 @@ const translations: Record<Locale, Record<string, string>> = {
 		"nav.menu": "导航菜单",
 		"nav.closeMenu": "关闭导航菜单",
 
-		// Top bar
-		"topBar.observability": "可观测性",
-		"topBar.notUpdated": "未更新",
-		"topBar.updated": "已更新 {time}",
-		"topBar.languageToggle": "切换语言",
-		"topBar.openMenu": "打开菜单",
-
 		// Time ranges
 		"range.all": "全部",
 		"range.lastHour": "过去一小时",
@@ -365,6 +355,14 @@ const translations: Record<Locale, Record<string, string>> = {
 		"range.last7d": "过去7天",
 		"range.last30d": "过去30天",
 		"range.last90d": "过去90天",
+
+		// Trend labels (for table columns)
+		"trend.1h": "1小时趋势",
+		"trend.24h": "24小时趋势",
+		"trend.7d": "7天趋势",
+		"trend.30d": "30天趋势",
+		"trend.90d": "90天趋势",
+		"trend.all": "趋势",
 
 		// Range control
 		"rangeControl.label": "选择时间范围",
@@ -374,8 +372,6 @@ const translations: Record<Locale, Record<string, string>> = {
 		// Sync button
 		"sync.syncing": "同步中...",
 		"sync.syncDb": "同步数据库",
-		"sync.db": "同步数据库",
-		"sync.synced": "已同步 {count} 个请求",
 		"sync.success": "同步完成: 发现 {count} 个新请求。",
 		"sync.failed": "同步失败: {error}",
 
@@ -421,17 +417,11 @@ const translations: Record<Locale, Record<string, string>> = {
 		"overview.throughput": "系统吞吐量",
 		"overview.throughput.title": "系统吞吐量",
 		"overview.throughput.subtitle": "请求量和错误随时间变化",
-		"overview.throughputSub": "请求量和错误随时间变化",
-		"overview.feed": "实时动态",
 		"overview.feed.title": "实时动态",
 		"overview.feed.subtitle": "实时请求日志",
-		"overview.feedSub": "实时请求日志",
-		"overview.preview": "最近请求预览",
 		"overview.preview.title": "最近请求预览",
 		"overview.preview.subtitle": "代理处理的最新事务",
-		"overview.previewSub": "代理处理的最新事务",
 		"overview.viewAll": "查看所有请求",
-		"overview.noRequests": "未找到最近请求",
 		"overview.noRecentRequests": "未找到最近请求",
 		"overview.noTimeSeries": "无时序数据",
 		"overview.chart.requests": "请求",
@@ -468,7 +458,6 @@ const translations: Record<Locale, Record<string, string>> = {
 
 		// Models route
 		"models.preference": "模型偏好",
-		"models.preferenceSub": "{window}内的请求份额",
 		"models.noData": "暂无数据",
 		"models.statistics": "模型统计",
 		"models.requests": "请求数",
@@ -569,6 +558,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"behavior.total": "总计",
 		"behavior.percentOfMsgs": "消息占比",
 		"behavior.perMsg": "每条消息",
+		"behavior.perMsgSuffix": "/ 消息",
 		"behavior.detailTotal": "总计",
 		"behavior.detailPerMsg": "每条消息",
 		"behavior.detailRate": "比率",
@@ -676,6 +666,10 @@ function detectInitialLocale(): Locale {
 }
 
 currentLocale = detectInitialLocale();
+// 初始化时同步 document lang，避免首次加载中文时 <html lang="en"> 未更新
+if (typeof document !== "undefined") {
+	document.documentElement.lang = currentLocale === "zh" ? "zh-CN" : "en";
+}
 
 function notifyListeners() {
 	for (const listener of listeners) {

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -1,0 +1,749 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export type Locale = "en" | "zh";
+
+type TranslationParams = Record<string, string | number>;
+
+export type TranslationFn = (key: string, params?: TranslationParams) => string;
+
+const STORAGE_KEY = "omp-stats-locale";
+
+const translations: Record<Locale, Record<string, string>> = {
+	en: {
+		// Navigation
+		"nav.title": "OH MY PI",
+		"nav.subtitle": "Observability",
+		"nav.version": "OMP Stats v1.0.0",
+		"nav.section.overview": "Overview",
+		"nav.section.requests": "Requests",
+		"nav.section.errors": "Errors",
+		"nav.section.models": "Models",
+		"nav.section.costs": "Costs",
+		"nav.section.behavior": "Behavior",
+		"nav.section.projects": "Projects",
+		"nav.menu": "Navigation menu",
+		"nav.closeMenu": "Close navigation menu",
+		"nav.observability": "Observability",
+		"nav.menu.open": "Open navigation menu",
+		"nav.menu.close": "Close navigation menu",
+		"nav.menu.title": "Navigation menu",
+
+		// Top bar
+		"topBar.observability": "Observability",
+		"topBar.languageToggle": "Switch language",
+		"topBar.openMenu": "Open menu",
+		"topBar.notUpdated": "Not updated",
+		"topBar.updated": "Updated {time}",
+
+		// Time ranges
+		"range.all": "All",
+		"range.lastHour": "the last hour",
+		"range.last24h": "the last 24 hours",
+		"range.last7d": "the last 7 days",
+		"range.last30d": "the last 30 days",
+		"range.last90d": "the last 90 days",
+
+		// Range control
+		"rangeControl.all": "All",
+		"rangeControl.selectRange": "Select time range",
+		"rangeControl.label": "Select time range",
+
+		// Sync button
+		"sync.syncing": "Syncing...",
+		"sync.syncDb": "Sync DB",
+		"sync.db": "Sync DB",
+		"sync.synced": "Synced {count} requests",
+		"sync.success": "Synced: {count} new request{plural} found.",
+		"sync.failed": "Sync failed: {error}",
+
+		// Theme toggle
+		"theme.system": "System theme",
+		"theme.light": "Light theme",
+		"theme.dark": "Dark theme",
+
+		// Metrics
+		"metric.totalCost": "Total Cost",
+		"metric.requests": "Requests",
+		"metric.cacheRate": "Cache Rate",
+		"metric.errorRate": "Error Rate",
+		"metric.inputTokens": "Input Tokens",
+		"metric.outputTokens": "Output Tokens",
+		"metric.premiumRequests": "Premium Requests",
+		"metric.tokensPerSec": "Tokens/s",
+		"metric.avgLatency": "Avg Latency",
+		"metric.avgTTFT": "Avg TTFT",
+
+		// Common labels
+		"common.model": "Model",
+		"common.provider": "Provider",
+		"common.time": "Time",
+		"common.tokens": "Tokens",
+		"common.cost": "Cost",
+		"common.duration": "Duration",
+		"common.status": "Status",
+		"common.input": "Input",
+		"common.output": "Output",
+		"common.cacheRead": "Cache Read",
+		"common.cacheWrite": "Cache Write",
+		"common.reasoning": "Reasoning",
+		"common.tps": "TPS",
+		"common.success": "Success",
+		"common.failed": "Failed",
+		"common.error": "Error",
+		"common.premium": "Premium",
+		"common.loading": "Loading...",
+		"common.noData": "No data available",
+		"common.retry": "Retry",
+		"common.failedToLoad": "Failed to load data",
+
+		// Overview route
+		"overview.throughput": "System Throughput",
+		"overview.throughput.title": "System Throughput",
+		"overview.throughput.subtitle": "Request volume and errors over time",
+		"overview.throughputSub": "Request volume and errors over time",
+		"overview.feed": "Operational Feed",
+		"overview.feed.subtitle": "Real-time request log",
+		"overview.feedSub": "Real-time request log",
+		"overview.preview": "Recent Requests Preview",
+		"overview.preview.title": "Recent Requests Preview",
+		"overview.preview.subtitle": "Latest transactions processed by the proxy",
+		"overview.previewSub": "Latest transactions processed by the proxy",
+		"overview.viewAll": "View All Requests",
+		"overview.noRequests": "No recent requests found",
+		"overview.noRecentRequests": "No recent requests found",
+		"overview.noTimeSeries": "No time-series data available",
+		"overview.chart.requests": "Requests",
+		"overview.chart.errors": "Errors",
+
+		// Requests route
+		"requests.title": "All Recent Requests",
+		"requests.subtitle": "Up to 50 most recent requests processed by OMP",
+		"requests.noRequests": "No recent requests found",
+		"requests.status.failed": "Failed",
+		"requests.status.success": "Success",
+		"requests.column.time": "Time",
+		"requests.column.model": "Model",
+		"requests.column.status": "Status",
+		"requests.column.tokens": "Tokens",
+		"requests.column.tokens": "Tokens",
+		"requests.column.inputOutput": "Input/Output",
+		"requests.column.cache": "Cache R/W",
+		"requests.column.tokensPerSec": "Tokens/s",
+		"requests.column.duration": "Duration",
+
+		// Errors route
+		"errors.title": "Recent Errors",
+		"errors.subtitle": "Up to 50 most recent failed requests in the stats database",
+		"errors.noErrors": "No recent failures in the local stats database",
+		"errors.noFailures": "No recent failures",
+		"errors.status.failed": "Failed",
+		"errors.unknownError": "Unknown error",
+		"errors.column.time": "Time",
+		"errors.column.model": "Model",
+		"errors.column.tokens": "Tokens",
+		"errors.column.cost": "Cost",
+		"errors.column.errorMessage": "Error Message",
+
+		// Models route
+		"models.preference": "Model Preference",
+		"models.preferenceSub": "Share of requests over {window}",
+		"models.share.title": "Model Share",
+		"models.noData": "No data available",
+		"models.statistics": "Model Statistics",
+		"models.requests": "Requests",
+		"models.cost": "Cost",
+		"models.tokens": "Tokens",
+		"models.tokensPerSec": "Tokens/s",
+		"models.ttft": "TTFT",
+		"models.trend": "Trend",
+		"models.quality": "Quality",
+		"models.errorRate": "Error rate",
+		"models.cacheRate": "Cache rate",
+		"models.latency": "Latency",
+		"models.avgDuration": "Avg duration",
+		"models.avgTTFT": "Avg TTFT",
+		"models.table.title": "Model Statistics",
+		"models.table.columns.model": "Model",
+		"models.table.columns.requests": "Requests",
+		"models.table.columns.tokens": "Tokens",
+		"models.table.columns.cost": "Cost",
+		"models.table.columns.tokensPerSec": "Tokens/s",
+		"models.table.columns.ttft": "TTFT",
+		"models.expanded-quality": "Quality",
+		"models.expanded-errorRate": "Error rate",
+		"models.expanded-cacheRate": "Cache rate",
+		"models.expanded-latency": "Latency",
+		"models.expanded-avgDuration": "Avg duration",
+		"models.expanded-avgTTFT": "Avg TTFT",
+		"models.shareChart-title": "Model Preference",
+		"models.shareChart-subtitle": "Share of requests over {window}",
+		"models.shareChart-noData": "No data available",
+
+		// Costs route
+		"costs.total": "Total",
+		"costs.totalCost": "Total Cost",
+		"costs.avgPerDay": "Average / Day",
+		"costs.avgDailyCost": "Average / Day",
+		"costs.topModel": "Top Model",
+		"costs.totalSpent": "Total spent: {amount}",
+		"costs.dailyCost": "Daily Cost",
+		"costs.dailyCostSub": "API spending over time",
+		"costs.label": "Cost",
+		"costs.apiSpending": "API spending over time",
+		"costs.noData": "No cost data available",
+		"costs.allModels": "All Models",
+		"costs.byModel": "By Model",
+
+		// Behavior route
+		"behavior.messages": "User Messages",
+		"behavior.userMessages": "User Messages",
+		"behavior.inRange": "in range",
+		"behavior.asPercentOfMessages": "as % of messages",
+		"behavior.yelling": "Yelling (CAPS)",
+		"behavior.yellingCaps": "Yelling (CAPS)",
+		"behavior.profanityHits": "Profanity Hits",
+		"behavior.anguishSignals": "Anguish Signals",
+		"behavior.frictionSignals": "Friction Signals",
+		"behavior.highestFrictionModel": "Highest Friction model",
+		"behavior.hits": "hits",
+		"behavior.title": "User Friction Signals",
+		"behavior.subtitle": "{metric} as % of user messages per day",
+		"behavior.noData": "No friction signal data available",
+		"behavior.noBehaviorData": "No user behavior recorded for this range yet.",
+		"behavior.allModels": "All Models",
+		"behavior.byModel": "By Model",
+		"behavior.byModelTitle": "Behavior Signals by Model",
+		"behavior.byModelSub": "Rates are per user message",
+		"behavior.byModelSubtitle": "Behavior signals breakdown by model",
+		"behavior.caps": "CAPS",
+		"behavior.profanity": "Profanity",
+		"behavior.anguish": "Anguish",
+		"behavior.negation": "Negation",
+		"behavior.repetition": "Repetition",
+		"behavior.blame": "Blame",
+		"behavior.frustration": "Frustration",
+		"behavior.all": "All",
+		"behavior.anguishFull": "Anguish (!!!, nooo, dude, ..)",
+		"behavior.negationFull": "Negation (no/nope/wrong)",
+		"behavior.repetitionFull": "Repetition (i meant, still doesnt)",
+		"behavior.blameFull": "Blame (you didnt, stop X-ing)",
+		"behavior.frustrationFull": "Frustration (neg + rep + blame)",
+		"behavior.allCombined": "All signals combined",
+		"behavior.model": "Model",
+		"behavior.messagesCol": "Messages",
+		"behavior.capsPercent": "CAPS %",
+		"behavior.profanityPercent": "Profanity %",
+		"behavior.anguishPercent": "Anguish %",
+		"behavior.frustrationPercent": "Frustration %",
+		"behavior.hitsPercent": "Hits %",
+		"behavior.trend": "Trend",
+		"behavior.avgCharsPerMsg": "Avg chars / msg",
+		"behavior.total": "Total",
+		"behavior.percentOfMsgs": "% of msgs",
+		"behavior.perMsg": "Per msg",
+		"behavior.detailTotal": "Total",
+		"behavior.detailPerMsg": "Per msg",
+		"behavior.detailRate": "Rate",
+		"behavior.metric-caps": "CAPS",
+		"behavior.metric-profanity": "Profanity",
+		"behavior.metric-anguish": "Anguish",
+		"behavior.metric-negation": "Negation",
+		"behavior.metric-repetition": "Repetition",
+		"behavior.metric-blame": "Blame",
+		"behavior.metric-frustration": "Frustration",
+		"behavior.metric-all": "All",
+		"behavior.metricTitle-caps": "Yelling (CAPS)",
+		"behavior.metricTitle-profanity": "Profanity",
+		"behavior.metricTitle-anguish": "Anguish (!!!, nooo, dude, ..)",
+		"behavior.metricTitle-negation": "Negation (no/nope/wrong)",
+		"behavior.metricTitle-repetition": "Repetition (i meant, still doesnt)",
+		"behavior.metricTitle-blame": "Blame (you didnt, stop X-ing)",
+		"behavior.metricTitle-frustration": "Frustration (neg + rep + blame)",
+		"behavior.metricTitle-all": "All signals combined",
+		"behavior.chart-yelling": "CAPS",
+		"behavior.chart-profanity": "Profanity",
+		"behavior.chart-anguish": "Anguish",
+		"behavior.chart-frustration": "Frustration",
+		"behavior.detail-yelling": "Yelling (CAPS)",
+		"behavior.detail-profanity": "Profanity",
+		"behavior.detail-anguish": "Anguish (!!!, nooo, dude, ..)",
+		"behavior.detail-negation": "Negation (no/nope/wrong)",
+		"behavior.detail-repetition": "Repetition (i meant, still doesnt)",
+		"behavior.detail-blame": "Blame (you didnt, stop X-ing)",
+		"behavior.detail-avgChars": "Avg chars / msg",
+		"behavior.errSuffix": "Err",
+		"behavior.columns.model": "Model",
+		"behavior.columns.messages": "Messages",
+		"behavior.columns.caps": "CAPS",
+		"behavior.columns.profanity": "Profanity",
+		"behavior.columns.anguish": "Anguish",
+		"behavior.columns.frustration": "Frustration",
+		"behavior.columns.hits": "Hits",
+		"behavior.columns.trend": "Trend",
+
+		// Projects route
+		"projects.title": "Projects & Folders",
+		"projects.subtitle": "Aggregate proxy metrics grouped by folder path",
+		"projects.noData": "No project folders recorded for this range.",
+		"projects.noFolders": "No folders found",
+		"projects.folder": "Project/Folder",
+		"projects.root": "(root)",
+		"projects.errSuffix": "Err",
+		"projects.requests": "Requests",
+		"projects.cost": "Cost",
+		"projects.tokens": "Tokens",
+		"projects.cacheRate": "Cache Rate",
+		"projects.errorRate": "Error Rate",
+		"projects.avgDuration": "Avg Duration",
+		"projects.column.folder": "Project/Folder",
+		"projects.column.requests": "Requests",
+		"projects.column.tokens": "Tokens",
+		"projects.column.cost": "Cost",
+		"projects.column.avgDuration": "Avg Duration",
+		"projects.column.errorRate": "Error Rate",
+		"projects.column.cacheRate": "Cache Rate",
+
+		// Request drawer
+		"detail.title": "Request Details",
+		"detail.id": "ID",
+		"detail.cost": "Cost",
+		"detail.premium": "Premium",
+		"detail.totalTokens": "Total Tokens",
+		"detail.duration": "Duration",
+		"detail.ttft": "TTFT",
+		"detail.throughput": "Throughput",
+		"detail.tokensPerSecond": "tokens/second",
+		"detail.outputPayload": "Output Payload",
+		"detail.rawMetadata": "Raw Request Metadata",
+		"detail.errorMessage": "Error Message",
+		"detail.failedToLoad": "Failed to load request details",
+		"detail.inOut": "{input} in · {output} out",
+		"detail.close": "Close request details",
+
+		// JSON block
+		"json.title": "JSON",
+		"json.copy": "Copy",
+		"json.copied": "Copied",
+		"json.copyToClipboard": "Copy JSON to clipboard",
+		"json.copiedToClipboard": "Copied to clipboard",
+		"json.show": "Show",
+		"json.hide": "Hide",
+	},
+
+	zh: {
+		// Navigation
+		"nav.title": "OH MY PI",
+		"nav.subtitle": "可观测性",
+		"nav.version": "OMP Stats v1.0.0",
+		"nav.section.overview": "概览",
+		"nav.section.requests": "请求",
+		"nav.section.errors": "错误",
+		"nav.section.models": "模型",
+		"nav.section.costs": "成本",
+		"nav.section.behavior": "行为",
+		"nav.section.projects": "项目",
+		"nav.menu.open": "打开导航菜单",
+		"nav.menu.close": "关闭导航菜单",
+		"nav.menu.title": "导航菜单",
+
+		// Top bar
+		"topBar.notUpdated": "未更新",
+		"topBar.updated": "已更新 {time}",
+
+		// Time ranges
+		"range.all": "全部",
+		"range.lastHour": "过去一小时",
+		"range.last24h": "过去24小时",
+		"range.last7d": "过去7天",
+		"range.last30d": "过去30天",
+		"range.last90d": "过去90天",
+
+		// Range control
+		"rangeControl.label": "选择时间范围",
+
+		// Sync button
+		"sync.syncing": "同步中...",
+		"sync.syncDb": "同步数据库",
+		"sync.db": "同步数据库",
+		"sync.synced": "已同步 {count} 个请求",
+		"sync.success": "同步完成: 发现 {count} 个新请求。",
+		"sync.failed": "同步失败: {error}",
+
+		// Theme toggle
+		"theme.system": "系统主题",
+		"theme.light": "浅色主题",
+		"theme.dark": "深色主题",
+
+		// Metrics
+		"metric.totalCost": "总成本",
+		"metric.requests": "请求数",
+		"metric.cacheRate": "缓存命中率",
+		"metric.errorRate": "错误率",
+		"metric.inputTokens": "输入 Tokens",
+		"metric.outputTokens": "输出 Tokens",
+		"metric.premiumRequests": "高级请求",
+		"metric.tokensPerSec": "Tokens/秒",
+		"metric.avgLatency": "平均延迟",
+		"metric.avgTTFT": "平均 TTFT",
+
+		// Common labels
+		"common.model": "模型",
+		"common.provider": "提供商",
+		"common.duration": "耗时",
+		"common.status": "状态",
+		"common.input": "输入",
+		"common.output": "输出",
+		"common.cacheRead": "缓存读取",
+		"common.cacheWrite": "缓存写入",
+		"common.reasoning": "推理",
+		"common.tps": "TPS",
+		"common.success": "成功",
+		"common.failed": "失败",
+		"common.error": "错误",
+		"common.premium": "高级",
+		"common.loading": "加载中...",
+		"common.noData": "暂无数据",
+		"common.retry": "重试",
+		"common.failedToLoad": "加载数据失败",
+
+		// Overview route
+		"overview.throughput": "系统吞吐量",
+		"overview.throughput.title": "系统吞吐量",
+		"overview.throughput.subtitle": "请求量和错误随时间变化",
+		"overview.throughputSub": "请求量和错误随时间变化",
+		"overview.feed": "实时动态",
+		"overview.feed.title": "实时动态",
+		"overview.feed.subtitle": "实时请求日志",
+		"overview.feedSub": "实时请求日志",
+		"overview.preview": "最近请求预览",
+		"overview.preview.title": "最近请求预览",
+		"overview.preview.subtitle": "代理处理的最新事务",
+		"overview.previewSub": "代理处理的最新事务",
+		"overview.viewAll": "查看所有请求",
+		"overview.noRequests": "未找到最近请求",
+		"overview.noRecentRequests": "未找到最近请求",
+		"overview.noTimeSeries": "无时序数据",
+		"overview.chart.requests": "请求",
+		"overview.chart.errors": "错误",
+
+		// Requests route
+		"requests.title": "所有最近请求",
+		"requests.subtitle": "OMP 处理的最多50个最近请求",
+		"requests.noRequests": "未找到最近请求",
+		"requests.status.success": "成功",
+		"requests.column.time": "时间",
+		"requests.column.model": "模型",
+		"requests.column.status": "状态",
+		"requests.column.tokens": "Tokens",
+		"requests.column.inputOutput": "输入/输出",
+		"requests.column.cache": "缓存读/写",
+		"requests.column.tokensPerSec": "Tokens/秒",
+		"requests.column.cost": "成本",
+		"requests.column.duration": "耗时",
+
+		// Errors route
+		"errors.title": "最近错误",
+		"errors.subtitle": "统计数据库中最多50个最近失败请求",
+		"errors.noErrors": "本地统计数据库中无最近失败",
+		"errors.column.time": "时间",
+		"errors.column.model": "模型",
+		"errors.column.tokens": "Tokens",
+		"errors.column.cost": "成本",
+		"errors.column.errorMessage": "错误信息",
+
+		// Models route
+		"models.preference": "模型偏好",
+		"models.preferenceSub": "{window}内的请求份额",
+		"models.noData": "暂无数据",
+		"models.statistics": "模型统计",
+		"models.requests": "请求数",
+		"models.cost": "成本",
+		"models.tokens": "Tokens",
+		"models.tokensPerSec": "Tokens/秒",
+		"models.ttft": "TTFT",
+		"models.trend": "趋势",
+		"models.quality": "质量",
+		"models.errorRate": "错误率",
+		"models.cacheRate": "缓存命中率",
+		"models.latency": "延迟",
+		"models.avgDuration": "平均耗时",
+		"models.avgTTFT": "平均 TTFT",
+		"models.table.title": "模型统计",
+		"models.table.columns.model": "模型",
+		"models.table.columns.requests": "请求数",
+		"models.table.columns.cost": "成本",
+		"models.table.columns.tokens": "Tokens",
+		"models.table.columns.tokensPerSec": "Tokens/秒",
+		"models.table.columns.ttft": "TTFT",
+		"models.expanded-quality": "质量",
+		"models.expanded-errorRate": "错误率",
+		"models.expanded-cacheRate": "缓存命中率",
+		"models.expanded-latency": "延迟",
+		"models.expanded-avgDuration": "平均耗时",
+		"models.expanded-avgTTFT": "平均 TTFT",
+		"models.shareChart-title": "模型偏好",
+		"models.shareChart-subtitle": "{window}内的请求份额",
+		"models.shareChart-noData": "暂无数据",
+
+		// Costs route
+		"costs.total": "总计",
+		"costs.totalCost": "总成本",
+		"costs.avgPerDay": "日均成本",
+		"costs.avgDailyCost": "日均成本",
+		"costs.topModel": "最高成本模型",
+		"costs.totalSpent": "总花费: {amount}",
+		"costs.dailyCostSub": "API 支出随时间变化",
+		"costs.dailyCost": "每日成本",
+		"costs.label": "成本",
+		"costs.apiSpending": "API 支出随时间变化",
+		"costs.noData": "无成本数据",
+		"costs.allModels": "所有模型",
+		"costs.byModel": "按模型",
+
+		// Behavior route
+		"behavior.messages": "用户消息",
+		"behavior.inRange": "范围内",
+		"behavior.byModelSub": "比率为每条用户消息",
+		"behavior.highestFrictionModel": "最高摩擦模型",
+		"behavior.userMessages": "用户消息",
+		"behavior.yellingCaps": "大写喊叫",
+		"behavior.profanityHits": "脏话命中",
+		"behavior.anguishSignals": "痛苦信号",
+		"behavior.frictionSignals": "摩擦信号",
+		"behavior.hits": "次命中",
+		"behavior.title": "用户摩擦信号",
+		"behavior.subtitle": "{metric} 占每日用户消息的百分比",
+		"behavior.asPercentOfMessages": "占消息百分比",
+		"behavior.noData": "无摩擦信号数据",
+		"behavior.noBehaviorData": "此范围内暂无用户行为记录。",
+		"behavior.allModels": "所有模型",
+		"behavior.byModel": "按模型",
+		"behavior.byModelTitle": "按模型的行为信号",
+		"behavior.byModelSubtitle": "按模型的行为信号细分",
+		"behavior.columns.model": "模型",
+		"behavior.columns.messages": "消息数",
+		"behavior.columns.caps": "大写",
+		"behavior.columns.profanity": "脏话",
+		"behavior.columns.anguish": "痛苦",
+		"behavior.columns.frustration": "沮丧",
+		"behavior.columns.hits": "命中",
+		"behavior.columns.trend": "趋势",
+		"behavior.caps": "大写",
+		"behavior.profanity": "脏话",
+		"behavior.anguish": "痛苦",
+		"behavior.negation": "否定",
+		"behavior.repetition": "重复",
+		"behavior.blame": "责备",
+		"behavior.frustration": "沮丧",
+		"behavior.all": "全部",
+		"behavior.anguishFull": "痛苦 (!!!, nooo, dude, ..)",
+		"behavior.negationFull": "否定 (no/nope/wrong)",
+		"behavior.repetitionFull": "重复 (i meant, still doesnt)",
+		"behavior.blameFull": "责备 (you didnt, stop X-ing)",
+		"behavior.frustrationFull": "沮丧 (否定 + 重复 + 责备)",
+		"behavior.allCombined": "所有信号合计",
+		"behavior.model": "模型",
+		"behavior.messagesCol": "消息数",
+		"behavior.capsPercent": "大写 %",
+		"behavior.profanityPercent": "脏话 %",
+		"behavior.anguishPercent": "痛苦 %",
+		"behavior.frustrationPercent": "沮丧 %",
+		"behavior.hitsPercent": "命中 %",
+		"behavior.trend": "趋势",
+		"behavior.avgCharsPerMsg": "平均字符/消息",
+		"behavior.total": "总计",
+		"behavior.percentOfMsgs": "消息占比",
+		"behavior.perMsg": "每条消息",
+		"behavior.detailTotal": "总计",
+		"behavior.detailPerMsg": "每条消息",
+		"behavior.detailRate": "比率",
+		"behavior.metric-caps": "大写",
+		"behavior.metric-profanity": "脏话",
+		"behavior.metric-anguish": "痛苦",
+		"behavior.metric-negation": "否定",
+		"behavior.metric-repetition": "重复",
+		"behavior.metric-blame": "责备",
+		"behavior.metric-frustration": "沮丧",
+		"behavior.metric-all": "全部",
+		"behavior.metricTitle-caps": "大写喊叫",
+		"behavior.metricTitle-profanity": "脏话",
+		"behavior.metricTitle-anguish": "痛苦 (!!!, nooo, dude, ..)",
+		"behavior.metricTitle-negation": "否定 (no/nope/wrong)",
+		"behavior.metricTitle-repetition": "重复 (i meant, still doesnt)",
+		"behavior.metricTitle-blame": "责备 (you didnt, stop X-ing)",
+		"behavior.metricTitle-frustration": "沮丧 (否定 + 重复 + 责备)",
+		"behavior.metricTitle-all": "所有信号合计",
+		"behavior.chart-yelling": "大写",
+		"behavior.chart-profanity": "脏话",
+		"behavior.chart-anguish": "痛苦",
+		"behavior.chart-frustration": "沮丧",
+		"behavior.detail-yelling": "大写喊叫",
+		"behavior.detail-profanity": "脏话",
+		"behavior.detail-anguish": "痛苦 (!!!, nooo, dude, ..)",
+		"behavior.detail-negation": "否定 (no/nope/wrong)",
+		"behavior.detail-repetition": "重复 (i meant, still doesnt)",
+		"behavior.detail-blame": "责备 (you didnt, stop X-ing)",
+		"behavior.detail-avgChars": "平均字符/消息",
+		"behavior.errSuffix": "错误",
+
+		// Projects route
+		"projects.title": "项目与文件夹",
+		"projects.subtitle": "按文件夹路径分组的聚合代理指标",
+		"projects.noData": "此范围内无项目文件夹记录。",
+		"projects.folder": "项目/文件夹",
+		"projects.root": "(根目录)",
+		"projects.errSuffix": "错误",
+		"projects.requests": "请求数",
+		"projects.cost": "成本",
+		"projects.tokens": "Tokens",
+		"projects.cacheRate": "缓存命中率",
+		"projects.errorRate": "错误率",
+		"projects.avgDuration": "平均耗时",
+		"projects.column.folder": "项目/文件夹",
+		"projects.column.requests": "请求数",
+		"projects.column.tokens": "Tokens",
+		"projects.column.cost": "成本",
+		"projects.column.avgDuration": "平均耗时",
+		"projects.column.errorRate": "错误率",
+		"projects.column.cacheRate": "缓存命中率",
+		"projects.noFolders": "未找到文件夹",
+
+		// Request drawer
+		"detail.title": "请求详情",
+		"detail.id": "ID",
+		"detail.cost": "成本",
+		"detail.premium": "高级",
+		"detail.totalTokens": "总 Tokens",
+		"detail.duration": "耗时",
+		"detail.ttft": "TTFT",
+		"detail.throughput": "吞吐量",
+		"detail.tokensPerSecond": "tokens/秒",
+		"detail.outputPayload": "输出负载",
+		"detail.rawMetadata": "原始请求元数据",
+		"detail.errorMessage": "错误信息",
+		"detail.failedToLoad": "加载请求详情失败",
+		"detail.inOut": "{input} 入 · {output} 出",
+		"detail.close": "关闭请求详情",
+
+		// JSON block
+		"json.title": "JSON",
+		"json.copy": "复制",
+		"json.copied": "已复制",
+		"json.copyToClipboard": "复制 JSON 到剪贴板",
+		"json.copiedToClipboard": "已复制到剪贴板",
+		"json.show": "显示",
+		"json.hide": "隐藏",
+	},
+};
+let currentLocale: Locale;
+const listeners = new Set<() => void>();
+
+function detectInitialLocale(): Locale {
+	// Check localStorage first
+	if (typeof window !== "undefined") {
+		try {
+			const stored = localStorage.getItem(STORAGE_KEY);
+			if (stored === "en" || stored === "zh") {
+				return stored;
+			}
+		} catch {
+			// localStorage unavailable (e.g. SSR or privacy mode)
+		}
+
+		// Detect from browser language
+		if (typeof navigator !== "undefined" && navigator.language) {
+			if (navigator.language.startsWith("zh")) {
+				return "zh";
+			}
+		}
+	}
+	return "en";
+}
+
+currentLocale = detectInitialLocale();
+
+function notifyListeners() {
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+function subscribe(listener: () => void) {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+function getSnapshot() {
+	return currentLocale;
+}
+
+/** Get the current locale. */
+export function getLocale(): Locale {
+	return currentLocale;
+}
+
+/** Set the locale and persist to localStorage. */
+export function setLocale(locale: Locale) {
+	if (currentLocale === locale) return;
+	currentLocale = locale;
+	if (typeof window !== "undefined") {
+		try {
+			localStorage.setItem(STORAGE_KEY, locale);
+		} catch {
+			// localStorage unavailable
+		}
+		// Update document lang attribute
+		document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
+	}
+	notifyListeners();
+}
+
+/** Toggle between en and zh. */
+export function toggleLocale() {
+	setLocale(currentLocale === "en" ? "zh" : "en");
+}
+
+/** Translate a key with optional parameters. */
+export function t(key: string, params?: TranslationParams): string {
+	const template = translations[currentLocale]?.[key] ?? translations.en[key] ?? key;
+	if (!params) return template;
+
+	let result = template;
+	for (const [paramKey, paramValue] of Object.entries(params)) {
+		result = result.replace(new RegExp(`\\{${paramKey}\\}`, "g"), String(paramValue));
+	}
+	return result;
+}
+
+/** React hook for translations. Returns { t, locale, setLocale, toggleLocale }. */
+export function useTranslation() {
+	const locale = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+	const translate = useCallback(
+		(key: string, params?: TranslationParams) => {
+			const template = translations[locale]?.[key] ?? translations.en[key] ?? key;
+			if (!params) return template;
+			let result = template;
+			for (const [paramKey, paramValue] of Object.entries(params)) {
+				result = result.replace(new RegExp(`\\{${paramKey}\\}`, "g"), String(paramValue));
+			}
+			return result;
+		},
+		[locale],
+	);
+
+	const changeLocale = useCallback((newLocale: Locale) => setLocale(newLocale), []);
+	const toggle = useCallback(() => toggleLocale(), []);
+
+	return { t: translate, locale, setLocale: changeLocale, toggleLocale: toggle };
+}
+
+/** React hook for just the locale and setter. */
+export function useLocale() {
+	const locale = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+	const changeLocale = useCallback((newLocale: Locale) => setLocale(newLocale), []);
+	const toggle = useCallback(() => toggleLocale(), []);
+	return { locale, setLocale: changeLocale, toggleLocale: toggle };
+}

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -37,6 +37,7 @@ const translations: Record<Locale, Record<string, string>> = {
 
 		// Time ranges
 		"range.all": "All",
+		"range.allTime": "all time",
 		"range.lastHour": "the last hour",
 		"range.last24h": "the last 24 hours",
 		"range.last7d": "the last 7 days",
@@ -350,6 +351,7 @@ const translations: Record<Locale, Record<string, string>> = {
 
 		// Time ranges
 		"range.all": "全部",
+		"range.allTime": "全部时间",
 		"range.lastHour": "过去一小时",
 		"range.last24h": "过去24小时",
 		"range.last7d": "过去7天",

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -348,8 +348,11 @@ const translations: Record<Locale, Record<string, string>> = {
 		"nav.menu.close": "关闭导航菜单",
 		"nav.menu.title": "导航菜单",
 		"nav.observability": "可观测性",
+		"nav.menu": "导航菜单",
+		"nav.closeMenu": "关闭导航菜单",
 
 		// Top bar
+		"topBar.observability": "可观测性",
 		"topBar.notUpdated": "未更新",
 		"topBar.updated": "已更新 {time}",
 		"topBar.languageToggle": "切换语言",
@@ -365,6 +368,8 @@ const translations: Record<Locale, Record<string, string>> = {
 
 		// Range control
 		"rangeControl.label": "选择时间范围",
+		"rangeControl.all": "全部",
+		"rangeControl.selectRange": "选择时间范围",
 
 		// Sync button
 		"sync.syncing": "同步中...",

--- a/packages/stats/src/client/i18n.ts
+++ b/packages/stats/src/client/i18n.ts
@@ -60,6 +60,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"theme.system": "System theme",
 		"theme.light": "Light theme",
 		"theme.dark": "Dark theme",
+		"theme.switchHint": "Switch to {theme}",
 
 		// Metrics
 		"metric.totalCost": "Total Cost",
@@ -102,6 +103,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"overview.throughput.subtitle": "Request volume and errors over time",
 		"overview.throughputSub": "Request volume and errors over time",
 		"overview.feed": "Operational Feed",
+		"overview.feed.title": "Operational Feed",
 		"overview.feed.subtitle": "Real-time request log",
 		"overview.feedSub": "Real-time request log",
 		"overview.preview": "Recent Requests Preview",
@@ -129,6 +131,7 @@ const translations: Record<Locale, Record<string, string>> = {
 		"requests.column.cache": "Cache R/W",
 		"requests.column.tokensPerSec": "Tokens/s",
 		"requests.column.duration": "Duration",
+		"requests.column.cost": "Cost",
 
 		// Errors route
 		"errors.title": "Recent Errors",

--- a/packages/stats/src/client/routes/BehaviorRoute.tsx
+++ b/packages/stats/src/client/routes/BehaviorRoute.tsx
@@ -31,6 +31,7 @@ import {
 import { formatInteger } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildBehaviorSummary } from "../data/view-models";
+import { useTranslation } from "../i18n";
 import type { BehaviorModelStats, BehaviorOverallStats, BehaviorTimeSeriesPoint, TimeRange } from "../types";
 import { AsyncBoundary, Panel, SegmentedControl } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -78,39 +79,40 @@ function BehaviorSummaryPanel({
 	overall: BehaviorOverallStats;
 	behaviorSeries: BehaviorTimeSeriesPoint[];
 }) {
+	const { t } = useTranslation();
 	const summary = useMemo(() => buildBehaviorSummary(overall, behaviorSeries), [overall, behaviorSeries]);
 	const messages = overall.totalMessages;
 
 	const cards = [
 		{
-			label: "User Messages",
+			label: t("behavior.userMessages"),
 			value: formatInteger(overall.totalMessages),
-			sub: messages > 0 ? "in range" : undefined,
+			sub: messages > 0 ? t("behavior.inRange") : undefined,
 		},
 		{
-			label: "Yelling (CAPS)",
+			label: t("behavior.yellingCaps"),
 			value: formatInteger(overall.totalYelling),
 			sub: perMsg(overall.totalYelling, messages),
 		},
 		{
-			label: "Profanity Hits",
+			label: t("behavior.profanityHits"),
 			value: formatInteger(overall.totalProfanity),
 			sub: perMsg(overall.totalProfanity, messages),
 		},
 		{
-			label: "Anguish Signals",
+			label: t("behavior.anguishSignals"),
 			value: formatInteger(overall.totalAnguish),
 			sub: perMsg(overall.totalAnguish, messages),
 		},
 		{
-			label: "Friction Signals",
+			label: t("behavior.frictionSignals"),
 			value: formatInteger(summary.totalFrustration),
 			sub: perMsg(summary.totalFrustration, messages),
 		},
 		{
-			label: "Highest Friction Model",
+			label: t("behavior.highestFrictionModel"),
 			value: summary.highestFrictionModel?.model ?? "—",
-			sub: summary.highestFrictionModel ? `${formatInteger(summary.highestFrictionModel.score)} hits` : undefined,
+			sub: summary.highestFrictionModel ? `${formatInteger(summary.highestFrictionModel.score)} ${t("behavior.hits")}` : undefined,
 		},
 	];
 
@@ -130,22 +132,22 @@ function BehaviorSummaryPanel({
 }
 
 const METRIC_OPTIONS = [
-	{ value: "yelling", label: "CAPS", title: "Yelling (CAPS)" },
-	{ value: "profanity", label: "Profanity", title: "Profanity" },
-	{ value: "anguish", label: "Anguish", title: "Anguish (!!!, nooo, dude, ..)" },
-	{ value: "negation", label: "Negation", title: "Negation (no/nope/wrong)" },
+	{ value: "yelling", labelKey: "behavior.metric-caps", titleKey: "behavior.metricTitle-caps" },
+	{ value: "profanity", labelKey: "behavior.metric-profanity", titleKey: "behavior.metricTitle-profanity" },
+	{ value: "anguish", labelKey: "behavior.metric-anguish", titleKey: "behavior.metricTitle-anguish" },
+	{ value: "negation", labelKey: "behavior.metric-negation", titleKey: "behavior.metricTitle-negation" },
 	{
 		value: "repetition",
-		label: "Repetition",
-		title: "Repetition (i meant, still doesnt)",
+		labelKey: "behavior.metric-repetition",
+		titleKey: "behavior.metricTitle-repetition",
 	},
-	{ value: "blame", label: "Blame", title: "Blame (you didnt, stop X-ing)" },
+	{ value: "blame", labelKey: "behavior.metric-blame", titleKey: "behavior.metricTitle-blame" },
 	{
 		value: "frustration",
-		label: "Frustration",
-		title: "Frustration (neg + rep + blame)",
+		labelKey: "behavior.metric-frustration",
+		titleKey: "behavior.metricTitle-frustration",
 	},
-	{ value: "total", label: "All", title: "All signals combined" },
+	{ value: "total", labelKey: "behavior.metric-all", titleKey: "behavior.metricTitle-all" },
 ] as const;
 
 type Metric = (typeof METRIC_OPTIONS)[number]["value"];
@@ -178,6 +180,7 @@ interface DailyBucket {
 }
 
 function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSeriesPoint[] }) {
+	const { t } = useTranslation();
 	const [byModel, setByModel] = useState(false);
 	const [metric, setMetric] = useState<Metric>("total");
 	const theme = useSystemTheme();
@@ -195,7 +198,7 @@ function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSe
 				bucketToValue: bucket => ratePercent(bucket.hits, bucket.messages),
 			});
 		}
-		const metricLabel = METRIC_OPTIONS.find(m => m.value === metric)?.title ?? "Hits";
+		const metricLabel = t(METRIC_OPTIONS.find(m => m.value === metric)?.titleKey ?? "behavior.metricTitle-all");
 		return buildAggregateTimeSeries<BehaviorTimeSeriesPoint, DailyBucket>(behaviorSeries, metricLabel, {
 			initBucket: () => ({ hits: 0, messages: 0 }),
 			accumulate: (bucket, point) => {
@@ -210,18 +213,18 @@ function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSe
 		return buildSharedPlugins({
 			chartTheme,
 			showLegend: byModel,
-			defaultLabel: "Hits",
+			defaultLabel: t("behavior.hits"),
 			formatValue: formatRateAxis,
 		});
-	}, [chartTheme, byModel]);
+	}, [chartTheme, byModel, t]);
 
 	const { sharedScaleBase, yScale } = useMemo(() => {
 		return buildSharedScales({ chartTheme, formatY: formatRateAxis });
 	}, [chartTheme]);
 
 	const metricLabel = useMemo(() => {
-		return METRIC_OPTIONS.find(m => m.value === metric)?.title ?? "";
-	}, [metric]);
+		return t(METRIC_OPTIONS.find(m => m.value === metric)?.titleKey ?? "behavior.metricTitle-all");
+	}, [metric, t]);
 
 	const lineData = useMemo(() => {
 		if (!byModel) return null;
@@ -264,21 +267,21 @@ function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSe
 	}, [sharedPlugins, sharedScaleBase, yScale]);
 
 	const byModelOptions = [
-		{ value: false, label: "All Models" },
-		{ value: true, label: "By Model" },
+		{ value: false, label: t("behavior.allModels") },
+		{ value: true, label: t("behavior.byModel") },
 	];
 
 	return (
 		<Panel
-			title="User Friction Signals"
-			subtitle={`${metricLabel} as % of user messages per day`}
+			title={t("behavior.frictionSignals")}
+			subtitle={`${metricLabel} ${t("behavior.asPercentOfMessages")}`}
 			actions={
 				<div className="flex items-center gap-3 flex-wrap">
 					<SegmentedControl
 						options={METRIC_OPTIONS.map(o => ({
 							value: o.value,
-							label: o.label,
-							title: o.title,
+							label: t(o.labelKey),
+							title: t(o.titleKey),
 						}))}
 						value={metric}
 						onChange={setMetric}
@@ -290,7 +293,7 @@ function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSe
 			<div className="h-[300px]">
 				{chartData.labels.length === 0 ? (
 					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-						No friction signal data available
+						{t("behavior.noData")}
 					</div>
 				) : byModel && lineData ? (
 					<Line data={lineData} options={lineOptions} />
@@ -332,6 +335,7 @@ function BehaviorModelsTable({
 	behaviorSeries: BehaviorTimeSeriesPoint[];
 }) {
 	const [expandedKey, setExpandedKey] = useState<string | null>(null);
+	const { t } = useTranslation();
 	const theme = useSystemTheme();
 	const chartTheme = TABLE_CHART_THEMES[theme];
 
@@ -347,18 +351,18 @@ function BehaviorModelsTable({
 	}, [models]);
 
 	return (
-		<ModelTableShell title="Behavior Signals by Model" subtitle="Rates are per user message">
+		<ModelTableShell title={t("behavior.byModelTitle")} subtitle={t("behavior.byModelSubtitle")}>
 			<ModelTableHeader
 				gridTemplate={TABLE_GRID_TEMPLATE}
 				columns={[
-					{ label: "Model" },
-					{ label: "Messages", align: "right" },
-					{ label: "CAPS %", align: "right" },
-					{ label: "Profanity %", align: "right" },
-					{ label: "Anguish %", align: "right" },
-					{ label: "Frustration %", align: "right" },
-					{ label: "Hits %", align: "right" },
-					{ label: "Trend", align: "center" },
+					{ label: t("behavior.columns.model") },
+					{ label: t("behavior.columns.messages"), align: "right" },
+					{ label: t("behavior.columns.caps"), align: "right" },
+					{ label: t("behavior.columns.profanity"), align: "right" },
+					{ label: t("behavior.columns.anguish"), align: "right" },
+					{ label: t("behavior.columns.frustration"), align: "right" },
+					{ label: t("behavior.columns.hits"), align: "right" },
+					{ label: t("behavior.columns.trend"), align: "center" },
 				]}
 			/>
 
@@ -412,49 +416,49 @@ function BehaviorModelsTable({
 							expandedContent={
 								<div className="grid gap-4" style={{ gridTemplateColumns: "220px 1fr" }}>
 									<div className="space-y-4 text-sm">
-										<DetailRow
-											label="Yelling (CAPS)"
-											total={model.totalYelling}
-											messages={model.totalMessages}
-											valueClass="text-[#ed4abf]"
-										/>
-										<DetailRow
-											label="Profanity"
-											total={model.totalProfanity}
-											messages={model.totalMessages}
-											valueClass="text-[#ff6b7d]"
-										/>
-										<DetailRow
-											label="Anguish (!!!, nooo, dude, ..)"
-											total={model.totalAnguish}
-											messages={model.totalMessages}
-											valueClass="text-[#9b4dff]"
-										/>
-										<DetailRow
-											label="Negation (no/nope/wrong)"
-											total={model.totalNegation}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Repetition (i meant, still doesnt)"
-											total={model.totalRepetition}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Blame (you didnt, stop X-ing)"
-											total={model.totalBlame}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Avg chars / msg"
-											total={model.totalChars}
-											messages={model.totalMessages}
-											valueClass="stats-text-secondary"
-											mode="average"
-										/>
+									<DetailRow
+										label={t("behavior.detail-yelling")}
+										total={model.totalYelling}
+										messages={model.totalMessages}
+										valueClass="text-[#ed4abf]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-profanity")}
+										total={model.totalProfanity}
+										messages={model.totalMessages}
+										valueClass="text-[#ff6b7d]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-anguish")}
+										total={model.totalAnguish}
+										messages={model.totalMessages}
+										valueClass="text-[#9b4dff]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-negation")}
+										total={model.totalNegation}
+										messages={model.totalMessages}
+										valueClass="text-[#5ad8e6]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-repetition")}
+										total={model.totalRepetition}
+										messages={model.totalMessages}
+										valueClass="text-[#5ad8e6]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-blame")}
+										total={model.totalBlame}
+										messages={model.totalMessages}
+										valueClass="text-[#5ad8e6]"
+									/>
+									<DetailRow
+										label={t("behavior.detail-avgChars")}
+										total={model.totalChars}
+										messages={model.totalMessages}
+										valueClass="stats-text-secondary"
+										mode="average"
+									/>
 									</div>
 									<div className="h-[200px]">
 										{trend.length === 0 ? (
@@ -470,7 +474,7 @@ function BehaviorModelsTable({
 				})}
 				{sortedModels.length === 0 ? (
 					<div className="border-t border-[var(--border-subtle)] px-5 py-8 text-center text-[var(--text-muted)] text-sm">
-						No user behavior recorded for this range yet.
+						{t("behavior.noBehaviorData")}
 					</div>
 				) : null}
 			</ModelTableBody>
@@ -491,7 +495,8 @@ function DetailRow({
 	valueClass: string;
 	mode?: "rate" | "average";
 }) {
-	const perMsgLabel = mode === "rate" ? "% of msgs" : "Per msg";
+	const { t } = useTranslation();
+	const perMsgLabel = mode === "rate" ? t("behavior.percentOfMsgs") : t("behavior.detailPerMsg");
 	const perMsgValue = useMemo(() => {
 		if (messages === 0) return "-";
 		return mode === "rate" ? formatRate(total, messages) : (total / messages).toFixed(0);
@@ -502,7 +507,7 @@ function DetailRow({
 			<div className="text-[var(--text-primary)] font-medium mb-1">{label}</div>
 			<div className="space-y-0.5 text-[var(--text-secondary)]">
 				<div className="flex items-center justify-between">
-					<span className="stats-text-muted text-xs">Total</span>
+					<span className="stats-text-muted text-xs">{t("behavior.detailTotal")}</span>
 					<span className={`font-mono text-xs ${valueClass}`}>{formatInteger(total)}</span>
 				</div>
 				<div className="flex items-center justify-between">
@@ -522,33 +527,34 @@ const SERIES_COLORS = {
 } as const;
 
 function BreakdownChart({ data, chartTheme }: { data: DailyPoint[]; chartTheme: TableChartTheme }) {
+	const { t } = useTranslation();
 	const chartData = useMemo(() => {
 		return {
 			labels: data.map(d => format(new Date(d.timestamp), "MMM d")),
 			datasets: [
 				{
-					label: "CAPS",
+					label: t("behavior.chart-yelling"),
 					data: data.map(d => d.yelling),
 					...lineSeriesStyle(SERIES_COLORS.yelling),
 				},
 				{
-					label: "Profanity",
+					label: t("behavior.chart-profanity"),
 					data: data.map(d => d.profanity),
 					...lineSeriesStyle(SERIES_COLORS.profanity),
 				},
 				{
-					label: "Anguish",
+					label: t("behavior.chart-anguish"),
 					data: data.map(d => d.anguish),
 					...lineSeriesStyle(SERIES_COLORS.anguish),
 				},
 				{
-					label: "Frustration",
+					label: t("behavior.chart-frustration"),
 					data: data.map(d => d.frustration),
 					...lineSeriesStyle(SERIES_COLORS.frustration),
 				},
 			],
 		};
-	}, [data]);
+	}, [data, t]);
 
 	const options = useMemo(() => {
 		return {

--- a/packages/stats/src/client/routes/BehaviorRoute.tsx
+++ b/packages/stats/src/client/routes/BehaviorRoute.tsx
@@ -31,7 +31,7 @@ import {
 import { formatInteger } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildBehaviorSummary } from "../data/view-models";
-import { useTranslation } from "../i18n";
+import { type TranslationFn, useTranslation } from "../i18n";
 import type { BehaviorModelStats, BehaviorOverallStats, BehaviorTimeSeriesPoint, TimeRange } from "../types";
 import { AsyncBoundary, Panel, SegmentedControl } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -67,9 +67,9 @@ export function BehaviorRoute({ active, range, refreshTrigger }: BehaviorRoutePr
 	);
 }
 
-function perMsg(total: number, messages: number): string | undefined {
+function perMsg(total: number, messages: number, t: TranslationFn): string | undefined {
 	if (messages <= 0) return undefined;
-	return `${(total / messages).toFixed(2)} / msg`;
+	return `${(total / messages).toFixed(2)} ${t("behavior.perMsgSuffix")}`;
 }
 
 function BehaviorSummaryPanel({
@@ -92,22 +92,22 @@ function BehaviorSummaryPanel({
 		{
 			label: t("behavior.yellingCaps"),
 			value: formatInteger(overall.totalYelling),
-			sub: perMsg(overall.totalYelling, messages),
+			sub: perMsg(overall.totalYelling, messages, t),
 		},
 		{
 			label: t("behavior.profanityHits"),
 			value: formatInteger(overall.totalProfanity),
-			sub: perMsg(overall.totalProfanity, messages),
+			sub: perMsg(overall.totalProfanity, messages, t),
 		},
 		{
 			label: t("behavior.anguishSignals"),
 			value: formatInteger(overall.totalAnguish),
-			sub: perMsg(overall.totalAnguish, messages),
+			sub: perMsg(overall.totalAnguish, messages, t),
 		},
 		{
 			label: t("behavior.frictionSignals"),
 			value: formatInteger(summary.totalFrustration),
-			sub: perMsg(summary.totalFrustration, messages),
+			sub: perMsg(summary.totalFrustration, messages, t),
 		},
 		{
 			label: t("behavior.highestFrictionModel"),

--- a/packages/stats/src/client/routes/BehaviorRoute.tsx
+++ b/packages/stats/src/client/routes/BehaviorRoute.tsx
@@ -112,7 +112,9 @@ function BehaviorSummaryPanel({
 		{
 			label: t("behavior.highestFrictionModel"),
 			value: summary.highestFrictionModel?.model ?? "—",
-			sub: summary.highestFrictionModel ? `${formatInteger(summary.highestFrictionModel.score)} ${t("behavior.hits")}` : undefined,
+			sub: summary.highestFrictionModel
+				? `${formatInteger(summary.highestFrictionModel.score)} ${t("behavior.hits")}`
+				: undefined,
 		},
 	];
 
@@ -416,49 +418,49 @@ function BehaviorModelsTable({
 							expandedContent={
 								<div className="grid gap-4" style={{ gridTemplateColumns: "220px 1fr" }}>
 									<div className="space-y-4 text-sm">
-									<DetailRow
-										label={t("behavior.detail-yelling")}
-										total={model.totalYelling}
-										messages={model.totalMessages}
-										valueClass="text-[#ed4abf]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-profanity")}
-										total={model.totalProfanity}
-										messages={model.totalMessages}
-										valueClass="text-[#ff6b7d]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-anguish")}
-										total={model.totalAnguish}
-										messages={model.totalMessages}
-										valueClass="text-[#9b4dff]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-negation")}
-										total={model.totalNegation}
-										messages={model.totalMessages}
-										valueClass="text-[#5ad8e6]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-repetition")}
-										total={model.totalRepetition}
-										messages={model.totalMessages}
-										valueClass="text-[#5ad8e6]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-blame")}
-										total={model.totalBlame}
-										messages={model.totalMessages}
-										valueClass="text-[#5ad8e6]"
-									/>
-									<DetailRow
-										label={t("behavior.detail-avgChars")}
-										total={model.totalChars}
-										messages={model.totalMessages}
-										valueClass="stats-text-secondary"
-										mode="average"
-									/>
+										<DetailRow
+											label={t("behavior.detail-yelling")}
+											total={model.totalYelling}
+											messages={model.totalMessages}
+											valueClass="text-[#ed4abf]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-profanity")}
+											total={model.totalProfanity}
+											messages={model.totalMessages}
+											valueClass="text-[#ff6b7d]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-anguish")}
+											total={model.totalAnguish}
+											messages={model.totalMessages}
+											valueClass="text-[#9b4dff]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-negation")}
+											total={model.totalNegation}
+											messages={model.totalMessages}
+											valueClass="text-[#5ad8e6]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-repetition")}
+											total={model.totalRepetition}
+											messages={model.totalMessages}
+											valueClass="text-[#5ad8e6]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-blame")}
+											total={model.totalBlame}
+											messages={model.totalMessages}
+											valueClass="text-[#5ad8e6]"
+										/>
+										<DetailRow
+											label={t("behavior.detail-avgChars")}
+											total={model.totalChars}
+											messages={model.totalMessages}
+											valueClass="stats-text-secondary"
+											mode="average"
+										/>
 									</div>
 									<div className="h-[200px]">
 										{trend.length === 0 ? (

--- a/packages/stats/src/client/routes/BehaviorRoute.tsx
+++ b/packages/stats/src/client/routes/BehaviorRoute.tsx
@@ -209,7 +209,7 @@ function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSe
 			},
 			bucketToValue: bucket => ratePercent(bucket.hits, bucket.messages),
 		});
-	}, [behaviorSeries, byModel, metric]);
+	}, [behaviorSeries, byModel, metric, t]);
 
 	const sharedPlugins = useMemo(() => {
 		return buildSharedPlugins({

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -144,7 +144,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 			},
 			bucketToValue: bucket => bucket.total,
 		});
-	}, [costSeries, byModel]);
+	}, [costSeries, byModel, t]);
 
 	const sharedPlugins = useMemo(() => {
 		return buildSharedPlugins({
@@ -158,7 +158,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 				return `${t("costs.total")}: $${total.toFixed(2)}`;
 			},
 		});
-	}, [chartTheme, byModel]);
+	}, [chartTheme, byModel, t]);
 
 	const { sharedScaleBase, yScale } = useMemo(() => {
 		return buildSharedScales({

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -16,6 +16,7 @@ import {
 import { formatCost } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildCostSummary } from "../data/view-models";
+import { useTranslation } from "../i18n";
 import type { CostTimeSeriesPoint, TimeRange } from "../types";
 import { AsyncBoundary, Panel, SegmentedControl } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -51,13 +52,14 @@ export function CostsRoute({ active, range, refreshTrigger }: CostsRouteProps) {
 }
 
 function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
+	const { t } = useTranslation();
 	const summary = useMemo(() => buildCostSummary(costSeries), [costSeries]);
 
 	const cards = [
-		{ label: "Total Cost", value: formatCost(summary.totalCost) },
-		{ label: "Average / Day", value: formatCost(summary.avgDailyCost) },
+		{ label: t("costs.totalCost"), value: formatCost(summary.totalCost) },
+		{ label: t("costs.avgDailyCost"), value: formatCost(summary.avgDailyCost) },
 		{
-			label: "Top Model",
+			label: t("costs.topModel"),
 			value: summary.topModelName || "—",
 			sub: summary.topModelName ? formatCost(summary.topModelCost) : undefined,
 		},
@@ -71,7 +73,7 @@ function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }
 					<p className="text-2xl font-bold stats-text-primary truncate" title={card.value}>
 						{card.value}
 					</p>
-					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">Total spent: {card.sub}</p>}
+					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">{t("costs.totalSpent")}: {card.sub}</p>}
 				</Panel>
 			))}
 		</div>
@@ -115,6 +117,7 @@ function makeBarLabelPlugin(color: string): Plugin<"bar"> {
 }
 
 function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
+	const { t } = useTranslation();
 	const [byModel, setByModel] = useState(false);
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
@@ -130,7 +133,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 				bucketToValue: bucket => bucket.total,
 			});
 		}
-		return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(costSeries, "Cost", {
+		return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(costSeries, t("costs.label"), {
 			initBucket: () => ({ total: 0 }),
 			accumulate: (bucket, point) => {
 				bucket.total += point.cost;
@@ -142,13 +145,12 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const sharedPlugins = useMemo(() => {
 		return buildSharedPlugins({
 			chartTheme,
-			showLegend: byModel,
-			defaultLabel: "Cost",
+			defaultLabel: t("costs.label"),
 			formatValue: v => `$${v.toFixed(2)}`,
 			footer: items => {
 				if (!byModel || items.length < 2) return undefined;
 				const total = items.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
-				return `Total: $${total.toFixed(2)}`;
+				return `${t("costs.total")}: $${total.toFixed(2)}`;
 			},
 		});
 	}, [chartTheme, byModel]);
@@ -208,20 +210,20 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	}, [sharedPlugins, sharedScaleBase, yScale]);
 
 	const toggleOptions = [
-		{ value: false, label: "All Models" },
-		{ value: true, label: "By Model" },
+		{ value: false, label: t("costs.allModels") },
+		{ value: true, label: t("costs.byModel") },
 	];
 
 	return (
 		<Panel
-			title="Daily Cost"
-			subtitle="API spending over time"
+			title={t("costs.dailyCost")}
+			subtitle={t("costs.apiSpending")}
 			actions={<SegmentedControl options={toggleOptions} value={byModel} onChange={setByModel} />}
 		>
 			<div className="h-[300px]">
 				{chartData.labels.length === 0 ? (
 					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-						No cost data available
+						{t("costs.noData")}
 					</div>
 				) : byModel && lineData ? (
 					<Line data={lineData} options={lineOptions} />

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -75,7 +75,7 @@ function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }
 					</p>
 					{card.sub && (
 						<p className="text-xs stats-text-muted mt-1 font-medium">
-							{t("costs.totalSpent")}: {card.sub}
+							{t("costs.totalSpent", { amount: card.sub })}
 						</p>
 					)}
 				</Panel>
@@ -149,7 +149,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const sharedPlugins = useMemo(() => {
 		return buildSharedPlugins({
 			chartTheme,
-			showLegend: false,
+			showLegend: !!byModel,
 			defaultLabel: t("costs.label"),
 			formatValue: v => `$${v.toFixed(2)}`,
 			footer: items => {

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -73,7 +73,11 @@ function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }
 					<p className="text-2xl font-bold stats-text-primary truncate" title={card.value}>
 						{card.value}
 					</p>
-					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">{t("costs.totalSpent")}: {card.sub}</p>}
+					{card.sub && (
+						<p className="text-xs stats-text-muted mt-1 font-medium">
+							{t("costs.totalSpent")}: {card.sub}
+						</p>
+					)}
 				</Panel>
 			))}
 		</div>
@@ -145,6 +149,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const sharedPlugins = useMemo(() => {
 		return buildSharedPlugins({
 			chartTheme,
+			showLegend: false,
 			defaultLabel: t("costs.label"),
 			formatValue: v => `$${v.toFixed(2)}`,
 			footer: items => {

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -82,7 +82,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 			<div className="stats-mobile-card-grid">
 				<div>
 					<div className="stats-mobile-card-label">{t("errors.column.time")}</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
+					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp, locale)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">{t("errors.column.cost")}</div>

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { getRecentErrors } from "../api";
 import { formatCost, formatInteger, formatRelativeTime } from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { useTranslation } from "../i18n";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
 
@@ -13,6 +14,8 @@ export interface ErrorsRouteProps {
 }
 
 export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRouteProps) {
+	const { t } = useTranslation();
+
 	const {
 		data: recentErrors,
 		error,
@@ -26,7 +29,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 		() => [
 			{
 				key: "model",
-				header: "Model",
+				header: t("errors.column.model"),
 				render: (item: MessageStats) => (
 					<div>
 						<div className="stats-font-medium stats-text-primary">{item.model}</div>
@@ -36,35 +39,35 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 			},
 			{
 				key: "timestamp",
-				header: "Time",
+				header: t("errors.column.time"),
 				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
 			},
 			{
 				key: "errorMessage",
-				header: "Error Message",
+				header: t("errors.column.errorMessage"),
 				render: (item: MessageStats) => (
 					<div
 						className="stats-text-xs stats-text-danger stats-truncate stats-max-w-md stats-font-mono"
 						title={item.errorMessage || ""}
 					>
-						{item.errorMessage || "Unknown error"}
+						{item.errorMessage || t("errors.unknownError")}
 					</div>
 				),
 			},
 			{
 				key: "tokens",
-				header: "Tokens",
+				header: t("errors.column.tokens"),
 				numeric: true,
 				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
 			},
 			{
 				key: "cost",
-				header: "Cost",
+				header: t("errors.column.cost"),
 				numeric: true,
 				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
 			},
 		],
-		[],
+		[t],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
@@ -74,19 +77,19 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 					<div className="stats-font-semibold stats-text-primary">{item.model}</div>
 					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
 				</div>
-				<StatusPill variant="danger">Failed</StatusPill>
+				<StatusPill variant="danger">{t("errors.status.failed")}</StatusPill>
 			</div>
 			<div className="stats-mobile-card-grid">
 				<div>
-					<div className="stats-mobile-card-label">Time</div>
+					<div className="stats-mobile-card-label">{t("errors.column.time")}</div>
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
+					<div className="stats-mobile-card-label">{t("errors.column.cost")}</div>
 					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Tokens</div>
+					<div className="stats-mobile-card-label">{t("errors.column.tokens")}</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
 				</div>
 			</div>
@@ -96,12 +99,12 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 
 	return (
 		<div className="stats-route-container">
-			<Panel title="Recent Errors" subtitle="Up to 50 most recent failed requests in the stats database">
+			<Panel title={t("errors.title")} subtitle={t("errors.subtitle")}>
 				<AsyncBoundary
 					loading={loading}
 					error={error}
 					data={recentErrors}
-					emptyText="No recent failures in the local stats database"
+					emptyText={t("errors.noFailures")}
 				>
 					<DataTable
 						columns={columns}
@@ -109,7 +112,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
 						onRowClick={item => item.id && onRequestClick(item.id)}
 						renderMobileCard={renderMobileCard}
-						emptyText="No recent failures in the local stats database"
+						emptyText={t("errors.noFailures")}
 					/>
 				</AsyncBoundary>
 			</Panel>

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -100,12 +100,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 	return (
 		<div className="stats-route-container">
 			<Panel title={t("errors.title")} subtitle={t("errors.subtitle")}>
-				<AsyncBoundary
-					loading={loading}
-					error={error}
-					data={recentErrors}
-					emptyText={t("errors.noFailures")}
-				>
+				<AsyncBoundary loading={loading} error={error} data={recentErrors} emptyText={t("errors.noFailures")}>
 					<DataTable
 						columns={columns}
 						data={recentErrors || []}

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -14,7 +14,7 @@ export interface ErrorsRouteProps {
 }
 
 export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRouteProps) {
-	const { t } = useTranslation();
+	const { t, locale } = useTranslation();
 
 	const {
 		data: recentErrors,
@@ -40,7 +40,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 			{
 				key: "timestamp",
 				header: t("errors.column.time"),
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
+				render: (item: MessageStats) => formatRelativeTime(item.timestamp, locale),
 			},
 			{
 				key: "errorMessage",
@@ -67,7 +67,7 @@ export function ErrorsRoute({ active, refreshTrigger, onRequestClick }: ErrorsRo
 				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
 			},
 		],
-		[t],
+		[t, locale],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (

--- a/packages/stats/src/client/routes/ModelsRoute.tsx
+++ b/packages/stats/src/client/routes/ModelsRoute.tsx
@@ -150,10 +150,15 @@ function ModelShareChart({ modelSeries, timeRange }: { modelSeries: ModelTimeSer
 	}, [chartTheme]);
 
 	return (
-		<Panel title={t("models.shareChart-title")} subtitle={t("models.shareChart-subtitle", { window: meta.windowLabel })}>
+		<Panel
+			title={t("models.shareChart-title")}
+			subtitle={t("models.shareChart-subtitle", { window: meta.windowLabel })}
+		>
 			<div className="h-[280px]">
 				{chartData.data.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">{t("models.shareChart-noData")}</div>
+					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
+						{t("models.shareChart-noData")}
+					</div>
 				) : (
 					<Line data={data} options={options} />
 				)}
@@ -324,44 +329,48 @@ function ModelsTable({
 							expandedContent={
 								<div className="grid gap-4" style={{ gridTemplateColumns: "200px 1fr" }}>
 									<div className="space-y-4 text-sm">
-									<div>
-										<div className="text-[var(--text-primary)] font-medium mb-2">{t("models.expanded-quality")}</div>
-										<div className="space-y-1 text-[var(--text-secondary)]">
-											<div className="flex items-center justify-between">
-												<span>{t("models.expanded-errorRate")}</span>
-												<span
-													className={
-														errorRate > 5 ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"
-													}
-												>
-													{errorRate.toFixed(1)}%
-												</span>
+										<div>
+											<div className="text-[var(--text-primary)] font-medium mb-2">
+												{t("models.expanded-quality")}
 											</div>
-											<div className="flex items-center justify-between">
-												<span>{t("models.expanded-cacheRate")}</span>
-												<span className="text-[var(--accent-cyan)]">
-													{(model.cacheRate * 100).toFixed(1)}%
-												</span>
-											</div>
-										</div>
-									</div>
-									<div>
-										<div className="text-[var(--text-primary)] font-medium mb-2">{t("models.expanded-latency")}</div>
-										<div className="space-y-1 text-[var(--text-secondary)]">
-											<div className="flex items-center justify-between">
-												<span>{t("models.expanded-avgDuration")}</span>
-												<span className="font-mono">
-													{model.avgDuration ? `${(model.avgDuration / 1000).toFixed(2)}s` : "-"}
-												</span>
-											</div>
-											<div className="flex items-center justify-between">
-												<span>{t("models.expanded-avgTTFT")}</span>
-												<span className="font-mono">
-													{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
-												</span>
+											<div className="space-y-1 text-[var(--text-secondary)]">
+												<div className="flex items-center justify-between">
+													<span>{t("models.expanded-errorRate")}</span>
+													<span
+														className={
+															errorRate > 5 ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"
+														}
+													>
+														{errorRate.toFixed(1)}%
+													</span>
+												</div>
+												<div className="flex items-center justify-between">
+													<span>{t("models.expanded-cacheRate")}</span>
+													<span className="text-[var(--accent-cyan)]">
+														{(model.cacheRate * 100).toFixed(1)}%
+													</span>
+												</div>
 											</div>
 										</div>
-									</div>
+										<div>
+											<div className="text-[var(--text-primary)] font-medium mb-2">
+												{t("models.expanded-latency")}
+											</div>
+											<div className="space-y-1 text-[var(--text-secondary)]">
+												<div className="flex items-center justify-between">
+													<span>{t("models.expanded-avgDuration")}</span>
+													<span className="font-mono">
+														{model.avgDuration ? `${(model.avgDuration / 1000).toFixed(2)}s` : "-"}
+													</span>
+												</div>
+												<div className="flex items-center justify-between">
+													<span>{t("models.expanded-avgTTFT")}</span>
+													<span className="font-mono">
+														{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
+													</span>
+												</div>
+											</div>
+										</div>
 									</div>
 									<div className="h-[200px]">
 										{trendData.length === 0 ? (

--- a/packages/stats/src/client/routes/ModelsRoute.tsx
+++ b/packages/stats/src/client/routes/ModelsRoute.tsx
@@ -20,6 +20,7 @@ import {
 import { formatRangeTick, rangeMeta } from "../components/range-meta";
 import { useResource } from "../data/useResource";
 import { buildModelPerformanceLookup } from "../data/view-models";
+import { useTranslation } from "../i18n";
 import type { ModelPerformancePoint, ModelStats, ModelTimeSeriesPoint, TimeRange } from "../types";
 import { AsyncBoundary, Panel } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -59,9 +60,10 @@ export function ModelsRoute({ active, range, refreshTrigger }: ModelsRouteProps)
 }
 
 function ModelShareChart({ modelSeries, timeRange }: { modelSeries: ModelTimeSeriesPoint[]; timeRange: TimeRange }) {
+	const { t } = useTranslation();
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
-	const meta = rangeMeta(timeRange);
+	const meta = rangeMeta(timeRange, t);
 
 	const chartData = useMemo(() => buildModelPreferenceSeries(modelSeries), [modelSeries]);
 
@@ -148,10 +150,10 @@ function ModelShareChart({ modelSeries, timeRange }: { modelSeries: ModelTimeSer
 	}, [chartTheme]);
 
 	return (
-		<Panel title="Model Preference" subtitle={`Share of requests over ${meta.windowLabel}`}>
+		<Panel title={t("models.shareChart-title")} subtitle={t("models.shareChart-subtitle", { window: meta.windowLabel })}>
 			<div className="h-[280px]">
 				{chartData.data.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">No data available</div>
+					<div className="h-full flex items-center justify-center text-stats-muted text-sm">{t("models.shareChart-noData")}</div>
 				) : (
 					<Line data={data} options={options} />
 				)}
@@ -243,7 +245,8 @@ function ModelsTable({
 	timeRange: TimeRange;
 }) {
 	const [expandedKey, setExpandedKey] = useState<string | null>(null);
-	const meta = rangeMeta(timeRange);
+	const { t } = useTranslation();
+	const meta = rangeMeta(timeRange, t);
 
 	const performanceSeriesByKey = useMemo(
 		() => buildModelPerformanceLookup(performanceSeries, timeRange),
@@ -260,16 +263,16 @@ function ModelsTable({
 	}, [models]);
 
 	return (
-		<ModelTableShell title="Model Statistics">
+		<ModelTableShell title={t("models.table.title")}>
 			<ModelTableHeader
 				gridTemplate={GRID_TEMPLATE}
 				columns={[
-					{ label: "Model" },
-					{ label: "Requests", align: "right" },
-					{ label: "Cost", align: "right" },
-					{ label: "Tokens", align: "right" },
-					{ label: "Tokens/s", align: "right" },
-					{ label: "TTFT", align: "right" },
+					{ label: t("models.table.columns.model") },
+					{ label: t("models.table.columns.requests"), align: "right" },
+					{ label: t("models.table.columns.cost"), align: "right" },
+					{ label: t("models.table.columns.tokens"), align: "right" },
+					{ label: t("models.table.columns.tokensPerSec"), align: "right" },
+					{ label: t("models.table.columns.ttft"), align: "right" },
 					{ label: meta.trendLabel, align: "center" },
 				]}
 			/>
@@ -321,44 +324,44 @@ function ModelsTable({
 							expandedContent={
 								<div className="grid gap-4" style={{ gridTemplateColumns: "200px 1fr" }}>
 									<div className="space-y-4 text-sm">
-										<div>
-											<div className="text-[var(--text-primary)] font-medium mb-2">Quality</div>
-											<div className="space-y-1 text-[var(--text-secondary)]">
-												<div className="flex items-center justify-between">
-													<span>Error rate</span>
-													<span
-														className={
-															errorRate > 5 ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"
-														}
-													>
-														{errorRate.toFixed(1)}%
-													</span>
-												</div>
-												<div className="flex items-center justify-between">
-													<span>Cache rate</span>
-													<span className="text-[var(--accent-cyan)]">
-														{(model.cacheRate * 100).toFixed(1)}%
-													</span>
-												</div>
+									<div>
+										<div className="text-[var(--text-primary)] font-medium mb-2">{t("models.expanded-quality")}</div>
+										<div className="space-y-1 text-[var(--text-secondary)]">
+											<div className="flex items-center justify-between">
+												<span>{t("models.expanded-errorRate")}</span>
+												<span
+													className={
+														errorRate > 5 ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"
+													}
+												>
+													{errorRate.toFixed(1)}%
+												</span>
+											</div>
+											<div className="flex items-center justify-between">
+												<span>{t("models.expanded-cacheRate")}</span>
+												<span className="text-[var(--accent-cyan)]">
+													{(model.cacheRate * 100).toFixed(1)}%
+												</span>
 											</div>
 										</div>
-										<div>
-											<div className="text-[var(--text-primary)] font-medium mb-2">Latency</div>
-											<div className="space-y-1 text-[var(--text-secondary)]">
-												<div className="flex items-center justify-between">
-													<span>Avg duration</span>
-													<span className="font-mono">
-														{model.avgDuration ? `${(model.avgDuration / 1000).toFixed(2)}s` : "-"}
-													</span>
-												</div>
-												<div className="flex items-center justify-between">
-													<span>Avg TTFT</span>
-													<span className="font-mono">
-														{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
-													</span>
-												</div>
+									</div>
+									<div>
+										<div className="text-[var(--text-primary)] font-medium mb-2">{t("models.expanded-latency")}</div>
+										<div className="space-y-1 text-[var(--text-secondary)]">
+											<div className="flex items-center justify-between">
+												<span>{t("models.expanded-avgDuration")}</span>
+												<span className="font-mono">
+													{model.avgDuration ? `${(model.avgDuration / 1000).toFixed(2)}s` : "-"}
+												</span>
+											</div>
+											<div className="flex items-center justify-between">
+												<span>{t("models.expanded-avgTTFT")}</span>
+												<span className="font-mono">
+													{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
+												</span>
 											</div>
 										</div>
+									</div>
 									</div>
 									<div className="h-[200px]">
 										{trendData.length === 0 ? (
@@ -397,25 +400,26 @@ function PerformanceChart({
 	chartTheme: TableChartTheme;
 	timeRange: TimeRange;
 }) {
+	const { t } = useTranslation();
 	const chartData = useMemo(() => {
 		return {
 			labels: data.map(d => formatRangeTick(d.timestamp, timeRange)),
 			datasets: [
 				{
-					label: "TTFT",
+					label: t("models.ttft"),
 					data: data.map(d => d.avgTtftSeconds ?? null),
 					...lineSeriesStyle("#5ad8e6"),
 					yAxisID: "y" as const,
 				},
 				{
-					label: "Tokens/s",
+					label: t("models.tokensPerSec"),
 					data: data.map(d => d.avgTokensPerSecond ?? null),
 					...lineSeriesStyle(color),
 					yAxisID: "y1" as const,
 				},
 			],
 		};
-	}, [data, color, timeRange]);
+	}, [data, color, timeRange, t]);
 
 	const options = useMemo(() => {
 		return {

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -18,7 +18,7 @@ export interface OverviewRouteProps {
 }
 
 export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }: OverviewRouteProps) {
-	const { t } = useTranslation();
+	const { t, locale } = useTranslation();
 
 	const {
 		data: overview,
@@ -149,7 +149,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			{
 				key: "timestamp",
 				header: t("requests.column.time"),
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
+				render: (item: MessageStats) => formatRelativeTime(item.timestamp, locale),
 			},
 			{
 				key: "tokens",
@@ -180,7 +180,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				),
 			},
 		],
-		[t],
+		[t, locale],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -236,7 +236,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 									<Line data={chartData} options={chartOptions} />
 								) : (
 									<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-									{t("overview.noTimeSeries")}
+										{t("overview.noTimeSeries")}
 									</div>
 								)}
 							</div>
@@ -302,7 +302,9 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 									);
 								})}
 								{previewRequests.length === 0 && (
-									<div className="py-8 text-center stats-text-muted text-sm">{t("overview.noRecentRequests")}</div>
+									<div className="py-8 text-center stats-text-muted text-sm">
+										{t("overview.noRecentRequests")}
+									</div>
 								)}
 							</div>
 						</AsyncBoundary>

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -197,7 +197,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			<div className="stats-mobile-card-grid">
 				<div>
 					<div className="stats-mobile-card-label">{t("requests.column.time")}</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
+					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp, locale)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">{t("requests.column.cost")}</div>
@@ -284,7 +284,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 														{req.model}
 													</div>
 													<div className="stats-text-xs stats-text-muted whitespace-nowrap">
-														{formatRelativeTime(req.timestamp)}
+														{formatRelativeTime(req.timestamp, locale)}
 													</div>
 												</div>
 												<div className="flex justify-between items-center text-xs stats-text-muted mt-0.5">

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -5,6 +5,7 @@ import { getOverviewStats, getRecentRequests } from "../api";
 import { CHART_THEMES } from "../components/chart-shared";
 import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { useTranslation } from "../i18n";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, MetricCluster, Panel, Skeleton, StatusPill } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -17,6 +18,8 @@ export interface OverviewRouteProps {
 }
 
 export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }: OverviewRouteProps) {
+	const { t } = useTranslation();
+
 	const {
 		data: overview,
 		error: overviewError,
@@ -50,7 +53,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			labels,
 			datasets: [
 				{
-					label: "Requests",
+					label: t("overview.chart.requests"),
 					data: overview.timeSeries.map(pt => pt.requests),
 					borderColor: "#5ad8e6",
 					backgroundColor: "rgba(90, 216, 230, 0.12)",
@@ -61,7 +64,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					fill: true,
 				},
 				{
-					label: "Errors",
+					label: t("overview.chart.errors"),
 					data: overview.timeSeries.map(pt => pt.errors),
 					borderColor: "#ff6b7d",
 					backgroundColor: "rgba(255, 107, 125, 0.12)",
@@ -73,7 +76,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				},
 			],
 		};
-	}, [overview?.timeSeries, range]);
+	}, [overview?.timeSeries, range, t]);
 
 	const chartOptions = useMemo(() => {
 		return {
@@ -135,7 +138,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		() => [
 			{
 				key: "model",
-				header: "Model",
+				header: t("requests.column.model"),
 				render: (item: MessageStats) => (
 					<div>
 						<div className="stats-font-medium stats-text-primary">{item.model}</div>
@@ -145,39 +148,39 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			},
 			{
 				key: "timestamp",
-				header: "Time",
+				header: t("requests.column.time"),
 				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
 			},
 			{
 				key: "tokens",
-				header: "Tokens",
+				header: t("requests.column.tokens"),
 				numeric: true,
 				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
 			},
 			{
 				key: "cost",
-				header: "Cost",
+				header: t("requests.column.cost"),
 				numeric: true,
 				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
 			},
 			{
 				key: "duration",
-				header: "Duration",
+				header: t("requests.column.duration"),
 				numeric: true,
 				render: (item: MessageStats) => formatDurationMs(item.duration),
 			},
 			{
 				key: "status",
-				header: "Status",
+				header: t("requests.column.status"),
 				className: "stats-text-center",
 				render: (item: MessageStats) => (
 					<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-						{item.errorMessage ? "Failed" : "Success"}
+						{item.errorMessage ? t("requests.status.failed") : t("requests.status.success")}
 					</StatusPill>
 				),
 			},
 		],
-		[],
+		[t],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
@@ -188,24 +191,24 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
 				</div>
 				<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-					{item.errorMessage ? "Failed" : "Success"}
+					{item.errorMessage ? t("requests.status.failed") : t("requests.status.success")}
 				</StatusPill>
 			</div>
 			<div className="stats-mobile-card-grid">
 				<div>
-					<div className="stats-mobile-card-label">Time</div>
+					<div className="stats-mobile-card-label">{t("requests.column.time")}</div>
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
+					<div className="stats-mobile-card-label">{t("requests.column.cost")}</div>
 					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Tokens</div>
+					<div className="stats-mobile-card-label">{t("requests.column.tokens")}</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Duration</div>
+					<div className="stats-mobile-card-label">{t("requests.column.duration")}</div>
 					<div className="stats-mobile-card-value">{formatDurationMs(item.duration)}</div>
 				</div>
 			</div>
@@ -226,14 +229,14 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 
 			<div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
 				<div className="lg:col-span-2">
-					<Panel title="System Throughput" subtitle="Request volume and errors over time">
+					<Panel title={t("overview.throughput.title")} subtitle={t("overview.throughput.subtitle")}>
 						<AsyncBoundary loading={overviewLoading} error={overviewError} data={overview}>
 							<div className="h-[280px]">
 								{overview?.timeSeries && overview.timeSeries.length > 0 ? (
 									<Line data={chartData} options={chartOptions} />
 								) : (
 									<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-										No time-series data available
+									{t("overview.noTimeSeries")}
 									</div>
 								)}
 							</div>
@@ -242,7 +245,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				</div>
 
 				<div>
-					<Panel title="Operational Feed" subtitle="Real-time request log">
+					<Panel title={t("overview.feed.title")} subtitle={t("overview.feed.subtitle")}>
 						<AsyncBoundary
 							loading={requestsLoading}
 							error={requestsError}
@@ -299,7 +302,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 									);
 								})}
 								{previewRequests.length === 0 && (
-									<div className="py-8 text-center stats-text-muted text-sm">No recent requests found</div>
+									<div className="py-8 text-center stats-text-muted text-sm">{t("overview.noRecentRequests")}</div>
 								)}
 							</div>
 						</AsyncBoundary>
@@ -308,11 +311,11 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			</div>
 
 			<Panel
-				title="Recent Requests Preview"
-				subtitle="Latest transactions processed by the proxy"
+				title={t("overview.preview.title")}
+				subtitle={t("overview.preview.subtitle")}
 				actions={
 					<a href={`#/requests?range=${range}`} className="stats-button stats-button-secondary text-xs">
-						View All Requests
+						{t("overview.viewAll")}
 					</a>
 				}
 			>
@@ -323,7 +326,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
 						onRowClick={item => item.id && onRequestClick(item.id)}
 						renderMobileCard={renderMobileCard}
-						emptyText="No recent requests found"
+						emptyText={t("overview.noRecentRequests")}
 					/>
 				</AsyncBoundary>
 			</Panel>

--- a/packages/stats/src/client/routes/ProjectsRoute.tsx
+++ b/packages/stats/src/client/routes/ProjectsRoute.tsx
@@ -146,12 +146,7 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 	return (
 		<div className="stats-route-container">
 			<Panel title={t("projects.title")} subtitle={t("projects.subtitle")}>
-				<AsyncBoundary
-					loading={loading}
-					error={error}
-					data={foldersData}
-					emptyText={t("projects.noFolders")}
-				>
+				<AsyncBoundary loading={loading} error={error} data={foldersData} emptyText={t("projects.noFolders")}>
 					<DataTable
 						columns={columns}
 						data={folderRows}

--- a/packages/stats/src/client/routes/ProjectsRoute.tsx
+++ b/packages/stats/src/client/routes/ProjectsRoute.tsx
@@ -3,6 +3,7 @@ import { getFolderStats } from "../api";
 import { formatCost, formatDurationMs, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildFolderRows, type FolderRowView } from "../data/view-models";
+import { useTranslation } from "../i18n";
 import type { TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
 
@@ -13,6 +14,8 @@ export interface ProjectsRouteProps {
 }
 
 export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRouteProps) {
+	const { t } = useTranslation();
+
 	const {
 		data: foldersData,
 		error,
@@ -31,19 +34,19 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 		() => [
 			{
 				key: "folder",
-				header: "Project/Folder",
+				header: t("projects.column.folder"),
 				render: (item: FolderRowView) => (
 					<div
 						className="stats-font-medium stats-text-primary truncate max-w-[440px]"
-						title={item.folder || "(root)"}
+						title={item.folder || t("projects.root")}
 					>
-						{item.folder || "(root)"}
+						{item.folder || t("projects.root")}
 					</div>
 				),
 			},
 			{
 				key: "totalRequests",
-				header: "Requests",
+				header: t("projects.column.requests"),
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<div className="stats-text-right">
@@ -60,7 +63,7 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "totalCost",
-				header: "Cost",
+				header: t("projects.column.cost"),
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<div className="stats-text-right">
@@ -77,7 +80,7 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "totalTokens",
-				header: "Tokens",
+				header: t("projects.column.tokens"),
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<div className="font-mono">{formatInteger(item.totalInputTokens + item.totalOutputTokens)}</div>
@@ -85,7 +88,7 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "cacheRate",
-				header: "Cache Rate",
+				header: t("projects.column.cacheRate"),
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<span className="stats-text-success font-medium">{formatPercent(item.cacheRate)}</span>
@@ -93,7 +96,7 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "errorRate",
-				header: "Error Rate",
+				header: t("projects.column.errorRate"),
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<StatusPill variant={item.errorRate > 0.1 ? "danger" : item.errorRate > 0 ? "warning" : "success"}>
@@ -103,37 +106,37 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "avgDuration",
-				header: "Avg Duration",
+				header: t("projects.column.avgDuration"),
 				numeric: true,
 				render: (item: FolderRowView) => formatDurationMs(item.avgDuration),
 			},
 		],
-		[],
+		[t],
 	);
 
 	const renderMobileCard = (item: FolderRowView) => (
 		<div className="stats-mobile-card">
 			<div className="stats-mobile-card-header mb-2">
-				<div className="stats-font-semibold stats-text-primary">{item.folder || "(root)"}</div>
+				<div className="stats-font-semibold stats-text-primary">{item.folder || t("projects.root")}</div>
 				<StatusPill variant={item.errorRate > 0.1 ? "danger" : item.errorRate > 0 ? "warning" : "success"}>
-					{formatPercent(item.errorRate)} Err
+					{formatPercent(item.errorRate)} {t("projects.errSuffix")}
 				</StatusPill>
 			</div>
 			<div className="stats-mobile-card-grid">
 				<div>
-					<div className="stats-mobile-card-label">Requests</div>
+					<div className="stats-mobile-card-label">{t("projects.column.requests")}</div>
 					<div className="stats-mobile-card-value font-mono">{formatInteger(item.totalRequests)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
+					<div className="stats-mobile-card-label">{t("projects.column.cost")}</div>
 					<div className="stats-mobile-card-value font-mono">{formatCost(item.totalCost)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cache</div>
+					<div className="stats-mobile-card-label">{t("projects.column.cacheRate")}</div>
 					<div className="stats-mobile-card-value">{formatPercent(item.cacheRate)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Duration</div>
+					<div className="stats-mobile-card-label">{t("projects.column.avgDuration")}</div>
 					<div className="stats-mobile-card-value">{formatDurationMs(item.avgDuration)}</div>
 				</div>
 			</div>
@@ -142,19 +145,19 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 
 	return (
 		<div className="stats-route-container">
-			<Panel title="Projects & Folders" subtitle="Aggregate proxy metrics grouped by folder path">
+			<Panel title={t("projects.title")} subtitle={t("projects.subtitle")}>
 				<AsyncBoundary
 					loading={loading}
 					error={error}
 					data={foldersData}
-					emptyText="No project folders recorded for this range."
+					emptyText={t("projects.noFolders")}
 				>
 					<DataTable
 						columns={columns}
 						data={folderRows}
 						keyExtractor={item => item.folder}
 						renderMobileCard={renderMobileCard}
-						emptyText="No project folders recorded for this range."
+						emptyText={t("projects.noFolders")}
 					/>
 				</AsyncBoundary>
 			</Panel>

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 import { getRecentRequests } from "../api";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
+import { formatCost, formatDurationMs, formatInteger, formatRelativeTime, formatTokensPerSecond } from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { useTranslation } from "../i18n";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
-
 export interface RequestsRouteProps {
 	active: boolean;
 	range: TimeRange;
@@ -13,6 +13,8 @@ export interface RequestsRouteProps {
 }
 
 export function RequestsRoute({ active, refreshTrigger, onRequestClick }: RequestsRouteProps) {
+	const { t } = useTranslation();
+
 	const {
 		data: recentRequests,
 		error,
@@ -21,12 +23,11 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 		pollMs: 30000,
 		enabled: active,
 	});
-
 	const columns = useMemo(
 		() => [
 			{
 				key: "model",
-				header: "Model",
+				header: t("requests.column.model"),
 				render: (item: MessageStats) => (
 					<div>
 						<div className="stats-font-medium stats-text-primary">{item.model}</div>
@@ -36,39 +37,69 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 			},
 			{
 				key: "timestamp",
-				header: "Time",
+				header: t("requests.column.time"),
 				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
 			},
 			{
 				key: "tokens",
-				header: "Tokens",
+				header: t("requests.column.tokens"),
 				numeric: true,
 				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
 			},
 			{
+				key: "inputOutput",
+				header: t("requests.column.inputOutput"),
+				numeric: true,
+				render: (item: MessageStats) => (
+					<div className="stats-text-right">
+						{formatInteger(item.usage.input)} / {formatInteger(item.usage.output)}
+					</div>
+				),
+			},
+			{
+				key: "cache",
+				header: t("requests.column.cache"),
+				numeric: true,
+				render: (item: MessageStats) => (
+					<div className="stats-text-right">
+						{formatInteger(item.usage.cacheRead)} / {formatInteger(item.usage.cacheWrite)}
+					</div>
+				),
+			},
+			{
+				key: "tokensPerSec",
+				header: t("requests.column.tokensPerSec"),
+				numeric: true,
+				render: (item: MessageStats) => {
+					if (!item.duration || item.duration === 0) return "-";
+					const tps = item.usage.totalTokens / (item.duration / 1000);
+					return formatTokensPerSecond(tps);
+				},
+			},
+			{
 				key: "cost",
-				header: "Cost",
+				header: t("requests.column.cost"),
 				numeric: true,
 				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
 			},
 			{
 				key: "duration",
-				header: "Duration",
+				header: t("requests.column.duration"),
 				numeric: true,
 				render: (item: MessageStats) => formatDurationMs(item.duration),
 			},
 			{
 				key: "status",
-				header: "Status",
+				header: t("requests.column.status"),
 				className: "stats-text-center",
 				render: (item: MessageStats) => (
 					<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-						{item.errorMessage ? "Failed" : "Success"}
+						{item.errorMessage ? t("requests.status.failed") : t("requests.status.success")}
 					</StatusPill>
 				),
 			},
 		],
-		[],
+		[t],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
@@ -79,24 +110,24 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
 				</div>
 				<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-					{item.errorMessage ? "Failed" : "Success"}
+					{item.errorMessage ? t("requests.status.failed") : t("requests.status.success")}
 				</StatusPill>
 			</div>
 			<div className="stats-mobile-card-grid">
 				<div>
-					<div className="stats-mobile-card-label">Time</div>
+					<div className="stats-mobile-card-label">{t("requests.column.time")}</div>
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
+					<div className="stats-mobile-card-label">{t("requests.column.cost")}</div>
 					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Tokens</div>
+					<div className="stats-mobile-card-label">{t("requests.column.tokens")}</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Duration</div>
+					<div className="stats-mobile-card-label">{t("requests.column.duration")}</div>
 					<div className="stats-mobile-card-value">{formatDurationMs(item.duration)}</div>
 				</div>
 			</div>
@@ -106,7 +137,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 
 	return (
 		<div className="stats-route-container">
-			<Panel title="All Recent Requests" subtitle="Up to 50 most recent requests processed by OMP">
+			<Panel title={t("requests.title")} subtitle={t("requests.subtitle")}>
 				<AsyncBoundary loading={loading} error={error} data={recentRequests}>
 					<DataTable
 						columns={columns}
@@ -114,7 +145,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
 						onRowClick={item => item.id && onRequestClick(item.id)}
 						renderMobileCard={renderMobileCard}
-						emptyText="No recent requests found"
+						emptyText={t("requests.noRequests")}
 					/>
 				</AsyncBoundary>
 			</Panel>

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -78,7 +78,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 				numeric: true,
 				render: (item: MessageStats) => {
 					if (!item.duration || item.duration === 0) return "-";
-					const tps = item.usage.totalTokens / (item.duration / 1000);
+					const tps = (item.usage.output * 1000) / item.duration;
 					return formatTokensPerSecond(tps);
 				},
 			},

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from "react";
 import { getRecentRequests } from "../api";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime, formatTokensPerSecond } from "../data/formatters";
+import {
+	formatCost,
+	formatDurationMs,
+	formatInteger,
+	formatRelativeTime,
+	formatTokensPerSecond,
+} from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { useTranslation } from "../i18n";
 import type { MessageStats, TimeRange } from "../types";

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -19,7 +19,7 @@ export interface RequestsRouteProps {
 }
 
 export function RequestsRoute({ active, refreshTrigger, onRequestClick }: RequestsRouteProps) {
-	const { t } = useTranslation();
+	const { t, locale } = useTranslation();
 
 	const {
 		data: recentRequests,
@@ -44,7 +44,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 			{
 				key: "timestamp",
 				header: t("requests.column.time"),
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
+				render: (item: MessageStats) => formatRelativeTime(item.timestamp, locale),
 			},
 			{
 				key: "tokens",
@@ -105,7 +105,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 				),
 			},
 		],
-		[t],
+		[t, locale],
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -122,7 +122,7 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 			<div className="stats-mobile-card-grid">
 				<div>
 					<div className="stats-mobile-card-label">{t("requests.column.time")}</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
+					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp, locale)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">{t("requests.column.cost")}</div>

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -1321,3 +1321,36 @@
     transition: none;
   }
 }
+
+/* ==========================================================================
+   Language Select (dropdown for language switching)
+   ========================================================================== */
+.stats-language-select {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s ease;
+}
+
+.stats-language-select:hover {
+  border-color: var(--accent);
+  background: var(--surface);
+}
+
+.stats-language-select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.1);
+}
+
+.stats-language-select option {
+  background: var(--surface);
+  color: var(--text);
+  padding: 4px 8px;
+}

--- a/packages/stats/src/client/ui/AsyncBoundary.tsx
+++ b/packages/stats/src/client/ui/AsyncBoundary.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useTranslation } from "../i18n";
 import { EmptyState } from "./EmptyState";
 import { ErrorState } from "./ErrorState";
 import { Skeleton } from "./Skeleton";
@@ -19,11 +20,14 @@ export function AsyncBoundary({
 	error,
 	data,
 	empty = false,
-	emptyText = "No data available",
+	emptyText,
 	fallback,
 	onRetry,
 	children,
 }: AsyncBoundaryProps) {
+	const { t } = useTranslation();
+	const defaultEmptyText = emptyText ?? t("common.noData");
+
 	// If there's an error and no stale data, render ErrorState
 	if (error && data === null) {
 		return <ErrorState error={error} onRetry={onRetry} />;
@@ -46,7 +50,7 @@ export function AsyncBoundary({
 
 	// If there is data but it's empty, render EmptyState
 	if (!loading && (empty || data === null)) {
-		return <EmptyState message={emptyText} />;
+		return <EmptyState message={defaultEmptyText} />;
 	}
 
 	// Render children (stale data is kept visible even if loading is true in background)

--- a/packages/stats/src/client/ui/DataTable.tsx
+++ b/packages/stats/src/client/ui/DataTable.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useTranslation } from "../i18n";
 
 export interface DataTableColumn<T> {
 	key: string;
@@ -23,8 +24,10 @@ export function DataTable<T>({
 	keyExtractor,
 	onRowClick,
 	renderMobileCard,
-	emptyText = "No data available",
+	emptyText,
 }: DataTableProps<T>) {
+	const { t } = useTranslation();
+	const defaultEmptyText = emptyText ?? t("common.noData");
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>, item: T) => {
 		if (onRowClick && (e.key === "Enter" || e.key === " ")) {
 			e.preventDefault();

--- a/packages/stats/src/client/ui/DataTable.tsx
+++ b/packages/stats/src/client/ui/DataTable.tsx
@@ -36,7 +36,7 @@ export function DataTable<T>({
 	};
 
 	if (data.length === 0) {
-		return <div className="stats-table-empty">{emptyText}</div>;
+		return <div className="stats-table-empty">{defaultEmptyText}</div>;
 	}
 
 	return (

--- a/packages/stats/src/client/ui/EmptyState.tsx
+++ b/packages/stats/src/client/ui/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { Inbox, type LucideIcon } from "lucide-react";
+import { useTranslation } from "../i18n";
 
 export interface EmptyStateProps {
 	message?: string;
@@ -6,11 +7,14 @@ export interface EmptyStateProps {
 	className?: string;
 }
 
-export function EmptyState({ message = "No data available", icon: Icon = Inbox, className = "" }: EmptyStateProps) {
+export function EmptyState({ message, icon: Icon = Inbox, className = "" }: EmptyStateProps) {
+	const { t } = useTranslation();
+	const displayMessage = message ?? t("common.noData");
+
 	return (
 		<div className={`stats-empty-state ${className}`}>
 			<Icon size={24} className="stats-empty-state-icon" aria-hidden="true" />
-			<p className="stats-empty-state-message">{message}</p>
+			<p className="stats-empty-state-message">{displayMessage}</p>
 		</div>
 	);
 }

--- a/packages/stats/src/client/ui/ErrorState.tsx
+++ b/packages/stats/src/client/ui/ErrorState.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "../i18n";
+
 export interface ErrorStateProps {
 	error?: Error | null;
 	onRetry?: () => void;
@@ -5,10 +7,12 @@ export interface ErrorStateProps {
 }
 
 export function ErrorState({ error, onRetry, className = "" }: ErrorStateProps) {
+	const { t } = useTranslation();
+
 	return (
 		<div className={`stats-error-state ${className}`}>
 			<div className="stats-error-state-content">
-				<h4 className="stats-error-state-title">Failed to load data</h4>
+				<h4 className="stats-error-state-title">{t("common.failedToLoad")}</h4>
 				{error && <p className="stats-error-state-message">{error.message}</p>}
 				{onRetry && (
 					<button
@@ -16,7 +20,7 @@ export function ErrorState({ error, onRetry, className = "" }: ErrorStateProps) 
 						onClick={onRetry}
 						className="stats-button stats-button-secondary stats-error-state-btn"
 					>
-						Retry
+						{t("common.retry")}
 					</button>
 				)}
 			</div>

--- a/packages/stats/src/client/ui/JsonBlock.tsx
+++ b/packages/stats/src/client/ui/JsonBlock.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "../i18n";
 
 export interface JsonBlockProps {
 	data: unknown;
@@ -9,6 +10,7 @@ export interface JsonBlockProps {
 }
 
 export function JsonBlock({ data, title, initialCollapsed = false }: JsonBlockProps) {
+	const { t } = useTranslation();
 	const [collapsed, setCollapsed] = useState(initialCollapsed);
 	const [copied, setCopied] = useState(false);
 	const copyResetRef = useRef<number>(0);
@@ -47,19 +49,19 @@ export function JsonBlock({ data, title, initialCollapsed = false }: JsonBlockPr
 				role="button"
 				aria-expanded={!collapsed}
 			>
-				<span className="stats-json-block-title">{title || "JSON"}</span>
+				<span className="stats-json-block-title">{title || t("json.title")}</span>
 				<div className="stats-json-actions">
 					<button
 						type="button"
 						className="stats-json-copy-btn"
 						onClick={handleCopy}
-						aria-label={copied ? "Copied to clipboard" : "Copy JSON to clipboard"}
+						aria-label={copied ? t("json.copiedToClipboard") : t("json.copyToClipboard")}
 					>
 						{copied ? <Check size={13} /> : <Copy size={13} />}
-						{copied ? "Copied" : "Copy"}
+						{copied ? t("json.copied") : t("json.copy")}
 					</button>
 					<span className="stats-json-block-toggle-indicator" data-collapsed={collapsed}>
-						{collapsed ? "▶ Show" : "▼ Hide"}
+						{collapsed ? `▶ ${t("json.show")}` : `▼ ${t("json.hide")}`}
 					</span>
 				</div>
 			</div>

--- a/packages/stats/src/client/ui/MetricCluster.tsx
+++ b/packages/stats/src/client/ui/MetricCluster.tsx
@@ -6,6 +6,7 @@ import {
 	formatPercent,
 	formatTokensPerSecond,
 } from "../data/formatters";
+import { useLocale, useTranslation } from "../i18n";
 import type { AggregatedStats } from "../types";
 
 export interface MetricClusterProps {
@@ -13,52 +14,55 @@ export interface MetricClusterProps {
 }
 
 export function MetricCluster({ stats }: MetricClusterProps) {
+	const { t } = useTranslation();
+	const { locale } = useLocale();
+
 	return (
 		<div className="stats-metric-cluster">
 			<div className="stats-metric-primary-grid">
 				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Total Cost</div>
+					<div className="stats-metric-label">{t("metric.totalCost")}</div>
 					<div className="stats-metric-value">
 						{formatCost(stats.totalCost, stats.totalCost > 0 && stats.totalCost < 0.01 ? 4 : 2)}
 					</div>
 				</div>
 				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Requests</div>
+					<div className="stats-metric-label">{t("metric.requests")}</div>
 					<div className="stats-metric-value">{formatInteger(stats.totalRequests)}</div>
 				</div>
 				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Cache Rate</div>
+					<div className="stats-metric-label">{t("metric.cacheRate")}</div>
 					<div className="stats-metric-value">{formatPercent(stats.cacheRate)}</div>
 				</div>
 				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Error Rate</div>
+					<div className="stats-metric-label">{t("metric.errorRate")}</div>
 					<div className="stats-metric-value">{formatPercent(stats.errorRate)}</div>
 				</div>
 			</div>
 
 			<div className="stats-metric-secondary-grid">
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Input Tokens</div>
-					<div className="stats-metric-value">{formatCompact(stats.totalInputTokens)}</div>
+					<div className="stats-metric-label">{t("metric.inputTokens")}</div>
+					<div className="stats-metric-value">{formatCompact(stats.totalInputTokens, locale)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Output Tokens</div>
-					<div className="stats-metric-value">{formatCompact(stats.totalOutputTokens)}</div>
+					<div className="stats-metric-label">{t("metric.outputTokens")}</div>
+					<div className="stats-metric-value">{formatCompact(stats.totalOutputTokens, locale)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Premium Requests</div>
+					<div className="stats-metric-label">{t("metric.premiumRequests")}</div>
 					<div className="stats-metric-value">{formatInteger(stats.totalPremiumRequests)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Tokens/s</div>
+					<div className="stats-metric-label">{t("metric.tokensPerSec")}</div>
 					<div className="stats-metric-value">{formatTokensPerSecond(stats.avgTokensPerSecond)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Avg Latency</div>
+					<div className="stats-metric-label">{t("metric.avgLatency")}</div>
 					<div className="stats-metric-value">{formatDurationMs(stats.avgDuration)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Avg TTFT</div>
+					<div className="stats-metric-label">{t("metric.avgTTFT")}</div>
 					<div className="stats-metric-value">{formatDurationMs(stats.avgTtft)}</div>
 				</div>
 			</div>

--- a/packages/stats/src/client/ui/RequestDrawer.tsx
+++ b/packages/stats/src/client/ui/RequestDrawer.tsx
@@ -84,7 +84,11 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 				<div className="stats-drawer-header">
 					<div className="stats-drawer-header-left">
 						<h2 className="stats-drawer-title">{t("detail.title")}</h2>
-						{details && <span className="stats-drawer-id">{t("detail.id")}: {id}</span>}
+						{details && (
+							<span className="stats-drawer-id">
+								{t("detail.id")}: {id}
+							</span>
+						)}
 					</div>
 					<button
 						ref={closeButtonRef}
@@ -162,7 +166,10 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 									</div>
 									<div className="stats-drawer-metric-value">{formatInteger(details.usage.totalTokens)}</div>
 									<div className="stats-drawer-metric-sub">
-										{t("detail.inOut", { input: formatInteger(details.usage.input), output: formatInteger(details.usage.output) })}
+										{t("detail.inOut", {
+											input: formatInteger(details.usage.input),
+											output: formatInteger(details.usage.output),
+										})}
 									</div>
 								</div>
 

--- a/packages/stats/src/client/ui/RequestDrawer.tsx
+++ b/packages/stats/src/client/ui/RequestDrawer.tsx
@@ -2,6 +2,7 @@ import { Clock, Coins, Gauge, Hash, Star, X, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getRequestDetails } from "../api";
 import { formatCost, formatDurationMs, formatInteger } from "../data/formatters";
+import { useTranslation } from "../i18n";
 import type { RequestDetails } from "../types";
 import { JsonBlock } from "./JsonBlock";
 import { Skeleton } from "./Skeleton";
@@ -13,6 +14,7 @@ export interface RequestDrawerProps {
 }
 
 export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
+	const { t } = useTranslation();
 	const [details, setDetails] = useState<RequestDetails | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<Error | null>(null);
@@ -77,19 +79,19 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 
 	return (
 		<div className="stats-drawer-overlay" onClick={handleOverlayClick} role="presentation">
-			<div className="stats-drawer" role="dialog" aria-modal="true" aria-label="Request details">
+			<div className="stats-drawer" role="dialog" aria-modal="true" aria-label={t("detail.close")}>
 				{/* Drawer Header */}
 				<div className="stats-drawer-header">
 					<div className="stats-drawer-header-left">
-						<h2 className="stats-drawer-title">Request Details</h2>
-						{details && <span className="stats-drawer-id">ID: {id}</span>}
+						<h2 className="stats-drawer-title">{t("detail.title")}</h2>
+						{details && <span className="stats-drawer-id">{t("detail.id")}: {id}</span>}
 					</div>
 					<button
 						ref={closeButtonRef}
 						type="button"
 						onClick={onClose}
 						className="stats-drawer-close-btn"
-						aria-label="Close request details"
+						aria-label={t("detail.close")}
 					>
 						<X size={18} />
 					</button>
@@ -107,7 +109,7 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 
 					{error && (
 						<div className="stats-drawer-error">
-							<p className="stats-drawer-error-title">Failed to load request details</p>
+							<p className="stats-drawer-error-title">{t("detail.failedToLoad")}</p>
 							<p className="stats-drawer-error-message">{error.message}</p>
 						</div>
 					)}
@@ -122,12 +124,12 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 										<div className="stats-drawer-provider">{details.provider}</div>
 									</div>
 									<StatusPill variant={details.errorMessage ? "danger" : "success"}>
-										{details.errorMessage ? "Error" : "Success"}
+										{details.errorMessage ? t("common.error") : t("common.success")}
 									</StatusPill>
 								</div>
 								{details.errorMessage && (
 									<div className="stats-drawer-error-block">
-										<div className="stats-drawer-error-label">Error Message</div>
+										<div className="stats-drawer-error-label">{t("detail.errorMessage")}</div>
 										<div className="stats-drawer-error-text">{details.errorMessage}</div>
 									</div>
 								)}
@@ -138,7 +140,7 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Coins size={14} className="stats-drawer-metric-icon" />
-										Cost
+										{t("detail.cost")}
 									</div>
 									<div className="stats-drawer-metric-value">{formatCost(details.usage.cost.total, 4)}</div>
 								</div>
@@ -146,7 +148,7 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Star size={14} className="stats-drawer-metric-icon" />
-										Premium
+										{t("detail.premium")}
 									</div>
 									<div className="stats-drawer-metric-value">
 										{formatInteger(details.usage.premiumRequests ?? 0)}
@@ -156,18 +158,18 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Hash size={14} className="stats-drawer-metric-icon" />
-										Total Tokens
+										{t("detail.totalTokens")}
 									</div>
 									<div className="stats-drawer-metric-value">{formatInteger(details.usage.totalTokens)}</div>
 									<div className="stats-drawer-metric-sub">
-										{formatInteger(details.usage.input)} in · {formatInteger(details.usage.output)} out
+										{t("detail.inOut", { input: formatInteger(details.usage.input), output: formatInteger(details.usage.output) })}
 									</div>
 								</div>
 
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Clock size={14} className="stats-drawer-metric-icon" />
-										Duration
+										{t("detail.duration")}
 									</div>
 									<div className="stats-drawer-metric-value">{formatDurationMs(details.duration)}</div>
 								</div>
@@ -175,7 +177,7 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Zap size={14} className="stats-drawer-metric-icon" />
-										TTFT
+										{t("detail.ttft")}
 									</div>
 									<div className="stats-drawer-metric-value">{formatDurationMs(details.ttft)}</div>
 								</div>
@@ -184,20 +186,20 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 									<div className="stats-drawer-metric-card">
 										<div className="stats-drawer-metric-label">
 											<Gauge size={14} className="stats-drawer-metric-icon" />
-											Throughput
+											{t("detail.throughput")}
 										</div>
 										<div className="stats-drawer-metric-value">
 											{((details.usage.output * 1000) / details.duration).toFixed(1)}
 										</div>
-										<div className="stats-drawer-metric-sub">tokens/second</div>
+										<div className="stats-drawer-metric-sub">{t("detail.tokensPerSecond")}</div>
 									</div>
 								)}
 							</div>
 
 							{/* JSON blocks */}
 							<div className="stats-drawer-json-blocks">
-								<JsonBlock data={details.output} title="Output Payload" initialCollapsed={false} />
-								<JsonBlock data={details} title="Raw Request Metadata" initialCollapsed={true} />
+								<JsonBlock data={details.output} title={t("detail.outputPayload")} initialCollapsed={false} />
+								<JsonBlock data={details} title={t("detail.rawMetadata")} initialCollapsed={true} />
 							</div>
 						</div>
 					)}

--- a/packages/stats/src/client/ui/RequestDrawer.tsx
+++ b/packages/stats/src/client/ui/RequestDrawer.tsx
@@ -79,7 +79,7 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 
 	return (
 		<div className="stats-drawer-overlay" onClick={handleOverlayClick} role="presentation">
-			<div className="stats-drawer" role="dialog" aria-modal="true" aria-label={t("detail.close")}>
+			<div className="stats-drawer" role="dialog" aria-modal="true" aria-label={t("detail.title")}>
 				{/* Drawer Header */}
 				<div className="stats-drawer-header">
 					<div className="stats-drawer-header-left">


### PR DESCRIPTION
## What

为 stats dashboard 添加国际化支持，包含英文和中文翻译。语言偏好持久化到 localStorage，用户可在 TopBar 切换语言。

主要改动：
- 新增 `i18n.ts` 实现翻译系统（749 行）
- 翻译所有 UI 组件、路由和通用元素
- 在 TopBar 添加语言切换功能

## Why

Stats dashboard 目前只有英文界面。添加 i18n 支持可以让中文用户更方便地使用，也为未来支持更多语言奠定基础。

## Testing

- ✅ `bun check` 通过（biome lint + TypeScript 类型检查）
- ✅ `bun test packages/stats` 通过（35 tests, 96 expect() calls）
- ✅ 本地手动验证语言切换功能

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated