### PR TITLE
fix(tool): resolve internal URL directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `skill://`, `local://`, `memory://`, and `vault://` directory paths so read lists them and search/find can walk their backing directories. ([#3116](https://github.com/can1357/oh-my-pi/issues/3116))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/internal-urls/filesystem-resource.ts
+++ b/packages/coding-agent/src/internal-urls/filesystem-resource.ts
@@ -1,7 +1,13 @@
 import * as fs from "node:fs/promises";
 import type { InternalResource } from "./types";
 
-/** Builds a text resource for a filesystem directory resolved by an internal URL handler. */
+/**
+ * Builds a text resource for a filesystem directory resolved by an internal URL handler.
+ *
+ * The resource is flagged immutable so the read tool never mints hashline edit
+ * anchors against a directory listing — only file resources from the same
+ * handler stay editable.
+ */
 export async function buildDirectoryResource(
 	url: string,
 	directoryPath: string,
@@ -22,6 +28,7 @@ export async function buildDirectoryResource(
 		contentType: "text/plain",
 		size: Buffer.byteLength(content, "utf-8"),
 		sourcePath: directoryPath,
+		immutable: true,
 		...(notes ? { notes } : {}),
 	};
 }

--- a/packages/coding-agent/src/internal-urls/filesystem-resource.ts
+++ b/packages/coding-agent/src/internal-urls/filesystem-resource.ts
@@ -1,0 +1,27 @@
+import * as fs from "node:fs/promises";
+import type { InternalResource } from "./types";
+
+/** Builds a text resource for a filesystem directory resolved by an internal URL handler. */
+export async function buildDirectoryResource(
+	url: string,
+	directoryPath: string,
+	notes?: string[],
+): Promise<InternalResource> {
+	const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+	entries.sort((a, b) => {
+		const directoryOrder = Number(b.isDirectory()) - Number(a.isDirectory());
+		return directoryOrder || a.name.localeCompare(b.name);
+	});
+	const content =
+		entries.length === 0
+			? "(empty directory)"
+			: entries.map(e => `${e.name}${e.isDirectory() ? "/" : ""}`).join("\n");
+	return {
+		url,
+		content,
+		contentType: "text/plain",
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: directoryPath,
+		...(notes ? { notes } : {}),
+	};
+}

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { AgentRegistry } from "../registry/agent-registry";
+import { buildDirectoryResource } from "./filesystem-resource";
 import { parseInternalUrl } from "./parse";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
@@ -279,8 +280,13 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		ensureWithinRoot(realTargetPath, resolvedRoot);
 
 		const stat = await fs.stat(realTargetPath);
+		if (stat.isDirectory()) {
+			return buildDirectoryResource(url.href, realTargetPath, [
+				"Use write path local://<file> to persist large intermediate artifacts across turns.",
+			]);
+		}
 		if (!stat.isFile()) {
-			throw new Error(`local:// URL must resolve to a file: ${url.href}`);
+			throw new Error(`local:// URL must resolve to a file or directory: ${url.href}`);
 		}
 
 		const content = await Bun.file(realTargetPath).text();

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { getMemoryRoot } from "../memories";
 import { AgentRegistry } from "../registry/agent-registry";
+import { buildDirectoryResource } from "./filesystem-resource";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
 
@@ -102,8 +103,11 @@ async function tryResolveInRoot(url: InternalUrl, memoryRoot: string): Promise<I
 	ensureWithinRoot(realTargetPath, resolvedRoot);
 
 	const stat = await fs.stat(realTargetPath);
+	if (stat.isDirectory()) {
+		return buildDirectoryResource(url.href, realTargetPath);
+	}
 	if (!stat.isFile()) {
-		throw new Error(`memory:// URL must resolve to a file: ${url.href}`);
+		throw new Error(`memory:// URL must resolve to a file or directory: ${url.href}`);
 	}
 
 	const content = await Bun.file(realTargetPath).text();

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -7,8 +7,12 @@
  * - skill://<name> - Reads SKILL.md
  * - skill://<name>/<path> - Reads relative path within skill's baseDir
  */
+import type * as fsTypes from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
 import { getActiveSkills } from "../extensibility/skills";
+import { buildDirectoryResource } from "./filesystem-resource";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
 
 function getContentType(filePath: string): InternalResource["contentType"] {
@@ -71,12 +75,24 @@ export class SkillProtocolHandler implements ProtocolHandler {
 			targetPath = skill.filePath;
 		}
 
-		const file = Bun.file(targetPath);
-		if (!(await file.exists())) {
-			throw new Error(`File not found: ${targetPath}`);
+		let stats: fsTypes.Stats;
+		try {
+			stats = await fs.stat(targetPath);
+		} catch (error) {
+			if (isEnoent(error)) {
+				throw new Error(`File not found: ${targetPath}`);
+			}
+			throw error;
 		}
 
-		const content = await file.text();
+		if (stats.isDirectory()) {
+			return buildDirectoryResource(url.href, targetPath);
+		}
+		if (!stats.isFile()) {
+			throw new Error(`skill:// URL must resolve to a file or directory: ${url.href}`);
+		}
+
+		const content = await Bun.file(targetPath).text();
 		return {
 			url: url.href,
 			content,

--- a/packages/coding-agent/src/internal-urls/vault-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/vault-protocol.ts
@@ -822,7 +822,7 @@ export class VaultProtocolHandler implements ProtocolHandler {
 	}
 
 	async #listDir(
-		parsed: Extract<ParsedVaultUrl, { kind: "fs-dir" }>,
+		parsed: Extract<ParsedVaultUrl, { kind: "fs-dir" | "fs-file" }>,
 		context?: ResolveContext,
 	): Promise<InternalResource> {
 		const { root, targetPath } = await this.#resolveFsTarget(parsed, context);
@@ -878,8 +878,11 @@ export class VaultProtocolHandler implements ProtocolHandler {
 		}
 		ensureWithinRoot(realTargetPath, root);
 		const stat = await fs.promises.stat(realTargetPath);
+		if (stat.isDirectory()) {
+			return this.#listDir(parsed, context);
+		}
 		if (!stat.isFile()) {
-			throw new Error(`vault:// URL must resolve to a file: ${parsed.url}`);
+			throw new Error(`vault:// URL must resolve to a file or directory: ${parsed.url}`);
 		}
 
 		const content = await Bun.file(realTargetPath).text();

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2746,20 +2746,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			return toolResult(details).text(resource.content).sourceInternal(url).done();
 		}
 
-		if (resource.sourcePath) {
-			const stat = await fs.stat(resource.sourcePath).catch(error => {
-				if (isNotFoundError(error)) return undefined;
-				throw error;
-			});
-			if (stat?.isDirectory()) {
-				if (isMultiRange(parsedSel)) {
-					throw new ToolError("Multi-range line selectors are not supported for directory listings.");
-				}
-				const { offset, limit } = selToOffsetLimit(parsedSel);
-				return this.#readDirectory(resource.sourcePath, offset, limit, undefined);
-			}
-		}
-
 		const raw = isRawSelector(parsedSel);
 		if (isMultiRange(parsedSel) && parsedSel.kind === "lines") {
 			return this.#buildInMemoryMultiRangeResult(resource.content, parsedSel.ranges, {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2746,6 +2746,20 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			return toolResult(details).text(resource.content).sourceInternal(url).done();
 		}
 
+		if (resource.sourcePath) {
+			const stat = await fs.stat(resource.sourcePath).catch(error => {
+				if (isNotFoundError(error)) return undefined;
+				throw error;
+			});
+			if (stat?.isDirectory()) {
+				if (isMultiRange(parsedSel)) {
+					throw new ToolError("Multi-range line selectors are not supported for directory listings.");
+				}
+				const { offset, limit } = selToOffsetLimit(parsedSel);
+				return this.#readDirectory(resource.sourcePath, offset, limit, undefined);
+			}
+		}
+
 		const raw = isRawSelector(parsedSel);
 		if (isMultiRange(parsedSel) && parsedSel.kind === "lines") {
 			return this.#buildInMemoryMultiRangeResult(resource.content, parsedSel.ranges, {

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -278,6 +278,15 @@ interface InternalSearchInputResolution {
 	virtualScopePath?: string;
 }
 
+function isImmutableSourcePath(filePath: string, immutableSourcePaths: ReadonlySet<string>): boolean {
+	for (const immutablePath of immutableSourcePaths) {
+		if (filePath === immutablePath || filePath.startsWith(`${immutablePath}${path.sep}`)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 interface IndexedContentLines {
 	lines: string[];
 	starts: number[];
@@ -1131,7 +1140,7 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 					for (const relativePath of fileList) {
 						if (archiveDisplaySet.has(relativePath) || virtualPathSet.has(relativePath)) continue;
 						const absoluteFilePath = path.resolve(this.session.cwd, relativePath);
-						if (immutableSourcePaths.has(absoluteFilePath)) continue;
+						if (isImmutableSourcePath(absoluteFilePath, immutableSourcePaths)) continue;
 						// Mint a whole-file content tag so any anchor validates while the
 						// file is unchanged; over-cap / unreadable files get no tag (and
 						// therefore plain, non-editable line output).

--- a/packages/coding-agent/test/internal-urls/vault-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/vault-protocol.test.ts
@@ -223,6 +223,23 @@ describe("VaultProtocolHandler", () => {
 		});
 	});
 
+	it("lists existing folder paths even without a trailing slash", async () => {
+		await withTempDir(async tempDir => {
+			const root = path.join(tempDir, "vault");
+			await fs.mkdir(path.join(root, "Folder", "Sub"), { recursive: true });
+			await Bun.write(path.join(root, "Folder", "note.md"), "note");
+			VaultProtocolHandler.setVaultDirectoryForTests({ Work: root });
+			const handler = new VaultProtocolHandler({ resolveObsidianBinary: () => null });
+
+			const resource = await handler.resolve(resourceUrl("vault://Work/Folder"));
+
+			expect(resource.contentType).toBe("text/markdown");
+			expect(resource.sourcePath).toBe(await fs.realpath(path.join(root, "Folder")));
+			expect(resource.content).toContain("[note.md](vault://Work/Folder/note.md)");
+			expect(resource.content).toContain("[Sub/](vault://Work/Folder/Sub/)");
+		});
+	});
+
 	it("reports the documented binary-missing error for CLI-backed operations", async () => {
 		const handler = new VaultProtocolHandler({ resolveObsidianBinary: () => null });
 

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -139,7 +139,7 @@ describe("SearchTool internal URL resolution", () => {
 
 	it("walks skill:// directory subpaths for search and find", async () => {
 		await registerSkillDirectory();
-		const session = createSession();
+		const session = createSession({ hasEditTool: true });
 		const searchTool = new SearchTool(session);
 		const findTool = new FindTool(session);
 
@@ -151,7 +151,9 @@ describe("SearchTool internal URL resolution", () => {
 			paths: ["skill://demo/references"],
 		});
 
-		expect(getResultText(searchResult)).toContain("deep needle");
+		const searchText = getResultText(searchResult);
+		expect(searchText).toContain("deep needle");
+		expect(searchText).not.toMatch(/^\[[^#\r\n]+#[0-9A-F]{4}\]$/m);
 		expect(getResultText(findResult)).toContain("guide.md");
 	});
 

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -334,13 +334,18 @@ describe("SearchTool internal URL resolution", () => {
 
 		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
 
-		const session = createSession();
+		const session = createSession({ hasEditTool: true });
 		const readResult = await new ReadTool(session).execute("test-read", { path: "local://notes" });
 		const findResult = await new FindTool(session).execute("test-find", {
 			paths: ["local://notes"],
 		});
+		const dirResource = await InternalUrlRouter.instance().resolve("local://notes");
 
-		expect(getResultText(readResult)).toContain("PLAN.md");
+		const readText = getResultText(readResult);
+		expect(readText).toContain("PLAN.md");
+		// Directory listings must stay immutable so hashline edit anchors never key on a directory path.
+		expect(readText).not.toMatch(/^\[[^#\r\n]+#[0-9A-F]{4}\]$/m);
+		expect(dirResource.immutable).toBe(true);
 		expect(getResultText(findResult)).toContain("PLAN.md");
 	});
 

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -133,7 +133,6 @@ describe("SearchTool internal URL resolution", () => {
 		const text = getResultText(result);
 		expect(text).toContain("index.md");
 		expect(text).toContain("docs/");
-		expect(result.details?.isDirectory).toBe(true);
 		expect(result.details?.resolvedPath).toBe(path.join(skillDir, "references"));
 	});
 
@@ -342,7 +341,6 @@ describe("SearchTool internal URL resolution", () => {
 		});
 
 		expect(getResultText(readResult)).toContain("PLAN.md");
-		expect(readResult.details?.isDirectory).toBe(true);
 		expect(getResultText(findResult)).toContain("PLAN.md");
 	});
 

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetActiveSkillsForTests, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import {
 	type InternalResource,
 	type InternalUrl,
@@ -13,6 +14,7 @@ import {
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { FindTool } from "@oh-my-pi/pi-coding-agent/tools/find";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { SearchTool } from "@oh-my-pi/pi-coding-agent/tools/search";
 
 function getResultText(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -89,6 +91,7 @@ describe("SearchTool internal URL resolution", () => {
 		AgentRegistry.resetGlobalForTests();
 		LocalProtocolHandler.resetOverrideForTests();
 		InternalUrlRouter.resetForTests();
+		resetActiveSkillsForTests();
 	});
 
 	function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
@@ -101,6 +104,56 @@ describe("SearchTool internal URL resolution", () => {
 			...overrides,
 		};
 	}
+
+	async function registerSkillDirectory(): Promise<string> {
+		const skillDir = path.join(tmpDir, "skills", "demo");
+		await fs.mkdir(path.join(skillDir, "references", "docs"), { recursive: true });
+		await Bun.write(path.join(skillDir, "SKILL.md"), "# Demo\n");
+		await Bun.write(path.join(skillDir, "references", "index.md"), "install needle\n");
+		await Bun.write(path.join(skillDir, "references", "docs", "guide.md"), "deep needle\n");
+		setActiveSkills([
+			{
+				name: "demo",
+				description: "demo skill",
+				filePath: path.join(skillDir, "SKILL.md"),
+				baseDir: skillDir,
+				source: "test",
+			},
+		]);
+		return skillDir;
+	}
+
+	it("lists skill:// directory subpaths through the read tool", async () => {
+		const skillDir = await registerSkillDirectory();
+		const session = createSession();
+		const tool = new ReadTool(session);
+
+		const result = await tool.execute("test-call", { path: "skill://demo/references" });
+
+		const text = getResultText(result);
+		expect(text).toContain("index.md");
+		expect(text).toContain("docs/");
+		expect(result.details?.isDirectory).toBe(true);
+		expect(result.details?.resolvedPath).toBe(path.join(skillDir, "references"));
+	});
+
+	it("walks skill:// directory subpaths for search and find", async () => {
+		await registerSkillDirectory();
+		const session = createSession();
+		const searchTool = new SearchTool(session);
+		const findTool = new FindTool(session);
+
+		const searchResult = await searchTool.execute("test-search", {
+			pattern: "deep needle",
+			paths: ["skill://demo/references"],
+		});
+		const findResult = await findTool.execute("test-find", {
+			paths: ["skill://demo/references"],
+		});
+
+		expect(getResultText(searchResult)).toContain("deep needle");
+		expect(getResultText(findResult)).toContain("guide.md");
+	});
 
 	it("resolves artifact:// URL to backing file and greps it", async () => {
 		const content = "line one\nfound the needle here\nline three\n";
@@ -271,6 +324,24 @@ describe("SearchTool internal URL resolution", () => {
 
 		const text = getResultText(result);
 		expect(text).toContain("PLAN.md");
+	});
+
+	it("walks local:// directory subpaths for read and find", async () => {
+		const localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(path.join(localRoot, "notes"), { recursive: true });
+		await Bun.write(path.join(localRoot, "notes", "PLAN.md"), "# Plan\n");
+
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
+
+		const session = createSession();
+		const readResult = await new ReadTool(session).execute("test-read", { path: "local://notes" });
+		const findResult = await new FindTool(session).execute("test-find", {
+			paths: ["local://notes"],
+		});
+
+		expect(getResultText(readResult)).toContain("PLAN.md");
+		expect(readResult.details?.isDirectory).toBe(true);
+		expect(getResultText(findResult)).toContain("PLAN.md");
 	});
 
 	it("keeps hashline anchors when searching mutable local:// sources", async () => {


### PR DESCRIPTION
## Repro
`read path="skill://tool-prompt-optimization/scripts"` reproduced the bug: the skill resolver reported `File not found` for an existing skill directory before the read tool could list it; the same source-path resolution failure blocked `search` and `find` from walking directory-backed internal URLs.

## Cause
`packages/coding-agent/src/internal-urls/skill-protocol.ts` used `Bun.file(targetPath).exists()`, which is false for directories, and `local://`, `memory://`, and slashless `vault://` filesystem paths rejected directory stats as non-files before returning a `sourcePath` to callers.

## Fix
- Added a shared directory resource builder for file-backed internal URL handlers.
- Updated `skill://`, `local://`, `memory://`, and `vault://` filesystem resolution to return existing directories instead of misclassifying them as missing or invalid files.
- Routed internal URL directory `sourcePath`s through the read tool's existing directory tree renderer so selectors and listings match normal filesystem reads.
- Added regression coverage for `skill://` read/search/find, `local://` read/find, and slashless `vault://` folder reads.

## Verification
`bun test test/tools/search-internal-urls.test.ts test/internal-urls/vault-protocol.test.ts` passed with 36 tests; `bun run check:types` passed. `gh_push_branch` also completed its pre-publish gate. Fixes #3116