### PR TITLE
fix(mcp): support array command and 'environment' key in opencode.json

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode `opencode.json` MCP server discovery failing when `command` is an array of strings (e.g. `["npx", "-y", "pkg"]`): the first element is now used as the executable and the rest are prepended to `args`, matching OpenCode's schema ([#3180](https://github.com/can1357/oh-my-pi/issues/3180))
+- Fixed OpenCode MCP server environment variables being silently dropped: the parser now reads the `environment` key (OpenCode's native field) and falls back to `env` ([#3180](https://github.com/can1357/oh-my-pi/issues/3180))
+
+
 ## [16.1.10] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/discovery/opencode.ts
+++ b/packages/coding-agent/src/discovery/opencode.ts
@@ -91,9 +91,12 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 /** OpenCode MCP server config (from opencode.json "mcp" key) */
 interface OpenCodeMCPConfig {
 	type?: "local" | "remote";
-	command?: string;
+	/** OpenCode allows command to be an array of strings (executable + args) */
+	command?: string | string[];
 	args?: string[];
+	/** OpenCode uses "environment" as the env-vars key; "env" accepted as fallback */
 	env?: Record<string, string>;
+	environment?: Record<string, string>;
 	url?: string;
 	headers?: Record<string, string>;
 	enabled?: boolean;
@@ -161,11 +164,26 @@ function extractMCPServers(
 			transport = "stdio";
 		}
 
+		// Normalise command array → scalar command + prepended args
+		const rawCmd = serverConfig.command;
+		const cmdStr = Array.isArray(rawCmd) ? rawCmd[0] : rawCmd;
+		const prependedArgs: string[] = Array.isArray(rawCmd) ? (rawCmd.slice(1) as string[]) : [];
+		const explicitArgs: string[] = Array.isArray(serverConfig.args) ? (serverConfig.args as string[]) : [];
+		const allArgs = [...prependedArgs, ...explicitArgs];
+
+		// OpenCode uses "environment" as the env-vars key; fall back to "env"
+		const envVars =
+			serverConfig.environment && typeof serverConfig.environment === "object"
+				? serverConfig.environment
+				: serverConfig.env && typeof serverConfig.env === "object"
+					? serverConfig.env
+					: undefined;
+
 		items.push({
 			name,
-			command: serverConfig.command,
-			args: Array.isArray(serverConfig.args) ? (serverConfig.args as string[]) : undefined,
-			env: serverConfig.env && typeof serverConfig.env === "object" ? serverConfig.env : undefined,
+			command: cmdStr,
+			args: allArgs.length > 0 ? allArgs : undefined,
+			env: envVars,
 			url: typeof serverConfig.url === "string" ? serverConfig.url : undefined,
 			headers: serverConfig.headers && typeof serverConfig.headers === "object" ? serverConfig.headers : undefined,
 			enabled: serverConfig.enabled,


### PR DESCRIPTION
## Summary

Closes #3180

Two silent bugs in the OpenCode discovery provider (`src/discovery/opencode.ts`) that cause all MCP servers defined in `opencode.json` with array-style commands to fail at launch, and silently drop environment variables for servers that use the `environment` key.

## Root Cause

**Bug 1 — Array command → `posix_spawn` ENOENT**

OpenCode's JSON schema allows `command` to be an array of strings combining the executable and its arguments:

```json
{ "command": ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"] }
```

`OpenCodeMCPConfig` typed `command` as `string` only, so `serverConfig.command` was the raw array object. When forwarded to `Bun.spawn`, the array was coerced to a comma-separated string (`"npx,-y,..."`), causing:
```
ENOENT: no such file or directory, posix_spawn 'npx,-y,@modelcontextprotocol/server-sequential-thinking'
```

**Bug 2 — `environment` key silently dropped**

OpenCode uses `"environment"` (not `"env"`) as the env-var key for MCP servers. The loader only read `serverConfig.env`, so API keys defined under `environment` were never forwarded to the spawned process.

## Fix

```diff
 interface OpenCodeMCPConfig {
-  command?: string;
+  /** OpenCode allows command to be an array of strings (executable + args) */
+  command?: string | string[];
   env?: Record<string, string>;
+  /** OpenCode uses "environment" as the env-vars key; "env" accepted as fallback */
+  environment?: Record<string, string>;
 }
```

In `extractMCPServers`:
- If `command` is an array: `command[0]` → scalar command, `command.slice(1)` prepended to explicit `args`
- `args` is returned as `undefined` (not `[]`) when no arguments are configured  
- Env resolution checks `environment` first, falls back to `env`

## Affected Servers

Any `opencode.json` entry that uses the standard OpenCode array command format, including the common `sequentialthinking` and `mcp-server-time` entries the OpenCode docs recommend.