### PR TITLE
Fix Ollama Cloud GLM-5.2 reasoning efforts

### DIFF
--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -99,21 +99,29 @@ function normalizeBaseUrl(baseUrl?: string): string {
 	return trimmed.endsWith("/api") ? trimmed.slice(0, -4) : trimmed;
 }
 
+type OllamaThinkValue = boolean | "low" | "medium" | "high" | "max" | undefined;
+
 function mapReasoning(
+	model: Model<"ollama-chat">,
 	reasoning: OllamaChatOptions["reasoning"],
 	disableReasoning: boolean | undefined,
-	modelReasoning: boolean,
-): boolean | "low" | "medium" | "high" | undefined {
+): OllamaThinkValue {
+	const modelReasoning = model.reasoning;
 	if (disableReasoning && modelReasoning) {
 		return false;
 	}
-	switch (reasoning) {
+	const mappedReasoning =
+		model.provider === "ollama-cloud" && reasoning ? (model.thinking?.effortMap?.[reasoning] ?? reasoning) : reasoning;
+	switch (mappedReasoning) {
 		case "minimal":
 		case "low":
 			return "low";
 		case "medium":
 			return "medium";
 		case "high":
+			return "high";
+		case "max":
+			return "max";
 		case "xhigh":
 			return "high";
 		default:
@@ -273,7 +281,7 @@ function convertTools(tools: Tool[] | undefined): OllamaFunctionTool[] | undefin
 }
 
 function createChatBody(model: Model<"ollama-chat">, context: Context, options: OllamaChatOptions | undefined) {
-	const think = mapReasoning(options?.reasoning, options?.disableReasoning, model.reasoning);
+	const think = mapReasoning(model, options?.reasoning, options?.disableReasoning);
 	const toolChoice = mapToolChoice(options?.toolChoice);
 	const selectedTools = selectToolsForToolChoice(context.tools, options?.toolChoice);
 	const tools = convertTools(selectedTools);

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -57,6 +57,7 @@ const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, E
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
+const GLM_52_HIGH_MAX_REASONING_EFFORTS: readonly Effort[] = [Effort.High, Effort.XHigh];
 
 type EffortMap = Partial<Record<Effort, string>>;
 
@@ -82,6 +83,9 @@ const ZAI_GLM_52_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.Low]: "high",
 	[Effort.Medium]: "high",
 	[Effort.High]: "high",
+	[Effort.XHigh]: "max",
+};
+const OLLAMA_CLOUD_GLM_52_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.XHigh]: "max",
 };
 
@@ -270,6 +274,9 @@ function getModelDefinedEfforts<TApi extends Api>(spec: ModelSpec<TApi>): readon
 	if (spec.api === "openai-completions" && isZaiGlm52ReasoningEffortModel(spec)) {
 		return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 	}
+	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+		return GLM_52_HIGH_MAX_REASONING_EFFORTS;
+	}
 	return spec.api === "openai-completions" && (isMinimaxM2FamilyModelId(spec.id) || isOpenAIGptOssModelId(spec.id))
 		? LOW_MEDIUM_HIGH_REASONING_EFFORTS
 		: undefined;
@@ -278,6 +285,10 @@ function getModelDefinedEfforts<TApi extends Api>(spec: ModelSpec<TApi>): readon
 function isZaiGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
 	if (!isGlm52ReasoningEffortModelId(spec.id)) return false;
 	return modelMatchesHost(spec, "zai") || modelMatchesHost(spec, "zhipu");
+}
+
+function isOllamaCloudGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	return spec.api === "ollama-chat" && spec.provider === "ollama-cloud" && isGlm52ReasoningEffortModelId(spec.id);
 }
 
 function readCompatEffortMap(compat: CompatOf<Api>): EffortMap | undefined {
@@ -297,6 +308,9 @@ function inferDetectedEffortMap<TApi extends Api>(
 		return anthropicModelHasRealXHighEffort(spec, parsedModel)
 			? ANTHROPIC_ADAPTIVE_EFFORT_MAP_5_TIER
 			: ANTHROPIC_ADAPTIVE_EFFORT_MAP_4_TIER;
+	}
+	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+		return OLLAMA_CLOUD_GLM_52_REASONING_EFFORT_MAP;
 	}
 	if (spec.api !== "openai-completions") {
 		return undefined;

--- a/packages/catalog/src/provider-models/ollama.ts
+++ b/packages/catalog/src/provider-models/ollama.ts
@@ -1,5 +1,6 @@
 import { fetchWithRetry } from "@oh-my-pi/pi-utils";
 import { Effort } from "../effort";
+import { isGlm52ReasoningEffortModelId } from "../identity/family";
 import type { ModelManagerOptions } from "../model-manager";
 import type { FetchImpl, ThinkingConfig } from "../types";
 import { createBundledReferenceMap, createReferenceResolver } from "./bundled-references";
@@ -21,6 +22,11 @@ type OllamaShowResponse = {
 };
 
 const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+const OLLAMA_CLOUD_GLM_52_THINKING: ThinkingConfig = {
+	mode: "effort",
+	efforts: [Effort.High, Effort.XHigh],
+	effortMap: { [Effort.XHigh]: "max" },
+};
 
 function trimTrailingSlash(value: string): string {
 	return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -56,9 +62,12 @@ function getContextWindow(modelInfo: Record<string, unknown> | undefined): numbe
 	}
 }
 
