### PR TITLE
feat(coding-agent): add Fortran support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "tree-sitter-elisp",
  "tree-sitter-elixir",
  "tree-sitter-erlang",
+ "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-graphql",
  "tree-sitter-haskell",
@@ -3538,6 +3539,16 @@ name = "tree-sitter-erlang"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceb442e728225d601db0661f60d64e166bd9b9a55c587f71d4e4f27378717cce"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-fortran"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5fea41363a9b59666001dc26c4b356d4e164da27c6ce31145e00aba6bf9b16"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ tree-sitter-dockerfile = { version = "0.2.0", package = "tree-sitter-dockerfile-
 tree-sitter-elixir = "0.3"
 tree-sitter-elisp = "1.6.1"
 tree-sitter-erlang = "0.16.0"
+tree-sitter-fortran = "0.6.0"
 tree-sitter-go = "0.25"
 tree-sitter-graphql = "0.1.0"
 tree-sitter-haskell = "0.23"

--- a/crates/pi-ast/Cargo.toml
+++ b/crates/pi-ast/Cargo.toml
@@ -31,6 +31,7 @@ tree-sitter-dockerfile.workspace = true
 tree-sitter-elixir.workspace = true
 tree-sitter-elisp.workspace = true
 tree-sitter-erlang.workspace = true
+tree-sitter-fortran.workspace = true
 tree-sitter-go.workspace = true
 tree-sitter-graphql.workspace = true
 tree-sitter-haskell.workspace = true

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -112,6 +112,7 @@ impl_lang_expando!(Css, language_css, '_');
 impl_lang_expando!(Dockerfile, language_dockerfile, 'µ');
 impl_lang_expando!(Elixir, language_elixir, 'µ');
 impl_lang_expando!(Erlang, language_erlang, 'µ');
+impl_lang_expando!(Fortran, language_fortran, 'µ');
 impl_lang_expando!(Go, language_go, 'µ');
 impl_lang!(Graphql, language_graphql);
 impl_lang_expando!(Haskell, language_haskell, 'µ');
