### PR TITLE
feat(memory): scope project memory by stable repository identity

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,6 +1,6 @@
 # Autonomous Memory
 
-When the local memory backend is enabled, the agent automatically extracts durable knowledge from past sessions and injects a compact summary into future sessions for the same project. Over time it builds a project-scoped memory store — technical decisions, recurring workflows, pitfalls — that carries forward without manual effort.
+When the local memory backend is enabled, the agent automatically extracts durable knowledge from past sessions and injects a compact summary into future sessions for the same project identity. Over time it builds a project-scoped memory store — technical decisions, recurring workflows, pitfalls — that carries forward without manual effort.
 
 Disabled by default. Enable the local summary pipeline via `/settings` or `config.yml`:
 
@@ -82,12 +82,21 @@ If the requested memory role is not configured, memory model resolution falls ba
 | Setting                               | Default | Description                                                                                                                              |
 | ------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `memory.backend`                      | `off`   | Select `local` for this pipeline; legacy `memories.enabled: true` is migrated to `memory.backend: local` when no explicit backend is set |
+| `memory.projectKey`                 | unset   | Optional stable project identity shared across worktrees, clones, and forks. Use a value such as `github.com/org/repo`, or leave empty to auto-detect from git. |
 | `memories.maxRolloutAgeDays`          | `30`    | Sessions older than this are not processed                                                                                               |
 | `memories.minRolloutIdleHours`        | `12`    | Sessions active more recently than this are skipped                                                                                      |
 | `memories.maxRolloutsPerStartup`      | `64`    | Cap on sessions processed in a single startup                                                                                            |
 | `memories.summaryInjectionTokenLimit` | `5000`  | Max tokens of the summary injected into the system prompt                                                                                |
 
 Additional tuning knobs (concurrency, lease durations, token budgets) are available in config for advanced use.
+
+### Project identity
+
+Memory scopes use a stable project identity instead of the current directory name when possible. Resolver order is: `OMP_PROJECT_KEY`, then `memory.projectKey`, then git remotes, then local git common-dir identity, then a path-hashed current-directory identity. Set the environment variable or config setting to force an identity shared across worktrees, clones, and forks.
+
+Values such as `github.com/org/repo`, HTTPS remotes, SSH remotes, and plain host/org/repo keys normalize to lowercase `host/org/repo` with a trailing `.git` stripped. The filesystem-safe segment replaces other characters with `-` and appends a short hash suffix so different project keys cannot collapse to the same directory or bank name. For git remotes, OMP prefers `upstream`, then `origin`, then the first valid remote. Local repositories without remotes share the git common directory identity across linked worktrees.
+
+Hindsight `per-project` scopes append the filesystem-safe segment to the bank id; `per-project-tagged` scopes use the tag `project:<key>`. Local memory roots and Mnemopi per-project banks use the same filesystem-safe segment. Outside git repositories, the fallback identity includes the cwd basename plus a path hash so unrelated directories with the same basename do not collide.
 
 ## Key files
 

--- a/docs/mnemosyne-memory-backend.md
+++ b/docs/mnemosyne-memory-backend.md
@@ -33,8 +33,9 @@ Recalled memory is background context, not instructions. Current user messages a
 | Setting                         | Default                | Description                                                                                                                                                             |
 | ------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `memory.backend`                | `off`                  | Set to `mnemopi` to enable this backend.                                                                                                                              |
-| `mnemopi.dbPath`              | agent memories dir     | Optional SQLite database path.                                                                                                                                          |
-| `mnemopi.bank`                | project directory name | Base bank name passed to `Mnemopi`; the coding-agent wrapper scopes from this base according to `mnemopi.scoping`.                                                  |
+| `memory.projectKey`             | unset                  | Optional stable project identity shared across worktrees, clones, and forks; `OMP_PROJECT_KEY` can override it, and git remotes are auto-detected when empty. |
+| `mnemopi.dbPath`                | agent memories dir     | Optional SQLite database path.                                                                                                                                          |
+| `mnemopi.bank`                  | default shared bank    | Base bank name passed to `Mnemopi`; the coding-agent wrapper scopes from this base according to `mnemopi.scoping`.                                                      |
 | `mnemopi.scoping`             | `per-project`          | Memory visibility mode: `global` = one shared bank, `per-project` = isolated project memory, `per-project-tagged` = project-local writes plus global recall visibility. |
 | `mnemopi.autoRecall`          | `true`                 | Recall memory on the first turn of a session.                                                                                                                           |
 | `mnemopi.autoRetain`          | `true`                 | Retain completed turns automatically.                                                                                                                                   |
@@ -58,8 +59,10 @@ Recalled memory is background context, not instructions. Current user messages a
 The coding-agent wrapper applies scoping on top of the underlying `Mnemopi` package:
 
 - `global` uses one shared bank for recall and writes.
-- `per-project` writes to and recalls from a bank derived from the current git repository root (or cwd) plus a stable hash.
-- `per-project-tagged` writes to the project-local bank and recalls from both the project-local bank and the shared global bank, with duplicate recall results merged.
+- `per-project` writes to and recalls from a bank derived from the stable project identity.
+- `per-project-tagged` writes to the project-local identity bank and recalls from both the project-local bank and the shared global bank, with duplicate recall results merged.
+
+The project bank name uses the filesystem-safe segment of the memory project identity, including its collision-resistant hash suffix. Outside git repositories, that identity already includes a cwd basename plus path hash so unrelated directories with the same basename do not collide.
 
 The combined project-plus-global behavior lives in the wrapper. The `@oh-my-pi/pi-mnemopi` package itself still exposes banks and constructor options directly, including `bank` for selecting a bank name. Project-local banks other than the shared bank are stored as sibling bank databases managed by Mnemopi's `BankManager`.
 

--- a/docs/tools/recall.md
+++ b/docs/tools/recall.md
@@ -60,12 +60,12 @@ When no matches exist:
 - Backend auto-recall has a richer query-composition path in `HindsightSessionState.beforeAgentStartPrompt(...)` / `maybeRecallOnAgentStart(...)` and `MnemopiSessionState.beforeAgentStartPrompt(...)` / `maybeRecallOnAgentStart(...)`.
 - Hindsight bank scoping:
   - `global` — no tag filter.
-  - `per-project` — separate bank id per cwd basename.
-  - `per-project-tagged` — shared bank id plus `project:<cwd basename>` filter with `tagsMatch = "any"`, so project-tagged and untagged global memories can both surface.
+  - `per-project` — separate bank id per normalized project identity.
+  - `per-project-tagged` — shared bank id plus `project:<key>` filter with `tagsMatch = "any"`, so project-tagged and untagged global memories can both surface.
 - Mnemopi bank scoping:
   - `global` — recall reads the shared bank.
-  - `per-project` — recall reads the project bank.
-  - `per-project-tagged` — recall reads the project bank and shared bank, then merges results.
+  - `per-project` — recall reads the project-identity bank.
+  - `per-project-tagged` — recall reads the project-identity bank and shared bank, then merges results.
 - Session scope: reads cross-session memory data, using the active session's cached config and scope.
 
 ## Side Effects
@@ -79,6 +79,7 @@ When no matches exist:
 
 ## Limits & Caps
 - Tool availability requires `memory.backend` to be `"hindsight"` or `"mnemopi"`; default `memory.backend` is `"off"`.
+- Shared project scoping uses `memory.projectKey` or `OMP_PROJECT_KEY` before falling back to git identity detection.
 - Hindsight client default budget for raw `HindsightApi.recall(...)` is `"mid"`; this tool overrides from config.
 - Hindsight recall settings:
   - `hindsight.recallBudget = "mid"`

--- a/docs/tools/reflect.md
+++ b/docs/tools/reflect.md
@@ -57,12 +57,12 @@ Mnemopi:
 - Mnemopi tool path: one local scoped recall followed by context formatting.
 - Hindsight bank scoping:
   - `global` — no tag filter.
-  - `per-project` — separate bank id per cwd basename.
-  - `per-project-tagged` — shared bank id plus `project:<cwd basename>` filter with `tagsMatch = "any"`.
+  - `per-project` — separate bank id per normalized project identity.
+  - `per-project-tagged` — shared bank id plus `project:<key>` filter with `tagsMatch = "any"`.
 - Mnemopi bank scoping:
   - `global` — reads the shared bank.
-  - `per-project` — reads the project bank.
-  - `per-project-tagged` — reads the project bank and shared bank, then merges results.
+  - `per-project` — reads the project-identity bank.
+  - `per-project-tagged` — reads the project-identity bank and shared bank, then merges results.
 - Session scope: reads cross-session memory data, but does not persist local output.
 
 ## Side Effects
@@ -77,6 +77,7 @@ Mnemopi:
 ## Limits & Caps
 - Tool availability requires `memory.backend` to be `"hindsight"` or `"mnemopi"`; default `memory.backend` is `"off"`.
 - Tool-level params: only `query` is required; `context` is optional.
+- Shared project scoping uses `memory.projectKey` or `OMP_PROJECT_KEY` before falling back to git identity detection.
 - Hindsight budget setting comes from `hindsight.recallBudget`, default `"mid"`.
 - Hindsight `reflect` has no client-side token cap parameter here; unlike `recall`, the tool does not pass `maxTokens`.
 - Hindsight mission initialization tracks up to `MISSION_SET_CAP = 10_000` bank ids, then drops the oldest half of the sorted set.

--- a/docs/tools/retain.md
+++ b/docs/tools/retain.md
@@ -59,12 +59,12 @@ Mnemopi:
 - Mnemopi tool path: direct local `remember(...)` into the scoped retain bank.
 - Hindsight bank scoping from `computeBankScope(...)`:
   - `global` — one shared bank, no project tags.
-  - `per-project` — bank id gets `-<cwd basename>` appended.
-  - `per-project-tagged` — shared bank plus `project:<cwd basename>` tags on retained memories.
+  - `per-project` — bank id gets the normalized project-identity segment appended.
+  - `per-project-tagged` — shared bank plus `project:<key>` tags on retained memories.
 - Mnemopi bank scoping from `resolveBankScope(...)`:
   - `global` — retain and recall use the shared bank.
-  - `per-project` — retain and recall use the project bank.
-  - `per-project-tagged` — retain writes project-local memories; recall also reads the shared bank.
+  - `per-project` — retain and recall use the project-identity bank.
+  - `per-project-tagged` — retain writes project-identity memories; recall also reads the shared bank.
 - Session scope:
   - tool-called retains are per-session work for the active backend;
   - persisted Hindsight memories are cross-session server-side bank data;
@@ -91,6 +91,7 @@ Mnemopi:
 ## Limits & Caps
 - Input schema requires `items.length >= 1`.
 - Tool availability requires `memory.backend` to be `"hindsight"` or `"mnemopi"`; default `memory.backend` is `"off"`.
