### PR TITLE
fix(config): allow Responses image detail compat in models.yml

### DIFF
--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -4,8 +4,12 @@ import {
 	type RequestBody,
 	transformRequestBody,
 } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
-import { streamOpenAICodexResponses } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	convertCodexResponsesMessages,
+	streamOpenAICodexResponses,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { createCodexModel } from "./helpers";
 
 function createCodexTestToken(accountId = "acc_test"): string {
@@ -139,6 +143,38 @@ describe("openai-codex Responses Lite input shaping", () => {
 		const plain = await transformRequestBody({ model: model.id, input: makeInput() }, model, {});
 		const plainMessage = plain.input?.[0]?.content as Array<Record<string, unknown>>;
 		expect(plainMessage[1]?.detail).toBe("auto");
+	});
+
+	it("clamps original image detail when Codex compat disables it", () => {
+		const model = buildModel({
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "cc-switch",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 100_000,
+			compat: { supportsImageDetailOriginal: false },
+		});
+		const messages = convertCodexResponsesMessages(model, {
+			messages: [
+				{
+					role: "user",
+					timestamp: Date.now(),
+					content: [
+						{ type: "text", text: "look" },
+						{ type: "image", mimeType: "image/png", data: "AAAA", detail: "original" },
+					],
+				},
+			],
+		});
+		expect(messages[0]).toMatchObject({
+			role: "user",
+			content: [{ type: "input_text" }, { type: "input_image", detail: "auto" }],
+		});
 	});
 
 	it("forces parallel_tool_calls off under lite when tools are present", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom `models.yml` providers rejecting the `compat.supportsImageDetailOriginal` override, so Responses-compatible proxies that reject snapcompact's native-resolution image hint can clamp frames to `detail: "auto"`. ([#3092](https://github.com/can1357/oh-my-pi/issues/3092))
+
 ## [16.1.6] - 2026-06-20
 
 ### Added

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -57,6 +57,7 @@ const OpenAICompatFields = {
 	"supportsReasoningParams?": "boolean",
 	"alwaysSendMaxTokens?": "boolean",
 	"strictResponsesPairing?": "boolean",
+	"supportsImageDetailOriginal?": "boolean",
 	// anthropic-messages compat flags (same `compat` slot, per-api interpretation)
 	"requiresToolResultId?": "boolean",
 	"replayUnsignedThinking?": "boolean",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -716,6 +716,7 @@ describe("ModelRegistry", () => {
 		let providerCompat: ModelRegistry;
 		let customCompat: ModelRegistry;
 		let customModelCompat: ModelRegistry;
+		let customResponsesCompat: ModelRegistry;
 		beforeAll(() => {
 			providerCompat = readonlyRegistry({
 				providers: {
@@ -749,6 +750,28 @@ describe("ModelRegistry", () => {
 								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 								contextWindow: 1000,
 								maxTokens: 100,
+							},
+						],
+					},
+				},
+			});
+			customResponsesCompat = readonlyRegistry({
+				providers: {
+					"cc-switch": {
+						baseUrl: "http://127.0.0.1:8080/v1",
+						apiKey: "CC_SWITCH_KEY",
+						api: "openai-codex-responses",
+						compat: {
+							supportsImageDetailOriginal: false,
+						},
+						models: [
+							{
+								id: "gpt-5.5",
+								reasoning: true,
+								input: ["text", "image"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 200_000,
+								maxTokens: 100_000,
 							},
 						],
 					},
@@ -801,6 +824,12 @@ describe("ModelRegistry", () => {
 			expect(compat?.supportsUsageInStreaming).toBe(false);
 			expect(compat?.maxTokensField).toBe("max_tokens");
 			expect(compat?.cacheControlFormat).toBe("anthropic");
+		});
+
+		test("custom Responses providers can disable original image detail", () => {
+			const model = customResponsesCompat.find("cc-switch", "gpt-5.5");
+			const compat = getOpenAICompat(model);
+			expect(compat?.supportsImageDetailOriginal).toBe(false);
 		});
 
 		test("model-level compat overrides provider-level compat for custom models", () => {


### PR DESCRIPTION
## Repro
The reporter confirmed the same CC Switch route works with `tools.format: auto` and `compaction.strategy: context-full`, narrowing the 400 to the custom Responses proxy path used with pi-format tooling plus snapcompact images. I could not connect to their CC Switch instance, so the local repro target is the config contract needed for that proxy: a custom `openai-codex-responses` provider must be able to set `compat.supportsImageDetailOriginal: false` so snapcompact frames avoid `detail: "original"`.

## Cause
`packages/coding-agent/src/config/models-config-schema.ts` omitted `supportsImageDetailOriginal` from `OpenAICompatFields`, even though `@oh-my-pi/pi-catalog` exposes the compat flag and the OpenAI/Codex Responses serializers already consult it when serializing `input_image.detail`. Custom `models.yml` providers therefore could not declare that a Responses-compatible proxy rejects the native-resolution image hint.

## Fix
- Added `compat.supportsImageDetailOriginal` to the custom models config schema.
- Added `packages/coding-agent/test/model-registry.test.ts` coverage for a CC Switch-style custom `openai-codex-responses` model preserving that override.
- Added `packages/ai/test/openai-codex-responses-lite.test.ts` coverage proving Codex Responses image blocks clamp `detail: "original"` to `detail: "auto"` when the compat flag is false.
- Added a `packages/coding-agent/CHANGELOG.md` entry under `[Unreleased]`.

## Verification
Ran `bun test packages/coding-agent/test/model-registry.test.ts packages/ai/test/openai-codex-responses-lite.test.ts && bun check`: 101 tests passed across the focused files, and `bun check` passed. Fixes #3092