### PR TITLE
feat(coding-agent): add native terminal progress setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Appearance setting for OSC 9;4 native terminal progress indicators during active agent turns and context maintenance.
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -772,6 +772,17 @@ export const SETTINGS_SCHEMA = {
 			"Maximum number of inline images kept as live terminal graphics (default 8). Older images fall back to a text placeholder via a full redraw once the limit is exceeded. Set to 0 to keep every image (no limit).",
 	},
 
+	"terminal.showProgress": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Native Terminal Progress",
+			description: "Emit OSC 9;4 indeterminate progress while the agent or context maintenance is running",
+		},
+	},
+
 	"tui.textSizing": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -82,6 +82,7 @@ export class EventController {
 	#streamingReveal: StreamingRevealController;
 	#toolArgsReveal: ToolArgsRevealController;
 	#handlers: AgentSessionEventHandlers;
+	#terminalProgressActive = false;
 
 	constructor(private ctx: InteractiveModeContext) {
 		this.#streamingReveal = new StreamingRevealController({
@@ -128,6 +129,7 @@ export class EventController {
 		this.#streamingReveal.stop();
 		this.#toolArgsReveal.stop();
 		this.#cancelIdleCompaction();
+		this.#setTerminalProgress(false);
 		for (const timer of this.#ircExpiryTimers.values()) {
 			clearTimeout(timer);
 		}
@@ -241,6 +243,18 @@ export class EventController {
 		await run(event);
 	}
 
+	#setTerminalProgress(active: boolean): void {
+		if (active) {
+			if (this.#terminalProgressActive || this.ctx.settings?.get("terminal.showProgress") !== true) return;
+			this.ctx.ui.terminal.setProgress(true);
+			this.#terminalProgressActive = true;
+			return;
+		}
+		if (!this.#terminalProgressActive) return;
+		this.ctx.ui.terminal.setProgress(false);
+		this.#terminalProgressActive = false;
+	}
+
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
@@ -258,6 +272,7 @@ export class EventController {
 			this.ctx.statusContainer.clear();
 		}
 		this.#cancelIdleCompaction();
+		this.#setTerminalProgress(true);
 		this.ctx.ensureLoadingAnimation();
 		this.ctx.ui.requestRender();
 	}
@@ -861,6 +876,7 @@ export class EventController {
 	}
 
 	async #finishAgentEnd(): Promise<void> {
+		this.#setTerminalProgress(false);
 		this.#streamingReveal.stop();
 		this.#toolArgsReveal.flushAll();
 		if (this.ctx.loadingAnimation) {
@@ -924,6 +940,7 @@ export class EventController {
 		event: Extract<AgentSessionEvent, { type: "auto_compaction_start" }>,
 	): Promise<void> {
 		this.#cancelIdleCompaction();
+		this.#setTerminalProgress(true);
 		this.#stopWorkingLoader();
 		this.ctx.statusContainer.clear();
 		const reasonText =
@@ -953,6 +970,7 @@ export class EventController {
 
 	async #handleAutoCompactionEnd(event: Extract<AgentSessionEvent, { type: "auto_compaction_end" }>): Promise<void> {
 		this.#cancelIdleCompaction();
+		this.#setTerminalProgress(false);
 		if (this.ctx.autoCompactionLoader) {
 			this.ctx.autoCompactionLoader.stop();
 			this.ctx.autoCompactionLoader = undefined;

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -60,6 +60,16 @@ describe("settings layout", () => {
 		}
 	});
 
+	it("exposes native terminal progress in the appearance settings menu", () => {
+		const def = getSettingsForTab("appearance").find(def => def.path === "terminal.showProgress");
+
+		expect(def).toMatchObject({
+			type: "boolean",
+			label: "Native Terminal Progress",
+			group: "Display",
+		});
+	});
+
 	it("hides advisor dependent settings when advisor is disabled", () => {
 		const advisorDependentPaths: SettingPath[] = ["advisor.subagents", "advisor.syncBacklog", "advisor.immuneTurns"];
 		const advisorDependentPathSet = new Set(advisorDependentPaths);

--- a/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
@@ -24,7 +24,7 @@ interface FakeWorkingLoader {
  * kept streaming. The fix tears the working loader down (stop + dereference) so
  * the next `agent_start` recreates and re-attaches it.
  */
-function createContext() {
+function createContext(options: { terminalProgress?: boolean } = {}) {
 	const streamState = { isStreaming: false };
 	const children: unknown[] = [];
 	const statusContainer = {
@@ -41,9 +41,12 @@ function createContext() {
 		},
 	};
 	const workingLoaders: FakeWorkingLoader[] = [];
+	const setProgress = vi.fn();
 	const ctx = {
 		isInitialized: true,
-		settings: { get: () => false },
+		settings: {
+			get: (path: string) => path === "terminal.showProgress" && options.terminalProgress === true,
+		},
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
 		pendingTools: new Map<string, unknown>(),
@@ -66,7 +69,7 @@ function createContext() {
 		showError: vi.fn(),
 		editor: { getText: () => "" },
 		sessionManager: { getSessionName: () => "test-session" },
-		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
+		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn(), terminal: { setProgress } },
 		viewSession: { isCompacting: false, getLastAssistantMessage: () => undefined },
 		session: {
 			get isStreaming() {
@@ -83,10 +86,11 @@ function createContext() {
 		ctx.loadingAnimation = working as unknown as typeof ctx.loadingAnimation;
 		statusContainer.addChild(ctx.loadingAnimation);
 	});
-	return { ctx, streamState, statusContainer, workingLoaders };
+	return { ctx, streamState, statusContainer, workingLoaders, setProgress };
 }
 
 const AGENT_START = { type: "agent_start" } as unknown as AgentSessionEvent;
+const AGENT_END = { type: "agent_end" } as unknown as AgentSessionEvent;
 const COMPACTION_START = {
 	type: "auto_compaction_start",
 	reason: "overflow",
@@ -173,5 +177,25 @@ describe("EventController loader recovery after overflow maintenance", () => {
 		await controller.handleEvent(AGENT_START);
 		expect(ctx.loadingAnimation).toBeDefined();
 		expect(statusContainer.children).toContain(ctx.loadingAnimation);
+	});
+
+	it("mirrors agent and auto-compaction activity to OSC 9;4 when enabled", async () => {
+		const { ctx, setProgress } = createContext({ terminalProgress: true });
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent(AGENT_START);
+		expect(setProgress).toHaveBeenCalledTimes(1);
+		expect(setProgress).toHaveBeenLastCalledWith(true);
+
+		await controller.handleEvent(COMPACTION_START);
+		expect(setProgress).toHaveBeenCalledTimes(1);
+
+		await controller.handleEvent(COMPACTION_END);
+		expect(setProgress).toHaveBeenCalledTimes(2);
+		expect(setProgress).toHaveBeenLastCalledWith(false);
+
+		await controller.handleEvent(AGENT_START);
+		await controller.handleEvent(AGENT_END);
+		expect(setProgress.mock.calls.map(call => call[0])).toEqual([true, false, true, false]);
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -66,6 +66,12 @@ describe("Settings", () => {
 			expect(settings.get("tui.maxInlineImages")).toBe(8);
 		});
 
+		it("keeps native terminal progress disabled by default", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("terminal.showProgress")).toBe(false);
+			expect(getDefault("terminal.showProgress")).toBe(false);
+		});
+
 		it("keeps the normal startup splash disabled by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("startup.showSplash")).toBe(false);
@@ -243,6 +249,17 @@ describe("Settings", () => {
 			expect(savedSettings.defaultThinkingLevel).toBe(Effort.High);
 			expect(savedSettings.theme).toEqual({ dark: "anthracite" });
 			expect((savedSettings.modelRoles as { default?: string } | undefined)?.default).toBe("claude-sonnet");
+		});
+
+		it("persists native terminal progress only after the user changes it", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(await readSettings()).toEqual({});
+
+			settings.set("terminal.showProgress", true);
+			await settings.flush();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.terminal).toEqual({ showProgress: true });
 		});
 
 		it("filters model allow-list and disabled providers by current path prefix", async () => {


### PR DESCRIPTION
## Problem

The TUI already has a low-level `Terminal.setProgress()` implementation for OSC 9;4 native terminal progress indicators, but the coding-agent never used it.

That meant users could not opt into terminal-native progress in tab bars / taskbars while an agent turn or context maintenance was running. The only visible progress remained inside the TUI itself, which is easy to miss when the terminal is backgrounded.

## Solution

Add a user-facing `terminal.showProgress` setting under **Appearance → Display → Native Terminal Progress**, defaulting to `false`.

When enabled, the interactive event controller mirrors long-running coding-agent activity into the existing TUI terminal primitive:

- `agent_start` starts OSC 9;4 indeterminate progress.
- `agent_end` clears it once the live turn really finishes.
- `auto_compaction_start` starts it for context maintenance.
- `auto_compaction_end` clears it when maintenance ends.
- controller disposal clears any active progress so teardown cannot leave a stale terminal indicator.

The setting persists through the existing settings system, so `config.yml` only gains:

```yaml
terminal:
  showProgress: true
```

when the user changes the default.

## Safety details

- Default stays off, so existing terminal behavior is unchanged.
- The implementation reuses `Terminal.setProgress()` instead of emitting OSC directly in coding-agent.
- `EventController` tracks whether progress is already active, so nested agent/maintenance events do not create duplicate start calls or keepalive timers.
- The low-level terminal implementation still owns TTY/headless/write-failure guards, keepalive emission, and final cleanup on terminal stop.
- Superseded `agent_end` events still follow the existing `session.isStreaming` guard, so they do not clear progress for a newer in-flight turn.

## Changes

**Settings**
- Add `terminal.showProgress` to the schema.
- Surface it in Appearance → Display as “Native Terminal Progress”.
- Cover the default and `config.yml` persistence behavior.

**Runtime wiring**
- Add a small `EventController` progress mirror around the existing TUI `setProgress()` API.
- Start/clear progress for agent turns and auto context maintenance.
- Clear progress during controller disposal.

**Tests**
- Assert the setting is disabled by default.
- Assert changing the setting writes the expected nested config key.
- Assert the settings menu exposes the option in the Appearance tab.
- Assert agent/context-maintenance events call the terminal progress API exactly once per active interval.

## Verification

- [x] `bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/modes/components/settings-layout.test.ts packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts`
- [x] `bun --cwd=packages/coding-agent biome check src/config/settings-schema.ts src/modes/controllers/event-controller.ts test/settings-manager.test.ts test/modes/components/settings-layout.test.ts test/modes/controllers/event-controller-loader-recovery.test.ts CHANGELOG.md`

Full package check was attempted but is currently blocked by unrelated existing failures outside this patch:

- `src/internal-urls/docs-index.generated.ts` generated-docs Biome warnings/errors about literal `${...}` fragments.
- existing type errors in `packages/ai/src/providers/cursor.ts`.
- existing ACP SDK type mismatches in `packages/coding-agent/src/modes/acp/acp-agent.ts`.
