### PR TITLE
fix(coding-agent): avoid image paste crash before settings init

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed linked image placeholders crashing when they render before settings initialization.
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -39,11 +39,12 @@ function feedGaps(editor: CustomEditor, gaps: number[]): void {
 	}
 }
 
-async function decorateInFreshProcess(text: string): Promise<string> {
+async function decorateInFreshProcess(text: string, imageLinks?: readonly string[]): Promise<string> {
 	const customEditorUrl = new URL("./custom-editor.ts", import.meta.url).href;
 	const script = `
 import { CustomEditor } from ${JSON.stringify(customEditorUrl)};
 const editor = new CustomEditor({});
+editor.imageLinks = ${JSON.stringify(imageLinks)};
 process.stdout.write(editor.decorateText(${JSON.stringify(text)}));
 `;
 	const child = await $`bun -e ${script}`.quiet().nothrow();
@@ -59,8 +60,8 @@ describe("CustomEditor placeholder decoration", () => {
 		expect(output).toBe("[Paste #1, +30 lines]");
 	});
 
-	it("renders image placeholders before theme initialization", async () => {
-		const output = await decorateInFreshProcess("[Image #1]");
+	it("renders linked image placeholders before theme and settings initialization", async () => {
+		const output = await decorateInFreshProcess("[Image #1]", ["/tmp/example.png"]);
 		expect(output).toBe("[Image #1]");
 	});
 });

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -7,7 +7,7 @@
  */
 import * as url from "node:url";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
-import { settings } from "../config/settings";
+import { isSettingsInitialized, settings } from "../config/settings";
 import {
 	LocalProtocolHandler,
 	memoryRootsFromRegistry,
@@ -47,6 +47,7 @@ function buildFileUri(filePath: string, opts?: { line?: number; col?: number }):
  * - `"always"`: unconditionally (useful for viewers that support OSC 8 without advertising it)
  */
 export function isHyperlinkEnabled(): boolean {
+	if (!isSettingsInitialized()) return false;
 	const mode = settings.get("tui.hyperlinks");
 	if (mode === "off") return false;
 	if (mode === "always") return true;


### PR DESCRIPTION
## Summary

Fixes a follow-up crash when an image placeholder has a resolved image link but renders before global settings initialization.

The prior placeholder fix made early theme rendering safe. Pasting an image can also set `CustomEditor.imageLinks`, which routes `[Image #1]` through `fileHyperlink(...)`. That path checks `settings.get("tui.hyperlinks")`; before `Settings.init()` has run, the settings proxy throws `Settings not initialized. Call Settings.init() first.`

## Reproduction

Before this fix, from a checkout with dependencies installed:

```sh
bun -e 'import { CustomEditor } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const e = new CustomEditor({}); e.imageLinks = ["/tmp/example.png"]; console.log(e.decorateText("[Image #1]"));'
```

failed with:

```txt
Error: Settings not initialized. Call Settings.init() first.
    at get (.../packages/coding-agent/src/config/settings.ts)
    at isHyperlinkEnabled (.../packages/coding-agent/src/tui/hyperlink.ts)
    at wrapHyperlink (.../packages/coding-agent/src/tui/hyperlink.ts)
    at renderPlaceholders (.../packages/coding-agent/src/modes/image-references.ts)
```

## Fix

- Treat hyperlinks as disabled until settings are initialized.
- Cover the linked-image placeholder early-render path in `CustomEditor` tests.
- Add a coding-agent changelog entry.

## Verification

- `bun -e 'import { CustomEditor } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const e = new CustomEditor({}); e.imageLinks = ["/tmp/example.png"]; console.log(e.decorateText("[Image #1]"));'`
- `bun --cwd=packages/coding-agent test src/modes/components/custom-editor.test.ts ../../packages/coding-agent/test/tui/hyperlink.test.ts`
- `bun --cwd=packages/coding-agent run fmt`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run lint`

Note: `fmt` and `lint` complete with an existing Biome warning that `src/internal-urls/docs-index.generated.ts` exceeds the configured max file size.
