### PR TITLE
fix(hashline): preserved replacement payload, fixed bare DEL and grammar

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Preserved replacement payload boundary lines verbatim instead of auto-dropping balance-neutral echoes that match neighboring unchanged lines. ([#2885](https://github.com/can1357/oh-my-pi/issues/2885))
+- Fixed the exported provider grammar to accept documented single-line `DEL N` hunks. ([#2885](https://github.com/can1357/oh-my-pi/issues/2885))
+- Treated bare `DEL` under `SWAP N.=M:` as an empty replacement delete instead of literal inserted text. ([#2885](https://github.com/can1357/oh-my-pi/issues/2885))
 ## [16.0.2] - 2026-06-16
 
 ### Fixed

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -112,116 +112,22 @@ function bucketAnchorEditsByLine(edits: IndexedEdit[]): Map<number, IndexedEdit[
 	return byLine;
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
 // Replacement-boundary repair
 //
-// Models routinely miscount a replacement range's edges. Sometimes the payload
-// re-states unchanged lines that still live on both sides of the range
-// (duplicating a function header and final statement); sometimes it only
-// re-states or omits a structural closer, which leaves delimiter balance broken.
-//
-// A balance-neutral boundary-echo repair fires only when both the leading and
-// trailing payload edges are exact copies of the surviving lines outside the
-// range. One-sided content echoes are left alone unless delimiter-balance repair
-// proves they are duplicated structural boundaries. This preserves intended
-// duplicate statements while absorbing the common "body includes the unchanged
-// wrapper" mistake.
+// The applier never drops authored replacement payload just because it matches
+// the unchanged lines outside the selected range. Exact payload fidelity wins:
+// callers can intentionally duplicate neighboring lines, and silently trimming
+// them is data loss. The only remaining repairs below are delimiter-balance
+// recoveries that either explain a syntax imbalance or keep an omitted
+// structural closer from being deleted.
 
 /** A line that is nothing but closing delimiters: `}`, `)`, `];`, `})`, `},`. */
 export const STRUCTURAL_CLOSER_RE = /^\s*[)\]}]+[;,]?\s*$/;
 
-/** A JSX/XML closing boundary that carries structure but no bracket tokens. */
-const JSX_CLOSER_RE = /^\s*(?:<\/>|<\/[A-Za-z][\w.:-]*>|\/>)\s*[;,]?\s*$/;
-const JSX_NAMED_CLOSER_RE = /^\s*<\/([A-Za-z][\w.:-]*)>\s*[;,]?\s*$/;
-const JSX_FRAGMENT_CLOSER_RE = /^\s*<\/>\s*[;,]?\s*$/;
-
-function isStructuralCloserLine(text: string): boolean {
-	return STRUCTURAL_CLOSER_RE.test(text) || JSX_CLOSER_RE.test(text);
-}
-
-function jsxCloserName(text: string): string | undefined {
-	if (JSX_FRAGMENT_CLOSER_RE.test(text)) return "";
-	const match = JSX_NAMED_CLOSER_RE.exec(text);
-	return match?.[1];
-}
-
-interface JsxPayloadTag {
-	readonly name: string;
-	readonly closing: boolean;
-	readonly selfClosing: boolean;
-}
-
-function isJsxTagStart(text: string, index: number): boolean {
-	const next = text[index + 1];
-	return next === ">" || next === "/" || (next >= "A" && next <= "Z") || (next >= "a" && next <= "z");
-}
-
-function findJsxTagEnd(text: string, start: number): number {
-	let quote: string | undefined;
-	let braces = 0;
-	for (let i = start + 1; i < text.length; i++) {
-		const ch = text[i];
-		if (quote) {
-			if (ch === "\\" && i + 1 < text.length) {
-				i++;
-			} else if (ch === quote) {
-				quote = undefined;
-			}
-			continue;
-		}
-		if (ch === '"' || ch === "'" || ch === "`") {
-			quote = ch;
-		} else if (ch === "{") {
-			braces++;
-		} else if (ch === "}" && braces > 0) {
-			braces--;
-		} else if (ch === ">" && braces === 0) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-function parseJsxPayloadTag(raw: string): JsxPayloadTag | undefined {
-	if (raw === "<>") return { name: "", closing: false, selfClosing: false };
-	if (raw === "</>") return { name: "", closing: true, selfClosing: false };
-	const closing = raw.startsWith("</");
-	const nameStart = closing ? 2 : 1;
-	let nameEnd = nameStart;
-	while (nameEnd < raw.length && /[\w.:-]/.test(raw[nameEnd])) nameEnd++;
-	if (nameEnd === nameStart) return undefined;
-	return {
-		name: raw.slice(nameStart, nameEnd),
-		closing,
-		selfClosing: !closing && /\/>\s*$/.test(raw),
-	};
-}
-
-function readJsxPayloadTags(text: string): JsxPayloadTag[] {
-	const tags: JsxPayloadTag[] = [];
-	for (let start = text.indexOf("<"); start >= 0; start = text.indexOf("<", start + 1)) {
-		if (!isJsxTagStart(text, start)) continue;
-		const end = findJsxTagEnd(text, start);
-		if (end < 0) break;
-		const tag = parseJsxPayloadTag(text.slice(start, end + 1));
-		if (tag) tags.push(tag);
-		start = end;
-	}
-	return tags;
-}
-
-function payloadHasJsxOpenerForEcho(payloadPrefix: readonly string[], echoLines: readonly string[]): boolean {
-	const openTags: string[] = [];
-	for (const tag of readJsxPayloadTags(payloadPrefix.join("\n"))) {
-		if (tag.closing) {
-			if (openTags[openTags.length - 1] === tag.name) openTags.pop();
-		} else if (!tag.selfClosing) {
-			openTags.push(tag.name);
-		}
-	}
-	for (const line of echoLines) {
-		const name = jsxCloserName(line);
-		if (name !== undefined && openTags.includes(name)) return true;
+function hasNonWhitespace(text: string): boolean {
+	for (let i = 0; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		if (code !== 9 && code !== 10 && code !== 11 && code !== 12 && code !== 13 && code !== 32) return true;
 	}
 	return false;
 }
@@ -446,92 +352,6 @@ function findDroppedSuffixClosers(
 	return 0;
 }
 
-interface BoundaryEcho {
-	leading: number;
-	trailing: number;
-}
-
-function hasNonWhitespace(text: string): boolean {
-	for (let i = 0; i < text.length; i++) {
-		const code = text.charCodeAt(i);
-		if (code !== 9 && code !== 10 && code !== 11 && code !== 12 && code !== 13 && code !== 32) return true;
-	}
-	return false;
-}
-
-function countDuplicateLeadingBoundaryLines(group: ReplacementGroup, fileLines: readonly string[]): number {
-	const { payload, startLine } = group;
-	const max = Math.min(payload.length, startLine - 1);
-	for (let count = max; count >= 1; count--) {
-		let matches = true;
-		let hasContent = false;
-		for (let offset = 0; offset < count; offset++) {
-			const line = payload[offset];
-			if (line !== fileLines[startLine - 1 - count + offset]) {
-				matches = false;
-				break;
-			}
-			hasContent ||= hasNonWhitespace(line);
-		}
-		if (matches && hasContent) return count;
-	}
-	return 0;
-}
-
-function countDuplicateTrailingBoundaryLines(group: ReplacementGroup, fileLines: readonly string[]): number {
-	const { payload, endLine } = group;
-	const max = Math.min(payload.length, fileLines.length - endLine);
-	for (let count = max; count >= 1; count--) {
-		let matches = true;
-		let hasContent = false;
-		for (let offset = 0; offset < count; offset++) {
-			const line = payload[payload.length - count + offset];
-			if (line !== fileLines[endLine + offset]) {
-				matches = false;
-				break;
-			}
-			hasContent ||= hasNonWhitespace(line);
-		}
-		if (matches && hasContent) return count;
-	}
-	return 0;
-}
-
-function findBoundaryEcho(group: ReplacementGroup, fileLines: readonly string[]): BoundaryEcho | undefined {
-	const leadingMax = countDuplicateLeadingBoundaryLines(group, fileLines);
-	if (leadingMax === 0) return undefined;
-	const trailingMax = countDuplicateTrailingBoundaryLines(group, fileLines);
-	if (trailingMax === 0) return undefined;
-	// Bail when every payload line could be claimed by a boundary echo: any
-	// repair would strip explicit replacement content with no signal that the
-	// payload was a mistake rather than an intentional duplication.
-	if (leadingMax + trailingMax >= group.payload.length) return undefined;
-	// Balance-neutrality guard (see header comment): the dropped echo lines must
-	// either be delimiter-neutral on their own or exactly cancel the payload/range
-	// balance delta. In brace-heavy code where bare closer lines repeat, an
-	// "echo" that shifts delimiter balance is structural content the payload
-	// placed intentionally — stripping it would corrupt the result.
-	const leadingBalance = computeDelimiterBalance(group.payload.slice(0, leadingMax));
-	const trailingBalance = computeDelimiterBalance(group.payload.slice(group.payload.length - trailingMax));
-	const droppedBalance = balanceDelta(leadingBalance, balanceNegate(trailingBalance));
-	if (!balanceIsZero(droppedBalance)) {
-		const delta = balanceDelta(
-			computeDelimiterBalance(group.payload),
-			computeDelimiterBalance(fileLines.slice(group.startLine - 1, group.endLine)),
-		);
-		if (!balanceEqual(droppedBalance, delta)) return undefined;
-	}
-	return { leading: leadingMax, trailing: trailingMax };
-}
-
-function describeBoundaryEchoRepair(group: ReplacementGroup, echo: BoundaryEcho): string {
-	return (
-		`Auto-repaired a replacement boundary echo at line ${group.startLine}: ` +
-		`dropped ${echo.leading} leading and ${echo.trailing} trailing payload line(s) already present outside the range. ` +
-		`Issue the payload as the final desired content for the selected range only — never restate unchanged lines bordering the range.`
-	);
-}
-
 function describeBoundaryRepair(group: ReplacementGroup, action: string): string {
 	return (
 		`Auto-repaired a delimiter-balance mismatch in the replacement at line ${group.startLine}: ${action}. ` +
@@ -540,57 +360,10 @@ function describeBoundaryRepair(group: ReplacementGroup, action: string): string
 }
 
 /**
- * A single-sided boundary echo in an otherwise delimiter-balanced *multi-line*
- * replacement: the payload's leading XOR trailing edge exactly restates the
- * surviving line(s) just outside the range — the off-by-one "range one line
- * short of the keeper I retyped" mistake (e.g. att: payload ends with
- * `const x = [];` and line B+1 is the same `const x = [];`). Two-sided echoes
- * are handled by {@link findBoundaryEcho}; delimiter-imbalanced one-sided echoes
- * by {@link findDuplicateSuffix}/{@link findDuplicatePrefix}.
- *
- * Scoped broadly for multi-line ranges (a construct rewrite) because retouched
- * neutral keepers are usually boundary mistakes there. Single-line expansions
- * are riskier — ordinary duplicated statements may be intentional — so they are
- * only repaired when the duplicated edge is a structural closer line that
- * carries no delimiter-balance signal itself, such as a JSX `</section>` close.
- * The dropped lines must keep the already-balanced result balanced, and must
- * not consume the whole payload.
- */
-function findOneSidedBoundaryEcho(
-	group: ReplacementGroup,
-	fileLines: readonly string[],
-): { side: "leading" | "trailing"; count: number } | undefined {
-	const leading = countDuplicateLeadingBoundaryLines(group, fileLines);
-	const trailing = countDuplicateTrailingBoundaryLines(group, fileLines);
-	if (leading > 0 === trailing > 0) return undefined;
-	const side = leading > 0 ? "leading" : "trailing";
-	const count = leading > 0 ? leading : trailing;
-	if (count >= group.payload.length) return undefined;
-	const echoLines =
-		side === "leading" ? group.payload.slice(0, count) : group.payload.slice(group.payload.length - count);
-	if (!balanceIsZero(computeDelimiterBalance(echoLines))) return undefined;
-	if (group.deleteIndices.length <= 1) {
-		if (side !== "trailing" || !echoLines.every(isStructuralCloserLine)) return undefined;
-		const payloadPrefix = group.payload.slice(0, group.payload.length - count);
-		if (payloadHasJsxOpenerForEcho(payloadPrefix, echoLines)) return undefined;
-	}
-	return { side, count };
-}
-
-function describeOneSidedEchoRepair(group: ReplacementGroup, side: "leading" | "trailing", count: number): string {
-	const where = side === "leading" ? "above" : "below";
-	return (
-		`Auto-repaired a replacement boundary echo at line ${group.startLine}: ` +
-		`dropped ${count} ${side} payload line(s) identical to the surviving line(s) just ${where} the range. ` +
-		`The range was one line short of the content you retyped — issue the payload as the final content for the ` +
-		`selected range only, and widen the range to consume any keeper you restate.`
-	);
-}
-
-/**
- * Normalize replacement groups so common off-by-one boundaries do not duplicate
- * unchanged surrounding lines or structural closers. Returns the repaired edit
- * list plus one warning per repaired group.
+ * Normalize replacement groups so common delimiter-balance mistakes do not
+ * duplicate or omit structural boundaries. Returns the repaired edit list plus
+ * one warning per repaired group. Balance-neutral boundary echoes are left
+ * intact so the replacement body stays byte-for-byte faithful to the author.
  */
 function repairReplacementBoundaries(
 	edits: readonly AppliedEdit[],
@@ -613,28 +386,11 @@ function repairReplacementBoundaries(
 		const deletes = group.deleteIndices.map(idx => edits[idx]);
 		i = group.deleteIndices[group.deleteIndices.length - 1] + 1;
 
-		const boundaryEcho = findBoundaryEcho(group, fileLines);
-		if (boundaryEcho) {
-			warnings.push(describeBoundaryEchoRepair(group, boundaryEcho));
-			out.push(...inserts.slice(boundaryEcho.leading, inserts.length - boundaryEcho.trailing), ...deletes);
-			continue;
-		}
-
 		const delta = balanceDelta(
 			computeDelimiterBalance(group.payload),
 			computeDelimiterBalance(fileLines.slice(group.startLine - 1, group.endLine)),
 		);
 		if (balanceIsZero(delta)) {
-			const oneSided = findOneSidedBoundaryEcho(group, fileLines);
-			if (oneSided) {
-				warnings.push(describeOneSidedEchoRepair(group, oneSided.side, oneSided.count));
-				const trimmed =
-					oneSided.side === "leading"
-						? inserts.slice(oneSided.count)
-						: inserts.slice(0, inserts.length - oneSided.count);
-				out.push(...trimmed, ...deletes);
-				continue;
-			}
 			out.push(...inserts, ...deletes);
 			continue;
 		}

--- a/packages/hashline/src/grammar.lark
+++ b/packages/hashline/src/grammar.lark
@@ -12,7 +12,7 @@ replace_hunk: replace_anchor LF emit_op*
 replace_block_hunk: replace_block_anchor LF emit_op+
 insert_hunk: insert_anchor LF emit_op+
 insert_block_hunk: insert_block_anchor LF emit_op+
-delete_hunk: "DEL " header_range LF
+delete_hunk: "DEL " (header_range | LID) LF
 delete_block_hunk: "DEL.BLK " LID LF
 replace_anchor: "SWAP " header_range ":"
 replace_block_anchor: "SWAP.BLK " LID ":"

--- a/packages/hashline/src/messages.ts
+++ b/packages/hashline/src/messages.ts
@@ -52,6 +52,10 @@ export const REPLACE_PAIR_COALESCED_WARNING = `Two hunks targeted the same range
 export const BARE_BODY_AUTO_PIPED_WARNING =
 	"Auto-prefixed bare body row(s) with `+`. Body rows must be `+TEXT` literal lines.";
 
+/** Bare `DEL` after a replace header means delete the named range, not literal payload. */
+export const BARE_DEL_REPLACE_DELETE_WARNING =
+	"Interpreted bare `DEL` after `SWAP N.=M:` as an empty replacement delete. Use `DEL N.=M` for deletions or `+DEL` for literal text.";
+
 /** Unified-diff-style `-` row in a hunk body. */
 export const MINUS_ROW_REJECTED =
 	"`-` rows are not valid; the range already names the lines being changed. For a literal `-` line, write `+-…`.";

--- a/packages/hashline/src/parser.ts
+++ b/packages/hashline/src/parser.ts
@@ -6,6 +6,7 @@
 import { HL_PAYLOAD_REPLACE, HL_RANGE_SEP } from "./format";
 import {
 	BARE_BODY_AUTO_PIPED_WARNING,
+	BARE_DEL_REPLACE_DELETE_WARNING,
 	DELETE_BLOCK_TAKES_NO_BODY,
 	DELETE_TAKES_NO_BODY,
 	EMPTY_BLOCK,
@@ -234,6 +235,17 @@ export class Executor {
 		if (this.#pending) {
 			if (text.trim().length === 0) {
 				this.#handleBlank(text, lineNum);
+				return;
+			}
+			if (
+				this.#pending.target.kind === "replace" &&
+				this.#pending.payloads.length === 0 &&
+				this.#pending.deferredBlanks.length === 0 &&
+				text.trim() === "DEL"
+			) {
+				if (!this.#warnings.includes(BARE_DEL_REPLACE_DELETE_WARNING)) {
+					this.#warnings.push(BARE_DEL_REPLACE_DELETE_WARNING);
+				}
 				return;
 			}
 			if (this.#pending.target.kind === "delete") throw new Error(`line ${lineNum}: ${DELETE_TAKES_NO_BODY}`);

--- a/packages/hashline/src/parser.ts
+++ b/packages/hashline/src/parser.ts
@@ -246,6 +246,7 @@ export class Executor {
 				if (!this.#warnings.includes(BARE_DEL_REPLACE_DELETE_WARNING)) {
 					this.#warnings.push(BARE_DEL_REPLACE_DELETE_WARNING);
 				}
+				this.#pending.target = { kind: "delete", range: this.#pending.target.range };
 				return;
 			}
 			if (this.#pending.target.kind === "delete") throw new Error(`line ${lineNum}: ${DELETE_TAKES_NO_BODY}`);

--- a/packages/hashline/src/prompt.md
+++ b/packages/hashline/src/prompt.md
@@ -38,7 +38,7 @@ There is NO other body row kind. NEVER write `-old` or a bare/context line. To k
 - `SWAP.BLK N` resolves EXACTLY the node at N. Leading decorators/attributes/doc-comments are separate nodes: point N at the FIRST decorator to sweep both; standalone line-comments are never swept — use `SWAP N.=M`.
 - Block ops (`SWAP.BLK`/`DEL.BLK`/`INS.BLK.POST`) anchor the OPENING line of a MULTI-LINE construct — never its closer, its last line, or a bare statement inside it. Anchoring a single statement resolves to ONE line and is REJECTED: use the plain op (`SWAP N.=N` / `DEL N` / `INS.POST N`) for one line, or point N at the real opener. Saw the closer? Use plain `INS.POST M:`.
 - Non-adjacent changes = separate hunks; untouched lines stay out of every range.
-- Pure additions use `INS.PRE` / `INS.POST` / `INS.HEAD` / `INS.TAIL`, never a widened `SWAP` — retyped keepers are exactly what gets dropped. A multi-line `SWAP` whose body restates the line just outside the range is auto-dropped as an off-by-one keeper (with a warning), but issue the payload as the final content for the range only and never lean on the repair.
+- Pure additions use `INS.PRE` / `INS.POST` / `INS.HEAD` / `INS.TAIL`, never a widened `SWAP` — body rows are applied verbatim, so retyped keepers become duplicated keepers.
 - NEVER format/restyle code with this tool; run the project formatter instead.
 </rules>
 

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -151,7 +151,7 @@ describe("boundary-balance repair", () => {
 		expect(warnings).toHaveLength(0);
 	});
 
-	it("drops duplicated leading and trailing boundary lines around a range replacement", () => {
+	it("preserves duplicated leading and trailing boundary lines around a range replacement", () => {
 		const file = [
 			"func _cmd_travel_homeworld():",
 			"\tvar destination = get_homeworld()",
@@ -171,14 +171,16 @@ describe("boundary-balance repair", () => {
 		expect(text).toBe(
 			[
 				"func _cmd_travel_homeworld():",
+				"func _cmd_travel_homeworld():",
 				"\tvar destination = find_homeworld()",
 				"\ttravel_to(destination)",
 				"\tprint_status()",
+				"\tprint_status()",
 			].join("\n"),
 		);
-		expect(text.split("\n").filter(line => line === "func _cmd_travel_homeworld():")).toHaveLength(1);
-		expect(text.split("\n").filter(line => line === "\tprint_status()")).toHaveLength(1);
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text.split("\n").filter(line => line === "func _cmd_travel_homeworld():")).toHaveLength(2);
+		expect(text.split("\n").filter(line => line === "\tprint_status()")).toHaveLength(2);
+		expect(warnings).toHaveLength(0);
 	});
 
 	it("preserves payloads where multi-line boundary echoes cover every line", () => {
@@ -217,16 +219,16 @@ describe("boundary-balance repair", () => {
 		expect(warnings).toHaveLength(0);
 	});
 
-	// The common wrapper-echo mistake stays repaired: balance-neutral edges
-	// (opener + closer) that duplicate the surviving neighbors are dropped.
-	it("still drops a balance-neutral wrapper echo", () => {
+	// Balance-neutral wrapper echoes are kept verbatim; a payload may
+	// intentionally duplicate the surrounding opener/closer.
+	it("preserves a balance-neutral wrapper echo", () => {
 		const file = ["function f() {", "old();", "}"].join("\n");
 		const diff = ["SWAP 2.=2:", "+function f() {", "+fresh();", "+}"].join("\n");
 
 		const { text, warnings } = apply(file, diff);
 
-		expect(text).toBe(["function f() {", "fresh();", "}"].join("\n"));
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text).toBe(["function f() {", "function f() {", "fresh();", "}", "}"].join("\n"));
+		expect(warnings).toHaveLength(0);
 	});
 
 	// Balance-preserving edits are never touched, even when the payload's last
@@ -261,34 +263,39 @@ describe("boundary-balance repair", () => {
 	});
 
 	// A MULTI-line construct rewrite whose payload restates the keeper that
-	// survives just below the range — the att#1 `replace 639.=644` shape where
-	// the range was one line short of the `const changedFiles` it retyped.
-	it("drops a one-sided trailing keeper echo in a multi-line rewrite", () => {
+	// survives just below the range keeps the duplicate: payload fidelity wins.
+	it("preserves a one-sided trailing keeper echo in a multi-line rewrite", () => {
 		const file = ["function f() {", "  a();", "  b();", "  const out = [];", "  return out;", "}"].join("\n");
 		const diff = ["SWAP 2.=3:", "+  a2();", "+  b2();", "+  const out = [];"].join("\n");
 		const { text, warnings } = apply(file, diff);
-		expect(text).toBe(["function f() {", "  a2();", "  b2();", "  const out = [];", "  return out;", "}"].join("\n"));
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text).toBe(
+			["function f() {", "  a2();", "  b2();", "  const out = [];", "  const out = [];", "  return out;", "}"].join(
+				"\n",
+			),
+		);
+		expect(warnings).toHaveLength(0);
 	});
 
-	it("drops a one-sided JSX closer echo in a single-line expansion", () => {
+	it("preserves a one-sided JSX closer echo in a single-line expansion", () => {
 		const file = ["const view = (", "  <section>", "    <Old />", "  </section>", ");"].join("\n");
 		const diff = ["SWAP 3.=3:", "+    <New />", "+  </section>"].join("\n");
 		const { text, warnings } = apply(file, diff);
 
-		expect(text).toBe(["const view = (", "  <section>", "    <New />", "  </section>", ");"].join("\n"));
-		expect(text.split("\n").filter(line => line === "  </section>")).toHaveLength(1);
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text).toBe(
+			["const view = (", "  <section>", "    <New />", "  </section>", "  </section>", ");"].join("\n"),
+		);
+		expect(text.split("\n").filter(line => line === "  </section>")).toHaveLength(2);
+		expect(warnings).toHaveLength(0);
 	});
 
-	it("drops a JSX closer echo after a self-closing tag with a greater-than prop expression", () => {
+	it("preserves a JSX closer echo after a self-closing tag with a greater-than prop expression", () => {
 		const file = ["const view = (", "<Foo>", "old text", "</Foo>", ");"].join("\n");
 		const diff = ["SWAP 3.=3:", "+<Foo value={a > b} />", "+</Foo>"].join("\n");
 		const { text, warnings } = apply(file, diff);
 
-		expect(text).toBe(["const view = (", "<Foo>", "<Foo value={a > b} />", "</Foo>", ");"].join("\n"));
-		expect(text.split("\n").filter(line => line === "</Foo>")).toHaveLength(1);
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text).toBe(["const view = (", "<Foo>", "<Foo value={a > b} />", "</Foo>", "</Foo>", ");"].join("\n"));
+		expect(text.split("\n").filter(line => line === "</Foo>")).toHaveLength(2);
+		expect(warnings).toHaveLength(0);
 	});
 
 	it("preserves a nested JSX closer that matches the surviving parent closer", () => {
@@ -335,12 +342,12 @@ describe("boundary-balance repair", () => {
 
 	// Mirror direction: the payload restates the keeper that survives just above
 	// the multi-line range (range one line low instead of one short).
-	it("drops a one-sided leading keeper echo in a multi-line rewrite", () => {
+	it("preserves a one-sided leading keeper echo in a multi-line rewrite", () => {
 		const file = ["setup();", "a();", "b();", "c();"].join("\n");
 		const diff = ["SWAP 3.=4:", "+a();", "+B();", "+C();"].join("\n");
 		const { text, warnings } = apply(file, diff);
-		expect(text).toBe(["setup();", "a();", "B();", "C();"].join("\n"));
-		expect(warnings.some(warning => /boundary echo/.test(warning))).toBe(true);
+		expect(text).toBe(["setup();", "a();", "a();", "B();", "C();"].join("\n"));
+		expect(warnings).toHaveLength(0);
 	});
 });
 

--- a/packages/hashline/test/format-v2.test.ts
+++ b/packages/hashline/test/format-v2.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { applyEdits, parsePatch, parsePatchStreaming } from "@oh-my-pi/hashline";
+import grammar from "../src/grammar.lark" with { type: "text" };
 
 function applyPatch(text: string, diff: string): string {
 	return applyEdits(text, parsePatch(diff).edits).text;
@@ -18,9 +19,21 @@ describe("hashline format v4", () => {
 		expect(applyPatch(text, "DEL 2")).toBe("a\nc");
 	});
 
+	it("documents single-line delete in the provider grammar", () => {
+		expect(grammar).toContain('delete_hunk: "DEL " (header_range | LID) LF');
+	});
+
 	it("deletes a concrete range", () => {
 		const text = "a\nb\nc\nd";
 		expect(applyPatch(text, "DEL 2.=3")).toBe("a\nd");
+	});
+
+	it("treats bare DEL under a replace header as deletion, not literal text", () => {
+		const text = "a\nb\nc\nd";
+		const result = parsePatch("SWAP 2.=3:\nDEL");
+
+		expect(applyEdits(text, result.edits).text).toBe("a\nd");
+		expect(result.warnings.some(warning => /bare `DEL`/.test(warning))).toBe(true);
 	});
 
 	it("inserts before and after concrete anchors", () => {

--- a/packages/hashline/test/format-v2.test.ts
+++ b/packages/hashline/test/format-v2.test.ts
@@ -115,4 +115,13 @@ describe("hashline format v4", () => {
 		const result = parsePatchStreaming("SWAP 2.=2:\nINS.TAIL:\n");
 		expect(result.edits).toEqual([{ kind: "delete", anchor: { line: 2 }, lineNum: 1, index: 0 }]);
 	});
+
+	it("flushes bare DEL under a replace hunk during streaming parse", () => {
+		const result = parsePatchStreaming("SWAP 2.=3:\nDEL");
+		expect(result.edits).toEqual([
+			{ kind: "delete", anchor: { line: 2 }, lineNum: 1, index: 0 },
+			{ kind: "delete", anchor: { line: 3 }, lineNum: 1, index: 1 },
+		]);
+		expect(result.warnings.some(warning => /bare `DEL`/.test(warning))).toBe(true);
+	});
 });

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -33,6 +33,22 @@ describe("Patcher snapshot tag integrity", () => {
 		expect(fs.get(PATH)).toBe("after\n");
 	});
 
+	it("accepts the fresh tag returned by the previous successful edit", async () => {
+		const fs = new InMemoryFilesystem([[PATH, "one\ntwo\nthree\n"]]);
+		const snapshots = new InMemorySnapshotStore();
+		const firstTag = snapshots.record(PATH, "one\ntwo\nthree\n");
+		const patcher = new Patcher({ fs, snapshots });
+
+		const first = await patcher.apply(Patch.parse(`[${PATH}#${firstTag}]\nSWAP 2.=2:\n+TWO`));
+		const nextHeader = first.sections[0]?.header;
+		expect(nextHeader).toMatch(/^\[a\.ts#[0-9A-F]{4}\]$/);
+
+		const second = await patcher.apply(Patch.parse(`${nextHeader}\nSWAP 3.=3:\n+THREE`));
+
+		expect(second.sections[0]?.op).toBe("update");
+		expect(fs.get(PATH)).toBe("one\nTWO\nTHREE\n");
+	});
+
 	it("validates any anchor purely from the content hash, even with no recorded snapshot", async () => {
 		// The core fix: the tag fingerprints the WHOLE file. An edit anchored at
 		// a line the model never saw recorded applies whenever the live file


### PR DESCRIPTION
## Repro

Two distinct hashline failures dropped or corrupted file content on common edit shapes:

1. Boundary-echo data loss — `SWAP N.=M:` followed by a payload whose first or last rows happen to equal the neighboring keepers had the matching edge rows silently dropped before the write. Minimal: file `keep\nold-a\nold-b\nkeep\n`, patch `SWAP 2.=3:\n+keep\n+new-a\n+new-b\n+keep\n` produced `keep\nnew-a\nnew-b\nkeep\n` — both authored `keep` lines were thrown away.
2. Bare `DEL` written as content — `SWAP N.=M:\nDEL` is parsed by the lenient body path and `DEL` is auto-prefixed as literal text. File `before\nremove a\nremove b\nafter\n` plus `SWAP 2.=3:\nDEL` produced `before\nDEL\nafter\n` instead of deleting lines 2-3.
3. Grammar/prompt drift — the documented single-line `DEL N` form was missing from the exported provider grammar.

Repro commands stored at `repro://...` in the issue session.

## Cause

`packages/hashline/src/apply.ts` ran `findBoundaryEcho` / `findOneSidedBoundaryEcho` even for balance-neutral replacements. Any payload whose first/last rows matched the keepers immediately outside the range was trimmed and the warning called the agent's intentional content a "boundary echo". `packages/hashline/src/parser.ts` `#handleRaw` had no special case for bare hashline op keywords inside a replace body, so `DEL` slipped through the bare-row auto-pipe path. `packages/hashline/src/grammar.lark` only spelled `delete_hunk: "DEL " header_range LF`, so `DEL N` (without `.=M`) failed grammar-constrained providers.

## Fix

- `packages/hashline/src/apply.ts`: removed the `findBoundaryEcho`/`findOneSidedBoundaryEcho` paths and their helpers. Replacement payloads are now applied verbatim; only the existing delimiter-balance repairs (`findDuplicateSuffix`, `findDuplicatePrefix`, `findDroppedSuffixClosers`) still trigger, and only when they explain a non-zero brace/paren/bracket delta.
- `packages/hashline/src/parser.ts` + `messages.ts`: bare `DEL` as the first row under a `SWAP N.=M:` header is interpreted as an empty replacement (delete) with a new `BARE_DEL_REPLACE_DELETE_WARNING` instructing callers to use `DEL N.=M` for deletes or `+DEL` for literal text.
- `packages/hashline/src/grammar.lark`: `delete_hunk` now accepts `LID` as well as `header_range`, matching the documented single-line `DEL N` shape.
- `packages/hashline/src/prompt.md`: dropped the line teaching agents to lean on the auto-drop repair, now that payload rows are kept verbatim.
- Refreshed `packages/hashline/test/boundary-repair.test.ts` to assert payload preservation across the previously-trimmed cases, added `format-v2.test.ts` coverage for bare `DEL` and grammar parity, plus a `patcher.test.ts` regression that re-uses a freshly-minted tag from a previous successful edit.

## Verification

```
bun test packages/hashline/test     # 181 pass, 0 fail
bun --cwd=packages/hashline run check   # bun check: passed
```

Fixes #2885