### PR TITLE
feat(debug): load user DAP adapter configs

### DIFF
--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -155,6 +155,44 @@ Side-channel artifacts outside the model tool result:
 - **Adapter selection**
   - `launch`: explicit `adapter` wins; otherwise `selectLaunchAdapter()` ranks available adapters by extension match, root-marker match, then native-debugger preference (`gdb`, `lldb-dap`) for extensionless binaries.
   - `attach`: explicit `adapter` wins; otherwise remote `port` prefers `debugpy`, then native debuggers, then first available adapter.
+- **Custom adapter config**
+  - Debug adapters can be added or overridden with `dap.json`, `.dap.json`, `dap.yaml`, `.dap.yaml`, `dap.yml`, or `.dap.yml`.
+  - Search order mirrors LSP config: project root, project config dirs (`.omp/`, `.pi/`, `.claude/`), user config dirs, plugin roots, then home-root fallback. Files are merged from lowest to highest priority.
+  - Config shape may be either `{ "adapters": { ... } }` or a top-level adapter map.
+  - Adapter fields:
+    - `command`: executable name or path. Required.
+    - `args`: adapter argv.
+    - `languages`: display/filter metadata.
+    - `fileTypes`: file extensions or filenames used for launch auto-selection.
+    - `rootMarkers`: files/directories used to rank adapters for a project.
+    - `launchDefaults`: default DAP launch arguments merged before the selected program/cwd/args.
+    - `attachDefaults`: default DAP attach arguments merged before pid/port/host/cwd.
+    - `connectMode`: `"stdio"` (default) or `"socket"`.
+    - `acceptsDirectoryProgram`: set `true` for adapters such as `dlv` that can launch a package/project directory.
+
+Example `.omp/dap.json`:
+
+```json
+{
+  "adapters": {
+    "custom-jvm": {
+      "command": "kotlin-debug-adapter",
+      "args": ["--stdio"],
+      "languages": ["java", "kotlin"],
+      "fileTypes": [".java", ".kt", ".kts"],
+      "rootMarkers": ["pom.xml", "build.gradle", "build.gradle.kts"],
+      "launchDefaults": {
+        "request": "launch",
+        "projectRoot": "."
+      },
+      "attachDefaults": {
+        "request": "attach",
+        "host": "127.0.0.1"
+      }
+    }
+  }
+}
+```
 - **Transport**
   - stdio adapters: direct `stdin`/`stdout` framing.
   - socket adapters: Unix domain socket on Linux; TCP callback on macOS/other.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Enabled inline prompts with `/loop` commands (e.g., `/loop 10 fix the bug`)
 - Added support for compound duration formats in `/loop` (e.g., `1h30m`)
