### PR TITLE
fix(mnemopi): cap embed() input so retention transcripts can't overflow the embedding model context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars) so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars) and clips with a head/tail split so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory. The head/tail clip keeps both the opening setup and the most recent turns so later episodes don't collapse onto the same prefix vector ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.7] - 2026-06-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000 chars) so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars) and clips with a head/tail split so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory. The head/tail clip keeps both the opening setup and the most recent turns so later episodes don't collapse onto the same prefix vector ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars) and clips with a head/tail split so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory. The head/tail clip keeps both the opening setup and the most recent turns so later episodes don't collapse onto the same prefix vector, and stored vectors are now stamped with `<model>@chars:<N>` so the next session open rebuilds existing long memories under the new clip instead of leaving them frozen on their pre-cap text ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.7] - 2026-06-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000 chars) so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Stopped Mnemopi retention from overflowing the embedding model's context window: `embed()` now caps each input at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars) so a long multi-turn `MnemopiSessionState.retainMessages` transcript can't make llama.cpp's `/embeddings` server reject the request with `request (N tokens) exceeds the available context size` and silently drop vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.7] - 2026-06-20
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. Oversized inputs are clipped with a head/tail split so chronological transcripts keep both the opening setup and the most recent turns instead of losing the latest content under a naive prefix slice. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.3] - 2026-06-19
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+
 ## [16.1.3] - 2026-06-19
 
 ### Added

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. Oversized inputs are clipped with a head/tail split so chronological transcripts keep both the opening setup and the most recent turns instead of losing the latest content under a naive prefix slice. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. Oversized inputs are clipped with a head/tail split so chronological transcripts keep both the opening setup and the most recent turns instead of losing the latest content under a naive prefix slice. Stored vectors are now stamped with `<model>@chars:<N>` instead of just `<model>`, so `reconcileEmbeddingModel` rebuilds existing long rows on the first upgraded open (and on any later cap change) instead of leaving them frozen on their pre-cap text. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.3] - 2026-06-19
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
+- Capped per-input length in `embed()` at `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192 chars, override via the env var or `embeddings.maxInputChars` runtime option; `0` disables) so a long retention transcript can no longer overflow the embedding model's context window. llama.cpp's `/embeddings` server used to reject the request with `request (N tokens) exceeds the available context size`, silently dropping vector recall for that memory ([#3126](https://github.com/can1357/oh-my-pi/issues/3126)).
 
 ## [16.1.3] - 2026-06-19
 

--- a/packages/mnemopi/src/config.ts
+++ b/packages/mnemopi/src/config.ts
@@ -99,6 +99,26 @@ export function embeddingsDisabled(env: Env = process.env): boolean {
 	return envString("MNEMOPI_NO_EMBEDDINGS", "", env) !== "";
 }
 
+/**
+ * Per-input character cap applied inside `embed()` before any provider sees the text.
+ *
+ * Long retention transcripts (full multi-turn session windows) routinely outgrow
+ * embedding model context windows: BGE/E5 defaults are 512 tokens, bge-m3 is
+ * 8192, and OpenAI's text-embedding-3-* is 8192. llama.cpp's `/embeddings`
+ * server rejects oversized requests with `request (N tokens) exceeds the
+ * available context size`; OpenAI silently right-truncates. Capping at the
+ * source gives both backends deterministic behavior and prevents the silent
+ * recall degradation we saw in issue #3126.
+ *
+ * Default `32000` ≈ 8k English tokens (4 chars/token) or ~16k–32k CJK tokens —
+ * fits 8k-context models (bge-m3, text-embedding-3) for English and most CJK
+ * content. Lower it for 512-token models like `BAAI/bge-small-en-v1.5`, raise
+ * it for larger contexts. `0` disables the cap.
+ */
+export function embeddingMaxInputChars(env: Env = process.env): number {
+	return Math.max(0, envInt("MNEMOPI_EMBEDDING_MAX_INPUT_CHARS", 32000, env));
+}
+
 export function isApiEmbeddingModel(model = embeddingModel(), env: Env = process.env): boolean {
 	if (model.startsWith("openai/") || model.includes("text-embedding") || model.startsWith("text-embedding"))
 		return true;

--- a/packages/mnemopi/src/config.ts
+++ b/packages/mnemopi/src/config.ts
@@ -110,13 +110,13 @@ export function embeddingsDisabled(env: Env = process.env): boolean {
  * source gives both backends deterministic behavior and prevents the silent
  * recall degradation we saw in issue #3126.
  *
- * Default `32000` ≈ 8k English tokens (4 chars/token) or ~16k–32k CJK tokens —
- * fits 8k-context models (bge-m3, text-embedding-3) for English and most CJK
- * content. Lower it for 512-token models like `BAAI/bge-small-en-v1.5`, raise
- * it for larger contexts. `0` disables the cap.
+ * Default `8192` chars is intentionally conservative for 8192-token embedding
+ * contexts (bge-m3, OpenAI text-embedding-3) and CJK-heavy transcripts. Raise
+ * it for larger local contexts (for example Qwen3-Embedding with 32k ctx).
+ * `0` disables the cap.
  */
 export function embeddingMaxInputChars(env: Env = process.env): number {
-	return Math.max(0, envInt("MNEMOPI_EMBEDDING_MAX_INPUT_CHARS", 32000, env));
+	return Math.max(0, envInt("MNEMOPI_EMBEDDING_MAX_INPUT_CHARS", 8192, env));
 }
 
 export function isApiEmbeddingModel(model = embeddingModel(), env: Env = process.env): boolean {

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { logger } from "@oh-my-pi/pi-utils";
 import { generateId as generateTimedId, sha256Hex16, stableMemoryId } from "../../util/ids";
-import { currentEmbeddingModel, embed } from "../embeddings";
+import { currentEmbeddingFingerprint, embed } from "../embeddings";
 import { getMnemopiRuntimeOptions, mnemopiDebugEnabled, withMnemopiRuntimeOptions } from "../runtime-options";
 import { buildExactVectorIndex, searchExactVectorIndex } from "../vector-index";
 import type { BeamMemoryState, JsonValue, Metadata } from "./types";
@@ -920,7 +920,7 @@ async function runEmbedding(beam: BeamMemoryState, items: readonly EmbedItem[]):
 	try {
 		const matrix = await embed(items.map(item => item.content));
 		if (matrix === null) return;
-		const model = currentEmbeddingModel();
+		const model = currentEmbeddingFingerprint();
 		const insertEmbedding = beam.db.prepare(
 			"INSERT OR REPLACE INTO memory_embeddings(memory_id, embedding_json, model) VALUES (?, ?, ?)",
 		);

--- a/packages/mnemopi/src/core/beam/store.ts
+++ b/packages/mnemopi/src/core/beam/store.ts
@@ -3,7 +3,7 @@ import { logger } from "@oh-my-pi/pi-utils";
 import { transaction } from "../../db";
 import { toUtcIso } from "../../util/datetime";
 import { generateId } from "../../util/ids";
-import { currentEmbeddingModel, embeddingsDisabled } from "../embeddings";
+import { currentEmbeddingFingerprint, currentEmbeddingModel, embeddingsDisabled } from "../embeddings";
 import { EpisodicGraph } from "../episodic-graph";
 import { extractFactsSafe } from "../extraction";
 import { getMnemopiRuntimeOptions, withMnemopiRuntimeOptions } from "../runtime-options";
@@ -255,29 +255,35 @@ function rowToDict(row: Row): Row {
 const EMBED_REBUILD_BATCH = 128;
 
 /**
- * Reconcile stored embeddings against the active embedding model at store open.
+ * Reconcile stored embeddings against the active embedding *configuration* on
+ * store open.
  *
- * Every `memory_embeddings` row is stamped with the model that produced it (see
- * `runEmbedding` in `helpers.ts`). When the configured embedding model changes,
- * its vector dimension changes too, so the previously-stored vectors are no
- * longer comparable. On a mismatch we wipe every stored vector — the
- * `memory_embeddings` table, the `episodic_memory.binary_vector` column, and the
- * sqlite-vec `vec_episodes` index — then enqueue all live memories for
- * background re-embedding under the new model via `scheduleEmbedding`.
+ * Every `memory_embeddings` row is stamped with `currentEmbeddingFingerprint()`
+ * — model name plus the active input cap — when it is written (see
+ * `runEmbedding` in `helpers.ts`). When the model changes its vector dimension
+ * changes too; when the cap (`MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` /
+ * `embeddings.maxInputChars`) changes, the *text* fed to the embedder changes
+ * via the head/tail clip in `embed()`. Both make previously-stored vectors
+ * stale, so on a fingerprint mismatch we wipe every stored vector — the
+ * `memory_embeddings` table, the `episodic_memory.binary_vector` column, and
+ * the sqlite-vec `vec_episodes` index — then enqueue all live memories for
+ * background re-embedding under the new configuration via `scheduleEmbedding`.
+ * Pre-#3126 rows stamped only with `<model>` mismatch the new
+ * `<model>@chars:<N>` fingerprint and rebuild on first upgraded open, so long
+ * memories embedded before the cap pick up the head/tail representation.
  *
- * Runs once per store open; a fresh store (no embeddings) or an already-current
- * store is a no-op. The destructive wipe is skipped whenever it could not be
- * rebuilt — embeddings disabled via the runtime option OR the
+ * Runs once per store open; a fresh store (no embeddings) or an already-
+ * current store is a no-op. The destructive wipe is skipped whenever it could
+ * not be rebuilt — embeddings disabled via the runtime option OR the
  * `MNEMOPI_NO_EMBEDDINGS` env, or an unresolved (empty) active model — so a
  * stale-but-valid corpus is never destroyed without a replacement. MUST run
- * inside the active runtime-options scope so `currentEmbeddingModel()` /
+ * inside the active runtime-options scope so `currentEmbeddingFingerprint()` /
  * `embeddingsDisabled()` reflect the per-instance configuration.
  */
 export function reconcileEmbeddingModel(beam: BeamMemoryState): void {
 	if (embeddingsDisabled()) return;
-	const active = currentEmbeddingModel().trim();
-	if (active === "") return;
-
+	if (currentEmbeddingModel().trim() === "") return;
+	const active = currentEmbeddingFingerprint();
 	// Re-embed in bounded batches so a corpus-wide rebuild never issues one giant
 	// embedding request; each batch is its own tracked background task.
 	const rebuild = (items: readonly EmbedItem[]): void => {

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -120,6 +120,54 @@ export function embeddingsDisabled(): boolean {
 	return $flag("MNEMOPI_NO_EMBEDDINGS");
 }
 
+/**
+ * Resolved per-input character cap for {@link embed}.
+ *
+ * Reads (in order): the active runtime scope's `embeddings.maxInputChars`, then
+ * `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`, then the bundled `32000` default. `0`
+ * disables the cap entirely.
+ */
+function effectiveMaxInputChars(): number {
+	const override = activeEmbeddingOptions()?.maxInputChars;
+	if (override !== undefined) return Math.max(0, Math.trunc(override));
+	const envValue = Number.parseInt($env.MNEMOPI_EMBEDDING_MAX_INPUT_CHARS ?? "", 10);
+	if (Number.isFinite(envValue) && envValue >= 0) return envValue;
+	return 32000;
+}
+
+/**
+ * Right-truncate every input to {@link effectiveMaxInputChars} so a runaway
+ * retention transcript can't blow past the embedding model's context window.
+ * Returns the original array when no input needs trimming (the common case);
+ * the new array is allocated only when at least one input is oversized so
+ * we don't churn arrays for the typical short-query path through `embedQuery`.
+ * Emits one debug-or-warn log per call summarizing how many inputs were
+ * trimmed and by how much — silent truncation was the original bug (#3126).
+ */
+function capInputs(texts: readonly string[]): readonly string[] {
+	const max = effectiveMaxInputChars();
+	if (max === 0) return texts;
+	let trimmed: string[] | null = null;
+	let trimmedCount = 0;
+	let maxOriginalLen = 0;
+	for (let i = 0; i < texts.length; i++) {
+		const text = texts[i] ?? "";
+		if (text.length <= max) continue;
+		if (trimmed === null) trimmed = texts.slice() as string[];
+		trimmed[i] = text.slice(0, max);
+		trimmedCount++;
+		if (text.length > maxOriginalLen) maxOriginalLen = text.length;
+	}
+	if (trimmed === null) return texts;
+	logger[mnemopiDebugEnabled() ? "warn" : "debug"]("mnemopi: embedding input truncated", {
+		inputCount: texts.length,
+		trimmedCount,
+		maxOriginalLen,
+		maxInputChars: max,
+	});
+	return trimmed;
+}
+
 function embeddingApiKey(): ApiKey {
 	const active = activeEmbeddingOptions();
 	if (active?.apiKey !== undefined) {
@@ -408,6 +456,7 @@ export async function embed(texts: readonly string[]): Promise<EmbeddingMatrix |
 	if (texts.length === 0 || embeddingsDisabled()) {
 		return null;
 	}
+	texts = capInputs(texts);
 	const activeProvider = resolveEmbeddingProvider(activeEmbeddingOptions()?.provider);
 	if (activeProvider !== undefined) {
 		try {

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -135,14 +135,39 @@ function effectiveMaxInputChars(): number {
 	return 8192;
 }
 
+/** Elision marker injected between the retained head and tail of an oversized input. */
+const EMBEDDING_ELISION_MARKER = "\n\n[...]\n\n";
+
 /**
- * Right-truncate every input to {@link effectiveMaxInputChars} so a runaway
- * retention transcript can't blow past the embedding model's context window.
- * Returns the original array when no input needs trimming (the common case);
- * the new array is allocated only when at least one input is oversized so
- * we don't churn arrays for the typical short-query path through `embedQuery`.
- * Emits one debug-or-warn log per call summarizing how many inputs were
- * trimmed and by how much — silent truncation was the original bug (#3126).
+ * Right-clip a single oversized input to {@link max} chars while preserving
+ * both ends. Retention transcripts are chronological (oldest → newest), so a
+ * naive `slice(0, max)` would drop the most recent — and most semantically
+ * loaded — turns once a session passed the cap, leaving every later retained
+ * episode with essentially the same prefix vector. Keeping a head/tail split
+ * lets the embedding capture the topic setup at the start AND the latest
+ * exchanges at the end. Falls back to a tail-only clip when `max` is too
+ * small to fit the elision marker plus a useful slice on either side.
+ */
+function clipToWindow(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= EMBEDDING_ELISION_MARKER.length + 16) return text.slice(text.length - max);
+	const budget = max - EMBEDDING_ELISION_MARKER.length;
+	const headLen = budget >>> 1;
+	const tailLen = budget - headLen;
+	return text.slice(0, headLen) + EMBEDDING_ELISION_MARKER + text.slice(text.length - tailLen);
+}
+
+/**
+ * Clip every input to {@link effectiveMaxInputChars} so a runaway retention
+ * transcript can't blow past the embedding model's context window. Uses a
+ * head/tail split via {@link clipToWindow} so the embedding still sees the
+ * tail of the conversation (where the latest topic shifts live) and not just
+ * the stale prefix. Returns the original array when no input needs trimming
+ * (the common case); the new array is allocated only when at least one input
+ * is oversized so we don't churn arrays for the typical short-query path
+ * through `embedQuery`. Emits one debug-or-warn log per call summarizing how
+ * many inputs were trimmed and by how much — silent truncation was the
+ * original bug (#3126).
  */
 function capInputs(texts: readonly string[]): readonly string[] {
 	const max = effectiveMaxInputChars();
@@ -154,7 +179,7 @@ function capInputs(texts: readonly string[]): readonly string[] {
 		const text = texts[i] ?? "";
 		if (text.length <= max) continue;
 		if (trimmed === null) trimmed = texts.slice() as string[];
-		trimmed[i] = text.slice(0, max);
+		trimmed[i] = clipToWindow(text, max);
 		trimmedCount++;
 		if (text.length > maxOriginalLen) maxOriginalLen = text.length;
 	}

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -124,7 +124,7 @@ export function embeddingsDisabled(): boolean {
  * Resolved per-input character cap for {@link embed}.
  *
  * Reads (in order): the active runtime scope's `embeddings.maxInputChars`, then
- * `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`, then the bundled `32000` default. `0`
+ * `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`, then the bundled `8192` default. `0`
  * disables the cap entirely.
  */
 function effectiveMaxInputChars(): number {
@@ -132,7 +132,7 @@ function effectiveMaxInputChars(): number {
 	if (override !== undefined) return Math.max(0, Math.trunc(override));
 	const envValue = Number.parseInt($env.MNEMOPI_EMBEDDING_MAX_INPUT_CHARS ?? "", 10);
 	if (Number.isFinite(envValue) && envValue >= 0) return envValue;
-	return 32000;
+	return 8192;
 }
 
 /**

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -226,12 +226,32 @@ function defaultModel(): string {
  * Resolve the embedding model name for the currently active runtime scope.
  *
  * Reads (in order): the active provider's `model` from `withMnemopiRuntimeOptions`,
- * the `MNEMOPI_EMBEDDING_MODEL` env var, then the bundled fastembed default. Stored
- * alongside each row in `memory_embeddings.model` so migrations can re-embed when
- * the active model changes.
+ * the `MNEMOPI_EMBEDDING_MODEL` env var, then the bundled fastembed default.
+ * Used by the embedding pipeline to decide which provider/dimensions to load;
+ * NOT what gets stamped into `memory_embeddings.model` (see
+ * {@link currentEmbeddingFingerprint}).
  */
 export function currentEmbeddingModel(): string {
 	return defaultModel();
+}
+
+/**
+ * Stable identifier for the current embedding *configuration*, not just the
+ * model. Stamped into `memory_embeddings.model` so
+ * `reconcileEmbeddingModel` can detect when the produced vector would
+ * meaningfully change — including changes to `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`
+ * or `embeddings.maxInputChars`, not only a model swap. Rows stamped with the
+ * bare model name (pre-#3126 builds) mismatch the new fingerprint on next
+ * store open so the head/tail clip reaches every existing long memory via
+ * the normal reconcile rebuild path.
+ *
+ * Format: `<model>` when the cap is `0`/disabled (preserves byte-compat for
+ * users who opt out of capping), `<model>@chars:<N>` otherwise.
+ */
+export function currentEmbeddingFingerprint(): string {
+	const model = currentEmbeddingModel();
+	const cap = effectiveMaxInputChars();
+	return cap === 0 ? model : `${model}@chars:${cap}`;
 }
 
 export function isApiModel(modelName: string): boolean {

--- a/packages/mnemopi/src/core/memory.ts
+++ b/packages/mnemopi/src/core/memory.ts
@@ -161,19 +161,22 @@ function resolveRuntimeOptions(options: MnemopiOptions): ResolvedMnemopiRuntimeO
 	const embeddingApiUrl = options.embeddingApiUrl ?? nestedEmbeddings?.apiUrl;
 	const embeddingApiKey = options.embeddingApiKey ?? nestedEmbeddings?.apiKey;
 	const embeddingProvider = resolveEmbeddingProvider(nestedEmbeddings?.provider);
+	const embeddingMaxInputChars = nestedEmbeddings?.maxInputChars;
 
 	const embeddings =
 		embeddingDisabled !== undefined ||
 		embeddingModel !== undefined ||
 		embeddingApiUrl !== undefined ||
 		embeddingApiKey !== undefined ||
-		embeddingProvider !== undefined
+		embeddingProvider !== undefined ||
+		embeddingMaxInputChars !== undefined
 			? {
 					disabled: embeddingDisabled,
 					model: embeddingModel,
 					apiUrl: embeddingApiUrl,
 					apiKey: embeddingApiKey,
 					provider: embeddingProvider,
+					maxInputChars: embeddingMaxInputChars,
 				}
 			: undefined;
 

--- a/packages/mnemopi/src/core/runtime-options.ts
+++ b/packages/mnemopi/src/core/runtime-options.ts
@@ -33,6 +33,8 @@ export interface MnemopiEmbeddingRuntimeOptions {
 	apiUrl?: string;
 	apiKey?: ApiKey;
 	provider?: MnemopiEmbeddingProvider | ((texts: readonly string[]) => EmbeddingOutput | Promise<EmbeddingOutput>);
+	/** Override `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`. `0` disables the cap. See `config.embeddingMaxInputChars`. */
+	maxInputChars?: number;
 }
 
 export interface MnemopiLlmRuntimeOptions {
@@ -61,6 +63,7 @@ export interface ResolvedMnemopiEmbeddingRuntimeOptions {
 	apiUrl?: string;
 	apiKey?: ApiKey;
 	provider?: MnemopiEmbeddingProvider;
+	maxInputChars?: number;
 }
 
 export interface ResolvedMnemopiLlmRuntimeOptions {

--- a/packages/mnemopi/test/embedding-input-cap.test.ts
+++ b/packages/mnemopi/test/embedding-input-cap.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import "./setup";
+import {
+	embed,
+	resetEmbeddingProviderForTests,
+	setEmbeddingProviderForTests,
+} from "@oh-my-pi/pi-mnemopi/core/embeddings";
+import { withMnemopiRuntimeOptions } from "@oh-my-pi/pi-mnemopi/core/runtime-options";
+
+/**
+ * Regression coverage for issue #3126: `MnemopiSessionState.retainMessages`
+ * passes the entire multi-turn transcript to `embed()`. Long sessions used to
+ * overflow whatever ctx the embedding server was started with — llama.cpp
+ * rejects oversized requests with `request (N tokens) exceeds the available
+ * context size`, OpenAI silently right-truncates. `embed()` now caps each
+ * input to `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000) before the
+ * provider sees it.
+ */
+function captureProvider(): {
+	embed: (texts: readonly string[]) => AsyncGenerator<number[][]>;
+	calls: string[][];
+} {
+	const calls: string[][] = [];
+	return {
+		calls,
+		async *embed(texts) {
+			calls.push([...texts]);
+			yield texts.map(text => [text.length]);
+		},
+	};
+}
+
+const ENV_KEY = "MNEMOPI_EMBEDDING_MAX_INPUT_CHARS";
+
+function withEnvValue<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+	const previous = process.env[ENV_KEY];
+	if (value === undefined) delete process.env[ENV_KEY];
+	else process.env[ENV_KEY] = value;
+	return fn().finally(() => {
+		if (previous === undefined) delete process.env[ENV_KEY];
+		else process.env[ENV_KEY] = previous;
+	});
+}
+
+afterEach(() => {
+	resetEmbeddingProviderForTests();
+});
+
+describe("embed() input cap (#3126)", () => {
+	it("truncates oversized inputs to the default cap before reaching the provider", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		const huge = "x".repeat(40_000);
+		await withEnvValue(undefined, () => embed(["short", huge]));
+
+		expect(provider.calls).toHaveLength(1);
+		const [seenShort, seenHuge] = provider.calls[0] ?? [];
+		expect(seenShort).toBe("short");
+		expect(seenHuge?.length).toBe(32_000);
+	});
+
+	it("honors MNEMOPI_EMBEDDING_MAX_INPUT_CHARS env override", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		await withEnvValue("1024", () => embed(["y".repeat(5000)]));
+
+		expect(provider.calls[0]?.[0]?.length).toBe(1024);
+	});
+
+	it("disables the cap when the env override is 0", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		const huge = "z".repeat(50_000);
+		await withEnvValue("0", () => embed([huge]));
+
+		expect(provider.calls[0]?.[0]).toBe(huge);
+	});
+
+	it("respects a constructor-scoped maxInputChars override", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		await withEnvValue(undefined, () =>
+			withMnemopiRuntimeOptions({ embeddings: { maxInputChars: 256 } }, () => embed(["w".repeat(10_000)])),
+		);
+
+		expect(provider.calls[0]?.[0]?.length).toBe(256);
+	});
+
+	it("returns the original array reference when no input needs trimming", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		await withEnvValue("1024", () => embed(["fits", "still fits"]));
+
+		expect(provider.calls[0]).toEqual(["fits", "still fits"]);
+	});
+});

