### PR TITLE
fix(tiny): stop respawning failed local model workers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local tiny-model inference failures respawning `__omp_worker_tiny_inference` for the same failed model, and blocked the unsupported Qwen3 1.7B ONNX memory model before load. ([#3132](https://github.com/can1357/oh-my-pi/issues/3132))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/tiny/models.ts
+++ b/packages/coding-agent/src/tiny/models.ts
@@ -12,6 +12,8 @@ export interface TinyTitleLocalModelSpec {
 	contextNote: string;
 	/** Model family emits hidden reasoning unless the chat template disables it. */
 	reasoning?: boolean;
+	/** Reason this model is blocked before loading the ONNX runtime. */
+	unsupportedReason?: string;
 }
 
 export const TINY_TITLE_LOCAL_MODELS = [
@@ -108,7 +110,7 @@ export function getTinyTitleModelSpec(key: TinyTitleLocalModelKey): (typeof TINY
 /** Default memory model: the online path (the configured smol / remote LLM; no local download). */
 export const ONLINE_MEMORY_MODEL_KEY = "online";
 /** Recommended local model for memory tasks when none is named. */
-export const DEFAULT_MEMORY_LOCAL_MODEL_KEY = "qwen3-1.7b";
+export const DEFAULT_MEMORY_LOCAL_MODEL_KEY = "lfm2-1.2b";
 
 /**
  * Local models for Mnemopi memory tasks (fact extraction + consolidation).
@@ -123,9 +125,11 @@ export const TINY_MEMORY_LOCAL_MODELS = [
 		dtype: "q4",
 		label: "Qwen3 1.7B",
 		description:
-			"Recommended; most disciplined extraction (ignores chit-chat), good consolidation, about 1.1 GB cached.",
-		contextNote: "Best single-model pick for memory from the local experiment.",
+			"Disabled for local inference: onnxruntime-node cannot run this ONNX export's RotaryEmbedding cache updates.",
+		contextNote: "Blocked before load to avoid the unsupported RotaryEmbedding runtime path.",
 		reasoning: true,
+		unsupportedReason:
+			"onnxruntime-node does not support Qwen3 RotaryEmbedding cache updates in onnx-community/Qwen3-1.7B-ONNX",
 	},
 	{
 		key: "gemma-3-1b",

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -497,7 +497,6 @@ export class TinyTitleClient {
 	#handleWorkerError(error: Error): void {
 		logger.warn("tiny-title: worker error", { error: error.message });
 		for (const pending of this.#pending.values()) {
-			this.#markFailedModel(pending);
 			this.#emitProgress({ modelKey: pending.modelKey, status: "error" });
 			if (pending.kind === "generate" || pending.kind === "complete") pending.resolve(null);
 			else pending.resolve(false);

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -296,6 +296,7 @@ export class TinyTitleClient {
 	#unsubscribeMessage: (() => void) | null = null;
 	#unsubscribeError: (() => void) | null = null;
 	#pending = new Map<string, PendingRequest>();
+	#failedModels = new Set<TinyLocalModelKey>();
 	#progressListeners = new Set<(event: TinyTitleProgressEvent) => void>();
 	#nextRequestId = 0;
 	#spawnWorker: () => WorkerHandle;
@@ -318,7 +319,7 @@ export class TinyTitleClient {
 	): Promise<string | null> {
 		const options = normalizeTinyTitleGenerateOptions(optionsOrSignal);
 		if (!isTinyTitleLocalModelKey(modelKey)) return null;
-		if (options.signal?.aborted) return null;
+		if (options.signal?.aborted || this.#failedModels.has(modelKey)) return null;
 
 		try {
 			const worker = this.#ensureWorker();
@@ -357,7 +358,7 @@ export class TinyTitleClient {
 		options: { maxTokens?: number; signal?: AbortSignal } = {},
 	): Promise<string | null> {
 		if (!isTinyMemoryLocalModelKey(modelKey)) return null;
-		if (options.signal?.aborted) return null;
+		if (options.signal?.aborted || this.#failedModels.has(modelKey)) return null;
 
 		try {
 			const worker = this.#ensureWorker();
@@ -478,10 +479,15 @@ export class TinyTitleClient {
 			return;
 		}
 		logger.debug("tiny-title: worker returned error", { error: message.error });
+		this.#markFailedModel(pending);
 		this.#emitProgress({ modelKey: pending.modelKey, status: "error" });
 		if (pending.kind === "generate" || pending.kind === "complete") pending.resolve(null);
 		else pending.resolve(false);
 		void this.terminate();
+	}
+
+	#markFailedModel(pending: PendingRequest): void {
+		if (pending.kind === "generate" || pending.kind === "complete") this.#failedModels.add(pending.modelKey);
 	}
 
 	#emitProgress(event: TinyTitleProgressEvent): void {
@@ -491,6 +497,7 @@ export class TinyTitleClient {
 	#handleWorkerError(error: Error): void {
 		logger.warn("tiny-title: worker error", { error: error.message });
 		for (const pending of this.#pending.values()) {
+			this.#markFailedModel(pending);
 			this.#emitProgress({ modelKey: pending.modelKey, status: "error" });
 			if (pending.kind === "generate" || pending.kind === "complete") pending.resolve(null);
 			else pending.resolve(false);

--- a/packages/coding-agent/src/tiny/worker.ts
+++ b/packages/coding-agent/src/tiny/worker.ts
@@ -317,6 +317,7 @@ async function loadPipeline(
 ): Promise<TextGenerationPipeline> {
 	const spec = getTinyLocalModelSpec(modelKey);
 	if (!spec) throw new Error(`Unknown tiny local model: ${modelKey}`);
+	if (spec.unsupportedReason) throw new Error(`${modelKey} is unavailable: ${spec.unsupportedReason}`);
 	const cached = pipelines.get(modelKey);
 	if (cached) {
 		void cached

--- a/packages/coding-agent/test/issue-1940-repro.test.ts
+++ b/packages/coding-agent/test/issue-1940-repro.test.ts
@@ -5,6 +5,7 @@ import type { TinyTitleWorkerInbound, TinyTitleWorkerOutbound } from "@oh-my-pi/
 class FakeTinyWorker {
 	terminated = false;
 	#messageHandlers = new Set<(message: TinyTitleWorkerOutbound) => void>();
+	#errorHandlers = new Set<(error: Error) => void>();
 	#onSend: (message: TinyTitleWorkerInbound, worker: FakeTinyWorker) => void;
 
 	constructor(onSend: (message: TinyTitleWorkerInbound, worker: FakeTinyWorker) => void) {
@@ -20,8 +21,9 @@ class FakeTinyWorker {
 		return () => this.#messageHandlers.delete(handler);
 	}
 
-	onError(): () => void {
-		return () => {};
+	onError(handler: (error: Error) => void): () => void {
+		this.#errorHandlers.add(handler);
+		return () => this.#errorHandlers.delete(handler);
 	}
 
 	async terminate(): Promise<void> {
@@ -30,6 +32,10 @@ class FakeTinyWorker {
 
 	emit(message: TinyTitleWorkerOutbound): void {
 		for (const handler of this.#messageHandlers) handler(message);
+	}
+
+	emitError(error: Error): void {
+		for (const handler of this.#errorHandlers) handler(error);
 	}
 }
 
@@ -101,6 +107,37 @@ describe("issue #1940 — local model failures release the worker process", () =
 			expect(await first).toBeNull();
 			expect(await second).toBeNull();
 			expect(worker.terminated).toBe(true);
+		} finally {
+			await client.terminate();
+		}
+	});
+
+	it("does not suppress unrelated queued models after a worker crash", async () => {
+		const first = new FakeTinyWorker(() => {});
+		const second = new FakeTinyWorker((message, worker) => {
+			if (message.type === "generate") {
+				worker.emit({ type: "title", id: message.id, title: "recovered title" });
+			}
+		});
+		const workers = [first, second];
+		let nextWorker = 0;
+		const client = new TinyTitleClient(() => {
+			const worker = workers[nextWorker];
+			if (!worker) throw new Error("unexpected worker spawn");
+			nextWorker += 1;
+			return worker;
+		});
+
+		try {
+			const crashedMemory = client.complete("qwen3-1.7b", "first prompt");
+			const queuedTitle = client.generate("lfm2-350m", "title prompt");
+			first.emitError(new Error("tiny model subprocess exited with signal SIGKILL"));
+
+			expect(await crashedMemory).toBeNull();
+			expect(await queuedTitle).toBeNull();
+			expect(first.terminated).toBe(true);
+			expect(await client.generate("lfm2-350m", "retry title")).toBe("recovered title");
+			expect(nextWorker).toBe(2);
 		} finally {
 			await client.terminate();
 		}

--- a/packages/coding-agent/test/issue-1940-repro.test.ts
+++ b/packages/coding-agent/test/issue-1940-repro.test.ts
@@ -63,31 +63,23 @@ describe("tiny title client prompt options", () => {
 });
 
 describe("issue #1940 — local model failures release the worker process", () => {
-	it("recycles the tiny-model worker after model execution returns an error", async () => {
+	it("releases the failed worker and suppresses repeated local model attempts", async () => {
 		const first = new FakeTinyWorker((message, worker) => {
 			if (message.type === "complete") {
 				worker.emit({ type: "error", id: message.id, error: "Error: Unknown failure" });
 			}
 		});
-		const second = new FakeTinyWorker((message, worker) => {
-			if (message.type === "complete") {
-				worker.emit({ type: "completion", id: message.id, text: "recovered" });
-			}
-		});
-		const workers = [first, second];
-		let nextWorker = 0;
+		let spawnCount = 0;
 		const client = new TinyTitleClient(() => {
-			const worker = workers[nextWorker];
-			if (!worker) throw new Error("unexpected worker spawn");
-			nextWorker += 1;
-			return worker;
+			spawnCount += 1;
+			return first;
 		});
 
 		try {
 			expect(await client.complete("qwen3-1.7b", "long prompt")).toBeNull();
 			expect(first.terminated).toBe(true);
-			expect(await client.complete("qwen3-1.7b", "retry prompt")).toBe("recovered");
-			expect(nextWorker).toBe(2);
+			expect(await client.complete("qwen3-1.7b", "retry prompt")).toBeNull();
+			expect(spawnCount).toBe(1);
 		} finally {
 			await client.terminate();
 		}


### PR DESCRIPTION
## Repro
A focused regression test reproduced the loop without downloading the 2GB model: `bun test packages/coding-agent/test/issue-1940-repro.test.ts --test-name-pattern "suppresses repeated local model attempts"` failed because `TinyTitleClient.complete("qwen3-1.7b", ...)` spawned a second `__omp_worker_tiny_inference` after the first worker returned an inference error.

## Cause
`packages/coding-agent/src/tiny/title-client.ts` terminated the failed subprocess on a worker error, but did not remember that the requested local model had failed, so the next memory extraction call immediately created another worker for the same model. `packages/coding-agent/src/tiny/worker.ts` also treated every listed local model as loadable, so `qwen3-1.7b` reached the unsupported `onnxruntime-node` RotaryEmbedding path instead of failing before model load.

## Fix
- Remember failed local title/memory model keys in `TinyTitleClient` and return `null` for repeat requests instead of respawning the worker.
- Mark `qwen3-1.7b` as unsupported in the tiny memory model registry, move the local memory fallback constant to `lfm2-1.2b`, and fail before loading transformers when a model has an unsupported runtime reason.
- Update the existing worker-release regression test to cover the no-respawn contract.

## Verification
`bun test packages/coding-agent/test/issue-1940-repro.test.ts packages/coding-agent/test/tiny-title-generator.test.ts packages/coding-agent/test/auto-thinking-classifier.test.ts` passed with 28 tests. `bun check` passed. Fixes #3132