### PR TITLE
fix(lsp): reply to defined server requests with spec no-ops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LSP client returning `-32601 Method not found` for defined server→client requests (`window/showMessageRequest`, `window/showDocument`, `workspace/{semanticTokens,inlayHint,codeLens,codeAction,diagnostic}/refresh`). Servers that stall waiting for a real reply (same failure mode as #3029) now receive the spec no-op result ([#3044](https://github.com/can1357/oh-my-pi/issues/3044)).
+
 ## [16.1.1] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -482,6 +482,28 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		await sendResponse(client, message.id, null, message.method);
 		return;
 	}
+	if (message.method === "window/showMessageRequest") {
+		// Headless: no UI to surface the prompt. Spec says null = "no action selected".
+		await sendResponse(client, message.id, null, message.method);
+		return;
+	}
+	if (message.method === "window/showDocument") {
+		// Headless: nothing to display. Spec result is `{ success: boolean }`.
+		await sendResponse(client, message.id, { success: false }, message.method);
+		return;
+	}
+	if (
+		message.method === "workspace/semanticTokens/refresh" ||
+		message.method === "workspace/inlayHint/refresh" ||
+		message.method === "workspace/codeLens/refresh" ||
+		message.method === "workspace/codeAction/refresh" ||
+		message.method === "workspace/diagnostic/refresh"
+	) {
+		// Void acknowledgement per spec; servers that stall waiting for a reply
+		// (same failure mode as the dynamic-registration hang in #3029) move on.
+		await sendResponse(client, message.id, null, message.method);
+		return;
+	}
 	await sendResponse(client, message.id, null, message.method, {
 		code: -32601,
 		message: `Method not found: ${message.method}`,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -380,6 +380,67 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("answers defined server→client requests with spec no-op results", async () => {
+		// Same failure class as #3029: a defined server→client request
+		// (window/showMessage{Request}, window/showDocument, workspace/*/refresh)
+		// must receive a spec-shaped reply, not a -32601. Headless omp can't
+		// surface UI prompts but still owes a defined no-op.
+		const tempDir = TempDir.createSync("@omp-lsp-server-requests-");
+		try {
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "initialized") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9101,
+						method: "window/showMessageRequest",
+						params: { type: 1, message: "x", actions: [{ title: "Cancel" }] },
+					});
+					srv.send({
+						jsonrpc: "2.0",
+						id: 9102,
+						method: "window/showDocument",
+						params: { uri: "file:///tmp/a.md" },
+					});
+					srv.send({ jsonrpc: "2.0", id: 9103, method: "workspace/semanticTokens/refresh" });
+					srv.send({ jsonrpc: "2.0", id: 9104, method: "workspace/inlayHint/refresh" });
+					srv.send({ jsonrpc: "2.0", id: 9105, method: "workspace/codeLens/refresh" });
+					srv.send({ jsonrpc: "2.0", id: 9106, method: "workspace/diagnostic/refresh" });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["rs"],
+				rootMarkers: [],
+			};
+
+			await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+
+			const showMessage = await server.waitFor(message => message.id === 9101 && message.method === undefined);
+			expect(showMessage.error).toBeUndefined();
+			expect(showMessage.result).toBeNull();
+
+			const showDocument = await server.waitFor(message => message.id === 9102 && message.method === undefined);
+			expect(showDocument.error).toBeUndefined();
+			expect(showDocument.result).toEqual({ success: false });
+
+			for (const id of [9103, 9104, 9105, 9106]) {
+				const refresh = await server.waitFor(message => message.id === id && message.method === undefined);
+				expect(refresh.error).toBeUndefined();
+				expect(refresh.result).toBeNull();
+			}
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {


### PR DESCRIPTION
## Repro

Any LSP server that issues `window/showMessageRequest`, `window/showDocument`, or one of the `workspace/{semanticTokens,inlayHint,codeLens,codeAction,diagnostic}/refresh` server→client requests gets a `-32601 Method not found` instead of a defined reply. Servers that block on a real response — the same failure mode as the `client/registerCapability` hang fixed in [#3029](https://github.com/can1357/oh-my-pi/issues/3029) — stall waiting.

Drive `installFakeLsp` to send the offending requests right after `initialized` and observe the wire:

```
bun test test/tools/lsp-regressions.test.ts -t "answers defined server"
```

Pre-fix output for `window/showMessageRequest` (id 9101):

```json
{ "jsonrpc": "2.0", "id": 9101, "error": { "code": -32601, "message": "Method not found: window/showMessageRequest" } }
```

## Cause

`handleServerRequest` in `packages/coding-agent/src/lsp/client.ts` only branches on `workspace/configuration|workspaceFolders|applyEdit`, `window/workDoneProgress/create`, and `client/{,un}registerCapability`. Every other server→client request falls through to the final `sendResponse(client, message.id, null, message.method, { code: -32601, … })`. That is a protocol error for any of the defined methods listed above.

## Fix

- `packages/coding-agent/src/lsp/client.ts` — `handleServerRequest` now answers each defined method with its spec no-op:
  - `window/showMessageRequest` → `null` ("no action selected").
  - `window/showDocument` → `{ success: false }` ("not displayed").
  - `workspace/{semanticTokens,inlayHint,codeLens,codeAction,diagnostic}/refresh` → `null` (void acknowledgement).
- `packages/coding-agent/test/tools/lsp-regressions.test.ts` — new regression test reuses `installFakeLsp` to assert each wire reply.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] > Fixed` entry.

Unknown server-initiated methods still receive `-32601`; this only fixes the defined ones.

## Verification

```
cd packages/coding-agent && bun test test/tools/lsp-regressions.test.ts
# 43 pass, 0 fail, 152 expect() calls
```

The new test (`answers defined server→client requests with spec no-op results`) fails on `main` and passes here.

Fixes #3044