### PR TITLE
test(ai): pin reasoning_content contract for null content deltas (#2996)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added regression test pinning that `openai-completions` emits a `thinking` block for `reasoning_content` deltas even when `delta.content` is explicitly JSON `null` (the DeepSeek-format dual-key pattern used by custom GLM/Qwen reasoning providers). See [#2996](https://github.com/can1357/oh-my-pi/issues/2996).
+
 ## [16.0.10] - 2026-06-18
 
 ### Added

--- a/packages/ai/test/issue-2996-repro.test.ts
+++ b/packages/ai/test/issue-2996-repro.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression guard for the openai-completions streaming reasoning contract.
+ *
+ * Some OpenAI-compatible hosts (GLM, Qwen reasoning variants behind custom
+ * `openai-completions` providers) stream the DeepSeek-format dual-key pattern:
+ *
+ *   {"delta":{"content":null,"reasoning_content":"..."}}
+ *
+ * where `content` is explicitly JSON `null` (not absent) while `reasoning_content`
+ * carries the thinking text. The provider must emit a `thinking` block for that
+ * text — the null `content` must not cause the reasoning delta to be dropped,
+ * and it must not be coerced into an empty text block either.
+ *
+ * This pins the behavior so a future change that introduces an `if (delta.content)`
+ * guard (or routes the reasoning path behind a content-presence check) is caught.
+ * See issue #2996 for the reported (non-reproducing) scenario this defends.
+ */
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+function createSseResponse(events: unknown[]): Response {
+	const payload = `${events
+		.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+		.join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createMockFetch(events: unknown[]): FetchImpl {
+	async function mockFetch(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+		return createSseResponse(events);
+	}
+	return Object.assign(mockFetch, { preconnect: fetch.preconnect });
+}
+
+function baseContext(): Context {
+	return {
+		messages: [{ role: "user", content: "1+1=?", timestamp: Date.now() }],
+	};
+}
+
+/** A custom openai-completions provider model (e.g. yunwu/glm-5.2) with reasoning enabled. */
+function customReasoningModel(id = "glm-5.2"): Model<"openai-completions"> {
+	const base = getBundledModel("openai", "gpt-4o-mini");
+	return buildModel({
+		...base,
+		api: "openai-completions",
+		provider: "yunwu",
+		baseUrl: "https://yunwu.ai/v1",
+		id,
+		reasoning: true,
+		compat: base.compatConfig,
+	} as ModelSpec<"openai-completions">);
+}
+
+function deltaChunk(model: Model<"openai-completions">, delta: Record<string, unknown>): unknown {
+	return {
+		id: "x",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: model.id,
+		choices: [{ index: 0, delta }],
+	};
+}
+
+describe("openai-completions keeps reasoning_content when delta.content is null", () => {
+	it("emits a thinking block for reasoning_content deltas paired with content:null", async () => {
+		const model = customReasoningModel();
+		const fetchMock = createMockFetch([
+			deltaChunk(model, { content: null, reasoning_content: "分析" }),
+			deltaChunk(model, { content: null, reasoning_content: "步骤" }),
+			deltaChunk(model, { content: "2", reasoning_content: null }),
+			{
+				id: "x",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+		}).result();
+
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "分析步骤", thinkingSignature: "reasoning_content" },
+			{ type: "text", text: "2" },
+		]);
+	});
+
+	it("does not coerce a content:null delta into a text block when only reasoning_content is present", async () => {
+		const model = customReasoningModel();
+		const fetchMock = createMockFetch([
+			deltaChunk(model, { content: null, reasoning_content: "only thinking" }),
+			deltaChunk(model, { content: "answer", reasoning_content: null }),
+			{
+				id: "x",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+		}).result();
+
+		const textBlocks = result.content.filter(b => b.type === "text");
+		expect(textBlocks).toEqual([{ type: "text", text: "answer" }]);
+	});
+});


### PR DESCRIPTION
## Summary

Investigated issue #2996 ("openai-completions drops thinking blocks when `delta.content` is null alongside `delta.reasoning_content`"). 

## Finding

**The bug does not reproduce in current code (v16.0.11).** The `openai-completions` streaming handler reads `reasoning_content` independently of `delta.content` (see `packages/ai/src/providers/openai-completions.ts` lines 983-1003): it checks the reasoning field first and emits a thinking block via `appendThinkingDelta` before `normalizeStreamingContentText(choice.delta.content)` is ever consulted. `normalizeStreamingContentText(null)` returns `""`, so a null content delta simply contributes no text — it does not cause the reasoning delta to be dropped.

Git blame confirms the reasoning handler has been unchanged since commit `a8829420d7` ("fix(ai): deduplicated minimax reasoning stream", 2026-06-13), released in v15.12.4 — well before v16.0.7 where the issue was reported. The reporter's root-cause hypothesis ("`if (delta.content)` treats null as falsy") does not match the actual code path, which has no such content-presence guard on the reasoning branch.

I verified this empirically by building the native addon and running a reproduction with the reporter's exact chunk shape (`{"delta":{"content":null,"reasoning_content":"..."}}`): the thinking block is emitted correctly.

## What this PR adds

A **regression test** pinning this contract at the parsing boundary the reporter flagged as fragile. This is a contract-level test (per the repo's testing guidance): it defends the externally-observable streaming output shape — that a `reasoning_content` delta produces a `thinking` block even when `content` is explicitly JSON `null`, and that a null content delta is not coerced into an empty text block. It catches a future regression where someone introduces an `if (delta.content)` guard or routes the reasoning path behind a content-presence check.

## Verification

- `bun test packages/ai/test/issue-2996-repro.test.ts` — 2 pass, 0 fail
- Related reasoning/streaming suites (issue-1203, issue-1838, deepseek-reasoning-content, openai-completions-progress-chunk, openai-completions-compat) — 104 pass, 0 fail
- `bun run check:types` (packages/ai) — clean
- `bunx biome check` — clean

## Test plan

- [x] New regression test passes and asserts the exact `content` array shape
- [x] No source changes — behavior is unchanged
- [x] Existing reasoning tests remain green

Closes #2996 (verified non-reproducing; pinned with regression test).