### PR TITLE
fix(coding-agent): show xhigh in model picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `/model` thinking picker labeling the OpenAI GPT-5.5 top effort as `max` instead of the catalog-declared `xhigh` ([#3194](https://github.com/can1357/oh-my-pi/issues/3194)).
+
 ## [16.1.10] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -32,7 +32,7 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 	[ThinkingLevel.High]: { value: ThinkingLevel.High, label: "high", description: "Deep reasoning (~16k tokens)" },
 	[ThinkingLevel.XHigh]: {
 		value: ThinkingLevel.XHigh,
-		label: "max",
+		label: "xhigh",
 		description: "Maximum reasoning (~32k tokens)",
 	},
 };

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -137,6 +137,24 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(menuRendered).toContain("Set as SMOL (Quick)");
 	});
 
+	test("renders xhigh effort for OpenAI GPT-5.5 thinking options", async () => {
+		installTestTheme();
+		const model = getBundledModel("openai", "gpt-5.5");
+		if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+
+		const selector = createSelector(model, Settings.isolated({}));
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Thinking for: Default (gpt-5.5)");
+		expect(rendered).toContain("low medium high xhigh");
+		expect(rendered).not.toContain("low medium high max");
+	});
+
 	test("shows compact auto badges for unconfigured role defaults", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});


### PR DESCRIPTION
## Repro
The `/model` picker for bundled `openai/gpt-5.5` rendered the role thinking menu as `inherit off auto low medium high max`; the repro script instantiated `ModelSelectorComponent`, opened the GPT-5.5 thinking menu, and failed when the rendered output lacked `xhigh`.

## Cause
`packages/coding-agent/src/thinking.ts` labeled `ThinkingLevel.XHigh` as `max`, and `packages/coding-agent/src/modes/components/model-selector.ts` renders effort options through `getConfiguredThinkingLevelMetadata`, so the picker hid the catalog vocabulary even though `getSupportedEfforts(model)` returned `xhigh`.

## Fix
- Changed the XHigh display label from `max` to `xhigh` while preserving `max` as a parsed alias.
- Added a `/model` selector regression test for bundled `openai/gpt-5.5` that opens the thinking menu and asserts `low medium high xhigh` is rendered.
- Added a coding-agent changelog entry for #3194.

## Verification
`bun --cwd=packages/coding-agent test test/model-selector-role-badge-thinking.test.ts` passed: 10 pass, 0 fail. Manual repro script now renders `inherit off auto low medium high xhigh`. Fixes #3194