### PR TITLE
fix(providers): add OpenCode Go usage reporting

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed OpenCode Go usage reporting to synthesize `/usage` limits from OMP-observed request costs for the 5h, weekly, and monthly provider caps. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
 - Fixed OpenAI Responses cost accounting to apply standard service-tier pricing multipliers (flex 0.5×, priority 2×) to the calculated cost based on the served (or requested) service tier for provider `"openai"` models.
 - Fixed OpenAI Chat Completions to consume the dedicated `requiresReasoningContentForAllAssistantTurns` compatibility flag, preventing unnecessary reasoning replay on non-tool-call turns for OpenRouter DeepSeek and OpenCode models.
 - Fixed the Kimi Code and Synthetic dual-surface shim (`streamOpenAIAnthropicShim`) to correctly forward caller-supplied `toolChoice`, `serviceTier`, and `disableReasoning` options.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -21,6 +21,8 @@ import type { Provider } from "./types";
 import type {
 	CredentialRankingContext,
 	CredentialRankingStrategy,
+	UsageCostHistoryEntry,
+	UsageCostHistoryQuery,
 	UsageCredential,
 	UsageFetchContext,
 	UsageFetchParams,
@@ -44,6 +46,7 @@ import {
 	consumeCodexResetCredit,
 	listCodexResetCredits,
 } from "./usage/openai-codex-reset";
+import { opencodeGoUsageProvider } from "./usage/opencode-go";
 import { zaiUsageProvider } from "./usage/zai";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
@@ -300,6 +303,10 @@ export interface AuthCredentialStore {
 	 * skipped — the broker host records into its own database instead.
 	 */
 	recordUsageSnapshots?(entries: UsageHistoryEntry[]): void;
+	/** Append observed request costs for providers without upstream usage APIs. */
+	recordUsageCosts?(entries: UsageCostHistoryEntry[]): void;
+	/** Read observed request costs, oldest first. */
+	listUsageCosts?(query?: UsageCostHistoryQuery): UsageCostHistoryEntry[];
 	/** Read recorded usage-limit snapshots, oldest first. */
 	listUsageHistory?(query?: UsageHistoryQuery): UsageHistoryEntry[];
 	/**
@@ -491,6 +498,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	googleGeminiCliUsageProvider,
 	claudeUsageProvider,
 	zaiUsageProvider,
+	opencodeGoUsageProvider,
 	githubCopilotUsageProvider,
 ];
 
@@ -1986,7 +1994,11 @@ export class AuthStorage {
 			typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
 				? AbortSignal.timeout(timeoutMs)
 				: undefined;
-		let params: UsageRequestDescriptor & { signal?: AbortSignal } = { ...request, signal: timeoutSignal };
+		let params: UsageFetchParams = {
+			...request,
+			accountKey: this.#buildUsageCacheIdentity(request.credential),
+			signal: timeoutSignal,
+		};
 
 		if (
 			request.credential.type === "oauth" &&
@@ -2009,8 +2021,10 @@ export class AuthStorage {
 					const refreshedCredential = this.#mergeRefreshedUsageCredential(request.credential, refreshed);
 					this.#persistRefreshedUsageCredential(request.provider, request.credential, refreshedCredential);
 					params = {
-						...params,
+						...request,
 						credential: refreshedCredential,
+						accountKey: this.#buildUsageCacheIdentity(refreshedCredential),
+						signal: timeoutSignal,
 					};
 				} catch (error) {
 					const errorMsg = String(error);
@@ -2068,6 +2082,7 @@ export class AuthStorage {
 			return await providerImpl.fetchUsage(params, {
 				fetch: this.#usageFetch,
 				logger: this.#usageLogger,
+				listUsageCosts: query => this.#store.listUsageCosts?.(query) ?? [],
 			});
 		} catch (error) {
 			logger.debug("AuthStorage usage fetch failed", {
@@ -2164,6 +2179,57 @@ export class AuthStorage {
 	 */
 	listUsageHistory(query?: UsageHistoryQuery): UsageHistoryEntry[] {
 		return this.#store.listUsageHistory?.(query) ?? [];
+	}
+
+	/** Record one observed provider request cost for later local usage aggregation. */
+	recordUsageCost(
+		provider: Provider,
+		costUsd: number,
+		options?: { sessionId?: string; recordedAt?: number },
+	): boolean {
+		if (!Number.isFinite(costUsd) || costUsd <= 0) return false;
+		const record = this.#store.recordUsageCosts;
+		if (!record) return false;
+		const credential = this.#resolveObservedUsageCredential(provider, options?.sessionId);
+		if (!credential) return false;
+		const entry: UsageCostHistoryEntry = {
+			recordedAt: options?.recordedAt ?? Date.now(),
+			provider,
+			accountKey: this.#buildUsageCacheIdentity(credential),
+			costUsd,
+		};
+		try {
+			record.call(this.#store, [entry]);
+			return true;
+		} catch (error) {
+			this.#usageLogger?.debug("usage cost record failed", {
+				provider,
+				error: String(error),
+			});
+			return false;
+		}
+	}
+
+	#resolveObservedUsageCredential(provider: Provider, sessionId?: string): UsageCredential | undefined {
+		const entries = this.#getStoredCredentials(provider);
+		const sessionCredential = this.#getSessionCredential(provider, sessionId);
+		if (sessionCredential) {
+			const credential = entries[sessionCredential.index]?.credential;
+			if (credential) {
+				return credential.type === "api_key"
+					? { type: "api_key", apiKey: credential.key }
+					: this.#buildUsageCredential(credential);
+			}
+		}
+		if (entries.length === 1) {
+			const credential = entries[0]!.credential;
+			return credential.type === "api_key"
+				? { type: "api_key", apiKey: credential.key }
+				: this.#buildUsageCredential(credential);
+		}
+		const envKey = getEnvApiKey(provider);
+		if (envKey) return { type: "api_key", apiKey: envKey };
+		return undefined;
 	}
 
 	ingestUsageHeaders(
@@ -2574,7 +2640,11 @@ export class AuthStorage {
 		const timeoutMs = options?.timeoutMs ?? this.#usageRequestTimeoutMs;
 		const completionProbe = options?.completionProbe;
 		const completionTimeoutMs = options?.completionTimeoutMs ?? timeoutMs;
-		const ctx: UsageFetchContext = { fetch: this.#usageFetch, logger: this.#usageLogger };
+		const ctx: UsageFetchContext = {
+			fetch: this.#usageFetch,
+			logger: this.#usageLogger,
+			listUsageCosts: query => this.#store.listUsageCosts?.(query) ?? [],
+		};
 
 		const results: CredentialHealthResult[] = [];
 		for (const row of stored) {
@@ -2600,7 +2670,11 @@ export class AuthStorage {
 
 			const timeoutSignal = AbortSignal.timeout(timeoutMs);
 			const probeSignal = options?.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
-			let params: UsageFetchParams & { signal: AbortSignal } = { ...initialRequest, signal: probeSignal };
+			let params: UsageFetchParams & { signal: AbortSignal } = {
+				...initialRequest,
+				accountKey: this.#buildUsageCacheIdentity(initialRequest.credential),
+				signal: probeSignal,
+			};
 			let refreshError: string | undefined;
 
 			// Refresh expired OAuth before probing — without this an expired access
@@ -2630,7 +2704,11 @@ export class AuthStorage {
 							initialRequest.credential,
 							refreshedCredential,
 						);
-						params = { ...params, credential: refreshedCredential };
+						params = {
+							...params,
+							credential: refreshedCredential,
+							accountKey: this.#buildUsageCacheIdentity(refreshedCredential),
+						};
 					} catch (error) {
 						refreshError = `oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`;
 					}
@@ -4409,6 +4487,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#upsertCacheStmt: Statement;
 	#deleteExpiredCacheStmt: Statement;
 	#insertUsageHistoryStmt: Statement;
+	#insertUsageCostStmt: Statement;
+	#listUsageCostsStmt: Statement;
 	#lastUsageHistoryStmt: Statement;
 	#listUsageHistoryStmt: Statement;
 	#updateUsageHistoryStmt: Statement;
@@ -4462,6 +4542,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		);
 		this.#listUsageHistoryStmt = this.#db.prepare(
 			"SELECT recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status, resets_at FROM usage_history WHERE recorded_at >= ? AND (? IS NULL OR provider = ?) ORDER BY recorded_at ASC",
+		);
+		this.#insertUsageCostStmt = this.#db.prepare(
+			"INSERT INTO usage_cost_history (recorded_at, provider, account_key, cost_usd) VALUES (?, ?, ?, ?)",
+		);
+		this.#listUsageCostsStmt = this.#db.prepare(
+			"SELECT recorded_at, provider, account_key, cost_usd FROM usage_cost_history WHERE recorded_at >= ? AND (? IS NULL OR provider = ?) AND (? IS NULL OR account_key = ?) ORDER BY recorded_at ASC",
 		);
 	}
 
