### PR TITLE
fix(agent): add provider failure fallback chains

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider billing/quota and string-form authentication errors so they enter credential/model retry fallback instead of surfacing as non-retryable provider failures. ([#2912](https://github.com/can1357/oh-my-pi/issues/2912))
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -70,6 +70,12 @@ export function seedApiKeyResolver(seed: string | undefined, resolver: ApiKeyRes
 	};
 }
 
+function isStringAuthStatusError(message: string): boolean {
+	return (
+		/\b401\b/.test(message) && /authentication_error|unauthorized|invalid.?x-api-key|invalid.?api.?key/i.test(message)
+	);
+}
+
 /**
  * Classifies whether an error should trigger a credential refresh/rotation
  * retry: a hard `401`, or a rotatable usage-limit ("usage_limit_reached",
@@ -79,7 +85,7 @@ export function isAuthRetryableError(error: unknown): boolean {
 	if (extractHttpStatusFromError(error) === 401) return true;
 	const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 	if (!message) return false;
-	if (extractHttpStatusFromError({ message }) === 401) return true;
+	if (extractHttpStatusFromError({ message }) === 401 || isStringAuthStatusError(message)) return true;
 	return isUsageLimitError(message);
 }
 

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -18,6 +18,8 @@ const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
 
 const ACCOUNT_RATE_LIMIT_PATTERN =
 	/\baccount(?:'s)?\b[^\n]{0,80}\brate.?limit\b|\brate.?limit\b[^\n]{0,80}\baccount\b/i;
+const BILLING_QUOTA_PATTERN =
+	/credit balance is too low|insufficient[_ -]?quota|quota.?exceeded|payment required|no credits?|billing quota/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
@@ -35,7 +37,11 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// The literal "capacity" used to pre-empt the QUOTA branch even though "quota
 	// will reset" is the long-wait signal — short-circuit here before the
 	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
-	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
+	if (
+		BILLING_QUOTA_PATTERN.test(errorMessage) ||
+		lower.includes("quota will reset") ||
+		lower.includes("exhausted your capacity")
+	) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -94,8 +100,12 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
-	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);
+	return (
+		USAGE_LIMIT_PATTERN.test(errorMessage) ||
+		BILLING_QUOTA_PATTERN.test(errorMessage) ||
+		ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage)
+	);
 }

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -57,6 +57,15 @@ describe("isAuthRetryableError", () => {
 		expect(isAuthRetryableError(new Error("network blip"))).toBe(false);
 		expect(isAuthRetryableError(undefined)).toBe(false);
 	});
+	it("treats string-form provider authentication errors as retryable", () => {
+		expect(
+			isAuthRetryableError(
+				'401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+			),
+		).toBe(true);
+		expect(isAuthRetryableError("403 payment required")).toBe(true);
+		expect(isAuthRetryableError("403 invalid provider configuration")).toBe(false);
+	});
 });
 
 describe("withAuth", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -66,6 +66,16 @@ describe("parseRateLimitReason", () => {
 			),
 		).toBe("QUOTA_EXHAUSTED");
 	});
+	it("classifies provider billing exhaustion as QUOTA_EXHAUSTED", () => {
+		const message = '400 {"message":"Your credit balance is too low to access the Anthropic API"}';
+
+		expect(parseRateLimitReason(message)).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("insufficient_quota")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("quota exceeded")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("payment required")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("no credits")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("billing quota")).toBe("QUOTA_EXHAUSTED");
+	});
 });
 
 describe("isUsageLimitError", () => {
@@ -105,6 +115,14 @@ describe("isUsageLimitError", () => {
 	it("detects bare 'quota reached' phrasing", () => {
 		expect(isUsageLimitError("quota reached")).toBe(true);
 		expect(isUsageLimitError("quota_reached")).toBe(true);
+	});
+	it("detects provider billing exhaustion as credential-rotatable usage limits", () => {
+		expect(isUsageLimitError('400 {"message":"Your credit balance is too low to access the Anthropic API"}')).toBe(
+			true,
+		);
+		expect(isUsageLimitError("insufficient_quota")).toBe(true);
+		expect(isUsageLimitError("payment required")).toBe(true);
+		expect(isUsageLimitError("400 invalid_request_error: schema validation failed")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed built-in agent roles to install provider-failure fallback chains for single-model subagents, so provider auth/quota/rate-limit/timeout failures can fall back to another configured provider. ([#2912](https://github.com/can1357/oh-my-pi/issues/2912))
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -263,6 +263,26 @@ export interface ModelTagDef {
 	/** If true, the role is functional but not shown in the model selector UI. */
 	hidden?: boolean;
 }
