### PR TITLE
fix(agent-session): clear openai-completions provider session state on model switch

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9021,6 +9021,41 @@ export class AgentSession {
 			providerKeys.add(`openai-responses:${nextModel.provider}`);
 		}
 
+		// openai-completions: clear cached per-model session state (strict tools
+		// disable scope, reasoning effort fallback, etc.) when provider or baseUrl
+		// changes. The session keys are per-model (provider:baseUrl:modelId), so
+		// iterate rather than add a single key.
+		const openaiCompletionsPrefix = "openai-completions:";
+		if (currentModel.api === "openai-completions" || nextModel.api === "openai-completions") {
+			const oldProvider = currentModel.api === "openai-completions" ? currentModel.provider : null;
+			const oldBaseUrl = currentModel.api === "openai-completions" ? (currentModel.baseUrl ?? "") : null;
+			const newProvider = nextModel.provider;
+			const newBaseUrl = nextModel.baseUrl ?? "";
+			if (oldProvider !== newProvider || oldBaseUrl !== newBaseUrl) {
+				// Collect and remove all session entries for the old provider+baseUrl
+				const staleKeys: string[] = [];
+				for (const key of this.#providerSessionState.keys()) {
+					if (oldProvider !== null && key.startsWith(`${openaiCompletionsPrefix}${oldProvider}:${oldBaseUrl}:`)) {
+						staleKeys.push(key);
+					}
+				}
+				for (const staleKey of staleKeys) {
+					const state = this.#providerSessionState.get(staleKey);
+					if (state) {
+						try {
+							state.close();
+						} catch (error) {
+							logger.warn("Failed to close openai-completions session state during model switch", {
+								providerKey: staleKey,
+								error: String(error),
+							});
+						}
+					}
+					this.#providerSessionState.delete(staleKey);
+				}
+			}
+		}
+
 		for (const providerKey of providerKeys) {
 			const state = this.#providerSessionState.get(providerKey);
 			if (!state) continue;


### PR DESCRIPTION
I run a local proxy (newapi) that aggregates several providers — OpenAI, DeepSeek, NVIDIA, GLM, etc. NVIDIA's free models tend to timeout or drop connections frequently, so when that happens I /model switch to something more stable.

Problem is, after switching away from an openai-completions model, the new model returns empty responses. Turns out #closeProviderSessionsForModelSwitch only cleans up openai-codex-responses / openai-responses sessions, but not openai-completions. The old cached ProviderSessionState (strict tools scope, reasoning fallback, etc.) lingers and messes up the new transport.

This patch adds the missing cleanup: when switching between openai-completions providers (or base URLs), iterate the session map and remove entries matching the old combo. Keys are per-model (openai-completions:provider:baseUrl:modelId), so prefix match rather than exact key.

Same-provider same-baseUrl switches are left alone — cached state is still valid for the same backend.