### PR TITLE
perf: reduce AgentSession memory — retention cap + task import redirects

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -523,6 +523,7 @@ memory:
 | `compaction.keepRecentTokens` | number | `20000` | Recent tokens always preserved. |
 | `compaction.remoteEnabled` | boolean | `true` | Allow remote compaction service. |
 | `compaction.autoContinue` | boolean | `true` | Continue automatically after compaction. |
+| `compaction.toolResultCapKb` | number | `0` | When `> 0`, truncate old tool-result text blocks beyond this KB limit in-place each turn (keeping the 3 most-recent full). Reduces retained session state. `0` = disabled. |
 | `memory.backend` | enum | `off` | `off`, `local`, `hindsight`, `mnemopi`. Each backend has its own `hindsight.*` / `mnemopi.*` / `memories.*` tuning keys. |
 | `autolearn.enabled` | boolean | `false` | Experimental: after the agent stops, nudge it to capture lessons to memory and create/enhance isolated managed skills under `~/.omp/agent/managed-skills`. Enables the `manage_skill` tool (and `learn` when a memory backend is active). |
 | `autolearn.autoContinue` | boolean | `false` | When `autolearn.enabled`, auto-run one capture turn at stop (uses extra tokens). Off = a passive reminder rides your next turn. |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -89,6 +89,10 @@
 
 - Added `compaction.toolResultCapKb` setting: when set above 0, truncates old tool-result text blocks beyond the specified KB limit in-place each turn (keeping the 3 most-recent results full). Reduces peak JS-heap usage by ~11% and retained session state by ~95% in long sessions with large tool outputs. Disabled by default (0). The cap mutates shared message objects directly — no `rewriteEntries`/`replaceMessages` rebuild overhead.
 
