### PR TITLE
fix(coding-agent): store slash commands in history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed built-in slash commands skipping editor history; `/settings` and other built-ins now participate in up-arrow recall, with `tui.slashHistory: false` as an opt-out. ([#3148](https://github.com/can1357/oh-my-pi/issues/3148))
+
 ## [16.1.7] - 2026-06-20
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1289,6 +1289,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Action when pressing Escape twice with empty editor",
 		},
 	},
+	"tui.slashHistory": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Slash Command History",
+			description: "Store built-in slash commands for up-arrow recall",
+		},
+	},
 
 	treeFilterMode: {
 		type: "enum",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -64,6 +64,17 @@ function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.ui.requestRender();
 }
 
+function shouldStoreSlashCommandHistory(ctx: InteractiveModeContext): boolean {
+	return ctx.settings === undefined || ctx.settings.get("tui.slashHistory") !== false;
+}
+
+function addSlashCommandToHistory(text: string, runtime: BuiltinSlashCommandRuntime): void {
+	const addToHistory = runtime.ctx.editor.addToHistory;
+	if (shouldStoreSlashCommandHistory(runtime.ctx) && typeof addToHistory === "function") {
+		addToHistory.call(runtime.ctx.editor, text);
+	}
+}
+
 /** `/fast status` label: "off", "on", or scope-qualified "on (… only)". */
 function formatFastModeStatus(session: AgentSession): string {
 	if (!session.isFastModeEnabled()) return "off";
@@ -254,11 +265,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[prompt]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
-			const hadArgs = !!command.args;
 			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
-			if (hadArgs) {
-				runtime.ctx.editor.addToHistory(command.text);
-			}
 			runtime.ctx.editor.setText("");
 		},
 	},
@@ -284,11 +291,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[objective]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
-			const hadArgs = !!command.args;
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
-			if (hadArgs) {
-				runtime.ctx.editor.addToHistory(command.text);
-			}
 			runtime.ctx.editor.setText("");
 		},
 	},
@@ -1194,7 +1197,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handle: handleMcpAcp,
 		handleTui: async (command, runtime) => {
-			runtime.ctx.editor.addToHistory(command.text);
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleMCPCommand(command.text);
 		},
@@ -1217,7 +1219,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handle: handleSshAcp,
 		handleTui: async (command, runtime) => {
-			runtime.ctx.editor.addToHistory(command.text);
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleSSHCommand(command.text);
 		},
