### PR TITLE
fix(lsp): accept dynamic capability registration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LSP servers that dynamically register capabilities, including Expert, hanging semantic requests after `client/registerCapability` was rejected ([#3029](https://github.com/can1357/oh-my-pi/issues/3029)).
+
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -5,6 +5,7 @@ import { applyWorkspaceEdit } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
 import type {
 	LspClient,
+	LspJsonRpcId,
 	LspJsonRpcNotification,
 	LspJsonRpcRequest,
 	LspJsonRpcResponse,
@@ -416,7 +417,6 @@ function currentWorkspaceFolders(client: LspClient): Array<{ uri: string; name: 
  * Handle workspace/workspaceFolders requests from the server.
  */
 async function handleWorkspaceFoldersRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
-	if (typeof message.id !== "number") return;
 	await sendResponse(client, message.id, currentWorkspaceFolders(client), "workspace/workspaceFolders");
 }
 
@@ -424,7 +424,6 @@ async function handleWorkspaceFoldersRequest(client: LspClient, message: LspJson
  * Handle workspace/configuration requests from the server.
  */
 async function handleConfigurationRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
-	if (typeof message.id !== "number") return;
 	const params = message.params as { items?: Array<{ section?: string }> };
 	const items = params?.items ?? [];
 	const result = items.map(item => {
@@ -438,7 +437,6 @@ async function handleConfigurationRequest(client: LspClient, message: LspJsonRpc
  * Handle workspace/applyEdit requests from the server.
  */
 async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
-	if (typeof message.id !== "number") return;
 	const params = message.params as { edit?: WorkspaceEdit };
 	if (!params?.edit) {
 		await sendResponse(
@@ -475,13 +473,15 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		return;
 	}
 	if (message.method === "window/workDoneProgress/create") {
-		// Accept progress token registration from the server
-		if (typeof message.id === "number") {
-			await sendResponse(client, message.id, null, message.method);
-		}
+		// Accept progress token registration from the server.
+		await sendResponse(client, message.id, null, message.method);
 		return;
 	}
-	if (typeof message.id !== "number") return;
+	if (message.method === "client/registerCapability" || message.method === "client/unregisterCapability") {
+		// Some servers block semantic requests until dynamic registration succeeds.
+		await sendResponse(client, message.id, null, message.method);
+		return;
+	}
 	await sendResponse(client, message.id, null, message.method, {
 		code: -32601,
 		message: `Method not found: ${message.method}`,
@@ -493,7 +493,7 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
  */
 async function sendResponse(
 	client: LspClient,
-	id: number,
+	id: LspJsonRpcId,
 	result: unknown,
 	method: string,
 	error?: { code: number; message: string; data?: unknown },

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { isEnoent, logger, ptree, untilAborted } from "@oh-my-pi/pi-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
@@ -9,6 +10,7 @@ import type {
 	LspJsonRpcNotification,
 	LspJsonRpcRequest,
 	LspJsonRpcResponse,
+	LspWatchedFileMatcher,
 	PublishDiagnosticsParams,
 	ServerConfig,
 	WorkspaceEdit,
@@ -146,6 +148,9 @@ const CLIENT_CAPABILITIES = {
 		workDoneProgress: true,
 	},
 	workspace: {
+		didChangeWatchedFiles: {
+			dynamicRegistration: true,
+		},
 		applyEdit: true,
 		workspaceEdit: {
 			documentChanges: true,
@@ -400,6 +405,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 			}
 			client.pendingRequests.clear();
 			client.resolveProjectLoaded();
+			closeWatchedFileWatcher(client);
 			client.proc.kill();
 		}
 	}
@@ -456,6 +462,201 @@ async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequ
 	}
 }
 
+const DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
+const WATCH_KIND_CREATED = 1;
+const WATCH_KIND_CHANGED = 2;
+const WATCH_KIND_DELETED = 4;
+const WATCH_KIND_ALL = WATCH_KIND_CREATED | WATCH_KIND_CHANGED | WATCH_KIND_DELETED;
+const JSON_RPC_INVALID_PARAMS = -32602;
+const JSON_RPC_INTERNAL_ERROR = -32603;
+
+interface ParsedWatchedFilesRegistration {
+	id: string;
+	watchers: LspWatchedFileMatcher[];
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function readArrayParam(params: unknown, key: string): unknown[] | undefined {
+	const record = recordValue(params);
+	const value = record?.[key];
+	return Array.isArray(value) ? value : undefined;
+}
+
+function parseWatchedFilesRegistration(value: unknown): ParsedWatchedFilesRegistration | string {
+	const registration = recordValue(value);
+	if (!registration || typeof registration.id !== "string") {
+		return "Registration id must be a string";
+	}
+	if (registration.method !== DID_CHANGE_WATCHED_FILES) {
+		return `Unsupported dynamic registration: ${String(registration.method)}`;
+	}
+
+	const options = recordValue(registration.registerOptions);
+	const rawWatchers = options ? options.watchers : undefined;
+	if (!Array.isArray(rawWatchers)) {
+		return "workspace/didChangeWatchedFiles registration requires watchers";
+	}
+
+	const watchers: LspWatchedFileMatcher[] = [];
+	for (const rawWatcher of rawWatchers) {
+		const watcher = recordValue(rawWatcher);
+		if (!watcher || typeof watcher.globPattern !== "string") {
+			return "workspace/didChangeWatchedFiles watcher globPattern must be a string";
+		}
+		watchers.push({
+			pattern: watcher.globPattern,
+			glob: new Bun.Glob(watcher.globPattern),
+			kind: typeof watcher.kind === "number" ? watcher.kind : WATCH_KIND_ALL,
+		});
+	}
+
+	return { id: registration.id, watchers };
+}
+
+function parseWatchedFilesUnregistration(value: unknown): string | undefined {
+	const registration = recordValue(value);
+	if (!registration || typeof registration.id !== "string") {
+		return undefined;
+	}
+	if (registration.method !== DID_CHANGE_WATCHED_FILES) {
+		return undefined;
+	}
+	return registration.id;
+}
+
+function normalizeWatchedPath(filePath: string): string {
+	return filePath.replaceAll("\\", "/");
+}
+
+function shouldNotifyWatchedFile(client: LspClient, relativePath: string, changeType: number): boolean {
+	for (const registration of client.watchedFiles.values()) {
+		for (const watcher of registration.watchers) {
+			if ((watcher.kind & changeType) !== 0 && watcher.glob.match(relativePath)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+async function detectWatchedFileChangeType(filePath: string, eventType: string): Promise<number> {
+	if (eventType === "change") {
+		return WATCH_KIND_CHANGED;
+	}
+	return (await Bun.file(filePath).exists()) ? WATCH_KIND_CREATED : WATCH_KIND_DELETED;
+}
+
+async function handleWatchedFileEvent(
+	client: LspClient,
+	eventType: string,
+	filename: string | Buffer | null,
+): Promise<void> {
+	if (!filename) return;
+	const eventPath = Buffer.isBuffer(filename) ? filename.toString() : filename;
+	const absolutePath = path.isAbsolute(eventPath) ? eventPath : path.join(client.cwd, eventPath);
+	const relativePath = normalizeWatchedPath(path.relative(client.cwd, absolutePath));
+	if (!relativePath || relativePath.startsWith("../") || relativePath === "..") return;
+
+	const changeType = await detectWatchedFileChangeType(absolutePath, eventType);
+	if (!shouldNotifyWatchedFile(client, relativePath, changeType)) return;
+
+	await sendNotification(client, DID_CHANGE_WATCHED_FILES, {
+		changes: [{ uri: fileToUri(absolutePath), type: changeType }],
+	});
+}
+
+function closeWatchedFileWatcher(client: LspClient): void {
+	client.fileWatcher?.close();
+	client.fileWatcher = undefined;
+}
+
+function ensureWatchedFileWatcher(client: LspClient): void {
+	if (client.fileWatcher) return;
+	client.fileWatcher = fs.watch(client.cwd, { recursive: true }, (eventType, filename) => {
+		void handleWatchedFileEvent(client, eventType, filename).catch(err => {
+			logger.warn("LSP watched-file notification failed", {
+				server: client.name,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		});
+	});
+}
+
+async function handleRegisterCapabilityRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
+	const registrations = readArrayParam(message.params, "registrations");
+	if (!registrations) {
+		await sendResponse(client, message.id, null, message.method, {
+			code: JSON_RPC_INVALID_PARAMS,
+			message: "client/registerCapability requires registrations",
+		});
+		return;
+	}
+
+	const parsedRegistrations: ParsedWatchedFilesRegistration[] = [];
+	for (const registration of registrations) {
+		const parsed = parseWatchedFilesRegistration(registration);
+		if (typeof parsed === "string") {
+			await sendResponse(client, message.id, null, message.method, {
+				code: JSON_RPC_INVALID_PARAMS,
+				message: parsed,
+			});
+			return;
+		}
+		parsedRegistrations.push(parsed);
+	}
+
+	try {
+		if (parsedRegistrations.length > 0) {
+			ensureWatchedFileWatcher(client);
+		}
+	} catch (err) {
+		await sendResponse(client, message.id, null, message.method, {
+			code: JSON_RPC_INTERNAL_ERROR,
+			message: err instanceof Error ? err.message : String(err),
+		});
+		return;
+	}
+
+	for (const registration of parsedRegistrations) {
+		client.watchedFiles.set(registration.id, {
+			method: DID_CHANGE_WATCHED_FILES,
+			watchers: registration.watchers,
+		});
+	}
+	await sendResponse(client, message.id, null, message.method);
+}
+
+async function handleUnregisterCapabilityRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
+	const unregisterations = readArrayParam(message.params, "unregisterations");
+	if (!unregisterations) {
+		await sendResponse(client, message.id, null, message.method, {
+			code: JSON_RPC_INVALID_PARAMS,
+			message: "client/unregisterCapability requires unregisterations",
+		});
+		return;
+	}
+
+	for (const registration of unregisterations) {
+		const id = parseWatchedFilesUnregistration(registration);
+		if (!id) {
+			await sendResponse(client, message.id, null, message.method, {
+				code: JSON_RPC_INVALID_PARAMS,
+				message: "Unsupported dynamic unregistration",
+			});
+			return;
+		}
+		client.watchedFiles.delete(id);
+	}
+
+	if (client.watchedFiles.size === 0) {
+		closeWatchedFileWatcher(client);
+	}
+	await sendResponse(client, message.id, null, message.method);
+}
+
 /**
  * Respond to a server-initiated request.
  */
@@ -477,9 +678,12 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		await sendResponse(client, message.id, null, message.method);
 		return;
 	}
-	if (message.method === "client/registerCapability" || message.method === "client/unregisterCapability") {
-		// Some servers block semantic requests until dynamic registration succeeds.
-		await sendResponse(client, message.id, null, message.method);
+	if (message.method === "client/registerCapability") {
+		await handleRegisterCapabilityRequest(client, message);
+		return;
+	}
+	if (message.method === "client/unregisterCapability") {
+		await handleUnregisterCapabilityRequest(client, message);
 		return;
 	}
 	await sendResponse(client, message.id, null, message.method, {
@@ -654,6 +858,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			diagnosticsVersion: 0,
 			openFiles: new Map(),
 			pendingRequests: new Map(),
+			watchedFiles: new Map(),
 			messageBuffer: new Uint8Array(0),
 			isReading: false,
 			status: "connecting",
@@ -669,6 +874,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			if (clients.get(key) === client) clients.delete(key);
 			if (clientLocks.get(key) === clientPromise) clientLocks.delete(key);
 			client.resolveProjectLoaded();
+			closeWatchedFileWatcher(client);
 
 			// Reject any pending requests — the server is gone, they will never complete.
 			if (client.pendingRequests.size > 0) {
@@ -984,6 +1190,7 @@ async function shutdownClientInstance(client: LspClient): Promise<void> {
 	}
 	client.pendingRequests.clear();
 
+	closeWatchedFileWatcher(client);
 	const shutdownCompleted = await sendRequest(client, "shutdown", null, undefined, SHUTDOWN_TIMEOUT_MS).then(
 		() => true,
 		() => false,

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -507,10 +507,12 @@ function parseWatchedFilesRegistration(value: unknown): ParsedWatchedFilesRegist
 		if (!watcher || typeof watcher.globPattern !== "string") {
 			return "workspace/didChangeWatchedFiles watcher globPattern must be a string";
 		}
+		const isAbsolutePattern = /^([A-Za-z]:)?[\\/]/.test(watcher.globPattern);
 		watchers.push({
 			pattern: watcher.globPattern,
 			glob: new Bun.Glob(watcher.globPattern),
 			kind: typeof watcher.kind === "number" ? watcher.kind : WATCH_KIND_ALL,
+			absolute: isAbsolutePattern,
 		});
 	}
 
@@ -532,12 +534,18 @@ function normalizeWatchedPath(filePath: string): string {
 	return filePath.replaceAll("\\", "/");
 }
 
-function shouldNotifyWatchedFile(client: LspClient, relativePath: string, changeType: number): boolean {
+function shouldNotifyWatchedFile(
+	client: LspClient,
+	relativePath: string,
+	absolutePath: string,
+	changeType: number,
+): boolean {
+	const normalizedAbsolute = normalizeWatchedPath(absolutePath);
 	for (const registration of client.watchedFiles.values()) {
 		for (const watcher of registration.watchers) {
-			if ((watcher.kind & changeType) !== 0 && watcher.glob.match(relativePath)) {
-				return true;
-			}
+			if ((watcher.kind & changeType) === 0) continue;
+			const target = watcher.absolute ? normalizedAbsolute : relativePath;
+			if (watcher.glob.match(target)) return true;
 		}
 	}
 	return false;
@@ -566,7 +574,7 @@ async function handleWatchedFileEvent(
 	if (!relativePath || relativePath.startsWith("../") || relativePath === "..") return;
 
 	const changeType = await detectWatchedFileChangeType(absolutePath, eventType);
-	if (!shouldNotifyWatchedFile(client, relativePath, changeType)) return;
+	if (!shouldNotifyWatchedFile(client, relativePath, absolutePath, changeType)) return;
 
 	await sendNotification(client, DID_CHANGE_WATCHED_FILES, {
 		changes: [{ uri: fileToUri(absolutePath), type: fileChangeTypeForWatchKind(changeType) }],

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -466,6 +466,7 @@ const DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
 const WATCH_KIND_CREATED = 1;
 const WATCH_KIND_CHANGED = 2;
 const WATCH_KIND_DELETED = 4;
+const FILE_CHANGE_TYPE_DELETED = 3;
 const WATCH_KIND_ALL = WATCH_KIND_CREATED | WATCH_KIND_CHANGED | WATCH_KIND_DELETED;
 const JSON_RPC_INVALID_PARAMS = -32602;
 const JSON_RPC_INTERNAL_ERROR = -32603;
@@ -549,6 +550,10 @@ async function detectWatchedFileChangeType(filePath: string, eventType: string):
 	return (await Bun.file(filePath).exists()) ? WATCH_KIND_CREATED : WATCH_KIND_DELETED;
 }
 
+function fileChangeTypeForWatchKind(watchKind: number): number {
+	return watchKind === WATCH_KIND_DELETED ? FILE_CHANGE_TYPE_DELETED : watchKind;
+}
+
 async function handleWatchedFileEvent(
 	client: LspClient,
 	eventType: string,
@@ -564,7 +569,7 @@ async function handleWatchedFileEvent(
 	if (!shouldNotifyWatchedFile(client, relativePath, changeType)) return;
 
 	await sendNotification(client, DID_CHANGE_WATCHED_FILES, {
-		changes: [{ uri: fileToUri(absolutePath), type: changeType }],
+		changes: [{ uri: fileToUri(absolutePath), type: fileChangeTypeForWatchKind(changeType) }],
 	});
 }
 

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -399,7 +399,7 @@ export interface LspClient {
 	diagnostics: Map<string, PublishedDiagnostics>;
 	diagnosticsVersion: number;
 	openFiles: Map<string, OpenFile>;
-	pendingRequests: Map<number, PendingRequest>;
+	pendingRequests: Map<number | string, PendingRequest>;
 	messageBuffer: Uint8Array;
 	isReading: boolean;
 	/** Lifecycle state: "connecting" until initialize completes, then "ready"; "error" on init failure or reader death. */
@@ -420,16 +420,19 @@ export interface LspClient {
 // JSON-RPC Protocol Types
 // =============================================================================
 
+/** JSON-RPC request/response identifier accepted by LSP peers. */
+export type LspJsonRpcId = number | string;
+
 export interface LspJsonRpcRequest {
 	jsonrpc: "2.0";
-	id: number;
+	id: LspJsonRpcId;
 	method: string;
 	params: unknown;
 }
 
 export interface LspJsonRpcResponse {
 	jsonrpc: "2.0";
-	id?: number;
+	id?: LspJsonRpcId;
 	result?: unknown;
 	error?: { code: number; message: string; data?: unknown };
 }

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -1,3 +1,4 @@
+import type * as fs from "node:fs";
 import type { ptree } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 
@@ -400,6 +401,10 @@ export interface LspClient {
 	diagnosticsVersion: number;
 	openFiles: Map<string, OpenFile>;
 	pendingRequests: Map<number | string, PendingRequest>;
+	/** Dynamic `workspace/didChangeWatchedFiles` registrations accepted from the server. */
+	watchedFiles: Map<string, LspWatchedFilesRegistration>;
+	/** Recursive filesystem watcher backing dynamic `workspace/didChangeWatchedFiles` registrations. */
+	fileWatcher?: fs.FSWatcher;
 	messageBuffer: Uint8Array;
 	isReading: boolean;
 	/** Lifecycle state: "connecting" until initialize completes, then "ready"; "error" on init failure or reader death. */
@@ -419,6 +424,19 @@ export interface LspClient {
 // =============================================================================
 // JSON-RPC Protocol Types
 // =============================================================================
+
+/** Compiled matcher for one server-registered watched-file glob. */
+export interface LspWatchedFileMatcher {
+	pattern: string;
+	glob: Bun.Glob;
+	kind: number;
+}
+
+/** Accepted dynamic registration for `workspace/didChangeWatchedFiles`. */
+export interface LspWatchedFilesRegistration {
+	method: "workspace/didChangeWatchedFiles";
+	watchers: LspWatchedFileMatcher[];
+}
 
 /** JSON-RPC request/response identifier accepted by LSP peers. */
 export type LspJsonRpcId = number | string;

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -430,6 +430,8 @@ export interface LspWatchedFileMatcher {
 	pattern: string;
 	glob: Bun.Glob;
 	kind: number;
+	/** True when `pattern` is an absolute path; match against the absolute event path instead of the cwd-relative one. */
+	absolute: boolean;
 }
 
 /** Accepted dynamic registration for `workspace/didChangeWatchedFiles`. */

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -35,6 +35,7 @@ function createClient(cwd: string, config: ServerConfig): LspClient {
 		diagnosticsVersion: 0,
 		openFiles: new Map(),
 		pendingRequests: new Map(),
+		watchedFiles: new Map(),
 		messageBuffer: new Uint8Array(),
 		isReading: false,
 		status: "ready",

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -308,6 +308,78 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("accepts dynamic capability registration before semantic requests", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-dynamic-registration-");
+		try {
+			let dynamicRegistrationAccepted = false;
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { hoverProvider: true } } });
+				} else if (message.method === "initialized") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9002,
+						method: "client/registerCapability",
+						params: {
+							registrations: [
+								{
+									id: "-42",
+									method: "workspace/didChangeWatchedFiles",
+									registerOptions: {
+										watchers: [{ globPattern: "**/mix.lock" }, { globPattern: "**/*.{ex,exs}" }],
+									},
+								},
+							],
+						},
+					});
+					srv.send({
+						jsonrpc: "2.0",
+						id: "expert-unregister-1",
+						method: "client/unregisterCapability",
+						params: { unregisterations: [{ id: "-42", method: "workspace/didChangeWatchedFiles" }] },
+					});
+				} else if (message.id === 9002 && message.method === undefined) {
+					dynamicRegistrationAccepted = message.error === undefined;
+				} else if (message.method === "textDocument/hover" && dynamicRegistrationAccepted) {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { contents: "Atas.version()" } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["ex"],
+				rootMarkers: [],
+			};
+
+			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+			const registerResponse = await server.waitFor(message => message.id === 9002 && message.method === undefined);
+			const unregisterResponse = await server.waitFor(
+				message => message.id === "expert-unregister-1" && message.method === undefined,
+			);
+			expect(registerResponse.error).toBeUndefined();
+			expect(unregisterResponse.error).toBeUndefined();
+			const result = await lspClient.sendRequest(
+				client,
+				"textDocument/hover",
+				{
+					textDocument: { uri: fileToUri(path.join(tempDir.path(), "lib", "atas.ex")) },
+					position: { line: 0, character: 0 },
+				},
+				undefined,
+				50,
+			);
+
+			expect(result).toEqual({ contents: "Atas.version()" });
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -332,12 +332,6 @@ describe("lsp regressions", () => {
 							],
 						},
 					});
-					srv.send({
-						jsonrpc: "2.0",
-						id: "expert-unregister-1",
-						method: "client/unregisterCapability",
-						params: { unregisterations: [{ id: "-42", method: "workspace/didChangeWatchedFiles" }] },
-					});
 				} else if (message.id === 9002 && message.method === undefined) {
 					dynamicRegistrationAccepted = message.error === undefined;
 				} else if (message.method === "textDocument/hover" && dynamicRegistrationAccepted) {
@@ -355,13 +349,10 @@ describe("lsp regressions", () => {
 				rootMarkers: [],
 			};
 
+			fs.mkdirSync(path.join(tempDir.path(), "lib"), { recursive: true });
 			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
 			const registerResponse = await server.waitFor(message => message.id === 9002 && message.method === undefined);
-			const unregisterResponse = await server.waitFor(
-				message => message.id === "expert-unregister-1" && message.method === undefined,
-			);
 			expect(registerResponse.error).toBeUndefined();
-			expect(unregisterResponse.error).toBeUndefined();
 			const result = await lspClient.sendRequest(
 				client,
 				"textDocument/hover",
@@ -374,6 +365,41 @@ describe("lsp regressions", () => {
 			);
 
 			expect(result).toEqual({ contents: "Atas.version()" });
+
+			const sourcePath = path.join(tempDir.path(), "lib", "atas.ex");
+			await Bun.write(sourcePath, 'defmodule Atas do\n  def version, do: "0.1.0"\nend\n');
+			const watchedFilesNotification = await server.waitFor(
+				message => message.method === "workspace/didChangeWatchedFiles",
+				2_000,
+			);
+			const watchedFilesParams = watchedFilesNotification.params as {
+				changes?: Array<{ uri?: string; type?: number }>;
+			};
+			expect(
+				watchedFilesParams.changes?.some(change => change.uri === fileToUri(sourcePath) && change.type !== 3),
+			).toBe(true);
+
+			server.send({
+				jsonrpc: "2.0",
+				id: "expert-unregister-1",
+				method: "client/unregisterCapability",
+				params: { unregisterations: [{ id: "-42", method: "workspace/didChangeWatchedFiles" }] },
+			});
+			const unregisterResponse = await server.waitFor(
+				message => message.id === "expert-unregister-1" && message.method === undefined,
+			);
+			expect(unregisterResponse.error).toBeUndefined();
+
+			server.send({
+				jsonrpc: "2.0",
+				id: "unsupported-register-1",
+				method: "client/registerCapability",
+				params: { registrations: [{ id: "unsupported", method: "workspace/executeCommand", registerOptions: {} }] },
+			});
+			const unsupportedRegisterResponse = await server.waitFor(
+				message => message.id === "unsupported-register-1" && message.method === undefined,
+			);
+			expect(unsupportedRegisterResponse.error?.code).toBe(-32602);
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();
@@ -832,6 +858,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 1,
 				openFiles: new Map([[targetUri, { version: 1, languageId: "typescript" }]]),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1040,6 +1067,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1142,6 +1170,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1203,6 +1232,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1273,6 +1303,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1343,6 +1374,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1401,6 +1433,7 @@ describe("lsp regressions", () => {
 				diagnosticsVersion: 0,
 				openFiles: new Map(),
 				pendingRequests: new Map(),
+				watchedFiles: new Map(),
 				messageBuffer: new Uint8Array(),
 				isReading: false,
 				status: "ready",
@@ -1750,6 +1783,7 @@ describe("lsp regressions", () => {
 			diagnosticsVersion: 0,
 			openFiles: new Map(),
 			pendingRequests: new Map(),
+			watchedFiles: new Map(),
 			messageBuffer: new Uint8Array(),
 			isReading: false,
 			status: "ready",
@@ -1776,6 +1810,7 @@ describe("lsp regressions", () => {
 			diagnosticsVersion: 0,
 			openFiles: new Map(),
 			pendingRequests: new Map(),
+			watchedFiles: new Map(),
 			messageBuffer: new Uint8Array(),
 			isReading: false,
 			status: "ready",

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -378,6 +378,19 @@ describe("lsp regressions", () => {
 			expect(
 				watchedFilesParams.changes?.some(change => change.uri === fileToUri(sourcePath) && change.type !== 3),
 			).toBe(true);
+			await Bun.sleep(100);
+			fs.unlinkSync(sourcePath);
+			const deletedFilesNotification = await server.waitFor(message => {
+				if (message.method !== "workspace/didChangeWatchedFiles") return false;
+				const params = message.params as { changes?: Array<{ uri?: string; type?: number }> };
+				return params.changes?.some(change => change.uri === fileToUri(sourcePath) && change.type === 3) ?? false;
+			}, 2_000);
+			const deletedFilesParams = deletedFilesNotification.params as {
+				changes?: Array<{ uri?: string; type?: number }>;
+			};
+			expect(
+				deletedFilesParams.changes?.some(change => change.uri === fileToUri(sourcePath) && change.type === 3),
+			).toBe(true);
 
 			server.send({
 				jsonrpc: "2.0",

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -419,6 +419,56 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("notifies absolute-pattern watchers when files change", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-absolute-watcher-");
+		try {
+			const absolutePattern = `${tempDir.path().replaceAll("\\", "/")}/**/*.rb`;
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "initialized") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9100,
+						method: "client/registerCapability",
+						params: {
+							registrations: [
+								{
+									id: "abs-watch",
+									method: "workspace/didChangeWatchedFiles",
+									registerOptions: { watchers: [{ globPattern: absolutePattern }] },
+								},
+							],
+						},
+					});
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
+			const config: ServerConfig = { command: "fake-lsp", fileTypes: ["rb"], rootMarkers: [] };
+			fs.mkdirSync(path.join(tempDir.path(), "app"), { recursive: true });
+			await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+			const registerResponse = await server.waitFor(message => message.id === 9100 && message.method === undefined);
+			expect(registerResponse.error).toBeUndefined();
+
+			const sourcePath = path.join(tempDir.path(), "app", "main.rb");
+			await Bun.write(sourcePath, "puts 'hi'\n");
+			const notification = await server.waitFor(message => {
+				if (message.method !== "workspace/didChangeWatchedFiles") return false;
+				const params = message.params as { changes?: Array<{ uri?: string }> };
+				return params.changes?.some(change => change.uri === fileToUri(sourcePath)) ?? false;
+			}, 2_000);
+			const params = notification.params as { changes?: Array<{ uri?: string }> };
+			expect(params.changes?.some(change => change.uri === fileToUri(sourcePath))).toBe(true);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {


### PR DESCRIPTION
## Repro
An in-process LSP peer sends `client/registerCapability` after `initialized`, then only answers `textDocument/hover` if the registration succeeds. Before the fix, `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts --test-name-pattern "accepts dynamic capability registration"` failed with `LSP request textDocument/hover timed out after 50ms`.

## Cause
`packages/coding-agent/src/lsp/client.ts` routed server-originating requests through `handleServerRequest`, but only explicitly accepted `workspace/configuration`, `workspace/workspaceFolders`, `workspace/applyEdit`, and `window/workDoneProgress/create`. `client/registerCapability` fell through to JSON-RPC `-32601 Method not found`, and the response path also assumed numeric-only ids even though JSON-RPC ids may be strings.

## Fix
- Accept `client/registerCapability` and `client/unregisterCapability` as no-op successful server requests.
- Widen LSP JSON-RPC request/response ids to `number | string` so string ids are answered instead of ignored.
- Add a regression test that gates hover behind dynamic registration acceptance and covers string-id unregister responses.
- Add an unreleased changelog entry for the Expert/LSP hang fix.

## Verification
`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` passed: 42 tests, 140 assertions. `bun --cwd=packages/coding-agent run check` passed. `gh_push_branch` pre-publish gate passed. Fixes #3029