### PR TITLE
feat(coding-agent): added enter_plan_mode tool for self-initiated plan mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an `enter_plan_mode` tool so the agent can switch into read-only plan mode on its own (parity with Claude Code's `EnterPlanMode`) when a task warrants up-front planning, instead of relying on `/plan` or the keybinding. Gated by the new `plan.allowAgentEntry` setting (default `true`, under `plan.enabled`); available in the interactive TUI and ACP, and never exposed to headless/print sessions or subagents.
+
 ## [16.0.5] - 2026-06-17
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3509,6 +3509,19 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"plan.allowAgentEntry": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Agent Can Enter Plan Mode",
+			description:
+				"Let the agent switch into plan mode on its own via the enter_plan_mode tool when a task warrants planning",
+			condition: "planModeEnabled",
+		},
+	},
+
 	"goal.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -369,6 +369,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			modelRegistry: args.modelRegistry,
 			agentId,
 			hasUI: false,
+			supportsAgentPlanEntry: true,
 			enableMCP: false,
 		});
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
@@ -1169,6 +1170,7 @@ export async function runRootCommand(
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
+	sessionOptions.supportsAgentPlanEntry = isInteractive || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
 
 	// OTEL: register the global OTLP trace exporter when an OTLP endpoint is

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1032,6 +1032,24 @@ export class AcpAgent implements Agent {
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
+		// Agent-initiated plan mode entry (`enter_plan_mode` tool): mirror the
+		// client-driven `setSessionMode` path, then notify the client so its mode
+		// selector and config option reflect the switch the agent made.
+		session.setPlanModeEntryHandler?.(async () => {
+			this.#applyModeChange(session, ACP_PLAN_MODE_ID);
+			try {
+				await this.#connection.sessionUpdate({
+					sessionId: session.sessionId,
+					update: this.#buildCurrentModeUpdate(session),
+				});
+				await this.#pushConfigOptionUpdateForSession(session);
+			} catch (error) {
+				logger.warn("Failed to emit mode updates after agent-initiated plan entry", {
+					sessionId: session.sessionId,
+					error,
+				});
+			}
+		});
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -548,6 +548,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.mcpManager = mcpManager;
 		this.#eventBus = eventBus;
 		this.titleSystemPrompt = titleSystemPrompt;
