### PR TITLE
fix(coding-agent): support quoted paths with spaces in file arguments and mentions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -54,6 +54,9 @@
 ### Security
 
 - Secured PDF image reads by validating requested image members against the extracted member list before opening files and refusing traversal-style names
+### Fixed
+
+ - Support quoted file paths with spaces (such as default macOS screenshots) in file mentions and `@`-prefixed CLI arguments ([#2909](https://github.com/can1357/oh-my-pi/pull/2909)).
 
 ## [16.0.5] - 2026-06-17
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -211,7 +211,13 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 		} else if (arg === "--auto-approve" || arg === "--yolo") {
 			result.autoApprove = true;
 		} else if (arg.startsWith("@")) {
-			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
+			let filePath = arg.slice(1);
+			if (filePath.startsWith('"') && filePath.endsWith('"') && filePath.length > 1) {
+				filePath = filePath.slice(1, -1);
+			} else if (filePath.startsWith("'") && filePath.endsWith("'") && filePath.length > 1) {
+				filePath = filePath.slice(1, -1);
+			}
+			result.fileArgs.push(filePath);
 		} else if (!arg.startsWith("-") || arg === "-") {
 			// Plain positional or lone `-` (stdin marker) — pass through as a
 			// message rather than flagging it.

--- a/packages/coding-agent/src/utils/file-mentions.ts
+++ b/packages/coding-agent/src/utils/file-mentions.ts
@@ -24,7 +24,7 @@ import { resolveReadPath } from "../tools/path-utils";
 import { formatDimensionNote, resizeImage } from "./image-resize";
 
 /** Regex to match @filepath patterns in text */
-const FILE_MENTION_REGEX = /@([^\s@]+)/g;
+const FILE_MENTION_REGEX = /@(?:"([^"]+)"|'([^']+)'|([^\s@]+))/g;
 const LEADING_PUNCTUATION_REGEX = /^[`"'([{<]+/;
 const TRAILING_PUNCTUATION_REGEX = /[)\]}>.,;:!?"'`]+$/;
 const MENTION_BOUNDARY_REGEX = /[\s([{<"'`]/;
@@ -168,7 +168,10 @@ export function extractFileMentions(text: string): string[] {
 		const index = match.index ?? 0;
 		if (!isMentionBoundary(text, index)) continue;
 
-		const cleaned = sanitizeMentionPath(match[1]);
+		const rawPath = match[1] ?? match[2] ?? match[3];
+		if (!rawPath) continue;
+
+		const cleaned = match[1] !== undefined || match[2] !== undefined ? rawPath.trim() : sanitizeMentionPath(rawPath);
 		if (!cleaned) continue;
 
 		mentions.push(cleaned);

--- a/packages/coding-agent/test/file-mentions.test.ts
+++ b/packages/coding-agent/test/file-mentions.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { generateFileMentionMessages } from "@oh-my-pi/pi-coding-agent/utils/file-mentions";
+import { extractFileMentions, generateFileMentionMessages } from "@oh-my-pi/pi-coding-agent/utils/file-mentions";
 
 const tempDirs: string[] = [];
 
@@ -85,7 +85,6 @@ describe("generateFileMentionMessages path resolution", () => {
 		await fs.mkdir(path.join(cwd, "My Folder"), { recursive: true });
 		await Bun.write(path.join(cwd, "My Folder", "my file.png"), "image content");
 
-		const { extractFileMentions } = await import("@oh-my-pi/pi-coding-agent/utils/file-mentions");
 		const mentions = extractFileMentions("Please see @\"My Folder/my file.png\" and @'My Folder/my file.png'");
 		expect(mentions).toEqual(["My Folder/my file.png"]);
 

--- a/packages/coding-agent/test/file-mentions.test.ts
+++ b/packages/coding-agent/test/file-mentions.test.ts
@@ -79,4 +79,23 @@ describe("generateFileMentionMessages path resolution", () => {
 		expect(message.files[0]?.path).toBe("real.txt");
 		expect(message.files[0]?.content).toContain("present");
 	});
+
+	test("resolves quoted paths containing spaces", async () => {
+		const cwd = await createTempDir();
+		await fs.mkdir(path.join(cwd, "My Folder"), { recursive: true });
+		await Bun.write(path.join(cwd, "My Folder", "my file.png"), "image content");
+
+		const { extractFileMentions } = await import("@oh-my-pi/pi-coding-agent/utils/file-mentions");
+		const mentions = extractFileMentions("Please see @\"My Folder/my file.png\" and @'My Folder/my file.png'");
+		expect(mentions).toEqual(["My Folder/my file.png"]);
+
+		const messages = await generateFileMentionMessages(mentions, cwd);
+		expect(messages).toHaveLength(1);
+		const message = messages[0];
+		if (message?.role !== "fileMention") {
+			throw new Error("expected file mention message");
+		}
+		expect(message.files).toHaveLength(1);
+		expect(message.files[0]?.path).toBe("My Folder/my file.png");
+	});
 });

--- a/packages/coding-agent/test/flag-tables.test.ts
+++ b/packages/coding-agent/test/flag-tables.test.ts
@@ -89,3 +89,20 @@ describe("parseArgs end-of-options (--)", () => {
 		expect(result.messages).toEqual(["hello", "--no-tools"]);
 	});
 });
+
+describe("parseArgs @file parsing with quotes", () => {
+	it("parses unquoted @file arguments normally", () => {
+		const result = parseArgs(["@foo.png"]);
+		expect(result.fileArgs).toEqual(["foo.png"]);
+	});
+
+	it('parses double-quoted @"file" arguments', () => {
+		const result = parseArgs(['@"foo bar.png"']);
+		expect(result.fileArgs).toEqual(["foo bar.png"]);
+	});
+
+	it("parses single-quoted @'file' arguments", () => {
+		const result = parseArgs(["@'foo bar.png'"]);
+		expect(result.fileArgs).toEqual(["foo bar.png"]);
+	});
+});


### PR DESCRIPTION
### Description
This PR resolves the issue where file mentions and CLI file arguments (starting with `@`) that contain spaces—such as default macOS screenshot filenames—fail to attach or resolve properly.

### Changes
- **CLI Argument parsing:** Updated `packages/coding-agent/src/cli/args.ts` to support single (`@'...'`) and double (`@"..."`) quoting around `@` prefixed file targets, stripping the quotes during argument ingestion.
- **File Mentions Auto-Reader:** Updated the regular expression `FILE_MENTION_REGEX` and parsing/sanitization in `packages/coding-agent/src/utils/file-mentions.ts` to identify, extract, and cleanly resolve quoted mention targets containing spaces.
- **Tests:** Appended thorough unit coverage in `file-mentions.test.ts` and `flag-tables.test.ts` asserting exact parsing mechanics for quoted targets.