### PR TITLE
fix(coding-agent): kept /resume picker scoped to the current folder

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/resume` and `omp --resume` no longer auto-switch to the "all projects" picker when the current folder has no sessions. The picker now stays scoped to the cwd and surfaces the existing "No sessions in current folder. Press Tab to view all." hint, so users in an empty project never see other projects' session history without asking. ([#3099](https://github.com/can1357/oh-my-pi/issues/3099))
+
 ## [16.1.6] - 2026-06-20
 
 ### Added

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -13,7 +13,7 @@ import { FileSessionStorage } from "../session/session-storage";
  */
 export async function selectSession(
 	sessions: SessionInfo[],
-	options?: { allSessions?: SessionInfo[]; startInAllScope?: boolean },
+	options?: { allSessions?: SessionInfo[] },
 ): Promise<SessionInfo | null> {
 	const { promise, resolve } = Promise.withResolvers<SessionInfo | null>();
 	const ui = new TUI(new ProcessTerminal());
@@ -64,7 +64,6 @@ export async function selectSession(
 				historyMatcher,
 				loadAllSessions: () => SessionManager.listAll(storage),
 				allSessions: options?.allSessions,
-				startInAllScope: options?.startInAllScope,
 				getTerminalRows: () => ui.terminal.rows,
 			},
 		);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1130,21 +1130,21 @@ export async function runRootCommand(
 	if (parsedArgs.resume === true && !parsedArgs.fork) {
 		const folderSessions = await logger.time("SessionManager.list", SessionManager.list, cwd, parsedArgs.sessionDir);
 		let preloadedAllSessions: SessionInfo[] | undefined;
-		let startInAllScope = false;
 		if (folderSessions.length === 0) {
-			// Nothing in the current folder — fall back to a global scan so the
-			// picker can still open in all-projects scope instead of dead-ending.
+			// Probe globally so we can exit fast when the user has no sessions at
+			// all, but never auto-switch the picker into all-projects scope — that
+			// silently surfaced other projects' history when the cwd was empty
+			// (issue #3099). The preloaded list also makes the user's Tab switch
+			// instant on the way in.
 			preloadedAllSessions = await logger.time("SessionManager.listAll", SessionManager.listAll);
 			if (preloadedAllSessions.length === 0) {
 				writeStartupNotice(parsedArgs, `${chalk.dim("No sessions found")}\n`);
 				return;
 			}
-			startInAllScope = true;
 		}
 		pauseStartupWatchdog();
 		const selected = await logger.time("selectSession", selectSession, folderSessions, {
 			allSessions: preloadedAllSessions,
-			startInAllScope,
 		});
 		resumeStartupWatchdog();
 		if (!selected) {

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -454,8 +454,6 @@ export interface SessionSelectorOptions {
 	loadAllSessions?: () => Promise<SessionInfo[]>;
 	/** Preloaded all-projects list; cached so the first Tab toggle is instant. */
 	allSessions?: SessionInfo[];
-	/** Open directly in all-projects scope (e.g. the current folder has no sessions). */
-	startInAllScope?: boolean;
 	/**
 	 * Reads the live terminal height so the visible window fits the viewport.
 	 * Omitted only in tests; defaults to a conservative 24 rows.
@@ -493,11 +491,6 @@ export class SessionSelectorComponent extends Container {
 		this.#loadAllSessions = options.loadAllSessions;
 		this.#folderSessions = sessions;
 		this.#globalSessions = options.allSessions ?? null;
-		// Open in all-projects scope when asked and we already have that list
-		// (e.g. the current folder has no sessions to show).
-		const startAll = options.startInAllScope === true && this.#globalSessions !== null;
-		this.#scope = startAll ? "all" : "folder";
-		const initialSessions = startAll ? this.#globalSessions! : sessions;
 		// Add header
 		this.addChild(new Spacer(1));
 		this.#headerText = new Text(this.#headerLabel(), 1, 0);
@@ -506,8 +499,10 @@ export class SessionSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 		this.addChild(this.#messageContainer);
-		// Create session list
-		this.#sessionList = new SessionList(initialSessions, startAll, options.historyMatcher, options.getTerminalRows);
+		// Create session list in folder scope; the empty-state hint invites the
+		// user to Tab into all-projects rather than silently surfacing other
+		// projects' history (issue #3099).
+		this.#sessionList = new SessionList(sessions, false, options.historyMatcher, options.getTerminalRows);
 		this.#sessionList.onSelect = onSelect;
 		this.#sessionList.onCancel = onCancel;
 		this.#sessionList.onExit = onExit;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -817,14 +817,9 @@ export class SelectorController {
 			this.ctx.sessionManager.getCwd(),
 			this.ctx.sessionManager.getSessionDir(),
 		);
-		// Current folder has no sessions: preload the global list so the picker
-		// can open straight into all-projects scope instead of dead-ending.
-		let allSessions: SessionInfo[] | undefined;
-		let startInAllScope = false;
-		if (sessions.length === 0) {
-			allSessions = await SessionManager.listAll();
-			startInAllScope = allSessions.length > 0;
-		}
+		// Always open in current-folder scope; the empty-state hint in SessionList
+		// invites the user to Tab into all-projects rather than silently surfacing
+		// every project's history when the cwd has nothing to resume. See #3099.
 		const historyStorage = this.ctx.historyStorage;
 		const historyMatcher = historyStorage ? (query: string) => historyStorage.matchingSessionIds(query) : undefined;
 		this.showSelector(done => {
@@ -858,8 +853,6 @@ export class SelectorController {
 					},
 					historyMatcher,
 					loadAllSessions: () => SessionManager.listAll(),
-					allSessions,
-					startInAllScope,
 					getTerminalRows: () => this.ctx.ui.terminal.rows,
 				},
 			);

--- a/packages/coding-agent/test/modes/components/session-selector-scope.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-scope.test.ts
@@ -90,18 +90,24 @@ describe("SessionSelectorComponent scope toggle", () => {
 		expect(selected[0]?.cwd).toBe("/work/other-project");
 	});
 
-	it("opens directly in all-projects scope when started there with a preloaded list", () => {
+	it("starts in current-folder scope even when the cwd is empty and a global list is preloaded (#3099)", () => {
 		const global = [createSession("remote", "Remote", "/work/other-project")];
 		const selector = new SessionSelectorComponent(
 			[],
 			() => {},
 			() => {},
 			() => {},
-			{ allSessions: global, startInAllScope: true, loadAllSessions: async () => global },
+			{ allSessions: global, loadAllSessions: async () => global },
 		);
 
 		const rendered = selector.render(120).join("\n");
-		expect(rendered).toContain("(all projects)");
-		expect(rendered).toContain("other-project");
+		// Header stays scoped to the cwd so the user is never silently shown
+		// other projects' sessions just because the current folder is empty.
+		expect(rendered).toContain("(current folder)");
+		expect(rendered).not.toContain("(all projects)");
+		expect(rendered).not.toContain("other-project");
+		// The empty-state hint must be visible so the user knows Tab is the way out.
+		expect(rendered).toContain("No sessions in current folder");
+		expect(rendered).toContain("Press Tab to view all");
 	});
 });


### PR DESCRIPTION
## Repro

Run `omp` (or `/resume`) from a project directory that has no sessions yet. The picker opens with header `Resume Session (all projects)` and lists every session from every other project, even though the user is in a specific cwd. From the reporter's POV: "/resume in project X shows all the projects' resumes." A regression test at `packages/coding-agent/test/modes/components/session-selector-scope.test.ts` (the `#3099` case) demonstrates the bug-then-fix.

