### PR TITLE
fix(prompting): render SYSTEM.md through custom prompt template

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `SYSTEM.md` prompt customization going through the raw system prompt override path, which dropped sections rendered by `custom-system-prompt.md` such as skills and rules ([#3014](https://github.com/can1357/oh-my-pi/issues/3014)).
+
 ## [16.0.10] - 2026-06-18
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -748,6 +748,20 @@ function discoverAppendSystemPromptFile(): string | undefined {
 	return undefined;
 }
 
+/** Apply resolved CLI/discovered prompt files without bypassing system prompt templates. */
+export function applyResolvedSystemPromptInputs(
+	options: CreateAgentSessionOptions,
+	resolvedSystemPrompt: string | undefined,
+	resolvedAppendPrompt: string | undefined,
+): void {
+	if (resolvedSystemPrompt) {
+		options.customSystemPrompt = resolvedSystemPrompt;
+	}
+	if (resolvedAppendPrompt) {
+		options.appendSystemPrompt = resolvedAppendPrompt;
+	}
+}
+
 async function buildSessionOptions(
 	parsed: Args,
 	scopedModels: ScopedModel[],
@@ -872,13 +886,7 @@ async function buildSessionOptions(
 	// (handled by caller before createAgentSession)
 
 	// System prompt
-	if (resolvedSystemPrompt && resolvedAppendPrompt) {
-		options.systemPrompt = defaultPrompt => [resolvedSystemPrompt, resolvedAppendPrompt, ...defaultPrompt.slice(1)];
-	} else if (resolvedSystemPrompt) {
-		options.systemPrompt = defaultPrompt => [resolvedSystemPrompt, ...defaultPrompt.slice(1)];
-	} else if (resolvedAppendPrompt) {
-		options.systemPrompt = defaultPrompt => [...defaultPrompt, resolvedAppendPrompt];
-	}
+	applyResolvedSystemPromptInputs(options, resolvedSystemPrompt, resolvedAppendPrompt);
 
 	// Tools
 	if (parsed.noTools) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -405,8 +405,12 @@ export interface CreateAgentSessionOptions {
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 
-	/** System prompt blocks. Array replaces default, function receives default blocks and returns final blocks. */
+	/** Provider-facing system prompt override. Replaces the fully rendered default blocks. */
 	systemPrompt?: string | string[] | ((defaultPrompt: string[]) => string | string[]);
+	/** Custom base prompt rendered through the bundled custom system prompt template. */
+	customSystemPrompt?: string;
+	/** Text appended through the bundled system prompt templates. */
+	appendSystemPrompt?: string;
 	/** Optional provider-facing session identifier for prompt caches and sticky auth selection.
 	 * Keeps persisted session files isolated while reusing provider-side caches. */
 	providerSessionId?: string;
@@ -837,6 +841,7 @@ export interface BuildSystemPromptOptions {
 	skills?: Skill[];
 	contextFiles?: Array<{ path: string; content: string }>;
 	cwd?: string;
+	customPrompt?: string;
 	appendPrompt?: string;
 	repeatToolDescriptions?: boolean;
 }
@@ -850,6 +855,7 @@ export interface BuildSystemPromptOptions {
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
 	return await buildSystemPromptInternal({
 		cwd: options.cwd,
+		customPrompt: options.customPrompt,
 		skills: options.skills,
 		contextFiles: options.contextFiles,
 		appendSystemPrompt: options.appendPrompt,
@@ -2201,15 +2207,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Owned/in-band tool dialect (non-native) repeats the catalog as `# Tool:`
 			// sections; native tool calling lets the compact name list suffice.
 			const nativeTools = resolveDialect(settings.get("tools.format"), agent?.state.model ?? model) === undefined;
+			if (options.appendSystemPrompt) {
+				appendPrompt = appendPrompt
+					? `${appendPrompt}\n\n${options.appendSystemPrompt}`
+					: options.appendSystemPrompt;
+			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd,
+				customPrompt: options.customSystemPrompt,
 				skills,
 				contextFiles,
 				tools: promptTools,
 				toolNames,
 				rules: rulebookRules,
 				alwaysApplyRules,
-				skillsSettings: settings.getGroup("skills"),
 				appendSystemPrompt: appendPrompt,
 				repeatToolDescriptions,
 				nativeTools,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -407,9 +407,9 @@ export interface CreateAgentSessionOptions {
 
 	/** Provider-facing system prompt override. Replaces the fully rendered default blocks. */
 	systemPrompt?: string | string[] | ((defaultPrompt: string[]) => string | string[]);
-	/** Custom base prompt rendered through the bundled custom system prompt template. */
+	/** Already-loaded custom prompt text rendered through the bundled custom system prompt template. */
 	customSystemPrompt?: string;
-	/** Text appended through the bundled system prompt templates. */
+	/** Already-loaded text appended through the bundled system prompt templates. */
 	appendSystemPrompt?: string;
 	/** Optional provider-facing session identifier for prompt caches and sticky auth selection.
 	 * Keeps persisted session files isolated while reusing provider-side caches. */
@@ -2214,14 +2214,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd,
-				customPrompt: options.customSystemPrompt,
+				resolvedCustomPrompt: options.customSystemPrompt,
 				skills,
 				contextFiles,
 				tools: promptTools,
 				toolNames,
 				rules: rulebookRules,
 				alwaysApplyRules,
-				appendSystemPrompt: appendPrompt,
+				resolvedAppendSystemPrompt: appendPrompt,
 				repeatToolDescriptions,
 				nativeTools,
 				intentField,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -505,9 +505,15 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		return result.value;
 	}
 
-	const systemPromptCustomizationPromise = logger.time("loadSystemPromptFiles", loadSystemPromptFiles, {
-		cwd: resolvedCwd,
-	});
+	// Caller-supplied `customPrompt` / `resolvedCustomPrompt` owns block 0; the
+	// secondary capability-path `SYSTEM.md` walk-up MUST NOT silently augment it,
+	// because that would defeat CLI precedence over project/user `SYSTEM.md`.
+	const callerControlsCustomPrompt =
+		(typeof providedResolvedCustomPrompt === "string" && providedResolvedCustomPrompt.length > 0) ||
+		(typeof customPrompt === "string" && customPrompt.length > 0);
+	const systemPromptCustomizationPromise: Promise<string | null> = callerControlsCustomPrompt
+		? Promise.resolve(null)
+		: logger.time("loadSystemPromptFiles", loadSystemPromptFiles, { cwd: resolvedCwd });
 	const contextFilesPromise = providedContextFiles
 		? Promise.resolve(providedContextFiles)
 		: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -677,7 +677,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	};
 	const rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 	const systemPrompt = [rendered];
-	const projectPrompt = resolvedCustomPrompt ? "" : prompt.render(projectPromptTemplate, data).trim();
+	// Custom prompt templates already render context files and append text; the
+	// project footer still carries environment, cwd, workspace, and dir-context.
+	const projectPrompt = prompt
+		.render(projectPromptTemplate, resolvedCustomPrompt ? { ...data, contextFiles: [], appendPrompt: "" } : data)
+		.trim();
 	if (projectPrompt) {
 		systemPrompt.push(projectPrompt);
 	}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -367,12 +367,16 @@ export function buildSystemPromptToolMetadata(
 export interface BuildSystemPromptOptions {
 	/** Custom system prompt (replaces default). */
 	customPrompt?: string;
+	/** Already-loaded custom system prompt text; bypasses path resolution. */
+	resolvedCustomPrompt?: string;
 	/** Tools to include in prompt. */
 	tools?: Map<string, SystemPromptToolMetadata>;
 	/** Tool names to include in prompt. */
 	toolNames?: string[];
 	/** Text to append to system prompt. */
 	appendSystemPrompt?: string;
+	/** Already-loaded append prompt text; bypasses path resolution. */
+	resolvedAppendSystemPrompt?: string;
 	/** Repeat full tool descriptions in system prompt. Default: false */
 	repeatToolDescriptions?: boolean;
 	/**
@@ -431,8 +435,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 
 	const {
 		customPrompt,
+		resolvedCustomPrompt: providedResolvedCustomPrompt,
 		tools,
 		appendSystemPrompt,
+		resolvedAppendSystemPrompt: providedResolvedAppendPrompt,
 		repeatToolDescriptions = false,
 		nativeTools = true,
 		skillsSettings,
@@ -522,12 +528,16 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		await Promise.all([
 			withDeadline(
 				"customPrompt",
-				resolvePromptInput(customPrompt, "system prompt"),
+				providedResolvedCustomPrompt !== undefined
+					? Promise.resolve(providedResolvedCustomPrompt)
+					: resolvePromptInput(customPrompt, "system prompt"),
 				prepDefaults.resolvedCustomPrompt,
 			),
 			withDeadline(
 				"appendSystemPrompt",
-				resolvePromptInput(appendSystemPrompt, "append system prompt"),
+				providedResolvedAppendPrompt !== undefined
+					? Promise.resolve(providedResolvedAppendPrompt)
+					: resolvePromptInput(appendSystemPrompt, "append system prompt"),
 				prepDefaults.resolvedAppendPrompt,
 			),
 			withDeadline(

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { submitInteractiveInput } from "@oh-my-pi/pi-coding-agent/main";
+import { applyResolvedSystemPromptInputs, submitInteractiveInput } from "@oh-my-pi/pi-coding-agent/main";
 import type { SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { CreateAgentSessionOptions } from "@oh-my-pi/pi-coding-agent/sdk";
 import { discoverTitleSystemPromptFile } from "@oh-my-pi/pi-coding-agent/system-prompt";
 
 const cleanupDirs: string[] = [];
@@ -32,6 +33,18 @@ describe("discoverTitleSystemPromptFile", () => {
 		await fs.writeFile(promptPath, "custom title prompt");
 
 		expect(discoverTitleSystemPromptFile(projectDir)).toBe(promptPath);
+	});
+});
+
+describe("applyResolvedSystemPromptInputs", () => {
+	it("routes SYSTEM.md content through template-aware session options", () => {
+		const options: CreateAgentSessionOptions = {};
+
+		applyResolvedSystemPromptInputs(options, "project system prompt", "append prompt");
+
+		expect(options.customSystemPrompt).toBe("project system prompt");
+		expect(options.appendSystemPrompt).toBe("append prompt");
+		expect(options.systemPrompt).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -106,6 +106,33 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(promptText).not.toContain("File content that must not replace the prompt.");
 	});
 
+	it("suppresses discovered SYSTEM.md when the caller supplies a custom prompt", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(path.join(projectDir, ".omp"), { recursive: true });
+		fs.writeFileSync(path.join(projectDir, ".omp", "SYSTEM.md"), "Discovered project SYSTEM prompt");
+
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: projectDir,
+			resolvedCustomPrompt: "CLI custom prompt",
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["read"],
+			tools: READ_TOOL,
+			workspaceTree: {
+				rootPath: projectDir,
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+		});
+
+		const promptText = systemPrompt.join("\n\n");
+		expect(promptText).toContain("CLI custom prompt");
+		expect(promptText).not.toContain("Discovered project SYSTEM prompt");
+	});
+
 	it("prefers project SYSTEM.md over user SYSTEM.md", async () => {
 		const projectDir = path.join(tempDir, "project");
 		fs.mkdirSync(path.join(projectDir, ".omp"), { recursive: true });

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -6,12 +6,24 @@ import {
 	buildSystemPrompt,
 	loadProjectContextFiles,
 	loadSystemPromptFiles,
+	type SystemPromptToolMetadata,
 } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
 function escapeRegExp(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+const READ_TOOL = new Map<string, SystemPromptToolMetadata>([
+	[
+		"read",
+		{
+			label: "Read",
+			description: "Reads files from disk.",
+			parameters: { type: "object", properties: { path: { type: "string" } } },
+		},
+	],
+]);
 
 describe("SYSTEM.md prompt assembly", () => {
 	let tempDir = "";
@@ -38,9 +50,18 @@ describe("SYSTEM.md prompt assembly", () => {
 			cwd: projectDir,
 			customPrompt: systemPrompt,
 			contextFiles: [],
-			skills: [],
+			skills: [
+				{
+					name: "focused-work",
+					description: "Focused work instructions",
+					filePath: "skills/focused-work/SKILL.md",
+					baseDir: "skills/focused-work",
+					source: "test",
+				},
+			],
 			rules: [],
-			toolNames: [],
+			toolNames: ["read"],
+			tools: READ_TOOL,
 			workspaceTree: {
 				rootPath: projectDir,
 				rendered: "",
@@ -53,6 +74,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		const promptText = renderedPrompt.join("\n\n");
 		const matches = promptText.match(new RegExp(escapeRegExp(systemPrompt), "g")) ?? [];
 		expect(matches).toHaveLength(1);
+		expect(promptText).toContain('<skill name="focused-work">');
 	});
 
 	it("prefers project SYSTEM.md over user SYSTEM.md", async () => {

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -106,14 +106,16 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(promptText).not.toContain("File content that must not replace the prompt.");
 	});
 
-	it("suppresses discovered SYSTEM.md when the caller supplies a custom prompt", async () => {
+	it("suppresses discovered SYSTEM.md while preserving the project footer", async () => {
 		const projectDir = path.join(tempDir, "project");
+		const appendPrompt = "Extra append instructions";
 		fs.mkdirSync(path.join(projectDir, ".omp"), { recursive: true });
 		fs.writeFileSync(path.join(projectDir, ".omp", "SYSTEM.md"), "Discovered project SYSTEM prompt");
 
 		const { systemPrompt } = await buildSystemPrompt({
 			cwd: projectDir,
 			resolvedCustomPrompt: "CLI custom prompt",
+			resolvedAppendSystemPrompt: appendPrompt,
 			contextFiles: [],
 			skills: [],
 			rules: [],
@@ -121,15 +123,21 @@ describe("SYSTEM.md prompt assembly", () => {
 			tools: READ_TOOL,
 			workspaceTree: {
 				rootPath: projectDir,
-				rendered: "",
+				rendered: ".\n  - nested/",
 				truncated: false,
-				totalLines: 0,
-				agentsMdFiles: [],
+				totalLines: 2,
+				agentsMdFiles: ["nested/AGENTS.md"],
 			},
 		});
 
 		const promptText = systemPrompt.join("\n\n");
+		const appendMatches = promptText.match(new RegExp(escapeRegExp(appendPrompt), "g")) ?? [];
+		expect(systemPrompt).toHaveLength(2);
 		expect(promptText).toContain("CLI custom prompt");
+		expect(promptText).toContain("<workspace-tree>");
+		expect(promptText).toContain("<dir-context>");
+		expect(promptText).toContain(`current working directory is '${projectDir}'`);
+		expect(appendMatches).toHaveLength(1);
 		expect(promptText).not.toContain("Discovered project SYSTEM prompt");
 	});
 

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -77,6 +77,35 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(promptText).toContain('<skill name="focused-work">');
 	});
 
+	it("does not resolve already-loaded prompt text as a path", async () => {
+		const projectDir = path.join(tempDir, "project");
+		const readablePromptText = path.join(projectDir, "README.md");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(readablePromptText, "File content that must not replace the prompt.");
+
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: projectDir,
+			resolvedCustomPrompt: readablePromptText,
+			resolvedAppendSystemPrompt: readablePromptText,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["read"],
+			tools: READ_TOOL,
+			workspaceTree: {
+				rootPath: projectDir,
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+		});
+
+		const promptText = systemPrompt.join("\n\n");
+		expect(promptText).toContain(readablePromptText);
+		expect(promptText).not.toContain("File content that must not replace the prompt.");
+	});
+
 	it("prefers project SYSTEM.md over user SYSTEM.md", async () => {
 		const projectDir = path.join(tempDir, "project");
 		fs.mkdirSync(path.join(projectDir, ".omp"), { recursive: true });


### PR DESCRIPTION
## Repro
Specifying `SYSTEM.md` caused the CLI to replace the first rendered system prompt block with raw file contents. Reproduced with `bun --cwd packages/coding-agent --eval "$REPRO_SCRIPT"`, which showed the simulated `main.ts` override preserved the custom prompt text but dropped the `<skills>` section rendered by `custom-system-prompt.md`.

## Cause
`packages/coding-agent/src/main.ts` assigned `options.systemPrompt = defaultPrompt => [resolvedSystemPrompt, ...defaultPrompt.slice(1)]` for discovered or CLI-provided `SYSTEM.md`. In `packages/coding-agent/src/sdk.ts`, `options.systemPrompt` is a final provider-facing override, so it bypassed `buildSystemPromptInternal` and never rendered `custom-system-prompt.md` with skills, rules, and related custom-template sections.

## Fix
- Added template-aware `customSystemPrompt` and `appendSystemPrompt` session options in `packages/coding-agent/src/sdk.ts`.
- Routed resolved `SYSTEM.md` and `APPEND_SYSTEM.md` inputs from `packages/coding-agent/src/main.ts` into those options instead of the raw final prompt override.
- Added regression coverage for CLI prompt option routing and custom prompt rendering retaining the `<skills>` section.
- Updated `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/system-prompt-dedup.test.ts packages/coding-agent/test/main-interactive-input.test.ts` passed. `bun run check` passed in `packages/coding-agent`. Manual prompt check `bun --cwd packages/coding-agent --eval "$VERIFY_SCRIPT"` printed `custom prompt template retained skills`. Fixes #3014