### PR TITLE
fix(tui): support slash command autocomplete after leading whitespace

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed autocomplete trigger and synchronous completion for slash commands containing leading whitespace.
+
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -339,12 +339,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		// Check for slash commands
-		if (textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
+		const trimmedTextBeforeCursor = textBeforeCursor.trimStart();
+		if (trimmedTextBeforeCursor.startsWith("/")) {
+			const spaceIndex = trimmedTextBeforeCursor.indexOf(" ");
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
-				const prefix = textBeforeCursor.slice(1); // Remove the "/"
+				const prefix = trimmedTextBeforeCursor.slice(1); // Remove the "/"
 				const lowerPrefix = prefix.toLowerCase();
 
 				const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
@@ -357,8 +358,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				};
 			} else {
 				// Space found - complete command arguments
-				const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
-				const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
+				const commandName = trimmedTextBeforeCursor.slice(1, spaceIndex); // Command without "/"
+				const argumentText = trimmedTextBeforeCursor.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
@@ -422,7 +423,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Slash command suggestions can be accepted before the debounced refresh
 		// catches up to newly typed characters. Replace the live command token,
 		// not only the prefix captured when the suggestion list was rendered.
-		if (prefix.startsWith("/") && hasOnlyWhitespaceBeforeSlash) {
+		if (prefix.trimStart().startsWith("/") && hasOnlyWhitespaceBeforeSlash) {
 			const slashPrefix = textBeforeCursor.slice(slashStart);
 			if (!slashPrefix.includes(" ") && !slashPrefix.slice(1).includes("/")) {
 				const beforeSlash = currentLine.slice(0, slashStart);
@@ -854,13 +855,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
-		if (!textBeforeCursor.startsWith("/")) return null;
+		const trimmedTextBeforeCursor = textBeforeCursor.trimStart();
+		if (!trimmedTextBeforeCursor.startsWith("/")) return null;
 
-		const spaceIndex = textBeforeCursor.indexOf(" ");
+		const spaceIndex = trimmedTextBeforeCursor.indexOf(" ");
 		if (spaceIndex === -1) return null;
 
-		const commandName = textBeforeCursor.slice(1, spaceIndex);
-		const argumentText = textBeforeCursor.slice(spaceIndex + 1);
+		const commandName = trimmedTextBeforeCursor.slice(1, spaceIndex);
+		const argumentText = trimmedTextBeforeCursor.slice(spaceIndex + 1);
 
 		const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 
@@ -871,11 +873,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return command.getInlineHint(argumentText);
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
-		if (!textBeforeCursor.startsWith("/")) return null;
-		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
-		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
+		const trimmedTextBeforeCursor = textBeforeCursor.trimStart();
+		if (!trimmedTextBeforeCursor.startsWith("/")) return null;
+		if (trimmedTextBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
+		if (trimmedTextBeforeCursor.includes(" ")) return null; // Only complete command name, not args
 
-		const prefix = textBeforeCursor.slice(1);
+		const prefix = trimmedTextBeforeCursor.slice(1);
 		const lowerPrefix = prefix.toLowerCase();
 
 		const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1116,11 +1116,11 @@ export class Editor implements Component, Focusable {
 				}
 
 				// If Enter was pressed on a slash command, apply completion and submit
-				if ((kb.matches(data, "tui.input.submit") || data === "\n") && this.#autocompletePrefix.startsWith("/")) {
+				if ((kb.matches(data, "tui.input.submit") || data === "\n") && this.#autocompletePrefix.trimStart().startsWith("/")) {
 					// Check for stale autocomplete state due to debounce
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (currentTextBeforeCursor !== this.#autocompletePrefix) {
+					if (currentTextBeforeCursor.trimStart() !== this.#autocompletePrefix.trimStart()) {
 						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
 					} else {
@@ -1263,7 +1263,6 @@ export class Editor implements Component, Focusable {
 				const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 				if (
-					textBeforeCursor.startsWith("/") &&
 					this.#isInSubmittedSlashCommandContext() &&
 					this.#autocompleteProvider?.trySyncSlashCompletion
 				) {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -76,6 +76,20 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result.cursorCol).toBe("/skills:fix-bug ".length);
 		});
 
+		it("preserves leading whitespace while replacing a slash command prefix", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(
+				["  /ski"],
+				0,
+				6,
+				{ value: "skills:fix-bug", label: "/skills:fix-bug" },
+				"  /s",
+			);
+
+			expect(result.lines[0]).toBe("  /skills:fix-bug ");
+			expect(result.cursorCol).toBe("  /skills:fix-bug ".length);
+		});
+
 		it("preserves earlier slash command arguments when completing a path inside the last argument", () => {
 			const provider = new CombinedAutocompleteProvider([], "/tmp");
 			const result = provider.applyCompletion(
@@ -247,6 +261,50 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("./src/");
 		});
 	});
+
+	describe("slash command leading whitespace", () => {
+		it("suggests slash commands when slash is the first non-whitespace token", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "model", description: "Switch AI model" },
+					{ name: "skill:reviewer", description: "Review code" },
+				],
+				"/tmp",
+			);
+
+			const bareResult = await provider.getSuggestions(["  /"], 0, 3);
+			expect(bareResult).not.toBeNull();
+			expect(bareResult!.prefix).toBe("  /");
+			expect(bareResult!.items.map(item => item.value)).toEqual(["model", "skill:reviewer"]);
+
+			const partialLine = "  /ski";
+			const partialResult = await provider.getSuggestions([partialLine], 0, partialLine.length);
+			expect(partialResult).not.toBeNull();
+			expect(partialResult!.prefix).toBe(partialLine);
+			expect(partialResult!.items.map(item => item.value)).toEqual(["skill:reviewer"]);
+		});
+
+		it("completes slash command arguments and inline hints after leading whitespace", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{
+						name: "setup",
+						aliases: ["onboarding"],
+						getArgumentCompletions: prefix =>
+							"providers".startsWith(prefix) ? [{ value: "providers ", label: "providers" }] : null,
+						getInlineHint: argumentText => (argumentText === "pro" ? "viders" : null),
+					},
+				],
+				"/tmp",
+			);
+			const line = "  /onboarding pro";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			expect(result?.prefix).toBe("pro");
+			expect(result?.items.map(item => item.value)).toEqual(["providers "]);
+			expect(provider.getInlineHint([line], 0, line.length)).toBe("viders");
+		});
+	});
+
 });
 describe("trySyncSlashCompletion", () => {
 	it("returns null for bare '/' (no prefix to match)", () => {
@@ -333,6 +391,17 @@ describe("trySyncSlashCompletion", () => {
 		const provider = new CombinedAutocompleteProvider([{ value: "model", label: "Switch model" }], "/tmp");
 		const result = provider.trySyncSlashCompletion("/mod");
 		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toEqual(["model"]);
+	});
+
+	it("matches slash command names after leading whitespace", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("  /mo");
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("  /mo");
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
 

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -78,7 +78,28 @@ describe("Editor slash autocomplete acceptance", () => {
 
 		expect(editor.getText()).toBe("/skills:fix-bug ");
 	});
+
+	it("triggers slash autocomplete after leading whitespace and accepts Tab", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "skills:fix-bug", description: "Fix a bug" }], "/tmp"),
+		);
+
+		editor.handleInput(" ");
+		editor.handleInput(" ");
+		editor.handleInput("/");
+		await Bun.sleep(0);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("s");
+		editor.handleInput("k");
+		editor.handleInput("i");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("  /skills:fix-bug ");
+	});
 });
