### PR TITLE
[codex] Fix Umans via-handoff vision capability

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Umans models that report `supports_vision: "via-handoff"` being advertised as native image-input models; only boolean `true` now enables direct image attachment.
+
 ## [16.1.9] - 2026-06-21
 
 ### Fixed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -587,7 +587,7 @@ function normalizeUmansBaseUrl(baseUrl: string | undefined): string {
 }
 
 function umansSupportsVision(value: unknown): boolean {
-	return value === true || (typeof value === "string" && value.length > 0);
+	return value === true;
 }
 
 function umansReasoningSupported(value: unknown): boolean {

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -53,6 +53,16 @@ describe("umans provider catalog", () => {
 							reasoning: { supported: true, can_disable: false, default_level: "medium" },
 						},
 					},
+					"umans-glm-5.2": {
+						display_name: "Umans GLM 5.2",
+						capabilities: {
+							context_window: 405_504,
+							recommended_max_tokens: 131_071,
+							supports_vision: "via-handoff",
+							supports_tools: true,
+							reasoning: { supported: true, can_disable: false, default_level: "high" },
+						},
+					},
 				}),
 				{ status: 200, headers: { "Content-Type": "application/json" } },
 			);
@@ -87,6 +97,14 @@ describe("umans provider catalog", () => {
 			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium", requiresEffort: true },
 			compat: { escapeBuiltinToolNames: true },
+		});
+		const handoffVisionModel = models?.find(item => item.id === "umans-glm-5.2");
+		expect(handoffVisionModel).toMatchObject({
+			id: "umans-glm-5.2",
+			input: ["text"],
+			contextWindow: 405_504,
+			maxTokens: 131_071,
+			thinking: { defaultLevel: "high", requiresEffort: true },
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Treat Umans `supports_vision: "via-handoff"` as non-native image input support
- Keep direct image attachment enabled only for boolean `supports_vision: true`
- Add a regression case for `umans-glm-5.2` discovery metadata

## Root cause

Umans GLM 5.2 reports `supports_vision: "via-handoff"`, but the catalog treated any non-empty string as native image support. That made OMP advertise GLM as `input: ["text", "image"]`, so image prompts could be sent directly to a text-only GLM endpoint and fail with `400 This model does not support image inputs`.

## Validation

- `bun --cwd=packages/catalog run check`
- `bun --cwd=packages/catalog test test/umans-provider.test.ts`
