### PR TITLE
fix(acp): list local speech models for mobile

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP mobile voice settings being unable to call `speech.models.list` by exposing the local STT/TTS model and voice catalog without triggering setup or downloads ([#3011](https://github.com/can1357/oh-my-pi/issues/3011)).
+
 ## [16.0.10] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -68,10 +68,17 @@ import type { SessionInfo as StoredSessionInfo } from "../../session/session-lis
 import { SessionManager } from "../../session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash-commands/available-commands";
+import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { runResolveInvocation } from "../../tools/resolve";
 import { ToolError } from "../../tools/tool-errors";
+import {
+	DEFAULT_TTS_LOCAL_MODEL_KEY,
+	DEFAULT_TTS_VOICE,
+	TTS_LOCAL_MODELS,
+	TTS_LOCAL_VOICE_OPTIONS,
+} from "../../tts/models";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { createAcpClientBridge } from "./acp-client-bridge";
 import {
@@ -91,6 +98,7 @@ const MODEL_CONFIG_ID = "model";
 const THINKING_CONFIG_ID = "thinking";
 const THINKING_OFF = "off";
 const SESSION_PAGE_SIZE = 50;
+const SPEECH_MODELS_LIST_METHOD = "speech.models.list";
 /**
  * Delay between `session/new` (or `session/load` / `session/resume` /
  * `unstable_session/fork`) returning and the agent firing the first
@@ -194,6 +202,59 @@ type MCPSourceMap = {
 };
 
 type CreateAcpSession = (cwd: string) => Promise<AgentSession>;
+
+type AcpSpeechOption = {
+	value: string;
+	label: string;
+	description?: string;
+};
+
+type AcpSpeechVoiceOption = {
+	value: string;
+	label: string;
+};
+
+type AcpSpeechTtsModelOption = AcpSpeechOption & {
+	voices: AcpSpeechVoiceOption[];
+};
+
+function buildAcpSpeechModelsCatalog(): Record<string, unknown> {
+	const voices = TTS_LOCAL_VOICE_OPTIONS.map(({ value, label }) => ({ value, label }));
+	return {
+		settings: {
+			speechToTextModel: "stt.modelName",
+			textToSpeechModel: "tts.localModel",
+			textToSpeechVoice: "tts.localVoice",
+			speechVoice: "speech.voice",
+		},
+		defaults: {
+			speechToTextModel: DEFAULT_STT_MODEL_KEY,
+			textToSpeechModel: DEFAULT_TTS_LOCAL_MODEL_KEY,
+			voice: DEFAULT_TTS_VOICE,
+		},
+		speechToText: {
+			setting: "stt.modelName",
+			defaultValue: DEFAULT_STT_MODEL_KEY,
+			models: STT_MODEL_OPTIONS.map(({ value, label, description }) => ({ value, label, description })),
+		},
+		textToSpeech: {
+			modelSetting: "tts.localModel",
+			voiceSetting: "tts.localVoice",
+			speechVoiceSetting: "speech.voice",
+			defaultModel: DEFAULT_TTS_LOCAL_MODEL_KEY,
+			defaultVoice: DEFAULT_TTS_VOICE,
+			models: TTS_LOCAL_MODELS.map(
+				({ key, label, description, voices: modelVoices }): AcpSpeechTtsModelOption => ({
+					value: key,
+					label,
+					description,
+					voices: modelVoices.map(({ id, label: voiceLabel }) => ({ value: id, label: voiceLabel })),
+				}),
+			),
+			voices,
+		},
+	};
+}
 
 /**
  * Bridge a single ExtensionUIContext call to the ACP `unstable_createElicitation`
@@ -850,6 +911,8 @@ export class AcpAgent implements Agent {
 
 	async extMethod(method: string, params: { [key: string]: unknown }): Promise<{ [key: string]: unknown }> {
 		switch (method) {
+			case SPEECH_MODELS_LIST_METHOD:
+				return buildAcpSpeechModelsCatalog();
 			case "_omp/sessions/listAll": {
 				const limit = typeof params.limit === "number" ? Math.max(1, Math.min(5000, params.limit as number)) : 1000;
 				const sessions = await SessionManager.listAll();

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -29,6 +29,13 @@ import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "@oh-my-pi/pi-coding-agent/stt/models";
+import {
+	DEFAULT_TTS_LOCAL_MODEL_KEY,
+	DEFAULT_TTS_VOICE,
+	TTS_LOCAL_MODELS,
+	TTS_LOCAL_VOICE_OPTIONS,
+} from "@oh-my-pi/pi-coding-agent/tts/models";
 import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
 import type { z } from "zod/v4";
 
@@ -876,7 +883,50 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
-	it("accepts only ACP underscore-prefixed extension methods", async () => {
+	it("lists static speech models for ACP mobile voice settings", async () => {
+		const harness = await createHarness();
+		const voices = TTS_LOCAL_VOICE_OPTIONS.map(({ value, label }) => ({ value, label }));
+
+		const result = await harness.agent.extMethod("speech.models.list", {});
+
+		expect(result).toEqual({
+			settings: {
+				speechToTextModel: "stt.modelName",
+				textToSpeechModel: "tts.localModel",
+				textToSpeechVoice: "tts.localVoice",
+				speechVoice: "speech.voice",
+			},
+			defaults: {
+				speechToTextModel: DEFAULT_STT_MODEL_KEY,
+				textToSpeechModel: DEFAULT_TTS_LOCAL_MODEL_KEY,
+				voice: DEFAULT_TTS_VOICE,
+			},
+			speechToText: {
+				setting: "stt.modelName",
+				defaultValue: DEFAULT_STT_MODEL_KEY,
+				models: STT_MODEL_OPTIONS.map(({ value, label, description }) => ({ value, label, description })),
+			},
+			textToSpeech: {
+				modelSetting: "tts.localModel",
+				voiceSetting: "tts.localVoice",
+				speechVoiceSetting: "speech.voice",
+				defaultModel: DEFAULT_TTS_LOCAL_MODEL_KEY,
+				defaultVoice: DEFAULT_TTS_VOICE,
+				models: TTS_LOCAL_MODELS.map(({ key, label, description, voices: modelVoices }) => ({
+					value: key,
+					label,
+					description,
+					voices: modelVoices.map(({ id, label: voiceLabel }) => ({ value: id, label: voiceLabel })),
+				})),
+				voices,
+			},
+		});
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("accepts OMP extension methods and rejects unknown unprefixed methods", async () => {
 		const harness = await createHarness();
 
 		const result = await harness.agent.extMethod("_omp/sessions/listAll", { limit: 2 });


### PR DESCRIPTION
## Repro
Calling the ACP agent extension method `speech.models.list` failed before this change: `bun --cwd=packages/coding-agent -e 'import { AcpAgent } from "./src/modes/acp/acp-agent.ts"; const controller = new AbortController(); const connection = { signal: controller.signal, closed: Promise.withResolvers().promise, sessionUpdate: async () => {} }; const agent = new AcpAgent(connection, async () => { throw new Error("unused"); }); try { const result = await agent.extMethod("speech.models.list", {}); console.log(JSON.stringify(result)); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); }'` exited 1 with `Unknown ACP ext method: speech.models.list`.

## Cause
`packages/coding-agent/src/modes/acp/acp-agent.ts` only routed `_omp/*` ACP extension methods in `AcpAgent.extMethod`, while OMP Mobile calls the unprefixed `speech.models.list` method to populate voice settings. The existing STT/TTS catalogs lived in `src/stt/models.ts` and `src/tts/models.ts`, but no ACP-safe catalog method exposed them.

## Fix
- Added `speech.models.list` handling in `AcpAgent.extMethod`.
- Returned static `stt.modelName`, `tts.localModel`, `tts.localVoice`, and `speech.voice` catalog data from the existing local speech registries without setup/download calls.
- Added an ACP agent regression test covering the exact mobile method and response shape.
- Added the coding-agent changelog entry.

## Verification
`bun --cwd=packages/coding-agent test test/acp-agent.test.ts` passed with 49 tests; `bun --cwd=packages/coding-agent run check:types` passed; the repro command now returns the STT/TTS catalog for `speech.models.list`. Fixes #3011