### PR TITLE
fix(mnemopi): use runtime remote LLM for extraction

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed background fact extraction skipping runtime-configured remote LLM endpoints when `MNEMOPI_LLM_BASE_URL` was unset, so `remember(..., { extract: true })` now stores remote-distilled facts from `mnemopi.llm` config instead of falling back to regex heuristics. ([#3041](https://github.com/can1357/oh-my-pi/issues/3041))
+
 ## [16.0.6] - 2026-06-18
 
 ### Fixed

--- a/packages/mnemopi/src/core/extraction.ts
+++ b/packages/mnemopi/src/core/extraction.ts
@@ -35,10 +35,6 @@ function hostLlmEnabled(): boolean {
 	return envBool("MNEMOPI_HOST_LLM_ENABLED", false);
 }
 
-function llmBaseUrl(): string {
-	return env("MNEMOPI_LLM_BASE_URL").replace(/\/+$/, "");
-}
-
 function llmMaxTokens(): number {
 	return envInt("MNEMOPI_LLM_MAX_TOKENS", 2048);
 }
@@ -301,23 +297,21 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 		return [];
 	}
 
-	if (llmEnabled() && llmBaseUrl() !== "") {
-		diag.recordAttempt("remote");
-		try {
-			const raw = await callRemoteLlm(prompt, 0, options);
-			if (raw !== null) {
-				const facts = parseFacts(cleanOutput(raw));
-				if (facts.length > 0) {
-					diag.recordSuccess("remote", facts.length);
-					diag.recordCall({ succeeded: true });
-					return facts;
-				}
+	diag.recordAttempt("remote");
+	try {
+		const raw = await callRemoteLlm(prompt, 0, options);
+		if (raw !== null) {
+			const facts = parseFacts(cleanOutput(raw));
+			if (facts.length > 0) {
+				diag.recordSuccess("remote", facts.length);
+				diag.recordCall({ succeeded: true });
+				return facts;
 			}
-			diag.recordNoOutput("remote");
-		} catch (exc) {
-			diag.recordFailure("remote", exc, "remote_call_raised");
-			console.warn(`extractFacts: remote LLM raised: ${safeForLog(exc)}`);
 		}
+		diag.recordNoOutput("remote");
+	} catch (exc) {
+		diag.recordFailure("remote", exc, "remote_call_raised");
+		console.warn(`extractFacts: remote LLM raised: ${safeForLog(exc)}`);
 	}
 
 	return localFallback(prompt, text, diag);

--- a/packages/mnemopi/test/extraction-wiring.test.ts
+++ b/packages/mnemopi/test/extraction-wiring.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { Mnemopi } from "@oh-my-pi/pi-mnemopi/core/memory";
 import type { MnemopiLlmCompletion } from "@oh-my-pi/pi-mnemopi/core/runtime-options";
 
@@ -45,6 +45,60 @@ describe("remember(extract) wires the LLM fact extractor", () => {
 		expect(calls).toBe(1);
 		expect(memory.beam.factRecall("coffee", 5).some(fact => fact.content.includes("coffee"))).toBe(true);
 		expect(memory.beam.factRecall("dark roast", 5).some(fact => fact.content.includes("dark roast"))).toBe(true);
+	});
+
+	it("uses a runtime-configured remote LLM in background extraction", async () => {
+		const previousEnabled = process.env.MNEMOPI_LLM_ENABLED;
+		const previousBaseUrl = process.env.MNEMOPI_LLM_BASE_URL;
+		let requestedUrl = "";
+		let requestedBody = "";
+		const fetchMock: typeof fetch = Object.assign(
+			(input: string | Request | URL, init?: BunFetchRequestInit | RequestInit) => {
+				requestedUrl = String(input);
+				requestedBody = typeof init?.body === "string" ? init.body : "";
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({ choices: [{ message: { content: '{"facts":["Remote runtime config fact"]}' } }] }),
+						{
+							status: 200,
+						},
+					),
+				);
+			},
+			{ preconnect: () => {} },
+		);
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+		try {
+			process.env.MNEMOPI_LLM_ENABLED = "true";
+			delete process.env.MNEMOPI_LLM_BASE_URL;
+			const memory = new Mnemopi({
+				sessionId: "extract-remote-runtime",
+				dbPath: ":memory:",
+				embeddings: false,
+				llm: {
+					enabled: true,
+					baseUrl: "http://remote.test/v1",
+					model: "remote-model",
+				},
+			});
+			instances.push(memory);
+
+			memory.remember("I prefer deterministic tests.", { source: "test", extract: true });
+			await memory.flushExtractions();
+
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			expect(requestedUrl).toBe("http://remote.test/v1/chat/completions");
+			expect(requestedBody).toContain('"model":"remote-model"');
+			expect(
+				memory.beam.factRecall("runtime config", 5).some(fact => fact.content === "Remote runtime config fact"),
+			).toBe(true);
+		} finally {
+			fetchSpy.mockRestore();
+			if (previousEnabled === undefined) delete process.env.MNEMOPI_LLM_ENABLED;
+			else process.env.MNEMOPI_LLM_ENABLED = previousEnabled;
+			if (previousBaseUrl === undefined) delete process.env.MNEMOPI_LLM_BASE_URL;
+			else process.env.MNEMOPI_LLM_BASE_URL = previousBaseUrl;
+		}
 	});
 
 	it("does not invoke the extractor when extract is not requested", async () => {


### PR DESCRIPTION
## Repro
With `MNEMOPI_LLM_BASE_URL` unset and `llm.baseUrl` supplied via runtime options, `bun --cwd packages/mnemopi -e "$REPRO_CODE"` returned `{"calls":0,"facts":["The user prefers deterministic tests"]}` and exited 1 because `extractFacts()` never called the mocked remote endpoint.

## Cause
`packages/mnemopi/src/core/extraction.ts` checked a local env-only `llmBaseUrl()` before calling `callRemoteLlm()`. `llmAvailable()` and `callRemoteLlm()` already resolve `getMnemopiRuntimeOptions()?.llm.baseUrl`, but the extra guard skipped that runtime-aware path whenever only `config.yml` supplied the remote URL.

## Fix
- Removed the duplicate env-only remote base URL guard from `extractFacts()` so the runtime-aware remote call path runs after `llmAvailable()` succeeds.
- Added background `remember(..., { extract: true })` coverage with `MNEMOPI_LLM_BASE_URL` unset and `llm.baseUrl` configured on the `Mnemopi` instance.
- Added the mnemopi changelog entry for #3041.

## Verification
`bun --cwd=packages/mnemopi run check` passed. `bun --cwd packages/mnemopi test test/extraction.test.ts test/extraction-wiring.test.ts && HOME=/tmp bun --cwd packages/mnemopi test test/local-llm.test.ts` passed. The original repro now returns `{"calls":1,"facts":["remote fact from runtime base"]}`. Fixes #3041