@@ -4543,6 +4629,14 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				resets_at INTEGER
 			);
 			CREATE INDEX IF NOT EXISTS idx_usage_history_series ON usage_history(provider, account_key, limit_id, recorded_at);
+			CREATE TABLE IF NOT EXISTS usage_cost_history (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				recorded_at INTEGER NOT NULL,
+				provider TEXT NOT NULL,
+				account_key TEXT NOT NULL,
+				cost_usd REAL NOT NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_usage_cost_history_lookup ON usage_cost_history(provider, account_key, recorded_at);
 			CREATE INDEX IF NOT EXISTS idx_usage_history_recorded ON usage_history(recorded_at);
 		`);
 
@@ -5019,6 +5113,42 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				usedFraction: row.used_fraction ?? undefined,
 				status: (row.status ?? undefined) as UsageHistoryEntry["status"],
 				resetsAt: row.resets_at ?? undefined,
+			}));
+		} catch {
+			return [];
+		}
+	}
+	recordUsageCosts(entries: UsageCostHistoryEntry[]): void {
+		try {
+			for (const entry of entries) {
+				this.#insertUsageCostStmt.run(entry.recordedAt, entry.provider, entry.accountKey, entry.costUsd);
+			}
+		} catch {
+			// Cost history is best-effort; never break request persistence.
+		}
+	}
+
+	listUsageCosts(query?: UsageCostHistoryQuery): UsageCostHistoryEntry[] {
+		try {
+			const provider = query?.provider ?? null;
+			const accountKey = query?.accountKey ?? null;
+			const rows = this.#listUsageCostsStmt.all(
+				query?.sinceMs ?? 0,
+				provider,
+				provider,
+				accountKey,
+				accountKey,
+			) as Array<{
+				recorded_at: number;
+				provider: string;
+				account_key: string;
+				cost_usd: number;
+			}>;
+			return rows.map(row => ({
+				recordedAt: row.recorded_at,
+				provider: row.provider as Provider,
+				accountKey: row.account_key,
+				costUsd: row.cost_usd,
 			}));
 		} catch {
 			return [];

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2185,7 +2185,7 @@ export class AuthStorage {
 	recordUsageCost(
 		provider: Provider,
 		costUsd: number,
-		options?: { sessionId?: string; recordedAt?: number },
+		options?: { sessionId?: string; recordedAt?: number; baseUrl?: string },
 	): boolean {
 		if (!Number.isFinite(costUsd) || costUsd <= 0) return false;
 		const record = this.#store.recordUsageCosts;
@@ -2200,6 +2200,13 @@ export class AuthStorage {
 		};
 		try {
 			record.call(this.#store, [entry]);
+			const cacheKey = this.#buildUsageReportCacheKey({
+				provider,
+				credential,
+				baseUrl: options?.baseUrl,
+			});
+			const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
+			this.#usageCache.set(cacheKey, { value: existing?.value ?? null, expiresAt: Date.now() - 1 });
 			return true;
 		} catch (error) {
 			this.#usageLogger?.debug("usage cost record failed", {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2729,6 +2729,8 @@ export class AuthStorage {
 				base.reason = `no usage probe configured for provider ${row.provider}`;
 			} else if (providerImpl.supports && !providerImpl.supports(initialRequest)) {
 				base.reason = `usage probe does not support ${cred.type} credentials for ${row.provider}`;
+			} else if (providerImpl.validatesCredentials === false) {
+				base.reason = `usage probe for ${row.provider} does not validate credentials`;
 			} else {
 				try {
 					const report = await providerImpl.fetchUsage(params, ctx);

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -36,6 +36,7 @@ export * from "./usage/kimi";
 export * from "./usage/minimax-code";
 export * from "./usage/openai-codex";
 export * from "./usage/openai-codex-reset";
+export * from "./usage/opencode-go";
 export * from "./usage/zai";
 export * from "./utils/anthropic-auth";
 export * from "./utils/event-stream";

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -134,6 +134,24 @@ export interface UsageHistoryQuery {
 	/** Inclusive lower bound on {@link UsageHistoryEntry.recordedAt} (epoch ms). */
 	sinceMs?: number;
 }
+/** One observed provider request cost, attributed to the credential that made it. */
+export interface UsageCostHistoryEntry {
+	/** Epoch ms the request completed. */
+	recordedAt: number;
+	provider: Provider;
+	/** Stable credential identity key (account/email/project/secret derived). */
+	accountKey: string;
+	/** Estimated request cost in USD. */
+	costUsd: number;
+}
+
+/** Filter for reading observed request costs. */
+export interface UsageCostHistoryQuery {
+	provider?: string;
+	accountKey?: string;
+	/** Inclusive lower bound on {@link UsageCostHistoryEntry.recordedAt} (epoch ms). */
+	sinceMs?: number;
+}
 
 // ─── Zod schemas (wire-shape validation for the broker `/v1/usage` endpoint) ─
 
@@ -217,6 +235,8 @@ export interface UsageCredential {
 export interface UsageFetchParams {
 	provider: Provider;
 	credential: UsageCredential;
+	/** Stable credential identity key derived by the auth storage layer. */
+	accountKey?: string;
 	baseUrl?: string;
 	signal?: AbortSignal;
 }
@@ -226,6 +246,8 @@ export interface UsageFetchContext {
 	fetch: FetchImpl;
 	logger?: UsageLogger;
 	retryWait?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+	/** Observed request-cost history for providers without upstream usage APIs. */
+	listUsageCosts?: (query?: UsageCostHistoryQuery) => UsageCostHistoryEntry[];
 }
 
 /** Provider implementation for fetching usage information. */

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -257,6 +257,8 @@ export interface UsageProvider {
 	/** Parse provider rate-limit response headers (lowercased keys) into a usage report, if supported. */
 	parseRateLimitHeaders?(headers: Record<string, string>, now?: number): UsageReport | null;
 	supports?(params: UsageFetchParams): boolean;
+	/** True when fetchUsage contacts upstream and can authenticate the credential for health checks. */
+	validatesCredentials?: boolean;
 }
 
 /** Request context used when ranking usage for a specific model. */

--- a/packages/ai/src/usage/opencode-go.ts
+++ b/packages/ai/src/usage/opencode-go.ts
@@ -1,0 +1,88 @@
+import type { UsageCostHistoryEntry, UsageLimit, UsageProvider, UsageWindow } from "../usage";
+
+const OPENCODE_GO_PROVIDER = "opencode-go";
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const OPENCODE_GO_LIMITS = [
+	{ id: "rolling-5h", label: "5 Hour", durationMs: 5 * HOUR_MS, limitUsd: 12 },
+	{ id: "weekly", label: "Weekly", durationMs: 7 * DAY_MS, limitUsd: 30 },
+	{ id: "monthly", label: "Monthly", durationMs: 30 * DAY_MS, limitUsd: 60 },
+] as const;
+
+function sumWindowCosts(entries: UsageCostHistoryEntry[], sinceMs: number): { used: number; resetsAt?: number } {
+	let used = 0;
+	let firstRecordedAt: number | undefined;
+	for (const entry of entries) {
+		if (entry.recordedAt < sinceMs) continue;
+		used += entry.costUsd;
+		if (firstRecordedAt === undefined || entry.recordedAt < firstRecordedAt) {
+			firstRecordedAt = entry.recordedAt;
+		}
+	}
+	return { used, resetsAt: firstRecordedAt };
+}
+
+function resolveStatus(usedFraction: number): UsageLimit["status"] {
+	if (usedFraction >= 1) return "exhausted";
+	if (usedFraction >= 0.8) return "warning";
+	return "ok";
+}
+
+function buildWindowLimit(
+	limit: (typeof OPENCODE_GO_LIMITS)[number],
+	entries: UsageCostHistoryEntry[],
+	nowMs: number,
+): UsageLimit {
+	const sinceMs = nowMs - limit.durationMs;
+	const windowCost = sumWindowCosts(entries, sinceMs);
+	const used = Number(windowCost.used.toFixed(6));
+	const usedFraction = used / limit.limitUsd;
+	const window: UsageWindow = {
+		id: limit.id,
+		label: limit.label,
+		durationMs: limit.durationMs,
+	};
+	if (windowCost.resetsAt !== undefined) {
+		window.resetsAt = windowCost.resetsAt + limit.durationMs;
+	}
+	return {
+		id: limit.id,
+		label: `${limit.label} limit`,
+		scope: {
+			provider: OPENCODE_GO_PROVIDER,
+			windowId: limit.id,
+		},
+		window,
+		amount: {
+			used,
+			limit: limit.limitUsd,
+			remaining: Math.max(0, limit.limitUsd - used),
+			usedFraction,
+			remainingFraction: Math.max(0, 1 - usedFraction),
+			unit: "usd",
+		},
+		status: resolveStatus(usedFraction),
+		notes: ["OMP-observed spend only; OpenCode usage outside OMP is not included."],
+	};
+}
+
+export const opencodeGoUsageProvider: UsageProvider = {
+	id: OPENCODE_GO_PROVIDER,
+	supports: params => params.provider === OPENCODE_GO_PROVIDER && params.credential.type === "api_key",
+	async fetchUsage(params, ctx) {
+		if (params.provider !== OPENCODE_GO_PROVIDER || params.credential.type !== "api_key") return null;
+		const nowMs = Date.now();
+		const sinceMs = nowMs - OPENCODE_GO_LIMITS[OPENCODE_GO_LIMITS.length - 1]!.durationMs;
+		const entries =
+			ctx.listUsageCosts?.({ provider: OPENCODE_GO_PROVIDER, accountKey: params.accountKey, sinceMs }) ?? [];
+		return {
+			provider: OPENCODE_GO_PROVIDER,
+			fetchedAt: nowMs,
+			limits: OPENCODE_GO_LIMITS.map(limit => buildWindowLimit(limit, entries, nowMs)),
+			metadata: {
+				planType: "OpenCode Go",
+				source: "omp-observed-request-costs",
+			},
+		};
+	},
+};

--- a/packages/ai/src/usage/opencode-go.ts
+++ b/packages/ai/src/usage/opencode-go.ts
@@ -69,6 +69,7 @@ function buildWindowLimit(
 export const opencodeGoUsageProvider: UsageProvider = {
 	id: OPENCODE_GO_PROVIDER,
 	supports: params => params.provider === OPENCODE_GO_PROVIDER && params.credential.type === "api_key",
+	validatesCredentials: false,
 	async fetchUsage(params, ctx) {
 		if (params.provider !== OPENCODE_GO_PROVIDER || params.credential.type !== "api_key") return null;
 		const nowMs = Date.now();

--- a/packages/ai/test/auth-storage-check-credentials.test.ts
+++ b/packages/ai/test/auth-storage-check-credentials.test.ts
@@ -15,10 +15,12 @@
  *   5. Providers with no registered `UsageProvider` report `ok: null` with
  *      "no usage probe configured" — the credential's status is unknown,
  *      not failed.
- *   6. When a `completionProbe` is supplied, it receives the post-refresh
+ *   6. Local-only usage providers opt out of health validation and leave
+ *      `ok: null` unless a separate completion probe is supplied.
+ *   7. When a `completionProbe` is supplied, it receives the post-refresh
  *      bearer for every row, runs independently of the usage probe (i.e. it
- *      still runs for providers without a `UsageProvider`), but is skipped
- *      when OAuth refresh fails.
+ *      still runs for providers without a validating `UsageProvider`), but is
+ *      skipped when OAuth refresh fails.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
@@ -32,6 +34,7 @@ import {
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { UsageProvider } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
+import { opencodeGoUsageProvider } from "@oh-my-pi/pi-ai/usage/opencode-go";
 
 function oauthRow(id: number, email: string, opts?: { expired?: boolean }): StoredAuthCredential {
 	const credential: AuthCredential = {
@@ -390,6 +393,33 @@ describe("AuthStorage.checkCredentials", () => {
 			// probe surfaces the real failure.
 			expect(result.ok).toBeNull();
 			expect(result.reason).toMatch(/no usage probe configured/);
+			expect(result.completion).toEqual({ ok: false, reason: "401 invalid_api_key" });
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("does not mark local-only usage providers healthy without upstream validation", async () => {
+		const apiKeyRow: StoredAuthCredential = {
+			id: 12,
+			provider: "opencode-go",
+			credential: { type: "api_key", key: "sk-opencode-go" },
+			disabledCause: null,
+		};
+		const store = makeStore([apiKeyRow]);
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "opencode-go" ? opencodeGoUsageProvider : undefined),
+		});
+		await storage.reload();
+
+		const probe = vi.fn<CompletionProbe>().mockResolvedValue({ ok: false, reason: "401 invalid_api_key" });
+
+		try {
+			const [result] = await storage.checkCredentials({ completionProbe: probe });
+			expect(result.ok).toBeNull();
+			expect(result.reason).toMatch(/does not validate credentials/);
+			expect(result.report).toBeUndefined();
+			expect(probe).toHaveBeenCalledTimes(1);
 			expect(result.completion).toEqual({ ok: false, reason: "401 invalid_api_key" });
 		} finally {
 			storage.close();

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -13,10 +13,11 @@
  *      fetched credential, whenever a fresh usage report lands.
  */
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, setSystemTime, vi } from "bun:test";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import type { UsageHistoryEntry, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
+import * as opencodeGoUsage from "@oh-my-pi/pi-ai/usage/opencode-go";
 
 const HOUR = 3_600_000;
 // Hour-aligned base so bucket boundaries in the tests are explicit.
@@ -184,5 +185,58 @@ describe("AuthStorage usage history recording", () => {
 		const sevenDay = rows.find(row => row.limitId === "anthropic:7d");
 		expect(sevenDay?.usedFraction).toBeCloseTo(0.84);
 		expect(sevenDay?.status).toBe("warning");
+	});
+});
+
+describe("OpenCode Go usage from observed request costs", () => {
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "opencode-go" ? opencodeGoUsage.opencodeGoUsageProvider : undefined,
+		});
+		await storage.reload();
+		await storage.set("opencode-go", { type: "api_key", key: "opencode-go-key" });
+	});
+
+	afterEach(() => {
+		setSystemTime();
+		storage.close();
+		vi.restoreAllMocks();
+	});
+
+	it("returns zero-dollar OpenCode Go limits for a fresh key", async () => {
+		const reports = await storage.fetchUsageReports();
+
+		const report = reports?.find(candidate => candidate.provider === "opencode-go");
+		expect(report?.limits.map(limit => [limit.id, limit.amount.used, limit.amount.limit])).toEqual([
+			["rolling-5h", 0, 12],
+			["weekly", 0, 30],
+			["monthly", 0, 60],
+		]);
+	});
+
+	it("aggregates one key's observed spend into OpenCode Go cap windows", async () => {
+		const nowMs = Date.parse("2026-06-18T12:00:00Z");
+		setSystemTime(new Date(nowMs));
+		storage.recordUsageCost("opencode-go", 4, { recordedAt: nowMs - HOUR });
+		storage.recordUsageCost("opencode-go", 7, { recordedAt: nowMs - 6 * HOUR });
+		storage.recordUsageCost("opencode-go", 11, { recordedAt: nowMs - 10 * 24 * HOUR });
+		storage.recordUsageCost("opencode-go", 13, { recordedAt: nowMs - 31 * 24 * HOUR });
+
+		const reports = await storage.fetchUsageReports();
+		const report = reports?.find(candidate => candidate.provider === "opencode-go");
+		if (!report) throw new Error("expected opencode-go usage report");
+
+		const usedByLimit = new Map(report.limits.map(limit => [limit.id, limit.amount.used]));
+		expect(usedByLimit.get("rolling-5h")).toBe(4);
+		expect(usedByLimit.get("weekly")).toBe(11);
+		expect(usedByLimit.get("monthly")).toBe(22);
+
+		const fiveHour = report.limits.find(limit => limit.id === "rolling-5h");
+		expect(fiveHour?.window?.resetsAt).toBe(nowMs - HOUR + 5 * HOUR);
 	});
 });

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -219,6 +219,21 @@ describe("OpenCode Go usage from observed request costs", () => {
 		]);
 	});
 
+	it("refreshes cached OpenCode Go limits after recording new observed spend", async () => {
+		const nowMs = Date.parse("2026-06-18T12:00:00Z");
+		setSystemTime(new Date(nowMs));
+
+		const initialReports = await storage.fetchUsageReports();
+		const initial = initialReports?.find(candidate => candidate.provider === "opencode-go");
+		expect(initial?.limits.find(limit => limit.id === "rolling-5h")?.amount.used).toBe(0);
+
+		storage.recordUsageCost("opencode-go", 3, { recordedAt: nowMs });
+
+		const refreshedReports = await storage.fetchUsageReports();
+		const refreshed = refreshedReports?.find(candidate => candidate.provider === "opencode-go");
+		expect(refreshed?.limits.find(limit => limit.id === "rolling-5h")?.amount.used).toBe(3);
+	});
+
 	it("aggregates one key's observed spend into OpenCode Go cap windows", async () => {
 		const nowMs = Date.parse("2026-06-18T12:00:00Z");
 		setSystemTime(new Date(nowMs));

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
 - Fixed legacy plugin validation for extensions that import `defineTool`, `StringEnum`, frontmatter helpers, `SettingsManager`, `createCodingTools`, or the bare `typebox` package through the hosted Pi compatibility shims ([#2858](https://github.com/can1357/oh-my-pi/issues/2858)).
 - Fixed edit seen-line guard mismatch assertion message formatting to report the actual state instead of generic failure notices
 - Fixed hashline edit mode rendering in the TUI when `setIgnoreTight` triggers synchronous display rebuilds in the constructor before `#editMode` is assigned, which previously caused the tool envelope target path to display as `…` instead of the parsed hashline filename.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2499,6 +2499,12 @@ export class AgentSession {
 					});
 					this.#retryAttempt = 0;
 				}
