### PR TITLE
feat(coding-agent): add goal status-line segment

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -571,7 +571,18 @@ tui:
 | `images.blockImages` | boolean | `false` | Never send images to providers. |
 | `tui.hyperlinks` | enum | `auto` | `off`, `auto`, `always`. |
 
-For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`.
+For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`. The existing `mode` segment keeps the Goal/Plan/Loop badge; the `goal` segment exposes the active goal objective for configs like:
+
+```yaml
+# ~/.omp/agent/config.yml
+statusLine:
+  preset: custom
+  leftSegments: [model, mode, goal, path, git]
+  rightSegments: [session_name, context_pct]
+  segmentOptions:
+    goal:
+      maxLength: 36
+```
 
 ### Interaction
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `goal` status-line segment for custom presets. It renders the active goal objective in `statusLine.leftSegments` / `statusLine.rightSegments` and supports `statusLine.segmentOptions.goal.maxLength` in `~/.omp/agent/config.yml`.
+
+### Fixed
+
+- Kept completed goals visible in status-line goal segments until goal-mode cleanup clears the session state.
+
 ## [16.1.5] - 2026-06-19
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -142,6 +142,7 @@ export type StatusLineSegmentId =
 	| "pi"
 	| "model"
 	| "mode"
+	| "goal"
 	| "path"
 	| "git"
 	| "pr"

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -19,6 +19,7 @@ import { calculateTokensPerSecond } from "./token-rate";
 import type {
 	CollabStatus,
 	EffectiveStatusLineSettings,
+	GoalModeStatus,
 	StatusLineSegmentId,
 	StatusLineSegmentOptions,
 	StatusLineSettings,
@@ -190,7 +191,7 @@ export class StatusLineComponent implements Component {
 	#sessionStartTime: number = Date.now();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#loopModeStatus: { enabled: boolean } | null = null;
-	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
+	#goalModeStatus: GoalModeStatus | null = null;
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 
@@ -292,7 +293,7 @@ export class StatusLineComponent implements Component {
 		this.#loopModeStatus = status ?? null;
 	}
 
-	setGoalModeStatus(status: { enabled: boolean; paused: boolean } | undefined): void {
+	setGoalModeStatus(status: GoalModeStatus | undefined): void {
 		this.#goalModeStatus = status ?? null;
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { Goal, GoalModeState } from "../../../goals/state";
+import { initTheme } from "../../theme/theme";
+import { renderSegment } from "./segments";
+import type { SegmentContext } from "./types";
+
+function makeGoal(status: Goal["status"]): Goal {
+	return {
+		id: "goal-test",
+		objective: "Ship goal completion status",
+		status,
+		tokensUsed: 12,
+		timeUsedSeconds: 3,
+		createdAt: 1,
+		updatedAt: 2,
+	};
+}
+
+function makeGoalState(status: Goal["status"], enabled: boolean): GoalModeState {
+	return {
+		enabled,
+		mode: status === "complete" ? "exiting" : "active",
+		reason: status === "complete" ? "completed" : undefined,
+		goal: makeGoal(status),
+	};
+}
+
+function makeContext(goalState: GoalModeState): SegmentContext {
+	const session = {
+		getGoalModeState: () => goalState,
+		settings: { get: () => false },
+	} as unknown as SegmentContext["session"];
+
+	return {
+		session,
+		width: 120,
+		options: {},
+		planMode: null,
+		loopMode: null,
+		goalMode: {
+			enabled: goalState.enabled,
+			paused: goalState.goal.status === "paused",
+			status: goalState.goal.status,
+		},
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: true,
+		subagentCount: 0,
+		sessionStartTime: 0,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+describe("status-line goal segments", () => {
+	it("renders completed goals even though goal mode is inactive", () => {
+		const ctx = makeContext(makeGoalState("complete", false));
+
+		const mode = renderSegment("mode", ctx);
+		const goal = renderSegment("goal", ctx);
+
+		expect(mode.visible).toBe(true);
+		expect(stripVTControlCharacters(mode.content)).toContain("Goal");
+		expect(goal.visible).toBe(true);
+		expect(stripVTControlCharacters(goal.content)).toContain("Ship goal completion status");
+	});
+
+	it("hides inactive active goals", () => {
+		const ctx = makeContext(makeGoalState("active", false));
+
+		expect(renderSegment("mode", ctx).visible).toBe(false);
+		expect(renderSegment("goal", ctx).visible).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -1,14 +1,15 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { TERMINAL, truncateToWidth } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
+import type { GoalStatus } from "../../../goals/state";
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath } from "../../../tools/render-utils";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
-import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
+import type { GoalModeStatus, RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
 
 export type { SegmentContext } from "./types";
 
@@ -134,11 +135,8 @@ function formatGoalBudget(current: number, budget?: number): string {
 	return `${used}/${formatNumber(budget)}`;
 }
 
-function renderGoalMode(ctx: SegmentContext, mode: { enabled: boolean; paused: boolean }): RenderedSegment {
-	const goal = ctx.session.getGoalModeState()?.goal;
-	const status = goal?.status ?? (mode.paused ? "paused" : "active");
-
-	let icon: string = theme.icon.goal;
+function goalStatusStyle(status: GoalStatus): { icon: string; color: ThemeColor } {
+	let icon = theme.icon.goal;
 	let color: ThemeColor = "accent";
 	switch (status) {
 		case "paused":
@@ -160,7 +158,13 @@ function renderGoalMode(ctx: SegmentContext, mode: { enabled: boolean; paused: b
 		default:
 			break;
 	}
+	return { icon, color };
+}
 
+function renderGoalMode(ctx: SegmentContext, mode: GoalModeStatus): RenderedSegment {
+	const goal = ctx.session.getGoalModeState()?.goal;
+	const status = goal?.status ?? mode.status ?? (mode.paused ? "paused" : "active");
+	const { icon, color } = goalStatusStyle(status);
 	const parts: string[] = [withIcon(icon, "Goal")];
 	const showBudget = ctx.session.settings.get("goal.statusInFooter") === true;
 	if (showBudget && goal) {
@@ -183,7 +187,7 @@ const modeSegment: StatusLineSegment = {
 		}
 
 		const goal = ctx.goalMode;
-		if (goal && (goal.enabled || goal.paused)) {
+		if (goal && (goal.enabled || goal.paused || goal.status === "complete")) {
 			return renderGoalMode(ctx, goal);
 		}
 
@@ -194,6 +198,27 @@ const modeSegment: StatusLineSegment = {
 		}
 
 		return { content: "", visible: false };
+	},
+};
+
+const goalSegment: StatusLineSegment = {
+	id: "goal",
+	render(ctx) {
+		if (!ctx.goalMode || (!ctx.goalMode.enabled && !ctx.goalMode.paused && ctx.goalMode.status !== "complete")) {
+			return { content: "", visible: false };
+		}
+		const goal = ctx.session.getGoalModeState()?.goal;
+		if (!goal) return { content: "", visible: false };
+		const objective = sanitizeStatusText(goal.objective);
+		if (!objective) return { content: "", visible: false };
+		const configuredMaxLength = ctx.options.goal?.maxLength;
+		const maxLength =
+			typeof configuredMaxLength === "number" && Number.isFinite(configuredMaxLength) && configuredMaxLength > 0
+				? Math.max(4, Math.floor(configuredMaxLength))
+				: 40;
+		const { icon, color } = goalStatusStyle(goal.status);
+		const content = withIcon(icon, truncateToWidth(objective, maxLength));
+		return { content: theme.fg(color, content), visible: true };
 	},
 };
 
@@ -582,6 +607,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	pi: piSegment,
 	model: modelSegment,
 	mode: modeSegment,
+	goal: goalSegment,
 	path: pathSegment,
 	git: gitSegment,
 	pr: prSegment,

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -1,5 +1,6 @@
 import type { CollabSessionState } from "../../../collab/protocol";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../../config/settings-schema";
+import type { GoalStatus } from "../../../goals/state";
 import type { AgentSession } from "../../../session/agent-session";
 
 export type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle };
@@ -12,10 +13,17 @@ export interface CollabStatus {
 	stateOverride?: CollabSessionState | null;
 }
 
+export interface GoalModeStatus {
+	enabled: boolean;
+	paused: boolean;
+	status?: GoalStatus;
+}
+
 export interface StatusLineSegmentOptions {
 	model?: { showThinkingLevel?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
+	goal?: { maxLength?: number };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 }
 
@@ -56,10 +64,7 @@ export interface SegmentContext {
 	loopMode: {
 		enabled: boolean;
 	} | null;
-	goalMode: {
-		enabled: boolean;
-		paused: boolean;
-	} | null;
+	goalMode: GoalModeStatus | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1615,9 +1615,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#updateGoalModeStatus(): void {
+		const goal = this.session.getGoalModeState()?.goal;
+		const completed = goal?.status === "complete";
 		const status =
-			this.goalModeEnabled || this.goalModePaused
-				? { enabled: this.goalModeEnabled, paused: this.goalModePaused }
+			this.goalModeEnabled || this.goalModePaused || completed
+				? { enabled: this.goalModeEnabled, paused: this.goalModePaused, status: goal?.status }
 				: undefined;
 		this.statusLine.setGoalModeStatus(status);
 		this.updateEditorTopBorder();

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -7,20 +9,43 @@ beforeAll(async () => {
 	await initTheme();
 });
 
-function createModelContext(advisorActive: boolean): SegmentContext {
+function createGoalState(objective: string): GoalModeState {
+	return {
+		enabled: true,
+		mode: "active",
+		goal: {
+			id: "goal-1",
+			objective,
+			status: "active",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: 0,
+			updatedAt: 0,
+		},
+	};
+}
+
+function createContext(options?: {
+	advisorActive?: boolean;
+	goalState?: GoalModeState | null;
+	goalMode?: SegmentContext["goalMode"];
+	segmentOptions?: SegmentContext["options"];
+}): SegmentContext {
 	return {
 		session: {
 			state: { model: { id: "test-model", name: "Test Model" } },
 			isFastModeActive: () => false,
 			isAutoThinking: false,
 			autoResolvedThinkingLevel: () => undefined,
-			isAdvisorActive: () => advisorActive,
+			isAdvisorActive: () => options?.advisorActive ?? false,
+			getGoalModeState: () => options?.goalState ?? undefined,
+			settings: { get: () => false },
 		} as unknown as SegmentContext["session"],
 		width: 120,
-		options: {},
+		options: options?.segmentOptions ?? {},
 		planMode: null,
 		loopMode: null,
-		goalMode: null,
+		goalMode: options?.goalMode ?? null,
 		collab: null,
 		usageStats: {
 			input: 0,
@@ -43,16 +68,37 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 
 describe("status line model segment advisor badge", () => {
 	it("appends a success-colored ++ badge when the advisor is active", () => {
-		const rendered = renderSegment("model", createModelContext(true));
+		const rendered = renderSegment("model", createContext({ advisorActive: true }));
 		expect(rendered.content).toContain("Test Model");
-		// The badge carries the success color, kept distinct from the statusLineModel
-		// name color (which several themes alias to `accent`).
 		expect(rendered.content).toContain(theme.fg("success", "++"));
 	});
 
 	it("omits the badge when the advisor is inactive", () => {
-		const rendered = renderSegment("model", createModelContext(false));
+		const rendered = renderSegment("model", createContext({ advisorActive: false }));
 		expect(rendered.content).toContain("Test Model");
 		expect(rendered.content).not.toContain("++");
+	});
+});
+
+describe("status line goal segment", () => {
+	it("sanitizes and truncates the active goal objective", () => {
+		const rendered = renderSegment(
+			"goal",
+			createContext({
+				goalState: createGoalState("Ship\tauth\nhardening now"),
+				goalMode: { enabled: true, paused: false },
+				segmentOptions: { goal: { maxLength: 10 } },
+			}),
+		);
+		const plain = stripVTControlCharacters(rendered.content);
+		expect(rendered.visible).toBe(true);
+		expect(plain).toContain("Ship auth…");
+		expect(plain).not.toContain("\n");
+		expect(plain).not.toContain("\t");
+	});
+
+	it("stays hidden when goal mode is not active", () => {
+		const rendered = renderSegment("goal", createContext({ goalState: createGoalState("Ship auth hardening") }));
+		expect(rendered.visible).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
 import { StatusLineComponent, type StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { STATUS_LINE_PRESETS } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/presets";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -31,7 +32,23 @@ afterEach(() => {
 	projectDir = "";
 });
 
-function makeSession(sessionName = "Cache Session") {
+function createGoalState(objective: string): GoalModeState {
+	return {
+		enabled: true,
+		mode: "active",
+		goal: {
+			id: "goal-1",
+			objective,
+			status: "active",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: 0,
+			updatedAt: 0,
+		},
+	};
+}
+
+function makeSession(sessionName = "Cache Session", goalState?: GoalModeState | null) {
 	const messages: unknown[] = [];
 	const model = { id: "test-model", name: "Test Model", contextWindow: 100_000 };
 	return {
@@ -46,7 +63,7 @@ function makeSession(sessionName = "Cache Session") {
 		autoResolvedThinkingLevel: () => undefined,
 		isFastModeActive: () => false,
 		isAdvisorActive: () => false,
-		getGoalModeState: () => null,
+		getGoalModeState: () => goalState ?? undefined,
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		settings: { get: () => false },
 		modelRegistry: { isUsingOAuth: () => false },
@@ -65,8 +82,11 @@ function makeSession(sessionName = "Cache Session") {
 	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
 }
 
-function makeComponent(statusLineSettings: StatusLineSettings): StatusLineComponent {
-	const component = new StatusLineComponent(makeSession());
+function makeComponent(
+	statusLineSettings: StatusLineSettings,
+	session: ConstructorParameters<typeof StatusLineComponent>[0] = makeSession(),
+): StatusLineComponent {
+	const component = new StatusLineComponent(session);
 	component.updateSettings(statusLineSettings);
 	return component;
 }
@@ -170,6 +190,23 @@ describe("StatusLineComponent effective settings cache", () => {
 		component.setHookStatus("hook", "hook done");
 		expect(component.render(80)).toEqual(["hook done"]);
 		expect(component.getEffectiveSettingsForTest()).toBe(effective);
+	});
+
+	it("renders goal objectives through custom segment arrays", () => {
+		const component = makeComponent(
+			{
+				preset: "custom",
+				leftSegments: ["mode", "goal"],
+				rightSegments: [],
+				separator: "pipe",
+				segmentOptions: { goal: { maxLength: 32 } },
+			},
+			makeSession("Cache Session", createGoalState("Ship auth hardening")),
+		);
+		component.setGoalModeStatus({ enabled: true, paused: false });
+		const plain = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(plain).toContain("Goal");
+		expect(plain).toContain("Ship auth hardening");
 	});
 
 	it("does not mutate shared preset segment options during narrow renders", () => {


### PR DESCRIPTION
## Repro

Custom status-line presets can include the existing `mode` segment, but that segment only renders the Goal/Plan/Loop badge. There was no segment that exposed the active goal objective, so users could not keep the current objective visible in `statusLine.leftSegments` / `statusLine.rightSegments`.

Completed goals also disappeared from the status line as soon as goal mode flipped inactive, even though the session still retained the completed goal state until cleanup. That made the completion state vanish during the exit window where the user expects confirmation.

## Cause

The status-line context only carried `{ enabled, paused }` for goal mode. Segment rendering had no access to the goal status after completion, and `StatusLineSegmentId` did not include a configurable `goal` segment.

## Fix

- Add `goal` to the status-line segment id union and registry.
- Render a dedicated `goal` segment that sanitizes the objective, truncates it with `statusLine.segmentOptions.goal.maxLength`, and colors/icons it from the goal status.
- Share goal status styling between `mode` and `goal` so active, paused, complete, budget-limited, and dropped goals stay consistent.
- Propagate `GoalModeStatus.status` from interactive mode into the status-line component so completed goals remain visible until goal-mode cleanup clears the session state.
- Document the custom preset configuration and add `[Unreleased]` changelog entries.
- Cover direct segment rendering, completed-goal visibility, custom segment arrays, and settings-cache behavior.

## Verification

- `bun test packages/coding-agent/src/modes/components/status-line/segments.test.ts packages/coding-agent/test/status-line-model.test.ts packages/coding-agent/test/status-line-settings-cache.test.ts` → 16 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` → passed.
- `bun check` → passed across TypeScript packages.
- `git diff HEAD~1..HEAD --check` → no whitespace errors.

## Files

- `packages/coding-agent/src/modes/components/status-line/segments.ts` — goal segment rendering and shared goal status styling.
- `packages/coding-agent/src/modes/components/status-line/types.ts` — `GoalModeStatus` and goal segment options.
- `packages/coding-agent/src/modes/components/status-line/component.ts` — typed goal status plumbing.
- `packages/coding-agent/src/modes/interactive-mode.ts` — completed-goal status propagation.
- `packages/coding-agent/src/config/settings-schema.ts` — `goal` segment id.
- `packages/coding-agent/src/modes/components/status-line/segments.test.ts` — completed/inactive goal segment coverage.
- `packages/coding-agent/test/status-line-model.test.ts` — objective sanitization/truncation coverage.
- `packages/coding-agent/test/status-line-settings-cache.test.ts` — custom status-line array coverage.
- `docs/settings.md` — configuration example.
- `packages/coding-agent/CHANGELOG.md` — Unreleased entries.