### PR TITLE
Add queue slash command

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -975,9 +975,9 @@ export class InputController {
 		}
 	}
 
-	/** Send editor text as a follow-up message (queued behind current stream). */
-	async handleFollowUp(): Promise<void> {
-		let text = this.ctx.editor.getText().trim();
+	/** Submit text as a follow-up message (queued behind current stream). */
+	async submitFollowUpText(rawText: string, options: { parseSlashCommands?: boolean } = {}): Promise<void> {
+		let text = rawText.trim();
 		if (!text) return;
 
 		// Focused subagent session: follow-ups go to it; non-chat input is gated.
@@ -998,21 +998,24 @@ export class InputController {
 			return;
 		}
 
-		const slashResult = await executeBuiltinSlashCommand(text, {
-			ctx: this.ctx,
-		});
-		if (slashResult === true) {
-			return;
-		}
-		if (typeof slashResult === "string") {
-			text = slashResult;
-		}
+		if (options.parseSlashCommands !== false) {
+			const slashResult = await executeBuiltinSlashCommand(text, {
+				ctx: this.ctx,
+			});
+			if (slashResult === true) {
+				return;
+			}
+			if (typeof slashResult === "string") {
+				text = slashResult;
+				if (!text) return;
+			}
 
-		// Skill commands invoke through the custom-message path regardless of
-		// which keybinding submitted them. Enter routes them as `steer`;
-		// Ctrl+Enter (this handler) routes them as `followUp`.
-		if (await this.#invokeSkillCommand(text, "followUp")) {
-			return;
+			// Skill commands invoke through the custom-message path regardless of
+			// which keybinding submitted them. Enter routes them as `steer`;
+			// Ctrl+Enter (this handler) routes them as `followUp`.
+			if (await this.#invokeSkillCommand(text, "followUp")) {
+				return;
+			}
 		}
 
 		// Forward any pending clipboard-pasted images alongside the queued text;
@@ -1044,6 +1047,11 @@ export class InputController {
 		await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, { images }), {
 			imageCount: images?.length ?? 0,
 		});
+	}
+
+	/** Send editor text as a follow-up message (queued behind current stream). */
+	async handleFollowUp(): Promise<void> {
+		await this.submitFollowUpText(this.ctx.editor.getText(), { parseSlashCommands: true });
 	}
 
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3745,6 +3745,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#inputController.handleImagePaste();
 	}
 
+	handleQueueCommand(message: string): Promise<void> {
+		return this.#inputController.submitFollowUpText(message, { parseSlashCommands: false });
+	}
+
 	handleBtwCommand(question: string): Promise<void> {
 		return this.#btwController.start(question);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -342,6 +342,7 @@ export interface InteractiveModeContext {
 	handleCtrlZ(): void;
 	handleDequeue(): void;
 	handleImagePaste(): Promise<boolean>;
+	handleQueueCommand(message: string): Promise<void>;
 	handleBtwCommand(question: string): Promise<void>;
 	handleTanCommand(work: string): Promise<void>;
 	hasActiveBtw(): boolean;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -125,6 +125,22 @@ const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashComma
 	return commandConsumed();
 };
 
+async function queueMessageHandlerTui(
+	command: ParsedSlashCommand,
+	runtime: TuiSlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const message = command.args.trim();
+	if (!message) {
+		runtime.ctx.showError("Usage: /queue <message>");
+		runtime.ctx.editor.setText("");
+		return commandConsumed();
+	}
+
+	runtime.ctx.editor.setText("");
+	await runtime.ctx.handleQueueCommand(message);
+	return commandConsumed();
+}
+
 async function handleUsageResetCommand(
 	arg: string,
 	session: AgentSession,
@@ -1357,6 +1373,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleBtwCommand(question);
 		},
