### PR TITLE
fix(coding-agent): bypass stream-interrupted guard for Gemini malformed function calls

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9683,6 +9683,7 @@ export class AgentSession {
 
 		if (this.#isClassifierRefusal(message)) return true;
 		if (this.#isProviderErrorFinishReasonBeforeToolUse(message)) return true;
+		if (this.#isMalformedFunctionCallError(message)) return true;
 		if (this.#streamInterruptedAfterObservableOutput(message)) return false;
 		if (this.#isStaleOpenAIResponsesReplayError(message)) return true;
 
@@ -9731,6 +9732,11 @@ export class AgentSession {
 		if (!message.errorMessage) return false;
 		if (message.content.some(block => block.type === "toolCall")) return false;
 		return /\bProvider (?:returned error finish_reason|finish_reason:\s*error)\b/i.test(message.errorMessage);
+	}
+
+	#isMalformedFunctionCallError(message: AssistantMessage): boolean {
+		if (!message.errorMessage) return false;
+		return /\bmalformed.?function.?call\b/i.test(message.errorMessage);
 	}
 
 	#isTransientErrorMessage(errorMessage: string): boolean {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1465,7 +1465,17 @@ describe("AgentSession retry fallback", () => {
 		const requestedModels: string[] = [];
 
 		const mock = createMockModel({
-			responses: [{ throw: malformedError }, { content: ["Recovered after Gemini malformed function call"] }],
+			responses: [
+				{
+					content: [
+						{ type: "thinking", thinking: "Thinking before malformed function call..." },
+						{ type: "text", text: "Text before malformed function call..." },
+					],
+					stopReason: "error",
+					errorMessage: malformedError,
+				},
+				{ content: ["Recovered after Gemini malformed function call"] },
+			],
 		});
 		const agent = new Agent({
 			getApiKey: model => `${model.provider}-test-key`,


### PR DESCRIPTION
Bypasses the #streamInterruptedAfterObservableOutput check in #isRetryableError for MALFORMED_FUNCTION_CALL stop reason errors. This ensures that when Gemini streams thinking or text content before generating a malformed function call, the session is correctly retried. Also updates the corresponding unit test to include thinking/text content in the mock response stream.