### PR TITLE
fix(stats): contain wide mobile-card tables on narrow desktops

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - The 1h time-range chart rendered an empty/single-point line; it now buckets at 5-minute granularity for a real trend.
+- Wide data tables (Requests, Errors, Overview, Projects) overflowed the page horizontally at narrow-desktop widths (768-1023px): the `.stats-table-desktop-only` wrapper used for mobile-card tables lacked the `overflow-x: auto` containment that `.stats-table-container` already has. They now scroll within their own bounds instead of spilling the page body.
 
 ## [15.13.3] - 2026-06-15
 

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -729,6 +729,13 @@
   display: none;
 }
 
+/* Match .stats-table-container so mobile-card tables also contain horizontal
+   overflow instead of spilling the page body on narrow desktops (768-1023px). */
+.stats-table-desktop-only {
+  width: 100%;
+  overflow-x: auto;
+}
+
 @media (max-width: 767px) {
   .stats-table-desktop-only {
     display: none;


### PR DESCRIPTION
## Problem

The stats dashboard's mobile-card tables (`.stats-table-desktop-only`) overflow horizontally on narrow desktop widths (roughly 768-1023px). The mobile card layout only engages at `max-width: 767px`, so in the gap just above that breakpoint a wide table spills past the page body instead of scrolling inside its own container.

## Fix

Add a base rule giving `.stats-table-desktop-only` `width: 100%` and `overflow-x: auto`, matching the existing `.stats-table-container` behavior. Wide tables now scroll within their own box on narrow desktops rather than pushing the page width.

CSS-only change, no behavior change at the existing mobile (`<= 767px`) or wide-desktop breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
