### PR TITLE
fix(agent): preserve memory recall in append-only prompt cache

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed first-turn memory recall invalidating append-only prompt caches by promoting injected memory into the stable session prompt before the next turn. ([#3111](https://github.com/can1357/oh-my-pi/issues/3111))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1251,6 +1251,7 @@ export class AgentSession {
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
+	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
 	 * Signature of the (toolNames, tool descriptions) tuple passed to the most
 	 * recent successful `rebuildSystemPrompt` call. Used to skip redundant rebuilds
@@ -4084,18 +4085,20 @@ export class AgentSession {
 	}
 
 	/** New session file: reset auto-recall / retain-threshold counters for the new transcript. */
-	#resetHindsightConversationTrackingIfHindsight(): void {
-		if (this.settings.get("memory.backend") !== "hindsight") return;
+	#resetHindsightConversationTrackingIfHindsight(): boolean {
+		if (this.settings.get("memory.backend") !== "hindsight") return false;
 		const state = this.getHindsightSessionState();
-		if (!state || state.aliasOf) return;
+		if (!state || state.aliasOf) return false;
 		state.resetConversationTracking();
+		return true;
 	}
 
-	#resetMnemopiConversationTrackingIfMnemopi(): void {
-		if (this.settings.get("memory.backend") !== "mnemopi") return;
+	#resetMnemopiConversationTrackingIfMnemopi(): boolean {
+		if (this.settings.get("memory.backend") !== "mnemopi") return false;
 		const state = this.getMnemopiSessionState();
-		if (!state || state.aliasOf) return;
+		if (!state || state.aliasOf) return false;
 		state.resetConversationTracking();
+		return true;
 	}
 
 	/** True once dispose() has begun; deferred background work (e.g. the deferred
@@ -4783,6 +4786,7 @@ export class AgentSession {
 			if (signature !== this.#lastAppliedToolSignature) {
 				const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
 				this.#baseSystemPrompt = built.systemPrompt;
+				this.#baseSystemPromptBeforeMemoryPromotion = undefined;
 				this.agent.setSystemPrompt(this.#baseSystemPrompt);
 				this.#lastAppliedToolSignature = signature;
 				this.#promptModelKey = this.#currentPromptModelKey();
@@ -4867,6 +4871,7 @@ export class AgentSession {
 		const activeToolNames = this.getActiveToolNames();
 		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
 		this.#baseSystemPrompt = built.systemPrompt;
+		this.#baseSystemPromptBeforeMemoryPromotion = undefined;
 		this.agent.setSystemPrompt(this.#baseSystemPrompt);
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `#applyActiveToolsByName` with
@@ -4903,6 +4908,7 @@ export class AgentSession {
 				return this.#baseSystemPrompt;
 			}
 
+			this.#baseSystemPromptBeforeMemoryPromotion ??= previousBaseSystemPrompt;
 			const stablePrompt = [...previousBaseSystemPrompt, injected];
 			this.#baseSystemPrompt = stablePrompt;
 			this.agent.setSystemPrompt(stablePrompt);
@@ -11281,6 +11287,7 @@ export class AgentSession {
 		const previousTools = [...this.agent.state.tools];
 		const previousBaseSystemPrompt = this.#baseSystemPrompt;
 		const previousSystemPrompt = this.agent.state.systemPrompt;
+		const previousBaseSystemPromptBeforeMemoryPromotion = this.#baseSystemPromptBeforeMemoryPromotion;
 		const previousFreshProviderSessionId = this.#freshProviderSessionId;
 		const previousFallbackSelectedMCPToolNames = previousSessionFile
 			? this.#getSessionDefaultSelectedMCPToolNames(previousSessionFile)
@@ -11389,8 +11396,18 @@ export class AgentSession {
 					: configuredServiceTier;
 
 			if (switchingToDifferentSession) {
-				this.#resetHindsightConversationTrackingIfHindsight();
-				this.#resetMnemopiConversationTrackingIfMnemopi();
+				const hadPromotedMemoryPrompt = this.#baseSystemPromptBeforeMemoryPromotion !== undefined;
+				const resetMemoryContext =
+					this.#resetHindsightConversationTrackingIfHindsight() ||
+					this.#resetMnemopiConversationTrackingIfMnemopi();
+				if (hadPromotedMemoryPrompt) {
+					this.#baseSystemPrompt = this.#baseSystemPromptBeforeMemoryPromotion!;
+					this.agent.setSystemPrompt(this.#baseSystemPrompt);
+					this.#baseSystemPromptBeforeMemoryPromotion = undefined;
+				}
+				if (resetMemoryContext || hadPromotedMemoryPrompt) {
+					await this.refreshBaseSystemPrompt();
+				}
 			}
 			this.#reconnectToAgent();
 			try {
@@ -11426,6 +11443,7 @@ export class AgentSession {
 				this.agent.setSystemPrompt(previousSystemPrompt);
 			}
 			this.#baseSystemPrompt = previousBaseSystemPrompt;
+			this.#baseSystemPromptBeforeMemoryPromotion = previousBaseSystemPromptBeforeMemoryPromotion;
 			this.agent.setSystemPrompt(previousSystemPrompt);
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4101,6 +4101,20 @@ export class AgentSession {
 		return true;
 	}
 
+	async #resetMemoryContextForNewTranscript(): Promise<void> {
+		const hadPromotedMemoryPrompt = this.#baseSystemPromptBeforeMemoryPromotion !== undefined;
+		const resetHindsight = this.#resetHindsightConversationTrackingIfHindsight();
+		const resetMnemopi = this.#resetMnemopiConversationTrackingIfMnemopi();
+		if (hadPromotedMemoryPrompt) {
+			this.#baseSystemPrompt = this.#baseSystemPromptBeforeMemoryPromotion!;
+			this.agent.setSystemPrompt(this.#baseSystemPrompt);
+			this.#baseSystemPromptBeforeMemoryPromotion = undefined;
+		}
+		if (resetHindsight || resetMnemopi || hadPromotedMemoryPrompt) {
+			await this.refreshBaseSystemPrompt();
+		}
+	}
+
 	/** True once dispose() has begun; deferred background work (e.g. the deferred
 	 *  MCP discovery task in sdk.ts) must not touch the session past this point. */
 	get isDisposed(): boolean {
@@ -6772,8 +6786,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
-		this.#resetHindsightConversationTrackingIfHindsight();
-		this.#resetMnemopiConversationTrackingIfMnemopi();
+		await this.#resetMemoryContextForNewTranscript();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
@@ -8018,8 +8031,7 @@ export class AgentSession {
 			this.#syncAgentSessionId();
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
-			this.#resetHindsightConversationTrackingIfHindsight();
-			this.#resetMnemopiConversationTrackingIfMnemopi();
+			await this.#resetMemoryContextForNewTranscript();
 			this.#pendingNextTurnMessages = [];
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#todoReminderCount = 0;
@@ -11396,18 +11408,7 @@ export class AgentSession {
 					: configuredServiceTier;
 
 			if (switchingToDifferentSession) {
-				const hadPromotedMemoryPrompt = this.#baseSystemPromptBeforeMemoryPromotion !== undefined;
-				const resetMemoryContext =
-					this.#resetHindsightConversationTrackingIfHindsight() ||
-					this.#resetMnemopiConversationTrackingIfMnemopi();
-				if (hadPromotedMemoryPrompt) {
-					this.#baseSystemPrompt = this.#baseSystemPromptBeforeMemoryPromotion!;
-					this.agent.setSystemPrompt(this.#baseSystemPrompt);
-					this.#baseSystemPromptBeforeMemoryPromotion = undefined;
-				}
-				if (resetMemoryContext || hadPromotedMemoryPrompt) {
-					await this.refreshBaseSystemPrompt();
-				}
+				await this.#resetMemoryContextForNewTranscript();
 			}
 			this.#reconnectToAgent();
 			try {
@@ -11522,8 +11523,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
-		this.#resetHindsightConversationTrackingIfHindsight();
-		this.#resetMnemopiConversationTrackingIfMnemopi();
+		await this.#resetMemoryContextForNewTranscript();
 
 		// Reload messages from entries (works for both file and in-memory mode)
 		const sessionContext = this.buildDisplaySessionContext();
@@ -11615,8 +11615,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
-		this.#resetHindsightConversationTrackingIfHindsight();
-		this.#resetMnemopiConversationTrackingIfMnemopi();
+		await this.#resetMemoryContextForNewTranscript();
 
 		const sessionContext = this.buildDisplaySessionContext();
 		await this.#restoreMCPSelectionsForSessionContext(sessionContext);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4885,7 +4885,28 @@ export class AgentSession {
 		try {
 			const injected = await backend.beforeAgentStartPrompt(this, promptText);
 			if (!injected) return this.#baseSystemPrompt;
-			return [...this.#baseSystemPrompt, injected];
+
+			const previousBaseSystemPrompt = this.#baseSystemPrompt;
+			try {
+				await this.refreshBaseSystemPrompt();
+			} catch (refreshErr) {
+				logger.debug("Memory backend prompt refresh after beforeAgentStartPrompt failed", {
+					backend: backend.id,
+					error: String(refreshErr),
+				});
+			}
+
+			if (
+				this.#baseSystemPrompt.length !== previousBaseSystemPrompt.length ||
+				this.#baseSystemPrompt.some((part, index) => part !== previousBaseSystemPrompt[index])
+			) {
+				return this.#baseSystemPrompt;
+			}
+
+			const stablePrompt = [...previousBaseSystemPrompt, injected];
+			this.#baseSystemPrompt = stablePrompt;
+			this.agent.setSystemPrompt(stablePrompt);
+			return stablePrompt;
 		} catch (err) {
 			logger.debug("Memory backend beforeAgentStartPrompt failed", {
 				backend: backend.id,

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -17,10 +17,12 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
 import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
+import { type MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm, wrapSteeringForModel } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 function createAgent(): Agent {
@@ -591,5 +593,104 @@ describe("AgentSession message pipeline", () => {
 		expect(firstSystemPrompt).toBeDefined();
 		expect(firstSystemPrompt!.join("\n")).toContain(injected);
 		expect(contexts[1]!.systemPrompt).toEqual(firstSystemPrompt);
+	});
+
+	it("clears promoted memory from the base prompt when switching sessions", async () => {
+		using tempDir = TempDir.createSync("@pi-injected-memory-switch-");
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.join("sessions"));
+		const firstSessionFile = sessionManager.getSessionFile();
+		expect(firstSessionFile).toBeString();
+		await sessionManager.flush();
+		const nextSessionManager = SessionManager.create(tempDir.path(), tempDir.join("sessions"));
+		const nextSessionFile = nextSessionManager.getSessionFile();
+		expect(nextSessionFile).toBeString();
+		await nextSessionManager.flush();
+
+		const api = "test-injected-memory-switch-cache";
+		const contexts: Context[] = [];
+		let remembered = false;
+		let recallAvailable = true;
+		const injected = "<memories>session A only</memories>";
+		const fakeBackend: MemoryBackend = {
+			id: "mnemopi",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return remembered ? `static memory instructions\n\n${injected}` : "static memory instructions";
+			},
+			async clear() {},
+			async enqueue() {},
+			async beforeAgentStartPrompt() {
+				if (remembered || !recallAvailable) return undefined;
+				remembered = true;
+				return injected;
+			},
+		};
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "local-model",
+			name: "Local Model",
+			api,
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["base", "static memory instructions"],
+				messages: [],
+				tools: [],
+			},
+		});
+		agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"memory.backend": "mnemopi",
+				"provider.appendOnlyContext": "on",
+			}),
+			modelRegistry: createModelRegistryStub() as never,
+			rebuildSystemPrompt: async () => ({
+				systemPrompt: remembered
+					? ["base", `static memory instructions\n\n${injected}`]
+					: ["base", "static memory instructions"],
+			}),
+		});
+		sessions.push(session);
+		setMnemopiSessionState(session, {
+			aliasOf: undefined,
+			setSessionId(_sessionId: string) {},
+			resetConversationTracking() {
+				remembered = false;
+			},
+			async dispose() {},
+		} as unknown as MnemopiSessionState);
+
+		await session.sendUserMessage("first");
+		expect(session.systemPrompt.join("\n")).toContain(injected);
+		recallAvailable = false;
+
+		await session.switchSession(nextSessionFile!);
+		await session.sendUserMessage("second");
+
+		expect(session.systemPrompt.join("\n")).not.toContain(injected);
+		expect(contexts).toHaveLength(2);
+		expect(contexts[1]!.systemPrompt?.join("\n")).not.toContain(injected);
 	});
 });

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -693,4 +693,93 @@ describe("AgentSession message pipeline", () => {
 		expect(contexts).toHaveLength(2);
 		expect(contexts[1]!.systemPrompt?.join("\n")).not.toContain(injected);
 	});