+/** Default provider-availability fallback order shared by built-in model roles. */
+export const DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN: string[] = [
+	"openai-codex/gpt-5.5:high",
+	"anthropic/claude-opus-4-8:high",
+	"google-gemini-cli/gemini-3.1-pro-preview",
+];
+
+/** Role-keyed fallback chains installed for fresh settings. */
+export const DEFAULT_RETRY_FALLBACK_CHAINS: Record<string, string[]> = {
+	default: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	smol: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	slow: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	vision: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	plan: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	designer: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	commit: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	title: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	task: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+	advisor: [...DEFAULT_PROVIDER_FAILURE_FALLBACK_CHAIN],
+};
 
 export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
@@ -1164,7 +1184,7 @@ export const SETTINGS_SCHEMA = {
 			description: "Allow retry recovery to switch to configured fallback models",
 		},
 	},
-	"retry.fallbackChains": { type: "record", default: {} as Record<string, string[]> },
+	"retry.fallbackChains": { type: "record", default: DEFAULT_RETRY_FALLBACK_CHAINS },
 	"retry.fallbackRevertPolicy": {
 		type: "enum",
 		values: ["cooldown-expiry", "never"] as const,
@@ -4543,6 +4563,8 @@ export interface RetrySettings {
 	baseDelayMs: number;
 	maxDelayMs: number;
 	modelFallback: boolean;
+	fallbackChains: Record<string, string[]>;
+	fallbackRevertPolicy: "cooldown-expiry" | "never";
 }
 
 export interface MemoriesSettings {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -686,6 +686,10 @@ function formatRetryFallbackSelector(model: Model, thinkingLevel: ThinkingLevel 
 function formatRetryFallbackBaseSelector(selector: RetryFallbackSelector): string {
 	return `${selector.provider}/${selector.id}`;
 }
+function retryFallbackSelectorDedupKeys(selector: RetryFallbackSelector): string[] {
+	const baseSelector = formatRetryFallbackBaseSelector(selector);
+	return selector.raw === baseSelector ? [selector.raw] : [selector.raw, baseSelector];
+}
 
 const EPHEMERAL_REPLY_MAX_BYTES = 4096;
 
@@ -9828,11 +9832,15 @@ export class AgentSession {
 		const primarySelector = this.#getRetryFallbackPrimarySelector(role);
 		if (!primarySelector) return [];
 		const chain = [primarySelector];
-		const seen = new Set<string>([primarySelector.raw]);
+		const seen = new Set<string>(retryFallbackSelectorDedupKeys(primarySelector));
 		for (const selector of this.#getRetryFallbackChains()[role] ?? []) {
 			const parsed = parseRetryFallbackSelector(selector);
-			if (!parsed || seen.has(parsed.raw)) continue;
-			seen.add(parsed.raw);
+			if (!parsed) continue;
+			const keys = retryFallbackSelectorDedupKeys(parsed);
+			if (keys.some(key => seen.has(key))) continue;
+			for (const key of keys) {
+				seen.add(key);
+			}
 			chain.push(parsed);
 		}
 		return chain;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -96,6 +96,7 @@ import {
 	clearAnthropicFastModeFallback,
 	deriveClaudeDeviceId,
 	Effort,
+	isAuthRetryableError,
 	isContextOverflow,
 	isUsageLimitError,
 	parseRateLimitReason,
@@ -9658,7 +9659,7 @@ export class AgentSession {
 		if (this.#isStaleOpenAIResponsesReplayError(message)) return true;
 
 		const err = message.errorMessage;
-		return this.#isTransientErrorMessage(err) || isUsageLimitError(err);
+		return this.#isTransientErrorMessage(err) || isUsageLimitError(err) || isAuthRetryableError(err);
 	}
 	#streamInterruptedAfterObservableOutput(message: AssistantMessage): boolean {
 		if (message.stopDetails?.type === STREAM_INTERRUPTED_AFTER_CONTENT_STOP_DETAIL) return true;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -14,6 +14,7 @@ import { ModelRegistry } from "../config/model-registry";
 import {
 	formatModelSelectorValue,
 	formatModelStringWithRouting,
+	resolveAgentModelPatterns,
 	resolveModelOverride,
 	resolveModelOverrideWithAuthFallback,
 } from "../config/model-resolver";
@@ -174,19 +175,20 @@ function pushSubagentRetryFallbackCandidate(
 }
 
 function resolveSubagentRetryFallbackCandidates(
-	modelPatterns: string[],
+	requestedModelPatterns: string[],
+	effectiveModelPatterns: string[],
 	modelRegistry: ModelRegistry,
 	settings: Settings,
 ): SubagentRetryFallbackCandidate[] {
 	const candidates: SubagentRetryFallbackCandidate[] = [];
 	const seen = new Set<string>();
-	for (const pattern of modelPatterns) {
+	for (const pattern of effectiveModelPatterns) {
 		pushSubagentRetryFallbackCandidate(candidates, seen, pattern, modelRegistry, settings);
 	}
 
-	if (modelPatterns.length === 1) {
+	if (requestedModelPatterns.length === 1) {
 		const fallbackChains = settings.get("retry.fallbackChains");
-		const role = modelPatternRole(modelPatterns[0]);
+		const role = modelPatternRole(requestedModelPatterns[0]);
 		const configuredChain = role ? fallbackChains[role] : undefined;
 		const roleChain = configuredChain && configuredChain.length > 0 ? configuredChain : fallbackChains.default;
 		for (const pattern of roleChain ?? []) {
@@ -1835,7 +1837,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		toolNames = Array.from(new Set(expanded));
 	}
 
-	const modelPatterns = normalizeModelPatterns(modelOverride ?? agent.model);
+	const requestedModelPatterns = normalizeModelPatterns(modelOverride ?? agent.model);
+	const resolvedModelPatterns = resolveAgentModelPatterns({
+		settingsOverride: modelOverride,
+		agentModel: agent.model,
+		settings,
+		activeModelPattern: options.parentActiveModelPattern,
+	});
+	const modelPatterns = resolvedModelPatterns.length > 0 ? resolvedModelPatterns : requestedModelPatterns;
 	const sessionFile = subtaskSessionFile ?? null;
 	const spawnsEnv = atMaxDepth
 		? ""
@@ -1964,7 +1973,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const retryFallbackRole = installSubagentRetryFallbackChain({
 				settings: subagentSettings,
 				id,
-				candidates: resolveSubagentRetryFallbackCandidates(modelPatterns, modelRegistry, settings),
+				candidates: resolveSubagentRetryFallbackCandidates(
+					requestedModelPatterns,
+					modelPatterns,
+					modelRegistry,
+					settings,
+				),
 				model,
 				authFallbackUsed,
 			});

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -41,6 +41,7 @@ import type { AuthStorage } from "../session/auth-storage";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
+import { parseThinkingLevel } from "../thinking";
 import type { ContextFileEntry } from "../tools";
 import { isIrcEnabled } from "../tools/irc";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
@@ -132,6 +133,46 @@ interface SubagentRetryFallbackCandidate {
 	selector: string;
 }
 
+function stripSelectorThinkingSuffix(selector: string): string {
+	const colonIndex = selector.lastIndexOf(":");
+	if (colonIndex < 0) return selector;
+	const suffix = selector.slice(colonIndex + 1);
+	return parseThinkingLevel(suffix) ? selector.slice(0, colonIndex) : selector;
+}
+
+function selectorDedupKeys(selector: string): string[] {
+	const baseSelector = stripSelectorThinkingSuffix(selector);
+	return baseSelector === selector ? [selector] : [selector, baseSelector];
+}
+
+function modelPatternRole(pattern: string): string | undefined {
+	const basePattern = stripSelectorThinkingSuffix(pattern.trim());
+	if (basePattern === "default") return "default";
+	if (!basePattern.startsWith("pi/")) return undefined;
+	const role = basePattern.slice("pi/".length).trim();
+	return role || undefined;
+}
+
+function pushSubagentRetryFallbackCandidate(
+	candidates: SubagentRetryFallbackCandidate[],
+	seen: Set<string>,
+	pattern: string,
+	modelRegistry: ModelRegistry,
+	settings: Settings,
+): void {
+	const resolved = resolveModelOverride([pattern], modelRegistry, settings);
+	if (!resolved.model) return;
+	const selector = resolved.explicitThinkingLevel
+		? formatModelSelectorValue(formatModelStringWithRouting(resolved.model), resolved.thinkingLevel)
+		: formatModelStringWithRouting(resolved.model);
+	const keys = selectorDedupKeys(selector);
+	if (keys.some(key => seen.has(key))) return;
+	for (const key of keys) {
+		seen.add(key);
+	}
+	candidates.push({ model: resolved.model, selector });
+}
+
 function resolveSubagentRetryFallbackCandidates(
 	modelPatterns: string[],
 	modelRegistry: ModelRegistry,
@@ -140,15 +181,19 @@ function resolveSubagentRetryFallbackCandidates(
 	const candidates: SubagentRetryFallbackCandidate[] = [];
 	const seen = new Set<string>();
 	for (const pattern of modelPatterns) {
-		const resolved = resolveModelOverride([pattern], modelRegistry, settings);
-		if (!resolved.model) continue;
-		const selector = resolved.explicitThinkingLevel
-			? formatModelSelectorValue(formatModelStringWithRouting(resolved.model), resolved.thinkingLevel)
-			: formatModelStringWithRouting(resolved.model);
-		if (seen.has(selector)) continue;
-		seen.add(selector);
-		candidates.push({ model: resolved.model, selector });
+		pushSubagentRetryFallbackCandidate(candidates, seen, pattern, modelRegistry, settings);
 	}
+
+	if (modelPatterns.length === 1) {
+		const fallbackChains = settings.get("retry.fallbackChains");
+		const role = modelPatternRole(modelPatterns[0]);
+		const configuredChain = role ? fallbackChains[role] : undefined;
+		const roleChain = configuredChain && configuredChain.length > 0 ? configuredChain : fallbackChains.default;
+		for (const pattern of roleChain ?? []) {
+			pushSubagentRetryFallbackCandidate(candidates, seen, pattern, modelRegistry, settings);
+		}
+	}
+
 	return candidates;
 }
 
@@ -166,7 +211,17 @@ function installSubagentRetryFallbackChain(args: {
 		candidate => candidate.model.provider === model.provider && candidate.model.id === model.id,
 	);
 	if (selectedIndex < 0) return undefined;
-	const fallbackSelectors = candidates.slice(selectedIndex + 1).map(candidate => candidate.selector);
+	const selectedCandidate = candidates[selectedIndex];
+	const fallbackSelectors: string[] = [];
+	const seenFallbackSelectors = new Set<string>(selectorDedupKeys(selectedCandidate.selector));
+	for (const candidate of candidates.slice(selectedIndex + 1)) {
+		const keys = selectorDedupKeys(candidate.selector);
+		if (keys.some(key => seenFallbackSelectors.has(key))) continue;
+		for (const key of keys) {
+			seenFallbackSelectors.add(key);
+		}
+		fallbackSelectors.push(candidate.selector);
+	}
 	if (fallbackSelectors.length === 0) return undefined;
 
 	const role = `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -90,6 +90,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage.setRuntimeApiKey("google", "google-test-key");
 		authStorage.setRuntimeApiKey("google-vertex", "google-vertex-test-key");
 		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
+		authStorage.setRuntimeApiKey("openai-codex", "openai-codex-test-key");
 		sharedRegistry = new ModelRegistry(authStorage);
 	});
 
@@ -221,6 +222,52 @@ describe("AgentSession retry fallback", () => {
 			},
 		]);
 	});
+	it("skips same-base default fallback selectors with different thinking suffixes", async () => {
+		const primaryModel = getBundledModel("openai-codex", "gpt-5.5");
+		const fallbackModel = getBundledModel("anthropic", "claude-opus-4-8");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const agent = createFallbackAgent(primaryModel, requestedModels, "quota exceeded");
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Skip same-base default fallback");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${fallbackModel.provider}/${fallbackModel.id}:high`,
+				role: "default",
+			},
+		]);
+	});
+
 	it("falls back on string-form provider authentication errors", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -43,7 +43,11 @@ function getLastAssistantMessage(session: AgentSession): AssistantMessage {
 	return lastMessage;
 }
 
-function createFallbackAgent(primaryModel: Model, requestedModels: string[]): Agent {
+function createFallbackAgent(
+	primaryModel: Model,
+	requestedModels: string[],
+	errorMessage = "rate limit exceeded retry-after-ms=200",
+): Agent {
 	const mock = createMockModel();
 	let primaryAttempts = 0;
 	return new Agent({
@@ -58,7 +62,7 @@ function createFallbackAgent(primaryModel: Model, requestedModels: string[]): Ag
 			requestedModels.push(`${model.provider}/${model.id}`);
 			if (model.provider === primaryModel.provider && model.id === primaryModel.id && primaryAttempts === 0) {
 				primaryAttempts += 1;
-				mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+				mock.push({ throw: errorMessage });
 			} else {
 				mock.push({ content: [`ok:${model.provider}/${model.id}`] });
 			}
@@ -213,6 +217,58 @@ describe("AgentSession retry fallback", () => {
 			{
 				type: "retry_fallback_succeeded",
 				model: `${secondFallback.provider}/${secondFallback.id}`,
+				role: "default",
+			},
+		]);
+	});
+	it("falls back on string-form provider authentication errors", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const agent = createFallbackAgent(
+			primaryModel,
+			requestedModels,
+			'401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+		);
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Recover from provider auth failure");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${fallbackModel.provider}/${fallbackModel.id}`,
 				role: "default",
 			},
 		]);
@@ -455,6 +511,7 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 
@@ -597,6 +654,7 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 
@@ -655,6 +713,7 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 
@@ -714,6 +773,7 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 
@@ -930,6 +990,7 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -184,6 +184,49 @@ describe("subagent runtime model fallback", () => {
 			"google-gemini-cli/gemini-3.1-pro-preview",
 		]);
 	});
+	it("resolves pi/task through the parent model before installing the task fallback chain", async () => {
+		const primary = model("openai-codex", "gpt-5.5");
+		const opus = model("anthropic", "claude-opus-4-8");
+		const gemini = model("google-gemini-cli", "gemini-3.1-pro-preview");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		let childModelRoles: Record<string, string> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			childModelRoles = options.settings?.getModelRoles() as Record<string, string> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "test",
+			systemPrompt: "test",
+			source: "bundled",
+			model: ["pi/task"],
+		};
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "issue-2912-task",
+			parentActiveModelPattern: "openai-codex/gpt-5.5",
+			settings: Settings.isolated(),
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, opus, gemini],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childModelRoles?.["subagent:issue-2912-task"]).toBe("openai-codex/gpt-5.5");
+		expect(childFallbackChains?.["subagent:issue-2912-task"]).toEqual([
+			"anthropic/claude-opus-4-8:high",
+			"google-gemini-cli/gemini-3.1-pro-preview",
+		]);
+	});
 
 	it("uses the default chain for a single concrete model without a role chain", async () => {
 		const primary = model("custom", "primary-model");

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -21,6 +21,24 @@ function model(provider: string, id: string): Model<Api> {
 		maxTokens: 8192,
 	});
 }
+const PROVIDER_FAILURE_CHAIN = [
+	"openai-codex/gpt-5.5:high",
+	"anthropic/claude-opus-4-8:high",
+	"google-gemini-cli/gemini-3.1-pro-preview",
+];
+
+const BUILT_IN_FALLBACK_ROLES = [
+	"default",
+	"smol",
+	"slow",
+	"vision",
+	"plan",
+	"designer",
+	"commit",
+	"title",
+	"task",
+	"advisor",
+];
 
 function createYieldingSession(): AgentSession {
 	const listeners: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
@@ -60,9 +78,17 @@ function createYieldingSession(): AgentSession {
 	return session as unknown as AgentSession;
 }
 
-describe("issue #2750: subagent runtime model fallback", () => {
+describe("subagent runtime model fallback", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("defaults every built-in role to the provider-failure chain", () => {
+		const fallbackChains = Settings.isolated().get("retry.fallbackChains");
+
+		for (const role of BUILT_IN_FALLBACK_ROLES) {
+			expect(fallbackChains[role]).toEqual(PROVIDER_FAILURE_CHAIN);
+		}
 	});
 
 	it("passes ordered subagent candidates as a child retry fallback chain", async () => {
@@ -118,6 +144,120 @@ describe("issue #2750: subagent runtime model fallback", () => {
 		expect(inheritedFallbackChain).toEqual(["global/inherited-model"]);
 		expect(result.modelOverride).toEqual(["primary/bad-runtime-model", "fallback/working-model"]);
 		expect(result.resolvedModel).toBe("fallback/working-model");
+	});
+	it("inherits the single-role smol provider-failure chain and removes the selected primary", async () => {
+		const primary = model("openai-codex", "gpt-5.5");
+		const opus = model("anthropic", "claude-opus-4-8");
+		const gemini = model("google-gemini-cli", "gemini-3.1-pro-preview");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		let childModelRoles: Record<string, string> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			childModelRoles = options.settings?.getModelRoles() as Record<string, string> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+		settings.setModelRole("smol", "openai-codex/gpt-5.5:high");
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "issue-2912-smol",
+			modelOverride: ["pi/smol"],
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, opus, gemini],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childModelRoles?.["subagent:issue-2912-smol"]).toBe("openai-codex/gpt-5.5:high");
+		expect(childFallbackChains?.["subagent:issue-2912-smol"]).toEqual([
+			"anthropic/claude-opus-4-8:high",
+			"google-gemini-cli/gemini-3.1-pro-preview",
+		]);
+	});
+
+	it("uses the default chain for a single concrete model without a role chain", async () => {
+		const primary = model("custom", "primary-model");
+		const fallback = model("fallback", "default-chain-model");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated({
+			"retry.fallbackChains": {
+				default: ["fallback/default-chain-model"],
+			},
+		});
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "issue-2912-default",
+			modelOverride: ["custom/primary-model"],
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childFallbackChains?.["subagent:issue-2912-default"]).toEqual(["fallback/default-chain-model"]);
+	});
+
+	it("keeps explicit multi-role candidates before default provider chains", async () => {
+		const plan = model("plan", "primary-model");
+		const slow = model("slow", "explicit-fallback");
+		const defaultFallback = model("fallback", "default-chain-model");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated({
+			"retry.fallbackChains": {
+				default: ["fallback/default-chain-model"],
+			},
+		});
+		settings.setModelRole("plan", "plan/primary-model");
+		settings.setModelRole("slow", "slow/explicit-fallback");
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "issue-2912-multi",
+			modelOverride: ["pi/plan", "pi/slow"],
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [plan, slow, defaultFallback],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childFallbackChains?.["subagent:issue-2912-multi"]).toEqual(["slow/explicit-fallback"]);
 	});
 
 	it("preserves upstream routing selectors in the child retry fallback chain", async () => {


### PR DESCRIPTION
## Repro
`retry.fallbackChains` defaulted to `{}` and Anthropic billing exhaustion was not classified as a usage-limit retry path: `packages/coding-agent: bun -e 'import { getDefault } from "./src/config/settings-schema.ts"; console.log(JSON.stringify(getDefault("retry.fallbackChains")))'` printed `{}`, and `packages/ai: bun -e 'import { isUsageLimitError, parseRateLimitReason } from "./src/rate-limit-utils.ts"; const msg = `400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API"}}`; console.log(JSON.stringify({ usageLimit: isUsageLimitError(msg), reason: parseRateLimitReason(msg) }));'` printed `{"usageLimit":false,"reason":"UNKNOWN"}`.

## Cause
`packages/coding-agent/src/config/settings-schema.ts` left `retry.fallbackChains` empty, and `packages/coding-agent/src/task/executor.ts` only installed subagent retry chains from explicit multi-model selectors. Single-role subagents such as `pi/smol` had no runtime fallback chain. Separately, `packages/ai/src/rate-limit-utils.ts` did not recognize provider billing/quota phrases, and `packages/coding-agent/src/session/agent-session.ts` did not route string-form provider auth failures through `isAuthRetryableError`.

## Fix
- Added default provider-failure fallback chains for every built-in model role.
- Taught subagents to inherit single-role/default fallback chains, preserve explicit multi-model candidates first, and deduplicate primary selectors with or without thinking suffixes.
- Classified provider billing/quota exhaustion and string-form `401 authentication_error` payloads for retry/fallback without making generic schema-validation errors retryable.
- Added focused regression tests and changelog entries for `packages/ai` and `packages/coding-agent`.

## Verification
`bun run fix` passed. `packages/ai: bun test test/auth-retry.test.ts test/rate-limit-utils.test.ts` passed with 34 tests. `packages/coding-agent: bun test test/issue-2750-subagent-runtime-fallback.test.ts test/agent-session-retry-fallback.test.ts` passed with 28 tests. `packages/ai: bun run check` passed. `packages/coding-agent: bun run check` passed. `packages/coding-agent: HOME=/data/workspaces/can1357__oh-my-pi__2912/repo/.tmp/home OMP_PROFILE=provider-fallback-smoke bun src/cli.ts config get retry.fallbackChains --json` showed all built-in role keys with the GPT → Opus → Gemini chain. Fixes #2912