### PR TITLE
fix(coding-agent): restore /model role selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/model` in the TUI to open the role and effort selector again while `/switch` remains the temporary active-session switcher ([#2976](https://github.com/can1357/oh-my-pi/issues/2976)).
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -301,7 +301,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "model",
 		aliases: ["models"],
-		description: "Switch model for this session",
+		description: "Select model roles and efforts",
 		acpDescription: "Show current model selection",
 		handle: async (command, runtime) => {
 			if (command.args) {
@@ -334,7 +334,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return commandConsumed();
 		},
 		handleTui: (_command, runtime) => {
-			runtime.ctx.showModelSelector({ temporaryOnly: true });
+			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -18,13 +18,13 @@ function createRuntime() {
 }
 
 describe("/model slash command", () => {
-	it("opens the temporary model selector for the active session", async () => {
+	it("opens the role and effort selector", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/model", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.showModelSelector).toHaveBeenCalledWith({ temporaryOnly: true });
+		expect(harness.showModelSelector).toHaveBeenCalledWith();
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
 });


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/slash-commands/switch.test.ts` reproduced the regression with a failing `/model` expectation: the command called `showModelSelector({ temporaryOnly: true })`, which skips role and effort selection.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` routed the TUI `/model` handler through the temporary active-session selector introduced for `/switch`, so `ModelSelectorComponent` selected the picked model immediately instead of entering its role/thinking menu.

## Fix
- Routed `/model` back to `showModelSelector()` so the role and effort picker opens.
- Left `/switch` on `showModelSelector({ temporaryOnly: true })` for temporary session switches.
- Updated `packages/coding-agent/test/slash-commands/switch.test.ts` to pin the split behavior.
- Added the coding-agent changelog entry for #2976.

## Verification
Passed: `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/slash-commands/switch.test.ts`. Passed: `bun --cwd=packages/coding-agent run check`. Fixes #2976