### PR TITLE
feat: add fastcontext bundled subagent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `fastcontext` bundled subagent: a read-only repository explorer that returns structured file:line citations. Port of [Microsoft FastContext](https://github.com/microsoft/fastcontext)'s exploration contract as a native TS subagent profile, reusing the existing `TaskTool` read-only classification, soft-request-budget convergence, and `yield`-enforced output schema. Uses `pi/smol` by default and works with any model — override via `task.agentModelOverrides` or the `model:` field in a task delegation.
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed
@@ -98,7 +102,6 @@
 - Cache-miss marker no longer fires on providers with implicit, best-effort prompt caching (Google/Gemini, OpenAI, Fireworks). Those report `cacheWrite: 0` and drop `cacheRead` to zero intermittently as routine propagation noise that self-heals the next turn. Only explicit, prefix-controlled caches (Anthropic/Bedrock `cache_control`), which re-create the prefix on a cold turn as `cacheWrite > 0`, now surface a marker — where a zero `cacheRead` genuinely means the prefix broke.
 - Fixed advisor dependent settings staying visible while `advisor.enabled` is off ([#3027](https://github.com/can1357/oh-my-pi/issues/3027)).
 - Fixed LSP servers that dynamically register capabilities, including Expert, hanging semantic requests after `client/registerCapability` was rejected ([#3029](https://github.com/can1357/oh-my-pi/issues/3029)).
-
 ## [16.1.0] - 2026-06-19
 
 ### Added

--- a/packages/coding-agent/src/prompts/agents/fastcontext.md
+++ b/packages/coding-agent/src/prompts/agents/fastcontext.md
@@ -1,0 +1,58 @@
+---
+name: fastcontext
+description: Repository explorer that finds relevant code via read-only tools and returns compact file:line citations
+tools: read, search, find
+model: pi/smol
+thinking-level: medium
+read-summarize: false
+output:
+  properties:
+    citations:
+      metadata:
+        description: Relevant file paths with line ranges, in priority order
+      elements:
+        properties:
+          path:
+            metadata:
+              description: Absolute or project-relative file path
+            type: string
+          reason:
+            metadata:
+              description: One-line reason this citation is relevant to the query
+            type: string
+        optionalProperties:
+          lineRange:
+            metadata:
+              description: Line range like "42-58" or single line "42"; omit if whole file is relevant
+            type: string
+    summary:
+      metadata:
+        description: Brief explanation of findings (max 50 words)
+      type: string
+---
+
+You are a codebase exploration specialist focused exclusively on searching and analyzing existing code. Your goal is to explore the repository based on a natural-language query and return precise file-path and line-range citations.
+
+<directives>
+- For file searches: search broadly when you don't know where something lives. Use `read` when you know the specific file path.
+- For analysis: start broad and narrow down. Use multiple search strategies if the first doesn't yield results.
+- Be thorough: check multiple locations, consider different naming conventions, look for related files.
+- You MUST make efficient use of your tools: be smart about how you search for files and implementations.
+- Wherever possible you SHOULD invoke tools in parallel — issue multiple `search`/`find`/`read` calls in a single batch to explore the codebase quickly.
+- If a search returns empty results, you MUST try at least one alternate strategy (different pattern, broader path, alternate naming convention) before concluding the target doesn't exist.
+</directives>
+
+<procedure>
+1. Broad search: use `find` to locate files by glob pattern, `search` for regex pattern matches across the codebase. Run these in parallel.
+2. Narrow read: read the most relevant files/sections once you've located them. NEVER read full files unless they're tiny — use line-range selectors to read only what's relevant.
+3. Cross-reference: check related files (imports, tests, type definitions) to confirm your findings.
+4. Report: call `yield` with structured citations matching the output schema.
+</procedure>
+
+<critical>
+- You MUST operate as read-only. You NEVER write, edit, or modify files, nor execute any state-changing commands.
+- You MUST keep going until complete.
+- Each citation MUST include a `path` and a `reason`. Include `lineRange` when a specific section of a file is the relevant reference; omit it when the whole file is relevant.
+- Order citations by relevance — most important first.
+- The `summary` field MUST be a brief explanation of your findings (no more than 50 words).
+</critical>

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, prompt } from "@oh-my-pi/pi-utils";
 import { parseAgentFields } from "../discovery/helpers";
 import designerMd from "../prompts/agents/designer.md" with { type: "text" };
 import exploreMd from "../prompts/agents/explore.md" with { type: "text" };
+import fastcontextMd from "../prompts/agents/fastcontext.md" with { type: "text" };
 // Embed agent markdown files at build time
 import agentFrontmatterTemplate from "../prompts/agents/frontmatter.md" with { type: "text" };
 import librarianMd from "../prompts/agents/librarian.md" with { type: "text" };
@@ -43,6 +44,7 @@ function buildAgentContent(def: EmbeddedAgentDef): string {
 
 const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
 	{ fileName: "explore.md", template: exploreMd },
+	{ fileName: "fastcontext.md", template: fastcontextMd },
 	{ fileName: "plan.md", template: planMd },
 	{ fileName: "designer.md", template: designerMd },
 	{ fileName: "reviewer.md", template: reviewerMd },

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -82,6 +82,7 @@ const MCP_CALL_TIMEOUT_MS = 60_000;
  */
 export const SOFT_REQUEST_BUDGET: Record<string, number> = {
 	explore: 40,
+	fastcontext: 40,
 	quick_task: 40,
 	default: 90,
 };

--- a/packages/coding-agent/test/tools/fastcontext-e2e.test.ts
+++ b/packages/coding-agent/test/tools/fastcontext-e2e.test.ts
@@ -1,0 +1,180 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadBundledAgents } from "@oh-my-pi/pi-coding-agent/task/agents";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+
+/**
+ * End-to-end test for the fastcontext subagent with real model providers.
+ *
+ * Gated on E2E=1 to avoid running network calls in CI. Requires stored
+ * credentials for the tested provider in ~/.omp/agent/agent.db.
+ *
+ * Run with: E2E=1 bun test test/tools/fastcontext-e2e.test.ts
+ *
+ * Confirms the fastcontext agent works with multiple model families:
+ * - z.ai GLM (anthropic-messages API)
+ * - umans GLM-5.2 (anthropic-messages API)
+ * - OpenAI Codex GPT-5.5 (openai-codex-responses API)
+ */
+
+const E2E = Bun.env.E2E === "1";
+
+// Derive the oh-my-pi repo root from this test file's location so the
+// E2E test works regardless of where the checkout lives.
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+function getAgent(name: string): AgentDefinition {
+	const agents = loadBundledAgents();
+	const agent = agents.find(a => a.name === name);
+	if (!agent) throw new Error(`Agent "${name}" not found in bundled agents`);
+	return agent;
+}
+
+async function createAuthStorage(): Promise<{ auth: AuthStorage; db: Database }> {
+	const dbPath = path.join(os.homedir(), ".omp", "agent", "agent.db");
+	const db = new Database(dbPath, { readonly: true });
+	const store = new SqliteAuthCredentialStore(db);
+	const auth = new AuthStorage(store);
+	await auth.reload();
+	return { auth, db };
+}
+
+describe.skipIf(!E2E)("fastcontext subagent E2E", () => {
+	let auth: AuthStorage;
+	let db: Database;
+	let tempCwd: string;
+
+	beforeEach(async () => {
+		const result = await createAuthStorage();
+		auth = result.auth;
+		db = result.db;
+		tempCwd = path.join(os.tmpdir(), `fastcontext-e2e-${Date.now()}`);
+		await fs.mkdir(tempCwd, { recursive: true });
+	});
+
+	afterEach(async () => {
+		db.close();
+		await fs.rm(tempCwd, { recursive: true, force: true }).catch(() => {});
+	});
+
+	it("runs with z.ai GLM model and yields structured citations", async () => {
+		const zaiKey = await auth.getApiKey("zai");
+		if (!zaiKey) {
+			console.warn("Skipping z.ai E2E: no stored ZAI credential");
+			return;
+		}
+
+		const agent = getAgent("fastcontext");
+		const settings = Settings.isolated({ extensions: [], "mcp.discoveryMode": false });
+
+		const result = await runSubprocess({
+			cwd: REPO_ROOT,
+			agent,
+			task: `Find the function that resolves agent model patterns in the coding-agent package at ${REPO_ROOT}/packages/coding-agent. Return citations.`,
+			assignment: "Find the function that resolves agent model patterns.",
+			index: 0,
+			id: "fastcontext-zai-e2e",
+			modelOverride: ["zai/glm-5-turbo"],
+			settings,
+			enableLsp: false,
+			authStorage: auth,
+			preloadedExtensionPaths: [],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.output).toBeTruthy();
+
+		const parsed = JSON.parse(result.output);
+		expect(parsed).toHaveProperty("citations");
+		expect(parsed).toHaveProperty("summary");
+		expect(Array.isArray(parsed.citations)).toBe(true);
+		expect(parsed.citations.length).toBeGreaterThan(0);
+
+		const firstCitation = parsed.citations[0];
+		expect(firstCitation).toHaveProperty("path");
+		expect(firstCitation).toHaveProperty("reason");
+		expect(typeof firstCitation.path).toBe("string");
+		expect(typeof firstCitation.reason).toBe("string");
+	}, 120000);
+
+	it("runs with umans GLM-5.2 model and yields structured citations", async () => {
+		const umansKey = await auth.getApiKey("umans");
+		if (!umansKey) {
+			console.warn("Skipping umans E2E: no stored umans credential");
+			return;
+		}
+
+		const agent = getAgent("fastcontext");
+		const settings = Settings.isolated({ extensions: [], "mcp.discoveryMode": false });
+
+		const result = await runSubprocess({
+			cwd: REPO_ROOT,
+			agent,
+			task: `Find the SOFT_REQUEST_BUDGET constant in the task executor at ${REPO_ROOT}/packages/coding-agent. Return citations.`,
+			assignment: "Find the SOFT_REQUEST_BUDGET constant.",
+			index: 0,
+			id: "fastcontext-umans-e2e",
+			modelOverride: ["umans/umans-glm-5.2"],
+			settings,
+			enableLsp: false,
+			authStorage: auth,
+			preloadedExtensionPaths: [],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.output).toBeTruthy();
+
+		const parsed = JSON.parse(result.output);
+		expect(parsed).toHaveProperty("citations");
+		expect(parsed).toHaveProperty("summary");
+		expect(Array.isArray(parsed.citations)).toBe(true);
+		expect(parsed.citations.length).toBeGreaterThan(0);
+	}, 120000);
+
+	it("runs with OpenAI Codex GPT-5.5 model and yields structured citations", async () => {
+		const codexKey = await auth.getApiKey("openai-codex");
+		if (!codexKey) {
+			console.warn("Skipping OpenAI Codex E2E: no stored credential");
+			return;
+		}
+
+		const agent = getAgent("fastcontext");
+		const settings = Settings.isolated({ extensions: [], "mcp.discoveryMode": false });
+
+		const result = await runSubprocess({
+			cwd: REPO_ROOT,
+			agent,
+			task: `Find the parseAgentFields function in the coding-agent package at ${REPO_ROOT}/packages/coding-agent. Return citations.`,
+			assignment: "Find the parseAgentFields function.",
+			index: 0,
+			id: "fastcontext-codex-e2e",
+			modelOverride: ["openai-codex/gpt-5.5"],
+			settings,
+			enableLsp: false,
+			authStorage: auth,
+			preloadedExtensionPaths: [],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.output).toBeTruthy();
+
+		const parsed = JSON.parse(result.output);
+		expect(parsed).toHaveProperty("citations");
+		expect(parsed).toHaveProperty("summary");
+		expect(Array.isArray(parsed.citations)).toBe(true);
+		expect(parsed.citations.length).toBeGreaterThan(0);
+
+		const firstCitation = parsed.citations[0];
+		expect(firstCitation).toHaveProperty("path");
+		expect(firstCitation).toHaveProperty("reason");
+	}, 120000);
+});

--- a/packages/coding-agent/test/tools/fastcontext-model-agnostic.test.ts
+++ b/packages/coding-agent/test/tools/fastcontext-model-agnostic.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelLookupRegistry } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { resolveAgentModelPatterns, resolveModelOverride } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { isReadOnlyAgent } from "@oh-my-pi/pi-coding-agent/task";
+import { loadBundledAgents } from "@oh-my-pi/pi-coding-agent/task/agents";
+
+/**
+ * Integration test proving the fastcontext subagent is model-agnostic:
+ * its default model is a role (`pi/smol`), and runtime overrides resolve
+ * to any provider's model — z.ai GLM, OpenAI GPT, etc.
+ *
+ * No network calls. Exercises the model-resolution pipeline only.
+ */
+
+function makeModel(provider: string, id: string, api: Api = "anthropic-messages"): Model<Api> {
+	return buildModel({
+		provider,
+		id,
+		name: id,
+		api,
+		baseUrl: `https://${provider}.example.test`,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	});
+}
+
+function makeRegistry(models: Model<Api>[]): ModelLookupRegistry {
+	return {
+		getAvailable: () => models,
+	} as unknown as ModelLookupRegistry;
+}
+
+describe("fastcontext subagent model-agnosticism", () => {
+	it("uses pi/smol as default model (a role, not a hardcoded provider)", () => {
+		const agents = loadBundledAgents();
+		const fc = agents.find(a => a.name === "fastcontext");
+		expect(fc).toBeDefined();
+		expect(fc!.model).toEqual(["pi/smol"]);
+		expect(fc!.model![0]).not.toMatch(/^(openai|zai|anthropic|google)\//);
+	});
+
+	it("is classified as read-only with verbatim reads", () => {
+		const agents = loadBundledAgents();
+		const fc = agents.find(a => a.name === "fastcontext")!;
+		expect(isReadOnlyAgent(fc)).toBe(true);
+		expect(fc.readSummarize).toBe(false);
+		expect(fc.tools).toEqual(["read", "search", "find", "yield"]);
+	});
+
+	it("resolves z.ai GLM model override without error", () => {
+		const zaiModel = makeModel("zai", "glm-5-turbo");
+		const registry = makeRegistry([zaiModel]);
+		const settings = Settings.isolated();
+
+		const patterns = resolveAgentModelPatterns({
+			settingsOverride: "zai/glm-5-turbo",
+			agentModel: ["pi/smol"],
+			settings,
+			activeModelPattern: "zai/glm-5-turbo",
+			fallbackModelPattern: "zai/glm-5-turbo",
+		});
+		expect(patterns).toEqual(["zai/glm-5-turbo"]);
+
+		const result = resolveModelOverride(patterns, registry, settings);
+		expect(result.model).toBeDefined();
+		expect(result.model!.provider).toBe("zai");
+		expect(result.model!.id).toBe("glm-5-turbo");
+	});
+
+	it("resolves OpenAI GPT model override without error", () => {
+		const gptModel = makeModel("openai", "gpt-5.5", "openai-responses");
+		const registry = makeRegistry([gptModel]);
+		const settings = Settings.isolated();
+
+		const patterns = resolveAgentModelPatterns({
+			settingsOverride: "openai/gpt-5.5",
+			agentModel: ["pi/smol"],
+			settings,
+			activeModelPattern: "openai/gpt-5.5",
+			fallbackModelPattern: "openai/gpt-5.5",
+		});
+		expect(patterns).toEqual(["openai/gpt-5.5"]);
+
+		const result = resolveModelOverride(patterns, registry, settings);
+		expect(result.model).toBeDefined();
+		expect(result.model!.provider).toBe("openai");
+		expect(result.model!.id).toBe("gpt-5.5");
+	});
+
+	it("resolves openai-codex GPT model override without error", () => {
+		const codexModel = makeModel("openai-codex", "gpt-5.5", "openai-codex-responses");
+		const registry = makeRegistry([codexModel]);
+		const settings = Settings.isolated();
+
+		const patterns = resolveAgentModelPatterns({
+			settingsOverride: "openai-codex/gpt-5.5",
+			agentModel: ["pi/smol"],
+			settings,
+			activeModelPattern: "openai-codex/gpt-5.5",
+			fallbackModelPattern: "openai-codex/gpt-5.5",
+		});
+		expect(patterns).toEqual(["openai-codex/gpt-5.5"]);
+
+		const result = resolveModelOverride(patterns, registry, settings);
+		expect(result.model).toBeDefined();
+		expect(result.model!.provider).toBe("openai-codex");
+		expect(result.model!.id).toBe("gpt-5.5");
+	});
+
+	it("falls back to agent model when no override is provided", () => {
+		const settings = Settings.isolated();
+		const patterns = resolveAgentModelPatterns({
+			agentModel: ["pi/smol"],
+			settings,
+			activeModelPattern: "zai/glm-5-turbo",
+			fallbackModelPattern: "zai/glm-5-turbo",
+		});
+		expect(patterns.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
+++ b/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
@@ -27,20 +27,22 @@ describe("task agent capability descriptions", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("classifies bundled explore as the only read-only delegated agent", () => {
+	it("classifies bundled explore and fastcontext as read-only delegated agents", () => {
 		const agents = loadBundledAgents();
 
 		expect(isReadOnlyAgent(agentByName(agents, "explore"))).toBe(true);
+		expect(isReadOnlyAgent(agentByName(agents, "fastcontext"))).toBe(true);
 		for (const name of ["task", "quick_task", "plan", "reviewer", "oracle", "designer"]) {
 			expect(isReadOnlyAgent(agentByName(agents, name))).toBe(false);
 		}
 	});
 
-	it("disables read summarization for explore and librarian, leaves other agents summarizing", () => {
+	it("disables read summarization for explore, librarian, and fastcontext", () => {
 		const agents = loadBundledAgents();
 
 		expect(agentByName(agents, "explore").readSummarize).toBe(false);
 		expect(agentByName(agents, "librarian").readSummarize).toBe(false);
+		expect(agentByName(agents, "fastcontext").readSummarize).toBe(false);
 		for (const name of ["task", "quick_task", "plan", "reviewer", "oracle", "designer"]) {
 			expect(agentByName(agents, name).readSummarize).toBeUndefined();
 		}


### PR DESCRIPTION
## Summary

Native TS port of [Microsoft FastContext](https://github.com/microsoft/fastcontext)'s exploration contract as a read-only repository explorer subagent for oh-my-pi.

FastContext's contract is a read-only subagent with `read`/`glob`/`grep` tools that explores a repo on a natural-language query and returns compact file-path:line-range citations. The main agent delegates exploration to it, keeping exploratory reads/searches out of the solver's context window. This port reuses oh-my-pi's existing `TaskTool` infrastructure — read-only classification, per-agent model overrides, JTD output schemas enforced by the `yield` tool, and soft-request-budget steer-then-abort for convergence.

## Model-agnostic by design

The agent uses `model: pi/smol` (a role alias), not a hardcoded provider. It works with **any** model the user configures — z.ai GLM, OpenAI GPT, Anthropic Claude, Google Gemini, etc. — via runtime model overrides (`task.agentModelOverrides` or the `model:` field in a task delegation).

## E2E verified with three model families

All three providers produced structured citations (`{path, lineRange, reason}` + `summary`) through real API calls:

| Provider | Model | API | Result |
|---|---|---|---|
| z.ai | GLM-5-Turbo | anthropic-messages | ✅ citations yielded |
| Umans | GLM-5.2 | anthropic-messages | ✅ citations yielded |
| OpenAI Codex | GPT-5.5 | openai-codex-responses | ✅ citations yielded |

## Changes

- **New prompt** (`src/prompts/agents/fastcontext.md`): System prompt with `model: pi/smol`, `tools: read, search, find`, `read-summarize: false`, and a JTD output schema with `citations` (array of `{path, lineRange, reason}`) + `summary` fields.
- **Agent registration** (`src/task/agents.ts`): Import + `EMBEDDED_AGENT_DEFS` entry.
- **Soft request budget** (`src/task/executor.ts`): `fastcontext: 40` in `SOFT_REQUEST_BUDGET` — matches `explore` agent budget for steer-then-abort convergence.
- **Capabilities test** (`test/tools/task-agent-capabilities.test.ts`): Updated to assert fastcontext is read-only and has `readSummarize: false`.
- **Integration test** (`test/tools/fastcontext-model-agnostic.test.ts`): CI-runnable, no network — asserts `pi/smol` default, read-only classification, and that `zai/glm-5-turbo`, `openai/gpt-5.5`, and `openai-codex/gpt-5.5` all resolve via `resolveAgentModelPatterns` without error.
- **E2E test** (`test/tools/fastcontext-e2e.test.ts`): `E2E=1` gated — runs the full subagent loop with real model providers and asserts structured citation output.
- **Changelog**: Entry under `[Unreleased]`.

## Test plan

- [x] `bun run check` — typecheck + lint pass
- [x] `bun test ./test/tools/fastcontext-model-agnostic.test.ts` — 6/6 pass (no network)
- [x] `bun test ./test/tools/task-agent-capabilities.test.ts` — 3/3 pass
- [x] `E2E=1 bun test ./test/tools/fastcontext-e2e.test.ts` — 3/3 pass (z.ai, umans, OpenAI Codex)
- [x] `bun run format-prompts` — all formatted