+				if (assistantMsg.provider === "opencode-go") {
+					this.#modelRegistry.authStorage.recordUsageCost(assistantMsg.provider, assistantMsg.usage.cost.total, {
+						sessionId: this.#activeProviderSessionId(),
+						recordedAt: assistantMsg.timestamp,
+					});
+				}
 			}
 			if (event.message.role === "toolResult") {
 				const { toolName, details, isError, content } = event.message as {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2503,6 +2503,7 @@ export class AgentSession {
 					this.#modelRegistry.authStorage.recordUsageCost(assistantMsg.provider, assistantMsg.usage.cost.total, {
 						sessionId: this.#activeProviderSessionId(),
 						recordedAt: assistantMsg.timestamp,
+						baseUrl: this.#modelRegistry.getProviderBaseUrl?.(assistantMsg.provider),
 					});
 				}
 			}


### PR DESCRIPTION
## Repro
A local `AuthStorage` with one `opencode-go` API-key credential returned no usage reports before the fix: `bun -e 'import { Database } from "bun:sqlite"; import { AuthStorage, SqliteAuthCredentialStore } from "./packages/ai/src/auth-storage.ts"; const store = new SqliteAuthCredentialStore(new Database(":memory:")); const storage = new AuthStorage(store, { usageFetch: async () => { throw new Error("unexpected fetch"); } }); await storage.reload(); await storage.set("opencode-go", { type: "api_key", key: "test-opencode-key" }); const reports = await storage.fetchUsageReports(); console.log(JSON.stringify({ reports, count: reports?.length ?? null })); storage.close();'` printed `{"reports":[],"count":0}`.

