### PR TITLE
fix(model): persist concrete canonical model selections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed canonical model selection persisting bare custom model ids instead of concrete `provider/id` selectors, so custom `models.yml` models remain resolvable from settings. ([#3112](https://github.com/can1357/oh-my-pi/issues/3112))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -99,6 +99,16 @@ interface CanonicalModelItem {
 	compactSearchText: string;
 }
 
+/**
+ * Stable identity for selection restore across registry refreshes.
+ * Canonical rows keep `record.id` because the chosen backing variant can shift
+ * between refreshes (different provider wins, different `provider/id`); their
+ * `selector` is only used as the persistable callback payload.
+ */
+function getRestoreKey(item: ModelItem | CanonicalModelItem): string {
+	return item.kind === "canonical" ? item.id : item.selector;
+}
+
 interface ScopedModelItem {
 	model: Model;
 	thinkingLevel?: string;
@@ -533,19 +543,24 @@ export class ModelSelectorComponent extends Container {
 	 * models must not yank the user's selection out from under a pending Enter.
 	 */
 	#syncFromRegistryState(): void {
-		const selectedKey = this.#getSelectedItem()?.selector;
+		const selectedKey = this.#getSelectedRestoreKey();
 		this.#loadModelsFromCurrentRegistryState();
 		this.#buildProviderTabs();
 		this.#updateTabBar();
 		this.#applyTabFilter();
 		if (selectedKey) {
 			const visibleItems = this.#getVisibleItems();
-			const restoredIndex = visibleItems.findIndex(item => item.selector === selectedKey);
+			const restoredIndex = visibleItems.findIndex(item => getRestoreKey(item) === selectedKey);
 			if (restoredIndex >= 0 && restoredIndex !== this.#selectedIndex) {
 				this.#selectedIndex = this.#coerceSelectedIndex(restoredIndex, visibleItems);
 				this.#updateList();
 			}
 		}
+	}
+
+	#getSelectedRestoreKey(): string | undefined {
+		const selected = this.#getSelectedItem();
+		return selected ? getRestoreKey(selected) : undefined;
 	}
 
 	#buildProviderTabs(): void {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -489,6 +489,8 @@ export class ModelSelectorComponent extends Container {
 			candidates,
 		});
 		const canonicalModels = canonicalSelections.map(({ record, model: selectedModel }): CanonicalModelItem => {
+			const selectedVariant = record.variants.find(variant => modelsAreEqual(variant.model, selectedModel));
+			const selectionSelector = selectedVariant?.selector ?? `${selectedModel.provider}/${selectedModel.id}`;
 			const searchText = [
 				record.id,
 				record.name,
@@ -501,7 +503,7 @@ export class ModelSelectorComponent extends Container {
 				kind: "canonical",
 				id: record.id,
 				model: selectedModel,
-				selector: record.id,
+				selector: selectionSelector,
 				variantCount: record.variants.length,
 				searchText,
 				normalizedSearchText: normalizeSearchText(searchText),

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -294,6 +294,87 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(selected).toEqual(["xiaomi-token-plan-cn/mimo-v2.5-pro"]);
 	});
 
+	test("keeps the canonical row highlighted when the preferred variant shifts on refresh", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const primary = buildModel({
+			id: "mimo-v2.5-pro",
+			name: "MiMo-V2.5-Pro",
+			api: "openai-completions",
+			provider: "custom-a",
+			baseUrl: "https://a.example.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		});
+		const fallback = buildModel({
+			id: "mimo-v2.5-pro",
+			name: "MiMo-V2.5-Pro",
+			api: "openai-completions",
+			provider: "custom-b",
+			baseUrl: "https://b.example.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		});
+
+		let preferred = fallback;
+		let variants = [
+			{ canonicalId: "mimo-v2.5-pro", selector: "custom-b/mimo-v2.5-pro", model: fallback, source: "heuristic" },
+		];
+		const refreshGate = Promise.withResolvers<void>();
+
+		const modelRegistry = {
+			getAll: () => [preferred],
+			refresh: vi.fn(() => refreshGate.promise),
+			refreshProvider: vi.fn(async () => {}),
+			getError: () => undefined,
+			getAvailable: () => [preferred],
+			getDiscoverableProviders: () => [],
+			getCanonicalModelSelections: () => [
+				{
+					record: { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", variants },
+					model: preferred,
+				},
+			],
+		} as unknown as ModelRegistry;
+		const selected: Array<string | undefined> = [];
+		const ui = {
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			settings,
+			modelRegistry,
+			[],
+			(_model, _role, _thinkingLevel, modelSelector) => selected.push(modelSelector),
+			() => {},
+			{ temporaryOnly: true },
+		);
+
+		// Switch to the canonical tab and highlight the only canonical row, then
+		// let the offline refresh land a higher-ranked variant — the row's
+		// persisted selector flips from custom-b/... to custom-a/..., but the
+		// canonical record id is unchanged, so the highlight must survive.
+		selector.handleInput("\t");
+		preferred = primary;
+		variants = [
+			{ canonicalId: "mimo-v2.5-pro", selector: "custom-a/mimo-v2.5-pro", model: primary, source: "heuristic" },
+			{ canonicalId: "mimo-v2.5-pro", selector: "custom-b/mimo-v2.5-pro", model: fallback, source: "heuristic" },
+		];
+		refreshGate.resolve();
+		await Bun.sleep(0);
+
+		selector.handleInput("\n");
+		expect(selected).toEqual(["custom-a/mimo-v2.5-pro"]);
+	});
+
 	test("keeps the highlighted model when a background refresh reorders the list", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -232,6 +232,68 @@ describe("ModelSelector role badge thinking display", () => {
 		refreshGate.resolve();
 	});
 
+	test("passes concrete selector when selecting a canonical custom model", () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const customModel = buildModel({
+			id: "mimo-v2.5-pro",
+			name: "MiMo-V2.5-Pro",
+			api: "openai-completions",
+			provider: "xiaomi-token-plan-cn",
+			baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		});
+		const modelRegistry = {
+			getAll: () => [customModel],
+			refresh: vi.fn(async () => {}),
+			refreshProvider: vi.fn(async () => {}),
+			getError: () => undefined,
+			getAvailable: () => [customModel],
+			getDiscoverableProviders: () => [],
+			getCanonicalModelSelections: () => [
+				{
+					record: {
+						id: "mimo-v2.5-pro",
+						name: "MiMo-V2.5-Pro",
+						variants: [
+							{
+								canonicalId: "mimo-v2.5-pro",
+								selector: "xiaomi-token-plan-cn/mimo-v2.5-pro",
+								model: customModel,
+								source: "heuristic",
+							},
+						],
+					},
+					model: customModel,
+				},
+			],
+		} as unknown as ModelRegistry;
+		const selected: Array<string | undefined> = [];
+		const ui = {
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			settings,
+			modelRegistry,
+			[],
+			(_model, _role, _thinkingLevel, modelSelector) => selected.push(modelSelector),
+			() => {},
+			{ temporaryOnly: true, initialSearchInput: "mimo-v2.5-pro" },
+		);
+
+		selector.handleInput("\t");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["xiaomi-token-plan-cn/mimo-v2.5-pro"]);
+	});
+
 	test("keeps the highlighted model when a background refresh reorders the list", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});


### PR DESCRIPTION
## Repro
A custom `models.yml` provider with `xiaomi-token-plan-cn/mimo-v2.5-pro` was loaded, the model selector was opened on the canonical tab, and selecting `mimo-v2.5-pro` produced the callback selector `mimo-v2.5-pro` instead of the concrete custom provider selector.

## Cause
`packages/coding-agent/src/modes/components/model-selector.ts` built `CanonicalModelItem.selector` from `record.id`, so canonical-tab selections discarded the resolved `CanonicalModelVariant.selector` that still contained the backing `provider/id` for custom providers.

## Fix
- Use the selected canonical variant selector when building canonical selector items.
- Fall back to `provider/id` if a canonical record is inconsistent with the selected model.
- Added a regression test covering canonical selection of a custom `models.yml` model.
- Added the coding-agent changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` and `bun run check:types` in `packages/coding-agent`; both passed. `gh_push_branch` also completed its pre-publish gate. Fixes #3112