### PR TITLE
fix(coding-agent): force-activated write tool while plan mode is live

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan mode leaving `write` hidden under `tools.discoveryMode: "all"`, which made the agent attempt to create the plan file via `edit` and stall. Plan-mode entry now force-activates `write` whenever the registry built it, matching the `write`+`edit` instructions in the plan-mode prompt ([#3165](https://github.com/can1357/oh-my-pi/issues/3165))
+
 ## [16.1.9] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1926,9 +1926,18 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		const planFilePath = options?.planFilePath ?? (await this.#getPlanFilePath());
 		const previousTools = this.session.getActiveToolNames();
-		const hasResolveTool = this.session.getToolByName("resolve") !== undefined;
-		const planTools = hasResolveTool ? [...previousTools, "resolve"] : previousTools;
-		const uniquePlanTools = [...new Set(planTools)];
+		// `plan-mode-active.md` instructs the agent to draft the plan file with
+		// `write` and refine it with `edit`. Both must be in the active set or the
+		// agent falls back to `edit` on a non-existent file and stalls. `edit` is an
+		// essential built-in so it survives `tools.discoveryMode === "all"`, but
+		// `write` has `loadMode: "discoverable"` and is hidden behind
+		// `search_tool_bm25` — re-activate it here whenever the registry built it
+		// (issue #3165). `resolve` is hidden too; the standing handler below
+		// consumes plan-approval calls through it.
+		const planAugmentations = ["resolve", "write"].filter(
+			name => this.session.getToolByName(name) !== undefined,
+		);
+		const uniquePlanTools = [...new Set([...previousTools, ...planAugmentations])];
 
 		this.#planModePreviousTools = previousTools;
 		this.planModePlanFilePath = planFilePath;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1931,10 +1931,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		// agent falls back to `edit` on a non-existent file and stalls. `edit` is an
 		// essential built-in so it survives `tools.discoveryMode === "all"`, but
 		// `write` has `loadMode: "discoverable"` and is hidden behind
-		// `search_tool_bm25` — re-activate it here whenever the registry built it
-		// (issue #3165). `resolve` is hidden too; the standing handler below
-		// consumes plan-approval calls through it.
-		const planAugmentations = ["resolve", "write"].filter(name => this.session.getToolByName(name) !== undefined);
+		// `search_tool_bm25` — re-activate it here only when the current registry
+		// entry is the built-in write tool (issue #3165). A shadowing extension
+		// tool named `write` must stay inactive because plan mode's read-only
+		// guarantee relies on the built-in write/edit guard. `resolve` is hidden
+		// too; the standing handler below consumes plan-approval calls through it.
+		const planAugmentations = ["resolve"];
+		if (this.session.hasBuiltInTool("write")) {
+			planAugmentations.push("write");
+		}
 		const uniquePlanTools = [...new Set([...previousTools, ...planAugmentations])];
 
 		this.#planModePreviousTools = previousTools;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1934,9 +1934,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// `search_tool_bm25` — re-activate it here whenever the registry built it
 		// (issue #3165). `resolve` is hidden too; the standing handler below
 		// consumes plan-approval calls through it.
-		const planAugmentations = ["resolve", "write"].filter(
-			name => this.session.getToolByName(name) !== undefined,
-		);
+		const planAugmentations = ["resolve", "write"].filter(name => this.session.getToolByName(name) !== undefined);
 		const uniquePlanTools = [...new Set([...previousTools, ...planAugmentations])];
 
 		this.#planModePreviousTools = previousTools;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2014,18 +2014,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		);
 
 		// All built-in tools are active (conditional tools like git/ask return null from factory if disabled)
+		const builtInRegistryToolNames = new Set<string>();
 		const toolRegistry = new Map<string, Tool>();
 		for (const tool of builtinTools) {
 			toolRegistry.set(tool.name, tool);
+			builtInRegistryToolNames.add(tool.name);
 		}
 		if (!toolRegistry.has("goal") && settings.get("goal.enabled")) {
 			const goalTool = await logger.time("createTools:goal:session", HIDDEN_TOOLS.goal, toolSession);
 			if (goalTool) {
 				toolRegistry.set(goalTool.name, wrapToolWithMetaNotice(goalTool));
+				builtInRegistryToolNames.add(goalTool.name);
 			}
 		}
 		for (const tool of wrappedExtensionTools) {
 			toolRegistry.set(tool.name, tool);
+			builtInRegistryToolNames.delete(tool.name);
 		}
 		if (deferMCPDiscoveryForUI && mcpManager) {
 			for (const name of collectPendingMCPToolNames(options.toolNames, existingSession.selectedMCPToolNames)) {
@@ -2043,6 +2047,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 		if (model?.provider === "cursor") {
 			toolRegistry.delete("edit");
+			builtInRegistryToolNames.delete("edit");
 		}
 
 		// `resolve` is hidden but must stay in the registry whenever any code path can invoke it:
@@ -2055,10 +2060,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const needsResolveTool = hasDeferrableTools || planModeAvailable;
 		if (!needsResolveTool) {
 			toolRegistry.delete("resolve");
+			builtInRegistryToolNames.delete("resolve");
 		} else if (!toolRegistry.has("resolve")) {
 			const resolveTool = await logger.time("createTools:resolve:session", HIDDEN_TOOLS.resolve, toolSession);
 			if (resolveTool) {
 				toolRegistry.set(resolveTool.name, wrapToolWithMetaNotice(resolveTool));
+				builtInRegistryToolNames.add(resolveTool.name);
 			}
 		}
 
@@ -2075,6 +2082,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				searchTool.name,
 				new ExtensionToolWrapper(wrapToolWithMetaNotice(searchTool), extensionRunner) as Tool,
 			);
+			builtInRegistryToolNames.add(searchTool.name);
 		}
 		let mcpDiscoveryEnabled = effectiveDiscoveryMode !== "off"; // back-compat: true when any discovery active
 
@@ -2616,6 +2624,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skillsSettings: settings.getGroup("skills"),
 			modelRegistry,
 			toolRegistry,
+			builtInToolNames: builtInRegistryToolNames,
 			transformContext,
 			onPayload,
 			onResponse,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -477,6 +477,8 @@ export interface AgentSessionConfig {
 	modelRegistry: ModelRegistry;
 	/** Tool registry for LSP and settings */
 	toolRegistry?: Map<string, AgentTool>;
+	/** Tool names whose current registry entry is still the built-in implementation. */
+	builtInToolNames?: Iterable<string>;
 	/** Current session pre-LLM message transform pipeline */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/** Provider payload hook used by the active session request path */
@@ -1290,6 +1292,7 @@ export class AgentSession {
 	// Generic tool discovery (covers built-in + MCP + extension when tools.discoveryMode === "all")
 	#discoverableToolSearchIndex: DiscoverableToolSearchIndex | null = null;
 	#selectedDiscoveredToolNames = new Set<string>();
+	#builtInToolNames = new Set<string>();
 	#rpcHostToolNames = new Set<string>();
 	#defaultSelectedMCPServerNames = new Set<string>();
 	#defaultSelectedMCPToolNames = new Set<string>();
@@ -1566,6 +1569,7 @@ export class AgentSession {
 		this.#pruneToolDescriptions = config.pruneToolDescriptions === true;
 		this.#validateRetryFallbackChains();
 		this.#toolRegistry = config.toolRegistry ?? new Map();
+		this.#builtInToolNames = new Set(config.builtInToolNames ?? []);
 		this.#requestedToolNames = config.requestedToolNames;
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#onPayload = config.onPayload;
@@ -4494,6 +4498,11 @@ export class AgentSession {
 	 */
 	getToolByName(name: string): AgentTool | undefined {
 		return this.#toolRegistry.get(name);
+	}
+
+	/** True when the current registry entry for `name` came from a built-in factory. */
+	hasBuiltInTool(name: string): boolean {
+		return this.#builtInToolNames.has(name);
 	}
 
 	/**

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -64,8 +64,11 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		return model;
 	}
 
-	/** Build an InteractiveMode over a brand-new (never-persisted) session. */
-	function createHarness(settings: Settings): InteractiveMode {
+	/** Build an InteractiveMode over a brand-new (never-persisted) session.
+	 *  `extraRegistryTools` registers additional tools that are NOT initially
+	 *  active — modeling tools hidden by `tools.discoveryMode === "all"` that
+	 *  modes may force-activate on entry. */
+	function createHarness(settings: Settings, extraRegistryTools: readonly AgentTool[] = []): InteractiveMode {
 		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${Bun.nanoseconds()}.yml`));
 		const initialModel = modelOrThrow(registry, "claude-sonnet-4-5");
 		const readTool = makeTool("read");
@@ -76,6 +79,9 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 			[readTool.name, readTool],
 			[resolveTool.name, resolveTool],
 		]);
+		for (const tool of extraRegistryTools) {
+			toolRegistry.set(tool.name, tool);
+		}
 		const manager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), `active-${Bun.nanoseconds()}`));
 		const createdSession = new AgentSession({
 			agent: new Agent({
@@ -104,6 +110,27 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 
 		expect(created.planModeEnabled).toBe(true);
 		expect(session?.getPlanModeState()).toMatchObject({ enabled: true, planFilePath: "local://PLAN.md" });
+		expect(session?.getActiveToolNames()).toContain("resolve");
+	});
+
+	it("activates write when entering plan mode even if it was hidden by discoveryMode (issue #3165)", async () => {
+		// `plan-mode-active.md` instructs the agent to draft the plan file with
+		// `write` and refine it with `edit`. Under `tools.discoveryMode === "all"`
+		// `write` is hidden behind `search_tool_bm25` so it's in the registry but
+		// not the initial active set. Plan-mode entry must force-activate it or
+		// the agent only has `edit`, which fails on a non-existent file.
+		const writeTool = makeTool("write");
+		const created = createHarness(
+			Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }),
+			[writeTool],
+		);
+
+		expect(session?.getActiveToolNames()).not.toContain("write");
+
+		await created.init({ suppressWelcomeIntro: true });
+
+		expect(created.planModeEnabled).toBe(true);
+		expect(session?.getActiveToolNames()).toContain("write");
 		expect(session?.getActiveToolNames()).toContain("resolve");
 	});
 

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -24,6 +24,11 @@ function makeTool(name: string): AgentTool {
 	};
 }
 
+interface HarnessOptions {
+	extraRegistryTools?: readonly AgentTool[];
+	builtInToolNames?: Iterable<string>;
+}
+
 describe("InteractiveMode plan.defaultOnStartup", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -67,8 +72,9 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 	/** Build an InteractiveMode over a brand-new (never-persisted) session.
 	 *  `extraRegistryTools` registers additional tools that are NOT initially
 	 *  active — modeling tools hidden by `tools.discoveryMode === "all"` that
-	 *  modes may force-activate on entry. */
-	function createHarness(settings: Settings, extraRegistryTools: readonly AgentTool[] = []): InteractiveMode {
+	 *  modes may force-activate on entry. `builtInToolNames` marks which registry
+	 *  entries still have built-in provenance after extension shadowing. */
+	function createHarness(settings: Settings, options: HarnessOptions = {}): InteractiveMode {
 		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${Bun.nanoseconds()}.yml`));
 		const initialModel = modelOrThrow(registry, "claude-sonnet-4-5");
 		const readTool = makeTool("read");
@@ -79,7 +85,7 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 			[readTool.name, readTool],
 			[resolveTool.name, resolveTool],
 		]);
-		for (const tool of extraRegistryTools) {
+		for (const tool of options.extraRegistryTools ?? []) {
 			toolRegistry.set(tool.name, tool);
 		}
 		const manager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), `active-${Bun.nanoseconds()}`));
@@ -97,6 +103,7 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 			settings,
 			modelRegistry: registry,
 			toolRegistry,
+			builtInToolNames: options.builtInToolNames ?? ["read", "resolve"],
 		});
 		session = createdSession;
 		mode = new InteractiveMode(createdSession, "test");
