### PR TITLE
fix(coding-agent): preserved queued steers/follow-ups during auto-compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the first steering/follow-up message typed as auto-compaction begins being dropped instead of queued; the compaction abort controller (which backs `isCompacting`) is now installed before the `auto_compaction_start` event fires, so input routed during that window lands in the compaction queue rather than the core agent queue.
+- Fixed queued steering/follow-up messages being silently cleared by the agent reset during a handoff; they are now captured and restored across the new-session reset.
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7680,7 +7680,17 @@ export class AgentSession {
 			await this.sessionManager.flush();
 			this.#cancelOwnAsyncJobs();
 			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
+			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
+			// steers/follow-ups (RPC/SDK steer()/followUp() issued during the handoff, or a
+			// pre-loader TUI steer) so they survive into the post-handoff session instead of
+			// being silently dropped. Capture is synchronous immediately before reset and
+			// restore is synchronous immediately after — no await gap — so a steer arriving
+			// later (during ensureOnDisk/Bun.write below) appends to the restored queue
+			// rather than being clobbered.
+			const preservedSteering = this.agent.peekSteeringQueue().slice();
+			const preservedFollowUp = this.agent.peekFollowUpQueue().slice();
 			this.agent.reset();
+			this.agent.replaceQueues(preservedSteering, preservedFollowUp);
 			this.#freshProviderSessionId = undefined;
 			this.#syncAgentSessionId();
 			this.#rekeyHindsightMemoryForCurrentSessionId();
@@ -9038,7 +9048,6 @@ export class AgentSession {
 				);
 			}
 		}
-		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 		// Abort any older auto-compaction before installing this run's controller.
 		this.#autoCompactionAbortController?.abort();
 		const autoCompactionAbortController = new AbortController();
