### PR TITLE
fix(catalog): pin MiniMax-M3 contextWindow to 1M on minimax-code(-cn)

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MiniMax-M3 catalog context for the MiniMax Coding/Token Plan providers `minimax-code` and `minimax-code-cn` to report the documented 1M long-context tier instead of the upstream 512K pricing boundary; the previous patch only covered `minimax`/`minimax-cn`, so the Coding Plan picker still showed 512K in the status bar ([#3097](https://github.com/can1357/oh-my-pi/issues/3097)).
+
 ## [16.1.4] - 2026-06-19
 
 ### Fixed

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -219,8 +219,17 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 		model.maxTokens = 131_072;
 	}
 	// MiniMax-M3: 512K is the standard pricing tier boundary, not the
-	// model ceiling. Pin the long-context providers to the documented 1M tier.
-	if ((model.provider === "minimax" || model.provider === "minimax-cn") && model.id === "MiniMax-M3") {
+	// model ceiling. Pin every long-context provider that serves the model
+	// (anthropic-messages `minimax`/`minimax-cn` and the openai-completions
+	// MiniMax Coding/Token Plan endpoints `minimax-code`/`minimax-code-cn`)
+	// to the documented 1M tier.
+	if (
+		model.id === "MiniMax-M3" &&
+		(model.provider === "minimax" ||
+			model.provider === "minimax-cn" ||
+			model.provider === "minimax-code" ||
+			model.provider === "minimax-code-cn")
+	) {
 		model.contextWindow = 1_000_000;
 	}
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -32139,7 +32139,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
@@ -32448,7 +32448,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -149,6 +149,13 @@ describe("generated model policies", () => {
 				contextWindow: 512_000,
 				maxTokens: 128_000,
 			}),
+			createSpec({
+				id: "MiniMax-M3",
+				api: "openai-completions",
+				provider: "minimax-code-cn",
+				contextWindow: 512_000,
+				maxTokens: 128_000,
+			}),
 		];
 
 		applyGeneratedModelPolicies(models);
@@ -157,8 +164,10 @@ describe("generated model policies", () => {
 		expect(models[0]?.maxTokens).toBe(128_000);
 		expect(models[1]?.contextWindow).toBe(1_000_000);
 		expect(models[1]?.maxTokens).toBe(128_000);
-		expect(models[2]?.contextWindow).toBe(512_000);
+		expect(models[2]?.contextWindow).toBe(1_000_000);
 		expect(models[2]?.maxTokens).toBe(128_000);
+		expect(models[3]?.contextWindow).toBe(1_000_000);
+		expect(models[3]?.maxTokens).toBe(128_000);
 	});
 
 	it("normalizes Copilot generated fallback limits", () => {

--- a/packages/catalog/test/minimax-bundled-catalog.test.ts
+++ b/packages/catalog/test/minimax-bundled-catalog.test.ts
@@ -6,6 +6,8 @@ describe("minimax bundled catalog", () => {
 		const providers = [
 			{ id: "minimax", models: modelsJson.minimax },
 			{ id: "minimax-cn", models: modelsJson["minimax-cn"] },
+			{ id: "minimax-code", models: modelsJson["minimax-code"] },
+			{ id: "minimax-code-cn", models: modelsJson["minimax-code-cn"] },
 		];
 
 		for (const provider of providers) {


### PR DESCRIPTION
## Repro

After logging into the MiniMax Token Plan (China) and `/switch`-ing to `MiniMax-M3`, the status bar still showed a 512K context window instead of the documented 1M tier. Direct read of the bundled catalog confirms the regression scope:

```
$ bun -e 'const m = require("./packages/catalog/src/models.json"); for (const p of ["minimax","minimax-cn","minimax-code","minimax-code-cn"]) console.log(p, "MiniMax-M3.contextWindow =", m[p]?.["MiniMax-M3"]?.contextWindow);'
minimax MiniMax-M3.contextWindow = 1000000
minimax-cn MiniMax-M3.contextWindow = 1000000
minimax-code MiniMax-M3.contextWindow = 512000
minimax-code-cn MiniMax-M3.contextWindow = 512000
```

## Cause

The MiniMax-M3 long-context carve-out in `packages/catalog/scripts/generated-policies.ts` only matched the anthropic-messages providers `minimax` and `minimax-cn`. The MiniMax Coding/Token Plan endpoints — `minimax-code` (international, `https://api.minimax.io/v1`) and `minimax-code-cn` (China, `https://api.minimaxi.com/v1`) — serve the same model over openai-completions and inherited the upstream 512K pricing-tier boundary baked into `models.json`. The previous fix (#2579 / #2578) and its regression test in `packages/catalog/test/generated-policies.test.ts` actually pinned the bug by asserting `minimax-code` stayed at `512_000`.

## Fix

- `packages/catalog/scripts/generated-policies.ts`: broadened the MiniMax-M3 predicate to also cover `minimax-code` and `minimax-code-cn`; updated the surrounding comment to describe the wider scope.
- `packages/catalog/src/models.json`: re-baked the two affected `MiniMax-M3` entries (`minimax-code` and `minimax-code-cn`) to `contextWindow: 1000000`, matching what the next `generate-models` run would emit.
- `packages/catalog/test/generated-policies.test.ts`: added the `minimax-code-cn` spec and flipped the previous `minimax-code` assertion from `512_000` to `1_000_000`.
- `packages/catalog/test/minimax-bundled-catalog.test.ts`: extended the bundled snapshot test to cover all four providers so a future regression is caught at the JSON layer too.
- `packages/catalog/CHANGELOG.md`: added a `## [Unreleased]` `### Fixed` entry referencing the issue.

## Verification

`bun test test/generated-policies.test.ts test/minimax-bundled-catalog.test.ts` from `packages/catalog/` → 12 pass / 0 fail / 63 expect() calls. Re-ran the repro one-liner: all four providers now report `1000000`.

Fixes #3097