### PR TITLE
fix(providers): accept Bedrock inference profile ARNs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bedrock application inference profile ARNs to route requests to the ARN's region instead of the default Bedrock runtime region. ([#3004](https://github.com/can1357/oh-my-pi/issues/3004))
+
 ## [16.0.8] - 2026-06-18
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -80,6 +80,13 @@ function resolveBearerToken(options: BedrockOptions): string | undefined {
 	return options.bearerToken || apiKey || $env.AWS_BEARER_TOKEN_BEDROCK;
 }
 
+function inferRegionFromBedrockArn(modelId: string): string | undefined {
+	const parts = modelId.split(":", 6);
+	if (parts[0] !== "arn" || parts[2] !== "bedrock") return undefined;
+	const region = parts[3];
+	return region || undefined;
+}
+
 type Block = (TextContent | ThinkingContent | ToolCall) & {
 	index?: number;
 	partialJson?: string;
@@ -206,7 +213,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 		const blocks = output.content as Block[];
 		let rawRequestDump: RawHttpRequestDump | undefined;
-		const region = options.region || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || "us-east-1";
+		const region =
+			options.region ||
+			inferRegionFromBedrockArn(model.id) ||
+			$env.AWS_REGION ||
+			$env.AWS_DEFAULT_REGION ||
+			"us-east-1";
 
 		try {
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);

--- a/packages/ai/test/bedrock-inference-profile.test.ts
+++ b/packages/ai/test/bedrock-inference-profile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
+const profileModel: Model<"bedrock-converse-stream"> = buildModel({
+	id: profileArn,
+	name: "Bedrock inference profile",
+	api: "bedrock-converse-stream",
+	provider: "amazon-bedrock",
+	baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+	contextWindow: 1000000,
+	maxTokens: 128000,
+});
+
+function userContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Say hello", timestamp: 0 }],
+	};
+}
+
+describe("Bedrock inference profile ARNs", () => {
+	test("routes requests to the ARN region and preserves the ARN model id", async () => {
+		const calls: string[] = [];
+		const customFetch: FetchImpl = Object.assign(
+			async (input: string | URL | Request, _init?: RequestInit) => {
+				calls.push(String(input instanceof Request ? input.url : input));
+				return new Response("nope", { status: 418 });
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamBedrock(profileModel, userContext(), {
+			bearerToken: "test-token",
+			fetch: customFetch,
+			maxTokens: 16,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(calls).toEqual([
+			`https://bedrock-runtime.us-east-2.amazonaws.com/model/${encodeURIComponent(profileArn)}/converse-stream`,
+		]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--provider=amazon-bedrock --model <application-inference-profile ARN>` being rejected as an unknown model before the Bedrock provider could send the ARN to Converse Stream. ([#3004](https://github.com/can1357/oh-my-pi/issues/3004))
+
 ## [16.0.8] - 2026-06-18
 
 ### Changed

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -214,17 +214,21 @@ function resolveBedrockInferenceProfileModelId(
 		return undefined;
 	}
 
-	const providerModels = availableModels.filter(model => model.provider.toLowerCase() === AMAZON_BEDROCK_PROVIDER);
-	const defaultModelId = DEFAULT_MODEL_PER_PROVIDER[AMAZON_BEDROCK_PROVIDER];
-	const template =
-		providerModels.find(model => model.id === defaultModelId) ?? pickDefaultAvailableModel(providerModels);
+	const template = availableModels.find(model => model.provider.toLowerCase() === AMAZON_BEDROCK_PROVIDER);
 	if (!template) return undefined;
 
-	return {
-		...template,
+	return buildModel({
 		id: requestedId,
 		name: "Bedrock inference profile",
-	};
+		api: "bedrock-converse-stream",
+		provider: AMAZON_BEDROCK_PROVIDER,
+		baseUrl: template.baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: null,
+		maxTokens: null,
+	});
 }
 
 function resolveBedrockInferenceProfileReference(

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -200,15 +200,19 @@ const AMAZON_BEDROCK_PROVIDER = "amazon-bedrock";
 const BEDROCK_INFERENCE_PROFILE_ARN =
 	/^arn:aws(?:-[a-z]+)*:bedrock:[a-z0-9-]+:[0-9]*:(?:application-inference-profile|inference-profile)\/[a-z0-9][a-z0-9._:-]*$/i;
 
-function resolveBedrockInferenceProfileReference(
-	provider: string,
+function hasBedrockInferenceProfileThinkingSuffix(modelId: string): boolean {
+	const { base, level } = splitThinkingSuffix(modelId);
+	return level !== undefined && BEDROCK_INFERENCE_PROFILE_ARN.test(base.trim());
+}
+
+function resolveBedrockInferenceProfileModelId(
 	modelId: string,
 	availableModels: readonly Model<Api>[],
 ): Model<Api> | undefined {
-	if (provider.toLowerCase() !== AMAZON_BEDROCK_PROVIDER) return undefined;
-
 	const requestedId = modelId.trim();
-	if (!BEDROCK_INFERENCE_PROFILE_ARN.test(requestedId)) return undefined;
+	if (hasBedrockInferenceProfileThinkingSuffix(requestedId) || !BEDROCK_INFERENCE_PROFILE_ARN.test(requestedId)) {
+		return undefined;
+	}
 
 	const providerModels = availableModels.filter(model => model.provider.toLowerCase() === AMAZON_BEDROCK_PROVIDER);
 	const defaultModelId = DEFAULT_MODEL_PER_PROVIDER[AMAZON_BEDROCK_PROVIDER];
@@ -221,6 +225,15 @@ function resolveBedrockInferenceProfileReference(
 		id: requestedId,
 		name: "Bedrock inference profile",
 	};
+}
+
+function resolveBedrockInferenceProfileReference(
+	provider: string,
+	modelId: string,
+	availableModels: readonly Model<Api>[],
+): Model<Api> | undefined {
+	if (provider.toLowerCase() !== AMAZON_BEDROCK_PROVIDER) return undefined;
+	return resolveBedrockInferenceProfileModelId(modelId, availableModels);
 }
 
 const UPSTREAM_ROUTING_SLUG = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
@@ -502,6 +515,7 @@ function findExactCanonicalModelMatch(
  * The single model-matching engine. Tries, in order:
  * 1. exact `provider/id` reference (variant-alias and OpenRouter routed/date
  *    fallbacks included),
+
  * 2. exact canonical id (coalesces provider variants),
  * 3. exact bare id (preference-ranked),
  * 4. retired effort-tier variant alias (collapsed catalog entries),
@@ -532,6 +546,11 @@ function matchModel(
 	const exactMatches = availableModels.filter(m => m.id.toLowerCase() === modelPattern.toLowerCase());
 	if (exactMatches.length > 0) {
 		return pickPreferredModel(exactMatches, context);
+	}
+
+	const bedrockInferenceProfile = resolveBedrockInferenceProfileModelId(modelPattern, availableModels);
+	if (bedrockInferenceProfile) {
+		return bedrockInferenceProfile;
 	}
 
 	// Retired effort-tier variant ids (bare, no provider prefix) resolve to

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -476,6 +476,27 @@ function isAlias(id: string): boolean {
 	return !datePattern.test(id);
 }
 
+function includeSyntheticAllowedModels(available: Model<Api>[], allowedModels: Iterable<Model<Api>>): Model<Api>[] {
+	const allowedByKey = new Map<string, Model<Api>>();
+	for (const model of allowedModels) {
+		const key = formatModelString(model);
+		if (!allowedByKey.has(key)) {
+			allowedByKey.set(key, model);
+		}
+	}
+	if (allowedByKey.size === 0) return [];
+
+	const result: Model<Api>[] = [];
+	for (const model of available) {
+		if (allowedByKey.delete(formatModelString(model))) {
+			result.push(model);
+		}
+	}
+
+	result.push(...allowedByKey.values());
+	return result;
+}
+
 /**
  * Find an exact explicit provider/model match.
  * Bare model ids are handled separately so canonical ids can coalesce variants.
@@ -1227,9 +1248,9 @@ export async function resolveModelScope(
  * the result to models matching those patterns.
  *
  * Returns the unfiltered available list when `enabledModels` is empty.
- * Returns an empty list when `enabledModels` is configured but no available
- * model matches any pattern — callers MUST treat this as "no usable model"
- * rather than falling back to the global default (see issue #1022).
+ * Returns an empty list when `enabledModels` is configured but no model matches
+ * any pattern — callers MUST treat this as "no usable model" rather than
+ * falling back to the global default (see issue #1022).
  */
 export async function resolveAllowedModels(
 	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getCanonicalVariants">,
@@ -1245,8 +1266,10 @@ export async function resolveAllowedModels(
 	if (scoped.length === 0) {
 		return [];
 	}
-	const allowed = new Set(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`));
-	return available.filter(model => allowed.has(`${model.provider}/${model.id}`));
+	return includeSyntheticAllowedModels(
+		available,
+		scoped.map(entry => entry.model),
+	);
 }
 
 /**
@@ -1274,9 +1297,9 @@ export function filterAvailableModelsByEnabledPatterns(
 	if (patterns.length === 0) return available;
 
 	const context = buildPreferenceContext(available, undefined);
-	const allowed = new Set<string>();
+	const allowedModels: Model<Api>[] = [];
 	const addAllowed = (model: Model<Api>) => {
-		allowed.add(`${model.provider}/${model.id}`);
+		allowedModels.push(model);
 	};
 
 	for (const pattern of patterns) {
@@ -1306,7 +1329,7 @@ export function filterAvailableModelsByEnabledPatterns(
 		}
 	}
 
-	return allowed.size === 0 ? [] : available.filter(model => allowed.has(`${model.provider}/${model.id}`));
+	return includeSyntheticAllowedModels(available, allowedModels);
 }
 
 export interface ResolveCliModelResult {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -196,6 +196,33 @@ function cloneModelWithRequestedId(model: Model<Api>, requestedId: string): Mode
 	};
 }
 
+const AMAZON_BEDROCK_PROVIDER = "amazon-bedrock";
+const BEDROCK_INFERENCE_PROFILE_ARN =
+	/^arn:aws(?:-[a-z]+)*:bedrock:[a-z0-9-]+:[0-9]*:(?:application-inference-profile|inference-profile)\/[a-z0-9][a-z0-9._:-]*$/i;
+
+function resolveBedrockInferenceProfileReference(
+	provider: string,
+	modelId: string,
+	availableModels: readonly Model<Api>[],
+): Model<Api> | undefined {
+	if (provider.toLowerCase() !== AMAZON_BEDROCK_PROVIDER) return undefined;
+
+	const requestedId = modelId.trim();
+	if (!BEDROCK_INFERENCE_PROFILE_ARN.test(requestedId)) return undefined;
+
+	const providerModels = availableModels.filter(model => model.provider.toLowerCase() === AMAZON_BEDROCK_PROVIDER);
+	const defaultModelId = DEFAULT_MODEL_PER_PROVIDER[AMAZON_BEDROCK_PROVIDER];
+	const template =
+		providerModels.find(model => model.id === defaultModelId) ?? pickDefaultAvailableModel(providerModels);
+	if (!template) return undefined;
+
+	return {
+		...template,
+		id: requestedId,
+		name: "Bedrock inference profile",
+	};
+}
+
 const UPSTREAM_ROUTING_SLUG = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
 
 /**
@@ -287,6 +314,11 @@ export function resolveProviderModelReference(
 		if (aliased) {
 			return aliased;
 		}
+	}
+
+	const bedrockInferenceProfile = resolveBedrockInferenceProfileReference(provider, modelId, availableModels);
+	if (bedrockInferenceProfile) {
+		return bedrockInferenceProfile;
 	}
 
 	if (normalizedProvider !== "openrouter") {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -494,6 +494,32 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("Bedrock inference profile ARN fallback", () => {
+		let registry: ModelRegistry;
+		beforeAll(() => {
+			registry = readonlyRegistry({
+				providers: {
+					"amazon-bedrock": providerConfig(
+						"https://bedrock-runtime.us-east-1.amazonaws.com",
+						[{ id: "us.anthropic.claude-opus-4-8", reasoning: true }],
+						"bedrock-converse-stream",
+					),
+				},
+			});
+		});
+
+		test("find restores synthetic inference profile ARN models", () => {
+			const profileArn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/company-opus-48";
+			const model = registry.find("amazon-bedrock", profileArn);
+
+			expect(model?.provider).toBe("amazon-bedrock");
+			expect(model?.id).toBe(profileArn);
+			expect(model?.api).toBe("bedrock-converse-stream");
+			expect(model?.reasoning).toBe(false);
+			expect(model?.thinking).toBeUndefined();
+		});
+	});
+
 	describe("baseUrl override (no custom models)", () => {
 		// Identical fixtures collapse to one registry; distinct override shapes get
 		// their own. All read-only — built in beforeAll, queried from bodies.

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -918,6 +918,10 @@ describe("resolveCliModel", () => {
 		expect(baseResult.model?.api).toBe("bedrock-converse-stream");
 		expect(baseResult.model?.id).toBe(profileArn);
 		expect(baseResult.model?.name).toBe("Bedrock inference profile");
+		expect(baseResult.model?.reasoning).toBe(false);
+		expect(baseResult.model?.thinking).toBeUndefined();
+		expect(baseResult.model?.contextWindow).toBeNull();
+		expect(baseResult.model?.maxTokens).toBeNull();
 		expect(baseResult.thinkingLevel).toBeUndefined();
 		expect(offResult.error).toBeUndefined();
 		expect(offResult.model?.id).toBe(profileArn);

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -11,6 +11,7 @@ import {
 	parseModelString,
 	pickDefaultAvailableModel,
 	resolveAgentModelPatterns,
+	resolveAllowedModels,
 	resolveCliModel,
 	resolveModelFromString,
 	resolveModelOverride,
@@ -215,6 +216,21 @@ const codexCanonicalRegistry: CanonicalModelRegistry = {
 	},
 	getCanonicalId: (model: Model<Api>) => (model.id === "gpt-5.5" ? "gpt-5.5" : undefined),
 };
+
+function createBedrockDefaultModel(): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id: "us.anthropic.claude-opus-4-8",
+		name: "Claude Opus 4.8 (US)",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1000000,
+		maxTokens: 128000,
+	});
+}
 
 function createOpusModel(provider: string, id: string, name: string): Model<"anthropic-messages"> {
 	return buildModel({
@@ -884,18 +900,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("accepts Bedrock inference profile ARNs and preserves thinking suffixes", () => {
-		const defaultBedrockModel = buildModel({
-			id: "us.anthropic.claude-opus-4-8",
-			name: "Claude Opus 4.8 (US)",
-			api: "bedrock-converse-stream",
-			provider: "amazon-bedrock",
-			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-			reasoning: true,
-			input: ["text", "image"],
-			cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-			contextWindow: 1000000,
-			maxTokens: 128000,
-		});
+		const defaultBedrockModel = createBedrockDefaultModel();
 		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
 
 		const baseResult = resolveCliModel({
@@ -1311,6 +1316,36 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		expect(result).toHaveLength(2);
 	});
 
+	test("keeps synthetic Bedrock inference profile matches", () => {
+		const bedrockModels = [createBedrockDefaultModel()];
+		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
+
+		const result = filterAvailableModelsByEnabledPatterns(bedrockModels, [`amazon-bedrock/${profileArn}`], registry);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe("amazon-bedrock");
+		expect(result[0].id).toBe(profileArn);
+		expect(result[0].reasoning).toBe(false);
+	});
+
+	test("resolveAllowedModels keeps synthetic Bedrock inference profile matches", async () => {
+		const bedrockModels = [createBedrockDefaultModel()];
+		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
+		const settings = Settings.isolated({ enabledModels: [profileArn] });
+
+		const result = await resolveAllowedModels(
+			{
+				getAvailable: () => bedrockModels,
+				getCanonicalVariants: registry.getCanonicalVariants,
+			},
+			settings,
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe("amazon-bedrock");
+		expect(result[0].id).toBe(profileArn);
+		expect(result[0].reasoning).toBe(false);
+	});
 	test("does not coalesce explicit provider/id patterns to Codex (regression for enabledModels)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(openaiGpt55Models, ["openai/gpt-5.5"], registry);
 		expect(result).toHaveLength(1);

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -883,7 +883,7 @@ describe("resolveCliModel", () => {
 		expect(result.model?.id).toBe("z-ai/glm-4.7-20251222:nitro");
 	});
 
-	test("accepts Bedrock inference profile ARNs as explicit provider model ids", () => {
+	test("accepts Bedrock inference profile ARNs and preserves thinking suffixes", () => {
 		const defaultBedrockModel = buildModel({
 			id: "us.anthropic.claude-opus-4-8",
 			name: "Claude Opus 4.8 (US)",
@@ -898,19 +898,30 @@ describe("resolveCliModel", () => {
 		});
 		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
 
-		const result = resolveCliModel({
+		const baseResult = resolveCliModel({
 			cliProvider: "amazon-bedrock",
 			cliModel: profileArn,
 			modelRegistry: {
 				getAll: () => [defaultBedrockModel],
 			},
 		});
+		const offResult = resolveCliModel({
+			cliProvider: "amazon-bedrock",
+			cliModel: `${profileArn}:off`,
+			modelRegistry: {
+				getAll: () => [defaultBedrockModel],
+			},
+		});
 
-		expect(result.error).toBeUndefined();
-		expect(result.model?.provider).toBe("amazon-bedrock");
-		expect(result.model?.api).toBe("bedrock-converse-stream");
-		expect(result.model?.id).toBe(profileArn);
-		expect(result.model?.name).toBe("Bedrock inference profile");
+		expect(baseResult.error).toBeUndefined();
+		expect(baseResult.model?.provider).toBe("amazon-bedrock");
+		expect(baseResult.model?.api).toBe("bedrock-converse-stream");
+		expect(baseResult.model?.id).toBe(profileArn);
+		expect(baseResult.model?.name).toBe("Bedrock inference profile");
+		expect(baseResult.thinkingLevel).toBeUndefined();
+		expect(offResult.error).toBeUndefined();
+		expect(offResult.model?.id).toBe(profileArn);
+		expect(offResult.thinkingLevel).toBe("off");
 	});
 
 	test("returns a clear error when there are no models", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -883,6 +883,36 @@ describe("resolveCliModel", () => {
 		expect(result.model?.id).toBe("z-ai/glm-4.7-20251222:nitro");
 	});
 
+	test("accepts Bedrock inference profile ARNs as explicit provider model ids", () => {
+		const defaultBedrockModel = buildModel({
+			id: "us.anthropic.claude-opus-4-8",
+			name: "Claude Opus 4.8 (US)",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+			contextWindow: 1000000,
+			maxTokens: 128000,
+		});
+		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
+
+		const result = resolveCliModel({
+			cliProvider: "amazon-bedrock",
+			cliModel: profileArn,
+			modelRegistry: {
+				getAll: () => [defaultBedrockModel],
+			},
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("amazon-bedrock");
+		expect(result.model?.api).toBe("bedrock-converse-stream");
+		expect(result.model?.id).toBe(profileArn);
+		expect(result.model?.name).toBe("Bedrock inference profile");
+	});
+
 	test("returns a clear error when there are no models", () => {
 		const registry = {
 			getAll: () => [],


### PR DESCRIPTION
## Repro
`--provider=amazon-bedrock --model arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48` reproduced the startup failure in `resolveCliModel`: the resolver returned `Model "amazon-bedrock/<arn>" not found` before the Bedrock Converse provider could use the ARN.

## Cause
`packages/coding-agent/src/config/model-resolver.ts` only accepted Bedrock model ids that already existed in the bundled catalog. Application inference profile ARNs are valid Bedrock `modelId` values, but they are user/account resources and cannot be prelisted. `packages/ai/src/providers/amazon-bedrock.ts` also selected the runtime region only from options/env/defaults, which would send an ARN from `us-east-2` to the wrong endpoint when no region override was set.

## Fix
- Added provider-scoped Bedrock inference profile ARN resolution that clones the bundled Bedrock default model metadata while preserving the requested ARN as `model.id`.
- Added Bedrock request-region inference from model ARNs before falling back to AWS region env/defaults.
- Added regression coverage for CLI model resolution and Bedrock request URL routing.
- Added changelog entries for `packages/coding-agent` and `packages/ai`.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts -t "Bedrock inference profile"` passed. `bun test packages/ai/test/bedrock-inference-profile.test.ts` passed. `bun run check` passed in `packages/coding-agent` and `packages/ai`. Fixes #3004