--- a/packages/mnemopi/test/embedding-input-cap.test.ts
+++ b/packages/mnemopi/test/embedding-input-cap.test.ts
@@ -90,6 +90,27 @@ describe("embed() input cap (#3126)", () => {
 		expect(provider.calls[0]?.[0]?.length).toBe(256);
 	});
 
+	it("preserves both ends of a chronological transcript via the head/tail clip", async () => {
+		const provider = captureProvider();
+		setEmbeddingProviderForTests(provider);
+
+		// `MnemopiSessionState.retainMessages` hands `embed()` the full
+		// chronological transcript. Before the head/tail clip, a `slice(0, max)`
+		// would land on the oldest turns and drop the most recent (and most
+		// semantically loaded) content. Verify both ends survive.
+		const earliest = "OPENING_TURN_MARKER";
+		const latest = "FINAL_TURN_MARKER";
+		const transcript = `${earliest}${"x".repeat(50_000)}${latest}`;
+
+		await withEnvValue(undefined, () => embed([transcript]));
+
+		const seen = provider.calls[0]?.[0] ?? "";
+		expect(seen.length).toBe(8192);
+		expect(seen.startsWith(earliest)).toBe(true);
+		expect(seen.endsWith(latest)).toBe(true);
+		expect(seen).toContain("[...]");
+	});
+
 	it("returns the original array reference when no input needs trimming", async () => {
 		const provider = captureProvider();
 		setEmbeddingProviderForTests(provider);

--- a/packages/mnemopi/test/embedding-input-cap.test.ts
+++ b/packages/mnemopi/test/embedding-input-cap.test.ts
@@ -13,7 +13,7 @@ import { withMnemopiRuntimeOptions } from "@oh-my-pi/pi-mnemopi/core/runtime-opt
  * overflow whatever ctx the embedding server was started with — llama.cpp
  * rejects oversized requests with `request (N tokens) exceeds the available
  * context size`, OpenAI silently right-truncates. `embed()` now caps each
- * input to `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 32000) before the
+ * input to `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` (default 8192) before the
  * provider sees it.
  */
 function captureProvider(): {
@@ -57,7 +57,7 @@ describe("embed() input cap (#3126)", () => {
 		expect(provider.calls).toHaveLength(1);
 		const [seenShort, seenHuge] = provider.calls[0] ?? [];
 		expect(seenShort).toBe("short");
-		expect(seenHuge?.length).toBe(32_000);
+		expect(seenHuge?.length).toBe(8192);
 	});
 
 	it("honors MNEMOPI_EMBEDDING_MAX_INPUT_CHARS env override", async () => {

--- a/packages/mnemopi/test/embedding-model-reconcile.test.ts
+++ b/packages/mnemopi/test/embedding-model-reconcile.test.ts
@@ -15,6 +15,13 @@ import { Mnemopi } from "@oh-my-pi/pi-mnemopi/core/memory";
 const OLD_MODEL = "BAAI/bge-small-en-v1.5";
 const NEW_MODEL = "intfloat/multilingual-e5-large";
 
+// `memory_embeddings.model` rows are stamped with `currentEmbeddingFingerprint()`
+// (model + active input cap) so a cap change triggers reconcile just like a
+// model change. The test runtime leaves `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS`
+// unset, so the default 8192 char cap applies.
+const DEFAULT_CAP_SUFFIX = "@chars:8192";
+const NEW_STAMP = `${NEW_MODEL}${DEFAULT_CAP_SUFFIX}`;
+
 // Deterministic fastembed-shaped provider so the background rebuild actually
 // writes rows (and stamps them with the active model) under the test runtime.
 function fakeEmbed() {
@@ -70,7 +77,7 @@ describe("reconcileEmbeddingModel on store open", () => {
 				model: string;
 			}[];
 			expect(rows.map(row => row.memory_id).sort()).toEqual([...ids].sort());
-			expect(rows.every(row => row.model === NEW_MODEL)).toBe(true);
+			expect(rows.every(row => row.model === NEW_STAMP)).toBe(true);
 		} finally {
 			memory.close();
 			db.close();
@@ -78,7 +85,7 @@ describe("reconcileEmbeddingModel on store open", () => {
 	});
 
 	it("leaves embeddings untouched when the stored model already matches", () => {
-		const { db } = seedDb(NEW_MODEL);
+		const { db } = seedDb(NEW_STAMP);
 		const memory = new Mnemopi({ db, embeddings: { model: NEW_MODEL, provider: fakeEmbed() } });
 		try {
 			// No mismatch -> no wipe, no rebuild enqueued.
@@ -91,6 +98,31 @@ describe("reconcileEmbeddingModel on store open", () => {
 			};
 			expect(ep.v).not.toBeNull();
 			expect(Array.from(ep.v as Uint8Array)).toEqual([1, 2, 3, 4]);
+		} finally {
+			memory.close();
+			db.close();
+		}
+	});
+
+	it("rebuilds existing rows when only the input cap changes (#3126 upgrade path)", async () => {
+		// Simulate a pre-#3126 DB: rows stamped with the bare model name and no
+		// cap suffix. After the upgrade, those rows mismatch the new
+		// `${MODEL}@chars:N` fingerprint, get wiped, and re-embedded through the
+		// head/tail clip — otherwise long memories from the silent-truncation era
+		// keep their stale prefix-only vectors forever.
+		const { db, ids } = seedDb(NEW_MODEL);
+		const memory = new Mnemopi({ db, embeddings: { model: NEW_MODEL, provider: fakeEmbed() } });
+		try {
+			expect(countEmbeddings(memory)).toBe(0);
+			expect(memory.beam.pendingExtractions.size).toBeGreaterThanOrEqual(1);
+
+			await memory.flushExtractions();
+			const rows = memory.conn.query("SELECT memory_id, model FROM memory_embeddings ORDER BY memory_id").all() as {
+				memory_id: string;
+				model: string;
+			}[];
+			expect(rows.map(row => row.memory_id).sort()).toEqual([...ids].sort());
+			expect(rows.every(row => row.model === NEW_STAMP)).toBe(true);
 		} finally {
 			memory.close();
 			db.close();
@@ -183,7 +215,7 @@ describe("reconcileEmbeddingModel on store open", () => {
 				model: string;
 			}[];
 			expect(rows.map(row => row.memory_id).sort()).toEqual(["ep-1", "wm-1"]);
-			expect(rows.every(row => row.model === NEW_MODEL)).toBe(true);
+			expect(rows.every(row => row.model === NEW_STAMP)).toBe(true);
 		} finally {
 			memory.close();
 			db.close();


### PR DESCRIPTION
## Repro

The reporter's `llama-server` log in #3126 shows a steadily growing series of `/embeddings` requests at session start (2k → 14k → 23k → 42k tokens) ending in:

```
E srv send_error: task id = 50, error: request (42017 tokens) exceeds the available context size (32768 tokens), try increasing it
```

Modeling that server as a custom embedding provider (throws when input exceeds its configured ctx) and calling `embed([transcript])` with a 42k-char retention payload reproduces the failure deterministically:

```
pre-fix (cap=0):       provider saw 42024 chars, threw=true,  embed returned null
post-fix (default cap): provider saw 32000 chars, threw=false, embed returned ok
```

## Cause

`MnemopiSessionState.retainMessages` (`packages/coding-agent/src/mnemopi/state.ts:352`) always calls `prepareRetentionTranscript(messages, true)` and forwards the entire multi-turn transcript to `embed([transcript])` via `remember(...)` → `scheduleEmbedding` → `runEmbedding`. `embed()` in `packages/mnemopi/src/core/embeddings.ts` had no input-length guard: every provider (custom, override, OpenAI-compatible API, local fastembed) received the raw text. Once a session's transcript outgrew the embedding model's ctx (8192 for `bge-m3` / `text-embedding-3-*`, 512 for the BGE/E5 small defaults, whatever the user configured for a llama.cpp server), the request failed and `runEmbedding` swallowed the error — the memory landed in storage without its vector row, silently degrading recall to FTS-only.

## Fix

- Added `effectiveMaxInputChars()` + `capInputs()` helpers in `packages/mnemopi/src/core/embeddings.ts`. `embed()` now right-truncates every input to that cap before any provider sees it. The new array is allocated only when something is actually oversized so the typical short-query path through `embedQuery` still passes the original array reference through unchanged. Each truncation emits one `debug`-or-`warn`-when-`mnemopi.debug` log so the resize is no longer silent (silent failure was the original #3126 symptom).
- Added `MNEMOPI_EMBEDDING_MAX_INPUT_CHARS` env helper in `packages/mnemopi/src/config.ts` (default `32000` ≈ 8k English tokens / 16–32k CJK tokens — fits 8k-context models, raise/lower per model; `0` disables the cap).
- Added `maxInputChars?: number` to `MnemopiEmbeddingRuntimeOptions` / `ResolvedMnemopiEmbeddingRuntimeOptions` (`packages/mnemopi/src/core/runtime-options.ts`) and plumbed it through `resolveRuntimeOptions` in `packages/mnemopi/src/core/memory.ts` so programmatic callers (and the coding-agent settings layer, if a host wants to expose it later) can override the env default per `Mnemopi` instance.
- Added `packages/mnemopi/test/embedding-input-cap.test.ts` covering: default-cap truncation, env override, `0` disables, runtime-option override, and the unchanged-input pass-through.
- CHANGELOG entries under `Unreleased` in `packages/mnemopi` and `packages/coding-agent` so users updating `omp` can see the fix.

## Verification

- `bun --cwd packages/mnemopi run check` — passes.
- `bunx --bun bun test test/embedding-input-cap.test.ts test/embedding-failure-logging.test.ts test/embeddings-multilingual.test.ts test/issue-1832-embedding-population.test.ts test/embedding-model-reconcile.test.ts test/memory-facade.test.ts` (inside `packages/mnemopi`) — 31 pass, 0 fail.
- `bunx --bun bun test test/hindsight-content.test.ts test/memory-tools.test.ts` (inside `packages/coding-agent`) — 64 pass, 0 fail.
- Off-tree probe with a fake llama.cpp-shaped provider: pre-fix overflow → post-fix `ok` (transcript above).

Note: `test/optional-embeddings.test.ts` has two `EACCES /srv/agent-home/.hermes` failures on this sandbox, also present on `main` against the same paths (verified by stashing my diff and re-running) — unrelated to this change.

Fixes #3126