### PR TITLE
fix(ai): omit unsupported Codex sampling params

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex Responses requests forwarding unsupported sampling parameters such as temperature and top_p, which caused the ChatGPT Codex backend to reject sessions with non-default sampling settings. ([#3119](https://github.com/can1357/oh-my-pi/pull/3119) by [@wolfiesch](https://github.com/wolfiesch))
+
 ## [16.1.4] - 2026-06-19
 
 ### Added

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -120,20 +120,20 @@ function deriveSessionId(modelId: string, context: Context): string {
 function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: AbortSignal): SimpleStreamOptions {
 	const opts: SimpleStreamOptions = { signal };
 	const { options } = parsed;
-	// Codex backend rejects `temperature` / `top_p` (per-model defaults only),
-	// so we drop them silently for that one provider. Every other unsupported
-	// option is just ignored by `streamSimple` if the underlying provider
-	// doesn't honour it.
+	// Codex backend rejects sampling params (per-model defaults only), so we
+	// drop them silently for that one provider. Every other unsupported option
+	// is just ignored by `streamSimple` if the underlying provider doesn't
+	// honour it.
 	const isCodex = api === "openai-codex-responses";
 	if (options.maxOutputTokens !== undefined) opts.maxTokens = options.maxOutputTokens;
 	if (options.temperature !== undefined && !isCodex) opts.temperature = options.temperature;
 	if (options.topP !== undefined && !isCodex) opts.topP = options.topP;
-	if (options.topK !== undefined) opts.topK = options.topK;
-	if (options.minP !== undefined) opts.minP = options.minP;
+	if (options.topK !== undefined && !isCodex) opts.topK = options.topK;
+	if (options.minP !== undefined && !isCodex) opts.minP = options.minP;
 	if (options.stopSequences !== undefined) opts.stopSequences = options.stopSequences;
-	if (options.presencePenalty !== undefined) opts.presencePenalty = options.presencePenalty;
+	if (options.presencePenalty !== undefined && !isCodex) opts.presencePenalty = options.presencePenalty;
 	if (options.frequencyPenalty !== undefined) opts.frequencyPenalty = options.frequencyPenalty;
-	if (options.repetitionPenalty !== undefined) opts.repetitionPenalty = options.repetitionPenalty;
+	if (options.repetitionPenalty !== undefined && !isCodex) opts.repetitionPenalty = options.repetitionPenalty;
 	if (options.metadata !== undefined) opts.metadata = options.metadata;
 	if (options.headers !== undefined) opts.headers = { ...(opts.headers ?? {}), ...options.headers };
 	if (options.toolChoice !== undefined) {
@@ -662,8 +662,8 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	// Build the SimpleStreamOptions actually handed to `streamSimple`. We
 	// trust the client's options (already allow-listed by `parseRequest`) and
-	// only inject server-controlled fields. The codex temperature/topP strip
-	// matches `buildStreamOptions` — Codex rejects them with a 400.
+	// only inject server-controlled fields. The codex sampling params strip
+	// matches `buildStreamOptions`; Codex rejects them with a 400.
 	const streamOpts: SimpleStreamOptions = { ...parsed.options, apiKey, signal: controller.signal };
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
 		bootOpts.storage,
@@ -677,6 +677,10 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	if (model.api === "openai-codex-responses") {
 		delete streamOpts.temperature;
 		delete streamOpts.topP;
+		delete streamOpts.topK;
+		delete streamOpts.minP;
+		delete streamOpts.presencePenalty;
+		delete streamOpts.repetitionPenalty;
 	}
 	// Merge gateway-captured passthrough headers under the client's own
 	// headers — the client's values win when they collide.

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -730,24 +730,6 @@ async function buildTransformedCodexRequestBody(
 	// `maxTokens` is intentionally not forwarded: transformRequestBody strips
 	// `max_output_tokens`/`max_completion_tokens` (the Codex backend rejects
 	// caller-supplied output caps).
-	if (options?.temperature !== undefined) {
-		params.temperature = options.temperature;
-	}
-	if (options?.topP !== undefined) {
-		params.top_p = options.topP;
-	}
-	if (options?.topK !== undefined) {
-		params.top_k = options.topK;
-	}
-	if (options?.minP !== undefined) {
-		params.min_p = options.minP;
-	}
-	if (options?.presencePenalty !== undefined) {
-		params.presence_penalty = options.presencePenalty;
-	}
-	if (options?.repetitionPenalty !== undefined) {
-		params.repetition_penalty = options.repetitionPenalty;
-	}
 	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
 	if (context.tools && context.tools.length > 0) {
 		params.tools = convertOpenAICodexResponsesTools(context.tools, model);

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -41,12 +41,6 @@ export interface RequestBody {
 	input?: InputItem[];
 	tools?: unknown;
 	tool_choice?: unknown;
-	temperature?: number;
-	top_p?: number;
-	top_k?: number;
-	min_p?: number;
-	presence_penalty?: number;
-	repetition_penalty?: number;
 	reasoning?: Partial<ReasoningConfig>;
 	text?: {
 		verbosity?: "low" | "medium" | "high";

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -322,6 +322,42 @@ describe("openai-codex streaming", () => {
 		expect(capturedBody?.prompt_cache_key).toBe("replacement-cache-key");
 	});
 
+	it("omits unsupported sampling params for Codex responses requests", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const context = createCodexTestContext();
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		let capturedBody: Record<string, unknown> | undefined;
+		const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+			capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(createCompletedCodexSse("Hello"), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			fetch: fetchMock as FetchImpl,
+			temperature: 0.2,
+			topP: 0.9,
+			topK: 40,
+			minP: 0.1,
+			presencePenalty: 0.5,
+			repetitionPenalty: 1.1,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedBody).toBeDefined();
+		if (!capturedBody) throw new Error("expected Codex request body capture");
+		for (const key of ["temperature", "top_p", "top_k", "min_p", "presence_penalty", "repetition_penalty"]) {
+			expect(Object.hasOwn(capturedBody, key)).toBe(false);
+		}
+		expect((capturedBody.text as { verbosity?: string } | undefined)?.verbosity).toBe("low");
+		expect(capturedBody.model).toBe(model.id);
+	});
+
 	it("maps end_turn=false on the terminal event to a pause_turn stop", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());


### PR DESCRIPTION
## What

Stop forwarding unsupported sampling parameters (`temperature`, `top_p`, `top_k`, `min_p`, `presence_penalty`, `repetition_penalty`) into `openai-codex-responses` requests, and align the auth-gateway defensive strip to the same key set.

## Why

The ChatGPT Codex backend rejects sampling controls for Codex-routed models, so any non-default sampling setting broke the session. Fixes #3117.

Live backend repro (`gpt-5.3-codex-spark`, `store: false`, `temperature: 0.2`):

```json
{"detail":"Unsupported parameter: temperature"}
```

The fix lands at `buildTransformedCodexRequestBody`, the single body builder shared by both the SSE and WebSocket Codex transports, so the default WebSocket path is covered too. `RequestBody` no longer declares those first-party fields, and `StreamOptions` mapping for other providers is untouched.

## Testing

- Live fixed provider path with all six sampling options set returned `Hello! 👋`.
- `bun test packages/ai/test/openai-codex-stream.test.ts` (57 pass; new test `omits unsupported sampling params for Codex responses requests` captures the outgoing body and asserts the six keys are absent while `model` and low `text.verbosity` remain).
- `bun check`
- `bun --cwd=packages/coding-agent src/cli.ts --smoke-test`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)