### PR TITLE
fix(coding-agent): stopped advisor from re-emitting identical advice

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,16 @@
         "@oh-my-pi/pi-coding-agent": "^13",
       },
     },
+    "packages/terminal-bench": {
+      "name": "@oh-my-pi/terminal-bench",
+      "version": "0.0.1",
+      "bin": {
+        "tb2": "src/runner.ts",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+      },
+    },
     "packages/tui": {
       "name": "@oh-my-pi/pi-tui",
       "version": "16.1.7",
@@ -746,6 +756,8 @@
     "@oh-my-pi/snapcompact": ["@oh-my-pi/snapcompact@workspace:packages/snapcompact"],
 
     "@oh-my-pi/swarm-extension": ["@oh-my-pi/swarm-extension@workspace:packages/swarm-extension"],
+
+    "@oh-my-pi/terminal-bench": ["@oh-my-pi/terminal-bench@workspace:packages/terminal-bench"],
 
     "@oh-my-pi/typescript-edit-benchmark": ["@oh-my-pi/typescript-edit-benchmark@workspace:packages/typescript-edit-benchmark"],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Fixed an advisor loop where a misbehaving advisor model emitted the same `concern`/`blocker` note every primary turn, flooding the transcript even after the user interrupted (the advisor's pending batches kept draining identical advice). `AdviseTool` now drops a note whose normalized text matches one of the last five delivered notes and tells the advisor it was a duplicate so it can stop repeating itself. The ring resets on `AdvisorRuntime.reset()` (compaction, `/new`, `/branch`, session switch) so re-stating advice after a conversation rewrite still goes through. ([#3154](https://github.com/can1357/oh-my-pi/issues/3154))
 - Fixed side-channel turns failing to correctly obfuscate secrets and tools when inheriting prompt cache layout
 - Fixed MCP startup status to live-update from "Connecting…" to connected, still-connecting, or failed server states so completed connections do not leave a stale banner. ([#3150](https://github.com/can1357/oh-my-pi/issues/3150))
 - Fixed session history becoming desynchronized when using the `rewind` tool

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -198,6 +198,42 @@ describe("advisor", () => {
 			expect(result.useless).toBe(true);
 		});
 
+		it("drops repeated identical advice and surfaces the duplicate-ness to the advisor (issue #3154)", async () => {
+			const onAdvice = vi.fn();
+			const tool = new AdviseTool(onAdvice);
+			const first = await tool.execute("tc-1", { note: "Run the verification commands now.", severity: "concern" });
+			const second = await tool.execute("tc-2", { note: "Run the verification commands now.", severity: "concern" });
+			const thirdDifferentWhitespace = await tool.execute("tc-3", {
+				note: "  Run the verification commands now.\n",
+				severity: "concern",
+			});
+			expect(onAdvice).toHaveBeenCalledTimes(1);
+			expect(onAdvice).toHaveBeenCalledWith("Run the verification commands now.", "concern");
+			// First call delivers; subsequent identical (or whitespace-equivalent) calls do not.
+			expect((first.content[0] as { text: string }).text).toBe("Recorded.");
+			expect((second.content[0] as { text: string }).text).toMatch(/duplicate/i);
+			expect((thirdDifferentWhitespace.content[0] as { text: string }).text).toMatch(/duplicate/i);
+		});
+
+		it("does not dedup advice with a distinct body even at the same severity", async () => {
+			const onAdvice = vi.fn();
+			const tool = new AdviseTool(onAdvice);
+			await tool.execute("tc-1", { note: "Check the null branch.", severity: "concern" });
+			await tool.execute("tc-2", { note: "Verify the retry budget.", severity: "concern" });
+			expect(onAdvice).toHaveBeenCalledTimes(2);
+		});
+
+		it("re-allows previously delivered advice after reset()", async () => {
+			const onAdvice = vi.fn();
+			const tool = new AdviseTool(onAdvice);
+			await tool.execute("tc-1", { note: "Run tests.", severity: "concern" });
+			await tool.execute("tc-2", { note: "Run tests.", severity: "concern" });
+			expect(onAdvice).toHaveBeenCalledTimes(1);
+			tool.reset();
+			await tool.execute("tc-3", { note: "Run tests.", severity: "concern" });
+			expect(onAdvice).toHaveBeenCalledTimes(2);
+		});
+
 		it("validates parameters using ArkType", () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -139,6 +139,24 @@ export function deriveAdvisorTelemetry(
  */
 export const ADVISOR_READONLY_TOOL_NAMES: ReadonlySet<string> = new Set(["read", "search", "find"]);
 
+/**
+ * How many previously delivered advice notes to remember for the duplicate
+ * filter. Sized to absorb the most common repeat patterns observed in the
+ * wild (issue #3154: an advisor model emitting the same `concern` every
+ * primary turn for a dozen turns) while still letting a long, distinct
+ * stream of advice through unimpeded.
+ */
+const ADVISE_DEDUP_WINDOW = 5;
+
+/**
+ * Collapse cosmetic whitespace and case so an advisor that retypes the same
+ * advice with trivial variation ("Run tests." vs "  Run tests.\n") is still
+ * detected as a repeat.
+ */
+function normalizeAdviceKey(note: string): string {
+	return note.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
 export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails> {
 	readonly name = "advise";
 	readonly label = "Advise";
@@ -146,7 +164,29 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	readonly parameters = adviseSchema;
 	readonly intent = "omit" as const;
 
+	/**
+	 * Sliding window of the last {@link ADVISE_DEDUP_WINDOW} normalized notes the
+	 * advisor delivered. The advisor system prompt forbids repeated advice
+	 * ("NEVER repeat advice you already gave"), but a misbehaving model can
+	 * still loop indefinitely with identical `concern`/`blocker` text — every
+	 * primary turn the advisor sees the new transcript delta, generates the
+	 * same advice, fires another interrupt, and the cycle repeats (issue #3154).
+	 * Cleared by {@link reset} when the advisor itself is re-primed.
+	 */
+	#recent: string[] = [];
+
 	constructor(private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void) {}
+
+	/**
+	 * Forget the recently delivered advice. Called from the advisor agent facade
+	 * when {@link AdvisorRuntime.reset} re-primes the advisor — after a
+	 * conversation rewrite (compaction, `/new`, `/branch`, session switch) the
+	 * primary has lost the prior context, so the advisor is allowed to re-state
+	 * advice it had already given.
+	 */
+	reset(): void {
+		this.#recent.length = 0;
+	}
 
 	async execute(
 		_toolCallId: string,
@@ -155,6 +195,25 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		_onUpdate?: AgentToolUpdateCallback<AdviseDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<AdviseDetails>> {
+		const key = normalizeAdviceKey(args.note);
+		if (key.length > 0 && this.#recent.includes(key)) {
+			// Tell the advisor model the note was a duplicate — silently dropping
+			// it would let a stuck advisor keep burning tokens with the same loop.
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Duplicate of recent advice; not delivered. The agent already has this note — stay silent or offer a distinct angle.",
+					},
+				],
+				details: { note: args.note, severity: args.severity },
+				useless: true,
+			};
+		}
+		if (key.length > 0) {
+			this.#recent.push(key);
+			if (this.#recent.length > ADVISE_DEDUP_WINDOW) this.#recent.shift();
+		}
 		this.onAdvice(args.note, args.severity);
 		return {
 			content: [{ type: "text", text: "Recorded." }],

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1908,6 +1908,9 @@ export class AgentSession {
 			reset: () => {
 				advisorAgent.reset();
 				appendOnlyContext.log.clear();
+				// Forget the recent-advice ring so post-rewrite the advisor can re-state
+				// notes the primary no longer remembers (issue #3154).
+				adviseTool.reset();
 			},
 			state: advisorAgent.state,
 		};


### PR DESCRIPTION
## Repro

A misbehaving advisor model can ignore the system-prompt rule "NEVER repeat advice you already gave" and emit the same `concern`/`blocker` note every primary turn, flooding the transcript with identical `Advisor 1 note ⟦concern⟧ Run the verification commands now.` cards (the screenshot in #3154 shows 12+ copies). Flooding continues even after the user interrupts because the advisor agent's pending batches keep draining identical advice through the post-interrupt `preserve` channel. Unit repro:

```
cd packages/coding-agent && bun test src/advisor/__tests__/advisor.test.ts -t 'drops repeated identical advice'
```

Pre-fix: `expect(onAdvice).toHaveBeenCalledTimes(1)` — received `3`.

## Cause

`AdviseTool.execute` in `packages/coding-agent/src/advisor/advise-tool.ts` unconditionally invoked the `onAdvice` callback (which in `agent-session.ts#enqueueAdvice` either fires an interrupting `sendCustomMessage(..., { deliverAs: "steer", triggerTurn: true })` or queues an aside/preserve card). The `advisor.immuneTurns` fence demotes the *second* interrupt to an aside, but once the primary completes that turn the fence expires and the advisor — seeing the new transcript delta — generates the same `concern` again. Nothing in the code path enforced the system-prompt rule, so a stuck advisor model looped indefinitely.

## Fix

- `packages/coding-agent/src/advisor/advise-tool.ts`: added a 5-deep ring of normalized note texts (whitespace collapsed + lowercased). When `execute` sees a duplicate it skips `onAdvice` and returns a tool-call result that tells the advisor `Duplicate of recent advice; not delivered. The agent already has this note — stay silent or offer a distinct angle.` so the advisor learns to stop rather than retry. Exposed `reset()` to drop the ring.
- `packages/coding-agent/src/session/agent-session.ts`: extended the advisor agent facade's existing `reset` (called by `AdvisorRuntime.reset()` on compaction/`/new`/`/branch`/session switch) to also call `adviseTool.reset()`, so a conversation rewrite re-allows the advisor to re-state advice the primary no longer remembers.
- `packages/coding-agent/src/advisor/__tests__/advisor.test.ts`: three new contract tests — identical-text dedup, whitespace-equivalent dedup, distinct notes pass through, and reset re-allows prior advice.
- `packages/coding-agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification

```
cd packages/coding-agent && bun test src/advisor/__tests__/advisor.test.ts
# 44 pass, 0 fail (was 42 pass + 2 new tests failing pre-fix)

cd packages/coding-agent && bun test test/advisor-toggle.test.ts test/advisor-watchdog.test.ts \
  test/agent-session-advisor-suppression.test.ts test/agent-hub-advisor-scroll.test.ts \
  test/cli-advisor-flag.test.ts test/advisor/advisor-visibility.test.ts \
  test/task/coordination-advisory.test.ts test/task/spawn-advisory.test.ts
# 46 pass, 0 fail
```

Fixes #3154