### PR TITLE
fix(mcp): normalize OpenCode MCP command arrays

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode MCP discovery so array commands are normalized into a stdio executable plus arguments, `environment` is accepted as the OpenCode env key, and argument lists are omitted when empty. ([#3180](https://github.com/can1357/oh-my-pi/issues/3180))
+
 ## [16.1.10] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/discovery/opencode.ts
+++ b/packages/coding-agent/src/discovery/opencode.ts
@@ -91,13 +91,53 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 /** OpenCode MCP server config (from opencode.json "mcp" key) */
 interface OpenCodeMCPConfig {
 	type?: "local" | "remote";
-	command?: string;
+	command?: string | string[];
 	args?: string[];
 	env?: Record<string, string>;
+	environment?: Record<string, string>;
 	url?: string;
 	headers?: Record<string, string>;
 	enabled?: boolean;
 	timeout?: number;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	for (const item of value) {
+		if (typeof item !== "string") return undefined;
+	}
+	return value;
+}
+
+function stringRecord(value: unknown): Record<string, string> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+	const record: Record<string, string> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (typeof item !== "string") return undefined;
+		record[key] = item;
+	}
+	return record;
+}
+
+function normalizeCommand(
+	commandValue: string | string[] | undefined,
+	argsValue: unknown,
+): { command: string | undefined; args: string[] | undefined } {
+	const configuredArgs = stringArray(argsValue);
+	if (Array.isArray(commandValue)) {
+		const [command, ...commandArgs] = commandValue;
+		const args = configuredArgs ? [...commandArgs, ...configuredArgs] : commandArgs;
+		return {
+			command: typeof command === "string" ? command : undefined,
+			args: args.length > 0 ? args : undefined,
+		};
+	}
+
+	return {
+		command: typeof commandValue === "string" ? commandValue : undefined,
+		args: configuredArgs && configuredArgs.length > 0 ? configuredArgs : undefined,
+	};
 }
 
 async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> {
@@ -161,11 +201,14 @@ function extractMCPServers(
 			transport = "stdio";
 		}
 
+		const command = normalizeCommand(serverConfig.command, serverConfig.args);
+		const env = stringRecord(serverConfig.environment) ?? stringRecord(serverConfig.env);
+
 		items.push({
 			name,
-			command: serverConfig.command,
-			args: Array.isArray(serverConfig.args) ? (serverConfig.args as string[]) : undefined,
-			env: serverConfig.env && typeof serverConfig.env === "object" ? serverConfig.env : undefined,
+			command: command.command,
+			args: command.args,
+			env,
 			url: typeof serverConfig.url === "string" ? serverConfig.url : undefined,
 			headers: serverConfig.headers && typeof serverConfig.headers === "object" ? serverConfig.headers : undefined,
 			enabled: serverConfig.enabled,

--- a/packages/coding-agent/test/discovery/opencode.test.ts
+++ b/packages/coding-agent/test/discovery/opencode.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+
+async function loadOpenCodeMcpConfig(cwd: string): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		providers: ["opencode"],
+	});
+	return result.items;
+}
+
+describe("OpenCode MCP discovery", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-opencode-mcp-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("normalizes array commands and OpenCode environment fields", async () => {
+		await fs.writeFile(
+			path.join(tempDir, "opencode.json"),
+			JSON.stringify({
+				mcp: {
+					sequentialthinking: {
+						type: "local",
+						command: ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
+						enabled: true,
+					},
+					github: {
+						type: "local",
+						command: ["npx", "-y", "@modelcontextprotocol/server-github"],
+						environment: {
+							GITHUB_PERSONAL_ACCESS_TOKEN: "token",
+						},
+						enabled: true,
+					},
+					firecrawl: {
+						type: "local",
+						command: ["firecrawl-mcp"],
+						env: {
+							FIRECRAWL_API_KEY: "legacy-token",
+						},
+					},
+				},
+			}),
+		);
+
+		const servers = await loadOpenCodeMcpConfig(tempDir);
+		const byName = Object.fromEntries(servers.map(server => [server.name, server]));
+
+		expect(byName.sequentialthinking).toMatchObject({
+			command: "npx",
+			args: ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+			transport: "stdio",
+		});
+		expect(byName.github).toMatchObject({
+			command: "npx",
+			args: ["-y", "@modelcontextprotocol/server-github"],
+			env: { GITHUB_PERSONAL_ACCESS_TOKEN: "token" },
+			transport: "stdio",
+		});
+		expect(byName.firecrawl).toMatchObject({
+			command: "firecrawl-mcp",
+			env: { FIRECRAWL_API_KEY: "legacy-token" },
+			transport: "stdio",
+		});
+		expect(byName.firecrawl?.args).toBeUndefined();
+	});
+
+	test("omits empty args for scalar OpenCode commands", async () => {
+		await fs.writeFile(
+			path.join(tempDir, "opencode.json"),
+			JSON.stringify({
+				mcp: {
+					plain: {
+						type: "local",
+						command: "server-bin",
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadOpenCodeMcpConfig(tempDir);
+
+		expect(server?.command).toBe("server-bin");
+		expect(server?.args).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
A project `opencode.json` with OpenCode MCP servers using array `command` values and `environment` fields failed discovery: `bun test packages/coding-agent/test/discovery/opencode.test.ts` reproduced the bad shape by showing `sequentialthinking.command` stayed as `string[]`, `args` stayed `undefined`, and `environment` did not populate `env`.

## Cause
`packages/coding-agent/src/discovery/opencode.ts` typed `OpenCodeMCPConfig.command` as only `string` and copied `serverConfig.command`, `serverConfig.args`, and `serverConfig.env` directly in `extractMCPServers`, so OpenCode's array command form was forwarded as the executable and its provider-native `environment` key was ignored.

## Fix
- Added OpenCode-specific normalization for `command: string | string[]`, prepending array tail values before configured `args` and omitting empty argument lists.
- Mapped `environment` to canonical MCP `env`, with the existing `env` key retained as fallback.
- Added focused OpenCode MCP discovery regression coverage and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/discovery/opencode.test.ts` passed: 2 tests, 6 assertions. `bun run check` in `packages/coding-agent` passed. Fixes #3180