### PR TITLE
fix(ai): retry transient Anthropic TLS errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic Messages retry classification for transient TLS/server-error failures such as `tls: bad record MAC (type=server_error)`. These pre-content transport blips are now retried inside the provider loop before the session sees an error banner.
+
 ## [16.1.4] - 2026-06-19
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1501,7 +1501,7 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	const msg = error.message.toLowerCase();
 	if (
 		isUnexpectedSocketCloseMessage(msg) ||
-		/rate.?limit|too many requests|overloaded|service.?unavailable|internal_error|stream error.*received from peer|1302|timed?\s*out while waiting for the first event|timeout waiting for first/i.test(
+		/rate.?limit|too many requests|overloaded|service.?unavailable|internal_error|server_error|bad record mac|stream error.*received from peer|1302|timed?\s*out while waiting for the first event|timeout waiting for first/i.test(
 			msg,
 		) ||
 		isTransientStreamParseError(error) ||

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -460,6 +460,50 @@ describe("anthropic provider retry delays", () => {
 		expect(result.content).toEqual([{ type: "text", text: "after backoff" }]);
 	});
 
+	it("retries transient TLS server errors before surfacing them to the session", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			if (attempt === 1) {
+				return createRejectedAnthropicRequest(
+					new Error(
+						'Post "https://api.anthropic.com/v1/messages?beta=true": remote error: tls: bad record MAC (type=server_error)',
+					),
+				) as never;
+			}
+			return createAnthropicMockStream({
+				signal: requestOptions?.signal,
+				events: createSuccessfulAnthropicEvents("recovered from tls retry"),
+			}) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async (_delayMs: number, _signal: AbortSignal | undefined) => {});
+
+		const result = await streamAnthropic(model, context, { client, providerRetryWait }).result();
+
+		expect(attempt).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledTimes(1);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "recovered from tls retry" }]);
+	});
+
+	it("does not retry permanent TLS configuration failures", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(new Error("tls: failed to verify certificate")) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async (_delayMs: number, _signal: AbortSignal | undefined) => {});
+
+		const result = await streamAnthropic(model, context, { client, providerRetryWait }).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("tls: failed to verify certificate");
+	});
+
 	it("retries 502s ten times with Anthropic-style capped backoff", async () => {
 		vi.spyOn(Math, "random").mockReturnValue(0);
 		let attempt = 0;


### PR DESCRIPTION
## What

Fixes the Anthropic Messages provider retry classifier so pre-content TLS/server transport failures like:

```shell
Post "https://api.anthropic.com/v1/messages?beta=true": remote error: tls: bad record MAC (type=server_error)
```

are treated as retryable provider errors instead of surfacing immediately to the session.

Adds regression coverage proving the first request can throw that transport error, the provider retry wait runs once, and the second request can complete normally. Also pins permanent TLS configuration failures, such as certificate verification errors, as non-retryable.

## Why

Fixes #3134.

This is a narrow follow-up to the existing Anthropic provider retry loop work. Prior-art checks found no exact existing issue/PR for `bad record MAC` or Anthropic `tls:` / `server_error` retry classification. Closest related work was #637, which hardened Anthropic stream retries but did not cover this transport signature, plus broader provider-failure fallback work in #2912.

The failure is transient and happens before replay-unsafe content is streamed, so keeping it inside the provider retry loop avoids a noisy error banner while preserving the existing behavior of surfacing the error if retries are exhausted.

## Testing

From `packages/ai`:

```shell
bun test test/anthropic-stream-timeout.test.ts
bun run check
```

Changelog updated in `packages/ai/CHANGELOG.md` under `## [Unreleased]`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
