### PR TITLE
fix(ai): preserve API keys on login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed API-key login flows replacing existing stored keys for the same provider, so providers such as NVIDIA NIM can keep multiple active keys available for session-level rotation. ([#2923](https://github.com/can1357/oh-my-pi/issues/2923))
+
 ## [16.1.4] - 2026-06-19
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1825,10 +1825,6 @@ export class AuthStorage {
 			onPrompt: (prompt: { message: string; placeholder?: string }) => Promise<string>;
 		},
 	): Promise<void> {
-		const saveApiKeyCredential = async (apiKey: string): Promise<void> => {
-			const newCredential: ApiKeyCredential = { type: "api_key", key: apiKey };
-			await this.set(provider, newCredential);
-		};
 		const manualCodeInput = () => ctrl.onPrompt({ message: "Paste the authorization code (or full redirect URL):" });
 		// Built-in registry first, then runtime-registered extension providers.
 		const def = getProviderDefinition(provider) ?? getOAuthProvider(provider);
@@ -1848,7 +1844,15 @@ export class AuthStorage {
 			if (!result) {
 				return;
 			}
-			await saveApiKeyCredential(result);
+			const newCredential: ApiKeyCredential = { type: "api_key", key: result };
+			const stored = this.#store.upsertAuthCredentialRemote
+				? await this.#store.upsertAuthCredentialRemote(provider, newCredential)
+				: this.#store.upsertAuthCredentialForProvider(provider, newCredential);
+			this.#setStoredCredentials(
+				provider,
+				stored.map(entry => ({ id: entry.id, credential: entry.credential })),
+			);
+			this.#resetProviderAssignments(provider);
 			return;
 		}
 		const newCredential: OAuthCredential = { type: "oauth", ...result };

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1845,9 +1845,14 @@ export class AuthStorage {
 				return;
 			}
 			const newCredential: ApiKeyCredential = { type: "api_key", key: result };
-			const stored = this.#store.upsertAuthCredentialRemote
-				? await this.#store.upsertAuthCredentialRemote(provider, newCredential)
-				: this.#store.upsertAuthCredentialForProvider(provider, newCredential);
+			const appendApiKeyLogin = "appendApiKeyLogin" in def && def.appendApiKeyLogin === true;
+			const stored = appendApiKeyLogin
+				? this.#store.upsertAuthCredentialRemote
+					? await this.#store.upsertAuthCredentialRemote(provider, newCredential)
+					: this.#store.upsertAuthCredentialForProvider(provider, newCredential)
+				: this.#store.replaceAuthCredentialsRemote
+					? await this.#store.replaceAuthCredentialsRemote(provider, [newCredential])
+					: this.#store.replaceAuthCredentialsForProvider(provider, [newCredential]);
 			this.#setStoredCredentials(
 				provider,
 				stored.map(entry => ({ id: entry.id, credential: entry.credential })),

--- a/packages/ai/src/registry/nvidia.ts
+++ b/packages/ai/src/registry/nvidia.ts
@@ -39,6 +39,7 @@ export async function loginNvidia(options: OAuthController): Promise<string> {
 			baseUrl: API_BASE_URL,
 			model: VALIDATION_MODEL,
 			signal: options.signal,
+			fetch: options.fetch,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -57,4 +58,5 @@ export const nvidiaProvider = {
 	id: "nvidia",
 	name: "NVIDIA",
 	login: (cb: OAuthLoginCallbacks) => loginNvidia(cb),
+	appendApiKeyLogin: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/types.ts
+++ b/packages/ai/src/registry/types.ts
@@ -44,6 +44,8 @@ export interface ProviderDefinition {
 	readonly envKeys?: KeyResolver;
 	// --- interactive login (OAuthProviderInterface-compatible) ---
 	readonly login?: (callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials | string>;
+	/** String-returning login appends API keys instead of replacing the provider's existing key. */
+	readonly appendApiKeyLogin?: boolean;
 	readonly refreshToken?: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
 	readonly getApiKey?: (credentials: OAuthCredentials) => string;
 	/** Store OAuth credentials under a different provider id (e.g. `openai-codex-device` ⇒ `openai-codex`). */

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -741,6 +741,45 @@ describe("AuthStorage OAuth login upgrade and multi-account coexistence", () => 
 			authStorage.close();
 		}
 	});
+
+	it("keeps existing API keys active when a provider login adds another key", async () => {
+		if (!tempDir) throw new Error("test setup failed");
+
+		const dbPath = path.join(tempDir, "api-key-rotation.db");
+		const authStorage = await AuthStorage.create(dbPath);
+		const prompts = ["nvapi-first", "nvapi-second"];
+		registerOAuthProvider({
+			id: "unit-api-key-rotation",
+			name: "Unit API Key Rotation",
+			sourceId: "auth-storage-login-upgrade-test",
+			login: async ({ onPrompt }) => onPrompt?.({ message: "Paste API key" }) ?? "",
+		});
+
+		try {
+			await authStorage.login("unit-api-key-rotation", {
+				onAuth: () => {},
+				onPrompt: async () => prompts.shift() ?? "",
+			});
+			await authStorage.login("unit-api-key-rotation", {
+				onAuth: () => {},
+				onPrompt: async () => prompts.shift() ?? "",
+			});
+
+			expect(authStorage.listStoredCredentials("unit-api-key-rotation").map(entry => entry.credential)).toEqual([
+				{ type: "api_key", key: "nvapi-first" },
+				{ type: "api_key", key: "nvapi-second" },
+			]);
+
+			const selectedKeys = new Set<string>();
+			for (let index = 0; index < 64; index += 1) {
+				const key = await authStorage.getApiKey("unit-api-key-rotation", `session-${index}`);
+				if (key) selectedKeys.add(key);
+			}
+			expect(selectedKeys).toEqual(new Set(["nvapi-first", "nvapi-second"]));
+		} finally {
+			authStorage.close();
+		}
+	});
 });
 
 describe("AuthStorage persistent session stickiness", () => {

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { AuthStorage, type FetchImpl, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import { registerOAuthProvider, unregisterOAuthProviders } from "../src/registry/oauth";
 
 const LEGACY_TIMESTAMP = 1_700_000_000;
@@ -742,37 +742,35 @@ describe("AuthStorage OAuth login upgrade and multi-account coexistence", () => 
 		}
 	});
 
-	it("keeps existing API keys active when a provider login adds another key", async () => {
+	it("keeps existing NVIDIA API keys active when login adds another key", async () => {
 		if (!tempDir) throw new Error("test setup failed");
 
 		const dbPath = path.join(tempDir, "api-key-rotation.db");
 		const authStorage = await AuthStorage.create(dbPath);
 		const prompts = ["nvapi-first", "nvapi-second"];
-		registerOAuthProvider({
-			id: "unit-api-key-rotation",
-			name: "Unit API Key Rotation",
-			sourceId: "auth-storage-login-upgrade-test",
-			login: async ({ onPrompt }) => onPrompt?.({ message: "Paste API key" }) ?? "",
-		});
+		const fetchMock: FetchImpl = async () =>
+			new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
 
 		try {
-			await authStorage.login("unit-api-key-rotation", {
+			await authStorage.login("nvidia", {
 				onAuth: () => {},
 				onPrompt: async () => prompts.shift() ?? "",
+				fetch: fetchMock,
 			});
-			await authStorage.login("unit-api-key-rotation", {
+			await authStorage.login("nvidia", {
 				onAuth: () => {},
 				onPrompt: async () => prompts.shift() ?? "",
+				fetch: fetchMock,
 			});
 
-			expect(authStorage.listStoredCredentials("unit-api-key-rotation").map(entry => entry.credential)).toEqual([
+			expect(authStorage.listStoredCredentials("nvidia").map(entry => entry.credential)).toEqual([
 				{ type: "api_key", key: "nvapi-first" },
 				{ type: "api_key", key: "nvapi-second" },
 			]);
 
 			const selectedKeys = new Set<string>();
 			for (let index = 0; index < 64; index += 1) {
-				const key = await authStorage.getApiKey("unit-api-key-rotation", `session-${index}`);
+				const key = await authStorage.getApiKey("nvidia", `session-${index}`);
 				if (key) selectedKeys.add(key);
 			}
 			expect(selectedKeys).toEqual(new Set(["nvapi-first", "nvapi-second"]));


### PR DESCRIPTION
﻿## Summary
- preserve existing API-key credentials when an API-key login adds another key for the same provider
- keep multiple keys selectable across sessions for providers such as NVIDIA NIM
- add regression coverage for API-key login coexistence and session selection

Fixes #2923.

## Verification
- bun test packages/ai/test/auth-storage-email-dedupe.test.ts -t "keeps existing API keys active when a provider login adds another key"
- bun --cwd=packages/ai run check
