### PR TITLE
fix(tui): preserve plan approval actions when overlay is clamped

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bottom-anchored fullscreen overlays keeping their body rows but clipping off footer actions when terminal-height clamping is applied, restoring plan-mode approval options on short or stale-size terminals ([#2957](https://github.com/can1357/oh-my-pi/issues/2957)).
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2309,7 +2309,11 @@ export class TUI extends Container {
 			const { width, maxHeight } = this.#resolveOverlayLayout(options, 0, termWidth, termHeight);
 			let overlayLines = component.render(width);
 			if (overlayLines.length > maxHeight) {
-				overlayLines = overlayLines.slice(0, maxHeight);
+				const anchor = options?.anchor ?? "center";
+				overlayLines =
+					anchor === "bottom-left" || anchor === "bottom-center" || anchor === "bottom-right"
+						? overlayLines.slice(overlayLines.length - maxHeight)
+						: overlayLines.slice(0, maxHeight);
 			}
 			const { row, col } = this.#resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 			for (let i = 0; i < overlayLines.length; i++) {

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -202,6 +202,28 @@ describe("TUI overlays", () => {
 		tui.stop();
 	});
 
+	it("preserves bottom-anchored overlay actions when clamped", async () => {
+		const term = new VirtualTerminal(80, 5);
+		const tui = new TUI(term);
+
+		tui.addChild(new LineComponent("base-", 1));
+
+		try {
+			tui.start();
+			await flushRender(term);
+
+			tui.showOverlay(new LineComponent("ov-", 10), { anchor: "bottom-center", width: "100%", maxHeight: "100%" });
+			await flushRender(term);
+
+			const viewport = term.getViewport().join("\n");
+			expect(viewport).toContain("ov-5");
+			expect(viewport).toContain("ov-9");
+			expect(viewport).not.toContain("ov-0");
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("clears stale viewport content on launch", async () => {
 		const term = new VirtualTerminal(40, 4);
 		term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");


### PR DESCRIPTION
## Repro
Plan review can render more rows than the current fullscreen frame when the component sees a stale or missing terminal height. Reproduced with `bun --cwd=packages/coding-agent --eval "$REPRO"`, where a 40-row plan-review overlay cropped to 20 rows did not contain `Approve and execute`.

## Cause
`packages/tui/src/tui.ts` clamped oversized overlays with `overlayLines.slice(0, maxHeight)` regardless of anchor. `InteractiveMode.showPlanReview` opens `PlanReviewOverlay` as a bottom-centered fullscreen overlay, so height clamping kept the plan body rows and discarded the footer approval actions.

## Fix
- Crop bottom-anchored overlays from the top when max-height clamping applies, preserving the anchored footer rows.
- Add a TUI regression test that verifies bottom-centered overlays keep their tail rows when clamped.
- Add the TUI changelog entry for the plan-review approval display fix.

## Verification
`bun --cwd=packages/tui test test/overlay-scroll.test.ts` passed: 23 tests. `bun --cwd=packages/coding-agent test test/modes/components/plan-review-overlay.test.ts` passed: 26 tests. `bun --cwd=packages/tui run check` passed. Fixes #2957