### PR TITLE
fix(catalog): preserve LiteLLM discovery transport

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the `moonshot` provider with no path to the Kimi China API: model discovery now honors a `MOONSHOT_BASE_URL` override (redirecting to `api.moonshot.cn`), and `KIMI_API_KEY` resolves as a fallback for `MOONSHOT_API_KEY`. ([#2883](https://github.com/can1357/oh-my-pi/issues/2883))
+- Fixed LiteLLM model discovery preserving colliding models.dev transport metadata (for example `ollama-cloud` `deepseek-v4-flash`) instead of keeping the LiteLLM `openai-completions` provider transport. ([#3162](https://github.com/can1357/oh-my-pi/issues/3162))
 
 ### Removed
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -197,6 +197,8 @@ function mapWithBundledReference<TApi extends Api>(
 		...reference,
 		id: defaults.id,
 		name,
+		api: defaults.api,
+		provider: defaults.provider,
 		baseUrl: defaults.baseUrl,
 		contextWindow: toPositiveNumber(entry.context_length, reference.contextWindow),
 		maxTokens: toPositiveNumber(entry.max_completion_tokens, reference.maxTokens),

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -39,6 +39,29 @@ function makeFetchMock(expectedModelUrl: string): FetchImpl {
 	}) as FetchImpl;
 }
 
+function makeCollisionFetchMock(): FetchImpl {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = inputUrl(input);
+		if (url === MODELS_DEV_URL) {
+			return Response.json({
+				"ollama-cloud": {
+					models: {
+						"deepseek-v4-flash": {
+							name: "DeepSeek V4 Flash",
+							tool_call: true,
+							limit: { context: 64_000, output: 8_000 },
+							cost: { input: 1, output: 2 },
+						},
+					},
+				},
+			});
+		}
+
+		expect(url).toBe("http://primary:4000/v1/models");
+		return Response.json({ data: [{ id: "deepseek-v4-flash" }] });
+	}) as FetchImpl;
+}
+
 afterEach(() => {
 	restoreLiteLLMBaseUrl();
 	vi.restoreAllMocks();
@@ -82,5 +105,31 @@ describe("LiteLLM provider discovery", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(models).toHaveLength(1);
 		expect(models?.[0]?.baseUrl).toBe("http://litellm-config.example:4200/v1");
+	});
+
+	test("keeps LiteLLM transport when models.dev has a colliding provider model id", async () => {
+		const fetchMock = makeCollisionFetchMock();
+
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-litellm-test",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({
+			id: "deepseek-v4-flash",
+			name: "DeepSeek V4 Flash",
+			api: "openai-completions",
+			provider: "litellm",
+			baseUrl: "http://primary:4000/v1",
+			contextWindow: 64_000,
+			maxTokens: 8_000,
+			cost: {
+				input: 1,
+				output: 2,
+			},
+		});
 	});
 });


### PR DESCRIPTION
## Repro
A mocked LiteLLM `/v1/models` response returning `deepseek-v4-flash` plus a models.dev `ollama-cloud` reference for the same bare id reproduced the collision with `bun -e`: discovery returned `api: "ollama-chat"` and `provider: "ollama-cloud"` while keeping the LiteLLM base URL, matching the reported `/api/chat` routing failure.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` used `mapWithBundledReference` to spread the reference model over discovered defaults, then restored only `id`, `name`, and `baseUrl`. For LiteLLM, references come from unscoped models.dev data, so a colliding `ollama-cloud` model could overwrite the LiteLLM-discovered model's `api` and `provider`.

## Fix
- Preserve discovered `api` and `provider` in `mapWithBundledReference` while still layering metadata such as pricing, context, token limits, reasoning, and input capabilities from references.
- Added a LiteLLM regression test for a `deepseek-v4-flash` collision with an `ollama-cloud` models.dev entry.
- Added the catalog changelog entry for the fix.

## Verification
`bun test test/litellm-provider.test.ts` passed: 3 tests, 17 assertions. `bun run check` passed in `packages/catalog`. Re-ran the mocked repro command and it now returns `api: "openai-completions"` and `provider: "litellm"`. Fixes #3162