### PR TITLE
fix(catalog/umans): treated supports_vision sentinels as text-only

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Umans `umans-glm-5.1` / `umans-glm-5.2` advertising native image input. The `models/info` endpoint reports `supports_vision: "via-handoff"` for the GLM models, meaning vision routes through a separate handoff pre-analysis step instead of accepting raw image blocks; `umansSupportsVision` treated any non-empty string as native vision support, so image prompts went directly to GLM and were rejected with `400 This model does not support image inputs`. The helper now requires `supports_vision === true`, and the bundled GLM 5.1/5.2 rows are corrected to text-only so the vision-handoff path runs. ([#3184](https://github.com/can1357/oh-my-pi/issues/3184))
+- Fixed Umans `umans-glm-5.1` / `umans-glm-5.2` advertising native image input. The `models/info` endpoint reports `supports_vision: "via-handoff"` for the GLM models, meaning vision routes through a separate handoff pre-analysis step instead of accepting raw image blocks; `umansSupportsVision` treated any non-empty string as native vision support, so image prompts went directly to GLM and were rejected with `400 This model does not support image inputs`. The helper now requires `supports_vision === true`, the bundled GLM 5.1/5.2 rows are corrected to text-only, and stale mismatched Umans cache rows for those ids are dropped so the vision-handoff path runs even before a successful refresh. ([#3184](https://github.com/can1357/oh-my-pi/issues/3184))
 
 ## [16.1.9] - 2026-06-21
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Umans `umans-glm-5.1` / `umans-glm-5.2` advertising native image input. The `models/info` endpoint reports `supports_vision: "via-handoff"` for the GLM models, meaning vision routes through a separate handoff pre-analysis step instead of accepting raw image blocks; `umansSupportsVision` treated any non-empty string as native vision support, so image prompts went directly to GLM and were rejected with `400 This model does not support image inputs`. The helper now requires `supports_vision === true`, and the bundled GLM 5.1/5.2 rows are corrected to text-only so the vision-handoff path runs. ([#3184](https://github.com/can1357/oh-my-pi/issues/3184))
+
 ## [16.1.9] - 2026-06-21
 
 ### Fixed

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -39,6 +39,8 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	cacheTtlMs?: number;
 	/** When true, a successful dynamic fetch is the complete provider catalog and prunes static-only models. */
 	dynamicModelsAuthoritative?: boolean;
+	/** Cached model ids to ignore when the cache was written against a different static catalog fingerprint. */
+	dropCachedModelIdsOnStaticMismatch?: readonly string[];
 	/** Optional dynamic endpoint fetcher. */
 	fetchDynamicModels?: () => Promise<readonly ModelSpec<TApi>[] | null>;
 	/** Optional models.dev fallback hook. */
@@ -148,7 +150,13 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const shouldUseFreshCacheAsAuthoritative =
 		strategy === "online-if-uncached" && hasUsableFreshCache && hasAuthoritativeCache;
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
-	const cacheModels = dynamicFetchSucceeded ? [] : normalizeModelList<TApi>(cache?.models ?? []);
+	const cacheModels = dynamicFetchSucceeded
+		? []
+		: dropCachedModelIdsOnStaticMismatch(
+				normalizeModelList<TApi>(cache?.models ?? []),
+				cacheFingerprintMatches,
+				options.dropCachedModelIdsOnStaticMismatch,
+			);
 	const dynamicModels = fetchedDynamicModels ?? [];
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
 	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
@@ -180,7 +188,11 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				collapseBuiltModelVariants(
 					mergeDynamicModels(
 						mergeModelSources(staticModels, modelsDevModels),
-						normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+						dropCachedModelIdsOnStaticMismatch(
+							normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+							cacheFingerprintMatches,
+							options.dropCachedModelIdsOnStaticMismatch,
+						),
 					),
 				),
 				false,
@@ -246,6 +258,18 @@ function shouldFetchRemoteSources(
 		return cacheAgeMs >= NON_AUTHORITATIVE_RETRY_MS;
 	}
 	return false;
+}
+
+function dropCachedModelIdsOnStaticMismatch<TApi extends Api>(
+	models: readonly Model<TApi>[],
+	cacheFingerprintMatches: boolean,
+	ids: readonly string[] | undefined,
+): Model<TApi>[] {
+	if (cacheFingerprintMatches || ids === undefined || ids.length === 0 || models.length === 0) {
+		return models.length === 0 ? [] : [...models];
+	}
+	const droppedIds = new Set(ids);
+	return models.filter(model => !droppedIds.has(model.id));
 }
 
 function mergeModelSources<TApi extends Api>(...sources: readonly (readonly Model<TApi>[])[]): Model<TApi>[] {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -69284,8 +69284,7 @@
 			"baseUrl": "https://api.code.umans.ai",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -69327,8 +69326,7 @@
 				]
 			},
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -568,6 +568,7 @@ const UMANS_REASONING_EFFORT_BY_LEVEL: Record<string, Effort> = {
 	xhigh: Effort.XHigh,
 };
 const UMANS_DEFAULT_REASONING_EFFORTS = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] as const;
+const UMANS_VIA_HANDOFF_MODEL_IDS = ["umans-glm-5.1", "umans-glm-5.2"] as const;
 
 export interface UmansModelManagerConfig {
 	apiKey?: string;
@@ -714,6 +715,7 @@ export function umansModelManagerOptions(config?: UmansModelManagerConfig): Mode
 	return {
 		providerId: "umans",
 		dynamicModelsAuthoritative: true,
+		dropCachedModelIdsOnStaticMismatch: UMANS_VIA_HANDOFF_MODEL_IDS,
 		fetchDynamicModels: () => fetchUmansModelsInfo({ baseUrl, apiKey, fetch: config?.fetch, references }),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -586,8 +586,18 @@ function normalizeUmansBaseUrl(baseUrl: string | undefined): string {
 	return normalized.endsWith("/v1") ? normalized.slice(0, -3) : normalized;
 }
 
+/**
+ * Umans `models/info` reports `supports_vision: true` for natively
+ * vision-capable models and a non-empty string sentinel (e.g.
+ * `"via-handoff"`) for models that route image inputs through a vision
+ * handoff pre-analysis step instead of accepting raw image blocks. Only
+ * `true` means the model accepts image content directly; sentinel values
+ * MUST map to text-only so the agent's vision-handoff path runs instead
+ * of triggering an upstream HTTP 400 (`This model does not support image
+ * inputs`).
+ */
 function umansSupportsVision(value: unknown): boolean {
-	return value === true || (typeof value === "string" && value.length > 0);
+	return value === true;
 }
 
 function umansReasoningSupported(value: unknown): boolean {

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -1,10 +1,14 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "bun:test";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
 	umansModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import modelsJson from "../src/models.json";
 
 interface BundledModel {
@@ -148,6 +152,66 @@ describe("umans provider catalog", () => {
 			const model = providers.umans?.[id];
 			expect(model, `${id} should be bundled`).toBeDefined();
 			expect(model.input, `${id} input should be text-only`).toEqual(["text"]);
+		}
+	});
+
+	it("drops stale cached GLM rows that predate the via-handoff static correction", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-umans-stale-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const staleGlm: ModelSpec<"anthropic-messages"> = {
+			id: "umans-glm-5.2",
+			name: "Umans GLM 5.2",
+			api: "anthropic-messages",
+			provider: "umans",
+			baseUrl: "https://api.code.umans.ai",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 405_504,
+			maxTokens: 131_071,
+		};
+		const correctedGlm: ModelSpec<"anthropic-messages"> = { ...staleGlm, input: ["text"] };
+
+		try {
+			await resolveProviderModels(
+				{
+					...umansModelManagerOptions({
+						fetch: async () =>
+							new Response(
+								JSON.stringify({
+									"umans-glm-5.2": {
+										display_name: "Umans GLM 5.2",
+										capabilities: {
+											context_window: 405_504,
+											recommended_max_tokens: 131_071,
+											supports_vision: true,
+											supports_tools: true,
+											reasoning: { supported: true },
+										},
+									},
+								}),
+								{ status: 200, headers: { "Content-Type": "application/json" } },
+							),
+					}),
+					staticModels: [staleGlm],
+					cacheDbPath: dbPath,
+				},
+				"online",
+			);
+
+			const offline = await resolveProviderModels(
+				{
+					...umansModelManagerOptions({ fetch: async () => new Response(null, { status: 503 }) }),
+					staticModels: [correctedGlm],
+					cacheDbPath: dbPath,
+				},
+				"offline",
+			);
+
+			const model = offline.models.find(item => item.id === "umans-glm-5.2");
+			expect(model?.input).toEqual(["text"]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
 

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "bun:test";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -101,6 +101,56 @@ describe("umans provider catalog", () => {
 		await expect(fetchDynamicModels()).rejects.toThrow("Failed to fetch Umans models info");
 	});
 
+	it('maps supports_vision sentinel values like "via-handoff" to text-only input', async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					"umans-glm-5.2": {
+						display_name: "Umans GLM 5.2",
+						capabilities: {
+							context_window: 405_504,
+							max_completion_tokens: 131_071,
+							recommended_max_tokens: 131_071,
+							supports_vision: "via-handoff",
+							supports_tools: true,
+							reasoning: { supported: true, can_disable: true, default_level: "medium" },
+						},
+					},
+					"umans-coder": {
+						display_name: "Umans Coder",
+						capabilities: {
+							context_window: 262_144,
+							max_completion_tokens: 262_144,
+							recommended_max_tokens: 32_768,
+							supports_vision: true,
+							supports_tools: true,
+							reasoning: { supported: true, can_disable: true, default_level: "medium" },
+						},
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const fetchDynamicModels = umansModelManagerOptions({ fetch: fetchImpl }).fetchDynamicModels;
+		if (!fetchDynamicModels) throw new Error("Umans dynamic discovery is not configured");
+
+		const models = await fetchDynamicModels();
+		const glm = models?.find(item => item.id === "umans-glm-5.2");
+		const coder = models?.find(item => item.id === "umans-coder");
+
+		expect(glm?.input).toEqual(["text"]);
+		expect(coder?.input).toEqual(["text", "image"]);
+	});
+
+	it("bundles Umans GLM via-handoff models as text-only", () => {
+		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
+		for (const id of ["umans-glm-5.1", "umans-glm-5.2"] as const) {
+			const model = providers.umans?.[id];
+			expect(model, `${id} should be bundled`).toBeDefined();
+			expect(model.input, `${id} input should be text-only`).toEqual(["text"]);
+		}
+	});
+
 	it("maps the models.dev Umans provider to the Anthropic endpoint", () => {
 		const models = mapModelsDevToModels(
 			{


### PR DESCRIPTION
## Repro

Umans `models/info` reports `supports_vision: "via-handoff"` for `umans-glm-5.1` / `umans-glm-5.2`, meaning vision is routed through a separate handoff pre-analysis step instead of accepting raw image blocks. With OMP v16.1.10, `omp models umans-glm-5.2 --json` reported `input: ["text", "image"]`; image prompts therefore went straight to GLM and were rejected with `400 This model does not support image inputs` (reporter logs in #3184).

Synthetic resolver repro against `umansModelManagerOptions({ fetch }).fetchDynamicModels()` with the live `models/info` shape produced:

```
umans-coder: input=["text","image"]    # supports_vision: true        — correct
umans-glm-5.2: input=["text","image"]  # supports_vision: "via-handoff" — bug
```

## Cause

`umansSupportsVision` in `packages/catalog/src/provider-models/openai-compat.ts` was permissive:

```ts
return value === true || (typeof value === "string" && value.length > 0);
```

so the `"via-handoff"` sentinel mapped to `input: ["text", "image"]` in `mapUmansModelInfo`. The bundled `umans` rows in `packages/catalog/src/models.json` were generated by an earlier regen under the same rule and carried the stale `["text", "image"]`, so even consumers that never see the dynamic refresh hit the bug.

## Fix

- `packages/catalog/src/provider-models/openai-compat.ts` — tightened `umansSupportsVision` to `value === true` and documented the `via-handoff` sentinel contract.
- `packages/catalog/src/models.json` — corrected the bundled `umans-glm-5.1` and `umans-glm-5.2` rows to `input: ["text"]`. Surgical edit only; a full regen pulled in ~1k lines of unrelated upstream drift, so I scoped this PR to the affected rows. The next clean regen by a maintainer will re-emit them identically.
- `packages/catalog/test/umans-provider.test.ts` — two regression tests: one against the resolver (`umansModelManagerOptions().fetchDynamicModels()` with a stubbed `models/info` payload covering both `supports_vision: "via-handoff"` and `supports_vision: true`), one against the bundle to pin `umans-glm-5.1` / `umans-glm-5.2` at text-only.
- `packages/catalog/CHANGELOG.md` — `[Unreleased]` `Fixed` entry citing #3184.

## Verification

- `bun --cwd packages/catalog test test/umans-provider.test.ts` — 7 pass / 0 fail (5 prior + 2 new).
- `bun --cwd packages/catalog test` — 311 pass / 0 fail across 46 files.
- In-source probe: `umansModelManagerOptions({ fetch }).fetchDynamicModels()` against the stubbed payload now reports `umans-glm-5.2 input=["text"]` and `umans-coder input=["text","image"]`.
- Confirmed against the live `models/info`: only `umans-glm-5.1` / `umans-glm-5.2` carry `via-handoff`; all other Umans models report `supports_vision: true` and remain image-capable.

Fixes #3184