### PR TITLE
Fix guided goal fallback model resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/guided-goal` to fall back to the current session model when neither the `plan` nor `slow` role resolves, instead of aborting during setup ([#2855](https://github.com/can1357/oh-my-pi/issues/2855)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/goals/guided-setup.ts
+++ b/packages/coding-agent/src/goals/guided-setup.ts
@@ -5,7 +5,7 @@ import { extractTextContent, extractToolCall, parseJsonPayload } from "../commit
 import guidedGoalInterviewPrompt from "../prompts/goals/guided-goal-interview.md" with { type: "text" };
 import guidedGoalSystemPrompt from "../prompts/goals/guided-goal-system.md" with { type: "text" };
 import type { AgentSession } from "../session/agent-session";
-import { toReasoningEffort } from "../thinking";
+import { shouldDisableReasoning, toReasoningEffort } from "../thinking";
 
 const RESPOND_TOOL_NAME = "respond";
 
@@ -66,9 +66,17 @@ export async function runGuidedGoalTurn(
 	options: GuidedGoalTurnOptions,
 ): Promise<GuidedGoalTurnResult> {
 	const plan = session.resolveRoleModelWithThinking("plan");
-	const resolved = plan.model ? plan : session.resolveRoleModelWithThinking("slow");
+	const slow = plan.model ? plan : session.resolveRoleModelWithThinking("slow");
+	const resolved = slow.model
+		? slow
+		: {
+				model: session.model,
+				thinkingLevel: session.thinkingLevel,
+				explicitThinkingLevel: false,
+				warning: undefined,
+			};
 	if (!resolved.model) {
-		throw new Error("No plan or slow model is available for /guided-goal.");
+		throw new Error("No plan, slow, or current session model is available for /guided-goal.");
 	}
 
 	const apiKey = await session.modelRegistry.getApiKey(resolved.model, session.sessionId);
@@ -95,6 +103,7 @@ export async function runGuidedGoalTurn(
 			apiKey: session.modelRegistry.resolver(resolved.model, session.sessionId),
 			signal: options.signal,
 			reasoning: toReasoningEffort(resolved.thinkingLevel),
+			disableReasoning: shouldDisableReasoning(resolved.thinkingLevel),
 			toolChoice: { type: "tool", name: RESPOND_TOOL_NAME },
 		},
 		{ telemetry: resolveTelemetry(session.agent.telemetry, session.sessionId), oneshotKind: "guided_goal_setup" },

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import * as path from "node:path";
 import * as core from "@oh-my-pi/pi-agent-core";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -16,10 +17,17 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 
 const planModel = { provider: "test", id: "plan" } as unknown as Model<Api>;
 const slowModel = { provider: "test", id: "slow" } as unknown as Model<Api>;
+const currentModel = { provider: "test", id: "current" } as unknown as Model<Api>;
 
-function createSession(options?: { plan?: boolean; slow?: boolean }): AgentSession {
+function createSession(options?: {
+	plan?: boolean;
+	slow?: boolean;
+	current?: boolean;
+	thinkingLevel?: ThinkingLevel;
+}): AgentSession {
 	const plan = options?.plan ?? true;
 	const slow = options?.slow ?? true;
+	const current = options?.current ?? false;
 	return {
 		resolveRoleModelWithThinking(role: string) {
 			if (role === "plan" && plan) return { model: planModel, explicitThinkingLevel: false };
@@ -27,9 +35,15 @@ function createSession(options?: { plan?: boolean; slow?: boolean }): AgentSessi
 			return { model: undefined, explicitThinkingLevel: false };
 		},
 		modelRegistry: {
+			getAvailable: () => [currentModel],
 			getApiKey: async () => "test-key",
 			resolver: (model: typeof planModel) => `${model.provider}/${model.id}:key`,
 		},
+		settings: {
+			getModelRole: () => undefined,
+		},
+		model: current ? currentModel : undefined,
+		thinkingLevel: options?.thinkingLevel,
 		sessionId: "session-1",
 		agent: { telemetry: undefined },
 	} as unknown as AgentSession;
@@ -105,7 +119,7 @@ async function createInteractiveGoalHarness(): Promise<{
 			mode.stop();
 			await session.dispose();
 			authStorage.close();
-			tempDir.removeSync();
+			await tempDir.remove();
 			resetSettingsForTest();
 		},
 	};
@@ -145,12 +159,42 @@ describe("guided goal setup", () => {
 		expect(complete.mock.calls[0]?.[0]).toBe(slowModel);
 	});
 
-	it("throws when neither plan nor slow resolves", async () => {
+	it("throws when no guided-goal fallback model resolves", async () => {
 		await expect(
 			runGuidedGoalTurn(createSession({ plan: false, slow: false }), {
 				messages: [{ role: "user", content: "Ship it" }],
 			}),
-		).rejects.toThrow("No plan or slow model is available for /guided-goal.");
+		).rejects.toThrow("No plan, slow, or current session model is available for /guided-goal.");
+	});
+
+	it("falls back to the current session model when plan and slow roles are unresolved", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
+			mockResponse({ kind: "ready", objective: "Deliver with the active model." }) as never,
+		);
+
+		const result = await runGuidedGoalTurn(
+			createSession({ plan: false, slow: false, current: true, thinkingLevel: ThinkingLevel.High }),
+			{ messages: [{ role: "user", content: "Ship it" }] },
+		);
+
+		expect(result).toEqual({ kind: "ready", objective: "Deliver with the active model." });
+		expect(complete.mock.calls[0]?.[0]).toBe(currentModel);
+		expect((complete.mock.calls[0]?.[2] as { reasoning?: ThinkingLevel } | undefined)?.reasoning).toBe(
+			ThinkingLevel.High,
+		);
+	});
+
+	it("preserves disabled reasoning when falling back to the current session model", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
+			mockResponse({ kind: "ready", objective: "Deliver without reasoning." }) as never,
+		);
+
+		await runGuidedGoalTurn(
+			createSession({ plan: false, slow: false, current: true, thinkingLevel: ThinkingLevel.Off }),
+			{ messages: [{ role: "user", content: "Ship it" }] },
+		);
+
+		expect((complete.mock.calls[0]?.[2] as { disableReasoning?: boolean } | undefined)?.disableReasoning).toBe(true);
 	});
 
 	it("rejects malformed structured responses", async () => {


### PR DESCRIPTION
## Summary
- Fallback `/guided-goal` model resolution from `plan` to `slow` to the current session model before aborting setup.
- Preserve the active session thinking level when using the current session model fallback.
- Use async temp cleanup in the guided-goal test harness to avoid Windows `EBUSY` cleanup flakes.

Fixes #2855

## Test Plan
- `bun test packages/coding-agent/test/goals/guided-goal.test.ts --test-name-pattern "falls back to the current session model"`
- `bun test packages/coding-agent/test/goals/guided-goal.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `cmd.exe /c ".\\packages\\coding-agent\\dist\\omp.exe --smoke-test"`