### PR TITLE
fix(coding-agent): anchored todo HUD with borders and progress header

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the persistent todo HUD above the editor reading as ambient status text rather than an anchored panel — the small "Todos" block now sits inside dim horizontal rules (matching `BtwPanel` / `OmfgPanel`) and the header inlines progress and the active-phase pointer (`Todos · 2/7 done · I/III Foundation`), so the list stays self-describing without scrolling back to the tool-result block in chat ([#3213](https://github.com/can1357/oh-my-pi/issues/3213)).
+
 ## [16.1.11] - 2026-06-21
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -104,7 +104,7 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
 import { type ResolveToolDetails, runResolveInvocation } from "../tools/resolve";
-import { formatPhaseDisplayName, selectStickyTodoWindow, todoMatchesAnyDescription } from "../tools/todo";
+import { formatPhaseDisplayName, phaseRomanNumeral, selectStickyTodoWindow, todoMatchesAnyDescription } from "../tools/todo";
 import { ToolError } from "../tools/tool-errors";
 import { vocalizer } from "../tts/vocalizer";
 import type { EventBus } from "../utils/event-bus";
@@ -1631,7 +1631,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (phases.length === 0) return;
 		const indent = "  ";
 		const hook = theme.tree.hook;
-		const lines = ["", indent + theme.bold(theme.fg("accent", "Todos"))];
+
+		// Header progress so the persistent HUD reads at a glance:
+		// "Todos · 2/7 done · I/III Foundation" (collapsed) or "· 2/7 done" (expanded).
+		const allTasks = phases.flatMap(p => p.tasks);
+		const doneCount = allTasks.filter(t => t.status === "completed").length;
+		const stats = `${doneCount}/${allTasks.length} done`;
+		const activeIdx = phases.indexOf(this.#getActivePhase(phases) ?? phases[0]);
+		const activePhase = phases[activeIdx];
+		let phaseSuffix = "";
+		if (!this.todoExpanded && activePhase) {
+			phaseSuffix =
+				phases.length > 1
+					? ` · ${phaseRomanNumeral(activeIdx + 1)}/${phaseRomanNumeral(phases.length)} ${activePhase.name}`
+					: ` · ${activePhase.name}`;
+		}
+		const header = `${indent}${theme.bold(theme.fg("accent", "Todos"))}${theme.fg("muted", ` · ${stats}${phaseSuffix}`)}`;
+		const lines: string[] = [header];
 
 		const activeDescs = this.#getActiveSubagentDescriptions();
 		// A pending todo "lights up" (accent + running glyph) when an in-flight
@@ -1640,14 +1656,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			activeDescs.length > 0 && todoMatchesAnyDescription(todo.content, activeDescs);
 
 		if (!this.todoExpanded) {
-			const activeIdx = phases.indexOf(this.#getActivePhase(phases) ?? phases[0]);
-			const activePhase = phases[activeIdx];
 			if (!activePhase) return;
 			const { visible, hiddenOpenCount } = selectStickyTodoWindow(activePhase.tasks, 5);
-
-			lines.push(
-				`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(activePhase.name, activeIdx + 1)}`)}`,
-			);
 			visible.forEach((todo, index) => {
 				const prefix = `${indent}${index === 0 ? hook : " "} `;
 				lines.push(this.#formatTodoLine(todo, prefix, isMatched(todo)));
@@ -1655,19 +1665,24 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (hiddenOpenCount > 0) {
 				lines.push(theme.fg("muted", `${indent}  ${hook} +${hiddenOpenCount} more`));
 			}
-			this.todoContainer.addChild(new Text(lines.join("\n"), 1, 0));
-			return;
+		} else {
+			phases.forEach((phase, phaseIndex) => {
+				lines.push(
+					`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(phase.name, phaseIndex + 1)}`)}`,
+				);
+				phase.tasks.forEach((todo, index) => {
+					const prefix = `${indent}${index === 0 ? hook : " "} `;
+					lines.push(this.#formatTodoLine(todo, prefix, isMatched(todo)));
+				});
+			});
 		}
 
