### PR TITLE
fix(catalog): restore Umans GLM-5.2 max reasoning

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic-compatible budget-effort models dropping the selected effort before request serialization, so `output_config.effort` is emitted alongside `thinking.budget_tokens` when model metadata declares `mode: "anthropic-budget-effort"`.
+
 ## [16.1.10] - 2026-06-21
 
 ### Changed
@@ -13,7 +17,6 @@
 
 ### Fixed
 
-- Fixed Anthropic-compatible budget-effort models dropping the selected effort before request serialization, so `output_config.effort` is emitted alongside `thinking.budget_tokens` when model metadata declares `mode: "anthropic-budget-effort"`.
 - Fixed tool call ID normalization for Anthropic-compatible models
 - Fixed Anthropic Messages replay sanitizing malformed tool-call IDs, including aborted native tool calls with empty IDs, so retries no longer send invalid `tool_use.id` / `tool_result.tool_use_id` pairs.
 - Fixed the Codex Responses WebSocket transport attributing a prior turn's output to the current one on a reused connection: a trailing/duplicate frame from a cleanly-completed previous response that slipped past the queue drain could be consumed as this request's terminal (ending the turn with empty output) or as a stale tool call. Frames are now keyed by `response.id` — a frame carrying the previous response's id is dropped, and one carrying a third id (or a regressed `sequence_number`) fails closed so the turn retries instead of mixing two responses' streams. Idless frames (deltas, the rate-limit/metadata preamble, `response.created`-less streams) still pass through, matching upstream codex-rs.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed Anthropic-compatible budget-effort models dropping the selected effort before request serialization, so `output_config.effort` is emitted alongside `thinking.budget_tokens` when model metadata declares `mode: "anthropic-budget-effort"`.
 - Fixed tool call ID normalization for Anthropic-compatible models
 - Fixed Anthropic Messages replay sanitizing malformed tool-call IDs, including aborted native tool calls with empty IDs, so retries no longer send invalid `tool_use.id` / `tool_result.tool_use_id` pairs.
 - Fixed the Codex Responses WebSocket transport attributing a prior turn's output to the current one on a reused connection: a trailing/duplicate frame from a cleanly-completed previous response that slipped past the queue drain could be consumed as this request's terminal (ending the turn with empty output) or as a stale tool call. Frames are now keyed by `response.id` — a frame carrying the previous response's id is dropped, and one carrying a third id (or a regressed `sequence_number`) fails closed so the turn retries instead of mixing two responses' streams. Idless frames (deltas, the rate-limit/metadata preamble, `response.created`-less streams) still pass through, matching upstream codex-rs.

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -808,10 +808,15 @@ function mapOptionsForApi<TApi extends Api>(
 				});
 			}
 
+			const thinkingMode = model.thinking?.mode;
+			const effort =
+				thinkingMode === "anthropic-adaptive" || thinkingMode === "anthropic-budget-effort"
+					? mapEffortToAnthropicAdaptiveEffort(model, reasoning)
+					: undefined;
+
 			// For Opus 4.6+ and Sonnet 4.6+: use adaptive thinking with effort level
 			// For older models: use budget-based thinking
