### PR TITLE
fix(compaction): enable custom provider remote compaction

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allowed configured custom OpenAI-compatible providers to use native remote compaction instead of falling back to local summarization. ([#3104](https://github.com/can1357/oh-my-pi/issues/3104))
+
 ## [16.1.5] - 2026-06-19
 
 ### Fixed

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -27,7 +27,7 @@ import {
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
-import { logger } from "@oh-my-pi/pi-utils";
+import { $env, logger } from "@oh-my-pi/pi-utils";
 
 // ============================================================================
 // Public types
@@ -44,6 +44,8 @@ export const OPENAI_REMOTE_COMPACTION_PRESERVE_KEY = "openaiRemoteCompaction";
  * behind it). On timeout the caller falls back to local summarization.
  */
 export const REMOTE_COMPACTION_TIMEOUT_MS = 180_000;
+
+const DEFAULT_AZURE_API_VERSION = "v1";
 
 /** Race the caller's signal against the request timeout; `timeoutMs <= 0` disables the watchdog. */
 function withRequestTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal | undefined {
@@ -99,8 +101,11 @@ export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
 
 function resolveOpenAiCompactEndpoint(model: Model): string {
 	const configuredEndpoint = model.remoteCompaction?.endpoint;
-	if (configuredEndpoint && configuredEndpoint.length > 0) return configuredEndpoint;
 	const compactionApi = model.remoteCompaction?.api ?? model.api;
+	if (compactionApi === "azure-openai-responses") {
+		return resolveAzureOpenAiCompactEndpoint(model, configuredEndpoint);
+	}
+	if (configuredEndpoint && configuredEndpoint.length > 0) return configuredEndpoint;
 	if (model.provider === "openai-codex" || compactionApi === "openai-codex-responses") {
 		return resolveOpenAiCodexCompactEndpoint(model.baseUrl);
 	}
@@ -110,6 +115,33 @@ function resolveOpenAiCompactEndpoint(model: Model): string {
 	const normalizedBase = rawBase.endsWith("/") ? rawBase.slice(0, -1) : rawBase;
 	if (normalizedBase.endsWith("/v1")) return `${normalizedBase}/responses/compact`;
 	return `${normalizedBase}/v1/responses/compact`;
+}
+
+function resolveAzureOpenAiCompactEndpoint(model: Model, configuredEndpoint: string | undefined): string {
+	const endpoint =
+		configuredEndpoint && configuredEndpoint.length > 0
+			? configuredEndpoint
+			: `${resolveAzureOpenAiBaseUrl(model)}/responses/compact`;
+	return appendAzureApiVersion(endpoint);
+}
+
+function resolveAzureOpenAiBaseUrl(model: Model): string {
+	const baseUrl = $env.AZURE_OPENAI_BASE_URL?.trim() || undefined;
+	const resourceName = $env.AZURE_OPENAI_RESOURCE_NAME;
+	const resolvedBaseUrl =
+		baseUrl ?? (resourceName ? `https://${resourceName}.openai.azure.com/openai/v1` : undefined) ?? model.baseUrl;
+	if (!resolvedBaseUrl) {
+		throw new Error(
+			"Azure OpenAI base URL is required. Set AZURE_OPENAI_BASE_URL or AZURE_OPENAI_RESOURCE_NAME, or configure model.baseUrl.",
+		);
+	}
+	return resolvedBaseUrl.replace(/\/+$/, "");
+}
+
+function appendAzureApiVersion(endpoint: string): string {
+	if (/[?&]api-version=/.test(endpoint)) return endpoint;
+	const separator = endpoint.includes("?") ? "&" : "?";
+	return `${endpoint}${separator}api-version=${encodeURIComponent($env.AZURE_OPENAI_API_VERSION || DEFAULT_AZURE_API_VERSION)}`;
 }
 
 function resolveOpenAiCodexCompactEndpoint(baseUrl: string | undefined): string {
@@ -469,11 +501,18 @@ export async function requestOpenAiRemoteCompaction(
 		input: trimOpenAiCompactInput(compactInput, model.contextWindow ?? Number.POSITIVE_INFINITY, instructions),
 		instructions,
 	};
-	const headers: Record<string, string> = {
-		"content-type": "application/json",
-		Authorization: `Bearer ${apiKey}`,
-		...(model.headers ?? {}),
-	};
+	const isAzureOpenAiResponses = (model.remoteCompaction?.api ?? model.api) === "azure-openai-responses";
+	const headers: Record<string, string> = isAzureOpenAiResponses
+		? {
+				"content-type": "application/json",
+				"api-key": apiKey,
+				...(model.headers ?? {}),
+			}
+		: {
+				"content-type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+				...(model.headers ?? {}),
+			};
 
 	// Codex endpoints require additional auth headers
 	if (model.provider === "openai-codex") {

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -15,7 +15,7 @@
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/errors";
 import { parseTextSignature } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
-import type { AssistantMessage, FetchImpl, Message, Model } from "@oh-my-pi/pi-ai/types";
+import type { Api, AssistantMessage, FetchImpl, Message, Model } from "@oh-my-pi/pi-ai/types";
 import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
@@ -86,12 +86,22 @@ export interface RemoteCompactionResponse {
 // OpenAI provider gating + endpoint resolution
 // ============================================================================
 
+function isOpenAiRemoteCompactionApi(api: Api | undefined): boolean {
+	return api === "openai-responses" || api === "azure-openai-responses" || api === "openai-codex-responses";
+}
+
 export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
-	return model.provider === "openai" || model.provider === "openai-codex";
+	if (model.remoteCompaction?.enabled === false) return false;
+	if (model.provider === "openai" || model.provider === "openai-codex") return true;
+	if (model.remoteCompaction?.enabled !== true) return false;
+	return isOpenAiRemoteCompactionApi(model.remoteCompaction.api ?? model.api);
 }
 
 function resolveOpenAiCompactEndpoint(model: Model): string {
-	if (model.provider === "openai-codex") {
+	const configuredEndpoint = model.remoteCompaction?.endpoint;
+	if (configuredEndpoint && configuredEndpoint.length > 0) return configuredEndpoint;
+	const compactionApi = model.remoteCompaction?.api ?? model.api;
+	if (model.provider === "openai-codex" || compactionApi === "openai-codex-responses") {
 		return resolveOpenAiCodexCompactEndpoint(model.baseUrl);
 	}
 
@@ -444,7 +454,6 @@ export function buildOpenAiNativeHistory(
 // ============================================================================
 // Endpoint requests
 // ============================================================================
-
 export async function requestOpenAiRemoteCompaction(
 	model: Model,
 	apiKey: string,
@@ -454,8 +463,9 @@ export async function requestOpenAiRemoteCompaction(
 	opts?: { fetch?: FetchImpl; timeoutMs?: number },
 ): Promise<OpenAiRemoteCompactionResponse> {
 	const endpoint = resolveOpenAiCompactEndpoint(model);
+	const requestModel = model.remoteCompaction?.model ?? model.requestModelId ?? model.id;
 	const request: OpenAiRemoteCompactionRequest = {
-		model: model.id,
+		model: requestModel,
 		input: trimOpenAiCompactInput(compactInput, model.contextWindow ?? Number.POSITIVE_INFINITY, instructions),
 		instructions,
 	};

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -31,6 +31,22 @@ function makeOpenAiModel(overrides: Partial<ModelSpec<"openai-responses">> = {})
 	});
 }
 
+function makeAzureModel(overrides: Partial<ModelSpec<"azure-openai-responses">> = {}): Model<"azure-openai-responses"> {
+	return buildModel({
+		id: "gpt-5",
+		name: "GPT-5 Azure",
+		api: "azure-openai-responses",
+		provider: "azure-openai",
+		baseUrl: "https://example-resource.openai.azure.com/openai/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+		...overrides,
+	});
+}
+
 describe("buildOpenAiNativeHistory custom tool calls", () => {
 	test("serializes customWireName tool calls as custom_tool_call + custom_tool_call_output", () => {
 		const patch = "*** Begin Patch\n*** End Patch\n";
@@ -267,6 +283,56 @@ test("uses configured OpenAI-compatible compaction for custom providers", async 
 		{ fetch: fetchMock },
 	);
 	expect(requestBody).toMatchObject({ model: "gpt-5.5" });
+});
+
+test("uses Azure request shape for Azure Responses remote compaction", async () => {
+	const model = makeAzureModel({
+		headers: { "x-custom-header": "custom" },
+		remoteCompaction: {
+			enabled: true,
+			api: "azure-openai-responses",
+			model: "gpt-5-compact",
+		},
+	});
+	let requestBody: unknown;
+	let requestApiKey: string | undefined;
+	let requestAuthorization: string | undefined;
+	let requestContentType: string | undefined;
+	let requestCustomHeader: string | undefined;
+	const stringHeader = (value: string | readonly string[] | undefined): string | undefined =>
+		typeof value === "string" ? value : undefined;
+	const fetchMock: FetchImpl = async (input, init) => {
+		expect(String(input)).toBe(
+			"https://example-resource.openai.azure.com/openai/v1/responses/compact?api-version=v1",
+		);
+		if (!init?.headers || init.headers instanceof Headers || Array.isArray(init.headers)) {
+			throw new Error("Expected remote compaction to send headers as a plain object");
+		}
+		requestApiKey = stringHeader(init.headers["api-key"]);
+		requestAuthorization = stringHeader(init.headers.Authorization);
+		requestContentType = stringHeader(init.headers["content-type"]);
+		requestCustomHeader = stringHeader(init.headers["x-custom-header"]);
+		requestBody = JSON.parse(String(init.body));
+		return Response.json({
+			output: [{ type: "compaction_summary", summary: "azure compacted" }],
+		});
+	};
+
+	expect(shouldUseOpenAiRemoteCompaction(model)).toBe(true);
+	await requestOpenAiRemoteCompaction(
+		model,
+		"azure-key",
+		[{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+		"instructions",
+		undefined,
+		{ fetch: fetchMock },
+	);
+
+	expect(requestApiKey).toBe("azure-key");
+	expect(requestAuthorization).toBeUndefined();
+	expect(requestContentType).toBe("application/json");
+	expect(requestCustomHeader).toBe("custom");
+	expect(requestBody).toMatchObject({ model: "gpt-5-compact" });
 });
 
 describe("requestOpenAiRemoteCompaction abort", () => {

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -5,7 +5,11 @@ import {
 	createFileOps,
 	DEFAULT_COMPACTION_SETTINGS,
 } from "@oh-my-pi/pi-agent-core/compaction";
-import { buildOpenAiNativeHistory, requestOpenAiRemoteCompaction } from "@oh-my-pi/pi-agent-core/compaction/openai";
+import {
+	buildOpenAiNativeHistory,
+	requestOpenAiRemoteCompaction,
+	shouldUseOpenAiRemoteCompaction,
+} from "@oh-my-pi/pi-agent-core/compaction/openai";
 import * as ai from "@oh-my-pi/pi-ai";
 import type { AssistantMessage, FetchImpl, Model, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -229,6 +233,40 @@ describe("remote compaction input trimming", () => {
 		expect(requestInput?.some(item => item.type === "custom_tool_call")).toBe(false);
 		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(false);
 	});
+});
+
+test("uses configured OpenAI-compatible compaction for custom providers", async () => {
+	const model = makeOpenAiModel({
+		provider: "cliproxy-codex",
+		baseUrl: "http://127.0.0.1:8317/v1",
+		remoteCompaction: {
+			enabled: true,
+			api: "openai-responses",
+			endpoint: "http://127.0.0.1:8317/v1/responses/compact",
+			model: "gpt-5.5",
+		},
+	});
+	let requestBody: unknown;
+	const fetchMock: FetchImpl = async (input, init) => {
+		expect(String(input)).toBe("http://127.0.0.1:8317/v1/responses/compact");
+		requestBody = JSON.parse(String(init?.body));
+		return new Response(
+			JSON.stringify({
+				output: [{ type: "compaction_summary", summary: "native compacted" }],
+			}),
+		);
+	};
+
+	expect(shouldUseOpenAiRemoteCompaction(model)).toBe(true);
+	await requestOpenAiRemoteCompaction(
+		model,
+		"test-key",
+		[{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+		"instructions",
+		undefined,
+		{ fetch: fetchMock },
+	);
+	expect(requestBody).toMatchObject({ model: "gpt-5.5" });
 });
 
 describe("requestOpenAiRemoteCompaction abort", () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added model metadata for provider-native remote compaction and compaction-only model selection. ([#3104](https://github.com/can1357/oh-my-pi/issues/3104))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -576,6 +576,18 @@ export type CompatOf<TApi extends Api> = TApi extends "openrouter"
 				? ResolvedAnthropicCompat
 				: undefined;
 
+/** Provider-native compaction endpoint configuration for one model. */
+export interface RemoteCompactionConfig<TApi extends Api = Api> {
+	/** Enables provider-native compaction for providers not enabled by built-in policy. */
+	enabled?: boolean;
+	/** Adapter family used by the configured compaction endpoint. */
+	api?: TApi;
+	/** Absolute compact endpoint URL; when omitted, the adapter derives it from the model base URL. */
+	endpoint?: string;
+	/** Model id sent to the compaction endpoint when it differs from the active model id. */
+	model?: string;
+}
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
 	id: string;
@@ -648,6 +660,10 @@ export interface Model<TApi extends Api = Api> {
 	preferWebsockets?: boolean;
 	/** Preferred model to switch to when context promotion is triggered (model id or provider/id). */
 	contextPromotionTarget?: string;
+	/** Preferred model to use only for compaction (model id or provider/id); the active session model is unchanged. */
+	compactionModel?: string;
+	/** Provider-native compaction endpoint configuration. */
+	remoteCompaction?: RemoteCompactionConfig<TApi>;
 	/** Provider-assigned priority value (lower = higher priority). */
 	priority?: number;
 	/** Canonical thinking capability metadata for this model. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `models.yml` `remoteCompaction` and `compactionModel` config so custom providers can opt into provider-native compaction and run compaction on a separate model without changing the active session model. ([#3104](https://github.com/can1357/oh-my-pi/issues/3104))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,7 +1,15 @@
 import { execSync } from "node:child_process";
 import * as path from "node:path";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
-import type { Api, Context, Model, ModelSpec, SimpleStreamOptions, ThinkingConfig } from "@oh-my-pi/pi-ai/types";
+import type {
+	Api,
+	Context,
+	Model,
+	ModelSpec,
+	RemoteCompactionConfig,
+	SimpleStreamOptions,
+	ThinkingConfig,
+} from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { isVertexExpressOpenAIUrl } from "@oh-my-pi/pi-catalog/hosts";
@@ -95,6 +103,7 @@ interface ProviderOverride {
 	apiKey?: string;
 	authHeader?: boolean;
 	compat?: ModelSpec<Api>["compat"];
+	remoteCompaction?: RemoteCompactionConfig<Api>;
 	transport?: Model<Api>["transport"];
 }
 
@@ -127,7 +136,7 @@ interface ProviderOverride {
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "transport">,
+	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "remoteCompaction" | "transport">,
 ): Model<TApi> {
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
@@ -136,6 +145,10 @@ export function mergeDiscoveredModel<TApi extends Api>(
 			baseUrl: providerOverride?.baseUrl ?? model.baseUrl ?? existing.baseUrl,
 			headers: existing.headers ? { ...existing.headers, ...model.headers } : model.headers,
 			transport: providerOverride?.transport ?? existing.transport ?? model.transport,
+			remoteCompaction: mergeRemoteCompactionConfig(
+				existing.remoteCompaction ?? model.remoteCompaction,
+				providerOverride?.remoteCompaction,
+			),
 			...(supportsTools !== undefined ? { supportsTools } : {}),
 			compat: model.compatConfig,
 		} as ModelSpec<TApi>);
@@ -146,6 +159,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 			baseUrl: providerOverride.baseUrl ?? model.baseUrl,
 			headers: providerOverride.headers ? { ...model.headers, ...providerOverride.headers } : model.headers,
 			...(providerOverride.transport !== undefined ? { transport: providerOverride.transport } : {}),
+			remoteCompaction: mergeRemoteCompactionConfig(model.remoteCompaction, providerOverride.remoteCompaction),
 			compat: model.compatConfig,
 		} as ModelSpec<TApi>);
 	}
@@ -353,6 +367,15 @@ function mergeCompat<TBase extends object, TOverride extends object>(
 	return merged as TBase & TOverride;
 }
 
+function mergeRemoteCompactionConfig(
+	baseConfig: RemoteCompactionConfig<Api> | undefined,
+	overrideConfig: RemoteCompactionConfig<Api> | undefined,
+): RemoteCompactionConfig<Api> | undefined {
+	if (!baseConfig) return overrideConfig;
+	if (!overrideConfig) return baseConfig;
+	return { ...baseConfig, ...overrideConfig };
+}
+
 /**
  * Project a built model back to spec shape for the model-manager/cache
  * boundary: sparse compat comes from `compatConfig`, never from the resolved
@@ -380,6 +403,8 @@ interface ModelPatch {
 	headers?: Record<string, string>;
 	compat?: ModelSpec<Api>["compat"];
 	contextPromotionTarget?: string;
+	compactionModel?: string;
+	remoteCompaction?: RemoteCompactionConfig<Api>;
 	premiumMultiplier?: number;
 }
 
@@ -403,6 +428,10 @@ function applyModelPatch(base: Model<Api>, patch: ModelPatch, transport: ModelTr
 	if (patch.maxTokens !== undefined) result.maxTokens = patch.maxTokens;
 	if (patch.omitMaxOutputTokens !== undefined) result.omitMaxOutputTokens = patch.omitMaxOutputTokens;
 	if (patch.contextPromotionTarget !== undefined) result.contextPromotionTarget = patch.contextPromotionTarget;
+	if (patch.compactionModel !== undefined) result.compactionModel = patch.compactionModel;
+	if (patch.remoteCompaction !== undefined) {
+		result.remoteCompaction = mergeRemoteCompactionConfig(base.remoteCompaction, patch.remoteCompaction);
+	}
 	if (patch.premiumMultiplier !== undefined) result.premiumMultiplier = patch.premiumMultiplier;
 	if (patch.cost) {
 		result.cost = {
@@ -475,8 +504,6 @@ function mergeAuthHeader(
 /**
  * Decide whether a custom-yaml model should force OAuth-style request shaping.
  * - Explicit `auth: oauth` → force on.
- * - Explicit `auth: apiKey` / `auth: none` → leave unset (auto-detect by key prefix).
- * - No `auth` specified and `api: anthropic-messages` → default on. Custom Anthropic
  *   endpoints are typically Claude-Code-style proxies (e.g. CLIProxyAPI) that expect
  *   the cloaked request shape regardless of how the proxy itself is authenticated.
  * - Otherwise → unset.
@@ -497,6 +524,7 @@ function buildCustomModelOverlay(
 	authHeader: boolean | undefined,
 	providerCompat: ModelSpec<Api>["compat"] | undefined,
 	providerAuth: ProviderAuthMode | undefined,
+	providerRemoteCompaction: RemoteCompactionConfig<Api> | undefined,
 	modelDef: CustomModelDefinitionLike,
 ): CustomModelOverlay | undefined {
 	const api = modelDef.api ?? providerApi;
@@ -518,6 +546,8 @@ function buildCustomModelOverlay(
 		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader, providerApiKey),
 		compat: mergeCompat(providerCompat, modelDef.compat),
 		contextPromotionTarget: modelDef.contextPromotionTarget,
+		compactionModel: modelDef.compactionModel,
+		remoteCompaction: mergeRemoteCompactionConfig(providerRemoteCompaction, modelDef.remoteCompaction),
 		premiumMultiplier: modelDef.premiumMultiplier,
 		isOAuth: resolveCustomModelIsOAuth(api, providerAuth),
 	};
@@ -558,6 +588,8 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		omitMaxOutputTokens: resolvedModel.omitMaxOutputTokens ?? reference?.omitMaxOutputTokens,
 		compat: mergeCompat(reference?.compatConfig, resolvedModel.compat),
 		contextPromotionTarget: resolvedModel.contextPromotionTarget,
+		compactionModel: resolvedModel.compactionModel,
+		remoteCompaction: resolvedModel.remoteCompaction,
 		premiumMultiplier: resolvedModel.premiumMultiplier,
 		isOAuth: resolvedModel.isOAuth,
 	} as ModelSpec<Api>);
@@ -1127,7 +1159,6 @@ export class ModelRegistry {
 		const discoverableProviders: DiscoveryProviderConfig[] = [];
 		const providerEntries = Object.entries(value.providers ?? {});
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
-
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
@@ -1138,6 +1169,7 @@ export class ModelRegistry {
 				providerConfig.authHeader !== undefined ||
 				providerConfig.compat ||
 				providerConfig.disableStrictTools ||
+				providerConfig.remoteCompaction ||
 				providerConfig.transport
 			) {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
@@ -1147,6 +1179,7 @@ export class ModelRegistry {
 					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
+					remoteCompaction: providerConfig.remoteCompaction,
 					transport: providerConfig.transport,
 				});
 			}
@@ -1538,12 +1571,18 @@ export class ModelRegistry {
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
 			headers: override.headers ? { ...(baseOverride?.headers ?? {}), ...override.headers } : baseOverride?.headers,
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
+			remoteCompaction: mergeRemoteCompactionConfig(baseOverride?.remoteCompaction, override.remoteCompaction),
 			transport: override.transport ?? baseOverride?.transport,
 		};
 	}
-	#applyProviderTransportOverride<T extends { baseUrl?: string; headers?: Record<string, string> }>(
+	#applyProviderTransportOverride<
+		T extends { baseUrl?: string; headers?: Record<string, string>; remoteCompaction?: RemoteCompactionConfig<Api> },
+	>(
 		entry: T,
-		override: Pick<ProviderOverride, "baseUrl" | "headers" | "authHeader" | "apiKey" | "transport">,
+		override: Pick<
+			ProviderOverride,
+			"baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
+		>,
 	): T {
 		const headers = mergeAuthHeader(
 			override.headers ? { ...entry.headers, ...override.headers } : entry.headers,
@@ -1557,6 +1596,7 @@ export class ModelRegistry {
 			// Preserve the model's existing transport when the override omits one;
 			// providers without a `transport` field keep the default per-API dispatch.
 			...(override.transport !== undefined ? { transport: override.transport } : {}),
+			remoteCompaction: mergeRemoteCompactionConfig(entry.remoteCompaction, override.remoteCompaction),
 		};
 	}
 	#applyRuntimeProviderOverrides(models: Model<Api>[]): Model<Api>[] {
@@ -1641,7 +1681,6 @@ export class ModelRegistry {
 
 	#parseModels(config: ModelsConfig): CustomModelOverlay[] {
 		const models: CustomModelOverlay[] = [];
-
 		for (const [providerName, providerConfig] of Object.entries(config.providers ?? {})) {
 			const modelDefs = providerConfig.models ?? [];
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
@@ -1662,6 +1701,7 @@ export class ModelRegistry {
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
+					providerConfig.remoteCompaction,
 					modelDef as CustomModelDefinitionLike,
 				);
 				if (!model) continue;
@@ -2069,6 +2109,7 @@ export class ModelRegistry {
 					config.authHeader,
 					config.compat,
 					undefined,
+					config.remoteCompaction,
 					modelDef as CustomModelDefinitionLike,
 				);
 				if (!overlay) {
@@ -2136,6 +2177,7 @@ export class ModelRegistry {
 							providerAuthHeader,
 							providerCompat,
 							undefined,
+							config.remoteCompaction,
 							modelDef as CustomModelDefinitionLike,
 						);
 						if (overlay) results.push(finalizeCustomModel(overlay, { useDefaults: true }));
@@ -2221,6 +2263,7 @@ export interface ProviderConfigInput {
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;
 	compat?: ModelSpec<Api>["compat"];
+	remoteCompaction?: RemoteCompactionConfig<Api>;
 	authHeader?: boolean;
 	/** Streaming transport override — see {@link Model.transport}. */
 	transport?: Model<Api>["transport"];
@@ -2255,6 +2298,8 @@ export interface ProviderConfigInput {
 		headers?: Record<string, string>;
 		compat?: ModelSpec<Api>["compat"];
 		contextPromotionTarget?: string;
+		compactionModel?: string;
+		remoteCompaction?: RemoteCompactionConfig<Api>;
 		premiumMultiplier?: number;
 	}>;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2195,6 +2195,7 @@ export class ModelRegistry {
 			config.headers ||
 			config.apiKey ||
 			config.authHeader !== undefined ||
+			config.remoteCompaction !== undefined ||
 			config.transport !== undefined
 		) {
 			const transportOverride = {
@@ -2202,6 +2203,7 @@ export class ModelRegistry {
 				headers: config.headers,
 				apiKey: config.apiKey,
 				authHeader: config.authHeader,
+				remoteCompaction: config.remoteCompaction,
 				transport: config.transport,
 			};
 			const nextRuntimeOverride = this.#mergeProviderOverride(

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -70,6 +70,10 @@ export const OpenAICompatSchema = type({
 	"whenThinking?": OpenAICompatFieldsSchema,
 });
 
+const ApiSchema = type(
+	'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
+);
+
 const EffortSchema = type('"minimal" | "low" | "medium" | "high" | "xhigh"');
 
 const ThinkingControlModeSchema = type(
@@ -118,11 +122,25 @@ const ModelThinkingSchema = type({
 		};
 	});
 
+const RemoteCompactionSchema = type({
+	"enabled?": "boolean",
+	"api?": ApiSchema,
+	"endpoint?": "string",
+	"model?": "string",
+}).narrow((value, ctx) => {
+	if (value.endpoint !== undefined && typeof value.endpoint === "string" && value.endpoint.length === 0) {
+		return ctx.mustBe("remoteCompaction.endpoint a non-empty string");
+	}
+	if (value.model !== undefined && typeof value.model === "string" && value.model.length === 0) {
+		return ctx.mustBe("remoteCompaction.model a non-empty string");
+	}
+	return true;
+});
+
 const ModelDefinitionSchema = type({
 	id: "string",
 	"name?": "string",
-	"api?":
-		'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
+	"api?": ApiSchema,
 	"baseUrl?": "string",
 	"reasoning?": "boolean",
 	"thinking?": ModelThinkingSchema,
@@ -141,6 +159,8 @@ const ModelDefinitionSchema = type({
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
 	"contextPromotionTarget?": "string",
+	"compactionModel?": "string",
+	"remoteCompaction?": RemoteCompactionSchema,
 }).narrow((value, ctx) => {
 	// Enforce id non-empty
 	if (typeof value.id === "string" && value.id.length === 0) {
@@ -158,6 +178,13 @@ const ModelDefinitionSchema = type({
 		value.contextPromotionTarget.length === 0
 	) {
 		return ctx.mustBe("contextPromotionTarget a non-empty string");
+	}
+	if (
+		value.compactionModel !== undefined &&
+		typeof value.compactionModel === "string" &&
+		value.compactionModel.length === 0
+	) {
+		return ctx.mustBe("compactionModel a non-empty string");
 	}
 	return true;
 });
@@ -181,6 +208,8 @@ export const ModelOverrideSchema = type({
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
 	"contextPromotionTarget?": "string",
+	"compactionModel?": "string",
+	"remoteCompaction?": RemoteCompactionSchema,
 }).narrow((value, ctx) => {
 	if (value.name !== undefined && typeof value.name === "string" && value.name.length === 0) {
 		return ctx.mustBe("name a non-empty string");
@@ -191,6 +220,13 @@ export const ModelOverrideSchema = type({
 		value.contextPromotionTarget.length === 0
 	) {
 		return ctx.mustBe("contextPromotionTarget a non-empty string");
+	}
+	if (
+		value.compactionModel !== undefined &&
+		typeof value.compactionModel === "string" &&
+		value.compactionModel.length === 0
+	) {
+		return ctx.mustBe("compactionModel a non-empty string");
 	}
 	return true;
 });
@@ -209,10 +245,10 @@ export type ProviderDiscovery = typeof ProviderDiscoverySchema.infer;
 const ProviderConfigSchema = type({
 	"baseUrl?": "string",
 	"apiKey?": "string",
-	"api?":
-		'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
+	"api?": ApiSchema,
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
+	"remoteCompaction?": RemoteCompactionSchema,
 	"authHeader?": "boolean",
 	"auth?": ProviderAuthSchema,
 	"discovery?": ProviderDiscoverySchema,

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -30,6 +30,7 @@ export interface ProviderValidationConfig {
 	oauthConfigured?: boolean;
 	discovery?: ProviderDiscovery;
 	compat?: ModelSpec<Api>["compat"];
+	remoteCompaction?: unknown;
 	disableStrictTools?: boolean;
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
@@ -53,11 +54,12 @@ export function validateProviderConfiguration(
 				!config.apiKey &&
 				config.auth !== "none" &&
 				!config.disableStrictTools &&
+				!config.remoteCompaction &&
 				!hasModelOverrides &&
 				!config.discovery
 			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "auth: none", "compat", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "auth: none", "compat", "disableStrictTools", "remoteCompaction", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -120,6 +122,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
 					discovery: providerConfig.discovery as ProviderDiscovery | undefined,
 					compat: providerConfig.compat,
+					remoteCompaction: providerConfig.remoteCompaction,
 					disableStrictTools: providerConfig.disableStrictTools,
 					modelOverrides: providerConfig.modelOverrides,
 					models: (providerConfig.models ?? []) as ProviderValidationModel[],

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7610,22 +7610,25 @@ export class AgentSession {
 			const effectiveSettings = compactMode
 				? { ...compactionSettings, ...compactMode.overrides }
 				: compactionSettings;
-			if (compactMode?.requiresRemote) {
-				const compactionTarget = this.#resolveCompactionConfiguredTarget(
-					this.model,
-					this.#modelRegistry.getAvailable(),
+			// /compact remote demands provider-native compaction. When no remote
+			// endpoint is configured (one would override per-model gating in
+			// compact()), drop fallback candidates that aren't remote-capable so the
+			// engine never silently runs a local summary on a configured-but-non-
+			// remote compactionModel. If filtering empties the chain, warn and fall
+			// back to the full chain so the operation still completes.
+			const availableModels = this.#modelRegistry.getAvailable();
+			const requireProviderRemote = Boolean(compactMode?.requiresRemote && !effectiveSettings.remoteEndpoint);
+			let compactionCandidates = this.#getCompactionModelCandidates(
+				availableModels,
+				requireProviderRemote ? shouldUseOpenAiRemoteCompaction : undefined,
+			);
+			if (requireProviderRemote && compactionCandidates.length === 0) {
+				this.emitNotice(
+					"warning",
+					`remote compaction is unavailable for ${this.model.id} (no remote endpoint configured and no provider-native remote-capable model in the fallback chain) — using a local summary instead`,
+					"compaction",
 				);
-				const remoteReady =
-					Boolean(effectiveSettings.remoteEndpoint) ||
-					shouldUseOpenAiRemoteCompaction(this.model) ||
-					(compactionTarget ? shouldUseOpenAiRemoteCompaction(compactionTarget) : false);
-				if (!remoteReady) {
-					this.emitNotice(
-						"warning",
-						`remote compaction is unavailable for ${this.model.id} (no remote endpoint configured) — using a local summary instead`,
-						"compaction",
-					);
-				}
+				compactionCandidates = this.#getCompactionModelCandidates(availableModels);
 			}
 			const pathEntries = this.sessionManager.getBranch();
 			const preparation = prepareCompaction(pathEntries, effectiveSettings);
@@ -7759,6 +7762,7 @@ export class AgentSession {
 							remoteInstructions: this.#obfuscateForProvider(this.#baseSystemPrompt.join("\n\n")),
 							convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 						},
+						compactionCandidates,
 					);
 					summary = result.summary;
 					shortSummary = result.shortSummary;
@@ -9104,11 +9108,15 @@ export class AgentSession {
 		});
 	}
 
-	#getCompactionModelCandidates(availableModels: Model[]): Model[] {
-		return this.#resolveCompactionModelCandidates(this.model, availableModels);
+	#getCompactionModelCandidates(availableModels: Model[], filter?: (model: Model) => boolean): Model[] {
+		return this.#resolveCompactionModelCandidates(this.model, availableModels, filter);
 	}
 
-	#resolveCompactionModelCandidates(preferredModel: Model | null | undefined, availableModels: Model[]): Model[] {
+	#resolveCompactionModelCandidates(
+		preferredModel: Model | null | undefined,
+		availableModels: Model[],
+		filter?: (model: Model) => boolean,
+	): Model[] {
 		const candidates: Model[] = [];
 		const seen = new Set<string>();
 
@@ -9117,6 +9125,10 @@ export class AgentSession {
 			const key = this.#getModelKey(model);
 			if (seen.has(key)) return;
 			seen.add(key);
+			// `seen` still tracks rejected models so the largest-context fallback
+			// scan below doesn't reintroduce them; the filter just suppresses
+			// inclusion in this caller's candidate chain.
+			if (filter && !filter(model)) return;
 			candidates.push(model);
 		};
 
@@ -9169,8 +9181,10 @@ export class AgentSession {
 		customInstructions: string | undefined,
 		signal: AbortSignal,
 		options?: SummaryOptions,
+		precomputedCandidates?: Model[],
 	): Promise<CompactionResult> {
-		const candidates = this.#getCompactionModelCandidates(this.#modelRegistry.getAvailable());
+		const candidates =
+			precomputedCandidates ?? this.#getCompactionModelCandidates(this.#modelRegistry.getAvailable());
 		const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
 
 		for (const candidate of candidates) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7611,8 +7611,14 @@ export class AgentSession {
 				? { ...compactionSettings, ...compactMode.overrides }
 				: compactionSettings;
 			if (compactMode?.requiresRemote) {
+				const compactionTarget = this.#resolveCompactionConfiguredTarget(
+					this.model,
+					this.#modelRegistry.getAvailable(),
+				);
 				const remoteReady =
-					Boolean(effectiveSettings.remoteEndpoint) || shouldUseOpenAiRemoteCompaction(this.model);
+					Boolean(effectiveSettings.remoteEndpoint) ||
+					shouldUseOpenAiRemoteCompaction(this.model) ||
+					(compactionTarget ? shouldUseOpenAiRemoteCompaction(compactionTarget) : false);
 				if (!remoteReady) {
 					this.emitNotice(
 						"warning",
@@ -9047,11 +9053,15 @@ export class AgentSession {
 		});
 		return formatModelSelectorValue(modelKey, thinkingLevel);
 	}
-	#resolveContextPromotionConfiguredTarget(currentModel: Model, availableModels: Model[]): Model | undefined {
-		const configuredTarget = currentModel.contextPromotionTarget?.trim();
-		if (!configuredTarget) return undefined;
+	#resolveConfiguredModelTarget(
+		configuredTarget: string | undefined,
+		currentModel: Model,
+		availableModels: Model[],
+	): Model | undefined {
+		const trimmedTarget = configuredTarget?.trim();
+		if (!trimmedTarget) return undefined;
 
-		const parsed = parseModelString(configuredTarget, {
+		const parsed = parseModelString(trimmedTarget, {
 			allowMaxAlias: true,
 			isLiteralModelId: (provider, id) =>
 				availableModels.some(model => model.provider === provider && model.id === id),
@@ -9061,7 +9071,15 @@ export class AgentSession {
 			if (explicitModel) return explicitModel;
 		}
 
-		return availableModels.find(m => m.provider === currentModel.provider && m.id === configuredTarget);
+		return availableModels.find(m => m.provider === currentModel.provider && m.id === trimmedTarget);
+	}
+
+	#resolveContextPromotionConfiguredTarget(currentModel: Model, availableModels: Model[]): Model | undefined {
+		return this.#resolveConfiguredModelTarget(currentModel.contextPromotionTarget, currentModel, availableModels);
+	}
+
+	#resolveCompactionConfiguredTarget(currentModel: Model, availableModels: Model[]): Model | undefined {
+		return this.#resolveConfiguredModelTarget(currentModel.compactionModel, currentModel, availableModels);
 	}
 
 	#resolveRoleModelFull(
@@ -9102,6 +9120,9 @@ export class AgentSession {
 			candidates.push(model);
 		};
 
+		if (preferredModel) {
+			addCandidate(this.#resolveCompactionConfiguredTarget(preferredModel, availableModels));
+		}
 		addCandidate(preferredModel ?? undefined);
 		for (const role of MODEL_ROLE_IDS) {
 			addCandidate(this.#resolveRoleModelFull(role, availableModels, preferredModel ?? undefined).model);

--- a/packages/coding-agent/test/compaction-prefer-current-model.test.ts
+++ b/packages/coding-agent/test/compaction-prefer-current-model.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -96,5 +97,69 @@ describe("compaction prefers the current session model over modelRoles.default",
 		expect(compactSpy).toHaveBeenCalled();
 		const [, firstCandidate] = compactSpy.mock.calls[0]!;
 		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
+	});
+
+	it("uses compactionModel only for the summary call and leaves the active model unchanged", async () => {
+		const baseCurrentModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const compactionModel = getBundledModel("openai", "gpt-5");
+		if (!baseCurrentModel || !compactionModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+		const currentModel = buildModel({
+			...baseCurrentModel,
+			compactionModel: `${compactionModel.provider}/${compactionModel.id}`,
+			compat: baseCurrentModel.compatConfig,
+		});
+
+		const agent = new Agent({
+			initialState: {
+				model: currentModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey(currentModel.provider, "anthropic-token");
+		authStorage.setRuntimeApiKey(compactionModel.provider, "openai-token");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.keepRecentTokens": 1 }),
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+
+		for (const [userText, assistantText] of [
+			["first question", "first answer"],
+			["second question", "second answer"],
+		] as const) {
+			const user = userMsg(userText);
+			const assistant = assistantMsg(assistantText);
+			session.agent.appendMessage(user);
+			session.sessionManager.appendMessage(user);
+			session.agent.appendMessage(assistant);
+			session.sessionManager.appendMessage(assistant);
+		}
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: { provider: model.provider },
+		}));
+
+		await session.compact();
+
+		expect(compactSpy).toHaveBeenCalled();
+		const [, firstCandidate] = compactSpy.mock.calls[0]!;
+		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(
+			`${compactionModel.provider}/${compactionModel.id}`,
+		);
+		expect(`${session.model?.provider}/${session.model?.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
 	});
 });

--- a/packages/coding-agent/test/compaction-prefer-current-model.test.ts
+++ b/packages/coding-agent/test/compaction-prefer-current-model.test.ts
@@ -162,4 +162,72 @@ describe("compaction prefers the current session model over modelRoles.default",
 		);
 		expect(`${session.model?.provider}/${session.model?.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
 	});
+
+	it("/compact remote skips a non-remote-capable compactionModel and uses the active remote-capable model", async () => {
+		// Active model is OpenAI (provider-native remote-capable per
+		// shouldUseOpenAiRemoteCompaction). compactionModel points at an
+		// Anthropic model that is NOT remote-capable, so the default candidate
+		// chain would try Anthropic first and run a local summary — exactly the
+		// silent-fallback the reviewer flagged for `/compact remote`. The fix
+		// filters non-remote candidates in this mode, so the spy must observe
+		// the OpenAI model as the first invocation.
+		const baseCurrentModel = getBundledModel("openai", "gpt-5");
+		const nonRemoteCompactionModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!baseCurrentModel || !nonRemoteCompactionModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+		const currentModel = buildModel({
+			...baseCurrentModel,
+			compactionModel: `${nonRemoteCompactionModel.provider}/${nonRemoteCompactionModel.id}`,
+			compat: baseCurrentModel.compatConfig,
+		});
+
+		const agent = new Agent({
+			initialState: {
+				model: currentModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey(currentModel.provider, "openai-token");
+		authStorage.setRuntimeApiKey(nonRemoteCompactionModel.provider, "anthropic-token");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.keepRecentTokens": 1 }),
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+
+		for (const [userText, assistantText] of [
+			["first question", "first answer"],
+			["second question", "second answer"],
+		] as const) {
+			const user = userMsg(userText);
+			const assistant = assistantMsg(assistantText);
+			session.agent.appendMessage(user);
+			session.sessionManager.appendMessage(user);
+			session.agent.appendMessage(assistant);
+			session.sessionManager.appendMessage(assistant);
+		}
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: { provider: model.provider },
+		}));
+
+		await session.compact(undefined, { mode: "remote" });
+
+		expect(compactSpy).toHaveBeenCalled();
+		const [, firstCandidate] = compactSpy.mock.calls[0]!;
+		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
+	});
 });

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -152,6 +152,35 @@ describe("ModelRegistry runtime provider registration", () => {
 		expectProviderHeader(registry, providerName, "Authorization", undefined);
 	});
 
+	test("registerProvider applies remoteCompaction-only overrides to existing provider models across refresh", async () => {
+		const providerName = "anthropic";
+		const overrideEndpoint = "https://runtime.example.com/v1/compact";
+
+		expect(getProviderModels(registry, providerName).length).toBeGreaterThan(1);
+		registry.registerProvider(
+			providerName,
+			{ remoteCompaction: { enabled: false, endpoint: overrideEndpoint } },
+			"ext://runtime",
+		);
+
+		const expectCompaction = () => {
+			for (const model of getProviderModels(registry, providerName)) {
+				expect(model.remoteCompaction?.enabled).toBe(false);
+				expect(model.remoteCompaction?.endpoint).toBe(overrideEndpoint);
+			}
+		};
+		expectCompaction();
+		await registry.refresh("offline");
+		expectCompaction();
+		await registry.refreshProvider(providerName, "offline");
+		expectCompaction();
+
+		registry.clearSourceRegistrations("ext://runtime");
+		for (const model of getProviderModels(registry, providerName)) {
+			expect(model.remoteCompaction?.endpoint).not.toBe(overrideEndpoint);
+		}
+	});
+
 	test("registerProvider preserves explicit thinking and backfills wire facts", () => {
 		const config: ProviderConfigInput = {
 			baseUrl: "https://runtime.example.com/v1",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -764,6 +764,12 @@ describe("ModelRegistry", () => {
 						compat: {
 							supportsImageDetailOriginal: false,
 						},
+						remoteCompaction: {
+							enabled: true,
+							api: "openai-responses",
+							endpoint: "http://127.0.0.1:8080/v1/responses/provider-compact",
+							model: "provider-compact",
+						},
 						models: [
 							{
 								id: "gpt-5.5",
@@ -772,6 +778,11 @@ describe("ModelRegistry", () => {
 								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 								contextWindow: 200_000,
 								maxTokens: 100_000,
+								compactionModel: "cc-switch/gpt-5.4",
+								remoteCompaction: {
+									endpoint: "http://127.0.0.1:8080/v1/responses/model-compact",
+									model: "gpt-5.5-compact",
+								},
 							},
 						],
 					},
@@ -830,6 +841,17 @@ describe("ModelRegistry", () => {
 			const model = customResponsesCompat.find("cc-switch", "gpt-5.5");
 			const compat = getOpenAICompat(model);
 			expect(compat?.supportsImageDetailOriginal).toBe(false);
+		});
+
+		test("custom Responses providers preserve compaction config", () => {
+			const model = customResponsesCompat.find("cc-switch", "gpt-5.5");
+			expect(model?.compactionModel).toBe("cc-switch/gpt-5.4");
+			expect(model?.remoteCompaction).toEqual({
+				enabled: true,
+				api: "openai-responses",
+				endpoint: "http://127.0.0.1:8080/v1/responses/model-compact",
+				model: "gpt-5.5-compact",
+			});
 		});
 
 		test("model-level compat overrides provider-level compat for custom models", () => {


### PR DESCRIPTION
## Repro
A custom `openai-responses` model with provider id `cliproxy-codex` could not enter the native remote compaction path: `bun -e 'import { shouldUseOpenAiRemoteCompaction } from "@oh-my-pi/pi-agent-core/compaction/openai"; import { buildModel } from "@oh-my-pi/pi-catalog/build"; const model = buildModel({ id: "gpt-5.5", name: "gpt-5.5", api: "openai-responses", provider: "cliproxy-codex", baseUrl: "http://127.0.0.1:8317/v1", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 272000, maxTokens: 128000 }); const allowed = shouldUseOpenAiRemoteCompaction(model); console.log(`remote compaction allowed: ${allowed}`); if (!allowed) process.exit(1);'` printed `remote compaction allowed: false`.

## Cause
`packages/agent/src/compaction/openai.ts` gated OpenAI Responses native compaction on `model.provider === "openai" || model.provider === "openai-codex"`; `packages/coding-agent/src/config/models-config-schema.ts` and `model-registry.ts` had no provider/model metadata to let custom providers declare a compatible compaction adapter, endpoint, or compaction-only model.

## Fix
- Added `remoteCompaction` metadata to catalog `Model`/`ModelSpec` and propagated it through `models.yml` provider, model, modelOverride, discovery, and runtime provider paths.
- Taught OpenAI remote compaction to honor explicit `remoteCompaction.enabled`, `api`, `endpoint`, and request `model` for custom providers while preserving built-in OpenAI/OpenAI Codex defaults.
- Added `compactionModel` as a summary-only model selector and candidate priority so compaction can run on a separate model without changing the active session model.
- Covered native custom-provider compaction, config propagation, and active-model preservation with regression tests.

## Verification
Reproduced the original gate returning `remote compaction allowed: false`; after the fix, the same custom provider with `remoteCompaction.enabled: true` returns `remote compaction allowed: true`. Ran `bun test packages/agent/test/remote-compaction.test.ts packages/coding-agent/test/compaction-prefer-current-model.test.ts && bun test packages/coding-agent/test/model-registry.test.ts --test-name-pattern "custom Responses providers"` (15 pass), package checks for `catalog`, `agent`, and `coding-agent`, and root `bun check` (passed). Fixes #3104