### PR TITLE
fix(coding-agent): allow multiple skill tokens per input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/skill:<name>` input handling so embedded or repeated registered skill tokens are injected and the remaining text is submitted as the prompt. ([#3121](https://github.com/can1357/oh-my-pi/issues/3121))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -27,6 +27,26 @@ import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } fr
 import { resizeImage } from "../../utils/image-resize";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
+const SKILL_COMMAND_NAME_PREFIX = "skill:";
+const SKILL_TOKEN_PREFIX = "/skill:";
+const SKILL_NAME_BOUNDARY_PATTERN = /[A-Za-z0-9_-]/;
+
+function isSkillTokenStartBoundary(char: string | undefined): boolean {
+	return char === undefined || /\s/.test(char);
+}
+
+function isSkillTokenEndBoundary(char: string | undefined): boolean {
+	return char === undefined || !SKILL_NAME_BOUNDARY_PATTERN.test(char);
+}
+
+interface SkillInvocation {
+	commandName: string;
+	skillPath: string;
+	start: number;
+	end: number;
+	token: string;
+}
+
 interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
@@ -596,8 +616,12 @@ export class InputController {
 			// free-text Enter semantics applied a few lines below at the streaming
 			// branch). Ctrl+Enter routes through `handleFollowUp` and dispatches the
 			// same helper with `"followUp"`.
-			if (await this.#invokeSkillCommand(text, "steer")) {
+			const skillResult = await this.#invokeSkillCommand(text, "steer");
+			if (skillResult === true) {
 				return;
+			}
+			if (typeof skillResult === "string") {
+				text = skillResult;
 			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
@@ -903,27 +927,91 @@ export class InputController {
 	}
 
 	/**
-	 * Dispatch a `/skill:<name> [args]` invocation through `promptCustomMessage`
-	 * using the supplied `streamingBehavior`. Returns true if the text was a
-	 * recognised skill command and was dispatched. A failure to load the skill
-	 * file is surfaced via `showError` but still returns true — the editor was
-	 * already cleared on the success path, so falling through to plain-text
-	 * handling at that point would double-submit. Returns false when the text
-	 * isn't a `/skill:` prefix or the command name isn't a registered skill,
-	 * so the caller can fall through to plain-text handling (this branch
-	 * leaves the editor state untouched). `streamingBehavior` is only consulted
-	 * while the agent is streaming; the idle path of `promptCustomMessage`
-	 * ignores it.
+	 * Dispatch `/skill:<name>` tokens through `promptCustomMessage`.
+	 *
+	 * A single leading `/skill:<name> [args]` keeps the historical args-as-skill-input
+	 * behavior. Embedded or repeated skill tokens are treated as prompt annotations:
+	 * every registered token is injected, and the non-skill text falls through as the
+	 * user prompt.
 	 */
-	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		if (!text.startsWith("/skill:")) return false;
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skillPath = this.ctx.skillCommands?.get(commandName);
-		if (!skillPath) return false;
-		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
+	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<string | boolean> {
+		const invocations = this.#findSkillInvocations(text);
+		if (invocations.length === 0) return false;
+
+		const isSingleLeadingCommand = invocations.length === 1 && invocations[0]?.start === 0;
+		const promptParts: string[] = [];
+		let cursor = 0;
+
+		for (const invocation of invocations) {
+			const args = isSingleLeadingCommand ? text.slice(invocation.end).trim() : "";
+			if (!isSingleLeadingCommand) {
+				const promptPart = text.slice(cursor, invocation.start).trim();
+				if (promptPart) promptParts.push(promptPart);
+				cursor = invocation.end;
+			}
+			await this.#dispatchSkillInvocation(invocation.commandName, invocation.skillPath, args, streamingBehavior, {
+				queueChipText: isSingleLeadingCommand ? text : invocation.token,
+			});
+		}
+
+		if (isSingleLeadingCommand) {
+			this.ctx.editor.addToHistory(text);
+			this.ctx.editor.setText("");
+			return true;
+		}
+
+		const finalPromptPart = text.slice(cursor).trim();
+		if (finalPromptPart) promptParts.push(finalPromptPart);
+
+		const prompt = promptParts.join(" ").trim();
+		if (!prompt) {
+			this.ctx.editor.addToHistory(text);
+			this.ctx.editor.setText("");
+			return true;
+		}
+		return prompt;
+	}
+
+	#findSkillInvocations(text: string): SkillInvocation[] {
+		const skillCommands = this.ctx.skillCommands;
+		if (!skillCommands || skillCommands.size === 0) return [];
+
+		const invocations: SkillInvocation[] = [];
+		let searchStart = 0;
+		while (searchStart < text.length) {
+			const start = text.indexOf(SKILL_TOKEN_PREFIX, searchStart);
+			if (start === -1) break;
+			searchStart = start + SKILL_TOKEN_PREFIX.length;
+			if (!isSkillTokenStartBoundary(text[start - 1])) continue;
+
+			let matched: SkillInvocation | undefined;
+			for (const [commandName, skillPath] of skillCommands) {
+				if (!commandName.startsWith(SKILL_COMMAND_NAME_PREFIX)) continue;
+				const token = `/${commandName}`;
+				const end = start + token.length;
+				if (
+					text.startsWith(token, start) &&
+					isSkillTokenEndBoundary(text[end]) &&
+					(!matched || token.length > matched.token.length)
+				) {
+					matched = { commandName, skillPath, start, end, token };
+				}
+			}
+			if (!matched) continue;
+
+			invocations.push(matched);
+			searchStart = matched.end;
+		}
+		return invocations;
+	}
+
+	async #dispatchSkillInvocation(
+		commandName: string,
+		skillPath: string,
+		args: string,
+		streamingBehavior: "steer" | "followUp",
+		options: { queueChipText: string },
+	): Promise<void> {
 		try {
 			const content = await Bun.file(skillPath).text();
 			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
@@ -932,7 +1020,7 @@ export class InputController {
 				metaLines.push(`User: ${args}`);
 			}
 			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-			const skillName = commandName.slice("skill:".length);
+			const skillName = commandName.slice(SKILL_COMMAND_NAME_PREFIX.length);
 			const details: SkillPromptDetails = {
 				name: skillName || commandName,
 				path: skillPath,
@@ -947,7 +1035,7 @@ export class InputController {
 					details,
 					attribution: "user",
 				},
-				{ streamingBehavior, queueChipText: text },
+				{ streamingBehavior, queueChipText: options.queueChipText },
 			);
 			if (this.ctx.session.isStreaming) {
 				this.ctx.updatePendingMessagesDisplay();
@@ -956,7 +1044,6 @@ export class InputController {
 		} catch (err) {
 			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
 		}
-		return true;
 	}
 
 	async handleRetry(): Promise<void> {
@@ -1011,8 +1098,12 @@ export class InputController {
 		// Skill commands invoke through the custom-message path regardless of
 		// which keybinding submitted them. Enter routes them as `steer`;
 		// Ctrl+Enter (this handler) routes them as `followUp`.
-		if (await this.#invokeSkillCommand(text, "followUp")) {
+		const skillResult = await this.#invokeSkillCommand(text, "followUp");
+		if (skillResult === true) {
 			return;
+		}
+		if (typeof skillResult === "string") {
+			text = skillResult;
 		}
 
 		// Forward any pending clipboard-pasted images alongside the queued text;

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -78,6 +78,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 			return (this as typeof ctx).session;
 		},
 		showError,
+		flushPendingBashComponents: vi.fn(),
 		handleGoalModeCommand,
 		goalModeEnabled: false,
 		updatePendingMessagesDisplay,
@@ -110,6 +111,8 @@ describe("InputController skill queue chip metadata", () => {
 		tempDir = TempDir.createSync("@pi-skill-queue-stub-");
 		const skillPath = await writeSkillFile(tempDir.path(), "test-skill", "Do the thing.");
 		skillCommands = new Map<string, string>([["skill:test-skill", skillPath]]);
+		const secondSkillPath = await writeSkillFile(tempDir.path(), "other-skill", "Do the other thing.");
+		skillCommands.set("skill:other-skill", secondSkillPath);
 	});
 
 	afterEach(() => {
@@ -131,6 +134,7 @@ describe("InputController skill queue chip metadata", () => {
 			streamingBehavior: "steer",
 			queueChipText: "/skill:test-skill arg1 arg2",
 		});
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.args).toBe("arg1 arg2");
 		expect(promptCustomMessage.mock.calls[0]?.[0].details.__queueChipText).toBeUndefined();
 		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
@@ -150,6 +154,7 @@ describe("InputController skill queue chip metadata", () => {
 			streamingBehavior: "followUp",
 			queueChipText: "/skill:test-skill arg1 arg2",
 		});
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.args).toBe("arg1 arg2");
 	});
 
 	it("streaming follow-up applies builtin slash commands instead of queueing them", async () => {
@@ -183,6 +188,51 @@ describe("InputController skill queue chip metadata", () => {
 			queueChipText: "/skill:test-skill arg1 arg2",
 		});
 		expect(promptCustomMessage.mock.calls[0]?.[0].details.__queueChipText).toBeUndefined();
+	});
+
+	it("injects every skill token and submits the remaining text", async () => {
+		const { ctx, editor, promptCustomMessage, prompt } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: true,
+		});
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		editor.setText("先用 /skill:test-skill arg1 /skill:other-skill arg2 幫我處理");
+		await editor.onSubmit?.("先用 /skill:test-skill arg1 /skill:other-skill arg2 幫我處理");
+
+		expect(promptCustomMessage).toHaveBeenCalledTimes(2);
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.name).toBe("test-skill");
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.args).toBeUndefined();
+		expect(promptCustomMessage.mock.calls[0]?.[1]).toEqual({
+			streamingBehavior: "steer",
+			queueChipText: "/skill:test-skill",
+		});
+		expect(promptCustomMessage.mock.calls[1]?.[0].details.name).toBe("other-skill");
+		expect(promptCustomMessage.mock.calls[1]?.[0].details.args).toBeUndefined();
+		expect(promptCustomMessage.mock.calls[1]?.[1]).toEqual({
+			streamingBehavior: "steer",
+			queueChipText: "/skill:other-skill",
+		});
+		expect(prompt).toHaveBeenCalledWith("先用 arg1 arg2 幫我處理", { images: undefined, streamingBehavior: "steer" });
+	});
+
+	it("injects embedded skill tokens during follow-ups and queues remaining text", async () => {
+		const { ctx, editor, promptCustomMessage, prompt } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: true,
+		});
+		const controller = new InputController(ctx);
+
+		editor.setText("review /skill:test-skill then /skill:other-skill");
+		await controller.handleFollowUp();
+
+		expect(promptCustomMessage).toHaveBeenCalledTimes(2);
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.name).toBe("test-skill");
+		expect(promptCustomMessage.mock.calls[0]?.[1]?.queueChipText).toBe("/skill:test-skill");
+		expect(promptCustomMessage.mock.calls[1]?.[0].details.name).toBe("other-skill");
+		expect(promptCustomMessage.mock.calls[1]?.[1]?.queueChipText).toBe("/skill:other-skill");
+		expect(prompt).toHaveBeenCalledWith("review then", { images: undefined, streamingBehavior: "followUp" });
 	});
 });
 


### PR DESCRIPTION
## Repro
A regression test submits `先用 /skill:test-skill arg1 /skill:other-skill arg2 幫我處理` through `InputController.setupEditorSubmitHandler()`; before the fix, `promptCustomMessage` was called 0 times and the whole input fell through as plain prompt text. Command: `bun --cwd=packages/collab-web run build:tool-views && bun test packages/coding-agent/test/input-controller-skill-queue.test.ts`.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` implemented `#invokeSkillCommand` as a single leading-command parser: it only dispatched when the full text began with `/skill:` and treated everything after the first space as that skill's args, so later `/skill:<name>` tokens or embedded tokens were never scanned.

## Fix
- Added registered-token scanning for `/skill:<name>` occurrences in `InputController.#findSkillInvocations`.
- Kept the historical single leading `/skill:<name> [args]` behavior.
- Injected embedded/repeated skill tokens as skill custom messages and forwarded the remaining non-skill text as the user prompt for Enter and follow-up submissions.
- Added regression coverage for both submit paths and updated the coding-agent changelog.

## Verification
Passed `bun --cwd=packages/coding-agent run check` and `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts`. Fixes #3121