-		phases.forEach((phase, phaseIndex) => {
-			lines.push(`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(phase.name, phaseIndex + 1)}`)}`);
-			phase.tasks.forEach((todo, index) => {
-				const prefix = `${indent}${index === 0 ? hook : " "} `;
-				lines.push(this.#formatTodoLine(todo, prefix, isMatched(todo)));
-			});
-		});
-
+		// Dim horizontal rules bracket the panel so the persistent HUD is
+		// visually distinct from chat scrollback above and any in-flight
+		// subagent/status rows below — mirrors `BtwPanel` / `OmfgPanel`.
+		this.todoContainer.addChild(new DynamicBorder(str => theme.fg("dim", str)));
 		this.todoContainer.addChild(new Text(lines.join("\n"), 1, 0));
+		this.todoContainer.addChild(new DynamicBorder(str => theme.fg("dim", str)));
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -104,7 +104,12 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
 import { type ResolveToolDetails, runResolveInvocation } from "../tools/resolve";
-import { formatPhaseDisplayName, phaseRomanNumeral, selectStickyTodoWindow, todoMatchesAnyDescription } from "../tools/todo";
+import {
+	formatPhaseDisplayName,
+	phaseRomanNumeral,
+	selectStickyTodoWindow,
+	todoMatchesAnyDescription,
+} from "../tools/todo";
 import { ToolError } from "../tools/tool-errors";
 import { vocalizer } from "../tts/vocalizer";
 import type { EventBus } from "../utils/event-bus";

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -109,3 +109,94 @@ describe("InteractiveMode todo auto-clear", () => {
 		expect(renderTodos(mode)).not.toContain("done task");
 	});
 });
+
+describe("InteractiveMode todo HUD anchor", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-todo-hud-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({}),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("brackets the panel with horizontal rules and a progress header", () => {
+		mode.setTodos([
+			{
+				name: "Foundation",
+				tasks: [
+					{ content: "first task", status: "completed" },
+					{ content: "second task", status: "in_progress" },
+					{ content: "third task", status: "pending" },
+				],
+			},
+			{
+				name: "Verification",
+				tasks: [{ content: "run tests", status: "pending" }],
+			},
+		]);
+
+		const lines = mode.todoContainer.render(80).flatMap(line => line.split("\n"));
+		const stripped = lines.map(line => Bun.stripANSI(line));
+		// Top + bottom rules — full-width horizontal rules render as ─ repeated.
+		expect(stripped[0]).toBe("─".repeat(80));
+		expect(stripped[stripped.length - 1]).toBe("─".repeat(80));
+		// Header shows progress and active-phase pointer so the HUD is
+		// self-describing without scrolling back to the tool result.
+		const header = stripped[1] ?? "";
+		expect(header).toContain("Todos");
+		expect(header).toContain("1/4 done");
+		expect(header).toContain("I/II Foundation");
+	});
+
+	it("renders nothing when there are no todos", () => {
+		mode.setTodos([]);
+		expect(mode.todoContainer.render(80)).toHaveLength(0);
+	});
+
+	it("omits the phase pointer in the header for a single-phase list", () => {
+		mode.setTodos([
+			{
+				name: "Tasks",
+				tasks: [
+					{ content: "alpha", status: "pending" },
+					{ content: "beta", status: "pending" },
+				],
+			},
+		]);
+		const header = Bun.stripANSI(mode.todoContainer.render(80)[1] ?? "");
+		expect(header).toContain("Todos");
+		expect(header).toContain("0/2 done");
+		expect(header).toContain("Tasks");
+		expect(header).not.toContain("/I ");
+	});
+});


### PR DESCRIPTION
## Repro

Create a multi-phase todo list with the `todo` tool. Watch the bordered tool-result block scroll into history as the agent keeps working. The small sticky panel above the editor (`#renderTodoList`) renders as plain bold text — no border, no separator — and is easy to miss next to the editor and status line. Users perceive the bordered chat block as the only todo display and conclude the list "isn't anchored".

```
$ bun packages/coding-agent/test/smoke-todo.ts   # before fix

   Todos
   └ I. Foundation
   └ ☐ Wire dependency graph
     ☐ Add minimal docs
```

## Cause

`InteractiveMode.#renderTodoList` (`packages/coding-agent/src/modes/interactive-mode.ts:1628`) emits a single `Text` node with only a leading blank line and a bold "Todos" header above the task tree. The container is in the right position (between `statusContainer` and the editor), but the rendering has no visual chrome that says "persistent HUD". In a busy transcript that small block blends into surrounding UI and gets visually lost, so users reach for the bordered tool-result block inside the chat (which scrolls into scrollback).

## Fix

- Bracket the panel with `DynamicBorder` lines (same `theme.fg("dim", …)` color the existing `BtwPanel` / `OmfgPanel` use). The HUD now reads as a real anchored panel rather than ambient status text.
- Inline progress + active-phase pointer in the header: `Todos · 2/7 done · I/III Foundation` (collapsed multi-phase) or `Todos · 0/2 done · Tasks` (single phase) or `Todos · 2/7 done` (expanded). The header is self-describing so users no longer need to scroll back to the bordered tool-result block to check status.
- Drop the leading blank-line spacer; the top border replaces it.
- Hoist the active-phase / phase-count compute above the expanded/collapsed branch and flatten the suffix logic so each branch only handles task-row rendering.

After:

```
────────────────────────────────────────────────────────────────────────────────
   Todos · 1/6 done · I/III Foundation
   └ ☐ Wire dependency graph
     ☐ Add minimal docs
────────────────────────────────────────────────────────────────────────────────
```

## Verification

Added three regression tests in `packages/coding-agent/test/interactive-mode-todo-clear.test.ts` that pin the new contract:

- `brackets the panel with horizontal rules and a progress header` — asserts top/bottom rows are full-width `─` rules and the header contains progress (`1/4 done`) and active-phase pointer (`I/II Foundation`).
- `renders nothing when there are no todos` — asserts the container collapses to zero lines when there are no phases.
- `omits the phase pointer in the header for a single-phase list` — asserts single-phase mode shows the phase name but no `I/I` pointer.

`bun test test/tools/todo.test.ts test/interactive-mode-todo-clear.test.ts test/acp-builtins.test.ts test/modes/controllers/todo-command-controller.test.ts` → 124 pass, 0 fail.
`lsp diagnostics` on the edited source + test file → clean.

Fixes #3213