## Cause

Both call sites probe the cwd's session list, detect zero entries, then pass `startInAllScope: true` to `SessionSelectorComponent`:

- `packages/coding-agent/src/modes/controllers/selector-controller.ts:822-827` (slash `/resume`).
- `packages/coding-agent/src/main.ts:1130-1143` (`omp --resume` startup).

`SessionList.render` already prints "No sessions in current folder. Press Tab to view all." when the cwd is empty, but the auto-switch flipped scope before that hint could ever appear.

## Fix

- Removed the auto-switch in both call sites; the picker always opens in folder scope.
- `omp --resume` still does a single global probe in the empty-cwd case so it can early-exit with `No sessions found` when the user truly has nothing anywhere. When sessions exist elsewhere, the preloaded list is forwarded so Tab is instant.
- Deleted the now-unused `startInAllScope` option from `SessionSelectorOptions` and the CLI session-picker wrapper (clean cutover — no callers remain).
- Replaced the test that asserted the bad behavior with a regression test that pins folder scope + the empty-folder hint.
- Added a CHANGELOG entry under `[Unreleased]`.

## Verification

- `bun --cwd=packages/coding-agent test test/modes/components/session-selector-scope.test.ts` → 3 pass.
- `bun --cwd=packages/coding-agent check` → passed (root biome ok, package typecheck ok).
- Two unrelated pre-existing test failures (`test/modes/components/tool-execution-background-task.test.ts`, `test/session/emit-listener-isolation.test.ts`, `test/cli/completions.test.ts`) reproduce against `main` because they need the `tool-views.generated.js` build artifact that lives outside this worktree — confirmed by stashing the diff and rerunning.

Fixes #3099