### PR TITLE
fix(tui): restore ask focus after settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed returning from `/settings` while an `ask` tool prompt is pending so focus returns to the ask selector instead of the main prompt editor ([#3203](https://github.com/can1357/oh-my-pi/issues/3203)).
+
 - Fixed Codex image reads re-encoding to WebP and then failing the next request with an invalid `input_image.image_url`; Codex-bound images now stay in PNG/JPEG-compatible formats.
 
 - Fixed the `/model` thinking picker labeling the OpenAI GPT-5.5 top effort as `max` instead of the catalog-declared `xhigh` ([#3194](https://github.com/can1357/oh-my-pi/issues/3194)).

--- a/packages/coding-agent/src/modes/controllers/editor-surface-focus.ts
+++ b/packages/coding-agent/src/modes/controllers/editor-surface-focus.ts
@@ -1,0 +1,13 @@
+import type { Component } from "@oh-my-pi/pi-tui";
+
+interface EditorSurfaceFocusContext {
+	editor: Component;
+	hookSelector?: Component;
+	hookInput?: Component;
+	hookEditor?: Component;
+}
+
+/** Returns the editor-surface component that should receive input after modal UI closes. */
+export function getEditorSurfaceFocusTarget(ctx: EditorSurfaceFocusContext): Component {
+	return ctx.hookSelector ?? ctx.hookInput ?? ctx.hookEditor ?? ctx.editor;
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -17,6 +17,7 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
+import { getEditorSurfaceFocusTarget } from "./editor-surface-focus";
 import {
 	getAvailableThemes,
 	getSymbolTheme,
@@ -109,7 +110,7 @@ export class SelectorController {
 			let overlayHandle: OverlayHandle | undefined;
 			const done = () => {
 				overlayHandle?.hide();
-				this.ctx.ui.setFocus(this.ctx.editor);
+				this.ctx.ui.setFocus(getEditorSurfaceFocusTarget(this.ctx));
 				this.ctx.ui.requestRender();
 			};
 			const selector = new SettingsSelectorComponent(

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -17,7 +17,6 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
-import { getEditorSurfaceFocusTarget } from "./editor-surface-focus";
 import {
 	getAvailableThemes,
 	getSymbolTheme,
@@ -69,6 +68,7 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
+import { getEditorSurfaceFocusTarget } from "./editor-surface-focus";
 
 const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";
 

--- a/packages/coding-agent/test/settings-focus.test.ts
+++ b/packages/coding-agent/test/settings-focus.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { Text, TUI, type Terminal, type TerminalAppearance } from "@oh-my-pi/pi-tui";
+import { getEditorSurfaceFocusTarget } from "@oh-my-pi/pi-coding-agent/modes/controllers/editor-surface-focus";
+
+class MemoryTerminal implements Terminal {
+	readonly columns = 80;
+	readonly rows = 24;
+	readonly kittyProtocolActive = false;
+	readonly kittyEnableSequence = null;
+	readonly appearance = undefined;
+
+	start(): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(): void {}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
+	onAppearanceChange(_callback: (appearance: TerminalAppearance) => void): void {}
+}
+
+const inertRenderScheduler = {
+	now: () => 0,
+	scheduleImmediate: () => {},
+	scheduleRender: () => ({ cancel() {} }),
+};
+
+describe("settings overlay focus restore", () => {
+	it("returns focus to a pending ask selector instead of the prompt editor", () => {
+		const ui = new TUI(new MemoryTerminal(), false, { renderScheduler: inertRenderScheduler });
+		const editor = new Text("editor", 0, 0);
+		const settingsOverlay = new Text("settings", 0, 0);
+		const askSelector = new Text("ask", 0, 0);
+		const ctx = {
+			editor,
+			hookSelector: askSelector,
+			hookInput: undefined,
+			hookEditor: undefined,
+		};
+
+		ui.setFocus(editor);
+		const overlay = ui.showOverlay(settingsOverlay, { fullscreen: true });
+
+		ui.setFocus(askSelector);
+		expect(ui.getFocused()).toBe(settingsOverlay);
+
+		overlay.hide();
+		ui.setFocus(getEditorSurfaceFocusTarget(ctx));
+
+		expect(ui.getFocused()).toBe(askSelector);
+	});
+});

--- a/packages/coding-agent/test/settings-focus.test.ts
+++ b/packages/coding-agent/test/settings-focus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { Text, TUI, type Terminal, type TerminalAppearance } from "@oh-my-pi/pi-tui";
 import { getEditorSurfaceFocusTarget } from "@oh-my-pi/pi-coding-agent/modes/controllers/editor-surface-focus";
+import { type Terminal, type TerminalAppearance, Text, TUI } from "@oh-my-pi/pi-tui";
 
 class MemoryTerminal implements Terminal {
 	readonly columns = 80;


### PR DESCRIPTION
## Repro
Opening `/settings` while a model turn is still running can leave an `ask` selector pending underneath the fullscreen settings overlay. The minimal focus repro is: focus the prompt editor, open a fullscreen settings overlay, attempt to focus a pending ask selector while the overlay is visible, close the overlay, and assert the ask selector has focus; before the fix it prints `duringOverlay=settings` and `afterClose=editor` and exits 1.

## Cause
`SelectorController.showSettingsSelector` in `packages/coding-agent/src/modes/controllers/selector-controller.ts` always called `ui.setFocus(this.ctx.editor)` when the settings overlay closed. If `ExtensionUiController.showHookSelector` had already mounted an `ask` selector in `editorContainer`, the fullscreen overlay prevented that selector from taking focus until close, and the settings close handler then forced focus back to the main prompt editor.

## Fix
- Added `getEditorSurfaceFocusTarget` to choose the active hook selector/input/editor before falling back to the main prompt editor.
- Updated the `/settings` close path to restore focus to that active editor-surface component after hiding the overlay.
- Added a regression test covering the fullscreen overlay close sequence with a pending ask selector.
- Added a coding-agent changelog entry for #3203.

## Verification
Ran `bun test test/settings-focus.test.ts` and `bun run check:types` in `packages/coding-agent`; both passed. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #3203