### PR TITLE
fix(lsp): answer server-initiated UI/refresh requests instead of erroring

### DIFF
--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -482,6 +482,33 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		await sendResponse(client, message.id, null, message.method);
 		return;
 	}
+	if (message.method === "window/showMessageRequest") {
+		// Server-initiated request asking the client to prompt the user with a set
+		// of actions. omp runs headless — there is no modal to surface — so answer
+		// with `null`, the spec-defined "no action selected" response. Returning
+		// `-32601` here is incorrect (this is a defined method) and some servers
+		// stall waiting on a real reply.
+		await sendResponse(client, message.id, null, message.method);
+		return;
+	}
+	if (message.method === "window/showDocument") {
+		// Server-initiated request asking the client to display a document. The
+		// agent drives no editor surface, so decline with `{ success: false }` —
+		// the spec requires the server to accept this and treat the doc as not
+		// shown — rather than erroring with `Method not found`.
+		await sendResponse(client, message.id, { success: false }, message.method);
+		return;
+	}
+	if (message.method.startsWith("workspace/") && message.method.endsWith("/refresh")) {
+		// `workspace/<feature>/refresh` requests (semanticTokens, inlayHint,
+		// codeLens, codeAction, diagnostic, …) ask the client to re-pull a feature.
+		// omp does not auto-refetch on server demand, but the request still
+		// requires a `null` (void) acknowledgement. These are defined methods, so
+		// `Method not found` is the wrong answer and can block servers that await
+		// the response before continuing.
+		await sendResponse(client, message.id, null, message.method);
+		return;
+	}
 	await sendResponse(client, message.id, null, message.method, {
 		code: -32601,
 		message: `Method not found: ${message.method}`,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -380,6 +380,68 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("answers server-initiated UI/refresh requests instead of returning Method not found", async () => {
+		// LSP defines several server->client requests beyond the configuration /
+		// workspaceFolders / applyEdit / registerCapability set. Answering them with
+		// `-32601 Method not found` is incorrect (they ARE defined methods) and can
+		// stall servers that block on a real reply — the same failure class as the
+		// registerCapability hang above. omp runs headless, so it cannot honour the
+		// UI surface, but it must still answer with the spec-correct no-op: `null`
+		// for showMessageRequest and the refresh family, `{ success: false }` for
+		// showDocument.
+		const tempDir = TempDir.createSync("@omp-lsp-server-requests-");
+		try {
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "initialized") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9101,
+						method: "window/showMessageRequest",
+						params: { type: 1, message: "Indexing workspace…", actions: [{ title: "Cancel" }] },
+					});
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9102,
+						method: "window/showDocument",
+						params: { uri: fileToUri(path.join(tempDir.path(), "README.md")) },
+					});
+					srv.send({ jsonrpc: "2.0", id: 9103, method: "workspace/semanticTokens/refresh" });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["ts"],
+				rootMarkers: [],
+			};
+
+			await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+
+			const showMsg = await server.waitFor(message => message.id === 9101 && message.method === undefined);
+			const showDoc = await server.waitFor(message => message.id === 9102 && message.method === undefined);
+			const refresh = await server.waitFor(message => message.id === 9103 && message.method === undefined);
+
+			// showMessageRequest: `null` == "no action selected", not a -32601 error.
+			expect(showMsg.error).toBeUndefined();
+			expect(showMsg.result).toBeNull();
+			// showDocument: `{ success: false }` == "not displayed", not a -32601 error.
+			expect(showDoc.error).toBeUndefined();
+			expect(showDoc.result).toEqual({ success: false });
+			// workspace/<feature>/refresh: `null` (void) acknowledgement.
+			expect(refresh.error).toBeUndefined();
+			expect(refresh.result).toBeNull();
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {


### PR DESCRIPTION
## Summary

`handleServerRequest` in `packages/coding-agent/src/lsp/client.ts` let several **defined** LSP server→client requests fall through to a `-32601 Method not found` error. That's the wrong answer for a defined method, and it's the same failure class as the `client/registerCapability` hang triaged in #3029 — some servers block on a real reply before proceeding. This handles the remaining ones:

- `window/showMessageRequest` → `null` (spec: "no action selected")
- `window/showDocument` → `{ success: false }` (spec: "not displayed")
- `workspace/<feature>/refresh` (semanticTokens, inlayHint, codeLens, codeAction, diagnostic, …) → `null` (void acknowledgement)

omp runs headless and can't honour the UI surface, so these answer with the spec-correct no-op instead of erroring. ~25 lines in `handleServerRequest` plus a regression test.

## Verification

- `bun test test/tools/lsp-regressions.test.ts` → **43 pass / 0 fail** (new case + existing #3029 case)
- `biome check` clean on both changed files
- native addon builds

## Notes

- Author is requesting a vouch in **Discussion #3039**; happy to address any scope feedback there or here (e.g. only patch the methods known to stall a specific server, or also surface the `window/showMessage` / `window/logMessage` notifications that are currently silently dropped).
- Refs #3029 (same bug class, now fixed for `client/registerCapability`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
