### PR TITLE
fix(ai): drop stale OpenAI image generation replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses native history replay dropping failed/incomplete image generation calls instead of resending their transient `ig_...` item IDs, preventing follow-up requests from failing with `404 Item with id ... not found`. ([#3225](https://github.com/can1357/oh-my-pi/issues/3225))
+
 ## [16.1.11] - 2026-06-21
 
 ### Fixed

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -3,7 +3,6 @@ import type { ResponseInput, ResponseInputItem } from "./providers/openai-respon
 import type { CacheRetention, OpenAIResponsesHistoryPayload, ProviderPayload } from "./types";
 
 type OpenAIResponsesReplayItem = ResponseInput[number];
-const IMAGE_GENERATION_CALL_STATUSES = new Set<string>(["in_progress", "completed", "generating", "failed"]);
 
 export { isRecord } from "@oh-my-pi/pi-utils";
 export function normalizeSystemPrompts(systemPrompt: readonly string[] | string | undefined | null): string[] {
@@ -92,17 +91,15 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 function sanitizeOpenAIResponsesImageGenerationCallForReplay(
 	item: Record<string, unknown>,
 ): ResponseInputItem.ImageGenerationCall | undefined {
-	if (typeof item.id !== "string" || !isImageGenerationCallStatus(item.status)) return undefined;
+	if (typeof item.id !== "string" || item.status !== "completed" || typeof item.result !== "string") {
+		return undefined;
+	}
 	return {
 		id: truncateResponseItemId(item.id, "ig"),
 		type: "image_generation_call",
-		status: item.status,
-		result: typeof item.result === "string" ? item.result : null,
+		status: "completed",
+		result: item.result,
 	};
-}
-
-function isImageGenerationCallStatus(status: unknown): status is ResponseInputItem.ImageGenerationCall["status"] {
-	return typeof status === "string" && IMAGE_GENERATION_CALL_STATUSES.has(status);
 }
 
 function normalizeReplayedResponsesHistoryCallId(value: string, normalizedValues: Map<string, string>): string {

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -439,7 +439,7 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
-	it("strips provider-only image generation fields from replayed native history", async () => {
+	it("drops unfinished image generation calls from replayed native history", async () => {
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const context: Context = {
 			messages: [
@@ -447,9 +447,21 @@ describe("OpenAI responses history payload", () => {
 				makeAssistantMessage(
 					[
 						{
-							id: "ig_history",
+							id: "ig_failed",
+							type: "image_generation_call",
+							status: "failed",
+						},
+						{
+							id: "ig_generating",
 							type: "image_generation_call",
 							status: "generating",
+							action: "generate",
+						},
+						{
+							id: "ig_completed",
+							type: "image_generation_call",
+							status: "completed",
+							result: "base64-image",
 							action: "generate",
 							background: "opaque",
 							output_format: "png",
@@ -462,13 +474,19 @@ describe("OpenAI responses history payload", () => {
 			],
 		};
 		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
-
-		expect(findResponsesInputItem(payload.input, "image_generation_call")).toEqual({
-			id: "ig_history",
-			type: "image_generation_call",
-			status: "generating",
-			result: null,
+		const imageGenerationItems = payload.input?.filter(item => {
+			if (!item || typeof item !== "object") return false;
+			return (item as { type?: unknown }).type === "image_generation_call";
 		});
+
+		expect(imageGenerationItems).toEqual([
+			{
+				id: "ig_completed",
+				type: "image_generation_call",
+				status: "completed",
+				result: "base64-image",
+			},
+		]);
 	});
 
 	it("falls back to rebuilt history on resumed same-provider sessions with fresh session state", async () => {


### PR DESCRIPTION
## Repro
A Responses assistant turn can persist failed `image_generation_call` output items in `providerPayload.items`; reproducing with `buildParams` showed the next `/v1/responses` payload replayed `{ id: "ig_09efa3bd106e1071016a388e58d2dc8191a58054aa86fd2487", type: "image_generation_call", status: "failed", result: null }` with `store: false`, matching the reporter's 404. Command: `bun -e "$REPRO_CODE"`.

## Cause
`packages/ai/src/utils.ts` `sanitizeOpenAIResponsesImageGenerationCallForReplay` accepted any known image-generation status and synthesized `result: null` for missing results, so failed/generating/in-progress provider output items were replayed as input item IDs even though those transient `ig_...` items may not be persisted server-side.

## Fix
- Filter OpenAI Responses image-generation native-history replay to completed calls with an inline string `result`.
- Preserve completed image-generation results while still stripping provider-only fields.
- Update `packages/ai/test/openai-responses-history-payload.test.ts` to cover failed/generating calls being dropped and completed results surviving.
- Add the `packages/ai` changelog entry.

## Verification
`bun test packages/ai/test/openai-responses-history-payload.test.ts` passed: 22 tests, 69 assertions. `bun run check:types` in `packages/ai` passed. The repro command now emits no replayed `image_generation_call`. Fixes #3225