### PR TITLE
refactor(coding-agent): replace new Promise constructor in AsyncDrain with Promise.withResolvers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `new Promise((resolve, reject) => ...)` in `AsyncDrain` with `Promise.withResolvers()` per the repo's promise-construction convention
+
 ## [16.1.5] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -38,24 +38,23 @@ class AsyncDrain<T> {
 		let queue = this.#queue;
 		if (!queue) {
 			this.#queue = queue = [];
-			this.#promise = new Promise((resolve, reject) => {
-				const exec = () => {
-					try {
-						if (this.#queue === queue) {
-							this.#queue = undefined;
-						}
-						resolve(hnd(queue!));
-					} catch (error) {
-						reject(error);
+			const { promise, resolve, reject } = Promise.withResolvers<void>();
+			const exec = (): void => {
+				try {
+					if (this.#queue === queue) {
+						this.#queue = undefined;
 					}
-				};
-
-				if (this.delayMs > 0) {
-					setTimeout(exec, this.delayMs);
-				} else {
-					queueMicrotask(exec);
+					resolve(hnd(queue!));
+				} catch (error) {
+					reject(error);
 				}
-			});
+			};
+			if (this.delayMs > 0) {
+				setTimeout(exec, this.delayMs);
+			} else {
+				queueMicrotask(exec);
+			}
+			this.#promise = promise;
 		}
 		queue.push(value);
 		return this.#promise;

--- a/packages/coding-agent/test/history-storage-drain.test.ts
+++ b/packages/coding-agent/test/history-storage-drain.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
+
+let tempDir = "";
+
+async function freshStorage(prefix = "omp-history-drain-"): Promise<HistoryStorage> {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	const dbPath = path.join(tempDir, "history.db");
+	HistoryStorage.resetInstance();
+	return HistoryStorage.open(dbPath);
+}
+
+/** Drain the 100ms insert batch window, then await the pending writes. */
+async function flush(...writes: Promise<void>[]): Promise<void> {
+	vi.advanceTimersByTime(100);
+	await Promise.all(writes);
+}
+
+beforeEach(() => {
+	HistoryStorage.resetInstance();
+	vi.useFakeTimers();
+});
+
+afterEach(async () => {
+	HistoryStorage.resetInstance();
+	vi.useRealTimers();
+	if (tempDir) {
+		await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+		tempDir = "";
+	}
+});
+
+/**
+ * Contract for the history-storage async drain: multiple rapid `add()` calls
+ * within the drain window are batched into a single flushed write, and the
+ * returned promise resolves once the batch is persisted. This guards the
+ * `Promise.withResolvers()` refactor of `AsyncDrain` — the drain must still
+ * coalesce pushes and resolve its per-batch promise.
+ */
+describe("HistoryStorage AsyncDrain batching", () => {
+	it("coalesces pushes within the drain window into one flushed write", async () => {
+		const storage = await freshStorage();
+		// Three rapid adds before the 100ms drain window fires.
+		const p1 = storage.add("first prompt");
+		const p2 = storage.add("second prompt");
+		const p3 = storage.add("third prompt");
+		await flush(p1, p2, p3);
+
+		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["third prompt", "second prompt", "first prompt"]);
+	});
+
+	it("resolves the returned promise for each coalesced push", async () => {
+		const storage = await freshStorage();
+		const p1 = storage.add("a");
+		const p2 = storage.add("b");
+		await flush(p1, p2);
+		// Both promises must have resolved (not hang) — flush awaited them.
+		expect(storage.getRecent(10)).toHaveLength(2);
+	});
+
+	it("starts a fresh batch after the prior one flushes", async () => {
+		const storage = await freshStorage();
+		await flush(storage.add("batch-one"));
+		// After the first batch flushes, a new add starts a new batch.
+		await flush(storage.add("batch-two"));
+		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["batch-two", "batch-one"]);
+	});
+});


### PR DESCRIPTION
## Summary

Replaces `new Promise((resolve, reject) => ...)` in `AsyncDrain` (the history-storage drain queue) with `Promise.withResolvers()`, per the repo's promise-construction convention (AGENTS.md: "use `Promise.withResolvers()` instead of `new Promise((resolve, reject) => ...)`").

## Change

`AsyncDrain` batches rapid `add()` calls into a single flushed write via a deferred `exec` (microtask or `setTimeout`). The constructor previously created the promise inline with `new Promise((resolve, reject) => { ... exec calls resolve/reject ... })`. This refactors it to destructure `{ promise, resolve, reject }` from `Promise.withResolvers()` and call them from the same deferred `exec` closure, then assign `promise` to `this.#promise`.

**No behavior change** — the queue-reset-before-handler, resolve/reject calls, and the `delayMs > 0 ? setTimeout : queueMicrotask` deferral are all preserved exactly. The commit agent mischaracterized this as a bug fix, but it is a pure convention-compliance refactor.

## Why

- Satisfies the AGENTS.md mandate to use `Promise.withResolvers()` over the `new Promise` constructor.
- Removes the nested `new Promise` callback shape in favor of flat destructured resolvers, which is easier to read.
- `AsyncDrain` was one of two remaining `new Promise` constructor sites in the coding-agent source (the other, `stats-cli.ts`, is an intentional never-resolving keep-alive).

## Verification

- New contract test `packages/coding-agent/test/history-storage-drain.test.ts` (3 tests): verifies the drain coalesces pushes within the 100ms window, resolves the returned promise for each coalesced push, and starts a fresh batch after the prior one flushes. Uses the established `freshStorage`/`flush` pattern from the existing history-storage tests.
- `bun test packages/coding-agent/test/history-storage-drain.test.ts` — 3 pass, 0 fail.
- `bun run check:types` (packages/coding-agent) — clean.
- `bunx biome check` — clean on both changed files.
- The pre-existing history-storage tests (`history-storage-session`, `history-storage-search`, `history-storage-sqlite-compat`) fail on Windows due to a known EBUSY temp-dir cleanup race (SQLite handle not released before `fs.rm`) — this is tracked separately (branch `fix/windows-test-failures`, PR #3019) and is **unrelated** to this refactor (the failures reproduce identically on the unmodified code, confirmed via `git stash` comparison).

## Test plan

- [x] Drain batching contract test passes (coalesce, resolve, fresh batch)
- [x] Typecheck clean
- [x] Lint clean
- [x] No behavior change — the refactor preserves the exact resolve/reject/deferral semantics