### PR TITLE
fix(compaction): support custom provider compaction config

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -151,6 +151,7 @@ export interface CompactionSettings {
 	autoContinue?: boolean;
 	remoteEnabled?: boolean;
 	remoteEndpoint?: string;
+	remoteAdapter?: "generic" | "openai-responses";
 }
 
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
@@ -1008,10 +1009,11 @@ export async function compact(
 		settings,
 	} = preparation;
 
+	const useOpenAiRemoteAdapter = settings.remoteAdapter === "openai-responses";
 	const summaryOptions: SummaryOptions = {
 		promptOverride: options?.promptOverride,
 		extraContext: options?.extraContext,
-		remoteEndpoint: settings.remoteEnabled === false ? undefined : settings.remoteEndpoint,
+		remoteEndpoint: settings.remoteEnabled === false || useOpenAiRemoteAdapter ? undefined : settings.remoteEndpoint,
 		remoteInstructions: options?.remoteInstructions,
 		initiatorOverride: options?.initiatorOverride,
 		metadata: options?.metadata,
@@ -1027,7 +1029,7 @@ export async function compact(
 	};
 
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
-	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model)) {
+	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model, settings.remoteAdapter)) {
 		const previousRemoteCompaction = getPreservedOpenAiRemoteCompactionData(previousPreserveData);
 		const remoteMessages = [...messagesToSummarize, ...turnPrefixMessages, ...recentMessages];
 		const previousReplacementHistory =
@@ -1050,7 +1052,10 @@ export async function compact(
 							remoteHistory,
 							summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
 							signal,
-							{ fetch: summaryOptions.fetch },
+							{
+								fetch: summaryOptions.fetch,
+								endpoint: useOpenAiRemoteAdapter ? settings.remoteEndpoint : undefined,
+							},
 						),
 					{ signal },
 				);

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -15,7 +15,7 @@
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/errors";
 import { parseTextSignature } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
-import type { AssistantMessage, FetchImpl, Message, Model } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessage, FetchImpl, Message, Model, ModelCompactionAdapter } from "@oh-my-pi/pi-ai/types";
 import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
