### PR TITLE
feat(collab): support TLS and static file serving in local relay

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Added
 
 - Added support for collab browser wrapper links whose web UI host differs from the relay host, so the connect screen joins the relay encoded in the URL fragment.
+### Added
+
+- Added support for `--tls-key` and `--tls-cert` arguments in the local relay to run WSS natively, with pair validation.
+- Added automatic static file serving from `collab-web/dist` in the local relay, with SPA fallback for `/r/<roomId>` browser deep links.
 
 ## [16.0.5] - 2026-06-17
 

--- a/packages/collab-web/scripts/local-relay.ts
+++ b/packages/collab-web/scripts/local-relay.ts
@@ -44,8 +44,10 @@ export interface LocalRelay {
 }
 
 export function startLocalRelay(port = 0, tls?: { key?: string; cert?: string }): LocalRelay {
+	if (tls && (tls.key === undefined) !== (tls.cert === undefined)) {
+		throw new Error("local-relay: both key and cert must be provided to enable TLS");
+	}
 	const rooms = new Map<string, Room>();
-
 	const server = Bun.serve({
 		port,
 		...(tls?.key && tls?.cert
@@ -69,8 +71,12 @@ export function startLocalRelay(port = 0, tls?: { key?: string; cert?: string })
 			// Serve static files from the build output directory
 			const distDir = `${import.meta.dir}/../dist`;
 			let filePath = url.pathname;
-			if (filePath === "/" || filePath === "") filePath = "/index.html";
-
+			if (filePath === "/" || filePath === "") {
+				filePath = "/index.html";
+			} else if (ROOM_PATH_RE.test(filePath) && !role) {
+				// Fallback to index.html for browser opens of collab links requested via HTTP (without WebSocket role parameter)
+				filePath = "/index.html";
+			}
 			const file = Bun.file(`${distDir}${filePath}`);
 			return file.exists().then(exists => {
 				if (exists) {
@@ -174,6 +180,10 @@ function parseArgs(argv: readonly string[]): {
 		else if (arg.startsWith("--tls-key=")) tlsKey = arg.slice("--tls-key=".length);
 		else if (arg === "--tls-cert") tlsCert = argv[i + 1];
 		else if (arg.startsWith("--tls-cert=")) tlsCert = arg.slice("--tls-cert=".length);
+	}
+	if ((tlsKey === undefined) !== (tlsCert === undefined)) {
+		console.error("local-relay: both --tls-key and --tls-cert must be provided to enable TLS");
+		process.exit(1);
 	}
 	const port = rawPort === undefined ? DEFAULT_PORT : Number(rawPort);
 	if (!Number.isInteger(port) || port < 0 || port > 65_535) {

--- a/packages/collab-web/scripts/local-relay.ts
+++ b/packages/collab-web/scripts/local-relay.ts
@@ -56,16 +56,28 @@ export function startLocalRelay(port = 0, tls?: { key?: string; cert?: string })
 					},
 				}
 			: {}),
-		fetch(req, srv): Response | undefined {
+		fetch(req, srv): Response | Promise<Response> | undefined {
 			const url = new URL(req.url);
 			const match = ROOM_PATH_RE.exec(url.pathname);
 			const role = url.searchParams.get("role");
-			if (!match || (role !== "host" && role !== "guest")) {
-				return new Response("not found", { status: 404 });
+			if (match && (role === "host" || role === "guest")) {
+				const data: SocketData = { roomId: match[1]!, role, peerId: 0 };
+				if (srv.upgrade(req, { data })) return undefined;
+				return new Response("websocket upgrade required", { status: 426 });
 			}
-			const data: SocketData = { roomId: match[1]!, role, peerId: 0 };
-			if (srv.upgrade(req, { data })) return undefined;
-			return new Response("websocket upgrade required", { status: 426 });
+
+			// Serve static files from the build output directory
+			const distDir = `${import.meta.dir}/../dist`;
+			let filePath = url.pathname;
+			if (filePath === "/" || filePath === "") filePath = "/index.html";
+
+			const file = Bun.file(`${distDir}${filePath}`);
+			return file.exists().then(exists => {
+				if (exists) {
+					return new Response(file);
+				}
+				return new Response("not found", { status: 404 });
+			});
 		},
 		websocket: {
 			open(ws: RelaySocket): void {

--- a/packages/collab-web/scripts/local-relay.ts
+++ b/packages/collab-web/scripts/local-relay.ts
@@ -43,11 +43,19 @@ export interface LocalRelay {
 	stop(): void;
 }
 
-export function startLocalRelay(port = 0): LocalRelay {
+export function startLocalRelay(port = 0, tls?: { key?: string; cert?: string }): LocalRelay {
 	const rooms = new Map<string, Room>();
 
 	const server = Bun.serve({
 		port,
+		...(tls?.key && tls?.cert
+			? {
+					tls: {
+						key: Bun.file(tls.key),
+						cert: Bun.file(tls.cert),
+					},
+				}
+			: {}),
 		fetch(req, srv): Response | undefined {
 			const url = new URL(req.url);
 			const match = ROOM_PATH_RE.exec(url.pathname);
@@ -121,8 +129,9 @@ export function startLocalRelay(port = 0): LocalRelay {
 		},
 	});
 
+	const isTls = !!(tls?.key && tls?.cert);
 	return {
-		url: `ws://localhost:${server.port}`,
+		url: `${isTls ? "wss" : "ws"}://localhost:${server.port}`,
 		stop(): void {
 			for (const room of rooms.values()) {
 				const closure = JSON.stringify({ t: "room-closed" });
@@ -137,24 +146,34 @@ export function startLocalRelay(port = 0): LocalRelay {
 		},
 	};
 }
-function parsePort(argv: readonly string[]): number {
-	let raw: string | undefined;
+function parseArgs(argv: readonly string[]): {
+	port: number;
+	tlsKey?: string;
+	tlsCert?: string;
+} {
+	let rawPort: string | undefined;
+	let tlsKey: string | undefined;
+	let tlsCert: string | undefined;
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i]!;
-		if (arg === "--port") raw = argv[i + 1];
-		else if (arg.startsWith("--port=")) raw = arg.slice("--port=".length);
+		if (arg === "--port") rawPort = argv[i + 1];
+		else if (arg.startsWith("--port=")) rawPort = arg.slice("--port=".length);
+		else if (arg === "--tls-key") tlsKey = argv[i + 1];
+		else if (arg.startsWith("--tls-key=")) tlsKey = arg.slice("--tls-key=".length);
+		else if (arg === "--tls-cert") tlsCert = argv[i + 1];
+		else if (arg.startsWith("--tls-cert=")) tlsCert = arg.slice("--tls-cert=".length);
 	}
-	if (raw === undefined) return DEFAULT_PORT;
-	const port = Number(raw);
+	const port = rawPort === undefined ? DEFAULT_PORT : Number(rawPort);
 	if (!Number.isInteger(port) || port < 0 || port > 65_535) {
-		console.error(`local-relay: invalid --port ${raw}`);
+		console.error(`local-relay: invalid --port ${rawPort}`);
 		process.exit(1);
 	}
-	return port;
+	return { port, tlsKey, tlsCert };
 }
 
 if (import.meta.main) {
-	const relay = startLocalRelay(parsePort(Bun.argv.slice(2)));
+	const config = parseArgs(Bun.argv.slice(2));
+	const relay = startLocalRelay(config.port, { key: config.tlsKey, cert: config.tlsCert });
 	let stopping = false;
 	const shutdown = (): void => {
 		if (stopping) return;

--- a/packages/collab-web/test/local-relay.test.ts
+++ b/packages/collab-web/test/local-relay.test.ts
@@ -177,4 +177,50 @@ describe("local collab relay", () => {
 		expect(JSON.parse(await closure)).toEqual({ t: "room-closed" });
 		expect((await guestClose).code).toBe(4001);
 	});
+
+	it("validates TLS argument pairs", () => {
+		expect(() => startLocalRelay(0, { key: "key.pem" })).toThrow();
+		expect(() => startLocalRelay(0, { cert: "cert.pem" })).toThrow();
+		try {
+			const tempRelay = startLocalRelay(0, { key: "key.pem", cert: "cert.pem" });
+			expect(tempRelay.url).toStartWith("wss://");
+			tempRelay.stop();
+		} catch (e: any) {
+			expect(e.message).not.toContain("both key and cert must be provided");
+		}
+	});
+
+	it("serves static assets and fallback SPA room pages", async () => {
+		relay = startLocalRelay();
+
+		const distDir = `${import.meta.dir}/../dist`;
+		const fs = require("fs");
+		const path = require("path");
+		if (!fs.existsSync(distDir)) {
+			fs.mkdirSync(distDir, { recursive: true });
+		}
+		fs.writeFileSync(path.join(distDir, "index.html"), "<html>mock index</html>");
+		fs.writeFileSync(path.join(distDir, "dummy.js"), "console.log(1)");
+
+		try {
+			// 1. Root serves index.html
+			const rootRes = await fetch(`${relayHttpUrl()}/`);
+			expect(rootRes.status).toBe(200);
+			expect(await rootRes.text()).toBe("<html>mock index</html>");
+
+			// 2. Existing asset file serves
+			const assetRes = await fetch(`${relayHttpUrl()}/dummy.js`);
+			expect(assetRes.status).toBe(200);
+			expect(await assetRes.text()).toBe("console.log(1)");
+
+			// 3. /r/<roomId> serves fallback index.html
+			const roomRes = await fetch(`${relayHttpUrl()}/r/${ROOM}`);
+			expect(roomRes.status).toBe(200);
+			expect(await roomRes.text()).toBe("<html>mock index</html>");
+		} finally {
+			try {
+				fs.unlinkSync(path.join(distDir, "dummy.js"));
+			} catch {}
+		}
+	});
 });


### PR DESCRIPTION
### Summary
This PR enhances the OMP local collaboration relay (`packages/collab-web/scripts/local-relay.ts`) with two main features:
1. **TLS support**: Adds command-line arguments `--tls-key` and `--tls-cert` to allow launching the relay over HTTPS/WSS directly (useful for private networks / tailnets).
2. **Static file serving**: Dynamically serves the React frontend assets from `packages/collab-web/dist` if requested over HTTP, making the local relay a fully self-contained Web + WebSocket server.

These improvements are generic and backwards-compatible (plain `ws://` on port 7466 remains the default if no TLS arguments are passed).