### PR TITLE
fix(ai): classify DashScope throttles as rate limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DashScope 429 rate-limit messages that mention authorization being classified as credential failures, preventing valid API keys from being invalidated after throttling. ([#3172](https://github.com/can1357/oh-my-pi/issues/3172))
+
 ## [16.1.9] - 2026-06-21
 
 ### Added

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -229,11 +229,10 @@ export function classifyGatewayError(err: unknown): { status: number; type: stri
 	if (/\baborted\b|\babort signal\b/i.test(message)) {
 		return { status: 499, type: "request_aborted", message };
 	}
-	if (/\b(?:unauthorized|forbidden)\b/i.test(message)) {
-		return { status: 401, type: "authentication_error", message };
-	}
 	if (
-		// Match rate-limit phrasings without colliding with
+		// Match rate-limit phrasings before auth wording: some providers
+		// describe throttling as "unauthorized due to rate limit".
+		// Keep boundaries so this does not collide with
 		// `GenerateContentRequest`, `accelerate`, `iterate`, `deprecated`, etc.
 		/\brate[- _]?limit(?:s|ed|ing)?\b|\bquota(?:_exceeded| exceeded)?\b|\btoo[- _]many[- _]requests\b/i.test(
 			message,
@@ -248,6 +247,9 @@ export function classifyGatewayError(err: unknown): { status: number; type: stri
 		isUsageLimitError(message)
 	) {
 		return { status: 429, type: "rate_limit_error", message };
+	}
+	if (/\b(?:unauthorized|forbidden)\b/i.test(message)) {
+		return { status: 401, type: "authentication_error", message };
 	}
 	if (/\b(?:unsupported|invalid_request|invalid request|bad request|malformed)\b/i.test(message)) {
 		return { status: 400, type: "invalid_request_error", message };

--- a/packages/ai/test/auth-gateway-classify-error.test.ts
+++ b/packages/ai/test/auth-gateway-classify-error.test.ts
@@ -54,6 +54,12 @@ describe("auth-gateway classifyGatewayError", () => {
 		expect(c.type).toBe("rate_limit_error");
 	});
 
+	it("prefers rate-limit wording over auth wording", () => {
+		const c = classifyGatewayError(new Error("Rate limit exceeded - unauthorized due to throttling"));
+		expect(c.status).toBe(429);
+		expect(c.type).toBe("rate_limit_error");
+	});
+
 	it("classifies Codex 'You have hit your ChatGPT usage limit' as 429", () => {
 		// Verbatim shape Codex returns from the `usage_limit_reached` branch
 		// in `parseCodexError`. No embedded `HTTP NNN`/`(NNN)`/`status NNN`


### PR DESCRIPTION
## Repro
`classifyGatewayError(new Error("Rate limit exceeded - unauthorized due to throttling"))` reproduced the issue before the fix: it returned `{ status: 401, type: "authentication_error" }` and exited non-zero with `bun -e 'import { classifyGatewayError } from "./packages/ai/src/auth-gateway/server.ts"; const c = classifyGatewayError(new Error("Rate limit exceeded - unauthorized due to throttling")); console.log(JSON.stringify({ status: c.status, type: c.type, message: c.message })); if (c.status !== 429 || c.type !== "rate_limit_error") process.exit(1);'`.

## Cause
`packages/ai/src/auth-gateway/server.ts` checked `unauthorized|forbidden` before rate-limit wording inside `classifyGatewayError`, so DashScope throttle messages containing both rate-limit and authorization terms were bucketed as `authentication_error`, which can flow into credential invalidation.

## Fix
- Check rate-limit and usage-limit wording before auth wording in `classifyGatewayError`.
- Add a regression test for `Rate limit exceeded - unauthorized due to throttling`.
- Add an `@oh-my-pi/pi-ai` changelog entry for #3172.

## Verification
`bun test packages/ai/test/auth-gateway-classify-error.test.ts` passed: 14 tests, 31 assertions. The repro command now returns `{ status: 429, type: "rate_limit_error" }`. Fixes #3172