### PR TITLE
fix(coding-agent): hide plan refine approval abort

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan-mode `Refine plan` so the internal approval abort is hidden and the editor is ready for a follow-up prompt instead of showing `Operation aborted` ([#2971](https://github.com/can1357/oh-my-pi/issues/2971)).
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2309,7 +2309,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Branchless mark+clear when !compactBeforeExecute: mark is gated; clear
 		// is unconditional and idempotent.
 		if (options.compactBeforeExecute) {
-			this.session.markPlanCompactAbortPending();
+			this.session.markPlanInternalAbortPending();
 		}
 		let compactOutcome: CompactionOutcome | undefined;
 		try {
@@ -2355,7 +2355,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			// (i.e., the !compactBeforeExecute branch), and a no-op when the flag
 			// was already consumed by AgentSession.#handleAgentEvent's aborted
 			// message_end stamping. Guarantees the flag is dead at every exit.
-			this.session.clearPlanCompactAbortPending();
+			this.session.clearPlanInternalAbortPending();
 		}
 
 		// Tool restoration runs on every path — the plan mode tools must be
@@ -2421,9 +2421,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		// in-flight turn first — abort() bumps the prompt generation and cancels pending
 		// continuations, so nothing re-streams in the synchronous gap before prompt().
 		if (this.session.isStreaming) {
-			await this.session.abort();
+			await this.#abortPlanApprovalTurnSilently();
 		}
 		await this.session.prompt(planModePrompt, { synthetic: true });
+	}
+	async #abortPlanApprovalTurnSilently(): Promise<void> {
+		this.session.markPlanInternalAbortPending();
+		try {
+			await this.session.abort();
+		} finally {
+			this.session.clearPlanInternalAbortPending();
+		}
 	}
 
 	async handlePlanModeCommand(initialPrompt?: string): Promise<void> {
@@ -2807,7 +2815,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		// plan) while the popup is showing. The event listener fires asynchronously
 		// (agent's #emit is fire-and-forget), so without this the model sees
 		// "Plan ready for approval." and immediately re-invokes `resolve` in a loop.
-		await this.session.abort();
+		// This abort is an internal UI transition, not operator cancellation.
+		await this.#abortPlanApprovalTurnSilently();
 
 		const planFilePath = details.planFilePath || this.planModePlanFilePath || (await this.#getPlanFilePath());
 		this.planModePlanFilePath = planFilePath;
@@ -2912,11 +2921,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (choice === "Refine plan") {
-			// Section annotations entered in the overlay become a refinement prompt
-			// re-submitted to the model. With no annotations, fall back to today's
-			// behavior: close the overlay and let the operator type their own.
-			if (feedback.trim() && this.onInputCallback) {
-				this.onInputCallback(this.startPendingSubmission({ text: feedback }));
+			const refinement = feedback.trim();
+			try {
+				if (refinement) {
+					if (this.onInputCallback) {
+						this.onInputCallback(this.startPendingSubmission({ text: feedback }));
+					} else {
+						await this.session.prompt(feedback);
+					}
+				} else {
+					this.showStatus("Refine plan: enter a follow-up prompt.");
+				}
+			} catch (error) {
+				this.showError(`Failed to refine plan: ${error instanceof Error ? error.message : String(error)}`);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1235,13 +1235,12 @@ export class AgentSession {
 	#ttsrResumePromise: Promise<void> | undefined = undefined;
 	#ttsrResumeResolve: (() => void) | undefined = undefined;
 
-	/** One-shot flag set in InteractiveMode.#approvePlan(compactBeforeExecute=true)
-	 *  before the plan-mode → compaction transition. Consumed inside
-	 *  #handleAgentEvent for the matching `message_end` + `stopReason: "aborted"`;
-	 *  cleared unconditionally by the caller's `finally` so it cannot leak into
-	 *  later unrelated aborts (e.g. when compaction returns cancelled/failed
-	 *  without producing an aborted message_end). */
-	#planCompactAbortPending = false;
+	/** One-shot flag for expected internal plan-mode aborts. Approval actions may
+	 *  abort the post-`resolve` continuation before compaction, execution, or
+	 *  manual refinement. Consumed inside `#handleAgentEvent` for the matching
+	 *  `message_end` + `stopReason: "aborted"`; callers clear it in `finally` so
+	 *  it cannot leak into later unrelated aborts. */
+	#planInternalAbortPending = false;
 
 	#postPromptTasks = new Set<Promise<unknown>>();
 	#postPromptTasksPromise: Promise<void> | undefined = undefined;
@@ -2115,25 +2114,24 @@ export class AgentSession {
 		return this.#ttsrAbortPending;
 	}
 
-	/** Whether the plan-mode → compaction transition's expected internal abort is
-	 *  pending. Consumed by `#handleAgentEvent` to stamp `SILENT_ABORT_MARKER`
-	 *  on the next aborted assistant message_end; cleared unconditionally by
-	 *  `InteractiveMode.#approvePlan`'s `finally` block. */
-	get isPlanCompactAbortPending(): boolean {
-		return this.#planCompactAbortPending;
+	/** Whether an expected internal plan-mode abort is pending. Consumed by
+	 *  `#handleAgentEvent` to stamp `SILENT_ABORT_MARKER` on the next aborted
+	 *  assistant message_end; callers clear it in `finally`. */
+	get isPlanInternalAbortPending(): boolean {
+		return this.#planInternalAbortPending;
 	}
 
 	/** Arm the silent-abort marker for the next aborted assistant message_end.
-	 *  Caller MUST clear via `clearPlanCompactAbortPending()` in a `finally`
+	 *  Caller MUST clear via `clearPlanInternalAbortPending()` in a `finally`
 	 *  to guarantee no leak. */
-	markPlanCompactAbortPending(): void {
-		this.#planCompactAbortPending = true;
+	markPlanInternalAbortPending(): void {
+		this.#planInternalAbortPending = true;
 	}
 
 	/** Unconditionally clear the silent-abort flag. Idempotent: safe when the
 	 *  flag was never set OR was already consumed by `#handleAgentEvent`. */
-	clearPlanCompactAbortPending(): void {
-		this.#planCompactAbortPending = false;
+	clearPlanInternalAbortPending(): void {
+		this.#planInternalAbortPending = false;
 	}
 
 	getAsyncJobSnapshot(options?: { recentLimit?: number }): AsyncJobSnapshot | null {
@@ -2283,7 +2281,7 @@ export class AgentSession {
 	};
 
 	#processAgentEvent = async (event: AgentEvent): Promise<void> => {
-		// Plan-mode → compaction transition: stamp `SILENT_ABORT_MARKER` on the
+		// Plan-mode internal transition: stamp `SILENT_ABORT_MARKER` on the
 		// persisted message BEFORE the obfuscator's display-side copy below.
 		// Invariant (must hold across refactors): this branch precedes the
 		// `let displayEvent = event; ... displayEvent = { ...event, message: { ...message, content: deobfuscated } }`
@@ -2291,18 +2289,16 @@ export class AgentSession {
 		// and `event.message` (in-place mutation, used by SessionManager
 		// persistence) carry the marker, guaranteeing streaming render and
 		// history replay branch identically. The one-shot flag is consumed
-		// here, scoped strictly to this aborted message_end; the caller's
-		// `finally` (in `InteractiveMode.#approvePlan`) clears it again on
-		// every terminal compaction outcome (`ok` / `cancelled` / `failed` /
-		// throw) so a leaked flag cannot silence a later unrelated abort.
+		// here, scoped strictly to this aborted message_end; callers still clear it
+		// in `finally` so a leaked flag cannot silence a later unrelated abort.
 		if (
 			event.type === "message_end" &&
 			event.message.role === "assistant" &&
 			event.message.stopReason === "aborted" &&
-			this.#planCompactAbortPending
+			this.#planInternalAbortPending
 		) {
 			(event.message as AssistantMessage).errorMessage = SILENT_ABORT_MARKER;
-			this.#planCompactAbortPending = false;
+			this.#planInternalAbortPending = false;
 		}
 
 		// Deobfuscate assistant message content for display emission — the LLM echoes back

--- a/packages/coding-agent/test/agent-session-silent-abort.test.ts
+++ b/packages/coding-agent/test/agent-session-silent-abort.test.ts
@@ -3,7 +3,7 @@
  *
  * Asserts that `#handleAgentEvent`:
  *   - stamps `SILENT_ABORT_MARKER` on aborted assistant `message_end` events
- *     when the `#planCompactAbortPending` flag is set and consumes the flag
+ *     when the `#planInternalAbortPending` flag is set and consumes the flag
  *     in the process (A1);
  *   - leaves `errorMessage` untouched (and the flag untouched) when the flag
  *     was never set (A2);
@@ -103,8 +103,8 @@ describe("AgentSession silent-abort marker stamping", () => {
 	it("A1: flag set + aborted assistant message_end stamps the marker and clears the flag", async () => {
 		fixture = await createSessionWithObfuscator();
 		const { session } = fixture;
-		session.markPlanCompactAbortPending();
-		expect(session.isPlanCompactAbortPending).toBe(true);
+		session.markPlanInternalAbortPending();
+		expect(session.isPlanInternalAbortPending).toBe(true);
 
 		const message = makeAbortedAssistantMessage();
 		session.agent.emitExternalEvent({ type: "message_end", message });
@@ -115,13 +115,13 @@ describe("AgentSession silent-abort marker stamping", () => {
 		await Promise.resolve();
 
 		expect(message.errorMessage).toBe(SILENT_ABORT_MARKER);
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 
 	it("A2: flag unset + aborted assistant message_end leaves errorMessage and flag alone", async () => {
 		fixture = await createSessionWithObfuscator();
 		const { session } = fixture;
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 
 		const message = makeAbortedAssistantMessage();
 		session.agent.emitExternalEvent({ type: "message_end", message });
@@ -129,13 +129,13 @@ describe("AgentSession silent-abort marker stamping", () => {
 		await Promise.resolve();
 
 		expect(message.errorMessage).toBeUndefined();
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 
 	it("A3: flag set + non-aborted message_end does NOT consume the flag", async () => {
 		fixture = await createSessionWithObfuscator();
 		const { session } = fixture;
-		session.markPlanCompactAbortPending();
+		session.markPlanInternalAbortPending();
 
 		// stop reason "stop" — the marker must NOT be stamped and the flag must stay armed.
 		const stopMsg = makeStoppedAssistantMessage();
@@ -144,7 +144,7 @@ describe("AgentSession silent-abort marker stamping", () => {
 		await Promise.resolve();
 
 		expect(stopMsg.errorMessage).toBeUndefined();
-		expect(session.isPlanCompactAbortPending).toBe(true);
+		expect(session.isPlanInternalAbortPending).toBe(true);
 
 		// Drive an explicit `error` stopReason next — same expectation.
 		const errMsg: AssistantMessage = { ...makeStoppedAssistantMessage("err"), stopReason: "error" };
@@ -153,7 +153,7 @@ describe("AgentSession silent-abort marker stamping", () => {
 		await Promise.resolve();
 
 		expect(errMsg.errorMessage).toBeUndefined();
-		expect(session.isPlanCompactAbortPending).toBe(true);
+		expect(session.isPlanInternalAbortPending).toBe(true);
 	});
 
 	it("A4: marker is stamped on event.message BEFORE the obfuscator's displayEvent copy", async () => {
@@ -182,7 +182,7 @@ describe("AgentSession silent-abort marker stamping", () => {
 			seen.push(event);
 		});
 
-		session.markPlanCompactAbortPending();
+		session.markPlanInternalAbortPending();
 
 		// Use the obfuscated text as the message content so the deobfuscation walk
 		// produces a different content array, exercising the spread-copy branch.
@@ -229,6 +229,6 @@ describe("AgentSession silent-abort marker stamping", () => {
 		expect(emittedText).toBe("hello SECRET_VALUE world");
 
 		// Flag is consumed.
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -320,7 +320,7 @@ describe("InteractiveMode plan review rendering", () => {
 		}
 	});
 
-	it("Refine with no annotations does not re-prompt the model", async () => {
+	it("Refine with no annotations silently aborts approval and returns to the editor", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -330,7 +330,20 @@ describe("InteractiveMode plan review rendering", () => {
 
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
-		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Refine plan");
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
+			streaming = false;
+		});
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async () => {
+			streaming = true;
+			return "Refine plan";
+		});
+		const statusSpy = vi.spyOn(mode, "showStatus");
+		const errorSpy = vi.spyOn(mode, "showError");
 		const startSpy = vi.spyOn(mode, "startPendingSubmission");
 		const onInput = vi.fn();
 		mode.onInputCallback = onInput;
@@ -341,8 +354,12 @@ describe("InteractiveMode plan review rendering", () => {
 			title: "PLAN",
 		});
 
+		expect(abortSpy).toHaveBeenCalledTimes(1);
+		expect(statusSpy).toHaveBeenCalledWith("Refine plan: enter a follow-up prompt.");
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to refine plan"));
 		expect(startSpy).not.toHaveBeenCalled();
 		expect(onInput).not.toHaveBeenCalled();
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 
 	it("approves with in-overlay edits and mirrors them to the plan file", async () => {
@@ -1139,8 +1156,7 @@ describe("InteractiveMode plan review rendering", () => {
 	// ==========================================================================
 	// Phase 6 — B layer: #approvePlan flag lifecycle via try/finally.
 	//
-	// Drives `handlePlanApproval` with each CompactionOutcome variant and
-	// asserts `session.isPlanCompactAbortPending === false` after `#approvePlan`
+	// asserts `session.isPlanInternalAbortPending === false` after `#approvePlan`
 	// resolves/rejects. The flag is the only state that can leak into later
 	// unrelated aborts; the `try/finally` in `#approvePlan` is what protects it.
 	// ==========================================================================
@@ -1189,7 +1205,7 @@ describe("InteractiveMode plan review rendering", () => {
 		"failed",
 	] as const)("B1-B3: Approve and compact context + %s outcome → flag cleared by finally", async outcome => {
 		await approveWithCompact(outcome);
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 
 	it("B4: Approve and compact context + handleCompactCommand throws → showError surfaces the failure AND flag cleared by finally before the outer catch", async () => {
@@ -1202,11 +1218,11 @@ describe("InteractiveMode plan review rendering", () => {
 		//      silenced).
 		const showErrorSpy = vi.spyOn(mode, "showError");
 		await approveWithCompact("throw", new Error("synthetic compaction failure"));
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 		expect(showErrorSpy).toHaveBeenCalledWith(expect.stringContaining("synthetic compaction failure"));
 	});
 
-	it("B5: Approve and execute (no compact) → markPlanCompactAbortPending never called; flag stays false", async () => {
+	it("B5: Approve and execute (no compact) → internal abort flag is cleared", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -1216,7 +1232,7 @@ describe("InteractiveMode plan review rendering", () => {
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
 		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
-		const markSpy = vi.spyOn(session, "markPlanCompactAbortPending");
+		const markSpy = vi.spyOn(session, "markPlanInternalAbortPending");
 		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
 
 		await mode.handlePlanApproval({
@@ -1225,8 +1241,8 @@ describe("InteractiveMode plan review rendering", () => {
 			title: "PLAN",
 		});
 
-		expect(markSpy).not.toHaveBeenCalled();
-		expect(session.isPlanCompactAbortPending).toBe(false);
+		expect(markSpy).toHaveBeenCalledTimes(1);
+		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
 
 	it("re-enters plan mode on the approved titled artifact after approval", async () => {


### PR DESCRIPTION
## Repro
Choosing `Refine plan` from the plan approval overlay with no section annotations reproduced the bug: `bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts -t "Refine with no annotations does not re-prompt"` passed while asserting that no follow-up input path was started, leaving the internal approval abort visible as `Operation aborted`.

## Cause
`InteractiveMode.handlePlanApproval` aborted the active plan-approval turn before showing the approval overlay, but that abort was treated like an operator cancellation. When the selected branch was `Refine plan`, no approval execution prompt followed to hide that aborted assistant message, so `EventController` rendered the generic abort label.

## Fix
- Generalized the plan approval silent-abort flag in `AgentSession` to cover internal plan-mode approval aborts, not only compact-before-execute aborts.
- Routed the initial plan approval abort through a silent helper so `Refine plan` returns to the editor without rendering `Operation aborted`.
- Updated plan-review and silent-abort regression tests, plus the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts packages/coding-agent/test/agent-session-silent-abort.test.ts` — 44 pass, 0 fail. `bun run fix` — no TypeScript formatting fixes, Rust checks passed. Fixes #2971