+		// Let the agent enter plan mode on its own via the `enter_plan_mode` tool.
+		// The session is reused across /new and session switches, so install once.
+		this.session.setPlanModeEntryHandler(() => this.#enterPlanMode());
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -1845,7 +1848,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		const planFilePath = options?.planFilePath ?? (await this.#getPlanFilePath());
 		const previousTools = this.session.getActiveToolNames();
 		const hasResolveTool = this.session.getToolByName("resolve") !== undefined;
-		const planTools = hasResolveTool ? [...previousTools, "resolve"] : previousTools;
+		// Drop `enter_plan_mode` from the plan toolset — re-entry while planning is a
+		// no-op. It stays in `#planModePreviousTools` so exit restores it.
+		const planToolBase = previousTools.filter(name => name !== "enter_plan_mode");
+		const planTools = hasResolveTool ? [...planToolBase, "resolve"] : planToolBase;
 		const uniquePlanTools = [...new Set(planTools)];
 
 		this.#planModePreviousTools = previousTools;

--- a/packages/coding-agent/src/prompts/tools/enter-plan-mode.md
+++ b/packages/coding-agent/src/prompts/tools/enter-plan-mode.md
@@ -1,0 +1,12 @@
+Enter plan mode: switch to read-only planning before making any code changes.
+
+Call this on your own initiative when a task is complex, multi-step, or ambiguous enough that an upfront plan reduces risk — or when the user asks you to plan, design, scope, or investigate before implementing. In plan mode the working tree is read-only (you may write ONLY the plan file), so you research, ground every claim in the real code, draft a plan, and then submit it for the user's approval. On approval, full write access is restored and implementation begins.
+
+- `reason` (optional): one short sentence on why planning is warranted.
+
+Do NOT call this when:
+- the change is small and well-specified enough to implement directly, or
+- you are already in plan mode, or
+- you are in goal mode (exit it first).
+
+After entering, follow the plan-mode workflow: draft the plan to `local://<slug>-plan.md`, then `resolve` with `action: "apply"` and `extra: { title: "<slug>" }` to submit it. You NEVER ask the user to switch modes in prose — call this tool instead.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -532,6 +532,10 @@ export interface CreateAgentSessionOptions {
 	/** Whether UI is available (enables interactive tools like ask). Default: false */
 	hasUI?: boolean;
 
+	/** Whether the host supports agent-initiated plan mode entry (the `enter_plan_mode`
+	 *  tool). Set true by the interactive TUI / rpc-ui and ACP frontends. Default: false */
+	supportsAgentPlanEntry?: boolean;
+
 	/**
 	 * Opt-in OpenTelemetry instrumentation forwarded to the underlying Agent.
 	 * Passing `{}` enables the loop's GenAI-semantic-convention spans. See
@@ -1493,6 +1497,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				return sessionManager.getCwd();
 			},
 			hasUI: options.hasUI ?? false,
+			supportsAgentPlanEntry: options.supportsAgentPlanEntry ?? false,
 			enableLsp,
 			get hasEditTool() {
 				const requestedToolNames = options.toolNames
@@ -1528,6 +1533,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getActiveModel: () => agent?.state.model ?? model,
 			getPlanModeState: () => session?.getPlanModeState(),
 			getPlanReferencePath: () => session?.getPlanReferencePath() ?? "local://PLAN.md",
+			canEnterPlanMode: () => session?.canEnterPlanMode() ?? false,
+			requestEnterPlanMode: () => {
+				if (!session) throw new Error("Session not ready for plan mode entry.");
+				return session.requestEnterPlanMode();
+			},
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
 			getUsageStatistics: () => sessionManager.getUsageStatistics(),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1087,6 +1087,11 @@ export class AgentSession {
 	#advisorPrimaryTurnsCompleted = 0;
 	#advisorInterruptImmuneTurnStart: number | undefined;
 	#planModeState: PlanModeState | undefined;
+	/** Frontend-installed handler that switches the session into plan mode on the
+	 *  agent's behalf (the `enter_plan_mode` tool). Interactive mode points this at
+	 *  `#enterPlanMode`; ACP at `#applyModeChange`. Absent in headless/subagent
+	 *  sessions, where agent-initiated entry is unsupported. */
+	#planModeEntryHandler: (() => Promise<void> | void) | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
 	#advisorRuntime?: AdvisorRuntime;
@@ -5081,6 +5086,27 @@ export class AgentSession {
 			this.#planReferenceSent = false;
 			this.#planReferencePath = state.planFilePath;
 		}
+	}
+
+	/** Install (or clear with `null`) the handler invoked by {@link requestEnterPlanMode}.
+	 *  Installed once per frontend session and stable for its lifetime. */
+	setPlanModeEntryHandler(handler: (() => Promise<void> | void) | null): void {
+		this.#planModeEntryHandler = handler ?? undefined;
+	}
+
+	/** True when the host can switch into plan mode at the agent's request. */
+	canEnterPlanMode(): boolean {
+		return this.#planModeEntryHandler !== undefined;
+	}
+
+	/** Switch into plan mode on the agent's behalf. Throws when no host handler is
+	 *  installed — the `enter_plan_mode` tool gates on {@link canEnterPlanMode} first. */
+	async requestEnterPlanMode(): Promise<void> {
+		const handler = this.#planModeEntryHandler;
+		if (!handler) {
+			throw new Error("Plan mode entry is not supported in this session.");
+		}
+		await handler();
 	}
 
 	getGoalModeState(): GoalModeState | undefined {

--- a/packages/coding-agent/src/tools/enter-plan-mode.ts
+++ b/packages/coding-agent/src/tools/enter-plan-mode.ts
@@ -1,0 +1,128 @@
+/**
+ * Enter Plan Mode tool — agent-initiated entry into read-only plan mode.
+ *
+ * Mirrors Claude Code's `EnterPlanMode`: the agent decides on its own that a
+ * task warrants planning, calls this tool, and the host (interactive TUI or
+ * ACP) switches the session into plan mode. The actual mode transition lives in
+ * the frontend (`InteractiveMode.#enterPlanMode` / `AcpAgent.#applyModeChange`)
+ * and is reached through `ToolSession.requestEnterPlanMode`, installed by that
+ * frontend. Hosts without a handler (print/headless, subagents) never expose
+ * this tool — see the `supportsAgentPlanEntry` gate in `createTools`.
+ */
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { Text } from "@oh-my-pi/pi-tui";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { z } from "zod/v4";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import enterPlanModeDescription from "../prompts/tools/enter-plan-mode.md" with { type: "text" };
+import { Ellipsis, renderStatusLine, truncateToWidth } from "../tui";
+import type { ToolSession } from ".";
+import { replaceTabs, TRUNCATE_LENGTHS } from "./render-utils";
+import { ToolError } from "./tool-errors";
+
+const enterPlanModeSchema = z.object({
+	reason: z.string().describe("one short sentence on why planning is warranted").optional(),
+});
+
+export type EnterPlanModeInput = z.infer<typeof enterPlanModeSchema>;
+
+export interface EnterPlanModeDetails {
+	entered: boolean;
+	reason?: string;
+}
+
+export class EnterPlanModeTool implements AgentTool<typeof enterPlanModeSchema, EnterPlanModeDetails> {
+	readonly name = "enter_plan_mode";
+	readonly label = "Plan Mode";
+	readonly approval = "read" as const;
+	readonly description = prompt.render(enterPlanModeDescription);
+	readonly parameters = enterPlanModeSchema;
+	readonly intent = (args: Partial<EnterPlanModeInput>) => args.reason?.trim() || "entering plan mode";
+	readonly #session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	static createIf(session: ToolSession): EnterPlanModeTool | null {
+		return session.supportsAgentPlanEntry ? new EnterPlanModeTool(session) : null;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: EnterPlanModeInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<EnterPlanModeDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<EnterPlanModeDetails>> {
+		const reason = params.reason?.trim() || undefined;
+		if (this.#session.getPlanModeState?.()?.enabled) {
+			return {
+				content: [{ type: "text", text: "Already in plan mode." }],
+				details: { entered: false, reason },
+			};
+		}
+		const goalState = this.#session.getGoalModeState?.();
+		if (goalState?.enabled || goalState?.goal.status === "paused") {
+			throw new ToolError("Exit goal mode before entering plan mode.");
+		}
+		if (!this.#session.canEnterPlanMode?.() || !this.#session.requestEnterPlanMode) {
+			throw new ToolError("Plan mode entry is not available in this session.");
+		}
+		await this.#session.requestEnterPlanMode();
+		return {
+			content: [
+				{
+					type: "text",
+					text: 'Entered plan mode. The working tree is now read-only — research, ground every claim in real code, and draft your plan to a `local://<slug>-plan.md` file, then call `resolve` with `action: "apply"` and `extra: { title: "<slug>" }` to submit it for approval.',
+				},
+			],
+			details: { entered: true, reason },
+		};
+	}
+}
+
+export const enterPlanModeToolRenderer = {
+	renderCall(args: EnterPlanModeInput, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const reasonTrimmed = args?.reason?.trim();
+		const reason = reasonTrimmed
+			? truncateToWidth(replaceTabs(reasonTrimmed), TRUNCATE_LENGTHS.CONTENT, Ellipsis.Omit)
+			: undefined;
+		const text = renderStatusLine(
+			{
+				icon: "pending",
+				title: "Enter plan mode",
+				meta: reason ? [uiTheme.fg("muted", reason)] : undefined,
+			},
+			uiTheme,
+		);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: EnterPlanModeDetails; isError?: boolean },
+		_options: RenderResultOptions,
+		uiTheme: Theme,
+	): Component {
+		const entered = result.details?.entered === true && !result.isError;
+		const title = result.isError ? "Plan mode" : entered ? "Plan mode enabled" : "Plan mode unchanged";
+		const text = renderStatusLine(
+			{
+				icon: result.isError ? "error" : entered ? "success" : "info",
+				title,
+				badge: result.isError
+					? { label: "error", color: "error" }
+					: entered
+						? { label: "read-only", color: "success" }
+						: undefined,
+			},
+			uiTheme,
+		);
+		return new Text(text, 0, 0);
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -40,6 +40,7 @@ import { BrowserTool } from "./browser";
 import type { BuiltinToolName } from "./builtin-names";
 import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
 import { DebugTool } from "./debug";
+import { EnterPlanModeTool } from "./enter-plan-mode";
 import { EvalTool } from "./eval";
 import { resolveEvalBackends } from "./eval-backends";
 import { FindTool } from "./find";
@@ -78,6 +79,7 @@ export * from "./bash";
 export * from "./browser";
 export * from "./checkpoint";
 export * from "./debug";
+export * from "./enter-plan-mode";
 export * from "./eval";
 export * from "./eval-backends";
 export * from "./find";
@@ -262,6 +264,14 @@ export interface ToolSession {
 	getPlanModeState?: () => PlanModeState | undefined;
 	/** Path of the session's active plan reference (e.g. `local://<title>.md`); defaults to `local://PLAN.md`. */
 	getPlanReferencePath?: () => string;
+	/** Whether the host supports agent-initiated plan mode entry (`enter_plan_mode`
+	 *  tool). Set at construction by the interactive/ACP frontends; false for
+	 *  print/headless and subagents. */
+	supportsAgentPlanEntry?: boolean;
+	/** True when plan mode entry is currently possible (frontend handler installed). */
+	canEnterPlanMode?: () => boolean;
+	/** Request the host to switch the session into plan mode on the agent's behalf. */
+	requestEnterPlanMode?: () => Promise<void>;
 	/** Goal mode state (if active or paused) */
 	getGoalModeState?: () => GoalModeState | undefined;
 	/** Goal runtime for the active agent session. */
@@ -451,6 +461,7 @@ export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	report_tool_issue: s => createReportToolIssueTool(s),
 	resolve: s => new ResolveTool(s),
 	goal: s => new GoalTool(s),
+	enter_plan_mode: EnterPlanModeTool.createIf,
 };
 
 export type ToolName = BuiltinToolName;
@@ -468,6 +479,16 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	if (goalModeActive && requestedTools && !requestedTools.includes("goal")) {
 		requestedTools = [...requestedTools, "goal"];
 	}
+	// `enter_plan_mode` is active by default at the top level when the host supports
+	// agent-initiated entry and plan mode is both enabled and agent-entry-permitted.
+	// Removed once already in plan mode (re-entry is a no-op). Mirror of the `goal`
+	// gating, inverted: present by default rather than only after the mode is active.
+	const planEntryToolActive =
+		(session.taskDepth ?? 0) === 0 &&
+		session.supportsAgentPlanEntry === true &&
+		session.settings.get("plan.enabled") &&
+		session.settings.get("plan.allowAgentEntry") &&
+		session.getPlanModeState?.()?.enabled !== true;
 	const backends = resolveEvalBackends(session);
 	const allowPython = backends.python;
 	const allowJs = backends.js;
@@ -581,6 +602,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "task") {
 			return canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0);
 		}
+		if (name === "enter_plan_mode") return planEntryToolActive;
 		return true;
 	};
 	if (includeYield && requestedTools && !requestedTools.includes("yield")) {
@@ -597,6 +619,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 						.map(([name, factory]) => [name, factory] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOLS.yield]] as const) : []),
 					...(goalModeActive ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
+					...(planEntryToolActive ? ([["enter_plan_mode", HIDDEN_TOOLS.enter_plan_mode]] as const) : []),
 				];
 
 	const baseResults = await Promise.all(

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -17,6 +17,7 @@ import { astGrepToolRenderer } from "./ast-grep";
 import { bashToolRenderer } from "./bash";
 import { browserToolRenderer } from "./browser/render";
 import { debugToolRenderer } from "./debug";
+import { enterPlanModeToolRenderer } from "./enter-plan-mode";
 import { evalToolRenderer } from "./eval-render";
 import { findToolRenderer } from "./find";
 import { githubToolRenderer } from "./gh-renderer";
@@ -62,6 +63,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	browser: browserToolRenderer as ToolRenderer,
 	debug: debugToolRenderer as ToolRenderer,
 	eval: evalToolRenderer as ToolRenderer,
+	enter_plan_mode: enterPlanModeToolRenderer as ToolRenderer,
 	edit: editToolRenderer as ToolRenderer,
 	apply_patch: editToolRenderer as ToolRenderer,
 	find: findToolRenderer as ToolRenderer,

--- a/packages/coding-agent/test/tools/enter-plan-mode.test.ts
+++ b/packages/coding-agent/test/tools/enter-plan-mode.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { EnterPlanModeTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+
+function createToolSession(overrides: Partial<ToolSession>): ToolSession {
+	return overrides as ToolSession;
+}
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content[0]?.text ?? "";
+}
+
+describe("EnterPlanModeTool.createIf", () => {
+	it("constructs the tool only when the host supports agent plan entry", () => {
+		expect(EnterPlanModeTool.createIf(createToolSession({ supportsAgentPlanEntry: true }))).toBeInstanceOf(
+			EnterPlanModeTool,
+		);
+		expect(EnterPlanModeTool.createIf(createToolSession({ supportsAgentPlanEntry: false }))).toBeNull();
+		expect(EnterPlanModeTool.createIf(createToolSession({}))).toBeNull();
+	});
+});
+
+describe("EnterPlanModeTool.execute", () => {
+	it("requests plan mode entry and reports the read-only transition", async () => {
+		let calls = 0;
+		const tool = new EnterPlanModeTool(
+			createToolSession({
+				supportsAgentPlanEntry: true,
+				getPlanModeState: () => undefined,
+				getGoalModeState: () => undefined,
+				canEnterPlanMode: () => true,
+				requestEnterPlanMode: async () => {
+					calls += 1;
+				},
+			}),
+		);
+
+		const result = await tool.execute("call-1", { reason: "multi-file refactor" });
+
+		expect(calls).toBe(1);
+		expect(result.details?.entered).toBe(true);
+		expect(result.details?.reason).toBe("multi-file refactor");
+		expect(firstText(result)).toContain("read-only");
+		expect(firstText(result)).toContain("resolve");
+	});
+
+	it("is a no-op when already in plan mode and never re-invokes the host", async () => {
+		let calls = 0;
+		const tool = new EnterPlanModeTool(
+			createToolSession({
+				supportsAgentPlanEntry: true,
+				getPlanModeState: () => ({ enabled: true, planFilePath: "local://PLAN.md" }),
+				canEnterPlanMode: () => true,
+				requestEnterPlanMode: async () => {
+					calls += 1;
+				},
+			}),
+		);
+
+		const result = await tool.execute("call-1", {});
+
+		expect(calls).toBe(0);
+		expect(result.details?.entered).toBe(false);
+		expect(firstText(result)).toBe("Already in plan mode.");
+	});
+
+	it("refuses while goal mode is active", async () => {
+		const tool = new EnterPlanModeTool(
+			createToolSession({
+				supportsAgentPlanEntry: true,
+				getPlanModeState: () => undefined,
+				getGoalModeState: () => ({ enabled: true, goal: { status: "active" } }) as never,
+				canEnterPlanMode: () => true,
+				requestEnterPlanMode: async () => undefined,
+			}),
+		);
+
+		await expect(tool.execute("call-1", {})).rejects.toThrow(/goal mode/i);
+	});
+
+	it("refuses while a goal is paused", async () => {
+		const tool = new EnterPlanModeTool(
+			createToolSession({
+				supportsAgentPlanEntry: true,
+				getPlanModeState: () => undefined,
+				getGoalModeState: () => ({ enabled: false, goal: { status: "paused" } }) as never,
+				canEnterPlanMode: () => true,
+				requestEnterPlanMode: async () => undefined,
+			}),
+		);
+
+		await expect(tool.execute("call-1", {})).rejects.toThrow(/goal mode/i);
+	});
+
+	it("errors when the host has no plan-entry handler installed", async () => {
+		let calls = 0;
+		const tool = new EnterPlanModeTool(
+			createToolSession({
+				supportsAgentPlanEntry: true,
+				getPlanModeState: () => undefined,
+				getGoalModeState: () => undefined,
+				canEnterPlanMode: () => false,
+				requestEnterPlanMode: async () => {
+					calls += 1;
+				},
+			}),
+		);
+
+		await expect(tool.execute("call-1", {})).rejects.toThrow(/not available/i);
+		expect(calls).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -262,9 +262,54 @@ describe("createTools", () => {
 
 		expect(names).toContain("search_tool_bm25");
 	});
+	it("includes enter_plan_mode when the host supports agent plan entry", async () => {
+		const session = createTestSession({ supportsAgentPlanEntry: true });
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).toContain("enter_plan_mode");
+	});
 
-	it("HIDDEN_TOOLS contains review tools and goal", () => {
+	it("omits enter_plan_mode when the host does not support agent plan entry", async () => {
+		const session = createTestSession({ supportsAgentPlanEntry: false });
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).not.toContain("enter_plan_mode");
+	});
+
+	it("omits enter_plan_mode when plan mode is disabled", async () => {
+		const session = createTestSession({
+			supportsAgentPlanEntry: true,
+			settings: createSettingsWithOverrides({ "plan.enabled": false }),
+		});
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).not.toContain("enter_plan_mode");
+	});
+
+	it("omits enter_plan_mode when plan.allowAgentEntry is off", async () => {
+		const session = createTestSession({
+			supportsAgentPlanEntry: true,
+			settings: createSettingsWithOverrides({ "plan.allowAgentEntry": false }),
+		});
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).not.toContain("enter_plan_mode");
+	});
+
+	it("omits enter_plan_mode once already in plan mode", async () => {
+		const session = createTestSession({
+			supportsAgentPlanEntry: true,
+			getPlanModeState: () => ({ enabled: true, planFilePath: "local://PLAN.md" }),
+		});
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).not.toContain("enter_plan_mode");
+	});
+
+	it("omits enter_plan_mode for subagents (taskDepth > 0)", async () => {
+		const session = createTestSession({ supportsAgentPlanEntry: true, taskDepth: 1 });
+		const names = (await createTools(session)).map(t => t.name);
+		expect(names).not.toContain("enter_plan_mode");
+	});
+
+	it("HIDDEN_TOOLS contains review tools, goal, and enter_plan_mode", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual([
+			"enter_plan_mode",
 			"goal",
 			"report_finding",
 			"report_tool_issue",


### PR DESCRIPTION

## What
Adds the tool for agents to enter plan mode autonomously (parity with Claude Code's EnterPlanMode) when a task warrants up-front planning, instead of having the user to invoke /plan or the keybinding manually.

## Why
In my workflows, I do not enable plan mode by default. Some require it, some don't. I usually fire off a custom command based on the workflow I need right now. Since some of them require plan mode, I need to type /plan followed by my custom command manually when using omp.
My commands that require plan mode encode the instruction for the agents to simply call EnterPlanMode, which in claude code, allows the agent to enter plan mode by itself. I'd very much appreciate a similar feature in omp to streamline these workflows. 

## Testing
Manually tested with my workflows and the agent not does not complain about missing EnterPlanMode. I did not adjust my commands as most engineers in my org use claude code. The agent translated EnterPlanMode from the command to omp's new enter_plan_mode successfully. 
```
✔ Plan mode enabled ⟦read-only⟧
```

Disclaimer: This has been implemented by AI. 

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) 

## Git commit message

Agent can switch into read-only plan mode on its own  

- New hidden tool gated by supportsAgentPlanEntry; exposed only in the interactive TUI and ACP, never in headless/print sessions or subagents, and dropped once already planning (re-entry is a no-op).
- Entry routed through ToolSession.requestEnterPlanMode → frontend handler (InteractiveMode.#enterPlanMode / AcpAgent.#applyModeChange).
- New plan.allowAgentEntry setting (default true, under plan.enabled).

