### PR TITLE
fix(coding-agent): auto-enable append-only context for Ollama and local servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama (and LM Studio / loopback llama.cpp / vLLM servers) reprocessing the full prompt on every turn because `provider.appendOnlyContext: auto` only recognized DeepSeek and Xiaomi as prefix-cache providers. The auto-detect now enables append-only mode for `ollama`, `ollama-cloud`, `lm-studio`, and any baseUrl resolving to a loopback/RFC1918/`.local` host, so the system prompt + tool catalogue + prior-turn message bytes stay byte-stable across turns and llama.cpp's KV-cache prefix reuse can hit ([#3033](https://github.com/can1357/oh-my-pi/issues/3033)).
+
 ## [16.1.1] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Ollama (and LM Studio / loopback llama.cpp / vLLM servers) reprocessing the full prompt on every turn because `provider.appendOnlyContext: auto` only recognized DeepSeek and Xiaomi as prefix-cache providers. The auto-detect now enables append-only mode for `ollama`, `ollama-cloud`, `lm-studio`, and any baseUrl resolving to a loopback/RFC1918/`.local` host, so the system prompt + tool catalogue + prior-turn message bytes stay byte-stable across turns and llama.cpp's KV-cache prefix reuse can hit ([#3033](https://github.com/can1357/oh-my-pi/issues/3033)).
+- Fixed Ollama, LM Studio, and llama.cpp (plus loopback vLLM / sglang servers) reprocessing the full prompt on every turn because `provider.appendOnlyContext: auto` only recognized DeepSeek and Xiaomi as prefix-cache providers. The auto-detect now enables append-only mode for `ollama`, `ollama-cloud`, `lm-studio`, `llama.cpp`, and any baseUrl resolving to a loopback/RFC1918/`.local` host, so the system prompt + tool catalogue + prior-turn message bytes stay byte-stable across turns and llama.cpp's KV-cache prefix reuse can hit ([#3033](https://github.com/can1357/oh-my-pi/issues/3033)).
 
 ## [16.1.1] - 2026-06-19
 

--- a/packages/coding-agent/src/config/append-only-context-mode.ts
+++ b/packages/coding-agent/src/config/append-only-context-mode.ts
@@ -8,10 +8,53 @@ export interface AppendOnlyContextModel {
 	compatConfig?: object;
 }
 
+/**
+ * Local model servers (Ollama, LM Studio, llama.cpp, vLLM, sglang, …) all
+ * rely on llama.cpp-style prefix KV-cache reuse: identical leading tokens
+ * skip re-prefill on the next request. Append-only mode is the only way to
+ * guarantee byte-stable bytes across turns, since the live system prompt,
+ * tool catalogue, and message log all flow through fresh allocations every
+ * step (see `agent-loop.ts` `streamAssistantResponse` fallback path).
+ */
+const LOCAL_INFERENCE_PROVIDERS = new Set(["ollama", "ollama-cloud", "lm-studio"]);
+
+/** True when `baseUrl` resolves to a loopback or RFC1918 host — the heuristic
+ * for user-defined providers (llama.cpp / vLLM via `models.yaml`) that omp
+ * has no provider id for. Substring match on parsed hostname only; ports,
+ * paths, and unparseable URLs return false.
+ */
+function hasLocalLoopbackBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	let hostname: string;
+	try {
+		hostname = new URL(baseUrl).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	if (
+		hostname === "localhost" ||
+		hostname === "127.0.0.1" ||
+		hostname === "0.0.0.0" ||
+		hostname === "::1" ||
+		hostname === "[::1]"
+	) {
+		return true;
+	}
+	// RFC1918 private IPv4 ranges.
+	if (/^10\./.test(hostname)) return true;
+	if (/^192\.168\./.test(hostname)) return true;
+	if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)) return true;
+	// Common ".local" mDNS hostnames used for home-LAN llama.cpp boxes.
+	if (hostname.endsWith(".local")) return true;
+	return false;
+}
+
 function shouldAutoEnableAppendOnlyContext(model: AppendOnlyContextModel | null | undefined): boolean {
 	if (!model) return false;
 	if (model.provider === "deepseek") return true;
+	if (LOCAL_INFERENCE_PROVIDERS.has(model.provider)) return true;
 	if (hostMatchesUrl(model.baseUrl, "xiaomi")) return true;
+	if (hasLocalLoopbackBaseUrl(model.baseUrl)) return true;
 	return !!model.compatConfig && "supportsStore" in model.compatConfig && model.compatConfig.supportsStore === true;
 }
 

