### PR TITLE
Harden user agent context authority

### DIFF
--- a/packages/coding-agent/src/capability/context-file.ts
+++ b/packages/coding-agent/src/capability/context-file.ts
@@ -28,12 +28,14 @@ export const contextFileCapability = defineCapability<ContextFile>({
 	id: "context-files",
 	displayName: "Context Files",
 	description: "Persistent instruction files (CLAUDE.md, AGENTS.md, etc.) that guide agent behavior",
-	// Deduplicate by scope: one user-level file, and one project-level file per directory depth.
-	// Within each depth level, higher-priority providers shadow lower-priority ones.
+	// Deduplicate by scope: user-level files keyed by basename (so AGENT.md and
+	// AGENTS.md do not shadow each other), and one project-level file per directory
+	// depth. Within each key, higher-priority providers shadow lower-priority ones.
 	// This supports monorepo hierarchies where AGENTS.md exists at multiple ancestor levels.
 	// Clamp depth >= 0: files inside config subdirectories of an ancestor (e.g. .claude/, .github/)
 	// are same-scope as the ancestor itself.
-	key: file => (file.level === "user" ? "user" : `project:${Math.max(0, file.depth ?? 0)}`),
+	key: file =>
+		file.level === "user" ? `user:${path.basename(file.path)}` : `project:${Math.max(0, file.depth ?? 0)}`,
 	toExtensionId: file => `context-file:${file.level}:${path.basename(file.path)}`,
 	validate: file => {
 		if (!file.path) return "Missing path";

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -10,7 +10,7 @@ import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { calculateDepth, createSourceMeta } from "./helpers";
+import { calculateDepth, createSourceMeta, shouldSuppressProjectAgentMds } from "./helpers";
 
 const PROVIDER_ID = "agents-md";
 const DISPLAY_NAME = "AGENTS.md";
@@ -19,6 +19,10 @@ const DISPLAY_NAME = "AGENTS.md";
  * Load standalone AGENTS.md files.
  */
 async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
+	if (await shouldSuppressProjectAgentMds(ctx)) {
+		return { items: [], warnings: [] };
+	}
+
 	const items: ContextFile[] = [];
 	const warnings: string[] = [];
 

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -19,8 +19,10 @@ import {
 	buildRuleFromMarkdown,
 	calculateDepth,
 	createSourceMeta,
+	getUserAgentMd,
 	loadFilesFromDir,
 	scanSkillsFromDir,
+	shouldSuppressProjectAgentMds,
 } from "./helpers";
 
 const PROVIDER_ID = "agents";
@@ -188,13 +190,26 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 		const depth = level === "project" ? calculateDepth(ctx.cwd, ancestorDir, path.sep) : undefined;
 		return { path: filePath, content, level, depth, _source: createSourceMeta(PROVIDER_ID, filePath, level) };
 	};
+	const agentMd = await getUserAgentMd(ctx);
+	const authorityFile: ContextFile | null =
+		agentMd === null
+			? null
+			: {
+					path: agentMd.path,
+					content: agentMd.content,
+					level: "user",
+					_source: createSourceMeta(PROVIDER_ID, agentMd.path, "user"),
+				};
 
+	const projectCandidates = (await shouldSuppressProjectAgentMds(ctx))
+		? []
+		: getProjectPathCandidates(ctx, "AGENTS.md");
 	const results = await Promise.all([
-		...getProjectPathCandidates(ctx, "AGENTS.md").map(p => load(p, "project")),
+		...projectCandidates.map(p => load(p, "project")),
 		...getUserPathCandidates(ctx, "AGENTS.md").map(p => load(p, "user")),
 	]);
 
-	return { items: results.filter((r): r is ContextFile => r !== null), warnings: [] };
+	return { items: [authorityFile, ...results].filter((r): r is ContextFile => r !== null), warnings: [] };
 }
 
 registerProvider<ContextFile>(contextFileCapability.id, {

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -33,6 +33,7 @@ import {
 	loadFilesFromDir,
 	SOURCE_PATHS,
 	scanSkillsFromDir,
+	shouldSuppressProjectAgentMds,
 } from "./helpers";
 
 const PROVIDER_ID = "native";
@@ -907,19 +908,21 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 		});
 	}
 
