### PR TITLE
fix(coding-agent): refresh GitHub plugin lockfile pin on re-install

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp plugin install github:owner/repo` silently keeping the user on a stale commit when re-run on an already-installed GitHub plugin. `bun install <spec>` respects the existing `bun.lock` pin when the spec is unchanged and never re-resolves the remote ref, so the manager now follows a git re-install with `bun update <name>` to refresh the lockfile pin against the upstream. First-time installs are unaffected. ([#3063](https://github.com/can1357/oh-my-pi/issues/3063))
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `omp plugin install github:owner/repo` silently keeping the user on a stale commit when re-run on an already-installed GitHub plugin. `bun install <spec>` respects the existing `bun.lock` pin when the spec is unchanged and never re-resolves the remote ref, so the manager now follows a git re-install with `bun update <name>` to refresh the lockfile pin against the upstream. First-time installs are unaffected. ([#3063](https://github.com/can1357/oh-my-pi/issues/3063))
+- Fixed `omp plugin install github:owner/repo` silently keeping the user on a stale commit when re-run on an already-installed GitHub plugin. `bun install <spec>` respects the existing `bun.lock` pin when the spec is unchanged and never re-resolves the remote ref, so the manager now follows a git re-install with `bun update <name>` to refresh the lockfile pin against the upstream. The install transaction also snapshots `bun.lock` up front and routes feature validation, extension validation, and runtime-config save through one rollback path so a failed install can never leave the rejected commit pinned in the active tree or lockfile. First-time installs are unaffected. ([#3063](https://github.com/can1357/oh-my-pi/issues/3063))
 
 ## [16.1.3] - 2026-06-19
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -351,19 +351,18 @@ export class PluginManager {
 		const packageSnapshot = await this.#snapshotInstalledPackage(existingActualName);
 
 		try {
-			// Run npm install
-			const proc = Bun.spawn(["bun", "install", packageInstallSpec], {
+			// Step 1: write the spec into plugins/package.json + node_modules.
+			const installProc = Bun.spawn(["bun", "install", packageInstallSpec], {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",
 				stderr: "pipe",
 				windowsHide: true,
 			});
-
-			const exitCode = await proc.exited;
-			if (exitCode !== 0) {
-				const stderr = await new Response(proc.stderr).text();
-				throw new Error(`npm install failed: ${stderr}`);
+			const installExit = await installProc.exited;
+			if (installExit !== 0) {
+				const stderr = await new Response(installProc.stderr).text();
+				throw new Error(`bun install failed: ${stderr}`);
 			}
 			// Resolve actual package name. npm specs encode the name (strip version);
 			// git specs do not, so diff plugins/package.json deps to find the new entry.
@@ -392,6 +391,31 @@ export class PluginManager {
 				actualName = resolved;
 			} else {
 				actualName = extractPackageName(spec.packageName);
+			}
+
+			// Step 2: refresh the git lockfile pin when re-installing an existing
+			// git plugin. `bun install <spec>` is a no-op when the spec matches the
+			// lockfile entry — it never re-resolves the remote ref — so re-running
+			// `omp plugin install github:owner/repo` would silently keep the user on
+			// the original resolved commit even after upstream moved (#3063).
+			// `bun update <name>` re-resolves the ref against the remote and
+			// rewrites the pin; SHA-pinned refs stay put because the commit can't
+			// move. First-time installs skip this — the initial `bun install` already
+			// fetched HEAD.
+			if (gitSource && existingActualName) {
+				const updateProc = Bun.spawn(["bun", "update", actualName], {
+					cwd: getPluginsDir(),
+					stdin: "ignore",
+					stdout: "pipe",
+					stderr: "pipe",
+					windowsHide: true,
+				});
+				const updateExit = await updateProc.exited;
+				if (updateExit !== 0) {
+					const stderr = await new Response(updateProc.stderr).text();
+					await this.#rollbackFailedInstall(actualName, packageJsonBefore, packageSnapshot);
+					throw new Error(`bun update ${actualName} failed: ${stderr}`);
+				}
 			}
 			const pkgPath = path.join(getPluginsNodeModules(), actualName, "package.json");
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -248,11 +248,29 @@ export class PluginManager {
 	}
 
 	async #rollbackFailedInstall(
-		actualName: string,
+		actualName: string | undefined,
 		packageJsonBefore: string,
+		bunLockBefore: string | null,
 		snapshot: PluginPackageSnapshot | null,
 	): Promise<void> {
 		await Bun.write(getPluginsPackageJson(), packageJsonBefore);
+
+		// Restore (or remove) bun's lockfile. Without this, a `bun install` +
+		// `bun update` pair that successfully rewrote `bun.lock` would leave the
+		// rejected commit pinned even when validation rolls everything else back.
+		const bunLockPath = path.join(getPluginsDir(), "bun.lock");
+		if (bunLockBefore === null) {
+			await fs.promises.rm(bunLockPath, { force: true });
+		} else {
+			await Bun.write(bunLockPath, bunLockBefore);
+		}
+
+		// `actualName` may be undefined when the install failed before the dep
+		// key was resolved — package.json + bun.lock restoration above is the
+		// complete rollback in that case.
+		if (!actualName) {
+			return;
+		}
 		const packagePath = path.join(getPluginsNodeModules(), actualName);
 		await fs.promises.rm(packagePath, { recursive: true, force: true });
 		if (!snapshot) {
@@ -343,6 +361,19 @@ export class PluginManager {
 		}
 		const pkgJsonPath = getPluginsPackageJson();
 		const packageJsonBefore = await Bun.file(pkgJsonPath).text();
+		// Snapshot bun's lockfile so the rollback path can restore the pin. Every
+		// step below — `bun install`, `bun update`, feature/extension validation,
+		// runtime-config save — must either complete entirely or leave the
+		// lockfile pointing at its pre-install state. Absent before install means
+		// "remove on rollback".
+		const bunLockPath = path.join(getPluginsDir(), "bun.lock");
+		let bunLockBefore: string | null;
+		try {
+			bunLockBefore = await Bun.file(bunLockPath).text();
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+			bunLockBefore = null;
+		}
 		const depsBefore = await this.#readDeps(pkgJsonPath);
 		const packageInstallSpec = gitSource ? gitInstallSpec(spec.packageName, gitSource) : spec.packageName;
 		const existingActualName = gitSource
@@ -350,6 +381,10 @@ export class PluginManager {
 			: extractPackageName(spec.packageName);
 		const packageSnapshot = await this.#snapshotInstalledPackage(existingActualName);
 
+		// `actualName` is hoisted so the rollback handler can clean up the right
+		// node_modules entry even if a step between `bun install` and the final
+		// validation throws.
+		let actualName: string | undefined;
 		try {
 			// Step 1: write the spec into plugins/package.json + node_modules.
 			const installProc = Bun.spawn(["bun", "install", packageInstallSpec], {
@@ -366,7 +401,6 @@ export class PluginManager {
 			}
 			// Resolve actual package name. npm specs encode the name (strip version);
 			// git specs do not, so diff plugins/package.json deps to find the new entry.
-			let actualName: string;
 			if (gitSource) {
 				const depsAfter = await this.#readDeps(pkgJsonPath);
 				let resolved: string | undefined;
@@ -401,7 +435,7 @@ export class PluginManager {
 			// `bun update <name>` re-resolves the ref against the remote and
 			// rewrites the pin; SHA-pinned refs stay put because the commit can't
 			// move. First-time installs skip this — the initial `bun install` already
-			// fetched HEAD.
+			// fetched HEAD. Rollback is handled by the outer catch.
 			if (gitSource && existingActualName) {
 				const updateProc = Bun.spawn(["bun", "update", actualName], {
 					cwd: getPluginsDir(),
@@ -413,12 +447,11 @@ export class PluginManager {
 				const updateExit = await updateProc.exited;
 				if (updateExit !== 0) {
 					const stderr = await new Response(updateProc.stderr).text();
-					await this.#rollbackFailedInstall(actualName, packageJsonBefore, packageSnapshot);
 					throw new Error(`bun update ${actualName} failed: ${stderr}`);
 				}
 			}
-			const pkgPath = path.join(getPluginsNodeModules(), actualName, "package.json");
 
+			const pkgPath = path.join(getPluginsNodeModules(), actualName, "package.json");
 			let pkg: { name: string; version: string; omp?: PluginManifest; pi?: PluginManifest };
 			try {
 				pkg = await Bun.file(pkgPath).json();
@@ -465,18 +498,7 @@ export class PluginManager {
 				enabled: true,
 			};
 
-			try {
-				await this.#validateInstalledExtensions(installedPlugin);
-			} catch (err) {
-				try {
-					await this.#rollbackFailedInstall(actualName, packageJsonBefore, packageSnapshot);
-				} catch (rollbackErr) {
-					const message = err instanceof Error ? err.message : String(err);
-					const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-					throw new Error(`${message}\nRollback failed: ${rollbackMessage}`);
-				}
-				throw err;
-			}
+			await this.#validateInstalledExtensions(installedPlugin);
 
 			// Update runtime config
 			const config = await this.#ensureConfigLoaded();
@@ -488,6 +510,20 @@ export class PluginManager {
 			await this.#saveRuntimeConfig();
 
 			return installedPlugin;
+		} catch (err) {
+			try {
+				await this.#rollbackFailedInstall(
+					actualName ?? existingActualName,
+					packageJsonBefore,
+					bunLockBefore,
+					packageSnapshot,
+				);
+			} catch (rollbackErr) {
+				const message = err instanceof Error ? err.message : String(err);
+				const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+				throw new Error(`${message}\nRollback failed: ${rollbackMessage}`);
+			}
+			throw err;
 		} finally {
 			await this.#cleanupSnapshot(packageSnapshot);
 		}

--- a/packages/coding-agent/test/plugin-install-git.test.ts
+++ b/packages/coding-agent/test/plugin-install-git.test.ts
@@ -160,6 +160,117 @@ describe("PluginManager.install with git sources", () => {
 		expect(result.version).toBe("1.0.0");
 	});
 
+	test("re-installing a github plugin runs `bun update` to refresh the stale lockfile pin (#3063)", async () => {
+		// Seed plugins/package.json + node_modules with a previously-installed
+		// github plugin. `findGitPackageName` matches the new install spec to
+		// this existing dep (by repository identity), which is the signal the
+		// manager uses to trigger the lockfile-refresh follow-up.
+		await Bun.write(
+			pluginsPkgJson,
+			JSON.stringify(
+				{
+					name: "omp-plugins",
+					private: true,
+					dependencies: { "stale-plugin": "github:foo/bar" },
+				},
+				null,
+				2,
+			),
+		);
+		const seedDir = path.join(pluginsNodeModules, "stale-plugin");
+		await fs.mkdir(seedDir, { recursive: true });
+		await Bun.write(
+			path.join(seedDir, "package.json"),
+			JSON.stringify({ name: "stale-plugin", version: "0.1.0" }, null, 2),
+		);
+
+		const spawnedCommands: string[][] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			spawnedCommands.push([...cmd]);
+			if (cmd[1] === "install") {
+				// `bun install <same spec>` is a no-op on the lockfile pin —
+				// the manager must NOT rely on this call to refresh the commit.
+				// Leave package.json and node_modules untouched so the test
+				// fails loudly if the manager skips the follow-up `bun update`.
+				return {
+					pid: 1,
+					stdout: emptyStream(),
+					stderr: emptyStream(),
+					exited: Promise.resolve(0),
+				} as Subprocess;
+			}
+			// The follow-up call: simulate bun resolving the upstream HEAD to a
+			// newer commit and bumping the on-disk version. The manager should
+			// read the new version from package.json after this step returns.
+			expect(cmd).toEqual(["bun", "update", "stale-plugin"]);
+			const prepare = (async () => {
+				await Bun.write(
+					path.join(seedDir, "package.json"),
+					JSON.stringify({ name: "stale-plugin", version: "0.1.6" }, null, 2),
+				);
+			})();
+			return {
+				pid: 2,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		const mgr = new PluginManager(tmpRoot);
+		const result = await mgr.install("github:foo/bar");
+
+		expect(result.version).toBe("0.1.6");
+		expect(spawnedCommands).toEqual([
+			["bun", "install", "github:foo/bar"],
+			["bun", "update", "stale-plugin"],
+		]);
+	});
+
+	test("first-time github install does NOT run `bun update` (no existing pin to refresh)", async () => {
+		await Bun.write(
+			pluginsPkgJson,
+			JSON.stringify({ name: "omp-plugins", private: true, dependencies: {} }, null, 2),
+		);
+
+		const spawnedCommands: string[][] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			spawnedCommands.push([...cmd]);
+			expect(cmd[1]).toBe("install");
+			const prepare = (async () => {
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{
+							name: "omp-plugins",
+							private: true,
+							dependencies: { "fresh-plugin": "github:foo/bar" },
+						},
+						null,
+						2,
+					),
+				);
+				const installedDir = path.join(pluginsNodeModules, "fresh-plugin");
+				await fs.mkdir(installedDir, { recursive: true });
+				await Bun.write(
+					path.join(installedDir, "package.json"),
+					JSON.stringify({ name: "fresh-plugin", version: "0.1.6" }, null, 2),
+				);
+			})();
+			return {
+				pid: 1,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		const mgr = new PluginManager(tmpRoot);
+		await mgr.install("github:foo/bar");
+
+		expect(spawnedCommands).toEqual([["bun", "install", "github:foo/bar"]]);
+	});
+
 	test("rejects git specs containing shell metacharacters", async () => {
 		const mgr = new PluginManager(tmpRoot);
 		await expect(mgr.install("github:foo/bar; rm -rf /")).rejects.toThrow(/Invalid characters in plugin source/);

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -290,4 +290,195 @@ describe("PluginManager.install load validation", () => {
 		expect(await Bun.file(path.join(pluginsNodeModules, "partial-plugin", "package.json")).exists()).toBe(false);
 		expect(await Bun.file(path.join(tmpRoot, "omp-plugins.lock.json")).exists()).toBe(false);
 	});
+
+	test("restores bun.lock when a git reinstall fails validation (#3069 follow-up)", async () => {
+		// Pre-existing valid v1 install plus a populated bun.lock pinning the
+		// original commit. The mock simulates `bun install` rewriting the lock
+		// to a new pin, then `bun update` rewriting it to a NEWER pin (the case
+		// the reviewer flagged: bun update mutates bun.lock before validation).
+		// Extension validation then fails and the rollback must restore the
+		// ORIGINAL pin — not the install-time pin, not the update-time pin.
+		await Bun.write(
+			pluginsPkgJson,
+			JSON.stringify(
+				{ name: "omp-plugins", private: true, dependencies: { "git-plugin": "github:org/plugin#v1" } },
+				null,
+				2,
+			),
+		);
+		const bunLockPath = path.join(pluginsDir, "bun.lock");
+		const ORIGINAL_LOCK = '# bun.lock\n"git-plugin": "github:org/plugin#sha-v1"\n';
+		await Bun.write(bunLockPath, ORIGINAL_LOCK);
+		await Bun.write(
+			path.join(tmpRoot, "omp-plugins.lock.json"),
+			JSON.stringify(
+				{ plugins: { "git-plugin": { version: "1.0.0", enabledFeatures: null, enabled: true } }, settings: {} },
+				null,
+				2,
+			),
+		);
+		await writePluginPackage(pluginsNodeModules, "git-plugin", {
+			version: "1.0.0",
+			source: 'export default function(pi) { pi.registerCommand("git-old-ok", { handler: async () => {} }); }\n',
+		});
+
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			if (cmd[1] === "install") {
+				const prepare = (async () => {
+					// bun install rewrites the lockfile to a stale-but-different pin
+					// and stages the broken v2 tree.
+					await Bun.write(bunLockPath, '# bun.lock\n"git-plugin": "github:org/plugin#sha-install"\n');
+					await Bun.write(
+						pluginsPkgJson,
+						JSON.stringify(
+							{ name: "omp-plugins", private: true, dependencies: { "git-plugin": "github:org/plugin" } },
+							null,
+							2,
+						),
+					);
+					await writePluginPackage(pluginsNodeModules, "git-plugin", {
+						version: "2.0.0",
+						peerDependencies: { "missing-peer": "^1.0.0" },
+						source:
+							'import { missing } from "missing-peer";\nexport default function(pi) { pi.registerCommand(String(missing), { handler: async () => {} }); }\n',
+					});
+				})();
+				return {
+					pid: 1,
+					stdout: emptyStream(),
+					stderr: emptyStream(),
+					exited: prepare.then(() => 0),
+				} as Subprocess;
+			}
+			expect(cmd).toEqual(["bun", "update", "git-plugin"]);
+			const prepare = (async () => {
+				// bun update re-resolves the ref and rewrites the lockfile pin
+				// AGAIN. Without bun.lock snapshotting this pin would survive
+				// the validation failure below.
+				await Bun.write(bunLockPath, '# bun.lock\n"git-plugin": "github:org/plugin#sha-update"\n');
+			})();
+			return {
+				pid: 2,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		await expect(new PluginManager(tmpRoot).install("github:org/plugin")).rejects.toThrow(/missing-peer/);
+
+		expect(await Bun.file(bunLockPath).text()).toBe(ORIGINAL_LOCK);
+		const pluginsPackage = await Bun.file(pluginsPkgJson).json();
+		expect(pluginsPackage.dependencies).toEqual({ "git-plugin": "github:org/plugin#v1" });
+		const restoredPackage = await Bun.file(path.join(pluginsNodeModules, "git-plugin", "package.json")).json();
+		expect(restoredPackage.version).toBe("1.0.0");
+	});
+
+	test("removes bun.lock on rollback when it did not exist before install", async () => {
+		// First-time install of a broken plugin: bun install creates bun.lock,
+		// extension validation fails, rollback must remove the newly-created
+		// lockfile so the next install starts clean.
+		const bunLockPath = path.join(pluginsDir, "bun.lock");
+		expect(await Bun.file(bunLockPath).exists()).toBe(false);
+
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			expect(cmd).toEqual(["bun", "install", "broken-plugin"]);
+			const prepare = (async () => {
+				await Bun.write(bunLockPath, '# bun.lock\n"broken-plugin": "1.0.0"\n');
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{ name: "omp-plugins", private: true, dependencies: { "broken-plugin": "1.0.0" } },
+						null,
+						2,
+					),
+				);
+				await writePluginPackage(pluginsNodeModules, "broken-plugin", {
+					version: "1.0.0",
+					peerDependencies: { "missing-peer": "^1.0.0" },
+					source:
+						'import { missing } from "missing-peer";\nexport default function(pi) { pi.registerCommand(String(missing), { handler: async () => {} }); }\n',
+				});
+			})();
+			return {
+				pid: 1,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		await expect(new PluginManager(tmpRoot).install("broken-plugin")).rejects.toThrow(/missing-peer/);
+
+		expect(await Bun.file(bunLockPath).exists()).toBe(false);
+	});
+
+	test("rolls back when an unknown feature is requested after a git reinstall", async () => {
+		// Feature validation lives between bun install/update and extension
+		// validation. Pre-#3069-followup it threw outside the rollback block,
+		// so an unknown feature would leave the rejected commit + lockfile pin
+		// in place. Now it must roll back everything.
+		await Bun.write(
+			pluginsPkgJson,
+			JSON.stringify(
+				{ name: "omp-plugins", private: true, dependencies: { "git-plugin": "github:org/plugin" } },
+				null,
+				2,
+			),
+		);
+		const bunLockPath = path.join(pluginsDir, "bun.lock");
+		const ORIGINAL_LOCK = '# bun.lock\n"git-plugin": "github:org/plugin#sha-v1"\n';
+		await Bun.write(bunLockPath, ORIGINAL_LOCK);
+		await writePluginPackage(pluginsNodeModules, "git-plugin", {
+			version: "1.0.0",
+			source: 'export default function(pi) { pi.registerCommand("git-old-ok", { handler: async () => {} }); }\n',
+		});
+		// The seeded manifest declares one feature `keep`; user will request
+		// the unknown feature `ghost` instead.
+		await Bun.write(
+			path.join(pluginsNodeModules, "git-plugin", "package.json"),
+			JSON.stringify(
+				{
+					name: "git-plugin",
+					version: "1.0.0",
+					omp: {
+						extensions: ["./dist/extension.ts"],
+						features: { keep: { description: "keep me" } },
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			if (cmd[1] === "install") {
+				const prepare = (async () => {
+					await Bun.write(bunLockPath, '# bun.lock\n"git-plugin": "github:org/plugin#sha-install"\n');
+				})();
+				return {
+					pid: 1,
+					stdout: emptyStream(),
+					stderr: emptyStream(),
+					exited: prepare.then(() => 0),
+				} as Subprocess;
+			}
+			expect(cmd).toEqual(["bun", "update", "git-plugin"]);
+			const prepare = (async () => {
+				await Bun.write(bunLockPath, '# bun.lock\n"git-plugin": "github:org/plugin#sha-update"\n');
+			})();
+			return {
+				pid: 2,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		await expect(new PluginManager(tmpRoot).install("github:org/plugin[ghost]")).rejects.toThrow(/Unknown feature/);
+
+		expect(await Bun.file(bunLockPath).text()).toBe(ORIGINAL_LOCK);
+		const pluginsPackage = await Bun.file(pluginsPkgJson).json();
+		expect(pluginsPackage.dependencies).toEqual({ "git-plugin": "github:org/plugin" });
+	});
 });

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -188,30 +188,42 @@ describe("PluginManager.install load validation", () => {
 		});
 
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "github:org/plugin#v2"]);
+			if (cmd[1] === "install") {
+				expect(cmd).toEqual(["bun", "install", "github:org/plugin#v2"]);
 
-			const prepare = (async () => {
-				await Bun.write(
-					pluginsPkgJson,
-					JSON.stringify(
-						{ name: "omp-plugins", private: true, dependencies: { "git-plugin": "github:org/plugin#v2" } },
-						null,
-						2,
-					),
-				);
-				await writePluginPackage(pluginsNodeModules, "git-plugin", {
-					version: "2.0.0",
-					peerDependencies: { "missing-peer": "^1.0.0" },
-					source:
-						'import { missing } from "missing-peer";\nexport default function(pi) { pi.registerCommand(String(missing), { handler: async () => {} }); }\n',
-				});
-			})();
+				const prepare = (async () => {
+					await Bun.write(
+						pluginsPkgJson,
+						JSON.stringify(
+							{ name: "omp-plugins", private: true, dependencies: { "git-plugin": "github:org/plugin#v2" } },
+							null,
+							2,
+						),
+					);
+					await writePluginPackage(pluginsNodeModules, "git-plugin", {
+						version: "2.0.0",
+						peerDependencies: { "missing-peer": "^1.0.0" },
+						source:
+							'import { missing } from "missing-peer";\nexport default function(pi) { pi.registerCommand(String(missing), { handler: async () => {} }); }\n',
+					});
+				})();
 
+				return {
+					pid: 1,
+					stdout: emptyStream(),
+					stderr: emptyStream(),
+					exited: prepare.then(() => 0),
+				} as Subprocess;
+			}
+			// The manager follows a git re-install with `bun update <name>` to refresh
+			// the lockfile pin (#3063). The mock treats it as a no-op exit-0 — the
+			// on-disk state already reflects the v2 install above.
+			expect(cmd).toEqual(["bun", "update", "git-plugin"]);
 			return {
-				pid: 1,
+				pid: 2,
 				stdout: emptyStream(),
 				stderr: emptyStream(),
-				exited: prepare.then(() => 0),
+				exited: Promise.resolve(0),
 			} as Subprocess;
 		}) as typeof Bun.spawn);
 


### PR DESCRIPTION
## Repro

Re-running `omp plugin install github:owner/repo` reports success but leaves the user pinned to the original resolved commit. Demonstrated against `github:kevva/is-positive` (no `#ref`): the bootstrap install resolves HEAD (`97edff6`) and pins it in `bun.lock`; a second `bun install "github:kevva/is-positive"` completes in `[1.00ms]` — bun never contacts the remote, so the pin can never advance. The reporter's workaround `cd ~/.omp/plugins && bun update <name>` succeeded because `bun update` is the one bun command that re-resolves the git ref.

