### PR TITLE
fix(auth): make setup sign-in URLs copyable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider setup sign-in URLs to attempt clipboard/OSC 52 copy and expose an Alt+C retry shortcut, so authentication is not blocked when TUI selection is unavailable ([#2908](https://github.com/can1357/oh-my-pi/issues/2908)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added
@@ -23,7 +27,6 @@
 
 ### Fixed
 
-- Fixed provider setup sign-in URLs to attempt clipboard/OSC 52 copy and expose an Alt+C retry shortcut, so authentication is not blocked when TUI selection is unavailable ([#2908](https://github.com/can1357/oh-my-pi/issues/2908)).
 - Fixed Matplotlib figure display to emit PNG output immediately when `display(fig)` is called, even if the figure is closed before the end-of-cell flush
 - Fixed persisted tool-result image payloads in `details.images` to externalize and resolve through the session blob store, so generated-image details survive resume without stale blob refs or truncation
 - Fixed duplicate Matplotlib image output by skipping the automatic end-of-request figure flush for figures that were already displayed through `display(fig)`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Fixed provider setup sign-in URLs to attempt clipboard/OSC 52 copy and expose an Alt+C retry shortcut, so authentication is not blocked when TUI selection is unavailable ([#2908](https://github.com/can1357/oh-my-pi/issues/2908)).
 - Fixed Matplotlib figure display to emit PNG output immediately when `display(fig)` is called, even if the figure is closed before the end-of-cell flush
 - Fixed persisted tool-result image payloads in `details.images` to externalize and resolve through the session blob store, so generated-image details survive resume without stale blob refs or truncation
 - Fixed duplicate Matplotlib image output by skipping the automatic end-of-request figure flush for figures that were already displayed through `display(fig)`

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -1,7 +1,14 @@
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { PASTE_CODE_LOGIN_PROVIDERS } from "@oh-my-pi/pi-ai";
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/oauth/types";
-import { Input, matchesKey, type SgrMouseEvent, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	type Focusable,
+	Input,
+	matchesKey,
+	type SgrMouseEvent,
+	wrapTextWithAnsi,
+} from "@oh-my-pi/pi-tui";
 import { getAgentDbPath } from "@oh-my-pi/pi-utils";
 import { copyToClipboard } from "../../../utils/clipboard";
 import { OAuthSelectorComponent } from "../../components/oauth-selector";
@@ -16,10 +23,48 @@ function loginCopyHint(): string {
 	return theme.fg("dim", "(clipboard copy attempted; Alt+C retries)");
 }
 
+class CopyablePromptInput implements Component, Focusable {
+	#input: Input;
+	#onCopy: () => void;
+
+	constructor(input: Input, onCopy: () => void) {
+		this.#input = input;
+		this.#onCopy = onCopy;
+	}
+
+	get focused(): boolean {
+		return this.#input.focused;
+	}
+
+	set focused(value: boolean) {
+		this.#input.focused = value;
+	}
+
+	setUseTerminalCursor(useTerminalCursor: boolean): void {
+		this.#input.setUseTerminalCursor(useTerminalCursor);
+	}
+
+	render(width: number): readonly string[] {
+		return this.#input.render(width);
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, "alt+c")) {
+			this.#onCopy();
+			return;
+		}
+		this.#input.handleInput(data);
+	}
+
+	invalidate(): void {
+		this.#input.invalidate();
+	}
+}
+
 interface PromptState {
 	message: string;
 	placeholder?: string;
-	input: Input;
+	input: CopyablePromptInput;
 }
 
 /**
@@ -211,9 +256,12 @@ export class SignInTab implements SetupTab {
 	#showPrompt(prompt: { message: string; placeholder?: string }): Promise<string> {
 		this.#resolvePrompt("");
 		const input = new Input();
+		const focusInput = new CopyablePromptInput(input, () => {
+			void this.#copyAuthUrl();
+		});
 		const pending = Promise.withResolvers<string>();
 		this.#promptResolve = pending.resolve;
-		this.#prompt = { message: prompt.message, placeholder: prompt.placeholder, input };
+		this.#prompt = { message: prompt.message, placeholder: prompt.placeholder, input: focusInput };
 		input.onSubmit = value => {
 			this.#resolvePrompt(value);
 		};
@@ -221,7 +269,7 @@ export class SignInTab implements SetupTab {
 			this.#loginAbort?.abort();
 			this.#resolvePrompt("");
 		};
-		this.host.setFocus(input);
+		this.host.setFocus(focusInput);
 		this.host.requestRender();
 		return pending.promise;
 	}

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -3,12 +3,17 @@ import { PASTE_CODE_LOGIN_PROVIDERS } from "@oh-my-pi/pi-ai";
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/oauth/types";
 import { Input, matchesKey, type SgrMouseEvent, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath } from "@oh-my-pi/pi-utils";
+import { copyToClipboard } from "../../../utils/clipboard";
 import { OAuthSelectorComponent } from "../../components/oauth-selector";
 import { theme } from "../../theme/theme";
 import type { SetupSceneHost, SetupTab } from "./types";
 
 function loginUrlLink(url: string): string {
 	return `\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`;
+}
+
+function loginCopyHint(): string {
+	return theme.fg("dim", "(clipboard copy attempted; Alt+C retries)");
 }
 
 interface PromptState {
@@ -62,6 +67,10 @@ export class SignInTab implements SetupTab {
 
 	handleInput(data: string): void {
 		if (this.#loggingInProvider) {
+			if (this.#authUrl && (matchesKey(data, "alt+c") || (data === "c" && !this.#prompt))) {
+				void this.#copyAuthUrl();
+				return;
+			}
 			if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
 				this.#loginAbort?.abort();
 			}
@@ -88,7 +97,10 @@ export class SignInTab implements SetupTab {
 
 		const urlLines = this.#authUrl ? wrapTextWithAnsi(theme.fg("dim", this.#authUrl), width) : [];
 		if (this.#authUrl) {
-			lines.push(theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)}`), ...urlLines.slice(0, 2));
+			lines.push(
+				theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)} ${loginCopyHint()}`),
+				...urlLines.slice(0, 2),
+			);
 		}
 		if (this.#prompt) {
 			lines.push(theme.fg("warning", this.#prompt.message));
@@ -140,6 +152,7 @@ export class SignInTab implements SetupTab {
 					if (useManualInput) {
 						this.#statusLines.push(theme.fg("dim", "Paste the returned code or redirect URL when prompted."));
 					}
+					void this.#copyAuthUrl();
 					this.host.ctx.openInBrowser(info.url);
 					this.host.requestRender();
 				},
@@ -182,6 +195,17 @@ export class SignInTab implements SetupTab {
 			this.host.restoreFocus();
 			this.host.requestRender();
 		}
+	}
+
+	async #copyAuthUrl(): Promise<void> {
+		const url = this.#authUrl;
+		if (!url) return;
+		try {
+			await copyToClipboard(url);
+		} catch {
+			// Clipboard integration is best-effort; the full URL remains rendered below.
+		}
+		this.host.requestRender();
 	}
 
 	#showPrompt(prompt: { message: string; placeholder?: string }): Promise<string> {

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -5,6 +5,7 @@ import { SignInTab } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/scenes/s
 import type { SetupSceneHost } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/scenes/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
+import type { Component } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	await initTheme();
@@ -19,6 +20,7 @@ describe("SignInTab", () => {
 		const url = `https://example.com/oauth/authorize?client_id=omp&redirect_uri=http%3A%2F%2Flocalhost%3A45454%2Fcallback&state=${"a".repeat(96)}`;
 		const loginGate = Promise.withResolvers<void>();
 		const copySpy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+		let focusTarget: Component | undefined;
 		const openedUrls: string[] = [];
 
 		const authStorage = {
@@ -47,7 +49,9 @@ describe("SignInTab", () => {
 			},
 			requestRender(): void {},
 			finish(): void {},
-			setFocus(): void {},
+			setFocus(component: Component | null): void {
+				focusTarget = component ?? undefined;
+			},
 			restoreFocus(): void {},
 		} as unknown as SetupSceneHost;
 
@@ -64,7 +68,10 @@ describe("SignInTab", () => {
 			expect(compact).not.toContain("…");
 			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
 			expect(openedUrls).toEqual([url]);
-			expect(copySpy).toHaveBeenCalledWith(url);
+			expect(focusTarget).toBeDefined();
+			focusTarget?.handleInput?.("\x1bc");
+			expect(copySpy).toHaveBeenCalledTimes(2);
+			expect(copySpy).toHaveBeenLastCalledWith(url);
 
 			// On a ~24-row terminal the wizard body ends up ~8 rows; the OSC8
 			// link, a plain URL row, and the focused input must survive that clip.

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -1,18 +1,24 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import type { OAuthLoginCallbacks, OAuthProviderId } from "@oh-my-pi/pi-ai/oauth/types";
 import { SignInTab } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/scenes/sign-in";
 import type { SetupSceneHost } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/scenes/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
 
 beforeAll(async () => {
 	await initTheme();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
 });
 
 describe("SignInTab", () => {
 	it("keeps the OSC8 login link and manual-code prompt above clipped wizard rows", async () => {
 		const url = `https://example.com/oauth/authorize?client_id=omp&redirect_uri=http%3A%2F%2Flocalhost%3A45454%2Fcallback&state=${"a".repeat(96)}`;
 		const loginGate = Promise.withResolvers<void>();
+		const copySpy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
 		const openedUrls: string[] = [];
 
 		const authStorage = {
@@ -58,17 +64,69 @@ describe("SignInTab", () => {
 			expect(compact).not.toContain("…");
 			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
 			expect(openedUrls).toEqual([url]);
+			expect(copySpy).toHaveBeenCalledWith(url);
 
 			// On a ~24-row terminal the wizard body ends up ~8 rows; the OSC8
 			// link, a plain URL row, and the focused input must survive that clip.
 			const clippedBody = rendered.slice(0, 8).map(line => Bun.stripANSI(line).trim());
 			const plainUrlIndex = clippedBody.findIndex(line => line.startsWith("https://example.com/oauth/authorize?"));
 			const inputIndex = clippedBody.findIndex(line => line.startsWith(">"));
-			expect(clippedBody.some(line => line === "Browser login: Open login URL")).toBe(true);
+			expect(clippedBody.some(line => line.startsWith("Browser login: Open login URL"))).toBe(true);
 			expect(plainUrlIndex).toBeGreaterThanOrEqual(0);
 			expect(clippedBody).toContain("Paste the authorization code (or full redirect URL):");
 			expect(inputIndex).toBeGreaterThanOrEqual(0);
 			expect(plainUrlIndex).toBeLessThan(inputIndex);
+		} finally {
+			tab.dispose();
+			loginGate.resolve();
+			await loginGate.promise;
+		}
+	});
+
+	it("copies the active login URL from the keyboard while the setup TUI owns selection", async () => {
+		const url = "https://example.com/oauth/authorize?client_id=omp&state=copy";
+		const loginGate = Promise.withResolvers<void>();
+		const copySpy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+
+		const authStorage = {
+			has: (_providerId: string) => false,
+			hasAuth: (_providerId: string) => false,
+			getCredentialOrigin: (_providerId: string) => undefined,
+			async login(_provider: OAuthProviderId, ctrl: OAuthLoginCallbacks): Promise<void> {
+				ctrl.onAuth({ url });
+				await loginGate.promise;
+			},
+		} as unknown as AuthStorage;
+
+		const host = {
+			ctx: {
+				openInBrowser(): void {},
+				session: {
+					modelRegistry: {
+						authStorage,
+						async refresh(): Promise<void> {},
+					},
+				},
+			},
+			requestRender(): void {},
+			finish(): void {},
+			setFocus(): void {},
+			restoreFocus(): void {},
+		} as unknown as SetupSceneHost;
+
+		const tab = new SignInTab(host);
+		try {
+			for (const char of "anthropic") {
+				tab.handleInput(char);
+			}
+			tab.handleInput("\n");
+			await Promise.resolve();
+			expect(copySpy).toHaveBeenCalledTimes(1);
+
+			tab.handleInput("\x1bc");
+			await Promise.resolve();
+			expect(copySpy).toHaveBeenCalledTimes(2);
+			expect(copySpy).toHaveBeenLastCalledWith(url);
 		} finally {
 			tab.dispose();
 			loginGate.resolve();


### PR DESCRIPTION
## Repro
Provider setup renders the authentication URL inside the TUI, but active sign-in input only handled cancellation keys, so a terminal configuration that prevents selection/copying inside the alternate-screen wizard had no keyboard copy fallback. Reproduced with `bun -e "$REPRO_SCRIPT"`, which starts `SignInTab`, emits an OAuth URL, presses `c`, and observes no copy/fallback behavior.

## Cause
`packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts` stored the URL in `SignInTab.#authUrl`, rendered it as an OSC8 link/plain wrapped URL, and opened it in the browser, but `SignInTab.handleInput()` returned during active login after only Esc/Ctrl+C cancellation handling. The setup wizard owns the TUI/alternate-screen input path, so mouse selection could be the only way to copy the rendered URL.

## Fix
- Attempt clipboard/OSC 52 copy with `copyToClipboard()` as soon as `onAuth` emits the provider login URL.
- Add an Alt+C retry path while a sign-in is active, with plain `c` also retrying before a prompt owns text entry.
- Render a visible copy hint beside the login link and keep the full URL/prompt above clipped wizard rows.
- Cover automatic copy and keyboard retry behavior in `setup-wizard-sign-in.test.ts`.

## Verification
`bun run --cwd packages/coding-agent test test/setup-wizard-sign-in.test.ts` passed with 2 tests and 13 assertions. `bun run --cwd packages/coding-agent check` passed (`biome check .` and `tsgo -p tsconfig.json --noEmit`). Fixes #2908