### PR TITLE
fix(mnemopi): restore local fastembed runtime on macOS

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
       },
       "peerDependencies": {
         "fastembed": "2.1.0",
-        "onnxruntime-node": "1.26.0",
+        "onnxruntime-node": "1.21.0",
       },
       "optionalPeers": [
         "fastembed",

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -517,7 +517,7 @@ describe("agentLoop with AgentMessage", () => {
 
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
 
-		const rawJsonPayload = '{"i": Finding getAvailable definition, "value": "hello"}' + "A".repeat(1000);
+		const rawJsonPayload = `{"i": Finding getAvailable definition, "value": "hello"}${"A".repeat(1000)}`;
 		const mock = createMockModel({
 			responses: [
 				{

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local fastembed startup on macOS ARM64 by letting `fastembed@2.1.0` install its matching `onnxruntime-node@1.21.0` native runtime instead of forcing `1.26.0`, and by repairing missing tokenizer sidecars from the upstream Hugging Face model cache when a stale fastembed archive lacks them. ([#3054](https://github.com/can1357/oh-my-pi/issues/3054))
+
 ## [16.0.6] - 2026-06-18
 
 ### Fixed

--- a/packages/mnemopi/package.json
+++ b/packages/mnemopi/package.json
@@ -46,7 +46,7 @@
 	},
 	"peerDependencies": {
 		"fastembed": "2.1.0",
-		"onnxruntime-node": "1.26.0"
+		"onnxruntime-node": "1.21.0"
 	},
 	"peerDependenciesMeta": {
 		"fastembed": {

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -11,6 +11,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import type { EmbeddingModel } from "fastembed";
 import { LRUCache } from "lru-cache/raw";
+import { ensureFastembedTokenizerSidecars } from "./fastembed-model-cache";
 import { loadFastembed } from "./fastembed-runtime";
 import {
 	type EmbeddingOutput,
@@ -62,7 +63,18 @@ let nextProviderId = 1;
 
 async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
 	const { FlagEmbedding } = await loadFastembed();
-	return FlagEmbedding.init(options);
+	try {
+		return await FlagEmbedding.init(options);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "";
+		if (
+			!/(?:Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u.test(message)
+		) {
+			throw error;
+		}
+		if (!(await ensureFastembedTokenizerSidecars(options.model, options.cacheDir))) throw error;
+		return FlagEmbedding.init(options);
+	}
 }
 
 function activeEmbeddingOptions() {

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -11,7 +11,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import type { EmbeddingModel } from "fastembed";
 import { LRUCache } from "lru-cache/raw";
-import { ensureFastembedTokenizerSidecars } from "./fastembed-model-cache";
+import { ensureFastembedModelSidecars } from "./fastembed-model-cache";
 import { loadFastembed } from "./fastembed-runtime";
 import {
 	type EmbeddingOutput,
@@ -68,11 +68,13 @@ async function defaultLocalModelInitializer(options: LocalModelInitOptions): Pro
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
 		if (
-			!/(?:Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u.test(message)
+			!/(?:Config file not found at .*config|Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u.test(
+				message,
+			)
 		) {
 			throw error;
 		}
-		if (!(await ensureFastembedTokenizerSidecars(options.model, options.cacheDir))) throw error;
+		if (!(await ensureFastembedModelSidecars(options.model, options.cacheDir))) throw error;
 		return FlagEmbedding.init(options);
 	}
 }

--- a/packages/mnemopi/src/core/fastembed-model-cache.ts
+++ b/packages/mnemopi/src/core/fastembed-model-cache.ts
@@ -1,0 +1,34 @@
+import * as path from "node:path";
+
+const FASTEMBED_TOKENIZER_SIDECARS = ["tokenizer.json", "tokenizer_config.json", "special_tokens_map.json"] as const;
+
+const FASTEMBED_HF_REPOS: Record<string, string> = {
+	"fast-all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+	"fast-bge-base-en": "BAAI/bge-base-en",
+	"fast-bge-base-en-v1.5": "BAAI/bge-base-en-v1.5",
+	"fast-bge-small-en": "BAAI/bge-small-en",
+	"fast-bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
+	"fast-bge-small-zh-v1.5": "BAAI/bge-small-zh-v1.5",
+	"fast-multilingual-e5-large": "intfloat/multilingual-e5-large",
+};
+
+/** Download missing tokenizer sidecars into a fastembed model cache directory. */
+export async function ensureFastembedTokenizerSidecars(model: string, cacheDir = "local_cache"): Promise<boolean> {
+	const repo = FASTEMBED_HF_REPOS[model];
+	if (repo === undefined) return false;
+
+	const modelDir = path.join(cacheDir, model);
+	for (const fileName of FASTEMBED_TOKENIZER_SIDECARS) {
+		const target = path.join(modelDir, fileName);
+		if (await Bun.file(target).exists()) continue;
+
+		const response = await fetch(`https://huggingface.co/${repo}/resolve/main/${fileName}`);
+		if (!response.ok) {
+			throw new Error(
+				`Failed to download ${model} ${fileName} from ${repo}: ${response.status} ${response.statusText}`,
+			);
+		}
+		await Bun.write(target, await response.arrayBuffer());
+	}
+	return true;
+}

--- a/packages/mnemopi/src/core/fastembed-model-cache.ts
+++ b/packages/mnemopi/src/core/fastembed-model-cache.ts
@@ -1,6 +1,11 @@
 import * as path from "node:path";
 
-const FASTEMBED_TOKENIZER_SIDECARS = ["tokenizer.json", "tokenizer_config.json", "special_tokens_map.json"] as const;
+const FASTEMBED_MODEL_SIDECARS = [
+	"config.json",
+	"tokenizer.json",
+	"tokenizer_config.json",
+	"special_tokens_map.json",
+] as const;
 
 const FASTEMBED_HF_REPOS: Record<string, string> = {
 	"fast-all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
@@ -12,13 +17,13 @@ const FASTEMBED_HF_REPOS: Record<string, string> = {
 	"fast-multilingual-e5-large": "intfloat/multilingual-e5-large",
 };
 
-/** Download missing tokenizer sidecars into a fastembed model cache directory. */
-export async function ensureFastembedTokenizerSidecars(model: string, cacheDir = "local_cache"): Promise<boolean> {
+/** Download missing config/tokenizer sidecars into a fastembed model cache directory. */
+export async function ensureFastembedModelSidecars(model: string, cacheDir = "local_cache"): Promise<boolean> {
 	const repo = FASTEMBED_HF_REPOS[model];
 	if (repo === undefined) return false;
 
 	const modelDir = path.join(cacheDir, model);
-	for (const fileName of FASTEMBED_TOKENIZER_SIDECARS) {
+	for (const fileName of FASTEMBED_MODEL_SIDECARS) {
 		const target = path.join(modelDir, fileName);
 		if (await Bun.file(target).exists()) continue;
 

--- a/packages/mnemopi/src/core/fastembed-runtime.ts
+++ b/packages/mnemopi/src/core/fastembed-runtime.ts
@@ -22,27 +22,27 @@ export interface FastembedRuntimeInstallPlan {
 }
 
 /**
- * `fastembed` and `onnxruntime-node` are optional peers (~270MB of native
- * assets across platforms), never bundled and never installed eagerly. When
- * the direct import cannot resolve — bundled `dist/cli.js`, compiled binary,
- * a consumer that skipped the optional peers, or a native loader failure from
- * fastembed's nested ORT — the pinned pair is `bun install`ed into a
- * per-version runtime cache on first use and loaded from there (#2389, #2920).
+ * `fastembed` is an optional peer (~270MB of native assets across platforms),
+ * never bundled and never installed eagerly. When the direct import cannot
+ * resolve — bundled `dist/cli.js`, compiled binary, a consumer that skipped the
+ * optional peer, or a native loader failure — fastembed is `bun install`ed into
+ * a per-version runtime cache on first use and loaded from there (#2389).
  *
- * The pins live in `peerDependencies` as exact versions (not `catalog:`) so
- * this module reads concrete specs even when the workspace manifest is
- * inlined into a bundle; a workspace test asserts they match the catalog.
+ * The fastembed pin lives in `peerDependencies` as an exact version (not
+ * `catalog:`) so this module reads a concrete spec even when the workspace
+ * manifest is inlined into a bundle. The runtime install deliberately does not
+ * override fastembed's `onnxruntime-node` dependency: the prebuilt native addon
+ * links against that package's bundled ORT dylib/so/dll name.
  */
 const FASTEMBED_SPEC = packageManifest.peerDependencies.fastembed;
-const ORT_SPEC = packageManifest.peerDependencies["onnxruntime-node"];
 
 /** Build the deterministic fastembed runtime install plan used by local embeddings. */
 export function fastembedRuntimeInstallPlan(): FastembedRuntimeInstallPlan {
 	return {
-		versionKey: `fastembed-${FASTEMBED_SPEC}_ort-${ORT_SPEC}_forced-ort`.replace(/[^A-Za-z0-9._-]/g, "_"),
+		versionKey: `fastembed-${FASTEMBED_SPEC}_transitive-ort`.replace(/[^A-Za-z0-9._-]/g, "_"),
 		install: {
-			dependencies: { fastembed: FASTEMBED_SPEC, "onnxruntime-node": ORT_SPEC },
-			overrides: { "onnxruntime-common": ORT_SPEC, "onnxruntime-node": ORT_SPEC },
+			dependencies: { fastembed: FASTEMBED_SPEC },
+			trustedDependencies: ["onnxruntime-node"],
 		},
 	};
 }

--- a/packages/mnemopi/test/fastembed-model-cache.test.ts
+++ b/packages/mnemopi/test/fastembed-model-cache.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ensureFastembedTokenizerSidecars } from "../src/core/fastembed-model-cache";
+import { ensureFastembedModelSidecars } from "../src/core/fastembed-model-cache";
 
 describe("fastembed model cache repair", () => {
-	it("downloads missing tokenizer sidecars without overwriting cached files", async () => {
+	it("downloads missing config and tokenizer sidecars without overwriting cached files", async () => {
 		const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-fastembed-"));
 		const model = "fast-bge-base-en-v1.5";
 		const modelDir = path.join(cacheDir, model);
@@ -25,12 +25,14 @@ describe("fastembed model cache repair", () => {
 			await fs.mkdir(modelDir, { recursive: true });
 			await Bun.write(path.join(modelDir, "tokenizer.json"), "cached-tokenizer");
 
-			expect(await ensureFastembedTokenizerSidecars(model, cacheDir)).toBe(true);
+			expect(await ensureFastembedModelSidecars(model, cacheDir)).toBe(true);
 
 			expect(requested).toEqual([
+				"https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/config.json",
 				"https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/tokenizer_config.json",
 				"https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/special_tokens_map.json",
 			]);
+			expect(await Bun.file(path.join(modelDir, "config.json")).text()).toBe("body:config.json");
 			expect(await Bun.file(path.join(modelDir, "tokenizer.json")).text()).toBe("cached-tokenizer");
 			expect(await Bun.file(path.join(modelDir, "tokenizer_config.json")).text()).toBe("body:tokenizer_config.json");
 			expect(await Bun.file(path.join(modelDir, "special_tokens_map.json")).text()).toBe(
@@ -52,7 +54,7 @@ describe("fastembed model cache repair", () => {
 			),
 		);
 		try {
-			expect(await ensureFastembedTokenizerSidecars("unknown-model", "/tmp/missing")).toBe(false);
+			expect(await ensureFastembedModelSidecars("unknown-model", "/tmp/missing")).toBe(false);
 			expect(fetchSpy).not.toHaveBeenCalled();
 		} finally {
 			fetchSpy.mockRestore();

--- a/packages/mnemopi/test/fastembed-model-cache.test.ts
+++ b/packages/mnemopi/test/fastembed-model-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ensureFastembedTokenizerSidecars } from "../src/core/fastembed-model-cache";
+
+describe("fastembed model cache repair", () => {
+	it("downloads missing tokenizer sidecars without overwriting cached files", async () => {
+		const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-fastembed-"));
+		const model = "fast-bge-base-en-v1.5";
+		const modelDir = path.join(cacheDir, model);
+		const requested: string[] = [];
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				(input: string | URL | Request, _init?: RequestInit) => {
+					const url = String(input);
+					requested.push(url);
+					return Promise.resolve(new Response(`body:${path.basename(url)}`));
+				},
+				{ preconnect: globalThis.fetch.preconnect },
+			),
+		);
+
+		try {
+			await fs.mkdir(modelDir, { recursive: true });
+			await Bun.write(path.join(modelDir, "tokenizer.json"), "cached-tokenizer");
+
+			expect(await ensureFastembedTokenizerSidecars(model, cacheDir)).toBe(true);
+
+			expect(requested).toEqual([
+				"https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/tokenizer_config.json",
+				"https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/special_tokens_map.json",
+			]);
+			expect(await Bun.file(path.join(modelDir, "tokenizer.json")).text()).toBe("cached-tokenizer");
+			expect(await Bun.file(path.join(modelDir, "tokenizer_config.json")).text()).toBe("body:tokenizer_config.json");
+			expect(await Bun.file(path.join(modelDir, "special_tokens_map.json")).text()).toBe(
+				"body:special_tokens_map.json",
+			);
+		} finally {
+			fetchSpy.mockRestore();
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reports unsupported fastembed cache names without network access", async () => {
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				() => {
+					throw new Error("fetch should not run");
+				},
+				{ preconnect: globalThis.fetch.preconnect },
+			),
+		);
+		try {
+			expect(await ensureFastembedTokenizerSidecars("unknown-model", "/tmp/missing")).toBe(false);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});

--- a/packages/mnemopi/test/fastembed-runtime.test.ts
+++ b/packages/mnemopi/test/fastembed-runtime.test.ts
@@ -3,19 +3,17 @@ import rootManifest from "../../../package.json" with { type: "json" };
 import packageManifest from "../package.json" with { type: "json" };
 import { fastembedRuntimeInstallPlan } from "../src/core/fastembed-runtime";
 
-// The fastembed/onnxruntime-node peers are pinned as exact versions (not
-// `catalog:`) because `core/fastembed-runtime.ts` reads them to `bun install`
-// the on-demand embedding runtime — including from bundles where the inlined
-// manifest would otherwise carry an uninstallable `catalog:` spec (#2389).
-// This pins the contract: the runtime install materializes exactly the
-// versions the workspace develops and tests against, and forces fastembed's
-// transitive ORT request away from its archived 1.21.0 pin (#2920).
+// The fastembed peer is pinned as an exact version (not `catalog:`) because
+// `core/fastembed-runtime.ts` reads it to `bun install` the on-demand embedding
+// runtime — including from bundles where the inlined manifest would otherwise
+// carry an uninstallable `catalog:` spec (#2389). The runtime cache must keep
+// fastembed's own ORT dependency intact because its native addon links against
+// that exact bundled library name (#3054).
 describe("fastembed runtime version pins", () => {
 	const catalog = rootManifest.workspaces.catalog;
 
-	test("peer pins match the workspace catalog", () => {
+	test("fastembed peer pin matches the workspace catalog", () => {
 		expect(packageManifest.peerDependencies.fastembed).toBe(catalog.fastembed);
-		expect(packageManifest.peerDependencies["onnxruntime-node"]).toBe(catalog["onnxruntime-node"]);
 	});
 
 	test("pins are exact installable versions, not catalog or range specs", () => {
@@ -23,16 +21,18 @@ describe("fastembed runtime version pins", () => {
 		expect(packageManifest.peerDependencies["onnxruntime-node"]).toMatch(/^\d+\.\d+\.\d+$/);
 	});
 
-	test("runtime install overrides fastembed's transitive onnxruntime pin", () => {
+	test("onnxruntime peer pin matches fastembed's native ABI", () => {
+		expect(packageManifest.peerDependencies["onnxruntime-node"]).toBe("1.21.0");
+	});
+
+	test("runtime install preserves fastembed's transitive onnxruntime pin", () => {
 		const plan = fastembedRuntimeInstallPlan();
 		expect(plan.install.dependencies).toEqual({
 			fastembed: packageManifest.peerDependencies.fastembed,
-			"onnxruntime-node": packageManifest.peerDependencies["onnxruntime-node"],
 		});
-		expect(plan.install.overrides).toEqual({
-			"onnxruntime-common": packageManifest.peerDependencies["onnxruntime-node"],
-			"onnxruntime-node": packageManifest.peerDependencies["onnxruntime-node"],
-		});
-		expect(plan.versionKey).toContain("forced-ort");
+		expect(plan.install.overrides).toBeUndefined();
+		expect(plan.install.trustedDependencies).toEqual(["onnxruntime-node"]);
+		expect(plan.versionKey).toContain("transitive-ort");
+		expect(plan.versionKey).not.toContain("forced-ort");
 	});
 });


### PR DESCRIPTION
## Repro
The failing runtime plan is reproducible by comparing `fastembed@2.1.0`'s transitive `onnxruntime-node@1.21.0` pin with Mnemopi's prior forced runtime cache plan, which installed `onnxruntime-node@1.26.0` under `fastembed-2.1.0_ort-1.26.0_forced-ort`. Command: `python3 -c "$PY"` exited 1 and printed `mismatch reproduced: fastembed 2.1.0 requires 1.21.0, but Mnemopi forces 1.26.0`.

## Cause
`packages/mnemopi/src/core/fastembed-runtime.ts` built an on-demand runtime manifest with both `fastembed` and a forced `onnxruntime-node` override from Mnemopi's peer pin. That dislodged `fastembed@2.1.0`'s own ORT dependency even though the prebuilt addon expects that bundled native library name. Separately, `packages/mnemopi/src/core/embeddings.ts` delegated directly to `FlagEmbedding.init`, so a stale/incomplete fastembed model cache that was missing tokenizer sidecars failed permanently instead of repairing the cache.

## Fix
- Changed the fastembed runtime install plan to install only `fastembed@2.1.0`, trust its transitive `onnxruntime-node` lifecycle script, and key the cache as `fastembed-2.1.0_transitive-ort`.
- Pinned Mnemopi's optional `onnxruntime-node` peer contract to `1.21.0`, matching `fastembed@2.1.0`'s native ABI.
- Added tokenizer-sidecar repair for stale fastembed model caches, downloading missing `tokenizer.json`, `tokenizer_config.json`, and `special_tokens_map.json` from the matching Hugging Face model repo before retrying `FlagEmbedding.init`.
- Added regression tests for the runtime plan and tokenizer cache repair.

## Verification
`bun test packages/mnemopi/test/fastembed-runtime.test.ts packages/mnemopi/test/fastembed-model-cache.test.ts` passed with 6 tests. `bun --cwd=packages/mnemopi run check` passed. A post-fix runtime-plan probe prints dependencies `{"fastembed":"2.1.0"}`, no overrides, trusted dependency `["onnxruntime-node"]`, and cache key `fastembed-2.1.0_transitive-ort`. Fixes #3054