### PR TITLE
perf(auth): switch Google OAuth callback hostname to 127.0.0.1 for fast loopback

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Switched Google OAuth callback hostname from `localhost` to `127.0.0.1` to prevent IPv6 loopback fallback delays and proxy routing interception.
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/ai/src/registry/oauth/google-oauth-shared.ts
+++ b/packages/ai/src/registry/oauth/google-oauth-shared.ts
@@ -39,7 +39,11 @@ export class GoogleOAuthFlow extends OAuthCallbackFlow {
 	private readonly config: GoogleOAuthFlowConfig;
 
 	constructor(ctrl: OAuthController, config: GoogleOAuthFlowConfig) {
-		super(ctrl, config.callbackPort, config.callbackPath);
+		super(ctrl, {
+			preferredPort: config.callbackPort,
+			callbackPath: config.callbackPath,
+			callbackHostname: "127.0.0.1",
+		});
 		this.config = config;
 	}
 

--- a/packages/ai/test/google-oauth-hostname.test.ts
+++ b/packages/ai/test/google-oauth-hostname.test.ts
@@ -15,6 +15,7 @@ describe("GoogleOAuthFlow callback hostname", () => {
 			scopes: ["scope1"],
 			callbackPort: 51121,
 			callbackPath: "/callback",
+			discoverProject: async () => "test-project",
 		});
 
 		expect(flow.callbackHostname).toBe("127.0.0.1");

--- a/packages/ai/test/google-oauth-hostname.test.ts
+++ b/packages/ai/test/google-oauth-hostname.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { GoogleOAuthFlow } from "../src/registry/oauth/google-oauth-shared";
+import type { OAuthController } from "../src/registry/oauth/types";
+
+describe("GoogleOAuthFlow callback hostname", () => {
+	it("uses 127.0.0.1 as the callback hostname to avoid IPv6 and proxy delays", () => {
+		const ctrl: OAuthController = {
+			onAuth: () => {},
+		};
+		const flow = new GoogleOAuthFlow(ctrl, {
+			clientId: "test-client",
+			clientSecret: "test-secret",
+			authUrl: "https://example.com/auth",
+			tokenUrl: "https://example.com/token",
+			scopes: ["scope1"],
+			callbackPort: 51121,
+			callbackPath: "/callback",
+		});
+
+		expect(flow.callbackHostname).toBe("127.0.0.1");
+	});
+});


### PR DESCRIPTION
### Description
This PR changes the callback hostname of the Google OAuth flow (Gemini CLI and Antigravity) from `localhost` to `127.0.0.1`.

### Motivation
When using `localhost` as the callback hostname:
1. **IPv6 resolution delay**: Many modern systems resolve `localhost` to `::1` (IPv6), but the local Bun server typically only binds to `127.0.0.1` (IPv4) or vice versa. This forces the browser to hang during authentication, wait for the IPv6 TCP connection to time out, and then fallback to IPv4 loopback, introducing a several-second delay.
2. **Proxy interception**: System-wide proxies (such as SOCKS/TUN VPNs or sing-box/clash routing) often intercept requests to `localhost`, causing them to hang or timeout.

Switching the callback hostname to `127.0.0.1` completely bypasses DNS/IPv6 lookups and proxy interception, connecting instantly to the local server (<1ms). This is a standard practice for native client OAuth (matching the behavior of the official Google Cloud SDK and OMP's `xai-oauth` implementation).

Note: Google's OAuth 2.0 client IDs natively support loopback IP redirect URIs (`http://127.0.0.1:<port>`), so this is fully compatible and does not trigger `redirect_uri_mismatch`.