### PR TITLE
fix(coding-agent): hide secrets in advisor prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hide-secrets handling so advisor session updates are redacted before the advisor model sees them and opaque assistant thinking blocks are no longer deobfuscated.
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -470,6 +470,37 @@ describe("advisor", () => {
 			expect(promptInputs[0]).not.toContain(secret);
 		});
 
+		it("redacts expanded primary context before XML escaping", async () => {
+			const secret = "ADVISOR&SECRET<TOKEN>123";
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const placeholder = obfuscator.obfuscate(secret);
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{
+					role: "custom",
+					customType: "plan-mode-context",
+					content: `Plan mode carries ${secret}`,
+					display: false,
+					timestamp: 1,
+				} as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd();
+			await Promise.resolve();
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain(placeholder);
+			expect(promptInputs[0]).not.toContain(secret);
+			expect(promptInputs[0]).not.toContain("ADVISOR&amp;SECRET&lt;TOKEN&gt;123");
+		});
+
 		it("expands plan-mode context once, then collapses an unchanged re-injection", async () => {
 			const promptInputs: string[] = [];
 			const agent = makeAgent(promptInputs);

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -501,6 +501,34 @@ describe("advisor", () => {
 			expect(promptInputs[0]).not.toContain("ADVISOR&amp;SECRET&lt;TOKEN&gt;123");
 		});
 
+		it("redacts file-mention paths before formatting", async () => {
+			const secret = "MENTION_SECRET_TOKEN_123";
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const placeholder = obfuscator.obfuscate(secret);
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{
+					role: "fileMention",
+					files: [{ path: `notes/${secret}.txt`, content: "ignored" }],
+					timestamp: 1,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd();
+			await Promise.resolve();
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain(placeholder);
+			expect(promptInputs[0]).not.toContain(secret);
+		});
+
 		it("expands plan-mode context once, then collapses an unchanged re-injection", async () => {
 			const promptInputs: string[] = [];
 			const agent = makeAgent(promptInputs);

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -5,6 +5,7 @@ import { createAdvisorMessageCard } from "../../modes/components/advisor-message
 import { getThemeByName } from "../../modes/theme/theme";
 import { formatSessionHistoryMarkdown } from "../../session/session-history-format";
 import { YieldQueue } from "../../session/yield-queue";
+import { SecretObfuscator } from "../../secrets/obfuscator";
 import {
 	ADVISOR_READONLY_TOOL_NAMES,
 	AdviseTool,
@@ -445,6 +446,28 @@ describe("advisor", () => {
 			expect(promptInputs).toHaveLength(1);
 			expect(promptInputs[0]).toContain("hello");
 			expect(promptInputs[0]).not.toContain("note");
+		});
+
+		it("obfuscates session updates before prompting the advisor", async () => {
+			const secret = "ADVISOR_SECRET_TOKEN_123";
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const placeholder = obfuscator.obfuscate(secret);
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [{ role: "user", content: `token ${secret}`, timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd();
+			await Promise.resolve();
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain(placeholder);
+			expect(promptInputs[0]).not.toContain(secret);
 		});
 
 		it("expands plan-mode context once, then collapses an unchanged re-injection", async () => {

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -529,6 +529,38 @@ describe("advisor", () => {
 			expect(promptInputs[0]).not.toContain(secret);
 		});
 
+		it("redacts nested async-result job labels before formatting", async () => {
+			const secret = "JOB_LABEL_SECRET_TOKEN_123";
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const placeholder = obfuscator.obfuscate(secret);
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{
+					role: "custom",
+					customType: "async-result",
+					content: "",
+					details: { jobs: [{ label: `bash: echo ${secret}`, jobId: "j1" }] },
+					display: true,
+					attribution: "agent",
+					timestamp: 1,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd();
+			await Promise.resolve();
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain(placeholder);
+			expect(promptInputs[0]).not.toContain(secret);
+		});
+
 		it("expands plan-mode context once, then collapses an unchanged re-injection", async () => {
 			const promptInputs: string[] = [];
 			const agent = makeAgent(promptInputs);

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -3,9 +3,9 @@ import type { AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core
 import { type } from "arktype";
 import { createAdvisorMessageCard } from "../../modes/components/advisor-message";
 import { getThemeByName } from "../../modes/theme/theme";
+import { SecretObfuscator } from "../../secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../../session/session-history-format";
 import { YieldQueue } from "../../session/yield-queue";
-import { SecretObfuscator } from "../../secrets/obfuscator";
 import {
 	ADVISOR_READONLY_TOOL_NAMES,
 	AdviseTool,

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -1,8 +1,8 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import { logger } from "@oh-my-pi/pi-utils";
-import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
 import type { SecretObfuscator } from "../secrets/obfuscator";
+import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
 
 /** Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core `Agent`. */
 export interface AdvisorAgent {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -346,23 +346,15 @@ function obfuscateAssistantMessage(obfuscator: SecretObfuscator, message: Assist
 	return changed ? { ...message, content } : message;
 }
 
-function obfuscateStringDetails(
+function obfuscateDetails(
 	obfuscator: SecretObfuscator,
 	details: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
 	if (!details) return details;
-	let changed = false;
-	const result: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(details)) {
-		if (typeof value === "string") {
-			const text = obfuscator.obfuscate(value);
-			if (text !== value) changed = true;
-			result[key] = text;
-		} else {
-			result[key] = value;
-		}
-	}
-	return changed ? result : details;
+	// Walk strings at every depth: `customOneLiner` renders nested fields
+	// (e.g. `async-result` reads `details.jobs[].label`/`jobId`), so a shallow
+	// pass leaks any secret a background job's label happens to contain.
+	return obfuscateToolArguments(obfuscator, details);
 }
 
 function obfuscateAdvisorMessage(obfuscator: SecretObfuscator, message: AgentMessage): AgentMessage {
@@ -382,7 +374,7 @@ function obfuscateAdvisorMessage(obfuscator: SecretObfuscator, message: AgentMes
 				details?: Record<string, unknown>;
 			};
 			const content = obfuscateTextualContent(obfuscator, msg.content);
-			const details = obfuscateStringDetails(obfuscator, msg.details);
+			const details = obfuscateDetails(obfuscator, msg.details);
 			if (content === msg.content && details === msg.details) return message;
 			return { ...(message as object), content, details } as AgentMessage;
 		}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import { logger } from "@oh-my-pi/pi-utils";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
+import type { SecretObfuscator } from "../secrets/obfuscator";
 
 /** Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core `Agent`. */
 export interface AdvisorAgent {
@@ -16,6 +17,8 @@ export interface AdvisorRuntimeHost {
 	snapshotMessages(): AgentMessage[];
 	/** Surface one advice note to the primary (enqueues into the session YieldQueue). */
 	enqueueAdvice(note: string, severity?: "nit" | "concern" | "blocker"): void;
+	/** Redact primary transcript bytes before they reach the advisor model. */
+	obfuscator?: SecretObfuscator;
 	/**
 	 * Pre-prompt context maintenance for the advisor's own append-only context.
 	 * Promotes the advisor model to a larger sibling when its context nears the
@@ -181,7 +184,9 @@ export class AdvisorRuntime {
 			expandPrimaryContext: true,
 		});
 		if (!md.trim()) return null;
-		return `### Session update\n\n${md}`;
+		const text = `### Session update\n\n${md}`;
+		const obfuscator = this.host.obfuscator;
+		return obfuscator?.hasSecrets() ? obfuscator.obfuscate(text) : text;
 	}
 
 	/**

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -412,6 +412,20 @@ function obfuscateAdvisorMessage(obfuscator: SecretObfuscator, message: AgentMes
 			const summary = obfuscator.obfuscate(msg.summary);
 			return summary === msg.summary ? message : ({ ...(message as object), summary } as AgentMessage);
 		}
+		case "fileMention": {
+			const msg = message as AgentMessage & {
+				files: Array<{ path: string; content: string; image?: unknown }>;
+			};
+			let changed = false;
+			const files = msg.files.map(file => {
+				const path = obfuscator.obfuscate(file.path);
+				const content = obfuscator.obfuscate(file.content);
+				if (path === file.path && content === file.content) return file;
+				changed = true;
+				return { ...file, path, content };
+			});
+			return changed ? ({ ...(message as object), files } as AgentMessage) : message;
+		}
 		default:
 			return message;
 	}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -1,7 +1,8 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { SecretObfuscator } from "../secrets/obfuscator";
+import { obfuscateToolArguments, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
 
 /** Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core `Agent`. */
@@ -177,16 +178,16 @@ export class AdvisorRuntime {
 			.map(m => this.#dedupContextMessage(m));
 		this.#lastCount = all.length;
 		if (delta.length === 0) return null;
-		const md = formatSessionHistoryMarkdown(delta, {
+		const obfuscator = this.host.obfuscator;
+		const formattedDelta = obfuscator?.hasSecrets() ? obfuscateAdvisorDelta(obfuscator, delta) : delta;
+		const md = formatSessionHistoryMarkdown(formattedDelta, {
 			includeThinking: true,
 			includeToolIntent: true,
 			watchedRoles: true,
 			expandPrimaryContext: true,
 		});
 		if (!md.trim()) return null;
-		const text = `### Session update\n\n${md}`;
-		const obfuscator = this.host.obfuscator;
-		return obfuscator?.hasSecrets() ? obfuscator.obfuscate(text) : text;
+		return `### Session update\n\n${md}`;
 	}
 
 	/**
@@ -308,4 +309,120 @@ export class AdvisorRuntime {
 			this.#busy = false;
 		}
 	}
+}
+
+type TextualContent = string | readonly (TextContent | ImageContent)[];
+
+function obfuscateTextualContent(obfuscator: SecretObfuscator, content: TextualContent): TextualContent {
+	if (typeof content === "string") return obfuscator.obfuscate(content);
+	let changed = false;
+	const result = content.map((block): TextContent | ImageContent => {
+		if (block.type !== "text") return block;
+		const text = obfuscator.obfuscate(block.text);
+		if (text === block.text) return block;
+		changed = true;
+		return { ...block, text };
+	});
+	return changed ? result : content;
+}
+
+function obfuscateAssistantMessage(obfuscator: SecretObfuscator, message: AssistantMessage): AssistantMessage {
+	let changed = false;
+	const content = message.content.map((block): AssistantMessage["content"][number] => {
+		if (block.type === "text") {
+			const text = obfuscator.obfuscate(block.text);
+			if (text === block.text) return block;
+			changed = true;
+			return { ...block, text };
+		}
+		if (block.type === "toolCall") {
+			const args = obfuscateToolArguments(obfuscator, block.arguments);
+			if (args === block.arguments) return block;
+			changed = true;
+			return { ...block, arguments: args };
+		}
+		return block;
+	});
+	return changed ? { ...message, content } : message;
+}
+
+function obfuscateStringDetails(
+	obfuscator: SecretObfuscator,
+	details: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!details) return details;
+	let changed = false;
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(details)) {
+		if (typeof value === "string") {
+			const text = obfuscator.obfuscate(value);
+			if (text !== value) changed = true;
+			result[key] = text;
+		} else {
+			result[key] = value;
+		}
+	}
+	return changed ? result : details;
+}
+
+function obfuscateAdvisorMessage(obfuscator: SecretObfuscator, message: AgentMessage): AgentMessage {
+	switch (message.role) {
+		case "user":
+		case "developer":
+		case "toolResult": {
+			const content = obfuscateTextualContent(obfuscator, message.content as TextualContent);
+			return content === message.content ? message : ({ ...(message as object), content } as AgentMessage);
+		}
+		case "assistant":
+			return obfuscateAssistantMessage(obfuscator, message as AssistantMessage) as AgentMessage;
+		case "custom":
+		case "hookMessage": {
+			const msg = message as AgentMessage & {
+				content: TextualContent;
+				details?: Record<string, unknown>;
+			};
+			const content = obfuscateTextualContent(obfuscator, msg.content);
+			const details = obfuscateStringDetails(obfuscator, msg.details);
+			if (content === msg.content && details === msg.details) return message;
+			return { ...(message as object), content, details } as AgentMessage;
+		}
+		case "bashExecution": {
+			const msg = message as AgentMessage & { command: string; output: string };
+			const command = obfuscator.obfuscate(msg.command);
+			const output = obfuscator.obfuscate(msg.output);
+			return command === msg.command && output === msg.output
+				? message
+				: ({ ...(message as object), command, output } as AgentMessage);
+		}
+		case "pythonExecution": {
+			const msg = message as AgentMessage & { code: string; output: string };
+			const code = obfuscator.obfuscate(msg.code);
+			const output = obfuscator.obfuscate(msg.output);
+			return code === msg.code && output === msg.output
+				? message
+				: ({ ...(message as object), code, output } as AgentMessage);
+		}
+		case "branchSummary": {
+			const msg = message as AgentMessage & { summary: string };
+			const summary = obfuscator.obfuscate(msg.summary);
+			return summary === msg.summary ? message : ({ ...(message as object), summary } as AgentMessage);
+		}
+		case "compactionSummary": {
+			const msg = message as AgentMessage & { summary: string };
+			const summary = obfuscator.obfuscate(msg.summary);
+			return summary === msg.summary ? message : ({ ...(message as object), summary } as AgentMessage);
+		}
+		default:
+			return message;
+	}
+}
+
+function obfuscateAdvisorDelta(obfuscator: SecretObfuscator, messages: AgentMessage[]): AgentMessage[] {
+	let changed = false;
+	const result = messages.map(message => {
+		const next = obfuscateAdvisorMessage(obfuscator, message);
+		if (next !== message) changed = true;
+		return next;
+	});
+	return changed ? result : messages;
 }

--- a/packages/coding-agent/src/secrets/obfuscator.ts
+++ b/packages/coding-agent/src/secrets/obfuscator.ts
@@ -259,9 +259,9 @@ export function deobfuscateAgentMessages(obfuscator: SecretObfuscator, messages:
 }
 
 /**
- * Restore placeholders in assistant content: visible text, thinking text, and
- * tool-call arguments/intent/rawBlock. Signatures and redacted-thinking bytes
- * are opaque provider-replay data and pass through byte-identical.
+ * Restore placeholders in assistant content: visible text and tool-call
+ * arguments/intent/rawBlock. Thinking and signatures are opaque
+ * provider-replay/hidden-reasoning data and pass through byte-identical.
  */
 export function deobfuscateAssistantContent(
 	obfuscator: SecretObfuscator,
@@ -275,12 +275,6 @@ export function deobfuscateAssistantContent(
 			if (text === block.text) return block;
 			changed = true;
 			return { ...block, text };
-		}
-		if (block.type === "thinking") {
-			const thinking = obfuscator.deobfuscate(block.thinking);
-			if (thinking === block.thinking) return block;
-			changed = true;
-			return { ...block, thinking };
 		}
 		if (block.type === "toolCall") {
 			const args = deobfuscateToolArguments(obfuscator, block.arguments);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1936,6 +1936,7 @@ export class AgentSession {
 			snapshotMessages: () => this.agent.state.messages,
 			enqueueAdvice,
 			maintainContext: incomingTokens => this.#maintainAdvisorContext(incomingTokens),
+			obfuscator: this.#obfuscator,
 		});
 		if (seedToCurrent) {
 			this.#advisorRuntime.seedTo(this.agent.state.messages.length);

--- a/packages/coding-agent/test/secrets-obfuscator.test.ts
+++ b/packages/coding-agent/test/secrets-obfuscator.test.ts
@@ -252,7 +252,7 @@ describe("SecretObfuscator cross-turn cache stability", () => {
 });
 
 describe("deobfuscateAgentMessages (display restore)", () => {
-	it("restores assistant content and model-generated summaries, leaving raw user text untouched", () => {
+	it("restores assistant text and tool calls while leaving raw user text and thinking untouched", () => {
 		const secret = "DISPLAY_SECRET_TOKEN_123";
 		const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 		const placeholder = obfuscator.obfuscate(secret);
@@ -302,11 +302,16 @@ describe("deobfuscateAgentMessages (display restore)", () => {
 
 		const restored = deobfuscateAgentMessages(obfuscator, [userMsg, assistantMsg, branchSummary, compactionSummary]);
 
-		// Assistant text, thinking, and tool-call args/intent are restored to the real secret.
+		// Assistant text and tool-call args/intent are restored to the real secret.
 		const restoredAssistant = restored[1] as AssistantMessage;
 		const assistantJson = JSON.stringify(restoredAssistant.content);
 		expect(assistantJson).toContain(secret);
-		expect(assistantJson).not.toContain(placeholder);
+		expect(assistantJson).not.toContain(`answer ${placeholder}`);
+		expect(assistantJson).not.toContain(`path ${placeholder}`);
+		expect(assistantJson).not.toContain(`intent ${placeholder}`);
+		// Opaque thinking is never walked: placeholder-shaped bytes survive unchanged.
+		expect(assistantJson).toContain(`reason ${placeholder}`);
+		expect(assistantJson).not.toContain(`reason ${secret}`);
 		// Model-generated summaries are restored.
 		expect((restored[2] as { summary: string }).summary).toBe(`branch ${secret}`);
 		expect((restored[3] as { summary: string; shortSummary?: string }).summary).toBe(`compact ${secret}`);


### PR DESCRIPTION
## Repro
A focused Bun script reproduced both failures: `deobfuscateAgentMessages()` restored a placeholder inside an assistant `thinking` block back to the original secret, and `AdvisorRuntime` sent `user typed SECRET_TOKEN_123456` to the advisor prompt unchanged. After the fix, the same script prints `thinking mutated: false` and `advisor leaked secret: false`.

## Cause
`packages/coding-agent/src/secrets/obfuscator.ts` treated assistant thinking as local-display text during deobfuscation, even though thinking/reasoning payloads are opaque provider data. Separately, `packages/coding-agent/src/advisor/runtime.ts` formatted primary transcript deltas for the advisor without using the session `SecretObfuscator`, and `packages/coding-agent/src/session/agent-session.ts` never passed that obfuscator into the advisor runtime host.

## Fix
- Stop deobfuscating assistant `thinking` blocks; visible assistant text and tool-call fields still deobfuscate for local display.
- Add an optional advisor-runtime host obfuscator and redact rendered session updates before `agent.prompt()` sends them to the advisor model.
- Thread `AgentSession`'s configured obfuscator into the advisor runtime.
- Add regression coverage for thinking preservation and advisor prompt redaction.

## Verification
Ran `bun --eval "$REPRO"` before and after the fix: before, `thinking mutated: true` and `advisor leaked secret: true`; after, both are `false`. Ran `bun test packages/coding-agent/test/secrets-obfuscator.test.ts packages/coding-agent/src/advisor/__tests__/advisor.test.ts` with 59 passing tests. Fixes #3237