### PR TITLE
fix(ux): hide advisor sub-options unless advisor is enabled

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed advisor dependent settings staying visible while `advisor.enabled` is off ([#3027](https://github.com/can1357/oh-my-pi/issues/3027)).
+
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -401,6 +401,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Advisor",
 			label: "Advisor for Subagents",
 			description: "Also enable the advisor on spawned task/eval subagents.",
+			condition: "advisorEnabled",
 		},
 	},
 	"advisor.syncBacklog": {
@@ -413,6 +414,7 @@ export const SETTINGS_SCHEMA = {
 			label: "Advisor Sync Backlog",
 			description:
 				"Pause the main agent for up to 30 seconds if the advisor falls behind by this many turns. Off disables catch-up delays.",
+			condition: "advisorEnabled",
 		},
 	},
 	"advisor.immuneTurns": {
@@ -432,6 +434,7 @@ export const SETTINGS_SCHEMA = {
 				{ value: "4", label: "4 turns" },
 				{ value: "5", label: "5 turns" },
 			],
+			condition: "advisorEnabled",
 		},
 	},
 	shellPath: { type: "string", default: undefined },

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -76,6 +76,13 @@ export type SettingDef = BooleanSettingDef | EnumSettingDef | SubmenuSettingDef 
 
 const CONDITIONS: Record<string, () => boolean> = {
 	hasImageProtocol: () => !!TERMINAL.imageProtocol,
+	advisorEnabled: () => {
+		try {
+			return Settings.instance.get("advisor.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
 	hindsightActive: () => {
 		try {
 			return Settings.instance.get("memory.backend") === "hindsight";

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	SETTING_TABS,
 	SETTINGS_SCHEMA,
+	type SettingPath,
 	type SettingTab,
 	TAB_GROUPS,
 } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
@@ -13,6 +15,15 @@ interface UiShape {
 }
 
 describe("settings layout", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
 	it("every UI setting declares a group registered in TAB_GROUPS for its tab", () => {
 		const violations: string[] = [];
 		for (const path in SETTINGS_SCHEMA) {
@@ -46,6 +57,23 @@ describe("settings layout", () => {
 			const grouped = sequence.filter(group => group !== "");
 			const expected = TAB_GROUPS[tab].filter(group => grouped.includes(group));
 			expect(grouped).toEqual(expected);
+		}
+	});
+
+	it("hides advisor dependent settings when advisor is disabled", () => {
+		const advisorDependentPaths: SettingPath[] = ["advisor.subagents", "advisor.syncBacklog", "advisor.immuneTurns"];
+		const advisorDependentPathSet = new Set(advisorDependentPaths);
+		const defs = getSettingsForTab("model").filter(def => advisorDependentPathSet.has(def.path));
+
+		expect(defs.map(def => def.path)).toEqual(advisorDependentPaths);
+		for (const def of defs) {
+			expect(def.condition?.()).toBe(false);
+		}
+
+		Settings.instance.set("advisor.enabled", true);
+
+		for (const def of defs) {
+			expect(def.condition?.()).toBe(true);
 		}
 	});
 });


### PR DESCRIPTION
## Repro
With `advisor.enabled` at its default `false`, the settings UI adapter exposed `advisor.subagents`, `advisor.syncBacklog`, and `advisor.immuneTurns` without a visibility predicate. Reproduced with `bun -e 'import { getSettingsForTab } from "./packages/coding-agent/src/modes/components/settings-defs"; const names = new Set(["advisor.enabled", "advisor.subagents", "advisor.syncBacklog", "advisor.immuneTurns"]); for (const def of getSettingsForTab("model").filter(def => names.has(def.path))) { console.log(`${def.path}: condition=${def.condition ? "present" : "missing"}`); }'`, which printed `condition=missing` for all advisor rows before the fix.

## Cause
`packages/coding-agent/src/config/settings-schema.ts` did not assign `ui.condition` to the advisor dependent settings, and `packages/coding-agent/src/modes/components/settings-defs.ts` had no `advisorEnabled` predicate for `settings-selector` to evaluate in `#defToItem`, so those rows were never hidden while `advisor.enabled` was off.

## Fix
- Added an `advisorEnabled` settings predicate that reads `advisor.enabled` defensively through `Settings.instance`.
- Wired `advisor.subagents`, `advisor.syncBacklog`, and `advisor.immuneTurns` to `condition: "advisorEnabled"`.
- Added regression coverage for the settings UI adapter so advisor dependents are hidden while disabled and visible after enabling the parent.
- Added the coding-agent changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/modes/components/settings-layout.test.ts` (`3 pass`) and `bun --cwd=packages/coding-agent run check` (`bun check: passed`). Verified the source probe now reports the three advisor dependents as `condition=false` while disabled and `condition=true` after `advisor.enabled` is set. Fixes #3027