### PR TITLE
Add retry keybinding

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -36,6 +36,7 @@ app.history.search: []
 | `app.editor.external`       | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
 | `app.message.followUp`      | `Ctrl+Q`, `Ctrl+Enter`                 | Queue a follow-up message                     |
 | `app.message.dequeue`       | `Alt+Up`                               | Dequeue a queued message back into the editor |
+| `app.retry`                 | `Alt+R`                                | Retry the last failed assistant turn          |
 | `app.display.reset`         | `Ctrl+L`                               | Reset terminal display                        |
 | `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |
 | `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `app.retry` as an `Alt+R` keybinding for retrying the last failed or aborted assistant turn ([#2790](https://github.com/can1357/oh-my-pi/issues/2790)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added
@@ -14,7 +18,6 @@
 - Added `advisor.immuneTurns` setting (default `1`) to limit how often advisor `concern`/`blocker` notes can interrupt the primary agent.
 - Added a main-session `session_stop` extension event with continuation feedback and an 8-continuation loop cap ([#2834](https://github.com/can1357/oh-my-pi/issues/2834)).
 - Added `--max-time <seconds>` so CLI sessions can stop after a wall-clock deadline.
-- Added `app.retry` as an `Alt+R` keybinding for retrying the last failed or aborted assistant turn ([#2790](https://github.com/can1357/oh-my-pi/issues/2790)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `advisor.immuneTurns` setting (default `1`) to limit how often advisor `concern`/`blocker` notes can interrupt the primary agent.
 - Added a main-session `session_stop` extension event with continuation feedback and an 8-continuation loop cap ([#2834](https://github.com/can1357/oh-my-pi/issues/2834)).
 - Added `--max-time <seconds>` so CLI sessions can stop after a wall-clock deadline.
+- Added `app.retry` as an `Alt+R` keybinding for retrying the last failed or aborted assistant turn ([#2790](https://github.com/can1357/oh-my-pi/issues/2790)).
 
 ### Changed
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -31,6 +31,7 @@ interface AppKeybindings {
 	"app.tools.expand": true;
 	"app.editor.external": true;
 	"app.message.followUp": true;
+	"app.retry": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
 	"app.clipboard.pasteTextRaw": true;
@@ -130,6 +131,10 @@ export const KEYBINDINGS = {
 		// first so the default binding works there without remapping (#1903).
 		defaultKeys: ["ctrl+q", "ctrl+enter"],
 		description: "Send follow-up message",
+	},
+	"app.retry": {
+		defaultKeys: "alt+r",
+		description: "Retry last failed assistant turn",
 	},
 	"app.message.dequeue": {
 		defaultKeys: "alt+up",
@@ -238,6 +243,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	toggleThinking: "app.thinking.toggle",
 	externalEditor: "app.editor.external",
 	followUp: "app.message.followUp",
+	retry: "app.retry",
 	dequeue: "app.message.dequeue",
 	pasteImage: "app.clipboard.pasteImage",
 	pasteTextRaw: "app.clipboard.pasteTextRaw",

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -586,8 +586,15 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured retry shortcut
+			// Intercept configured retry shortcut. Later user/custom handlers keep
+			// precedence so adding the default Alt+R binding does not steal existing
+			// shortcuts such as app.plan.toggle or extension commands.
 			if (this.#matchesAction(canonical, "app.retry") && this.onRetry) {
+				const customHandler = this.#customMatchKeys.get(canonical);
+				if (customHandler) {
+					customHandler();
+					return;
+				}
 				this.onRetry();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -22,6 +22,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.editor.external"
 	| "app.history.search"
 	| "app.message.dequeue"
+	| "app.retry"
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.pasteTextRaw"
 	| "app.clipboard.copyPrompt"
@@ -43,6 +44,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],
 	"app.message.dequeue": ["alt+up"],
+	"app.retry": ["alt+r"],
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
@@ -268,6 +270,8 @@ export class CustomEditor extends Editor {
 	onPasteTextRaw?: () => void;
 	/** Called when the configured dequeue shortcut is pressed. */
 	onDequeue?: () => void;
+	/** Called when the configured retry shortcut is pressed. */
+	onRetry?: () => void;
 	/** Called when Caps Lock is pressed. */
 	onCapsLock?: () => void;
 	/** Called when left-arrow is pressed while the editor is empty (cursor necessarily at start). */
@@ -579,6 +583,12 @@ export class CustomEditor extends Editor {
 			// Intercept configured dequeue shortcut (restore queued message to editor)
 			if (this.#matchesAction(canonical, "app.message.dequeue") && this.onDequeue) {
 				this.onDequeue();
+				return;
+			}
+
+			// Intercept configured retry shortcut
+			if (this.#matchesAction(canonical, "app.retry") && this.onRetry) {
+				this.onRetry();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -586,9 +586,16 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
+			// Intercept configured copy-prompt shortcut
+			if (this.#matchesAction(canonical, "app.clipboard.copyPrompt") && this.onCopyPrompt) {
+				this.onCopyPrompt();
+				return;
+			}
+
 			// Intercept configured retry shortcut. Later user/custom handlers keep
 			// precedence so adding the default Alt+R binding does not steal existing
-			// shortcuts such as app.plan.toggle or extension commands.
+			// shortcuts such as app.plan.toggle or extension commands; copy-prompt is
+			// checked above for the same reason.
 			if (this.#matchesAction(canonical, "app.retry") && this.onRetry) {
 				const customHandler = this.#customMatchKeys.get(canonical);
 				if (customHandler) {
@@ -596,12 +603,6 @@ export class CustomEditor extends Editor {
 					return;
 				}
 				this.onRetry();
-				return;
-			}
-
-			// Intercept configured copy-prompt shortcut
-			if (this.#matchesAction(canonical, "app.clipboard.copyPrompt") && this.onCopyPrompt) {
-				this.onCopyPrompt();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -928,6 +928,10 @@ export class InputController {
 	}
 
 	async handleRetry(): Promise<void> {
+		if (this.ctx.collabGuest) {
+			this.ctx.showStatus("/retry is host-only during a collab session");
+			return;
+		}
 		const didRetry = await this.ctx.viewSession.retry();
 		if (didRetry) {
 			this.ctx.editor.setText("");

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -929,10 +929,14 @@ export class InputController {
 
 	async handleRetry(): Promise<void> {
 		const didRetry = await this.ctx.viewSession.retry();
-		if (!didRetry) {
+		if (didRetry) {
+			this.ctx.editor.setText("");
+			this.ctx.pendingImages = [];
+			this.ctx.pendingImageLinks = [];
+			this.ctx.editor.imageLinks = undefined;
+		} else {
 			this.ctx.showStatus("Nothing to retry");
 		}
-		this.ctx.editor.setText("");
 	}
 
 	/** Send editor text as a follow-up message (queued behind current stream). */

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -304,6 +304,8 @@ export class InputController {
 		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
+		this.ctx.editor.setActionKeys("app.retry", this.ctx.keybindings.getKeys("app.retry"));
+		this.ctx.editor.onRetry = () => void this.handleRetry();
 		this.ctx.editor.clearCustomKeyHandlers();
 		// Wire up extension shortcuts
 		this.registerExtensionShortcuts();
@@ -923,6 +925,14 @@ export class InputController {
 			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
 		}
 		return true;
+	}
+
+	async handleRetry(): Promise<void> {
+		const didRetry = await this.ctx.viewSession.retry();
+		if (!didRetry) {
+			this.ctx.showStatus("Nothing to retry");
+		}
+		this.ctx.editor.setText("");
 	}
 
 	/** Send editor text as a follow-up message (queued behind current stream). */

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -48,6 +48,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
 		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
+		`| \`${appKey(bindings, "app.retry")}\` | Retry last failed assistant turn |`,
 		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image or text from clipboard |`,
 		"| Hold `Space` | Speech-to-text (push-to-talk): hold to record, release to transcribe |",
 		`| \`${appKey(bindings, "app.agents.hub")}\` / \`${appKey(bindings, "app.session.observe")}\` / double-tap \`←\` (empty editor) | Open the agent hub |`,

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -17,4 +17,17 @@ describe("CustomEditor keybindings", () => {
 
 		expect(onRetry).toHaveBeenCalledTimes(1);
 	});
+
+	it("lets custom handlers keep precedence over the default retry chord", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onRetry = vi.fn();
+		const customHandler = vi.fn();
+
+		editor.onRetry = onRetry;
+		editor.setCustomKeyHandler("alt+r", customHandler);
+		editor.handleInput("\x1br");
+
+		expect(customHandler).toHaveBeenCalledTimes(1);
+		expect(onRetry).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,0 +1,20 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
+import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+describe("CustomEditor keybindings", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("routes the configured retry chord through handleInput", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onRetry = vi.fn();
+
+		editor.setActionKeys("app.retry", ["alt+shift+r"]);
+		editor.onRetry = onRetry;
+		editor.handleInput("\x1bR");
+
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -30,4 +30,18 @@ describe("CustomEditor keybindings", () => {
 		expect(customHandler).toHaveBeenCalledTimes(1);
 		expect(onRetry).not.toHaveBeenCalled();
 	});
+
+	it("lets copy-prompt remaps keep precedence over the default retry chord", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onRetry = vi.fn();
+		const onCopyPrompt = vi.fn();
+
+		editor.onRetry = onRetry;
+		editor.onCopyPrompt = onCopyPrompt;
+		editor.setActionKeys("app.clipboard.copyPrompt", ["alt+r"]);
+		editor.handleInput("\x1br");
+
+		expect(onCopyPrompt).toHaveBeenCalledTimes(1);
+		expect(onRetry).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -231,6 +231,22 @@ describe("InputController keybinding setup", () => {
 		expect(spies.retry).not.toHaveBeenCalled();
 	});
 
+	it("keeps retry host-only for collab guests", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const showStatus = ctx.showStatus as unknown as Mock<(message: string) => void>;
+		(ctx as unknown as { collabGuest: { readOnly: boolean } }).collabGuest = { readOnly: true };
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("guest draft");
+		editor.onRetry?.();
+		await Promise.resolve();
+
+		expect(spies.retry).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledWith("/retry is host-only during a collab session");
+		expect(editor.getText()).toBe("guest draft");
+	});
+
 	it("keeps the draft when there is nothing to retry", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		spies.retry.mockResolvedValueOnce(false);

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "bun:test";
+import { describe, expect, it, type Mock, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import manualContinuePrompt from "../src/prompts/system/manual-continue.md" with { type: "text" };
@@ -30,6 +31,7 @@ type FakeEditor = {
 	setCustomKeyHandler(key: string, handler: () => void): void;
 	clearCustomKeyHandlers(): void;
 	pasteText(text: string): void;
+	imageLinks?: (string | undefined)[];
 };
 
 async function createContext() {
@@ -229,17 +231,38 @@ describe("InputController keybinding setup", () => {
 		expect(spies.retry).not.toHaveBeenCalled();
 	});
 
-	it("shows the slash-command retry status when there is nothing to retry", async () => {
+	it("keeps the draft when there is nothing to retry", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		spies.retry.mockResolvedValueOnce(false);
-		const showStatus = ctx.showStatus as unknown as ReturnType<typeof vi.fn>;
+		const showStatus = ctx.showStatus as unknown as Mock<(message: string) => void>;
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
+		editor.setText("draft that should survive");
 		editor.onRetry?.();
 		await Promise.resolve();
 
 		expect(showStatus).toHaveBeenCalledWith("Nothing to retry");
+		expect(editor.getText()).toBe("draft that should survive");
+	});
+
+	it("clears retry draft attachments only after retry starts", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "abc" };
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		ctx.pendingImages = [image];
+		ctx.pendingImageLinks = ["local://draft.png"];
+		editor.imageLinks = ctx.pendingImageLinks;
+		editor.setText("draft with image");
+		editor.onRetry?.();
+		await Promise.resolve();
+
+		expect(ctx.pendingImages).toEqual([]);
+		expect(ctx.pendingImageLinks).toEqual([]);
+		expect(editor.imageLinks).toBeUndefined();
+		expect(editor.getText()).toBe("");
 	});
 
 	it("empty Enter aborts the active stream when queued messages are pending", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -20,7 +20,7 @@ type FakeEditor = {
 	onExpandTools?: () => void;
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
-	onDequeue?: () => void;
+	onRetry?: () => void;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => Promise<void>;
 	setText(text: string): void;
@@ -38,6 +38,7 @@ async function createContext() {
 		"app.display.reset": ["ctrl+l"],
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["alt+m"],
+		"app.retry": ["alt+r"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -54,7 +55,20 @@ async function createContext() {
 	const addStartListener = vi.fn();
 	const terminalWrite = vi.fn();
 	const prompt = vi.fn(async () => {});
+	const retry = vi.fn(async () => true);
 	const abort = vi.fn(async () => {});
+	const session = {
+		isStreaming: false,
+		isCompacting: false,
+		isGeneratingHandoff: false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		extensionRunner: undefined,
+		prompt,
+		queuedMessageCount: 0,
+		abort,
+		retry,
+	};
 	const updatePendingMessagesDisplay = vi.fn();
 	const editor: FakeEditor = {
 		setText(text: string) {
@@ -85,17 +99,8 @@ async function createContext() {
 		retryLoader: undefined,
 		autoCompactionEscapeHandler: undefined,
 		retryEscapeHandler: undefined,
-		session: {
-			isStreaming: false,
-			isCompacting: false,
-			isGeneratingHandoff: false,
-			isBashRunning: false,
-			isEvalRunning: false,
-			extensionRunner: undefined,
-			prompt,
-			queuedMessageCount: 0,
-			abort,
-		} as unknown as InteractiveModeContext["session"],
+		session: session as unknown as InteractiveModeContext["session"],
+		viewSession: session as unknown as InteractiveModeContext["viewSession"],
 		keybindings: {
 			getKeys(action: string) {
 				return keyMap[action] ? [...keyMap[action]] : [];
@@ -146,6 +151,7 @@ async function createContext() {
 		updateEditorBorderColor: vi.fn(),
 		hasActiveBtw: vi.fn(() => false),
 		showError: vi.fn(),
+		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -159,6 +165,7 @@ async function createContext() {
 			prompt,
 			updatePendingMessagesDisplay,
 			requestRender,
+			retry,
 			abort,
 			resetDisplay,
 		},
@@ -187,6 +194,52 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers retry as an editor action and retries the failed turn", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.retry", ["alt+r"]);
+		expect(editor.onRetry).toBeDefined();
+
+		editor.setText("draft that should clear after retry");
+		editor.onRetry?.();
+		await Promise.resolve();
+
+		expect(spies.retry).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("retries the focused view session instead of the main session", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const focusedRetry = vi.fn(async () => true);
+		(ctx as unknown as { focusedAgentId: string; viewSession: { retry: typeof focusedRetry } }).focusedAgentId =
+			"worker";
+		(ctx as unknown as { viewSession: { retry: typeof focusedRetry } }).viewSession = { retry: focusedRetry };
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onRetry?.();
+		await Promise.resolve();
+
+		expect(focusedRetry).toHaveBeenCalledTimes(1);
+		expect(spies.retry).not.toHaveBeenCalled();
+	});
+
+	it("shows the slash-command retry status when there is nothing to retry", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		spies.retry.mockResolvedValueOnce(false);
+		const showStatus = ctx.showStatus as unknown as ReturnType<typeof vi.fn>;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onRetry?.();
+		await Promise.resolve();
+
+		expect(showStatus).toHaveBeenCalledWith("Nothing to retry");
 	});
 
 	it("empty Enter aborts the active stream when queued messages are pending", async () => {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -10,6 +10,12 @@ describe("KeybindingsManager.getDisplayString", () => {
 		expect(keybindings.getDisplayString("app.message.dequeue")).toBe("Alt+Up");
 	});
 
+	it("defaults retry to Alt+R", () => {
+		const keybindings = KeybindingsManager.inMemory();
+
+		expect(keybindings.getDisplayString("app.retry")).toBe("Alt+R");
+	});
+
 	it("formats multiple bindings with the existing separator", () => {
 		const keybindings = KeybindingsManager.inMemory({
 			"app.clipboard.copyPrompt": ["alt+shift+c", "ctrl+shift+c"],

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -21,6 +21,7 @@ describe("buildHotkeysMarkdown", () => {
 			"app.history.search": "Ctrl+R",
 			"app.thinking.toggle": "Ctrl+T",
 			"app.editor.external": "Ctrl+G",
+			"app.retry": "Alt+R",
 			"app.clipboard.pasteImage": "Ctrl+V",
 			"app.stt.toggle": "Alt+H",
 		};
@@ -38,6 +39,7 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Ctrl+Shift+L` | Select model (temporary) |");
 		expect(markdown).toContain("| `Alt+M` | Select model (set roles) |");
 		expect(markdown).toContain("| `Ctrl+L` | Reset terminal display |");
+		expect(markdown).toContain("| `Alt+R` | Retry last failed assistant turn |");
 		expect(markdown).toContain("| `Alt+Shift+P` | Toggle plan mode |");
 		expect(markdown).toContain("| `#` | Open prompt actions |");
 		for (const line of lines) {


### PR DESCRIPTION
## Summary
- Add configurable `app.retry` keybinding with `Alt+R` as the default shortcut.
- Wire the shortcut through `CustomEditor` and `InputController` to retry the currently visible session, including focused subagent sessions.
- Document the action in `/hotkeys`, `docs/keybindings.md`, and the coding-agent changelog.

## Test Plan
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/keybindings-display.test.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts`
- `bun --cwd=packages/coding-agent run check`

Fixes #2790