### PR TITLE
fix(auth): persist session-sticky credentials in SQLite cache across restarts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed OpenCode Go usage reporting to synthesize `/usage` limits from OMP-observed request costs for the 5h, weekly, and monthly provider caps. ([#2942](https://github.com/can1357/oh-my-pi/issues/2942))
 - Fixed MiniMax Anthropic-compatible requests to serialize adaptive thinking without an invalid Anthropic `output_config.effort` tier ([#2928](https://github.com/can1357/oh-my-pi/issues/2928)).
 
+- Fixed a logic issue where AuthStorage lost session-to-credential stickiness upon CLI restarts, causing cold-starts for server-side prompt cache (KV cache) and wasting tokens.
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1352,6 +1352,16 @@ export class AuthStorage {
 		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map();
 		sessionMap.set(sessionId, { type, index });
 		this.#sessionLastCredential.set(provider, sessionMap);
+
+		try {
+			const cacheKey = `session:sticky:${provider}:${sessionId}`;
+			const cacheValue = JSON.stringify({ type, index });
+			// Expires in 30 days
+			const expiresAtSec = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+			this.#store.setCache(cacheKey, cacheValue, expiresAtSec);
+		} catch (err) {
+			logger.debug("Failed to write session sticky credential to persistent store cache", { err });
+		}
 	}
 
 	/** Retrieves the last credential used by a session. */
@@ -1360,17 +1370,43 @@ export class AuthStorage {
 		sessionId: string | undefined,
 	): { type: AuthCredential["type"]; index: number } | undefined {
 		if (!sessionId) return undefined;
-		return this.#sessionLastCredential.get(provider)?.get(sessionId);
+		let sessionMap = this.#sessionLastCredential.get(provider);
+		if (sessionMap?.has(sessionId)) {
+			return sessionMap.get(sessionId);
+		}
+		try {
+			const cacheKey = `session:sticky:${provider}:${sessionId}`;
+			const raw = this.#store.getCache(cacheKey);
+			if (raw) {
+				const val = JSON.parse(raw) as { type: AuthCredential["type"]; index: number };
+				if (!sessionMap) {
+					sessionMap = new Map();
+					this.#sessionLastCredential.set(provider, sessionMap);
+				}
+				sessionMap.set(sessionId, val);
+				return val;
+			}
+		} catch (err) {
+			logger.debug("Failed to read session sticky credential from persistent store cache", { err });
+		}
+		return undefined;
 	}
 
 	/** Clears the last credential used by a session for a provider. */
 	#clearSessionCredential(provider: string, sessionId: string | undefined): void {
 		if (!sessionId) return;
 		const sessionMap = this.#sessionLastCredential.get(provider);
-		if (!sessionMap) return;
-		sessionMap.delete(sessionId);
-		if (sessionMap.size === 0) {
-			this.#sessionLastCredential.delete(provider);
+		if (sessionMap) {
+			sessionMap.delete(sessionId);
+			if (sessionMap.size === 0) {
+				this.#sessionLastCredential.delete(provider);
+			}
+		}
+		try {
+			const cacheKey = `session:sticky:${provider}:${sessionId}`;
+			this.#store.setCache(cacheKey, "", 0);
+		} catch (err) {
+			logger.debug("Failed to clear session sticky credential from persistent store cache", { err });
 		}
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1354,11 +1354,14 @@ export class AuthStorage {
 		this.#sessionLastCredential.set(provider, sessionMap);
 
 		try {
-			const cacheKey = `session:sticky:${provider}:${sessionId}`;
-			const cacheValue = JSON.stringify({ type, index });
-			// Expires in 30 days
-			const expiresAtSec = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
-			this.#store.setCache(cacheKey, cacheValue, expiresAtSec);
+			const credentialId = this.#getStoredCredentials(provider)[index]?.id;
+			if (credentialId !== undefined) {
+				const cacheKey = `session:sticky:${provider}:${sessionId}`;
+				const cacheValue = JSON.stringify({ type, index, credentialId });
+				// Expires in 30 days
+				const expiresAtSec = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+				this.#store.setCache(cacheKey, cacheValue, expiresAtSec);
+			}
 		} catch (err) {
 			logger.debug("Failed to write session sticky credential to persistent store cache", { err });
 		}
@@ -1378,13 +1381,29 @@ export class AuthStorage {
 			const cacheKey = `session:sticky:${provider}:${sessionId}`;
 			const raw = this.#store.getCache(cacheKey);
 			if (raw) {
-				const val = JSON.parse(raw) as { type: AuthCredential["type"]; index: number };
+				const val = JSON.parse(raw) as { type: AuthCredential["type"]; index: number; credentialId?: number };
+				
+				if (val.credentialId !== undefined) {
+					const stored = this.#getStoredCredentials(provider);
+					const actualIndex = stored.findIndex(entry => entry.id === val.credentialId);
+					if (actualIndex === -1 || stored[actualIndex]?.credential.type !== val.type) {
+						this.#store.setCache(cacheKey, "", 0);
+						return undefined;
+					}
+					val.index = actualIndex;
+				} else {
+					// Fallback: drop unsafe index-only cache rows to prevent wrong-account routing
+					this.#store.setCache(cacheKey, "", 0);
+					return undefined;
+				}
+
 				if (!sessionMap) {
 					sessionMap = new Map();
 					this.#sessionLastCredential.set(provider, sessionMap);
 				}
-				sessionMap.set(sessionId, val);
-				return val;
+				const sessionVal = { type: val.type, index: val.index };
+				sessionMap.set(sessionId, sessionVal);
+				return sessionVal;
 			}
 		} catch (err) {
 			logger.debug("Failed to read session sticky credential from persistent store cache", { err });

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -650,3 +650,66 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		}
 	});
 });
+
+describe("AuthStorage persistent session stickiness", () => {
+	let tempDir = "";
+	let dbPath = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-auth-test-"));
+		dbPath = path.join(tempDir, "auth.db");
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("persists session-sticky credentials across AuthStorage restarts", async () => {
+		// 1. Initialize AuthStorage and log in two accounts
+		let authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(dbPath)));
+
+		try {
+			const credential1: OAuthCredential = {
+				type: "oauth",
+				refresh: "refresh-token-1",
+				access: "access-token-1",
+				expires: Date.now() + 3600_000,
+				projectId: "project-1",
+				email: "user-1@example.com",
+			};
+			const credential2: OAuthCredential = {
+				type: "oauth",
+				refresh: "refresh-token-2",
+				access: "access-token-2",
+				expires: Date.now() + 3600_000,
+				projectId: "project-2",
+				email: "user-2@example.com",
+			};
+			await authStorage.set("unit-session-stickiness", [credential1, credential2]);
+
+			// 2. Resolve initial key for session-1
+			const key1 = await authStorage.getApiKey("unit-session-stickiness", "session-1");
+			expect(key1).toBe("access-token-2");
+
+			// 3. Rotate session-1's sticky credential to the sibling
+			await authStorage.rotateSessionCredential("unit-session-stickiness", "session-1");
+			const key2 = await authStorage.getApiKey("unit-session-stickiness", "session-1");
+			expect(key2).toBe("access-token-1");
+
+			// 4. Close AuthStorage to simulate process restart
+			authStorage.close();
+
+			// 5. Re-instantiate AuthStorage using the same DB
+			authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(dbPath)));
+			await authStorage.reload();
+
+			// 6. Retrieve the sticky key again for session-1 (should still be access-token-1)
+			const key3 = await authStorage.getApiKey("unit-session-stickiness", "session-1");
+			expect(key3).toBe("access-token-1");
+
+			authStorage.close();
+		} finally {
+			// No-op
+		}
+	});
+});


### PR DESCRIPTION
### Description

This PR resolves a logic issue where `AuthStorage` loses its session-to-credential stickiness mapping (`#sessionLastCredential` Map) whenever the `omp` CLI restarts. 

When a user has multiple credentials configured for a provider (e.g. rotating accounts to balance usage limits), restarting the process causes `AuthStorage` to lose track of which account was active for the current session. Consequently, the next call arbitrarily re-allocates a credential (falling back to xxHash32 load-balancing or re-ranking), leading to unnecessary account switching. This cold-starts the prompt cache on the model provider's side and wastes tokens/increases latency.

### Changes

- Persists the `{ type, index }` session-sticky preference into the persistent SQLite `cache` table under key `session:sticky:<provider>:<sessionId>` with a 30-day expiration.
- Recovers the sticky selection from the persistent cache upon `AuthStorage` re-initialization / `reload()`.
- Added unit test coverage to verify session stickiness persistence across re-initialization.