### PR TITLE
feat(coding-agent): add autonomous next-step and publish flags

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -107,6 +107,9 @@
 
 - Fixed `/model` in the TUI to open the model setup picker again, leaving `/switch` as the temporary session model switcher ([#2933](https://github.com/can1357/oh-my-pi/issues/2933)).
 - Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
+### Added
+
+- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The loop halts on a user interrupt (Esc) or a failed turn and re-arms on the next clean turn; it is armed only in interactive mode (disabled for `--print`/rpc/acp).
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,8 @@
 ### Removed
 
 - Removed `display.tabWidth` setting and configurable tab width support
+- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The controller arms only after startup prompts drain and is restricted to interactive mode (disabled for `--print`/rpc/acp). It halts on a user interrupt (Esc) or a failed turn, leaves plan/goal mode to their own drivers, and `--auto-next-steps` (alone) also stops once an autonomous turn performs no further action (objective complete); idea/combined run until interrupted.
+- Added `--auto-commit` and `--auto-pr` launch flags for autonomous operation. They extend the hidden auto-next prompt so completed, verified work is committed through the existing commit workflow and published through the GitHub pull-request path before the agent continues.
 
 ## [16.0.10] - 2026-06-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -109,7 +109,7 @@
 - Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
 ### Added
 
-- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The loop halts on a user interrupt (Esc) or a failed turn and re-arms on the next clean turn; it is armed only in interactive mode (disabled for `--print`/rpc/acp).
+- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The controller arms only after startup prompts drain and is restricted to interactive mode (disabled for `--print`/rpc/acp). It halts on a user interrupt (Esc) or a failed turn, leaves plan/goal mode to their own drivers, and `--auto-next-steps` (alone) also stops once an autonomous turn performs no further action (objective complete); idea/combined run until interrupted.
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely.
+- Added `--auto-commit`, `--auto-pr`, `--auto-group-pr`, and `--auto-agents <N>` launch flags for autonomous operation. Pull-request modes override commit-only publishing, `--auto-group-pr` keeps autonomous changes under one shared PR, and `--auto-agents` tells autonomous turns how many IRC-enabled subagents to use.
+
+### Fixed
+
+- Fixed `--auto-next-*` autonomous continuation queueing so it preserves user follow-up ordering, carries pending next-turn context, runs pre-prompt compaction before hidden turns, and respects goal-mode exit cleanup.
+
 ## [16.0.11] - 2026-06-19
 
 ### Added
@@ -36,12 +45,6 @@
 ### Removed
 
 - Removed `display.tabWidth` setting and configurable tab width support
-- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The controller arms only after startup prompts drain and is restricted to interactive mode (disabled for `--print`/rpc/acp). It halts on a user interrupt (Esc) or a failed turn, leaves plan/goal mode to their own drivers, and `--auto-next-steps` (alone) also stops once an autonomous turn performs no further action (objective complete); idea/combined run until interrupted.
-- Added `--auto-commit` and `--auto-pr` launch flags for autonomous operation. They extend the hidden auto-next prompt so completed, verified work is committed through the existing commit workflow and published through the GitHub pull-request path before the agent continues.
-
-### Fixed
-
-- Fixed `--auto-next-*` autonomous continuation reordering itself ahead of a stranded user follow-up. When a user follow-up lands in the queue after the agent loop final queue poll, `#endInFlight` flushes `agent_end` (which fires the autonomous continuation) before the stranded-queue drain runs. `sendCustomMessage` with `deliverAs: "followUp"` and `triggerTurn` on an idle session with queued messages now queues behind them instead of starting a turn immediately, preserving user to autonomous ordering.
 
 ## [16.0.10] - 2026-06-18
 
@@ -113,9 +116,6 @@
 
 - Fixed `/model` in the TUI to open the model setup picker again, leaving `/switch` as the temporary session model switcher ([#2933](https://github.com/can1357/oh-my-pi/issues/2933)).
 - Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
-### Added
-
-- Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The controller arms only after startup prompts drain and is restricted to interactive mode (disabled for `--print`/rpc/acp). It halts on a user interrupt (Esc) or a failed turn, leaves plan/goal mode to their own drivers, and `--auto-next-steps` (alone) also stops once an autonomous turn performs no further action (objective complete); idea/combined run until interrupted.
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Added `--auto-next-steps` and `--auto-next-idea` CLI flags for autonomous operation. After each completed turn the agent automatically queues a follow-up so it keeps working without user input: `--auto-next-steps` continues the current objective (including running tests), `--auto-next-idea` brainstorms and implements a new improvement, and both together cycle indefinitely. The controller arms only after startup prompts drain and is restricted to interactive mode (disabled for `--print`/rpc/acp). It halts on a user interrupt (Esc) or a failed turn, leaves plan/goal mode to their own drivers, and `--auto-next-steps` (alone) also stops once an autonomous turn performs no further action (objective complete); idea/combined run until interrupted.
 - Added `--auto-commit` and `--auto-pr` launch flags for autonomous operation. They extend the hidden auto-next prompt so completed, verified work is committed through the existing commit workflow and published through the GitHub pull-request path before the agent continues.
 
+### Fixed
+
+- Fixed `--auto-next-*` autonomous continuation reordering itself ahead of a stranded user follow-up. When a user follow-up lands in the queue after the agent loop final queue poll, `#endInFlight` flushes `agent_end` (which fires the autonomous continuation) before the stranded-queue drain runs. `sendCustomMessage` with `deliverAs: "followUp"` and `triggerTurn` on an idle session with queued messages now queues behind them instead of starting a turn immediately, preserving user to autonomous ordering.
+
 ## [16.0.10] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -376,15 +376,15 @@ describe("AutonomousController loop", () => {
 });
 
 describe("AutonomousController steps completion", () => {
-	it("disarms when an autonomous turn performs no action (objective done)", () => {
+	it("skips immediate requeue when an autonomous turn performs no action", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
 		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queues; next turn is autonomous
 		expect(sent).toHaveLength(1);
-		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // autonomous turn, no action -> halt
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // autonomous turn, no action -> halt current objective
 		expect(sent).toHaveLength(1);
-		emit(agentEndEvent([assistantActing("stop")])); // disarmed: no further queue
-		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([assistantActing("stop")])); // later manual objective: controller remains armed
+		expect(sent).toHaveLength(2);
 	});
 
 	it("keeps the autonomous marker when a continuation is queued behind another turn", () => {

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -4,14 +4,25 @@ import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { AutonomousController, type AutonomousSession } from "../controller";
 
-/** Build an `agent_end` event carrying the given assistant tail. */
+/** Build an `agent_end` event carrying the given turn messages. */
 function agentEndEvent(messages: AgentMessage[]): AgentSessionEvent {
 	return { type: "agent_end", messages };
 }
 
-/** Minimal assistant tail — only `role`/`stopReason` are read by the controller. */
+const START: AgentSessionEvent = { type: "agent_start" };
+
+/** A prose-only assistant tail (no actions). Only `role`/`stopReason`/content are read. */
 function assistant(stopReason: AssistantMessage["stopReason"]): AssistantMessage {
-	return { role: "assistant", stopReason } as AssistantMessage;
+	return { role: "assistant", stopReason, content: [{ type: "text", text: "done" }] } as AssistantMessage;
+}
+
+/** An assistant turn that called a tool (signals tool activity to the controller). */
+function assistantActing(stopReason: AssistantMessage["stopReason"]): AssistantMessage {
+	return {
+		role: "assistant",
+		stopReason,
+		content: [{ type: "toolCall", id: "t1", name: "edit", arguments: {} }],
+	} as AssistantMessage;
 }
 
 interface FakeOptions {
@@ -24,7 +35,7 @@ interface FakeOptions {
 function setup(options: FakeOptions) {
 	let streaming = false;
 	let planEnabled = options.planMode ?? false;
-	const goalEnabled = options.goalMode ?? false;
+	let goalEnabled = options.goalMode ?? false;
 	let handler: ((event: AgentSessionEvent) => void) | undefined;
 	const sent: Array<{ content: string; triggerTurn?: boolean; deliverAs?: string }> = [];
 	const session: AutonomousSession = {
@@ -60,13 +71,75 @@ function setup(options: FakeOptions) {
 		setPlanMode: (value: boolean) => {
 			planEnabled = value;
 		},
+		setGoalMode: (value: boolean) => {
+			goalEnabled = value;
+		},
 	};
 }
 
-describe("AutonomousController", () => {
-	it("queues a continuation after a normally-completed turn", () => {
-		const { emit, sent } = setup({ autoNextSteps: true });
-		emit(agentEndEvent([assistant("stop")]));
+describe("AutonomousController arming", () => {
+	it("ignores agent_end until begin() arms it", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistantActing("stop")]));
+		expect(sent).toHaveLength(0);
+		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		expect(sent).toHaveLength(1);
+	});
+
+	it("idea/combined self-starts with no message", () => {
+		const idea = setup({ autoNextIdea: true });
+		idea.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		expect(idea.sent).toHaveLength(1);
+		expect(idea.sent[0]!.content).toContain("ideation mode");
+	});
+
+	it("steps-only with no message and no resume idles (nothing to continue)", () => {
+		const steps = setup({ autoNextSteps: true });
+		steps.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		expect(steps.sent).toHaveLength(0);
+	});
+
+	it("steps-only self-starts on resume (transcript already holds an objective)", () => {
+		const steps = setup({ autoNextSteps: true });
+		steps.controller.begin({ hadInitialMessage: false, resuming: true, startupFailed: false });
+		expect(steps.sent).toHaveLength(1);
+	});
+
+	it("begin() honors a failed/aborted startup turn instead of re-queueing", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistant("aborted")])); // suppressed (not armed), but recorded
+		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		expect(sent).toHaveLength(0);
+	});
+
+	it("begin() honors a startup prompt that threw without an agent_end (startupFailed)", () => {
+		const { controller, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: true });
+		expect(sent).toHaveLength(0);
+	});
+
+	it("begin() leaves plan/goal mode to its own driver", () => {
+		const plan = setup({ autoNextIdea: true, planMode: true });
+		plan.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		expect(plan.sent).toHaveLength(0);
+	});
+
+	it("begin() skips when the suppressed startup turn started in goal mode (exit-cleanup race)", () => {
+		const { controller, emit, sent, setGoalMode } = setup({ autoNextSteps: true });
+		setGoalMode(true);
+		emit(START); // startup turn began in goal mode
+		setGoalMode(false); // goal completed mid-turn; live flag clears before agent_end
+		emit(agentEndEvent([assistantActing("stop")])); // suppressed (not armed)
+		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		expect(sent).toHaveLength(0);
+	});
+});
+
+describe("AutonomousController loop", () => {
+	it("queues a continuation after a working turn", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // arm, no queue
+		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(1);
 		expect(sent[0]!.triggerTurn).toBe(true);
 		expect(sent[0]!.deliverAs).toBe("followUp");
@@ -74,71 +147,105 @@ describe("AutonomousController", () => {
 	});
 
 	it("does not re-queue after an interrupted (aborted) turn", () => {
-		const { emit, sent } = setup({ autoNextSteps: true });
-		emit(agentEndEvent([assistant("aborted")]));
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("aborted")]));
 		expect(sent).toHaveLength(0);
-	});
-
-	it("re-arms on the next normal stop after an interrupt", () => {
-		const { emit, sent } = setup({ autoNextSteps: true });
-		emit(agentEndEvent([assistant("aborted")]));
-		expect(sent).toHaveLength(0);
-		emit(agentEndEvent([assistant("stop")]));
-		expect(sent).toHaveLength(1);
 	});
 
 	it("does not re-queue after a failed (error) turn", () => {
-		const { emit, sent } = setup({ autoNextSteps: true });
-		emit(agentEndEvent([assistant("error")]));
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("error")]));
 		expect(sent).toHaveLength(0);
 	});
 
 	it("does not re-queue while a new turn is already streaming", () => {
-		const { emit, sent, setStreaming } = setup({ autoNextSteps: true });
+		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		setStreaming(true);
-		emit(agentEndEvent([assistant("stop")]));
+		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
 	});
 
-	it("leaves plan mode to its own continuation driver", () => {
-		const { emit, sent } = setup({ autoNextSteps: true, planMode: true });
-		emit(agentEndEvent([assistant("stop")]));
+	it("skips a turn that started in goal mode (avoids the exit-cleanup race)", () => {
+		const { controller, emit, sent, setGoalMode } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		setGoalMode(true);
+		emit(START); // latch start-of-turn goal state
+		setGoalMode(false); // goal completed mid-turn, live flag clears before agent_end
+		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
+		// A subsequent normal turn resumes the loop.
+		emit(START);
+		emit(agentEndEvent([assistantActing("stop")]));
+		expect(sent).toHaveLength(1);
 	});
 
-	it("leaves goal mode to its own continuation driver", () => {
-		const { emit, sent } = setup({ autoNextSteps: true, goalMode: true });
-		emit(agentEndEvent([assistant("stop")]));
+	it("skips a turn that started in plan mode", () => {
+		const { controller, emit, sent, setPlanMode } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		setPlanMode(true);
+		emit(START);
+		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
+	});
+});
+
+describe("AutonomousController steps completion", () => {
+	it("disarms when an autonomous turn performs no action (objective done)", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("stop")])); // queues; next turn is autonomous
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([assistant("stop")])); // autonomous turn, no action -> halt
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([assistantActing("stop")])); // disarmed: no further queue
+		expect(sent).toHaveLength(1);
+	});
+
+	it("a superseded agent_end while streaming does not consume the autonomous marker", () => {
+		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("stop")])); // queue -> next turn is autonomous + streaming
+		expect(sent).toHaveLength(1);
+		setStreaming(true);
+		emit(agentEndEvent([assistantActing("stop")])); // stale agent_end while streaming
+		expect(sent).toHaveLength(1);
+		setStreaming(false);
+		// The real autonomous agent_end must still be classified autonomous and halt.
+		emit(agentEndEvent([assistant("stop")])); // no action -> halt (would queue if the stale event cleared the marker)
+		expect(sent).toHaveLength(1);
+	});
+
+	it("a user turn with no action does NOT halt the loop", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistant("stop")])); // non-autonomous turn (nothing queued yet)
+		expect(sent).toHaveLength(1);
+	});
+
+	it("an aborted autonomous turn does not misclassify the next manual turn", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("stop")])); // queue (turn becomes autonomous)
+		emit(agentEndEvent([assistant("aborted")])); // autonomous turn aborted -> must reset latch
+		emit(agentEndEvent([assistant("stop")])); // manual turn, no action -> must NOT halt
+		expect(sent).toHaveLength(2);
+	});
+
+	it("idea mode never halts on an action-free turn (endless by design)", () => {
+		const { controller, emit, sent } = setup({ autoNextIdea: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // queues first
+		emit(agentEndEvent([assistant("stop")])); // autonomous, no action -> still continues
+		expect(sent).toHaveLength(2);
 	});
 
 	it("uses the combined prompt when both flags are set", () => {
-		const { emit, sent } = setup({ autoNextSteps: true, autoNextIdea: true });
-		emit(agentEndEvent([assistant("stop")]));
+		const { controller, emit, sent } = setup({ autoNextSteps: true, autoNextIdea: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		expect(sent[0]!.content).toContain("fully autonomous");
-	});
-
-	it("uses the ideation prompt when only --auto-next-idea is set", () => {
-		const { emit, sent } = setup({ autoNextIdea: true });
-		emit(agentEndEvent([assistant("stop")]));
-		expect(sent[0]!.content).toContain("ideation mode");
-	});
-
-	it("kickoff starts a first turn in idea/combined mode but not steps-only", () => {
-		const idea = setup({ autoNextIdea: true });
-		idea.controller.kickoff();
-		expect(idea.sent).toHaveLength(1);
-		expect(idea.sent[0]!.content).toContain("ideation mode");
-
-		const steps = setup({ autoNextSteps: true });
-		steps.controller.kickoff();
-		expect(steps.sent).toHaveLength(0);
-	});
-
-	it("kickoff is a no-op once a turn is already streaming", () => {
-		const { controller, sent, setStreaming } = setup({ autoNextIdea: true });
-		setStreaming(true);
-		controller.kickoff();
-		expect(sent).toHaveLength(0);
+		emit(agentEndEvent([assistant("stop")])); // combined never halts
+		expect(sent).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -64,6 +64,8 @@ interface FakeOptions {
 	autoNextIdea?: boolean;
 	autoCommit?: boolean;
 	autoPr?: boolean;
+	autoGroupPr?: boolean;
+	autoAgents?: number;
 	planMode?: boolean;
 	goalMode?: boolean;
 	history?: AgentMessage[];
@@ -119,6 +121,8 @@ function setup(options: FakeOptions) {
 		autoNextIdea: options.autoNextIdea ?? false,
 		autoCommit: options.autoCommit ?? false,
 		autoPr: options.autoPr ?? false,
+		autoGroupPr: options.autoGroupPr ?? false,
+		autoAgents: options.autoAgents,
 	});
 	return {
 		sent,
@@ -319,6 +323,16 @@ describe("AutonomousController loop", () => {
 		expect(sent).toHaveLength(1);
 	});
 
+	it("skips a turn that started while goal mode was exiting", () => {
+		const { controller, emit, sent, setGoalModeState } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false });
+		setGoalModeState({ enabled: false, mode: "exiting" });
+		emit(START); // latch exiting goal cleanup as mode-owned
+		setGoalModeState(undefined); // cleanup clears before agent_end
+		emit(agentEndEvent([assistantActing("stop")]));
+		expect(sent).toHaveLength(0);
+	});
+
 	it("skips a turn that started in plan mode", () => {
 		const { controller, emit, sent, setPlanMode } = setup({ autoNextSteps: true });
 		controller.begin({ startupFailed: false });
@@ -473,7 +487,20 @@ describe("AutonomousController steps completion", () => {
 		expect(sent).toHaveLength(2);
 	});
 
-	it("adds auto-commit and auto-pr instructions to the continuation prompt", () => {
+	it("adds auto-commit instructions when no PR publishing mode is active", () => {
+		const { controller, sent } = setup({
+			autoNextSteps: true,
+			autoCommit: true,
+			history: [assistant("stop")],
+		});
+		controller.begin({ startupFailed: false });
+		expect(sent[0]!.content).toContain("continuation mode");
+		expect(sent[0]!.content).toContain("--auto-commit is enabled");
+		expect(sent[0]!.content).toContain("existing commit workflow");
+		expect(sent[0]!.content).not.toContain("--auto-pr is enabled");
+	});
+
+	it("auto-pr overrides auto-commit so combined flags always publish through a PR", () => {
 		const { controller, sent } = setup({
 			autoNextSteps: true,
 			autoCommit: true,
@@ -481,11 +508,35 @@ describe("AutonomousController steps completion", () => {
 			history: [assistant("stop")],
 		});
 		controller.begin({ startupFailed: false });
-		expect(sent[0]!.content).toContain("continuation mode");
-		expect(sent[0]!.content).toContain("--auto-commit is enabled");
-		expect(sent[0]!.content).toContain("existing commit workflow");
 		expect(sent[0]!.content).toContain("--auto-pr is enabled");
-		expect(sent[0]!.content).toContain("`github` tool `pr_create`");
+		expect(sent[0]!.content).toContain("pull-request branch");
+		expect(sent[0]!.content).toContain("NEVER treat a local commit alone as complete");
+		expect(sent[0]!.content).not.toContain("--auto-commit is enabled");
+	});
+
+	it("auto-group-pr overrides auto-pr and uses one shared pull request", () => {
+		const { controller, sent } = setup({
+			autoNextSteps: true,
+			autoPr: true,
+			autoGroupPr: true,
+			history: [assistant("stop")],
+		});
+		controller.begin({ startupFailed: false });
+		expect(sent[0]!.content).toContain("--auto-group-pr is enabled");
+		expect(sent[0]!.content).toContain("one shared pull request");
+		expect(sent[0]!.content).toContain("overrides `--auto-pr`");
+		expect(sent[0]!.content).not.toContain("--auto-pr is enabled");
+	});
+
+	it("adds auto-agents instructions with the configured subagent count", () => {
+		const { controller, sent } = setup({
+			autoNextSteps: true,
+			autoAgents: 3,
+			history: [assistant("stop")],
+		});
+		controller.begin({ startupFailed: false });
+		expect(sent[0]!.content).toContain("--auto-agents is enabled with 3 subagent");
+		expect(sent[0]!.content).toContain("Coordinate through the irc tool");
 	});
 
 	it("drops queued autonomous continuation when plan mode enters", () => {
@@ -528,7 +579,16 @@ describe("AutonomousController steps completion", () => {
 
 		// GoalRuntime emits goal_updated with state.enabled before setGoalModeState runs.
 		// The controller's goal_updated handler drops the queued continuation and clears the marker.
-		emit({ type: "goal_updated", goal: null, state: { enabled: true } });
+		const goal = {
+			id: "goal-1",
+			objective: "finish",
+			status: "active" as const,
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: 0,
+			updatedAt: 0,
+		};
+		emit({ type: "goal_updated", goal, state: { enabled: true, mode: "active", goal } });
 
 		// A subsequent clean turn should resume the loop (marker was cleared, not stuck).
 		emit(agentEndEvent([assistantActing("stop")]));

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -36,6 +36,8 @@ function setup(options: FakeOptions) {
 	let streaming = false;
 	let planEnabled = options.planMode ?? false;
 	let goalEnabled = options.goalMode ?? false;
+	const history = options.history ?? [];
+	let queueFollowUps = false;
 	let handler: ((event: AgentSessionEvent) => void) | undefined;
 	const sent: Array<{ content: string; triggerTurn?: boolean; deliverAs?: string }> = [];
 	const session: AutonomousSession = {
@@ -53,7 +55,7 @@ function setup(options: FakeOptions) {
 		sendCustomMessage: async (message, opts) => {
 			const content = typeof message.content === "string" ? message.content : "";
 			sent.push({ content, triggerTurn: opts?.triggerTurn, deliverAs: opts?.deliverAs });
-			return true;
+			return !queueFollowUps;
 		},
 	};
 	const controller = new AutonomousController({
@@ -73,6 +75,9 @@ function setup(options: FakeOptions) {
 		},
 		setGoalMode: (value: boolean) => {
 			goalEnabled = value;
+		},
+		setQueueFollowUps: (value: boolean) => {
+			queueFollowUps = value;
 		},
 	};
 }
@@ -222,6 +227,19 @@ describe("AutonomousController steps completion", () => {
 		emit(agentEndEvent([assistant("stop")])); // autonomous turn, no action -> halt
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([assistantActing("stop")])); // disarmed: no further queue
+		expect(sent).toHaveLength(1);
+	});
+
+	it("keeps the autonomous marker when a continuation is queued behind another turn", () => {
+		const { controller, emit, sent, setQueueFollowUps } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false }); // arm
+		setQueueFollowUps(true); // sendCustomMessage resolves false (queued, e.g. behind autolearn's capture turn)
+		emit(agentEndEvent([assistantActing("stop")])); // working turn -> queue, marker preserved
+		expect(sent).toHaveLength(1);
+		setQueueFollowUps(false);
+		// The queued follow-up eventually runs; its no-action agent_end must still be
+		// classified autonomous and halt (would re-queue to 2 if !started cleared the marker).
+		emit(agentEndEvent([assistant("stop")]));
 		expect(sent).toHaveLength(1);
 	});
 

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AgentSessionEvent } from "../../session/agent-session";
+import { AutonomousController, type AutonomousSession } from "../controller";
+
+/** Build an `agent_end` event carrying the given assistant tail. */
+function agentEndEvent(messages: AgentMessage[]): AgentSessionEvent {
+	return { type: "agent_end", messages };
+}
+
+/** Minimal assistant tail — only `role`/`stopReason` are read by the controller. */
+function assistant(stopReason: AssistantMessage["stopReason"]): AssistantMessage {
+	return { role: "assistant", stopReason } as AssistantMessage;
+}
+
+interface FakeOptions {
+	autoNextSteps?: boolean;
+	autoNextIdea?: boolean;
+	planMode?: boolean;
+	goalMode?: boolean;
+}
+
+function setup(options: FakeOptions) {
+	let streaming = false;
+	let planEnabled = options.planMode ?? false;
+	const goalEnabled = options.goalMode ?? false;
+	let handler: ((event: AgentSessionEvent) => void) | undefined;
+	const sent: Array<{ content: string; triggerTurn?: boolean; deliverAs?: string }> = [];
+	const session: AutonomousSession = {
+		subscribe: h => {
+			handler = h;
+			return () => {
+				handler = undefined;
+			};
+		},
+		get isStreaming() {
+			return streaming;
+		},
+		getPlanModeState: () => ({ enabled: planEnabled }),
+		getGoalModeState: () => ({ enabled: goalEnabled }),
+		sendCustomMessage: async (message, opts) => {
+			const content = typeof message.content === "string" ? message.content : "";
+			sent.push({ content, triggerTurn: opts?.triggerTurn, deliverAs: opts?.deliverAs });
+			return true;
+		},
+	};
+	const controller = new AutonomousController({
+		session,
+		autoNextSteps: options.autoNextSteps ?? false,
+		autoNextIdea: options.autoNextIdea ?? false,
+	});
+	return {
+		sent,
+		controller,
+		emit: (event: AgentSessionEvent) => handler?.(event),
+		setStreaming: (value: boolean) => {
+			streaming = value;
+		},
+		setPlanMode: (value: boolean) => {
+			planEnabled = value;
+		},
+	};
+}
+
+describe("AutonomousController", () => {
+	it("queues a continuation after a normally-completed turn", () => {
+		const { emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(1);
+		expect(sent[0]!.triggerTurn).toBe(true);
+		expect(sent[0]!.deliverAs).toBe("followUp");
+		expect(sent[0]!.content).toContain("continuation mode");
+	});
+
+	it("does not re-queue after an interrupted (aborted) turn", () => {
+		const { emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistant("aborted")]));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("re-arms on the next normal stop after an interrupt", () => {
+		const { emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistant("aborted")]));
+		expect(sent).toHaveLength(0);
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(1);
+	});
+
+	it("does not re-queue after a failed (error) turn", () => {
+		const { emit, sent } = setup({ autoNextSteps: true });
+		emit(agentEndEvent([assistant("error")]));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("does not re-queue while a new turn is already streaming", () => {
+		const { emit, sent, setStreaming } = setup({ autoNextSteps: true });
+		setStreaming(true);
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("leaves plan mode to its own continuation driver", () => {
+		const { emit, sent } = setup({ autoNextSteps: true, planMode: true });
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("leaves goal mode to its own continuation driver", () => {
+		const { emit, sent } = setup({ autoNextSteps: true, goalMode: true });
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("uses the combined prompt when both flags are set", () => {
+		const { emit, sent } = setup({ autoNextSteps: true, autoNextIdea: true });
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent[0]!.content).toContain("fully autonomous");
+	});
+
+	it("uses the ideation prompt when only --auto-next-idea is set", () => {
+		const { emit, sent } = setup({ autoNextIdea: true });
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent[0]!.content).toContain("ideation mode");
+	});
+
+	it("kickoff starts a first turn in idea/combined mode but not steps-only", () => {
+		const idea = setup({ autoNextIdea: true });
+		idea.controller.kickoff();
+		expect(idea.sent).toHaveLength(1);
+		expect(idea.sent[0]!.content).toContain("ideation mode");
+
+		const steps = setup({ autoNextSteps: true });
+		steps.controller.kickoff();
+		expect(steps.sent).toHaveLength(0);
+	});
+
+	it("kickoff is a no-op once a turn is already streaming", () => {
+		const { controller, sent, setStreaming } = setup({ autoNextIdea: true });
+		setStreaming(true);
+		controller.kickoff();
+		expect(sent).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -313,6 +313,22 @@ describe("AutonomousController loop", () => {
 		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
 	});
+
+	it("skips a turn that entered plan or goal mode mid-turn", () => {
+		const goal = setup({ autoNextSteps: true });
+		goal.controller.begin({ startupFailed: false });
+		goal.emit(START); // turn began outside goal mode
+		goal.setGoalMode(true); // /goal enabled while the autonomous turn was streaming
+		goal.emit(agentEndEvent([assistantActing("stop")]));
+		expect(goal.sent).toHaveLength(0);
+
+		const plan = setup({ autoNextSteps: true });
+		plan.controller.begin({ startupFailed: false });
+		plan.emit(START); // turn began outside plan mode
+		plan.setPlanMode(true); // /plan enabled while the autonomous turn was streaming
+		plan.emit(agentEndEvent([assistantActing("stop")]));
+		expect(plan.sent).toHaveLength(0);
+	});
 });
 
 describe("AutonomousController steps completion", () => {

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import type { AgentSessionEvent } from "../../session/agent-session";
+import type { CustomMessage } from "../../session/messages";
 import { AutonomousController, type AutonomousSession } from "../controller";
 
 /** Build an `agent_end` event carrying the given turn messages. */
@@ -23,6 +24,28 @@ function assistantActing(stopReason: AssistantMessage["stopReason"]): AssistantM
 		stopReason,
 		content: [{ type: "toolCall", id: "t1", name: "edit", arguments: {} }],
 	} as AssistantMessage;
+}
+
+function autonomousPrompt(): CustomMessage {
+	return {
+		role: "custom",
+		customType: "autonomous-continuation",
+		content: "Continue autonomously",
+		display: false,
+		attribution: "user",
+		timestamp: 0,
+	};
+}
+
+function autolearnPrompt(): CustomMessage {
+	return {
+		role: "custom",
+		customType: "autolearn-nudge",
+		content: "Capture a lesson",
+		display: false,
+		attribution: "user",
+		timestamp: 0,
+	};
 }
 
 interface FakeOptions {
@@ -55,7 +78,7 @@ function setup(options: FakeOptions) {
 		sendCustomMessage: async (message, opts) => {
 			const content = typeof message.content === "string" ? message.content : "";
 			sent.push({ content, triggerTurn: opts?.triggerTurn, deliverAs: opts?.deliverAs });
-			return !queueFollowUps;
+			return !(queueFollowUps || streaming);
 		},
 	};
 	const controller = new AutonomousController({
@@ -67,6 +90,9 @@ function setup(options: FakeOptions) {
 		sent,
 		controller,
 		emit: (event: AgentSessionEvent) => handler?.(event),
+		appendHistory: (message: AgentMessage) => {
+			history.push(message);
+		},
 		setStreaming: (value: boolean) => {
 			streaming = value;
 		},
@@ -170,7 +196,7 @@ describe("AutonomousController loop", () => {
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // working turn -> queue
 		expect(sent).toHaveLength(1);
-		emit(agentEndEvent([])); // --max-time expiry: agent_end with no assistant message
+		emit(agentEndEvent([autonomousPrompt()])); // --max-time expiry after the autonomous prompt: no assistant
 		expect(sent).toHaveLength(1); // no spin (idea/combined would otherwise loop past the deadline)
 		// The failed path clears the autonomous marker, so the next clean no-action
 		// turn re-queues instead of being false-halted as a completed objective.
@@ -182,11 +208,21 @@ describe("AutonomousController loop", () => {
 		const { controller, emit, sent } = setup({ autoNextIdea: true });
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // queues first
 		expect(sent).toHaveLength(1);
-		emit(agentEndEvent([])); // deadline expiry: no assistant message
+		emit(agentEndEvent([autonomousPrompt()])); // deadline expiry after the autonomous prompt: no assistant
 		expect(sent).toHaveLength(1); // idea would otherwise loop forever appending continuations
 	});
 
-	it("does not re-queue while a new turn is already streaming", () => {
+	it("queues a continuation behind a turn another controller already started", () => {
+		const { appendHistory, controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false });
+		setStreaming(true); // e.g. AutoLearnController.autoContinue started capture from the same agent_end
+		appendHistory(autolearnPrompt());
+		emit(agentEndEvent([assistantActing("stop")]));
+		expect(sent).toHaveLength(1);
+		expect(sent[0]!.deliverAs).toBe("followUp");
+	});
+
+	it("does not queue from a generic stale agent_end while another turn is streaming", () => {
 		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		setStreaming(true);
@@ -224,7 +260,7 @@ describe("AutonomousController steps completion", () => {
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queues; next turn is autonomous
 		expect(sent).toHaveLength(1);
-		emit(agentEndEvent([assistant("stop")])); // autonomous turn, no action -> halt
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // autonomous turn, no action -> halt
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([assistantActing("stop")])); // disarmed: no further queue
 		expect(sent).toHaveLength(1);
@@ -239,7 +275,19 @@ describe("AutonomousController steps completion", () => {
 		setQueueFollowUps(false);
 		// The queued follow-up eventually runs; its no-action agent_end must still be
 		// classified autonomous and halt (would re-queue to 2 if !started cleared the marker).
-		emit(agentEndEvent([assistant("stop")]));
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")]));
+		expect(sent).toHaveLength(1);
+	});
+
+	it("keeps the autonomous marker when the preceding queued turn aborts before draining it", () => {
+		const { controller, emit, sent, setQueueFollowUps } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false });
+		setQueueFollowUps(true);
+		emit(agentEndEvent([assistantActing("stop")])); // queue behind another turn
+		expect(sent).toHaveLength(1);
+		setQueueFollowUps(false);
+		emit(agentEndEvent([assistant("aborted")])); // preceding synthetic turn, no autonomous prompt yet
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // queued autonomous follow-up finally runs
 		expect(sent).toHaveLength(1);
 	});
 
@@ -253,7 +301,24 @@ describe("AutonomousController steps completion", () => {
 		expect(sent).toHaveLength(1);
 		setStreaming(false);
 		// The real autonomous agent_end must still be classified autonomous and halt.
-		emit(agentEndEvent([assistant("stop")])); // no action -> halt (would queue if the stale event cleared the marker)
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // no action -> halt (would queue if the stale event cleared the marker)
+		expect(sent).toHaveLength(1);
+	});
+
+	it("ignores earlier synthetic tool activity when checking autonomous completion", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false });
+		emit(agentEndEvent([assistantActing("stop")])); // queue -> next turn is autonomous
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([assistantActing("stop"), autonomousPrompt(), assistant("stop")]));
+		expect(sent).toHaveLength(1);
+	});
+
+	it("treats no assistant after the autonomous boundary as a deadline halt", () => {
+		const { controller, emit, sent } = setup({ autoNextIdea: true });
+		controller.begin({ startupFailed: false });
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([assistantActing("stop"), autonomousPrompt()]));
 		expect(sent).toHaveLength(1);
 	});
 
@@ -268,15 +333,15 @@ describe("AutonomousController steps completion", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queue (turn becomes autonomous)
-		emit(agentEndEvent([assistant("aborted")])); // autonomous turn aborted -> must reset latch
+		emit(agentEndEvent([autonomousPrompt(), assistant("aborted")])); // autonomous turn aborted -> must reset latch
 		emit(agentEndEvent([assistant("stop")])); // manual turn, no action -> must NOT halt
 		expect(sent).toHaveLength(2);
 	});
 
 	it("idea mode never halts on an action-free turn (endless by design)", () => {
 		const { controller, emit, sent } = setup({ autoNextIdea: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // queues first
-		emit(agentEndEvent([assistant("stop")])); // autonomous, no action -> still continues
+		controller.begin({ startupFailed: false }); // queues first
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // autonomous, no action -> still continues
 		expect(sent).toHaveLength(2);
 	});
 
@@ -284,7 +349,7 @@ describe("AutonomousController steps completion", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true, autoNextIdea: true });
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		expect(sent[0]!.content).toContain("fully autonomous");
-		emit(agentEndEvent([assistant("stop")])); // combined never halts
+		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // combined never halts
 		expect(sent).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -63,6 +63,9 @@ function setup(options: FakeOptions) {
 	let queueFollowUps = false;
 	let handler: ((event: AgentSessionEvent) => void) | undefined;
 	const sent: Array<{ content: string; triggerTurn?: boolean; deliverAs?: string }> = [];
+	const queuedCustomTypes = new Set<string>();
+	const notices: Array<{ level: "info" | "warning" | "error"; message: string; source?: string }> = [];
+	let sendError: Error | undefined;
 	const session: AutonomousSession = {
 		subscribe: h => {
 			handler = h;
@@ -75,10 +78,19 @@ function setup(options: FakeOptions) {
 		},
 		getPlanModeState: () => ({ enabled: planEnabled }),
 		getGoalModeState: () => ({ enabled: goalEnabled }),
+		emitNotice: (level, message, source) => {
+			notices.push({ level, message, source });
+		},
+		hasQueuedCustomMessage: customType => queuedCustomTypes.has(customType),
 		sendCustomMessage: async (message, opts) => {
+			if (sendError) throw sendError;
 			const content = typeof message.content === "string" ? message.content : "";
 			sent.push({ content, triggerTurn: opts?.triggerTurn, deliverAs: opts?.deliverAs });
-			return !(queueFollowUps || streaming);
+			if (queueFollowUps || streaming) {
+				queuedCustomTypes.add(message.customType);
+				return false;
+			}
+			return true;
 		},
 	};
 	const controller = new AutonomousController({
@@ -88,10 +100,23 @@ function setup(options: FakeOptions) {
 	});
 	return {
 		sent,
+		notices,
 		controller,
-		emit: (event: AgentSessionEvent) => handler?.(event),
+		emit: (event: AgentSessionEvent) => {
+			const messages = "messages" in event ? event.messages : [];
+			for (const message of messages) {
+				if (message.role === "custom") queuedCustomTypes.delete(message.customType);
+			}
+			handler?.(event);
+		},
 		appendHistory: (message: AgentMessage) => {
 			history.push(message);
+		},
+		dropQueuedCustomType: (customType: string) => {
+			queuedCustomTypes.delete(customType);
+		},
+		setSendError: (error: Error | undefined) => {
+			sendError = error;
 		},
 		setStreaming: (value: boolean) => {
 			streaming = value;
@@ -124,7 +149,24 @@ describe("AutonomousController arming", () => {
 		expect(idea.sent[0]!.content).toContain("ideation mode");
 	});
 
-	it("steps-only with no message and no resume idles (nothing to continue)", () => {
+	it("surfaces hidden kickoff send failures", async () => {
+		const { controller, notices, sent, setSendError } = setup({ autoNextIdea: true });
+		setSendError(new Error("missing API key"));
+		controller.begin({ startupFailed: false });
+		await Promise.resolve();
+		expect(sent).toHaveLength(0);
+		expect(notices).toEqual([
+			{
+				level: "error",
+				message: "Autonomous continuation failed: missing API key",
+				source: "auto-next",
+			},
+		]);
+	});
+
+	it("steps-only idles with no restored transcript (continue fallback to fresh)", () => {
+		// `--continue --auto-next-steps` in a project with no prior session opens an
+		// empty transcript; steps-only must not invent an objective.
 		const steps = setup({ autoNextSteps: true });
 		steps.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
 		expect(steps.sent).toHaveLength(0);
@@ -289,6 +331,19 @@ describe("AutonomousController steps completion", () => {
 		emit(agentEndEvent([assistant("aborted")])); // preceding synthetic turn, no autonomous prompt yet
 		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // queued autonomous follow-up finally runs
 		expect(sent).toHaveLength(1);
+	});
+
+	it("clears the autonomous marker when an interrupt dropped the queued follow-up", () => {
+		const { controller, dropQueuedCustomType, emit, sent, setQueueFollowUps } = setup({ autoNextSteps: true });
+		controller.begin({ startupFailed: false });
+		setQueueFollowUps(true);
+		emit(agentEndEvent([assistantActing("stop")])); // queue behind another turn
+		expect(sent).toHaveLength(1);
+		dropQueuedCustomType("autonomous-continuation"); // clearQueue({ forInterrupt: true }) dropped the hidden prompt
+		setQueueFollowUps(false);
+		emit(agentEndEvent([assistant("aborted")])); // no autonomous prompt will drain now
+		emit(agentEndEvent([assistant("stop")])); // next manual clean turn resumes the loop
+		expect(sent).toHaveLength(2);
 	});
 
 	it("a superseded agent_end while streaming does not consume the autonomous marker", () => {

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import type { CustomMessage } from "../../session/messages";
 import { AutonomousController, type AutonomousSession } from "../controller";
@@ -24,6 +24,17 @@ function assistantActing(stopReason: AssistantMessage["stopReason"]): AssistantM
 		stopReason,
 		content: [{ type: "toolCall", id: "t1", name: "edit", arguments: {} }],
 	} as AssistantMessage;
+}
+
+function abortedToolResult(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "t1",
+		toolName: "edit",
+		content: [{ type: "text", text: "Deadline exceeded" }],
+		isError: true,
+		timestamp: 0,
+	};
 }
 
 function autonomousPrompt(): CustomMessage {
@@ -252,6 +263,14 @@ describe("AutonomousController loop", () => {
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([autonomousPrompt()])); // deadline expiry after the autonomous prompt: no assistant
 		expect(sent).toHaveLength(1); // idea would otherwise loop forever appending continuations
+	});
+
+	it("idea mode does not spin past deadline-truncated tool turns", () => {
+		const { controller, emit, sent } = setup({ autoNextIdea: true });
+		controller.begin({ startupFailed: false }); // queues first (canKickoff)
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([autonomousPrompt(), assistantActing("stop"), abortedToolResult()]));
+		expect(sent).toHaveLength(1);
 	});
 
 	it("queues a continuation behind a turn another controller already started", () => {

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -62,6 +62,8 @@ function autolearnPrompt(): CustomMessage {
 interface FakeOptions {
 	autoNextSteps?: boolean;
 	autoNextIdea?: boolean;
+	autoCommit?: boolean;
+	autoPr?: boolean;
 	planMode?: boolean;
 	goalMode?: boolean;
 }
@@ -110,6 +112,8 @@ function setup(options: FakeOptions) {
 		session,
 		autoNextSteps: options.autoNextSteps ?? false,
 		autoNextIdea: options.autoNextIdea ?? false,
+		autoCommit: options.autoCommit ?? false,
+		autoPr: options.autoPr ?? false,
 	});
 	return {
 		sent,
@@ -455,5 +459,20 @@ describe("AutonomousController steps completion", () => {
 		expect(sent[0]!.content).toContain("fully autonomous");
 		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // combined never halts
 		expect(sent).toHaveLength(2);
+	});
+
+	it("adds auto-commit and auto-pr instructions to the continuation prompt", () => {
+		const { controller, sent } = setup({
+			autoNextSteps: true,
+			autoCommit: true,
+			autoPr: true,
+			history: [assistant("stop")],
+		});
+		controller.begin({ startupFailed: false });
+		expect(sent[0]!.content).toContain("continuation mode");
+		expect(sent[0]!.content).toContain("--auto-commit is enabled");
+		expect(sent[0]!.content).toContain("existing commit workflow");
+		expect(sent[0]!.content).toContain("--auto-pr is enabled");
+		expect(sent[0]!.content).toContain("`github` tool `pr_create`");
 	});
 });

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -66,6 +66,7 @@ interface FakeOptions {
 	autoPr?: boolean;
 	planMode?: boolean;
 	goalMode?: boolean;
+	history?: AgentMessage[];
 }
 
 function setup(options: FakeOptions) {
@@ -91,12 +92,16 @@ function setup(options: FakeOptions) {
 		get isStreaming() {
 			return streaming;
 		},
+		get messages() {
+			return history;
+		},
 		getPlanModeState: () => ({ enabled: planEnabled }),
 		getGoalModeState: () => goalState,
 		emitNotice: (level, message, source) => {
 			notices.push({ level, message, source });
 		},
 		hasQueuedCustomMessage: customType => queuedCustomTypes.has(customType),
+		dropQueuedCustomMessage: customType => queuedCustomTypes.delete(customType),
 		sendCustomMessage: async (message, opts) => {
 			if (sendError) throw sendError;
 			const content = typeof message.content === "string" ? message.content : "";
@@ -155,16 +160,16 @@ function setup(options: FakeOptions) {
 
 describe("AutonomousController arming", () => {
 	it("ignores agent_end until begin() arms it", () => {
-		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		const { controller, emit, sent } = setup({ autoNextSteps: true, history: [assistant("stop")] });
 		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
-		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		expect(sent).toHaveLength(1);
 	});
 
 	it("idea/combined self-starts with no message", () => {
 		const idea = setup({ autoNextIdea: true });
-		idea.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		idea.controller.begin({ startupFailed: false });
 		expect(idea.sent).toHaveLength(1);
 		expect(idea.sent[0]!.content).toContain("ideation mode");
 	});
@@ -173,6 +178,7 @@ describe("AutonomousController arming", () => {
 		const { controller, notices, sent, setSendError } = setup({ autoNextIdea: true });
 		setSendError(new Error("missing API key"));
 		controller.begin({ startupFailed: false });
+		await Promise.resolve();
 		await Promise.resolve();
 		expect(sent).toHaveLength(0);
 		expect(notices).toEqual([
@@ -188,32 +194,31 @@ describe("AutonomousController arming", () => {
 		// `--continue --auto-next-steps` in a project with no prior session opens an
 		// empty transcript; steps-only must not invent an objective.
 		const steps = setup({ autoNextSteps: true });
-		steps.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		steps.controller.begin({ startupFailed: false });
 		expect(steps.sent).toHaveLength(0);
 	});
-
 	it("steps-only self-starts on resume (transcript already holds an objective)", () => {
-		const steps = setup({ autoNextSteps: true });
-		steps.controller.begin({ hadInitialMessage: false, resuming: true, startupFailed: false });
+		const steps = setup({ autoNextSteps: true, history: [assistant("stop")] });
+		steps.controller.begin({ startupFailed: false });
 		expect(steps.sent).toHaveLength(1);
 	});
 
 	it("begin() honors a failed/aborted startup turn instead of re-queueing", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
 		emit(agentEndEvent([assistant("aborted")])); // suppressed (not armed), but recorded
-		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		expect(sent).toHaveLength(0);
 	});
 
 	it("begin() honors a startup prompt that threw without an agent_end (startupFailed)", () => {
 		const { controller, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: true });
+		controller.begin({ startupFailed: true });
 		expect(sent).toHaveLength(0);
 	});
 
 	it("begin() leaves plan/goal mode to its own driver", () => {
 		const plan = setup({ autoNextIdea: true, planMode: true });
-		plan.controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		plan.controller.begin({ startupFailed: false });
 		expect(plan.sent).toHaveLength(0);
 	});
 
@@ -223,7 +228,7 @@ describe("AutonomousController arming", () => {
 		emit(START); // startup turn began in goal mode
 		setGoalMode(false); // goal completed mid-turn; live flag clears before agent_end
 		emit(agentEndEvent([assistantActing("stop")])); // suppressed (not armed)
-		controller.begin({ hadInitialMessage: true, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		expect(sent).toHaveLength(0);
 	});
 });
@@ -231,7 +236,7 @@ describe("AutonomousController arming", () => {
 describe("AutonomousController loop", () => {
 	it("queues a continuation after a working turn", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // arm, no queue
+		controller.begin({ startupFailed: false }); // arm, no queue
 		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(1);
 		expect(sent[0]!.triggerTurn).toBe(true);
@@ -241,21 +246,21 @@ describe("AutonomousController loop", () => {
 
 	it("does not re-queue after an interrupted (aborted) turn", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("aborted")]));
 		expect(sent).toHaveLength(0);
 	});
 
 	it("does not re-queue after a failed (error) turn", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("error")]));
 		expect(sent).toHaveLength(0);
 	});
 
 	it("does not re-queue a deadline-style agent_end with no assistant message", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // working turn -> queue
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([autonomousPrompt()])); // --max-time expiry after the autonomous prompt: no assistant
@@ -268,7 +273,7 @@ describe("AutonomousController loop", () => {
 
 	it("idea mode does not spin past --max-time (no-assistant agent_end)", () => {
 		const { controller, emit, sent } = setup({ autoNextIdea: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // queues first
+		controller.begin({ startupFailed: false }); // queues first
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([autonomousPrompt()])); // deadline expiry after the autonomous prompt: no assistant
 		expect(sent).toHaveLength(1); // idea would otherwise loop forever appending continuations
@@ -294,7 +299,7 @@ describe("AutonomousController loop", () => {
 
 	it("does not queue from a generic stale agent_end while another turn is streaming", () => {
 		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		setStreaming(true);
 		emit(agentEndEvent([assistantActing("stop")]));
 		expect(sent).toHaveLength(0);
@@ -302,7 +307,7 @@ describe("AutonomousController loop", () => {
 
 	it("skips a turn that started in goal mode (avoids the exit-cleanup race)", () => {
 		const { controller, emit, sent, setGoalMode } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		setGoalMode(true);
 		emit(START); // latch start-of-turn goal state
 		setGoalMode(false); // goal completed mid-turn, live flag clears before agent_end
@@ -316,7 +321,7 @@ describe("AutonomousController loop", () => {
 
 	it("skips a turn that started in plan mode", () => {
 		const { controller, emit, sent, setPlanMode } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		setPlanMode(true);
 		emit(START);
 		emit(agentEndEvent([assistantActing("stop")]));
@@ -347,12 +352,19 @@ describe("AutonomousController loop", () => {
 		goal.emit(agentEndEvent([assistantActing("stop")]));
 		expect(goal.sent).toHaveLength(0);
 	});
+
+	it("begin() skips when goal mode is exiting after startup", () => {
+		const goal = setup({ autoNextIdea: true, goalMode: true });
+		goal.setGoalModeState({ enabled: false, mode: "exiting" }); // startup turn completed a goal
+		goal.controller.begin({ startupFailed: false });
+		expect(goal.sent).toHaveLength(0);
+	});
 });
 
 describe("AutonomousController steps completion", () => {
 	it("disarms when an autonomous turn performs no action (objective done)", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queues; next turn is autonomous
 		expect(sent).toHaveLength(1);
 		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // autonomous turn, no action -> halt
@@ -401,7 +413,7 @@ describe("AutonomousController steps completion", () => {
 
 	it("a superseded agent_end while streaming does not consume the autonomous marker", () => {
 		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queue -> next turn is autonomous + streaming
 		expect(sent).toHaveLength(1);
 		setStreaming(true);
@@ -432,14 +444,14 @@ describe("AutonomousController steps completion", () => {
 
 	it("a user turn with no action does NOT halt the loop", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistant("stop")])); // non-autonomous turn (nothing queued yet)
 		expect(sent).toHaveLength(1);
 	});
 
 	it("an aborted autonomous turn does not misclassify the next manual turn", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		emit(agentEndEvent([assistantActing("stop")])); // queue (turn becomes autonomous)
 		emit(agentEndEvent([autonomousPrompt(), assistant("aborted")])); // autonomous turn aborted -> must reset latch
 		emit(agentEndEvent([assistant("stop")])); // manual turn, no action -> must NOT halt
@@ -455,7 +467,7 @@ describe("AutonomousController steps completion", () => {
 
 	it("uses the combined prompt when both flags are set", () => {
 		const { controller, emit, sent } = setup({ autoNextSteps: true, autoNextIdea: true });
-		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		controller.begin({ startupFailed: false });
 		expect(sent[0]!.content).toContain("fully autonomous");
 		emit(agentEndEvent([autonomousPrompt(), assistant("stop")])); // combined never halts
 		expect(sent).toHaveLength(2);
@@ -474,5 +486,52 @@ describe("AutonomousController steps completion", () => {
 		expect(sent[0]!.content).toContain("existing commit workflow");
 		expect(sent[0]!.content).toContain("--auto-pr is enabled");
 		expect(sent[0]!.content).toContain("`github` tool `pr_create`");
+	});
+
+	it("drops queued autonomous continuation when plan mode enters", () => {
+		const { controller, emit, sent, setQueueFollowUps, setPlanMode, dropQueuedCustomType } = setup({
+			autoNextSteps: true,
+			history: [assistant("stop")],
+		});
+		setQueueFollowUps(true); // before begin so the first continuation queues as follow-up
+		controller.begin({ startupFailed: false });
+		expect(sent).toHaveLength(1);
+
+		// The autonomous turn runs and ends cleanly (with tool activity, so it doesn't halt).
+		emit(agentEndEvent([autonomousPrompt(), assistantActing("stop")]));
+		expect(sent).toHaveLength(2); // queues next continuation
+
+		// Simulate plan mode entry: session drops the queued message and emits mode_changed.
+		setPlanMode(true);
+		dropQueuedCustomType("autonomous-continuation");
+		emit({ type: "mode_changed", mode: "plan", active: true, droppedCustomType: "autonomous-continuation" });
+
+		// The mode turn's agent_end has no autonomous prompt; controller must not be stuck.
+		setPlanMode(false);
+		emit(agentEndEvent([assistantActing("stop")]));
+		// After mode exits, a clean turn should resume the loop (marker was cleared).
+		expect(sent).toHaveLength(3);
+	});
+
+	it("drops queued autonomous continuation on goal_updated with enabled state", () => {
+		const { controller, emit, sent, setQueueFollowUps } = setup({
+			autoNextSteps: true,
+			history: [assistant("stop")],
+		});
+		controller.begin({ startupFailed: false });
+		expect(sent).toHaveLength(1); // begin queues first continuation
+
+		// The autonomous turn runs and ends cleanly (with tool activity, so it doesn't halt).
+		setQueueFollowUps(true); // before the autonomous turn so its continuation queues as follow-up
+		emit(agentEndEvent([autonomousPrompt(), assistantActing("stop")]));
+		expect(sent).toHaveLength(2); // queues next continuation
+
+		// GoalRuntime emits goal_updated with state.enabled before setGoalModeState runs.
+		// The controller's goal_updated handler drops the queued continuation and clears the marker.
+		emit({ type: "goal_updated", goal: null, state: { enabled: true } });
+
+		// A subsequent clean turn should resume the loop (marker was cleared, not stuck).
+		emit(agentEndEvent([assistantActing("stop")]));
+		expect(sent).toHaveLength(3);
 	});
 });

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -160,6 +160,27 @@ describe("AutonomousController loop", () => {
 		expect(sent).toHaveLength(0);
 	});
 
+	it("does not re-queue a deadline-style agent_end with no assistant message", () => {
+		const { controller, emit, sent } = setup({ autoNextSteps: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });
+		emit(agentEndEvent([assistantActing("stop")])); // working turn -> queue
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([])); // --max-time expiry: agent_end with no assistant message
+		expect(sent).toHaveLength(1); // no spin (idea/combined would otherwise loop past the deadline)
+		// The failed path clears the autonomous marker, so the next clean no-action
+		// turn re-queues instead of being false-halted as a completed objective.
+		emit(agentEndEvent([assistant("stop")]));
+		expect(sent).toHaveLength(2);
+	});
+
+	it("idea mode does not spin past --max-time (no-assistant agent_end)", () => {
+		const { controller, emit, sent } = setup({ autoNextIdea: true });
+		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false }); // queues first
+		expect(sent).toHaveLength(1);
+		emit(agentEndEvent([])); // deadline expiry: no assistant message
+		expect(sent).toHaveLength(1); // idea would otherwise loop forever appending continuations
+	});
+
 	it("does not re-queue while a new turn is already streaming", () => {
 		const { controller, emit, sent, setStreaming } = setup({ autoNextSteps: true });
 		controller.begin({ hadInitialMessage: false, resuming: false, startupFailed: false });

--- a/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
+++ b/packages/coding-agent/src/autonomous/__tests__/controller.test.ts
@@ -69,7 +69,9 @@ interface FakeOptions {
 function setup(options: FakeOptions) {
 	let streaming = false;
 	let planEnabled = options.planMode ?? false;
-	let goalEnabled = options.goalMode ?? false;
+	let goalState: { enabled: boolean; mode?: "active" | "exiting" } | undefined = options.goalMode
+		? { enabled: true, mode: "active" }
+		: undefined;
 	const history = options.history ?? [];
 	let queueFollowUps = false;
 	let handler: ((event: AgentSessionEvent) => void) | undefined;
@@ -88,7 +90,7 @@ function setup(options: FakeOptions) {
 			return streaming;
 		},
 		getPlanModeState: () => ({ enabled: planEnabled }),
-		getGoalModeState: () => ({ enabled: goalEnabled }),
+		getGoalModeState: () => goalState,
 		emitNotice: (level, message, source) => {
 			notices.push({ level, message, source });
 		},
@@ -136,7 +138,10 @@ function setup(options: FakeOptions) {
 			planEnabled = value;
 		},
 		setGoalMode: (value: boolean) => {
-			goalEnabled = value;
+			goalState = value ? { enabled: true, mode: "active" } : undefined;
+		},
+		setGoalModeState: (state: { enabled: boolean; mode?: "active" | "exiting" } | undefined) => {
+			goalState = state;
 		},
 		setQueueFollowUps: (value: boolean) => {
 			queueFollowUps = value;
@@ -328,6 +333,15 @@ describe("AutonomousController loop", () => {
 		plan.setPlanMode(true); // /plan enabled while the autonomous turn was streaming
 		plan.emit(agentEndEvent([assistantActing("stop")]));
 		expect(plan.sent).toHaveLength(0);
+	});
+
+	it("skips a mid-turn goal that completed before agent_end cleanup", () => {
+		const goal = setup({ autoNextSteps: true });
+		goal.controller.begin({ startupFailed: false });
+		goal.emit(START); // turn began outside goal mode
+		goal.setGoalModeState({ enabled: false, mode: "exiting" }); // goal tool completed before agent_end
+		goal.emit(agentEndEvent([assistantActing("stop")]));
+		expect(goal.sent).toHaveLength(0);
 	});
 });
 

--- a/packages/coding-agent/src/autonomous/auto-agents.md
+++ b/packages/coding-agent/src/autonomous/auto-agents.md
@@ -1,0 +1,8 @@
+--auto-agents is enabled with {{autoAgents}} subagent(s).
+
+For each completed work unit or autonomous improvement:
+- Use up to {{autoAgents}} subagents when there is meaningful independent work to split. Do not invent fake parallel work just to fill the count.
+- Give each subagent a complete assignment with exact scope, target files or systems, non-goals, and acceptance criteria.
+- Tell subagents to skip project-wide verification; you run the final focused verification after integrating their work.
+- Coordinate through the irc tool when scopes overlap, decisions are shared, or a subagent may duplicate another subagent's work. Subagents already have irc access.
+- You remain responsible for integrating results, resolving conflicts, and deciding when the work is complete.

--- a/packages/coding-agent/src/autonomous/auto-commit.md
+++ b/packages/coding-agent/src/autonomous/auto-commit.md
@@ -1,0 +1,6 @@
+--auto-commit is enabled.
+
+After every completed, verified work unit:
+- Use the existing commit workflow (`omp commit`) before declaring done or starting another idea.
+- Include required changelog, test, and doc updates before committing.
+- No local changes? skip the commit.

--- a/packages/coding-agent/src/autonomous/auto-commit.md
+++ b/packages/coding-agent/src/autonomous/auto-commit.md
@@ -1,4 +1,4 @@
---auto-commit is enabled.
+--auto-commit is enabled without a pull-request publishing mode.
 
 After every completed, verified work unit:
 - Use the existing commit workflow (`omp commit`) before declaring done or starting another idea.

--- a/packages/coding-agent/src/autonomous/auto-group-pr.md
+++ b/packages/coding-agent/src/autonomous/auto-group-pr.md
@@ -1,0 +1,8 @@
+--auto-group-pr is enabled.
+
+After completed, verified work:
+- Publish through one shared pull request for this autonomous run, not one pull request per work unit.
+- Ensure local changes are committed to the shared PR branch and pushed before continuing.
+- If the shared pull request already exists, update that PR by pushing new commits and reporting or updating the same PR. NEVER create a duplicate pull request for the same autonomous run.
+- `--auto-group-pr` overrides `--auto-pr` when both are enabled.
+- No local changes and no new commits? skip pull-request work.

--- a/packages/coding-agent/src/autonomous/auto-pr.md
+++ b/packages/coding-agent/src/autonomous/auto-pr.md
@@ -1,0 +1,8 @@
+--auto-pr is enabled.
+
+After every completed, verified work unit:
+- Ensure local changes are committed; `--auto-pr` implies committing completed work first.
+- Ensure the branch is pushed to a remote head branch.
+- Use the existing GitHub pull-request path: prefer the `github` tool `pr_create`; use `gh pr` only when the tool is unavailable.
+- NEVER create a duplicate pull request for the same branch. If one already exists, report or update that PR instead.
+- No local changes and no new commits? skip pull-request work.

--- a/packages/coding-agent/src/autonomous/auto-pr.md
+++ b/packages/coding-agent/src/autonomous/auto-pr.md
@@ -1,8 +1,9 @@
 --auto-pr is enabled.
 
 After every completed, verified work unit:
-- Ensure local changes are committed; `--auto-pr` implies committing completed work first.
-- Ensure the branch is pushed to a remote head branch.
+- Ensure local changes are committed on a pull-request branch; `--auto-pr` implies committing completed work first.
+- NEVER treat a local commit alone as complete when `--auto-pr` is enabled. Push the branch and create or update a pull request before continuing.
+- Do not commit completed autonomous work directly to the default/main branch when `--auto-pr` is enabled; it must be merged through the pull request.
 - Use the existing GitHub pull-request path: prefer the `github` tool `pr_create`; use `gh pr` only when the tool is unavailable.
 - NEVER create a duplicate pull request for the same branch. If one already exists, report or update that PR instead.
 - No local changes and no new commits? skip pull-request work.

--- a/packages/coding-agent/src/autonomous/combined.md
+++ b/packages/coding-agent/src/autonomous/combined.md
@@ -1,0 +1,7 @@
+You are in fully autonomous mode — keep working without asking for permission or confirmation.
+
+First, finish the current objective: identify the remaining steps, carry them out in order, and run the relevant tests or checks after each meaningful change.
+
+Once the current objective is complete, switch to improvements: brainstorm at least three concrete, high-impact ideas for this codebase, choose the best one, and implement it.
+
+Repeat this cycle — finish, then improve — until you are interrupted.

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -175,9 +175,17 @@ export class AutonomousController {
 		// Honor a deliberate stop (user interrupt / internal abort) or a failed
 		// turn: re-queueing an error would loop on a broken state and burn tokens.
 		if (failed) return;
-		// A turn that started in plan/goal mode is owned by that mode; its agent_end
-		// fires before exit cleanup settles, so skip to avoid racing it.
-		if (startedInPlanOrGoal) return;
+		// A turn that started in plan/goal mode, or entered it mid-turn via the
+		// interactive slash command, is owned by that mode; its agent_end fires
+		// before mode cleanup/continuation scheduling settles, so skip to avoid
+		// queueing hidden auto-next prompts into the mode-owned flow.
+		if (
+			startedInPlanOrGoal ||
+			this.#session.getPlanModeState()?.enabled === true ||
+			this.#session.getGoalModeState()?.enabled === true
+		) {
+			return;
+		}
 		// Pure-steps completion: an autonomous continuation that performed no
 		// action means the objective is done — disarm rather than loop forever.
 		// Only counts for turns the controller queued, so a user's question

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -60,7 +60,7 @@ export interface AutonomousSession {
 	hasQueuedCustomMessage(customType: string): boolean;
 	readonly isStreaming: boolean;
 	getPlanModeState(): { enabled: boolean } | undefined;
-	getGoalModeState(): { enabled: boolean } | undefined;
+	getGoalModeState(): { enabled: boolean; mode?: "active" | "exiting" } | undefined;
 }
 
 export interface AutonomousControllerOptions {
@@ -179,10 +179,12 @@ export class AutonomousController {
 		// interactive slash command, is owned by that mode; its agent_end fires
 		// before mode cleanup/continuation scheduling settles, so skip to avoid
 		// queueing hidden auto-next prompts into the mode-owned flow.
+		const liveGoalState = this.#session.getGoalModeState();
 		if (
 			startedInPlanOrGoal ||
 			this.#session.getPlanModeState()?.enabled === true ||
-			this.#session.getGoalModeState()?.enabled === true
+			liveGoalState?.enabled === true ||
+			liveGoalState?.mode === "exiting"
 		) {
 			return;
 		}

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -63,7 +63,10 @@ export interface AutonomousSession {
 	): Promise<boolean>;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
 	hasQueuedCustomMessage(customType: string): boolean;
+	dropQueuedCustomMessage(customType: string): boolean;
 	readonly isStreaming: boolean;
+	/** Live transcript — used to tell a restored session from a fresh empty one. */
+	readonly messages: readonly AgentMessage[];
 	getPlanModeState(): { enabled: boolean } | undefined;
 	getGoalModeState(): { enabled: boolean; mode?: "active" | "exiting" } | undefined;
 }
@@ -77,10 +80,6 @@ export interface AutonomousControllerOptions {
 }
 
 export interface AutonomousBeginOptions {
-	/** A user message was submitted this launch (initial prompt or extra positionals). */
-	hadInitialMessage: boolean;
-	/** Resuming/forking an existing session, so the transcript already holds an objective. */
-	resuming: boolean;
 	/** A startup prompt threw before producing an agent_end (e.g. no model/API key). */
 	startupFailed: boolean;
 }
@@ -136,6 +135,24 @@ export class AutonomousController {
 			// Latch the start-of-turn mode before any tool can flip it.
 			this.#turnStartedInPlanOrGoal =
 				this.#session.getPlanModeState()?.enabled === true || this.#session.getGoalModeState()?.enabled === true;
+			return;
+		}
+		if (event.type === "mode_changed" && event.droppedCustomType === AUTONOMOUS_CONTINUATION_MESSAGE_TYPE) {
+			// Plan/goal mode entry dropped our queued autonomous continuation
+			// synchronously. Clear the marker so the mode turn's agent_end doesn't
+			// leave the controller stuck — and so the next clean turn after mode
+			// exits resumes the loop normally.
+			this.#pendingAutonomousTurn = false;
+			return;
+		}
+		if (event.type === "goal_updated" && event.state?.enabled) {
+			// GoalRuntime can emit goal_updated with state.enabled before
+			// InteractiveMode calls setGoalModeState(). Drop any queued
+			// autonomous continuation so it doesn't drain into the goal turn
+			// during that window.
+			if (this.#session.dropQueuedCustomMessage(AUTONOMOUS_CONTINUATION_MESSAGE_TYPE)) {
+				this.#pendingAutonomousTurn = false;
+			}
 			return;
 		}
 		if (event.type === "agent_end") {
@@ -235,8 +252,9 @@ export class AutonomousController {
 		this.#turnStartedInPlanOrGoal = false;
 		if (this.#lastTurnFailed || options.startupFailed || startedInPlanOrGoal) return;
 		if (this.#session.getPlanModeState()?.enabled) return;
-		if (this.#session.getGoalModeState()?.enabled) return;
-		if (options.hadInitialMessage || options.resuming || this.#canKickoff) {
+		const liveGoalState = this.#session.getGoalModeState();
+		if (liveGoalState?.enabled || liveGoalState?.mode === "exiting") return;
+		if (this.#session.messages.length > 0 || this.#canKickoff) {
 			this.#queueContinuation();
 		}
 	}
@@ -249,7 +267,6 @@ export class AutonomousController {
 		// turn) and WILL still run — so keep the marker for that follow-up's
 		// eventual agent_end; only a failed send clears it (the catch below).
 		// Clearing on !started would make the queued turn's agent_end look manual
-		// and skip the steps-mode completion halt.
 		this.#pendingAutonomousTurn = true;
 		this.#session
 			.sendCustomMessage(
@@ -261,12 +278,32 @@ export class AutonomousController {
 				},
 				{ deliverAs: "followUp", triggerTurn: true },
 			)
+			.then(started => {
+				// If the continuation was queued (!started) and plan/goal mode was
+				// entered before the follow-up drained, drop it so the autonomous
+				// prompt doesn't run inside the mode-owned flow. The async gap between
+				// sendCustomMessage and the follow-up landing in the queue is the race
+				// window; this .then closes it by checking mode state after the send
+				// resolves and removing the queued message if a mode is now active.
+				if (!started && this.#isModeActive()) {
+					this.#session.dropQueuedCustomMessage(AUTONOMOUS_CONTINUATION_MESSAGE_TYPE);
+					this.#pendingAutonomousTurn = false;
+				}
+			})
 			.catch(err => {
 				this.#pendingAutonomousTurn = false;
 				const message = err instanceof Error ? err.message : String(err);
 				this.#session.emitNotice("error", `Autonomous continuation failed: ${message}`, "auto-next");
 				logger.warn("autonomous continuation failed", { err: message });
 			});
+	}
+
+	#isModeActive(): boolean {
+		return (
+			this.#session.getPlanModeState()?.enabled === true ||
+			this.#session.getGoalModeState()?.enabled === true ||
+			this.#session.getGoalModeState()?.mode === "exiting"
+		);
 	}
 }
 

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -34,10 +34,12 @@
  * Idea and combined modes are endless by design ("until interrupted") and never auto-halt.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { AgentSessionEvent } from "../session/agent-session";
 import type { CustomMessage } from "../session/messages";
+import autoAgentsPrompt from "./auto-agents.md" with { type: "text" };
 import autoCommitPrompt from "./auto-commit.md" with { type: "text" };
+import autoGroupPrPrompt from "./auto-group-pr.md" with { type: "text" };
 import autoPrPrompt from "./auto-pr.md" with { type: "text" };
 import combinedPrompt from "./combined.md" with { type: "text" };
 import ideaPrompt from "./next-idea.md" with { type: "text" };
@@ -50,6 +52,8 @@ const AUTONOMOUS_IDEA = ideaPrompt.trim();
 const AUTONOMOUS_COMBINED = combinedPrompt.trim();
 const AUTONOMOUS_AUTO_COMMIT = autoCommitPrompt.trim();
 const AUTONOMOUS_AUTO_PR = autoPrPrompt.trim();
+const AUTONOMOUS_AUTO_AGENTS = autoAgentsPrompt.trim();
+const AUTONOMOUS_AUTO_GROUP_PR = autoGroupPrPrompt.trim();
 
 /**
  * Minimal session surface the controller depends on. {@link AgentSession}
@@ -77,6 +81,8 @@ export interface AutonomousControllerOptions {
 	autoNextIdea: boolean;
 	autoCommit: boolean;
 	autoPr: boolean;
+	autoGroupPr: boolean;
+	autoAgents?: number;
 }
 
 export interface AutonomousBeginOptions {
@@ -92,8 +98,16 @@ function selectContinuationPrompt(options: AutonomousControllerOptions): string 
 
 function buildAutonomousPrompt(options: AutonomousControllerOptions): string {
 	const parts = [selectContinuationPrompt(options)];
-	if (options.autoCommit) parts.push(AUTONOMOUS_AUTO_COMMIT);
-	if (options.autoPr) parts.push(AUTONOMOUS_AUTO_PR);
+	if (options.autoAgents !== undefined && options.autoAgents > 0) {
+		parts.push(prompt.render(AUTONOMOUS_AUTO_AGENTS, { autoAgents: options.autoAgents }));
+	}
+	if (options.autoGroupPr) {
+		parts.push(AUTONOMOUS_AUTO_GROUP_PR);
+	} else if (options.autoPr) {
+		parts.push(AUTONOMOUS_AUTO_PR);
+	} else if (options.autoCommit) {
+		parts.push(AUTONOMOUS_AUTO_COMMIT);
+	}
 	return parts.join("\n\n");
 }
 
@@ -133,8 +147,11 @@ export class AutonomousController {
 	#onEvent(event: AgentSessionEvent): void {
 		if (event.type === "agent_start") {
 			// Latch the start-of-turn mode before any tool can flip it.
+			const goalState = this.#session.getGoalModeState();
 			this.#turnStartedInPlanOrGoal =
-				this.#session.getPlanModeState()?.enabled === true || this.#session.getGoalModeState()?.enabled === true;
+				this.#session.getPlanModeState()?.enabled === true ||
+				goalState?.enabled === true ||
+				goalState?.mode === "exiting";
 			return;
 		}
 		if (event.type === "mode_changed" && event.droppedCustomType === AUTONOMOUS_CONTINUATION_MESSAGE_TYPE) {

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -242,13 +242,14 @@ export class AutonomousController {
 			return;
 		}
 		// Pure-steps completion: an autonomous continuation that performed no
-		// action means the objective is done — disarm rather than loop forever.
+		// action means the current objective is done — skip this requeue rather than
+		// loop forever. Keep the controller armed so a later manual prompt in the
+		// same `--auto-next-steps` session still receives autonomous follow-ups.
 		// Only counts for turns the controller queued, so a user's question
 		// (a non-autonomous turn) can't halt the loop. When the autonomous prompt
 		// ran as a queued follow-up behind another synthetic turn, ignore tool
 		// activity before our prompt boundary.
 		if (wasAutonomous && this.#stepsOnly && !turnHadToolActivity(event.messages, autonomousPayloadStartIndex)) {
-			this.#armed = false;
 			return;
 		}
 		this.#queueContinuation();

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -2,11 +2,12 @@
  * Autonomous continuation controller (`--auto-next-steps` / `--auto-next-idea`).
  *
  * After each completed turn the controller queues a follow-up prompt so the
- * agent keeps working without user input. `--auto-next-steps` drives it through
- * the next concrete steps of the current objective (including running tests);
- * `--auto-next-idea` pivots it to brainstorming and implementing a new
- * improvement once the current plan is done. With both flags it cycles between
- * the two until the user interrupts.
+ * agent keeps working without user input. `--auto-next-steps` drives the next
+ * concrete steps of the current objective (including running tests);
+ * `--auto-next-idea` pivots to brainstorming and implementing improvements.
+ * `--auto-commit` and `--auto-pr` append completion-time publishing
+ * instructions to that hidden prompt. With both next flags it cycles until the
+ * user interrupts.
  *
  * Installed once per interactive session. The session's listener array retains
  * the controller for its lifetime (same pattern as AutoLearnController), so no
@@ -36,6 +37,8 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { AgentSessionEvent } from "../session/agent-session";
 import type { CustomMessage } from "../session/messages";
+import autoCommitPrompt from "./auto-commit.md" with { type: "text" };
+import autoPrPrompt from "./auto-pr.md" with { type: "text" };
 import combinedPrompt from "./combined.md" with { type: "text" };
 import ideaPrompt from "./next-idea.md" with { type: "text" };
 import stepsPrompt from "./next-steps.md" with { type: "text" };
@@ -45,6 +48,8 @@ const AUTOLEARN_NUDGE_MESSAGE_TYPE = "autolearn-nudge";
 const AUTONOMOUS_STEPS = stepsPrompt.trim();
 const AUTONOMOUS_IDEA = ideaPrompt.trim();
 const AUTONOMOUS_COMBINED = combinedPrompt.trim();
+const AUTONOMOUS_AUTO_COMMIT = autoCommitPrompt.trim();
+const AUTONOMOUS_AUTO_PR = autoPrPrompt.trim();
 
 /**
  * Minimal session surface the controller depends on. {@link AgentSession}
@@ -67,6 +72,8 @@ export interface AutonomousControllerOptions {
 	session: AutonomousSession;
 	autoNextSteps: boolean;
 	autoNextIdea: boolean;
+	autoCommit: boolean;
+	autoPr: boolean;
 }
 
 export interface AutonomousBeginOptions {
@@ -76,6 +83,19 @@ export interface AutonomousBeginOptions {
 	resuming: boolean;
 	/** A startup prompt threw before producing an agent_end (e.g. no model/API key). */
 	startupFailed: boolean;
+}
+
+function selectContinuationPrompt(options: AutonomousControllerOptions): string {
+	if (options.autoNextSteps && options.autoNextIdea) return AUTONOMOUS_COMBINED;
+	if (options.autoNextIdea) return AUTONOMOUS_IDEA;
+	return AUTONOMOUS_STEPS;
+}
+
+function buildAutonomousPrompt(options: AutonomousControllerOptions): string {
+	const parts = [selectContinuationPrompt(options)];
+	if (options.autoCommit) parts.push(AUTONOMOUS_AUTO_COMMIT);
+	if (options.autoPr) parts.push(AUTONOMOUS_AUTO_PR);
+	return parts.join("\n\n");
 }
 
 export class AutonomousController {
@@ -99,12 +119,11 @@ export class AutonomousController {
 	constructor(options: AutonomousControllerOptions) {
 		this.#session = options.session;
 		// Steps → continue the objective; idea → brainstorm/improve; both → cycle.
-		this.#prompt =
-			options.autoNextSteps && options.autoNextIdea
-				? AUTONOMOUS_COMBINED
-				: options.autoNextIdea
-					? AUTONOMOUS_IDEA
-					: AUTONOMOUS_STEPS;
+		// Commit/PR flags add completion-time publishing instructions to that base
+		// prompt instead of running side effects from this event listener: agent_end
+		// can represent mid-objective turns, and committing there would publish
+		// partial work.
+		this.#prompt = buildAutonomousPrompt(options);
 		this.#stepsOnly = options.autoNextSteps && !options.autoNextIdea;
 		this.#canKickoff = options.autoNextIdea;
 		// The listener closure captures `this`, so the session keeps the

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -9,15 +9,28 @@
  * the two until the user interrupts.
  *
  * Installed once per interactive session. The session's listener array retains
- * the controller for the session's lifetime (same pattern as AutoLearnController),
- * so no explicit disposal is needed.
+ * the controller for its lifetime (same pattern as AutoLearnController), so no
+ * explicit disposal is needed.
+ *
+ * Arming: the controller is constructed before `runInteractiveMode` drains its
+ * startup messages, so it starts disarmed and ignores `agent_end` until
+ * {@link AutonomousController.begin} is called once startup is done. This keeps
+ * the first startup turn's `agent_end` from racing the remaining
+ * `session.prompt(...)` calls.
  *
  * Interrupt safety: a user interrupt (Esc) aborts the in-flight turn with
- * `stopReason: "aborted"`. The controller treats an aborted stop as a stop
- * signal and does not re-queue, so the agent stays idle until the next manual
- * turn — which ends normally and re-arms the loop. Plan and goal modes are left
- * alone: both own their own continuation and would conflict with an autonomous
- * nudge.
+ * `stopReason: "aborted"`. The controller treats a non-clean stop (`aborted` or
+ * `error`) as a halt signal and does not re-queue, so the agent stays idle
+ * until the next clean turn re-arms the loop. A turn that started in plan or
+ * goal mode is owned by that mode (its `agent_end` fires before the mode's exit
+ * cleanup settles), so it is skipped — the start-of-turn mode is latched on
+ * `agent_start`, mirroring AutoLearnController, because a `goal`/`plan` tool can
+ * clear the live flag mid-turn.
+ *
+ * Completion (steps mode only): a pure-steps autonomous continuation that takes
+ * no action (no tool calls) means the objective is done, so the controller
+ * disarms instead of re-queuing forever. Idea and combined modes are endless by
+ * design ("until interrupted") and never auto-halt.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
@@ -52,12 +65,32 @@ export interface AutonomousControllerOptions {
 	autoNextIdea: boolean;
 }
 
+export interface AutonomousBeginOptions {
+	/** A user message was submitted this launch (initial prompt or extra positionals). */
+	hadInitialMessage: boolean;
+	/** Resuming/forking an existing session, so the transcript already holds an objective. */
+	resuming: boolean;
+	/** A startup prompt threw before producing an agent_end (e.g. no model/API key). */
+	startupFailed: boolean;
+}
+
 export class AutonomousController {
 	readonly #session: AutonomousSession;
 	readonly #prompt: string;
-	/** Without an initial user message there is no objective to "continue", so
-	 *  only idea/combined mode self-starts (brainstorming from scratch). */
+	/** Pure `--auto-next-steps` (no idea flag): eligible for completion-based halt. */
+	readonly #stepsOnly: boolean;
+	/** Idea/combined mode can self-start with no initial message (brainstorm from scratch). */
 	readonly #canKickoff: boolean;
+	/** False until {@link begin} arms the loop after startup messages drain. */
+	#armed = false;
+	/** Mode snapshot taken at `agent_start`; a goal/plan tool can clear the live flag mid-turn. */
+	#turnStartedInPlanOrGoal = false;
+	/** True between queueing a continuation and the `agent_end` of that turn. Marks a turn as
+	 *  controller-driven so the steps-mode halt only fires on autonomous turns, not user turns. */
+	#pendingAutonomousTurn = false;
+	/** Outcome of the most recent `agent_end`, recorded even while disarmed so {@link begin}
+	 *  can honor a failed/aborted startup turn instead of immediately re-queuing. */
+	#lastTurnFailed = false;
 
 	constructor(options: AutonomousControllerOptions) {
 		this.#session = options.session;
@@ -68,6 +101,7 @@ export class AutonomousController {
 				: options.autoNextIdea
 					? AUTONOMOUS_IDEA
 					: AUTONOMOUS_STEPS;
+		this.#stepsOnly = options.autoNextSteps && !options.autoNextIdea;
 		this.#canKickoff = options.autoNextIdea;
 		// The listener closure captures `this`, so the session keeps the
 		// controller alive — no stored unsubscribe needed.
@@ -75,34 +109,82 @@ export class AutonomousController {
 	}
 
 	#onEvent(event: AgentSessionEvent): void {
+		if (event.type === "agent_start") {
+			// Latch the start-of-turn mode before any tool can flip it.
+			this.#turnStartedInPlanOrGoal =
+				this.#session.getPlanModeState()?.enabled === true || this.#session.getGoalModeState()?.enabled === true;
+			return;
+		}
 		if (event.type === "agent_end") {
 			this.#onAgentEnd(event);
 		}
 	}
 
 	#onAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): void {
-		// A superseded agent_end: a fresh turn is already streaming, so this
-		// event belongs to a turn that has been replaced (see event-controller's
-		// #handleAgentEnd for the same guard).
+		// Record the outcome on every turn (even suppressed ones) so begin() can
+		// honor a failed startup turn.
+		const failed = lastAssistantTurnFailed(event.messages);
+		this.#lastTurnFailed = failed;
+		// Suppressed until begin() arms us after startup drains. Leave
+		// #turnStartedInPlanOrGoal set so begin() can read the last startup turn's
+		// mode (a goal/plan completion can clear the live flag before agent_end).
+		if (!this.#armed) return;
+		// A superseded agent_end: a fresh turn is already streaming. Don't consume
+		// the per-turn latches here — the real agent_end for the in-flight turn is
+		// still coming, and clearing #pendingAutonomousTurn now would make that turn
+		// look non-autonomous (see event-controller's #handleAgentEnd for the guard).
 		if (this.#session.isStreaming) return;
-		// Halt on a non-clean stop: a user interrupt / internal abort, or a failed
-		// turn (exhausted retries, API error). Re-queueing an error would loop on a
-		// broken state and burn tokens; the loop re-arms on the next clean turn.
-		if (lastAssistantTurnFailed(event.messages)) return;
-		// Leave plan/goal mode to their own continuation drivers.
+		// Consume the per-turn latches before the failed/plan-goal early returns: an
+		// aborted autonomous turn must clear #pendingAutonomousTurn so the next
+		// manual turn isn't misclassified, and a stale start-mode latch can't carry
+		// into a turn that lacked a fresh agent_start (mirrors AutoLearnController).
+		const startedInPlanOrGoal = this.#turnStartedInPlanOrGoal;
+		this.#turnStartedInPlanOrGoal = false;
+		const wasAutonomous = this.#pendingAutonomousTurn;
+		this.#pendingAutonomousTurn = false;
+		// Honor a deliberate stop (user interrupt / internal abort) or a failed
+		// turn: re-queueing an error would loop on a broken state and burn tokens.
+		if (failed) return;
+		// A turn that started in plan/goal mode is owned by that mode; its agent_end
+		// fires before exit cleanup settles, so skip to avoid racing it.
+		if (startedInPlanOrGoal) return;
+		// Pure-steps completion: an autonomous continuation that performed no
+		// action means the objective is done — disarm rather than loop forever.
+		// Only counts for turns the controller queued, so a user's question
+		// (a non-autonomous turn) can't halt the loop.
+		if (wasAutonomous && this.#stepsOnly && !turnHadToolActivity(event.messages)) {
+			this.#armed = false;
+			return;
+		}
+		this.#queueContinuation();
+	}
+
+	/**
+	 * Arm the loop once startup messages have drained, then start the first
+	 * continuation. A startup that ended badly is honored — an aborted/errored
+	 * last turn, a startup prompt that threw before any agent_end, or a turn that
+	 * started in plan/goal mode — so begin() never races cleanup or re-queues a
+	 * failing turn. With no prior objective (fresh launch, no message), only
+	 * idea/combined mode self-starts; pure steps has nothing to continue.
+	 */
+	begin(options: AutonomousBeginOptions): void {
+		this.#armed = true;
+		if (this.#session.isStreaming) return;
+		const startedInPlanOrGoal = this.#turnStartedInPlanOrGoal;
+		this.#turnStartedInPlanOrGoal = false;
+		if (this.#lastTurnFailed || options.startupFailed || startedInPlanOrGoal) return;
 		if (this.#session.getPlanModeState()?.enabled) return;
 		if (this.#session.getGoalModeState()?.enabled) return;
-		this.#queueContinuation("turn");
+		if (options.hadInitialMessage || options.resuming || this.#canKickoff) {
+			this.#queueContinuation();
+		}
 	}
 
-	/** Start the first autonomous turn when no initial user message was provided. */
-	kickoff(): void {
-		if (!this.#canKickoff) return;
-		if (this.#session.isStreaming) return;
-		this.#queueContinuation("kickoff");
-	}
-
-	#queueContinuation(reason: "turn" | "kickoff"): void {
+	#queueContinuation(): void {
+		// Mark the next turn as controller-driven before the async send resolves;
+		// cleared if no turn actually starts (deferred/queued/failed) so the flag
+		// can't swallow a later turn's halt check.
+		this.#pendingAutonomousTurn = true;
 		this.#session
 			.sendCustomMessage(
 				{
@@ -114,10 +196,11 @@ export class AutonomousController {
 				{ deliverAs: "followUp", triggerTurn: true },
 			)
 			.then(started => {
-				if (!started) logger.debug("autonomous continuation did not start a turn", { reason });
+				if (!started) this.#pendingAutonomousTurn = false;
 			})
 			.catch(err => {
-				logger.warn("autonomous continuation failed", { reason, err: String(err) });
+				this.#pendingAutonomousTurn = false;
+				logger.warn("autonomous continuation failed", { err: String(err) });
 			});
 	}
 }
@@ -133,6 +216,25 @@ function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined):
 		const message = messages[i]!;
 		if (message.role === "assistant") {
 			return message.stopReason === "aborted" || message.stopReason === "error";
+		}
+	}
+	return false;
+}
+
+/**
+ * True when the turn performed any action — an assistant tool call or a tool
+ * result. `agent_end` carries the turn's own messages, so an empty result means
+ * the agent responded with prose only (no next step), the steps-mode completion
+ * signal.
+ */
+function turnHadToolActivity(messages: readonly AgentMessage[] | undefined): boolean {
+	if (!messages) return false;
+	for (const message of messages) {
+		if (message.role === "toolResult") return true;
+		if (message.role === "assistant") {
+			for (const block of message.content) {
+				if (block.type === "toolCall") return true;
+			}
 		}
 	}
 	return false;

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -243,24 +243,21 @@ export class AutonomousController {
 
 /**
  * True when the turn did not end with a clean assistant message: a user
- * interrupt / internal abort (`aborted`), a failed turn (`error`), or no
- * assistant message at all. That last case is the `--max-time` deadline path
- * (the agent loop exits with an empty/degenerate `agent_end`), which must not
- * trigger another continuation — idea/combined would otherwise spin past the
- * deadline. Read from the public event payload so the controller needs no
- * private session state.
+ * interrupt / internal abort (`aborted`), a failed turn (`error`), no assistant
+ * message at all, or tool results with no later assistant response. The last
+ * two cases cover `--max-time` deadline paths: one exits before an assistant
+ * exists, and one exits after appending skipped/aborted tool results for an
+ * assistant tool-call turn. Both must not trigger another continuation —
+ * idea/combined would otherwise spin past the deadline. Read from the public
+ * event payload so the controller needs no private session state.
  */
 function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined, startIndex: number): boolean {
 	if (!messages) return true;
 	const firstIndex = startIndex < 0 ? 0 : startIndex;
 	if (firstIndex >= messages.length) return true;
-	for (let i = messages.length - 1; i >= firstIndex; i--) {
-		const message = messages[i]!;
-		if (message.role === "assistant") {
-			return message.stopReason === "aborted" || message.stopReason === "error";
-		}
-	}
-	return true;
+	const finalMessage = messages[messages.length - 1]!;
+	if (finalMessage.role !== "assistant") return true;
+	return finalMessage.stopReason === "aborted" || finalMessage.stopReason === "error";
 }
 
 /** Return the last autonomous continuation prompt in an agent_end payload, if present. */

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -28,9 +28,9 @@
  * clear the live flag mid-turn.
  *
  * Completion (steps mode only): a pure-steps autonomous continuation that takes
- * no action (no tool calls) means the objective is done, so the controller
- * disarms instead of re-queuing forever. Idea and combined modes are endless by
- * design ("until interrupted") and never auto-halt.
+ * no action after its continuation prompt (no tool calls) means the objective is
+ * done, so the controller disarms instead of re-queuing forever.
+ * Idea and combined modes are endless by design ("until interrupted") and never auto-halt.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
@@ -40,6 +40,8 @@ import combinedPrompt from "./combined.md" with { type: "text" };
 import ideaPrompt from "./next-idea.md" with { type: "text" };
 import stepsPrompt from "./next-steps.md" with { type: "text" };
 
+const AUTONOMOUS_CONTINUATION_MESSAGE_TYPE = "autonomous-continuation";
+const AUTOLEARN_NUDGE_MESSAGE_TYPE = "autolearn-nudge";
 const AUTONOMOUS_STEPS = stepsPrompt.trim();
 const AUTONOMOUS_IDEA = ideaPrompt.trim();
 const AUTONOMOUS_COMBINED = combinedPrompt.trim();
@@ -121,19 +123,35 @@ export class AutonomousController {
 	}
 
 	#onAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): void {
+		// Locate our continuation prompt before classifying the turn: agent_end can
+		// cover multiple drained queued turns, so an auto-learn capture before the
+		// autonomous follow-up must not mask the follow-up's failure/deadline state.
+		const autonomousPromptIndex = lastAutonomousPromptIndex(event.messages);
+		// If a queued autonomous turn is pending and this agent_end does not contain
+		// that autonomous prompt, the event belongs to another turn (for example an
+		// auto-learn capture that aborted before draining follow-ups). Leave the
+		// autonomous marker intact for the follow-up's eventual agent_end.
+		if (this.#pendingAutonomousTurn && autonomousPromptIndex === -1) return;
+		const autonomousPayloadStartIndex = autonomousPromptIndex === -1 ? 0 : autonomousPromptIndex + 1;
 		// Record the outcome on every turn (even suppressed ones) so begin() can
 		// honor a failed startup turn.
-		const failed = lastAssistantTurnFailed(event.messages);
+		const failed = lastAssistantTurnFailed(event.messages, autonomousPayloadStartIndex);
 		this.#lastTurnFailed = failed;
 		// Suppressed until begin() arms us after startup drains. Leave
 		// #turnStartedInPlanOrGoal set so begin() can read the last startup turn's
 		// mode (a goal/plan completion can clear the live flag before agent_end).
 		if (!this.#armed) return;
-		// A superseded agent_end: a fresh turn is already streaming. Don't consume
-		// the per-turn latches here — the real agent_end for the in-flight turn is
-		// still coming, and clearing #pendingAutonomousTurn now would make that turn
-		// look non-autonomous (see event-controller's #handleAgentEnd for the guard).
-		if (this.#session.isStreaming) return;
+		// If some other turn is already streaming, only queue behind the known
+		// AutoLearn capture turn. Generic in-flight turns can be delayed/stale
+		// agent_end delivery after a real new user turn started; those must not
+		// synthesize an autonomous follow-up.
+		if (
+			this.#session.isStreaming &&
+			!this.#pendingAutonomousTurn &&
+			!isAutoLearnCaptureInFlight(this.#session.messages)
+		) {
+			return;
+		}
 		// Consume the per-turn latches before the failed/plan-goal early returns: an
 		// aborted autonomous turn must clear #pendingAutonomousTurn so the next
 		// manual turn isn't misclassified, and a stale start-mode latch can't carry
@@ -151,8 +169,10 @@ export class AutonomousController {
 		// Pure-steps completion: an autonomous continuation that performed no
 		// action means the objective is done — disarm rather than loop forever.
 		// Only counts for turns the controller queued, so a user's question
-		// (a non-autonomous turn) can't halt the loop.
-		if (wasAutonomous && this.#stepsOnly && !turnHadToolActivity(event.messages)) {
+		// (a non-autonomous turn) can't halt the loop. When the autonomous prompt
+		// ran as a queued follow-up behind another synthetic turn, ignore tool
+		// activity before our prompt boundary.
+		if (wasAutonomous && this.#stepsOnly && !turnHadToolActivity(event.messages, autonomousPayloadStartIndex)) {
 			this.#armed = false;
 			return;
 		}
@@ -193,7 +213,7 @@ export class AutonomousController {
 		this.#session
 			.sendCustomMessage(
 				{
-					customType: "autonomous-continuation",
+					customType: AUTONOMOUS_CONTINUATION_MESSAGE_TYPE,
 					content: this.#prompt,
 					display: false,
 					attribution: "user",
@@ -216,9 +236,11 @@ export class AutonomousController {
  * deadline. Read from the public event payload so the controller needs no
  * private session state.
  */
-function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined): boolean {
-	if (!messages || messages.length === 0) return true;
-	for (let i = messages.length - 1; i >= 0; i--) {
+function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined, startIndex: number): boolean {
+	if (!messages) return true;
+	const firstIndex = startIndex < 0 ? 0 : startIndex;
+	if (firstIndex >= messages.length) return true;
+	for (let i = messages.length - 1; i >= firstIndex; i--) {
 		const message = messages[i]!;
 		if (message.role === "assistant") {
 			return message.stopReason === "aborted" || message.stopReason === "error";
@@ -227,15 +249,44 @@ function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined):
 	return true;
 }
 
+/** Return the last autonomous continuation prompt in an agent_end payload, if present. */
+function lastAutonomousPromptIndex(messages: readonly AgentMessage[] | undefined): number {
+	if (!messages) return -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]!;
+		if (message.role === "custom" && message.customType === AUTONOMOUS_CONTINUATION_MESSAGE_TYPE) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 /**
- * True when the turn performed any action — an assistant tool call or a tool
- * result. `agent_end` carries the turn's own messages, so an empty result means
- * the agent responded with prose only (no next step), the steps-mode completion
- * signal.
+ * True when the live streaming turn was started by AutoLearn's synthetic
+ * capture prompt. Scan backward past assistant/tool-result messages so a capture
+ * that is already working still resolves to its initiating custom prompt.
  */
-function turnHadToolActivity(messages: readonly AgentMessage[] | undefined): boolean {
+function isAutoLearnCaptureInFlight(messages: readonly AgentMessage[]): boolean {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]!;
+		if (message.role === "assistant" || message.role === "toolResult") continue;
+		return message.role === "custom" && message.customType === AUTOLEARN_NUDGE_MESSAGE_TYPE;
+	}
+	return false;
+}
+
+/**
+ * True when the selected message window performed any action — an assistant tool
+ * call or a tool result. `agent_end` can include multiple drained queued turns;
+ * `startIndex` lets steps-mode completion consider only messages after this
+ * controller's autonomous continuation prompt, so a preceding synthetic turn
+ * (for example auto-learn capture) cannot mask a no-action autonomous follow-up.
+ */
+function turnHadToolActivity(messages: readonly AgentMessage[] | undefined, startIndex: number): boolean {
 	if (!messages) return false;
-	for (const message of messages) {
+	const firstIndex = startIndex < 0 ? 0 : startIndex;
+	for (let i = firstIndex; i < messages.length; i++) {
+		const message = messages[i]!;
 		if (message.role === "toolResult") return true;
 		if (message.role === "assistant") {
 			for (const block of message.content) {

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -1,0 +1,139 @@
+/**
+ * Autonomous continuation controller (`--auto-next-steps` / `--auto-next-idea`).
+ *
+ * After each completed turn the controller queues a follow-up prompt so the
+ * agent keeps working without user input. `--auto-next-steps` drives it through
+ * the next concrete steps of the current objective (including running tests);
+ * `--auto-next-idea` pivots it to brainstorming and implementing a new
+ * improvement once the current plan is done. With both flags it cycles between
+ * the two until the user interrupts.
+ *
+ * Installed once per interactive session. The session's listener array retains
+ * the controller for the session's lifetime (same pattern as AutoLearnController),
+ * so no explicit disposal is needed.
+ *
+ * Interrupt safety: a user interrupt (Esc) aborts the in-flight turn with
+ * `stopReason: "aborted"`. The controller treats an aborted stop as a stop
+ * signal and does not re-queue, so the agent stays idle until the next manual
+ * turn — which ends normally and re-arms the loop. Plan and goal modes are left
+ * alone: both own their own continuation and would conflict with an autonomous
+ * nudge.
+ */
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { AgentSessionEvent } from "../session/agent-session";
+import type { CustomMessage } from "../session/messages";
+import combinedPrompt from "./combined.md" with { type: "text" };
+import ideaPrompt from "./next-idea.md" with { type: "text" };
+import stepsPrompt from "./next-steps.md" with { type: "text" };
+
+const AUTONOMOUS_STEPS = stepsPrompt.trim();
+const AUTONOMOUS_IDEA = ideaPrompt.trim();
+const AUTONOMOUS_COMBINED = combinedPrompt.trim();
+
+/**
+ * Minimal session surface the controller depends on. {@link AgentSession}
+ * satisfies this structurally; tests pass a fake that implements only it.
+ */
+export interface AutonomousSession {
+	subscribe(handler: (event: AgentSessionEvent) => void): unknown;
+	sendCustomMessage(
+		message: Pick<CustomMessage, "customType" | "content" | "display" | "attribution">,
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	): Promise<boolean>;
+	readonly isStreaming: boolean;
+	getPlanModeState(): { enabled: boolean } | undefined;
+	getGoalModeState(): { enabled: boolean } | undefined;
+}
+
+export interface AutonomousControllerOptions {
+	session: AutonomousSession;
+	autoNextSteps: boolean;
+	autoNextIdea: boolean;
+}
+
+export class AutonomousController {
+	readonly #session: AutonomousSession;
+	readonly #prompt: string;
+	/** Without an initial user message there is no objective to "continue", so
+	 *  only idea/combined mode self-starts (brainstorming from scratch). */
+	readonly #canKickoff: boolean;
+
+	constructor(options: AutonomousControllerOptions) {
+		this.#session = options.session;
+		// Steps → continue the objective; idea → brainstorm/improve; both → cycle.
+		this.#prompt =
+			options.autoNextSteps && options.autoNextIdea
+				? AUTONOMOUS_COMBINED
+				: options.autoNextIdea
+					? AUTONOMOUS_IDEA
+					: AUTONOMOUS_STEPS;
+		this.#canKickoff = options.autoNextIdea;
+		// The listener closure captures `this`, so the session keeps the
+		// controller alive — no stored unsubscribe needed.
+		this.#session.subscribe(event => this.#onEvent(event));
+	}
+
+	#onEvent(event: AgentSessionEvent): void {
+		if (event.type === "agent_end") {
+			this.#onAgentEnd(event);
+		}
+	}
+
+	#onAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): void {
+		// A superseded agent_end: a fresh turn is already streaming, so this
+		// event belongs to a turn that has been replaced (see event-controller's
+		// #handleAgentEnd for the same guard).
+		if (this.#session.isStreaming) return;
+		// Halt on a non-clean stop: a user interrupt / internal abort, or a failed
+		// turn (exhausted retries, API error). Re-queueing an error would loop on a
+		// broken state and burn tokens; the loop re-arms on the next clean turn.
+		if (lastAssistantTurnFailed(event.messages)) return;
+		// Leave plan/goal mode to their own continuation drivers.
+		if (this.#session.getPlanModeState()?.enabled) return;
+		if (this.#session.getGoalModeState()?.enabled) return;
+		this.#queueContinuation("turn");
+	}
+
+	/** Start the first autonomous turn when no initial user message was provided. */
+	kickoff(): void {
+		if (!this.#canKickoff) return;
+		if (this.#session.isStreaming) return;
+		this.#queueContinuation("kickoff");
+	}
+
+	#queueContinuation(reason: "turn" | "kickoff"): void {
+		this.#session
+			.sendCustomMessage(
+				{
+					customType: "autonomous-continuation",
+					content: this.#prompt,
+					display: false,
+					attribution: "user",
+				},
+				{ deliverAs: "followUp", triggerTurn: true },
+			)
+			.then(started => {
+				if (!started) logger.debug("autonomous continuation did not start a turn", { reason });
+			})
+			.catch(err => {
+				logger.warn("autonomous continuation failed", { reason, err: String(err) });
+			});
+	}
+}
+
+/**
+ * True when the most recent assistant message ended in a non-clean stop — a user
+ * interrupt / internal abort (`aborted`) or a failed turn (`error`). Read from
+ * the public event payload so the controller needs no private session state.
+ */
+function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined): boolean {
+	if (!messages) return false;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]!;
+		if (message.role === "assistant") {
+			return message.stopReason === "aborted" || message.stopReason === "error";
+		}
+	}
+	return false;
+}

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -206,19 +206,23 @@ export class AutonomousController {
 }
 
 /**
- * True when the most recent assistant message ended in a non-clean stop — a user
- * interrupt / internal abort (`aborted`) or a failed turn (`error`). Read from
- * the public event payload so the controller needs no private session state.
+ * True when the turn did not end with a clean assistant message: a user
+ * interrupt / internal abort (`aborted`), a failed turn (`error`), or no
+ * assistant message at all. That last case is the `--max-time` deadline path
+ * (the agent loop exits with an empty/degenerate `agent_end`), which must not
+ * trigger another continuation — idea/combined would otherwise spin past the
+ * deadline. Read from the public event payload so the controller needs no
+ * private session state.
  */
 function lastAssistantTurnFailed(messages: readonly AgentMessage[] | undefined): boolean {
-	if (!messages) return false;
+	if (!messages || messages.length === 0) return true;
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i]!;
 		if (message.role === "assistant") {
 			return message.stopReason === "aborted" || message.stopReason === "error";
 		}
 	}
-	return false;
+	return true;
 }
 
 /**

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -181,9 +181,14 @@ export class AutonomousController {
 	}
 
 	#queueContinuation(): void {
-		// Mark the next turn as controller-driven before the async send resolves;
-		// cleared if no turn actually starts (deferred/queued/failed) so the flag
-		// can't swallow a later turn's halt check.
+		// Mark the next turn as controller-driven before the async send resolves.
+		// The marker is consumed by the next non-superseded agent_end. If the send
+		// resolves started=false the message was queued as a follow-up behind
+		// another in-flight turn (e.g. AutoLearnController.autoContinue's capture
+		// turn) and WILL still run — so keep the marker for that follow-up's
+		// eventual agent_end; only a failed send clears it (the catch below).
+		// Clearing on !started would make the queued turn's agent_end look manual
+		// and skip the steps-mode completion halt.
 		this.#pendingAutonomousTurn = true;
 		this.#session
 			.sendCustomMessage(
@@ -195,9 +200,6 @@ export class AutonomousController {
 				},
 				{ deliverAs: "followUp", triggerTurn: true },
 			)
-			.then(started => {
-				if (!started) this.#pendingAutonomousTurn = false;
-			})
 			.catch(err => {
 				this.#pendingAutonomousTurn = false;
 				logger.warn("autonomous continuation failed", { err: String(err) });

--- a/packages/coding-agent/src/autonomous/controller.ts
+++ b/packages/coding-agent/src/autonomous/controller.ts
@@ -56,6 +56,8 @@ export interface AutonomousSession {
 		message: Pick<CustomMessage, "customType" | "content" | "display" | "attribution">,
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
 	): Promise<boolean>;
+	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
+	hasQueuedCustomMessage(customType: string): boolean;
 	readonly isStreaming: boolean;
 	getPlanModeState(): { enabled: boolean } | undefined;
 	getGoalModeState(): { enabled: boolean } | undefined;
@@ -128,10 +130,20 @@ export class AutonomousController {
 		// autonomous follow-up must not mask the follow-up's failure/deadline state.
 		const autonomousPromptIndex = lastAutonomousPromptIndex(event.messages);
 		// If a queued autonomous turn is pending and this agent_end does not contain
-		// that autonomous prompt, the event belongs to another turn (for example an
-		// auto-learn capture that aborted before draining follow-ups). Leave the
-		// autonomous marker intact for the follow-up's eventual agent_end.
-		if (this.#pendingAutonomousTurn && autonomousPromptIndex === -1) return;
+		// that autonomous prompt, the event belongs to another turn. Preserve the
+		// marker for clean stale/superseded events and for failed turns that still
+		// have the queued hidden follow-up. Clear it only when the intervening
+		// failure also removed the queued prompt (Esc drops hidden continuations via
+		// clearQueue({ forInterrupt: true })).
+		if (this.#pendingAutonomousTurn && autonomousPromptIndex === -1) {
+			const interveningFailed = lastAssistantTurnFailed(event.messages, 0);
+			this.#lastTurnFailed = interveningFailed;
+			if (interveningFailed && !this.#session.hasQueuedCustomMessage(AUTONOMOUS_CONTINUATION_MESSAGE_TYPE)) {
+				this.#pendingAutonomousTurn = false;
+				this.#turnStartedInPlanOrGoal = false;
+			}
+			return;
+		}
 		const autonomousPayloadStartIndex = autonomousPromptIndex === -1 ? 0 : autonomousPromptIndex + 1;
 		// Record the outcome on every turn (even suppressed ones) so begin() can
 		// honor a failed startup turn.
@@ -222,7 +234,9 @@ export class AutonomousController {
 			)
 			.catch(err => {
 				this.#pendingAutonomousTurn = false;
-				logger.warn("autonomous continuation failed", { err: String(err) });
+				const message = err instanceof Error ? err.message : String(err);
+				this.#session.emitNotice("error", `Autonomous continuation failed: ${message}`, "auto-next");
+				logger.warn("autonomous continuation failed", { err: message });
 			});
 	}
 }

--- a/packages/coding-agent/src/autonomous/next-idea.md
+++ b/packages/coding-agent/src/autonomous/next-idea.md
@@ -1,0 +1,3 @@
+You are in autonomous ideation mode — keep working without asking for permission or confirmation.
+
+Brainstorm at least three concrete, high-impact improvements for this codebase, choose the single best one, and implement it now. Keep the change focused, run the relevant tests, and verify it works end to end.

--- a/packages/coding-agent/src/autonomous/next-steps.md
+++ b/packages/coding-agent/src/autonomous/next-steps.md
@@ -1,0 +1,3 @@
+You are in autonomous continuation mode — keep working without asking for permission or confirmation.
+
+Continue advancing the current objective. Identify the concrete next steps that still remain, carry them out in order, and run the relevant tests or checks after each meaningful change. Only stop when the objective is genuinely complete and verified.

--- a/packages/coding-agent/src/autonomous/next-steps.md
+++ b/packages/coding-agent/src/autonomous/next-steps.md
@@ -1,3 +1,3 @@
 You are in autonomous continuation mode — keep working without asking for permission or confirmation.
 
-Continue advancing the current objective. Identify the concrete next steps that still remain, carry them out in order, and run the relevant tests or checks after each meaningful change. Only stop when the objective is genuinely complete and verified.
+Continue advancing the current objective. Identify the remaining concrete steps, carry them out in order, and run the relevant tests or checks after each change. When the objective is genuinely complete and verified, confirm it briefly and take no further actions — autonomous continuation stops once a turn performs no work. Do not invent busywork once the objective is done.

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -64,6 +64,10 @@ export interface Args {
 	noTitle?: boolean;
 	autoApprove?: boolean;
 	approvalMode?: "always-ask" | "write" | "yolo";
+	/** --auto-next-steps: keep working through the next steps after each turn. */
+	autoNextSteps?: boolean;
+	/** --auto-next-idea: brainstorm and implement a new improvement after each turn. */
+	autoNextIdea?: boolean;
 	messages: string[];
 	fileArgs: string[];
 	/** Extension-registered flags this parse recognized — name to value. */
@@ -213,6 +217,10 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.noTitle = true;
 		} else if (arg === "--auto-approve" || arg === "--yolo") {
 			result.autoApprove = true;
+		} else if (arg === "--auto-next-steps") {
+			result.autoNextSteps = true;
+		} else if (arg === "--auto-next-idea") {
+			result.autoNextIdea = true;
 		} else if (arg.startsWith("@")) {
 			let filePath = arg.slice(1);
 			if (filePath.startsWith('"') && filePath.endsWith('"') && filePath.length > 1) {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -68,6 +68,10 @@ export interface Args {
 	autoNextSteps?: boolean;
 	/** --auto-next-idea: brainstorm and implement a new improvement after each turn. */
 	autoNextIdea?: boolean;
+	/** --auto-commit: commit verified autonomous work before continuing. */
+	autoCommit?: boolean;
+	/** --auto-pr: open a pull request for verified autonomous work. */
+	autoPr?: boolean;
 	messages: string[];
 	fileArgs: string[];
 	/** Extension-registered flags this parse recognized — name to value. */
@@ -221,6 +225,10 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.autoNextSteps = true;
 		} else if (arg === "--auto-next-idea") {
 			result.autoNextIdea = true;
+		} else if (arg === "--auto-commit") {
+			result.autoCommit = true;
+		} else if (arg === "--auto-pr") {
+			result.autoPr = true;
 		} else if (arg.startsWith("@")) {
 			let filePath = arg.slice(1);
 			if (filePath.startsWith('"') && filePath.endsWith('"') && filePath.length > 1) {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -72,6 +72,10 @@ export interface Args {
 	autoCommit?: boolean;
 	/** --auto-pr: open a pull request for verified autonomous work. */
 	autoPr?: boolean;
+	/** --auto-group-pr: publish autonomous work through one shared pull request. */
+	autoGroupPr?: boolean;
+	/** --auto-agents <N>: spawn up to N autonomous subagents per work unit. */
+	autoAgents?: number;
 	messages: string[];
 	fileArgs: string[];
 	/** Extension-registered flags this parse recognized — name to value. */
@@ -229,6 +233,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.autoCommit = true;
 		} else if (arg === "--auto-pr") {
 			result.autoPr = true;
+		} else if (arg === "--auto-group-pr") {
+			result.autoGroupPr = true;
 		} else if (arg.startsWith("@")) {
 			let filePath = arg.slice(1);
 			if (filePath.startsWith('"') && filePath.endsWith('"') && filePath.length > 1) {

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -277,4 +277,6 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--no-title",
 	"--auto-approve",
 	"--yolo",
+	"--auto-next-steps",
+	"--auto-next-idea",
 ]);

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -128,6 +128,14 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 			deps.logger.warn("Invalid seconds passed to --max-time", { value });
 		}
 	},
+	"--auto-agents": (result, value, deps) => {
+		const count = Number(value);
+		if (Number.isSafeInteger(count) && count > 0) {
+			result.autoAgents = count;
+		} else {
+			deps.logger.warn("Invalid count passed to --auto-agents", { value });
+		}
+	},
 	"--api-key": (result, value) => {
 		result.apiKey = value;
 	},
@@ -281,4 +289,5 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--auto-next-idea",
 	"--auto-commit",
 	"--auto-pr",
+	"--auto-group-pr",
 ]);

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -279,4 +279,6 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--yolo",
 	"--auto-next-steps",
 	"--auto-next-idea",
+	"--auto-commit",
+	"--auto-pr",
 ]);

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -158,6 +158,15 @@ export default class Index extends Command {
 			options: ["always-ask", "write", "yolo"],
 			description: "Override tools.approvalMode for this session (always-ask|write|yolo)",
 		}),
+		// `--auto-next-steps` / `--auto-next-idea`: declared here so oclif's auto-generated
+		// `--help` lists them. Runtime parsing happens in `cli/args.ts parseArgs` — runRootCommand
+		// consumes the manual-parser output, not these oclif flag values.
+		"auto-next-steps": Flags.boolean({
+			description: "Keep working through the next steps after each turn (until interrupted)",
+		}),
+		"auto-next-idea": Flags.boolean({
+			description: "After each turn, brainstorm and implement a new improvement (until interrupted)",
+		}),
 	};
 
 	static examples = [

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -167,11 +167,17 @@ export default class Index extends Command {
 		"auto-next-idea": Flags.boolean({
 			description: "After each turn, brainstorm and implement a new improvement (until interrupted)",
 		}),
+		"auto-agents": Flags.string({
+			description: "Spawn up to N autonomous subagents per completed work unit",
+		}),
 		"auto-commit": Flags.boolean({
 			description: "Commit verified autonomous work before continuing",
 		}),
 		"auto-pr": Flags.boolean({
 			description: "Create or update a pull request for verified autonomous work",
+		}),
+		"auto-group-pr": Flags.boolean({
+			description: "Publish autonomous work through one shared pull request",
 		}),
 	};
 

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -158,14 +158,20 @@ export default class Index extends Command {
 			options: ["always-ask", "write", "yolo"],
 			description: "Override tools.approvalMode for this session (always-ask|write|yolo)",
 		}),
-		// `--auto-next-steps` / `--auto-next-idea`: declared here so oclif's auto-generated
-		// `--help` lists them. Runtime parsing happens in `cli/args.ts parseArgs` — runRootCommand
-		// consumes the manual-parser output, not these oclif flag values.
+		// Autonomous launch flags: declared here so oclif's auto-generated
+		// `--help` lists them. Runtime parsing happens in `cli/args.ts parseArgs` —
+		// runRootCommand consumes the manual-parser output, not these oclif flag values.
 		"auto-next-steps": Flags.boolean({
 			description: "Keep working through the next steps after each turn (until interrupted)",
 		}),
 		"auto-next-idea": Flags.boolean({
 			description: "After each turn, brainstorm and implement a new improvement (until interrupted)",
+		}),
+		"auto-commit": Flags.boolean({
+			description: "Commit verified autonomous work before continuing",
+		}),
+		"auto-pr": Flags.boolean({
+			description: "Create or update a pull request for verified autonomous work",
 		}),
 	};
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1342,6 +1342,8 @@ export async function runRootCommand(
 						autoNextIdea: parsedArgs.autoNextIdea === true,
 						autoCommit: parsedArgs.autoCommit === true,
 						autoPr: parsedArgs.autoPr === true,
+						autoGroupPr: parsedArgs.autoGroupPr === true,
+						autoAgents: parsedArgs.autoAgents,
 					})
 				: undefined;
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1325,15 +1325,17 @@ export async function runRootCommand(
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
 		}
 		// Autonomous continuation (--auto-next-steps / --auto-next-idea): armed only
-		// for interactive sessions — print/protocol modes are one-shot. The controller
-		// subscribes to the session event stream for its lifetime; runInteractiveMode
-		// calls kickoff() to start the first turn when no initial user message is given.
+		// for interactive sessions — print/protocol modes are one-shot. Optional
+		// publishing flags only extend the hidden continuation prompt; side effects
+		// stay model-driven so mid-objective turns are not committed or pushed.
 		const autonomousController =
 			isInteractive && (parsedArgs.autoNextSteps || parsedArgs.autoNextIdea)
 				? new AutonomousController({
 						session,
 						autoNextSteps: parsedArgs.autoNextSteps === true,
 						autoNextIdea: parsedArgs.autoNextIdea === true,
+						autoCommit: parsedArgs.autoCommit === true,
+						autoPr: parsedArgs.autoPr === true,
 					})
 				: undefined;
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -472,11 +472,13 @@ async function runInteractiveMode(
 		await executeBuiltinSlashCommand(`/join ${joinLink}`, { ctx: mode });
 	}
 
+	let startupPromptFailed = false;
 	if (initialMessage !== undefined) {
 		try {
 			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(initialMessage, { images: initialImages });
 		} catch (error: unknown) {
+			startupPromptFailed = true;
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
 		}
@@ -487,16 +489,25 @@ async function runInteractiveMode(
 			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(message);
 		} catch (error: unknown) {
+			startupPromptFailed = true;
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
 		}
 	}
-	// Autonomous mode with no initial user message: start the first turn so
-	// `--auto-next-idea` (or `--auto-next-steps --auto-next-idea`) can begin
-	// ideating from scratch. Steps-only mode with no objective has nothing to
-	// continue, so kickoff() is a no-op there.
-	if (autonomousController && initialMessage === undefined && initialMessages.length === 0) {
-		autonomousController.kickoff();
+	// Arm autonomous mode only after every startup message has been submitted,
+	// so the first startup turn's agent_end can't race the remaining
+	// session.prompt(...) calls. begin() then starts the first continuation:
+	// idea/combined self-starts even with no message; steps-only self-starts on
+	// resume (the transcript already holds an objective) or after an initial
+	// message, and otherwise idles until the user gives it work. A startup prompt
+	// that threw (no agent_end) is passed through so begin() won't re-queue a
+	// failing turn.
+	if (autonomousController) {
+		autonomousController.begin({
+			hadInitialMessage: initialMessage !== undefined || initialMessages.length > 0,
+			resuming,
+			startupFailed: startupPromptFailed,
+		});
 	}
 
 	while (true) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -20,6 +20,7 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { AutonomousController } from "./autonomous/controller";
 import { reset as resetCapabilities } from "./capability";
 import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
@@ -388,6 +389,7 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	titleSystemPrompt?: string,
 	joinLink?: string,
+	autonomousController?: AutonomousController,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -488,6 +490,13 @@ async function runInteractiveMode(
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
 		}
+	}
+	// Autonomous mode with no initial user message: start the first turn so
+	// `--auto-next-idea` (or `--auto-next-steps --auto-next-idea`) can begin
+	// ideating from scratch. Steps-only mode with no objective has nothing to
+	// continue, so kickoff() is a no-op there.
+	if (autonomousController && initialMessage === undefined && initialMessages.length === 0) {
+		autonomousController.kickoff();
 	}
 
 	while (true) {
@@ -1304,6 +1313,18 @@ export async function runRootCommand(
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
 		}
+		// Autonomous continuation (--auto-next-steps / --auto-next-idea): armed only
+		// for interactive sessions — print/protocol modes are one-shot. The controller
+		// subscribes to the session event stream for its lifetime; runInteractiveMode
+		// calls kickoff() to start the first turn when no initial user message is given.
+		const autonomousController =
+			isInteractive && (parsedArgs.autoNextSteps || parsedArgs.autoNextIdea)
+				? new AutonomousController({
+						session,
+						autoNextSteps: parsedArgs.autoNextSteps === true,
+						autoNextIdea: parsedArgs.autoNextIdea === true,
+					})
+				: undefined;
 
 		if (modelFallbackMessage) {
 			notifs.push({ kind: "warn", message: modelFallbackMessage });
@@ -1373,6 +1394,7 @@ export async function runRootCommand(
 				initialImages,
 				titleSystemPrompt,
 				parsedArgs.join,
+				autonomousController,
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -504,8 +504,6 @@ async function runInteractiveMode(
 	// failing turn.
 	if (autonomousController) {
 		autonomousController.begin({
-			hadInitialMessage: initialMessage !== undefined || initialMessages.length > 0,
-			resuming,
 			startupFailed: startupPromptFailed,
 		});
 	}
@@ -1328,8 +1326,16 @@ export async function runRootCommand(
 		// for interactive sessions — print/protocol modes are one-shot. Optional
 		// publishing flags only extend the hidden continuation prompt; side effects
 		// stay model-driven so mid-objective turns are not committed or pushed.
+		// When active, disable compaction.autoContinue so the controller owns
+		// post-handoff continuation: without this, auto-handoff schedules a generic
+		// "resume work" prompt that races — and lacks — the autonomous steps/idea/
+		// commit/PR instructions the controller would queue on the next agent_end.
+		const hasAutonomousFlags = parsedArgs.autoNextSteps || parsedArgs.autoNextIdea;
+		if (isInteractive && hasAutonomousFlags) {
+			settingsInstance.override("compaction.autoContinue", false);
+		}
 		const autonomousController =
-			isInteractive && (parsedArgs.autoNextSteps || parsedArgs.autoNextIdea)
+			isInteractive && hasAutonomousFlags
 				? new AutonomousController({
 						session,
 						autoNextSteps: parsedArgs.autoNextSteps === true,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -119,6 +119,7 @@ export class EventController {
 				this.ctx.ui.requestRender();
 			},
 			goal_updated: async () => {},
+			mode_changed: async () => {},
 		} satisfies AgentSessionEventHandlers;
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -121,6 +121,7 @@ const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
 	"notice",
 	"thinking_level_changed",
 	"goal_updated",
+	"mode_changed",
 ]);
 
 function isRpcResponse(value: unknown): value is RpcResponse {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6361,6 +6361,20 @@ export class AgentSession {
 			return false;
 		}
 
+		// `deliverAs: "followUp"` with a turn trigger but already-queued messages
+		// (e.g. a user follow-up that landed after the loop's final queue poll and
+		// strands in #drainStrandedQueuedMessages): starting a turn immediately
+		// would reorder the new message ahead of the queued user input. Queue it
+		// behind the existing work instead and let the idle-queue drain drive the
+		// turn once #endInFlight settles. Without this, an autonomous continuation
+		// (#onAgentEnd → sendCustomMessage) can jump in front of a stranded user
+		// follow-up because agent_end is flushed before the stranded drain runs.
+		if (options?.deliverAs === "followUp" && options?.triggerTurn && this.agent.hasQueuedMessages()) {
+			this.agent.followUp(normalizedAppMessage);
+			this.#scheduleIdleQueueDrain();
+			return false;
+		}
+
 		if (options?.triggerTurn) {
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6295,15 +6295,26 @@ export class AgentSession {
 
 	async #promptAgentInitiatedMessage(message: CustomMessage): Promise<void> {
 		this.#beginInFlight();
+		const generation = this.#promptGeneration;
 		try {
 			// Inject pending "nextTurn" context (e.g. todo error reminders) so it is
 			// delivered alongside the agent-initiated turn. #promptWithMessage does
 			// this at line ~5837, but this path bypasses it — without this, autonomous
 			// continuations would skip next-turn guidance every turn.
-			const messages: AgentMessage[] = [...this.#pendingNextTurnMessages, message];
+			const nextTurnMessages = [...this.#pendingNextTurnMessages];
+			const messages: AgentMessage[] = [...nextTurnMessages, message];
+			await this.#runPrePromptCompactionIfNeeded(messages);
+			if (this.#promptGeneration !== generation) {
+				return;
+			}
 			this.#pendingNextTurnMessages = [];
-			await this.agent.prompt(messages);
-			await this.#waitForPostPromptRecovery();
+			try {
+				await this.agent.prompt(messages);
+				await this.#waitForPostPromptRecovery();
+			} catch (error) {
+				this.#pendingNextTurnMessages = [...nextTurnMessages, ...this.#pendingNextTurnMessages];
+				throw error;
+			}
 		} finally {
 			this.#endInFlight();
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6297,6 +6297,13 @@ export class AgentSession {
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
 		try {
+			// Match the normal #promptWithMessage path: side-channel records (bash,
+			// Python eval, IRC asides) must be materialized before constructing the
+			// hidden agent-initiated prompt, otherwise auto-next can run without
+			// seeing results that arrived while the previous turn was streaming.
+			this.#flushPendingBashMessages();
+			this.#flushPendingPythonMessages();
+			this.#flushPendingIrcAsides();
 			// Inject pending "nextTurn" context (e.g. todo error reminders) so it is
 			// delivered alongside the agent-initiated turn. #promptWithMessage does
 			// this at line ~5837, but this path bypasses it — without this, autonomous

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -341,7 +341,8 @@ export type AgentSessionEvent =
 			/** The level `auto` resolved to this turn, once classified. */
 			resolved?: Effort;
 	  }
-	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState };
+	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState }
+	| { type: "mode_changed"; mode: "plan" | "goal"; active: boolean; droppedCustomType?: string };
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
@@ -5239,6 +5240,13 @@ export class AgentSession {
 			this.#planReferenceSent = false;
 			this.#planReferencePath = state.planFilePath;
 		}
+		const dropped = state?.enabled ? this.dropQueuedCustomMessage("autonomous-continuation") : false;
+		this.#emit({
+			type: "mode_changed",
+			mode: "plan",
+			active: state?.enabled === true,
+			droppedCustomType: dropped ? "autonomous-continuation" : undefined,
+		});
 	}
 
 	getGoalModeState(): GoalModeState | undefined {
@@ -5247,6 +5255,13 @@ export class AgentSession {
 
 	setGoalModeState(state: GoalModeState | undefined): void {
 		this.#goalModeState = state;
+		const dropped = state?.enabled ? this.dropQueuedCustomMessage("autonomous-continuation") : false;
+		this.#emit({
+			type: "mode_changed",
+			mode: "goal",
+			active: state?.enabled === true,
+			droppedCustomType: dropped ? "autonomous-continuation" : undefined,
+		});
 	}
 
 	get goalRuntime(): GoalRuntime {
@@ -6281,7 +6296,13 @@ export class AgentSession {
 	async #promptAgentInitiatedMessage(message: CustomMessage): Promise<void> {
 		this.#beginInFlight();
 		try {
-			await this.agent.prompt(message);
+			// Inject pending "nextTurn" context (e.g. todo error reminders) so it is
+			// delivered alongside the agent-initiated turn. #promptWithMessage does
+			// this at line ~5837, but this path bypasses it — without this, autonomous
+			// continuations would skip next-turn guidance every turn.
+			const messages: AgentMessage[] = [...this.#pendingNextTurnMessages, message];
+			this.#pendingNextTurnMessages = [];
+			await this.agent.prompt(messages);
 			await this.#waitForPostPromptRecovery();
 		} finally {
 			this.#endInFlight();
@@ -6468,7 +6489,45 @@ export class AgentSession {
 	hasQueuedCustomMessage(customType: string): boolean {
 		const matches = (message: AgentMessage): boolean =>
 			message.role === "custom" && message.customType === customType;
-		return this.agent.peekSteeringQueue().some(matches) || this.agent.peekFollowUpQueue().some(matches);
+		return (
+			this.agent.peekSteeringQueue().some(matches) ||
+			this.agent.peekFollowUpQueue().some(matches) ||
+			this.#pendingNextTurnMessages.some(matches)
+		);
+	}
+
+	dropQueuedCustomMessage(customType: string): boolean {
+		const matches = (message: AgentMessage): boolean =>
+			message.role === "custom" && message.customType === customType;
+		const steering = [...this.agent.peekSteeringQueue()];
+		const followUp = [...this.agent.peekFollowUpQueue()];
+		const nextTurn = [...this.#pendingNextTurnMessages];
+		let dropped = false;
+		const keptSteering = steering.filter(msg => {
+			if (matches(msg)) {
+				dropped = true;
+				return false;
+			}
+			return true;
+		});
+		const keptFollowUp = followUp.filter(msg => {
+			if (matches(msg)) {
+				dropped = true;
+				return false;
+			}
+			return true;
+		});
+		const keptNextTurn = nextTurn.filter(msg => {
+			if (matches(msg)) {
+				dropped = true;
+				return false;
+			}
+			return true;
+		});
+		if (!dropped) return false;
+		this.agent.replaceQueues(keptSteering, keptFollowUp);
+		this.#pendingNextTurnMessages = keptNextTurn;
+		return true;
 	}
 
 	/** Number of pending displayable messages (includes steering, follow-up, and next-turn messages).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6451,6 +6451,12 @@ export class AgentSession {
 		return { steering, followUp };
 	}
 
+	hasQueuedCustomMessage(customType: string): boolean {
+		const matches = (message: AgentMessage): boolean =>
+			message.role === "custom" && message.customType === customType;
+		return this.agent.peekSteeringQueue().some(matches) || this.agent.peekFollowUpQueue().some(matches);
+	}
+
 	/** Number of pending displayable messages (includes steering, follow-up, and next-turn messages).
 	 *  Reflects actual queued work (advisor cards included) — feeds hasPendingMessages()/RPC and the
 	 *  empty-submit abort gate. The user-restorable subset is surfaced by getQueuedMessages()/clearQueue(). */

--- a/packages/coding-agent/test/agent-session-agent-initiated-next-turn.test.ts
+++ b/packages/coding-agent/test/agent-session-agent-initiated-next-turn.test.ts
@@ -102,6 +102,17 @@ describe("AgentSession agent-initiated nextTurn context", () => {
 			},
 			{ deliverAs: "nextTurn", triggerTurn: false },
 		);
+		activeSession.recordBashResult("echo result", {
+			output: "bash output",
+			exitCode: 0,
+			cancelled: false,
+			truncated: false,
+			totalLines: 1,
+			totalBytes: 11,
+			outputLines: 1,
+			outputBytes: 11,
+		});
+		expect(activeSession.hasPendingBashMessages).toBe(true);
 		await activeSession.abort();
 		await firstPrompt.catch(() => {});
 		await activeSession.waitForIdle();
@@ -124,6 +135,15 @@ describe("AgentSession agent-initiated nextTurn context", () => {
 				{ deliverAs: "nextTurn", triggerTurn: true },
 			),
 		).rejects.toThrow("missing model");
+		expect(activeSession.hasPendingBashMessages).toBe(false);
+		expect(
+			activeSession.agent.state.messages.some(
+				message =>
+					message.role === "bashExecution" &&
+					message.command === "echo result" &&
+					message.output === "bash output",
+			),
+		).toBe(true);
 
 		promptSpy.mockImplementationOnce(async messages => {
 			promptInputs.push(Array.isArray(messages) ? messages : [messages as AgentMessage]);

--- a/packages/coding-agent/test/agent-session-agent-initiated-next-turn.test.ts
+++ b/packages/coding-agent/test/agent-session-agent-initiated-next-turn.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+describe("AgentSession agent-initiated nextTurn context", () => {
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+	let tempDir: string | undefined;
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		if (authStorage) {
+			authStorage.close();
+			authStorage = undefined;
+		}
+		if (tempDir) {
+			try {
+				await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+			} catch (error) {
+				if (!isBusyError(error)) throw error;
+			}
+			tempDir = undefined;
+		}
+		vi.restoreAllMocks();
+	});
+
+	function isBusyError(error: unknown): boolean {
+		return (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			(error as { code?: unknown }).code === "EBUSY"
+		);
+	}
+
+	async function createSession(): Promise<{ session: AgentSession; firstTurnStarted: Promise<void> }> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const firstTurnStarted = Promise.withResolvers<void>();
+		let abortSignal: AbortSignal | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+			},
+			streamFn: (_model, _context, options) => {
+				abortSignal = options?.signal;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: createAssistantMessage("") });
+					firstTurnStarted.resolve();
+					abortSignal?.addEventListener(
+						"abort",
+						() => {
+							stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
+						},
+						{ once: true },
+					);
+				});
+				return stream;
+			},
+		});
+
+		tempDir = path.join(os.tmpdir(), `pi-agent-initiated-next-turn-${Date.now()}-${Math.random()}`);
+		await fs.mkdir(tempDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		return { session, firstTurnStarted: firstTurnStarted.promise };
+	}
+
+	it("restores hidden nextTurn context when an agent-initiated prompt fails before acceptance", async () => {
+		const { session: activeSession, firstTurnStarted } = await createSession();
+		const firstPrompt = activeSession.prompt("First message");
+		await firstTurnStarted;
+		await activeSession.sendCustomMessage(
+			{
+				customType: "todo-error-reminder",
+				content: "Fix the todo payload",
+				display: false,
+				attribution: "agent",
+			},
+			{ deliverAs: "nextTurn", triggerTurn: false },
+		);
+		await activeSession.abort();
+		await firstPrompt.catch(() => {});
+		await activeSession.waitForIdle();
+
+		const promptInputs: AgentMessage[][] = [];
+		const promptSpy = vi.spyOn(activeSession.agent, "prompt");
+		promptSpy.mockImplementationOnce(async messages => {
+			promptInputs.push(Array.isArray(messages) ? messages : [messages as AgentMessage]);
+			throw new Error("missing model");
+		});
+
+		await expect(
+			activeSession.sendCustomMessage(
+				{
+					customType: "autonomous-continuation",
+					content: "continue",
+					display: false,
+					attribution: "user",
+				},
+				{ deliverAs: "nextTurn", triggerTurn: true },
+			),
+		).rejects.toThrow("missing model");
+
+		promptSpy.mockImplementationOnce(async messages => {
+			promptInputs.push(Array.isArray(messages) ? messages : [messages as AgentMessage]);
+		});
+
+		await activeSession.sendCustomMessage(
+			{
+				customType: "autonomous-continuation",
+				content: "continue again",
+				display: false,
+				attribution: "user",
+			},
+			{ deliverAs: "nextTurn", triggerTurn: true },
+		);
+
+		expect(promptInputs).toHaveLength(2);
+		expect(
+			promptInputs[1]?.some(message => {
+				if (message.role !== "custom" || message.customType !== "todo-error-reminder") return false;
+				if (typeof message.content === "string") return message.content.includes("Fix the todo payload");
+				return message.content.some(
+					content => content.type === "text" && content.text.includes("Fix the todo payload"),
+				);
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/agent-session-follow-up-queue-order.test.ts
+++ b/packages/coding-agent/test/agent-session-follow-up-queue-order.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+/**
+ * Regression: an autonomous continuation (AutonomousController.#queueContinuation →
+ * sendCustomMessage with `{ deliverAs: "followUp", triggerTurn: true }`) can fire
+ * from inside #endInFlight's #flushPendingAgentEnd, which runs BEFORE
+ * #drainStrandedQueuedMessages. If a user follow-up stranded after the loop's
+ * final queue poll is sitting in the follow-up queue, the continuation started
+ * a turn immediately (the not-streaming + triggerTurn branch of sendCustomMessage)
+ * and reordered itself ahead of the user's input.
+ *
+ * Contract: when sendCustomMessage is asked to deliver as a "followUp" with a
+ * turn trigger but the session already has queued messages, it queues behind
+ * them (agent.followUp + idle drain) instead of starting a turn, so the
+ * stranded-queue drain runs the user's input first. The drain's continue()
+ * dequeues follow-ups in insertion order, preserving the user → autonomous order.
+ */
+describe("AgentSession follow-up queue order", () => {
+	let session: AgentSession;
+	let authStorage: AuthStorage;
+
+	function assistantTail(): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text: "Done." }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 100,
+				output: 20,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 120,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+	}
+
+	async function createSession(
+		responses: MockResponse[],
+		messages: Parameters<typeof Agent.prototype.appendMessage>[0][] = [],
+	): Promise<MockModel> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const mock = createMockModel({ responses });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		return mock;
+	}
+
+	beforeEach(async () => {
+		// In-memory SQLite avoids Windows EBUSY file-lock contention on cleanup.
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		vi.restoreAllMocks();
+	});
+
+	it("queues a triggerTurn follow-up behind an existing queued user message", async () => {
+		await createSession([], [{ role: "user", content: "initial objective", timestamp: Date.now() }, assistantTail()]);
+
+		// Simulate a stranded user follow-up: a message that landed in the
+		// follow-up queue after the loop's final queue poll, with no drain
+		// scheduled yet (the session is idle between #flushPendingAgentEnd and
+		// #drainStrandedQueuedMessages). Queue at the agent level directly so
+		// no idle drain is kicked.
+		session.agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "user follow-up" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+		expect(session.agent.hasQueuedMessages()).toBe(true);
+		expect(session.isStreaming).toBe(false);
+
+		// Block agent.prompt (the turn-start path) so sendCustomMessage's
+		// triggerTurn branch cannot start a real turn. Clear queues in the spy
+		// so the idle drain (continue → hasQueuedMessages) settles instead of
+		// rescheduling forever against a no-op.
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			session.agent.clearAllQueues();
+		});
+
+		const started = await session.sendCustomMessage(
+			{
+				customType: "autonomous-continuation",
+				content: "continue the next steps",
+				display: false,
+				attribution: "user",
+			},
+			{ deliverAs: "followUp", triggerTurn: true },
+		);
+
+		// Must NOT start a turn immediately — the user follow-up is still queued
+		// ahead of it. The idle drain (continue) is scheduled to run the queue in
+		// order once #endInFlight settles, not to jump the autonomous message ahead.
+		expect(started).toBe(false);
+		// agent.prompt (turn start) was never called — the message was queued.
+		expect(promptSpy).not.toHaveBeenCalled();
+		// Let the idle drain settle before afterEach disposes the session.
+		await session.waitForIdle();
+	});
+
+	it("starts a turn immediately when no messages are queued (no reordering to avoid)", async () => {
+		await createSession(
+			[{ content: ["autonomous answer"] }],
+			[{ role: "user", content: "initial objective", timestamp: Date.now() }, assistantTail()],
+		);
+
+		// Spy on prompt to detect turn start without running a real turn.
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			session.agent.clearAllQueues();
+		});
+
+		const started = await session.sendCustomMessage(
+			{
+				customType: "autonomous-continuation",
+				content: "continue the next steps",
+				display: false,
+				attribution: "user",
+			},
+			{ deliverAs: "followUp", triggerTurn: true },
+		);
+
+		// No queued work to respect — the continuation starts its own turn.
+		expect(started).toBe(true);
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		await session.waitForIdle();
+	});
+});

--- a/packages/coding-agent/test/cli-autonomous-publish-flags.test.ts
+++ b/packages/coding-agent/test/cli-autonomous-publish-flags.test.ts
@@ -3,12 +3,22 @@ import { parseArgs } from "../src/cli/args";
 import { extractProfileFlags } from "../src/cli/profile-bootstrap";
 
 describe("parseArgs — autonomous publish flags", () => {
-	it("parses --auto-commit and --auto-pr as boolean launch flags", () => {
-		const result = parseArgs(["--auto-next-steps", "--auto-commit", "--auto-pr", "ship it"]);
+	it("parses autonomous publish flags as launch flags", () => {
+		const result = parseArgs([
+			"--auto-next-steps",
+			"--auto-commit",
+			"--auto-pr",
+			"--auto-group-pr",
+			"--auto-agents",
+			"3",
+			"ship it",
+		]);
 
 		expect(result.autoNextSteps).toBe(true);
 		expect(result.autoCommit).toBe(true);
 		expect(result.autoPr).toBe(true);
+		expect(result.autoGroupPr).toBe(true);
+		expect(result.autoAgents).toBe(3);
 		expect(result.messages).toEqual(["ship it"]);
 	});
 
@@ -18,6 +28,13 @@ describe("parseArgs — autonomous publish flags", () => {
 		expect(result.autoPr).toBe(true);
 		expect(result.model).toBe("opus");
 		expect(result.messages).toEqual([]);
+	});
+
+	it("parses --auto-agents=N form", () => {
+		const result = parseArgs(["--auto-next-steps", "--auto-agents=2", "ship it"]);
+
+		expect(result.autoAgents).toBe(2);
+		expect(result.messages).toEqual(["ship it"]);
 	});
 });
 
@@ -30,6 +47,19 @@ describe("profile bootstrap — autonomous publish flags", () => {
 		});
 		expect(extractProfileFlags(["--auto-pr", "--profile", "work"])).toEqual({
 			argv: ["--auto-pr"],
+			profile: "work",
+			aliasName: undefined,
+		});
+		expect(extractProfileFlags(["--auto-group-pr", "--profile", "work"])).toEqual({
+			argv: ["--auto-group-pr"],
+			profile: "work",
+			aliasName: undefined,
+		});
+	});
+
+	it("preserves --auto-agents value while extracting trailing profiles", () => {
+		expect(extractProfileFlags(["--auto-agents", "3", "--profile", "work"])).toEqual({
+			argv: ["--auto-agents", "3"],
 			profile: "work",
 			aliasName: undefined,
 		});

--- a/packages/coding-agent/test/cli-autonomous-publish-flags.test.ts
+++ b/packages/coding-agent/test/cli-autonomous-publish-flags.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+import { extractProfileFlags } from "../src/cli/profile-bootstrap";
+
+describe("parseArgs — autonomous publish flags", () => {
+	it("parses --auto-commit and --auto-pr as boolean launch flags", () => {
+		const result = parseArgs(["--auto-next-steps", "--auto-commit", "--auto-pr", "ship it"]);
+
+		expect(result.autoNextSteps).toBe(true);
+		expect(result.autoCommit).toBe(true);
+		expect(result.autoPr).toBe(true);
+		expect(result.messages).toEqual(["ship it"]);
+	});
+
+	it("does not consume the following flag as a value", () => {
+		const result = parseArgs(["--auto-pr", "--model", "opus"]);
+
+		expect(result.autoPr).toBe(true);
+		expect(result.model).toBe("opus");
+		expect(result.messages).toEqual([]);
+	});
+});
+
+describe("profile bootstrap — autonomous publish flags", () => {
+	it("extracts trailing profiles after autonomous publish booleans", () => {
+		expect(extractProfileFlags(["--auto-commit", "--profile", "work"])).toEqual({
+			argv: ["--auto-commit"],
+			profile: "work",
+			aliasName: undefined,
+		});
+		expect(extractProfileFlags(["--auto-pr", "--profile", "work"])).toEqual({
+			argv: ["--auto-pr"],
+			profile: "work",
+			aliasName: undefined,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds autonomous launch flags so the coding agent can keep working without user input and optionally publish each verified work unit.

- `--auto-next-steps` continues the current objective after each clean turn, including relevant checks.
- `--auto-next-idea` brainstorms and implements follow-up improvements after the current work is complete.
- `--auto-commit` adds completion-time instructions to commit verified work through the existing `omp commit` workflow before continuing.
- `--auto-pr` adds completion-time instructions to ensure work is committed, pushed, and published through the existing GitHub pull-request path without creating duplicate PRs.

## Design

`AutonomousController` subscribes to the session event stream and queues hidden follow-up prompts with `session.sendCustomMessage(..., { deliverAs: "followUp", triggerTurn: true })`. The controller is only created for interactive sessions, so `--print`, rpc, acp, and subagent sessions remain one-shot.

The commit/PR flags intentionally do **not** run side effects directly from `agent_end`; auto-next turns can be mid-objective. Instead they append static prompt fragments that tell the agent to commit or create/update a PR only after the current work unit is complete and verified, using existing surfaces (`omp commit` and the `github` tool `pr_create` / `gh pr`).

## Auto-handoff compaction safety

When `--auto-next-steps` or `--auto-next-idea` is active, `compaction.autoContinue` is overridden to `false`. Without this, auto-handoff would schedule a generic "resume work" continuation prompt (`auto-continue.md`) that:

1. **Races** the autonomous controller's own continuation prompt — two turns queue back-to-back.
2. **Lacks** the autonomous steps/idea/commit/PR instructions — the generic prompt only says "resume the user's most recent intent."

With the override, the autonomous controller owns post-handoff continuation exclusively. After auto-handoff completes (new session created, handoff context injected, `agent_end` flushed to subscribers), the controller queues its own continuation prompt — which carries the full autonomous instructions — into the new session. The handoff's generated document provides the context; the controller's prompt provides the direction.

## Safety

- Halts on user interrupt, failed turn, or deadline-style no-assistant completion.
- Leaves plan/goal mode to their own drivers.
- Pure `--auto-next-steps` stops when an autonomous turn has no tool activity, treating that as objective completion.
- Idea/combined modes remain endless until interrupted.
- Profile bootstrap treats all four autonomous flags as valueless booleans, so `omp --auto-pr --profile work` still selects the profile.

## Files

- `src/autonomous/controller.ts` plus prompt files for next steps, ideas, combined mode, auto-commit, and auto-pr
- `src/autonomous/__tests__/controller.test.ts`
- `src/cli/args.ts`, `src/cli/flag-tables.ts`, `src/commands/launch.ts`
- `src/main.ts` (wiring + `compaction.autoContinue` override)
- `test/cli-autonomous-publish-flags.test.ts`
- `CHANGELOG.md`

## Verification

- `bun test packages/coding-agent/src/autonomous/__tests__/controller.test.ts packages/coding-agent/test/cli-autonomous-publish-flags.test.ts`
- `bun --cwd=packages/coding-agent run check`
