### PR TITLE
fix(tui): replace raw optimistic slash prompt renders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed prompt-template and file slash-command submissions rendering both the raw slash invocation and the expanded prompt in the interactive transcript. ([#3199](https://github.com/can1357/oh-my-pi/issues/3199))
 - Fixed the `/model` thinking picker labeling the OpenAI GPT-5.5 top effort as `max` instead of the catalog-declared `xhigh` ([#3194](https://github.com/can1357/oh-my-pi/issues/3194)).
 - Fixed session-title generation silently falling back to the online `smol` model (and billing whatever provider held the resolved API key — OpenRouter in the reporter's case) when the user had explicitly configured a **local** `providers.tinyModel`: `generateSessionTitle` raced local against online with a 10s timeout and fired the online request immediately whenever the local worker returned `null` (unknown key, model not downloaded, transformers.js failure). Now an explicit local-model choice is honored end-to-end — on local failure the session is left untitled with a `logger.warn` instead of billing the smol fallback ([#3187](https://github.com/can1357/oh-my-pi/issues/3187))
 - Fixed OpenCode MCP discovery so array commands are normalized into a stdio executable plus arguments, `environment` is accepted as the OpenCode env key, and argument lists are omitted when empty. ([#3180](https://github.com/can1357/oh-my-pi/issues/3180))

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -296,9 +296,10 @@ export class EventController {
 			this.#resetReadGroup();
 			this.#resolveDisplaceablePoll();
 			const wasOptimistic = this.ctx.optimisticUserMessageSignature === signature;
-			const replacesOptimistic = this.ctx.optimisticUserMessageSignature !== undefined && !wasOptimistic;
-			const wasLocallySubmitted =
-				this.ctx.locallySubmittedUserSignatures.delete(signature) || wasOptimistic || replacesOptimistic;
+			const matchedLocalSubmission = this.ctx.locallySubmittedUserSignatures.delete(signature);
+			const replacesOptimistic =
+				this.ctx.optimisticUserMessageSignature !== undefined && !wasOptimistic && !matchedLocalSubmission;
+			const wasLocallySubmitted = matchedLocalSubmission || wasOptimistic || replacesOptimistic;
 			if (wasOptimistic) {
 				this.ctx.clearOptimisticUserMessage();
 			} else if (replacesOptimistic) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -296,8 +296,14 @@ export class EventController {
 			this.#resetReadGroup();
 			this.#resolveDisplaceablePoll();
 			const wasOptimistic = this.ctx.optimisticUserMessageSignature === signature;
-			const wasLocallySubmitted = this.ctx.locallySubmittedUserSignatures.delete(signature) || wasOptimistic;
-			if (!wasOptimistic) {
+			const replacesOptimistic = this.ctx.optimisticUserMessageSignature !== undefined && !wasOptimistic;
+			const wasLocallySubmitted =
+				this.ctx.locallySubmittedUserSignatures.delete(signature) || wasOptimistic || replacesOptimistic;
+			if (wasOptimistic) {
+				this.ctx.clearOptimisticUserMessage();
+			} else if (replacesOptimistic) {
+				this.ctx.replaceOptimisticUserMessage(event.message);
+			} else {
 				// Append synchronously: #emit dispatches to this listener fire-and-forget
 				// (see AgentSession.#emit), so any await between the user message_start and
 				// addMessageToChat lets later events (assistant message_start, tool execution
@@ -305,9 +311,6 @@ export class EventController {
 				// live-region block boundaries. addMessageToChat materializes clickable image
 				// links via the synchronous putBlobSync fallback, so no await is needed here.
 				this.ctx.addMessageToChat(event.message);
-			}
-			if (wasOptimistic) {
-				this.ctx.optimisticUserMessageSignature = undefined;
 			}
 
 			// Clear the editor only when the submission did not originate from a

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -435,6 +435,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	locallySubmittedUserSignatures: Set<string> = new Set();
 	#pendingSubmittedInput: SubmittedUserInput | undefined;
 	#pendingSubmissionDispose: (() => void) | undefined;
+	#optimisticUserMessageComponents: Component[] = [];
 	lastSigintTime = 0;
 	lastEscapeTime = 0;
 	lastLeftTapTime = 0;
@@ -1247,6 +1248,32 @@ export class InteractiveMode implements InteractiveModeContext {
 			throw err;
 		}
 	}
+	#captureAddedChatComponents(render: () => void): Component[] {
+		const start = this.chatContainer.children.length;
+		render();
+		return this.chatContainer.children.slice(start);
+	}
+
+	clearOptimisticUserMessage(): void {
+		this.optimisticUserMessageSignature = undefined;
+		this.#pendingSubmissionDispose?.();
+		this.#pendingSubmissionDispose = undefined;
+		this.#optimisticUserMessageComponents = [];
+	}
+
+	replaceOptimisticUserMessage(
+		message: AgentMessage,
+		options?: { imageLinks?: readonly (string | undefined)[] },
+	): void {
+		this.optimisticUserMessageSignature = undefined;
+		this.#pendingSubmissionDispose?.();
+		this.#pendingSubmissionDispose = undefined;
+		for (const component of this.#optimisticUserMessageComponents) {
+			this.chatContainer.removeChild(component);
+		}
+		this.#optimisticUserMessageComponents = [];
+		this.addMessageToChat(message, options);
+	}
 
 	startPendingSubmission(input: {
 		text: string;
@@ -1272,18 +1299,19 @@ export class InteractiveMode implements InteractiveModeContext {
 			const imageCount = submission.images?.length ?? 0;
 			this.optimisticUserMessageSignature = `${submission.text}\u0000${imageCount}`;
 			this.#pendingSubmissionDispose = this.recordLocalSubmission(submission.text, imageCount);
-			this.addMessageToChat(
-				{
-					role: "user",
-					content: [{ type: "text", text: submission.text }, ...(submission.images ?? [])],
-					attribution: "user",
-					timestamp: Date.now(),
-				},
-				{ imageLinks: input.imageLinks },
-			);
+			this.#optimisticUserMessageComponents = this.#captureAddedChatComponents(() => {
+				this.addMessageToChat(
+					{
+						role: "user",
+						content: [{ type: "text", text: submission.text }, ...(submission.images ?? [])],
+						attribution: "user",
+						timestamp: Date.now(),
+					},
+					{ imageLinks: input.imageLinks },
+				);
+			});
 		} else {
-			this.optimisticUserMessageSignature = undefined;
-			this.#pendingSubmissionDispose = undefined;
+			this.clearOptimisticUserMessage();
 		}
 		this.editor.setText("");
 		this.editor.imageLinks = undefined;
@@ -1300,9 +1328,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		submission.cancelled = true;
 		this.#pendingSubmittedInput = undefined;
-		this.optimisticUserMessageSignature = undefined;
-		this.#pendingSubmissionDispose?.();
-		this.#pendingSubmissionDispose = undefined;
+		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (submission.customType === "goal-continuation") {
 			this.#goalContinuationTurnInFlight = false;
@@ -1344,6 +1370,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (wasPendingSubmission && !this.session.isStreaming && !this.streamingComponent) {
 			this.optimisticUserMessageSignature = undefined;
 			pendingSubmissionDispose?.();
+			this.#optimisticUserMessageComponents = [];
 			this.#pendingWorkingMessage = undefined;
 			if (this.loadingAnimation) {
 				this.#stopLoadingAnimation(true);
@@ -3256,9 +3283,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	showError(message: string): void {
 		this.#pendingSubmittedInput = undefined;
-		this.optimisticUserMessageSignature = undefined;
-		this.#pendingSubmissionDispose?.();
-		this.#pendingSubmissionDispose = undefined;
+		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (this.loadingAnimation) {
 			this.#stopLoadingAnimation(true);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1461,15 +1461,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!this.optimisticUserMessageSignature) return;
 		const submission = this.#pendingSubmittedInput;
 		if (!submission || submission.cancelled || submission.customType) return;
-		this.addMessageToChat(
-			{
-				role: "user",
-				content: [{ type: "text", text: submission.text }, ...(submission.images ?? [])],
-				attribution: "user",
-				timestamp: Date.now(),
-			},
-			{ imageLinks: submission.imageLinks },
-		);
+		this.#optimisticUserMessageComponents = this.#captureAddedChatComponents(() => {
+			this.addMessageToChat(
+				{
+					role: "user",
+					content: [{ type: "text", text: submission.text }, ...(submission.images ?? [])],
+					attribution: "user",
+					timestamp: Date.now(),
+				},
+				{ imageLinks: submission.imageLinks },
+			);
+		});
 	}
 
 	#formatTodoLine(todo: TodoItem, prefix: string, matched: boolean): string {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -258,6 +258,13 @@ export interface InteractiveModeContext {
 	 * delivery error should leave the signature set untouched.
 	 */
 	withLocalSubmission<T>(text: string, fn: () => Promise<T>, options?: { imageCount?: number }): Promise<T>;
+	/** Clears bookkeeping for an optimistic local user message once the matching session event arrives. */
+	clearOptimisticUserMessage(): void;
+	/** Replaces the raw optimistic user render with the canonical message emitted by the session. */
+	replaceOptimisticUserMessage(
+		message: AgentMessage,
+		options?: { imageLinks?: readonly (string | undefined)[] },
+	): void;
 	isKnownSlashCommand(text: string): boolean;
 	addMessageToChat(
 		message: AgentMessage,

--- a/packages/coding-agent/test/issue-2372-repro.test.ts
+++ b/packages/coding-agent/test/issue-2372-repro.test.ts
@@ -142,6 +142,52 @@ describe("issue #2372 pre-streaming chat rebuild preserves optimistic submission
 		expect(mode.locallySubmittedUserSignatures.has("/jira-task\u00000")).toBe(false);
 	});
 
+	it("does not replace a pending optimistic prompt with another local user event", async () => {
+		mode.isInitialized = true;
+		const controller = new EventController(mode);
+		const addMessageSpy = vi.spyOn(mode, "addMessageToChat");
+
+		mode.startPendingSubmission({ text: "/jira-task" });
+		mode.locallySubmittedUserSignatures.add("queued before prompt\u00000");
+
+		await controller.handleEvent({
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "queued before prompt" }],
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		});
+
+		expect(mode.optimisticUserMessageSignature).toBe("/jira-task\u00000");
+		expect(mode.chatContainer.children).toHaveLength(2);
+		expect(mode.locallySubmittedUserSignatures.has("queued before prompt\u00000")).toBe(false);
+
+		await controller.handleEvent({
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "Expanded Jira task prompt" }],
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		});
+
+		const renderedTexts = addMessageSpy.mock.calls.map(([message]) => {
+			if (message.role !== "user") throw new Error(`Expected user message, got ${message.role}`);
+			return typeof message.content === "string"
+				? message.content
+				: message.content
+						.filter(content => content.type === "text")
+						.map(content => content.text)
+						.join("\n");
+		});
+		expect(renderedTexts).toEqual(["/jira-task", "queued before prompt", "Expanded Jira task prompt"]);
+		expect(mode.chatContainer.children).toHaveLength(2);
+		expect(mode.optimisticUserMessageSignature).toBeUndefined();
+	});
+
 	it("does not replay after the submission is cancelled", () => {
 		const addMessageSpy = vi.spyOn(mode, "addMessageToChat");
 

--- a/packages/coding-agent/test/issue-2372-repro.test.ts
+++ b/packages/coding-agent/test/issue-2372-repro.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -107,6 +108,37 @@ describe("issue #2372 pre-streaming chat rebuild preserves optimistic submission
 
 		// Only the initial optimistic add — no replay duplication.
 		expect(addMessageSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("replaces raw slash optimistic text when message_start carries expanded content", async () => {
+		mode.isInitialized = true;
+		const controller = new EventController(mode);
+		const addMessageSpy = vi.spyOn(mode, "addMessageToChat");
+
+		mode.startPendingSubmission({ text: "/jira-task" });
+		await controller.handleEvent({
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "Expanded Jira task prompt" }],
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		});
+
+		const renderedTexts = addMessageSpy.mock.calls.map(([message]) => {
+			if (message.role !== "user") throw new Error(`Expected user message, got ${message.role}`);
+			return typeof message.content === "string"
+				? message.content
+				: message.content
+						.filter(content => content.type === "text")
+						.map(content => content.text)
+						.join("\n");
+		});
+		expect(renderedTexts).toEqual(["/jira-task", "Expanded Jira task prompt"]);
+		expect(mode.chatContainer.children).toHaveLength(1);
+		expect(mode.optimisticUserMessageSignature).toBeUndefined();
+		expect(mode.locallySubmittedUserSignatures.has("/jira-task\u00000")).toBe(false);
 	});
 
 	it("does not replay after the submission is cancelled", () => {

--- a/packages/coding-agent/test/issue-2372-repro.test.ts
+++ b/packages/coding-agent/test/issue-2372-repro.test.ts
@@ -116,6 +116,7 @@ describe("issue #2372 pre-streaming chat rebuild preserves optimistic submission
 		const addMessageSpy = vi.spyOn(mode, "addMessageToChat");
 
 		mode.startPendingSubmission({ text: "/jira-task" });
+		mode.rebuildChatFromMessages();
 		await controller.handleEvent({
 			type: "message_start",
 			message: {
@@ -135,7 +136,7 @@ describe("issue #2372 pre-streaming chat rebuild preserves optimistic submission
 						.map(content => content.text)
 						.join("\n");
 		});
-		expect(renderedTexts).toEqual(["/jira-task", "Expanded Jira task prompt"]);
+		expect(renderedTexts).toEqual(["/jira-task", "/jira-task", "Expanded Jira task prompt"]);
 		expect(mode.chatContainer.children).toHaveLength(1);
 		expect(mode.optimisticUserMessageSignature).toBeUndefined();
 		expect(mode.locallySubmittedUserSignatures.has("/jira-task\u00000")).toBe(false);

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -36,6 +36,12 @@ function createContext(options: {
 	};
 	const addMessageToChat = vi.fn();
 	const updatePendingMessagesDisplay = vi.fn();
+	const clearOptimisticUserMessage = vi.fn(() => {
+		ctx.optimisticUserMessageSignature = undefined;
+	});
+	const replaceOptimisticUserMessage = vi.fn(() => {
+		ctx.optimisticUserMessageSignature = undefined;
+	});
 	const ctx = {
 		isInitialized: true,
 		statusLine: { invalidate: vi.fn() },
@@ -53,9 +59,19 @@ function createContext(options: {
 						.join(""),
 		optimisticUserMessageSignature: options.optimisticSignature,
 		locallySubmittedUserSignatures: new Set<string>(options.locallySubmittedSignatures ?? []),
+		clearOptimisticUserMessage,
+		replaceOptimisticUserMessage,
 		pendingTools: new Map(),
 	} as unknown as InteractiveModeContext;
-	return { ctx, editor, setText, addMessageToChat, updatePendingMessagesDisplay };
+	return {
+		ctx,
+		editor,
+		setText,
+		addMessageToChat,
+		updatePendingMessagesDisplay,
+		clearOptimisticUserMessage,
+		replaceOptimisticUserMessage,
+	};
 }
 
 describe("EventController message_start (user role)", () => {


### PR DESCRIPTION
## Repro
A focused TUI controller regression reproduced the issue by rendering an optimistic `/jira-task` submission, then delivering a `message_start` event with `Expanded Jira task prompt`; before the fix, `mode.chatContainer.children` had length 2. Commands: `bun --cwd=packages/collab-web run build:tool-views && bun test ./tmp/repro-3199.test.ts`.

## Cause
`EventController` in `packages/coding-agent/src/modes/controllers/event-controller.ts` reconciled optimistic user messages only when the event signature matched `InteractiveMode.optimisticUserMessageSignature`. `InteractiveMode.startPendingSubmission` keyed and rendered the raw slash text in `packages/coding-agent/src/modes/interactive-mode.ts`, while `AgentSession.prompt()` emits the expanded prompt text, so the event path appended a second user message and left the raw optimistic render in place.

## Fix
- Track the concrete components created for optimistic user renders in `InteractiveMode`.
- Add `clearOptimisticUserMessage` and `replaceOptimisticUserMessage` so a canonical session user message can replace raw optimistic UI when expansion changes text.
- Update `EventController` to treat an optimistic signature mismatch as local replacement, not a remote user message append.
- Add regression coverage for slash prompt expansion reconciliation and document the fix in the coding-agent changelog.

## Verification
- `bun test packages/coding-agent/test/issue-2372-repro.test.ts` passed: 4 tests, 17 assertions.
- `bun --cwd=packages/coding-agent run check` passed.

Fixes #3199