### PR TITLE
fix(tui): complete slash commands after leading spaces

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash command autocomplete, inline hints, and Enter completion when the slash command is preceded by leading whitespace ([#3095](https://github.com/can1357/oh-my-pi/issues/3095)).
+
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -56,16 +56,16 @@ function isTokenStart(text: string, index: number): boolean {
 	return index === 0 || PATH_DELIMITERS.has(text[index - 1] ?? "");
 }
 
-function isCommandLeadingWhitespace(code: number): boolean {
-	return code === 0x20 || (code >= 0x09 && code <= 0x0d);
-}
-
-function findLeadingSlashCommandStart(text: string): number | null {
-	let index = 0;
-	while (index < text.length && isCommandLeadingWhitespace(text.charCodeAt(index))) {
-		index += 1;
-	}
-	return text.charCodeAt(index) === 0x2f ? index : null;
+/**
+ * Locate the slash that opens a slash command on the line, allowing leading
+ * whitespace. Returns the index of the `/` or `null` when the line is not a
+ * slash command. Aligns with `trimStart` semantics so the editor and provider
+ * agree on which prefixes count.
+ */
+export function findLeadingSlashCommandStart(text: string): number | null {
+	const trimmed = text.trimStart();
+	if (!trimmed.startsWith("/")) return null;
+	return text.length - trimmed.length;
 }
 
 function extractQuotedPrefix(text: string): string | null {
@@ -366,7 +366,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				return {
 					items: matches,
-					prefix: commandText,
+					// Preserve the full text-before-cursor (incl. leading
+					// whitespace) so the editor's Enter-staleness check
+					// (`autocompletePrefix !== currentTextBeforeCursor`)
+					// still applies the completion for `  /sk`.
+					prefix: textBeforeCursor,
 				};
 			} else {
 				// Space found - complete command arguments
@@ -434,7 +438,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Slash command suggestions can be accepted before the debounced refresh
 		// catches up to newly typed characters. Replace the live command token,
 		// not only the prefix captured when the suggestion list was rendered.
-		if (prefix.startsWith("/") && slashStart !== null) {
+		if (findLeadingSlashCommandStart(prefix) !== null && slashStart !== null) {
 			const slashPrefix = textBeforeCursor.slice(slashStart);
 			if (!slashPrefix.includes(" ") && !slashPrefix.slice(1).includes("/")) {
 				const beforeSlash = currentLine.slice(0, slashStart);
@@ -897,6 +901,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
 
 		if (matches.length === 0) return null;
-		return { items: matches, prefix: commandText };
+		// Mirror `getSuggestions`: preserve leading whitespace so the editor's
+		// sync apply path passes the full text-before-cursor through.
+		return { items: matches, prefix: textBeforeCursor };
 	}
 }

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -56,6 +56,18 @@ function isTokenStart(text: string, index: number): boolean {
 	return index === 0 || PATH_DELIMITERS.has(text[index - 1] ?? "");
 }
 
+function isCommandLeadingWhitespace(code: number): boolean {
+	return code === 0x20 || (code >= 0x09 && code <= 0x0d);
+}
+
+function findLeadingSlashCommandStart(text: string): number | null {
+	let index = 0;
+	while (index < text.length && isCommandLeadingWhitespace(text.charCodeAt(index))) {
+		index += 1;
+	}
+	return text.charCodeAt(index) === 0x2f ? index : null;
+}
+
 function extractQuotedPrefix(text: string): string | null {
 	const quoteStart = findUnclosedQuoteStart(text);
 	if (quoteStart === null) {
@@ -338,13 +350,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		// Check for slash commands
-		if (textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
+		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		if (slashStart !== null) {
+			const commandText = textBeforeCursor.slice(slashStart);
+			const spaceIndex = commandText.indexOf(" ");
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
-				const prefix = textBeforeCursor.slice(1); // Remove the "/"
+				const prefix = commandText.slice(1); // Remove the "/"
 				const lowerPrefix = prefix.toLowerCase();
 
 				const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
@@ -353,12 +366,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				return {
 					items: matches,
-					prefix: textBeforeCursor,
+					prefix: commandText,
 				};
 			} else {
 				// Space found - complete command arguments
-				const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
-				const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
+				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
+				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
@@ -416,13 +429,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 		const afterCursor = currentLine.slice(cursorCol);
 
-		const slashStart = textBeforeCursor.indexOf("/");
-		const hasOnlyWhitespaceBeforeSlash = slashStart >= 0 && textBeforeCursor.slice(0, slashStart).trim() === "";
+		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
 
 		// Slash command suggestions can be accepted before the debounced refresh
 		// catches up to newly typed characters. Replace the live command token,
 		// not only the prefix captured when the suggestion list was rendered.
-		if (prefix.startsWith("/") && hasOnlyWhitespaceBeforeSlash) {
+		if (prefix.startsWith("/") && slashStart !== null) {
 			const slashPrefix = textBeforeCursor.slice(slashStart);
 			if (!slashPrefix.includes(" ") && !slashPrefix.slice(1).includes("/")) {
 				const beforeSlash = currentLine.slice(0, slashStart);
@@ -854,13 +866,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
-		if (!textBeforeCursor.startsWith("/")) return null;
+		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		if (slashStart === null) return null;
 
-		const spaceIndex = textBeforeCursor.indexOf(" ");
+		const commandText = textBeforeCursor.slice(slashStart);
+		const spaceIndex = commandText.indexOf(" ");
 		if (spaceIndex === -1) return null;
 
-		const commandName = textBeforeCursor.slice(1, spaceIndex);
-		const argumentText = textBeforeCursor.slice(spaceIndex + 1);
+		const commandName = commandText.slice(1, spaceIndex);
+		const argumentText = commandText.slice(spaceIndex + 1);
 
 		const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 
@@ -871,16 +885,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return command.getInlineHint(argumentText);
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
-		if (!textBeforeCursor.startsWith("/")) return null;
-		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
-		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
+		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		if (slashStart === null) return null;
+		const commandText = textBeforeCursor.slice(slashStart);
+		if (commandText.length <= 1) return null; // Bare "/" alone, don't auto-complete
+		if (commandText.includes(" ")) return null; // Only complete command name, not args
 
-		const prefix = textBeforeCursor.slice(1);
+		const prefix = commandText.slice(1);
 		const lowerPrefix = prefix.toLowerCase();
 
 		const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
 
 		if (matches.length === 0) return null;
-		return { items: matches, prefix: textBeforeCursor };
+		return { items: matches, prefix: commandText };
 	}
 }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,9 @@
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
-import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete";
+import {
+	type AutocompleteProvider,
+	type CombinedAutocompleteProvider,
+	findLeadingSlashCommandStart,
+} from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
 import { extractPrintableText, matchesKey } from "../keys";
@@ -1116,7 +1120,10 @@ export class Editor implements Component, Focusable {
 				}
 
 				// If Enter was pressed on a slash command, apply completion and submit
-				if ((kb.matches(data, "tui.input.submit") || data === "\n") && this.#autocompletePrefix.startsWith("/")) {
+				if (
+					(kb.matches(data, "tui.input.submit") || data === "\n") &&
+					findLeadingSlashCommandStart(this.#autocompletePrefix) !== null
+				) {
 					// Check for stale autocomplete state due to debounce
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
@@ -1263,7 +1270,7 @@ export class Editor implements Component, Focusable {
 				const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 				if (
-					textBeforeCursor.startsWith("/") &&
+					findLeadingSlashCommandStart(textBeforeCursor) !== null &&
 					this.#isInSubmittedSlashCommandContext() &&
 					this.#autocompleteProvider?.trySyncSlashCompletion
 				) {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -68,7 +68,7 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const result = await provider.getSuggestions([line], 0, line.length);
 
-			expect(result?.prefix).toBe("/sk");
+			expect(result?.prefix).toBe("  /sk");
 			expect(result?.items.map(item => item.value)).toEqual(["skill"]);
 		});
 
@@ -108,6 +108,14 @@ describe("CombinedAutocompleteProvider", () => {
 
 			expect(result.lines[0]).toBe("  /skills:fix-bug ");
 			expect(result.cursorCol).toBe("  /skills:fix-bug ".length);
+		});
+
+		it("applies a slash completion whose prefix carries leading whitespace", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(["  /sk"], 0, 5, { value: "skill", label: "skill" }, "  /sk");
+
+			expect(result.lines[0]).toBe("  /skill ");
+			expect(result.cursorCol).toBe("  /skill ".length);
 		});
 
 		it("preserves earlier slash command arguments when completing a path inside the last argument", () => {
@@ -325,7 +333,7 @@ describe("trySyncSlashCompletion", () => {
 		);
 		const result = provider.trySyncSlashCompletion("  /mo");
 		expect(result).not.toBeNull();
-		expect(result!.prefix).toBe("/mo");
+		expect(result!.prefix).toBe("  /mo");
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
 

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -61,6 +61,26 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 
+	describe("slash commands", () => {
+		it("suggests slash commands when slash is the first non-whitespace token", async () => {
+			const provider = new CombinedAutocompleteProvider([{ name: "skill", description: "Manage skills" }], "/tmp");
+			const line = "  /sk";
+
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result?.prefix).toBe("/sk");
+			expect(result?.items.map(item => item.value)).toEqual(["skill"]);
+		});
+
+		it("does not suggest slash commands after prose", async () => {
+			const provider = new CombinedAutocompleteProvider([{ name: "skill", description: "Manage skills" }], "/tmp");
+			const line = "run /sk";
+
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result).toBeNull();
+		});
+	});
 	describe("applyCompletion", () => {
 		it("replaces the live slash command prefix when rendered suggestions are stale", () => {
 			const provider = new CombinedAutocompleteProvider([], "/tmp");
@@ -74,6 +94,20 @@ describe("CombinedAutocompleteProvider", () => {
 
 			expect(result.lines[0]).toBe("/skills:fix-bug ");
 			expect(result.cursorCol).toBe("/skills:fix-bug ".length);
+		});
+
+		it("preserves leading whitespace when applying a slash command completion", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(
+				["  /ski"],
+				0,
+				6,
+				{ value: "skills:fix-bug", label: "/skills:fix-bug" },
+				"/s",
+			);
+
+			expect(result.lines[0]).toBe("  /skills:fix-bug ");
+			expect(result.cursorCol).toBe("  /skills:fix-bug ".length);
 		});
 
 		it("preserves earlier slash command arguments when completing a path inside the last argument", () => {
@@ -284,6 +318,17 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
 
+	it("returns matching items when slash is the first non-whitespace token", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("  /mo");
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/mo");
+		expect(result!.items.map(i => i.value)).toEqual(["model"]);
+	});
+
 	it("matches multiple commands and sorts by relevance", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[
@@ -405,5 +450,6 @@ describe("trySyncSlashCompletion", () => {
 			"/tmp",
 		);
 		expect(provider.getInlineHint(["/onboarding pro"], 0, "/onboarding pro".length)).toBe("viders");
+		expect(provider.getInlineHint(["  /onboarding pro"], 0, "  /onboarding pro".length)).toBe("viders");
 	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,
+	findLeadingSlashCommandStart,
 } from "@oh-my-pi/pi-tui/autocomplete";
 import { Editor } from "@oh-my-pi/pi-tui/components/editor";
 import { defaultEditorTheme } from "./test-themes";
@@ -90,12 +91,14 @@ class SyncSlashProvider implements AutocompleteProvider {
 
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
 		this.callCount += 1;
-		if (!textBeforeCursor.startsWith("/")) return null;
-		if (textBeforeCursor.length <= 1) return null;
-		if (textBeforeCursor.includes(" ")) return null;
+		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		if (slashStart === null) return null;
+		const commandText = textBeforeCursor.slice(slashStart);
+		if (commandText.length <= 1) return null;
+		if (commandText.includes(" ")) return null;
 		// Only match known slash commands: /mo or /model
-		const prefix = textBeforeCursor.slice(1);
-		if (prefix === "mo" || prefix === "model") {
+		const name = commandText.slice(1);
+		if (name === "mo" || name === "model") {
 			return {
 				prefix: textBeforeCursor,
 				items: [{ value: "model", label: "/model" }],
@@ -112,14 +115,18 @@ class SyncSlashProvider implements AutocompleteProvider {
 		prefix: string,
 	): { lines: string[]; cursorLine: number; cursorCol: number; onApplied?: () => void } {
 		const line = lines[cursorLine] || "";
-		const beforePrefix = line.slice(0, cursorCol - prefix.length);
+		const slashStart = findLeadingSlashCommandStart(prefix);
+		// Anchor the replacement at the slash so leading whitespace survives,
+		// matching CombinedAutocompleteProvider's behavior.
+		const replaceStart = slashStart === null ? cursorCol - prefix.length : cursorCol - prefix.length + slashStart;
+		const beforeSlash = line.slice(0, replaceStart);
 		const afterCursor = line.slice(cursorCol);
 		const nextLines = [...lines];
-		nextLines[cursorLine] = `${beforePrefix}/${_item.value} ${afterCursor}`;
+		nextLines[cursorLine] = `${beforeSlash}/${_item.value} ${afterCursor}`;
 		return {
 			lines: nextLines,
 			cursorLine,
-			cursorCol: beforePrefix.length + _item.value.length + 2,
+			cursorCol: beforeSlash.length + _item.value.length + 2,
 		};
 	}
 
@@ -176,6 +183,24 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.setText("\n/mo");
 		editor.handleInput("\r");
 
+		expect(submitted).toBe("/model");
+		expect(provider.callCount).toBe(1);
+	});
+
+	it("completes slash command after leading spaces", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("  /mo");
+		editor.handleInput("\r");
+
+		// `#submitValue` trims the joined lines, so the leading spaces survive
+		// the apply but the submitted command itself is the trimmed `/model`.
 		expect(submitted).toBe("/model");
 		expect(provider.callCount).toBe(1);
 	});
@@ -258,5 +283,23 @@ describe("Editor Enter handler sync slash completion", () => {
 		// then cancels autocomplete and submits the completed text.
 		expect(submitted).toBe("/model");
 		expect(suggestionsCallCount).toBeGreaterThan(0);
+	});
+
+	it("applies the popup slash completion on Enter when slash is preceded by spaces", async () => {
+		const provider = new CombinedAutocompleteProvider([{ name: "model", description: "Switch AI model" }], "/tmp");
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("  /mo");
+		await Bun.sleep(0);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/model");
 	});
 });


### PR DESCRIPTION
## Repro
`CombinedAutocompleteProvider.getSuggestions()` returned `null` for `"  /sk"`, so the slash command popup never offered `skill` when `/` was preceded by spaces. Reproduced with `bun -e 'import { CombinedAutocompleteProvider } from "./packages/tui/src/autocomplete.ts"; const provider = new CombinedAutocompleteProvider([{ name: "skill", description: "Manage skills" }], process.cwd()); const line = "  /sk"; const suggestions = await provider.getSuggestions([line], 0, line.length); console.log(JSON.stringify({ suggestions })); if (suggestions?.items.some(item => item.value === "skill")) process.exit(0); process.exit(1);'`, which exited 1 before the fix.

## Cause
`packages/tui/src/autocomplete.ts` only entered the slash command paths when `textBeforeCursor.startsWith("/")` was true, so leading whitespace bypassed popup suggestions, `getInlineHint()`, and `trySyncSlashCompletion()` before the slash token was parsed.

## Fix
- Added a shared leading-whitespace slash detector in `packages/tui/src/autocomplete.ts`.
- Routed popup suggestions, slash command application, inline hints, and synchronous Enter completion through that detector.
- Added regression coverage for leading-whitespace slash suggestions, completion application, sync completion, and inline hints in `packages/tui/test/autocomplete.test.ts`.
- Added the fix to `packages/tui/CHANGELOG.md`.

## Verification
Passed: `bun test packages/tui/test/autocomplete.test.ts`; `bun check`. Manual repro now returns `{"suggestions":{"items":[{"value":"skill","label":"skill","description":"Manage skills"}],"prefix":"/sk"}}`. Fixes #3095