### PR TITLE
fix(ipc): harden worker IPC send against async EPIPE rejections (#2997)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened TTS, STT, and tiny-title worker IPC `send()` paths against async EPIPE rejections: `Subprocess.send()` is now wrapped so neither a synchronous "process exited" throw nor an asynchronous EPIPE rejection (when the pipe breaks between exit being observed and the next send) can escape as a fatal unhandled rejection. A dying Kokoro/TTS/STT worker can no longer crash the whole agent session mid-task. ([#2997](https://github.com/can1357/oh-my-pi/issues/2997))
+
 ## [16.0.11] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/src/stt/asr-client.ts
+++ b/packages/coding-agent/src/stt/asr-client.ts
@@ -3,6 +3,7 @@ import { $env, isBunTestRuntime, isCompiledBinary, logger, workerHostEntry } fro
 import type { Subprocess } from "bun";
 import { settings } from "../config/settings";
 import { tinyWorkerEnvOverlay } from "../tiny/title-client";
+import { safeSend } from "../utils/ipc";
 import type { SttProgressEvent, SttWorkerInbound, SttWorkerOutbound } from "./asr-protocol";
 import type { SttModelKey } from "./models";
 
@@ -181,13 +182,7 @@ export function createSttSubprocess(): SpawnedSubprocess {
 function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): WorkerHandle {
 	return {
 		send(message) {
-			try {
-				proc.send(message);
-			} catch (error) {
-				logger.debug("stt: send to subprocess failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
+			safeSend(proc, message, "stt");
 		},
 		onMessage(handler) {
 			inbound.add(handler);

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { $env, isBunTestRuntime, isCompiledBinary, logger, workerHostEntry } from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 import { settings } from "../config/settings";
+import { safeSend } from "../utils/ipc";
 import { tinyModelDeviceSettingToEnv } from "./device";
 import { tinyModelDtypeSettingToEnv } from "./dtype";
 import {
@@ -216,13 +217,7 @@ export function createTinyTitleSubprocess(): SpawnedSubprocess {
 function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): WorkerHandle {
 	return {
 		send(message) {
-			try {
-				proc.send(message);
-			} catch (error) {
-				logger.debug("tiny-title: send to subprocess failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
+			safeSend(proc, message, "tiny-title");
 		},
 		onMessage(handler) {
 			inbound.add(handler);

--- a/packages/coding-agent/src/tts/tts-client.ts
+++ b/packages/coding-agent/src/tts/tts-client.ts
@@ -3,6 +3,7 @@ import { $env, isBunTestRuntime, isCompiledBinary, logger, workerHostEntry } fro
 import type { Subprocess } from "bun";
 import { settings } from "../config/settings";
 import { tinyWorkerEnvOverlay } from "../tiny/title-client";
+import { safeSend } from "../utils/ipc";
 import { isTtsLocalModelKey, type TtsLocalModelKey } from "./models";
 import type { TtsProgressEvent, TtsWorkerInbound, TtsWorkerOutbound } from "./tts-protocol";
 
@@ -245,13 +246,7 @@ export function createTtsSubprocess(): SpawnedSubprocess {
 function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): WorkerHandle {
 	return {
 		send(message) {
-			try {
-				proc.send(message);
-			} catch (error) {
-				logger.debug("tts: send to subprocess failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
+			safeSend(proc, message, "tts");
 		},
 		onMessage(handler) {
 			inbound.add(handler);

--- a/packages/coding-agent/src/utils/ipc.ts
+++ b/packages/coding-agent/src/utils/ipc.ts
@@ -1,0 +1,38 @@
+import { logger } from "@oh-my-pi/pi-utils";
+
+/**
+ * Narrow a value to a thenable so a rejection handler can be attached.
+ *
+ * Mirrors the local helper in `mcp/transports/stdio.ts` (kept separate because
+ * that copy serves the FileSink stdin-write path and is battle-tested there).
+ * This shared copy is the home for the IPC `send()` sites.
+ */
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+	return (
+		value != null &&
+		(typeof value === "object" || typeof value === "function") &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
+/**
+ * Send a message to a Bun subprocess over IPC, neutralizing both the
+ * synchronous throw ("cannot be used after the process has exited") and any
+ * asynchronous rejection (EPIPE from a pipe that broke between exit being
+ * observed and the next `send()`). The dead worker is detected separately via
+ * `onExit`/`onError` and respawned or disabled by the owning client; an
+ * un-awaited EPIPE rejection must not escape as a fatal unhandled rejection
+ * that takes down the whole session. See issue #2997.
+ *
+ * `label` prefixes the debug log on synchronous failure (e.g. "tts").
+ */
+export function safeSend(proc: { send(message: unknown): unknown }, message: unknown, label: string): void {
+	try {
+		const result = proc.send(message);
+		if (isThenable(result)) result.then(undefined, () => {});
+	} catch (error) {
+		logger.debug(`${label}: send to subprocess failed`, {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}

--- a/packages/coding-agent/test/ipc-safe-send.test.ts
+++ b/packages/coding-agent/test/ipc-safe-send.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { safeSend } from "@oh-my-pi/pi-coding-agent/utils/ipc";
+
+/**
+ * Contract for issue #2997: `safeSend` wraps `Subprocess.send()` so neither a
+ * synchronous throw ("cannot be used after the process has exited") nor an
+ * asynchronous EPIPE rejection (pipe broke between exit being observed and the
+ * next send) can escape and crash the session via the global `unhandledRejection`
+ * handler. The dead worker is detected separately via `onExit`; the send itself
+ * must be fire-and-forget-safe.
+ */
+describe("safeSend", () => {
+	it("calls send with the message on the happy path", () => {
+		const sent: unknown[] = [];
+		const proc = { send: (m: unknown) => sent.push(m) };
+		safeSend(proc, { type: "ping" }, "test");
+		expect(sent).toEqual([{ type: "ping" }]);
+	});
+
+	it("swallows a synchronous throw without rethrowing", () => {
+		const proc = {
+			send: () => {
+				throw new Error("Subprocess.send() cannot be used after the process has exited.");
+			},
+		};
+		expect(() => safeSend(proc, {}, "test")).not.toThrow();
+	});
+
+	it("neutralizes a rejected thenable returned by send so it cannot become an unhandled rejection", async () => {
+		const epipe = Object.assign(new Error("EPIPE: broken pipe, send"), { code: "EPIPE", syscall: "send" });
+		const proc = { send: () => Promise.reject(epipe) };
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			safeSend(proc, {}, "test");
+			// Drain the microtask queue deterministically (two microtask ticks:
+			// one for the promise rejection, one for the .then(noop) handler).
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("neutralizes a resolved thenable without affecting the happy path", async () => {
+		const proc = { send: () => Promise.resolve(undefined) };
+		expect(() => safeSend(proc, {}, "test")).not.toThrow();
+		// Drain the microtask queue so a stray rejection would surface.
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made EPIPE rejections from IPC `send()` to worker subprocesses (`syscall: "send"`) non-fatal: the global `unhandledRejection` handler now logs and continues instead of terminating the session when an optional subsystem's pipe breaks. A broken optional subsystem (TTS/STT/tiny-title/MCP) can no longer crash the whole agent session mid-task. ([#2997](https://github.com/can1357/oh-my-pi/issues/2997))
+
 ## [16.0.11] - 2026-06-19
 
 ### Removed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -65,6 +65,19 @@ function runCleanup(reason: Reason): Promise<void> {
 // Worker thread: exit only (workers use self.addEventListener for exceptions)
 let inspectorOpened = false;
 
+/**
+ * Detect an EPIPE rejection that originated from an IPC `send()` to a worker
+ * subprocess (`syscall: "send"`), as opposed to a stdin/stdout pipe write
+ * (`syscall: "write"`). Only the IPC-send path can break an optional worker
+ * subsystem without affecting the main process, so only this shape is safe to
+ * swallow at the global `unhandledRejection` level. See issue #2997.
+ */
+export function isIpcSendEpipe(err: Error): boolean {
+	const code = (err as { code?: unknown }).code;
+	const syscall = (err as { syscall?: unknown }).syscall;
+	return code === "EPIPE" && syscall === "send";
+}
+
 function formatFatalError(label: string, err: Error): string {
 	const name = err.name || "Error";
 	const message = err.message || "(no message)";
@@ -95,6 +108,19 @@ if (isMainThread) {
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
+			// EPIPE from an IPC `send()` (`syscall: "send"`) originates from a
+			// worker subprocess whose pipe broke between the exit being observed
+			// and the next `proc.send()` — a race window that Bun surfaces as an
+			// async rejection rather than the synchronous "cannot be used after
+			// the process has exited" guard. Every `send()` target is an optional
+			// worker subsystem (TTS, STT, tiny-title, MCP servers), so a broken
+			// send pipe must never take down the whole session. Log and continue
+			// instead of exiting; the owning client detects the dead worker via
+			// its own `onExit`/error path and respawns or disables it. See #2997.
+			if (isIpcSendEpipe(err)) {
+				logger.warn("Ignoring EPIPE from worker IPC send; optional subsystem will self-recover", { err });
+				return;
+			}
 			process.stderr.write(formatFatalError("Unhandled Rejection", err));
 			logger.error("Unhandled rejection", { err });
 			await runCleanup(Reason.UNHANDLED_REJECTION);

--- a/packages/utils/test/postmortem-epipe.test.ts
+++ b/packages/utils/test/postmortem-epipe.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { postmortem } from "@oh-my-pi/pi-utils";
+
+/**
+ * Contract for issue #2997: an EPIPE rejection from an IPC `send()` to a worker
+ * subprocess (`syscall: "send"`) must be recognizable as a non-fatal, optional-
+ * subsystem failure so the global `unhandledRejection` handler can swallow it
+ * instead of terminating the session. The predicate must be narrow: a bare
+ * EPIPE, or an EPIPE from a stdin/stdout write (`syscall: "write"`), is NOT
+ * swallowed — those may signal a real broken pipe to a critical stream.
+ */
+describe("postmortem.isIpcSendEpipe", () => {
+	function makeErr(props: { code?: string; syscall?: string; message?: string }): Error {
+		const err = new Error(props.message ?? "broken pipe");
+		Object.assign(err, { code: props.code, syscall: props.syscall });
+		return err;
+	}
+
+	it("matches EPIPE with syscall 'send' (worker IPC send)", () => {
+		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE", syscall: "send" }))).toBe(true);
+	});
+
+	it("does not match EPIPE from a stdin/stdout write (syscall 'write')", () => {
+		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE", syscall: "write" }))).toBe(false);
+	});
+
+	it("does not match a bare EPIPE without a syscall", () => {
+		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE" }))).toBe(false);
+	});
+
+	it("does not match a non-EPIPE error even with syscall 'send'", () => {
+		expect(postmortem.isIpcSendEpipe(makeErr({ code: "ENOENT", syscall: "send" }))).toBe(false);
+	});
+
+	it("does not match a plain Error with no code/syscall", () => {
+		expect(postmortem.isIpcSendEpipe(new Error("boom"))).toBe(false);
+	});
+
+	it("does not match nullish/missing errno-style fields gracefully", () => {
+		expect(postmortem.isIpcSendEpipe(makeErr({ code: undefined, syscall: undefined }))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2997 — a dying worker subprocess (e.g. Kokoro TTS exiting with code 7) could crash the entire agent session mid-task.

## Bug

`Subprocess.send()` to a Bun worker subprocess is wrapped in a synchronous `try/catch` that catches the "cannot be used after the process has exited" guard. But when the pipe breaks *between* the exit being observed and the next `send()`, the write rejects **asynchronously** with `EPIPE` (`syscall: "send"`). That un-awaited rejection escapes to the global `unhandledRejection` handler, which calls `process.exit(1)` — killing the session and discarding in-flight work (in the reporter's case, a 20-minute `cargo check --workspace`).

The reporter observed two distinct outcomes of "send to a dead worker": a handled synchronous guard (harmless, debug-level) and an unhandled async `EPIPE` (session crash). The async path is a race window that fires when the pipe is already broken but `subprocess.exited` hasn't been observed yet.

## Fix (two layers)

1. **Source fix** — new shared `safeSend(proc, message, label)` helper in `packages/coding-agent/src/utils/ipc.ts` neutralizes any thenable return from `proc.send()`, mirroring the proven `writeFrame` pattern in `mcp/transports/stdio.ts` (which handles the same class of bug for the MCP stdin-write path). Wired into all three IPC clients: TTS, STT, and tiny-title — they previously each carried an identical inline `try/catch` that only caught the synchronous case.

2. **Defense-in-depth** — the global `unhandledRejection` handler in `packages/utils/src/postmortem.ts` now recognizes `EPIPE` with `syscall: "send"` as a non-fatal, optional-subsystem failure: it logs and continues instead of calling `process.exit(1)`. The filter is deliberately narrow — it only matches IPC-send EPIPE, not stdin/stdout pipe breaks (`syscall: "write"`), so it won't mask a real broken-pipe bug in a critical stream. Every `send()` target is an optional worker subsystem (TTS/STT/tiny-title/MCP servers), so a broken send pipe can never indicate a main-process failure.

### Why both layers

I probed `Subprocess.send()` directly: on Bun 1.3.14 it returns `boolean` (not a thenable), so layer 1 alone cannot catch the async EPIPE on current Bun. Layer 2 is what actually prevents the session crash; layer 1 is belt-and-suspenders for Bun versions/platforms where `send()` may return a thenable. The dead worker is still detected via its own `onExit`/`onError` path and respawned or disabled by the owning client — the session just no longer dies in the gap.

## Verification

- New tests: `packages/utils/test/postmortem-epipe.test.ts` (6 tests for the `isIpcSendEpipe` predicate — distinguishes IPC-send EPIPE from stdin/stdout-write EPIPE, handles nullish/missing fields) + `packages/coding-agent/test/ipc-safe-send.test.ts` (4 tests for `safeSend`: happy path, sync-throw swallowing, async-rejection neutralization verified via `unhandledRejection` listener, resolved-thenable).
- Related suites green: issue-1606-repro, tiny-title-generator, tiny-worker-env — 14 pass, 0 fail across the touched modules.
- `omp --smoke-test` passes (exercises the worker IPC end-to-end through the new `safeSend`).
- `bun run check:types` clean on both `packages/utils` and `packages/coding-agent`.
- `bunx biome check` clean on all changed files.

## Files

- `packages/coding-agent/src/utils/ipc.ts` (new) — shared `safeSend` + `isThenable`.
- `packages/coding-agent/src/tts/tts-client.ts`, `stt/asr-client.ts`, `tiny/title-client.ts` — use `safeSend` (removes the triplicated inline `try/catch`).
- `packages/utils/src/postmortem.ts` — exported `isIpcSendEpipe` predicate + non-fatal EPIPE-send branch in `unhandledRejection`.
- Changelogs + the two test files.

## Test plan

- [x] `isIpcSendEpipe` correctly distinguishes IPC-send EPIPE (`syscall: "send"`) from stdin/stdout-write EPIPE (`syscall: "write"`)
- [x] `safeSend` swallows sync throws without rethrowing
- [x] `safeSend` neutralizes async thenable rejections (no `unhandledRejection` surfaces, asserted via listener)
- [x] Existing worker tests + `omp --smoke-test` remain green
- [x] No behavior change on the happy path

Closes #2997.