### PR TITLE
fix(providers): refresh discovery cache after model config edits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed configured model discovery caches to refresh when `models.yml`/`models.json` is newer than the cached row, so updated local model metadata is not shadowed by fresh `models.db` entries. ([#3242](https://github.com/can1357/oh-my-pi/issues/3242))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -992,6 +992,7 @@ export class ModelRegistry {
 				});
 				continue;
 			}
+			const configStale = this.#isDiscoveryCacheOlderThanModelsConfig(cache.updatedAt);
 			const models = this.#applyProviderModelOverrides(
 				providerConfig.provider,
 				this.#normalizeDiscoverableModels(
@@ -1007,7 +1008,7 @@ export class ModelRegistry {
 				provider: providerConfig.provider,
 				status: "cached",
 				optional: providerConfig.optional ?? false,
-				stale: !cache.fresh || !cache.authoritative,
+				stale: !cache.fresh || !cache.authoritative || configStale,
 				fetchedAt: cache.updatedAt,
 				models: models.map(model => model.id),
 			});
@@ -1259,12 +1260,19 @@ export class ModelRegistry {
 		return providerConfig.provider;
 	}
 
+	#isDiscoveryCacheOlderThanModelsConfig(cacheUpdatedAt: number): boolean {
+		const configMtime = this.#modelsConfigFile.getMtimeMs();
+		return configMtime !== null && cacheUpdatedAt < Math.floor(configMtime);
+	}
+
 	async #discoverProviderModels(
 		providerConfig: DiscoveryProviderConfig,
 		strategy: ModelRefreshStrategy,
 	): Promise<Model<Api>[]> {
 		const cacheProviderId = this.#configuredDiscoveryCacheProviderId(providerConfig);
 		const cached = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+		const cacheOlderThanConfig = cached !== null && this.#isDiscoveryCacheOlderThanModelsConfig(cached.updatedAt);
+		const effectiveStrategy = strategy === "online-if-uncached" && cacheOlderThanConfig ? "online" : strategy;
 		const requiresAuth = !this.#keylessProviders.has(providerConfig.provider);
 		if (requiresAuth) {
 			const apiKey = await this.#peekApiKeyForProvider(providerConfig.provider);
@@ -1311,12 +1319,12 @@ export class ModelRegistry {
 			cacheTtlMs: 24 * 60 * 60 * 1000,
 			fetchDynamicModels,
 		});
-		const result = await manager.refresh(strategy);
+		const result = await manager.refresh(effectiveStrategy);
 		const status = discoveryError
 			? result.models.length > 0
 				? "cached"
 				: "unavailable"
-			: strategy === "offline"
+			: effectiveStrategy === "offline"
 				? cached
 					? "cached"
 					: "idle"
@@ -1327,7 +1335,7 @@ export class ModelRegistry {
 			provider: providerId,
 			status,
 			optional: providerConfig.optional ?? false,
-			stale: result.stale || status === "cached",
+			stale: result.stale || status === "cached" || (cacheOlderThanConfig && status !== "ok"),
 			fetchedAt: discoveryError ? cached?.updatedAt : Date.now(),
 			models: result.models.map(model => model.id),
 			error: discoveryError,

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -60,8 +60,8 @@ describe("ModelRegistry runtime discovery", () => {
 		}
 	});
 
-	function writeCachedOllamaModels(models: Model<"openai-completions">[]) {
-		writeModelCache("ollama", Date.now(), models, true, "", cacheDbPath);
+	function writeCachedOllamaModels(models: Model<"openai-completions">[], updatedAt = Date.now()) {
+		writeModelCache("ollama", updatedAt, models, true, "", cacheDbPath);
 	}
 
 	function getModelsForProvider(registry: ModelRegistry, provider: string) {
@@ -304,6 +304,57 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(ollama?.api).toBe("openai-responses");
 		expect(ollama?.baseUrl).toBe("http://127.0.0.1:11434/v1");
 		expect(registry.getProviderDiscoveryState("ollama")?.status).toBe("cached");
+	});
+
+	test("refreshes cached discovery when models config is newer than the cache", async () => {
+		writeRawModelsJson({
+			ollama: {
+				baseUrl: "http://127.0.0.1:11434/v1",
+				api: "openai-responses",
+				auth: "none",
+				discovery: { type: "ollama" },
+				modelOverrides: {
+					"phi3:3.8b": { contextWindow: 8192, maxTokens: 4096 },
+				},
+			},
+		});
+		const configMtime = fs.statSync(modelsJsonPath).mtimeMs;
+		writeCachedOllamaModels(
+			[
+				buildModel({
+					id: "phi3:3.8b",
+					name: "phi3:3.8b",
+					api: "openai-completions",
+					provider: "ollama",
+					baseUrl: "http://127.0.0.1:11434/v1",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 32768,
+				}),
+			],
+			Math.floor(configMtime) - 1,
+		);
+		let tagCalls = 0;
+		const fetchMock = mockOllamaDiscovery(["phi3:3.8b"], "http://127.0.0.1:11434", {
+			capabilities: ["completion"],
+			model_info: { "phi3.context_length": 8192 },
+		});
+		const countingFetch: FetchImpl = async (input, init) => {
+			if (String(input) === "http://127.0.0.1:11434/api/tags") {
+				tagCalls++;
+			}
+			return fetchMock(input, init);
+		};
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: countingFetch });
+		await registry.refresh("online-if-uncached");
+
+		const phi3 = registry.find("ollama", "phi3:3.8b");
+		expect(tagCalls).toBe(1);
+		expect(phi3?.contextWindow).toBe(8192);
+		expect(phi3?.maxTokens).toBe(4096);
 	});
 
 	test("discovers ollama thinking capabilities from show metadata", async () => {


### PR DESCRIPTION
## Repro
A fresh configured-discovery row in `models.db` was reused by `online-if-uncached` even when `models.json`/`models.yml` had been edited after that row was written. Repro command: `bun test test/model-discovery.test.ts --test-name-pattern "refreshes cached discovery"` failed before the fix because Ollama discovery was never called (`tagCalls` stayed `0`).

## Cause
`ModelRegistry.#discoverProviderModels` delegated `online-if-uncached` to `createModelManager` with only the cache row TTL as freshness input. `ModelRegistry.#loadCachedDiscoverableModels` also marked cached rows stale only by row TTL/authority. Neither path compared `model_cache.updated_at` with `ModelsConfigFile.getMtimeMs()`, so config edits did not make a fresh configured-discovery cache row stale.

## Fix
- Added a configured-discovery freshness check that treats cache rows older than `models.yml`/`models.json` as stale.
- Forced `online-if-uncached` configured discoveries to perform an online refresh when the config file is newer than the cache row.
- Added an Ollama regression test covering a cached `phi3:3.8b` row plus newer config metadata overrides.
- Added a coding-agent changelog entry for #3242.

## Verification
Passed `bun test test/model-discovery.test.ts --test-name-pattern "refreshes cached discovery"`, `bun test test/model-discovery.test.ts`, `bun test test/model-registry.test.ts`, and `bun check`. Fixes #3242