### PR TITLE
Add print-mode thinking output flag

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -56,6 +56,7 @@ export interface Args {
 	noExtensions?: boolean;
 	pluginDirs?: string[];
 	print?: boolean;
+	printThoughts?: boolean;
 	export?: string;
 	noSkills?: boolean;
 	skills?: string[];
@@ -200,6 +201,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.advisor = true;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
+		} else if (arg === "--print-thoughts") {
+			result.printThoughts = true;
 		} else if (arg === "--no-extensions") {
 			result.noExtensions = true;
 		} else if (arg === "--no-skills") {

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -270,6 +270,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--hide-thinking",
 	"--advisor",
 	"--print",
+	"--print-thoughts",
 	"--no-extensions",
 	"--no-skills",
 	"--no-rules",

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -136,6 +136,9 @@ export default class Index extends Command {
 		"no-title": Flags.boolean({
 			description: "Disable title auto-generation",
 		}),
+		"print-thoughts": Flags.boolean({
+			description: "Include thinking blocks in print mode text output",
+		}),
 		"max-time": Flags.string({
 			description: "Stop the session after this many seconds",
 		}),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1373,6 +1373,7 @@ export async function runRootCommand(
 				messages: initialArgs.messages,
 				initialMessage,
 				initialImages,
+				printThoughts: initialArgs.printThoughts,
 			});
 			if ($env.PI_TIMING) {
 				logger.printTimings();

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -24,6 +24,8 @@ export interface PrintModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
+	/** If true, include thinking blocks in text output */
+	printThoughts?: boolean;
 }
 
 /**
@@ -31,7 +33,7 @@ export interface PrintModeOptions {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
-	const { mode, messages = [], initialMessage, initialImages } = options;
+	const { mode, messages = [], initialMessage, initialImages, printThoughts } = options;
 
 	// Emit session header for JSON mode
 	if (mode === "json") {
@@ -108,6 +110,8 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			for (const content of assistantMsg.content) {
 				if (content.type === "text") {
 					process.stdout.write(`${sanitizeText(content.text)}\n`);
+				} else if (printThoughts && content.type === "thinking" && content.thinking.trim().length > 0) {
+					process.stdout.write(`${sanitizeText(content.thinking)}\n`);
 				}
 			}
 		}

--- a/packages/coding-agent/test/cli-print-thoughts-flag.test.ts
+++ b/packages/coding-agent/test/cli-print-thoughts-flag.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+
+describe("parseArgs — --print-thoughts flag", () => {
+	it("parses --print-thoughts as a boolean flag", () => {
+		const result = parseArgs(["--print-thoughts"]);
+		expect(result.printThoughts).toBe(true);
+	});
+
+	it("does not consume the next argument", () => {
+		const result = parseArgs(["--print", "--print-thoughts", "explain"]);
+		expect(result.print).toBe(true);
+		expect(result.printThoughts).toBe(true);
+		expect(result.messages).toEqual(["explain"]);
+	});
+});

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -48,15 +48,19 @@ function createMockSession(messages: AssistantMessage[]): AgentSession {
 describe("Print-mode silent-abort regression", () => {
 	let exitSpy: ReturnType<typeof vi.spyOn>;
 	let stderrOutput: string[];
+	let stdoutOutput: string[];
 
 	beforeEach(() => {
 		stderrOutput = [];
+		stdoutOutput = [];
 		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
 			stderrOutput.push(String(chunk));
 			return true;
 		});
 		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const chunk = args[0];
+			if (typeof chunk === "string") stdoutOutput.push(chunk);
 			// Invoke callback if present (runPrintMode flushes stdout before returning)
 			const last = args[args.length - 1];
 			if (typeof last === "function") last();
@@ -104,5 +108,23 @@ describe("Print-mode silent-abort regression", () => {
 		expect(stderrText).toContain("Rate limit exceeded");
 		// process.exit(1) SHOULD have been called
 		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("prints thinking blocks only when printThoughts is enabled", async () => {
+		const { runPrintMode } = await import("@oh-my-pi/pi-coding-agent/modes/print-mode");
+
+		const message = makeAssistantMessage({
+			content: [
+				{ type: "thinking", thinking: "inspect hidden branch" },
+				{ type: "text", text: "final answer" },
+			],
+		});
+
+		await runPrintMode(createMockSession([message]), { mode: "text" });
+		expect(stdoutOutput.join("")).toBe("final answer\n");
+
+		stdoutOutput = [];
+		await runPrintMode(createMockSession([message]), { mode: "text", printThoughts: true });
+		expect(stdoutOutput.join("")).toBe("inspect hidden branch\nfinal answer\n");
 	});
 });


### PR DESCRIPTION
## Summary
- add an opt-in `--print-thoughts` flag for single-shot print mode
- keep print mode hiding thinking blocks by default, but include sanitized thinking text when explicitly requested
- thread the flag through manual CLI parsing, oclif help, valueless-flag bootstrap handling, and `runPrintMode`
- add coverage for CLI parsing and print-mode output behavior

## Why this helps
This gives debugging/automation workflows a deliberate way to inspect reasoning summaries in non-interactive `--print` runs without changing the default clean final-answer output.

## Tests
- `bun test packages/coding-agent/test/cli-print-thoughts-flag.test.ts packages/coding-agent/test/silent-abort-print-mode.test.ts packages/coding-agent/test/flag-tables.test.ts`
- `bun --cwd=packages/coding-agent run check`