### PR TITLE
fix(agent): compact active goal yields

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/goal` continuation turns that end with a successful `yield` skipping threshold auto-compaction while the active goal remains over `compaction.thresholdTokens`. ([#3146](https://github.com/can1357/oh-my-pi/issues/3146))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2761,6 +2761,11 @@ export class AgentSession {
 
 			if (this.#assistantEndedWithSuccessfulYield(msg)) {
 				this.#lastSuccessfulYieldToolCallId = undefined;
+				if (this.#goalModeState?.enabled && this.#goalModeState.goal.status === "active") {
+					const compactionTask = this.#checkCompaction(msg);
+					this.#trackPostPromptTask(compactionTask);
+					await compactionTask;
+				}
 				await emitAgentEndNotification();
 				return;
 			}

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -213,6 +213,66 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
 	});
 
+	it("runs threshold compaction for active goal turns that end with yield", async () => {
+		const now = Date.now();
+		session.setGoalModeState({
+			enabled: true,
+			mode: "active",
+			goal: {
+				id: "goal-threshold",
+				objective: "continue until compacted",
+				status: "active",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: now,
+				updatedAt: now,
+			},
+		});
+
+		const yieldCall = {
+			type: "toolCall" as const,
+			id: "call_goal_yield",
+			name: "yield",
+			arguments: { status: "progress" },
+		};
+		const assistantMsg = {
+			role: "assistant" as const,
+			content: [yieldCall],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "toolUse" as const,
+			usage: {
+				input: 190000,
+				output: 1000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 191000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: now,
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({
+			type: "tool_execution_end",
+			toolCallId: yieldCall.id,
+			toolName: "yield",
+			isError: false,
+			result: {
+				content: [{ type: "text" as const, text: "Yielded." }],
+				details: { status: "success" },
+			},
+		});
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		const runtimeSignals = getRuntimeSignals();
+		expect(runtimeSignals).toContain("compaction:start:threshold");
+		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
+	});
+
 	it("has isCompacting true when the auto_compaction_start event fires", async () => {
 		// Defect 1: the compaction AbortController (which backs isCompacting) must be
 		// installed before auto_compaction_start is emitted. If it is installed after,


### PR DESCRIPTION
## Repro
A focused regression test drives an active `/goal` turn whose assistant message ends with a successful `yield` tool call and usage above the compaction threshold: `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts -t "runs threshold compaction for active goal turns that end with yield"`. Before the fix, it timed out waiting for `auto_compaction_end`.

## Cause
`AgentSession.#processAgentEvent` returned immediately when `#assistantEndedWithSuccessfulYield(msg)` was true, before calling `#checkCompaction(msg)`. Active goal continuation turns that yielded successfully therefore skipped the threshold compaction branch in `packages/coding-agent/src/session/agent-session.ts`.

## Fix
- Run `#checkCompaction(msg)` for successful yield turns only while goal mode is still enabled with an active goal.
- Preserve the existing non-goal/final-yield maintenance skip, including the handoff guard path.
- Add a regression test covering active goal yield threshold compaction.
- Add a coding-agent changelog entry.

## Verification
Passed `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts`; passed `bun test packages/coding-agent/test/agent-session-handoff.test.ts -t "does not run auto maintenance after final yield"`; passed `bun --cwd=packages/coding-agent run check`. Fixes #3146