### PR TITLE
fix(coding-agent): timebox status usage refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Deferred status-line usage refreshes off the render path and timeboxed the startup fetch so slow Anthropic quota lookups no longer block interactive startup. ([#3057](https://github.com/can1357/oh-my-pi/issues/3057))
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -532,9 +532,8 @@ export class StatusLineComponent implements Component {
 	}
 
 	/**
-	 * Background-refresh the Anthropic OAuth quota report outside the render call.
-	 * Startup redraws only arm a short-delayed task; the fetch itself gets a hard
-	 * timeout and render continues with cached/empty quota data.
+	 * Startup redraws only arm a short-delayed task; timeout releases the render
+	 * cadence while a late successful fetch can still refresh the cached segment.
 	 */
 	refreshUsageInBackground(): void {
 		const now = Date.now();
@@ -556,17 +555,36 @@ export class StatusLineComponent implements Component {
 			return;
 		}
 		const signal = AbortSignal.timeout(STATUS_USAGE_REFRESH_TIMEOUT_MS);
+		let reportsPromise: Promise<unknown> | undefined;
 		try {
-			const reports = await this.#raceUsageRefreshWithSignal(fetcher.call(session, signal), signal);
-			if (this.session !== session) return;
-			this.#cachedUsage = this.#normalizeUsageReports(reports);
-			this.#usageFetchedAt = Date.now();
+			reportsPromise = fetcher.call(session, signal);
+			this.#applyUsageRefreshReports(session, await this.#raceUsageRefreshWithSignal(reportsPromise, signal));
 		} catch {
 			if (this.session !== session) return;
 			this.#usageFetchedAt = Date.now();
+			if (signal.aborted && reportsPromise) {
+				this.#observeLateUsageRefresh(session, reportsPromise);
+			}
 		} finally {
 			if (this.session === session) this.#usageInFlight = false;
 		}
+	}
+
+	#applyUsageRefreshReports(session: AgentSession, reports: unknown): void {
+		if (this.#disposed || this.session !== session) return;
+		this.#cachedUsage = this.#normalizeUsageReports(reports);
+		this.#usageFetchedAt = Date.now();
+	}
+
+	#observeLateUsageRefresh(session: AgentSession, reportsPromise: Promise<unknown>): void {
+		void reportsPromise
+			.then(reports => {
+				this.#applyUsageRefreshReports(session, reports);
+			})
+			.catch(() => {
+				if (this.#disposed || this.session !== session) return;
+				this.#usageFetchedAt = Date.now();
+			});
 	}
 
 	async #raceUsageRefreshWithSignal(promise: Promise<unknown>, signal: AbortSignal): Promise<unknown> {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -154,6 +154,8 @@ interface ContextUsageMemo {
 }
 
 const EMPTY_MESSAGES: readonly AgentMessage[] = [];
+const STATUS_USAGE_START_DELAY_MS = 0;
+const STATUS_USAGE_REFRESH_TIMEOUT_MS = 2_000;
 
 function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return segments.includes("context_pct") || segments.includes("context_total");
@@ -212,6 +214,7 @@ export class StatusLineComponent implements Component {
 	} | null = null;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
+	#usageStartTimer: Timer | null = null;
 	// Context-usage memo. The status line redraws on every agent event, so the
 	// hot path must not recompute context tokens unless an input changed.
 	// `getContextUsage()` anchors on the last assistant's real prompt-token
@@ -344,16 +347,24 @@ export class StatusLineComponent implements Component {
 	dispose(): void {
 		this.#disposed = true;
 		this.#onBranchChange = null;
+		this.#clearUsageStartTimer();
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;
 		}
 	}
 
+	#clearUsageStartTimer(): void {
+		if (!this.#usageStartTimer) return;
+		clearTimeout(this.#usageStartTimer);
+		this.#usageStartTimer = null;
+	}
+
 	invalidate(): void {
 		this.#invalidateGitCaches();
 	}
 	#invalidateSessionCaches(): void {
+		this.#clearUsageStartTimer();
 		this.#cachedUsage = null;
 		this.#usageFetchedAt = 0;
 		this.#usageInFlight = false;
@@ -521,36 +532,53 @@ export class StatusLineComponent implements Component {
 	}
 
 	/**
-	 * Background-refresh the Anthropic OAuth quota report. Guarded by a 5-min
-	 * TTL on both success (cache lifetime) and error (backoff). Exposed
-	 * (non-private) so unit tests can verify the backoff invariant.
+	 * Background-refresh the Anthropic OAuth quota report outside the render call.
+	 * Startup redraws only arm a short-delayed task; the fetch itself gets a hard
+	 * timeout and render continues with cached/empty quota data.
 	 */
 	refreshUsageInBackground(): void {
 		const now = Date.now();
-		if (this.#usageInFlight) return;
+		if (this.#usageInFlight || this.#usageStartTimer) return;
 		if (this.#usageFetchedAt > 0 && now - this.#usageFetchedAt < 5 * 60_000) return;
 		const session = this.session;
-		const fetcher = (session as { fetchUsageReports?: () => Promise<unknown> }).fetchUsageReports;
+		const fetcher = (session as { fetchUsageReports?: (signal?: AbortSignal) => Promise<unknown> }).fetchUsageReports;
 		if (typeof fetcher !== "function") return;
 		this.#usageInFlight = true;
-		void fetcher
-			.call(session)
-			.then(reports => {
-				if (this.session !== session) return;
-				this.#cachedUsage = this.#normalizeUsageReports(reports);
-				this.#usageFetchedAt = Date.now();
-			})
-			.catch(() => {
-				if (this.session !== session) return;
-				// Backoff on error: stamp the fetch time so the 5-min TTL guard
-				// also acts as an error budget. Without this, every render
-				// kicks off another fetch (gated only by #usageInFlight),
-				// which hammers the endpoint during a network outage / 5xx.
-				this.#usageFetchedAt = Date.now();
-			})
-			.finally(() => {
-				if (this.session === session) this.#usageInFlight = false;
-			});
+		this.#usageStartTimer = setTimeout(() => {
+			this.#usageStartTimer = null;
+			void this.#runUsageRefresh(session, fetcher);
+		}, STATUS_USAGE_START_DELAY_MS);
+	}
+
+	async #runUsageRefresh(session: AgentSession, fetcher: (signal?: AbortSignal) => Promise<unknown>): Promise<void> {
+		if (this.#disposed || this.session !== session) {
+			this.#usageInFlight = false;
+			return;
+		}
+		const signal = AbortSignal.timeout(STATUS_USAGE_REFRESH_TIMEOUT_MS);
+		try {
+			const reports = await this.#raceUsageRefreshWithSignal(fetcher.call(session, signal), signal);
+			if (this.session !== session) return;
+			this.#cachedUsage = this.#normalizeUsageReports(reports);
+			this.#usageFetchedAt = Date.now();
+		} catch {
+			if (this.session !== session) return;
+			this.#usageFetchedAt = Date.now();
+		} finally {
+			if (this.session === session) this.#usageInFlight = false;
+		}
+	}
+
+	async #raceUsageRefreshWithSignal(promise: Promise<unknown>, signal: AbortSignal): Promise<unknown> {
+		if (signal.aborted) throw signal.reason;
+		const aborted = Promise.withResolvers<never>();
+		const onAbort = () => aborted.reject(signal.reason);
+		signal.addEventListener("abort", onAbort, { once: true });
+		try {
+			return await Promise.race([promise, aborted.promise]);
+		} finally {
+			signal.removeEventListener("abort", onAbort);
+		}
 	}
 
 	#normalizeUsageReports(reports: unknown): {

--- a/packages/coding-agent/test/status-line-usage-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-usage-refresh.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 async function flushMicrotasks(): Promise<void> {
@@ -9,13 +11,57 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 function makeSession(fetchUsageReports: (signal?: AbortSignal) => Promise<unknown>): AgentSession {
-	return { fetchUsageReports } as unknown as AgentSession;
+	const messages: unknown[] = [];
+	return {
+		fetchUsageReports,
+		messages,
+		state: { messages, model: { contextWindow: 200_000 } },
+		model: { contextWindow: 200_000 },
+		isStreaming: false,
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => "test",
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		getContextUsage: () => undefined,
+		contextUsageRevision: 0,
+	} as unknown as AgentSession;
+}
+
+function usageReport(percent: number): unknown[] {
+	return [
+		{
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h" },
+					window: { id: "5h", label: "5h", resetsAt: Date.now() + 60_000 },
+					amount: { unit: "percent", usedFraction: percent / 100 },
+				},
+			],
+		},
+	];
+}
+
+function plain(text: string): string {
+	return stripVTControlCharacters(text);
 }
 
 describe("StatusLineComponent usage refresh", () => {
 	beforeEach(async () => {
 		resetSettingsForTest();
 		await Settings.init({ inMemory: true });
+		await initTheme();
 		vi.useFakeTimers();
 	});
 
@@ -83,5 +129,29 @@ describe("StatusLineComponent usage refresh", () => {
 		await flushMicrotasks();
 
 		expect(calls).toBe(1);
+	});
+
+	it("applies late usage reports that resolve after the startup timeout", async () => {
+		const late = Promise.withResolvers<unknown>();
+		const component = new StatusLineComponent(makeSession(() => late.promise));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["usage"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		component.refreshUsageInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		vi.advanceTimersByTime(2_000);
+		await flushMicrotasks();
+
+		expect(plain(component.getTopBorder(80).content)).not.toContain("5h");
+
+		late.resolve(usageReport(42));
+		await flushMicrotasks();
+
+		expect(plain(component.getTopBorder(80).content)).toContain("5h 42%");
 	});
 });

--- a/packages/coding-agent/test/status-line-usage-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-usage-refresh.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function makeSession(fetchUsageReports: (signal?: AbortSignal) => Promise<unknown>): AgentSession {
+	return { fetchUsageReports } as unknown as AgentSession;
+}
+
+describe("StatusLineComponent usage refresh", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		resetSettingsForTest();
+	});
+
+	it("does not invoke usage fetching synchronously on the render path", async () => {
+		let calls = 0;
+		const component = new StatusLineComponent(
+			makeSession(async () => {
+				calls++;
+				return [];
+			}),
+		);
+
+		component.refreshUsageInBackground();
+		expect(calls).toBe(0);
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(calls).toBe(1);
+	});
+
+	it("passes a startup timeout signal to the background usage fetch", async () => {
+		let signal: AbortSignal | undefined;
+		const component = new StatusLineComponent(
+			makeSession(async nextSignal => {
+				signal = nextSignal;
+				return [];
+			}),
+		);
+
+		component.refreshUsageInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("backs off after the startup timeout when usage fetching hangs", async () => {
+		let calls = 0;
+		const component = new StatusLineComponent(
+			makeSession(() => {
+				calls++;
+				return Promise.withResolvers<unknown>().promise;
+			}),
+		);
+
+		component.refreshUsageInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(calls).toBe(1);
+
+		component.refreshUsageInBackground();
+		expect(calls).toBe(1);
+
+		vi.advanceTimersByTime(2_000);
+		await flushMicrotasks();
+
+		component.refreshUsageInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(calls).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro
A status-line startup probe reproduced the UI-path block by calling `StatusLineComponent.refreshUsageInBackground()` with a `fetchUsageReports()` implementation that spent 200ms synchronously before resolving; before the fix the call returned after 200ms, proving the usage refresh was invoked on the render path.

## Cause
`packages/coding-agent/src/modes/components/status-line/component.ts` started `session.fetchUsageReports()` directly inside `refreshUsageInBackground()`, which is called from `#buildSegmentContext()` during status-line rendering. Any slow synchronous setup before the fetch yielded, or any caller that ignored cancellation, could keep the interactive startup path blocked until the usage lookup resolved.

## Fix
- Defer status-line usage refresh startup through a timer so render only arms background work.
- Race the refresh against a 2s startup timeout signal and stamp the existing 5-minute backoff on timeout/failure.
- Clear pending usage-start timers on dispose/session switch.
- Add regression tests for non-synchronous startup, timeout signal propagation, and timeout backoff.

## Verification
Repro probe now returns immediately: `refreshUsageInBackground returned after 0ms`. Ran `bun --cwd=packages/coding-agent test test/status-line-usage-refresh.test.ts` (3 pass), `bun --cwd=packages/coding-agent run check:types`, and `bun --cwd=packages/coding-agent run check` (passed). Fixes #3057