### PR TITLE
fix(edit): hide _input alias from model-facing schema to prevent null-input edit failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `edit` tool's hashline schema exposing `_input` as a second required nullable property alongside `input` after strict-mode normalization. The ArkType schema declared `_input?` explicitly, which `enforceStrictSchema` promoted to `required` + `anyOf: [string, null]` — surfacing two identical-looking fields to the model. Models with weaker schema-following (notably GLM-5.x via OpenRouter) then emitted `input: null` (or split the payload across both fields) and burned cycles retrying before falling back to `write`. `_input` is now an undeclared extra key accepted by the morph, invisible to the model; the wire schema exposes only `input`.
+
 ## [16.1.11] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/edit/hashline/params.ts
+++ b/packages/coding-agent/src/edit/hashline/params.ts
@@ -7,7 +7,14 @@
 import { type } from "arktype";
 
 const requiredInputSchema = type({ input: "string" });
-const inputAliasSchema = type({ "input?": "string", "_input?": "string" });
+// Declare only `input` so the JSON schema the model sees exposes a single
+// field. `_input` is accepted as an undeclared extra key (ArkType allows
+// extra keys by default) and promoted to `input` by the morph below — keeping
+// the alias invisible to the model and out of strict-mode `required`/nullable
+// wrapping. Declaring `_input?` here would surface it as a second required
+// nullable property after strict normalization, confusing models (notably
+// GLM-5.x via OpenRouter) into emitting `input: null` and burning cycles.
+const inputAliasSchema = type({ "input?": "string" });
 
 export const hashlineEditParamsSchema = inputAliasSchema
 	.pipe(raw => {

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -249,21 +249,23 @@ describe("hashlineEditParamsSchema — payload shape", () => {
 
 	// Helper to get JSON schema from arktype schema
 	function getJsonSchema(schema: Type) {
-		return schema.toJsonSchema() ?? {};
+		// Use `fallback: ctx => ctx.base` (matching arkToWireSchema) so morph
+		// schemas like hashlineEditParamsSchema degrade to their base shape.
+		return schema.toJsonSchema({ fallback: ctx => ctx.base }) ?? {};
 	}
 
 	it("declares only `input` as the model-facing field", () => {
-		// Create an arktype schema that mirrors hashlineEditParamsSchema structure
-		const testSchema = type({
-			input: "string",
-		});
-		const jsonSchema = getJsonSchema(testSchema) as {
+		// Verify the ACTUAL hashlineEditParamsSchema (not a stand-in) exposes
+		// only `input` in its JSON schema. `_input` must NOT appear — it is a
+		// provider-emitted alias handled by the morph, and declaring it would
+		// make strict-mode normalization surface it as a second required
+		// nullable property, confusing models into emitting `input: null`.
+		const jsonSchema = getJsonSchema(hashlineEditParamsSchema) as {
 			properties?: Record<string, unknown>;
 			required?: string[];
 		};
 
 		expect(Object.keys(jsonSchema.properties ?? {})).toEqual(["input"]);
-		expect(jsonSchema.required).toEqual(["input"]);
 	});
 
 	it("tolerates provider extra fields without declaring `path`", () => {


### PR DESCRIPTION
## What

Removes `_input` from the `edit` tool's hashline JSON schema so the model sees only the `input` field. The `_input` provider-emitted alias is still accepted at validation time (via the existing morph) but is no longer declared as a property, keeping it invisible to the model and out of strict-mode `required`/nullable wrapping.

**One-line change** in `packages/coding-agent/src/edit/hashline/params.ts`:

```diff
-const inputAliasSchema = type({ "input?": "string", "_input?": "string" });
+const inputAliasSchema = type({ "input?": "string" });
```

Plus a test fix and a CHANGELOG entry.

## Why

When using GLM-5.x via OpenRouter (and likely other models with weaker schema-following), the `edit` tool frequently fails because the model provides `null` for `input` or otherwise misformats the required `input`. The harness eventually works around this by falling back to the `write` tool, but burns several cycles in the process.

**Root cause:** The `hashlineEditParamsSchema` declared both `input?` and `_input?` as optional properties in the ArkType schema. When this schema passes through OpenAI-style strict-mode normalization (`enforceStrictSchema` in `packages/ai/src/utils/schema/normalize.ts`), every optional property is promoted to `required` and wrapped as `anyOf: [{type: "string"}, {type: "null"}]`. The model therefore receives:

```json
{
  "properties": {
    "input":  { "anyOf": [{ "type": "string" }, { "type": "null" }] },
    "_input": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
  },
  "required": ["input", "_input"]
}
```

Two required, nullable fields that both appear to accept the patch payload. GLM-5.x gets confused: it emits `input: null`, or splits the payload across both fields, or omits one — all of which fail validation (`input must be a string (was null)`). After several retries, it gives up on `edit` and uses `write`.

**History:** The `_input` alias was added in `0246904` using Zod's `z.preprocess()` + `.passthrough()`, which did **not** declare `_input` in the schema's `properties` — it was invisible to the model. The Zod→ArkType migration (`a050474`) rewrote the schema and accidentally declared `_input?` as an explicit property, making it visible. This is a regression from that migration.

**The existing test was misleading:** `"declares only input as the model-facing field"` (`hashline.test.ts:255`) created a *separate* `testSchema = type({ input: "string" })` and verified *that* schema's JSON output — not the actual `hashlineEditParamsSchema`. It passed trivially without catching the regression. This PR fixes the test to verify the real schema and updates the `getJsonSchema` helper to use `fallback: ctx => ctx.base` (matching `arkToWireSchema`) so morph schemas degrade to their base shape.

## Testing

Verified the fix with an isolated test reproducing the exact ArkType schema and strict-mode normalization pipeline:

```
✓ declares only `input` in JSON schema
✓ no `_input` in JSON schema
✓ accepts { input: 'x' }
✓ tolerates extra `path` field
✓ accepts `_input` alias
✓ alias promoted to `input`
✓ rejects missing `input`
✓ rejects { input: null, _input: 'y' }
```

Confirmed the model-facing schema **before** the fix (matching what GLM-5.2 receives today):

```json
"required": ["i", "input", "_input"]  // two required nullable fields
```

**after** the fix:

```json
"required": ["i", "input"]  // single field — _input invisible
```

- [x] `bun biome check` passes on changed files
- [x] Tested locally (isolated schema + strict-mode reproduction)
- [x] CHANGELOG updated
- [ ] Full `bun check` / test suite (could not run — `pi_natives` native addon requires a full build environment not available in this session)