-function getThinkingConfig(capabilities: string[] | undefined): ThinkingConfig | undefined {
+function getThinkingConfig(modelId: string, capabilities: string[] | undefined): ThinkingConfig | undefined {
 	if (!capabilities?.includes("thinking")) {
 		return undefined;
+	}
+	if (isGlm52ReasoningEffortModelId(modelId)) {
+		return OLLAMA_CLOUD_GLM_52_THINKING;
 	}
 	return { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] };
 }
@@ -128,7 +137,7 @@ export function ollamaCloudModelManagerOptions(
 					// different catalog; keep the historical safe fallback instead.
 					const contextWindow = discoveredContextWindow ?? 128000;
 					const reasoning = capabilities ? capabilities.includes("thinking") : (reference?.reasoning ?? false);
-					const thinking = capabilities ? getThinkingConfig(capabilities) : reference?.thinking;
+					const thinking = capabilities ? getThinkingConfig(id, capabilities) : reference?.thinking;
 					const input = capabilities
 						? capabilities.includes("vision")
 							? (["text", "image"] as Array<"text" | "image">)

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -500,6 +500,26 @@ describe("model thinking runtime helpers", () => {
 		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
 	});
 
+	it("maps Ollama Cloud GLM-5.2 xhigh to max and hides unsupported lower efforts", () => {
+		const model = createModel({
+			id: "glm-5.2",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.High, Effort.XHigh],
+			effortMap: {
+				xhigh: "max",
+			},
+		});
+		expect(requireSupportedEffort(model, Effort.High)).toBe(Effort.High);
+		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
+		expect(() => requireSupportedEffort(model, Effort.Medium)).toThrow(/Supported efforts: high, xhigh/);
+	});
+
 	it("derives binary-thinking fallback from resolved compat when catalog compat is partial", () => {
 		const model = createModel({
 			id: "qwen/qwen3-32b",

--- a/packages/catalog/test/ollama-cloud-provider.test.ts
+++ b/packages/catalog/test/ollama-cloud-provider.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "bun:test";
 import { completeSimple, getEnvApiKey, stream, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { ollamaCloudModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/ollama";
 import type { FetchImpl, Model } from "@oh-my-pi/pi-catalog/types";
 
@@ -109,6 +110,40 @@ describe("ollama-cloud provider support", () => {
 		expect(qwen?.name).toBe("Qwen 3 32B");
 		expect(qwen?.input).toEqual(["text", "image"]);
 		expect(fetchMock).toHaveBeenCalledWith("https://ollama.com/api/tags", expect.objectContaining({ method: "GET" }));
+	});
+
+	test("discovers GLM-5.2 with Ollama Cloud high/max reasoning efforts", async () => {
+		const fetchMock: FetchImpl = vi.fn(async (input, _init) => {
+			const url = String(input);
+			if (url === "https://ollama.com/api/tags") {
+				return new Response(JSON.stringify({ models: [{ name: "glm-5.2" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://ollama.com/api/show") {
+				return new Response(
+					JSON.stringify({
+						capabilities: ["completion", "thinking"],
+						model_info: { "glm.context_length": 1000000 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		});
+
+		const options = ollamaCloudModelManagerOptions({ apiKey: "cloud-test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		const model = models?.find(candidate => candidate.id === "glm-5.2");
+		const built = model ? buildModel(model) : undefined;
+
+		expect(model?.reasoning).toBe(true);
+		expect(built?.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.High, Effort.XHigh],
+			effortMap: { xhigh: "max" },
+		});
 	});
 
 	test("tolerates individual /api/show failures during model discovery", async () => {
@@ -230,6 +265,38 @@ describe("ollama-cloud provider support", () => {
 			{ type: "thinking", thinking: "Need to think." },
 			{ type: "text", text: "Hello world" },
 		]);
+	});
+
+	test("sends max for GLM-5.2 xhigh reasoning on Ollama Cloud", async () => {
+		let requestBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (_input, init) => {
+			requestBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+			return createNdjsonResponse([
+				{ model: "glm-5.2", message: { role: "assistant", content: "ok" }, done: false },
+				{ model: "glm-5.2", done: true, done_reason: "stop", prompt_eval_count: 1, eval_count: 1 },
+			]);
+		});
+		const model: Model<"ollama-chat"> = buildModel({
+			id: "glm-5.2",
+			name: "GLM-5.2",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+			reasoning: true,
+			thinking: { mode: "effort", efforts: [Effort.High, Effort.XHigh], effortMap: { [Effort.XHigh]: "max" } },
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 131_072,
+		});
+
+		await stream(model, { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] }, {
+			apiKey: "cloud-test-key",
+			fetch: fetchMock,
+			reasoning: Effort.XHigh,
+		}).result();
+
+		expect(requestBody?.think).toBe("max");
 	});
 
 	test("supports ollama-cloud through streamSimple option mapping", async () => {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          Fixes Ollama Cloud GLM-5.2 reasoning effort metadata and request mapping.
                                                                                                                                                                                                                                                                                                                                                                                                                                          
- Advertises GLM-5.2 on Ollama Cloud as supporting only `high` and `xhigh`
- Maps OMP `xhigh` to Ollama native `think: "max"`
- Preserves existing Ollama Cloud behavior for other reasoning models
                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Testing                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
- `bun test packages/catalog/test/ollama-provider.test.ts packages/catalog/test/ollama-cloud-output-caps.test.ts packages/catalog/test/model-thinking.test.ts packages/catalog/test/ollama-cloud-provider.test.ts`                                                                                                                                                                                                                     
- `bun run check:types` in `packages/catalog`                                                                                                                                                                                                                                                                                                                                                                                          
- `bun run check:types` in `packages/ai`      