### PR TITLE
fix(cli): /models opens role-assignment picker; remove redundant /switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/models` slash command now opens the permanent model setup (role-assignment) picker instead of acting as an alias for `/model`'s session switcher. This restores a slash-command path to the role/thinking picker that was lost when `/model` was rerouted to the temporary switcher in [#2849](https://github.com/can1357/oh-my-pi/pull/2849); `/model` remains the quick session switcher (same as `Alt+P`). ([#2933](https://github.com/can1357/oh-my-pi/issues/2933))
+
+### Removed
+
+- `/switch` slash command; it was redundant with `/model` and `Alt+P`. Use `/model` or `Alt+P` to switch the session model. ([#2933](https://github.com/can1357/oh-my-pi/issues/2933))
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -12,7 +12,7 @@ Say `orchestrate` in your message to drive a multi-phase task with parallel suba
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically
 Run `omp auth-broker serve` once and every machine pulls live tokens over the wire — refresh keys never leave the host; `omp auth-gateway` fronts it as a drop-in proxy any OpenAI-compatible client can hit
-Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow -> etc
+Press alt+p (or /model) to switch model, and ctrl+p to cycle role models smol -> slow -> etc
 Press ctrl+r to search your prompt history and reuse a past message
 `/force read` pins the next turn to one specific tool when the model keeps reaching for the wrong one
 `/copy code` grabs the last code block to your clipboard — `/copy cmd` grabs the last shell/python command

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -300,7 +300,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "model",
-		aliases: ["models"],
 		description: "Switch model for this session",
 		acpDescription: "Show current model selection",
 		handle: async (command, runtime) => {
@@ -339,10 +338,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
-		name: "switch",
-		description: "Switch model for this session (same as alt+p)",
+		name: "models",
+		description: "Set up models and roles for this session (same as alt+m)",
 		handleTui: (_command, runtime) => {
-			runtime.ctx.showModelSelector({ temporaryOnly: true });
+			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -18,7 +18,7 @@ function createRuntime() {
 }
 
 describe("/model slash command", () => {
-	it("opens the temporary model selector for the active session", async () => {
+	it("opens the temporary session model switcher", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/model", harness.runtime);
@@ -29,14 +29,28 @@ describe("/model slash command", () => {
 	});
 });
 
-describe("/switch slash command", () => {
-	it("opens the temporary model selector (mirrors alt+p)", async () => {
+describe("/models slash command", () => {
+	it("opens the permanent model setup (role-assignment) picker", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/models", harness.runtime);
+
+		expect(handled).toBe(true);
+		// Permanent picker: showModelSelector() with no temporaryOnly flag, so
+		// Enter opens the role/thinking menu instead of selecting directly.
+		expect(harness.showModelSelector).toHaveBeenCalledTimes(1);
+		expect(harness.showModelSelector.mock.calls[0]).toEqual([]);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});
+
+describe("/switch slash command (removed)", () => {
+	it("is no longer a recognized command", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/switch", harness.runtime);
 
-		expect(handled).toBe(true);
-		expect(harness.showModelSelector).toHaveBeenCalledWith({ temporaryOnly: true });
-		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(handled).toBe(false);
+		expect(harness.showModelSelector).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Resolves #2933.

#2849 (fixing #2846) rerouted `/model` to the temporary session switcher, which removed the only slash-command path to the permanent role-assignment picker (reachable only via `Alt+M` since). This PR restores that path **without reverting #2849 or flipping its test**.

## Changes

| Command | Before | After |
|---|---|---|
| `/model` | temporary switch | **temporary switch** (unchanged — keeps #2846/#2849 resolved) |
| `/models` | alias of `/model` | **permanent role-assignment picker** (`showModelSelector()`, same as `Alt+M`) |
| `/switch` | temporary switch | **removed** (was byte-identical to `/model`; use `/model` or `Alt+P`) |

Singular `/model` = switch one model for this session; plural `/models` = configure the set (roles + thinking). Mirrors the existing `Alt+P` (temporary) vs `Alt+M` (set roles) keybinding split.

## Why not just revert #2849?

`/switch` already covered #2846's use case (quick session switch) before and after #2849. But reverting `/model` would re-expose the role-assignment picker to users expecting a quick switch (#2846's original confusion). Splitting `/model` / `/models` instead keeps #2849's resolution intact (its test stays green) while restoring permanent-picker access via a distinct, semantically-clear command.

## Verification (TDD)

`test/slash-commands/switch.test.ts` → `model.test.ts` (renamed). Added contracts:
- `/model` opens the temporary switcher (unchanged).
- `/models` opens the permanent picker (`showModelSelector()` with no args).
- `/switch` is no longer recognized (`executeBuiltinSlashCommand` returns `false`).

Red→green: the two new tests failed before the registry change; all 3 pass after. Full slash-commands suite: **50 pass / 0 fail**. `tips.txt` updated (`/switch` → `/model`). LSP diagnostics clean on `builtin-registry.ts`.

## Notes

- `bun check` is currently broken in this environment (Biome config error: unknown `preset` key at `biome.json:12`) — pre-existing and unrelated; verified types via LSP. Did not touch `biome.json`.
- CHANGELOG entries added under `[Unreleased]` only.
