### PR TITLE
fix(tui): restore plan-mode shortcut handling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed `Ctrl+Enter` follow-up handling and the first post-plan-mode `Esc` by routing raw modified-Enter input before editor newline handling and clearing stale double-Esc state when plan mode exits ([#2896](https://github.com/can1357/oh-my-pi/issues/2896)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -81,6 +81,19 @@ describe("CustomEditor custom key handlers", () => {
 		expect(events).toEqual(["follow-up"]);
 		expect(editor.getText()).toBe("draft");
 	});
+
+	it("preserves active bracketed paste chunks that start with newline bytes", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const events: string[] = [];
+		editor.setCustomKeyHandler("ctrl+enter", () => events.push("follow-up"));
+
+		editor.handleInput("draft");
+		editor.handleInput("\x1b[200~");
+		editor.handleInput("\nbody\x1b[201~");
+
+		expect(events).toEqual([]);
+		expect(editor.getText()).toBe("draft\nbody");
+	});
 });
 
 describe("CustomEditor space-hold push-to-talk", () => {

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -65,6 +65,24 @@ describe("CustomEditor placeholder decoration", () => {
 	});
 });
 
+describe("CustomEditor custom key handlers", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("routes raw modified Enter to ctrl+enter before parent newline handling", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const events: string[] = [];
+		editor.setCustomKeyHandler("ctrl+enter", () => events.push("follow-up"));
+
+		editor.handleInput("draft");
+		editor.handleInput("\nX");
+
+		expect(events).toEqual(["follow-up"]);
+		expect(editor.getText()).toBe("draft");
+	});
+});
+
 describe("CustomEditor space-hold push-to-talk", () => {
 	beforeAll(async () => {
 		await initTheme();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -461,6 +461,8 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
+		if (this.handleBracketedPasteInput(data)) return;
+
 		const parsedKey = parseKey(data);
 
 		if (isRawModifiedEnter(data)) {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -56,6 +56,10 @@ function buildMatchKeys(keys: readonly KeyId[]): Set<string> {
 	return matchKeys;
 }
 
+function isRawModifiedEnter(data: string): boolean {
+	return data.charCodeAt(0) === 10 && data.length > 1;
+}
+
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 const BRACKETED_IMAGE_PATH_REGEX = /\.(?:png|jpe?g|gif|webp)$/i;
@@ -458,6 +462,14 @@ export class CustomEditor extends Editor {
 		}
 
 		const parsedKey = parseKey(data);
+
+		if (isRawModifiedEnter(data)) {
+			const handler = this.#customMatchKeys.get("ctrl+enter");
+			if (handler) {
+				handler();
+				return;
+			}
+		}
 		const canonical = parsedKey !== undefined ? canonicalKeyId(parsedKey) : undefined;
 
 		// Left-arrow on an empty editor: surface for the agent-hub double-tap

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1972,6 +1972,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.planModePlanFilePath = undefined;
 		this.#planModePreviousTools = undefined;
 		if (!options?.deferModelRestore) this.#planModePreviousModelState = undefined;
+		this.lastEscapeTime = 0;
 		this.#updatePlanModeStatus();
 		const paused = options?.paused ?? false;
 		this.sessionManager.appendModeChange(paused ? "plan_paused" : "none");

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -650,6 +650,7 @@ describe("InteractiveMode plan review rendering", () => {
 
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
+		mode.lastEscapeTime = Date.now();
 		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
 		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
 		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
@@ -661,6 +662,7 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 
 		expect(clear).toHaveBeenCalledTimes(1);
+		expect(mode.lastEscapeTime).toBe(0);
 		expect(prompt).toHaveBeenCalledWith(expect.any(String), {
 			synthetic: true,
 		});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1003,6 +1003,21 @@ export class Editor implements Component, Focusable {
 		return result;
 	}
 
+	/** Consumes bracketed paste chunks before subclass shortcut handling can interpret paste bytes as keys. */
+	handleBracketedPasteInput(data: string): boolean {
+		const paste = this.#pasteHandler.process(data);
+		if (paste.handled) {
+			if (paste.pasteContent !== undefined) {
+				this.#handlePaste(paste.pasteContent);
+				if (paste.remaining.length > 0) {
+					this.handleInput(paste.remaining);
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
 	handleInput(data: string): void {
 		const kb = getKeybindings();
 
@@ -1027,16 +1042,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
-		if (paste.handled) {
-			if (paste.pasteContent !== undefined) {
-				this.#handlePaste(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					this.handleInput(paste.remaining);
-				}
-			}
-			return;
-		}
+		if (this.handleBracketedPasteInput(data)) return;
 
 		// Handle special key combinations first
 


### PR DESCRIPTION
## Repro
`Ctrl+Enter` delivered as raw modified newline bytes reproduces the failure: `bun --cwd packages/coding-agent --eval ...` previously printed `{"followUps":0,"text":"draft\n"}`, proving the input fell through to newline insertion instead of `app.message.followUp`.

## Cause
`packages/coding-agent/src/modes/components/custom-editor.ts` only checked custom key handlers after `parseKey()`. Windows Terminal can deliver `Ctrl+Enter` as raw `\n` plus modifier bytes, which `parseKey()` does not canonicalize to `ctrl+enter`; the payload then reached `packages/tui/src/components/editor.ts` newline handling. Plan-mode exit also left `InteractiveMode.lastEscapeTime` intact, so the next `Esc` could be consumed by stale double-Esc timing.

## Fix
- Route raw modified Enter (`charCodeAt(0) === 10 && length > 1`) to the registered `ctrl+enter` custom handler before parent editor input handling.
- Clear `lastEscapeTime` in `InteractiveMode.#exitPlanMode()` so post-plan `Esc` starts a fresh double-Esc window.
- Added regression coverage for raw modified Enter follow-up routing and plan approval clearing escape timing.
- Added an Unreleased changelog entry for #2896.

## Verification
`bun run fix` passed. `bun --cwd packages/coding-agent test src/modes/components/custom-editor.test.ts test/interactive-mode-plan-review.test.ts` passed: 49 tests, 124 assertions. `bun run check` passed in `packages/coding-agent`. Fixes #2896