### PR TITLE
fix(agent): guard against undefined content blocks in estimateTokens

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -286,9 +286,9 @@ export function estimateTokens(message: AgentMessage): number {
 		case "assistant": {
 			const assistant = message as AssistantMessage;
 			for (const block of assistant.content) {
-				if (block.type === "text") {
+				if (block.type === "text" && block.text) {
 					fragments.push(block.text);
-				} else if (block.type === "thinking") {
+				} else if (block.type === "thinking" && block.thinking) {
 					fragments.push(block.thinking);
 					// Providers charge for the opaque signature/reasoning payload that
 					// rides alongside the thinking text (OpenAI Responses encrypted


### PR DESCRIPTION
## Problem

`estimateTokens()` in `packages/agent/src/compaction/compaction.ts` crashes when an assistant message has content blocks with `type: "text"` but no `text` property (or `text: undefined`), or `type: "thinking"` with undefined `thinking` content. The undefined value flows into `countTokens()` and hits the native tokenizer:

```
TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received undefined
    at nZA (Buffer.byteLength)
    at getContextBreakdown
    at getCachedContextBreakdown
```

This was observed after a model switch where the new model produced a text block without content, causing OMP to crash on startup when computing the status-line context breakdown.

## Fix

Added truthiness guards (`&& block.text`, `&& block.thinking`) on lines 289 and 291 — matching the same defensive pattern already used for user messages (line 280) and toolResult/hookMessage blocks (line 317).

## Testing

- Reproduced crash by running OMP with a session containing a malformed assistant text block
- Applied fix, rebuilt, verified OMP starts cleanly
- No type changes — purely a runtime guard