@@ -86,11 +86,21 @@ export interface RemoteCompactionResponse {
 // OpenAI provider gating + endpoint resolution
 // ============================================================================
 
-export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
+function isOpenAiResponsesCompactionApi(model: Model): boolean {
+	return (
+		model.api === "openai-responses" ||
+		model.api === "azure-openai-responses" ||
+		model.api === "openai-codex-responses"
+	);
+}
+
+export function shouldUseOpenAiRemoteCompaction(model: Model, adapter?: ModelCompactionAdapter): boolean {
+	if (adapter === "openai-responses") return isOpenAiResponsesCompactionApi(model);
 	return model.provider === "openai" || model.provider === "openai-codex";
 }
 
-function resolveOpenAiCompactEndpoint(model: Model): string {
+function resolveOpenAiCompactEndpoint(model: Model, endpoint?: string): string {
+	if (endpoint) return endpoint;
 	if (model.provider === "openai-codex") {
 		return resolveOpenAiCodexCompactEndpoint(model.baseUrl);
 	}
@@ -451,9 +461,9 @@ export async function requestOpenAiRemoteCompaction(
 	compactInput: Array<Record<string, unknown>>,
 	instructions: string,
 	signal?: AbortSignal,
-	opts?: { fetch?: FetchImpl; timeoutMs?: number },
+	opts?: { fetch?: FetchImpl; timeoutMs?: number; endpoint?: string },
 ): Promise<OpenAiRemoteCompactionResponse> {
-	const endpoint = resolveOpenAiCompactEndpoint(model);
+	const endpoint = resolveOpenAiCompactEndpoint(model, opts?.endpoint);
 	const request: OpenAiRemoteCompactionRequest = {
 		model: model.id,
 		input: trimOpenAiCompactInput(compactInput, model.contextWindow ?? Number.POSITIVE_INFINITY, instructions),

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -576,6 +576,21 @@ export type CompatOf<TApi extends Api> = TApi extends "openrouter"
 				? ResolvedAnthropicCompat
 				: undefined;
 
+/** Remote compaction protocol used for provider/model-specific context maintenance. */
+export type ModelCompactionAdapter = "generic" | "openai-responses";
+
+/** Provider/model compaction override carried by custom catalog entries. */
+export interface ModelCompactionConfig {
+	/** Whether this provider/model-specific compaction override participates in maintenance. */
+	enabled?: boolean;
+	/** Explicit compact endpoint; adapter decides the request/response shape. */
+	endpoint?: string;
+	/** Model selector used only for compaction calls; the active session model is preserved. */
+	model?: string;
+	/** Remote compaction protocol. Omitted endpoints default to provider-family inference. */
+	adapter?: ModelCompactionAdapter;
+}
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
 	id: string;
@@ -648,6 +663,8 @@ export interface Model<TApi extends Api = Api> {
 	preferWebsockets?: boolean;
 	/** Preferred model to switch to when context promotion is triggered (model id or provider/id). */
 	contextPromotionTarget?: string;
+	/** Provider/model-specific compaction endpoint or one-shot model override. */
+	compaction?: ModelCompactionConfig;
 	/** Provider-assigned priority value (lower = higher priority). */
 	priority?: number;
 	/** Canonical thinking capability metadata for this model. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom provider compaction configuration so `models.yml` providers/models can route context maintenance through a configured compaction endpoint or compaction-only model while preserving the active session model. ([#3105](https://github.com/can1357/oh-my-pi/issues/3105))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -6,7 +6,7 @@
  * discovery lives in pi-catalog's provider-models.
  */
 import { type ApiKey, type FetchImpl, withAuth } from "@oh-my-pi/pi-ai";
-import type { Api, Model } from "@oh-my-pi/pi-ai/types";
+import type { Api, Model, ModelCompactionConfig } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	getBundledModelReferenceIndex,
@@ -89,6 +89,7 @@ export interface DiscoveryProviderConfig {
 	baseUrl?: string;
 	headers?: Record<string, string>;
 	compat?: ModelSpec<Api>["compat"];
+	compaction?: ModelCompactionConfig;
 	discovery: ProviderDiscovery;
 	optional?: boolean;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,7 +1,15 @@
 import { execSync } from "node:child_process";
 import * as path from "node:path";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
-import type { Api, Context, Model, ModelSpec, SimpleStreamOptions, ThinkingConfig } from "@oh-my-pi/pi-ai/types";
+import type {
+	Api,
+	Context,
+	Model,
+	ModelCompactionConfig,
+	ModelSpec,
+	SimpleStreamOptions,
+	ThinkingConfig,
+} from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { isVertexExpressOpenAIUrl } from "@oh-my-pi/pi-catalog/hosts";
@@ -88,13 +96,14 @@ function isDiscoveryBearerApiKey(apiKey: string | undefined | null): apiKey is s
 	return isAuthenticated(apiKey) && apiKey !== DEFAULT_LOCAL_TOKEN && apiKey !== DEFAULT_VLLM_LOCAL_TOKEN;
 }
 
-/** Provider override config (baseUrl, headers, apiKey, compat, transport) without custom models */
+/** Provider override config without custom models. */
 interface ProviderOverride {
 	baseUrl?: string;
 	headers?: Record<string, string>;
 	apiKey?: string;
 	authHeader?: boolean;
 	compat?: ModelSpec<Api>["compat"];
+	compaction?: ModelCompactionConfig;
 	transport?: Model<Api>["transport"];
 }
 
@@ -127,7 +136,7 @@ interface ProviderOverride {
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "transport">,
+	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "transport" | "compaction">,
 ): Model<TApi> {
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
@@ -136,6 +145,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 			baseUrl: providerOverride?.baseUrl ?? model.baseUrl ?? existing.baseUrl,
 			headers: existing.headers ? { ...existing.headers, ...model.headers } : model.headers,
 			transport: providerOverride?.transport ?? existing.transport ?? model.transport,
+			compaction: mergeCompaction(existing.compaction, providerOverride?.compaction),
 			...(supportsTools !== undefined ? { supportsTools } : {}),
 			compat: model.compatConfig,
 		} as ModelSpec<TApi>);
@@ -146,6 +156,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 			baseUrl: providerOverride.baseUrl ?? model.baseUrl,
 			headers: providerOverride.headers ? { ...model.headers, ...providerOverride.headers } : model.headers,
 			...(providerOverride.transport !== undefined ? { transport: providerOverride.transport } : {}),
+			compaction: providerOverride.compaction,
 			compat: model.compatConfig,
 		} as ModelSpec<TApi>);
 	}
@@ -353,6 +364,15 @@ function mergeCompat<TBase extends object, TOverride extends object>(
 	return merged as TBase & TOverride;
 }
 
+function mergeCompaction(
+	baseCompaction: ModelCompactionConfig | undefined,
+	overrideCompaction: ModelCompactionConfig | undefined,
+): ModelCompactionConfig | undefined {
+	if (!baseCompaction) return overrideCompaction;
+	if (!overrideCompaction) return baseCompaction;
+	return { ...baseCompaction, ...overrideCompaction };
+}
+
 /**
  * Project a built model back to spec shape for the model-manager/cache
  * boundary: sparse compat comes from `compatConfig`, never from the resolved
@@ -379,6 +399,7 @@ interface ModelPatch {
 	omitMaxOutputTokens?: boolean;
 	headers?: Record<string, string>;
 	compat?: ModelSpec<Api>["compat"];
+	compaction?: ModelCompactionConfig;
 	contextPromotionTarget?: string;
 	premiumMultiplier?: number;
 }
@@ -403,6 +424,9 @@ function applyModelPatch(base: Model<Api>, patch: ModelPatch, transport: ModelTr
 	if (patch.maxTokens !== undefined) result.maxTokens = patch.maxTokens;
 	if (patch.omitMaxOutputTokens !== undefined) result.omitMaxOutputTokens = patch.omitMaxOutputTokens;
 	if (patch.contextPromotionTarget !== undefined) result.contextPromotionTarget = patch.contextPromotionTarget;
+	if (patch.compaction !== undefined) {
+		result.compaction = transport === "merge" ? mergeCompaction(base.compaction, patch.compaction) : patch.compaction;
+	}
 	if (patch.premiumMultiplier !== undefined) result.premiumMultiplier = patch.premiumMultiplier;
 	if (patch.cost) {
 		result.cost = {
@@ -496,6 +520,7 @@ function buildCustomModelOverlay(
 	providerApiKey: string | undefined,
 	authHeader: boolean | undefined,
 	providerCompat: ModelSpec<Api>["compat"] | undefined,
+	providerCompaction: ModelCompactionConfig | undefined,
 	providerAuth: ProviderAuthMode | undefined,
 	modelDef: CustomModelDefinitionLike,
 ): CustomModelOverlay | undefined {
@@ -517,6 +542,7 @@ function buildCustomModelOverlay(
 		omitMaxOutputTokens: modelDef.omitMaxOutputTokens,
 		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader, providerApiKey),
 		compat: mergeCompat(providerCompat, modelDef.compat),
+		compaction: mergeCompaction(providerCompaction, modelDef.compaction),
 		contextPromotionTarget: modelDef.contextPromotionTarget,
 		premiumMultiplier: modelDef.premiumMultiplier,
 		isOAuth: resolveCustomModelIsOAuth(api, providerAuth),
@@ -558,6 +584,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		omitMaxOutputTokens: resolvedModel.omitMaxOutputTokens ?? reference?.omitMaxOutputTokens,
 		compat: mergeCompat(reference?.compatConfig, resolvedModel.compat),
 		contextPromotionTarget: resolvedModel.contextPromotionTarget,
+		compaction: mergeCompaction(reference?.compaction, resolvedModel.compaction),
 		premiumMultiplier: resolvedModel.premiumMultiplier,
 		isOAuth: resolvedModel.isOAuth,
 	} as ModelSpec<Api>);
@@ -1033,12 +1060,22 @@ export class ModelRegistry {
 					)
 				: models;
 
+		const withProviderCompaction = providerConfig.compaction
+			? withDecoderMetadata.map(model =>
+					buildModel({
+						...model,
+						compaction: mergeCompaction(model.compaction, providerConfig.compaction),
+						compat: model.compatConfig,
+					} as ModelSpec<Api>),
+				)
+			: withDecoderMetadata;
+
 		if (providerConfig.provider !== "ollama" || providerConfig.api !== "openai-responses") {
-			return withDecoderMetadata;
+			return withProviderCompaction;
 		}
 
 		const contextLengthOverride = getOllamaContextLengthOverride();
-		return withDecoderMetadata.map(model => {
+		return withProviderCompaction.map(model => {
 			const normalized =
 				model.api === "openai-completions"
 					? buildModel({
@@ -1130,13 +1167,14 @@ export class ModelRegistry {
 
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
-			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
+			// Always set overrides when provider-level transport, compatibility, or compaction fields are present.
 			if (
 				providerConfig.baseUrl ||
 				resolvedProviderHeaders ||
 				providerConfig.apiKey ||
 				providerConfig.authHeader !== undefined ||
 				providerConfig.compat ||
+				providerConfig.compaction ||
 				providerConfig.disableStrictTools ||
 				providerConfig.transport
 			) {
@@ -1147,6 +1185,7 @@ export class ModelRegistry {
 					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
+					compaction: providerConfig.compaction,
 					transport: providerConfig.transport,
 				});
 			}
@@ -1167,6 +1206,7 @@ export class ModelRegistry {
 					baseUrl: providerConfig.baseUrl,
 					headers: resolvedProviderHeaders,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
+					compaction: providerConfig.compaction,
 					discovery: providerConfig.discovery,
 					optional: false,
 				});
@@ -1538,12 +1578,17 @@ export class ModelRegistry {
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
 			headers: override.headers ? { ...(baseOverride?.headers ?? {}), ...override.headers } : baseOverride?.headers,
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
+			compaction: override.compaction
+				? mergeCompaction(baseOverride?.compaction, override.compaction)
+				: baseOverride?.compaction,
 			transport: override.transport ?? baseOverride?.transport,
 		};
 	}
-	#applyProviderTransportOverride<T extends { baseUrl?: string; headers?: Record<string, string> }>(
+	#applyProviderTransportOverride<
+		T extends { baseUrl?: string; headers?: Record<string, string>; compaction?: ModelCompactionConfig },
+	>(
 		entry: T,
-		override: Pick<ProviderOverride, "baseUrl" | "headers" | "authHeader" | "apiKey" | "transport">,
+		override: Pick<ProviderOverride, "baseUrl" | "headers" | "authHeader" | "apiKey" | "transport" | "compaction">,
 	): T {
 		const headers = mergeAuthHeader(
 			override.headers ? { ...entry.headers, ...override.headers } : entry.headers,
@@ -1554,6 +1599,7 @@ export class ModelRegistry {
 			...entry,
 			baseUrl: override.baseUrl ?? entry.baseUrl,
 			headers,
+			compaction: mergeCompaction(entry.compaction, override.compaction),
 			// Preserve the model's existing transport when the override omits one;
 			// providers without a `transport` field keep the default per-API dispatch.
 			...(override.transport !== undefined ? { transport: override.transport } : {}),
@@ -1661,6 +1707,7 @@ export class ModelRegistry {
 					providerConfig.apiKey,
 					providerConfig.authHeader,
 					providerCompat,
+					providerConfig.compaction,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
 					modelDef as CustomModelDefinitionLike,
 				);
@@ -2007,6 +2054,7 @@ export class ModelRegistry {
 				apiKey: config.apiKey,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
+				compaction: config.compaction,
 				models: (config.models ?? []) as ProviderValidationModel[],
 			},
 			"runtime-register",
@@ -2068,6 +2116,7 @@ export class ModelRegistry {
 					config.apiKey,
 					config.authHeader,
 					config.compat,
+					config.compaction,
 					undefined,
 					modelDef as CustomModelDefinitionLike,
 				);
@@ -2115,6 +2164,7 @@ export class ModelRegistry {
 			const providerApiKey = config.apiKey;
 			const providerAuthHeader = config.authHeader;
 			const providerCompat = config.compat;
+			const providerCompaction = config.compaction;
 			const managerOptions: ModelManagerOptions<Api> = {
 				providerId: providerName as Parameters<typeof createModelManager>[0]["providerId"],
 				staticModels: [],
@@ -2135,6 +2185,7 @@ export class ModelRegistry {
 							providerApiKey,
 							providerAuthHeader,
 							providerCompat,
+							providerCompaction,
 							undefined,
 							modelDef as CustomModelDefinitionLike,
 						);
@@ -2153,6 +2204,7 @@ export class ModelRegistry {
 			config.headers ||
 			config.apiKey ||
 			config.authHeader !== undefined ||
+			config.compaction !== undefined ||
 			config.transport !== undefined
 		) {
 			const transportOverride = {
@@ -2160,6 +2212,7 @@ export class ModelRegistry {
 				headers: config.headers,
 				apiKey: config.apiKey,
 				authHeader: config.authHeader,
+				compaction: config.compaction,
 				transport: config.transport,
 			};
 			const nextRuntimeOverride = this.#mergeProviderOverride(
@@ -2221,6 +2274,7 @@ export interface ProviderConfigInput {
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;
 	compat?: ModelSpec<Api>["compat"];
+	compaction?: ModelCompactionConfig;
 	authHeader?: boolean;
 	/** Streaming transport override — see {@link Model.transport}. */
 	transport?: Model<Api>["transport"];
@@ -2254,6 +2308,7 @@ export interface ProviderConfigInput {
 		maxTokens: number;
 		headers?: Record<string, string>;
 		compat?: ModelSpec<Api>["compat"];
+		compaction?: ModelCompactionConfig;
 		contextPromotionTarget?: string;
 		premiumMultiplier?: number;
 	}>;

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -70,6 +70,21 @@ export const OpenAICompatSchema = type({
 	"whenThinking?": OpenAICompatFieldsSchema,
 });
 
+const CompactionConfigSchema = type({
+	"enabled?": "boolean",
+	"endpoint?": "string",
+	"model?": "string",
+	"adapter?": '"generic" | "openai-responses"',
+}).narrow((value, ctx) => {
+	if (value.endpoint !== undefined && typeof value.endpoint === "string" && value.endpoint.length === 0) {
+		return ctx.mustBe("endpoint a non-empty string");
+	}
+	if (value.model !== undefined && typeof value.model === "string" && value.model.length === 0) {
+		return ctx.mustBe("model a non-empty string");
+	}
+	return true;
+});
+
 const EffortSchema = type('"minimal" | "low" | "medium" | "high" | "xhigh"');
 
 const ThinkingControlModeSchema = type(
@@ -140,6 +155,7 @@ const ModelDefinitionSchema = type({
 	"omitMaxOutputTokens?": "boolean",
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
+	"compaction?": CompactionConfigSchema,
 	"contextPromotionTarget?": "string",
 }).narrow((value, ctx) => {
 	// Enforce id non-empty
@@ -180,6 +196,7 @@ export const ModelOverrideSchema = type({
 	"omitMaxOutputTokens?": "boolean",
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
+	"compaction?": CompactionConfigSchema,
 	"contextPromotionTarget?": "string",
 }).narrow((value, ctx) => {
 	if (value.name !== undefined && typeof value.name === "string" && value.name.length === 0) {
@@ -213,6 +230,7 @@ const ProviderConfigSchema = type({
 		'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
 	"headers?": { "[string]": "string" },
 	"compat?": OpenAICompatSchema,
+	"compaction?": CompactionConfigSchema,
 	"authHeader?": "boolean",
 	"auth?": ProviderAuthSchema,
 	"discovery?": ProviderDiscoverySchema,

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -2,7 +2,7 @@
  * models.json config file handle and provider configuration validation.
  */
 
-import type { Api, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import type { Api, ModelCompactionConfig, ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { ConfigFile } from "./config-file";
 import {
 	type ModelsConfig,
@@ -30,6 +30,7 @@ export interface ProviderValidationConfig {
 	oauthConfigured?: boolean;
 	discovery?: ProviderDiscovery;
 	compat?: ModelSpec<Api>["compat"];
+	compaction?: ModelCompactionConfig;
 	disableStrictTools?: boolean;
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
@@ -53,11 +54,12 @@ export function validateProviderConfiguration(
 				!config.apiKey &&
 				config.auth !== "none" &&
 				!config.disableStrictTools &&
+				!config.compaction &&
 				!hasModelOverrides &&
 				!config.discovery
 			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "auth: none", "compat", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "auth: none", "compat", "compaction", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -120,6 +122,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
 					discovery: providerConfig.discovery as ProviderDiscovery | undefined,
 					compat: providerConfig.compat,
+					compaction: providerConfig.compaction,
 					disableStrictTools: providerConfig.disableStrictTools,
 					modelOverrides: providerConfig.modelOverrides,
 					models: (providerConfig.models ?? []) as ProviderValidationModel[],

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -22,6 +22,7 @@ import type {
 	Context,
 	ImageContent,
 	Model,
+	ModelCompactionConfig,
 	ModelSpec,
 	ProviderResponseMetadata,
 	SimpleStreamOptions,
@@ -1195,6 +1196,8 @@ export interface ProviderConfig {
 	headers?: Record<string, string>;
 	/** If true, adds Authorization: Bearer header with the resolved API key. */
 	authHeader?: boolean;
+	/** Provider-level compaction endpoint/model used without changing the active session model. */
+	compaction?: ModelCompactionConfig;
 	/** Models to register. If provided, replaces all existing models for this provider. */
 	models?: ProviderModelConfig[];
 	/** OAuth provider for /login support. */
@@ -1245,6 +1248,8 @@ export interface ProviderModelConfig {
 	headers?: Record<string, string>;
 	/** OpenAI compatibility settings. */
 	compat?: ModelSpec<Api>["compat"];
+	/** Model-specific compaction endpoint/model override. */
+	compaction?: ModelCompactionConfig;
 }
 
 /** Extension factory function type. Supports both sync and async initialization. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -44,6 +44,7 @@ import {
 	CompactionCancelledError,
 	type CompactionPreparation,
 	type CompactionResult,
+	type CompactionSettings,
 	calculateContextTokens,
 	calculatePromptTokens,
 	collectEntriesForBranchSummary,
@@ -79,6 +80,7 @@ import type {
 	Message,
 	MessageAttribution,
 	Model,
+	ModelCompactionAdapter,
 	ProviderResponseMetadata,
 	ProviderSessionState,
 	ResetCreditAccountStatus,
@@ -2000,11 +2002,11 @@ export class AgentSession {
 		const advisor = this.#advisorAgent;
 		if (!advisor) return false;
 
-		const compactionSettings = this.settings.getGroup("compaction");
+		const advisorModel = advisor.state.model;
+		const compactionSettings = this.#resolveCompactionSettings(advisorModel, this.settings.getGroup("compaction"));
 		if (compactionSettings.strategy === "off") return false;
 		if (!compactionSettings.enabled) return false;
 
-		const advisorModel = advisor.state.model;
 		const contextWindow = advisorModel.contextWindow ?? 0;
 		if (contextWindow <= 0) return false;
 
@@ -7602,7 +7604,7 @@ export class AgentSession {
 				throw new Error("No model selected");
 			}
 
-			const compactionSettings = this.settings.getGroup("compaction");
+			const compactionSettings = this.#resolveCompactionSettings(this.model, this.settings.getGroup("compaction"));
 			// The `/compact <mode>` override (resolved above) replaces the configured
 			// strategy/remote flags for this one invocation. Merged before
 			// prepareCompaction so the remote gating (preparation.settings.
@@ -7612,7 +7614,8 @@ export class AgentSession {
 				: compactionSettings;
 			if (compactMode?.requiresRemote) {
 				const remoteReady =
-					Boolean(effectiveSettings.remoteEndpoint) || shouldUseOpenAiRemoteCompaction(this.model);
+					Boolean(effectiveSettings.remoteEndpoint) ||
+					shouldUseOpenAiRemoteCompaction(this.model, effectiveSettings.remoteAdapter);
 				if (!remoteReady) {
 					this.emitNotice(
 						"warning",
@@ -9064,6 +9067,54 @@ export class AgentSession {
 		return availableModels.find(m => m.provider === currentModel.provider && m.id === configuredTarget);
 	}
 
+	#resolveConfiguredCompactionModel(
+		currentModel: Model | null | undefined,
+		availableModels: Model[],
+	): Model | undefined {
+		const configuredTarget =
+			currentModel?.compaction?.enabled === false ? undefined : currentModel?.compaction?.model?.trim();
+		if (!configuredTarget) return undefined;
+
+		const parsed = parseModelString(configuredTarget, {
+			allowMaxAlias: true,
+			isLiteralModelId: (provider, id) =>
+				availableModels.some(model => model.provider === provider && model.id === id),
+		});
+		if (parsed) {
+			const explicitModel = availableModels.find(m => m.provider === parsed.provider && m.id === parsed.id);
+			if (explicitModel) return explicitModel;
+		}
+
+		return currentModel
+			? availableModels.find(m => m.provider === currentModel.provider && m.id === configuredTarget)
+			: undefined;
+	}
+
+	#inferCompactionRemoteAdapter(model: Model, endpoint: string | undefined): ModelCompactionAdapter | undefined {
+		const configured = model.compaction?.adapter;
+		if (configured) return configured;
+		if (
+			model.api === "openai-responses" ||
+			model.api === "azure-openai-responses" ||
+			model.api === "openai-codex-responses"
+		) {
+			return endpoint || model.compaction?.enabled === true ? "openai-responses" : undefined;
+		}
+		if (!endpoint) return undefined;
+		return "generic";
+	}
+
+	#resolveCompactionSettings(model: Model, baseSettings: CompactionSettings): CompactionSettings {
+		const compaction = model.compaction;
+		if (!compaction || compaction.enabled === false) return baseSettings;
+		const endpoint = compaction.endpoint ?? baseSettings.remoteEndpoint;
+		return {
+			...baseSettings,
+			remoteEndpoint: endpoint,
+			remoteAdapter: this.#inferCompactionRemoteAdapter(model, endpoint) ?? baseSettings.remoteAdapter,
+		};
+	}
+
 	#resolveRoleModelFull(
 		role: string,
 		availableModels: Model[],
@@ -9102,6 +9153,7 @@ export class AgentSession {
 			candidates.push(model);
 		};
 
+		addCandidate(this.#resolveConfiguredCompactionModel(preferredModel, availableModels));
 		addCandidate(preferredModel ?? undefined);
 		for (const role of MODEL_ROLE_IDS) {
 			addCandidate(this.#resolveRoleModelFull(role, availableModels, preferredModel ?? undefined).model);
@@ -9429,7 +9481,8 @@ export class AgentSession {
 
 			const pathEntries = this.sessionManager.getBranch();
 
-			const preparation = prepareCompaction(pathEntries, compactionSettings);
+			const effectiveCompactionSettings = this.#resolveCompactionSettings(this.model, compactionSettings);
+			const preparation = prepareCompaction(pathEntries, effectiveCompactionSettings);
 			if (!preparation) {
 				await this.#emitSessionEvent({
 					type: "auto_compaction_end",
@@ -9502,7 +9555,7 @@ export class AgentSession {
 				const ctxWindow = this.model?.contextWindow ?? 0;
 				const budget =
 					ctxWindow > 0
-						? ctxWindow - effectiveReserveTokens(ctxWindow, compactionSettings)
+						? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveCompactionSettings)
 						: Number.POSITIVE_INFINITY;
 				const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
 				if (projected > budget) {

--- a/packages/coding-agent/test/compaction-prefer-current-model.test.ts
+++ b/packages/coding-agent/test/compaction-prefer-current-model.test.ts
@@ -97,4 +97,74 @@ describe("compaction prefers the current session model over modelRoles.default",
 		const [, firstCandidate] = compactSpy.mock.calls[0]!;
 		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
 	});
+
+	it("uses the configured compaction model without changing the active session model", async () => {
+		const modelsPath = path.join(tempDir.path(), "models.yml");
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://proxy.example.com/v1",
+						apiKey: "CUSTOM_TOKEN",
+						api: "openai-responses",
+						compaction: { model: "compact-model" },
+						models: [{ id: "work-model" }, { id: "compact-model" }],
+					},
+				},
+			}),
+		);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const currentModel = modelRegistry.find("custom-proxy", "work-model");
+		const compactionModel = modelRegistry.find("custom-proxy", "compact-model");
+		if (!currentModel || !compactionModel) {
+			throw new Error("Expected custom compaction test models to exist");
+		}
+
+		const agent = new Agent({
+			initialState: {
+				model: currentModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.keepRecentTokens": 1 }),
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+
+		for (const [userText, assistantText] of [
+			["first question", "first answer"],
+			["second question", "second answer"],
+		] as const) {
+			const user = userMsg(userText);
+			const assistant = assistantMsg(assistantText);
+			session.agent.appendMessage(user);
+			session.sessionManager.appendMessage(user);
+			session.agent.appendMessage(assistant);
+			session.sessionManager.appendMessage(assistant);
+		}
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: { provider: model.provider },
+		}));
+
+		await session.compact();
+
+		expect(compactSpy).toHaveBeenCalled();
+		const [, firstCandidate] = compactSpy.mock.calls[0]!;
+		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(
+			`${compactionModel.provider}/${compactionModel.id}`,
+		);
+		expect(`${session.model?.provider}/${session.model?.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
+	});
 });

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -560,6 +560,54 @@ describe("remote compaction setting", () => {
 		expect(fetchHandler.mock.calls[0]?.[0]).toBe("https://chatgpt.com/backend-api/codex/responses/compact");
 	});
 
+	it("uses configured OpenAI Responses compact endpoint for custom providers", async () => {
+		const baseModel = getBundledModel("openai", "gpt-5.1");
+		if (!baseModel) throw new Error("Expected openai/gpt-5.1 model to exist");
+
+		const model: Model = {
+			...baseModel,
+			api: "openai-responses",
+			provider: "custom-proxy",
+			baseUrl: "https://proxy.example.com/v1",
+			compaction: {
+				enabled: true,
+				endpoint: "https://proxy.example.com/v1/responses/compact",
+				adapter: "openai-responses",
+			},
+		};
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createOpenAiAssistantMessage("Answer 1", model, createMockUsage(0, 100, 9000, 0))),
+		];
+		const preparation = prepareCompaction(entries, {
+			...DEFAULT_COMPACTION_SETTINGS,
+			keepRecentTokens: 1,
+			remoteEnabled: true,
+			remoteEndpoint: model.compaction?.endpoint,
+			remoteAdapter: "openai-responses",
+		});
+		if (!preparation) throw new Error("Expected compaction preparation");
+
+		const fetchHandler = vi.fn(
+			async (_input, _init) =>
+				new Response(JSON.stringify({ output: [{ type: "compaction", encrypted_content: "new_encrypted" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		const fetchSpy = mockFetch(fetchHandler);
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("Short summary"));
+
+		await compact(preparation, model, "test-api-key", undefined, undefined, { fetch: fetchSpy });
+
+		expect(fetchHandler).toHaveBeenCalledTimes(1);
+		expect(fetchHandler.mock.calls[0]?.[0]).toBe("https://proxy.example.com/v1/responses/compact");
+		const requestBody = JSON.parse(String(fetchHandler.mock.calls[0]?.[1]?.body)) as {
+			model: string;
+		};
+		expect(requestBody.model).toBe(model.id);
+	});
+
 	it("preserves codex assistant text signature metadata in remote compaction history", async () => {
 		const baseModel = getBundledModel("openai", "gpt-5.1");
 		if (!baseModel) throw new Error("Expected openai/gpt-5.1 model to exist");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1095,6 +1095,47 @@ describe("ModelRegistry", () => {
 			expect(openaiGpt54Override.find("openai", "gpt-5.4")?.contextWindow).toBe(512000);
 		});
 
+		test("custom provider compaction config is inherited and model-overridable", () => {
+			const registry = readonlyRegistry({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://proxy.example.com/v1",
+						apiKey: "TEST_KEY",
+						api: "openai-responses",
+						compaction: {
+							enabled: true,
+							endpoint: "https://proxy.example.com/v1/responses/compact",
+							model: "compact-model",
+							adapter: "openai-responses",
+						},
+						models: [
+							{ id: "work-model" },
+							{
+								id: "compact-model",
+								compaction: {
+									endpoint: "https://proxy.example.com/v1/custom-compact",
+									model: "tiny-compact-model",
+								},
+							},
+						],
+					},
+				},
+			});
+
+			expect(registry.find("custom-proxy", "work-model")?.compaction).toEqual({
+				enabled: true,
+				endpoint: "https://proxy.example.com/v1/responses/compact",
+				model: "compact-model",
+				adapter: "openai-responses",
+			});
+			expect(registry.find("custom-proxy", "compact-model")?.compaction).toEqual({
+				enabled: true,
+				endpoint: "https://proxy.example.com/v1/custom-compact",
+				model: "tiny-compact-model",
+				adapter: "openai-responses",
+			});
+		});
+
 		test("discoverable bundled replacement survives refresh", async () => {
 			writeModelsJson({
 				openai: providerConfig(


### PR DESCRIPTION
## Repro
A source-level repro against pre-fix `HEAD` showed `models.yml` had no provider/model `compaction` field, the registry did not carry compaction metadata onto resolved models, and native remote compaction was gated to only `openai` / `openai-codex`: `bun -e "$SCRIPT"` printed `{ "schemaHasCompaction": false, "registryCarriesCompaction": false, "remoteGateIsBuiltInOnly": true }` and exited 1.

## Cause
`packages/coding-agent/src/config/models-config-schema.ts` and `model-registry.ts` only modeled transport/compat/context-promotion metadata for custom providers, while `packages/agent/src/compaction/openai.ts` enabled native compact endpoints solely by provider id. `AgentSession` therefore had no model/provider compaction metadata to choose a compaction-only model or endpoint.

## Fix
- Added `ModelCompactionConfig` to catalog model types and threaded provider/model `compaction` config through `models.yml`, runtime provider registration, discovery, model overrides, and extension provider types.
- Added compaction candidate resolution in `AgentSession` so configured compaction models are tried before the active model without calling `setModel`, preserving the active session model.
- Added OpenAI Responses remote compaction adapter selection and explicit endpoint override support for custom providers, while leaving generic remote endpoints and context promotion separate.
- Added regression coverage for config inheritance/overrides, custom OpenAI Responses compact endpoints, and return-to-original active model behavior.

## Verification
- `bun test packages/coding-agent/test/compaction-prefer-current-model.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/compaction.test.ts` → 125 pass, 1 skip, 0 fail.
- `bun check` → passed.

Fixes #3105