### PR TITLE
feat(coding-agent): add context_audit tool to audit context-window usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -72,6 +72,9 @@
 
 - Fixed `/model` in the TUI to open the model setup picker again, leaving `/switch` as the temporary session model switcher ([#2933](https://github.com/can1357/oh-my-pi/issues/2933)).
 - Fixed OpenCode Go sessions recording per-request cost history so `/usage` can show local cap utilization. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
+### Added
+
+- Added the `context_audit` built-in tool, which lets the model audit what is consuming its context window: it reports the authoritative per-category breakdown (system prompt, tool schemas, system context, skills, conversation messages) and ranks the heaviest provider-visible message rows, with `min_tokens`/`query`/`max_items` filtering. Exposed via two new optional `ToolSession` accessors — `getContextBreakdown` and `getProviderMessages` (the post-transform message list that actually goes to the provider) — wired at the session tool-context boundary.
 
 ## [16.0.6] - 2026-06-18
 

--- a/packages/coding-agent/src/prompts/tools/context-audit.md
+++ b/packages/coding-agent/src/prompts/tools/context-audit.md
@@ -1,0 +1,17 @@
+Audit what is consuming the model context window before deciding to compact, drop images, or restructure the conversation.
+
+Use when context is running low, when you want to justify a compaction, or when you need to know which specific messages or categories (system prompt, tool schemas, skills, conversation) dominate the window. Do NOT use for general session statistics — only for context-window composition.
+
+## Parameters
+- `min_tokens` (optional): only list rows estimated at or above this many tokens.
+- `max_items` (optional): cap on rows returned (default 40, max 200).
+- `query` (optional): only list rows whose label or content contain this substring (content is searchable even when `include_previews` is false).
+- `include_previews` (optional): include a short text preview per row (default true).
+
+## Output
+- Window usage and free space (authoritative, anchored on the provider's last reported prompt-token count when available).
+- Category breakdown in real tokens: system prompt, tool schemas, system context, skills, conversation messages.
+- Heaviest individual message rows (estimated tokens), filtered and ranked.
+- Largest groups aggregated by label.
+
+The category breakdown is authoritative; per-row token counts are estimates. Use the breakdown to decide IF action is needed and the row ranking to decide WHAT to act on.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -16,7 +16,7 @@ import {
 	type SimpleStreamOptions,
 	streamSimple,
 } from "@oh-my-pi/pi-ai";
-import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
+import { type Dialect, encodeInbandToolHistory } from "@oh-my-pi/pi-ai/dialect";
 import {
 	getOpenAICodexTransportDetails,
 	prewarmOpenAICodexResponses,
@@ -1549,6 +1549,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
 			getUsageStatistics: () => sessionManager.getUsageStatistics(),
+			getContextBreakdown: () => session?.getContextBreakdown(),
+			getProviderMessages: async signal => {
+				if (!session) return [];
+				let messages = await session.convertMessagesToLlm(session.messages, signal);
+				// Mirror the provider send path: when an owned (non-native) tool dialect is
+				// active, fold assistant tool calls and tool-result runs into dialect text
+				// so the audit ranks/searches the same in-band text the provider receives.
+				const dialect = resolveDialect(settings.get("tools.format"), agent?.state.model ?? model);
+				if (dialect) {
+					const activeTools = session
+						.getActiveToolNames()
+						.map(name => session.getToolByName(name))
+						.filter((t): t is AgentTool => t !== undefined);
+					if (activeTools.length > 0) {
+						messages = encodeInbandToolHistory(messages, dialect, activeTools);
+					}
+				}
+				return messages;
+			},
 			getTurnBudget: () => sessionManager.getTurnBudget(),
 			recordEvalSubagentUsage: output => sessionManager.recordEvalSubagentOutput(output),
 			getClientBridge: () => session?.clientBridge,

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -29,6 +29,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"reflect",
 	"learn",
 	"manage_skill",
+	"context_audit",
 ] as const;
 
 export type BuiltinToolName = (typeof BUILTIN_TOOL_NAMES)[number];

--- a/packages/coding-agent/src/tools/context-audit.ts
+++ b/packages/coding-agent/src/tools/context-audit.ts
@@ -1,0 +1,351 @@
+/**
+ * context_audit — let the model inspect what is consuming its context window.
+ *
+ * Surfaces the authoritative per-category breakdown the session already computes
+ * (`AgentSession.getContextBreakdown`): system prompt, tool schemas, system
+ * context, skills, and conversation messages — each in real tokens, anchored on
+ * the provider's last reported prompt-token count when available. Then drills
+ * into the provider-visible message list (`session.convertMessagesToLlm`) — the
+ * post-transform messages that actually go to the provider — to rank the heaviest
+ * individual rows so the model can decide what to compact, drop, or restructure.
+ *
+ * Read-only and side-effect free. Built on oh-my-pi's real breakdown machinery
+ * (real token totals) rather than a chars/4 estimate.
+ */
+import type {
+	AgentMessage,
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+} from "@oh-my-pi/pi-agent-core";
+import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import contextAuditDescription from "../prompts/tools/context-audit.md" with { type: "text" };
+import type { ContextUsageBreakdown } from "../session/agent-session";
+import type { ToolSession } from "./index";
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+const contextAuditSchema = type({
+	"min_tokens?": type("number").describe("only list rows estimated at or above this many tokens (default 0 = all)"),
+	"max_items?": type("number").describe("cap on rows returned (default 40, max 200)"),
+	"query?": type("string").describe("only list rows whose label or content contain this substring"),
+	"include_previews?": type("boolean").describe("include a short text preview per row (default true)"),
+}).describe("audit what is consuming the model context window");
+
+type ContextAuditParams = typeof contextAuditSchema.infer;
+
+/** Structured snapshot attached to the result for UI/logging. */
+export interface ContextAuditDetails {
+	contextWindow: number;
+	usedTokens: number;
+	anchored: boolean;
+	categories: {
+		systemPrompt: number;
+		tools: number;
+		systemContext: number;
+		skills: number;
+		messages: number;
+	};
+	rowCount: number;
+}
+
+// =============================================================================
+// Tunables
+// =============================================================================
+
+const DEFAULT_MAX_ITEMS = 40;
+const MAX_MAX_ITEMS = 200;
+const DEFAULT_PREVIEW_CHARS = 180;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatTokens(n: number): string {
+	if (n >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+	return n.toLocaleString("en-US");
+}
+
+function capPreview(text: string, limit = DEFAULT_PREVIEW_CHARS): string {
+	const compact = text.replace(/\s+/g, " ").trim();
+	if (compact.length <= limit) return compact;
+	return `${compact.slice(0, Math.max(0, limit - 1))}…`;
+}
+
+/**
+ * Short human label for a message, derived only from the role discriminant and
+ * the fields TypeScript narrows to after that check — no casts.
+ */
+function messageLabel(message: AgentMessage): string {
+	switch (message.role) {
+		case "assistant": {
+			const toolCallCount = message.content.filter(block => block.type === "toolCall").length;
+			return toolCallCount > 0
+				? `assistant (${toolCallCount} tool call${toolCallCount > 1 ? "s" : ""})`
+				: "assistant";
+		}
+		case "user":
+			return "user";
+		case "toolResult":
+			return message.toolName ? `tool result: ${message.toolName}` : "tool result";
+		case "developer":
+			return "developer";
+		case "custom":
+			return message.customType ? `custom: ${message.customType}` : "custom";
+		case "branchSummary":
+			return "branch summary";
+		case "compactionSummary":
+			return "compaction summary";
+		default:
+			return message.role;
+	}
+}
+
+/**
+ * Extract a bounded preview of a message's text. Block fields are read only
+ * after narrowing on the `type` discriminant — no inline casts.
+ */
+function messagePreview(message: AgentMessage): string {
+	switch (message.role) {
+		case "user":
+		case "developer":
+		case "toolResult":
+		case "hookMessage":
+		case "custom": {
+			const content = message.content;
+			if (typeof content === "string") return content;
+			return content.flatMap(block => (block.type === "text" ? [block.text] : [])).join(" ");
+		}
+		case "assistant": {
+			return message.content
+				.flatMap(block => {
+					if (block.type === "text") return [block.text];
+					if (block.type === "thinking") return [`[thinking ${block.thinking.length} chars]`];
+					if (block.type === "toolCall") return [`[call ${block.name}: ${JSON.stringify(block.arguments)}]`];
+					return [];
+				})
+				.join(" ");
+		}
+		case "branchSummary":
+		case "compactionSummary":
+			return message.summary;
+		default:
+			return "";
+	}
+}
+
+/**
+ * Provider-visible token estimate per message. `estimateTokens` counts image blocks
+ * only on `toolResult` (not `user`/`developer`) and has no `developer` case, so:
+ *  - user/developer array content is routed through a toolResult-shaped view, which
+ *    counts both text and image blocks (pasted screenshots, @file images) — otherwise
+ *    image-only rows would read 0 and be filtered out, hiding exactly what to drop;
+ *  - developer string content falls back to a user-shaped view (estimateTokens has
+ *    no developer case).
+ * No casts: the literals are valid Message shapes. Routing through toolResult stays
+ * in sync with estimateTokens' image surcharge rather than duplicating the constant.
+ */
+function estimateVisibleMessageTokens(message: AgentMessage): number {
+	if ((message.role === "user" || message.role === "developer") && Array.isArray(message.content)) {
+		return estimateTokens({
+			role: "toolResult",
+			toolCallId: "",
+			toolName: "",
+			content: message.content,
+			isError: false,
+			timestamp: message.timestamp,
+		});
+	}
+	if (message.role === "developer") {
+		return estimateTokens({ role: "user", content: message.content, timestamp: message.timestamp });
+	}
+	return estimateTokens(message);
+}
+interface MessageRow {
+	index: number;
+	tokens: number;
+	label: string;
+	searchText: string;
+	preview: string;
+}
+
+function buildRows(messages: AgentMessage[], includePreviews: boolean): MessageRow[] {
+	return messages.map((message, index) => {
+		const text = messagePreview(message);
+		return {
+			index,
+			tokens: estimateVisibleMessageTokens(message),
+			label: messageLabel(message),
+			searchText: text,
+			preview: includePreviews ? capPreview(text) : "",
+		};
+	});
+}
+
+function pct(part: number, whole: number): string {
+	if (whole <= 0) return "—";
+	return `${((part / whole) * 100).toFixed(1)}%`;
+}
+// =============================================================================
+// Report
+// =============================================================================
+
+function renderReport(
+	breakdown: ContextUsageBreakdown,
+	rows: MessageRow[],
+	params: ContextAuditParams,
+	snapcompactEnabled: boolean,
+): string {
+	const { contextWindow, usedTokens, anchored } = breakdown;
+	const lines: string[] = [];
+
+	lines.push("Context audit");
+	lines.push("─".repeat(60));
+	lines.push(
+		`Window: ${formatTokens(usedTokens)} / ${formatTokens(contextWindow)} tokens ` +
+			`(${pct(usedTokens, contextWindow)} of context window)`,
+	);
+	const free = Math.max(0, contextWindow - usedTokens);
+	lines.push(`Free: ${formatTokens(free)} tokens (${pct(free, contextWindow)})`);
+	lines.push(
+		`Estimate basis: ${anchored ? "anchored on provider usage" : "fully estimated (no provider anchor yet)"}`,
+	);
+	lines.push("");
+
+	lines.push("Category breakdown (authoritative)");
+	lines.push("─".repeat(60));
+	const categoryRows: Array<[string, number]> = [
+		["System prompt", breakdown.systemPromptTokens],
+		["Tool schemas", breakdown.systemToolsTokens],
+		["System context (rules/skills injections)", breakdown.systemContextTokens],
+		["Skills", breakdown.skillsTokens],
+		["Conversation messages", breakdown.messagesTokens],
+	];
+	for (const [label, tokens] of categoryRows) {
+		lines.push(`  ${label.padEnd(46)} ${formatTokens(tokens).padStart(8)}  ${pct(tokens, contextWindow)}`);
+	}
+	lines.push("");
+
+	const visible = rows.filter(row => row.tokens > 0);
+	const totalRowTokens = visible.reduce((sum, row) => sum + row.tokens, 0);
+	lines.push(`Heaviest message rows (${visible.length} non-empty, ~${formatTokens(totalRowTokens)} tokens)`);
+	lines.push("─".repeat(60));
+
+	const minTokens = typeof params.min_tokens === "number" ? Math.max(0, params.min_tokens) : 0;
+	const query = typeof params.query === "string" && params.query.length > 0 ? params.query.toLowerCase() : undefined;
+	const maxItemsRaw = typeof params.max_items === "number" ? params.max_items : DEFAULT_MAX_ITEMS;
+	const maxItems = Math.max(1, Math.min(MAX_MAX_ITEMS, Math.floor(maxItemsRaw)));
+
+	let ranked = visible;
+	if (minTokens > 0) ranked = ranked.filter(row => row.tokens >= minTokens);
+	if (query)
+		ranked = ranked.filter(
+			row => row.label.toLowerCase().includes(query) || row.searchText.toLowerCase().includes(query),
+		);
+	ranked = [...ranked].sort((a, b) => b.tokens - a.tokens).slice(0, maxItems);
+
+	if (ranked.length === 0) {
+		lines.push("  (no rows match the filters)");
+	} else {
+		for (const row of ranked) {
+			const head = `#${row.index} ${row.label} · ${formatTokens(row.tokens)}t · ${pct(row.tokens, contextWindow)}`;
+			lines.push(`  ${head}`);
+			if (row.preview) lines.push(`      ${row.preview}`);
+		}
+	}
+	lines.push("");
+
+	// Largest groups by label.
+	const groups: Record<string, number> = {};
+	for (const row of visible) {
+		groups[row.label] = (groups[row.label] ?? 0) + row.tokens;
+	}
+	const rankedGroups = Object.entries(groups)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 6);
+	if (rankedGroups.length > 0) {
+		lines.push("Largest groups");
+		lines.push("─".repeat(60));
+		for (const [label, tokens] of rankedGroups) {
+			lines.push(
+				`  ${label.padEnd(46)} ${formatTokens(tokens).padStart(8)}  ${pct(tokens, totalRowTokens || contextWindow)}`,
+			);
+		}
+	}
+
+	lines.push("");
+	lines.push(
+		"Per-row token counts are local estimates (real tokenizer where available); the category breakdown above is the authoritative total.",
+	);
+	if (snapcompactEnabled) {
+		lines.push(
+			"Note: snapcompact is on — large historical tool results / system-prompt text may already be replaced by image frames on the wire, so row rankings can over-state those rows. The category total remains authoritative (anchored on the provider's real prompt tokens).",
+		);
+	}
+	return lines.join("\n");
+}
+
+// =============================================================================
+// Tool
+// =============================================================================
+
+export class ContextAuditTool implements AgentTool<typeof contextAuditSchema, ContextAuditDetails> {
+	readonly name = "context_audit";
+	readonly approval = "read" as const;
+	readonly label = "Context audit";
+	readonly summary = "Audit what is consuming the model context window";
+	readonly description: string;
+	readonly parameters = contextAuditSchema;
+	readonly loadMode = "discoverable" as const;
+
+	constructor(private readonly session: ToolSession) {
+		this.description = prompt.render(contextAuditDescription);
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: ContextAuditParams,
+		signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<ContextAuditDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<ContextAuditDetails>> {
+		const breakdown = this.session.getContextBreakdown?.();
+		if (!breakdown || breakdown.contextWindow <= 0) {
+			return {
+				content: [{ type: "text", text: "Context usage unavailable: no model or context window resolved yet." }],
+			};
+		}
+
+		const messages = (await this.session.getProviderMessages?.(signal)) ?? [];
+		const includePreviews = params.include_previews !== false;
+		const rows = buildRows(messages, includePreviews);
+		const snapcompactEnabled =
+			this.session.settings.get("snapcompact.systemPrompt") !== "none" ||
+			this.session.settings.get("snapcompact.toolResults") === true;
+		const text = renderReport(breakdown, rows, params, snapcompactEnabled);
+
+		const details: ContextAuditDetails = {
+			contextWindow: breakdown.contextWindow,
+			usedTokens: breakdown.usedTokens,
+			anchored: breakdown.anchored,
+			categories: {
+				systemPrompt: breakdown.systemPromptTokens,
+				tools: breakdown.systemToolsTokens,
+				systemContext: breakdown.systemContextTokens,
+				skills: breakdown.skillsTokens,
+				messages: breakdown.messagesTokens,
+			},
+			rowCount: rows.filter(row => row.tokens > 0).length,
+		};
+
+		return {
+			content: [{ type: "text", text }],
+			details,
+		};
+	}
+}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,5 +1,5 @@
 import type { InMemorySnapshotStore } from "@oh-my-pi/hashline";
-import type { AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AgentMessage, AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { FetchImpl, ImageContent, Model, ToolChoice } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { AsyncJobManager } from "../async/job-manager";
@@ -19,6 +19,7 @@ import type { MCPManager } from "../mcp";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import type { PlanModeState } from "../plan-mode/state";
 import type { AgentRegistry } from "../registry/agent-registry";
+import type { ContextUsageBreakdown } from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
@@ -39,6 +40,7 @@ import { BashTool } from "./bash";
 import { BrowserTool } from "./browser";
 import type { BuiltinToolName } from "./builtin-names";
 import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
+import { ContextAuditTool } from "./context-audit";
 import { DebugTool } from "./debug";
 import { EvalTool } from "./eval";
 import { resolveEvalBackends } from "./eval-backends";
@@ -77,6 +79,7 @@ export * from "./ast-grep";
 export * from "./bash";
 export * from "./browser";
 export * from "./checkpoint";
+export * from "./context-audit";
 export * from "./debug";
 export * from "./eval";
 export * from "./eval-backends";
@@ -362,6 +365,10 @@ export interface ToolSession {
 	getTelemetry?: () => AgentTelemetryConfig | undefined;
 	/** Return image attachments visible to tools for resolving labels such as `Image #1`. */
 	getImageAttachments?: () => ImageAttachmentEntry[];
+	/** Authoritative per-category context-window breakdown (system prompt, tools, skills, messages). */
+	getContextBreakdown?: () => ContextUsageBreakdown | undefined;
+	/** Provider-visible messages: the post-`transformContext` + `convertToLlm` list that actually goes to the provider (excluded entries dropped, @file mentions expanded into developer content). Reconciles with the breakdown's message-token total. */
+	getProviderMessages?: (signal?: AbortSignal) => Promise<AgentMessage[]>;
 }
 
 export type ToolFactory = (session: ToolSession) => Tool | null | Promise<Tool | null>;
@@ -452,6 +459,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
 	manage_skill: ManageSkillTool.createIf,
+	context_audit: s => new ContextAuditTool(s),
 };
 
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {

--- a/packages/coding-agent/test/tools/context-audit.test.ts
+++ b/packages/coding-agent/test/tools/context-audit.test.ts
@@ -1,0 +1,313 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, ContextUsageBreakdown } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { BUILTIN_TOOLS, ContextAuditTool, createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+function createSession(overloads: { breakdown?: ContextUsageBreakdown; messages?: AgentMessage[] }): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		skipPythonPreflight: true,
+		getContextBreakdown: () => overloads.breakdown,
+		getProviderMessages: async () => overloads.messages ?? [],
+	};
+}
+
+const BREAKDOWN: ContextUsageBreakdown = {
+	contextWindow: 100_000,
+	anchored: true,
+	usedTokens: 5_000,
+	systemPromptTokens: 800,
+	systemToolsTokens: 1_200,
+	systemContextTokens: 500,
+	skillsTokens: 300,
+	messagesTokens: 2_200,
+};
+
+// A heavy tool result, a tool-call assistant turn, and a tiny user message —
+// distinct token weights so ranking/filtering is observable.
+const MESSAGES: AgentMessage[] = [
+	{ role: "user", content: "hi", timestamp: 1 },
+	{
+		role: "assistant",
+		content: [
+			{ type: "text", text: "reading the file now" },
+			{ type: "toolCall", id: "c1", name: "read", arguments: { path: "/a" } },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 2,
+	},
+	{
+		role: "toolResult",
+		toolCallId: "c1",
+		toolName: "read",
+		content: [{ type: "text", text: "x".repeat(6_000) }],
+		isError: false,
+		timestamp: 3,
+	},
+	{
+		role: "developer",
+		content: [{ type: "text", text: `\x3Cfile path="/big.txt">\n${"y".repeat(8_000)}\n\x3C/file>` }],
+		timestamp: 4,
+	},
+];
+
+async function run(params: Record<string, unknown> = {}) {
+	const tool = new ContextAuditTool(createSession({ breakdown: BREAKDOWN, messages: MESSAGES }));
+	return tool.execute("call-1", params as never, undefined, undefined, undefined);
+}
+
+describe("context_audit registration", () => {
+	it("is a default built-in tool with a discoverable loadMode and summary", async () => {
+		expect("context_audit" in BUILTIN_TOOLS).toBe(true);
+		const session = createSession({});
+		const tools = await createTools(session);
+		const names = tools.map(t => t.name);
+		expect(names).toContain("context_audit");
+		const tool = tools.find(t => t.name === "context_audit");
+		expect(tool?.loadMode).toBe("discoverable");
+		expect(tool?.summary).toBe("Audit what is consuming the model context window");
+	});
+});
+
+describe("context_audit report", () => {
+	it("reports window usage and the authoritative category breakdown", async () => {
+		const result = await run();
+		expect(result.content).toHaveLength(1);
+		const text = (result.content[0] as { text: string }).text;
+		// Window line anchored on the breakdown's real numbers.
+		expect(text).toContain("5,000 / 100.0k tokens");
+		expect(text).toContain("5.0% of context window");
+		expect(text).toContain("anchored on provider usage");
+		// Every category label is present.
+		for (const label of ["System prompt", "Tool schemas", "System context", "Skills", "Conversation messages"]) {
+			expect(text).toContain(label);
+		}
+		// Details snapshot mirrors the breakdown.
+		expect(result.details).toMatchObject({
+			contextWindow: 100_000,
+			usedTokens: 5_000,
+			anchored: true,
+			categories: { systemPrompt: 800, tools: 1_200, systemContext: 500, skills: 300, messages: 2_200 },
+		});
+	});
+
+	it("ranks the heaviest message rows and labels them", async () => {
+		const text = ((await run()).content[0] as { text: string }).text;
+		// Rows are labeled and ranked by estimated tokens; the assistant tool-call turn
+		// carries its tool-call count in the label, and every ranked row precedes the tiny "hi" user row.
+		expect(text).toContain("tool result: read");
+		expect(text).toContain("assistant (1 tool call)");
+		// Heaviest row appears before the tiny "hi" user row.
+		const toolResultIdx = text.indexOf("tool result: read");
+		const userIdx = text.indexOf("#0 user");
+		expect(toolResultIdx).toBeGreaterThan(-1);
+		expect(userIdx).toBeGreaterThan(-1);
+		expect(toolResultIdx).toBeLessThan(userIdx);
+	});
+
+	it("respects min_tokens, query, and max_items filters", async () => {
+		// min_tokens filters out the tiny user message.
+		const minTokens = ((await run({ min_tokens: 50 })).content[0] as { text: string }).text;
+		expect(minTokens).toContain("tool result: read");
+		expect(minTokens).not.toContain("#0 user");
+
+		// query keeps only rows whose label/preview match.
+		const queried = ((await run({ query: "read" })).content[0] as { text: string }).text;
+		expect(queried).toContain("tool result: read");
+		expect(queried).not.toContain("#0 user");
+
+		// max_items caps the row count even when more rows match.
+		const capped = ((await run({ max_items: 1 })).content[0] as { text: string }).text;
+		// Only one row index line should appear under "Heaviest message rows".
+		const heaviestSection = capped.split("Heaviest message rows")[1]?.split("Largest groups")[0] ?? "";
+		const rowIndexLines = heaviestSection.match(/^ {2}#\d+ /gm) ?? [];
+		expect(rowIndexLines.length).toBe(1);
+	});
+
+	it("reports unavailable when no context window has resolved", async () => {
+		const tool = new ContextAuditTool(createSession({ breakdown: undefined, messages: MESSAGES }));
+		const result = await tool.execute("call-1", {} as never, undefined, undefined, undefined);
+		const text = (result.content[0] as { text: string }).text;
+		expect(text).toContain("Context usage unavailable");
+		expect(result.details).toBeUndefined();
+	});
+	it("counts expanded developer (@file) content as provider-visible tokens", async () => {
+		const text = ((await run()).content[0] as { text: string }).text;
+		// The 8000-char @file expansion (role: developer) is the heaviest row. estimateTokens
+		// has no developer case, so ranking it first guards the developer-aware estimator shim.
+		const heaviestSection = text.split("Heaviest message rows")[1]?.split("Largest groups")[0] ?? "";
+		const firstRow = heaviestSection.match(/^ {2}#\d+ .+$/m)?.[0] ?? "";
+		expect(firstRow).toContain("developer");
+	});
+
+	it("query matches message content even when previews are hidden", async () => {
+		// "xxx" appears only in the tool result's content, not its label. With previews
+		// suppressed, label-only matching would hide this row — finding it proves query
+		// searches the separate content (searchText) field, not just the displayed preview.
+		const text = ((await run({ include_previews: false, query: "xxx" })).content[0] as { text: string }).text;
+		expect(text).toContain("tool result: read");
+		// The preview is genuinely suppressed: the tool result's "xxx" content is not rendered.
+		expect(text).not.toContain("xxx");
+	});
+	it("counts image-bearing rows so they are not dropped", async () => {
+		// An image-only user message: estimateTokens' user branch ignores images (0 tokens),
+		// which would filter it out — hiding exactly the screenshots worth dropping.
+		const imageMessages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "image", data: "AAAA", mimeType: "image/png" }], timestamp: 1 },
+		];
+		const tool = new ContextAuditTool(createSession({ breakdown: BREAKDOWN, messages: imageMessages }));
+		const text = (
+			(await tool.execute("c", {} as never, undefined, undefined, undefined)).content[0] as { text: string }
+		).text;
+		// The image row survives (not zero-filtered) and carries the image surcharge (1,200 tokens).
+		expect(text).toContain("#0 user");
+		expect(text).toContain("1,200t");
+	});
+	it("query matches tool-call arguments on assistant rows", async () => {
+		// A write/edit tool call's arguments are provider-visible and token-counted, so they
+		// must be searchable even though they appear in neither the label nor a text block.
+		const callMessages: AgentMessage[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "w1",
+						name: "write",
+						arguments: { path: "/a.ts", content: "ZZUNIQUE_MARKER_ZZ body" },
+					},
+				],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 1,
+			},
+		];
+		const tool = new ContextAuditTool(createSession({ breakdown: BREAKDOWN, messages: callMessages }));
+		const text = (
+			(await tool.execute("c", { query: "ZZUNIQUE_MARKER_ZZ" } as never, undefined, undefined, undefined))
+				.content[0] as {
+				text: string;
+			}
+		).text;
+		// The marker appears only in the tool-call arguments — finding the row proves query
+		// searches the arguments, not just the `[call name]` label.
+		expect(text).toContain("assistant (1 tool call)");
+	});
+});
+
+// Real-session integration test: guards that sdk.ts:getProviderMessages actually
+// applies encodeInbandToolHistory when an owned dialect is active. A simulated
+// fake-session test would not catch the glue being deleted.
+describe("context_audit in-band dialect integration", () => {
+	let registryDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	const sessions: AgentSession[] = [];
+
+	beforeAll(async () => {
+		registryDir = path.join(os.tmpdir(), `pi-ctxaudit-dialect-${Snowflake.next()}`);
+		fs.mkdirSync(registryDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(registryDir, "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(async () => {
+		for (const session of sessions) await session.dispose().catch(() => {});
+		authStorage.close();
+		try {
+			if (fs.existsSync(registryDir)) fs.rmSync(registryDir, { recursive: true, force: true });
+		} catch {}
+	});
+
+	it("folds assistant tool calls into dialect text on the wire (qwen3)", async () => {
+		// tools.format: qwen3 forces the owned dialect regardless of model capabilities.
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.format": "qwen3", "compaction.enabled": false }),
+			model: getBundledModel("anthropic", "claude-sonnet-4-5"),
+			disableExtensionDiscovery: true,
+			enableMCP: false,
+		});
+		sessions.push(session);
+		// Append an assistant tool-call whose arguments carry a distinctive marker. Under
+		// qwen3, encodeInbandToolHistory folds this into a text block rendering the call
+		// as dialect-specific tagged text, so the marker appears in the folded text —
+		// not as a separate toolCall block.
+		session.agent.appendMessage({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "writing now" },
+				{
+					type: "toolCall",
+					id: "q1",
+					name: "write",
+					arguments: { path: "/p.ts", content: "DIALECT_QWEN3_MARKER" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		});
+		const tool = session.getToolByName("context_audit");
+		expect(tool).toBeDefined();
+		// Query for the qwen3 dialect closing tag — it only appears after
+		// encodeInbandToolHistory folds the toolCall into dialect text. The raw
+		// messagePreview renders the call as "[call write: ...]" with no dialect
+		// tag, so finding this marker proves the sdk.ts getProviderMessages glue
+		// applied the in-band transform.
+		const dialectCloseTag = "\x3C/tool_call>";
+		const result = await tool!.execute("c", { query: dialectCloseTag } as never, undefined, undefined, undefined);
+		const text = (result.content[0] as { text: string }).text;
+		expect(text).toContain(dialectCloseTag);
+		// The row is no longer labeled as a tool-call row — calls are folded into text.
+		expect(text).not.toContain("assistant (1 tool call)");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new built-in **`context_audit`** tool that lets the model inspect what is consuming its context window — the named deliverable.

It reports the **authoritative per-category breakdown** the session already computes (`AgentSession.getContextBreakdown`: system prompt, tool schemas, system context, skills, conversation messages) and **ranks the heaviest provider-visible message rows**, with `min_tokens` / `query` / `max_items` filtering so the model can decide what to compact, drop, or restructure.

## What changed

- **New** `src/tools/context-audit.ts` — a built-in `AgentTool` (arktype schema, class-based, consistent with `read`/`bash`/`edit`/`todo`).
- **New** `src/prompts/tools/context-audit.md` — tool description (imported `with { type: "text" }`, rendered via `prompt.render`).
- **Registered** in `BUILTIN_TOOL_NAMES` / `BUILTIN_TOOLS` / the tools barrel export → default-active (passes the `isToolAllowed` fall-through).
- **`ToolSession`** gains two focused optional accessors — `getContextBreakdown` and `getProviderMessages` (async; the post-`transformContext` + `convertToLlm` message list that actually goes to the provider) — wired at the single tool-context construction site in `src/sdk.ts`.
- **10 contract tests** in `test/tools/context-audit.test.ts`.
- `CHANGELOG.md` entry under `[Unreleased] → Added`.

## Design notes

- **Built-in `AgentTool`, not an extension `ToolDefinition`** — matches every other always-on tool and made it default-active for free.
- **Surfaced the existing `getContextBreakdown()`** rather than re-estimating tokens from chars/4, so the numbers are the authoritative totals (anchored on the provider's last reported prompt-token count when available).
- **Drill-down uses provider-visible messages** (`session.convertMessagesToLlm`) — excluded `bashExecution`/`pythonExecution` output is dropped and `@file` mentions are expanded into developer-with-content, so the per-row sum reconciles with the breakdown's message-token total. A developer- and image-aware estimator covers content `estimateTokens` would otherwise miss (no `developer` case; image surcharge lives only on `toolResult`), so screenshot / `@file`-image rows aren't zero-filtered. `query` searches a separate content field (message text **and** tool-call arguments) independent of the displayed `preview`.
- **In-band tool dialects**: when an owned (non-native) dialect is active (`tools.format` is non-native, or `auto` for a `supportsTools:false` model), `getProviderMessages` runs `encodeInbandToolHistory` on the converted messages — folding assistant tool calls and tool-result runs into dialect text — so the audit ranks/searches the same in-band text the provider receives. (`AgentTool extends Tool`, so the session's tool registry satisfies the `InbandTool[]` the dialect renderer expects.)
- **snapcompact**: `transformProviderContext` runs `SnapcompactInlineTransformer` with a savings recorder (writes journal/cache frames), so it's not invoked from this read-only tool. When snapcompact is enabled, the report prints a note that row rankings are pre-frame-swap while the category total stays authoritative.
- **Cast-free message handling** — narrows on `message.role` then `block.type === "text"` → `.text` (the same pattern the repo's own `estimateTokens` / `assistantTranscriptParts` use), per the `ts-no-inline-cast-access` rule.

## Verification

- `bun run check:ts` — **passes** (full tsc `check:types` + biome across all packages).
- New tests **10/10 pass** (registration; window + category breakdown; heaviest-row ranking + labels; filters; unavailable-when-no-window edge case; developer `@file` content counted; `query` matches content with previews hidden; image-bearing rows counted; `query` matches tool-call arguments; in-band dialect fold integration through real `createAgentSession`).
- `test/tools/index.test.ts` + `test/tool-discovery/initial-tools.test.ts` (the default-tool-set and `loadMode`/`summary` gates): **30/30 pass**.
- Full `tools/` suite vs pristine HEAD (`git stash -u`): **+10 pass, +0 new failures**. The pre-existing failures are environmental on this machine (Windows home-cwd shortening, `file://` hyperlinks, `gh` cache, EXA/SearXNG API keys) and identical with these changes stashed.