### PR TITLE
docs(coding-agent): document ACP approval mode

### DIFF
--- a/docs/approval-mode.md
+++ b/docs/approval-mode.md
@@ -89,6 +89,32 @@ approval: (args) =>
     : "exec";
 ```
 
+## ACP sessions
+
+ACP (`omp acp`) uses the same settings resolver as normal OMP launches. Global `~/.omp/agent/config.yml` applies, project config for the ACP session `cwd` applies, and any `--config <file>` overlays passed to the ACP server process apply to sessions created by that process.
+
+To auto-approve ACP tool calls, set the mode in global or project config:
+
+```yaml
+tools:
+  approvalMode: yolo
+```
+
+Or launch the ACP server with a runtime override or a one-process config overlay:
+
+```bash
+omp acp --yolo
+omp acp --auto-approve
+omp acp --approval-mode yolo
+omp acp --config ./acp-yolo.yml   # file contains tools.approvalMode: yolo
+```
+
+Precedence is the normal settings precedence: runtime flags (`--approval-mode`, `--auto-approve`, `--yolo`) override `--config` overlays, which override project config, which overrides global config. ACP does not currently define a `session/new`, `session/load`, or `session/resume` approval-policy field, so ACP clients that need per-session yolo should launch a separate `omp acp` process with one of the flags above or with a session-specific `--config` overlay.
+
+`tools.approvalMode: yolo` fully applies to ACP when it is explicitly configured or supplied by a runtime flag. It skips OMP's approval prompts and also skips the ACP client permission gate for `bash`, `edit`, `delete`, and `move` unless `tools.approval.<tool>` is `prompt` or `deny`. The schema default is `yolo`, but default-config ACP sessions still keep the client permission gate; set `tools.approvalMode: yolo` explicitly when the client wants unattended execution.
+
+When ACP approval is required, OMP routes it through the ACP client instead of the terminal TUI. Client-gated `bash`, `edit`, `delete`, and `move` calls use ACP `session/request_permission`; generic approval prompts use form elicitation when the client advertises `elicitation.form`. A rejected, cancelled, or unsupported prompt rejects/cancels the tool call; OMP does not silently allow it.
+
 ## Subagents
 
 Subagents run headless with `tools.approvalMode: yolo` so they do not stall waiting for UI. The parent `task` approval is the authorization boundary. User `tools.approval.<tool>` settings continue to control whether a tool is allowed, prompted, or blocked.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP approval-mode documentation to describe config inheritance, `omp acp --yolo`/`--auto-approve` runtime overrides, client permission precedence, and headless prompt behavior ([#2900](https://github.com/can1357/oh-my-pi/issues/2900)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added


### PR DESCRIPTION
## Repro
`docs/approval-mode.md` documented `tools.approvalMode`, `--auto-approve`, `--yolo`, and subagents, but it did not mention ACP. Reproduced with `search(pattern="Approval|approval|approval-mode|ACP|Agent Client Protocol", paths=["docs/approval-mode.md", "docs/settings.md"])` and `read("docs/approval-mode.md")`, which showed no ACP-specific approval guidance.

## Cause
The existing approval-mode docs stopped at generic CLI/session behavior in `docs/approval-mode.md`; ACP-specific behavior lives in `createAcpSessionFactory` (`packages/coding-agent/src/main.ts`), `createAcpClientBridge` (`packages/coding-agent/src/modes/acp/acp-client-bridge.ts`), and `AgentSession.#wrapToolForAcpPermission` (`packages/coding-agent/src/session/agent-session.ts`) without user-facing documentation.

## Fix
- Added an ACP section to `docs/approval-mode.md` covering global/project config inheritance, explicit `tools.approvalMode: yolo`, `omp acp --yolo` / `--auto-approve` / `--approval-mode yolo`, `--config` overlays, and the lack of an ACP `session/new` approval-policy field.
- Documented precedence and the explicit-yolo nuance for ACP client permission gates.
- Documented how ACP prompts are routed through `session/request_permission` or form elicitation, and that rejected/cancelled/unsupported prompts do not silently allow tools.
- Added the coding-agent changelog entry for #2900.

## Verification
Ran `bun install` to install workspace dependencies and regenerate docs index, `bun test packages/coding-agent/test/agent-session-acp-permission.test.ts packages/coding-agent/test/tools/approval-mode.test.ts` (31 pass), and `bun --cwd=packages/coding-agent run generate-docs-index`. Fixes #2900.