### PR TITLE
fix(ai): keep Bedrock toolConfig for no-tool tool history

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bedrock `/btw` and other no-tool ephemeral turns failing after prior tool calls by sending the required sentinel `toolConfig` whenever replayed history contains `toolUse`/`toolResult` blocks. ([#3124](https://github.com/can1357/oh-my-pi/issues/3124))
+
 ## [16.1.4] - 2026-06-19
 
 ### Added

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -142,10 +142,12 @@ interface WireToolConfig {
 	toolChoice?: WireToolChoice;
 }
 
+const NO_TOOLS_SENTINEL_NAME = "__no_tools__";
+
 const NO_TOOLS_SENTINEL: WireToolSpec = {
 	toolSpec: {
-		name: "__no_tools__",
-		description: "Placeholder required when Bedrock replays prior tool history with tools disabled.",
+		name: NO_TOOLS_SENTINEL_NAME,
+		description: "Placeholder required by Bedrock validation. Do not call; answer with text.",
 		inputSchema: { json: { type: "object", properties: {} } },
 	},
 };
@@ -389,7 +391,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					}
 					case "messageStop": {
 						const ev = payload as MessageStopEvent;
-						output.stopReason = mapStopReason(ev.stopReason);
+						output.stopReason =
+							isNoToolsSentinelConfig(toolConfig) && ev.stopReason === "tool_use"
+								? "stop"
+								: mapStopReason(ev.stopReason);
 						if (output.stopReason === "error") {
 							output.errorMessage = `Generation failed with stop reason: ${ev.stopReason ?? "unknown"}`;
 						}
@@ -471,6 +476,8 @@ function handleContentBlockStart(
 ): void {
 	const index = event.contentBlockIndex;
 	const start = event.start;
+
+	if (start?.toolUse?.name === NO_TOOLS_SENTINEL_NAME) return;
 
 	if (start?.toolUse) {
 		const block: Block = {
@@ -843,6 +850,10 @@ function convertToolConfig(
 	}
 
 	return { tools: bedrockTools, toolChoice: bedrockToolChoice };
+}
+
+function isNoToolsSentinelConfig(toolConfig: WireToolConfig | undefined): boolean {
+	return toolConfig?.tools.length === 1 && toolConfig.tools[0]?.toolSpec.name === NO_TOOLS_SENTINEL_NAME;
 }
 
 function mapStopReason(reason: string | undefined): StopReason {

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -142,6 +142,14 @@ interface WireToolConfig {
 	toolChoice?: WireToolChoice;
 }
 
+const NO_TOOLS_SENTINEL: WireToolSpec = {
+	toolSpec: {
+		name: "__no_tools__",
+		description: "Placeholder required when Bedrock replays prior tool history with tools disabled.",
+		inputSchema: { json: { type: "object", properties: {} } },
+	},
+};
+
 interface ConverseStreamRequest {
 	messages: WireMessage[];
 	system?: SystemContent[];
@@ -222,10 +230,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 		try {
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
-			const historyHasToolBlocks = context.messages.some(
-				m => m.role === "toolResult" || (m.role === "assistant" && m.content.some(b => b.type === "toolCall")),
-			);
-			const toolConfig = convertToolConfig(context.tools, options.toolChoice, historyHasToolBlocks);
+			const convertedMessages = convertMessages(context, model, cacheRetention);
+			const toolConfig = convertToolConfig(context.tools, options.toolChoice, convertedMessages);
 			let additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
 
 			// Bedrock rejects thinking + forced tool_choice ("any" or specific tool).
@@ -236,7 +242,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			}
 
 			const commandInput: ConverseStreamRequest = {
-				messages: convertMessages(context, model, cacheRetention),
+				messages: convertedMessages,
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
 				inferenceConfig: {
 					maxTokens: options.maxTokens,
@@ -784,28 +790,44 @@ function convertMessages(
 	return result;
 }
 
-function convertToolConfig(
-	tools: Tool[] | undefined,
-	toolChoice: BedrockOptions["toolChoice"],
-	historyHasToolBlocks: boolean,
-): WireToolConfig | undefined {
-	if (!tools?.length) return undefined;
+function messagesHaveToolBlocks(messages: WireMessage[]): boolean {
+	for (const message of messages) {
+		for (const block of message.content) {
+			if ("toolUse" in block || "toolResult" in block) return true;
+		}
+	}
+	return false;
+}
 
-	const bedrockTools: WireToolSpec[] = tools.map(tool => ({
+function convertToolSpec(tool: Tool): WireToolSpec {
+	return {
 		toolSpec: {
 			name: tool.name,
 			description: tool.description || "",
 			inputSchema: { json: toolWireSchema(tool) },
 		},
-	}));
+	};
+}
 
-	// Bedrock rejects requests whose history contains toolUse/toolResult blocks without a
-	// toolConfig. With prior tool use we must keep the tool specs and merely omit the choice
-	// (there is no "none" choice on Converse); dropping toolConfig entirely would 400.
+function convertToolConfig(
+	tools: Tool[] | undefined,
+	toolChoice: BedrockOptions["toolChoice"],
+	messages: WireMessage[],
+): WireToolConfig | undefined {
+	const activeTools = tools ?? [];
+	const hasTools = activeTools.length > 0;
+	const historyHasToolBlocks = messagesHaveToolBlocks(messages);
+
 	if (toolChoice === "none") {
-		return historyHasToolBlocks ? { tools: bedrockTools } : undefined;
+		if (!historyHasToolBlocks) return undefined;
+		if (!hasTools) return { tools: [NO_TOOLS_SENTINEL], toolChoice: { auto: {} } };
+		const bedrockTools = activeTools.map(convertToolSpec);
+		return { tools: bedrockTools };
 	}
 
+	if (!hasTools) return undefined;
+
+	const bedrockTools = activeTools.map(convertToolSpec);
 	let bedrockToolChoice: WireToolChoice | undefined;
 	switch (toolChoice) {
 		case "auto":

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -142,6 +142,13 @@ interface WireToolConfig {
 	toolChoice?: WireToolChoice;
 }
 
+/**
+ * Bedrock validates that requests carrying any `toolUse`/`toolResult` history
+ * include a `toolConfig`. For no-tool ephemeral turns (`/btw`, IRC auto-replies)
+ * we have nothing real to send, so we inject this placeholder. Its presence is
+ * tracked by a per-request flag — never the wire name — so callers who happen
+ * to register a real tool literally called `__no_tools__` are not affected.
+ */
 const NO_TOOLS_SENTINEL_NAME = "__no_tools__";
 
 const NO_TOOLS_SENTINEL: WireToolSpec = {
@@ -151,6 +158,11 @@ const NO_TOOLS_SENTINEL: WireToolSpec = {
 		inputSchema: { json: { type: "object", properties: {} } },
 	},
 };
+
+interface BedrockToolPlan {
+	toolConfig: WireToolConfig | undefined;
+	sentinelInjected: boolean;
+}
 
 interface ConverseStreamRequest {
 	messages: WireMessage[];
@@ -233,7 +245,9 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 		try {
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
 			const convertedMessages = convertMessages(context, model, cacheRetention);
-			const toolConfig = convertToolConfig(context.tools, options.toolChoice, convertedMessages);
+			const toolPlan = planToolConfig(context.tools, options.toolChoice, convertedMessages);
+			const toolConfig = toolPlan.toolConfig;
+			const sentinelInjected = toolPlan.sentinelInjected;
 			let additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
 
 			// Bedrock rejects thinking + forced tool_choice ("any" or specific tool).
@@ -377,7 +391,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					}
 					case "contentBlockStart": {
 						if (!firstTokenTime) firstTokenTime = Date.now();
-						handleContentBlockStart(payload as ContentBlockStartEvent, blocks, output, stream);
+						handleContentBlockStart(payload as ContentBlockStartEvent, blocks, output, stream, sentinelInjected);
 						break;
 					}
 					case "contentBlockDelta": {
@@ -391,10 +405,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					}
 					case "messageStop": {
 						const ev = payload as MessageStopEvent;
+						// A sentinel-only request must never surface a tool-use stop:
+						// no real tool exists for the agent to dispatch.
 						output.stopReason =
-							isNoToolsSentinelConfig(toolConfig) && ev.stopReason === "tool_use"
-								? "stop"
-								: mapStopReason(ev.stopReason);
+							sentinelInjected && ev.stopReason === "tool_use" ? "stop" : mapStopReason(ev.stopReason);
 						if (output.stopReason === "error") {
 							output.errorMessage = `Generation failed with stop reason: ${ev.stopReason ?? "unknown"}`;
 						}
@@ -473,11 +487,15 @@ function handleContentBlockStart(
 	blocks: Block[],
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
+	sentinelInjected: boolean,
 ): void {
 	const index = event.contentBlockIndex;
 	const start = event.start;
 
-	if (start?.toolUse?.name === NO_TOOLS_SENTINEL_NAME) return;
+	// Drop the sentinel call only when we injected it ourselves. A caller that
+	// registers a real tool named `__no_tools__` would otherwise lose its
+	// legitimate tool-use events on normal turns.
+	if (sentinelInjected && start?.toolUse?.name === NO_TOOLS_SENTINEL_NAME) return;
 
 	if (start?.toolUse) {
 		const block: Block = {
@@ -816,23 +834,27 @@ function convertToolSpec(tool: Tool): WireToolSpec {
 	};
 }
 
-function convertToolConfig(
+function planToolConfig(
 	tools: Tool[] | undefined,
 	toolChoice: BedrockOptions["toolChoice"],
 	messages: WireMessage[],
-): WireToolConfig | undefined {
+): BedrockToolPlan {
 	const activeTools = tools ?? [];
 	const hasTools = activeTools.length > 0;
 	const historyHasToolBlocks = messagesHaveToolBlocks(messages);
 
 	if (toolChoice === "none") {
-		if (!historyHasToolBlocks) return undefined;
-		if (!hasTools) return { tools: [NO_TOOLS_SENTINEL], toolChoice: { auto: {} } };
-		const bedrockTools = activeTools.map(convertToolSpec);
-		return { tools: bedrockTools };
+		if (!historyHasToolBlocks) return { toolConfig: undefined, sentinelInjected: false };
+		if (!hasTools) {
+			return {
+				toolConfig: { tools: [NO_TOOLS_SENTINEL], toolChoice: { auto: {} } },
+				sentinelInjected: true,
+			};
+		}
+		return { toolConfig: { tools: activeTools.map(convertToolSpec) }, sentinelInjected: false };
 	}
 
-	if (!hasTools) return undefined;
+	if (!hasTools) return { toolConfig: undefined, sentinelInjected: false };
 
 	const bedrockTools = activeTools.map(convertToolSpec);
 	let bedrockToolChoice: WireToolChoice | undefined;
@@ -849,11 +871,7 @@ function convertToolConfig(
 			}
 	}
 
-	return { tools: bedrockTools, toolChoice: bedrockToolChoice };
-}
-
-function isNoToolsSentinelConfig(toolConfig: WireToolConfig | undefined): boolean {
-	return toolConfig?.tools.length === 1 && toolConfig.tools[0]?.toolSpec.name === NO_TOOLS_SENTINEL_NAME;
+	return { toolConfig: { tools: bedrockTools, toolChoice: bedrockToolChoice }, sentinelInjected: false };
 }
 
 function mapStopReason(reason: string | undefined): StopReason {

--- a/packages/ai/test/issue-3124-repro.test.ts
+++ b/packages/ai/test/issue-3124-repro.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
-import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { crc32 } from "@oh-my-pi/pi-ai/providers/aws-eventstream";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
@@ -23,6 +24,83 @@ interface BedrockToolConfigPayload {
 
 function isBedrockToolConfigPayload(payload: unknown): payload is BedrockToolConfigPayload {
 	return typeof payload === "object" && payload !== null;
+}
+
+function encodeStringHeader(name: string, value: string): Uint8Array {
+	const nameBytes = new TextEncoder().encode(name);
+	const valueBytes = new TextEncoder().encode(value);
+	if (nameBytes.length > 255) throw new Error("name too long");
+	const buffer = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+	const view = new DataView(buffer.buffer);
+	let offset = 0;
+	view.setUint8(offset, nameBytes.length);
+	offset += 1;
+	buffer.set(nameBytes, offset);
+	offset += nameBytes.length;
+	view.setUint8(offset, 7);
+	offset += 1;
+	view.setUint16(offset, valueBytes.length, false);
+	offset += 2;
+	buffer.set(valueBytes, offset);
+	return buffer;
+}
+
+function encodeFrame(headers: Record<string, string>, payload: Uint8Array): Uint8Array {
+	const headerChunks: Uint8Array[] = [];
+	for (const name in headers) headerChunks.push(encodeStringHeader(name, headers[name]));
+	const headerLength = headerChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+	const headerBytes = new Uint8Array(headerLength);
+	let offset = 0;
+	for (const chunk of headerChunks) {
+		headerBytes.set(chunk, offset);
+		offset += chunk.length;
+	}
+	const totalLength = 4 + 4 + 4 + headerLength + payload.length + 4;
+	const frame = new Uint8Array(totalLength);
+	const view = new DataView(frame.buffer);
+	view.setUint32(0, totalLength, false);
+	view.setUint32(4, headerLength, false);
+	view.setUint32(8, crc32(frame.subarray(0, 8)), false);
+	frame.set(headerBytes, 12);
+	frame.set(payload, 12 + headerLength);
+	view.setUint32(totalLength - 4, crc32(frame.subarray(0, totalLength - 4)), false);
+	return frame;
+}
+
+function encodeBedrockEvent(eventType: string, payload: string): Uint8Array {
+	return encodeFrame({ ":message-type": "event", ":event-type": eventType }, new TextEncoder().encode(payload));
+}
+
+function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+	let index = 0;
+	return new ReadableStream({
+		pull(controller) {
+			if (index < chunks.length) controller.enqueue(chunks[index++]);
+			else controller.close();
+		},
+	});
+}
+
+function sentinelToolUseFetch(): FetchImpl {
+	const frames = [
+		encodeBedrockEvent("messageStart", '{"role":"assistant"}'),
+		encodeBedrockEvent(
+			"contentBlockStart",
+			'{"contentBlockIndex":0,"start":{"toolUse":{"toolUseId":"sentinel_1","name":"__no_tools__"}}}',
+		),
+		encodeBedrockEvent("contentBlockDelta", '{"contentBlockIndex":0,"delta":{"toolUse":{"input":"{}"}}}'),
+		encodeBedrockEvent("contentBlockStop", '{"contentBlockIndex":0}'),
+		encodeBedrockEvent("messageStop", '{"stopReason":"tool_use"}'),
+		encodeBedrockEvent("metadata", '{"usage":{"inputTokens":1,"outputTokens":1,"totalTokens":2}}'),
+	];
+	return Object.assign(
+		async (_input: string | URL | Request, _init?: RequestInit) =>
+			new Response(streamFrom(frames), {
+				status: 200,
+				headers: { "content-type": "application/vnd.amazon.eventstream" },
+			}),
+		{ preconnect: fetch.preconnect },
+	);
 }
 
 function model(): Model<"bedrock-converse-stream"> {
@@ -100,5 +178,15 @@ describe("issue #3124 — Bedrock /btw with tool history", () => {
 
 		expect(payload.toolConfig?.tools?.[0]?.toolSpec?.name).toBe("__no_tools__");
 		expect(payload.toolConfig?.toolChoice?.auto).toEqual({});
+	});
+
+	it("filters sentinel toolUse blocks before they reach normal tool execution", async () => {
+		const result = await streamBedrock(model(), toolHistoryContext(), {
+			toolChoice: "none",
+			fetch: sentinelToolUseFetch(),
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.some(block => block.type === "toolCall")).toBe(false);
 	});
 });

--- a/packages/ai/test/issue-3124-repro.test.ts
+++ b/packages/ai/test/issue-3124-repro.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
+
+beforeAll(() => {
+	process.env.AWS_BEDROCK_SKIP_AUTH = "1";
+});
+
+afterAll(() => {
+	if (originalSkipAuth === undefined) delete process.env.AWS_BEDROCK_SKIP_AUTH;
+	else process.env.AWS_BEDROCK_SKIP_AUTH = originalSkipAuth;
+});
+
+interface BedrockToolConfigPayload {
+	toolConfig?: {
+		tools?: Array<{ toolSpec?: { name?: string } }>;
+		toolChoice?: { auto?: Record<string, never> };
+	};
+}
+
+function isBedrockToolConfigPayload(payload: unknown): payload is BedrockToolConfigPayload {
+	return typeof payload === "object" && payload !== null;
+}
+
+function model(): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		name: "Claude 3.5 Sonnet",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	});
+}
+
+function toolHistoryContext(): Context {
+	return {
+		messages: [
+			{ role: "user", content: "Read the file", timestamp: 0 },
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "README.md" } }],
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 0,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_1",
+				toolName: "read",
+				content: [{ type: "text", text: "contents" }],
+				isError: false,
+				timestamp: 0,
+			},
+			{ role: "user", content: "Side-channel question", timestamp: 1 },
+		],
+		tools: [],
+	};
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function captureBedrockPayload(context: Context): Promise<BedrockToolConfigPayload> {
+	const { promise, resolve } = Promise.withResolvers<BedrockToolConfigPayload>();
+	void streamBedrock(model(), context, {
+		signal: abortedSignal(),
+		toolChoice: "none",
+		onPayload: payload => {
+			resolve(isBedrockToolConfigPayload(payload) ? payload : {});
+			return undefined;
+		},
+	});
+	return promise;
+}
+
+describe("issue #3124 — Bedrock /btw with tool history", () => {
+	it("keeps toolConfig when a no-tool ephemeral turn replays toolUse/toolResult history", async () => {
+		const payload = await captureBedrockPayload(toolHistoryContext());
+
+		expect(payload.toolConfig?.tools?.[0]?.toolSpec?.name).toBe("__no_tools__");
+		expect(payload.toolConfig?.toolChoice?.auto).toEqual({});
+	});
+});

--- a/packages/ai/test/issue-3124-repro.test.ts
+++ b/packages/ai/test/issue-3124-repro.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { crc32 } from "@oh-my-pi/pi-ai/providers/aws-eventstream";
-import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import type { Context, FetchImpl, Model, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { z } from "zod/v4";
 
 const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
 
@@ -188,5 +189,29 @@ describe("issue #3124 — Bedrock /btw with tool history", () => {
 
 		expect(result.stopReason).toBe("stop");
 		expect(result.content.some(block => block.type === "toolCall")).toBe(false);
+	});
+
+	it("preserves a real caller tool literally named __no_tools__ on normal turns", async () => {
+		const userTool: Tool = {
+			name: "__no_tools__",
+			description: "Caller-registered tool that collides with the sentinel name.",
+			parameters: z.object({ query: z.string() }),
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "Use my tool", timestamp: 0 }],
+			tools: [userTool],
+		};
+
+		const result = await streamBedrock(model(), context, {
+			toolChoice: "auto",
+			fetch: sentinelToolUseFetch(),
+		}).result();
+
+		expect(result.stopReason).toBe("toolUse");
+		const toolCalls = result.content.filter(
+			(block): block is Extract<typeof block, { type: "toolCall" }> => block.type === "toolCall",
+		);
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0]?.name).toBe("__no_tools__");
 	});
 });


### PR DESCRIPTION
## Repro
A Bedrock Converse Stream turn that mirrors `/btw` sends `context.tools = []` and `toolChoice: "none"` while replaying prior `toolUse`/`toolResult` history. `bun test packages/ai/test/issue-3124-repro.test.ts` failed before the fix because the captured payload had `toolConfig: undefined`, matching Bedrock's HTTP 400 validation failure.

## Cause
`packages/ai/src/providers/amazon-bedrock.ts` computed `historyHasToolBlocks` from session messages, but `convertToolConfig()` returned early on `!tools?.length`, so ephemeral no-tool turns dropped `toolConfig` even when the converted Bedrock messages contained `toolUse` or `toolResult` blocks.

## Fix
- Convert Bedrock messages once before building `commandInput`, then derive tool-history requirements from those converted wire messages.
- Add a Bedrock sentinel `__no_tools__` toolConfig for `toolChoice: "none"` requests with prior tool history and no active tools.
- Keep existing real-tool behavior for non-empty tool catalogs.
- Add issue #3124 regression coverage and an `@oh-my-pi/pi-ai` changelog entry.

## Verification
`bun test packages/ai/test/issue-3124-repro.test.ts packages/ai/test/issue-1373-repro.test.ts packages/ai/test/bedrock-inference-profile.test.ts` passed. `bun check` passed. `bun run fix` reported no TS fixes and completed Rust checks. Fixes #3124