### PR TITLE
fix(ai): clear pre-response stream watchdogs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed pre-response stream watchdogs for Codex, Bedrock, Gemini CLI, and Ollama so the first-event timeout is cleared after response headers arrive instead of aborting long active response bodies. ([#2879](https://github.com/can1357/oh-my-pi/issues/2879))
 - Fixed Gemini usage-tier mapping so `gemini-3.5-flash` is treated as `Flash` and `gemini-3.1-pro` plus `gemini-pro-agent` are treated as `Pro` in usage accounting
 - Fixed Antigravity stream state handling so a request’s `last_execution_id` is committed only after a successful completion and cleared between retry attempts
 - Fixed `streamSimple()` Gemini streams to run through the thinking-loop guard for custom API and pi-native transports, so degenerate `thinking` loops now abort with the same retryable empty-content error path as other Gemini stream paths

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -33,6 +33,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { appendRawHttpRequestDumpFor400, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs } from "../utils/idle-iterator";
 import { parseStreamingJson, parseStreamingJsonThrottled } from "../utils/json-parse";
+import { createPreResponseTimeoutSignal } from "../utils/pre-response-timeout";
 import { toolWireSchema } from "../utils/schema/wire";
 import { invalidateAwsCredentialCache, resolveAwsCredentials } from "./aws-credentials";
 import { decodeEventStream } from "./aws-eventstream";
@@ -287,26 +288,23 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			// configurable watchdogs govern slow-prefill streams (issue #2422).
 			// Direct callers that bypass `register-builtins` (which installs the
 			// iterator-level first-event watchdog) still need a pre-response
-			// timer, otherwise a Bedrock/proxy that accepts the POST and never
-			// sends headers would hang forever.
+			// timer, but it must stop once headers arrive so it cannot abort a
+			// healthy response body mid-stream.
 			const firstEventTimeoutMs = options.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs();
-			const preResponseWatchdog =
-				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0
-					? AbortSignal.timeout(firstEventTimeoutMs)
-					: undefined;
-			const fetchSignal = preResponseWatchdog
-				? options.signal
-					? AbortSignal.any([options.signal, preResponseWatchdog])
-					: preResponseWatchdog
-				: options.signal;
-			const response = await fetchWithRetry(url, {
-				method: "POST",
-				headers: requestHeaders,
-				body,
-				signal: fetchSignal,
-				fetch: options.fetch,
-				timeout: false,
-			});
+			const preResponseTimeout = createPreResponseTimeoutSignal(options.signal, firstEventTimeoutMs);
+			let response: Response;
+			try {
+				response = await fetchWithRetry(url, {
+					method: "POST",
+					headers: requestHeaders,
+					body,
+					signal: preResponseTimeout.signal,
+					fetch: options.fetch,
+					timeout: false,
+				});
+			} finally {
+				preResponseTimeout.clear();
+			}
 
 			if (!response.ok) {
 				if (!bearerToken && (response.status === 401 || response.status === 403)) {

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -31,6 +31,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { extractGoogleValidationUrl, formatGoogleValidationRequiredMessage } from "../utils/google-validation";
 import { appendRawHttpRequestDumpFor400, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs } from "../utils/idle-iterator";
+import { createPreResponseTimeoutSignal } from "../utils/pre-response-timeout";
 // Refresh is the sole responsibility of AuthStorage (broker-aware, single-flighted);
 // the stream provider trusts the access token threaded through `options.apiKey`.
 import { normalizeSchemaForCCA } from "../utils/schema";
@@ -451,22 +452,13 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				headers: requestHeaders,
 			};
 
-			// Direct callers that skip `register-builtins` (which installs the
+			// Direct callers that bypass `register-builtins` (which installs the
 			// iterator-level watchdog) need a pre-response timer alongside
 			// `timeout: false`; otherwise a stalled Cloud Code Assist proxy
-			// would hang forever. Floor matches the lazy wrapper's 5min default.
+			// would hang forever. Clear that timer once headers arrive so active
+			// long streams are governed by the iterator-level idle watchdog.
 			const firstEventTimeoutMs =
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(undefined, 300_000);
-			const preResponseWatchdog =
-				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0
-					? AbortSignal.timeout(firstEventTimeoutMs)
-					: undefined;
-			const callerSignal = options?.signal;
-			const fetchSignal = preResponseWatchdog
-				? callerSignal
-					? AbortSignal.any([callerSignal, preResponseWatchdog])
-					: preResponseWatchdog
-				: callerSignal;
 
 			let started = false;
 			let sawFinishReason = false;
@@ -665,17 +657,23 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					started = false;
 					resetOutput();
 
-					const response = await fetchWithRetry(() => `${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
-						method: "POST",
-						headers: requestHeaders,
-						body: requestBodyJson,
-						signal: fetchSignal,
-						maxAttempts: isLastEndpoint ? MAX_RETRIES + 1 : 1,
-						defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
-						maxDelayMs: options?.maxRetryDelayMs ?? RATE_LIMIT_BUDGET_MS,
-						fetch: options?.fetch,
-						timeout: false,
-					});
+					const preResponseTimeout = createPreResponseTimeoutSignal(options?.signal, firstEventTimeoutMs);
+					let response: Response;
+					try {
+						response = await fetchWithRetry(() => `${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
+							method: "POST",
+							headers: requestHeaders,
+							body: requestBodyJson,
+							signal: preResponseTimeout.signal,
+							maxAttempts: isLastEndpoint ? MAX_RETRIES + 1 : 1,
+							defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
+							maxDelayMs: options?.maxRetryDelayMs ?? RATE_LIMIT_BUDGET_MS,
+							fetch: options?.fetch,
+							timeout: false,
+						});
+					} finally {
+						preResponseTimeout.clear();
+					}
 
 					if (!response.ok) {
 						if (response.status === 429 || (response.status >= 500 && response.status < 600)) {

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -400,6 +400,8 @@ function mapDoneReason(doneReason: string | undefined, output: AssistantMessage)
 	return "stop";
 }
 
+const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+
 export const streamOllama: StreamFunction<"ollama-chat"> = (
 	model: Model<"ollama-chat">,
 	context: Context,
@@ -541,14 +543,15 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 					method: "POST",
 					headers: {
 						...model.headers,
+						...options.headers,
 						Authorization: `Bearer ${apiKey}`,
 						"Content-Type": "application/json",
-						Accept: "application/x-ndjson",
 					},
 					body: JSON.stringify(body),
 					signal: preResponseTimeout.signal,
 					fetch: options.fetch,
 					timeout: false,
+					defaultDelayMs: OLLAMA_RETRY_DELAYS_MS,
 				});
 			} finally {
 				preResponseTimeout.clear();

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -20,6 +20,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { type CapturedHttpErrorResponse, finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getOpenAIStreamFirstEventTimeoutMs, getOpenAIStreamIdleTimeoutMs } from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
+import { createPreResponseTimeoutSignal } from "../utils/pre-response-timeout";
 import { toolWireSchema } from "../utils/schema/wire";
 import {
 	getStreamMarkupHealingPattern,
@@ -399,8 +400,6 @@ function mapDoneReason(doneReason: string | undefined, output: AssistantMessage)
 	return "stop";
 }
 
-const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
-
 export const streamOllama: StreamFunction<"ollama-chat"> = (
 	model: Model<"ollama-chat">,
 	context: Context,
@@ -530,32 +529,30 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 			// the iterator-level watchdog) need a pre-response timer alongside
 			// `timeout: false`; otherwise an Ollama server that accepts the
 			// POST and never streams headers would hang forever (issue #2422).
+			// Clear the pre-response timer after headers so active streams are
+			// governed by the idle watchdog, not by total wall-clock duration.
 			const idleTimeoutMs = options.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 			const firstEventTimeoutMs =
 				options.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
-			const preResponseWatchdog =
-				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0
-					? AbortSignal.timeout(firstEventTimeoutMs)
-					: undefined;
-			const fetchSignal = preResponseWatchdog
-				? options.signal
-					? AbortSignal.any([options.signal, preResponseWatchdog])
-					: preResponseWatchdog
-				: options.signal;
-			const response = await fetchWithRetry(`${baseUrl}/api/chat`, {
-				method: "POST",
-				headers: {
-					...model.headers,
-					...options.headers,
-					Authorization: `Bearer ${apiKey}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify(body),
-				signal: fetchSignal,
-				defaultDelayMs: OLLAMA_RETRY_DELAYS_MS,
-				fetch: options.fetch,
-				timeout: false,
-			});
+			const preResponseTimeout = createPreResponseTimeoutSignal(options.signal, firstEventTimeoutMs);
+			let response: Response;
+			try {
+				response = await fetchWithRetry(`${baseUrl}/api/chat`, {
+					method: "POST",
+					headers: {
+						...model.headers,
+						Authorization: `Bearer ${apiKey}`,
+						"Content-Type": "application/json",
+						Accept: "application/x-ndjson",
+					},
+					body: JSON.stringify(body),
+					signal: preResponseTimeout.signal,
+					fetch: options.fetch,
+					timeout: false,
+				});
+			} finally {
+				preResponseTimeout.clear();
+			}
 			if (!response.ok) {
 				capturedErrorResponse = await captureHttpErrorResponse(response);
 				throw new OllamaApiError(`HTTP ${response.status} from ${baseUrl}/api/chat`, response.status, {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -51,6 +51,7 @@ import {
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { parseStreamingJson, parseStreamingJsonThrottled } from "../utils/json-parse";
+import { createPreResponseTimeoutSignal } from "../utils/pre-response-timeout";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { notifyRawSseEvent } from "../utils/sse-debug";
@@ -3133,29 +3134,25 @@ async function openCodexSseEventStream(
 	// `wrapCodexSseStream` arms a first-event watchdog only after this fetch
 	// resolves (it wraps the SSE generator). With `timeout: false` disabling
 	// Bun's native 300s ceiling, a stalled pre-response request needs its own
-	// watchdog — combine the caller signal with a fresh
-	// `AbortSignal.timeout(firstEventTimeoutMs)` so headers must arrive
-	// within the configured budget (issue #2422).
-	const preResponseWatchdog =
-		firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0
-			? AbortSignal.timeout(firstEventTimeoutMs)
-			: undefined;
-	const fetchSignal = preResponseWatchdog
-		? signal
-			? AbortSignal.any([signal, preResponseWatchdog])
-			: preResponseWatchdog
-		: signal;
-	const response = await fetchWithRetry(url, {
-		method: "POST",
-		headers,
-		body: JSON.stringify(body),
-		signal: fetchSignal,
-		maxAttempts: CODEX_MAX_RETRIES + 1,
-		defaultDelayMs: attempt => CODEX_RETRY_DELAY_MS * (attempt + 1),
-		maxDelayMs: CODEX_RATE_LIMIT_BUDGET_MS,
-		fetch: fetchOverride,
-		timeout: false,
-	});
+	// watchdog, but that timer must be cleared once headers arrive so it cannot
+	// abort a healthy response body mid-stream.
+	const preResponseTimeout = createPreResponseTimeoutSignal(signal, firstEventTimeoutMs);
+	let response: Response;
+	try {
+		response = await fetchWithRetry(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal: preResponseTimeout.signal,
+			maxAttempts: CODEX_MAX_RETRIES + 1,
+			defaultDelayMs: attempt => CODEX_RETRY_DELAY_MS * (attempt + 1),
+			maxDelayMs: CODEX_RATE_LIMIT_BUDGET_MS,
+			fetch: fetchOverride,
+			timeout: false,
+		});
+	} finally {
+		preResponseTimeout.clear();
+	}
 	logCodexDebug("codex response", {
 		url: response.url,
 		status: response.status,

--- a/packages/ai/src/utils/pre-response-timeout.ts
+++ b/packages/ai/src/utils/pre-response-timeout.ts
@@ -1,0 +1,25 @@
+/**
+ * Creates a fetch signal whose timeout only covers the pre-response phase.
+ *
+ * Streaming providers disable Bun's native fetch timeout and rely on iterator-level
+ * first-event/idle watchdogs after headers arrive. A plain `AbortSignal.timeout()`
+ * keeps running after `fetch()` resolves and can abort a healthy response body, so
+ * callers must clear the timer immediately after the response is received.
+ */
+export function createPreResponseTimeoutSignal(
+	callerSignal: AbortSignal | undefined,
+	timeoutMs: number | undefined,
+): { signal: AbortSignal | undefined; clear: () => void } {
+	if (timeoutMs === undefined || timeoutMs <= 0) {
+		return { signal: callerSignal, clear: () => {} };
+	}
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	timer.unref?.();
+
+	return {
+		signal: callerSignal ? AbortSignal.any([callerSignal, controller.signal]) : controller.signal,
+		clear: () => clearTimeout(timer),
+	};
+}

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -18,6 +18,19 @@ function createReasoningOllamaModel() {
 	});
 }
 
+function getHeader(headers: RequestInit["headers"], name: string): string | undefined {
+	if (!headers) return undefined;
+	if (headers instanceof Headers) return headers.get(name) ?? undefined;
+	if (Array.isArray(headers)) {
+		for (const [key, value] of headers) {
+			if (key.toLowerCase() === name.toLowerCase()) return value;
+		}
+		return undefined;
+	}
+	const value = headers[name];
+	return typeof value === "string" ? value : value?.[0];
+}
+
 describe("Ollama chat thinking controls", () => {
 	it("sends think false when reasoning is explicitly disabled", async () => {
 		let payload: object | undefined;
@@ -42,5 +55,27 @@ describe("Ollama chat thinking controls", () => {
 		}).result();
 
 		expect(payload ? Reflect.get(payload, "think") : undefined).toBe(false);
+	});
+
+	it("forwards per-call headers to the chat request", async () => {
+		let requestHeaders: RequestInit["headers"];
+		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			requestHeaders = init?.headers;
+			return new Response('{"message":{"content":"ok"},"done":true,"prompt_eval_count":1,"eval_count":1}\n', {
+				status: 200,
+			});
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "Ping", timestamp: 0 }],
+		};
+
+		await streamOllama(createReasoningOllamaModel(), context, {
+			apiKey: "test-key",
+			headers: { "X-Proxy-Token": "proxy-token" },
+			fetch: fetchMock,
+		}).result();
+
+		expect(getHeader(requestHeaders, "X-Proxy-Token")).toBe("proxy-token");
+		expect(getHeader(requestHeaders, "Authorization")).toBe("Bearer test-key");
 	});
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -148,6 +148,78 @@ function createNoProgressCodexSse(signal: AbortSignal | undefined): Response {
 	return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
 }
 
+function createSlowActiveCodexSse(signal: AbortSignal | undefined): Response {
+	const encoder = new TextEncoder();
+	const text = "Long active stream completed";
+	const deltas = ["Long ", "active ", "stream ", "completed"];
+	const events: Record<string, unknown>[] = [
+		{ type: "response.created", response: { id: "resp_active" } },
+		{
+			type: "response.output_item.added",
+			item: { type: "message", id: "msg_active", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+		...deltas.map(delta => ({ type: "response.output_text.delta", delta })),
+		{
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_active",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_active",
+				status: "completed",
+				usage: DEFAULT_USAGE,
+			},
+		},
+	];
+
+	let timer: NodeJS.Timeout | undefined;
+	let abortListener: (() => void) | undefined;
+	let closed = false;
+	const cleanup = () => {
+		closed = true;
+		if (timer) clearTimeout(timer);
+		if (abortListener) signal?.removeEventListener("abort", abortListener);
+	};
+	const encode = (event: unknown): Uint8Array => encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			let index = 0;
+			const enqueueNext = () => {
+				if (closed) return;
+				if (index >= events.length) {
+					cleanup();
+					controller.close();
+					return;
+				}
+				controller.enqueue(encode(events[index++]));
+				timer = setTimeout(enqueueNext, 3);
+			};
+			abortListener = () => {
+				cleanup();
+				controller.error(new Error("pre-response timeout aborted active stream"));
+			};
+			if (signal?.aborted) {
+				queueMicrotask(() => abortListener?.());
+			} else {
+				signal?.addEventListener("abort", abortListener, { once: true });
+				enqueueNext();
+			}
+		},
+		cancel() {
+			cleanup();
+		},
+	});
+	return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
 function encodeWebSocketMessage(value: Record<string, unknown>): Uint8Array {
 	return new TextEncoder().encode(JSON.stringify(value));
 }
@@ -702,6 +774,24 @@ describe("openai-codex streaming", () => {
 		const byName = new Map(calls.map(c => [c.name, c] as const));
 		expect(byName.get("newer")?.arguments).toEqual({ input: "id-only-current" });
 		expect(byName.get("older")?.arguments).toEqual({});
+	});
+
+	it("does not let the pre-response timeout abort active SSE bodies", async () => {
+		const token = createCodexTestToken();
+		const context = createCodexTestContext();
+		const fetchMock: FetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+			Promise.resolve(createSlowActiveCodexSse(getRequestSignal(input, init)));
+
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const result = await streamOpenAICodexResponses(model, context, {
+			fetch: fetchMock,
+			apiKey: token,
+			streamFirstEventTimeoutMs: 5,
+			streamIdleTimeoutMs: 25,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "Long active stream completed" })]);
 	});
 
 	it("waits for caller abort when SSE streams only no-progress status events", async () => {

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -7,6 +7,7 @@ import {
 	iterateWithIdleTimeout,
 	iterateWithTerminalGrace,
 } from "@oh-my-pi/pi-ai/utils/idle-iterator";
+import { createPreResponseTimeoutSignal } from "@oh-my-pi/pi-ai/utils/pre-response-timeout";
 
 /**
  * Per-provider fallback overrides on the stream-watchdog helpers.
@@ -143,6 +144,29 @@ async function expectRejectsWithMessage(run: () => Promise<void>, message: strin
 	expect(caught).toBeInstanceOf(Error);
 	expect((caught as Error).message).toBe(message);
 }
+
+describe("createPreResponseTimeoutSignal", () => {
+	it("stops the timeout from aborting after headers arrive", async () => {
+		const preResponseTimeout = createPreResponseTimeoutSignal(undefined, 5);
+
+		preResponseTimeout.clear();
+		await Bun.sleep(10);
+
+		expect(preResponseTimeout.signal?.aborted).toBe(false);
+	});
+
+	it("keeps forwarding caller aborts after the timeout is cleared", () => {
+		const caller = new AbortController();
+		const preResponseTimeout = createPreResponseTimeoutSignal(caller.signal, 1_000);
+
+		preResponseTimeout.clear();
+		caller.abort(new Error("caller cancelled"));
+
+		expect(preResponseTimeout.signal?.aborted).toBe(true);
+		expect(preResponseTimeout.signal?.reason).toBeInstanceOf(Error);
+		expect((preResponseTimeout.signal?.reason as Error).message).toBe("caller cancelled");
+	});
+});
 
 describe("iterateWithIdleTimeout", () => {
 	it("does not reset the first-progress deadline for no-progress items", async () => {

--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -19,10 +19,10 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
-import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { type Component, Container, Image, ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 beforeAll(() => {
 	initTheme();
@@ -171,8 +171,10 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 		},
 		addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) =>
 			helpers.addMessageToChat(message, options),
-		renderSessionContext: (context: SessionContext, options?: { updateFooter?: boolean; populateHistory?: boolean }) =>
-			helpers.renderSessionContext(context, options),
+		renderSessionContext: (
+			context: SessionContext,
+			options?: { updateFooter?: boolean; populateHistory?: boolean },
+		) => helpers.renderSessionContext(context, options),
 		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
 	helpers = new UiHelpers(ctx);
@@ -277,7 +279,9 @@ describe("UiHelpers.renderInitialMessages — image replay", () => {
 			isError: false,
 			timestamp: 2,
 		});
-		session.appendMessage(assistantToolCall("eval-reopened", "eval", { cells: [{ language: "py", code: "display(image)" }] }));
+		session.appendMessage(
+			assistantToolCall("eval-reopened", "eval", { cells: [{ language: "py", code: "display(image)" }] }),
+		);
 		session.appendMessage({
 			role: "toolResult",
 			toolCallId: "eval-reopened",


### PR DESCRIPTION
## Repro
A minimal stream tied to a first-event `AbortSignal.timeout()` still emits `chunk-0` and then fails with `pre-response timeout aborted active stream; chunks=1`, showing the timeout remains attached after response headers and aborts an active body. Recorded with `bun --eval "$REPRO"`.

## Cause
`packages/ai/src/providers/openai-codex-responses.ts`, `amazon-bedrock.ts`, `google-gemini-cli.ts`, and `ollama.ts` used a pre-response `AbortSignal.timeout()` as the fetch signal while `timeout: false` disabled Bun’s native ceiling. That signal was never cleared after `fetchWithRetry()` returned, so the same first-event deadline could later abort the response body even while provider chunks were still being read.

## Fix
- Added `createPreResponseTimeoutSignal()` in `packages/ai/src/utils/pre-response-timeout.ts` to create a clearable pre-response timer while preserving caller abort forwarding.
- Switched Codex SSE, Bedrock Converse Stream, Gemini CLI, and Ollama fetch paths to clear the pre-response timer immediately after headers arrive.
- Added regression coverage for a Codex SSE stream that remains active past the first-event timeout and helper coverage for clearing the timeout while retaining caller abort behavior.

## Verification
Passed: `bun test packages/ai/test/stream-timeout-defaults.test.ts -t createPreResponseTimeoutSignal && bun test packages/ai/test/openai-codex-stream.test.ts -t "does not let the pre-response timeout abort active SSE bodies"`; `bun run check` in `packages/ai`. Fixes #2879