@@ -120,9 +127,10 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		// not the initial active set. Plan-mode entry must force-activate it or
 		// the agent only has `edit`, which fails on a non-existent file.
 		const writeTool = makeTool("write");
-		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), [
-			writeTool,
-		]);
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "resolve", "write"],
+		});
 
 		expect(session?.getActiveToolNames()).not.toContain("write");
 
@@ -131,6 +139,19 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(created.planModeEnabled).toBe(true);
 		expect(session?.getActiveToolNames()).toContain("write");
 		expect(session?.getActiveToolNames()).toContain("resolve");
+	});
+
+	it("does not activate an extension-shadowed write tool in plan mode", async () => {
+		const shadowWriteTool = makeTool("write");
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			extraRegistryTools: [shadowWriteTool],
+		});
+
+		await created.init({ suppressWelcomeIntro: true });
+
+		expect(created.planModeEnabled).toBe(true);
+		expect(session?.getActiveToolNames()).toContain("resolve");
+		expect(session?.getActiveToolNames()).not.toContain("write");
 	});
 
 	it("does not enter plan mode at startup by default", async () => {

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -120,10 +120,9 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		// not the initial active set. Plan-mode entry must force-activate it or
 		// the agent only has `edit`, which fails on a non-existent file.
 		const writeTool = makeTool("write");
-		const created = createHarness(
-			Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }),
-			[writeTool],
-		);
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), [
+			writeTool,
+		]);
 
 		expect(session?.getActiveToolNames()).not.toContain("write");
 


