### PR TITLE
feat(utils): export removeSyncWithRetries for test cleanup

### DIFF
--- a/packages/coding-agent/test/helpers/temp-home-cleanup.ts
+++ b/packages/coding-agent/test/helpers/temp-home-cleanup.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 export interface TempHomeState {
 	tempDir: string;
@@ -10,10 +10,10 @@ export function cleanupTempHome(getState: () => TempHomeState): () => void {
 	return () => {
 		const { tempDir, tempHomeDir, originalHome } = getState();
 		if (tempDir) {
-			fs.rmSync(tempDir, { recursive: true, force: true });
+			removeSyncWithRetries(tempDir);
 		}
 		if (tempHomeDir) {
-			fs.rmSync(tempHomeDir, { recursive: true, force: true });
+			removeSyncWithRetries(tempHomeDir);
 		}
 		if (originalHome === undefined) {
 			delete process.env.HOME;

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exported `removeSyncWithRetries()` from `@oh-my-pi/pi-utils` as a standalone function, so tests that manage their own temp dirs (not via `TempDir`) can use the same retry-on-EBUSY cleanup logic.
+
 ## [16.1.3] - 2026-06-19
 
 ### Changed

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -95,7 +95,7 @@ async function removeWithRetries(target: string): Promise<void> {
 	}
 }
 
-function removeSyncWithRetries(target: string): void {
+export function removeSyncWithRetries(target: string): void {
 	for (let attempt = 0; ; attempt++) {
 		try {
 			fs.rmSync(target, kRemoveOptions);


### PR DESCRIPTION
## Summary

Exports the standalone `removeSyncWithRetries()` function from `@oh-my-pi/pi-utils`, enabling tests that manage their own temp dirs (not via `TempDir.createSync`) to use the same retry-on-EBUSY cleanup logic.

## Changes

- **`packages/utils/src/temp.ts`**: Changed `removeSyncWithRetries` from a private function to an exported function
- **`packages/coding-agent/test/helpers/temp-home-cleanup.ts`**: Updated to use `removeSyncWithRetries` instead of bare `fs.rmSync`, fixing EBUSY cleanup failures for all tests using the `cleanupTempHome` helper

## Why

Over 150 test files in `packages/coding-agent/test/` use bare `fs.rmSync` for temp dir cleanup. On Windows, SQLite file handles aren't released immediately after `db.close()`, causing `EBUSY: resource busy or locked` errors. `TempDir.removeSync` already handles this with retries (40×25ms = 1s), but tests that manage their own temp dirs can't use it. This export provides a drop-in replacement: `fs.rmSync(dir, {recursive: true, force: true})` → `removeSyncWithRetries(dir)`.

## Verification

- `tsgo --noEmit` passes for utils and coding-agent
- `biome check` passes
- `fix-changelogs --check` passes

## Note

This is the first step — subsequent PRs can gradually migrate the 150+ `fs.rmSync` call sites to `removeSyncWithRetries`. The `cleanupTempHome` helper is the highest-impact single change since it's used by many tests.