### PR TITLE
fix(ai): sanitize Responses image history replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed OpenAI Responses native history replay leaking image generation provider-only fields into the next request, which made OpenAI-compatible proxies reject `pi` tool-calling sessions with `Unknown parameter: input[1].action`. ([#3201](https://github.com/can1357/oh-my-pi/issues/3201))
+
 - Fixed a stream thought-leakage issue for `gemini-3.5-flash` where the model's internal reasoning JSON could leak into the visible text stream. The stream parser now uses a brace-balanced counting algorithm to accurately slice and discard the leading thought JSON block, with a robust fallback for unescaped double quotes, dynamic tool-name derivation, and preservation of subsequent text deltas without triggering empty-response retries.
 
 ## [16.1.10] - 2026-06-21

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -5,7 +5,6 @@ import type { CacheRetention, OpenAIResponsesHistoryPayload, ProviderPayload } f
 type OpenAIResponsesReplayItem = ResponseInput[number];
 const IMAGE_GENERATION_CALL_STATUSES = new Set<string>(["in_progress", "completed", "generating", "failed"]);
 
-
 export { isRecord } from "@oh-my-pi/pi-utils";
 export function normalizeSystemPrompts(systemPrompt: readonly string[] | string | undefined | null): string[] {
 	if (systemPrompt === undefined || systemPrompt === null) return [];

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -1,8 +1,10 @@
 import { $env } from "@oh-my-pi/pi-utils";
-import type { ResponseInput } from "./providers/openai-responses-wire";
+import type { ResponseInput, ResponseInputItem } from "./providers/openai-responses-wire";
 import type { CacheRetention, OpenAIResponsesHistoryPayload, ProviderPayload } from "./types";
 
 type OpenAIResponsesReplayItem = ResponseInput[number];
+const IMAGE_GENERATION_CALL_STATUSES = new Set<string>(["in_progress", "completed", "generating", "failed"]);
+
 
 export { isRecord } from "@oh-my-pi/pi-utils";
 export function normalizeSystemPrompts(systemPrompt: readonly string[] | string | undefined | null): string[] {
@@ -77,6 +79,7 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	normalizedCallIds: Map<string, string>,
 ): OpenAIResponsesReplayItem | undefined {
 	if (item.type === "item_reference") return undefined;
+	if (item.type === "image_generation_call") return sanitizeOpenAIResponsesImageGenerationCallForReplay(item);
 
 	// providerPayload stores raw output items; replay strips item ids and keeps only normalized call_id.
 	const { id: _id, ...sanitizedItem } = item;
@@ -85,6 +88,22 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	}
 
 	return sanitizedItem as unknown as OpenAIResponsesReplayItem;
+}
+
+function sanitizeOpenAIResponsesImageGenerationCallForReplay(
+	item: Record<string, unknown>,
+): ResponseInputItem.ImageGenerationCall | undefined {
+	if (typeof item.id !== "string" || !isImageGenerationCallStatus(item.status)) return undefined;
+	return {
+		id: truncateResponseItemId(item.id, "ig"),
+		type: "image_generation_call",
+		status: item.status,
+		result: typeof item.result === "string" ? item.result : null,
+	};
+}
+
+function isImageGenerationCallStatus(status: unknown): status is ResponseInputItem.ImageGenerationCall["status"] {
+	return typeof status === "string" && IMAGE_GENERATION_CALL_STATUSES.has(status);
 }
 
 function normalizeReplayedResponsesHistoryCallId(value: string, normalizedValues: Map<string, string>): string {

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -439,6 +439,38 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
+	it("strips provider-only image generation fields from replayed native history", async () => {
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "first user", timestamp: Date.now() },
+				makeAssistantMessage(
+					[
+						{
+							id: "ig_history",
+							type: "image_generation_call",
+							status: "generating",
+							action: "generate",
+							background: "opaque",
+							output_format: "png",
+							quality: "medium",
+						},
+					],
+					true,
+				),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		};
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+
+		expect(findResponsesInputItem(payload.input, "image_generation_call")).toEqual({
+			id: "ig_history",
+			type: "image_generation_call",
+			status: "generating",
+			result: null,
+		});
+	});
+
 	it("falls back to rebuilt history on resumed same-provider sessions with fresh session state", async () => {
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const providerSessionState = new Map<string, ProviderSessionState>();


### PR DESCRIPTION
## Repro
A stored OpenAI Responses native history item shaped like the reporter's payload (`image_generation_call` with provider-only fields such as `action`, `background`, `output_format`, and `quality`) was replayed into the next request. Reproduced with a `bun -e` buildResponsesInput script that emitted `input[1].action` in the next `/responses` input array.

## Cause
`packages/ai/src/utils.ts` `sanitizeOpenAIResponsesHistoryItemForReplay` stripped only `id` from raw provider output items before replay. Raw `image_generation_call` output items can contain output-only/provider-only fields, but `ResponseInputItem.ImageGenerationCall` accepts only the replay-safe item identity, status, and result shape.

## Fix
- Whitelist replayed `image_generation_call` fields to `id`, `type`, `status`, and `result`.
- Drop malformed image-generation history items instead of replaying invalid wire payloads.
- Added a regression test in `packages/ai/test/openai-responses-history-payload.test.ts` for the `input[1].action` leak.
- Added the package changelog entry.

## Verification
Reproduced before the fix with a `bun -e` script emitting `input[1].action`; after the fix the same script emits `{"id":"ig_1","type":"image_generation_call","status":"generating","result":null}`. Ran `bun test packages/ai/test/openai-responses-history-payload.test.ts` → 22 pass, 0 fail. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #3201