### PR TITLE
fix(natives): resolve pre-existing clippy dead-code warnings breaking CI

### DIFF
--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -44,6 +44,7 @@ const DEFAULT_CONFIG_DIR: &str = ".omp";
 
 /// App name used as the XDG-root subdirectory (`$XDG_STATE_HOME/omp/`),
 /// matching `APP_NAME` in `packages/utils/src/dirs.ts`.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 const APP_NAME: &str = "omp";
 
 static INSTALL: Once = Once::new();
@@ -234,6 +235,7 @@ fn xdg_state_logs_from_env(_home: &Path, _config_dir_override: Option<&OsStr>) -
 /// Pure XDG-eligibility computation extracted for unit testing — no env
 /// reads, no fs reads. `omp_dir_exists` decides whether the candidate
 /// `<xdg_state_home>/omp` actually lives on disk.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn xdg_state_logs(
 	xdg_state_home: Option<&OsStr>,
 	agent_dir_override: Option<&OsStr>,
@@ -256,7 +258,7 @@ fn xdg_state_logs(
 	}
 	Some(omp_dir.join("logs"))
 }
-
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn default_agent_dir(home: &Path, config_dir_override: Option<&OsStr>) -> PathBuf {
 	let config_dir = config_dir_override
 		.filter(|s| !s.is_empty())
@@ -384,6 +386,7 @@ mod tests {
 		assert_eq!(dir, PathBuf::from("/tmp/pi-natives-test-home/.omp-dev/logs"));
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_ignores_empty_agent_dir_override() {
 		// An empty PI_CODING_AGENT_DIR is "unset", not a divergent override; it
@@ -414,6 +417,7 @@ mod tests {
 		assert_eq!(dir, PathBuf::from("/xdg/state/omp/logs"));
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_resolves_when_dir_exists_and_no_agent_override() {
 		let dir = xdg_state_logs(
@@ -425,6 +429,7 @@ mod tests {
 		assert_eq!(dir, Some(PathBuf::from("/xdg/state/omp/logs")));
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_skipped_when_omp_dir_missing() {
 		let dir = xdg_state_logs(
@@ -436,6 +441,7 @@ mod tests {
 		assert_eq!(dir, None);
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_skipped_when_xdg_state_home_unset_or_empty() {
 		let default_agent = Path::new("/tmp/pi-natives-test-home/.omp/agent");
@@ -443,6 +449,7 @@ mod tests {
 		assert_eq!(xdg_state_logs(Some(OsStr::new("")), None, default_agent, |_p| true), None);
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_skipped_when_agent_dir_overridden() {
 		// `PI_CODING_AGENT_DIR` pointing elsewhere mirrors the JS `isDefault === false`
@@ -456,6 +463,7 @@ mod tests {
 		assert_eq!(dir, None);
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn xdg_state_logs_honored_when_agent_override_matches_default() {
 		let default_agent = std::path::absolute(Path::new("./.omp/agent")).unwrap();
@@ -468,12 +476,13 @@ mod tests {
 		assert_eq!(dir, Some(PathBuf::from("/xdg/state/omp/logs")));
 	}
 
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn default_agent_dir_uses_dot_omp_by_default() {
 		let dir = default_agent_dir(Path::new("/tmp/pi-natives-test-home"), None);
 		assert_eq!(dir, PathBuf::from("/tmp/pi-natives-test-home/.omp/agent"));
 	}
-
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
 	#[test]
 	fn default_agent_dir_respects_pi_config_dir() {
 		let dir =

--- a/crates/pi-natives/src/ps.rs
+++ b/crates/pi-natives/src/ps.rs
@@ -166,6 +166,7 @@ impl Process {
 
 	/// Process group id for this process, when supported by the platform.
 	#[napi]
+	#[allow(clippy::missing_const_for_fn, reason = "#[napi] generates a non-const wrapper")]
 	pub fn group_id(&self) -> Option<i32> {
 		self.inner.group_id()
 	}


### PR DESCRIPTION
## Problem

`bun check` (and the CI `native_linux_x64 (baseline)` job with `rust_checks: true`) fail with 4 clippy errors in `crates/pi-natives`:

- `APP_NAME` is never used (dead code on Windows)
- `xdg_state_logs` is never used (dead code on Windows)
- `default_agent_dir` is never used (dead code on Windows)
- `Process::group_id` could be a `const fn` (false positive — `#[napi]` generates a non-const wrapper)

These are pre-existing on `main` and break the Rust check on **every** PR.

## Fix

- Gated `APP_NAME`, `xdg_state_logs`, `default_agent_dir`, and their 8 unit tests with `#[cfg(any(target_os = "linux", target_os = "macos"))]` — these functions are only called from the Unix `xdg_state_logs_from_env` implementation, so they are legitimately dead on Windows.
- Suppressed the `missing_const_for_fn` lint on `Process::group_id` with a reason annotation — `#[napi]` generates a non-const FFI wrapper, so the function cannot actually be `const`.

## Verification

- `cargo clippy --manifest-path crates/pi-natives/Cargo.toml -- -D warnings` → clean
- `cargo test --manifest-path crates/pi-natives/Cargo.toml` → 97 passed, 0 failed
- `bun check` → both `check:ts` and `check:rs` pass (previously `check:rs` failed)