+	},
+	{
+		name: "queue",
+		description: "Queue a follow-up message after the current turn",
+		inlineHint: "<message>",
+		allowArgs: true,
+		handleTui: queueMessageHandlerTui,
 	},
 	{
 		name: "tan",

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -35,6 +35,7 @@ function createContext(opts: { isStreaming: boolean; pendingImages: ImageContent
 	const prompt = vi.fn(async (_text: string, _options?: PromptOptionsLike) => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
+	const showError = vi.fn();
 
 	const ctx = {
 		editor,
@@ -55,6 +56,7 @@ function createContext(opts: { isStreaming: boolean; pendingImages: ImageContent
 		locallySubmittedUserSignatures: new Set<string>(),
 		updatePendingMessagesDisplay,
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		showError,
 	} as unknown as InteractiveModeContext;
 
 	return { ctx, editor, prompt };
@@ -113,5 +115,36 @@ describe("InputController.handleFollowUp image forwarding", () => {
 		if (!call) throw new Error("expected session.prompt to be called");
 		expect(call[1]?.images).toBeUndefined();
 		expect(call[1]?.streamingBehavior).toBe("followUp");
+	});
+
+	it("submits provided queue text as a streaming follow-up message", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "cXVldWU=" };
+		const { ctx, editor, prompt } = createContext({ isStreaming: true, pendingImages: [image] });
+
+		const controller = new InputController(ctx);
+		await controller.submitFollowUpText("finish this after the turn", { parseSlashCommands: false });
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		const call = prompt.mock.calls[0];
+		if (!call) throw new Error("expected session.prompt to be called");
+		expect(call[0]).toBe("finish this after the turn");
+		expect(call[1]?.streamingBehavior).toBe("followUp");
+		expect(call[1]?.images).toEqual([image]);
+		expect(editor.getText()).toBe("");
+		expect(ctx.pendingImages).toEqual([]);
+		expect(ctx.pendingImageLinks).toEqual([]);
+	});
+
+	it("submits provided queue text normally when no turn is streaming", async () => {
+		const { ctx, prompt } = createContext({ isStreaming: false, pendingImages: [] });
+
+		const controller = new InputController(ctx);
+		await controller.submitFollowUpText("start this now", { parseSlashCommands: false });
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		const call = prompt.mock.calls[0];
+		if (!call) throw new Error("expected session.prompt to be called");
+		expect(call[0]).toBe("start this now");
+		expect(call[1]?.streamingBehavior).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/slash-command-queue.test.ts
+++ b/packages/coding-agent/test/slash-command-queue.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createContext() {
+	let editorText = "";
+	const handleQueueCommand = vi.fn(async (_message: string) => {});
+	const showError = vi.fn();
+	const ctx = {
+		editor: {
+			setText(text: string) {
+				editorText = text;
+			},
+			getText() {
+				return editorText;
+			},
+		},
+		showError,
+		handleQueueCommand,
+	} as unknown as InteractiveModeContext;
+
+	return { ctx, handleQueueCommand, showError };
+}
+
+describe("/queue slash command", () => {
+	it("delegates arguments to the TUI queue handler", async () => {
+		const { ctx, handleQueueCommand } = createContext();
+		ctx.editor.setText("/queue finish this after the turn");
+
+		const result = await executeBuiltinSlashCommand("/queue finish this after the turn", { ctx });
+
+		expect(result).toBe(true);
+		expect(handleQueueCommand).toHaveBeenCalledWith("finish this after the turn");
+		expect(ctx.editor.getText()).toBe("");
+	});
+
+	it("shows usage when no message is provided", async () => {
+		const { ctx, handleQueueCommand, showError } = createContext();
+		ctx.editor.setText("/queue");
+
+		const result = await executeBuiltinSlashCommand("/queue", { ctx });
+
+		expect(result).toBe(true);
+		expect(showError).toHaveBeenCalledWith("Usage: /queue <message>");
+		expect(handleQueueCommand).not.toHaveBeenCalled();
+		expect(ctx.editor.getText()).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary
- Add a TUI-only `/queue <message>` slash command for explicit follow-up queueing.
- Route `/queue` through the input controller so delivery matches the existing Ctrl+Enter follow-up path instead of duplicating queue logic in the command registry.
- Cover command delegation, missing-argument usage, streaming follow-up delivery, idle delivery, and pending-image forwarding.

## Test plan
- [x] `bun test packages/coding-agent/test/input-controller-followup-image.test.ts packages/coding-agent/test/slash-command-queue.test.ts`
- [x] `bunx biome check --write packages/coding-agent/src/slash-commands/builtin-registry.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/test/input-controller-followup-image.test.ts packages/coding-agent/test/slash-command-queue.test.ts`
- [x] `bun --cwd=packages/coding-agent run check`
