### PR TITLE
fix(ai): handle OpenCode insufficient balance quota errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode Go `401 Insufficient balance` quota errors being treated as unknown failures instead of usage-limit errors, restoring credential rotation and fallback chains. ([#3169](https://github.com/can1357/oh-my-pi/issues/3169))
+
 ## [16.1.9] - 2026-06-21
 
 ### Added

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -18,6 +18,7 @@ const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
 
 const ACCOUNT_RATE_LIMIT_PATTERN =
 	/\baccount(?:'s)?\b[^\n]{0,80}\brate.?limit\b|\brate.?limit\b[^\n]{0,80}\baccount\b/i;
+const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
@@ -62,7 +63,12 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "RATE_LIMIT_EXCEEDED";
 	}
 
-	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit")) {
+	if (
+		lower.includes("exhausted") ||
+		lower.includes("quota") ||
+		lower.includes("usage limit") ||
+		INSUFFICIENT_BALANCE_PATTERN.test(errorMessage)
+	) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -94,7 +100,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?balance/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -54,6 +54,12 @@ describe("parseRateLimitReason", () => {
 		).toBe("QUOTA_EXHAUSTED");
 	});
 
+	it("classifies OpenCode Go insufficient balance as QUOTA_EXHAUSTED", () => {
+		expect(
+			parseRateLimitReason("401 Insufficient balance. Manage your billing here: https://opencode.ai/workspace/demo"),
+		).toBe("QUOTA_EXHAUSTED");
+	});
+
 	it("classifies Antigravity capacity-exhausted as QUOTA_EXHAUSTED, not transient MODEL_CAPACITY", () => {
 		// Antigravity returns "You have exhausted your capacity on this model. Your
 		// quota will reset after 3h6m38s." The literal "capacity" used to win the
@@ -74,6 +80,12 @@ describe("isUsageLimitError", () => {
 			isUsageLimitError(
 				'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s rate limit. Please try again later."}}',
 			),
+		).toBe(true);
+	});
+
+	it("detects OpenCode Go insufficient balance as a credential-rotatable usage limit", () => {
+		expect(
+			isUsageLimitError("401 Insufficient balance. Manage your billing here: https://opencode.ai/workspace/demo"),
 		).toBe(true);
 	});
 


### PR DESCRIPTION
## Repro
`bun -e 'import { isUsageLimitError, parseRateLimitReason } from "./packages/ai/src/rate-limit-utils.ts"; const msg = "401 Insufficient balance. Manage your billing here: https://opencode.ai/workspace/demo"; console.log(JSON.stringify({ isUsageLimitError: isUsageLimitError(msg), reason: parseRateLimitReason(msg) })); process.exit(isUsageLimitError(msg) || parseRateLimitReason(msg) !== "UNKNOWN" ? 1 : 0);'` reproduced the bug before the fix: OpenCode Go `401 Insufficient balance` returned `isUsageLimitError=false` and `parseRateLimitReason=UNKNOWN`.

## Cause
`packages/ai/src/rate-limit-utils.ts` only classified quota exhaustion through quota/usage/resource phrases in `parseRateLimitReason()` and `USAGE_LIMIT_PATTERN`; OpenCode Go reports the same exhausted-account state as `Insufficient balance`, so the message fell through to `UNKNOWN` and skipped usage-limit retry handling.

## Fix
- Added an `insufficient.?balance` classifier to `parseRateLimitReason()` so OpenCode Go exhausted-account errors become `QUOTA_EXHAUSTED`.
- Added the same phrase to `USAGE_LIMIT_PATTERN` so `isUsageLimitError()` engages credential rotation and fallback chains.
- Added regression coverage in `packages/ai/test/rate-limit-utils.test.ts` for both parsing and usage-limit detection.

## Verification
`bun test packages/ai/test/rate-limit-utils.test.ts` passed: 18 tests, 58 assertions. `bun --cwd=packages/ai run check` passed. The fixed repro now returns `{"isUsageLimitError":true,"reason":"QUOTA_EXHAUSTED"}`. Fixes #3169