### PR TITLE
fix(hashline): respect multi-hunk delimiter balance

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed delimiter-balance repair so a valid multi-hunk replacement that deletes an opener in a separate hunk does not keep the matching deleted closer. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
+- Fixed delimiter-balance repair so a multi-hunk patch no longer keeps a deleted closer when another hunk has already balanced the imbalance (e.g. a `DEL` of the matching opener); the closer-spare decision now uses the patch delta computed after the local boundary/duplicate repairs have settled. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
 
 ## [16.1.2] - 2026-06-19
 

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed delimiter-balance repair so a valid multi-hunk replacement that deletes an opener in a separate hunk does not keep the matching deleted closer. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
+
 ## [16.1.2] - 2026-06-19
 
 ### Changed

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed delimiter-balance repair so a multi-hunk patch no longer keeps a deleted closer when another hunk has already balanced the imbalance (e.g. a `DEL` of the matching opener); the closer-spare decision now uses the patch delta computed after the local boundary/duplicate repairs have settled. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
+- Fixed delimiter-balance repair so a multi-hunk patch no longer keeps a deleted closer when another hunk has already balanced the imbalance (e.g. a `DEL` of the matching opener); the closer-spare decision now uses the patch delta computed after local boundary/duplicate repairs, consumes that residual per accepted closer repair, and treats adjacent deleted opener prefixes as wrapper removals. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
 
 ## [16.1.2] - 2026-06-19
 

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed delimiter-balance repair so a multi-hunk patch no longer keeps a deleted closer when another hunk has already balanced the imbalance (e.g. a `DEL` of the matching opener); the closer-spare decision now uses the patch delta computed after local boundary/duplicate repairs, consumes that residual per accepted closer repair, and treats adjacent deleted opener prefixes as wrapper removals. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
+- Fixed delimiter-balance repair so a multi-hunk patch no longer keeps a deleted closer when another hunk has already balanced the imbalance (e.g. a `DEL` of the matching opener); the closer-spare decision now uses the patch delta computed after local boundary/duplicate repairs, consumes that residual per accepted closer repair, and nets adjacent prefix replacements before treating opener removal as a wrapper-removal signal. ([#3142](https://github.com/can1357/oh-my-pi/issues/3142))
 
 ## [16.1.2] - 2026-06-19
 

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -312,6 +312,32 @@ function balanceIsZero(a: DelimiterBalance): boolean {
 	return a.paren === 0 && a.bracket === 0 && a.brace === 0;
 }
 
+function balanceComponentCovers(candidate: number, target: number): boolean {
+	if (target === 0) return true;
+	return candidate > 0 === target > 0 && Math.abs(candidate) >= Math.abs(target);
+}
+
+function balanceCovers(candidate: DelimiterBalance, target: DelimiterBalance): boolean {
+	return (
+		balanceComponentCovers(candidate.paren, target.paren) &&
+		balanceComponentCovers(candidate.bracket, target.bracket) &&
+		balanceComponentCovers(candidate.brace, target.brace)
+	);
+}
+
+function computeEditBalanceDelta(edits: readonly AppliedEdit[], fileLines: readonly string[]): DelimiterBalance {
+	const inserted: string[] = [];
+	const deleted: string[] = [];
+	for (const edit of edits) {
+		if (edit.kind === "insert") {
+			inserted.push(edit.text);
+		} else {
+			deleted.push(fileLines[edit.anchor.line - 1] ?? "");
+		}
+	}
+	return balanceDelta(computeDelimiterBalance(inserted), computeDelimiterBalance(deleted));
+}
+
 interface ReplacementGroup {
 	/** Positions in the edit array of the payload inserts, in payload order. */
 	insertIndices: number[];
@@ -601,6 +627,7 @@ function repairReplacementBoundaries(
 } {
 	const out: AppliedEdit[] = [];
 	const warnings: string[] = [];
+	const patchDelta = computeEditBalanceDelta(edits, fileLines);
 	let i = 0;
 	while (i < edits.length) {
 		const group = findReplacementGroup(edits, i);
@@ -661,7 +688,7 @@ function repairReplacementBoundaries(
 			out.push(...inserts.slice(dupPrefix), ...deletes);
 			continue;
 		}
-		const droppedClosers = findDroppedSuffixClosers(group, fileLines, delta);
+		const droppedClosers = balanceCovers(patchDelta, delta) ? findDroppedSuffixClosers(group, fileLines, delta) : 0;
 		if (droppedClosers > 0) {
 			warnings.push(
 				describeBoundaryRepair(

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -625,14 +625,27 @@ function repairReplacementBoundaries(
 	edits: AppliedEdit[];
 	warnings: string[];
 } {
-	const out: AppliedEdit[] = [];
-	const warnings: string[] = [];
-	const patchDelta = computeEditBalanceDelta(edits, fileLines);
+	type RepairSlot =
+		| { kind: "edits"; edits: AppliedEdit[]; warning?: string }
+		| {
+				kind: "candidate";
+				group: ReplacementGroup;
+				inserts: AppliedEdit[];
+				deletes: AppliedEdit[];
+				delta: DelimiterBalance;
+		  };
+
+	// Pass 1: walk the edit stream once. Apply every repair whose correctness
+	// is local to its group (boundary echo, dup suffix/prefix, one-sided echo).
+	// Defer the dropped-closer repair: it must compare its group's imbalance
+	// against the whole patch's residual balance, which is only known once the
+	// local repairs above have settled.
+	const slots: RepairSlot[] = [];
 	let i = 0;
 	while (i < edits.length) {
 		const group = findReplacementGroup(edits, i);
 		if (!group) {
-			out.push(edits[i]);
+			slots.push({ kind: "edits", edits: [edits[i]] });
 			i++;
 			continue;
 		}
@@ -642,8 +655,11 @@ function repairReplacementBoundaries(
 
 		const boundaryEcho = findBoundaryEcho(group, fileLines);
 		if (boundaryEcho) {
-			warnings.push(describeBoundaryEchoRepair(group, boundaryEcho));
-			out.push(...inserts.slice(boundaryEcho.leading, inserts.length - boundaryEcho.trailing), ...deletes);
+			slots.push({
+				kind: "edits",
+				edits: [...inserts.slice(boundaryEcho.leading, inserts.length - boundaryEcho.trailing), ...deletes],
+				warning: describeBoundaryEchoRepair(group, boundaryEcho),
+			});
 			continue;
 		}
 
@@ -654,52 +670,83 @@ function repairReplacementBoundaries(
 		if (balanceIsZero(delta)) {
 			const oneSided = findOneSidedBoundaryEcho(group, fileLines);
 			if (oneSided) {
-				warnings.push(describeOneSidedEchoRepair(group, oneSided.side, oneSided.count));
 				const trimmed =
 					oneSided.side === "leading"
 						? inserts.slice(oneSided.count)
 						: inserts.slice(0, inserts.length - oneSided.count);
-				out.push(...trimmed, ...deletes);
+				slots.push({
+					kind: "edits",
+					edits: [...trimmed, ...deletes],
+					warning: describeOneSidedEchoRepair(group, oneSided.side, oneSided.count),
+				});
 				continue;
 			}
-			out.push(...inserts, ...deletes);
+			slots.push({ kind: "edits", edits: [...inserts, ...deletes] });
 			continue;
 		}
 
 		const dupSuffix = findDuplicateSuffix(group, fileLines, delta);
 		if (dupSuffix > 0) {
-			warnings.push(
-				describeBoundaryRepair(
+			slots.push({
+				kind: "edits",
+				edits: [...inserts.slice(0, inserts.length - dupSuffix), ...deletes],
+				warning: describeBoundaryRepair(
 					group,
 					`dropped ${dupSuffix} duplicated trailing payload line(s) already present below the range`,
 				),
-			);
-			out.push(...inserts.slice(0, inserts.length - dupSuffix), ...deletes);
+			});
 			continue;
 		}
 		const dupPrefix = findDuplicatePrefix(group, fileLines, delta);
 		if (dupPrefix > 0) {
-			warnings.push(
-				describeBoundaryRepair(
+			slots.push({
+				kind: "edits",
+				edits: [...inserts.slice(dupPrefix), ...deletes],
+				warning: describeBoundaryRepair(
 					group,
 					`dropped ${dupPrefix} duplicated leading payload line(s) already present above the range`,
 				),
-			);
-			out.push(...inserts.slice(dupPrefix), ...deletes);
+			});
 			continue;
 		}
-		const droppedClosers = balanceCovers(patchDelta, delta) ? findDroppedSuffixClosers(group, fileLines, delta) : 0;
+		slots.push({ kind: "candidate", group, inserts, deletes, delta });
+	}
+
+	// Pass 2: with local repairs already projected, compute the residual
+	// delimiter delta from the post-pass1 edit stream (candidate groups still
+	// in their raw form). A dropped-closer repair only fires when this
+	// patchDelta covers the candidate's delta in the same direction — sparing
+	// a closer in a patch already balanced by some other hunk (e.g. a DEL of
+	// the matching opener, #3142) would inject a stray closer.
+	const projected: AppliedEdit[] = [];
+	for (const slot of slots) {
+		if (slot.kind === "candidate") projected.push(...slot.inserts, ...slot.deletes);
+		else projected.push(...slot.edits);
+	}
+	const patchDelta = computeEditBalanceDelta(projected, fileLines);
+
+	const out: AppliedEdit[] = [];
+	const warnings: string[] = [];
+	for (const slot of slots) {
+		if (slot.kind !== "candidate") {
+			if (slot.warning !== undefined) warnings.push(slot.warning);
+			out.push(...slot.edits);
+			continue;
+		}
+		const droppedClosers = balanceCovers(patchDelta, slot.delta)
+			? findDroppedSuffixClosers(slot.group, fileLines, slot.delta)
+			: 0;
 		if (droppedClosers > 0) {
 			warnings.push(
 				describeBoundaryRepair(
-					group,
+					slot.group,
 					`kept ${droppedClosers} structural closing line(s) the range deleted without restating`,
 				),
 			);
-			out.push(...inserts, ...deletes.slice(0, deletes.length - droppedClosers));
+			out.push(...slot.inserts, ...slot.deletes.slice(0, slot.deletes.length - droppedClosers));
 			continue;
 		}
-		out.push(...inserts, ...deletes);
+		out.push(...slot.inserts, ...slot.deletes);
 	}
 	return { edits: out, warnings };
 }

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -338,6 +338,18 @@ function computeEditBalanceDelta(edits: readonly AppliedEdit[], fileLines: reado
 	return balanceDelta(computeDelimiterBalance(inserted), computeDelimiterBalance(deleted));
 }
 
+function deletedPrefixBalance(
+	group: ReplacementGroup,
+	deletedLines: ReadonlySet<number>,
+	fileLines: readonly string[],
+): DelimiterBalance {
+	const lines: string[] = [];
+	for (let line = group.startLine - 1; line >= 1 && deletedLines.has(line); line--) {
+		lines.unshift(fileLines[line - 1] ?? "");
+	}
+	return computeDelimiterBalance(lines);
+}
+
 interface ReplacementGroup {
 	/** Positions in the edit array of the payload inserts, in payload order. */
 	insertIndices: number[];
@@ -714,16 +726,21 @@ function repairReplacementBoundaries(
 
 	// Pass 2: with local repairs already projected, compute the residual
 	// delimiter delta from the post-pass1 edit stream (candidate groups still
-	// in their raw form). A dropped-closer repair only fires when this
-	// patchDelta covers the candidate's delta in the same direction — sparing
-	// a closer in a patch already balanced by some other hunk (e.g. a DEL of
-	// the matching opener, #3142) would inject a stray closer.
+	// in their raw form). A dropped-closer repair only fires when the remaining
+	// residual delta covers that candidate's delta in the same direction, then
+	// consumes that residual. Candidates whose adjacent deleted prefix already
+	// accounts for the delta are wrapper removals, not missing closers.
 	const projected: AppliedEdit[] = [];
 	for (const slot of slots) {
 		if (slot.kind === "candidate") projected.push(...slot.inserts, ...slot.deletes);
 		else projected.push(...slot.edits);
 	}
 	const patchDelta = computeEditBalanceDelta(projected, fileLines);
+	const deletedLines = new Set<number>();
+	for (const edit of projected) {
+		if (edit.kind === "delete") deletedLines.add(edit.anchor.line);
+	}
+	let remainingDelta = patchDelta;
 
 	const out: AppliedEdit[] = [];
 	const warnings: string[] = [];
@@ -733,9 +750,11 @@ function repairReplacementBoundaries(
 			out.push(...slot.edits);
 			continue;
 		}
-		const droppedClosers = balanceCovers(patchDelta, slot.delta)
-			? findDroppedSuffixClosers(slot.group, fileLines, slot.delta)
-			: 0;
+		const prefixBalance = deletedPrefixBalance(slot.group, deletedLines, fileLines);
+		const droppedClosers =
+			!balanceCovers(prefixBalance, slot.delta) && balanceCovers(remainingDelta, slot.delta)
+				? findDroppedSuffixClosers(slot.group, fileLines, slot.delta)
+				: 0;
 		if (droppedClosers > 0) {
 			warnings.push(
 				describeBoundaryRepair(
@@ -744,6 +763,7 @@ function repairReplacementBoundaries(
 				),
 			);
 			out.push(...slot.inserts, ...slot.deletes.slice(0, slot.deletes.length - droppedClosers));
+			remainingDelta = balanceDelta(remainingDelta, slot.delta);
 			continue;
 		}
 		out.push(...slot.inserts, ...slot.deletes);

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -338,16 +338,20 @@ function computeEditBalanceDelta(edits: readonly AppliedEdit[], fileLines: reado
 	return balanceDelta(computeDelimiterBalance(inserted), computeDelimiterBalance(deleted));
 }
 
-function deletedPrefixBalance(
+function netDeletedPrefixBalance(
 	group: ReplacementGroup,
 	deletedLines: ReadonlySet<number>,
+	insertedByLine: ReadonlyMap<number, readonly string[]>,
 	fileLines: readonly string[],
 ): DelimiterBalance {
-	const lines: string[] = [];
+	const deleted: string[] = [];
+	const inserted: string[] = [];
 	for (let line = group.startLine - 1; line >= 1 && deletedLines.has(line); line--) {
-		lines.unshift(fileLines[line - 1] ?? "");
+		deleted.unshift(fileLines[line - 1] ?? "");
+		const insertedAtLine = insertedByLine.get(line);
+		if (insertedAtLine) inserted.unshift(...insertedAtLine);
 	}
-	return computeDelimiterBalance(lines);
+	return balanceDelta(computeDelimiterBalance(deleted), computeDelimiterBalance(inserted));
 }
 
 interface ReplacementGroup {
@@ -728,8 +732,8 @@ function repairReplacementBoundaries(
 	// delimiter delta from the post-pass1 edit stream (candidate groups still
 	// in their raw form). A dropped-closer repair only fires when the remaining
 	// residual delta covers that candidate's delta in the same direction, then
-	// consumes that residual. Candidates whose adjacent deleted prefix already
-	// accounts for the delta are wrapper removals, not missing closers.
+	// consumes that residual. Candidates whose adjacent prefix edits net-remove
+	// the opener balance are wrapper removals, not missing closers.
 	const projected: AppliedEdit[] = [];
 	for (const slot of slots) {
 		if (slot.kind === "candidate") projected.push(...slot.inserts, ...slot.deletes);
@@ -739,6 +743,15 @@ function repairReplacementBoundaries(
 	const deletedLines = new Set<number>();
 	for (const edit of projected) {
 		if (edit.kind === "delete") deletedLines.add(edit.anchor.line);
+	}
+	const insertedByLine = new Map<number, string[]>();
+	for (const edit of projected) {
+		if (edit.kind !== "insert") continue;
+		for (const anchor of getCursorAnchors(edit.cursor)) {
+			const lines = insertedByLine.get(anchor.line);
+			if (lines) lines.push(edit.text);
+			else insertedByLine.set(anchor.line, [edit.text]);
+		}
 	}
 	let remainingDelta = patchDelta;
 
@@ -750,7 +763,7 @@ function repairReplacementBoundaries(
 			out.push(...slot.edits);
 			continue;
 		}
-		const prefixBalance = deletedPrefixBalance(slot.group, deletedLines, fileLines);
+		const prefixBalance = netDeletedPrefixBalance(slot.group, deletedLines, insertedByLine, fileLines);
 		const droppedClosers =
 			!balanceCovers(prefixBalance, slot.delta) && balanceCovers(remainingDelta, slot.delta)
 				? findDroppedSuffixClosers(slot.group, fileLines, slot.delta)

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -147,6 +147,45 @@ describe("boundary-balance repair", () => {
 		expect(warnings).toHaveLength(0);
 	});
 
+	// A separate hunk's dupSuffix repair leaves another hunk's missing-closer
+	// imbalance unmasked: pass 2 must recompute the patch delta from the
+	// post-pass1 edit stream so the genuine droppedClosers repair still fires.
+	it("still fires droppedClosers when another hunk's dupSuffix masks the raw patch delta", () => {
+		const file = [
+			'addEventListener("click", () => {', // 1
+			"\tfoo();", // 2
+			"\tbar();", // 3
+			"});", // 4
+			"", // 5
+			"const config = {", // 6
+			"\ta: 1,", // 7
+			"};", // 8
+		].join("\n");
+		// Hunk A duplicates the surviving `});` at line 4 (dupSuffix).
+		// Hunk B replaces `};` at line 8 without restating it (droppedClosers).
+		// Raw patch delta is `paren: -1, brace: 0` — opposite-direction parens
+		// hide hunk B's `brace: +1` until pass 1 cancels hunk A's contribution.
+		const diff = ["SWAP 2.=3:", "+\tsetup();", "+\tfoo();", "+\tbar();", "+});", "SWAP 8.=8:", "+\tb: 2,"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(
+			[
+				'addEventListener("click", () => {',
+				"\tsetup();",
+				"\tfoo();",
+				"\tbar();",
+				"});",
+				"",
+				"const config = {",
+				"\ta: 1,",
+				"\tb: 2,",
+				"};",
+			].join("\n"),
+		);
+		expect(warnings.some(w => /trailing payload line/.test(w))).toBe(true);
+		expect(warnings.some(w => /structural closing line/.test(w))).toBe(true);
+	});
+
 	// If the selected range is already imbalanced internally, a payload that
 	// restates the range's final closer must not trigger "missing closer" repair;
 	// keeping the deleted suffix would duplicate the closer outside the payload.

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -138,6 +138,15 @@ describe("boundary-balance repair", () => {
 		expect(warnings.some(w => /delimiter-balance/.test(w))).toBe(true);
 	});
 
+	it("does not spare a deleted closer when another hunk deletes its opener", () => {
+		const file = ["if enabled {", '\tText("Old")', "}", '\tText("Tail")'].join("\n");
+		const diff = ["DEL 1", "SWAP 2.=3:", '+Text("New")'].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(['Text("New")', '\tText("Tail")'].join("\n"));
+		expect(warnings).toHaveLength(0);
+	});
+
 	// If the selected range is already imbalanced internally, a payload that
 	// restates the range's final closer must not trigger "missing closer" repair;
 	// keeping the deleted suffix would duplicate the closer outside the payload.

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -147,6 +147,15 @@ describe("boundary-balance repair", () => {
 		expect(warnings).toHaveLength(0);
 	});
 
+	it("does not spend a genuine missing-closer residual on an earlier wrapper removal", () => {
+		const file = ["if enabled {", '\tText("Old")', "}", "const config = {", "\ta: 1,", "};"].join("\n");
+		const diff = ["DEL 1", "SWAP 2.=3:", '+Text("New")', "SWAP 6.=6:", "+\tb: 2,"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(['Text("New")', "const config = {", "\ta: 1,", "\tb: 2,", "};"].join("\n"));
+		expect(warnings.filter(w => /structural closing line/.test(w))).toHaveLength(1);
+	});
+
 	// A separate hunk's dupSuffix repair leaves another hunk's missing-closer
 	// imbalance unmasked: pass 2 must recompute the patch delta from the
 	// post-pass1 edit stream so the genuine droppedClosers repair still fires.

--- a/packages/hashline/test/boundary-repair.test.ts
+++ b/packages/hashline/test/boundary-repair.test.ts
@@ -156,6 +156,15 @@ describe("boundary-balance repair", () => {
 		expect(warnings.filter(w => /structural closing line/.test(w))).toHaveLength(1);
 	});
 
+	it("nets a replaced opener prefix before deciding wrapper-removal suppression", () => {
+		const file = ["if (a) {", "\told();", "}"].join("\n");
+		const diff = ["SWAP 1.=1:", "+if (b) {", "SWAP 2.=3:", "+\tnew();"].join("\n");
+		const { text, warnings } = apply(file, diff);
+
+		expect(text).toBe(["if (b) {", "\tnew();", "}"].join("\n"));
+		expect(warnings.filter(w => /structural closing line/.test(w))).toHaveLength(1);
+	});
+
 	// A separate hunk's dupSuffix repair leaves another hunk's missing-closer
 	// imbalance unmasked: pass 2 must recompute the patch delta from the
 	// post-pass1 edit stream so the genuine droppedClosers repair still fires.


### PR DESCRIPTION
## Repro
A valid hashline edit that deletes an opener in one hunk and replaces the body plus closer in another hunk was corrupted by closer repair: `bun --cwd packages/hashline -e 'import { applyEdits, parsePatch } from "@oh-my-pi/hashline"; const file = ["if enabled {", "    Text(\"Old\")", "}", "Text(\"Tail\")"].join("\n"); const diff = ["DEL 1", "SWAP 2.=3:", "+Text(\"New\")"].join("\n"); const result = applyEdits(file, parsePatch(diff).edits); console.log(result.text); console.log(JSON.stringify(result.warnings ?? [])); if (result.text !== ["Text(\"New\")", "Text(\"Tail\")"].join("\n")) process.exit(1);'` previously left `}` in the output and exited 1.

## Cause
`packages/hashline/src/apply.ts` repaired each replacement group in isolation. `findDroppedSuffixClosers` saw `SWAP 2.=3:` as missing a deleted structural closer, but it did not consider the separate `DEL 1` hunk that removed the matching opener and already balanced the whole patch.

## Fix
- Added whole-patch delimiter delta accounting before replacement-boundary repair keeps deleted suffix closers.
- Limited dropped-closer repair to replacement imbalances still present in the complete edit batch.
- Added a regression test for the multi-hunk wrapper-removal shape.
- Added the hashline changelog entry for #3142.

## Verification
`bun --cwd packages/hashline -e ...` now prints `Text("New")\nText("Tail")` with no warnings; `bun test --parallel` in `packages/hashline` passed 179 tests; `bun run check` in `packages/hashline` passed. Fixes #3142