### PR TITLE
fix(coding-agent): delay image credential lookup until execution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed image tool registration resolving image provider credentials during session startup, so broken or slow `google-antigravity` OAuth state no longer blocks sessions that never invoke `generate_image` ([#3036](https://github.com/can1357/oh-my-pi/issues/3036)).
+
 ## [16.1.1] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1572,19 +1572,15 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 };
 
 export async function getImageGenTools(
-	modelRegistry?: ModelRegistry,
-	activeModel?: Model,
+	_modelRegistry?: ModelRegistry,
+	_activeModel?: Model,
 ): Promise<Array<CustomTool<typeof imageGenSchema, ImageGenToolDetails>>> {
-	const apiKey = await findImageApiKey(modelRegistry, activeModel);
-	if (!apiKey) return [];
 	return [imageGenTool];
 }
 
 export async function getImageGenToolsWithRegistry(
-	modelRegistry: ModelRegistry,
-	activeModel?: Model,
+	_modelRegistry: ModelRegistry,
+	_activeModel?: Model,
 ): Promise<Array<CustomTool<typeof imageGenSchema, ImageGenToolDetails>>> {
-	const apiKey = await findImageApiKey(modelRegistry, activeModel);
-	if (!apiKey) return [];
 	return [imageGenTool];
 }

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -4,7 +4,12 @@ import type { Model } from "@oh-my-pi/pi-ai";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import type { ReadonlySessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { imageGenTool, setPreferredImageProvider } from "@oh-my-pi/pi-coding-agent/tools/image-gen";
+import {
+	getImageGenTools,
+	getImageGenToolsWithRegistry,
+	imageGenTool,
+	setPreferredImageProvider,
+} from "@oh-my-pi/pi-coding-agent/tools/image-gen";
 
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
 const generatedImagePaths: string[] = [];
@@ -20,6 +25,45 @@ afterEach(async () => {
 });
 
 describe("imageGenTool", () => {
+	it("registers without resolving image provider credentials", async () => {
+		const modelRegistry = {
+			getApiKey: async () => {
+				throw new Error("active model credentials should not be resolved during registration");
+			},
+			getApiKeyForProvider: async () => {
+				throw new Error("provider credentials should not be resolved during registration");
+			},
+		} as unknown as ModelRegistry;
+
+		expect(await getImageGenTools(modelRegistry, undefined)).toEqual([imageGenTool]);
+		expect(await getImageGenToolsWithRegistry(modelRegistry, undefined)).toEqual([imageGenTool]);
+	});
+
+	it("resolves image provider credentials on execution", async () => {
+		setPreferredImageProvider("antigravity");
+		const ctx: CustomToolContext = {
+			fetch: async () => new Response(null),
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => undefined,
+				getApiKeyForProvider: async () => {
+					throw new Error("provider credentials resolved during execution");
+				},
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await expect(imageGenTool.execute("call-registration", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			"provider credentials resolved during execution",
+		);
+	});
+
 	it("e2e writes OpenAI Responses image_generation WebP output to a temp file", async () => {
 		let requestUrl: string | undefined;
 		let requestBody: unknown;


### PR DESCRIPTION
## Repro
`getImageGenTools(registry, undefined)` during session startup could be reproduced with a registry stub whose `getApiKeyForProvider("google-antigravity", ..., { modelId: "gemini-3-pro-image" })` throws; the command `bun --cwd packages/coding-agent --eval "$REPRO"` failed before any `generate_image` execution path ran.

## Cause
`packages/coding-agent/src/tools/image-gen.ts` used `findImageApiKey()` inside `getImageGenTools()` and `getImageGenToolsWithRegistry()`, so tool registration performed provider credential discovery. With `providers.image=auto`, that discovery includes the Antigravity credential path, which can refresh OAuth during `createAgentSession` startup.

## Fix
- Return `generate_image` from image tool registration without credential discovery.
- Leave `imageGenTool.execute()` as the credential-resolution boundary so missing or expired credentials surface only when image generation is invoked.
- Add regression coverage for lazy registration and execution-time credential lookup.
- Add the coding-agent changelog entry for #3036.

## Verification
`bun test packages/coding-agent/test/tools/image-gen.test.ts` passed with 4 tests. `bun --cwd packages/coding-agent run check` passed. The repro command now prints `registration returned generate_image` and an empty credential-call list. Fixes #3036