### PR TITLE
fix(auth-gateway): prevent 429 rate-limit errors from being misclassified as 401 auth errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DashScope (Alibaba Cloud China) 429 rate-limit errors being misclassified as 401 authentication errors when the error message contained both "rate limit" and "unauthorized" wording. The `classifyGatewayError` function now checks rate-limit patterns before auth patterns, preventing credential deletion via `invalidateCredentialMatching` and avoiding spurious "re-enter API key" prompts.
+
 ## [16.1.9] - 2026-06-21
 
 ### Added

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -229,9 +229,14 @@ export function classifyGatewayError(err: unknown): { status: number; type: stri
 	if (/\baborted\b|\babort signal\b/i.test(message)) {
 		return { status: 499, type: "request_aborted", message };
 	}
-	if (/\b(?:unauthorized|forbidden)\b/i.test(message)) {
-		return { status: 401, type: "authentication_error", message };
-	}
+	// Rate-limit check MUST run before unauthorized/forbidden: providers like
+	// DashScope (Alibaba Cloud China) sometimes return 429 messages containing
+	// both "rate limit" and "unauthorized" (e.g., "Rate limit exceeded -
+	// unauthorized due to throttling"). If the auth check ran first, these
+	// would be misclassified as 401, triggering credential deletion via
+	// `invalidateCredentialMatching` and prompting the user to re-enter their
+	// API key. Real auth errors (bad API key) never mention rate limits, so
+	// checking rate-limit patterns first is safe.
 	if (
 		// Match rate-limit phrasings without colliding with
 		// `GenerateContentRequest`, `accelerate`, `iterate`, `deprecated`, etc.
@@ -248,6 +253,9 @@ export function classifyGatewayError(err: unknown): { status: number; type: stri
 		isUsageLimitError(message)
 	) {
 		return { status: 429, type: "rate_limit_error", message };
+	}
+	if (/\b(?:unauthorized|forbidden)\b/i.test(message)) {
+		return { status: 401, type: "authentication_error", message };
 	}
 	if (/\b(?:unsupported|invalid_request|invalid request|bad request|malformed)\b/i.test(message)) {
 		return { status: 400, type: "invalid_request_error", message };

--- a/packages/ai/test/auth-gateway-classify-error.test.ts
+++ b/packages/ai/test/auth-gateway-classify-error.test.ts
@@ -103,6 +103,32 @@ describe("auth-gateway classifyGatewayError", () => {
 		expect(c.type).toBe("request_aborted");
 	});
 
+	it("classifies rate-limit messages containing 'unauthorized' as 429, not 401 (DashScope China bug)", () => {
+		// DashScope China sometimes returns 429 messages with both "rate limit"
+		// and "unauthorized" wording. The rate-limit check must win so the
+		// credential is not deleted via invalidateCredentialMatching.
+		const cases = [
+			"Rate limit exceeded - unauthorized due to throttling",
+			"429 unauthorized: rate limit exceeded for your account",
+			"Request unauthorized - rate limit reached, please retry later",
+			"Throttling: unauthorized due to rate limit",
+		];
+		for (const msg of cases) {
+			const c = classifyGatewayError(new Error(msg));
+			expect({ msg, status: c.status, type: c.type }).toEqual({
+				msg,
+				status: 429,
+				type: "rate_limit_error",
+			});
+		}
+	});
+
+	it("still classifies pure 'unauthorized' without rate-limit wording as 401", () => {
+		const c = classifyGatewayError(new Error("unauthorized: invalid API key"));
+		expect(c.status).toBe(401);
+		expect(c.type).toBe("authentication_error");
+	});
+
 	it("falls through to 502 upstream_error when nothing matches", () => {
 		const c = classifyGatewayError(new Error("something inscrutable happened"));
 		expect(c.status).toBe(502);


### PR DESCRIPTION
## Problem

When using Alibaba Cloud DashScope (China endpoint), 429 rate-limit errors were being misclassified as 401 authentication errors. This caused the credential to be deleted via `invalidateCredentialMatching`, prompting users to re-enter their API key.

## Root Cause

In `classifyGatewayError`, the `unauthorized|forbidden` check ran **before** the rate-limit check. DashScope China sometimes returns 429 messages containing both "rate limit" and "unauthorized" wording (e.g., "Rate limit exceeded - unauthorized due to throttling"). The auth pattern matched first, misclassifying the error as 401.

## Solution

Reordered the checks in `classifyGatewayError` so rate-limit patterns are evaluated **before** auth patterns. This is safe because:
- Real auth errors (bad API key) never mention rate limits
- Rate-limit errors sometimes use "unauthorized" loosely

## Changes

- `packages/ai/src/auth-gateway/server.ts`: Moved rate-limit check before unauthorized/forbidden check
- `packages/ai/test/auth-gateway-classify-error.test.ts`: Added regression tests for DashScope-style error messages
- `packages/ai/CHANGELOG.md`: Added fix entry

## Testing

All 15 tests pass, including 2 new regression tests:
- `classifies rate-limit messages containing 'unauthorized' as 429, not 401 (DashScope China bug)`
- `still classifies pure 'unauthorized' without rate-limit wording as 401`

Fixes #2886