### PR TITLE
fix(coding-agent): show omfg dismiss hint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,9 @@
 
 - Fixed `/model` in the TUI to open the model setup picker again, leaving `/switch` as the temporary session model switcher ([#2933](https://github.com/can1357/oh-my-pi/issues/2933)).
 - Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
+### Fixed
+
+- Fixed `/omfg` saved-state copy to advertise `Esc dismiss` after saving and registering the rule live.
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/src/modes/components/omfg-panel.ts
+++ b/packages/coding-agent/src/modes/components/omfg-panel.ts
@@ -117,7 +117,7 @@ export class OmfgPanelComponent extends Container {
 			case "saved":
 				return theme.fg(
 					"success",
-					`${theme.status.success} Registered live · ${replaceTabs(this.#savedPath ?? "saved")}`,
+					`${theme.status.success} Registered live · ${replaceTabs(this.#savedPath ?? "saved")} · Esc dismiss`,
 				);
 			case "rejected":
 				return theme.fg("warning", `${theme.status.warning} Not saved · Esc dismiss`);

--- a/packages/coding-agent/test/modes/controllers/omfg-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/omfg-controller.test.ts
@@ -193,6 +193,14 @@ describe("OmfgController", () => {
 			[PROJECT_OPTION, GLOBAL_OPTION, AMEND_OPTION],
 		]);
 		expect(harness.ttsrAddRule.mock.calls[0]?.[0].path).toBe(savedPath);
+		const rendered = Bun.stripANSI(harness.container.render(120).join("\n"));
+		expect(rendered).toContain("Registered live");
+		expect(rendered).toContain(path.join(".omp", "rules", "ts-no-any.md"));
+		expect(rendered).toContain("Esc dismiss");
+		expect(controller.hasActiveRequest()).toBe(true);
+		expect(controller.handleEscape()).toBe(true);
+		expect(harness.container.children).toHaveLength(0);
+		expect(controller.hasActiveRequest()).toBe(false);
 	});
 
 	it("reiterates when the first valid rule does not match history", async () => {


### PR DESCRIPTION
## Summary
- Add an explicit `Esc dismiss` affordance to the saved `/omfg` panel footer
- Cover the saved state with a no-token controller regression that also verifies Escape clears the panel
- Add an Unreleased changelog entry

## Verification
- `bun test packages/coding-agent/test/modes/controllers/omfg-controller.test.ts`
- `bunx biome check packages/coding-agent/src/modes/components/omfg-panel.ts packages/coding-agent/test/modes/controllers/omfg-controller.test.ts packages/coding-agent/CHANGELOG.md --no-errors-on-unmatched`

## Visual check
Before: `✔ Registered live · <path>`
After: `✔ Registered live · <path> · Esc dismiss`

![Before and after /omfg saved panel states](https://omp-pr.wolfie.gg/2946/omfg-before-after.png)

Individual images:
- [Before](https://omp-pr.wolfie.gg/2946/omfg-before.png)
- [After](https://omp-pr.wolfie.gg/2946/omfg-after.png)