### PR TITLE
fix(cli): avoid unsupported using syntax in npm bundle

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -966,7 +966,7 @@ export class Agent {
 		if (!model) throw new Error("No model configured");
 
 		let skipInitialSteeringPoll = options?.skipInitialSteeringPoll === true;
-		using _ = new EventLoopKeepalive();
+		const keepalive = new EventLoopKeepalive();
 		const { promise, resolve } = Promise.withResolvers<void>();
 		this.#runningPrompt = promise;
 		this.#resolveRunningPrompt = resolve;
@@ -1208,6 +1208,7 @@ export class Agent {
 				this.#emit({ type: "agent_end", messages: [errorMsg] });
 			}
 		} finally {
+			keepalive[Symbol.dispose]();
 			this.#state.isStreaming = false;
 			this.#state.streamMessage = null;
 			this.#state.pendingToolCalls.clear();

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -1643,7 +1643,7 @@ export async function instrumentedCompleteSimple<TApi extends Api>(
 	// long-lived completion promise, freezing any host spinner (e.g. the
 	// `/handoff` Loader) until an unrelated I/O event (a terminal resize)
 	// pokes the loop. Keep the loop healthy for the duration of the call.
-	using _keepalive = new EventLoopKeepalive();
+	const keepalive = new EventLoopKeepalive();
 	const { telemetry, parent, oneshotKind } = span;
 	const stepNumber = span.stepNumber ?? -1;
 	const reasoning = options.reasoning;
@@ -1700,6 +1700,8 @@ export async function instrumentedCompleteSimple<TApi extends Api>(
 			baseUrl: model.baseUrl,
 		});
 		throw err;
+	} finally {
+		keepalive[Symbol.dispose]();
 	}
 }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the npm CLI bundle so installs launched by Bun 1.3.8 no longer fail during parse on explicit resource-management `using` declarations ([#2962](https://github.com/can1357/oh-my-pi/issues/2962)).
+
 ## [16.0.6] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -268,8 +268,8 @@ export async function submitInteractiveInput(
 		return;
 	}
 
+	const keepalive = new EventLoopKeepalive();
 	try {
-		using _keepalive = new EventLoopKeepalive();
 		// Honor the submission's queue intent, defaulting to followUp. Reading
 		// `session.isStreaming` to decide queue-vs-fresh is NOT atomic with the
 		// eventual `agent.prompt()` call inside `session.prompt()`: a background turn
@@ -315,6 +315,7 @@ export async function submitInteractiveInput(
 		const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 		mode.showError(errorMessage);
 	} finally {
+		keepalive[Symbol.dispose]();
 		mode.finishPendingSubmission(input);
 		await mode.checkShutdownRequested();
 	}
@@ -468,22 +469,26 @@ async function runInteractiveMode(
 	}
 
 	if (initialMessage !== undefined) {
+		const keepalive = new EventLoopKeepalive();
 		try {
-			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(initialMessage, { images: initialImages });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
+		} finally {
+			keepalive[Symbol.dispose]();
 		}
 	}
 
 	for (const message of initialMessages) {
+		const keepalive = new EventLoopKeepalive();
 		try {
-			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(message);
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
+		} finally {
+			keepalive[Symbol.dispose]();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -982,8 +982,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#scheduleLoopAutoSubmit();
 		this.#scheduleGoalContinuation();
 
-		using _ = new EventLoopKeepalive();
-		return await promise;
+		const keepalive = new EventLoopKeepalive();
+		try {
+			return await promise;
+		} finally {
+			keepalive[Symbol.dispose]();
+		}
 	}
 
 	#scheduleLoopAutoSubmit(): void {

--- a/packages/coding-agent/src/ssh/ssh-executor.ts
+++ b/packages/coding-agent/src/ssh/ssh-executor.ts
@@ -114,7 +114,7 @@ export async function executeSSH(
 		}
 	}
 
-	using child = ptree.spawn(["ssh", ...(await buildRemoteCommand(host, resolvedCommand))], {
+	const child = ptree.spawn(["ssh", ...(await buildRemoteCommand(host, resolvedCommand))], {
 		signal: options?.signal,
 		timeout: options?.timeout,
 		stdin: "pipe",
@@ -184,6 +184,7 @@ export async function executeSSH(
 		}
 		throw err;
 	} finally {
+		child[Symbol.dispose]();
 		abortWaiter.cleanup();
 	}
 }

--- a/packages/coding-agent/src/ssh/ssh-executor.ts
+++ b/packages/coding-agent/src/ssh/ssh-executor.ts
@@ -44,6 +44,8 @@ export interface SSHResult {
 
 type SSHExitEvent = { kind: "exit"; exitCode: number } | { kind: "error"; error: unknown };
 
+type AbortWaiter = { promise: Promise<ptree.AbortError> | undefined; cleanup: () => void };
+
 function sshExitEvent(exitCode: number): SSHExitEvent {
 	return { kind: "exit", exitCode };
 }
@@ -52,10 +54,7 @@ function sshErrorEvent(error: unknown): SSHExitEvent {
 	return { kind: "error", error };
 }
 
-function createAbortWaiter(
-	signal: AbortSignal | undefined,
-	streamAbort: AbortController,
-): { promise: Promise<ptree.AbortError> | undefined; cleanup: () => void } {
+function createAbortWaiter(signal: AbortSignal | undefined, streamAbort: AbortController): AbortWaiter {
 	if (!signal) {
 		return { promise: undefined, cleanup: () => {} };
 	}
@@ -114,13 +113,6 @@ export async function executeSSH(
 		}
 	}
 
-	const child = ptree.spawn(["ssh", ...(await buildRemoteCommand(host, resolvedCommand))], {
-		signal: options?.signal,
-		timeout: options?.timeout,
-		stdin: "pipe",
-		stderr: "full",
-	});
-
 	const settings = await Settings.init();
 	const sink = new OutputSink({
 		onChunk: options?.onChunk,
@@ -129,17 +121,24 @@ export async function executeSSH(
 		headBytes: resolveOutputSinkHeadBytes(settings),
 		maxColumns: resolveOutputMaxColumns(settings),
 	});
-
 	const streamAbort = new AbortController();
-	const abortWaiter = createAbortWaiter(options?.signal, streamAbort);
-	const streamOptions = { signal: streamAbort.signal };
-	const streams = [child.stdout.pipeTo(sink.createInput(), streamOptions)];
-	if (child.stderr) {
-		streams.push(child.stderr.pipeTo(sink.createInput(), streamOptions));
-	}
-	const streamsSettled = Promise.allSettled(streams).then(() => {});
+	const child = ptree.spawn(["ssh", ...(await buildRemoteCommand(host, resolvedCommand))], {
+		signal: options?.signal,
+		timeout: options?.timeout,
+		stdin: "pipe",
+		stderr: "full",
+	});
+
+	let abortWaiter: AbortWaiter | undefined;
 
 	try {
+		abortWaiter = createAbortWaiter(options?.signal, streamAbort);
+		const streamOptions = { signal: streamAbort.signal };
+		const streams = [child.stdout.pipeTo(sink.createInput(), streamOptions)];
+		if (child.stderr) {
+			streams.push(child.stderr.pipeTo(sink.createInput(), streamOptions));
+		}
+		const streamsSettled = Promise.allSettled(streams).then(() => {});
 		const exitEvent = child.exited.then(sshExitEvent, sshErrorEvent);
 		const abortEvent = abortWaiter.promise?.then(sshErrorEvent);
 		const event = await (abortEvent ? Promise.race([exitEvent, abortEvent]) : exitEvent);
@@ -160,7 +159,6 @@ export async function executeSSH(
 		if (!streamAbort.signal.aborted) {
 			streamAbort.abort(err);
 		}
-		void streamsSettled;
 		if (err instanceof ptree.Exception) {
 			if (err instanceof ptree.TimeoutError) {
 				return {
@@ -185,6 +183,6 @@ export async function executeSSH(
 		throw err;
 	} finally {
 		child[Symbol.dispose]();
-		abortWaiter.cleanup();
+		abortWaiter?.cleanup();
 	}
 }

--- a/packages/coding-agent/test/ssh/ssh-executor.test.ts
+++ b/packages/coding-agent/test/ssh/ssh-executor.test.ts
@@ -25,6 +25,22 @@ function createBlockedChild<In extends TestStdin>(exited?: Promise<number>): Chi
 	} as unknown as ChildProcess<In>;
 }
 
+function createPipeThrowingChild<In extends TestStdin>(onDispose: () => void): ChildProcess<In> {
+	const { promise } = Promise.withResolvers<number>();
+	const stdout = {
+		pipeTo() {
+			throw new Error("stream setup failed");
+		},
+	} as unknown as ReadableStream<Uint8Array>;
+
+	return {
+		stdout,
+		stderr: undefined,
+		exited: promise,
+		[Symbol.dispose]: onDispose,
+	} as unknown as ChildProcess<In>;
+}
+
 async function flushMicrotasks(count: number): Promise<void> {
 	for (let i = 0; i < count; i++) {
 		await Promise.resolve();
@@ -91,5 +107,16 @@ describe("executeSSH", () => {
 		expect(result.cancelled).toBe(true);
 		expect(result.exitCode).toBeUndefined();
 		expect(result.output).toContain("Command aborted");
+	});
+
+	it("disposes the ssh child when output stream setup throws", async () => {
+		vi.spyOn(connectionManager, "ensureConnection").mockResolvedValue();
+		vi.spyOn(connectionManager, "buildRemoteCommand").mockResolvedValue(["remote", "sleep 60"]);
+		vi.spyOn(sshfsMount, "hasSshfs").mockReturnValue(false);
+		const dispose = vi.fn();
+		vi.spyOn(ptree, "spawn").mockImplementation(<In extends TestStdin>() => createPipeThrowingChild<In>(dispose));
+
+		await expect(executeSSH({ name: "remote", host: "remote" }, "sleep 60")).rejects.toThrow("stream setup failed");
+		expect(dispose).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/stats-dashboard-bundle.test.ts
+++ b/packages/coding-agent/test/stats-dashboard-bundle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 describe("stats dashboard assets in distributed CLI builds", () => {
@@ -27,4 +28,36 @@ describe("stats dashboard assets in distributed CLI builds", () => {
 		expect(cliSource).toContain("127.0.0.1");
 		expect(cliSource).toContain("dashboard HTML was not served");
 	});
+
+	it("keeps npm bundle sources parseable by Bun 1.3.8", async () => {
+		const bundledSourceRoots = [
+			path.join(repoRoot, "packages/agent/src"),
+			path.join(repoRoot, "packages/coding-agent/src"),
+			path.join(repoRoot, "packages/utils/src"),
+		];
+		const sourceFiles = (await Promise.all(bundledSourceRoots.map(root => collectTypeScriptFiles(root)))).flat();
+		const offenders: string[] = [];
+		for (const file of sourceFiles) {
+			const source = await Bun.file(file).text();
+			if (explicitResourceManagementDeclaration.test(source)) {
+				offenders.push(path.relative(repoRoot, file));
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
 });
+
+const explicitResourceManagementDeclaration = /^\s*(?:await\s+)?using\s+[$A-Z_a-z][$\w]*\s*=/m;
+
+async function collectTypeScriptFiles(dir: string, files: string[] = []): Promise<string[]> {
+	for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+		if (entry.name === "__tests__") continue;
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await collectTypeScriptFiles(fullPath, files);
+		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
+			files.push(fullPath);
+		}
+	}
+	return files;
+}

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ptree.exec()` to avoid explicit resource-management syntax in shipped sources while preserving child-process disposal on errors ([#2962](https://github.com/can1357/oh-my-pi/issues/2962)).
+
 ## [16.0.3] - 2026-06-16
 
 ### Added

--- a/packages/utils/src/ptree.ts
+++ b/packages/utils/src/ptree.ts
@@ -352,8 +352,12 @@ export async function exec(cmd: string[], opts?: ExecOptions): Promise<ExecResul
 	const { input, stderr, allowAbort, allowNonZero, ...spawnOpts } = opts ?? {};
 	const stdin = typeof input === "string" ? Buffer.from(input) : input;
 	const resolved: ChildSpawnOptions = stdin === undefined ? spawnOpts : { ...spawnOpts, stdin };
-	using child = spawn(cmd, resolved);
-	return await child.wait({ stderr, allowAbort, allowNonZero });
+	const child = spawn(cmd, resolved);
+	try {
+		return await child.wait({ stderr, allowAbort, allowNonZero });
+	} finally {
+		child[Symbol.dispose]();
+	}
 }
 
 // ── Signal combinators ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Repro
Fresh global installs of `@oh-my-pi/pi-coding-agent@16.0.7` launched with Bun 1.3.8 fail before startup: `bunx bun@1.3.8 "$tmp/bun/bin/omp" --version` exits 1 with `SyntaxError: Unexpected identifier 'child'` while parsing `dist/cli.js`. After the fix, `bunx bun@1.3.8 packages/coding-agent/dist/cli.js --version` parses the bundle and reaches the runtime guard: `Bun runtime must be >= 1.3.14`.

## Cause
The published npm entry is the bundled `packages/coding-agent/dist/cli.js`. Bun 1.3.8 cannot parse explicit resource-management declarations (`using child = ...`, `using _keepalive = ...`) emitted from `packages/utils/src/ptree.ts`, `packages/coding-agent/src/ssh/ssh-executor.ts`, `packages/agent/src/agent.ts`, `packages/agent/src/telemetry.ts`, `packages/coding-agent/src/main.ts`, and `packages/coding-agent/src/modes/interactive-mode.ts`, so startup failed during parse before the package engine check could run.

## Fix
- Replaced bundled runtime `using` declarations with explicit `try/finally` disposal.
- Kept `ChildProcess` and `EventLoopKeepalive` cleanup behavior intact on success, errors, and early returns.
- Added a bundle-source regression test that rejects explicit resource-management declarations in bundled source roots.
- Added coding-agent and utils changelog entries.

## Verification
- Reproduced the published failure with `bunx bun@1.3.8 install -g @oh-my-pi/pi-coding-agent@16.0.7 && bunx bun@1.3.8 "$tmp/bun/bin/omp" --version`.
- Ran `bun test packages/coding-agent/test/stats-dashboard-bundle.test.ts packages/coding-agent/test/ssh/ssh-executor.test.ts` — 6 pass.
- Ran `bun --cwd=packages/utils run check && bun --cwd=packages/agent run check && bun --cwd=packages/coding-agent run check` — passed.
- Built `packages/coding-agent/dist/cli.js`, built the native addon, then ran `bunx bun@1.3.8 packages/coding-agent/dist/cli.js --version` — no parse error; exits at the intended Bun `>=1.3.14` runtime guard.
- Ran `bun packages/coding-agent/dist/cli.js --version` — `omp/16.0.6`.

Fixes #2962