+
 class SyncSlashProvider implements AutocompleteProvider {
 	async getSuggestions(
 		_lines: string[],
@@ -90,11 +111,11 @@ class SyncSlashProvider implements AutocompleteProvider {
 
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
 		this.callCount += 1;
-		if (!textBeforeCursor.startsWith("/")) return null;
-		if (textBeforeCursor.length <= 1) return null;
-		if (textBeforeCursor.includes(" ")) return null;
-		// Only match known slash commands: /mo or /model
-		const prefix = textBeforeCursor.slice(1);
+		const trimmedText = textBeforeCursor.trimStart();
+		if (!trimmedText.startsWith("/")) return null;
+		if (trimmedText.length <= 1) return null;
+		if (trimmedText.includes(" ")) return null;
+		const prefix = trimmedText.slice(1);
 		if (prefix === "mo" || prefix === "model") {
 			return {
 				prefix: textBeforeCursor,
@@ -162,6 +183,22 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("\r");
 
 		expect(submitted).toBe("/model");
+	});
+
+	it("completes slash command synchronously with leading whitespace", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("  /mo");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/model");
+		expect(provider.callCount).toBe(1);
 	});
 
 	it("completes slash command after leading blank lines", () => {


### PR DESCRIPTION
## Summary

- Replaced column-0 slash detection with trimmed text checks so slash commands (e.g. `  /skill`) trigger autocomplete, inline hints, synchronous Enter completion, and correct applyCompletion replacement.
- Provider now uses `textBeforeCursor.trimStart()` in getSuggestions, trySyncSlashCompletion, getInlineHint, and applyCompletion.
- Editor drops redundant `startsWith('\/')` gate in sync submission, using `#isInSubmittedSlashCommandContext()` exclusively.
- Editor uses `trimStart()` for autocomplete staleness comparison to prevent false mismatches.

## Test Plan

- [x] ` /` shows slash commands
- [x] ` /ski` filters to matching command
- [x] `  /onboarding pro` shows argument completions and inline hints
- [x] Tab selection works with leading whitespace
- [x] Enter sync completion works with leading whitespace
- [x] Leading blank lines do not interfere
- [x] Non-whitespace text before slash still blocks command triggering
- [x] All 43 existing + new tests pass

## Related

- Issue #2875 (skills ranking) fixed by PR #2878
- This PR addresses the separate leading-whitespace trigger problem