### PR TITLE
fix(coding-agent): restore /model role picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/model` in the TUI to open the model setup picker again, leaving `/switch` as the temporary session model switcher ([#2933](https://github.com/can1357/oh-my-pi/issues/2933)).
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -334,7 +334,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return commandConsumed();
 		},
 		handleTui: (_command, runtime) => {
-			runtime.ctx.showModelSelector({ temporaryOnly: true });
+			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -18,13 +18,13 @@ function createRuntime() {
 }
 
 describe("/model slash command", () => {
-	it("opens the temporary model selector for the active session", async () => {
+	it("opens the model setup picker for role and thinking assignment", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/model", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.showModelSelector).toHaveBeenCalledWith({ temporaryOnly: true });
+		expect(harness.showModelSelector.mock.calls).toEqual([[]]);
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
 });


### PR DESCRIPTION
## Repro
Running `bun test packages/coding-agent/test/slash-commands/switch.test.ts` on the reported build passed because the `/model` test asserted `showModelSelector({ temporaryOnly: true })`, proving `/model` used the temporary session switcher path instead of the model setup picker.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` routed `/model` through `runtime.ctx.showModelSelector({ temporaryOnly: true })`, making it byte-identical to `/switch`; the role-assignment picker remains the no-argument `showModelSelector()` path used by `Alt+M`.

## Fix
- Changed `/model` TUI handling to call `showModelSelector()` so it opens the model setup picker.
- Kept `/switch` on `showModelSelector({ temporaryOnly: true })` for quick session switching.
- Updated `packages/coding-agent/test/slash-commands/switch.test.ts` and the coding-agent changelog for the restored split.

## Verification
`bun test packages/coding-agent/test/slash-commands/switch.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. Pre-publish `bun run fix` and `bun check` passed during branch publish. Fixes #2933