### PR TITLE
fix(agent): clear stale pending preview gates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Cleared stale pending-preview gates when `resolve` finds no runnable handler, so phantom preview state no longer blocks all other tools after reporting no pending action. ([#3061](https://github.com/can1357/oh-my-pi/issues/3061))
+- Cleared stale pending-preview gates when `resolve` finds no runnable handler, and forwarded the missing `peekPendingInvoker` and `clearPendingInvokers` hooks on the production session so staged previews actually reach the resolve tool and the gate drains on dispatch failure. ([#3061](https://github.com/can1357/oh-my-pi/issues/3061))
 
 ## [16.1.3] - 2026-06-19
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cleared stale pending-preview gates when `resolve` finds no runnable handler, so phantom preview state no longer blocks all other tools after reporting no pending action. ([#3061](https://github.com/can1357/oh-my-pi/issues/3061))
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1518,6 +1518,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					timestamp: Date.now(),
 				}),
 			peekQueueInvoker: () => session.peekQueueInvoker(),
+			peekPendingInvoker: () => session.peekPendingInvoker(),
+			clearPendingInvokers: () => session.clearPendingInvokers(),
 			peekStandingResolveHandler: () => session.peekStandingResolveHandler(),
 			setStandingResolveHandler: handler => session.setStandingResolveHandler(handler),
 			allocateOutputArtifact: async toolType => {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2181,6 +2181,11 @@ export class AgentSession {
 		return this.#toolChoiceQueue.peekPendingInvoker();
 	}
 
+	/** Clear stale non-forcing pending preview invokers after `resolve` proves none can run. */
+	clearPendingInvokers(): void {
+		this.#toolChoiceQueue.clearPendingInvokers();
+	}
+
 	/**
 	 * Force the next model call to target a specific active tool, then terminate
 	 * the agent loop. Pushes a two-step sequence [forced, "none"] so the model

--- a/packages/coding-agent/src/session/tool-choice-queue.ts
+++ b/packages/coding-agent/src/session/tool-choice-queue.ts
@@ -231,6 +231,12 @@ export class ToolChoiceQueue {
 		this.#pendingInvokers = this.#pendingInvokers.filter(p => p.id !== id);
 	}
 
+	/** Drop every pending preview invoker without touching hard tool-choice directives. */
+	clearPendingInvokers(): void {
+		if (this.#pendingInvokers.length === 0) return;
+		this.#pendingInvokers = [];
+	}
+
 	/** True when at least one non-forcing pending preview is registered. */
 	get hasPendingInvoker(): boolean {
 		return this.#pendingInvokers.length > 0;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -316,6 +316,8 @@ export interface ToolSession {
 	 *  tool dispatches to it so a staged preview resolves WITHOUT forcing tool_choice — the
 	 *  agent-loop's SoftToolRequirement lifecycle owns reminder injection and escalation. */
 	peekPendingInvoker?(): ((input: unknown) => Promise<unknown> | unknown) | undefined;
+	/** Clear stale pending preview markers when `resolve` cannot dispatch them. */
+	clearPendingInvokers?(): void;
 	/** Peek the long-lived "standing" resolve handler registered by a mode (e.g. plan mode).
 	 *  Consulted by the `resolve` tool as a fallback when no queue invoker is in flight,
 	 *  letting modes accept `resolve` invocations without forcing the tool choice every turn. */

--- a/packages/coding-agent/src/tools/resolve.ts
+++ b/packages/coding-agent/src/tools/resolve.ts
@@ -212,6 +212,7 @@ export class ResolveTool implements AgentTool<typeof resolveSchema, ResolveToolD
 				this.session.peekPendingInvoker?.() ??
 				this.session.peekStandingResolveHandler?.();
 			if (!invoker) {
+				this.session.clearPendingInvokers?.();
 				// `discard` is a request to cancel/abort a staged action. When nothing is
 				// pending, the desired end-state (no staged change) already holds, so honor
 				// it as a successful cancellation instead of surfacing a hard error to the

--- a/packages/coding-agent/test/agent-session-resolve-reminder.test.ts
+++ b/packages/coding-agent/test/agent-session-resolve-reminder.test.ts
@@ -11,7 +11,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { queueResolveHandler } from "@oh-my-pi/pi-coding-agent/tools/resolve";
+import { queueResolveHandler, ResolveTool } from "@oh-my-pi/pi-coding-agent/tools/resolve";
 import { buildNamedToolChoice } from "@oh-my-pi/pi-coding-agent/utils/tool-choice";
 import { Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -40,6 +40,10 @@ describe("AgentSession resolve reminder", () => {
 		toolSession = {
 			getToolChoiceQueue: () => session.toolChoiceQueue,
 			buildToolChoice: (name: string) => buildNamedToolChoice(name, session.model!),
+			peekQueueInvoker: () => session.peekQueueInvoker(),
+			peekPendingInvoker: () => session.peekPendingInvoker(),
+			clearPendingInvokers: () => session.clearPendingInvokers(),
+			peekStandingResolveHandler: () => session.peekStandingResolveHandler(),
 		} as unknown as ToolSession;
 
 		const agent = new Agent({
@@ -89,5 +93,51 @@ describe("AgentSession resolve reminder", () => {
 
 		// Nothing was steered into the conversation — no prefix churn.
 		expect(session.agent.peekSteeringQueue()).toHaveLength(0);
+	});
+
+	it("dispatches a staged preview through the production toolSession wiring and drains the gate", async () => {
+		let applyRuns = 0;
+		queueResolveHandler(toolSession, {
+			label: "AST Edit: 1 replacement in 1 file",
+			sourceToolName: "ast_edit",
+			apply: async () => {
+				applyRuns++;
+				return { content: [{ type: "text", text: "Applied" }] };
+			},
+		});
+
+		// Gate armed before resolve runs.
+		expect(isSoftToolRequirement(session.nextToolChoiceDirective())).toBe(true);
+
+		const tool = new ResolveTool(toolSession);
+		await tool.execute("call-apply", { action: "apply", reason: "looks correct" });
+
+		// Apply ran (forwarding works) AND the gate cleared (no phantom pending).
+		expect(applyRuns).toBe(1);
+		expect(session.nextToolChoiceDirective()).toBeUndefined();
+	});
+
+	it("drains a phantom pending gate when resolve cannot dispatch", async () => {
+		queueResolveHandler(toolSession, {
+			label: "AST Edit: 1 replacement in 1 file",
+			sourceToolName: "ast_edit",
+			apply: async () => ({ content: [{ type: "text", text: "Applied" }] }),
+		});
+		expect(isSoftToolRequirement(session.nextToolChoiceDirective())).toBe(true);
+
+		// Mirror the production deadlock: the queue still reports a pending head, but
+		// every dispatch peek returns undefined (the original loop-trigger).
+		const facade = {
+			...toolSession,
+			peekQueueInvoker: () => undefined,
+			peekPendingInvoker: () => undefined,
+			peekStandingResolveHandler: () => undefined,
+		} as ToolSession;
+		const tool = new ResolveTool(facade);
+
+		// `discard` with no invoker now drains the gate instead of leaving a phantom.
+		const result = await tool.execute("call-discard", { action: "discard", reason: "drain stale gate" });
+		expect(result.isError ?? false).toBe(false);
+		expect(session.nextToolChoiceDirective()).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/tools/resolve.test.ts
+++ b/packages/coding-agent/test/tools/resolve.test.ts
@@ -5,7 +5,7 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ResolveTool, resolveToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/resolve";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 
-function createSession(handler?: (input: unknown) => Promise<unknown>): ToolSession {
+function createSession(handler?: (input: unknown) => Promise<unknown>, clearPendingInvokers?: () => void): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
@@ -13,6 +13,7 @@ function createSession(handler?: (input: unknown) => Promise<unknown>): ToolSess
 		getSessionSpawns: () => "*",
 		settings: Settings.isolated(),
 		peekQueueInvoker: handler ? () => handler : () => undefined,
+		clearPendingInvokers,
 	};
 }
 
@@ -35,15 +36,26 @@ describe("ResolveTool", () => {
 		expect(required).toEqual(["action", "reason"]);
 	});
 
-	it("errors when there is no pending action", async () => {
-		const tool = new ResolveTool(createSession());
+	it("errors and clears stale pending markers when apply has no invoker", async () => {
+		let clearRuns = 0;
+		const tool = new ResolveTool(
+			createSession(undefined, () => {
+				clearRuns++;
+			}),
+		);
 		await expect(tool.execute("call-none", { action: "apply", reason: "looks correct" })).rejects.toThrow(
 			"No pending action to resolve. Nothing to apply or discard.",
 		);
+		expect(clearRuns).toBe(1);
 	});
 
-	it("treats discard with no pending action as a successful cancellation, not an error", async () => {
-		const tool = new ResolveTool(createSession());
+	it("treats discard with no pending action as a successful cancellation and clears stale markers", async () => {
+		let clearRuns = 0;
+		const tool = new ResolveTool(
+			createSession(undefined, () => {
+				clearRuns++;
+			}),
+		);
 		const result = await tool.execute("call-discard-none", {
 			action: "discard",
 			reason: "Abandoning the staged edit.",
@@ -51,6 +63,7 @@ describe("ResolveTool", () => {
 		expect(result.isError ?? false).toBe(false);
 		expect(getText(result)).toContain("Nothing to discard");
 		expect(result.details).toMatchObject({ action: "discard", reason: "Abandoning the staged edit." });
+		expect(clearRuns).toBe(1);
 	});
 
 	it("discards pending action and clears store", async () => {


### PR DESCRIPTION
## Repro
A stale pending-preview gate can be reproduced with a `ResolveTool` session whose gate marker remains set while `peekQueueInvoker`, `peekPendingInvoker`, and `peekStandingResolveHandler` all return `undefined`: `resolve(action="apply")` reports `No pending action to resolve. Nothing to apply or discard.`, and before this fix the gate stayed armed so the next non-`resolve` tool was skipped with `Not executed: call the \`resolve\` tool to resolve the pending action before using other tools.`

## Cause
`ResolveTool.execute` in `packages/coding-agent/src/tools/resolve.ts` only handled the missing-invoker case locally: `apply` threw and `discard` returned a cosmetic success. Neither path told `AgentSession.nextToolChoiceDirective()` / `ToolChoiceQueue.peekPendingHead()` to drop stale pending-preview markers, so the soft tool requirement could keep forcing `resolve` after dispatch had no runnable handler.

## Fix
- Added `ToolChoiceQueue.clearPendingInvokers()` and exposed it through `AgentSession` / `ToolSession` without touching hard tool-choice directives.
- Updated `ResolveTool.execute` to clear stale pending-preview markers whenever no resolve invoker can run, before either throwing for `apply` or succeeding for `discard`.
- Added regression coverage for both no-invoker `apply` and no-invoker `discard` draining stale pending markers.
- Added the `packages/coding-agent` changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/resolve.test.ts` passed. `bun run check` in `packages/coding-agent` passed. The stale-gate repro now prints `gate cleared after failed apply` instead of re-emitting the skipped-tool gate. Fixes #3061