### PR TITLE
fix(ai): retry Anthropic TLS server transport errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic Messages pre-content TLS `bad record MAC` server transport errors surfacing before the provider retry loop exhausts its budget. ([#3134](https://github.com/can1357/oh-my-pi/issues/3134))
+
 ## [16.1.4] - 2026-06-19
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1485,6 +1485,10 @@ function isProviderRetryableStreamEnvelopeError(error: unknown): boolean {
 	return /stream event order|before message_start/i.test(error.message);
 }
 
+function isAnthropicTransientTransportMessage(message: string): boolean {
+	return message.includes("tls: bad record mac") || message.includes("type=server_error");
+}
+
 export function isProviderRetryableError(error: unknown, provider?: string): boolean {
 	if (!(error instanceof Error)) return false;
 	if (provider === "github-copilot" && isCopilotTransientModelError(error)) return true;
@@ -1501,6 +1505,7 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	const msg = error.message.toLowerCase();
 	if (
 		isUnexpectedSocketCloseMessage(msg) ||
+		isAnthropicTransientTransportMessage(msg) ||
 		/rate.?limit|too many requests|overloaded|service.?unavailable|internal_error|stream error.*received from peer|1302|timed?\s*out while waiting for the first event|timeout waiting for first/i.test(
 			msg,
 		) ||

--- a/packages/ai/test/anthropic-retry.test.ts
+++ b/packages/ai/test/anthropic-retry.test.ts
@@ -34,6 +34,17 @@ describe("isProviderRetryableError", () => {
 		).toBe(true);
 	});
 
+	it("retries Anthropic TLS server transport errors", () => {
+		expect(
+			isProviderRetryableError(
+				new Error(
+					'Post "https://api.anthropic.com/v1/messages?beta=true": remote error: tls: bad record MAC (type=server_error)',
+				),
+				"anthropic",
+			),
+		).toBe(true);
+	});
+
 	it("retries Bun socket closure errors", () => {
 		expect(
 			isProviderRetryableError(


### PR DESCRIPTION
## Repro
`bun -e 'import { isProviderRetryableError } from "./packages/ai/src/providers/anthropic.ts"; const err = new Error("Post \"https://api.anthropic.com/v1/messages?beta=true\": remote error: tls: bad record MAC (type=server_error)"); const retryable = isProviderRetryableError(err, "anthropic"); console.log(`retryable=${retryable}`); if (!retryable) process.exit(1);'` returned `retryable=false` before the fix, matching the reported pre-content Anthropic transport error escaping the provider retry classifier.

## Cause
`packages/ai/src/providers/anthropic.ts` only treated socket closes, rate limits, overloads, `internal_error`, peer HTTP/2 stream errors, and first-event timeouts as provider-retryable. The reported Anthropic Messages transport signature contains `tls: bad record MAC` and `(type=server_error)`, so `isProviderRetryableError()` returned `false` and the pre-content stream loop surfaced it instead of retrying.

## Fix
- Added Anthropic transport-message classification for TLS `bad record MAC` and `type=server_error` before the generic retry fallback.
- Added a regression test pinning the reported Messages API error string as retryable.
- Added a `packages/ai` changelog entry for the fix.

## Verification
`bun test packages/ai/test/anthropic-retry.test.ts` passed with 10 tests / 20 assertions. The repro command now returns `retryable=true`. `gh_push_branch` completed the repository pre-publish gate and pushed `farm/ca022409/anthropic-tls-retry`. Fixes #3134