### PR TITLE
fix(agent): clamp provider context images

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed model switches to providers with lower image caps by clamping the transient outgoing context to the target provider's image budget, preserving text history and the newest images instead of wedging the session on a provider 400. ([#3227](https://github.com/can1357/oh-my-pi/issues/3227))
+
 ## [16.1.12] - 2026-06-21
 
 ### Changed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -113,6 +113,7 @@ import {
 	USER_INTERRUPT_LABEL,
 	wrapSteeringForModel,
 } from "./session/messages";
+import { clampProviderContextImages } from "./session/provider-image-budget";
 import { getRestorableSessionModels } from "./session/session-context";
 import { SessionManager } from "./session/session-manager";
 import { SnapcompactInlineTransformer } from "./session/snapcompact-inline";
@@ -2417,7 +2418,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		};
 		// Per-request provider-context transforms. Obfuscate FIRST so secrets are
 		// redacted from text before snapcompact rasterizes it into PNG frames.
-		// Both operate on the transient outgoing Context only — never persisted.
+		// All transforms operate on the transient outgoing Context only — never persisted.
 		const snapcompactSystemPromptMode = settings.get("snapcompact.systemPrompt");
 		const snapcompactInline =
 			snapcompactSystemPromptMode !== "none" || settings.get("snapcompact.toolResults")
@@ -2432,14 +2433,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						createSnapcompactSavingsRecorder(() => sessionManager.getSessionFile() ?? null),
 					)
 				: undefined;
-		const transformProviderContext =
-			obfuscator || snapcompactInline
-				? async (context: Context, transformModel: Model): Promise<Context> => {
-						let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
-						if (snapcompactInline) transformed = await snapcompactInline.transform(transformed, transformModel);
-						return transformed;
-					}
-				: undefined;
+		const transformProviderContext = async (context: Context, transformModel: Model): Promise<Context> => {
+			let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
+			if (snapcompactInline) transformed = await snapcompactInline.transform(transformed, transformModel);
+			return clampProviderContextImages(transformed, transformModel);
+		};
 		const onPayload = async (payload: unknown, _model?: Model) => {
 			return await extensionRunner.emitBeforeProviderRequest(payload);
 		};

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -1,0 +1,57 @@
+import type { Context, ImageContent, Message, Model, TextContent } from "@oh-my-pi/pi-ai";
+import { providerImageBudget } from "@oh-my-pi/snapcompact";
+
+const IMAGE_LIMIT_OMISSION: TextContent = {
+	type: "text",
+	text: "[image omitted: provider image limit]",
+};
+
+type ImageBearingMessage = Extract<Message, { content: string | (TextContent | ImageContent)[] }>;
+
+function countImages(context: Context): number {
+	let count = 0;
+	for (const message of context.messages) {
+		if (!Array.isArray(message.content)) continue;
+		for (const part of message.content) {
+			if (part.type === "image") count++;
+		}
+	}
+	return count;
+}
+
+function clampImageBearingMessage(
+	message: ImageBearingMessage,
+	state: { remainingDrops: number },
+): ImageBearingMessage {
+	if (!Array.isArray(message.content) || state.remainingDrops <= 0) return message;
+
+	let changed = false;
+	const content: (TextContent | ImageContent)[] = [];
+	for (const part of message.content) {
+		if (part.type === "image" && state.remainingDrops > 0) {
+			state.remainingDrops--;
+			changed = true;
+			content.push(IMAGE_LIMIT_OMISSION);
+			continue;
+		}
+		content.push(part);
+	}
+	return changed ? { ...message, content } : message;
+}
+
+/** Drops oldest transient image blocks so the outgoing request fits the active provider's image cap. */
+export function clampProviderContextImages(context: Context, model: Model): Context {
+	if (!model.input.includes("image")) return context;
+	const limit = providerImageBudget(model.provider);
+	const totalImages = countImages(context);
+	if (totalImages <= limit) return context;
+
+	const state = { remainingDrops: totalImages - limit };
+	const messages = context.messages.map(message => {
+		if (message.role === "user" || message.role === "developer" || message.role === "toolResult") {
+			return clampImageBearingMessage(message, state);
+		}
+		return message;
+	});
+	return { ...context, messages };
+}