+
+	it("clears promoted memory from the base prompt when starting a new session", async () => {
+		const api = "test-injected-memory-new-session-cache";
+		const contexts: Context[] = [];
+		let remembered = false;
+		let recallAvailable = true;
+		const injected = "<memories>previous session only</memories>";
+		const fakeBackend: MemoryBackend = {
+			id: "mnemopi",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return remembered ? `static memory instructions\n\n${injected}` : "static memory instructions";
+			},
+			async clear() {},
+			async enqueue() {},
+			async beforeAgentStartPrompt() {
+				if (remembered || !recallAvailable) return undefined;
+				remembered = true;
+				return injected;
+			},
+		};
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "local-model",
+			name: "Local Model",
+			api,
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["base", "static memory instructions"],
+				messages: [],
+				tools: [],
+			},
+		});
+		agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"memory.backend": "mnemopi",
+				"provider.appendOnlyContext": "on",
+			}),
+			modelRegistry: createModelRegistryStub() as never,
+			rebuildSystemPrompt: async () => ({
+				systemPrompt: remembered
+					? ["base", `static memory instructions\n\n${injected}`]
+					: ["base", "static memory instructions"],
+			}),
+		});
+		sessions.push(session);
+		setMnemopiSessionState(session, {
+			aliasOf: undefined,
+			setSessionId(_sessionId: string) {},
+			resetConversationTracking() {
+				remembered = false;
+			},
+			async dispose() {},
+		} as unknown as MnemopiSessionState);
+
+		await session.sendUserMessage("first");
+		expect(session.systemPrompt.join("\n")).toContain(injected);
+		recallAvailable = false;
+
+		await session.newSession();
+		await session.sendUserMessage("second");
+
+		expect(session.systemPrompt.join("\n")).not.toContain(injected);
+		expect(contexts).toHaveLength(2);
+		expect(contexts[1]!.systemPrompt?.join("\n")).not.toContain(injected);
+	});
 });

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, AppendOnlyContextManager } from "@oh-my-pi/pi-agent-core";
 import {
 	type Api,
 	type Context,
@@ -15,6 +15,8 @@ import {
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm, wrapSteeringForModel } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -515,5 +517,79 @@ describe("AgentSession message pipeline", () => {
 
 		resolve();
 		await Bun.sleep(0);
+	});
+
+	it("keeps first-turn memory in the stable prompt on the next turn", async () => {
+		const api = "test-injected-memory-append-only-cache";
+		const contexts: Context[] = [];
+		let remembered = false;
+		const injected = "<memories>remember blue</memories>";
+		const fakeBackend: MemoryBackend = {
+			id: "mnemopi",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return remembered ? `static memory instructions\n\n${injected}` : "static memory instructions";
+			},
+			async clear() {},
+			async enqueue() {},
+			async beforeAgentStartPrompt() {
+				if (remembered) return undefined;
+				remembered = true;
+				return injected;
+			},
+		};
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "local-model",
+			name: "Local Model",
+			api,
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["base", "static memory instructions"],
+				messages: [],
+				tools: [],
+			},
+		});
+		agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "provider.appendOnlyContext": "on" }),
+			modelRegistry: createModelRegistryStub() as never,
+			rebuildSystemPrompt: async () => ({
+				systemPrompt: remembered
+					? ["base", `static memory instructions\n\n${injected}`]
+					: ["base", "static memory instructions"],
+			}),
+		});
+		sessions.push(session);
+
+		await session.sendUserMessage("first");
+		await session.sendUserMessage("second");
+
+		expect(contexts).toHaveLength(2);
+		const firstSystemPrompt = contexts[0]!.systemPrompt;
+		expect(firstSystemPrompt).toBeDefined();
+		expect(firstSystemPrompt!.join("\n")).toContain(injected);
+		expect(contexts[1]!.systemPrompt).toEqual(firstSystemPrompt);
 	});
 });


### PR DESCRIPTION
## Repro
With `provider.appendOnlyContext` enabled and a memory backend that injects first-turn recall, the first model request includes the recalled `<memories>` block in the system prompt, while the second request reverts to the base memory instructions. Reproduced with `bun --cwd=packages/collab-web run build:tool-views && bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts --test-name-pattern "keeps first-turn memory"` before the fix; the new assertion showed the second prompt dropped the recalled memory block.

## Cause
`AgentSession.#buildSystemPromptForAgentStart` appended `beforeAgentStartPrompt()` output directly to `#baseSystemPrompt` for the first request only. Hindsight and Mnemopi set `hasRecalledForFirstTurn` after that hook, so later turns returned no transient injection; append-only mode then saw a different stable prefix and rebuilt the provider prompt cache.

## Fix
- Refresh the base system prompt immediately after first-turn memory recall so backend-cached memory instructions become the stable prompt.
- Promote the transient injected block into `#baseSystemPrompt` when no rebuild hook is available or the rebuild produces no prompt change.
- Add an append-only regression test proving first-turn memory remains present and byte-stable on the next turn.
- Add a coding-agent changelog entry for #3111.

## Verification
`bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts` passed (12 tests, 40 assertions). `bun check` passed. Fixes #3111