### PR TITLE
fix(ai): classify 'insufficient balance' as usage-limit error

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `isUsageLimitError` not recognizing OpenCode Go's `401 Insufficient balance` quota-exhaustion phrasing, which prevented the retry pipeline from engaging and left fallback chains unused for exhausted OpenCode Go accounts. ([#3169](https://github.com/can1357/oh-my-pi/issues/3169))
+
 ## [16.1.9] - 2026-06-21
 
 ### Added

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -62,7 +62,7 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "RATE_LIMIT_EXCEEDED";
 	}
 
-	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit")) {
+	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit") || lower.includes("insufficient balance")) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -94,7 +94,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?balance/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -66,6 +66,14 @@ describe("parseRateLimitReason", () => {
 			),
 		).toBe("QUOTA_EXHAUSTED");
 	});
+
+	it("classifies OpenCode Go 'Insufficient balance' as QUOTA_EXHAUSTED", () => {
+		expect(
+			parseRateLimitReason(
+				"401 Insufficient balance. Manage your billing here: https://opencode.ai/workspace/<id>",
+			),
+		).toBe("QUOTA_EXHAUSTED");
+	});
 });
 
 describe("isUsageLimitError", () => {
@@ -98,6 +106,14 @@ describe("isUsageLimitError", () => {
 		expect(
 			isUsageLimitError(
 				"Cloud Code Assist API error (429): Individual quota reached. Contact your administrator to enable overages.",
+			),
+		).toBe(true);
+	});
+
+	it("detects OpenCode Go 'Insufficient balance' as a credential-rotatable usage limit", () => {
+		expect(
+			isUsageLimitError(
+				"401 Insufficient balance. Manage your billing here: https://opencode.ai/workspace/<id>",
 			),
 		).toBe(true);
 	});


### PR DESCRIPTION
## Problem

OpenCode Go returns `401 Insufficient balance` when quota is exhausted. This phrasing is not matched by `USAGE_LIMIT_PATTERN`, so `isUsageLimitError()` returns `false`, the retry pipeline never engages, and fallback chains (`retry.fallbackChains`) are never consulted.

Fixes #3169.

## Fix

Two-line change in `packages/ai/src/rate-limit-utils.ts`:
- Add `insufficient.?balance` to `USAGE_LIMIT_PATTERN`
- Add `insufficient balance` check to `parseRateLimitReason` → `QUOTA_EXHAUSTED`

## Testing

- **Unit:** 18/18 pass (2 new test cases added)
- **Live:** Built locally, ran against exhausted OpenCode Go account with configured fallback chain. Retry pipeline engaged, fallback fired, turn completed successfully. Same exhausted account errored out before the fix.