### PR TITLE
fix(login): honor disabledProviders in /login provider list

### DIFF
--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -19,6 +19,7 @@ const builtInOAuthProviders: OAuthProviderInfo[] = PROVIDER_REGISTRY.filter(
 	id: provider.id,
 	name: provider.name,
 	available: provider.available ?? true,
+	storeCredentialsAs: provider.storeCredentialsAs,
 }));
 
 const customOAuthProviders = new Map<string, OAuthProviderInterface>();
@@ -163,6 +164,7 @@ export function getOAuthProviders(): OAuthProviderInfo[] {
 		id: provider.id,
 		name: provider.name,
 		available: true,
+		storeCredentialsAs: provider.storeCredentialsAs,
 	}));
 	return [...builtInOAuthProviders, ...customProviders];
 }

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -31,6 +31,12 @@ export interface OAuthProviderInfo {
 	id: OAuthProviderId;
 	name: string;
 	available: boolean;
+	/**
+	 * Provider id the login stores credentials under, when it differs from `id`
+	 * (e.g. `openai-codex-device` ⇒ `openai-codex`). Lets callers map a login
+	 * entry back to the model provider it authenticates.
+	 */
+	storeCredentialsAs?: string;
 }
 
 export interface OAuthController {

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -10,12 +10,27 @@ import {
 	Spacer,
 	TruncatedText,
 } from "@oh-my-pi/pi-tui";
+import { settings } from "../../config/settings";
 import { theme } from "../../modes/theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { AuthStorage, CredentialOriginKind } from "../../session/auth-storage";
 import { DynamicBorder } from "./dynamic-border";
 
 const OAUTH_SELECTOR_MAX_VISIBLE = 10;
+
+/**
+ * Provider ids the user has disabled via settings. `/login` (login mode) hides
+ * these so a disabled provider's models stay out of reach end-to-end, mirroring
+ * the model picker's `disabledProviders` filtering. Reads the settings singleton
+ * defensively: it throws before `Settings.init()`, in which case nothing is disabled.
+ */
+function getDisabledProviderIds(): ReadonlySet<string> {
+	try {
+		return new Set(settings.get("disabledProviders"));
+	} catch {
+		return new Set();
+	}
+}
 
 /**
  * Rendered lines before the provider rows: top border, spacer, title, spacer
@@ -102,8 +117,14 @@ export class OAuthSelectorComponent extends Container {
 
 	#loadProviders(): void {
 		const providers = getOAuthProviders();
-		this.#allProviders =
-			this.#mode === "logout" ? providers.filter(provider => this.#hasSelectableAuth(provider.id)) : providers;
+		if (this.#mode === "logout") {
+			// Logout stays unfiltered by `disabledProviders`: a now-disabled
+			// provider may still hold stored credentials worth removing.
+			this.#allProviders = providers.filter(provider => this.#hasSelectableAuth(provider.id));
+		} else {
+			const disabled = getDisabledProviderIds();
+			this.#allProviders = providers.filter(provider => !disabled.has(provider.id));
+		}
 		this.#filteredProviders = this.#allProviders;
 	}
 

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -123,7 +123,15 @@ export class OAuthSelectorComponent extends Container {
 			this.#allProviders = providers.filter(provider => this.#hasSelectableAuth(provider.id));
 		} else {
 			const disabled = getDisabledProviderIds();
-			this.#allProviders = providers.filter(provider => !disabled.has(provider.id));
+			// Hide a login entry when either its own id or the provider id it
+			// stores credentials under is disabled, so alias logins (e.g.
+			// `openai-codex-device` ⇒ `openai-codex`) disappear alongside the
+			// model provider they authenticate.
+			this.#allProviders = providers.filter(
+				provider =>
+					!disabled.has(provider.id) &&
+					!(provider.storeCredentialsAs && disabled.has(provider.storeCredentialsAs)),
+			);
 		}
 		this.#filteredProviders = this.#allProviders;
 	}

--- a/packages/coding-agent/test/modes/components/oauth-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/oauth-selector.test.ts
@@ -137,6 +137,31 @@ describe("OAuthSelectorComponent", () => {
 			expect(rendered).not.toContain(victim.name);
 		});
 
+		it("hides alias logins whose storeCredentialsAs target is disabled", async () => {
+			const alias = getOAuthProviders().find(provider => provider.storeCredentialsAs === "openai-codex");
+			expect(alias).toBeDefined();
+			if (!alias) return;
+			expect(alias.id).not.toBe("openai-codex");
+
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, overrides: { disabledProviders: ["openai-codex"] } });
+
+			const component = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+			);
+			for (const char of alias.id) {
+				component.handleInput(char);
+			}
+			const rendered = component
+				.render(80)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered).not.toContain(alias.name);
+		});
+
 		it("keeps disabled providers as logout targets", async () => {
 			resetSettingsForTest();
 			await Settings.init({ inMemory: true, overrides: { disabledProviders: ["opencode-go"] } });

--- a/packages/coding-agent/test/modes/components/oauth-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/oauth-selector.test.ts
@@ -1,5 +1,6 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { OAuthSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/oauth-selector";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -101,5 +102,64 @@ describe("OAuthSelectorComponent", () => {
 
 		component.handleInput("\n");
 		expect(selected).toEqual(["opencode-go"]);
+	});
+
+	describe("disabledProviders", () => {
+		afterEach(() => {
+			resetSettingsForTest();
+		});
+
+		it("hides disabled providers from the login list even when searched", async () => {
+			const providers = getOAuthProviders();
+			const victim =
+				providers.find(provider => provider.available && provider.id === "vllm") ??
+				providers.find(provider => provider.available) ??
+				providers[0];
+			expect(victim).toBeDefined();
+			if (!victim) return;
+
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, overrides: { disabledProviders: [victim.id] } });
+
+			const component = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+			);
+			for (const char of victim.id) {
+				component.handleInput(char);
+			}
+			const rendered = component
+				.render(80)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered).not.toContain(victim.name);
+		});
+
+		it("keeps disabled providers as logout targets", async () => {
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, overrides: { disabledProviders: ["opencode-go"] } });
+
+			const selected: string[] = [];
+			const component = new OAuthSelectorComponent(
+				"logout",
+				{
+					has: (providerId: string) => providerId === "opencode-go",
+					hasAuth: (providerId: string) => providerId === "opencode-go",
+					getCredentialOrigin: (_providerId: string) => undefined,
+				} as unknown as AuthStorage,
+				providerId => selected.push(providerId),
+				() => {},
+			);
+			for (const char of "opencode-go") {
+				component.handleInput(char);
+			}
+			const rendered = component
+				.render(80)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered).toContain("OpenCode Go");
+		});
 	});
 });


### PR DESCRIPTION
## Problem

The `/login` provider selector lists every OAuth-capable provider returned by `getOAuthProviders()`, ignoring the `disabledProviders` setting. As a result, a provider the user disabled (hidden from the model picker via `disabledProviders`) still shows up as a login target, which is inconsistent — its models are unreachable, yet `/login` still offers it.

The model registry already filters on this setting (`model-registry.ts` `#createAvailabilityCheck` etc.), so `/login` was the odd one out.

## Change

`OAuthSelectorComponent#loadProviders()`:
- **login mode**: filter out providers whose id is in `disabledProviders` (read from the `settings` singleton, the same source the model picker uses; guarded for the pre-`Settings.init()` case).
- **logout mode**: intentionally left unfiltered — a now-disabled provider may still hold stored credentials the user wants to remove.

Scope is limited to the interactive TUI selector (covers `/login` and the setup-wizard sign-in). The RPC `get_login_providers` and `auth-broker` CLI paths are unchanged.

## Tests

Added to `oauth-selector.test.ts`:
- disabled provider is hidden from the login list even when searched by id
- disabled provider is still offered as a logout target

`bun test packages/coding-agent/test/modes/components/oauth-selector.test.ts` → 5 pass / 0 fail. Biome clean.