+### Added
+
+- Added project/user/plugin `dap.json` and `dap.yaml` support for defining or overriding debugger adapters used by the `debug` tool. ([#2999](https://github.com/can1357/oh-my-pi/issues/2999))
 
 ## [16.1.5] - 2026-06-19
 
@@ -114,9 +117,6 @@
 - Snapcompact compaction summaries now reach the model as ordered history blocks instead of one lead-in text block plus appended images: plain text at the oldest edge, an imaged middle, then plain text at the newest edge. This matches the new text-first snapcompact archive layout and preserves chronological order in the provider prompt.
 - Fixed `/dump` output repeating the tool inventory twice when `inlineToolDescriptors` is enabled.
 - Unified TUI border corners on the rounded style: tool-result frames, overlays, code fences, debug frames, and the interactive bash box now draw rounded corners (`╭╮╰╯`) to match the editor and message cards, instead of mixing rounded boxes with sharp (`┌┐└┘`) ones. `boxRound` now carries the sharp tee/cross junction glyphs (no rounded variant exists), so dividers still honor `boxSharp.tee*`/`cross` theme overrides. Markdown tables intentionally keep the fully sharp `boxSharp` set; its corner tokens now affect tables only.
-### Added
-
-- Added project/user/plugin `dap.json` and `dap.yaml` support for defining or overriding debugger adapters used by the `debug` tool. ([#2999](https://github.com/can1357/oh-my-pi/issues/2999))
 
 ## [16.0.11] - 2026-06-19
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -114,6 +114,9 @@
 - Snapcompact compaction summaries now reach the model as ordered history blocks instead of one lead-in text block plus appended images: plain text at the oldest edge, an imaged middle, then plain text at the newest edge. This matches the new text-first snapcompact archive layout and preserves chronological order in the provider prompt.
 - Fixed `/dump` output repeating the tool inventory twice when `inlineToolDescriptors` is enabled.
 - Unified TUI border corners on the rounded style: tool-result frames, overlays, code fences, debug frames, and the interactive bash box now draw rounded corners (`╭╮╰╯`) to match the editor and message cards, instead of mixing rounded boxes with sharp (`┌┐└┘`) ones. `boxRound` now carries the sharp tee/cross junction glyphs (no rounded variant exists), so dividers still honor `boxSharp.tee*`/`cross` theme overrides. Markdown tables intentionally keep the fully sharp `boxSharp` set; its corner tokens now affect tables only.
+### Added
+
+- Added project/user/plugin `dap.json` and `dap.yaml` support for defining or overriding debugger adapters used by the `debug` tool. ([#2999](https://github.com/can1357/oh-my-pi/issues/2999))
 
 ## [16.0.11] - 2026-06-19
 

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -1,10 +1,10 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isRecord, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
+import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { getConfigDirPaths } from "../config";
-import { type ClaudePluginRoot, getPreloadedPluginRoots } from "../discovery/helpers";
+import { getPreloadedPluginRoots } from "../discovery/helpers";
 import { hasRootMarkers, resolveCommand } from "../lsp/config";
 import DEFAULTS from "./defaults.json" with { type: "json" };
 import type { DapAdapterConfig, DapResolvedAdapter } from "./types";
@@ -121,44 +121,6 @@ function fileConfigSource(filePath: string): ConfigSource {
 	};
 }
 
-function readMarketplaceDapConfig(root: ClaudePluginRoot): NormalizedConfig | null {
-	const catalogPaths = [
-		path.resolve(root.path, "..", "..", ".omp-plugin", "marketplace.json"),
-		path.resolve(root.path, "..", "..", "marketplace.json"),
-		path.resolve(root.path, "..", "..", ".claude-plugin", "marketplace.json"),
-	];
-
-	for (const catalogPath of catalogPaths) {
-		try {
-			const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf-8")) as unknown;
-			if (!isRecord(catalog) || !Array.isArray(catalog.plugins)) continue;
-
-			for (const plugin of catalog.plugins) {
-				if (!isRecord(plugin) || plugin.name !== root.plugin) continue;
-
-				const dapAdapters = plugin.dapAdapters;
-				if (typeof dapAdapters === "string") {
-					const configPath = path.resolve(root.path, dapAdapters);
-					if (!pathIsWithin(root.path, configPath)) return null;
-					return readConfigFile(configPath);
-				}
-				if (isRecord(dapAdapters)) {
-					return normalizeConfig({ adapters: dapAdapters });
-				}
-				return null;
-			}
-		} catch {}
-	}
-
-	return null;
-}
-
-function marketplaceConfigSource(root: ClaudePluginRoot): ConfigSource {
-	return {
-		read: () => readMarketplaceDapConfig(root),
-	};
-}
-
 function getConfigSources(cwd: string): ConfigSource[] {
 	const filenames = ["dap.json", ".dap.json", "dap.yaml", ".dap.yaml", "dap.yml", ".dap.yml"];
 	const sources: ConfigSource[] = [];
@@ -186,7 +148,6 @@ function getConfigSources(cwd: string): ConfigSource[] {
 		for (const filename of filenames) {
 			sources.push(fileConfigSource(path.join(root.path, filename)));
 		}
-		sources.push(marketplaceConfigSource(root));
 	}
 
 	for (const filename of filenames) {

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -87,7 +87,22 @@ function mergeAdapters(
 ): Record<string, DapAdapterConfig> {
 	const merged: Record<string, DapAdapterConfig> = { ...base };
 	for (const [name, config] of Object.entries(overrides)) {
-		const candidate = isRecord(merged[name]) && isRecord(config) ? { ...merged[name], ...config } : config;
+		const existing = merged[name];
+		const candidate =
+			isRecord(existing) && isRecord(config)
+				? {
+						...existing,
+						...config,
+						launchDefaults:
+							isRecord(existing.launchDefaults) || isRecord(config.launchDefaults)
+								? { ...existing.launchDefaults, ...normalizeObject(config.launchDefaults) }
+								: undefined,
+						attachDefaults:
+							isRecord(existing.attachDefaults) || isRecord(config.attachDefaults)
+								? { ...existing.attachDefaults, ...normalizeObject(config.attachDefaults) }
+								: undefined,
+					}
+				: config;
 		const normalized = normalizeAdapterConfig(candidate);
 		if (normalized) {
 			merged[name] = normalized;

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -171,6 +171,19 @@ export function getAdapterConfigs(cwd?: string): Record<string, DapAdapterConfig
 	return cwd ? loadAdapterConfigs(cwd) : { ...DEFAULT_ADAPTERS };
 }
 
+function normalizeCommandForCwd(command: string, cwd: string): string {
+	if (path.isAbsolute(command)) return command;
+	if (
+		command.startsWith("./") ||
+		command.startsWith("../") ||
+		command.startsWith(".\\") ||
+		command.startsWith("..\\")
+	) {
+		return path.resolve(cwd, command);
+	}
+	return command;
+}
+
 function resolveAdapterFromConfig(
 	adapterName: string,
 	configs: Record<string, DapAdapterConfig>,
@@ -178,7 +191,7 @@ function resolveAdapterFromConfig(
 ): DapResolvedAdapter | null {
 	const config = configs[adapterName];
 	if (!config) return null;
-	const resolvedCommand = resolveCommand(config.command, cwd);
+	const resolvedCommand = resolveCommand(normalizeCommandForCwd(config.command, cwd), cwd);
 	if (!resolvedCommand) return null;
 	return {
 		name: adapterName,

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -123,6 +123,7 @@ function fileConfigSource(filePath: string): ConfigSource {
 
 function readMarketplaceDapConfig(root: ClaudePluginRoot): NormalizedConfig | null {
 	const catalogPaths = [
+		path.resolve(root.path, "..", "..", ".omp-plugin", "marketplace.json"),
 		path.resolve(root.path, "..", "..", "marketplace.json"),
 		path.resolve(root.path, "..", "..", ".claude-plugin", "marketplace.json"),
 	];

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -1,10 +1,37 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import { isRecord } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { getConfigDirPaths } from "../config";
+import { type ClaudePluginRoot, getPreloadedPluginRoots } from "../discovery/helpers";
 import { hasRootMarkers, resolveCommand } from "../lsp/config";
 import DEFAULTS from "./defaults.json" with { type: "json" };
 import type { DapAdapterConfig, DapResolvedAdapter } from "./types";
 
 const EXTENSIONLESS_DEBUGGER_ORDER = ["gdb", "lldb-dap"] as const;
+
+interface NormalizedConfig {
+	adapters: Record<string, unknown>;
+}
+
+interface ConfigSource {
+	read(): NormalizedConfig | null;
+}
+
+function parseConfigContent(content: string, filePath: string): unknown {
+	const extension = path.extname(filePath).toLowerCase();
+	if (extension === ".yaml" || extension === ".yml") {
+		return YAML.parse(content) as unknown;
+	}
+	return JSON.parse(content) as unknown;
+}
+
+function normalizeConfig(value: unknown): NormalizedConfig | null {
+	if (!isRecord(value)) return null;
+	if (isRecord(value.adapters)) return { adapters: value.adapters };
+	return { adapters: value };
+}
 
 function normalizeStringArray(value: unknown): string[] {
 	if (!Array.isArray(value)) return [];
@@ -32,6 +59,15 @@ function normalizeAdapterConfig(config: unknown): DapAdapterConfig | null {
 	};
 }
 
+function readConfigFile(filePath: string): NormalizedConfig | null {
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		return normalizeConfig(parseConfigContent(content, filePath));
+	} catch {
+		return null;
+	}
+}
+
 function getDefaults(): Record<string, DapAdapterConfig> {
 	const adapters: Record<string, DapAdapterConfig> = {};
 	for (const [name, config] of Object.entries(DEFAULTS)) {
@@ -45,12 +81,125 @@ function getDefaults(): Record<string, DapAdapterConfig> {
 
 const DEFAULT_ADAPTERS = getDefaults();
 
-export function getAdapterConfigs(): Record<string, DapAdapterConfig> {
-	return { ...DEFAULT_ADAPTERS };
+function mergeAdapters(
+	base: Record<string, DapAdapterConfig>,
+	overrides: Record<string, unknown>,
+): Record<string, DapAdapterConfig> {
+	const merged: Record<string, DapAdapterConfig> = { ...base };
+	for (const [name, config] of Object.entries(overrides)) {
+		const candidate = isRecord(merged[name]) && isRecord(config) ? { ...merged[name], ...config } : config;
+		const normalized = normalizeAdapterConfig(candidate);
+		if (normalized) {
+			merged[name] = normalized;
+		} else if (merged[name]) {
+			logger.warn("Ignoring invalid DAP adapter override (keeping previous config).", { name });
+		} else {
+			logger.warn("Ignoring invalid DAP adapter config.", { name });
+		}
+	}
+	return merged;
 }
 
-export function resolveAdapter(adapterName: string, cwd: string): DapResolvedAdapter | null {
-	const config = DEFAULT_ADAPTERS[adapterName];
+function fileConfigSource(filePath: string): ConfigSource {
+	return {
+		read: () => readConfigFile(filePath),
+	};
+}
+
+function readMarketplaceDapConfig(root: ClaudePluginRoot): NormalizedConfig | null {
+	const catalogPaths = [
+		path.resolve(root.path, "..", "..", "marketplace.json"),
+		path.resolve(root.path, "..", "..", ".claude-plugin", "marketplace.json"),
+	];
+
+	for (const catalogPath of catalogPaths) {
+		try {
+			const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf-8")) as unknown;
+			if (!isRecord(catalog) || !Array.isArray(catalog.plugins)) continue;
+
+			for (const plugin of catalog.plugins) {
+				if (!isRecord(plugin) || plugin.name !== root.plugin) continue;
+
+				const dapAdapters = plugin.dapAdapters;
+				if (typeof dapAdapters === "string") {
+					const configPath = path.resolve(root.path, dapAdapters);
+					if (!pathIsWithin(root.path, configPath)) return null;
+					return readConfigFile(configPath);
+				}
+				if (isRecord(dapAdapters)) {
+					return normalizeConfig({ adapters: dapAdapters });
+				}
+				return null;
+			}
+		} catch {}
+	}
+
+	return null;
+}
+
+function marketplaceConfigSource(root: ClaudePluginRoot): ConfigSource {
+	return {
+		read: () => readMarketplaceDapConfig(root),
+	};
+}
+
+function getConfigSources(cwd: string): ConfigSource[] {
+	const filenames = ["dap.json", ".dap.json", "dap.yaml", ".dap.yaml", "dap.yml", ".dap.yml"];
+	const sources: ConfigSource[] = [];
+
+	for (const filename of filenames) {
+		sources.push(fileConfigSource(path.join(cwd, filename)));
+	}
+
+	const projectDirs = getConfigDirPaths("", { user: false, project: true, cwd });
+	for (const dir of projectDirs) {
+		for (const filename of filenames) {
+			sources.push(fileConfigSource(path.join(dir, filename)));
+		}
+	}
+
+	const userDirs = getConfigDirPaths("", { user: true, project: false });
+	for (const dir of userDirs) {
+		for (const filename of filenames) {
+			sources.push(fileConfigSource(path.join(dir, filename)));
+		}
+	}
+
+	const pluginRoots = getPreloadedPluginRoots();
+	for (const root of pluginRoots) {
+		for (const filename of filenames) {
+			sources.push(fileConfigSource(path.join(root.path, filename)));
+		}
+		sources.push(marketplaceConfigSource(root));
+	}
+
+	for (const filename of filenames) {
+		sources.push(fileConfigSource(path.join(os.homedir(), filename)));
+	}
+
+	return sources;
+}
+
+function loadAdapterConfigs(cwd: string): Record<string, DapAdapterConfig> {
+	let adapters = { ...DEFAULT_ADAPTERS };
+	for (const source of getConfigSources(cwd).reverse()) {
+		const parsed = source.read();
+		if (!parsed) continue;
+		adapters = mergeAdapters(adapters, parsed.adapters);
+	}
+	return adapters;
+}
+
+export function getAdapterConfigs(cwd?: string): Record<string, DapAdapterConfig> {
+	return cwd ? loadAdapterConfigs(cwd) : { ...DEFAULT_ADAPTERS };
+}
+
+function resolveAdapterFromConfig(
+	adapterName: string,
+	configs: Record<string, DapAdapterConfig>,
+	cwd: string,
+): DapResolvedAdapter | null {
+	const config = configs[adapterName];
 	if (!config) return null;
 	const resolvedCommand = resolveCommand(config.command, cwd);
 	if (!resolvedCommand) return null;
@@ -69,9 +218,14 @@ export function resolveAdapter(adapterName: string, cwd: string): DapResolvedAda
 	};
 }
 
+export function resolveAdapter(adapterName: string, cwd: string): DapResolvedAdapter | null {
+	return resolveAdapterFromConfig(adapterName, getAdapterConfigs(cwd), cwd);
+}
+
 export function getAvailableAdapters(cwd: string): DapResolvedAdapter[] {
-	return Object.keys(DEFAULT_ADAPTERS)
-		.map(name => resolveAdapter(name, cwd))
+	const configs = getAdapterConfigs(cwd);
+	return Object.keys(configs)
+		.map(name => resolveAdapterFromConfig(name, configs, cwd))
 		.filter((adapter): adapter is DapResolvedAdapter => adapter !== null);
 }
 

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -289,7 +289,7 @@ export class DapSessionManager {
 				...(options.extraLaunchArguments ?? {}),
 				program: options.program,
 				cwd: options.cwd,
-				args: options.args,
+				...(options.args !== undefined ? { args: options.args } : {}),
 			};
 			// Subscribe to stop events BEFORE launching so we don't miss
 			// stopOnEntry events that arrive before we start listening.

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -291,6 +291,7 @@ export class MarketplaceManager {
 			version = await this.#resolvePluginVersion(pluginEntry, sourcePath);
 			cachePath = await cachePlugin(sourcePath, this.#opts.pluginsCacheDir, marketplace, name, version);
 			await this.#writeEmbeddedLspConfig(pluginEntry, cachePath);
+			await this.#writeEmbeddedDapConfig(pluginEntry, cachePath);
 		} finally {
 			// Clean up temp clone dirs created by resolvePluginSource; leave user-supplied local dirs alone
 			if (tempCloneRoot) {
@@ -359,6 +360,24 @@ export class MarketplaceManager {
 		}
 
 		await Bun.write(targetPath, `${JSON.stringify({ servers: lspServers }, null, 2)}\n`);
+	}
+
+	async #writeEmbeddedDapConfig(entry: MarketplacePluginEntry, cachePath: string): Promise<void> {
+		const dapAdapters = entry.dapAdapters;
+		if (!dapAdapters) return;
+
+		const targetPath = path.join(cachePath, ".dap.json");
+		if (typeof dapAdapters === "string") {
+			const sourcePath = path.resolve(cachePath, dapAdapters);
+			if (!pathIsWithin(cachePath, sourcePath)) {
+				throw new Error(`Plugin "${entry.name}" dapAdapters path escapes the plugin directory`);
+			}
+			const content = await Bun.file(sourcePath).text();
+			await Bun.write(targetPath, content);
+			return;
+		}
+
+		await Bun.write(targetPath, `${JSON.stringify({ adapters: dapAdapters }, null, 2)}\n`);
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -366,17 +366,20 @@ export class MarketplaceManager {
 		const dapAdapters = entry.dapAdapters;
 		if (!dapAdapters) return;
 
-		const targetPath = path.join(cachePath, ".dap.json");
 		if (typeof dapAdapters === "string") {
 			const sourcePath = path.resolve(cachePath, dapAdapters);
 			if (!pathIsWithin(cachePath, sourcePath)) {
 				throw new Error(`Plugin "${entry.name}" dapAdapters path escapes the plugin directory`);
 			}
+			const extension = path.extname(sourcePath).toLowerCase();
+			const targetFilename = extension === ".yaml" || extension === ".yml" ? `.dap${extension}` : ".dap.json";
+			const targetPath = path.join(cachePath, targetFilename);
 			const content = await Bun.file(sourcePath).text();
 			await Bun.write(targetPath, content);
 			return;
 		}
 
+		const targetPath = path.join(cachePath, ".dap.json");
 		await Bun.write(targetPath, `${JSON.stringify({ adapters: dapAdapters }, null, 2)}\n`);
 	}
 

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
@@ -92,6 +92,7 @@ export interface MarketplacePluginEntry {
 	hooks?: string | Record<string, unknown>;
 	mcpServers?: string | Record<string, unknown>;
 	lspServers?: string | Record<string, unknown>;
+	dapAdapters?: string | Record<string, unknown>;
 }
 
 // ── Plugin source variants ───────────────────────────────────────────

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -62,7 +62,7 @@ describe("DAP adapter configuration", () => {
 				adapters: {
 					debugpy: {
 						args: ["-m", "debugpy.adapter", "--log-dir", ".debugpy-logs"],
-						launchDefaults: { request: "launch", justMyCode: false },
+						launchDefaults: { justMyCode: false },
 					},
 				},
 			}),

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAdapterConfigs, resolveAdapter, selectLaunchAdapter } from "../../src/dap/config";
-import { clearClaudePluginRootsCache, injectPluginDirRoots } from "../../src/discovery/helpers";
+import { injectPluginDirRoots } from "../../src/discovery/helpers";
 
 const tempDirs: string[] = [];
 const ORIGINAL_OMP_PLUGIN_DIR = process.env.OMP_PLUGIN_DIR;
@@ -28,7 +28,6 @@ afterEach(async () => {
 		process.env.OMP_MARKETPLACE_DIR = ORIGINAL_OMP_MARKETPLACE_DIR;
 	}
 	await injectPluginDirRoots(os.homedir(), []);
-	clearClaudePluginRootsCache();
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -122,11 +121,9 @@ describe("DAP adapter configuration", () => {
 		expect(selected?.launchDefaults).toEqual({ request: "launch", projectRoot: "." });
 	});
 
-	it("loads plugin DAP adapters from OMP marketplace catalogs", async () => {
-		const cwd = await makeTempDir("omp-dap-config-marketplace-");
-		const marketplaceRoot = path.join(cwd, "marketplaces", "test-market");
-		const pluginRoot = path.join(marketplaceRoot, "plugins", "acme-debug");
-		await fs.mkdir(path.join(marketplaceRoot, ".omp-plugin"), { recursive: true });
+	it("loads plugin DAP adapters from plugin config files", async () => {
+		const cwd = await makeTempDir("omp-dap-config-plugin-");
+		const pluginRoot = path.join(cwd, "plugins", "acme-debug");
 		await fs.mkdir(path.join(pluginRoot, ".claude-plugin"), { recursive: true });
 		await fs.writeFile(path.join(cwd, "app.rb"), "puts 'hi'\n");
 		await fs.writeFile(
@@ -134,19 +131,14 @@ describe("DAP adapter configuration", () => {
 			JSON.stringify({ name: "acme-debug" }),
 		);
 		await fs.writeFile(
-			path.join(marketplaceRoot, ".omp-plugin", "marketplace.json"),
+			path.join(pluginRoot, ".dap.json"),
 			JSON.stringify({
-				plugins: [
-					{
-						name: "acme-debug",
-						dapAdapters: {
-							"acme-ruby": {
-								command: "ruby-debug-adapter",
-								fileTypes: [".rb"],
-							},
-						},
+				adapters: {
+					"acme-ruby": {
+						command: "ruby-debug-adapter",
+						fileTypes: [".rb"],
 					},
-				],
+				},
 			}),
 		);
 		process.env.OMP_PLUGIN_DIR = path.join(cwd, "plugins");

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getAdapterConfigs, resolveAdapter, selectLaunchAdapter } from "@oh-my-pi/pi-coding-agent/dap/config";
+import { getAdapterConfigs, resolveAdapter, selectLaunchAdapter } from "../../src/dap/config";
+import { clearClaudePluginRootsCache, injectPluginDirRoots } from "../../src/discovery/helpers";
 
 const tempDirs: string[] = [];
+const ORIGINAL_OMP_PLUGIN_DIR = process.env.OMP_PLUGIN_DIR;
+const ORIGINAL_OMP_MARKETPLACE_DIR = process.env.OMP_MARKETPLACE_DIR;
 
 async function makeTempDir(prefix: string): Promise<string> {
 	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -14,6 +17,18 @@ async function makeTempDir(prefix: string): Promise<string> {
 
 afterEach(async () => {
 	vi.restoreAllMocks();
+	if (ORIGINAL_OMP_PLUGIN_DIR === undefined) {
+		delete process.env.OMP_PLUGIN_DIR;
+	} else {
+		process.env.OMP_PLUGIN_DIR = ORIGINAL_OMP_PLUGIN_DIR;
+	}
+	if (ORIGINAL_OMP_MARKETPLACE_DIR === undefined) {
+		delete process.env.OMP_MARKETPLACE_DIR;
+	} else {
+		process.env.OMP_MARKETPLACE_DIR = ORIGINAL_OMP_MARKETPLACE_DIR;
+	}
+	await injectPluginDirRoots(os.homedir(), []);
+	clearClaudePluginRootsCache();
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -105,6 +120,40 @@ describe("DAP adapter configuration", () => {
 		const selected = selectLaunchAdapter("Main.kt", cwd);
 		expect(selected?.name).toBe("yaml-kotlin");
 		expect(selected?.launchDefaults).toEqual({ request: "launch", projectRoot: "." });
+	});
+
+	it("loads plugin DAP adapters from OMP marketplace catalogs", async () => {
+		const cwd = await makeTempDir("omp-dap-config-marketplace-");
+		const marketplaceRoot = path.join(cwd, "marketplaces", "test-market");
+		const pluginRoot = path.join(marketplaceRoot, "plugins", "acme-debug");
+		await fs.mkdir(path.join(marketplaceRoot, ".omp-plugin"), { recursive: true });
+		await fs.mkdir(path.join(pluginRoot, ".claude-plugin"), { recursive: true });
+		await fs.writeFile(path.join(cwd, "app.rb"), "puts 'hi'\n");
+		await fs.writeFile(
+			path.join(pluginRoot, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "acme-debug" }),
+		);
+		await fs.writeFile(
+			path.join(marketplaceRoot, ".omp-plugin", "marketplace.json"),
+			JSON.stringify({
+				plugins: [
+					{
+						name: "acme-debug",
+						dapAdapters: {
+							"acme-ruby": {
+								command: "ruby-debug-adapter",
+								fileTypes: [".rb"],
+							},
+						},
+					},
+				],
+			}),
+		);
+		process.env.OMP_PLUGIN_DIR = path.join(cwd, "plugins");
+		process.env.OMP_MARKETPLACE_DIR = path.join(cwd, "marketplaces");
+		await injectPluginDirRoots(cwd, [pluginRoot], cwd);
+
+		expect(getAdapterConfigs(cwd)["acme-ruby"]?.command).toBe("ruby-debug-adapter");
 	});
 
 	it("ignores invalid custom adapters without discarding valid configs", async () => {

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -121,6 +121,31 @@ describe("DAP adapter configuration", () => {
 		expect(selected?.launchDefaults).toEqual({ request: "launch", projectRoot: "." });
 	});
 
+	it("resolves relative adapter commands from the debug cwd", async () => {
+		const cwd = await makeTempDir("omp-dap-config-relative-command-");
+		const command = path.join(cwd, "tools", process.platform === "win32" ? "debug-adapter.cmd" : "debug-adapter");
+		await fs.mkdir(path.dirname(command), { recursive: true });
+		await fs.writeFile(command, "");
+		await fs.chmod(command, 0o755);
+		await fs.writeFile(
+			path.join(cwd, "dap.json"),
+			JSON.stringify({
+				adapters: {
+					relative: {
+						command: process.platform === "win32" ? ".\\tools\\debug-adapter.cmd" : "./tools/debug-adapter",
+						fileTypes: [".rel"],
+					},
+				},
+			}),
+		);
+
+		const adapter = resolveAdapter("relative", cwd);
+		expect(adapter?.command).toBe(
+			process.platform === "win32" ? ".\\tools\\debug-adapter.cmd" : "./tools/debug-adapter",
+		);
+		expect(adapter?.resolvedCommand).toBe(command);
+	});
+
 	it("loads plugin DAP adapters from plugin config files", async () => {
 		const cwd = await makeTempDir("omp-dap-config-plugin-");
 		const pluginRoot = path.join(cwd, "plugins", "acme-debug");

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAdapterConfigs, resolveAdapter, selectLaunchAdapter } from "@oh-my-pi/pi-coding-agent/dap/config";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	return cwd;
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("DAP adapter configuration", () => {
+	it("loads a custom adapter from dap.json and selects it by file extension", async () => {
+		const cwd = await makeTempDir("omp-dap-config-json-");
+		await fs.writeFile(path.join(cwd, "pom.xml"), "<project />\n");
+		await fs.mkdir(path.join(cwd, "src"), { recursive: true });
+		await fs.writeFile(path.join(cwd, "src", "Main.java"), "class Main {}\n");
+		await fs.writeFile(
+			path.join(cwd, "dap.json"),
+			JSON.stringify({
+				adapters: {
+					"custom-jvm": {
+						command: "bun",
+						args: ["run", "debug-adapter"],
+						languages: ["java", "kotlin"],
+						fileTypes: [".java", ".kt"],
+						rootMarkers: ["pom.xml", "build.gradle.kts"],
+						launchDefaults: { request: "launch", mainClass: "" },
+						attachDefaults: { request: "attach", host: "127.0.0.1" },
+					},
+				},
+			}),
+		);
+
+		const adapter = resolveAdapter("custom-jvm", cwd);
+		expect(adapter?.name).toBe("custom-jvm");
+		expect(adapter?.command).toBe("bun");
+		expect(adapter?.args).toEqual(["run", "debug-adapter"]);
+		expect(adapter?.languages).toEqual(["java", "kotlin"]);
+		expect(adapter?.fileTypes).toEqual([".java", ".kt"]);
+		expect(adapter?.launchDefaults).toEqual({ request: "launch", mainClass: "" });
+		expect(adapter?.attachDefaults).toEqual({ request: "attach", host: "127.0.0.1" });
+
+		const selected = selectLaunchAdapter(path.join("src", "Main.java"), cwd);
+		expect(selected?.name).toBe("custom-jvm");
+	});
+
+	it("merges partial user overrides over built-in adapters", async () => {
+		const cwd = await makeTempDir("omp-dap-config-override-");
+		await fs.writeFile(path.join(cwd, "script.py"), "print('hi')\n");
+		await fs.writeFile(
+			path.join(cwd, "dap.json"),
+			JSON.stringify({
+				adapters: {
+					debugpy: {
+						args: ["-m", "debugpy.adapter", "--log-dir", ".debugpy-logs"],
+						launchDefaults: { request: "launch", justMyCode: false },
+					},
+				},
+			}),
+		);
+
+		const config = getAdapterConfigs(cwd).debugpy;
+		expect(config.command).toBe("python");
+		expect(config.args).toEqual(["-m", "debugpy.adapter", "--log-dir", ".debugpy-logs"]);
+		expect(config.fileTypes).toContain(".py");
+		expect(config.launchDefaults).toMatchObject({ request: "launch", justMyCode: false });
+	});
+
+	it("loads adapter config from project config directories and YAML", async () => {
+		const cwd = await makeTempDir("omp-dap-config-yaml-");
+		await fs.mkdir(path.join(cwd, ".omp"), { recursive: true });
+		await fs.writeFile(path.join(cwd, "build.gradle.kts"), "plugins {}\n");
+		await fs.writeFile(path.join(cwd, "Main.kt"), "fun main() {}\n");
+		await fs.writeFile(
+			path.join(cwd, ".omp", "dap.yaml"),
+			[
+				"adapters:",
+				"  yaml-kotlin:",
+				"    command: bun",
+				"    args:",
+				"      - run",
+				"      - kotlin-debug-adapter",
+				"    languages:",
+				"      - kotlin",
+				"    fileTypes:",
+				"      - .kt",
+				"    rootMarkers:",
+				"      - build.gradle.kts",
+				"    launchDefaults:",
+				"      request: launch",
+				"      projectRoot: .",
+				"",
+			].join("\n"),
+		);
+
+		const selected = selectLaunchAdapter("Main.kt", cwd);
+		expect(selected?.name).toBe("yaml-kotlin");
+		expect(selected?.launchDefaults).toEqual({ request: "launch", projectRoot: "." });
+	});
+
+	it("ignores invalid custom adapters without discarding valid configs", async () => {
+		const cwd = await makeTempDir("omp-dap-config-invalid-");
+		await fs.writeFile(
+			path.join(cwd, "dap.json"),
+			JSON.stringify({
+				adapters: {
+					"missing-command": {
+						fileTypes: [".bad"],
+					},
+					valid: {
+						command: "bun",
+						fileTypes: [".ok"],
+						rootMarkers: ["."],
+					},
+				},
+			}),
+		);
+
+		const config = getAdapterConfigs(cwd);
+		expect(config["missing-command"]).toBeUndefined();
+		expect(config.valid?.command).toBe("bun");
+	});
+});

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -62,6 +62,7 @@ class FakeDapClient {
 	readonly #exited = Promise.withResolvers<void>();
 	readonly #handlers = new Map<string, Set<DapEventHandler>>();
 	#alive = true;
+	requests: Array<{ command: string; args: unknown }> = [];
 
 	constructor(
 		readonly adapter: DapResolvedAdapter,
@@ -73,6 +74,7 @@ class FakeDapClient {
 			attachErrorDelayMs?: number;
 			configurationDoneError?: string;
 			rejectStopWaiters?: boolean;
+			stopAfterLaunch?: boolean;
 		},
 	) {
 		this.proc = {
@@ -95,7 +97,8 @@ class FakeDapClient {
 		return { supportsConfigurationDoneRequest: true };
 	}
 
-	async sendRequest(command: string): Promise<unknown> {
+	async sendRequest(command: string, args?: unknown): Promise<unknown> {
+		this.requests.push({ command, args });
 		if (command === "launch" && this.options.launchError) {
 			if (this.options.launchErrorDelayMs) await Bun.sleep(this.options.launchErrorDelayMs);
 			throw new Error(this.options.launchError);
@@ -106,6 +109,9 @@ class FakeDapClient {
 		}
 		if (command === "configurationDone" && this.options.configurationDoneError) {
 			throw new Error(this.options.configurationDoneError);
+		}
+		if (command === "launch" && this.options.stopAfterLaunch) {
+			queueMicrotask(() => this.#emit("stopped", { reason: "entry", threadId: 1 }));
 		}
 		return {};
 	}
@@ -158,6 +164,21 @@ afterEach(() => {
 });
 
 describe("DAP launch failure handling", () => {
+	it("preserves adapter launchDefaults args when launch omits args", async () => {
+		const adapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			launchDefaults: { request: "launch", args: ["--configured"], stopOnEntry: true },
+		};
+		const manager = new DapSessionManager();
+		const fake = new FakeDapClient(adapter, process.cwd(), { stopAfterLaunch: true });
+		spyOn(DapClient, "spawn").mockResolvedValue(fake as unknown as DapClient);
+
+		await manager.launch({ adapter, program: "/bin/echo", cwd: process.cwd() }, undefined, 10);
+
+		const launch = fake.requests.find(request => request.command === "launch");
+		expect(launch?.args).toMatchObject({ args: ["--configured"], program: "/bin/echo" });
+	});
+
 	it("surfaces the launch failure when configurationDone also fails", async () => {
 		const manager = new DapSessionManager();
 		const fake = new FakeDapClient(TEST_ADAPTER, process.cwd(), {

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -229,6 +229,51 @@ describe("MarketplaceManager", () => {
 		});
 	});
 
+	it("installPlugin embeds config-only marketplace DAP metadata", async () => {
+		const marketplaceDir = path.join(ctx.tmpDir, "config-only-dap-marketplace");
+		const pluginDir = path.join(marketplaceDir, "plugins", "ruby-dap");
+		await fs.promises.mkdir(pluginDir, { recursive: true });
+		await Bun.write(path.join(pluginDir, "README.md"), "config-only Ruby DAP plugin\n");
+		await fs.promises.mkdir(path.join(marketplaceDir, ".claude-plugin"), { recursive: true });
+		await Bun.write(
+			path.join(marketplaceDir, ".claude-plugin", "marketplace.json"),
+			`${JSON.stringify(
+				{
+					name: "config-only-dap-marketplace",
+					owner: { name: "Test Author" },
+					plugins: [
+						{
+							name: "ruby-dap",
+							source: "./plugins/ruby-dap",
+							version: "1.0.0",
+							dapAdapters: {
+								"ruby-debug": {
+									command: "ruby-debug-adapter",
+									fileTypes: [".rb"],
+								},
+							},
+						},
+					],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		await ctx.manager.addMarketplace(marketplaceDir);
+		const instEntry = await ctx.manager.installPlugin("ruby-dap", "config-only-dap-marketplace");
+
+		const dapConfig = await Bun.file(path.join(instEntry.installPath, ".dap.json")).json();
+		expect(dapConfig).toEqual({
+			adapters: {
+				"ruby-debug": {
+					command: "ruby-debug-adapter",
+					fileTypes: [".rb"],
+				},
+			},
+		});
+	});
+
 	it("installPlugin with scope:project → persisted in project registry, isolated from user", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		const instEntry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace", {

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -274,6 +274,45 @@ describe("MarketplaceManager", () => {
 		});
 	});
 
+	it("installPlugin preserves YAML extension when embedding DAP metadata files", async () => {
+		const marketplaceDir = path.join(ctx.tmpDir, "yaml-dap-marketplace");
+		const pluginDir = path.join(marketplaceDir, "plugins", "ruby-dap-yaml");
+		await fs.promises.mkdir(pluginDir, { recursive: true });
+		await Bun.write(
+			path.join(pluginDir, "dap.yaml"),
+			["adapters:", "  ruby-debug:", "    command: ruby-debug-adapter", "    fileTypes:", "      - .rb", ""].join(
+				"\n",
+			),
+		);
+		await fs.promises.mkdir(path.join(marketplaceDir, ".claude-plugin"), { recursive: true });
+		await Bun.write(
+			path.join(marketplaceDir, ".claude-plugin", "marketplace.json"),
+			`${JSON.stringify(
+				{
+					name: "yaml-dap-marketplace",
+					owner: { name: "Test Author" },
+					plugins: [
+						{
+							name: "ruby-dap-yaml",
+							source: "./plugins/ruby-dap-yaml",
+							version: "1.0.0",
+							dapAdapters: "dap.yaml",
+						},
+					],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		await ctx.manager.addMarketplace(marketplaceDir);
+		const instEntry = await ctx.manager.installPlugin("ruby-dap-yaml", "yaml-dap-marketplace");
+
+		expect(fs.existsSync(path.join(instEntry.installPath, ".dap.yaml"))).toBe(true);
+		expect(fs.existsSync(path.join(instEntry.installPath, ".dap.json"))).toBe(false);
+		expect(await Bun.file(path.join(instEntry.installPath, ".dap.yaml")).text()).toContain("ruby-debug-adapter");
+	});
+
 	it("installPlugin with scope:project → persisted in project registry, isolated from user", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		const instEntry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace", {


### PR DESCRIPTION
## Summary
- add DAP adapter config loading from project, user, plugin, and home-root dap.json/dap.yaml files
- merge user adapter overrides over built-in defaults so existing adapters can be customized without redefining every field
- document the custom adapter config shape with a JVM/Kotlin-style example

Closes #2999 for the user-definable adapter path. The first-class JDT-LS java-debug bridge remains separate future work.

## Tests
- bun test packages/coding-agent/test/debug/dap-config.test.ts
- bun --cwd=packages/coding-agent run check