### PR TITLE
fix: classify 'insufficient balance' as usage-limit error

### DIFF
--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -62,7 +62,7 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "RATE_LIMIT_EXCEEDED";
 	}
 
-	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit")) {
+	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit") || lower.includes("insufficient balance")) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -94,7 +94,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?balance/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);


### PR DESCRIPTION
## Problem

OpenCode Go returns `401 Insufficient balance` when quota is exhausted. This phrasing is not matched by `USAGE_LIMIT_PATTERN`, so `isUsageLimitError()` returns `false`, the retry pipeline never engages, and fallback chains (`retry.fallbackChains`) are never consulted.

## Fix

Add `insufficient.?balance` to `USAGE_LIMIT_PATTERN` so the error is recognized as retryable, and add the same check to `parseRateLimitReason` so it classifies as `QUOTA_EXHAUSTED` (30 min backoff, triggers credential rotation and model fallback).

## Testing

- `isUsageLimitError('401 Insufficient balance. Manage your billing here: …')` → formerly `false`, now `true`
- `parseRateLimitReason` → formerly `UNKNOWN`, now `QUOTA_EXHAUSTED`