--- a/packages/coding-agent/test/session/provider-image-budget.test.ts
+++ b/packages/coding-agent/test/session/provider-image-budget.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import type { Context, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { clampProviderContextImages } from "@oh-my-pi/pi-coding-agent/session/provider-image-budget";
+
+const UMANS_MODEL = buildModel({
+	id: "umans-kimi-k2.7",
+	name: "umans-kimi-k2.7",
+	api: "anthropic-messages",
+	provider: "umans",
+	baseUrl: "https://api.code.umans.ai",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 4096,
+});
+
+function image(data: string): ImageContent {
+	return { type: "image", data, mimeType: "image/png" };
+}
+
+function text(value: string): TextContent {
+	return { type: "text", text: value };
+}
+
+function imageData(context: Context): string[] {
+	const data: string[] = [];
+	for (const message of context.messages) {
+		if (!Array.isArray(message.content)) continue;
+		for (const part of message.content) {
+			if (part.type === "image") data.push(part.data);
+		}
+	}
+	return data;
+}
+
+describe("provider context image budgets", () => {
+	it("drops oldest transient images above the active provider cap", () => {
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: [text("first text"), ...Array.from({ length: 8 }, (_, index) => image(`user-${index}`))],
+					timestamp: 1,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "inspect_image",
+					content: [text("tool text"), ...Array.from({ length: 8 }, (_, index) => image(`tool-${index}`))],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+		};
+
+		const clamped = clampProviderContextImages(context, UMANS_MODEL);
+
+		expect(imageData(clamped)).toEqual([
+			"user-6",
+			"user-7",
+			"tool-0",
+			"tool-1",
+			"tool-2",
+			"tool-3",
+			"tool-4",
+			"tool-5",
+			"tool-6",
+			"tool-7",
+		]);
+		expect(clamped.messages[0]?.content).toContainEqual(text("first text"));
+		expect(clamped.messages[1]?.content).toContainEqual(text("tool text"));
+		expect(clamped).not.toBe(context);
+		expect(context.messages[0]?.content).toContainEqual(image("user-0"));
+	});
+
+	it("preserves context identity when the provider cap is not exceeded", () => {
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: [text("ok"), ...Array.from({ length: 10 }, (_, index) => image(`img-${index}`))],
+					timestamp: 1,
+				},
+			],
+		};
+
+		expect(clampProviderContextImages(context, UMANS_MODEL)).toBe(context);
+	});
+});

--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Umans provider image budget to match its 10-image request cap.
+
 ## [16.1.8] - 2026-06-20
 
 ### Breaking Changes

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -420,6 +420,7 @@ export const PROVIDER_IMAGE_BUDGETS: Record<string, number> = {
 	"google-vertex": 200,
 	"google-gemini-cli": 200,
 	openrouter: 90,
+	umans: 10,
 };
 
 /** Safe floor for unknown providers (strictest mainstream measured: Groq ~5). */

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -944,6 +944,7 @@ describe("archive helpers", () => {
 
 	it("provider image budgets stay permissive while unknown providers keep the safe floor", () => {
 		expect(snapcompact.providerImageBudget("openrouter")).toBe(90);
+		expect(snapcompact.providerImageBudget("umans")).toBe(10);
 		// Unknown providers fall to the safe floor.
 		expect(snapcompact.providerImageBudget(undefined)).toBe(snapcompact.DEFAULT_PROVIDER_IMAGE_BUDGET);
 		expect(snapcompact.providerImageBudget("some-new-router")).toBe(snapcompact.DEFAULT_PROVIDER_IMAGE_BUDGET);


### PR DESCRIPTION
## Repro
A local provider-context probe built a `umans`/`anthropic-messages` request with 16 existing image blocks and counted the outgoing image parts: `provider=umans api=anthropic-messages request_images=16 provider_limit=10`, matching the reporter's 400 shape when switching to `umans/umans-kimi-k2.7`.

## Cause
`packages/coding-agent/src/sdk.ts` only installed a provider-context transform when secret obfuscation or snapcompact was enabled, and neither path clamped pre-existing image blocks before the request reached `streamAnthropic`; `@oh-my-pi/snapcompact` also had no explicit `umans` provider image budget, so the target provider's 10-image cap was not represented.

## Fix
- Added `clampProviderContextImages()` in `packages/coding-agent/src/session/provider-image-budget.ts` to drop oldest transient image blocks above the active provider budget while preserving text blocks and newest images.
- Always runs the provider-context transform from `sdk.ts`, after obfuscation and snapcompact, so the final outgoing context fits the target provider image budget without rewriting session history.
- Added `umans: 10` to `PROVIDER_IMAGE_BUDGETS` and regression tests for both the clamp behavior and provider budget.

## Verification
`bun test packages/coding-agent/test/session/provider-image-budget.test.ts packages/snapcompact/test/snapcompact.test.ts` passed (66 tests). `bun --cwd=packages/coding-agent run check` passed. `bun --cwd=packages/snapcompact run check` passed. Manual clamp probe after the fix reported `provider=umans request_images=10 text_preserved=true`. Fixes #3227