@@ -2285,10 +2286,12 @@ export async function executeBuiltinSlashCommand(
 	if (runtime.ctx.collabGuest && !COLLAB_GUEST_ALLOWED_COMMANDS[command.name]) {
 		runtime.ctx.showStatus(`/${command.name} is host-only during a collab session`);
 		runtime.ctx.editor.setText("");
+		addSlashCommandToHistory(text, runtime);
 		return true;
 	}
 	if (command.handleTui) {
 		const result = await command.handleTui(parsed, runtime);
+		addSlashCommandToHistory(text, runtime);
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;
 		return true;
 	}
@@ -2318,6 +2321,7 @@ export async function executeBuiltinSlashCommand(
 		};
 		const result = await command.handle(parsed, adapted);
 		ctx.editor.setText("");
+		addSlashCommandToHistory(text, runtime);
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;
 		return true;
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -68,10 +68,20 @@ function shouldStoreSlashCommandHistory(ctx: InteractiveModeContext): boolean {
 	return ctx.settings === undefined || ctx.settings.get("tui.slashHistory") !== false;
 }
 
-function addSlashCommandToHistory(text: string, runtime: BuiltinSlashCommandRuntime): void {
+function slashCommandHistoryText(command: ParsedSlashCommand): string | undefined {
+	if (command.name !== "login") return command.text;
+	const args = command.args.trim();
+	if (!args) return command.text;
+	if (getOAuthProviders().some(provider => provider.id === args)) return command.text;
+	return undefined;
+}
+
+function addSlashCommandToHistory(command: ParsedSlashCommand, runtime: BuiltinSlashCommandRuntime): void {
+	const historyText = slashCommandHistoryText(command);
+	if (historyText === undefined) return;
 	const addToHistory = runtime.ctx.editor.addToHistory;
 	if (shouldStoreSlashCommandHistory(runtime.ctx) && typeof addToHistory === "function") {
-		addToHistory.call(runtime.ctx.editor, text);
+		addToHistory.call(runtime.ctx.editor, historyText);
 	}
 }
 
@@ -2286,12 +2296,12 @@ export async function executeBuiltinSlashCommand(
 	if (runtime.ctx.collabGuest && !COLLAB_GUEST_ALLOWED_COMMANDS[command.name]) {
 		runtime.ctx.showStatus(`/${command.name} is host-only during a collab session`);
 		runtime.ctx.editor.setText("");
-		addSlashCommandToHistory(text, runtime);
+		addSlashCommandToHistory(parsed, runtime);
 		return true;
 	}
 	if (command.handleTui) {
 		const result = await command.handleTui(parsed, runtime);
-		addSlashCommandToHistory(text, runtime);
+		addSlashCommandToHistory(parsed, runtime);
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;
 		return true;
 	}
@@ -2321,7 +2331,7 @@ export async function executeBuiltinSlashCommand(
 		};
 		const result = await command.handle(parsed, adapted);
 		ctx.editor.setText("");
-		addSlashCommandToHistory(text, runtime);
+		addSlashCommandToHistory(parsed, runtime);
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;
 		return true;
 	}

--- a/packages/coding-agent/test/slash-commands/history.test.ts
+++ b/packages/coding-agent/test/slash-commands/history.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntime(slashHistory: boolean | undefined = undefined) {
+	const addToHistory = vi.fn();
+	const setText = vi.fn();
+	const showSettingsSelector = vi.fn();
+	const get = vi.fn((path: string) => (path === "tui.slashHistory" ? slashHistory : undefined));
+
+	return {
+		addToHistory,
+		setText,
+		showSettingsSelector,
+		runtime: {
+			ctx: {
+				editor: { addToHistory, setText },
+				settings: { get },
+				showSettingsSelector,
+			} as unknown as InteractiveModeContext,
+		},
+	};
+}
+
+describe("slash command history", () => {
+	it("stores built-in slash commands for recall by default", async () => {
+		const harness = createRuntime();
+
+		expect(await executeBuiltinSlashCommand("/settings", harness.runtime)).toBe(true);
+
+		expect(harness.showSettingsSelector).toHaveBeenCalledTimes(1);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.addToHistory).toHaveBeenCalledWith("/settings");
+	});
+
+	it("respects the slash command history opt-out", async () => {
+		const harness = createRuntime(false);
+
+		expect(await executeBuiltinSlashCommand("/settings", harness.runtime)).toBe(true);
+
+		expect(harness.addToHistory).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/slash-commands/history.test.ts
+++ b/packages/coding-agent/test/slash-commands/history.test.ts
@@ -7,16 +7,25 @@ function createRuntime(slashHistory: boolean | undefined = undefined) {
 	const setText = vi.fn();
 	const showSettingsSelector = vi.fn();
 	const get = vi.fn((path: string) => (path === "tui.slashHistory" ? slashHistory : undefined));
+	const submit = vi.fn(() => true);
+	const showStatus = vi.fn();
+	const showWarning = vi.fn();
 
 	return {
 		addToHistory,
 		setText,
 		showSettingsSelector,
+		showStatus,
+		showWarning,
+		submit,
 		runtime: {
 			ctx: {
 				editor: { addToHistory, setText },
+				oauthManualInput: { hasPending: vi.fn(() => false), pendingProviderId: undefined, submit },
 				settings: { get },
 				showSettingsSelector,
+				showStatus,
+				showWarning,
 			} as unknown as InteractiveModeContext,
 		},
 	};
@@ -38,6 +47,17 @@ describe("slash command history", () => {
 
 		expect(await executeBuiltinSlashCommand("/settings", harness.runtime)).toBe(true);
 
+		expect(harness.addToHistory).not.toHaveBeenCalled();
+	});
+
+	it("does not store OAuth redirect URLs submitted through /login", async () => {
+		const harness = createRuntime();
+		const callbackUrl = "http://localhost:1455/callback?code=secret-code&state=secret-state";
+
+		expect(await executeBuiltinSlashCommand(`/login ${callbackUrl}`, harness.runtime)).toBe(true);
+
+		expect(harness.submit).toHaveBeenCalledWith(callbackUrl);
+		expect(harness.showStatus).toHaveBeenCalledWith("OAuth callback received; completing login…");
 		expect(harness.addToHistory).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Repro
A direct TUI registry dispatch of `/settings` consumed the command but left editor history empty: `bun --cwd=packages/collab-web run build:tool-views && bun -e 'import { executeBuiltinSlashCommand } from "./packages/coding-agent/src/slash-commands/builtin-registry.ts"; const history = []; const runtime = { ctx: { collabGuest: undefined, showSettingsSelector() {}, editor: { setText() {}, addToHistory(text) { history.push(text); } } } }; await executeBuiltinSlashCommand("/settings", runtime); if (history[0] !== "/settings") { console.error(`slash command was not stored; history length=${history.length}`); process.exit(1); }'` failed with `history length=0` before the fix.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` returned `true` immediately after `handleTui`/`handle` consumed a built-in command, so `InputController` never reached its normal `editor.addToHistory(...)` calls. Four handlers had local history writes, but the registry had no general history path for built-ins.

## Fix
- Added centralized slash-command history recording in `executeBuiltinSlashCommand()` after successful TUI/adapted handler dispatch and for collab-host-only consumed commands.
- Removed the per-command history writes from `/plan`, `/goal`, `/mcp`, and `/ssh` so built-ins use one path.
- Added the `tui.slashHistory` setting, defaulting to `true`, to preserve recall while allowing opt-out.
- Added regression tests for default slash history storage and the opt-out.
- Added a coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/slash-commands/*.test.ts packages/coding-agent/test/slash-command-format.test.ts packages/coding-agent/test/loop-limit.test.ts` passed: 77 tests. `bun --cwd=packages/coding-agent run check` passed. The direct `/settings` repro now prints `stored`. Fixes #3148