### PR TITLE
fix(tui): guard hyperlinks before settings init

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed image paste placeholders falling through to terminal hyperlink settings before `Settings.init()`, so early editor rendering falls back to plain text instead of crashing. ([#3064](https://github.com/can1357/oh-my-pi/issues/3064))
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -39,11 +39,12 @@ function feedGaps(editor: CustomEditor, gaps: number[]): void {
 	}
 }
 
-async function decorateInFreshProcess(text: string): Promise<string> {
+async function decorateInFreshProcess(text: string, imageLinks?: readonly string[]): Promise<string> {
 	const customEditorUrl = new URL("./custom-editor.ts", import.meta.url).href;
 	const script = `
 import { CustomEditor } from ${JSON.stringify(customEditorUrl)};
 const editor = new CustomEditor({});
+editor.imageLinks = ${JSON.stringify(imageLinks)};
 process.stdout.write(editor.decorateText(${JSON.stringify(text)}));
 `;
 	const child = await $`bun -e ${script}`.quiet().nothrow();
@@ -59,8 +60,8 @@ describe("CustomEditor placeholder decoration", () => {
 		expect(output).toBe("[Paste #1, +30 lines]");
 	});
 
-	it("renders image placeholders before theme initialization", async () => {
-		const output = await decorateInFreshProcess("[Image #1]");
+	it("renders linked image placeholders before theme and settings initialization", async () => {
+		const output = await decorateInFreshProcess("[Image #1]", ["/tmp/example.png"]);
 		expect(output).toBe("[Image #1]");
 	});
 });

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -7,7 +7,7 @@
  */
 import * as url from "node:url";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
-import { settings } from "../config/settings";
+import { isSettingsInitialized, settings } from "../config/settings";
 import {
 	LocalProtocolHandler,
 	memoryRootsFromRegistry,
@@ -45,8 +45,10 @@ function buildFileUri(filePath: string, opts?: { line?: number; col?: number }):
  * - `"off"`: never
  * - `"auto"`: when `process.stdout.isTTY`, `NO_COLOR` is unset, and the detected terminal reports hyperlink support
  * - `"always"`: unconditionally (useful for viewers that support OSC 8 without advertising it)
+ * Before settings initialization, returns false so early render paths stay plain text.
  */
 export function isHyperlinkEnabled(): boolean {
+	if (!isSettingsInitialized()) return false;
 	const mode = settings.get("tui.hyperlinks");
 	if (mode === "off") return false;
 	if (mode === "always") return true;
@@ -104,10 +106,11 @@ export function urlHyperlink(url: string, displayText: string): string {
  * Wrap `displayText` in an OSC 8 hyperlink pointing at an HTTP(S) URL,
  * bypassing terminal capability auto-detection. Used for auth prompts where
  * an inert "click" label blocks login on terminals whose capabilities are
- * not advertised. Still returns plain text when the user has explicitly
- * opted out via `tui.hyperlinks=off`.
+ * not advertised. Still returns plain text before settings initialization or
+ * when the user has explicitly opted out via `tui.hyperlinks=off`.
  */
 export function urlHyperlinkAlways(url: string, displayText: string): string {
+	if (!isSettingsInitialized()) return displayText;
 	if (settings.get("tui.hyperlinks") === "off") return displayText;
 	const normalized = url.match(/^www\./i) ? `https://${url}` : url;
 	try {

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -60,6 +60,17 @@ afterEach(() => {
 });
 
 describe("isHyperlinkEnabled", () => {
+	it("falls back to plain text before Settings.init", async () => {
+		resetSettingsForTest();
+		try {
+			expect(isHyperlinkEnabled()).toBe(false);
+			expect(fileHyperlink(path.resolve("/Users/foo/bar.ts"), "bar.ts")).toBe("bar.ts");
+			expect(urlHyperlinkAlways("https://example.com/path", "example")).toBe("example");
+		} finally {
+			await Settings.init({ inMemory: true });
+		}
+	});
+
 	it('returns false when mode is "off"', () => {
 		setHyperlinkMode("off");
 		expect(isHyperlinkEnabled()).toBe(false);


### PR DESCRIPTION
## Repro
The reported early-render command reproduced the crash before the fix: `bun -e 'import { CustomEditor } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const e = new CustomEditor({}); e.imageLinks = ["/tmp/example.png"]; console.log(e.decorateText("[Image #1]"));'` exited 1 with `Settings not initialized. Call Settings.init() first.` from `packages/coding-agent/src/tui/hyperlink.ts`.

## Cause
`CustomEditor.decorateText(...)` renders image placeholders through `imageReferenceHyperlink(...)`, which calls `fileHyperlink(...)`; `fileHyperlink(...)` called `isHyperlinkEnabled()`, and `isHyperlinkEnabled()` unconditionally read `settings.get("tui.hyperlinks")` before `Settings.init()` had completed.

## Fix
- Guarded `isHyperlinkEnabled()` with `isSettingsInitialized()` so uninitialized settings behave like hyperlinks are disabled.
- Guarded `urlHyperlinkAlways(...)` with the same pre-init fallback, keeping all hyperlink helpers plain-text safe until settings exist.
- Added a regression test covering pre-init plain-text fallback for `isHyperlinkEnabled()`, `fileHyperlink(...)`, and `urlHyperlinkAlways(...)`.
- Added the coding-agent changelog entry for #3064.

## Verification
Ran `bun -e 'import { CustomEditor } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const e = new CustomEditor({}); e.imageLinks = ["/tmp/example.png"]; console.log(e.decorateText("[Image #1]"));'` and it printed `[Image #1]`. Ran `bun test packages/coding-agent/test/tui/hyperlink.test.ts packages/coding-agent/test/modes/image-references.test.ts`: 35 pass, 0 fail. `gh_push_branch` completed its pre-publish gate and pushed `farm/867a4231/image-paste-placeholder-crash`. Fixes #3064