### PR TITLE
feat(ai,catalog): add Command Code provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Command Code as a provider: interactive `/login` paste-key flow plus `COMMAND_CODE_API_KEY` and `COMMAND_CODE_BASE_URL` environment variables, exposing a Command Code subscription's models through its OpenAI-compatible Provider API (`https://api.commandcode.ai/provider/v1`).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -78,6 +78,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 - **Ollama Cloud** (hosted native Ollama API; requires `OLLAMA_CLOUD_API_KEY`)
 - **llama.cpp** (local OpenAI and Anthropic compatible inference server)
 - **vLLM** (OpenAI-compatible server; `VLLM_API_KEY` for secured deployments)
+- **Command Code** (subscription gateway to top open & closed models; requires `COMMAND_CODE_API_KEY`, optional `COMMAND_CODE_BASE_URL`)
 - **GitHub Copilot** (requires OAuth, see below)
 - **Google Gemini CLI** (requires OAuth, see below)
 - **Antigravity** (requires OAuth, see below)
@@ -960,6 +961,7 @@ In Node.js environments, you can set environment variables to avoid passing API 
 | vLLM           | `VLLM_API_KEY`                                                               |
 | Cloudflare AI Gateway | `CLOUDFLARE_AI_GATEWAY_API_KEY`                                      |
 | GitHub Copilot | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN` or `GITHUB_TOKEN`                      |
+| Command Code   | `COMMAND_CODE_API_KEY` (optional `COMMAND_CODE_BASE_URL` to override the base URL)        |
 
 For Cloudflare AI Gateway models, use provider base URL format
 `https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic`.

--- a/packages/ai/src/registry/command-code.ts
+++ b/packages/ai/src/registry/command-code.ts
@@ -1,0 +1,35 @@
+import type { OAuthController, OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const COMMAND_CODE_KEYS_URL = "https://commandcode.ai/studio/";
+
+export async function loginCommandCode(options: OAuthController): Promise<string> {
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	if (!options.onPrompt) {
+		throw new Error("Interactive prompt is required for Command Code login");
+	}
+	options.onAuth?.({
+		url: COMMAND_CODE_KEYS_URL,
+		instructions: "Create a Command Code API key (Provider plan), then paste it here.",
+	});
+	const apiKey = await options.onPrompt({
+		message: "Paste your Command Code API key",
+		placeholder: "cmd-...",
+	});
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("Command Code API key is required");
+	}
+	return trimmed;
+}
+
+export const commandCodeProvider = {
+	id: "command-code",
+	name: "Command Code",
+	login: (cb: OAuthLoginCallbacks) => loginCommandCode(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -6,6 +6,7 @@ import { anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
+import { commandCodeProvider } from "./command-code";
 import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
 import { firepassProvider } from "./firepass";
@@ -96,6 +97,7 @@ const ALL = [
 	xiaomiTokenPlanCnProvider,
 	firepassProvider,
 	waferPassProvider,
+	commandCodeProvider,
 	deepseekProvider,
 	moonshotProvider,
 	cerebrasProvider,

--- a/packages/ai/test/auth-storage-api-key-login.test.ts
+++ b/packages/ai/test/auth-storage-api-key-login.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as commandCodeModule from "@oh-my-pi/pi-ai/registry/command-code";
 import * as deepseekModule from "@oh-my-pi/pi-ai/registry/deepseek";
 import * as kagiModule from "@oh-my-pi/pi-ai/registry/kagi";
 import * as ollamaCloudModule from "@oh-my-pi/pi-ai/registry/ollama-cloud";
@@ -26,6 +27,7 @@ describe("AuthStorage api-key login replacement", () => {
 	let dbPath = "";
 	let store: SqliteAuthCredentialStore | null = null;
 	let authStorage: AuthStorage | null = null;
+	let loginCommandCodeSpy: Mock<typeof commandCodeModule.loginCommandCode>;
 	let loginDeepSeekSpy: Mock<typeof deepseekModule.loginDeepSeek>;
 	let loginKagiSpy: Mock<typeof kagiModule.loginKagi>;
 	let loginOllamaCloudSpy: Mock<typeof ollamaCloudModule.loginOllamaCloud>;
@@ -35,6 +37,7 @@ describe("AuthStorage api-key login replacement", () => {
 		dbPath = path.join(tempDir, "agent.db");
 		store = await SqliteAuthCredentialStore.open(dbPath);
 		authStorage = new AuthStorage(store);
+		loginCommandCodeSpy = vi.spyOn(commandCodeModule, "loginCommandCode");
 		loginDeepSeekSpy = vi.spyOn(deepseekModule, "loginDeepSeek");
 		loginKagiSpy = vi.spyOn(kagiModule, "loginKagi");
 		loginOllamaCloudSpy = vi.spyOn(ollamaCloudModule, "loginOllamaCloud");
@@ -102,6 +105,32 @@ describe("AuthStorage api-key login replacement", () => {
 		expect(stored.credential.key).toBe("same-ollama-cloud-key");
 		expect(store.getApiKey("ollama-cloud")).toBe("same-ollama-cloud-key");
 		expect(await authStorage.getApiKey("ollama-cloud", "session-ollama-cloud-relogin")).toBe("same-ollama-cloud-key");
+	});
+
+	it("reuses the stored api-key row when command-code re-login returns the same key", async () => {
+		if (!store || !authStorage || !dbPath) throw new Error("test setup failed");
+
+		loginCommandCodeSpy.mockResolvedValueOnce("same-command-code-key").mockResolvedValueOnce("same-command-code-key");
+
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => "",
+		};
+
+		await authStorage.login("command-code", controller);
+		await authStorage.login("command-code", controller);
+
+		expect(countCredentialRows(dbPath, "command-code")).toBe(1);
+		const credentials = store.listAuthCredentials("command-code");
+		expect(credentials).toHaveLength(1);
+		const [stored] = credentials;
+		expect(stored?.credential.type).toBe("api_key");
+		if (stored?.credential.type !== "api_key") {
+			throw new Error("expected stored api-key credential");
+		}
+		expect(stored.credential.key).toBe("same-command-code-key");
+		expect(store.getApiKey("command-code")).toBe("same-command-code-key");
+		expect(await authStorage.getApiKey("command-code", "session-command-code-relogin")).toBe("same-command-code-key");
 	});
 
 	it("stores DeepSeek login credentials as a reusable api-key credential", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `command-code` provider descriptor and `commandCodeModelManagerOptions` (OpenAI-compatible model discovery against `https://api.commandcode.ai/provider/v1`, with `COMMAND_CODE_BASE_URL` override), registered as discovery-only so a subscription's models are fetched live at runtime and never baked into `models.json`.
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -51,14 +51,16 @@ import {
 const packageRoot = path.join(import.meta.dir, "..");
 
 /**
- * Local/self-hosted providers (Ollama, vLLM, LM Studio, LiteLLM). Their model
- * catalogs are whatever happens to be running on the machine that invokes the
- * generator — bundling them would leak machine-specific endpoints (e.g.
- * `http://localhost:4000/v1`) into the committed snapshot. They are discovered
- * dynamically at runtime instead, so they are never fetched during generation
- * and never written to models.json.
+ * Providers whose available models depend on the caller's environment rather
+ * than a stable public list: local/self-hosted servers (Ollama, vLLM, LM Studio,
+ * LiteLLM) whose catalog is whatever runs on the generating machine, and
+ * subscription-gated cloud aggregators (Command Code) whose catalog depends on
+ * the caller's plan. Bundling either would leak machine-specific endpoints or
+ * pin account-specific models into the committed snapshot, so they are discovered
+ * dynamically at runtime instead — never fetched during generation and never
+ * written to models.json.
  */
-const DISCOVERY_ONLY_PROVIDERS = new Set(["ollama", "vllm", "lm-studio", "litellm"]);
+const DISCOVERY_ONLY_PROVIDERS = new Set(["ollama", "vllm", "lm-studio", "litellm", "command-code"]);
 
 async function resolveProviderApiKey(providerId: string, catalog: CatalogDiscoveryConfig): Promise<string | undefined> {
 	for (const envVar of catalog.envVars ?? []) {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -14,6 +14,7 @@ import {
 	anthropicModelManagerOptions,
 	cerebrasModelManagerOptions,
 	cloudflareAiGatewayModelManagerOptions,
+	commandCodeModelManagerOptions,
 	deepseekModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
@@ -94,6 +95,13 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => cloudflareAiGatewayModelManagerOptions(config),
 		catalogDiscovery: { label: "Cloudflare AI Gateway" },
+	},
+	{
+		id: "command-code",
+		defaultModel: "deepseek/deepseek-v4-flash",
+		envVars: ["COMMAND_CODE_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => commandCodeModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 	},
 	{
 		id: "cursor",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2216,6 +2216,40 @@ export function lmStudioModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// 12.6. Command Code (cloud OpenAI-compatible aggregator)
+// ---------------------------------------------------------------------------
+
+export interface CommandCodeModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function commandCodeModelManagerOptions(
+	config?: CommandCodeModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? Bun.env.COMMAND_CODE_BASE_URL ?? "https://api.commandcode.ai/provider/v1";
+	const references = createBundledReferenceMap<"openai-completions">("command-code" as any);
+	return {
+		providerId: "command-code",
+		dynamicModelsAuthoritative: true,
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels({
+				api: "openai-completions",
+				provider: "command-code",
+				baseUrl,
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const reference = references.get(defaults.id);
+					return mapWithBundledReference(entry, defaults, reference);
+				},
+				fetch: config?.fetch,
+			}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 13. Synthetic
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds **Command Code** ([commandcode.ai](https://commandcode.ai)) as a first-class provider, so a Command Code subscription's models are usable in omp via `/login` (or `COMMAND_CODE_API_KEY`). Command Code's Provider API is OpenAI-compatible (`https://api.commandcode.ai/provider/v1`, `Authorization: Bearer`, `/chat/completions` + `/models`), so this slots into the existing OpenAI-compatible + dynamic-discovery machinery — same shape as LM Studio / vLLM, with Ollama Cloud's required-key login UX.

## Changes

**`@oh-my-pi/pi-ai`**
- New `registry/command-code.ts`: `commandCodeProvider` with a paste-key `login` (mirrors `ollama-cloud.ts`).
- Wired into `registry.ts`. The `OAuthProvider` union, `/login` list, and `AuthStorage.login` dispatch all derive from the registry — no other edits needed.

**`@oh-my-pi/pi-catalog`**
- `commandCodeModelManagerOptions` (OpenAI-compatible discovery against the Provider API, `COMMAND_CODE_BASE_URL` override).
- `command-code` entry in `CATALOG_PROVIDERS` (`envVars: ["COMMAND_CODE_API_KEY"]`, `dynamicModelsAuthoritative`). This adds `command-code` to `KnownProvider`, satisfying the registry completeness check.
- Added to `DISCOVERY_ONLY_PROVIDERS` so the subscription-gated catalog is discovered live and never baked into `models.json`.

**Docs/tests**
- README provider list + env-var table; CHANGELOG entries (pi-ai, pi-catalog).
- `command-code` case in `auth-storage-api-key-login.test.ts` (stores a reusable api_key, dedupes on re-login).

## Verification
- `bun check` green for both packages (incl. the `Exclude<KnownProvider, RegistryDef["id"]>` completeness gate).
- biome clean; the new login dispatch test passes (4/4).
- End-to-end against a real binary: `/login` lists **Command Code**, login stores the key, and discovery returned 32 live models (Claude Opus/Sonnet, GPT-5.5/Codex, DeepSeek V4, Kimi, MiniMax, Nemotron, Gemini, …).
