### PR TITLE
refactor(tui): replace ReturnType<typeof setInterval> with Timer for #progressTimer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `ReturnType<typeof setInterval>` with `Timer` for `#progressTimer` to match the three adjacent timer fields in `Terminal` (per the repo convention against `ReturnType<>`)
+
 ## [16.0.11] - 2026-06-19
 
 ### Breaking Changes

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -437,7 +437,7 @@ export class ProcessTerminal implements Terminal {
 	#reportedRows?: number;
 	#osc11PollTimer?: Timer;
 	#mode2031DebounceTimer?: Timer;
-	#progressTimer?: ReturnType<typeof setInterval>;
+	#progressTimer?: Timer;
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;


### PR DESCRIPTION
## Summary

Replaces `ReturnType<typeof setInterval>` with `Timer` for the `#progressTimer` field in `Terminal`, matching the three adjacent timer fields (`#modifyOtherKeysTimeout`, `#osc11PollTimer`, `#mode2031DebounceTimer`) that already use `Timer`.

## Why

AGENTS.md states: "NEVER use `ReturnType<>` — use the actual type name." The `#progressTimer` field was the lone outlier in `Terminal` — its three siblings all use `Timer` (the global Bun type from `bun-types/globals.d.ts`). `#progressTimer` is assigned via `setInterval` (line 1406) and cleared via `clearInterval` (line 1419), the same usage pattern as the adjacent `Timer`-typed fields, so `Timer` is the correct and consistent type.

The other 4 `ReturnType<typeof set*>` occurrences in the repo are in files with no `Timer`-typed siblings, so they're internally consistent (if not ideal) and left alone — only the one clear inconsistency is fixed here.

## Verification

- `bun run check:types` (packages/tui) — clean.
- `bunx biome check packages/tui/src/terminal.ts` — clean.
- Pre-existing tui test failures on Windows (2 autocomplete path-separator issues, 1 scrollback sentinel issue) reproduce identically on the unmodified code — confirmed via `git stash` comparison. Unrelated to this one-line type-annotation change.

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] No behavior change — pure type-annotation fix