+- Shared project scoping uses `memory.projectKey` or `OMP_PROJECT_KEY` before falling back to git identity detection.
 - Hindsight queue flush threshold: `RETAIN_FLUSH_BATCH_SIZE = 16`.
 - Hindsight queue debounce: `RETAIN_FLUSH_INTERVAL_MS = 5_000`.
 - Hindsight queue writes use `retainBatch(..., { async: true })`; the client does not wait for server-side consolidation.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added a structured memory runtime surface for extensions and UI integrations to query backend status, search memories, and save explicit memories across the configured memory backend.
 - Added support for Git repositories using the `reftable` storage format by detecting `extensions.refStorage = reftable` in the repository configuration and falling back to shelling out to Git commands (`git symbolic-ref`, `git rev-parse`) for reference and HEAD resolution.
 - Added `/setup providers` (also available as `/setup` or `/providers`) to reopen the interactive provider setup scene from an active TUI session, letting users sign in and choose a web search provider without rerunning the full onboarding flow.
+- Added `memory.projectKey`, a `/settings` memory identity that keeps local memory roots, Hindsight scopes, and Mnemopi banks stable across worktrees, clones, and forks while still auto-detecting git remotes when unset.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1398,6 +1398,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"memory.projectKey": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			label: "Memory Project Identity",
+			description:
+				"Optional stable memory identity shared across worktrees, clones, and forks (for example github.com/org/repo). Leave empty to auto-detect from the git remote.",
+		},
+	},
+
 	// Mnemopi local SQLite memory backend.
 	"mnemopi.dbPath": {
 		type: "string",
@@ -1427,7 +1438,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "memory",
 			label: "Mnemopi Scoping",
 			description:
-				"global = one shared bank; per-project = isolated bank per cwd; per-project-tagged = project-local writes plus global recall visibility",
+				"global = one shared bank; per-project = isolated bank per project identity; per-project-tagged = project-local writes plus global recall visibility",
 			options: [
 				{
 					value: "global",
@@ -1437,7 +1448,7 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "per-project",
 					label: "Per project",
-					description: "Project-local Mnemopi bank per cwd basename",
+					description: "Project-local Mnemopi bank per normalized project identity",
 				},
 				{
 					value: "per-project-tagged",
@@ -1581,7 +1592,8 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "memory",
 			label: "Hindsight Bank ID",
-			description: "Memory bank identifier (default: project name)",
+			description:
+				"Optional Hindsight bank base id. Per-project modes derive scope from the memory project identity.",
 			condition: "hindsightActive",
 		},
 	},
@@ -1595,7 +1607,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "memory",
 			label: "Hindsight Scoping",
 			description:
-				"global = one shared bank; per-project = isolated bank per cwd; per-project-tagged = shared bank with project tags so global + project memories merge on recall",
+				"global = one shared bank; per-project = isolated bank per project identity; per-project-tagged = shared bank with project tags so global + project memories merge on recall",
 			options: [
 				{
 					value: "global",
@@ -1605,13 +1617,13 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "per-project",
 					label: "Per project",
-					description: "Isolated bank per cwd basename — projects cannot see each other's memories",
+					description: "Isolated bank per normalized project identity — projects cannot see each other's memories",
 				},
 				{
 					value: "per-project-tagged",
 					label: "Per project (tagged)",
 					description:
-						"Shared bank, retains tagged with project:<cwd>. Recall surfaces project + untagged global memories together",
+						"Shared bank, retains tagged with project:<key>. Recall surfaces project + untagged global memories together",
 				},
 			],
 			condition: "hindsightActive",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1074,6 +1074,7 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 			appendOnlyModeSignal.fire(value);
 		}
 	},
+	"memory.projectKey": () => hindsightScopeSignal.fire(),
 	"hindsight.bankId": () => hindsightScopeSignal.fire(),
 	"hindsight.bankIdPrefix": () => hindsightScopeSignal.fire(),
 	"hindsight.scoping": () => hindsightScopeSignal.fire(),