```
=== re-run 'bun install github:kevva/is-positive' (the omp action) ===
installed is-positive@github:kevva/is-positive#97edff6
[1.00ms] done
*** Same pin — bun install was a NO-OP. Stale lockfile pins are not refreshed. ***
```

## Cause

`PluginManager.install` in `packages/coding-agent/src/extensibility/plugins/manager.ts` only shells out to `bun install <spec>`. For git sources, `bun install` is documented to honor the existing lockfile entry whenever the spec string is unchanged; it never re-resolves the remote `HEAD` / branch / tag. The manager has no follow-up step, so an unpinned `github:owner/repo` re-install is a guaranteed no-op on the resolved commit. The CLI's `--force` flag is also dropped on the floor (`options.force` is accepted but unused).

## Fix

- `PluginManager.install` now follows a git re-install with `bun update <name>` to force re-resolution of the ref against upstream. Triggered only when `gitSource && existingActualName` — i.e. the same repo was already in `plugins/package.json#dependencies` before this call. First-time installs skip the update (the initial `bun install` already fetched HEAD).
- `bun update` failures route through the same `#rollbackFailedInstall` path as validation failures, so a network-failed refresh restores the prior package tree and `package.json`.
- The misleading `npm install failed:` error string is updated to `bun install failed:` since the same line is now adjacent to the new `bun update <name> failed:` branch.
- Two new tests in `plugin-install-git.test.ts` pin the contract: (1) re-installing a github plugin spawns `bun install` followed by `bun update <name>` and surfaces the upstream-bumped `package.json` version; (2) a first-time install spawns ONLY `bun install`.
- The existing rollback test for `restores the previous git plugin tree when reinstalling a different ref fails validation` is updated to dispatch its `Bun.spawn` mock on `cmd[1]`, returning a no-op exit-0 for the new follow-up `bun update git-plugin` call.

## Verification

```
$ bun test packages/coding-agent/test/plugin-install-git.test.ts packages/coding-agent/test/plugin-install-validation.test.ts packages/coding-agent/test/plugin-install-local.test.ts packages/coding-agent/test/plugin-config.test.ts
 22 pass
 0 fail
 74 expect() calls
Ran 22 tests across 4 files.

$ bun check
bun check: passed
```

Manual: the empirical repro above (`is-positive`) confirms `bun install <unchanged-spec>` is a 1ms no-op; `bun update <name>` does perform the re-resolution. Pre-publish gate (`bun run fix` + `bun check`) passed unchanged.

Fixes #3063