### PR TITLE
fix(coding-agent): preserve plan and goal slash history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fixed the `tools.format` setting schema so `minimax` can be selected as an owned tool-calling dialect, and taught auto mode to route tool-less MiniMax-family models to the MiniMax owned dialect. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
 - Fixed WSL2 TUI stutter by adding a `git.enabled` setting and skipping footer/status-line git probes when disabled or when no git-backed status segment is visible ([#2847](https://github.com/can1357/oh-my-pi/issues/2847)).
 - Fixed JSON-mode startup notices (export/resume/session-picker messages) writing to stdout before the JSON event stream; they now route to stderr so stdout remains newline-delimited JSON.
+- Fixed `/plan <prompt>` and `/goal <objective>` to preserve the typed slash-command line in TUI input history when entering those modes from off ([#2887](https://github.com/can1357/oh-my-pi/issues/2887)).
 
 ## [16.0.4] - 2026-06-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/plan <prompt>` and `/goal <objective>` to preserve the typed slash-command line in TUI input history when entering those modes from off ([#2887](https://github.com/can1357/oh-my-pi/issues/2887)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added
@@ -42,7 +46,6 @@
 - Fixed the `tools.format` setting schema so `minimax` can be selected as an owned tool-calling dialect, and taught auto mode to route tool-less MiniMax-family models to the MiniMax owned dialect. ([#2759](https://github.com/can1357/oh-my-pi/issues/2759))
 - Fixed WSL2 TUI stutter by adding a `git.enabled` setting and skipping footer/status-line git probes when disabled or when no git-backed status segment is visible ([#2847](https://github.com/can1357/oh-my-pi/issues/2847)).
 - Fixed JSON-mode startup notices (export/resume/session-picker messages) writing to stdout before the JSON event stream; they now route to stderr so stdout remains newline-delimited JSON.
-- Fixed `/plan <prompt>` and `/goal <objective>` to preserve the typed slash-command line in TUI input history when entering those modes from off ([#2887](https://github.com/can1357/oh-my-pi/issues/2887)).
 
 ## [16.0.4] - 2026-06-17
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -240,13 +240,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			const hadArgs = !!command.args;
-			// Capture state BEFORE the call: when plan mode is already active,
-			// handlePlanModeCommand may exit it (on confirmed exit) or leave it on (on cancel
-			// or warning). In every "already active" case the typed args are NOT consumed,
-			// so preserve them in history regardless of the user's confirm/cancel choice.
-			const wasPlanModeEnabled = runtime.ctx.planModeEnabled;
 			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
-			if (hadArgs && wasPlanModeEnabled) {
+			if (hadArgs) {
 				runtime.ctx.editor.addToHistory(command.text);
 			}
 			runtime.ctx.editor.setText("");
@@ -275,10 +270,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			const hadArgs = !!command.args;
-			// Capture state BEFORE the call (see /plan above for rationale).
-			const wasGoalModeEnabled = runtime.ctx.goalModeEnabled;
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
-			if (hadArgs && wasGoalModeEnabled) {
+			if (hadArgs) {
 				runtime.ctx.editor.addToHistory(command.text);
 			}
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/slash-commands/plan-history.test.ts
+++ b/packages/coding-agent/test/slash-commands/plan-history.test.ts
@@ -47,8 +47,9 @@ function createGoalHarness(opts: { goalModeEnabled: boolean; dropOnCall: boolean
 		get goalModeEnabled() {
 			return state.goalModeEnabled;
 		},
-		handleGoalModeCommand: mock(async (_rest?: string) => {
+		handleGoalModeCommand: mock(async (rest?: string) => {
 			if (state.goalModeEnabled && opts.dropOnCall) state.goalModeEnabled = false;
+			else if (!state.goalModeEnabled && rest) state.goalModeEnabled = true;
 		}),
 	} as unknown as InteractiveModeContext;
 
@@ -86,14 +87,14 @@ describe("/plan history preservation when already active", () => {
 		expect(h.setText).toHaveBeenCalledWith("");
 	});
 
-	it("does not add to history when entering plan mode for the first time", async () => {
-		// Plan mode was off; the typed args are consumed as the initial prompt.
+	it("preserves typed text in history when entering plan mode for the first time", async () => {
 		const h = createPlanHarness({ planModeEnabled: false, confirmExit: false });
 
 		await executeBuiltinSlashCommand("/plan hello world", h.runtime);
 
 		expect(h.state.planModeEnabled).toBe(true);
-		expect(h.addToHistory).not.toHaveBeenCalled();
+		expect(h.addToHistory).toHaveBeenCalledWith("/plan hello world");
+		expect(h.setText).toHaveBeenCalledWith("");
 	});
 });
 
@@ -113,6 +114,15 @@ describe("/goal history preservation when already active", () => {
 
 	it("preserves typed text in history when goal mode stays active", async () => {
 		const h = createGoalHarness({ goalModeEnabled: true, dropOnCall: false });
+
+		await executeBuiltinSlashCommand("/goal new objective", h.runtime);
+
+		expect(h.state.goalModeEnabled).toBe(true);
+		expect(h.addToHistory).toHaveBeenCalledWith("/goal new objective");
+	});
+
+	it("preserves typed text in history when entering goal mode for the first time", async () => {
+		const h = createGoalHarness({ goalModeEnabled: false, dropOnCall: false });
 
 		await executeBuiltinSlashCommand("/goal new objective", h.runtime);
 


### PR DESCRIPTION
## Repro
Running `bun test packages/coding-agent/test/slash-commands/plan-history.test.ts -t "does not add to history when entering plan mode for the first time"` on `main` reproduces the current contract: the focused test passes because `/plan hello world` is not added to input history when plan mode starts off.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` gated `/plan` and `/goal` history writes on `wasPlanModeEnabled` / `wasGoalModeEnabled`. First-time `/plan <prompt>` and `/goal <objective>` invocations are consumed through `handlePlanModeCommand` / `handleGoalModeCommand` and `startPendingSubmission`, while the normal `InputController` submit-time `editor.addToHistory` path is skipped after `executeBuiltinSlashCommand` returns `true`.

## Fix
- Record args-bearing `/plan` commands in TUI input history regardless of prior plan-mode state.
- Record args-bearing `/goal` commands in TUI input history regardless of prior goal-mode state.
- Flip the existing first-entry `/plan` history test and add first-entry `/goal` coverage.
- Add a coding-agent changelog entry for the input-history fix.

## Verification
`bun test packages/coding-agent/test/slash-commands/plan-history.test.ts` passed with 6 tests and 18 assertions; `bun --cwd=packages/coding-agent run check` passed. Fixes #2887