@@ -1097,15 +1098,15 @@ const statusLineSessionAccentSignal = new SettingSignal("statusLine.sessionAccen
  */
 export const onStatusLineSessionAccentChanged = (cb: () => void) => statusLineSessionAccentSignal.on(cb);
 
-/** Fires when any `hindsight.bankId` / `bankIdPrefix` / `scoping` value changes. */
+/** Fires when any Hindsight scope-affecting setting changes. */
 const hindsightScopeSignal = new SettingSignal("hindsight scope");
 
 /**
  * Subscribe to changes in the Hindsight bank-scoping settings. Lets the
  * Hindsight backend rebuild the active `HindsightSessionState` when the
- * operator switches `hindsight.bankId`, `hindsight.bankIdPrefix`, or
- * `hindsight.scoping` mid-session so subsequent retain/recall calls land in
- * the new bank instead of the one selected at session start.
+ * operator switches `memory.projectKey`, `hindsight.bankId`,
+ * `hindsight.bankIdPrefix`, or `hindsight.scoping` mid-session so subsequent
+ * retain/recall calls land in the new scope instead of the one selected at session start.
  *
  * Returns an unsubscribe function. The callback receives no arguments — the
  * caller is expected to re-read the relevant settings via `Settings.get`.

--- a/packages/coding-agent/src/hindsight/bank.ts
+++ b/packages/coding-agent/src/hindsight/bank.ts
@@ -3,13 +3,14 @@
  *
  * Three scoping modes (`HindsightConfig.scoping`):
  *   - `global`              — single shared bank, no per-project filter.
- *   - `per-project`         — one bank per cwd basename, hard isolation.
- *   - `per-project-tagged`  — single shared bank, retains carry a `project:<name>`
- *                              tag and recall filters on it but still surfaces
- *                              untagged ("global") memories alongside.
+ *   - `per-project`         — one bank per resolved project identity segment,
+ *                              hard isolation.
+ *   - `per-project-tagged`  — single shared bank, retains carry a
+ *                              `project:<identity>` tag and recall filters on it
+ *                              but still surfaces untagged ("global") memories.
  *
  * The base bank id is `bankIdPrefix-bankId` (default `omp`). Per-project mode
- * appends `-<project>`; tagged mode leaves the bank untouched and uses tags.
+ * appends `-<project-segment>`; tagged mode leaves the bank untouched and uses tags.
  *
  * Bank existence is idempotent at module level — a banksSet keeps track of
  * banks we've already PUT so each session boundary doesn't fire a fresh
@@ -20,15 +21,13 @@
  * lands against a missing bank.
  */
 
-import * as path from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
-import * as git from "../utils/git";
+import { resolveMemoryProjectIdentity } from "../memory-project-identity";
 import type { HindsightApi } from "./client";
 import type { HindsightConfig } from "./config";
 
 const DEFAULT_BANK_NAME = "omp";
 const PROJECT_TAG_PREFIX = "project:";
-const UNKNOWN_PROJECT = "unknown";
 const MISSION_SET_CAP = 10_000;
 
 export type RecallTagsMatch = "any" | "all" | "any_strict" | "all_strict";
@@ -55,26 +54,6 @@ function baseBankId(config: HindsightConfig): string {
 }
 
 /**
- * Best-effort project label from a working-directory path.
- *
- * When `directory` lives inside a git repository we resolve the primary
- * checkout root (or the shared common dir for bare-repo worktrees) via
- * {@link git.repo.primaryRootSync} and basename that, so every linked
- * worktree of one repo shares the same `project:<name>` tag.
- * Outside a repo (or when resolution fails), fall back to the cwd basename.
- *
- * Sync only: this runs on the hot path of `computeBankScope`, which is
- * exposed as a sync API to callers like `backend.ts` and must stay sync.
- * `git.repo.primaryRootSync` walks `.git`/`commondir` with sync file reads —
- * no subprocess — so the cost is one or two `stat`s and a small `readFile`.
- */
-function projectLabel(directory: string): string {
-	if (!directory) return UNKNOWN_PROJECT;
-	const primary = git.repo.primaryRootSync(directory);
-	return path.basename(primary ?? directory) || UNKNOWN_PROJECT;
-}
-
-/**
  * Resolve the active bank target plus optional tag scoping.
  *
  * Always returns a non-empty `bankId`. Tag fields are populated only for
@@ -82,13 +61,14 @@ function projectLabel(directory: string): string {
  */
 export function computeBankScope(config: HindsightConfig, directory: string): BankScope {
 	const base = baseBankId(config);
+	const identity = resolveMemoryProjectIdentity(directory, config.projectKey);
 	switch (config.scoping) {
 		case "global":
 			return { bankId: base };
 		case "per-project":
-			return { bankId: `${base}-${projectLabel(directory)}` };
+			return { bankId: `${base}-${identity.segment}` };
 		case "per-project-tagged": {
-			const tag = `${PROJECT_TAG_PREFIX}${projectLabel(directory)}`;
+			const tag = `${PROJECT_TAG_PREFIX}${identity.key}`;
 			return {
 				bankId: base,
 				retainTags: [tag],

--- a/packages/coding-agent/src/hindsight/config.ts
+++ b/packages/coding-agent/src/hindsight/config.ts
@@ -12,6 +12,7 @@
 
 import { logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
+import { resolveConfiguredMemoryProjectKey } from "../memory-project-identity";
 
 export type HindsightScoping = "global" | "per-project" | "per-project-tagged";
 
@@ -22,6 +23,7 @@ export interface HindsightConfig {
 	bankId: string | null;
 	bankIdPrefix: string;
 	scoping: HindsightScoping;
+	projectKey: string | null;
 	bankMission: string;
 	retainMission: string | null;
 
@@ -117,6 +119,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 	const retainEveryNTurnsEnv = envInt(env.HINDSIGHT_RETAIN_EVERY_N_TURNS);
 
 	// Read from settings (each falls back to its schema default).
+	const projectKey = resolveConfiguredMemoryProjectKey(settings.get("memory.projectKey"), env);
 	const settingsRetainMode = pickRetainMode(settings.get("hindsight.retainMode"));
 	if (settings.get("hindsight.retainMode") && !settingsRetainMode) {
 		logger.warn("Hindsight: invalid retainMode setting, falling back to full-session", {
@@ -138,6 +141,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 		bankId: bankIdEnv ?? settings.get("hindsight.bankId") ?? null,
 		bankIdPrefix: settings.get("hindsight.bankIdPrefix") ?? "",
 		scoping: scopingEnv ?? settingsScoping ?? "per-project-tagged",
+		projectKey,
 		bankMission: bankMissionEnv ?? settings.get("hindsight.bankMission") ?? "",
 		retainMission: settings.get("hindsight.retainMission") ?? null,
 

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { getMemoryRoot } from "../memories";
+import { resolveConfiguredMemoryProjectKey } from "../memory-project-identity";
 import { AgentRegistry } from "../registry/agent-registry";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
@@ -20,7 +21,8 @@ export function memoryRootsFromRegistry(): string[] {
 	for (const ref of AgentRegistry.global().list()) {
 		const sm = ref.session?.sessionManager;
 		if (!sm) continue;
-		const root = getMemoryRoot(agentDir, sm.getCwd());
+		const projectKey = resolveConfiguredMemoryProjectKey(ref.session?.settings?.get("memory.projectKey"));
+		const root = getMemoryRoot(agentDir, sm.getCwd(), projectKey);
 		if (root && !roots.includes(root)) roots.push(root);
 	}
 	return roots;

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -10,6 +10,7 @@ import { getAgentDbPath, getMemoriesDir, logger, parseJsonlLenient, prompt } fro
 import type { ModelRegistry } from "../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
+import { resolveConfiguredMemoryProjectKey, resolveMemoryProjectIdentity } from "../memory-project-identity";
 import consolidationTemplate from "../prompts/memories/consolidation.md" with { type: "text" };
 import readPathTemplate from "../prompts/memories/read-path.md" with { type: "text" };
 import stageOneInputTemplate from "../prompts/memories/stage_one_input.md" with { type: "text" };
@@ -22,6 +23,7 @@ import {
 	enqueueGlobalWatermark,
 	heartbeatGlobalJob,
 	listStage1OutputsForGlobal,
+	listThreadScopes,
 	type MemoryThread,
 	markGlobalPhase2Failed,
 	markGlobalPhase2FailedUnowned,
@@ -29,6 +31,7 @@ import {
 	markStage1Failed,
 	markStage1SucceededNoOutput,
 	markStage1SucceededWithOutput,
+	migrateThreadProjectScope,
 	openMemoryDb,
 	type Stage1Claim,
 	type Stage1OutputRow,
@@ -38,6 +41,7 @@ import {
 
 interface MemoryRuntimeConfig {
 	enabled: boolean;
+	projectKey: string | null;
 	maxRolloutsPerStartup: number;
 	maxRolloutAgeDays: number;
 	minRolloutIdleHours: number;
@@ -57,6 +61,7 @@ interface MemoryRuntimeConfig {
 
 const DEFAULTS: MemoryRuntimeConfig = {
 	enabled: false,
+	projectKey: null,
 	maxRolloutsPerStartup: 64,
 	maxRolloutAgeDays: 30,
 	minRolloutIdleHours: 12,
@@ -154,7 +159,7 @@ export async function buildMemoryToolDeveloperInstructions(
 ): Promise<string | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd(), cfg.projectKey);
 	const summaryPath = path.join(memoryRoot, "memory_summary.md");
 
 	let text: string;
@@ -177,23 +182,37 @@ export async function buildMemoryToolDeveloperInstructions(
 /**
  * Clear all persisted memory state and generated artifacts.
  */
-export async function clearMemoryData(agentDir: string, cwd: string): Promise<void> {
+export async function clearMemoryData(
+	agentDir: string,
+	cwd: string,
+	configuredProjectKey?: string | null,
+): Promise<void> {
+	const projectKey = resolveConfiguredMemoryProjectKey(configuredProjectKey);
+	const scopeKey = resolveLocalMemoryProjectKey(cwd, projectKey);
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
-		clearMemoryDataInDb(db);
+		clearMemoryDataInDb(db, scopeKey, cwd);
 	} finally {
 		closeMemoryDb(db);
 	}
-	await fs.rm(getMemoryRoot(agentDir, cwd), { recursive: true, force: true });
+	await fs.rm(getMemoryRoot(agentDir, cwd, projectKey), { recursive: true, force: true });
+	await fs.rm(getLegacyMemoryRoot(agentDir, cwd), { recursive: true, force: true });
 }
 
 /**
  * Force-enqueue global consolidation maintenance work.
  */
-export function enqueueMemoryConsolidation(agentDir: string, cwd: string, sourceUpdatedAt = unixNow()): void {
+export function enqueueMemoryConsolidation(
+	agentDir: string,
+	cwd: string,
+	configuredProjectKey?: string | null,
+	sourceUpdatedAt = unixNow(),
+): void {
+	const projectKey = resolveConfiguredMemoryProjectKey(configuredProjectKey);
+	const scopeKey = resolveLocalMemoryProjectKey(cwd, projectKey);
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
-		enqueueGlobalWatermark(db, sourceUpdatedAt, cwd, { forceDirtyWhenNotAdvanced: true });
+		enqueueGlobalWatermark(db, sourceUpdatedAt, scopeKey, { forceDirtyWhenNotAdvanced: true });
 	} finally {
 		closeMemoryDb(db);
 	}
@@ -222,12 +241,15 @@ async function runPhase1(options: {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, session.sessionManager.getCwd());
+	const activeCwd = session.sessionManager.getCwd();
+	const activeProjectKey = resolveMemoryProjectIdentity(activeCwd).key;
+	const memoryRoot = getMemoryRoot(agentDir, activeCwd, config.projectKey);
 	const currentThreadId = session.sessionManager.getSessionId();
 
 	try {
-		const threads = await collectThreads(session, currentThreadId);
+		const threads = await collectThreads(session, currentThreadId, config.projectKey);
 		upsertThreads(db, threads);
+		migrateLegacyThreadScopes(db, activeCwd, activeProjectKey, config.projectKey);
 
 		const phase1Model = await resolveMemoryModel({
 			modelRegistry,
@@ -356,22 +378,23 @@ async function runPhase2(options: {
 }): Promise<void> {
 	const { session, modelRegistry, agentDir, config } = options;
 	const cwd = session.sessionManager.getCwd();
+	const projectKey = resolveLocalMemoryProjectKey(cwd, config.projectKey);
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, cwd);
+	const memoryRoot = getMemoryRoot(agentDir, cwd, config.projectKey);
 
 	try {
 		const claimResult = tryClaimGlobalPhase2Job(db, {
 			workerId,
 			leaseSeconds: config.phase2LeaseSeconds,
 			nowSec,
-			cwd,
+			cwd: projectKey,
 		});
 		if (claimResult.kind !== "claimed") return;
 
 		const claim = claimResult.claim;
-		const outputs = listStage1OutputsForGlobal(db, config.maxRawMemoriesForGlobal, cwd);
+		const outputs = listStage1OutputsForGlobal(db, config.maxRawMemoriesForGlobal, projectKey);
 		const newWatermark = computeCompletionWatermark(claim.inputWatermark, outputs);
 
 		await syncPhase2Artifacts(memoryRoot, outputs);
@@ -381,7 +404,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				newWatermark,
 				nowSec: unixNow(),
-				cwd,
+				cwd: projectKey,
 			});
 			if (!marked) {
 				logger.warn("Phase2 empty-input completion lost ownership", { memoryRoot });
@@ -400,7 +423,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: "No model available for phase2",
 				memoryRoot,
-				cwd,
+				cwd: projectKey,
 			});
 			return;
 		}
@@ -411,7 +434,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: "No API key available for phase2",
 				memoryRoot,
-				cwd,
+				cwd: projectKey,
 			});
 			return;
 		}
@@ -422,7 +445,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				leaseSeconds: config.phase2LeaseSeconds,
 				nowSec: unixNow(),
-				cwd,
+				cwd: projectKey,
 			});
 			if (!ok) {
 				heartbeatLostOwnership = true;
@@ -449,7 +472,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				newWatermark,
 				nowSec: unixNow(),
-				cwd,
+				cwd: projectKey,
 			});
 			if (!marked) {
 				throw new Error("Phase2 could not mark success: ownership lost");
@@ -460,7 +483,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: String(error),
 				memoryRoot,
-				cwd,
+				cwd: projectKey,
 				error,
 			});
 		} finally {
@@ -509,10 +532,49 @@ function markPhase2FailureWithFallback(
 	}
 }
 
-async function collectThreads(session: AgentSession, currentThreadId?: string): Promise<MemoryThread[]> {
+function migrateLegacyThreadScopes(
+	db: Database,
+	activeCwd: string,
+	activeProjectKey: string,
+	configuredProjectKey?: string | null,
+): void {
+	const resolvedProjectKey = resolveMemoryProjectIdentity(activeCwd, configuredProjectKey).key;
+	for (const row of listThreadScopes(db)) {
+		if (row.cwd === resolvedProjectKey) continue;
+		if (!shouldApplyActiveProjectKey(row.cwd, activeCwd, activeProjectKey)) continue;
+		migrateThreadProjectScope(db, {
+			threadId: row.id,
+			projectKey: resolvedProjectKey,
+			sourceUpdatedAt: row.sourceUpdatedAt,
+		});
+	}
+}
+
+function shouldApplyActiveProjectKey(threadCwd: string, activeCwd: string, activeProjectKey: string): boolean {
+	if (!threadCwd) return false;
+	if (isSameFilesystemPath(threadCwd, activeCwd)) return true;
+	if (!looksLikeFilesystemPath(threadCwd)) return false;
+	return resolveMemoryProjectIdentity(threadCwd).key === activeProjectKey;
+}
+
+function isSameFilesystemPath(left: string, right: string): boolean {
+	return looksLikeFilesystemPath(left) && looksLikeFilesystemPath(right) && path.resolve(left) === path.resolve(right);
+}
+
+function looksLikeFilesystemPath(value: string): boolean {
+	return path.isAbsolute(value) || value.startsWith(".");
+}
+
+async function collectThreads(
+	session: AgentSession,
+	currentThreadId?: string,
+	configuredProjectKey?: string | null,
+): Promise<MemoryThread[]> {
 	const sessionDir = session.sessionManager.getSessionDir();
 	const files = await fs.readdir(sessionDir);
 	const threads: MemoryThread[] = [];
+	const activeCwd = session.sessionManager.getCwd();
+	const activeProjectKey = resolveMemoryProjectIdentity(activeCwd).key;
 	for (const name of files) {
 		if (!name.endsWith(".jsonl")) continue;
 		const fullPath = path.join(sessionDir, name);
@@ -538,11 +600,12 @@ async function collectThreads(session: AgentSession, currentThreadId?: string): 
 		}
 
 		if (currentThreadId && id === currentThreadId) continue;
+		const projectKey = resolveThreadMemoryProjectKey(cwd, activeCwd, activeProjectKey, configuredProjectKey);
 		threads.push({
 			id,
 			updatedAt: Math.floor(stat.mtimeMs / 1000),
 			rolloutPath: fullPath,
-			cwd,
+			cwd: projectKey,
 			sourceKind: "cli",
 		});
 	}
@@ -1102,6 +1165,7 @@ async function resolveMemoryModel(options: {
 function loadMemoryConfig(settings: Settings): MemoryRuntimeConfig {
 	return {
 		enabled: settings.get("memory.backend") === "local" || settings.get("memories.enabled") === true,
+		projectKey: resolveConfiguredMemoryProjectKey(settings.get("memory.projectKey")),
 		maxRolloutsPerStartup: settings.get("memories.maxRolloutsPerStartup") ?? DEFAULTS.maxRolloutsPerStartup,
 		maxRolloutAgeDays: settings.get("memories.maxRolloutAgeDays") ?? DEFAULTS.maxRolloutAgeDays,
 		minRolloutIdleHours: settings.get("memories.minRolloutIdleHours") ?? DEFAULTS.minRolloutIdleHours,
@@ -1121,12 +1185,33 @@ function loadMemoryConfig(settings: Settings): MemoryRuntimeConfig {
 	};
 }
 
-export function getMemoryRoot(agentDir: string, cwd: string): string {
-	return path.join(getMemoriesDir(agentDir), encodeProjectPath(cwd));
+function resolveLocalMemoryProjectKey(cwd: string, configuredProjectKey?: string | null): string {
+	const identity = resolveMemoryProjectIdentity(cwd, configuredProjectKey);
+	return identity.key;
 }
 
-function encodeProjectPath(cwd: string): string {
-	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+function resolveThreadMemoryProjectKey(
+	threadCwd: string,
+	activeCwd: string,
+	activeProjectKey: string,
+	configuredProjectKey?: string | null,
+): string {
+	const autoIdentity = resolveMemoryProjectIdentity(threadCwd);
+	if (!configuredProjectKey) return autoIdentity.key;
+	if (shouldApplyActiveProjectKey(threadCwd, activeCwd, activeProjectKey)) {
+		return resolveMemoryProjectIdentity(threadCwd, configuredProjectKey).key;
+	}
+	return autoIdentity.key;
+}
+
+export function getMemoryRoot(agentDir: string, cwd: string, configuredProjectKey?: string | null): string {
+	const identity = resolveMemoryProjectIdentity(cwd, configuredProjectKey);
+	return path.join(getMemoriesDir(agentDir), `--${identity.segment}--`);
+}
+
+function getLegacyMemoryRoot(agentDir: string, cwd: string): string {
+	const encoded = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+	return path.join(getMemoriesDir(agentDir), encoded);
 }
 
 function unixNow(): number {

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -4,6 +4,7 @@ export interface MemoryThread {
 	id: string;
 	updatedAt: number;
 	rolloutPath: string;
+	/** Legacy DB column name; stores the resolved memory project key for new rows. */
 	cwd: string;
 	sourceKind: string;
 }
@@ -37,11 +38,11 @@ const GLOBAL_KIND = "memory_consolidate_global";
 const DEFAULT_RETRY_REMAINING = 3;
 
 /**
- * Per-project job key so Phase 2 consolidation is isolated to a single cwd.
- * Previously a single "global" key caused cross-project memory contamination.
+ * Per-memory-project job key so Phase 2 consolidation is isolated to a single
+ * resolved memory project identity.
  */
-function globalJobKey(cwd: string): string {
-	return `global:${cwd}`;
+function globalJobKey(projectKey: string): string {
+	return `global:${projectKey}`;
 }
 
 export function openMemoryDb(dbPath: string): Database {
@@ -92,14 +93,45 @@ export function closeMemoryDb(db: Database): void {
 	db.close();
 }
 
-export function clearMemoryData(db: Database): void {
-	db.exec(`
+export function clearMemoryData(db: Database, projectKey?: string, legacyCwd?: string): void {
+	const scopeKeys = uniqueScopeKeys(projectKey, legacyCwd);
+	if (scopeKeys.length === 0) {
+		db.exec(`
 DELETE FROM stage1_outputs;
 DELETE FROM threads;
 DELETE FROM jobs WHERE kind IN ('memory_stage1', 'memory_consolidate_global');
 `);
+		return;
+	}
+
+	const tx = db.transaction((keys: string[]) => {
+		for (const key of keys) {
+			db.prepare("DELETE FROM stage1_outputs WHERE thread_id IN (SELECT id FROM threads WHERE cwd = ?)").run(key);
+			db.prepare(`
+DELETE FROM jobs
+WHERE (kind = ? AND job_key IN (SELECT id FROM threads WHERE cwd = ?))
+   OR (kind = ? AND job_key = ?)
+`).run(STAGE1_KIND, key, GLOBAL_KIND, globalJobKey(key));
+			db.prepare("DELETE FROM threads WHERE cwd = ?").run(key);
+		}
+	});
+	tx(scopeKeys);
 }
 
+function uniqueScopeKeys(...keys: Array<string | undefined>): string[] {
+	return [...new Set(keys.filter((key): key is string => Boolean(key)))];
+}
+
+interface ExistingThreadScope {
+	cwd: string;
+	source_updated_at: number | null;
+}
+
+export interface MemoryThreadScope {
+	id: string;
+	cwd: string;
+	sourceUpdatedAt: number | null;
+}
 export function upsertThreads(db: Database, threads: MemoryThread[]): void {
 	if (threads.length === 0) return;
 	const stmt = db.prepare(`
@@ -111,12 +143,51 @@ ON CONFLICT(id) DO UPDATE SET
 	cwd = excluded.cwd,
 	source_kind = excluded.source_kind
 `);
+	const existingStmt = db.prepare(`
+SELECT t.cwd, o.source_updated_at
+FROM threads t
+LEFT JOIN stage1_outputs o ON o.thread_id = t.id
+WHERE t.id = ?
+`);
 	const tx = db.transaction((rows: MemoryThread[]) => {
 		for (const row of rows) {
+			const existing = existingStmt.get(row.id) as ExistingThreadScope | undefined;
 			stmt.run(row.id, row.updatedAt, row.rolloutPath, row.cwd, row.sourceKind);
+			if (existing?.cwd && existing.cwd !== row.cwd && existing.source_updated_at !== null) {
+				enqueueGlobalWatermark(db, existing.source_updated_at, row.cwd, { forceDirtyWhenNotAdvanced: true });
+			}
 		}
 	});
 	tx(threads);
+}
+
+export function listThreadScopes(db: Database): MemoryThreadScope[] {
+	const rows = db
+		.prepare(`
+SELECT t.id, t.cwd, o.source_updated_at
+FROM threads t
+LEFT JOIN stage1_outputs o ON o.thread_id = t.id
+`)
+		.all() as Array<{ id: string; cwd: string; source_updated_at: number | null }>;
+	return rows.map(row => ({
+		id: row.id,
+		cwd: row.cwd,
+		sourceUpdatedAt: row.source_updated_at,
+	}));
+}
+
+export function migrateThreadProjectScope(
+	db: Database,
+	params: { threadId: string; projectKey: string; sourceUpdatedAt: number | null },
+): void {
+	const tx = db.transaction(() => {
+		const result = db
+			.prepare("UPDATE threads SET cwd = ? WHERE id = ? AND cwd != ?")
+			.run(params.projectKey, params.threadId, params.projectKey);
+		if (Number(result.changes ?? 0) <= 0 || params.sourceUpdatedAt === null) return;
+		enqueueGlobalWatermark(db, params.sourceUpdatedAt, params.projectKey, { forceDirtyWhenNotAdvanced: true });
+	});
+	tx();
 }
 
 function ensureStage1Job(db: Database, threadId: string): void {
@@ -486,9 +557,10 @@ WHERE kind = ? AND job_key = ? AND status = 'running' AND ownership_token = ?
 	return Number(result.changes ?? 0) > 0;
 }
 
-// Filter by cwd so each project only consolidates its own thread outputs.
-// Before this filter existed, whichever project ran Phase 2 first got every
-// project's data written into its memory directory (see #369).
+// Filter by the resolved project key stored in `threads.cwd`, so each project
+// only consolidates its own thread outputs. Before this filter existed, whichever
+// project ran Phase 2 first wrote every project's data into its memory directory
+// (see #369).
 export function listStage1OutputsForGlobal(db: Database, limit: number, cwd: string): Stage1OutputRow[] {
 	const rows = db
 		.prepare(`

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -9,9 +9,9 @@ import type { MemoryBackend } from "./types";
 /**
  * Wraps the existing `memories/` module as a `MemoryBackend`.
  *
- * No behavioural change — every call delegates to the legacy entry points so
- * the local memory pipeline (rollout summarisation → SQLite → memory_summary.md)
- * keeps working exactly as before.
+ * The local pipeline still owns rollout summarisation → SQLite →
+ * memory_summary.md; this adapter only supplies backend lifecycle hooks and
+ * passes through the configured project identity for scoped roots/jobs.
  */
 export const localBackend: MemoryBackend = {
 	id: "local",
@@ -21,11 +21,11 @@ export const localBackend: MemoryBackend = {
 	async buildDeveloperInstructions(agentDir, settings) {
 		return buildMemoryToolDeveloperInstructions(agentDir, settings);
 	},
-	async clear(agentDir, cwd) {
-		await clearMemoryData(agentDir, cwd);
+	async clear(agentDir, cwd, session) {
+		await clearMemoryData(agentDir, cwd, session?.settings.get("memory.projectKey"));
 	},
-	async enqueue(agentDir, cwd) {
-		enqueueMemoryConsolidation(agentDir, cwd);
+	async enqueue(agentDir, cwd, session) {
+		enqueueMemoryConsolidation(agentDir, cwd, session?.settings.get("memory.projectKey"));
 	},
 	async status() {
 		return {

--- a/packages/coding-agent/src/memory-project-identity.test.ts
+++ b/packages/coding-agent/src/memory-project-identity.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "./config/settings";
+import { computeBankScope } from "./hindsight/bank";
+import { type HindsightConfig, loadHindsightConfig } from "./hindsight/config";
+import { getMemoryRoot } from "./memories";
+import { resolveMemoryProjectIdentity } from "./memory-project-identity";
+import { loadMnemopiConfig } from "./mnemopi/config";
+
+process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+process.env.GIT_CONFIG_NOSYSTEM = "1";
+process.env.GIT_TERMINAL_PROMPT = "0";
+process.env.GIT_ASKPASS = "true";
+delete process.env.XDG_CONFIG_HOME;
+
+const baseHindsightConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig => ({
+	hindsightApiUrl: "http://localhost:8888",
+	hindsightApiToken: null,
+	bankId: "omp",
+	bankIdPrefix: "",
+	scoping: "per-project-tagged",
+	projectKey: null,
+	bankMission: "",
+	retainMission: null,
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	recallBudget: "mid",
+	recallMaxTokens: 1024,
+	recallTypes: ["world", "experience"],
+	recallContextTurns: 1,
+	recallMaxQueryChars: 800,
+	recallPromptPreamble: "preamble",
+	debug: false,
+	mentalModelsEnabled: false,
+	mentalModelAutoSeed: false,
+	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
+	mentalModelMaxRenderChars: 16_000,
+	...overrides,
+});
+
+function runGit(cwd: string, args: string[]): string {
+	const result = Bun.spawnSync(["git", ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: "Test User",
+			GIT_AUTHOR_EMAIL: "test@example.com",
+			GIT_COMMITTER_NAME: "Test User",
+			GIT_COMMITTER_EMAIL: "test@example.com",
+		},
+	});
+	if (result.exitCode !== 0) {
+		const stderr = new TextDecoder().decode(result.stderr).trim();
+		const stdout = new TextDecoder().decode(result.stdout).trim();
+		throw new Error(`git ${args.join(" ")} failed: ${stderr || stdout || `exit ${result.exitCode}`}`);
+	}
+	return new TextDecoder().decode(result.stdout).trim();
+}
+
+async function withTempRepo(
+	callback: (roots: { main: string; linked: string }) => void | Promise<void>,
+): Promise<void> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-memory-project-identity-"));
+	try {
+		const main = path.join(baseDir, "repo-main");
+		const linked = path.join(baseDir, "repo-feature");
+		await fs.mkdir(main, { recursive: true });
+		runGit(main, ["-c", "init.defaultBranch=main", "init"]);
+		await fs.writeFile(path.join(main, "README.md"), "hello\n");
+		runGit(main, ["add", "README.md"]);
+		runGit(main, ["commit", "-m", "base"]);
+		runGit(main, ["worktree", "add", linked, "-b", "feature"]);
+		await callback({ main, linked });
+	} finally {
+		await fs.rm(baseDir, { recursive: true, force: true });
+	}
+}
+
+describe("memory project identity", () => {
+	it("uses an explicit project identity for Hindsight tags and local memory roots", () => {
+		const identity = resolveMemoryProjectIdentity("/tmp/any-worktree", " https://github.com/Org/Repo.git ");
+
+		expect(identity.key).toBe("github.com/org/repo");
+		expect(identity.segment).toStartWith("github-com-org-repo-");
+		expect(identity.source).toBe("explicit");
+		expect(
+			computeBankScope(baseHindsightConfig({ projectKey: "https://github.com/Org/Repo.git" }), "/tmp/a"),
+		).toEqual({
+			bankId: "omp",
+			retainTags: ["project:github.com/org/repo"],
+			recallTags: ["project:github.com/org/repo"],
+			recallTagsMatch: "any",
+		});
+		const memoryRoot = getMemoryRoot("/tmp/agent", "/tmp/a", "https://github.com/Org/Repo.git");
+		expect(path.basename(memoryRoot)).toStartWith("--github-com-org-repo-");
+		expect(memoryRoot).toEndWith("--");
+	});
+
+	it("prefers an upstream git remote so forks share the canonical project identity", async () => {
+		await withTempRepo(({ main, linked }) => {
+			runGit(main, ["remote", "add", "origin", "git@github.com:Fork/Repo.git"]);
+			runGit(main, ["remote", "add", "upstream", "https://github.com/Org/Repo.git"]);
+
+			const mainIdentity = resolveMemoryProjectIdentity(main);
+			const linkedIdentity = resolveMemoryProjectIdentity(linked);
+
+			expect(mainIdentity.key).toBe("github.com/org/repo");
+			expect(mainIdentity.segment).toStartWith("github-com-org-repo-");
+			expect(mainIdentity.source).toBe("git-remote");
+			expect(linkedIdentity).toEqual(mainIdentity);
+		});
+	});
+
+	it("ignores file remotes instead of treating local paths as hosted project identities", async () => {
+		await withTempRepo(({ main }) => {
+			runGit(main, ["remote", "add", "origin", "file:///tmp/Repo.git"]);
+
+			const identity = resolveMemoryProjectIdentity(main);
+
+			expect(identity.source).toBe("git-common-dir");
+			expect(identity.key).toStartWith("local/repo-main/");
+		});
+	});
+
+	it("uses the cwd path hash for non-git directories with the same basename", async () => {
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-memory-cwd-identity-"));
+		try {
+			const first = path.join(baseDir, "one", "app");
+			const second = path.join(baseDir, "two", "app");
+			await fs.mkdir(first, { recursive: true });
+			await fs.mkdir(second, { recursive: true });
+
+			const firstIdentity = resolveMemoryProjectIdentity(first);
+			const secondIdentity = resolveMemoryProjectIdentity(second);
+
+			expect(firstIdentity.source).toBe("cwd");
+			expect(secondIdentity.source).toBe("cwd");
+			expect(firstIdentity.key).toStartWith("cwd/app/");
+			expect(secondIdentity.key).toStartWith("cwd/app/");
+			expect(secondIdentity.key).not.toBe(firstIdentity.key);
+		} finally {
+			await fs.rm(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("adds a hash suffix so colliding normalized project segments stay distinct", () => {
+		const first = resolveMemoryProjectIdentity("/tmp/any-worktree", "github.com/org/repo-a");
+		const second = resolveMemoryProjectIdentity("/tmp/any-worktree", "github.com/org-repo/a");
+
+		expect(first.key).toBe("github.com/org/repo-a");
+		expect(second.key).toBe("github.com/org-repo/a");
+		expect(first.segment).toStartWith("github-com-org-repo-a-");
+		expect(second.segment).toStartWith("github-com-org-repo-a-");
+		expect(second.segment).not.toBe(first.segment);
+	});
+
+	it("uses the same local git identity for linked worktrees without remotes", async () => {
+		await withTempRepo(({ main, linked }) => {
+			const mainIdentity = resolveMemoryProjectIdentity(main);
+			const linkedIdentity = resolveMemoryProjectIdentity(linked);
+
+			expect(mainIdentity.source).toBe("git-common-dir");
+			expect(mainIdentity.key).toStartWith("local/repo-main/");
+			expect(linkedIdentity).toEqual(mainIdentity);
+		});
+	});
+
+	it("loads the explicit identity from settings and env for memory backends", () => {
+		const settings = Settings.isolated({
+			"memory.projectKey": "github.com/Org/Repo.git",
+			"mnemopi.scoping": "per-project-tagged",
+			"hindsight.scoping": "per-project-tagged",
+		});
+
+		expect(loadHindsightConfig(settings, {}).projectKey).toBe("github.com/Org/Repo.git");
+		expect(loadHindsightConfig(settings, { OMP_PROJECT_KEY: "https://gitlab.com/Team/App" }).projectKey).toBe(
+			"https://gitlab.com/Team/App",
+		);
+
+		const mnemopiConfig = loadMnemopiConfig(settings, "/tmp/agent");
+		expect(mnemopiConfig.retainBank).toStartWith("github-com-org-repo-");
+		expect(mnemopiConfig.recallBanks?.[0]).toStartWith("github-com-org-repo-");
+		expect(mnemopiConfig.recallBanks?.[1]).toBe("default");
+	});
+});

--- a/packages/coding-agent/src/memory-project-identity.ts
+++ b/packages/coding-agent/src/memory-project-identity.ts
@@ -1,0 +1,220 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as git from "./utils/git";
+
+export type MemoryProjectIdentitySource = "explicit" | "git-remote" | "git-common-dir" | "cwd";
+
+export interface MemoryProjectIdentity {
+	key: string;
+	segment: string;
+	source: MemoryProjectIdentitySource;
+}
+
+interface RemoteConfigEntry {
+	name: string;
+	url: string;
+}
+
+const DEFAULT_PROJECT_KEY = "unknown";
+const GIT_SUFFIX = /\.git$/i;
+const REMOTE_SECTION = /^\s*\[remote\s+"([^"]+)"\]\s*$/;
+const SECTION_HEADER = /^\s*\[/;
+const URL_ENTRY = /^\s*url\s*=\s*(.*?)\s*$/;
+const SCP_LIKE_REMOTE = /^(?:[^@\s]+@)?([^:/\s]+):(.+)$/;
+const URL_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+export function resolveConfiguredMemoryProjectKey(
+	configuredProjectKey: string | null | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): string | null {
+	const ompProjectKey = normalizeConfiguredProjectKey(env.OMP_PROJECT_KEY);
+	if (ompProjectKey) return ompProjectKey;
+	const hindsightProjectKey = normalizeConfiguredProjectKey(env.HINDSIGHT_PROJECT_KEY);
+	return hindsightProjectKey ?? normalizeConfiguredProjectKey(configuredProjectKey) ?? null;
+}
+
+export function resolveMemoryProjectIdentity(cwd: string, configuredProjectKey?: string | null): MemoryProjectIdentity {
+	const explicitKey = normalizeExplicitProjectKey(configuredProjectKey);
+	if (explicitKey) return toIdentity(explicitKey, "explicit");
+
+	const repository = cwd ? git.repo.resolveSync(cwd) : null;
+	if (repository) {
+		const remoteKey = resolveRemoteProjectKey(repository.commonDir);
+		if (remoteKey) return toIdentity(remoteKey, "git-remote");
+		return toIdentity(resolveLocalGitKey(repository), "git-common-dir");
+	}
+
+	if (!cwd) return toIdentity(DEFAULT_PROJECT_KEY, "cwd");
+	return toIdentity(resolveLocalCwdKey(cwd), "cwd");
+}
+
+function normalizeConfiguredProjectKey(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function toIdentity(key: string, source: MemoryProjectIdentitySource): MemoryProjectIdentity {
+	return {
+		key,
+		segment: projectSegment(key),
+		source,
+	};
+}
+
+function resolveRemoteProjectKey(commonDir: string): string | undefined {
+	const remotes = readRemoteConfig(path.join(commonDir, "config"));
+	const upstreamKey = pickRemoteKey(remotes, "upstream");
+	if (upstreamKey) return upstreamKey;
+	const originKey = pickRemoteKey(remotes, "origin");
+	return originKey ?? pickFirstRemoteKey(remotes);
+}
+
+function readRemoteConfig(configPath: string): RemoteConfigEntry[] {
+	let text: string;
+	try {
+		text = fs.readFileSync(configPath, "utf8");
+	} catch {
+		return [];
+	}
+
+	const remotes: RemoteConfigEntry[] = [];
+	let currentRemote: string | undefined;
+	for (const rawLine of text.split(/\r?\n/)) {
+		const section = REMOTE_SECTION.exec(rawLine);
+		if (section) {
+			currentRemote = section[1];
+			continue;
+		}
+		if (SECTION_HEADER.test(rawLine)) {
+			currentRemote = undefined;
+			continue;
+		}
+		if (!currentRemote) continue;
+		const url = URL_ENTRY.exec(rawLine);
+		if (!url) continue;
+		const value = url[1]?.trim();
+		if (value) remotes.push({ name: currentRemote, url: value });
+	}
+	return remotes;
+}
+
+function pickRemoteKey(remotes: readonly RemoteConfigEntry[], name: string): string | undefined {
+	for (const remote of remotes) {
+		if (remote.name !== name) continue;
+		const key = normalizeRemoteProjectKey(remote.url);
+		if (key) return key;
+	}
+	return undefined;
+}
+
+function pickFirstRemoteKey(remotes: readonly RemoteConfigEntry[]): string | undefined {
+	for (const remote of remotes) {
+		const key = normalizeRemoteProjectKey(remote.url);
+		if (key) return key;
+	}
+	return undefined;
+}
+
+function normalizeExplicitProjectKey(value: string | null | undefined): string | undefined {
+	const trimmed = normalizeConfiguredProjectKey(value);
+	if (!trimmed) return undefined;
+	return normalizeRemoteProjectKey(trimmed) ?? normalizePlainProjectKey(trimmed) ?? normalizeFallbackKey(trimmed);
+}
+
+function normalizeRemoteProjectKey(value: string): string | undefined {
+	const trimmed = value.trim();
+	const urlKey = normalizeUrlProjectKey(trimmed);
+	if (urlKey) return urlKey;
+	if (URL_SCHEME.test(trimmed)) return undefined;
+	return normalizeScpLikeProjectKey(trimmed);
+}
+
+function normalizeScpLikeProjectKey(value: string): string | undefined {
+	const scpLike = SCP_LIKE_REMOTE.exec(value);
+	if (!scpLike) return undefined;
+	return normalizeHostPath(scpLike[1] ?? "", scpLike[2] ?? "");
+}
+
+function normalizePlainProjectKey(value: string): string | undefined {
+	const trimmed = value.trim().replace(/^\/+|\/+$/g, "");
+	const parts = trimmed.split("/").filter(Boolean);
+	if (parts.length < 3) return undefined;
+	return normalizeHostPath(parts[0] ?? "", parts.slice(1).join("/"));
+}
+
+function normalizeUrlProjectKey(value: string): string | undefined {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return undefined;
+	}
+	if (!isRemoteUrlProtocol(url.protocol) || !url.hostname) return undefined;
+	return normalizeHostPath(url.hostname, url.pathname);
+}
+
+function isRemoteUrlProtocol(protocol: string): boolean {
+	switch (protocol) {
+		case "http:":
+		case "https:":
+		case "ssh:":
+		case "git:":
+		case "git+ssh:":
+			return true;
+		default:
+			return false;
+	}
+}
+
+function normalizeHostPath(host: string, rawPath: string): string | undefined {
+	const normalizedHost = host.trim().toLowerCase();
+	if (!normalizedHost) return undefined;
+	const parts = rawPath
+		.replace(/^\/+|\/+$/g, "")
+		.split("/")
+		.filter(Boolean);
+	if (parts.length < 2) return undefined;
+	const lastIndex = parts.length - 1;
+	const repoName = (parts[lastIndex] ?? "").replace(GIT_SUFFIX, "");
+	if (!repoName) return undefined;
+	parts[lastIndex] = repoName;
+	return `${normalizedHost}/${parts.join("/")}`.toLowerCase();
+}
+
+function canonicalPath(filePath: string): string {
+	try {
+		return fs.realpathSync.native(filePath);
+	} catch {
+		return path.resolve(filePath);
+	}
+}
+
+function resolveLocalGitKey(repository: git.GitRepository): string {
+	const commonDir = canonicalPath(repository.commonDir);
+	const primaryRoot = path.basename(commonDir) === ".git" ? path.dirname(commonDir) : commonDir;
+	const name = normalizeFallbackKey(path.basename(primaryRoot));
+	return `local/${name}/${stablePathHash(commonDir)}`;
+}
+
+function resolveLocalCwdKey(cwd: string): string {
+	const resolvedCwd = canonicalPath(cwd);
+	const name = normalizeFallbackKey(path.basename(resolvedCwd));
+	return `cwd/${name}/${stablePathHash(resolvedCwd)}`;
+}
+
+function stablePathHash(value: string): string {
+	return Bun.hash(value).toString(36).replace(/^-/, "n").toLowerCase();
+}
+
+function normalizeFallbackKey(value: string): string {
+	const normalized = value.trim().replace(GIT_SUFFIX, "").toLowerCase();
+	return normalized || DEFAULT_PROJECT_KEY;
+}
+
+function projectSegment(key: string): string {
+	const base = key
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return `${base || DEFAULT_PROJECT_KEY}-${stablePathHash(key)}`;
+}

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -2,7 +2,11 @@ import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
-import * as git from "../utils/git";
+import {
+	type MemoryProjectIdentity,
+	resolveConfiguredMemoryProjectKey,
+	resolveMemoryProjectIdentity,
+} from "../memory-project-identity";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
 
@@ -40,7 +44,11 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 	const configuredDbPath = settings.get("mnemopi.dbPath");
 	const cwd = settings.getCwd();
 	const scoping = settings.get("mnemopi.scoping");
-	const scope = resolveBankScope(settings.get("mnemopi.bank"), cwd, scoping);
+	const identity = resolveMemoryProjectIdentity(
+		cwd,
+		resolveConfiguredMemoryProjectKey(settings.get("memory.projectKey")),
+	);
+	const scope = resolveBankScope(settings.get("mnemopi.bank"), identity, scoping);
 	const llmMode = settings.get("mnemopi.llmMode");
 	return {
 		dbPath: configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db"),
@@ -91,8 +99,12 @@ interface MnemopiBankScope {
 
 // Mnemopi does not have built-in tag-filtered recall, so `per-project-tagged`
 // maps to a project-local write bank plus a shared recall-visible bank.
-function resolveBankScope(configured: string | undefined, cwd: string, scoping: MnemopiScoping): MnemopiBankScope {
-	const project = projectBank(configured, cwd);
+function resolveBankScope(
+	configured: string | undefined,
+	identity: MemoryProjectIdentity,
+	scoping: MnemopiScoping,
+): MnemopiBankScope {
+	const project = projectBank(configured, identity);
 	const globalBank = sharedBank(configured);
 	switch (scoping) {
 		case "global":
@@ -126,16 +138,9 @@ function sharedBank(configured: string | undefined): string {
 	return sanitizeBankName(configured) ?? DEFAULT_SHARED_BANK;
 }
 
-function projectBank(configured: string | undefined, cwd: string): string {
-	const projectRoot = git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd);
-	const project = projectBankSegment(projectRoot);
+function projectBank(configured: string | undefined, identity: MemoryProjectIdentity): string {
 	const base = sanitizeBankName(configured);
-	return limitBankName(base ? `${base}-${project}` : project);
-}
-
-function projectBankSegment(projectRoot: string): string {
-	const project = sanitizeBankName(path.basename(projectRoot)) ?? "default";
-	return limitBankName(`${project}-${Bun.hash(path.resolve(projectRoot)).toString(36)}`);
+	return limitBankName(base ? `${base}-${identity.segment}` : identity.segment);
 }
 
 function sanitizeBankName(value: string | undefined): string | undefined {

--- a/packages/coding-agent/test/hindsight-bank.test.ts
+++ b/packages/coding-agent/test/hindsight-bank.test.ts
@@ -64,6 +64,7 @@ const baseConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig =
 	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
 	mentalModelMaxRenderChars: 16_000,
 	...overrides,
+	projectKey: overrides.projectKey ?? null,
 });
 
 describe("computeBankScope", () => {
@@ -93,16 +94,16 @@ describe("computeBankScope", () => {
 	});
 
 	describe("scoping=per-project", () => {
-		it("appends the cwd basename to the base bank id", () => {
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), "/work/proj")).toEqual({
-				bankId: "omp-proj",
-			});
+		it("appends a path-hashed cwd fallback to the base bank id", () => {
+			const scope = computeBankScope(baseConfig({ scoping: "per-project" }), "/work/proj");
+
+			expect(scope.bankId).toStartWith("omp-cwd-proj-");
 		});
 
 		it("appends `unknown` for an empty cwd", () => {
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), "")).toEqual({
-				bankId: "omp-unknown",
-			});
+			const scope = computeBankScope(baseConfig({ scoping: "per-project" }), "");
+
+			expect(scope.bankId).toStartWith("omp-unknown-");
 		});
 
 		it("composes prefix + bankId + project", () => {
@@ -110,7 +111,7 @@ describe("computeBankScope", () => {
 				baseConfig({ scoping: "per-project", bankId: "team", bankIdPrefix: "prod" }),
 				"/work/cool-app",
 			);
-			expect(scope.bankId).toBe("prod-team-cool-app");
+			expect(scope.bankId).toStartWith("prod-team-cwd-cool-app-");
 		});
 
 		it("does not surface tag fields (isolation is at the bank level)", () => {
@@ -122,31 +123,31 @@ describe("computeBankScope", () => {
 
 	describe("scoping=per-project-tagged", () => {
 		it("keeps the base bank id and emits project tags with `any` match", () => {
-			expect(computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "/work/proj")).toEqual({
-				bankId: "omp",
-				retainTags: ["project:proj"],
-				recallTags: ["project:proj"],
-				recallTagsMatch: "any",
-			});
+			const scope = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "/work/proj");
+
+			expect(scope.bankId).toBe("omp");
+			expect(scope.retainTags?.[0]).toStartWith("project:cwd/proj/");
+			expect(scope.recallTags?.[0]).toStartWith("project:cwd/proj/");
+			expect(scope.recallTagsMatch).toBe("any");
 		});
 
 		it("uses the same project label for retain and recall tags", () => {
 			const scope = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "/repo/cool-app");
-			expect(scope.retainTags).toEqual(["project:cool-app"]);
-			expect(scope.recallTags).toEqual(["project:cool-app"]);
+			expect(scope.retainTags?.[0]).toStartWith("project:cwd/cool-app/");
+			expect(scope.recallTags).toEqual(scope.retainTags);
 		});
 
 		it("falls back to project:unknown when cwd is empty", () => {
 			const scope = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "");
 			expect(scope.retainTags).toEqual(["project:unknown"]);
-			expect(scope.recallTags).toEqual(["project:unknown"]);
+			expect(scope.recallTags).toEqual(scope.retainTags);
 		});
 	});
 
-	// Regression for #2232: linked git worktrees used to silo memory into
-	// distinct `project:<basename>` tags. The fix resolves the primary
-	// checkout root via `git.repo.primaryRootSync`, so every worktree of one
-	// repo collapses to the same tag (and the same per-project bank id).
+	// Regression for #2232 and follow-up stable identity scoping: linked git
+	// worktrees should resolve to one project identity. With a remote, that
+	// identity is the normalized remote key. Without a remote, it is a stable
+	// local key derived from the shared git common dir.
 	describe("git worktree handling", () => {
 		let baseDir: string;
 		let primaryRoot: string;
@@ -184,32 +185,30 @@ describe("computeBankScope", () => {
 		it("emits the same project tag from the primary checkout and a linked worktree", () => {
 			const fromPrimary = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), primaryRoot);
 			const fromWorktree = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), worktreeRoot);
-			expect(fromPrimary.retainTags).toEqual(["project:myrepo"]);
-			expect(fromWorktree.retainTags).toEqual(["project:myrepo"]);
+			expect(fromPrimary.retainTags?.[0]).toStartWith("project:local/myrepo/");
 			expect(fromWorktree).toEqual(fromPrimary);
 		});
 
 		it("uses the primary root basename for the per-project bank id from a worktree", () => {
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), worktreeRoot)).toEqual({
-				bankId: "omp-myrepo",
-			});
+			expect(computeBankScope(baseConfig({ scoping: "per-project" }), worktreeRoot).bankId).toStartWith(
+				"omp-local-myrepo-",
+			);
 		});
 
 		it("emits one shared project label across worktrees attached to a bare repository", () => {
 			const fromA = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeA);
 			const fromB = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeB);
-			expect(fromA.retainTags).toEqual(["project:bare-repo.git"]);
+			expect(fromA.retainTags?.[0]).toStartWith("project:local/bare-repo/");
 			expect(fromB).toEqual(fromA);
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), bareWorktreeB)).toEqual({
-				bankId: "omp-bare-repo.git",
-			});
+			expect(computeBankScope(baseConfig({ scoping: "per-project" }), bareWorktreeB).bankId).toStartWith(
+				"omp-local-bare-repo-",
+			);
 		});
 
-		it("falls back to the cwd basename outside any repository", () => {
+		it("falls back to a path-hashed cwd identity outside any repository", () => {
 			// The temp parent dir is not itself a repo — it just contains one.
-			expect(computeBankScope(baseConfig({ scoping: "per-project-tagged" }), baseDir).retainTags).toEqual([
-				`project:${path.basename(baseDir)}`,
-			]);
+			const tag = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), baseDir).retainTags?.[0];
+			expect(tag).toStartWith(`project:cwd/${path.basename(baseDir).toLowerCase()}/`);
 		});
 	});
 });
@@ -217,7 +216,7 @@ describe("computeBankScope", () => {
 describe("deriveBankId (legacy wrapper)", () => {
 	it("returns the bankId field of the resolved scope", () => {
 		expect(deriveBankId(baseConfig({ bankId: "team", bankIdPrefix: "prod" }), "/cwd")).toBe("prod-team");
-		expect(deriveBankId(baseConfig({ scoping: "per-project" }), "/work/proj")).toBe("omp-proj");
+		expect(deriveBankId(baseConfig({ scoping: "per-project" }), "/work/proj")).toStartWith("omp-cwd-proj-");
 		expect(deriveBankId(baseConfig({ scoping: "per-project-tagged" }), "/work/proj")).toBe("omp");
 	});
 });

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
@@ -15,7 +16,10 @@ interface MemoryFixture {
 	cleanupRoot: string;
 }
 
-async function withMemoryFixture(fn: (fixture: MemoryFixture) => Promise<void>): Promise<void> {
+async function withMemoryFixture(
+	fn: (fixture: MemoryFixture) => Promise<void>,
+	options?: { settings?: Settings },
+): Promise<void> {
 	const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-"));
 	const previousAgentDir = getAgentDir();
 	try {
@@ -24,13 +28,15 @@ async function withMemoryFixture(fn: (fixture: MemoryFixture) => Promise<void>):
 		const cwd = path.join(cleanupRoot, "project");
 		await fs.mkdir(cwd, { recursive: true });
 		setAgentDir(agentDir);
-		const memoryRoot = getMemoryRoot(agentDir, cwd);
+		const projectKey = options?.settings?.get("memory.projectKey");
+		const memoryRoot = getMemoryRoot(agentDir, cwd, projectKey);
 		await fs.mkdir(memoryRoot, { recursive: true });
 		AgentRegistry.global().register({
 			id: "test-main",
 			displayName: "test",
 			kind: "main",
 			session: {
+				...(options?.settings ? { settings: options.settings } : {}),
 				sessionManager: {
 					getCwd: () => cwd,
 					getArtifactsDir: () => null,
@@ -67,6 +73,22 @@ describe("MemoryProtocolHandler", () => {
 			expect(resource.content).toBe("summary");
 			expect(resource.contentType).toBe("text/markdown");
 		});
+	});
+
+	it("resolves memory://root from the configured project identity", async () => {
+		const settings = Settings.isolated({ "memory.projectKey": "github.com/Org/Repo" });
+		await withMemoryFixture(
+			async ({ memoryRoot }) => {
+				await Bun.write(path.join(memoryRoot, "memory_summary.md"), "project summary");
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("memory://root");
+
+				expect(path.basename(memoryRoot)).toStartWith("--github-com-org-repo-");
+				expect(resource.content).toBe("project summary");
+			},
+			{ settings },
+		);
 	});
 
 	it("resolves memory://root/<path> within memory root", async () => {

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -7,10 +7,12 @@ import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
+	clearMemoryData,
 	getMemoryRoot,
 	startMemoryStartupTask,
 } from "@oh-my-pi/pi-coding-agent/memories";
 import * as memoryStorage from "@oh-my-pi/pi-coding-agent/memories/storage";
+import { resolveMemoryProjectIdentity } from "@oh-my-pi/pi-coding-agent/memory-project-identity";
 import { getAgentDbPath, Snowflake } from "@oh-my-pi/pi-utils";
 
 interface SessionFixture {
@@ -301,6 +303,167 @@ describe("memories runtime", () => {
 		expect(spy.mock.calls[1]?.[2]?.reasoning).toBe(Effort.High);
 	});
 
+	test("explicit project key only rewrites matching histories in shared session dirs", async () => {
+		const fx = await createFixture({
+			"memory.projectKey": "github.com/current/repo",
+			"memories.minRolloutIdleHours": 999,
+		});
+		const unrelatedCwd = await makeTempDir("memories-runtime-unrelated");
+		const unrelatedSession = path.join(fx.sessionDir, "unrelated-session.jsonl");
+		await fs.writeFile(
+			unrelatedSession,
+			`${JSON.stringify({ type: "session", id: "unrelated-thread", cwd: unrelatedCwd })}\n`,
+		);
+		const sameProjectSession = path.join(fx.sessionDir, "same-project-session.jsonl");
+		await fs.writeFile(
+			sameProjectSession,
+			`${JSON.stringify({
+				type: "session",
+				id: "same-project-thread",
+				cwd: fx.session.sessionManager.getCwd(),
+			})}\n`,
+		);
+
+		startMemoryStartupTask({
+			session: fx.session,
+			settings: fx.settings,
+			modelRegistry: fx.modelRegistry,
+			agentDir: fx.agentDir,
+			taskDepth: 0,
+		});
+
+		await waitFor(() => {
+			const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+			try {
+				const unrelatedRow = db.prepare("SELECT cwd FROM threads WHERE id = ?").get("unrelated-thread") as
+					| { cwd: string }
+					| undefined;
+				const sameProjectRow = db.prepare("SELECT cwd FROM threads WHERE id = ?").get("same-project-thread") as
+					| { cwd: string }
+					| undefined;
+				expect(unrelatedRow?.cwd).toBe(resolveMemoryProjectIdentity(unrelatedCwd).key);
+				expect(sameProjectRow?.cwd).toBe("github.com/current/repo");
+			} finally {
+				memoryStorage.closeMemoryDb(db);
+			}
+		});
+	});
+
+	test("explicit project key migrates legacy stored thread outputs without the session file", async () => {
+		const fx = await createFixture({
+			"memory.projectKey": "github.com/current/repo",
+			"memories.minRolloutIdleHours": 999,
+		});
+		vi.spyOn(ai, "completeSimple").mockResolvedValueOnce({
+			stopReason: "end_turn",
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						memory_md: "# Memory\n\nMigrated",
+						memory_summary: "Migrated summary",
+						skills: [],
+					}),
+				},
+			],
+		} as any);
+
+		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+		memoryStorage.upsertThreads(db, [
+			{
+				id: "legacy-thread",
+				updatedAt: 100,
+				rolloutPath: "/tmp/missing-legacy-thread.jsonl",
+				cwd: fx.session.sessionManager.getCwd(),
+				sourceKind: "cli",
+			},
+		]);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("legacy-thread", 100, "legacy raw", "legacy summary", null, 100);
+		memoryStorage.closeMemoryDb(db);
+
+		startMemoryStartupTask({
+			session: fx.session,
+			settings: fx.settings,
+			modelRegistry: fx.modelRegistry,
+			agentDir: fx.agentDir,
+			taskDepth: 0,
+		});
+
+		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd(), "github.com/current/repo");
+		await waitFor(async () => {
+			expect((await fs.readFile(path.join(memoryRoot, "MEMORY.md"), "utf8")).trim()).toBe("# Memory\n\nMigrated");
+			expect(await fs.readFile(path.join(memoryRoot, "raw_memories.md"), "utf8")).toContain("legacy raw");
+			const scopedDb = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+			try {
+				const row = scopedDb.prepare("SELECT cwd FROM threads WHERE id = ?").get("legacy-thread") as
+					| { cwd: string }
+					| undefined;
+				expect(row?.cwd).toBe("github.com/current/repo");
+			} finally {
+				memoryStorage.closeMemoryDb(scopedDb);
+			}
+		});
+	});
+
+	test("auto project identity migrates legacy stored thread outputs without the session file", async () => {
+		const fx = await createFixture({ "memories.minRolloutIdleHours": 999 });
+		vi.spyOn(ai, "completeSimple").mockResolvedValueOnce({
+			stopReason: "end_turn",
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						memory_md: "# Memory\n\nAuto migrated",
+						memory_summary: "Auto migrated summary",
+						skills: [],
+					}),
+				},
+			],
+		} as any);
+		const projectKey = resolveMemoryProjectIdentity(fx.session.sessionManager.getCwd()).key;
+
+		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+		memoryStorage.upsertThreads(db, [
+			{
+				id: "auto-legacy-thread",
+				updatedAt: 100,
+				rolloutPath: "/tmp/missing-auto-legacy-thread.jsonl",
+				cwd: fx.session.sessionManager.getCwd(),
+				sourceKind: "cli",
+			},
+		]);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("auto-legacy-thread", 100, "auto legacy raw", "auto legacy summary", null, 100);
+		memoryStorage.closeMemoryDb(db);
+
+		startMemoryStartupTask({
+			session: fx.session,
+			settings: fx.settings,
+			modelRegistry: fx.modelRegistry,
+			agentDir: fx.agentDir,
+			taskDepth: 0,
+		});
+
+		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
+		await waitFor(async () => {
+			expect((await fs.readFile(path.join(memoryRoot, "MEMORY.md"), "utf8")).trim()).toBe(
+				"# Memory\n\nAuto migrated",
+			);
+			const scopedDb = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+			try {
+				const row = scopedDb.prepare("SELECT cwd FROM threads WHERE id = ?").get("auto-legacy-thread") as
+					| { cwd: string }
+					| undefined;
+				expect(row?.cwd).toBe(projectKey);
+			} finally {
+				memoryStorage.closeMemoryDb(scopedDb);
+			}
+		});
+	});
+
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {
 		const fx = await createFixture();
 		vi.spyOn(ai, "completeSimple").mockResolvedValue({
@@ -317,20 +480,21 @@ describe("memories runtime", () => {
 			],
 		} as any);
 
+		const projectKey = resolveMemoryProjectIdentity(fx.session.sessionManager.getCwd()).key;
 		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
 		memoryStorage.upsertThreads(db, [
 			{
 				id: "thread-a",
 				updatedAt: 100,
 				rolloutPath: "/tmp/a.jsonl",
-				cwd: fx.session.sessionManager.getCwd(),
+				cwd: projectKey,
 				sourceKind: "cli",
 			},
 			{
 				id: "thread-b",
 				updatedAt: 200,
 				rolloutPath: "/tmp/b.jsonl",
-				cwd: fx.session.sessionManager.getCwd(),
+				cwd: projectKey,
 				sourceKind: "cli",
 			},
 		]);
@@ -340,7 +504,7 @@ describe("memories runtime", () => {
 		db.prepare(
 			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
 		).run("thread-b", 200, "raw-b", "summary-b", "beta", 200);
-		memoryStorage.enqueueGlobalWatermark(db, 200, fx.session.sessionManager.getCwd(), {
+		memoryStorage.enqueueGlobalWatermark(db, 200, projectKey, {
 			forceDirtyWhenNotAdvanced: true,
 		});
 		memoryStorage.closeMemoryDb(db);
@@ -368,6 +532,7 @@ describe("memories runtime", () => {
 
 	test("phase2 empty-input cleanup removes consolidated files and skills dir", async () => {
 		const fx = await createFixture();
+		const projectKey = resolveMemoryProjectIdentity(fx.session.sessionManager.getCwd()).key;
 		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
 		await fs.mkdir(path.join(memoryRoot, "skills", "legacy"), { recursive: true });
 		await fs.writeFile(path.join(memoryRoot, "MEMORY.md"), "legacy memory");
@@ -375,7 +540,7 @@ describe("memories runtime", () => {
 		await fs.writeFile(path.join(memoryRoot, "skills", "legacy", "SKILL.md"), "legacy skill");
 
 		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
-		memoryStorage.enqueueGlobalWatermark(db, 300, fx.session.sessionManager.getCwd(), {
+		memoryStorage.enqueueGlobalWatermark(db, 300, projectKey, {
 			forceDirtyWhenNotAdvanced: true,
 		});
 		memoryStorage.closeMemoryDb(db);
@@ -396,6 +561,49 @@ describe("memories runtime", () => {
 				"# Raw Memories\n\nNo raw memories yet.",
 			);
 		});
+	});
+
+	test("clearMemoryData removes configured project artifacts and legacy cwd artifacts", async () => {
+		const fx = await createFixture({ "memory.projectKey": "github.com/current/repo" });
+		const cwd = fx.session.sessionManager.getCwd();
+		const projectRoot = getMemoryRoot(fx.agentDir, cwd, "github.com/current/repo");
+		const legacyRoot = path.join(fx.agentDir, "memories", `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`);
+		await fs.mkdir(projectRoot, { recursive: true });
+		await fs.mkdir(legacyRoot, { recursive: true });
+		await fs.writeFile(path.join(projectRoot, "memory_summary.md"), "project");
+		await fs.writeFile(path.join(legacyRoot, "memory_summary.md"), "legacy");
+
+		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+		memoryStorage.upsertThreads(db, [
+			{ id: "legacy-thread", updatedAt: 100, rolloutPath: "/tmp/legacy.jsonl", cwd, sourceKind: "cli" },
+			{
+				id: "project-thread",
+				updatedAt: 101,
+				rolloutPath: "/tmp/project.jsonl",
+				cwd: "github.com/current/repo",
+				sourceKind: "cli",
+			},
+			{
+				id: "other-thread",
+				updatedAt: 102,
+				rolloutPath: "/tmp/other.jsonl",
+				cwd: "github.com/other/repo",
+				sourceKind: "cli",
+			},
+		]);
+		memoryStorage.closeMemoryDb(db);
+
+		await clearMemoryData(fx.agentDir, cwd, "github.com/current/repo");
+
+		expect(await Bun.file(projectRoot).exists()).toBe(false);
+		expect(await Bun.file(legacyRoot).exists()).toBe(false);
+		const scopedDb = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
+		try {
+			const rows = scopedDb.prepare("SELECT id FROM threads ORDER BY id").all() as { id: string }[];
+			expect(rows.map(row => row.id)).toEqual(["other-thread"]);
+		} finally {
+			memoryStorage.closeMemoryDb(scopedDb);
+		}
 	});
 });
 

--- a/packages/coding-agent/test/memories-storage.test.ts
+++ b/packages/coding-agent/test/memories-storage.test.ts
@@ -143,6 +143,85 @@ describe("memories/storage", () => {
 		closeMemoryDb(db);
 	});
 
+	test("upsertThreads re-enqueues processed outputs when a thread moves to a new project key", () => {
+		const db = openMemoryDb(dbPath);
+		upsertThreads(db, [
+			{
+				id: "thread-a",
+				updatedAt: 100,
+				rolloutPath: "/tmp/thread-a.jsonl",
+				cwd: "/repo",
+				sourceKind: "cli",
+			},
+		]);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("thread-a", 100, "raw", "summary", null, 100);
+
+		upsertThreads(db, [
+			{
+				id: "thread-a",
+				updatedAt: 100,
+				rolloutPath: "/tmp/thread-a.jsonl",
+				cwd: "github.com/org/repo",
+				sourceKind: "cli",
+			},
+		]);
+
+		const row = db
+			.prepare("SELECT status, input_watermark FROM jobs WHERE kind = ? AND job_key = ?")
+			.get(GLOBAL_KIND, "global:github.com/org/repo") as { status: string; input_watermark: number } | undefined;
+		expect(row).toEqual({ status: "pending", input_watermark: 100 });
+		closeMemoryDb(db);
+	});
+
+	test("scoped clear removes both project-key and legacy cwd rows", () => {
+		const db = openMemoryDb(dbPath);
+		upsertThreads(db, [
+			{ id: "legacy-thread", updatedAt: 100, rolloutPath: "/tmp/legacy.jsonl", cwd: "/repo", sourceKind: "cli" },
+			{
+				id: "project-thread",
+				updatedAt: 101,
+				rolloutPath: "/tmp/project.jsonl",
+				cwd: "github.com/org/repo",
+				sourceKind: "cli",
+			},
+			{
+				id: "other-thread",
+				updatedAt: 102,
+				rolloutPath: "/tmp/other.jsonl",
+				cwd: "github.com/other/repo",
+				sourceKind: "cli",
+			},
+		]);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("legacy-thread", 100, "legacy raw", "legacy summary", null, 100);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("project-thread", 101, "project raw", "project summary", null, 101);
+		db.prepare(
+			"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run("other-thread", 102, "other raw", "other summary", null, 102);
+		enqueueGlobalWatermark(db, 100, "/repo", { forceDirtyWhenNotAdvanced: true });
+		enqueueGlobalWatermark(db, 101, "github.com/org/repo", { forceDirtyWhenNotAdvanced: true });
+		enqueueGlobalWatermark(db, 102, "github.com/other/repo", { forceDirtyWhenNotAdvanced: true });
+
+		clearMemoryData(db, "github.com/org/repo", "/repo");
+
+		const threads = db.prepare("SELECT id FROM threads ORDER BY id").all() as { id: string }[];
+		const outputs = db.prepare("SELECT thread_id FROM stage1_outputs ORDER BY thread_id").all() as {
+			thread_id: string;
+		}[];
+		const jobs = db.prepare("SELECT job_key FROM jobs WHERE kind = ? ORDER BY job_key").all(GLOBAL_KIND) as {
+			job_key: string;
+		}[];
+		expect(threads.map(row => row.id)).toEqual(["other-thread"]);
+		expect(outputs.map(row => row.thread_id)).toEqual(["other-thread"]);
+		expect(jobs.map(row => row.job_key)).toEqual(["global:github.com/other/repo"]);
+		closeMemoryDb(db);
+	});
+
 	test("clearMemoryData removes thread/output/job state", () => {
 		const db = openMemoryDb(dbPath);
 		upsertThreads(db, [

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -67,6 +67,7 @@ function makeConfig(overrides: Partial<HindsightConfig> = {}): HindsightConfig {
 		mentalModelRefreshIntervalMs: 5 * 60 * 1000,
 		mentalModelMaxRenderChars: 16_000,
 		...overrides,
+		projectKey: overrides.projectKey ?? null,
 	};
 }
 


### PR DESCRIPTION
## Summary

Memory scopes keyed on the current directory name, so a single project fragmented across git worktrees, clones, forks, and renamed directories — and unrelated directories that happened to share a basename collided into the same memory. This introduces a stable project identity used everywhere memory is scoped.

When `memory.projectKey` is unset, OMP auto-detects identity from git. Set it (or `OMP_PROJECT_KEY` / `HINDSIGHT_PROJECT_KEY`) to force one shared identity such as `github.com/org/repo` across machines and checkouts.

### Resolver order

1. Explicit key: `OMP_PROJECT_KEY`, `HINDSIGHT_PROJECT_KEY`, then the `memory.projectKey` setting.
2. Git remote URL — prefers `upstream`, then `origin`, then the first valid remote. HTTPS, SSH/SCP, and plain `host/org/repo` forms normalize to lowercase `host/org/repo` with a trailing `.git` stripped.
3. Shared git common-dir identity, so linked worktrees and bare-repo checkouts of one repo share a key.
4. Path-hashed cwd fallback (basename + hash) outside any repository.

### Where it applies

- Hindsight `per-project` bank ids and `per-project-tagged` `project:<key>` tags.
- Local memory roots and `memory://root` resolution.
- Mnemopi per-project banks.

### Notable decisions

- Filesystem-safe segments append a short hash suffix, so two distinct keys (e.g. `org/repo-a` vs `org-repo/a`) can never collapse to the same directory or bank name.
- `file://` and local filesystem remotes are not treated as hosted identities; only URL/SCP-like remotes produce a remote key. Plain `host/org/repo` is still valid as an explicit setting value.
- Local git identity canonicalizes the common dir (`/var` vs `/private/var`) so it hashes consistently across symlinked temp roots.

### Backward compatibility

Installs with the setting unset keep working via auto-detection. On startup the local-memory pipeline migrates the active project's thread rows to the resolved key and re-enqueues phase2 consolidation, so processed outputs are not stranded under the old cwd key. Scoped clear removes both the new project-key rows/roots and the legacy cwd-scoped ones.

### Tests

`bun test` across memory project identity, Hindsight bank scoping, memory tools, storage migration/clear, memories isolation/runtime, and the `memory://` protocol — 94 pass, 0 fail. `bun --cwd=packages/coding-agent run check` and `run build` are green.