@@ -282,6 +283,7 @@ pub enum SupportLang {
 	EmacsLisp,
 	Elixir,
 	Erlang,
+	Fortran,
 	Go,
 	Graphql,
 	Haskell,
@@ -338,7 +340,7 @@ impl SupportLang {
 		use SupportLang::*;
 		&[
 			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, EmacsLisp,
-			Elixir, Erlang, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia,
+			Elixir, Erlang, Fortran, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia,
 			Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python,
 			R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx,
 			TypeScript, Verilog, Vue, Xml, Yaml, Zig,
@@ -363,6 +365,7 @@ impl SupportLang {
 			Self::EmacsLisp => "emacs-lisp",
 			Self::Elixir => "elixir",
 			Self::Erlang => "erlang",
+			Self::Fortran => "fortran",
 			Self::Go => "go",
 			Self::Graphql => "graphql",
 			Self::Haskell => "haskell",
@@ -449,6 +452,7 @@ macro_rules! execute_lang_method {
 			S::EmacsLisp => EmacsLisp.$method($($pname,)*),
 			S::Elixir => Elixir.$method($($pname,)*),
 			S::Erlang => Erlang.$method($($pname,)*),
+			S::Fortran => Fortran.$method($($pname,)*),
 			S::Go => Go.$method($($pname,)*),
 			S::Graphql => Graphql.$method($($pname,)*),
 			S::Haskell => Haskell.$method($($pname,)*),
@@ -564,6 +568,7 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		EmacsLisp => &["el"],
 		Elixir => &["ex", "exs"],
 		Erlang => &["erl", "hrl"],
+		Fortran => &["f", "F", "for", "f77", "F77", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"],
 		Go => &["go"],
 		Graphql => &["graphql", "gql"],
 		Haskell => &["hs"],
@@ -711,6 +716,14 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "erlang"         => SupportLang::Erlang,
 "erl"            => SupportLang::Erlang,
 "hrl"            => SupportLang::Erlang,
+"fortran"        => SupportLang::Fortran,
+"f"              => SupportLang::Fortran,
+"for"            => SupportLang::Fortran,
+"f77"            => SupportLang::Fortran,
+"f90"            => SupportLang::Fortran,
+"f95"            => SupportLang::Fortran,
+"f03"            => SupportLang::Fortran,
+"f08"            => SupportLang::Fortran,
 "go"             => SupportLang::Go,
 "golang"         => SupportLang::Go,
 "graphql"        => SupportLang::Graphql,

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -340,10 +340,10 @@ impl SupportLang {
 		use SupportLang::*;
 		&[
 			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, EmacsLisp,
-			Elixir, Erlang, Fortran, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia,
-			Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python,
-			R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx,
-			TypeScript, Verilog, Vue, Xml, Yaml, Zig,
+			Elixir, Erlang, Fortran, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json,
+			Just, Julia, Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell,
+			Proto, Python, R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml,
+			Tlaplus, Tsx, TypeScript, Verilog, Vue, Xml, Yaml, Zig,
 		]
 	}
 
@@ -568,7 +568,9 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		EmacsLisp => &["el"],
 		Elixir => &["ex", "exs"],
 		Erlang => &["erl", "hrl"],
-		Fortran => &["f", "F", "for", "f77", "F77", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"],
+		Fortran => {
+			&["f", "F", "for", "f77", "F77", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"]
+		},
 		Go => &["go"],
 		Graphql => &["graphql", "gql"],
 		Haskell => &["hs"],

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -112,7 +112,6 @@ impl_lang_expando!(Css, language_css, '_');
 impl_lang_expando!(Dockerfile, language_dockerfile, 'µ');
 impl_lang_expando!(Elixir, language_elixir, 'µ');
 impl_lang_expando!(Erlang, language_erlang, 'µ');
-impl_lang_expando!(Fortran, language_fortran, 'µ');
 impl_lang_expando!(Go, language_go, 'µ');
 impl_lang!(Graphql, language_graphql);
 impl_lang_expando!(Haskell, language_haskell, 'µ');
@@ -168,6 +167,7 @@ impl_lang!(Xml, language_xml);
 impl_lang!(Regex, language_regex);
 impl_lang!(Dart, language_dart);
 impl_lang!(EmacsLisp, language_elisp);
+impl_lang!(Fortran, language_fortran);
 
 // ── Html (custom implementation with injection support) ──────────────────
 

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -568,9 +568,7 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		EmacsLisp => &["el"],
 		Elixir => &["ex", "exs"],
 		Erlang => &["erl", "hrl"],
-		Fortran => {
-			&["f", "F", "for", "f77", "F77", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"]
-		},
+		Fortran => &["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"],
 		Go => &["go"],
 		Graphql => &["graphql", "gql"],
 		Haskell => &["hs"],
@@ -719,9 +717,6 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "erl"            => SupportLang::Erlang,
 "hrl"            => SupportLang::Erlang,
 "fortran"        => SupportLang::Fortran,
-"f"              => SupportLang::Fortran,
-"for"            => SupportLang::Fortran,
-"f77"            => SupportLang::Fortran,
 "f90"            => SupportLang::Fortran,
 "f95"            => SupportLang::Fortran,
 "f03"            => SupportLang::Fortran,

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -112,6 +112,7 @@ impl_lang_expando!(Css, language_css, '_');
 impl_lang_expando!(Dockerfile, language_dockerfile, 'µ');
 impl_lang_expando!(Elixir, language_elixir, 'µ');
 impl_lang_expando!(Erlang, language_erlang, 'µ');
+impl_lang_expando!(Fortran, language_fortran, '𐀀');
 impl_lang_expando!(Go, language_go, 'µ');
 impl_lang!(Graphql, language_graphql);
 impl_lang_expando!(Haskell, language_haskell, 'µ');
@@ -167,7 +168,6 @@ impl_lang!(Xml, language_xml);
 impl_lang!(Regex, language_regex);
 impl_lang!(Dart, language_dart);
 impl_lang!(EmacsLisp, language_elisp);
-impl_lang!(Fortran, language_fortran);
 
 // ── Html (custom implementation with injection support) ──────────────────
 

--- a/crates/pi-ast/src/language/parsers.rs
+++ b/crates/pi-ast/src/language/parsers.rs
@@ -44,6 +44,9 @@ pub fn language_elisp() -> TSLanguage {
 pub fn language_erlang() -> TSLanguage {
 	tree_sitter_erlang::LANGUAGE.into()
 }
+pub fn language_fortran() -> TSLanguage {
+	tree_sitter_fortran::LANGUAGE.into()
+}
 pub fn language_go() -> TSLanguage {
 	tree_sitter_go::LANGUAGE.into()
 }

--- a/crates/pi-ast/src/summary.rs
+++ b/crates/pi-ast/src/summary.rs
@@ -401,6 +401,7 @@ fn is_comment_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Rust => kind == "block_comment",
 		SupportLang::Python => kind == "comment",
 		SupportLang::Go => kind == "comment",
+		SupportLang::Fortran => kind == "comment",
 		SupportLang::Java => kind == "block_comment",
 		SupportLang::C | SupportLang::Cpp | SupportLang::ObjC => kind == "comment",
 		SupportLang::CSharp => kind == "comment",
@@ -732,6 +733,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Cmake => matches!(kind, "argument_list" | "body"),
 		SupportLang::Make => kind == "recipe",
 		SupportLang::Just => kind == "recipe_body",
+		SupportLang::Fortran => false,
 		// Skip: data formats with no closing-token anchor (Yaml mappings,
 		// Toml tables, Ini sections), the diff format whose informational
 		// content IS the lines inside hunks, and the leaf-token-only Regex
@@ -768,6 +770,7 @@ fn is_groupable_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Julia => matches!(kind, "import_statement" | "using_statement"),
 		SupportLang::Proto => kind == "import",
 		SupportLang::Perl => kind == "use_statement",
+		SupportLang::Fortran => kind == "use_statement",
 		// Languages where imports either have no run pattern, are wrapped in a
 		// single AST node already covered by `is_elidable_kind` (Kotlin's
 		// `import_list`, Haskell's `imports`), or live inside a too-generic

--- a/crates/pi-ast/src/summary.rs
+++ b/crates/pi-ast/src/summary.rs
@@ -988,6 +988,19 @@ mod tests {
 	}
 
 	#[test]
+	fn summarizes_fortran_program() {
+		let result = summarize(
+			"program hello\n  print *, 'hi'\nend program hello\n",
+			"fixture.f90",
+		);
+
+		assert!(result.parsed);
+		assert_eq!(result.language.as_deref(), Some("fortran"));
+		assert!(!result.segments.is_empty());
+	}
+
+
+	#[test]
 	fn summarizes_emacs_lisp_defun_body() {
 		let code = "(defun greet (name)\n  \"Doc.\"\n  (let ((message (format \"Hello %s\" \
 		            name)))\n    (message \"%s\" message)\n    message)\n)\n";

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -1178,6 +1178,7 @@ mod tests {
 		assert_eq!(resolve_supported_lang("emacs-lisp").ok(), Some(SupportLang::EmacsLisp));
 		assert_eq!(resolve_supported_lang("elisp").ok(), Some(SupportLang::EmacsLisp));
 		assert_eq!(resolve_supported_lang("el").ok(), Some(SupportLang::EmacsLisp));
+		assert_eq!(resolve_supported_lang("f90").ok(), Some(SupportLang::Fortran));
 		assert!(resolve_supported_lang("brainfuck").is_err());
 	}
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Fortran support to the AST tooling, including file/alias resolution.
+
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Changelog
 
 ## [Unreleased]
-### Added
-
-- Added Fortran support to the AST tooling, including file/alias resolution.
-
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Fortran support to the AST tooling, including file/alias resolution.
+
 ## [16.0.6] - 2026-06-18
 
 ### Removed


### PR DESCRIPTION
## What

Add Fortran support to `pi-ast` and `pi-natives`.

## Why

The harness previously lacked Fortran parsing and language resolution support, so files like `*.f`, `*.f90`, and related aliases could not be handled correctly.

## Testing

- `cargo test -p pi-ast --lib`                                                                                                                 
- `cargo test -p pi-natives resolves_supported_language_aliases -- --exact`

---

- [x] `bun check` passes                                                                                                                       
- [x] Tested locally                                                                                                                           
- [x] CHANGELOG updated (if user-facing)