### PR DESCRIPTION
## Repro

Set `tools.discoveryMode: "all"` (which hides non-essential discoverable built-ins behind `search_tool_bm25`), enable plan mode, and ask the agent to draft a plan. The active toolset becomes `["read", "edit", … , "resolve"]` — `write` is in the tool registry but inactive — and the model, following `plan-mode-active.md`, calls `edit` to create the plan file. `edit` requires an existing target, so it fails and the planning turn stalls. Reproduced by a new test in `packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts` that drives `#enterPlanMode` over a registry containing `write` (built) but starting with `write` inactive; without the fix the test sees `["read","resolve"]` after entry, exactly the state the reporter hit.

## Cause

`InteractiveMode.#enterPlanMode` (`packages/coding-agent/src/modes/interactive-mode.ts`) augmented the previous active tool set with `resolve` only:

```ts
const planTools = hasResolveTool ? [...previousTools, "resolve"] : previousTools;
```

`plan-mode-active.md` explicitly tells the agent to draft the plan with `write` and refine it with `edit`. `edit` is `loadMode: "essential"` and survives discovery filtering, but `write` is `loadMode: "discoverable"` and gets removed from the initial active set by `filterInitialToolsForDiscoveryAll` in `packages/coding-agent/src/tools/index.ts` whenever `tools.discoveryMode === "all"`. Plan-mode entry never re-activated it, leaving the prompt's instructions un-executable.