## Cause
`packages/ai/src/auth-storage.ts` registered no default `UsageProvider` for `opencode-go`, and OpenCode Go has no JSON usage endpoint in `packages/catalog/src/provider-models/descriptors.ts`; `fetchUsageReports()` therefore built no supported usage request for stored `opencode-go` API-key credentials, so `/usage` only rendered an unreported account row.

## Fix
- Added `packages/ai/src/usage/opencode-go.ts`, registered it in `DEFAULT_USAGE_PROVIDERS`, and exported it from `packages/ai/src/index.ts`.
- Added best-effort request-cost history storage and an `AuthStorage.recordUsageCost()` hook so providers without upstream usage APIs can aggregate OMP-observed spend per credential.
- Recorded successful `opencode-go` assistant message costs from `packages/coding-agent/src/session/agent-session.ts` against the active provider-session credential.
- Added regression coverage for fresh OpenCode Go keys and 5h/weekly/monthly observed-spend aggregation.

## Verification
`bun test packages/ai/test/auth-storage-usage-history.test.ts` passed (7 tests); `bun check` passed; the fixed repro with the OpenCode Go usage provider now prints `{"count":1,"provider":"opencode-go","limits":[["rolling-5h",0,12],["weekly",0,30],["monthly",0,60]]}`. Fixes #2942