### PR TITLE
fix(mnemopi): isolate local embeddings worker in subprocess

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Isolated mnemopi's local embedding provider in a dedicated `Bun.spawn` subprocess so `onnxruntime-node` and `fastembed` never load into the main agent process. Previously `memory.backend: mnemopi` crashed Bun on Windows — standalone binaries faulted in the NAPI `process.dlopen` constructor at session start, npm installs faulted in the NAPI finalizer at process teardown. Mirrors the tiny-model isolation pattern from [#1607](https://github.com/can1357/oh-my-pi/pull/1607); the parent SIGKILLs the child on dispose so the destructor never runs in either address space ([#3031](https://github.com/can1357/oh-my-pi/issues/3031)).
+
 ## [16.1.1] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -68,6 +68,7 @@ async function runSmokeTest(): Promise<void> {
 	const { smokeTestTinyTitleWorker } = await import("./tiny/title-client");
 	const { smokeTestSttWorker } = await import("./stt/asr-client");
 	const { smokeTestTtsWorker } = await import("./tts/tts-client");
+	const { smokeTestMnemopiEmbedWorker } = await import("./mnemopi/embed-client");
 	const { smokeTestJsEvalWorker } = await import("./eval/js/context-manager");
 	await smokeTestSyncWorker();
 
@@ -87,6 +88,7 @@ async function runSmokeTest(): Promise<void> {
 	await smokeTestSttWorker();
 	await smokeTestJsEvalWorker();
 	await smokeTestTtsWorker();
+	await smokeTestMnemopiEmbedWorker();
 	process.stdout.write("smoke-test: ok\n");
 }
 
@@ -96,6 +98,7 @@ const TAB_WORKER_ARG = "__omp_worker_tab";
 const JS_EVAL_WORKER_ARG = "__omp_worker_js_eval";
 const STT_WORKER_ARG = "__omp_worker_stt";
 const TTS_WORKER_ARG = "__omp_worker_tts";
