### PR TITLE
fix(auth-storage): atomic legacy api_key cleanup within sqlite transaction during oauth login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OAuth login replacing all other active accounts for the same provider, allowing multiple OAuth accounts to coexist concurrently.
+- Fixed legacy `api_key` credentials not being replaced/disabled atomically upon upgrading to OAuth login.
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1541,6 +1541,17 @@ export class AuthStorage {
 		return rows;
 	}
 
+	async #upsertOAuthCredential(provider: string, credential: OAuthCredential): Promise<void> {
+		const stored = this.#store.upsertAuthCredentialRemote
+			? await this.#store.upsertAuthCredentialRemote(provider, credential)
+			: this.#store.upsertAuthCredentialForProvider(provider, credential);
+		this.#setStoredCredentials(
+			provider,
+			stored.map(entry => ({ id: entry.id, credential: entry.credential })),
+		);
+		this.#resetProviderAssignments(provider);
+	}
+
 	/**
 	 * Remove credential for a provider.
 	 */
@@ -1778,10 +1789,10 @@ export class AuthStorage {
 			return;
 		}
 		const newCredential: OAuthCredential = { type: "oauth", ...result };
-		// Use set() instead of #upsertOAuthCredential to replace ALL existing credentials
-		// (including legacy api_key rows from older versions) with the new OAuth credential.
-		// This ensures getApiKey() doesn't match an old api_key row before the new OAuth row.
-		await this.set(def.storeCredentialsAs ?? provider, newCredential);
+		// Use #upsertOAuthCredential to upsert the new credential.
+		// Any legacy api_key rows from older versions will be cleaned up so they do not
+		// shadow the new OAuth row, while preserving other active OAuth credentials.
+		await this.#upsertOAuthCredential(def.storeCredentialsAs ?? provider, newCredential);
 	}
 
 	/**
@@ -4812,6 +4823,14 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				credential: deserializeCredential(row),
 				identityKey: resolveRowCredentialIdentityKey(providerName, row),
 			}));
+
+			if (item.type === "oauth") {
+				for (const row of existing) {
+					if (row.credential && row.credential.type === "api_key") {
+						this.#deleteStmt.run("replaced by oauth login", row.id);
+					}
+				}
+			}
 
 			let targetId: number | null = null;
 			for (const row of existing) {

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -678,13 +678,21 @@ describe("AuthStorage OAuth login upgrade and multi-account coexistence", () => 
 			expect(await authStorage.getApiKey("unit-login-upgrade")).toBe("sk-legacy-key");
 
 			// 2. Register custom oauth provider
-			let loginReturns: any = null;
+			let loginReturns: (Omit<OAuthCredential, "type"> & { type?: string }) | null = null;
 			registerOAuthProvider({
 				id: "unit-login-upgrade",
 				name: "Unit Login Upgrade",
 				sourceId: "auth-storage-login-upgrade-test",
-				login: async () => loginReturns,
-				refreshToken: async () => loginReturns,
+				login: async () => {
+					if (!loginReturns) throw new Error("no credentials");
+					const { type, ...rest } = loginReturns;
+					return rest;
+				},
+				refreshToken: async () => {
+					if (!loginReturns) throw new Error("no credentials");
+					const { type, ...rest } = loginReturns;
+					return rest;
+				},
 			});
 
 			// 3. Login first OAuth account

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { registerOAuthProvider, unregisterOAuthProviders } from "../src/registry/oauth";
 
 const LEGACY_TIMESTAMP = 1_700_000_000;
 
@@ -647,6 +648,89 @@ describe("AuthStorage openai-codex email dedupe", () => {
 			]);
 		} finally {
 			migratedStore.close();
+		}
+	});
+});
+
+describe("AuthStorage OAuth login upgrade and multi-account coexistence", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-auth-login-test-"));
+	});
+
+	afterEach(async () => {
+		unregisterOAuthProviders("auth-storage-login-upgrade-test");
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("allows multiple OAuth accounts to coexist and replaces legacy api_key rows on OAuth login", async () => {
+		if (!tempDir) throw new Error("test setup failed");
+
+		const dbPath = path.join(tempDir, "login-upgrade.db");
+		const authStorage = await AuthStorage.create(dbPath);
+
+		try {
+			// 1. Setup a legacy api_key credential
+			await authStorage.set("unit-login-upgrade", { type: "api_key", key: "sk-legacy-key" });
+			expect(await authStorage.getApiKey("unit-login-upgrade")).toBe("sk-legacy-key");
+
+			// 2. Register custom oauth provider
+			let loginReturns: any = null;
+			registerOAuthProvider({
+				id: "unit-login-upgrade",
+				name: "Unit Login Upgrade",
+				sourceId: "auth-storage-login-upgrade-test",
+				login: async () => loginReturns,
+				refreshToken: async () => loginReturns,
+			});
+
+			// 3. Login first OAuth account
+			loginReturns = {
+				refresh: "refresh-token-1",
+				access: "access-token-1",
+				expires: Date.now() + 60_000,
+				projectId: "project-1",
+				email: "user-1@example.com",
+			};
+			await authStorage.login("unit-login-upgrade", {
+				onAuth: () => {},
+				onPrompt: async () => "",
+			});
+
+			// Legacy api_key should be gone/replaced, and first oauth account is active.
+			// getApiKey should now return the first OAuth access token (since the api_key is gone).
+			expect(await authStorage.getApiKey("unit-login-upgrade")).toBe("access-token-1");
+			const firstRows = readStoredIdentityRows(dbPath, "unit-login-upgrade");
+			expect(firstRows).toEqual([
+				{ identity_key: null, disabled_cause: "replaced by oauth login" },
+				{ identity_key: "email:user-1@example.com", disabled_cause: null },
+			]);
+
+			// 4. Login second OAuth account
+			loginReturns = {
+				refresh: "refresh-token-2",
+				access: "access-token-2",
+				expires: Date.now() + 60_000,
+				projectId: "project-2",
+				email: "user-2@example.com",
+			};
+			await authStorage.login("unit-login-upgrade", {
+				onAuth: () => {},
+				onPrompt: async () => "",
+			});
+
+			// Both OAuth accounts should coexist! No accounts should be disabled
+			const secondRows = readStoredIdentityRows(dbPath, "unit-login-upgrade");
+			expect(secondRows).toEqual([
+				{ identity_key: null, disabled_cause: "replaced by oauth login" },
+				{ identity_key: "email:user-1@example.com", disabled_cause: null },
+				{ identity_key: "email:user-2@example.com", disabled_cause: null },
+			]);
+		} finally {
+			authStorage.close();
 		}
 	});
 });


### PR DESCRIPTION
### Description
This PR resolves a regression introduced in commit `e264d8b100` (which attempted to replace legacy `api_key` rows on OAuth login upgrade). That commit switched the credential saving path from `#upsertOAuthCredential` to `set()`. 

However, `set()` replaces all active credentials for the provider, which silently deleted/disabled all other active OAuth credentials for that provider, breaking multi-account coexistence.

Closes #2930

### Changes
1. Reinstates `#upsertOAuthCredential` to ensure incremental upserts instead of full replacements.
2. Moves the legacy `api_key` deletion/disable logic directly into the SQLite database transaction (`upsertAuthCredentialForProvider`). When upserting an `oauth` credential, any active `api_key` rows for the same provider are atomically disabled (marked as `"replaced by oauth login"`).
3. Eliminates client-side/broker-client loop races and non-atomic transient shadowing states.
4. Updates unit tests in `packages/ai/test/auth-storage-email-dedupe.test.ts` to assert that multiple OAuth accounts coexist and legacy `api_key` rows are cleanly replaced, validating high-level `getApiKey` behavior and cleanly closing SQLite handles.