@@ -9046,11 +9055,16 @@ export class AgentSession {
 		const autoCompactionSignal = autoCompactionAbortController.signal;
 
 		try {
+			// Emit start AFTER the controller is installed so isCompacting is already true
+			// for any listener — and for input routed during this emit's event-loop yield:
+			// a message typed as the compaction loader appears must land in the compaction
+			// queue, not the core steering queue (which handoff's agent.reset() would wipe).
+			await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 			if (compactionSettings.strategy === "handoff" && reason !== "overflow") {
 				const handoffFocus = AUTO_HANDOFF_THRESHOLD_FOCUS;
 				const handoffResult = await this.handoff(handoffFocus, {
 					autoTriggered: true,
-					signal: this.#autoCompactionAbortController.signal,
+					signal: autoCompactionSignal,
 				});
 				if (!handoffResult) {
 					const aborted = autoCompactionSignal.aborted;
@@ -9466,12 +9480,12 @@ export class AgentSession {
 		triggerContextTokens?: number,
 	): Promise<CompactionCheckResult | "fallback"> {
 		const action = "shake";
-		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 		this.#autoCompactionAbortController?.abort();
 		const controller = new AbortController();
 		this.#autoCompactionAbortController = controller;
 		const signal = controller.signal;
 		try {
+			await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 			const result = await this.shake("elide", { config: DEFAULT_SHAKE_CONFIG, signal });
 			if (signal.aborted) {
 				await this.#emitSessionEvent({

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -206,6 +206,54 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
 	});
 
+	it("has isCompacting true when the auto_compaction_start event fires", async () => {
+		// Defect 1: the compaction AbortController (which backs isCompacting) must be
+		// installed before auto_compaction_start is emitted. If it is installed after,
+		// a message typed the instant the loader appears is read while
+		// isCompacting === false and mis-routed into the core steering queue (which a
+		// later handoff reset would wipe) instead of the safe UI compaction queue.
+		let capturedIsCompacting: boolean | undefined;
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_start") {
+				capturedIsCompacting = session.isCompacting;
+			} else if (event.type === "auto_compaction_end") {
+				onCompactionDone();
+			}
+		});
+
+		// Defensive: mirror the resume-drain stub so any queued continuation settles
+		// instead of spinning the drain (see the threshold test above).
+		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			session.agent.clearAllQueues();
+		});
+
+		const assistantMsg = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "Done." }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "stop" as const,
+			usage: {
+				input: 190000,
+				output: 1000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 191000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+
+		expect(capturedIsCompacting).toBe(true);
+	});
+
 	it("forwards todo reminder lifecycle signals to extensions", async () => {
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -153,6 +153,101 @@ describe("AgentSession handoff", () => {
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
 	});
 
+	it("preserves queued steering and follow-up messages across the handoff reset", async () => {
+		// Defect 2: handoff() calls agent.reset(), which clears the core steering/follow-up
+		// queues. Steers/follow-ups already queued (the mis-routed first compaction message,
+		// or RPC/SDK steer()/followUp() issued during the handoff) must survive into the new
+		// session instead of being silently dropped.
+		vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue("## Goal\nContinue");
+
+		const textOf = (message: AgentMessage): string => {
+			if (!("content" in message)) return "";
+			const content = message.content;
+			if (typeof content === "string") return content;
+			const textBlock = content.find(block => block.type === "text");
+			return textBlock?.type === "text" ? textBlock.text : "";
+		};
+
+		const userMsg: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "keep-steer" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		// A hidden, user-attributed companion (e.g. an ultrathink notice). It is
+		// display:false, so isUserQueuedMessage(...) is false for it: preservation must
+		// keep it adjacent to its prompt rather than filter it out or reorder it.
+		const companionMsg: AgentMessage = {
+			role: "custom",
+			customType: "ultrathink-notice",
+			content: [{ type: "text", text: "companion" }],
+			attribution: "user",
+			display: false,
+			timestamp: Date.now(),
+		};
+		const followUpMsg: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "keep-followup" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		session.agent.steer(userMsg);
+		session.agent.steer(companionMsg);
+		session.agent.followUp(followUpMsg);
+		expect(session.agent.hasQueuedMessages()).toBe(true);
+
+		await session.handoff();
+
+		expect(session.agent.peekSteeringQueue().map(textOf)).toEqual(["keep-steer", "companion"]);
+		expect(session.agent.peekFollowUpQueue().map(textOf)).toEqual(["keep-followup"]);
+	});
+
+	it("preserves steering and follow-up messages enqueued while the handoff is in flight", async () => {
+		// Defect 2 in-flight window: the queue snapshot must be captured immediately before
+		// agent.reset() (after generateHandoff resolves), NOT at handoff entry. A steer or
+		// follow-up issued WHILE the handoff document is still generating must survive the
+		// reset — proving capture happens late rather than at the start of handoff().
+		const { promise: handoffDoc, resolve: releaseHandoff } = Promise.withResolvers<string>();
+		let generateHandoffCalled = false;
+		vi.spyOn(compactionModule, "generateHandoff").mockImplementation(async () => {
+			generateHandoffCalled = true;
+			return handoffDoc;
+		});
+
+		const textOf = (message: AgentMessage): string => {
+			if (!("content" in message)) return "";
+			const content = message.content;
+			if (typeof content === "string") return content;
+			const textBlock = content.find(block => block.type === "text");
+			return textBlock?.type === "text" ? textBlock.text : "";
+		};
+
+		const handoffPromise = session.handoff();
+		// Block until we are genuinely mid-handoff (document generation in flight).
+		await waitFor(() => generateHandoffCalled);
+
+		// Enqueue AFTER generation started but BEFORE it resolves — the window where the old
+		// session is still live and agent.reset() has not yet fired.
+		session.agent.steer({
+			role: "user",
+			content: [{ type: "text", text: "inflight-steer" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+		session.agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "inflight-followup" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+
+		releaseHandoff("## Goal\nContinue");
+		await handoffPromise;
+
+		expect(session.agent.peekSteeringQueue().map(textOf)).toEqual(["inflight-steer"]);
+		expect(session.agent.peekFollowUpQueue().map(textOf)).toEqual(["inflight-followup"]);
+	});
+
 	it("obfuscates custom instructions before generating a handoff", async () => {
 		const placeholder = obfuscator.obfuscate(HANDOFF_SECRET);
 		const generateHandoffSpy = vi

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -192,6 +192,52 @@ describe("AgentSession shake", () => {
 			expect(end[0]).toMatchObject({ type: "auto_compaction_end", action: "shake" });
 		});
 
+		it("has isCompacting true when the shake auto_compaction_start event fires", async () => {
+			// Defect 1 parity for the shake strategy: the controller backing isCompacting
+			// must be installed before auto_compaction_start is emitted, so a message
+			// typed as the loader appears is queued safely rather than mis-routed.
+			session.settings.set("compaction.strategy", "shake");
+			session.settings.set("compaction.thresholdPercent", 1);
+			session.settings.set("contextPromotion.enabled", false);
+
+			let capturedIsCompacting: boolean | undefined;
+			const { promise: shakeStarted, resolve: onShakeStarted } = Promise.withResolvers<void>();
+			session.subscribe(event => {
+				if (event.type === "auto_compaction_start" && event.action === "shake") {
+					capturedIsCompacting = session.isCompacting;
+					onShakeStarted();
+				}
+			});
+
+			vi.spyOn(session, "shake").mockResolvedValue({
+				mode: "elide",
+				toolResultsDropped: 1,
+				blocksDropped: 0,
+				tokensFreed: 10_000,
+			});
+
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: {
+					input: 10_000,
+					output: 1_000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 11_000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await shakeStarted;
+
+			expect(capturedIsCompacting).toBe(true);
+		});
+
 		it("falls back to context-full when shake cannot drop context below the threshold (regression #2119)", async () => {
 			session.settings.set("compaction.strategy", "shake");
 			session.settings.set("compaction.thresholdPercent", 1);


### PR DESCRIPTION
## Summary

Typing a message the instant auto-compaction begins could silently drop it: the *first* steer/follow-up vanished while later ones queued normally. Both loss paths are now closed, so a message typed as the compaction loader appears is queued and delivered once compaction finishes.

## What was broken

Two independent defects produced the same symptom.

1. **Timing window.** `isCompacting` is backed by the compaction `AbortController`, which was installed *after* `auto_compaction_start` was emitted. The emit awaits extension delivery and yields to the event loop, so a message typed during that window was read while `isCompacting` was `false` and routed into the core agent queue — which the subsequent handoff reset then wiped. The controller is now installed *before* the emit (in both the context-full and shake paths), and the emit moved to the first statement inside the existing `try` so the `catch`/`finally` cleanup still runs. The handoff branch now passes the run's *local* abort signal instead of the mutable controller field, so a superseded run bails at the handoff entry check rather than resetting the session.

2. **Handoff queue wipe.** `handoff()` calls `agent.reset()`, which clears the core steering/follow-up queues. They are now captured immediately before the reset and restored immediately after (synchronous, no await gap), so queued steers/follow-ups — including in-flight RPC/SDK `steer()`/`followUp()` and a hidden user companion such as an ultrathink notice — survive the new-session reset instead of being dropped.

## Tests

Regression coverage for both defects:

- `isCompacting === true` at `auto_compaction_start` for the context-full and shake paths (proves controller-before-emit).
- Queue preservation across the handoff reset for both pre-enqueued messages (asserting hidden-companion adjacency and order) and messages enqueued *while* the handoff document is still generating (proves the snapshot is taken late, right before reset).

`bun test` on the three affected files: **35 pass / 0 fail** (129 assertions).

## Out of scope (noted, not fixed)

A review of this change surfaced two *pre-existing* concurrency issues in adjacent code, intentionally left for a separate focused change:

- Shake → context-full fallback emits an intermediate `auto_compaction_end{willRetry:false}`, so the TUI's `flushCompactionQueue` can fire a queued prompt against the still-oversized context before the fallback runs. The fix belongs in the event controller / fallback semantics.
- `handoff()` does not re-check the abort signal after `flush()`/`newSession()`; an abort that flips during that window still proceeds to reset. The fix needs commit-point design, since `newSession()` already commits state.

Repo-wide `bun check` / `bun fmt` are currently blocked by a pre-existing `biome.json` config error unrelated to this change, so verification used `bun test` directly.