-	const nearestProjectConfigDir = await findNearestProjectConfigDir(ctx.cwd, ctx.repoRoot);
-	if (nearestProjectConfigDir) {
-		const projectPath = path.join(nearestProjectConfigDir.dir, "AGENTS.md");
-		const projectContent = await readFile(projectPath);
-		if (projectContent) {
-			items.push({
-				path: projectPath,
-				content: projectContent,
-				level: "project",
-				depth: nearestProjectConfigDir.depth,
-				_source: createSourceMeta(PROVIDER_ID, projectPath, "project"),
-			});
-			return { items, warnings };
+	if (!(await shouldSuppressProjectAgentMds(ctx))) {
+		const nearestProjectConfigDir = await findNearestProjectConfigDir(ctx.cwd, ctx.repoRoot);
+		if (nearestProjectConfigDir) {
+			const projectPath = path.join(nearestProjectConfigDir.dir, "AGENTS.md");
+			const projectContent = await readFile(projectPath);
+			if (projectContent) {
+				items.push({
+					path: projectPath,
+					content: projectContent,
+					level: "project",
+					depth: nearestProjectConfigDir.depth,
+					_source: createSourceMeta(PROVIDER_ID, projectPath, "project"),
+				});
+				return { items, warnings };
+			}
 		}
 	}
 	return { items, warnings };

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -25,8 +25,10 @@ import {
 	discoverExtensionModulePaths,
 	expandEnvVarsDeep,
 	getExtensionNameFromPath,
+	getUserAgentMd,
 	loadFilesFromDir,
 	scanSkillsFromDir,
+	shouldSuppressProjectAgentMds,
 } from "./helpers";
 
 const PROVIDER_ID = "claude";
@@ -46,6 +48,14 @@ function getUserClaude(ctx: LoadContext): string {
  */
 function getProjectClaude(ctx: LoadContext): string {
 	return path.join(ctx.cwd, CONFIG_DIR);
+}
+
+/**
+ * If ~/.agent/AGENT.md exists, project-level config autoload is suppressed.
+ * The user's personal agent file is the sole autoloaded behavioral authority.
+ */
+async function shouldSkipProjectLevel(ctx: LoadContext): Promise<boolean> {
+	return shouldSuppressProjectAgentMds(ctx);
 }
 
 function isMissingDirectoryError(error: unknown): boolean {
@@ -110,12 +120,14 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		}
 	}
 
-	const projectOffset = userPaths.length;
-	for (let i = 0; i < projectPaths.length; i++) {
-		const servers = parseMcpServers(contents[projectOffset + i], projectPaths[i].path, projectPaths[i].level);
-		if (servers.length > 0) {
-			items.push(...servers);
-			break;
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		const projectOffset = userPaths.length;
+		for (let i = 0; i < projectPaths.length; i++) {
+			const servers = parseMcpServers(contents[projectOffset + i], projectPaths[i].path, projectPaths[i].level);
+			if (servers.length > 0) {
+				items.push(...servers);
+				break;
+			}
 		}
 	}
 
@@ -123,38 +135,52 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 }
 
 // =============================================================================
-// Context Files (CLAUDE.md)
+// Context Files (~/.agent/AGENT.md or ~/.claude/CLAUDE.md)
 // =============================================================================
 
 async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
 	const items: ContextFile[] = [];
 	const warnings: string[] = [];
 
-	const userBase = getUserClaude(ctx);
-	const userClaudeMd = path.join(userBase, "CLAUDE.md");
+	const agentMd = await getUserAgentMd(ctx);
 
-	const userContent = await readFile(userClaudeMd);
-	if (userContent !== null) {
+	// When ~/.agent/AGENT.md exists, ~/.agent/ is the sole user-level authority —
+	// ~/.claude/CLAUDE.md is suppressed as a hot override.
+	if (agentMd !== null) {
 		items.push({
-			path: userClaudeMd,
-			content: userContent,
+			path: agentMd.path,
+			content: agentMd.content,
 			level: "user",
-			_source: createSourceMeta(PROVIDER_ID, userClaudeMd, "user"),
+			_source: createSourceMeta(PROVIDER_ID, agentMd.path, "user"),
 		});
+	} else {
+		const userBase = getUserClaude(ctx);
+		const userClaudeMd = path.join(userBase, "CLAUDE.md");
+		const userContent = await readFile(userClaudeMd);
+		if (userContent !== null) {
+			items.push({
+				path: userClaudeMd,
+				content: userContent,
+				level: "user",
+				_source: createSourceMeta(PROVIDER_ID, userClaudeMd, "user"),
+			});
+		}
 	}
 
-	const projectBase = getProjectClaude(ctx);
-	const projectClaudeMd = path.join(projectBase, "CLAUDE.md");
-	const projectContent = await readFile(projectClaudeMd);
-	if (projectContent !== null) {
-		const depth = calculateDepth(ctx.cwd, path.dirname(projectBase), path.sep);
-		items.push({
-			path: projectClaudeMd,
-			content: projectContent,
-			level: "project",
-			depth,
-			_source: createSourceMeta(PROVIDER_ID, projectClaudeMd, "project"),
-		});
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		const projectBase = getProjectClaude(ctx);
+		const projectClaudeMd = path.join(projectBase, "CLAUDE.md");
+		const projectContent = await readFile(projectClaudeMd);
+		if (projectContent !== null) {
+			const depth = calculateDepth(ctx.cwd, path.dirname(projectBase), path.sep);
+			items.push({
+				path: projectClaudeMd,
+				content: projectContent,
+				level: "project",
+				depth,
+				_source: createSourceMeta(PROVIDER_ID, projectClaudeMd, "project"),
+			});
+		}
 	}
 
 	return { items, warnings };
@@ -169,19 +195,21 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 
 	// Walk up from cwd finding .claude/skills/ in ancestors
 	const projectScans: Promise<LoadResult<Skill>>[] = [];
-	let current = ctx.cwd;
-	while (true) {
-		projectScans.push(
-			scanSkillsFromDir(ctx, {
-				dir: path.join(current, CONFIG_DIR, "skills"),
-				providerId: PROVIDER_ID,
-				level: "project",
-			}),
-		);
-		if (current === (ctx.repoRoot ?? ctx.home)) break;
-		const parent = path.dirname(current);
-		if (parent === current) break; // filesystem root
-		current = parent;
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		let current = ctx.cwd;
+		while (true) {
+			projectScans.push(
+				scanSkillsFromDir(ctx, {
+					dir: path.join(current, CONFIG_DIR, "skills"),
+					providerId: PROVIDER_ID,
+					level: "project",
+				}),
+			);
+			if (current === (ctx.repoRoot ?? ctx.home)) break;
+			const parent = path.dirname(current);
+			if (parent === current) break; // filesystem root
+			current = parent;
+		}
 	}
 
 	const [userResult, ...projectResults] = await Promise.allSettled([
@@ -223,10 +251,10 @@ async function loadExtensionModules(ctx: LoadContext): Promise<LoadResult<Extens
 	const userExtensionsDir = path.join(userBase, "extensions");
 	const projectExtensionsDir = path.join(ctx.cwd, CONFIG_DIR, "extensions");
 
-	const dirsToDiscover: { dir: string; level: "user" | "project" }[] = [
-		{ dir: userExtensionsDir, level: "user" },
-		{ dir: projectExtensionsDir, level: "project" },
-	];
+	const dirsToDiscover: { dir: string; level: "user" | "project" }[] = [{ dir: userExtensionsDir, level: "user" }];
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		dirsToDiscover.push({ dir: projectExtensionsDir, level: "project" });
+	}
 
 	const pathsByLevel = await Promise.all(
 		dirsToDiscover.map(async ({ dir, level }) => {
@@ -317,7 +345,7 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 		if (userResult.warnings) warnings.push(...userResult.warnings);
 	}
 
-	if (enableProject) {
+	if (enableProject && !(await shouldSkipProjectLevel(ctx))) {
 		const projectCommandsDir = path.join(ctx.cwd, CONFIG_DIR, "commands");
 
 		const projectResult = await loadFilesFromDir<SlashCommand>(ctx, projectCommandsDir, PROVIDER_ID, "project", {
@@ -358,8 +386,10 @@ async function loadHooks(ctx: LoadContext): Promise<LoadResult<Hook>> {
 	for (const hookType of hookTypes) {
 		loadTasks.push({ dir: path.join(userHooksDir, hookType), hookType, level: "user" });
 	}
-	for (const hookType of hookTypes) {
-		loadTasks.push({ dir: path.join(projectHooksDir, hookType), hookType, level: "project" });
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		for (const hookType of hookTypes) {
+			loadTasks.push({ dir: path.join(projectHooksDir, hookType), hookType, level: "project" });
+		}
 	}
 
 	const results = await Promise.all(
@@ -415,24 +445,26 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 	items.push(...userResult.items);
 	if (userResult.warnings) warnings.push(...userResult.warnings);
 
-	const projectBase = getProjectClaude(ctx);
-	const projectToolsDir = path.join(projectBase, "tools");
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		const projectBase = getProjectClaude(ctx);
+		const projectToolsDir = path.join(projectBase, "tools");
 
-	const projectResult = await loadFilesFromDir<CustomTool>(ctx, projectToolsDir, PROVIDER_ID, "project", {
-		transform: (name, _content, path, source) => {
-			const toolName = name.replace(/\.(ts|js|sh|bash|py)$/, "");
-			return {
-				name: toolName,
-				path,
-				description: `${toolName} custom tool`,
-				level: "project",
-				_source: source,
-			};
-		},
-	});
+		const projectResult = await loadFilesFromDir<CustomTool>(ctx, projectToolsDir, PROVIDER_ID, "project", {
+			transform: (name, _content, path, source) => {
+				const toolName = name.replace(/\.(ts|js|sh|bash|py)$/, "");
+				return {
+					name: toolName,
+					path,
+					description: `${toolName} custom tool`,
+					level: "project",
+					_source: source,
+				};
+			},
+		});
 
-	items.push(...projectResult.items);
-	if (projectResult.warnings) warnings.push(...projectResult.warnings);
+		items.push(...projectResult.items);
+		if (projectResult.warnings) warnings.push(...projectResult.warnings);
+	}
 
 	return { items, warnings };
 }
@@ -487,20 +519,22 @@ async function loadSettings(ctx: LoadContext): Promise<LoadResult<Settings>> {
 		}
 	}
 
-	const projectBase = getProjectClaude(ctx);
-	const projectSettingsJson = path.join(projectBase, "settings.json");
-	const projectContent = await readFile(projectSettingsJson);
-	if (projectContent) {
-		const data = tryParseJson<Record<string, unknown>>(projectContent);
-		if (data) {
-			items.push({
-				path: projectSettingsJson,
-				data,
-				level: "project",
-				_source: createSourceMeta(PROVIDER_ID, projectSettingsJson, "project"),
-			});
-		} else {
-			warnings.push(`Failed to parse JSON in ${projectSettingsJson}`);
+	if (!(await shouldSkipProjectLevel(ctx))) {
+		const projectBase = getProjectClaude(ctx);
+		const projectSettingsJson = path.join(projectBase, "settings.json");
+		const projectContent = await readFile(projectSettingsJson);
+		if (projectContent) {
+			const data = tryParseJson<Record<string, unknown>>(projectContent);
+			if (data) {
+				items.push({
+					path: projectSettingsJson,
+					data,
+					level: "project",
+					_source: createSourceMeta(PROVIDER_ID, projectSettingsJson, "project"),
+				});
+			} else {
+				warnings.push(`Failed to parse JSON in ${projectSettingsJson}`);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -118,6 +118,25 @@ export function resolveCopilotHome(home: string): string {
 	return override ? override : path.join(home, ".copilot");
 }
 
+type UserAgentMd = { path: string; content: string };
+
+export async function getUserAgentMd(ctx: LoadContext): Promise<UserAgentMd | null> {
+	const variations = ["AGENT.md", "agent.md", "AGENT.MD", "Agent.md"];
+	for (const filename of variations) {
+		const agentMdPath = path.join(ctx.home, ".agent", filename);
+		const content = await readFile(agentMdPath);
+		if (content !== null) {
+			return { path: agentMdPath, content };
+		}
+	}
+
+	return null;
+}
+
+export async function shouldSuppressProjectAgentMds(ctx: LoadContext): Promise<boolean> {
+	return (await getUserAgentMd(ctx)) !== null;
+}
+
 /**
  * Create source metadata for an item.
  */

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -14,6 +14,7 @@ import { findConfigFile } from "./config";
 import type { Personality, SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { expandAtImports } from "./discovery/at-imports";
+import { shouldSuppressProjectAgentMds } from "./discovery/helpers";
 import { loadSkills, type Skill } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
@@ -505,6 +506,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const contextFilesPromise = providedContextFiles
 		? Promise.resolve(providedContextFiles)
 		: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });
+	const suppressProjectAgentMdsPromise = shouldSuppressProjectAgentMds({
+		cwd: resolvedCwd,
+		home: os.homedir(),
+		repoRoot: null,
+	});
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined
 			? Promise.resolve(providedWorkspaceTree)
@@ -518,30 +524,36 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				? loadSkills({ ...skillsSettings, cwd: resolvedCwd }).then(result => result.skills)
 				: Promise.resolve([]);
 
-	const [resolvedCustomPrompt, resolvedAppendPrompt, systemPromptCustomization, contextFiles, skills, workspaceTree] =
-		await Promise.all([
-			withDeadline(
-				"customPrompt",
-				resolvePromptInput(customPrompt, "system prompt"),
-				prepDefaults.resolvedCustomPrompt,
-			),
-			withDeadline(
-				"appendSystemPrompt",
-				resolvePromptInput(appendSystemPrompt, "append system prompt"),
-				prepDefaults.resolvedAppendPrompt,
-			),
-			withDeadline(
-				"loadSystemPromptFiles",
-				systemPromptCustomizationPromise,
-				prepDefaults.systemPromptCustomization,
-			),
-			withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles).then(
-				dedupeExactContextFiles,
-			),
-			withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
-			withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),
-		]);
-	const agentsMdFiles = Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
+	const [
+		resolvedCustomPrompt,
+		resolvedAppendPrompt,
+		systemPromptCustomization,
+		contextFiles,
+		skills,
+		workspaceTree,
+		suppressProjectAgentMds,
+	] = await Promise.all([
+		withDeadline(
+			"customPrompt",
+			resolvePromptInput(customPrompt, "system prompt"),
+			prepDefaults.resolvedCustomPrompt,
+		),
+		withDeadline(
+			"appendSystemPrompt",
+			resolvePromptInput(appendSystemPrompt, "append system prompt"),
+			prepDefaults.resolvedAppendPrompt,
+		),
+		withDeadline("loadSystemPromptFiles", systemPromptCustomizationPromise, prepDefaults.systemPromptCustomization),
+		withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles).then(
+			dedupeExactContextFiles,
+		),
+		withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
+		withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),
+		withDeadline("shouldSuppressProjectAgentMds", suppressProjectAgentMdsPromise, false),
+	]);
+	const agentsMdFiles = suppressProjectAgentMds
+		? []
+		: Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
 
 	if (timedOut.length > 0) {
 		logger.warn("System prompt preparation steps timed out; using minimal fallback for those steps", {

--- a/packages/coding-agent/test/discovery/context-file-dedup.test.ts
+++ b/packages/coding-agent/test/discovery/context-file-dedup.test.ts
@@ -13,12 +13,17 @@ function makeContextFile(overrides: Partial<ContextFile> & Pick<ContextFile, "pa
 describe("contextFileCapability.key", () => {
 	const key = contextFileCapability.key.bind(contextFileCapability);
 
-	test("user-level files share the same key regardless of depth", () => {
-		const a = makeContextFile({ path: "/home/user/.omp/agent/AGENTS.md", level: "user" });
-		const b = makeContextFile({ path: "/home/user/.claude/CLAUDE.md", level: "user" });
-		expect(key(a)).toBe("user");
-		expect(key(b)).toBe("user");
-		expect(key(a)).toBe(key(b));
+	test("user-level files are keyed by basename", () => {
+		const authority = makeContextFile({ path: "/home/user/.agent/AGENT.md", level: "user" });
+		const agents = makeContextFile({ path: "/home/user/.omp/agent/AGENTS.md", level: "user" });
+		const claude = makeContextFile({ path: "/home/user/.claude/CLAUDE.md", level: "user" });
+		const duplicateAgents = makeContextFile({ path: "/home/user/.agent/AGENTS.md", level: "user" });
+
+		expect(key(authority)).toBe("user:AGENT.md");
+		expect(key(agents)).toBe("user:AGENTS.md");
+		expect(key(claude)).toBe("user:CLAUDE.md");
+		expect(key(agents)).toBe(key(duplicateAgents));
+		expect(key(authority)).not.toBe(key(agents));
 	});
 
 	test("project-level files at the same depth share the same key", () => {

--- a/packages/coding-agent/test/discovery/project-agent-md-suppression.test.ts
+++ b/packages/coding-agent/test/discovery/project-agent-md-suppression.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ContextFile, contextFileCapability } from "@oh-my-pi/pi-coding-agent/capability/context-file";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+
+const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+describe("user agent authority suppresses project AGENTS.md sources", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(async () => {
+		clearCache();
+		resetSettingsForTest();
+		originalHome = process.env.HOME;
+		tempHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-authority-home-"));
+		process.env.HOME = tempHomeDir;
+		vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
+		setAgentDir(path.join(tempHomeDir, ".omp", "agent"));
+
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-authority-project-"));
+		await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
+		await fs.mkdir(path.join(tempHomeDir, ".agent"), { recursive: true });
+		await fs.mkdir(path.join(tempHomeDir, ".claude"), { recursive: true });
+		await fs.mkdir(path.join(tempDir, ".agent"), { recursive: true });
+		await fs.mkdir(path.join(tempDir, ".claude"), { recursive: true });
+		await fs.mkdir(path.join(tempDir, ".omp"), { recursive: true });
+		await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+
+		await Bun.write(path.join(tempHomeDir, ".agent", "AGENT.md"), "# User authority\n");
+		await Bun.write(path.join(tempHomeDir, ".claude", "CLAUDE.md"), "# User Claude\n");
+		await Bun.write(path.join(tempDir, "AGENTS.md"), "# Bare project AGENTS\n");
+		await Bun.write(path.join(tempDir, ".agent", "AGENTS.md"), "# Project .agent AGENTS\n");
+		await Bun.write(path.join(tempDir, ".claude", "CLAUDE.md"), "# Project Claude\n");
+		await Bun.write(path.join(tempDir, ".omp", "AGENTS.md"), "# Project .omp AGENTS\n");
+		await Bun.write(path.join(tempDir, "src", "AGENTS.md"), "# Project src AGENTS\n");
+
+		const settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		initializeWithSettings(settings);
+	});
+
+	afterEach(async () => {
+		clearCache();
+		resetSettingsForTest();
+		vi.restoreAllMocks();
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		if (originalAgentDirEnv) {
+			setAgentDir(originalAgentDirEnv);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		await fs.rm(tempHomeDir, { recursive: true, force: true });
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("runtime context loading excludes project behavioral context", async () => {
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+
+		const projectAgents = result.items.filter(
+			item => item.level === "project" && path.basename(item.path) === "AGENTS.md",
+		);
+		expect(projectAgents).toHaveLength(0);
+		expect(result.items.some(item => item.path === path.join(tempDir, ".claude", "CLAUDE.md"))).toBe(false);
+
+		const userAgent = result.items.find(item => item.level === "user" && path.basename(item.path) === "AGENT.md");
+		expect(userAgent?.path).toBe(path.join(tempHomeDir, ".agent", "AGENT.md"));
+		expect(result.items.some(item => item.path === path.join(tempHomeDir, ".claude", "CLAUDE.md"))).toBe(false);
+	});
+
+	test("authority file is re-evaluated after filesystem cache reset", async () => {
+		const authorityPath = path.join(tempHomeDir, ".agent", "AGENT.md");
+		await fs.rm(authorityPath);
+		clearCache();
+
+		let result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		expect(result.items.some(item => item.level === "project" && path.basename(item.path) === "AGENTS.md")).toBe(
+			true,
+		);
+
+		await Bun.write(authorityPath, "# User authority\n");
+		clearCache();
+
+		result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		expect(result.items.some(item => item.level === "project" && path.basename(item.path) === "AGENTS.md")).toBe(
+			false,
+		);
+		expect(result.items.some(item => item.path === authorityPath)).toBe(true);
+	});
+
+	test("buildSystemPrompt omits AGENTS.md dir-context path hints under user authority", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			workspaceTree: {
+				rootPath: tempDir,
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: ["src/AGENTS.md"],
+			},
+		});
+		const promptText = systemPrompt.join("\n\n");
+
+		expect(promptText).not.toContain("<dir-context>");
+		expect(promptText).not.toContain("src/AGENTS.md");
+	});
+});


### PR DESCRIPTION
## Summary
- add a `~/.agent/AGENT.md` authority detector and suppress project AGENTS.md / Claude project autoload when present
- load the authority file through standard context discovery and key user context files by basename so AGENT.md is not shadowed by AGENTS.md/CLAUDE.md
- suppress AGENTS.md dir-context path hints in the system prompt under user authority
- add discovery coverage for suppression, cache reset behavior, and updated user context deduping

## Why this helps
This gives users a simple "my rules come first; don't auto-load project behavior" switch via `~/.agent/AGENT.md`.

When that file exists, Oh My Pi treats it as the user's explicit personal authority file and stops auto-loading project-level behavioral files such as repo `AGENTS.md`, project `.agent/AGENTS.md`, project `.omp/AGENTS.md`, project `.claude/CLAUDE.md`, and user `~/.claude/CLAUDE.md`.

Benefits:
- protects personal preferences by making the user's own agent rules win cleanly
- reduces repo prompt-injection risk from project files that would otherwise be auto-loaded
- makes behavior more predictable by centering one user authority file across repos
- keeps prompts cleaner by suppressing ignored `AGENTS.md` path hints
- reduces conflicting behavioral context for multi-agent workflows

## Tests
- `bun test packages/coding-agent/test/discovery/`
- `bun --cwd=packages/coding-agent run check`