-			if (model.thinking?.mode === "anthropic-adaptive") {
-				const effort = mapEffortToAnthropicAdaptiveEffort(model, reasoning);
+			if (thinkingMode === "anthropic-adaptive") {
 				return castApi<"anthropic-messages">({
 					...base,
 					requestModelId: resolveWireModelId(model, reasoning),
@@ -829,6 +834,7 @@ function mapOptionsForApi<TApi extends Api>(
 					requestModelId: resolveWireModelId(model, reasoning),
 					thinkingEnabled: true,
 					thinkingBudgetTokens: thinkingBudget,
+					effort,
 					toolChoice: mapAnthropicToolChoice(options?.toolChoice),
 					thinkingDisplay: options?.hideThinkingSummary ? "omitted" : undefined,
 					serviceTier: options?.serviceTier,
@@ -860,6 +866,7 @@ function mapOptionsForApi<TApi extends Api>(
 					requestModelId: resolveWireModelId(model, reasoning),
 					thinkingEnabled: true,
 					thinkingBudgetTokens: thinkingBudget,
+					effort,
 					toolChoice: mapAnthropicToolChoice(options?.toolChoice),
 					thinkingDisplay: options?.hideThinkingSummary ? "omitted" : undefined,
 					serviceTier: options?.serviceTier,

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -21,7 +21,7 @@ import {
 	streamAnthropic,
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
-import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+import { getEnvApiKey, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type {
 	AssistantMessage,
 	Context,
@@ -109,6 +109,21 @@ function captureAnthropicPayload(
 		thinkingDisplay: options?.thinkingDisplay,
 		sessionId: options?.sessionId,
 		headers: options?.headers,
+		onPayload: payload => resolve(payload),
+	});
+	return promise;
+}
+
+function captureSimpleAnthropicPayload(
+	model: Model<"anthropic-messages">,
+	context: Context,
+	reasoning: Effort,
+): Promise<unknown> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	streamSimple(model, context, {
+		apiKey: "sk-ant-oat-test",
+		signal: createAbortedSignal(),
+		reasoning,
 		onPayload: payload => resolve(payload),
 	});
 	return promise;
@@ -1868,6 +1883,35 @@ describe("Anthropic request fingerprint alignment", () => {
 		};
 		expect(maxPayload.thinking).toEqual({ type: "adaptive", display: "summarized" });
 		expect(maxPayload.output_config).toEqual({ effort: "max" });
+	});
+
+	it("maps simple-stream budget-effort reasoning to Anthropic output_config effort", async () => {
+		const payload = (await captureSimpleAnthropicPayload(
+			buildModel({
+				...ANTHROPIC_MODEL_SPEC,
+				id: "umans-glm-5.2",
+				name: "Umans GLM 5.2",
+				provider: "umans",
+				baseUrl: "https://api.code.umans.ai",
+				thinking: {
+					mode: "anthropic-budget-effort",
+					efforts: [Effort.High, Effort.XHigh],
+					effortMap: { [Effort.XHigh]: "max" },
+				},
+			}),
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			Effort.XHigh,
+		)) as {
+			thinking?: { type?: string; budget_tokens?: number };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.thinking?.budget_tokens).toBeGreaterThan(0);
+		expect(payload.output_config).toEqual({ effort: "max" });
 	});
 
 	it("keeps summarized adaptive thinking by default for API-key Opus 4.7+ requests", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the Umans GLM-5.2 thinking-level picker collapsing to a single `high` tier after dynamic discovery: the `max` upstream level now resolves to the internal `xhigh` effort and the picker shows both `high` and `xhigh` again, matching Umans's native `high/max` scale. ([#3192](https://github.com/can1357/oh-my-pi/issues/3192))
+- Fixed the Umans GLM-5.2 thinking-level picker collapsing to a single `high` tier after dynamic discovery: the `max` upstream level now resolves to the internal `xhigh` effort, the picker shows both `high` and `xhigh`, and the metadata maps `xhigh` back to Umans's native `max` wire tier. ([#3192](https://github.com/can1357/oh-my-pi/issues/3192))
 
 ## [16.1.9] - 2026-06-21
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Umans GLM-5.2 reasoning discovery to retain the provider's `max` tier as `xhigh` and send it upstream as `"max"`, restoring the top thinking selector in dynamic and bundled catalogs. ([#3192](https://github.com/can1357/oh-my-pi/issues/3192))
+
 ## [16.1.9] - 2026-06-21
 
 ### Fixed

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Umans GLM-5.2 reasoning discovery to retain the provider's `max` tier as `xhigh` and send it upstream as `"max"`, restoring the top thinking selector in dynamic and bundled catalogs. ([#3192](https://github.com/can1357/oh-my-pi/issues/3192))
+- Fixed the Umans GLM-5.2 thinking-level picker collapsing to a single `high` tier after dynamic discovery: the `max` upstream level now resolves to the internal `xhigh` effort and the picker shows both `high` and `xhigh` again, matching Umans's native `high/max` scale. ([#3192](https://github.com/can1357/oh-my-pi/issues/3192))
 
 ## [16.1.9] - 2026-06-21
 

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -370,20 +370,16 @@ function inferDetectedEffortMap<TApi extends Api>(
 	//     `xhigh` 400s — collapse minimal->none, low/medium/high->high, xhigh->max.
 	//   - OpenRouter: `max` 400s and `xhigh` IS its max tier, so it passes `xhigh`
 	//     through literally (no map; the tier is exposed via getModelDefinedEfforts).
-	//   - Ollama Cloud exposes only high/max on its GLM-5.2 route.
+	//   - Umans and Ollama Cloud expose only high/max on their GLM-5.2 routes.
 	//   - Other openai-compat hosts (Fireworks, resellers) keep their distinct
 	//     lower tiers and host quirks (e.g. Fireworks rejects `minimal`, so
 	//     `minimal->none` stays) and only remap the top `xhigh` UI tier onto the
 	//     genuine `max` budget. Filtered to supported efforts later.
-	// Umans GLM-5.2 (anthropic-messages, `mode: "budget"`) encodes the selected
-	// tier through `thinking.budget_tokens`; it does not consume `effortMap`,
-	// so no entry is baked here. The picker collapse to high/xhigh happens via
-	// `getModelDefinedEfforts` above.
 	const isGlm52 = isGlm52ReasoningEffortModelId(spec.id);
 	if (isGlm52 && isZaiThinkingFormat(compat)) {
 		return ZAI_GLM_52_REASONING_EFFORT_MAP;
 	}
-	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+	if (isUmansGlm52ReasoningEffortModel(spec) || isOllamaCloudGlm52ReasoningEffortModel(spec)) {
 		return GLM_52_XHIGH_MAX_EFFORT_MAP;
 	}
 	if (!isOpenAICompatReasoningApi(spec.api)) {
@@ -566,6 +562,9 @@ function inferThinkingControlMode<TApi extends Api>(
 		case "anthropic-messages":
 			if (isMinimaxReasoningModelOnAnthropicEndpoint(spec)) {
 				return "anthropic-adaptive";
+			}
+			if (isUmansGlm52ReasoningEffortModel(spec)) {
+				return "anthropic-budget-effort";
 			}
 			if (parsedModel.family === "anthropic") {
 				if (semverGte(parsedModel.version, "4.6")) {

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -292,12 +292,12 @@ function getModelDefinedEfforts<TApi extends Api>(
 ): readonly Effort[] | undefined {
 	if (isGlm52ReasoningEffortModelId(spec.id)) {
 		// Z.ai/Zhipu and OpenRouter both surface GLM-5.2's full effort ladder,
-		// including the top `xhigh` (= "max") tier; Ollama Cloud exposes only
-		// high/xhigh.
+		// including the top `xhigh` (= "max") tier; Umans and Ollama Cloud
+		// expose only high/max.
 		if (isZaiThinkingFormat(compat) || isOpenRouterThinkingFormat(compat)) {
 			return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 		}
-		if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+		if (isUmansGlm52ReasoningEffortModel(spec) || isOllamaCloudGlm52ReasoningEffortModel(spec)) {
 			return GLM_52_HIGH_MAX_REASONING_EFFORTS;
 		}
 	}
@@ -311,6 +311,10 @@ function getModelDefinedEfforts<TApi extends Api>(
 
 function isOllamaCloudGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
 	return spec.api === "ollama-chat" && spec.provider === "ollama-cloud" && isGlm52ReasoningEffortModelId(spec.id);
+}
+
+function isUmansGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	return spec.api === "anthropic-messages" && spec.provider === "umans" && isGlm52ReasoningEffortModelId(spec.id);
 }
 
 function isMinimaxReasoningModelOnAnthropicEndpoint<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
@@ -366,15 +370,19 @@ function inferDetectedEffortMap<TApi extends Api>(
 	//     `xhigh` 400s — collapse minimal->none, low/medium/high->high, xhigh->max.
 	//   - OpenRouter: `max` 400s and `xhigh` IS its max tier, so it passes `xhigh`
 	//     through literally (no map; the tier is exposed via getModelDefinedEfforts).
-	//   - Other openai-compat hosts (Fireworks, resellers) and Ollama Cloud keep
-	//     their distinct lower tiers and host quirks (e.g. Fireworks rejects
-	//     `minimal`, so `minimal->none` stays) and only remap the top `xhigh` UI
-	//     tier onto the genuine `max` budget. Filtered to supported efforts later.
+	//   - Umans and Ollama Cloud expose only high/max on their GLM-5.2 routes.
+	//   - Other openai-compat hosts (Fireworks, resellers) keep their distinct
+	//     lower tiers and host quirks (e.g. Fireworks rejects `minimal`, so
+	//     `minimal->none` stays) and only remap the top `xhigh` UI tier onto the
+	//     genuine `max` budget. Filtered to supported efforts later.
 	const isGlm52 = isGlm52ReasoningEffortModelId(spec.id);
 	if (isGlm52 && isZaiThinkingFormat(compat)) {
 		return ZAI_GLM_52_REASONING_EFFORT_MAP;
 	}
 	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+		return GLM_52_XHIGH_MAX_EFFORT_MAP;
+	}
+	if (isUmansGlm52ReasoningEffortModel(spec)) {
 		return GLM_52_XHIGH_MAX_EFFORT_MAP;
 	}
 	if (!isOpenAICompatReasoningApi(spec.api)) {

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -370,19 +370,20 @@ function inferDetectedEffortMap<TApi extends Api>(
 	//     `xhigh` 400s — collapse minimal->none, low/medium/high->high, xhigh->max.
 	//   - OpenRouter: `max` 400s and `xhigh` IS its max tier, so it passes `xhigh`
 	//     through literally (no map; the tier is exposed via getModelDefinedEfforts).
-	//   - Umans and Ollama Cloud expose only high/max on their GLM-5.2 routes.
+	//   - Ollama Cloud exposes only high/max on its GLM-5.2 route.
 	//   - Other openai-compat hosts (Fireworks, resellers) keep their distinct
 	//     lower tiers and host quirks (e.g. Fireworks rejects `minimal`, so
 	//     `minimal->none` stays) and only remap the top `xhigh` UI tier onto the
 	//     genuine `max` budget. Filtered to supported efforts later.
+	// Umans GLM-5.2 (anthropic-messages, `mode: "budget"`) encodes the selected
+	// tier through `thinking.budget_tokens`; it does not consume `effortMap`,
+	// so no entry is baked here. The picker collapse to high/xhigh happens via
+	// `getModelDefinedEfforts` above.
 	const isGlm52 = isGlm52ReasoningEffortModelId(spec.id);
 	if (isGlm52 && isZaiThinkingFormat(compat)) {
 		return ZAI_GLM_52_REASONING_EFFORT_MAP;
 	}
 	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
-		return GLM_52_XHIGH_MAX_EFFORT_MAP;
-	}
-	if (isUmansGlm52ReasoningEffortModel(spec)) {
 		return GLM_52_XHIGH_MAX_EFFORT_MAP;
 	}
 	if (!isOpenAICompatReasoningApi(spec.api)) {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -69317,11 +69317,14 @@
 			"baseUrl": "https://api.code.umans.ai",
 			"reasoning": true,
 			"thinking": {
-				"mode": "budget",
+				"mode": "anthropic-budget-effort",
 				"efforts": [
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"xhigh": "max"
+				}
 			},
 			"input": [
 				"text",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -69319,12 +69319,12 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
 					"high",
 					"xhigh"
-				]
+				],
+				"effortMap": {
+					"xhigh": "max"
+				}
 			},
 			"input": [
 				"text",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -69321,10 +69321,7 @@
 				"efforts": [
 					"high",
 					"xhigh"
-				],
-				"effortMap": {
-					"xhigh": "max"
-				}
+				]
 			},
 			"input": [
 				"text",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -568,6 +568,7 @@ const UMANS_REASONING_EFFORT_BY_LEVEL: Record<string, Effort> = {
 	xhigh: Effort.XHigh,
 	max: Effort.XHigh,
 };
+const UMANS_MAX_REASONING_EFFORT_MAP = { [Effort.XHigh]: "max" } as const;
 const UMANS_DEFAULT_REASONING_EFFORTS = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] as const;
 
 export interface UmansModelManagerConfig {
@@ -610,10 +611,20 @@ function mapUmansReasoningEfforts(value: unknown): readonly Effort[] {
 	return efforts.length > 0 ? efforts : UMANS_DEFAULT_REASONING_EFFORTS;
 }
 
+function umansHasMaxReasoningLevel(value: unknown): boolean {
+	return isRecord(value) && Array.isArray(value.levels) && value.levels.includes("max");
+}
+
 function mapUmansThinkingConfig(value: unknown): ThinkingConfig | undefined {
 	if (!umansReasoningSupported(value)) return undefined;
 	const efforts = mapUmansReasoningEfforts(value);
-	const thinking: ThinkingConfig = { mode: "budget", efforts };
+	const thinking: ThinkingConfig = {
+		mode: umansHasMaxReasoningLevel(value) ? "anthropic-budget-effort" : "budget",
+		efforts,
+	};
+	if (thinking.mode === "anthropic-budget-effort") {
+		thinking.effortMap = UMANS_MAX_REASONING_EFFORT_MAP;
+	}
 	if (isRecord(value)) {
 		if (value.can_disable === false) {
 			thinking.requiresEffort = true;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -566,8 +566,10 @@ const UMANS_REASONING_EFFORT_BY_LEVEL: Record<string, Effort> = {
 	medium: Effort.Medium,
 	high: Effort.High,
 	xhigh: Effort.XHigh,
+	max: Effort.XHigh,
 };
 const UMANS_DEFAULT_REASONING_EFFORTS = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] as const;
+const UMANS_MAX_REASONING_EFFORT_MAP: ThinkingConfig["effortMap"] = { [Effort.XHigh]: "max" };
 
 export interface UmansModelManagerConfig {
 	apiKey?: string;
@@ -609,10 +611,17 @@ function mapUmansReasoningEfforts(value: unknown): readonly Effort[] {
 	return efforts.length > 0 ? efforts : UMANS_DEFAULT_REASONING_EFFORTS;
 }
 
+function umansHasMaxReasoningLevel(value: unknown): boolean {
+	return isRecord(value) && Array.isArray(value.levels) && value.levels.some(level => level === "max");
+}
+
 function mapUmansThinkingConfig(value: unknown): ThinkingConfig | undefined {
 	if (!umansReasoningSupported(value)) return undefined;
 	const efforts = mapUmansReasoningEfforts(value);
 	const thinking: ThinkingConfig = { mode: "budget", efforts };
+	if (umansHasMaxReasoningLevel(value) && efforts.includes(Effort.XHigh)) {
+		thinking.effortMap = UMANS_MAX_REASONING_EFFORT_MAP;
+	}
 	if (isRecord(value)) {
 		if (value.can_disable === false) {
 			thinking.requiresEffort = true;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -569,7 +569,6 @@ const UMANS_REASONING_EFFORT_BY_LEVEL: Record<string, Effort> = {
 	max: Effort.XHigh,
 };
 const UMANS_DEFAULT_REASONING_EFFORTS = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] as const;
-const UMANS_MAX_REASONING_EFFORT_MAP: ThinkingConfig["effortMap"] = { [Effort.XHigh]: "max" };
 
 export interface UmansModelManagerConfig {
 	apiKey?: string;
@@ -611,17 +610,10 @@ function mapUmansReasoningEfforts(value: unknown): readonly Effort[] {
 	return efforts.length > 0 ? efforts : UMANS_DEFAULT_REASONING_EFFORTS;
 }
 
-function umansHasMaxReasoningLevel(value: unknown): boolean {
-	return isRecord(value) && Array.isArray(value.levels) && value.levels.some(level => level === "max");
-}
-
 function mapUmansThinkingConfig(value: unknown): ThinkingConfig | undefined {
 	if (!umansReasoningSupported(value)) return undefined;
 	const efforts = mapUmansReasoningEfforts(value);
 	const thinking: ThinkingConfig = { mode: "budget", efforts };
-	if (umansHasMaxReasoningLevel(value) && efforts.includes(Effort.XHigh)) {
-		thinking.effortMap = UMANS_MAX_REASONING_EFFORT_MAP;
-	}
 	if (isRecord(value)) {
 		if (value.can_disable === false) {
 			thinking.requiresEffort = true;

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { Effort } from "@oh-my-pi/pi-catalog";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Effort, mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
@@ -18,6 +19,8 @@ interface BundledModel {
 	thinking?: {
 		defaultLevel?: string;
 		requiresEffort?: boolean;
+		efforts?: string[];
+		effortMap?: Record<string, string>;
 	};
 	compat?: {
 		escapeBuiltinToolNames?: boolean;
@@ -51,6 +54,22 @@ describe("umans provider catalog", () => {
 							supports_vision: true,
 							supports_tools: true,
 							reasoning: { supported: true, can_disable: false, default_level: "medium" },
+						},
+					},
+					"umans-glm-5.2": {
+						display_name: "Umans GLM 5.2",
+						capabilities: {
+							context_window: 405_504,
+							max_completion_tokens: 131_072,
+							recommended_max_tokens: 131_071,
+							supports_vision: "via-handoff",
+							supports_tools: true,
+							reasoning: {
+								supported: true,
+								can_disable: true,
+								levels: ["none", "high", "max"],
+								default_level: "high",
+							},
 						},
 					},
 				}),
@@ -88,6 +107,18 @@ describe("umans provider catalog", () => {
 			thinking: { defaultLevel: "medium", requiresEffort: true },
 			compat: { escapeBuiltinToolNames: true },
 		});
+		const glm52 = models?.find(item => item.id === "umans-glm-5.2");
+		expect(glm52).toMatchObject({
+			id: "umans-glm-5.2",
+			reasoning: true,
+			thinking: {
+				defaultLevel: "high",
+				efforts: ["high", "xhigh"],
+				effortMap: { xhigh: "max" },
+			},
+		});
+		if (!glm52) throw new Error("Umans GLM 5.2 was not discovered");
+		expect(mapEffortToAnthropicAdaptiveEffort(glm52, Effort.XHigh)).toBe("max");
 	});
 
 	it("surfaces Umans discovery fetch failures", async () => {
@@ -159,6 +190,17 @@ describe("umans provider catalog", () => {
 		expect(model.compat?.escapeBuiltinToolNames).toBe(true);
 		expect(model.thinking).toMatchObject({
 			requiresEffort: true,
+		});
+	});
+
+	it("bundles Umans GLM 5.2 max reasoning metadata", () => {
+		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
+		const model = providers.umans?.["umans-glm-5.2"];
+
+		expect(model).toBeDefined();
+		expect(model.thinking).toMatchObject({
+			efforts: ["high", "xhigh"],
+			effortMap: { xhigh: "max" },
 		});
 	});
 });

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -112,13 +112,14 @@ describe("umans provider catalog", () => {
 			id: "umans-glm-5.2",
 			reasoning: true,
 			thinking: {
-				mode: "budget",
+				mode: "anthropic-budget-effort",
 				defaultLevel: "high",
 				efforts: ["high", "xhigh"],
+				effortMap: { xhigh: "max" },
 			},
 		});
 		if (!glm52) throw new Error("Umans GLM 5.2 was not discovered");
-		expect(glm52.thinking?.effortMap).toBeUndefined();
+		expect(glm52.thinking?.effortMap).toEqual({ [Effort.XHigh]: "max" });
 		expect(glm52.thinking?.defaultLevel).toBe(Effort.High);
 	});
 
@@ -194,14 +195,15 @@ describe("umans provider catalog", () => {
 		});
 	});
 
-	it("bundles Umans GLM 5.2 high/max reasoning metadata without dead effortMap", () => {
+	it("bundles Umans GLM 5.2 high/max reasoning metadata with the max wire effort", () => {
 		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
 		const model = providers.umans?.["umans-glm-5.2"];
 
 		expect(model).toBeDefined();
 		expect(model.thinking).toMatchObject({
+			mode: "anthropic-budget-effort",
 			efforts: ["high", "xhigh"],
+			effortMap: { xhigh: "max" },
 		});
-		expect(model.thinking?.effortMap).toBeUndefined();
 	});
 });

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { Effort, mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog";
+import { Effort } from "@oh-my-pi/pi-catalog";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
@@ -112,13 +112,14 @@ describe("umans provider catalog", () => {
 			id: "umans-glm-5.2",
 			reasoning: true,
 			thinking: {
+				mode: "budget",
 				defaultLevel: "high",
 				efforts: ["high", "xhigh"],
-				effortMap: { xhigh: "max" },
 			},
 		});
 		if (!glm52) throw new Error("Umans GLM 5.2 was not discovered");
-		expect(mapEffortToAnthropicAdaptiveEffort(glm52, Effort.XHigh)).toBe("max");
+		expect(glm52.thinking?.effortMap).toBeUndefined();
+		expect(glm52.thinking?.defaultLevel).toBe(Effort.High);
 	});
 
 	it("surfaces Umans discovery fetch failures", async () => {
@@ -193,14 +194,14 @@ describe("umans provider catalog", () => {
 		});
 	});
 
-	it("bundles Umans GLM 5.2 max reasoning metadata", () => {
+	it("bundles Umans GLM 5.2 high/max reasoning metadata without dead effortMap", () => {
 		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
 		const model = providers.umans?.["umans-glm-5.2"];
 
 		expect(model).toBeDefined();
 		expect(model.thinking).toMatchObject({
 			efforts: ["high", "xhigh"],
-			effortMap: { xhigh: "max" },
 		});
+		expect(model.thinking?.effortMap).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Repro
Feeding Umans discovery metadata for `umans-glm-5.2` with `levels: ["none","high","max"]` through `umansModelManagerOptions()` reproduced the regression: before the fix the model thinking metadata was `{"mode":"budget","efforts":["high"],"defaultLevel":"high"}`, so the picker could only show the surviving `high` tier plus global selectors.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` mapped Umans reasoning levels through `UMANS_REASONING_EFFORT_BY_LEVEL`, which did not recognize the upstream `"max"` level, and Umans GLM-5.2 had no baked `thinking.effortMap` to send `Effort.XHigh` as the provider wire value `"max"`. `packages/catalog/src/model-thinking.ts` also re-baked bundled catalog thinking from model identity without the Umans GLM-5.2 high/max constraint, so regenerated fallback metadata lost the provider-specific wire map.

## Fix
- Map Umans `"max"` to `Effort.XHigh` and attach `{ xhigh: "max" }` when dynamic discovery reports a max level.
- Teach the shared thinking resolver that Umans GLM-5.2 exposes only `high`/`xhigh` and uses the `xhigh -> max` wire mapping, keeping regenerated `models.json` consistent.
- Add Umans resolver coverage for the dynamic high/max ladder, wire mapping, and bundled catalog fallback.

## Verification
Ran `bun --cwd=packages/catalog test test/umans-provider.test.ts`, `bun --cwd=packages/catalog test test/model-thinking.test.ts test/generated-policies.test.ts`, `bun --cwd=packages/catalog test test/umans-provider.test.ts test/model-thinking.test.ts test/generated-policies.test.ts && bun --cwd=packages/catalog run check:types`, and a one-off repro command verifying the fixed output is `{"thinking":{"mode":"budget","efforts":["high","xhigh"],"effortMap":{"xhigh":"max"},"defaultLevel":"high"},"xhighWire":"max"}`. Fixes #3192