### PR TITLE
fix(coding-agent): re-encode WebP for local-server models

### DIFF
--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -595,6 +595,11 @@ export interface Model<TApi extends Api = Api> {
 	reasoning: boolean;
 	input: ("text" | "image")[];
 	/**
+	 * Decoder family used for image inputs when it has narrower format support
+	 * than OMP's general image pipeline. `stb` local backends reject WebP.
+	 */
+	imageInputDecoder?: "stb";
+	/**
 	 * Native provider tool-call support. `false` is the only unsupported signal:
 	 * `true` and `undefined` both mean callers may use native tools. Catalog and
 	 * discovery sources should set this sparsely when an upstream explicitly

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed WebP images being sent unchanged to `local-server` vision models, which can fail through llama.cpp/STB-backed decoders that do not support WebP ([#2922](https://github.com/can1357/oh-my-pi/issues/2922)).
+
 ## [16.0.11] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -275,6 +275,7 @@ export async function discoverOllamaModels(
 			baseUrl: `${endpoint}/v1`,
 			reasoning: metadata?.reasoning ?? false,
 			input: metadata?.input ?? ["text"],
+			imageInputDecoder: "stb",
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: metadata?.contextWindow ?? 128000,
 			maxTokens: Math.min(metadata?.contextWindow ?? Number.POSITIVE_INFINITY, DISCOVERY_DEFAULT_MAX_TOKENS),
@@ -352,6 +353,7 @@ export async function discoverLlamaCppModels(
 				baseUrl,
 				reasoning: false,
 				input: serverMetadata?.input ?? ["text"],
+				imageInputDecoder: "stb",
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: serverMetadata?.contextWindow ?? 128000,
 				maxTokens: Math.min(
@@ -424,6 +426,7 @@ export async function discoverOpenAIModelsList(
 				baseUrl,
 				reasoning: false,
 				input: nativeMetadataForModel?.input ?? ["text"],
+				...(providerConfig.discovery.type === "lm-studio" ? { imageInputDecoder: "stb" as const } : {}),
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow,
 				maxTokens: Math.min(contextWindow, discoveryDefaultMaxTokens(providerConfig.api)),

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1023,12 +1023,21 @@ export class ModelRegistry {
 	}
 
 	#normalizeDiscoverableModels(providerConfig: DiscoveryProviderConfig, models: Model<Api>[]): Model<Api>[] {
+		const withDecoderMetadata =
+			providerConfig.discovery.type === "ollama" ||
+			providerConfig.discovery.type === "llama.cpp" ||
+			providerConfig.discovery.type === "lm-studio"
+				? models.map(model =>
+						buildModel({ ...model, imageInputDecoder: "stb", compat: model.compatConfig } as ModelSpec<Api>),
+					)
+				: models;
+
 		if (providerConfig.provider !== "ollama" || providerConfig.api !== "openai-responses") {
-			return models;
+			return withDecoderMetadata;
 		}
 
 		const contextLengthOverride = getOllamaContextLengthOverride();
-		return models.map(model => {
+		return withDecoderMetadata.map(model => {
 			const normalized =
 				model.api === "openai-completions"
 					? buildModel({

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1278,7 +1278,12 @@ export class ModelRegistry {
 					models: cached?.models.map(model => model.id) ?? [],
 				});
 				this.#lastDiscoveryWarnings.delete(providerConfig.provider);
-				return cached ? cached.models.map(model => buildModel(model)) : [];
+				return cached
+					? this.#normalizeDiscoverableModels(
+							providerConfig,
+							cached.models.map(model => buildModel(model)),
+						)
+					: [];
 			}
 		}
 

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -13,9 +13,12 @@ export const SUPPORTED_INPUT_IMAGE_MIME_TYPES = SUPPORTED_IMAGE_MIME_TYPES;
  * with an opaque HTTP 400. Detect those models so the resize pipeline encodes
  * to PNG/JPEG instead — the automatic equivalent of `OMP_NO_WEBP=1`.
  */
-export function modelLacksWebpSupport(model: Pick<Model, "provider" | "api"> | undefined): boolean {
+export function modelLacksWebpSupport(
+	model: Pick<Model, "provider" | "api" | "imageInputDecoder"> | undefined,
+): boolean {
 	if (!model) return false;
 	return (
+		model.imageInputDecoder === "stb" ||
 		model.provider === "ollama" ||
 		model.provider === "ollama-cloud" ||
 		model.provider === "llama.cpp" ||

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -18,6 +18,8 @@ export function modelLacksWebpSupport(model: Pick<Model, "provider" | "api"> | u
 	return (
 		model.provider === "ollama" ||
 		model.provider === "ollama-cloud" ||
+		model.provider === "llama.cpp" ||
+		model.provider === "lm-studio" ||
 		model.provider === "local-server" ||
 		model.api === "ollama-chat"
 	);

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -15,7 +15,12 @@ export const SUPPORTED_INPUT_IMAGE_MIME_TYPES = SUPPORTED_IMAGE_MIME_TYPES;
  */
 export function modelLacksWebpSupport(model: Pick<Model, "provider" | "api"> | undefined): boolean {
 	if (!model) return false;
-	return model.provider === "ollama" || model.provider === "ollama-cloud" || model.api === "ollama-chat";
+	return (
+		model.provider === "ollama" ||
+		model.provider === "ollama-cloud" ||
+		model.provider === "local-server" ||
+		model.api === "ollama-chat"
+	);
 }
 
 /**

--- a/packages/coding-agent/test/image-webp-exclusion.test.ts
+++ b/packages/coding-agent/test/image-webp-exclusion.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import {
 	modelLacksWebpSupport,
@@ -29,6 +30,10 @@ describe("modelLacksWebpSupport", () => {
 	test("flags the ollama-chat api even behind a custom provider id", () => {
 		// A proxy/custom provider still routes images through Ollama's STB decoder.
 		expect(modelLacksWebpSupport({ provider: "my-local-ollama", api: "ollama-chat" })).toBe(true);
+	});
+
+	test("flags local-server models", () => {
+		expect(modelLacksWebpSupport({ provider: "local-server", api: "openai-completions" })).toBe(true);
 	});
 
 	test("leaves WebP-capable providers and undefined untouched", () => {
@@ -64,6 +69,29 @@ describe("normalizeModelContextImages model-aware WebP exclusion", () => {
 		const webp = { type: "image" as const, data: await makeRedWebP(200, 200), mimeType: "image/webp" };
 
 		const result = await normalizeModelContextImages([webp], { model: ollama });
+		expect(result).toHaveLength(1);
+		const mime = result![0]!.mimeType;
+		expect(mime).not.toBe("image/webp");
+		expect(["image/png", "image/jpeg"]).toContain(mime);
+	});
+
+	test("re-encodes a WebP image out of WebP for a local-server model", async () => {
+		const localServer = buildModel({
+			id: "local-vision",
+			name: "Local vision",
+			api: "openai-completions",
+			provider: "local-server",
+			baseUrl: "http://localhost:8001/v1",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		});
+		const webp = { type: "image" as const, data: await makeRedWebP(200, 200), mimeType: "image/webp" };
+
+		const result = await normalizeModelContextImages([webp], { model: localServer });
+
 		expect(result).toHaveLength(1);
 		const mime = result![0]!.mimeType;
 		expect(mime).not.toBe("image/webp");

--- a/packages/coding-agent/test/image-webp-exclusion.test.ts
+++ b/packages/coding-agent/test/image-webp-exclusion.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import {
@@ -21,6 +22,21 @@ async function makeRedWebP(width: number, height: number): Promise<string> {
 	return Buffer.from(upscaled).toBase64();
 }
 
+function buildLocalVisionModel(provider: string, api: Api = "openai-completions"): Model {
+	return buildModel({
+		id: "local-vision",
+		name: "Local vision",
+		api,
+		provider,
+		baseUrl: "http://localhost:8001/v1",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	});
+}
+
 describe("modelLacksWebpSupport", () => {
 	test("flags the local + cloud Ollama providers", () => {
 		expect(modelLacksWebpSupport({ provider: "ollama", api: "openai-responses" })).toBe(true);
@@ -32,8 +48,10 @@ describe("modelLacksWebpSupport", () => {
 		expect(modelLacksWebpSupport({ provider: "my-local-ollama", api: "ollama-chat" })).toBe(true);
 	});
 
-	test("flags local-server models", () => {
-		expect(modelLacksWebpSupport({ provider: "local-server", api: "openai-completions" })).toBe(true);
+	test("flags local model provider ids", () => {
+		for (const provider of ["llama.cpp", "lm-studio", "local-server"]) {
+			expect(modelLacksWebpSupport({ provider, api: "openai-completions" })).toBe(true);
+		}
 	});
 
 	test("leaves WebP-capable providers and undefined untouched", () => {
@@ -75,27 +93,17 @@ describe("normalizeModelContextImages model-aware WebP exclusion", () => {
 		expect(["image/png", "image/jpeg"]).toContain(mime);
 	});
 
-	test("re-encodes a WebP image out of WebP for a local-server model", async () => {
-		const localServer = buildModel({
-			id: "local-vision",
-			name: "Local vision",
-			api: "openai-completions",
-			provider: "local-server",
-			baseUrl: "http://localhost:8001/v1",
-			reasoning: false,
-			input: ["text", "image"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128_000,
-			maxTokens: 8_192,
-		});
-		const webp = { type: "image" as const, data: await makeRedWebP(200, 200), mimeType: "image/webp" };
+	test("re-encodes a WebP image out of WebP for local model provider ids", async () => {
+		for (const provider of ["llama.cpp", "lm-studio", "local-server"]) {
+			const webp = { type: "image" as const, data: await makeRedWebP(200, 200), mimeType: "image/webp" };
 
-		const result = await normalizeModelContextImages([webp], { model: localServer });
+			const result = await normalizeModelContextImages([webp], { model: buildLocalVisionModel(provider) });
 
-		expect(result).toHaveLength(1);
-		const mime = result![0]!.mimeType;
-		expect(mime).not.toBe("image/webp");
-		expect(["image/png", "image/jpeg"]).toContain(mime);
+			expect(result).toHaveLength(1);
+			const mime = result![0]!.mimeType;
+			expect(mime).not.toBe("image/webp");
+			expect(["image/png", "image/jpeg"]).toContain(mime);
+		}
 	});
 
 	test("keeps WebP for a WebP-capable model when OMP_NO_WEBP is unset", async () => {

--- a/packages/coding-agent/test/image-webp-exclusion.test.ts
+++ b/packages/coding-agent/test/image-webp-exclusion.test.ts
@@ -37,6 +37,13 @@ function buildLocalVisionModel(provider: string, api: Api = "openai-completions"
 	});
 }
 
+function buildStbVisionModel(provider: string, api: Api = "openai-completions"): Model {
+	return buildModel({
+		...buildLocalVisionModel(provider, api),
+		imageInputDecoder: "stb",
+	});
+}
+
 describe("modelLacksWebpSupport", () => {
 	test("flags the local + cloud Ollama providers", () => {
 		expect(modelLacksWebpSupport({ provider: "ollama", api: "openai-responses" })).toBe(true);
@@ -52,6 +59,16 @@ describe("modelLacksWebpSupport", () => {
 		for (const provider of ["llama.cpp", "lm-studio", "local-server"]) {
 			expect(modelLacksWebpSupport({ provider, api: "openai-completions" })).toBe(true);
 		}
+	});
+
+	test("flags discovered STB-backed models even behind a custom provider id", () => {
+		expect(
+			modelLacksWebpSupport({
+				provider: "my-renamed-llama",
+				api: "openai-completions",
+				imageInputDecoder: "stb",
+			}),
+		).toBe(true);
 	});
 
 	test("leaves WebP-capable providers and undefined untouched", () => {
@@ -104,6 +121,19 @@ describe("normalizeModelContextImages model-aware WebP exclusion", () => {
 			expect(mime).not.toBe("image/webp");
 			expect(["image/png", "image/jpeg"]).toContain(mime);
 		}
+	});
+
+	test("re-encodes a WebP image out of WebP for renamed STB-backed local providers", async () => {
+		const webp = { type: "image" as const, data: await makeRedWebP(200, 200), mimeType: "image/webp" };
+
+		const result = await normalizeModelContextImages([webp], {
+			model: buildStbVisionModel("my-renamed-llama"),
+		});
+
+		expect(result).toHaveLength(1);
+		const mime = result![0]!.mimeType;
+		expect(mime).not.toBe("image/webp");
+		expect(["image/png", "image/jpeg"]).toContain(mime);
 	});
 
 	test("keeps WebP for a WebP-capable model when OMP_NO_WEBP is unset", async () => {


### PR DESCRIPTION
## What

- Treat `local-server` models as WebP-unsupported in the image loading policy.
- Add regression coverage for detector behavior and model-context image normalization.

## Why

Fixes #2922. llama.cpp/STB-backed local servers can reject `image/webp` payloads with 400s, so WebP inputs should be re-encoded before reaching those models.

## Testing

- `bun test packages/coding-agent/test/image-webp-exclusion.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)