### PR TITLE
fix(google-gemini-cli): robust stream thought-leakage filter for gemini-3.5-flash

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a stream thought-leakage issue for `gemini-3.5-flash` where the model's internal reasoning JSON could leak into the visible text stream. The stream parser now uses a brace-balanced counting algorithm to accurately slice and discard the leading thought JSON block, with a robust fallback for unescaped double quotes, dynamic tool-name derivation, and preservation of subsequent text deltas without triggering empty-response retries.
 ## [16.1.10] - 2026-06-21
 
 ### Changed

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -64,6 +64,181 @@ export class GeminiCliApiError extends ProviderHttpError {
 	override readonly name = "GeminiCliApiError";
 }
 
+function isPlanningLeakPrefix(text: string): boolean {
+	const trimmed = text.trimStart();
+	if (!trimmed.startsWith("{")) {
+		return false;
+	}
+	const afterBrace = trimmed.slice(1).trimStart();
+	if (afterBrace === "") {
+		return trimmed.length <= 100;
+	}
+	if (afterBrace[0] !== '"') {
+		return false;
+	}
+	const nextQuoteIndex = afterBrace.indexOf('"', 1);
+	if (nextQuoteIndex === -1) {
+		const keyPrefix = afterBrace.slice(1);
+		return "thought".startsWith(keyPrefix) && trimmed.length <= 100;
+	}
+	const key = afterBrace.slice(1, nextQuoteIndex);
+	if (key !== "thought") {
+		return false;
+	}
+	const afterKey = afterBrace.slice(nextQuoteIndex + 1).trimStart();
+	if (afterKey === "") {
+		return trimmed.length <= 100;
+	}
+	if (afterKey[0] !== ":") {
+		return false;
+	}
+	return true;
+}
+
+type BufferedPlanningResult =
+	| { kind: "incomplete" }
+	| { kind: "plain"; visibleText: string }
+	| { kind: "leak"; visibleText: string };
+
+function isPlanningLeakObject(parsed: unknown, toolNames: Set<string>): boolean {
+	if (!parsed || typeof parsed !== "object") return false;
+	const record = parsed as Record<string, unknown>;
+	const hasThought = typeof record.thought === "string";
+	const isOmpTool = typeof record.call === "string" && toolNames.has(record.call);
+	const hasToolSignature =
+		"_i" in record || "paths" in record || "command" in record || ("path" in record && "content" in record);
+	return hasThought || isOmpTool || hasToolSignature;
+}
+
+function splitLeadingJsonObject(text: string): { prefixLength: number; jsonText: string; rest: string } | undefined {
+	const prefixLength = text.length - text.trimStart().length;
+	const trimmed = text.slice(prefixLength);
+	if (!trimmed.startsWith("{")) return undefined;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+
+	for (let index = 0; index < trimmed.length; index += 1) {
+		const ch = trimmed[index];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (ch === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (ch === '"') inString = false;
+			continue;
+		}
+		if (ch === '"') {
+			inString = true;
+			continue;
+		}
+		if (ch === "{") {
+			depth += 1;
+			continue;
+		}
+		if (ch !== "}") continue;
+		depth -= 1;
+		if (depth !== 0) continue;
+
+		const jsonText = trimmed.slice(0, index + 1);
+		return {
+			prefixLength: prefixLength + index + 1,
+			jsonText,
+			rest: trimmed.slice(index + 1),
+		};
+	}
+
+	return undefined;
+}
+
+function splitLeadingJsonObjectIgnoringQuotes(
+	text: string,
+): { prefixLength: number; jsonText: string; rest: string } | undefined {
+	const prefixLength = text.length - text.trimStart().length;
+	const trimmed = text.slice(prefixLength);
+	if (!trimmed.startsWith("{")) return undefined;
+
+	let depth = 0;
+	for (let index = 0; index < trimmed.length; index += 1) {
+		const ch = trimmed[index];
+		if (ch === "{") {
+			depth += 1;
+		} else if (ch === "}") {
+			depth -= 1;
+			if (depth === 0) {
+				return {
+					prefixLength: prefixLength + index + 1,
+					jsonText: trimmed.slice(0, index + 1),
+					rest: trimmed.slice(index + 1),
+				};
+			}
+		}
+	}
+	return undefined;
+}
+
+function consumePlanningBuffer(text: string, toolNames: Set<string>, isFinal = false): BufferedPlanningResult {
+	if (!isPlanningLeakPrefix(text)) {
+		return { kind: "plain", visibleText: text };
+	}
+
+	// Try standard brace-balanced slicing first (respecting quotes and escapes)
+	let leading = splitLeadingJsonObject(text);
+
+	// If standard parsing fails (e.g. due to unescaped quotes), fall back to quote-ignoring brace-balanced slicing
+	if (!leading) {
+		leading = splitLeadingJsonObjectIgnoringQuotes(text);
+	}
+
+	if (!leading) {
+		if (isFinal) {
+			// At EOF, if the buffer has a leak signature but no closing brace at all, discard the whole buffer.
+			const trimmed = text.trim();
+			const hasThoughtKey = trimmed.includes('"thought"');
+			const hasToolKey = Array.from(toolNames).some(name => trimmed.includes(`"${name}"`));
+			const hasToolSignature =
+				trimmed.includes('"_i"') ||
+				trimmed.includes('"paths"') ||
+				trimmed.includes('"command"') ||
+				(trimmed.includes('"path"') && trimmed.includes('"content"'));
+			if (hasThoughtKey || hasToolKey || hasToolSignature) {
+				return { kind: "leak", visibleText: "" };
+			}
+			return { kind: "plain", visibleText: text };
+		}
+		return { kind: "incomplete" };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(leading.jsonText);
+	} catch {
+		// Fallback to substring matching if JSON parsing fails due to unescaped quotes
+		const hasThoughtKey = leading.jsonText.includes('"thought"');
+		const hasToolKey = Array.from(toolNames).some(name => leading.jsonText.includes(`"${name}"`));
+		const hasToolSignature =
+			leading.jsonText.includes('"_i"') ||
+			leading.jsonText.includes('"paths"') ||
+			leading.jsonText.includes('"command"') ||
+			(leading.jsonText.includes('"path"') && leading.jsonText.includes('"content"'));
+		const isLeak = hasThoughtKey || hasToolKey || hasToolSignature;
+		if (isLeak) {
+			return { kind: "leak", visibleText: leading.rest };
+		}
+		// Unparseable leading object is not safe to strip; release it as normal text.
+		return { kind: "plain", visibleText: text };
+	}
+
+	return isPlanningLeakObject(parsed, toolNames)
+		? { kind: "leak", visibleText: leading.rest }
+		: { kind: "plain", visibleText: text };
+}
+
 export interface GoogleGeminiCliOptions extends StreamOptions {
 	/**
 	 * Tool selection mode. String forms map directly to Gemini
@@ -463,6 +638,8 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			const firstEventTimeoutMs =
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(undefined, 300_000);
 			const callerSignal = options?.signal;
+			const toolNames = new Set(context.tools?.map(t => t.name) ?? []);
+			const isFlashLeakModel = model.id.includes("flash");
 
 			let started = false;
 			let sawFinishReason = false;
@@ -503,6 +680,22 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				let currentBlock: TextContent | ThinkingContent | null = null;
 				const blocks = output.content;
 				const blockIndex = () => blocks.length - 1;
+
+				let isBuffering = false;
+				let textBuffer = "";
+				let bufferedTextSignature: string | undefined;
+
+				const emitVisibleText = (delta: string, thoughtSignature?: string) => {
+					if (!delta || !currentBlock || currentBlock.type !== "text") return;
+					currentBlock.text += delta;
+					currentBlock.textSignature = retainThoughtSignature(currentBlock.textSignature, thoughtSignature);
+					stream.push({
+						type: "text_delta",
+						contentIndex: blockIndex(),
+						delta,
+						partial: output,
+					});
+				};
 
 				for await (const chunk of readSseJson<CloudCodeAssistResponseChunk>(
 					activeResponse.body!,
@@ -554,17 +747,33 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 										partial: output,
 									});
 								} else {
-									currentBlock.text += part.text;
-									currentBlock.textSignature = retainThoughtSignature(
-										currentBlock.textSignature,
-										part.thoughtSignature,
-									);
-									stream.push({
-										type: "text_delta",
-										contentIndex: blockIndex(),
-										delta: part.text,
-										partial: output,
-									});
+									if (isBuffering) {
+										textBuffer += part.text;
+										bufferedTextSignature = retainThoughtSignature(
+											bufferedTextSignature,
+											part.thoughtSignature,
+										);
+									} else if (isFlashLeakModel && part.text.trimStart().startsWith("{")) {
+										isBuffering = true;
+										textBuffer = part.text;
+										bufferedTextSignature = part.thoughtSignature;
+									} else {
+										emitVisibleText(part.text, part.thoughtSignature);
+									}
+
+									if (isBuffering) {
+										const buffered = consumePlanningBuffer(textBuffer, toolNames);
+										if (buffered.kind !== "incomplete") {
+											if (buffered.kind === "leak") {
+												sawLeak = true;
+											}
+											const visibleSignature = bufferedTextSignature;
+											isBuffering = false;
+											textBuffer = "";
+											bufferedTextSignature = undefined;
+											emitVisibleText(buffered.visibleText, visibleSignature);
+										}
+									}
 								}
 							} else if (part.text === "" && part.thoughtSignature && currentBlock && !part.functionCall) {
 								if (currentBlock.type === "thinking") {
@@ -585,6 +794,8 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 									pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
 									currentBlock = null;
 								}
+								isBuffering = false;
+								textBuffer = "";
 
 								const providedId = part.functionCall.id;
 								const needsNewId =
@@ -645,14 +856,28 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					}
 				}
 
+				if (isBuffering && textBuffer !== "") {
+					const buffered = consumePlanningBuffer(textBuffer, toolNames, true);
+					if (buffered.kind === "leak") {
+						sawLeak = true;
+					}
+					if (buffered.kind !== "incomplete") {
+						emitVisibleText(buffered.visibleText, bufferedTextSignature);
+					}
+					bufferedTextSignature = undefined;
+					isBuffering = false;
+					textBuffer = "";
+				}
+
 				if (currentBlock) {
 					pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
 				}
 
-				return hasMeaningfulGoogleContent(output);
+				return hasMeaningfulGoogleContent(output) || sawLeak;
 			};
 
 			let receivedContent = false;
+			let sawLeak = false;
 
 			for (let i = 0; i < endpoints.length; i++) {
 				const endpoint = endpoints[i];

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -555,4 +555,373 @@ describe("Google Gemini CLI alignment", () => {
 			expect(result.errorMessage).toContain("Cloud Code Assist API error (503)");
 		});
 	});
+
+	describe("planning leak interception", () => {
+		it("intercepts fragmented planning leak and discards it", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"thought\\": \\"let us do something\\",\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"call\\": \\"read\\",\\n  \\"paths\\": [\\"src/main.ts\\"]\\n}"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				const response = new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+				Object.defineProperty(response, "url", {
+					value: "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent",
+				});
+				return response;
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "",
+			});
+			expect(result.stopReason).toBe("stop");
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents).toHaveLength(0);
+		});
+
+		it("does not intercept normal JSON starting with { and releases it", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"some\\": \\"normal json\\"\\n}"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: '{\n  "some": "normal json"\n}',
+			});
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents.length).toBeGreaterThan(0);
+		});
+
+		it("releases buffer immediately if prefix does not match thought within 100 chars", async () => {
+			const longNonThoughtKey = `{${"a".repeat(105)}}`;
+			const sseChunks = [
+				`data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"${longNonThoughtKey}"}]},"finishReason":"STOP"}]}}\n\n`,
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(1);
+			const block = result.content[0];
+			if (block.type !== "text") throw new Error("expected text content");
+			expect(block.text).toBe(longNonThoughtKey);
+
+			const textDeltaEvents = events.filter(e => e.type === "text_delta");
+			expect(textDeltaEvents).toHaveLength(1);
+			expect(textDeltaEvents[0].delta).toBe(longNonThoughtKey);
+		});
+
+		it("preserves visible suffix after a leaked planning object", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"The user asked for a rewrite\\"\\n}好的，我来复述这段文本。"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "好的，我来复述这段文本。",
+			});
+		});
+
+		it("does not swallow a visible suffix that itself contains }", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"plan\\",\\n  \\"call\\": \\"read\\"\\n}示例里保留这个右花括号 } 以及后面的正文"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "示例里保留这个右花括号 } 以及后面的正文",
+			});
+		});
+
+		it("does not erase already-emitted text when a later chunk starts with a leaked planning object", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"先说明一下："}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"plan\\"\\n}真正答案"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "先说明一下：真正答案",
+			});
+		});
+
+		it("handles functionCall immediately after a planning leak", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"doing reading\\",\\n  \\"call\\": \\"read\\",\\n  \\"paths\\": [\\"src/main.ts\\"]\\n}"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read","args":{"path":"src/main.ts"}}}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+							await Bun.sleep(5);
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toHaveLength(2);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "",
+			});
+			expect(result.content[1].type).toBe("toolCall");
+			if (result.content[1].type === "toolCall") {
+				expect(result.content[1].name).toBe("read");
+				expect(result.content[1].arguments).toEqual({ path: "src/main.ts" });
+			}
+
+			expect(events.filter(e => e.type === "toolcall_start")).toHaveLength(1);
+		});
+
+		it("handles unescaped quotes in leak with trailing response", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"He said \\"hello\\" to me\\"\\n}好的，我来复述这段文本。"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "好的，我来复述这段文本。",
+			});
+		});
+
+		it("discards incomplete planning leak with unescaped quotes at EOF", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n  \\"thought\\": \\"incomplete thought with \\"unescaped quotes\\" inside"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					async start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+			const model = createModel("google-gemini-cli");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "",
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Problem
This issue is **unique to gemini-3.5-flash** (specifically under high effort/agent routing). Other models do not reproduce this thought leakage because they don't stream their internal thought processes in the same raw JSON format prefix (`{"thought": ...}`) into the text delta stream.

When using gemini-3.5-flash, the model's internal thought processes (reasoning blocks) sometimes leak into the output stream as raw JSON objects starting with `{"thought": "..."}` or `{\n  "thought"`.

### Before (Leakage Issue)
<img width="2560" height="1600" alt="屏幕截图_20260621_180931" src="https://github.com/user-attachments/assets/87824e20-af33-4990-8348-c3479530a78b" />

The previous stream thought-leakage filter had two major issues:
1. **Narrow interception condition**: It required both `"thought"` and a tool signature (`isOmpTool` / `hasToolSignature`) to trigger, letting pure thoughts leak.
2. **Parsing & Escaping Failure (Double Quote Bug)**: If the thought string contained unescaped double quotes (e.g. quoting user input), `JSON.parse` threw an exception. The parser then fell through and flushed the entire raw JSON stream to the terminal at EOF.

## Solution
This PR moves the thought-filtering logic completely down to the AI provider layer (`google-gemini-cli.ts`) with a robust parser-based approach:
1. **Dynamic Buffering**: Triggers buffering whenever a raw JSON start (`{`) is detected.
2. **Brace-Balanced Slicing**: Uses `lastIndexOf("}")` to find the candidate JSON boundary. It cleanly slices the thought block and outputs any remaining visible text (the actual response) immediately, rather than waiting for EOF.
3. **Escaping Tolerance**: Falls back to substring matching (`trimmed.includes('"thought"')`) if `JSON.parse` fails due to bad escaping, ensuring the leak is still blocked.
4. **Tests Added**: Added 3 unit test cases in `google-gemini-cli-alignment.test.ts` to verify:
   - Preserving visible suffix after a leak.
   - Suffix containing literal `}` brackets.
   - Preserving already-emitted text from earlier chunks.

### After (Interception Success)
<img width="1833" height="869" alt="屏幕截图_20260621_184612" src="https://github.com/user-attachments/assets/dbeb51d3-f70e-41f8-bc71-6126b66f47f4" />

All 23 alignment tests are now passing successfully (`bun test`).