--- a/packages/coding-agent/src/config/append-only-context-mode.ts
+++ b/packages/coding-agent/src/config/append-only-context-mode.ts
@@ -16,12 +16,14 @@ export interface AppendOnlyContextModel {
  * tool catalogue, and message log all flow through fresh allocations every
  * step (see `agent-loop.ts` `streamAssistantResponse` fallback path).
  */
-const LOCAL_INFERENCE_PROVIDERS = new Set(["ollama", "ollama-cloud", "lm-studio"]);
+const LOCAL_INFERENCE_PROVIDERS = new Set(["ollama", "ollama-cloud", "lm-studio", "llama.cpp"]);
 
-/** True when `baseUrl` resolves to a loopback or RFC1918 host — the heuristic
- * for user-defined providers (llama.cpp / vLLM via `models.yaml`) that omp
- * has no provider id for. Substring match on parsed hostname only; ports,
- * paths, and unparseable URLs return false.
+/** True when `baseUrl` resolves to a loopback or RFC1918 host — covers
+ * llama.cpp/vLLM/sglang servers registered under a user-defined provider id
+ * via `models.yaml`. Built-in local provider ids (`ollama`, `lm-studio`,
+ * `llama.cpp`) are already handled by `LOCAL_INFERENCE_PROVIDERS`.
+ * Substring match on the parsed hostname only; ports, paths, and unparseable
+ * URLs return false.
  */
 function hasLocalLoopbackBaseUrl(baseUrl: string | undefined): boolean {
 	if (!baseUrl) return false;

--- a/packages/coding-agent/test/append-only-context-mode.test.ts
+++ b/packages/coding-agent/test/append-only-context-mode.test.ts
@@ -41,4 +41,46 @@ describe("shouldEnableAppendOnlyContext", () => {
 	test("auto remains off for unknown providers without prefix-cache signals", () => {
 		expect(shouldEnableAppendOnlyContext("auto", GENERIC_PROXY)).toBe(false);
 	});
+
+	test("auto enables for local inference providers", () => {
+		// Ollama serves both `ollama-chat` (cloud-managed) and the openai-responses
+		// path used by locally pulled models — issue #3033 (llama.cpp KV-cache prefix
+		// resets every turn without append-only mode).
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "ollama", baseUrl: "http://127.0.0.1:11434" })).toBe(
+			true,
+		);
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "ollama-cloud", baseUrl: "https://ollama.com" })).toBe(
+			true,
+		);
+		expect(
+			shouldEnableAppendOnlyContext("auto", { provider: "lm-studio", baseUrl: "http://127.0.0.1:1234/v1" }),
+		).toBe(true);
+	});
+
+	test("auto enables for loopback and private baseUrls (user-defined llama.cpp/vLLM)", () => {
+		const cases: Array<{ provider: string; baseUrl: string }> = [
+			{ provider: "my-llamacpp", baseUrl: "http://localhost:8080/v1" },
+			{ provider: "my-vllm", baseUrl: "http://127.0.0.1:8000/v1" },
+			{ provider: "my-sglang", baseUrl: "http://[::1]:30000/v1" },
+			{ provider: "lan-host", baseUrl: "http://192.168.1.42:11434" },
+			{ provider: "lan-host", baseUrl: "http://10.0.0.5:11434" },
+			{ provider: "lan-host", baseUrl: "http://172.17.0.3:11434" },
+			{ provider: "mdns-host", baseUrl: "http://gpu-box.local:11434" },
+		];
+		for (const model of cases) {
+			expect(shouldEnableAppendOnlyContext("auto", model)).toBe(true);
+		}
+	});
+
+	test("auto stays off for public hosts that merely share an IP prefix", () => {
+		// 172.15.x.x sits just outside the RFC1918 16-31 band.
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "x", baseUrl: "http://172.15.0.1/v1" })).toBe(false);
+		// 172.32.x.x sits just outside the RFC1918 16-31 band on the other side.
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "x", baseUrl: "http://172.32.0.1/v1" })).toBe(false);
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "x", baseUrl: "https://example.com/v1" })).toBe(false);
+	});
+
+	test("malformed baseUrl never crashes the resolver", () => {
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "x", baseUrl: "not a url" })).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/append-only-context-mode.test.ts
+++ b/packages/coding-agent/test/append-only-context-mode.test.ts
@@ -55,6 +55,14 @@ describe("shouldEnableAppendOnlyContext", () => {
 		expect(
 			shouldEnableAppendOnlyContext("auto", { provider: "lm-studio", baseUrl: "http://127.0.0.1:1234/v1" }),
 		).toBe(true);
+		// `llama.cpp` is a built-in provider id (ModelRegistry registers it for keyless local discovery);
+		// the allowlist must catch it even when the user reverse-proxies the server through a public host.
+		expect(
+			shouldEnableAppendOnlyContext("auto", { provider: "llama.cpp", baseUrl: "https://llamacpp.example.com/v1" }),
+		).toBe(true);
+		expect(shouldEnableAppendOnlyContext("auto", { provider: "llama.cpp", baseUrl: "http://127.0.0.1:8080" })).toBe(
+			true,
+		);
 	});
 
 	test("auto enables for loopback and private baseUrls (user-defined llama.cpp/vLLM)", () => {


### PR DESCRIPTION
## Repro

Starting any chat session against an Ollama (or LM Studio / loopback llama.cpp / vLLM) endpoint and asking a few sequential questions: every turn forces a full prompt re-evaluation server-side instead of reusing the KV cache for the unchanged prefix. The behavior persists across simple turns, tool calls, and queued follow-up messages, even though the conversation grows strictly append-only from the user's perspective. Other clients (opencode, open-webui) keep the prefix warm against the same Ollama instance.

Setting `provider.appendOnlyContext: on` in `~/.omp/settings.json` fixes it; the default `auto` does not. Verified by reading the resolver:

```
$ bun -e 'import { shouldEnableAppendOnlyContext } from "./packages/coding-agent/src/config/append-only-context-mode.ts"; ...'
ollama (auto):       false
ollama-cloud (auto): false
lm-studio (auto):    false
deepseek (auto):     true
```

## Cause

`shouldAutoEnableAppendOnlyContext` in `packages/coding-agent/src/config/append-only-context-mode.ts` only recognized DeepSeek and Xiaomi Token Plan endpoints as "prefix-cache providers". Ollama and other local model servers, which rely on llama.cpp-style KV-cache prefix reuse for the same effect, fell through to `false`.

Without `AppendOnlyContextManager`, the agent loop's fallback path in `streamAssistantResponse` (`packages/agent/src/agent-loop.ts`) builds the per-turn `llmContext` from scratch:

```ts
llmContext = {
    systemPrompt: context.systemPrompt,
    messages: normalizedMessages,
    tools: normalizeTools(context.tools, !!config.intentTracing, exampleDialect, pruneToolDescriptions),
};
```

`normalizeTools` allocates fresh `Tool` records and re-runs `renderToolExamples` each call, `convertToLlm` reassembles every prior message, and `AgentSession.#buildSystemPromptForAgentStart` lets the memory backend append a per-turn block ahead of `agent.setSystemPrompt`. Any of these introducing even a single byte of drift breaks Ollama's prefix match and forces full re-prefill. The fix turns on the existing stable-prefix machinery (proven for DeepSeek) so the system prompt, tool catalogue, and prior-turn message bytes are snapshotted once and only the new tail is appended.

## Fix

- `packages/coding-agent/src/config/append-only-context-mode.ts`: extend the auto allowlist.
  - Add a `LOCAL_INFERENCE_PROVIDERS` set covering `ollama`, `ollama-cloud`, `lm-studio`.
  - Add `hasLocalLoopbackBaseUrl(baseUrl)` for user-defined providers (llama.cpp / vLLM via `models.yaml`): loopback (`localhost`/`127.0.0.1`/`0.0.0.0`/`::1`), RFC1918 private IPv4, and `.local` mDNS hostnames. Wrapped in `try { new URL(…) } catch`, so a malformed string returns `false` and never throws.
  - Preserve the existing `compat.supportsStore` opt-in and the explicit `provider.appendOnlyContext: on`/`off` overrides.
- `packages/coding-agent/test/append-only-context-mode.test.ts`: add regression cases for each new positive path (Ollama / LM Studio / loopback / RFC1918 / `.local`) plus negative samples (172.15.x and 172.32.x just outside the RFC1918 band, public hosts, malformed URLs).
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased]` → `### Fixed` entry referencing #3033.

## Verification

`bun test test/append-only-context-mode.test.ts` from `packages/coding-agent/` — 9/9 pass:

```
 9 pass
 0 fail
 20 expect() calls
Ran 9 tests across 1 file. [46.00ms]
```

`bun test` for `packages/agent` (295/295 pass) and the Ollama-touching tests in `packages/ai` / `packages/catalog` (30 tests, all green) confirm no regressions in the surrounding paths.

`bun check` on `packages/coding-agent` passes (`bun check: passed`, `root biome: ok`).

Two pre-existing failures in `packages/coding-agent/test/agent-session-retry-cap.test.ts` (account rate-limit credential switching) reproduce on `main` against this branch with the diff stashed; unrelated to this change.

Fixes #3033.