+### Changed
+
+- Lazy-loaded the `task` tool module (18MB of subagent machinery) so it only loads when the agent actually spawns a subagent, not on every session startup
+
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -87,11 +87,11 @@
 - Fixed LSP servers that dynamically register capabilities, including Expert, hanging semantic requests after `client/registerCapability` was rejected ([#3029](https://github.com/can1357/oh-my-pi/issues/3029)).
 ### Added
 
-- Added `compaction.toolResultCapKb` setting: when set above 0, truncates old tool-result text blocks beyond the specified KB limit in-place each turn (keeping the 3 most-recent results full). Reduces peak JS-heap usage by ~11% and retained session state by ~95% in long sessions with large tool outputs. Disabled by default (0). The cap mutates shared message objects directly — no `rewriteEntries`/`replaceMessages` rebuild overhead.
+- Added `compaction.toolResultCapKb` setting: when set above 0, truncates old tool-result text blocks beyond the specified KB limit in-place each turn (keeping the 3 most-recent results full). Reduces retained session state in long sessions with large tool outputs. Disabled by default (0). The cap mutates shared message objects directly — no `rewriteEntries`/`replaceMessages` rebuild overhead, and its estimated savings are deducted from the compaction threshold so it does not over-trigger.
 
 ### Changed
 
-- Lazy-loaded the `task` tool module (18MB of subagent machinery) so it only loads when the agent actually spawns a subagent, not on every session startup
+- Redirected `collab/host.ts` and `modes/session-observer-registry.ts` imports from the heavy `../task` barrel to the lightweight `../task/types` module, removing two eager import paths into the 18MB subagent machinery (MCPManager, model-resolver, theme, worktree isolation) for sessions that never spawn a subagent.
 
 ## [16.1.0] - 2026-06-19
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -85,6 +85,9 @@
 - Cache-miss marker no longer fires on providers with implicit, best-effort prompt caching (Google/Gemini, OpenAI, Fireworks). Those report `cacheWrite: 0` and drop `cacheRead` to zero intermittently as routine propagation noise that self-heals the next turn. Only explicit, prefix-controlled caches (Anthropic/Bedrock `cache_control`), which re-create the prefix on a cold turn as `cacheWrite > 0`, now surface a marker — where a zero `cacheRead` genuinely means the prefix broke.
 - Fixed advisor dependent settings staying visible while `advisor.enabled` is off ([#3027](https://github.com/can1357/oh-my-pi/issues/3027)).
 - Fixed LSP servers that dynamically register capabilities, including Expert, hanging semantic requests after `client/registerCapability` was rejected ([#3029](https://github.com/can1357/oh-my-pi/issues/3029)).
+### Added
+
+- Added `compaction.toolResultCapKb` setting: when set above 0, truncates old tool-result text blocks beyond the specified KB limit in-place each turn (keeping the 3 most-recent results full). Reduces peak JS-heap usage by ~11% and retained session state by ~95% in long sessions with large tool outputs. Disabled by default (0). The cap mutates shared message objects directly — no `rewriteEntries`/`replaceMessages` rebuild overhead.
 
 ## [16.1.0] - 2026-06-19
 

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -21,7 +21,7 @@ import { type AgentRef, AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "../session/agent-session";
 import { stripImagesFromMessage, USER_INTERRUPT_LABEL } from "../session/messages";
 import type { SessionEntry as StoredSessionEntry } from "../session/session-entries";
-import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task/types";
 import { generateRoomKey, generateWriteToken, importRoomKey } from "./crypto";
 import {
 	type AgentSnapshot,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1816,6 +1816,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"compaction.toolResultCapKb": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "context",
+			group: "Compaction",
+			label: "Tool Result Cap (KB)",
+			description: "Truncate old tool-result text blocks beyond this many KB, keeping the 3 most recent full. 0 = disabled. Reduces memory for long sessions.",
+		},
+	},
+
 	// Experimental: snapcompact inline imaging (transient, per-request; never persisted)
 	"snapcompact.systemPrompt": {
 		type: "enum",
@@ -4582,6 +4593,7 @@ export interface CompactionSettings {
 	idleTimeoutSeconds: number;
 	supersedeReads: boolean;
 	dropUseless: boolean;
+	toolResultCapKb: number;
 }
 
 export interface ContextPromotionSettings {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1823,7 +1823,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "context",
 			group: "Compaction",
 			label: "Tool Result Cap (KB)",
-			description: "Truncate old tool-result text blocks beyond this many KB, keeping the 3 most recent full. 0 = disabled. Reduces memory for long sessions.",
+			description:
+				"Truncate old tool-result text blocks beyond this many KB, keeping the 3 most recent full. 0 = disabled. Reduces memory for long sessions.",
 		},
 	},
 

--- a/packages/coding-agent/src/modes/session-observer-registry.ts
+++ b/packages/coding-agent/src/modes/session-observer-registry.ts
@@ -1,5 +1,5 @@
-import type { AgentProgress, SubagentLifecyclePayload, SubagentProgressPayload } from "../task";
-import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task";
+import type { AgentProgress, SubagentLifecyclePayload, SubagentProgressPayload } from "../task/types";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task/types";
 import type { EventBus } from "../utils/event-bus";
 
 export interface ObservableSession {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5880,6 +5880,9 @@ export class AgentSession {
 			// next microtask alongside the new turn.
 			const lastAssistant = this.#findLastAssistantMessage();
 			if (lastAssistant && !options?.skipCompactionCheck) {
+				// Apply the retention cap before the pre-prompt compaction check so
+				// threshold detection reflects already-truncated tool results.
+				this.#applyRetentionCap();
 				await this.#checkCompaction(lastAssistant, false, false, false);
 			}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2800,7 +2800,8 @@ export class AgentSession {
 			}
 			this.#resolveRetry();
 
-			const compactionTask = this.#checkCompaction(msg);
+			this.#applyRetentionCap();
+		const compactionTask = this.#checkCompaction(msg);
 			this.#trackPostPromptTask(compactionTask);
 			const compactionResult = await compactionTask;
 			// Check for incomplete todos only after a final assistant stop, not intermediate tool-use turns.
@@ -7367,6 +7368,34 @@ export class AgentSession {
 	#withPlanProtection<T extends { protectedTools: ProtectedToolMatcher[] }>(config: T): T {
 		const planMatcher = createPlanReadMatcher(() => this.#planReferencePath);
 		return { ...config, protectedTools: [...config.protectedTools, planMatcher] };
+	}
+
+	/**
+	 * Lightweight in-place retention cap: truncates old tool-result text blocks
+	 * that exceed the configured KB limit, keeping the 3 most-recent results full.
+	 * Runs every turn before #checkCompaction. Unlike #pruneToolOutputs, this does
+	 * NOT call rewriteEntries/replaceMessages — it mutates the shared message
+	 * objects in-place (agent.state.messages and sessionManager branch entries
+	 * share the same references), so there is no rebuild overhead.
+	 */
+	#applyRetentionCap(): void {
+		const capKb = this.settings.getGroup("compaction").toolResultCapKb;
+		if (!capKb || capKb <= 0) return;
+		const capBytes = capKb * 1024;
+		const keepCount = 3;
+		const messages = this.agent.state.messages;
+		let toolResultCount = 0;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const msg = messages[i];
+			if (msg.role !== "toolResult" || !Array.isArray(msg.content)) continue;
+			toolResultCount++;
+			if (toolResultCount <= keepCount) continue;
+			for (const block of msg.content) {
+				if (block.type === "text" && block.text.length > capBytes) {
+					block.text = `[truncated — ${block.text.length} bytes]`;
+				}
+			}
+		}
 	}
 
 	async #pruneToolOutputs(): Promise<{ prunedCount: number; tokensSaved: number } | undefined> {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1250,6 +1250,8 @@ export class AgentSession {
 	#reloadSshTool: (() => Promise<AgentTool | null>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
+	/** Token savings from the most recent #applyRetentionCap run; consumed by #checkCompaction's threshold path. */
+	#retentionCapTokensSaved: number = 0;
 	#baseSystemPrompt: string[];
 	/**
 	 * Signature of the (toolNames, tool descriptions) tuple passed to the most
@@ -2801,7 +2803,7 @@ export class AgentSession {
 			this.#resolveRetry();
 
 			this.#applyRetentionCap();
-		const compactionTask = this.#checkCompaction(msg);
+			const compactionTask = this.#checkCompaction(msg);
 			this.#trackPostPromptTask(compactionTask);
 			const compactionResult = await compactionTask;
 			// Check for incomplete todos only after a final assistant stop, not intermediate tool-use turns.
@@ -7369,7 +7371,6 @@ export class AgentSession {
 		const planMatcher = createPlanReadMatcher(() => this.#planReferencePath);
 		return { ...config, protectedTools: [...config.protectedTools, planMatcher] };
 	}
-
 	/**
 	 * Lightweight in-place retention cap: truncates old tool-result text blocks
 	 * that exceed the configured KB limit, keeping the 3 most-recent results full.
@@ -7377,14 +7378,21 @@ export class AgentSession {
 	 * NOT call rewriteEntries/replaceMessages — it mutates the shared message
 	 * objects in-place (agent.state.messages and sessionManager branch entries
 	 * share the same references), so there is no rebuild overhead.
+	 *
+	 * Stores the estimated token savings on #retentionCapTokensSaved so the
+	 * threshold path in #checkCompaction can deduct them from the usage-derived
+	 * context estimate; otherwise compaction could over-trigger on a context
+	 * that the cap has already shrunk below threshold.
 	 */
 	#applyRetentionCap(): void {
+		this.#retentionCapTokensSaved = 0;
 		const capKb = this.settings.getGroup("compaction").toolResultCapKb;
 		if (!capKb || capKb <= 0) return;
 		const capBytes = capKb * 1024;
 		const keepCount = 3;
 		const messages = this.agent.state.messages;
 		let toolResultCount = 0;
+		let bytesSaved = 0;
 		for (let i = messages.length - 1; i >= 0; i--) {
 			const msg = messages[i];
 			if (msg.role !== "toolResult" || !Array.isArray(msg.content)) continue;
@@ -7392,10 +7400,14 @@ export class AgentSession {
 			if (toolResultCount <= keepCount) continue;
 			for (const block of msg.content) {
 				if (block.type === "text" && block.text.length > capBytes) {
-					block.text = `[truncated — ${block.text.length} bytes]`;
+					const notice = `[truncated — ${block.text.length} bytes]`;
+					bytesSaved += block.text.length - notice.length;
+					block.text = notice;
 				}
 			}
 		}
+		// 4 chars/token matches the estimate used by compaction's prune savings.
+		this.#retentionCapTokensSaved = Math.ceil(bytesSaved / 4);
 	}
 
 	async #pruneToolOutputs(): Promise<{ prunedCount: number; tokensSaved: number } | undefined> {
@@ -8237,6 +8249,13 @@ export class AgentSession {
 		}
 		if (pruneResult) {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
+		}
+		// Deduct the in-place retention cap's savings (set by #applyRetentionCap)
+		// so threshold compaction reflects the already-shrunk context. Not reset
+		// here — the pre-prompt #checkCompaction call also needs the savings.
+		// Cleared naturally on the next #applyRetentionCap run.
+		if (this.#retentionCapTokensSaved > 0) {
+			contextTokens = Math.max(0, contextTokens - this.#retentionCapTokensSaved);
 		}
 		if (shouldCompact(contextTokens, contextWindow, compactionSettings)) {
 			// Try promotion first — if a larger model is available, switch instead of compacting

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -24,7 +24,14 @@ import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
 import type { UsageStatistics } from "../session/session-entries";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
-import { TaskTool } from "../task";
+// Lazy-loaded: TaskTool pulls in 18MB of subagent machinery (MCPManager,
+// model-resolver, theme, worktree isolation). Only loaded when the
+// agent actually spawns a subagent, not every session.
+let TaskToolCtor: typeof import("../task").TaskTool | undefined;
+async function getTaskTool() {
+	if (!TaskToolCtor) TaskToolCtor = (await import("../task")).TaskTool;
+	return TaskToolCtor;
+}
 import type { AgentOutputManager } from "../task/output-manager";
 import { canSpawnAtDepth } from "../task/types";
 import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "../tool-discovery/mode";
@@ -69,7 +76,8 @@ export * from "../edit";
 export * from "../goals";
 export * from "../lsp";
 export * from "../session/streaming-output";
-export * from "../task";
+// Lazy: task module (18MB) loads on first use, not at import.
+// Consumers that need TaskTool types use `import type` which is erased at runtime.
 export * from "../web/search";
 export * from "./ask";
 export * from "./ast-edit";
@@ -445,7 +453,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	browser: s => new BrowserTool(s),
 	checkpoint: CheckpointTool.createIf,
 	rewind: RewindTool.createIf,
-	task: s => TaskTool.create(s),
+	task: async s => (await getTaskTool()).create(s),
 	job: s => new JobTool(s),
 	irc: IrcTool.createIf,
 	todo: s => new TodoTool(s),

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -24,14 +24,7 @@ import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
 import type { UsageStatistics } from "../session/session-entries";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
-// Lazy-loaded: TaskTool pulls in 18MB of subagent machinery (MCPManager,
-// model-resolver, theme, worktree isolation). Only loaded when the
-// agent actually spawns a subagent, not every session.
-let TaskToolCtor: typeof import("../task").TaskTool | undefined;
-async function getTaskTool() {
-	if (!TaskToolCtor) TaskToolCtor = (await import("../task")).TaskTool;
-	return TaskToolCtor;
-}
+import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
 import { canSpawnAtDepth } from "../task/types";
 import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "../tool-discovery/mode";
@@ -76,8 +69,7 @@ export * from "../edit";
 export * from "../goals";
 export * from "../lsp";
 export * from "../session/streaming-output";
-// Lazy: task module (18MB) loads on first use, not at import.
-// Consumers that need TaskTool types use `import type` which is erased at runtime.
+export * from "../task";
 export * from "../web/search";
 export * from "./ask";
 export * from "./ast-edit";
@@ -453,7 +445,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	browser: s => new BrowserTool(s),
 	checkpoint: CheckpointTool.createIf,
 	rewind: RewindTool.createIf,
-	task: async s => (await getTaskTool()).create(s),
+	task: s => TaskTool.create(s),
 	job: s => new JobTool(s),
 	irc: IrcTool.createIf,
 	todo: s => new TodoTool(s),

--- a/packages/coding-agent/test/agent-session-retention-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retention-cap.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+// The retention cap (`compaction.toolResultCapKb`) mutates old tool-result text
+// blocks in-place each turn, keeping the 3 most-recent results full. This test
+// pins that contract: old oversized results are truncated to a notice while the
+// keep-count window stays intact, and the cap is a no-op when set to 0.
+
+const CAP_KB = 5; // 5 KB → 5120 bytes
+const CAP_BYTES = CAP_KB * 1024;
+const KEEP_COUNT = 3;
+
+function makeToolResult(text: string): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId: `call_${Math.random().toString(36).slice(2)}`,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	} as AgentMessage;
+}
+
+function makeAssistant(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/** A large payload well over the cap so truncation is unambiguous. */
+function largePayload(label: string): string {
+	return `${label}: ${"x".repeat(CAP_BYTES * 4)}`;
+}
+
+function toolResultText(msg: AgentMessage): string {
+	if (msg.role !== "toolResult" || !Array.isArray(msg.content)) return "";
+	const block = msg.content.find((b): b is { type: "text"; text: string } => b.type === "text");
+	return block?.text ?? "";
+}
+
+function toolResultMessages(messages: AgentMessage[]): AgentMessage[] {
+	return messages.filter(m => m.role === "toolResult");
+}
+
+describe("AgentSession retention cap (compaction.toolResultCapKb)", () => {
+	let tempDir: TempDir;
+	const cleanups: Array<() => Promise<void>> = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-retention-cap-");
+		cleanups.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const cleanup of cleanups) await cleanup();
+		cleanups.length = 0;
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	async function createSession(
+		messages: AgentMessage[],
+		settingsOverride: Record<string, unknown> = {},
+	): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"compaction.toolResultCapKb": CAP_KB,
+			"todo.enabled": false,
+			...settingsOverride,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+
+		const mockBash: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock",
+			parameters: type({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		};
+
+		const session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model, systemPrompt: ["Test"], tools: [mockBash], messages },
+				convertToLlm,
+				// Mock model returns a text-only assistant turn (no tool calls),
+				// so the agent settles after one turn and #applyRetentionCap runs
+				// during the agent_end maintenance path before prompt() resolves.
+				streamFn: () => {
+					const response = makeAssistant("done");
+					const stream = new AssistantMessageEventStream();
+					queueMicrotask(() => {
+						stream.push({ type: "start", partial: response });
+						stream.push({ type: "done", reason: "stop", message: response });
+					});
+					return stream;
+				},
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry: new Map<string, AgentTool>([[mockBash.name, mockBash]]),
+		});
+		cleanups.push(async () => {
+			await session.dispose();
+			authStorage.close();
+		});
+		return session;
+	}
+
+	it("truncates old oversized tool results beyond the keep-count window", async () => {
+		// 5 large tool results: the 3 most-recent stay full, the 2 oldest are capped.
+		const messages: AgentMessage[] = [
+			makeAssistant("a1"),
+			makeToolResult(largePayload("old-1")),
+			makeAssistant("a2"),
+			makeToolResult(largePayload("old-2")),
+			makeAssistant("a3"),
+			makeToolResult(largePayload("recent-3")),
+			makeAssistant("a4"),
+			makeToolResult(largePayload("recent-4")),
+			makeAssistant("a5"),
+			makeToolResult(largePayload("recent-5")),
+		];
+		const session = await createSession(messages);
+
+		// Drive a full turn; when prompt() resolves, the agent_end maintenance
+		// path (including #applyRetentionCap) has completed.
+		await session.prompt("continue");
+
+		const result = toolResultMessages(session.agent.state.messages);
+		expect(result.length).toBe(5);
+
+		// Most-recent KEEP_COUNT (3) are untouched.
+		const recent = result.slice(-KEEP_COUNT);
+		for (const msg of recent) {
+			const text = toolResultText(msg);
+			expect(text.startsWith("recent-")).toBe(true);
+			expect(text.length).toBeGreaterThan(CAP_BYTES);
+		}
+
+		// The 2 oldest are truncated to a notice shorter than the cap.
+		const old = result.slice(0, -KEEP_COUNT);
+		for (const msg of old) {
+			const text = toolResultText(msg);
+			expect(text.startsWith("[truncated —")).toBe(true);
+			expect(text.length).toBeLessThan(CAP_BYTES);
+		}
+	});
+
+	it("is a no-op when the cap is 0 (disabled)", async () => {
+		const payload = largePayload("keep-me");
+		const messages: AgentMessage[] = [
+			makeAssistant("a1"),
+			makeToolResult(payload),
+			makeAssistant("a2"),
+			makeToolResult(payload),
+			makeAssistant("a3"),
+			makeToolResult(payload),
+			makeAssistant("a4"),
+			makeToolResult(payload),
+		];
+		const session = await createSession(messages, { "compaction.toolResultCapKb": 0 });
+
+		await session.prompt("continue");
+
+		for (const msg of toolResultMessages(session.agent.state.messages)) {
+			expect(toolResultText(msg)).toBe(payload);
+		}
+	});
+
+	it("leaves tool results under the cap untouched even when old", async () => {
+		const small = "small result";
+		const messages: AgentMessage[] = [
+			makeAssistant("a1"),
+			makeToolResult(small),
+			makeAssistant("a2"),
+			makeToolResult(small),
+			makeAssistant("a3"),
+			makeToolResult(small),
+			makeAssistant("a4"),
+			makeToolResult(small),
+		];
+		const session = await createSession(messages);
+
+		await session.prompt("continue");
+
+		for (const msg of toolResultMessages(session.agent.state.messages)) {
+			expect(toolResultText(msg)).toBe(small);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Two memory-reduction changes for `AgentSession`, addressing review feedback from the prior close:

### 1. Retention cap (`compaction.toolResultCapKb` setting)

`AgentSession.#applyRetentionCap()` runs before `#checkCompaction` each turn. When `compaction.toolResultCapKb > 0`, truncates old tool-result text blocks (beyond the 3 most-recent) to a `[truncated]` notice. Mutates shared message objects in-place — `agent.state.messages` and `sessionManager` branch entries share the same object references, so the mutation propagates to both with zero `rewriteEntries`/`replaceMessages` overhead.

The cap's estimated token savings are tracked and deducted from the compaction threshold in `#checkCompaction`, so the cap does not cause compaction to over-trigger on an already-shrunk context (fixes P2 review comment).

Disabled by default (0). Users can enable it in Settings → Context → Compaction → Tool Result Cap (KB).

### 2. Task barrel import redirects

`collab/host.ts` and `modes/session-observer-registry.ts` previously imported `TASK_SUBAGENT_*_CHANNEL` constants from the heavy `../task` barrel (58KB index.ts pulling in MCPManager, model-resolver, theme, worktree isolation). Redirected both to the lightweight `../task/types` module where the channels are actually defined. This removes two eager import paths into the subagent machinery for sessions that never spawn a subagent.

### What changed from the prior close

- **Reverted the lazy TaskTool loader** (P1: `AGENTS.md` forbids `await import()` in the coding-agent package; the lazy loader used both `await import()` and `typeof import("../task").TaskTool`). The deferral was never realized anyway — the factory still ran eagerly via `createTools`. Restored the static `import { TaskTool } from "../task"` and sync factory `task: s => TaskTool.create(s)`.
- **Fixed indentation regression** on the `#checkCompaction(msg)` call site (lost a tab in the prior edit).
- **Added compaction pressure fix** (P2): `#applyRetentionCap` now returns estimated token savings, deducted in the threshold path so compaction reflects the already-shrunk context.

## Type safety

- `CompactionSettings` interface has `toolResultCapKb: number`
- `settings-schema.ts` has the new setting with UI metadata
- `tsgo --noEmit` passes for `@oh-my-pi/pi-coding-agent`

## Test

Added `agent-session-retention-cap.test.ts` — three contract tests pinning the cap's observable behavior:
- Truncates old oversized tool results beyond the keep-count window (3 most-recent stay full)
- No-op when cap is 0 (disabled)
- Leaves tool results under the cap untouched even when old