## Fix

- Extended the plan-mode augmentation in `#enterPlanMode` from `["resolve"]` to `["resolve", "write"]`, each gated on the tool existing in the registry via `getToolByName(...)` (so configurations that genuinely don't build `write` — e.g. via `tools.essentialOverride` shrinkage — are unaffected).
- `#planModePreviousTools` still records the pre-plan active set, so `#exitPlanMode` restores it verbatim and `write` drops back out when plan mode ends.
- Added a regression test (`activates write when entering plan mode even if it was hidden by discoveryMode`) that asserts the active toolset goes from `[read]` → `[read, resolve, write]` on plan-mode entry. Verified the test fails on the unpatched code with `Expected to contain: "write" / Received: [ "read", "resolve" ]`.
- Added a `[Unreleased]` `### Fixed` entry to `packages/coding-agent/CHANGELOG.md`.

The companion suggestion from the reporter — making `search_tool_bm25` easier for weaker models to recognize — is a separate prompt-tuning change and is not in this PR.

## Verification

- `bun --cwd=packages/coding-agent test test/interactive-mode-default-plan-mode.test.ts test/tools/plan-mode-guard-local.test.ts test/plan-mode/ test/plan-mode-thinking-level.test.ts test/interactive-mode-plan-review.test.ts test/interactive-mode-loop.test.ts` → 108/108 pass.
- One pre-existing failure in `test/tool-discovery/initial-tools.test.ts` (`github` tool has no `loadMode`) reproduces on the base branch with this diff stashed, so it predates and is unrelated to this change.

Fixes #3165