### PR TITLE
feat(coding-agent): add /roles slash command for model role assignment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `/roles` slash command (alias `/role`) that opens the persistent model role-assignment picker (the `app.model.select` / `Alt+M` view), restoring discoverable slash-command access to role assignment after `/model` was repurposed to the temporary session switcher.
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -347,6 +347,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "roles",
+		aliases: ["role"],
+		description: "Assign models to roles (default/smol/slow/plan/…) — same as alt+m",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showModelSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "fast",
 		description: "Toggle priority service tier (OpenAI service_tier=priority, Anthropic speed=fast)",
 		acpDescription: "Toggle fast mode",

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -40,3 +40,26 @@ describe("/switch slash command", () => {
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
 });
+
+describe("/roles slash command", () => {
+	it("opens the persistent role-assignment picker (mirrors alt+m), not the temporary switcher", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/roles", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showModelSelector).toHaveBeenCalledWith();
+		expect(harness.showModelSelector).not.toHaveBeenCalledWith({ temporaryOnly: true });
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("resolves the /role alias to the same role-assignment picker", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/role", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showModelSelector).toHaveBeenCalledWith();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});


### PR DESCRIPTION
## Issues

Addresses **#2933** (`/model` opens the temporary switcher instead of the role-assignment picker) — this PR implements that issue's **Option B**: keep `/model` temporary and add a dedicated `/roles` command for the permanent picker.

Related: **#2952** (temporary picker gives no path to role assignment).

> **Note — competing approach.** #2933 is also targeted by **#2938**, which implements **Option A** (restore `/model` itself to the permanent picker; keep `/switch` temporary). This PR is the **alternative Option B** and is intentionally left for the maintainer to choose between. It deliberately uses no `Fixes` keyword so it does not auto-close #2933 out from under #2938.
>
> | | `/model` | `/switch` | new cmd | flips `/model` test |
> |---|---|---|---|---|
> | #2938 (A) | permanent | temporary | — | yes |
> | this PR (B) | temporary | temporary | `/roles` | no |
>
> Trade-off vs A: B preserves #2849/#2846's `/model`-as-quick-switch decision and does not touch the existing `/model` test, at the cost of a new top-level command name. The two PRs will textually conflict on `switch.test.ts` and the changelog; only one should land.

## Why

`/model` (and `/switch`) in the TUI open the **temporary active-session model switcher** — `showModelSelector({ temporaryOnly: true })`. The **persistent role-assignment picker**, which assigns models to the `default` / `smol` / `slow` / `plan` / … roles, is now reachable only through the `app.model.select` keybinding (**Alt+M**). There is no slash-command equivalent.

Two problems with that:

1. **Discoverability.** Role assignment is invisible to anyone who lives in the slash menu. After `/model` was repurposed to the temporary switcher (CHANGELOG: *"Fixed `/model` in the TUI to open the active-session model switcher instead of the role-assignment picker"*, PR #2849 / #2846), the role picker quietly lost its only command-driven entry point.
2. **macOS / terminal ergonomics.** On macOS the binding is Option+M (⌥M), but terminals (iTerm2, etc.) frequently eat Option as a compose key or remap it, so the default binding silently does nothing until the user reconfigures the terminal or remaps the action. There was no keyboard-independent way to open the picker.

## What

Add a `/roles` slash command (alias `/role`) that opens the role-assignment picker by calling `showModelSelector()` with **no** `temporaryOnly` — the same view bound to `Alt+M`. This restores discoverable, keyboard-independent, cross-platform access to role assignment without changing the `/model` / `/switch` temporary-switch behavior.

- Mirrors the existing `/model` + `/models` singular/plural alias pair (here: `/roles` primary, `/role` alias).
- TUI-only via `handleTui`, consistent with `/switch` (the picker is interactive; non-TUI ACP/RPC hosts have no equivalent).

## Tests

`packages/coding-agent/test/slash-commands/switch.test.ts` gains two cases asserting the contract:
- `/roles` opens the picker with **no** `temporaryOnly` (the role-assignment view), explicitly distinct from the temporary switcher.
- the `/role` alias resolves to the same handler.

Existing `/model` and `/switch` cases still pass — full file: **4 pass / 0 fail**.

## Notes

- `bun run check:types` shows no errors in the changed files.
- `biome check` clean on all changed files.
- CHANGELOG entry added under `[Unreleased] → Added`.