+const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
 
 async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	if (arg === TINY_WORKER_ARG) {
@@ -149,6 +152,11 @@ async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	if (arg === TTS_WORKER_ARG) {
 		const { startTtsWorker } = await import("./tts/tts-worker");
 		await runIpcSubprocessWorker(startTtsWorker);
+		return true;
+	}
+	if (arg === MNEMOPI_EMBED_WORKER_ARG) {
+		const { startMnemopiEmbedWorker } = await import("./mnemopi/embed-worker");
+		await runIpcSubprocessWorker(startMnemopiEmbedWorker);
 		return true;
 	}
 	return false;

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -11,7 +11,7 @@ import type { MnemopiEmbedModelId, MnemopiEmbedWorkerInbound, MnemopiEmbedWorker
  * provider loads fastembed in the main process (issue #3031; the mnemopi
  * sibling of the tiny-model fix from #1606 / #1607).
  */
-interface WorkerHandle {
+export interface MnemopiEmbedWorkerHandle {
 	send(message: MnemopiEmbedWorkerInbound): void;
 	onMessage(handler: (message: MnemopiEmbedWorkerOutbound) => void): () => void;
 	onError(handler: (error: Error) => void): () => void;
@@ -124,7 +124,7 @@ export function createMnemopiEmbedSubprocess(): SpawnedSubprocess {
 	return { proc, inbound, errors, intentionalExit };
 }
 
-function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): WorkerHandle {
+function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): MnemopiEmbedWorkerHandle {
 	return {
 		send(message) {
 			try {
@@ -159,7 +159,7 @@ function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubpr
 	};
 }
 
-function spawnInlineUnavailableWorker(error: unknown): WorkerHandle {
+function spawnInlineUnavailableWorker(error: unknown): MnemopiEmbedWorkerHandle {
 	const listeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
 	const errorMessage = error instanceof Error ? error.message : String(error);
 	const emit = (message: MnemopiEmbedWorkerOutbound): void => {
@@ -188,7 +188,7 @@ function spawnInlineUnavailableWorker(error: unknown): WorkerHandle {
 	};
 }
 
-function spawnMnemopiEmbedWorker(): WorkerHandle {
+function spawnMnemopiEmbedWorker(): MnemopiEmbedWorkerHandle {
 	try {
 		return wrapSubprocess(createMnemopiEmbedSubprocess());
 	} catch (error) {
@@ -217,14 +217,14 @@ export interface MnemopiSubprocessEmbeddingModel {
 }
 
 export class MnemopiEmbedClient {
-	#worker: WorkerHandle | null = null;
+	#worker: MnemopiEmbedWorkerHandle | null = null;
 	#unsubscribeMessage: (() => void) | null = null;
 	#unsubscribeError: (() => void) | null = null;
 	#pending = new Map<string, PendingRequest>();
 	#nextRequestId = 0;
-	#spawnWorker: () => WorkerHandle;
+	#spawnWorker: () => MnemopiEmbedWorkerHandle;
 
-	constructor(spawnWorker: () => WorkerHandle = spawnMnemopiEmbedWorker) {
+	constructor(spawnWorker: () => MnemopiEmbedWorkerHandle = spawnMnemopiEmbedWorker) {
 		this.#spawnWorker = spawnWorker;
 	}
 
@@ -259,7 +259,7 @@ export class MnemopiEmbedClient {
 			});
 			return null;
 		}
-		return { embed: (texts, batchSize) => this.#streamEmbed(model, texts, batchSize) };
+		return { embed: (texts, batchSize) => this.#streamEmbed(model, cacheDir, texts, batchSize) };
 	}
 
 	async terminate(): Promise<void> {
@@ -281,13 +281,23 @@ export class MnemopiEmbedClient {
 		}
 	}
 
-	async #embed(model: MnemopiEmbedModelId, texts: string[], batchSize: number | undefined): Promise<number[][]> {
+	async #embed(
+		model: MnemopiEmbedModelId,
+		cacheDir: string | undefined,
+		texts: string[],
+		batchSize: number | undefined,
+	): Promise<number[][]> {
 		const worker = this.#ensureWorker();
 		const id = String(++this.#nextRequestId);
 		const { promise, resolve } = Promise.withResolvers<number[][] | Error>();
 		this.#pending.set(id, { kind: "embed", model, resolve });
 		try {
-			worker.send({ type: "embed", id, texts, batchSize });
+			// Carry the (model, cacheDir) the wrapper was bound to in every
+			// embed message: dispose + respawn between two embeds on the same
+			// `LocalEmbeddingModel` handle would otherwise hit a fresh
+			// worker's "embed before init" guard. Worker `ensureLoaded` is
+			// idempotent so steady-state embeds pay no extra cost.
+			worker.send({ type: "embed", id, model, cacheDir, texts, batchSize });
 			const result = await promise;
 			if (result instanceof Error) throw result;
 			return result;
@@ -298,10 +308,11 @@ export class MnemopiEmbedClient {
 
 	async *#streamEmbed(
 		model: MnemopiEmbedModelId,
+		cacheDir: string | undefined,
 		texts: string[],
 		batchSize: number | undefined,
 	): AsyncIterable<number[][]> {
-		const vectors = await this.#embed(model, texts, batchSize);
+		const vectors = await this.#embed(model, cacheDir, texts, batchSize);
 		// Mnemopi's `collectMatrix` re-batches via async iteration anyway; yield
 		// a single batch carrying the full result so the caller's drain loop
 		// behaves identically to the in-process fastembed iterator (one yield
@@ -309,7 +320,7 @@ export class MnemopiEmbedClient {
 		yield vectors;
 	}
 
-	#ensureWorker(): WorkerHandle {
+	#ensureWorker(): MnemopiEmbedWorkerHandle {
 		if (this.#worker) return this.#worker;
 		const worker = this.#spawnWorker();
 		this.#worker = worker;

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -1,0 +1,390 @@
+import * as path from "node:path";
+import { $env, isBunTestRuntime, isCompiledBinary, logger, workerHostEntry } from "@oh-my-pi/pi-utils";
+import type { Subprocess } from "bun";
+import type { MnemopiEmbedModelId, MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
+
+/**
+ * Abstraction over the mnemopi embeddings subprocess. The runtime
+ * implementation is a Bun child process so `onnxruntime-node`'s NAPI
+ * constructor + finalizer never run inside the main agent address space —
+ * those destructors segfault Bun on Windows when mnemopi's local embedding
+ * provider loads fastembed in the main process (issue #3031; the mnemopi
+ * sibling of the tiny-model fix from #1606 / #1607).
+ */
+interface WorkerHandle {
+	send(message: MnemopiEmbedWorkerInbound): void;
+	onMessage(handler: (message: MnemopiEmbedWorkerOutbound) => void): () => void;
+	onError(handler: (error: Error) => void): () => void;
+	terminate(): Promise<void>;
+}
+
+type PendingRequest =
+	| { kind: "init"; model: MnemopiEmbedModelId; resolve: (ok: boolean) => void }
+	| { kind: "embed"; model: MnemopiEmbedModelId; resolve: (vectors: number[][] | Error) => void };
+
+// Cold-starting the worker from a compiled binary (decompress + module graph load)
+// is slow on contended CI runners; the probe only proves the worker spawns and
+// ponges, so a generous bound removes flakes without weakening the check.
+const SMOKE_TEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Hidden subcommand on the main CLI that boots the mnemopi embeddings worker
+ * in the spawned subprocess. Kept in sync with the dispatch in `cli.ts`.
+ */
+export const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
+
+/**
+ * Env handed to the embeddings subprocess. The child inherits the parent's
+ * environment verbatim — fastembed honours `HF_HUB_*`, `HTTPS_PROXY`, etc.,
+ * and our `loadFastembed()` reads the same `OMP_*` runtime-install knobs the
+ * parent uses. `process.env` carries `undefined` slots that Bun.spawn rejects;
+ * filter them out.
+ */
+function mnemopiEmbedWorkerEnv(): Record<string, string> {
+	const base = $env as Record<string, string | undefined>;
+	const merged: Record<string, string> = {};
+	for (const key in base) {
+		const value = base[key];
+		if (typeof value === "string") merged[key] = value;
+	}
+	return merged;
+}
+
+interface MnemopiEmbedWorkerSpawnCommand {
+	cmd: string[];
+	cwd?: string;
+}
+
+/**
+ * Resolve the command used to relaunch the agent CLI into mnemopi-embed-worker
+ * mode. In a compiled binary the entry point is the binary itself; otherwise
+ * re-enter the declared worker-host entry (cwd-relative for reliable Bun IPC),
+ * falling back to this package's own `src/cli.ts` when no host entry is
+ * declared (bun test, SDK embedding).
+ */
+function mnemopiEmbedWorkerSpawnCmd(): MnemopiEmbedWorkerSpawnCommand {
+	if (isCompiledBinary()) return { cmd: [process.execPath, MNEMOPI_EMBED_WORKER_ARG] };
+	const hostEntry = workerHostEntry();
+	if (hostEntry) {
+		return {
+			cmd: [process.execPath, path.basename(hostEntry), MNEMOPI_EMBED_WORKER_ARG],
+			cwd: path.dirname(hostEntry),
+		};
+	}
+	const packageRoot = path.resolve(import.meta.dir, "..", "..");
+	return { cmd: [process.execPath, "src/cli.ts", MNEMOPI_EMBED_WORKER_ARG], cwd: packageRoot };
+}
+
+interface SpawnedSubprocess {
+	proc: Subprocess<"ignore", "ignore", "ignore">;
+	inbound: Set<(message: MnemopiEmbedWorkerOutbound) => void>;
+	errors: Set<(error: Error) => void>;
+	/**
+	 * Flipped to `true` right before the deliberate SIGKILL so `onExit` can
+	 * distinguish the expected hard-kill from a crash (SIGSEGV from a native
+	 * fault, OOM SIGKILL, operator `kill -9`). Only the latter surfaces as a
+	 * worker error so callers don't await forever.
+	 */
+	intentionalExit: { value: boolean };
+}
+
+/**
+ * Spawn the mnemopi embeddings worker as a subprocess. Exported for tests and
+ * the smoke probe; production callers go through {@link spawnMnemopiEmbedWorker}.
+ */
+export function createMnemopiEmbedSubprocess(): SpawnedSubprocess {
+	const inbound = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	const errors = new Set<(error: Error) => void>();
+	const intentionalExit = { value: false };
+	const spawnCommand = mnemopiEmbedWorkerSpawnCmd();
+	const proc = Bun.spawn({
+		cmd: spawnCommand.cmd,
+		cwd: spawnCommand.cwd,
+		env: mnemopiEmbedWorkerEnv(),
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "ignore",
+		serialization: "advanced",
+		windowsHide: true,
+		ipc(message) {
+			for (const handler of inbound) handler(message as MnemopiEmbedWorkerOutbound);
+		},
+		onExit(_proc, exitCode, signalCode) {
+			if (exitCode === 0) return;
+			if (exitCode === null && intentionalExit.value) return;
+			const reason = exitCode !== null ? `code ${exitCode}` : `signal ${signalCode ?? "unknown"}`;
+			const err = new Error(`mnemopi embed subprocess exited with ${reason}`);
+			for (const handler of errors) handler(err);
+		},
+	});
+	// Don't keep the parent event loop alive on an idle worker; the agent
+	// dispose path calls `terminate()` explicitly. Bun's test runner starves
+	// IPC for unref'd subprocesses, so keep it referenced only under tests.
+	if (!isBunTestRuntime()) proc.unref();
+	return { proc, inbound, errors, intentionalExit };
+}
+
+function wrapSubprocess({ proc, inbound, errors, intentionalExit }: SpawnedSubprocess): WorkerHandle {
+	return {
+		send(message) {
+			try {
+				proc.send(message);
+			} catch (error) {
+				logger.debug("mnemopi-embed: send to subprocess failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		},
+		onMessage(handler) {
+			inbound.add(handler);
+			return () => inbound.delete(handler);
+		},
+		onError(handler) {
+			errors.add(handler);
+			return () => errors.delete(handler);
+		},
+		async terminate() {
+			// SIGKILL: the point of subprocess isolation is that the parent
+			// never runs `onnxruntime-node`'s NAPI finalizer (it crashes Bun
+			// on Windows). Hard-kill instead; the OS reclaims the model
+			// memory. Flip the intentional-exit flag *before* killing so
+			// `onExit` can tell this apart from a native crash.
+			intentionalExit.value = true;
+			try {
+				proc.kill("SIGKILL");
+			} catch {
+				// Already gone.
+			}
+		},
+	};
+}
+
+function spawnInlineUnavailableWorker(error: unknown): WorkerHandle {
+	const listeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	const emit = (message: MnemopiEmbedWorkerOutbound): void => {
+		for (const listener of listeners) listener(message);
+	};
+	return {
+		send(message) {
+			queueMicrotask(() => {
+				if (message.type === "ping") {
+					emit({ type: "pong", id: message.id });
+					return;
+				}
+				emit({ type: "error", id: message.id, error: errorMessage });
+			});
+		},
+		onMessage(handler) {
+			listeners.add(handler);
+			return () => listeners.delete(handler);
+		},
+		onError() {
+			return () => {};
+		},
+		async terminate() {
+			listeners.clear();
+		},
+	};
+}
+
+function spawnMnemopiEmbedWorker(): WorkerHandle {
+	try {
+		return wrapSubprocess(createMnemopiEmbedSubprocess());
+	} catch (error) {
+		logger.warn("mnemopi embed worker spawn failed; local embeddings disabled", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return spawnInlineUnavailableWorker(error);
+	}
+}
+
+function logWorkerMessage(message: Extract<MnemopiEmbedWorkerOutbound, { type: "log" }>): void {
+	if (message.level === "debug") logger.debug(message.msg, message.meta);
+	else if (message.level === "warn") logger.warn(message.msg, message.meta);
+	else logger.error(message.msg, message.meta);
+}
+
+/**
+ * Per-model wrapper produced by {@link MnemopiEmbedClient.initialize}.
+ * `embed()` round-trips one batch of texts through the worker subprocess and
+ * yields the resulting vectors in a single asynchronous batch — fastembed's
+ * own iterator was emitting batches that we collect on the child side anyway,
+ * and serializing per-batch over IPC would not improve throughput.
+ */
+export interface MnemopiSubprocessEmbeddingModel {
+	embed(texts: string[], batchSize?: number): AsyncIterable<number[][]>;
+}
+
+export class MnemopiEmbedClient {
+	#worker: WorkerHandle | null = null;
+	#unsubscribeMessage: (() => void) | null = null;
+	#unsubscribeError: (() => void) | null = null;
+	#pending = new Map<string, PendingRequest>();
+	#nextRequestId = 0;
+	#spawnWorker: () => WorkerHandle;
+
+	constructor(spawnWorker: () => WorkerHandle = spawnMnemopiEmbedWorker) {
+		this.#spawnWorker = spawnWorker;
+	}
+
+	/**
+	 * Load the named fastembed model inside the subprocess. Resolves to a
+	 * thin wrapper whose `embed()` round-trips through the same worker, or
+	 * `null` when the worker cannot init the model (missing peer, native
+	 * load failure, etc.). Multiple calls with the same model reuse the
+	 * single in-flight worker; calling with a different model loads it on
+	 * the child without restarting the process.
+	 */
+	async initialize(
+		model: MnemopiEmbedModelId,
+		cacheDir: string | undefined,
+	): Promise<MnemopiSubprocessEmbeddingModel | null> {
+		try {
+			const worker = this.#ensureWorker();
+			const id = String(++this.#nextRequestId);
+			const { promise, resolve } = Promise.withResolvers<boolean>();
+			this.#pending.set(id, { kind: "init", model, resolve });
+			try {
+				worker.send({ type: "init", id, model, cacheDir });
+				const ok = await promise;
+				if (!ok) return null;
+			} finally {
+				this.#pending.delete(id);
+			}
+		} catch (error) {
+			logger.debug("mnemopi-embed: init failed", {
+				model,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return null;
+		}
+		return { embed: (texts, batchSize) => this.#streamEmbed(model, texts, batchSize) };
+	}
+
+	async terminate(): Promise<void> {
+		const worker = this.#worker;
+		this.#worker = null;
+		this.#unsubscribeMessage?.();
+		this.#unsubscribeMessage = null;
+		this.#unsubscribeError?.();
+		this.#unsubscribeError = null;
+		for (const pending of this.#pending.values()) {
+			if (pending.kind === "init") pending.resolve(false);
+			else pending.resolve(new Error("mnemopi embed worker terminated"));
+		}
+		this.#pending.clear();
+		try {
+			await worker?.terminate();
+		} catch {
+			// Already gone.
+		}
+	}
+
+	async #embed(model: MnemopiEmbedModelId, texts: string[], batchSize: number | undefined): Promise<number[][]> {
+		const worker = this.#ensureWorker();
+		const id = String(++this.#nextRequestId);
+		const { promise, resolve } = Promise.withResolvers<number[][] | Error>();
+		this.#pending.set(id, { kind: "embed", model, resolve });
+		try {
+			worker.send({ type: "embed", id, texts, batchSize });
+			const result = await promise;
+			if (result instanceof Error) throw result;
+			return result;
+		} finally {
+			this.#pending.delete(id);
+		}
+	}
+
+	async *#streamEmbed(
+		model: MnemopiEmbedModelId,
+		texts: string[],
+		batchSize: number | undefined,
+	): AsyncIterable<number[][]> {
+		const vectors = await this.#embed(model, texts, batchSize);
+		// Mnemopi's `collectMatrix` re-batches via async iteration anyway; yield
+		// a single batch carrying the full result so the caller's drain loop
+		// behaves identically to the in-process fastembed iterator (one yield
+		// per `embed()` call) without paying extra IPC round-trips.
+		yield vectors;
+	}
+
+	#ensureWorker(): WorkerHandle {
+		if (this.#worker) return this.#worker;
+		const worker = this.#spawnWorker();
+		this.#worker = worker;
+		this.#unsubscribeMessage = worker.onMessage(message => this.#handleMessage(message));
+		this.#unsubscribeError = worker.onError(error => this.#handleWorkerError(error));
+		return worker;
+	}
+
+	#handleMessage(message: MnemopiEmbedWorkerOutbound): void {
+		if (message.type === "log") {
+			logWorkerMessage(message);
+			return;
+		}
+		if (message.type === "pong") return;
+
+		const pending = this.#pending.get(message.id);
+		if (!pending) return;
+		this.#pending.delete(message.id);
+		if (message.type === "ready") {
+			if (pending.kind === "init") pending.resolve(true);
+			return;
+		}
+		if (message.type === "vectors") {
+			if (pending.kind === "embed") pending.resolve(message.vectors);
+			return;
+		}
+		logger.debug("mnemopi-embed: worker returned error", { error: message.error });
+		if (pending.kind === "init") pending.resolve(false);
+		else pending.resolve(new Error(message.error));
+	}
+
+	#handleWorkerError(error: Error): void {
+		logger.warn("mnemopi-embed: worker error", { error: error.message });
+		for (const pending of this.#pending.values()) {
+			if (pending.kind === "init") pending.resolve(false);
+			else pending.resolve(error);
+		}
+		this.#pending.clear();
+		void this.terminate();
+	}
+}
+
+export const mnemopiEmbedClient = new MnemopiEmbedClient();
+
+export async function shutdownMnemopiEmbedClient(): Promise<void> {
+	await mnemopiEmbedClient.terminate();
+}
+
+export async function smokeTestMnemopiEmbedWorker({
+	timeoutMs = SMOKE_TEST_TIMEOUT_MS,
+}: {
+	timeoutMs?: number;
+} = {}): Promise<void> {
+	const handle = wrapSubprocess(createMnemopiEmbedSubprocess());
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const timer = setTimeout(
+		() => reject(new Error(`mnemopi embed worker did not pong within ${timeoutMs}ms`)),
+		timeoutMs,
+	);
+	const unsubscribeMessage = handle.onMessage(message => {
+		if (message.type === "pong") {
+			resolve();
+			return;
+		}
+		if (message.type === "log") return;
+		reject(new Error(`mnemopi embed worker: expected pong, got ${JSON.stringify(message)}`));
+	});
+	const unsubscribeError = handle.onError(reject);
+	try {
+		handle.send({ type: "ping", id: "smoke" } satisfies MnemopiEmbedWorkerInbound);
+		await promise;
+	} finally {
+		clearTimeout(timer);
+		unsubscribeMessage();
+		unsubscribeError();
+		await handle.terminate();
+	}
+}

--- a/packages/coding-agent/src/mnemopi/embed-protocol.ts
+++ b/packages/coding-agent/src/mnemopi/embed-protocol.ts
@@ -1,0 +1,30 @@
+/**
+ * Wire types between the parent (`MnemopiEmbedClient`) and the local
+ * embeddings subprocess. The parent owns the subprocess lifecycle (graceful
+ * work, hard `SIGKILL` on shutdown); the protocol carries no explicit close
+ * handshake — once the parent decides to terminate, it signals the OS to reap
+ * the child so `onnxruntime-node`'s NAPI finalizer never runs in the main
+ * agent address space (it crashes Bun on Windows shutdown — issue #3031, the
+ * mnemopi sibling of the tiny-model fix from #1606/#1607). See
+ * `embed-client.ts` for the spawn/kill glue.
+ */
+
+/** Identifier of the fastembed model the worker should load (e.g. `fast-bge-base-en-v1.5`). */
+export type MnemopiEmbedModelId = string;
+
+export type MnemopiEmbedWorkerInbound =
+	| { type: "ping"; id: string }
+	| { type: "init"; id: string; model: MnemopiEmbedModelId; cacheDir?: string }
+	| { type: "embed"; id: string; texts: string[]; batchSize?: number };
+
+export type MnemopiEmbedWorkerOutbound =
+	| { type: "pong"; id: string }
+	| { type: "ready"; id: string }
+	| { type: "vectors"; id: string; vectors: number[][] }
+	| { type: "error"; id: string; error: string }
+	| { type: "log"; level: "debug" | "warn" | "error"; msg: string; meta?: Record<string, unknown> };
+
+export interface MnemopiEmbedTransport {
+	send(message: MnemopiEmbedWorkerOutbound): void;
+	onMessage(handler: (message: MnemopiEmbedWorkerInbound) => void): () => void;
+}

--- a/packages/coding-agent/src/mnemopi/embed-protocol.ts
+++ b/packages/coding-agent/src/mnemopi/embed-protocol.ts
@@ -15,7 +15,12 @@ export type MnemopiEmbedModelId = string;
 export type MnemopiEmbedWorkerInbound =
 	| { type: "ping"; id: string }
 	| { type: "init"; id: string; model: MnemopiEmbedModelId; cacheDir?: string }
-	| { type: "embed"; id: string; texts: string[]; batchSize?: number };
+	// `embed` always carries the same `model` / `cacheDir` the wrapper was
+	// initialized with so a fresh subprocess (after the parent SIGKILLed the
+	// previous one but mnemopi still holds the cached `LocalEmbeddingModel`)
+	// can lazily reload the model on demand instead of returning
+	// "embed before init".
+	| { type: "embed"; id: string; model: MnemopiEmbedModelId; cacheDir?: string; texts: string[]; batchSize?: number };
 
 export type MnemopiEmbedWorkerOutbound =
 	| { type: "pong"; id: string }

--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -59,18 +59,12 @@ async function handleEmbed(
 	message: Extract<MnemopiEmbedWorkerInbound, { type: "embed" }>,
 ): Promise<void> {
 	try {
-		// Embedding requests always carry the model context they were initialized with
-		// — the parent issues `init` before the first `embed`, so `loaded` is set.
-		// If a request races ahead (e.g. after a recovered crash), surface the error.
-		if (loaded === null) {
-			transport.send({
-				type: "error",
-				id: message.id,
-				error: "mnemopi embed worker: embed before init",
-			});
-			return;
-		}
-		const { instance } = await loaded;
+		// Each `embed` carries the model + cacheDir the wrapper was bound to.
+		// `ensureLoaded` is idempotent for the same key, so this is a no-op
+		// once the model is in memory — and it transparently re-loads after
+		// the parent SIGKILLed the previous subprocess but mnemopi still
+		// holds the cached `LocalEmbeddingModel` wrapper from before.
+		const { instance } = await ensureLoaded(message.model, message.cacheDir);
 		const vectors: number[][] = [];
 		const batches = instance.embed([...message.texts], message.batchSize);
 		for await (const batch of batches) {

--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -1,0 +1,119 @@
+/**
+ * Mnemopi local-embeddings worker. Loaded inside the dedicated subprocess
+ * spawned by `embed-client.ts` (re-entered through the agent CLI's hidden
+ * `__omp_worker_mnemopi_embed` selector). The whole point of this module is
+ * that `loadFastembed()` — and therefore `onnxruntime-node`'s NAPI
+ * constructor + finalizer — only ever runs in this child address space. The
+ * parent `SIGKILL`s us on shutdown so the destructor that crashes Bun on
+ * Windows shutdown (issue #3031, mnemopi sibling of #1606/#1607) never runs
+ * in either process.
+ */
+
+import type { StandardEmbeddingModel } from "@oh-my-pi/pi-mnemopi/core";
+import { loadFastembed } from "@oh-my-pi/pi-mnemopi/core/fastembed-runtime";
+import type { MnemopiEmbedModelId, MnemopiEmbedTransport, MnemopiEmbedWorkerInbound } from "./embed-protocol";
+
+interface LoadedModel {
+	model: MnemopiEmbedModelId;
+	cacheDir: string | undefined;
+	instance: {
+		embed(texts: string[], batchSize?: number): AsyncIterable<number[][]> | Iterable<number[][]>;
+	};
+}
+
+let loaded: Promise<LoadedModel> | null = null;
+let loadedKey = "";
+
+async function loadModel(model: MnemopiEmbedModelId, cacheDir: string | undefined): Promise<LoadedModel> {
+	const { FlagEmbedding } = await loadFastembed();
+	// Cast: `model` arrives as a string from the parent (resolved by
+	// mnemopi's `fastembedModelName`). Cast to the non-CUSTOM overload's
+	// argument so TypeScript picks the standard-model branch — the parent
+	// only ever passes pre-vetted fast-* identifiers.
+	const instance = await FlagEmbedding.init({
+		model: model as StandardEmbeddingModel,
+		cacheDir,
+		showDownloadProgress: false,
+	});
+	return { model, cacheDir, instance };
+}
+
+function ensureLoaded(model: MnemopiEmbedModelId, cacheDir: string | undefined): Promise<LoadedModel> {
+	const key = `${model}\u0000${cacheDir ?? ""}`;
+	if (loaded !== null && loadedKey === key) return loaded;
+	const loading = loadModel(model, cacheDir).catch(error => {
+		// Failed loads must not poison the cache — a retry with the same key
+		// should re-attempt the load.
+		if (loaded === loading) {
+			loaded = null;
+			loadedKey = "";
+		}
+		throw error;
+	});
+	loaded = loading;
+	loadedKey = key;
+	return loading;
+}
+async function handleEmbed(
+	transport: MnemopiEmbedTransport,
+	message: Extract<MnemopiEmbedWorkerInbound, { type: "embed" }>,
+): Promise<void> {
+	try {
+		// Embedding requests always carry the model context they were initialized with
+		// — the parent issues `init` before the first `embed`, so `loaded` is set.
+		// If a request races ahead (e.g. after a recovered crash), surface the error.
+		if (loaded === null) {
+			transport.send({
+				type: "error",
+				id: message.id,
+				error: "mnemopi embed worker: embed before init",
+			});
+			return;
+		}
+		const { instance } = await loaded;
+		const vectors: number[][] = [];
+		const batches = instance.embed([...message.texts], message.batchSize);
+		for await (const batch of batches) {
+			for (const row of batch) vectors.push(row);
+		}
+		transport.send({ type: "vectors", id: message.id, vectors });
+	} catch (error) {
+		transport.send({
+			type: "error",
+			id: message.id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+async function handleInit(
+	transport: MnemopiEmbedTransport,
+	message: Extract<MnemopiEmbedWorkerInbound, { type: "init" }>,
+): Promise<void> {
+	try {
+		await ensureLoaded(message.model, message.cacheDir);
+		transport.send({ type: "ready", id: message.id });
+	} catch (error) {
+		transport.send({
+			type: "error",
+			id: message.id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export function startMnemopiEmbedWorker(transport: MnemopiEmbedTransport): void {
+	transport.onMessage(message => {
+		switch (message.type) {
+			case "ping":
+				transport.send({ type: "pong", id: message.id });
+				return;
+			case "init":
+				void handleInit(transport, message);
+				return;
+			case "embed":
+				void handleEmbed(transport, message);
+				return;
+		}
+	});
+}

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type * as MnemopiNs from "@oh-my-pi/pi-mnemopi";
 import type { Mnemopi, RecallResult } from "@oh-my-pi/pi-mnemopi";
 import type * as MnemopiCoreNs from "@oh-my-pi/pi-mnemopi/core";
+import type { LocalModelInitializer } from "@oh-my-pi/pi-mnemopi/core";
 import { logger } from "@oh-my-pi/pi-utils";
 import {
 	composeRecallQuery,
@@ -13,16 +14,42 @@ import {
 import { extractMessages } from "../hindsight/transcript";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import type { MnemopiBackendConfig, MnemopiScoping } from "./config";
+import { mnemopiEmbedClient } from "./embed-client";
 
 // The mnemopi package pulls the embeddings stack; keep it off the CLI startup
 // module graph by loading it lazily at the async boundaries that need it.
 let mnemopiMod: typeof MnemopiNs | undefined;
 let mnemopiCoreMod: typeof MnemopiCoreNs | undefined;
 
-/** Lazily load `@oh-my-pi/pi-mnemopi` (memoized). */
+// `setLocalModelInitializer` writes a single module-level slot shared by
+// both the root and `/core` re-exports, so install at most once across both
+// loaders. Either entry point is enough to wire up the override.
+let localModelInitializerInstalled = false;
+
+function installLocalModelInitializer(setInitializer: (initializer: LocalModelInitializer) => void): void {
+	if (localModelInitializerInstalled) return;
+	localModelInitializerInstalled = true;
+	setInitializer(({ model, cacheDir }) =>
+		mnemopiEmbedClient.initialize(model, cacheDir).then(handle => {
+			if (handle) return handle;
+			throw new Error("mnemopi embed subprocess unavailable");
+		}),
+	);
+}
+
+/**
+ * Lazily load `@oh-my-pi/pi-mnemopi` (memoized) and route fastembed loads
+ * through the dedicated embeddings subprocess. The override is installed once
+ * — before any consumer gets the chance to call `embed()` — so
+ * `onnxruntime-node`'s NAPI constructor + finalizer never run inside the
+ * agent's address space (issue #3031). Test seams that swap the initializer
+ * with `setLocalModelInitializerForTests` still win because both go through
+ * the same module-level slot.
+ */
 export async function loadMnemopi(): Promise<typeof MnemopiNs> {
 	if (!mnemopiMod) {
 		mnemopiMod = await import("@oh-my-pi/pi-mnemopi");
+		installLocalModelInitializer(mnemopiMod.setLocalModelInitializer);
 	}
 	return mnemopiMod;
 }
@@ -31,6 +58,7 @@ export async function loadMnemopi(): Promise<typeof MnemopiNs> {
 export async function loadMnemopiCore(): Promise<typeof MnemopiCoreNs> {
 	if (!mnemopiCoreMod) {
 		mnemopiCoreMod = await import("@oh-my-pi/pi-mnemopi/core");
+		installLocalModelInitializer(mnemopiCoreMod.setLocalModelInitializer);
 	}
 	return mnemopiCoreMod;
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -205,6 +205,7 @@ import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { IrcBus, type IrcMessage } from "../irc/bus";
 import { resolveMemoryBackend } from "../memory-backend";
+import { shutdownMnemopiEmbedClient } from "../mnemopi/embed-client";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
 import { getCurrentThemeName, theme } from "../modes/theme/theme";
@@ -4204,6 +4205,11 @@ export class AgentSession {
 		hindsightState?.dispose();
 		const mnemopiState = setMnemopiSessionState(this, undefined);
 		await mnemopiState?.dispose();
+		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
+		// consolidate-on-dispose may still call `embed()` to store the final
+		// memories, and that round-trips through the worker we are about to
+		// hard-kill (issue #3031).
+		await shutdownMnemopiEmbedClient();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();

--- a/packages/coding-agent/test/issue-3031-repro.test.ts
+++ b/packages/coding-agent/test/issue-3031-repro.test.ts
@@ -17,7 +17,16 @@
  */
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { createMnemopiEmbedSubprocess, MNEMOPI_EMBED_WORKER_ARG } from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+import {
+	createMnemopiEmbedSubprocess,
+	MNEMOPI_EMBED_WORKER_ARG,
+	MnemopiEmbedClient,
+	type MnemopiEmbedWorkerHandle,
+} from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+import type {
+	MnemopiEmbedWorkerInbound,
+	MnemopiEmbedWorkerOutbound,
+} from "@oh-my-pi/pi-coding-agent/mnemopi/embed-protocol";
 
 describe("issue #3031 — mnemopi embeddings live in an isolated subprocess", () => {
 	it("ping/pongs through the spawned worker subprocess and tears it down cleanly", async () => {
@@ -117,5 +126,74 @@ describe("issue #3031 — mnemopi embeddings live in an isolated subprocess", ()
 			expect(source).not.toContain('"fastembed"');
 			expect(source).not.toContain('"onnxruntime-node"');
 		}
+	});
+	it("carries (model, cacheDir) on every embed so a respawned worker can self-init", async () => {
+		// Without this contract: after `shutdownMnemopiEmbedClient()` runs on
+		// session dispose, mnemopi still holds the cached `LocalEmbeddingModel`
+		// wrapper. The next embed re-spawns a fresh subprocess that has never
+		// seen `init`, and a bare `embed` request would trip the "embed before
+		// init" guard and break local embeddings for the rest of the process.
+		// Drive the protocol with a fake worker so the assertion runs without
+		// fastembed/onnxruntime; we only care about the IPC the client emits.
+		const sentMessages: MnemopiEmbedWorkerInbound[] = [];
+		let messageHandler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
+		const spawnCount = { value: 0 };
+		const spawn = (): MnemopiEmbedWorkerHandle => {
+			spawnCount.value += 1;
+			return {
+				send(message) {
+					sentMessages.push(message);
+					// Synthesize the worker's reply on the next tick so the
+					// client's awaited promise resolves before the test asserts.
+					queueMicrotask(() => {
+						if (message.type === "ping") messageHandler?.({ type: "pong", id: message.id });
+						else if (message.type === "init") messageHandler?.({ type: "ready", id: message.id });
+						else if (message.type === "embed") {
+							messageHandler?.({ type: "vectors", id: message.id, vectors: [[0, 0, 0]] });
+						}
+					});
+				},
+				onMessage(handler) {
+					messageHandler = handler;
+					return () => {
+						if (messageHandler === handler) messageHandler = undefined;
+					};
+				},
+				onError() {
+					return () => {};
+				},
+				async terminate() {
+					messageHandler = undefined;
+				},
+			};
+		};
+
+		const client = new MnemopiEmbedClient(spawn);
+		const wrapper = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+		expect(wrapper).not.toBeNull();
+
+		// Drain the wrapper once normally and snapshot the embed message.
+		for await (const _ of wrapper!.embed(["hello"])) {
+			/* drain */
+		}
+		// Tear down the worker as the session-dispose path does, then drive
+		// the SAME cached wrapper again — the client must re-spawn and the
+		// embed message must still carry (model, cacheDir).
+		await client.terminate();
+		for await (const _ of wrapper!.embed(["world"])) {
+			/* drain */
+		}
+
+		expect(spawnCount.value).toBe(2);
+		const embeds = sentMessages.filter(
+			(m): m is Extract<MnemopiEmbedWorkerInbound, { type: "embed" }> => m.type === "embed",
+		);
+		expect(embeds.length).toBe(2);
+		for (const embed of embeds) {
+			expect(embed.model).toBe("fast-bge-base-en-v1.5");
+			expect(embed.cacheDir).toBe("/tmp/cache");
+		}
+
+		await client.terminate();
 	});
 });

--- a/packages/coding-agent/test/issue-3031-repro.test.ts
+++ b/packages/coding-agent/test/issue-3031-repro.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/3031
+ *
+ * Mnemopi's local embedding provider used to `import("onnxruntime-node")` and
+ * `import("fastembed")` directly inside `fastembed-runtime.ts`. With
+ * `memory.backend: mnemopi` enabled on Windows that crashed Bun in two ways:
+ *   - Standalone binary: NAPI `process.dlopen` constructor segfault at
+ *     session start, before any prompt rendered.
+ *   - NPM install: NAPI finalizer segfault at process teardown.
+ *
+ * The fix relocates the embeddings stack into a Bun.spawn child process. The
+ * agent's main process hands `mnemopi.setLocalModelInitializer` a wrapper that
+ * round-trips through `__omp_worker_mnemopi_embed`, and `SIGKILL`s the child
+ * on dispose so the destructor never runs in either address space. These tests
+ * pin the three pieces of that contract so a future refactor cannot quietly
+ * re-introduce the crash.
+ */
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { createMnemopiEmbedSubprocess, MNEMOPI_EMBED_WORKER_ARG } from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+
+describe("issue #3031 — mnemopi embeddings live in an isolated subprocess", () => {
+	it("ping/pongs through the spawned worker subprocess and tears it down cleanly", async () => {
+		// `smokeTestMnemopiEmbedWorker` is the runtime probe wired into
+		// `omp --smoke-test`. Run it in a child Bun process instead of this
+		// Bun-test worker: the test runner owns its own IPC channel and can
+		// starve nested Bun subprocess IPC on some Bun builds.
+		const repoRoot = path.resolve(import.meta.dir, "../../..");
+		const script =
+			'const { smokeTestMnemopiEmbedWorker } = await import("@oh-my-pi/pi-coding-agent/mnemopi/embed-client"); await smokeTestMnemopiEmbedWorker({ timeoutMs: 15000 });';
+		const proc = Bun.spawn([process.execPath, "-e", script], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(`${stdout}${stderr}`).toBe("");
+		expect(exitCode).toBe(0);
+	}, 30_000);
+
+	it("CLI dispatches the flag that `embed-client.ts` passes to the spawned child", async () => {
+		// `mnemopiEmbedWorkerSpawnCmd()` and the cli switch must agree on the
+		// exact flag, character-for-character — the spawned `bun`/binary sees
+		// only `argv` and there is no fallback path that "re-routes" the
+		// worker on misnamed flags. Pin the spelling on both ends.
+		const cliSource = await Bun.file(new URL("../src/cli.ts", import.meta.url)).text();
+		expect(cliSource).toContain(`"${MNEMOPI_EMBED_WORKER_ARG}"`);
+		expect(cliSource).toContain("startMnemopiEmbedWorker");
+	});
+
+	it("surfaces unexpected signal exits so in-flight callers don't await forever", async () => {
+		// If the child dies from a signal we did NOT request — SIGSEGV from
+		// onnxruntime's NAPI fault (the original Windows shutdown bug, now
+		// relocated to the child), an OOM SIGKILL, or an operator `kill -9`
+		// — the subprocess wrapper must fault every in-flight request via
+		// the `errors` channel. Without this contract a `TinyTitleClient`-
+		// style swallow would leave callers waiting forever on `await embed`.
+		const sub = createMnemopiEmbedSubprocess();
+		try {
+			const { promise, resolve } = Promise.withResolvers<Error>();
+			sub.errors.add(resolve);
+			sub.proc.kill("SIGKILL");
+			const err = await promise;
+			expect(err.message).toMatch(/signal/i);
+		} finally {
+			try {
+				sub.proc.kill("SIGKILL");
+			} catch {}
+			await sub.proc.exited;
+		}
+	}, 15_000);
+
+	it("does not surface intentional terminate() SIGKILLs as worker errors", async () => {
+		// Inverse of the previous test: a SIGKILL issued by the wrapper's
+		// own `terminate()` MUST NOT fault callers — terminate is the
+		// shutdown path and the worker handle is already torn down by then.
+		// Regression guard against an over-eager fix that surfaces every
+		// signal exit indiscriminately.
+		const sub = createMnemopiEmbedSubprocess();
+		let errored = false;
+		sub.errors.add(() => {
+			errored = true;
+		});
+		// Simulate what `wrapSubprocess.terminate()` does: flip the flag,
+		// then SIGKILL. We test the primitive directly rather than going
+		// through the wrapper to avoid coupling to `WorkerHandle` internals.
+		// `proc.exited` resolves only after the `onExit` handler runs, so by
+		// the time the await returns the error channel reflects the truth —
+		// no real-clock sleep needed.
+		sub.intentionalExit.value = true;
+		sub.proc.kill("SIGKILL");
+		await sub.proc.exited;
+		expect(errored).toBe(false);
+	}, 10_000);
+
+	it("does not import fastembed-runtime from the main agent module graph", async () => {
+		// Issue #3031 caused: `mnemopi/state.ts` (or anything it transitively
+		// loaded) statically importing `core/fastembed-runtime`, which loads
+		// `onnxruntime-node` natively. Only the dedicated worker module is
+		// allowed to reach into that runtime. Scan the agent's mnemopi shim
+		// surface and the session entrypoint to lock the rule in.
+		const candidates = [
+			"../src/mnemopi/state.ts",
+			"../src/mnemopi/backend.ts",
+			"../src/mnemopi/embed-client.ts",
+			"../src/mnemopi/embed-protocol.ts",
+			"../src/session/agent-session.ts",
+			"../src/cli.ts",
+		];
+		for (const rel of candidates) {
+			const source = await Bun.file(new URL(rel, import.meta.url)).text();
+			expect(source).not.toContain("fastembed-runtime");
+			expect(source).not.toContain('"fastembed"');
+			expect(source).not.toContain('"onnxruntime-node"');
+		}
+	});
+});

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `setLocalModelInitializer` (and the `LocalEmbeddingModel`, `LocalModelInitializer`, `LocalModelInitOptions`, `StandardEmbeddingModel` types) so hosts can route fastembed loads through a dedicated subprocess and keep `onnxruntime-node`'s NAPI constructor + finalizer out of their own address space. Same wipe semantics as the existing `setLocalModelInitializerForTests` seam; the agent CLI uses it to crash-proof Windows when `memory.backend: mnemopi` is enabled ([#3031](https://github.com/can1357/oh-my-pi/issues/3031)).
+
 ## [16.0.6] - 2026-06-18
 
 ### Fixed

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -30,19 +30,19 @@ export interface EmbeddingProvider {
 	available?(): boolean | Promise<boolean>;
 }
 
-type StandardEmbeddingModel = Exclude<EmbeddingModel, EmbeddingModel.CUSTOM>;
+export type StandardEmbeddingModel = Exclude<EmbeddingModel, EmbeddingModel.CUSTOM>;
 
-interface LocalEmbeddingModel {
+export interface LocalEmbeddingModel {
 	embed(texts: string[], batchSize?: number): EmbeddingOutput;
 	queryEmbed?(query: string): Promise<number[]>;
 }
 
-type LocalModelInitOptions = {
+export type LocalModelInitOptions = {
 	model: StandardEmbeddingModel;
 	cacheDir?: string;
 	showDownloadProgress?: boolean;
 };
-type LocalModelInitializer = (options: LocalModelInitOptions) => Promise<LocalEmbeddingModel>;
+export type LocalModelInitializer = (options: LocalModelInitOptions) => Promise<LocalEmbeddingModel>;
 
 const QUERY_CACHE_MAX = 512;
 
@@ -323,6 +323,16 @@ export function setLocalModelInitializerForTests(initializer: LocalModelInitiali
 	localModelPromise = null;
 	queryCache.clear();
 }
+
+/**
+ * Override the function used to construct the local fastembed model the next
+ * time `embed()` is called. Lets a host (e.g. the agent CLI) keep
+ * `onnxruntime-node` out of its own address space by routing every fastembed
+ * load + inference through a dedicated subprocess. Same wipe semantics as the
+ * `*ForTests` form: clears the cached model promise and the query cache so
+ * subsequent embeds run through the new initializer immediately.
+ */
+export const setLocalModelInitializer = setLocalModelInitializerForTests;
 
 export function resetEmbeddingProviderForTests(): void {
 	providerOverride = null;

--- a/packages/mnemopi/src/core/index.ts
+++ b/packages/mnemopi/src/core/index.ts
@@ -1,6 +1,13 @@
 export { configureRecallFeatures, type RecallFeatureFlags } from "../config";
 export * from "./banks";
 export * from "./beam/index";
+export {
+	type LocalEmbeddingModel,
+	type LocalModelInitializer,
+	type LocalModelInitOptions,
+	type StandardEmbeddingModel,
+	setLocalModelInitializer,
+} from "./embeddings";
 export * from "./memory";
 export {
 	addMemory,


### PR DESCRIPTION
## Repro

With `memory.backend: mnemopi` enabled on Windows, the agent crashes the moment its main process touches mnemopi's local embedding provider — either at session start (standalone `omp.exe` binary, NAPI constructor segfault in `process.dlopen`) or at process teardown (`bun .../dist/cli.js` npm install, NAPI finalizer segfault). The Bun crash report fingers `onnxruntime_binding.node` in both modes. Reproduce by setting `memory.backend: mnemopi` in `~/.omp/agent/config.yml` and running `omp` on Windows; switching to `memory.backend: none` or `mnemopi.noEmbeddings: true` works around the crash.

## Cause

`packages/mnemopi/src/core/fastembed-runtime.ts` `await import("onnxruntime-node")` / `await import("fastembed")` runs inside the main agent process the first time `embed()` is called. That pulls the native NAPI module into the parent's address space, where its constructor + finalizer crash Bun on Windows. Same class of bug as #1606 (the tiny/STT/TTS workers were already moved out of process in #1607); mnemopi was the last consumer still loading ORT in the main process.

## Fix

Mirrors the #1607 pattern for mnemopi:

- `packages/coding-agent/src/mnemopi/embed-{protocol,worker,client}.ts` — new IPC protocol, child entry that calls `loadFastembed()` inside the subprocess, and parent client that wraps it as a `LocalEmbeddingModel`.
- `packages/coding-agent/src/cli.ts` — adds the `__omp_worker_mnemopi_embed` dispatch, runs it through the existing `runIpcSubprocessWorker` helper, and pings it from `omp --smoke-test`.
- `packages/coding-agent/src/mnemopi/state.ts` — on first `loadMnemopi()` / `loadMnemopiCore()`, installs the subprocess wrapper via `setLocalModelInitializer`. Single guard prevents double-install.
- `packages/coding-agent/src/session/agent-session.ts` — `shutdownMnemopiEmbedClient()` SIGKILLs the child after `mnemopiState.dispose()` so consolidate-on-dispose still gets to call `embed()`, but the NAPI finalizer never runs in the parent.
- `packages/mnemopi/src/core/embeddings.ts` (+ `core/index.ts`) — promotes the previously test-only `setLocalModelInitializerForTests` to a documented production seam (`setLocalModelInitializer`) and exports the `LocalEmbeddingModel` / `LocalModelInitializer` / `LocalModelInitOptions` / `StandardEmbeddingModel` types the host needs.
- `packages/coding-agent/test/issue-3031-repro.test.ts` — pins the spawn/dispatch contract, the intentional-vs-external SIGKILL distinction, and a static guard that no agent-surface file imports `fastembed-runtime` / `"fastembed"` / `"onnxruntime-node"`.
- Changelog entries in both packages.

## Verification

- `cd packages/coding-agent && bun run check` — passes.
- `cd packages/mnemopi && bun run check` — passes.
- `cd packages/coding-agent && bun test test/issue-3031-repro.test.ts test/issue-1606-repro.test.ts` — 9 pass, 0 fail (the new 5-case repro plus the existing tiny-model contract).
- `cd packages/coding-agent && bun -e 'const { smokeTestMnemopiEmbedWorker } = await import("./src/mnemopi/embed-client"); await smokeTestMnemopiEmbedWorker({ timeoutMs: 15000 });'` — smoke probe spawns the worker, ping/pongs, and tears it down cleanly.
- `cd packages/mnemopi && bun test test/embedding-failure-logging.test.ts test/embeddings-multilingual.test.ts test/fastembed-runtime.test.ts` — 9 pass, 0 fail (the embeddings seam I touched).
- Cross-platform note: cannot exercise Bun on Windows from this Linux runner; the regression test asserts the contract that prevented the crash (no fastembed/onnxruntime import on the agent surface, subprocess spawn + SIGKILL) rather than the Windows-specific segfault.

Fixes #3031