### PR TITLE
fix(agent): wire-encode normalizeTools parameters for omit-intent tools

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Wire-encoded `normalizeTools` parameters unconditionally so tools whose `intent` resolves to `"omit"` (function intent or `intent: "omit"`, e.g. builtin `eval` / `resolve`) no longer leak raw arktype/zod schema objects in `parameters` ([#3074](https://github.com/can1357/oh-my-pi/issues/3074))
+
 ## [16.1.2] - 2026-06-19
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -5,12 +5,9 @@
 import {
 	type AssistantMessage,
 	type AssistantMessageEvent,
-	arkToWireSchema,
 	type Context,
 	EventStream,
 	isApiKeyResolver,
-	isArkSchema,
-	isZodSchema,
 	resolveApiKeyOnce,
 	seedApiKeyResolver,
 	streamSimple,
@@ -20,7 +17,6 @@ import {
 	type TSchema,
 	toolWireSchema,
 	validateToolArguments,
-	zodToWireSchema,
 } from "@oh-my-pi/pi-ai";
 import {
 	type Dialect,
@@ -598,16 +594,8 @@ export function normalizeTools(
 			if (doInjectIntent) parameters = injectIntentIntoSchema(parameters, intentMode, false) as TSchema;
 			return { ...t, parameters, description: "" };
 		}
-		let parameters: TSchema = t.parameters;
-		if (doInjectIntent) {
-			if (isZodSchema(parameters)) {
-				parameters = injectIntentIntoSchema(zodToWireSchema(parameters), intentMode) as TSchema;
-			} else if (isArkSchema(parameters)) {
-				parameters = injectIntentIntoSchema(arkToWireSchema(parameters), intentMode) as TSchema;
-			} else {
-				parameters = injectIntentIntoSchema(parameters, intentMode) as TSchema;
-			}
-		}
+		let parameters = toolWireSchema(t) as TSchema;
+		if (doInjectIntent) parameters = injectIntentIntoSchema(parameters, intentMode) as TSchema;
 		const description = t.description ?? "";
 		const examplesBlock = exampleDialect
 			? renderToolExamples({ ...t, parameters }, exampleDialect, doInjectIntent ? INTENT_FIELD : undefined)

--- a/packages/agent/test/normalize-tools-prune.test.ts
+++ b/packages/agent/test/normalize-tools-prune.test.ts
@@ -76,3 +76,50 @@ describe("normalizeTools — pruneDescriptions", () => {
 		expect(typeof fieldDescription(tools?.[0]?.parameters, INTENT_FIELD)).toBe("string");
 	});
 });
+
+describe("normalizeTools — omit-intent tools", () => {
+	it("wire-encodes arktype parameters when intent is a function", () => {
+		const params = type({ action: "string", reason: "string" });
+		const tool: AgentTool<typeof params> = {
+			name: "resolve",
+			label: "Resolve",
+			description: "",
+			parameters: params,
+			intent: () => "resolving",
+			async execute() {
+				return { content: [{ type: "text", text: "ok" }] };
+			},
+		};
+		const out = normalizeTools([tool], true)?.[0];
+		expect(out?.parameters).toMatchObject({ type: "object" });
+		expect(hasField(out?.parameters, "action")).toBe(true);
+		expect(hasField(out?.parameters, "reason")).toBe(true);
+		// Function intent => intentMode is "omit"; INTENT_FIELD must NOT be injected.
+		expect(hasField(out?.parameters, INTENT_FIELD)).toBe(false);
+	});
+
+	it("wire-encodes arktype parameters when intent is the literal 'omit'", () => {
+		const params = type({ note: "string" });
+		const tool: AgentTool<typeof params> = {
+			name: "demo-omit",
+			label: "Demo",
+			description: "",
+			parameters: params,
+			intent: "omit",
+			async execute() {
+				return { content: [{ type: "text", text: "ok" }] };
+			},
+		};
+		const out = normalizeTools([tool], true)?.[0];
+		expect(out?.parameters).toMatchObject({ type: "object" });
+		expect(hasField(out?.parameters, "note")).toBe(true);
+		expect(hasField(out?.parameters, "i")).toBe(false);
+	});
+
+	it("wire-encodes parameters even when intent injection is disabled globally", () => {
+		const out = normalizeTools([makeTool()], false)?.[0];
+		expect(out?.parameters).toMatchObject({ type: "object" });
+		expect(hasField(out?.parameters, "path")).toBe(true);
+		expect(hasField(out?.parameters, "nested")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro

`normalizeTools` returns wire-ready tool specs for every tool, but for tools whose intent resolves to `"omit"` — function intent, or `intent: "omit"` (builtin `eval` / `resolve`) — `parameters` came back as the raw arktype/zod schema object instead of JSON Schema.

```ts
import { type } from "arktype";
import { normalizeTools } from "@oh-my-pi/pi-agent-core/agent-loop";

const params = type({ action: "string", reason: "string" });
const tool = {
  name: "resolve",
  label: "Resolve",
  description: "",
  parameters: params,
  intent: () => "resolving",
  async execute() { return { content: [{ type: "text", text: "ok" }] }; },
};

const out = normalizeTools([tool], true)?.[0];
console.log(JSON.stringify(out?.parameters));
```

Before: `{"required":[{"key":"action","value":"string"},{"key":"reason","value":"string"}],"domain":"object"}` (arktype internal AST).
After: `{"type":"object","properties":{"action":{"type":"string"},"reason":{"type":"string"}},"required":["action","reason"],"additionalProperties":false}`.

## Cause

In `packages/agent/src/agent-loop.ts:601-610`, the `zodToWireSchema` / `arkToWireSchema` conversion only ran inside `if (doInjectIntent)`. `resolveIntentMode` collapses function intents and the literal `"omit"` to `"omit"`, so `doInjectIntent` was false and `parameters` stayed as the live arktype/zod object. The `pruneDescriptions` branch above (line 596) already wire-encoded unconditionally via `toolWireSchema`, so the two branches disagreed; first-party providers happen to re-encode with `toolWireSchema` themselves and never tripped the bug, but anything downstream that serialized `parameters` as-is got an invalid schema.

## Fix

- Hoist `toolWireSchema(t)` out of the `if (doInjectIntent)` branch so it always runs, then inject intent on top — mirrors the `pruneDescriptions` shape.
- Drop the now-unused `isZodSchema` / `isArkSchema` / `zodToWireSchema` / `arkToWireSchema` imports.
- Extend `packages/agent/test/normalize-tools-prune.test.ts` with three regression cases: function intent, literal `intent: "omit"`, and `injectIntent: false` — each must yield a `type: "object"` JSON Schema with the original properties and no `i` field.

## Verification

- `bun test packages/agent/test/normalize-tools-prune.test.ts` → 7 pass.
- `bun test` (packages/agent) → 301 pass, 0 fail.
- `bun check` → green (all packages).

Fixes #3074