### PR TITLE
fix: expose ACP speech model catalog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP mobile voice settings failing to list local speech models by exposing the supported STT/TTS model and voice catalog through `speech.models.list`. ([#3011](https://github.com/can1357/oh-my-pi/issues/3011))
+
 ## [16.0.10] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -68,10 +68,17 @@ import type { SessionInfo as StoredSessionInfo } from "../../session/session-lis
 import { SessionManager } from "../../session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash-commands/available-commands";
+import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { runResolveInvocation } from "../../tools/resolve";
 import { ToolError } from "../../tools/tool-errors";
+import {
+	DEFAULT_TTS_LOCAL_MODEL_KEY,
+	DEFAULT_TTS_VOICE,
+	TTS_LOCAL_MODEL_OPTIONS,
+	TTS_LOCAL_VOICE_OPTIONS,
+} from "../../tts/models";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { createAcpClientBridge } from "./acp-client-bridge";
 import {
@@ -103,6 +110,34 @@ export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
 const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
 const ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS = 250;
 const ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES = 3;
+
+function buildSpeechModelsListResult(): { [key: string]: unknown } {
+	return {
+		defaults: {
+			sttModel: DEFAULT_STT_MODEL_KEY,
+			ttsModel: DEFAULT_TTS_LOCAL_MODEL_KEY,
+			voice: DEFAULT_TTS_VOICE,
+		},
+		models: [
+			...STT_MODEL_OPTIONS.map(model => ({
+				id: model.value,
+				name: model.label,
+				description: model.description,
+				kind: "stt",
+			})),
+			...TTS_LOCAL_MODEL_OPTIONS.map(model => ({
+				id: model.value,
+				name: model.label,
+				description: model.description,
+				kind: "tts",
+			})),
+		],
+		voices: TTS_LOCAL_VOICE_OPTIONS.map(voice => ({
+			id: voice.value,
+			name: voice.label,
+		})),
+	};
+}
 
 type AgentImageContent = {
 	type: "image";
@@ -904,6 +939,10 @@ export class AcpAgent implements Agent {
 				const reports = await target.fetchUsageReports();
 				return { reports: reports ?? [] };
 			}
+			// OMP Mobile calls this public speech settings method directly; keep the
+			// response static so opening settings never downloads or warms local models.
+			case "speech.models.list":
+				return buildSpeechModelsListResult();
 			case "_omp/extensions": {
 				const cwd = typeof params.cwd === "string" ? (params.cwd as string) : undefined;
 				const sm = await Settings.init();

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -876,13 +876,34 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
-	it("accepts only ACP underscore-prefixed extension methods", async () => {
+	it("exposes speech model catalogs to ACP mobile clients", async () => {
 		const harness = await createHarness();
 
-		const result = await harness.agent.extMethod("_omp/sessions/listAll", { limit: 2 });
+		const result = await harness.agent.extMethod("speech.models.list", {});
+		const models = result.models;
+		const voices = result.voices;
+		const defaults = result.defaults;
+		expect(Array.isArray(models)).toBe(true);
+		expect(Array.isArray(voices)).toBe(true);
+		expect(defaults && typeof defaults === "object").toBe(true);
 
-		expect(Array.isArray(result.sessions)).toBe(true);
-		expect(typeof result.total).toBe("number");
+		if (!Array.isArray(models) || !Array.isArray(voices)) {
+			throw new Error("speech.models.list did not return model and voice arrays");
+		}
+
+		const modelIds = models.map(model =>
+			model && typeof model === "object" ? (model as { id?: unknown }).id : undefined,
+		);
+		const voiceIds = voices.map(voice =>
+			voice && typeof voice === "object" ? (voice as { id?: unknown }).id : undefined,
+		);
+		expect(modelIds).toContain("parakeet");
+		expect(modelIds).toContain("kokoro");
+		expect(voiceIds).toContain("af_heart");
+
+		const prefixedSessions = await harness.agent.extMethod("_omp/sessions/listAll", { limit: 2 });
+		expect(Array.isArray(prefixedSessions.sessions)).toBe(true);
+
 		await expect(harness.agent.extMethod("omp/sessions/listAll", { limit: 2 })).rejects.toThrow(
 			"Unknown ACP ext method",
 		);

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -19,6 +19,8 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+
 const TEST_MODEL: Model = buildModel({
 	id: "claude-sonnet-4-20250514",
 	name: "Claude Sonnet",
@@ -441,6 +443,79 @@ describe("ACP lazy startup", () => {
 			await closeTransport(agentToClient.writable);
 			await Promise.allSettled([agentConnection.closed, serverConnection.closed]);
 		}
+	});
+
+	it("routes speech model catalog requests before creating the first AgentSession", async () => {
+		const clientToAgent = new TransformStream();
+		const agentToClient = new TransformStream();
+		const client = new TestClient();
+		let createCalls = 0;
+
+		const agentConnection = new ClientSideConnection(
+			() => client,
+			ndJsonStream(clientToAgent.writable, agentToClient.readable),
+		);
+		const serverConnection = createAcpConnection(
+			ndJsonStream(agentToClient.writable, clientToAgent.readable),
+			async cwd => {
+				createCalls++;
+				return new LazyFakeSession(cwd) as unknown as AgentSession;
+			},
+		);
+
+		try {
+			const result = await agentConnection.extMethod("speech.models.list", {});
+			const models = result.models;
+			const voices = result.voices;
+			const defaults = result.defaults;
+
+			expect(createCalls).toBe(0);
+			expect(Array.isArray(models)).toBe(true);
+			expect(Array.isArray(voices)).toBe(true);
+			expect(defaults && typeof defaults === "object").toBe(true);
+
+			if (!Array.isArray(models) || !Array.isArray(voices) || !defaults || typeof defaults !== "object") {
+				throw new Error("speech.models.list did not return model arrays, voice arrays, and defaults");
+			}
+
+			expect(models).toContainEqual(expect.objectContaining({ id: "parakeet", kind: "stt" }));
+			expect(models).toContainEqual(expect.objectContaining({ id: "kokoro", kind: "tts" }));
+			expect(voices).toContainEqual(expect.objectContaining({ id: "af_heart" }));
+			expect(defaults).toEqual(
+				expect.objectContaining({
+					sttModel: "parakeet",
+					ttsModel: "kokoro",
+					voice: "af_heart",
+				}),
+			);
+		} finally {
+			await closeTransport(clientToAgent.writable);
+			await closeTransport(agentToClient.writable);
+			await Promise.allSettled([agentConnection.closed, serverConnection.closed]);
+		}
+	});
+
+	it("imports ACP speech catalog without loading TTS worker env validation", async () => {
+		const proc = Bun.spawn([process.execPath, "-e", 'import "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";'], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				PI_TINY_DEVICE: "not-a-device",
+				PI_TINY_DTYPE: "not-a-dtype",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode, stderr || stdout).toBe(0);
+		expect(stderr).not.toContain("Unsupported PI_TINY_DEVICE");
+		expect(stderr).not.toContain("Unsupported PI_TINY_DTYPE");
 	});
 
 	it("applies CLI runtime API keys after ACP lazy session creation resolves extension models", async () => {


### PR DESCRIPTION
## What

- Add the ACP `speech.models.list` method used by OMP Mobile voice settings.
- Return static local STT/TTS model and voice catalogs from existing coding-agent registries.
- Add handler-level and in-memory ACP transport regression coverage plus changelog entry.

## Why

Fixes #3011. Mobile voice settings were trying to populate the speech model picker and hit `Method 'speech.models.list' is not available to mobile clients`.

## Testing

- [x] `bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts --test-name-pattern "speech model catalog|TTS worker env"`
- [x] `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)