### PR TITLE
fix(cli): register marketplace plugin installs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed marketplace plugin installs registering only in `installed_plugins.json` and never in the runtime plugin tree, leaving slash commands and extensions unavailable after `omp plugin install name@marketplace` ([#3244](https://github.com/can1357/oh-my-pi/issues/3244)).
+- Fixed marketplace plugin installs registering only in `installed_plugins.json` and never in the runtime plugin tree, leaving slash commands and extensions unavailable after `omp plugin install name@marketplace`. The runtime loader now also enumerates the project-scope plugins root (`<projectAnchor>/.omp/plugins`) so `--scope project` installs surface alongside user-scope installs, with project entries shadowing same-named user entries ([#3244](https://github.com/can1357/oh-my-pi/issues/3244)).
 
 ## [16.1.14] - 2026-06-22
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed marketplace plugin installs registering only in `installed_plugins.json` and never in the runtime plugin tree, leaving slash commands and extensions unavailable after `omp plugin install name@marketplace` ([#3244](https://github.com/can1357/oh-my-pi/issues/3244)).
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -180,9 +180,7 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 async function listInstalledPluginRoots(ctx: LoadContext): Promise<InjectedRoot[]> {
 	try {
 		const plugins = await getEnabledPlugins(ctx.cwd, { home: ctx.home });
-		// Installed plugins are always user-scope; project disablement is already
-		// honored by `getEnabledPlugins` via `loadProjectOverrides`.
-		return plugins.map(({ path: p }) => ({ path: p, level: "user" }));
+		return plugins.map(({ path: p, scope }) => ({ path: p, level: scope }));
 	} catch (err) {
 		logger.debug("listInstalledPluginRoots: enumeration failed", { error: String(err) });
 		return [];

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -6,8 +6,9 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getPluginsLockfile, getPluginsNodeModules, getPluginsPackageJson, isEnoent } from "@oh-my-pi/pi-utils";
+import { getPluginsDir, getPluginsLockfile, isEnoent } from "@oh-my-pi/pi-utils";
 import { getConfigDirPaths } from "../../config";
+import { resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig, ProjectPluginOverrides } from "./types";
@@ -51,38 +52,37 @@ async function loadProjectOverrides(cwd: string): Promise<ProjectPluginOverrides
 	return {};
 }
 /**
- * Get list of enabled plugins with their resolved configurations.
- *
- * Respects both global runtime config and project overrides. Iterates the
- * union of `<plugins>/package.json#dependencies` (`bun install`-installed
- * packages) and `<plugins>/omp-plugins.lock.json#plugins` (so locally
- * `plugin link`-symlinked extensions, which never get a dependency entry,
- * are still discovered). The optional `home` parameter pins the plugins
- * root for callers that need to enumerate plugins relative to a non-default
- * home (tests with a tempdir, discovery loaders threaded with
- * `LoadContext.home`).
+ * Per-root enumeration of plugins from `<root>/node_modules`,
+ * `<root>/package.json#dependencies`, and `<root>/omp-plugins.lock.json#plugins`.
+ * Honors `projectOverrides.disabled` and `projectOverrides.features`. Returns an
+ * empty array when the root has no `node_modules` yet.
  */
-export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<InstalledPlugin[]> {
-	const { home } = opts;
-
-	const nodeModulesPath = getPluginsNodeModules(home);
-	if (!fs.existsSync(nodeModulesPath)) {
-		return [];
-	}
+async function collectPluginsAtRoot(
+	root: string,
+	projectOverrides: ProjectPluginOverrides,
+): Promise<InstalledPlugin[]> {
+	const nodeModulesPath = path.join(root, "node_modules");
+	if (!fs.existsSync(nodeModulesPath)) return [];
 
 	let depsKeys: string[] = [];
-	const pkgJsonPath = getPluginsPackageJson(home);
+	const pkgJsonPath = path.join(root, "package.json");
 	try {
 		const pkg: { dependencies?: Record<string, string> } = await Bun.file(pkgJsonPath).json();
 		depsKeys = Object.keys(pkg.dependencies ?? {});
 	} catch (err) {
-		// Linked-only setups may have no `<plugins>/package.json` yet — that's
+		// Linked-only setups may have no `<root>/package.json` yet — that's
 		// fine, the lockfile still records the link.
 		if (!isEnoent(err)) throw err;
 	}
 
-	const runtimeConfig = await loadRuntimeConfig(home);
-	const projectOverrides = await loadProjectOverrides(cwd);
+	const lockPath = path.join(root, "omp-plugins.lock.json");
+	let runtimeConfig: PluginRuntimeConfig;
+	try {
+		runtimeConfig = normalizePluginRuntimeConfig(await Bun.file(lockPath).json());
+	} catch (err) {
+		if (!isEnoent(err)) throw err;
+		runtimeConfig = normalizePluginRuntimeConfig({});
+	}
 
 	// Union: dependencies (npm/marketplace installs) ∪ runtime-config plugins
 	// (links + already-recorded installs). Set preserves first-seen order,
@@ -137,6 +137,47 @@ export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {
 	}
 
 	return plugins;
+}
+
+/**
+ * Get list of enabled plugins with their resolved configurations.
+ *
+ * Enumerates two plugin roots in order: the user root
+ * (`getPluginsDir(home)`) and, when a project anchor (`.omp/` or `.git/`)
+ * exists at or above `cwd`, the project root
+ * (`<projectAnchor>/.omp/plugins`). Each root contributes the union of its
+ * `package.json#dependencies` and `omp-plugins.lock.json#plugins`. Project
+ * entries shadow user entries with the same package name, matching the
+ * shadow semantics of `MarketplaceManager.listInstalledPlugins`.
+ *
+ * The optional `home` parameter pins the user plugins root for callers that
+ * need to enumerate plugins relative to a non-default home (tests with a
+ * tempdir, discovery loaders threaded with `LoadContext.home`).
+ */
+export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<InstalledPlugin[]> {
+	const { home } = opts;
+	const projectOverrides = await loadProjectOverrides(cwd);
+
+	const userRoot = getPluginsDir(home);
+	const userPlugins = await collectPluginsAtRoot(userRoot, projectOverrides);
+
+	let projectPlugins: InstalledPlugin[] = [];
+	const projectRegistryPath = await resolveActiveProjectRegistryPath(cwd);
+	if (projectRegistryPath) {
+		const projectRoot = path.dirname(projectRegistryPath);
+		if (projectRoot !== userRoot) {
+			projectPlugins = await collectPluginsAtRoot(projectRoot, projectOverrides);
+		}
+	}
+
+	if (projectPlugins.length === 0) return userPlugins;
+	if (userPlugins.length === 0) return projectPlugins;
+
+	// Project entries shadow user entries with the same package name.
+	const merged = new Map<string, InstalledPlugin>();
+	for (const plugin of userPlugins) merged.set(plugin.name, plugin);
+	for (const plugin of projectPlugins) merged.set(plugin.name, plugin);
+	return Array.from(merged.values());
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -18,7 +18,6 @@ export interface ScopedInstalledPlugin extends InstalledPlugin {
 	scope: "user" | "project";
 }
 
-
 installLegacyPiSpecifierShim();
 
 // =============================================================================

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -13,6 +13,12 @@ import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig, ProjectPluginOverrides } from "./types";
 
+/** Installed plugin plus the root scope that supplied its runtime metadata. */
+export interface ScopedInstalledPlugin extends InstalledPlugin {
+	scope: "user" | "project";
+}
+
+
 installLegacyPiSpecifierShim();
 
 // =============================================================================
@@ -60,7 +66,8 @@ async function loadProjectOverrides(cwd: string): Promise<ProjectPluginOverrides
 async function collectPluginsAtRoot(
 	root: string,
 	projectOverrides: ProjectPluginOverrides,
-): Promise<InstalledPlugin[]> {
+	scope: ScopedInstalledPlugin["scope"],
+): Promise<ScopedInstalledPlugin[]> {
 	const nodeModulesPath = path.join(root, "node_modules");
 	if (!fs.existsSync(nodeModulesPath)) return [];
 
@@ -92,7 +99,7 @@ async function collectPluginsAtRoot(
 		names.add(name);
 	}
 
-	const plugins: InstalledPlugin[] = [];
+	const plugins: ScopedInstalledPlugin[] = [];
 	for (const name of names) {
 		const pluginPkgPath = path.join(nodeModulesPath, name, "package.json");
 		let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
@@ -130,6 +137,7 @@ async function collectPluginsAtRoot(
 			name,
 			version: pluginPkg.version,
 			path: path.join(nodeModulesPath, name),
+			scope,
 			manifest,
 			enabledFeatures,
 			enabled: true,
@@ -154,19 +162,19 @@ async function collectPluginsAtRoot(
  * need to enumerate plugins relative to a non-default home (tests with a
  * tempdir, discovery loaders threaded with `LoadContext.home`).
  */
-export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<InstalledPlugin[]> {
+export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<ScopedInstalledPlugin[]> {
 	const { home } = opts;
 	const projectOverrides = await loadProjectOverrides(cwd);
 
 	const userRoot = getPluginsDir(home);
-	const userPlugins = await collectPluginsAtRoot(userRoot, projectOverrides);
+	const userPlugins = await collectPluginsAtRoot(userRoot, projectOverrides, "user");
 
-	let projectPlugins: InstalledPlugin[] = [];
+	let projectPlugins: ScopedInstalledPlugin[] = [];
 	const projectRegistryPath = await resolveActiveProjectRegistryPath(cwd);
 	if (projectRegistryPath) {
 		const projectRoot = path.dirname(projectRegistryPath);
 		if (projectRoot !== userRoot) {
-			projectPlugins = await collectPluginsAtRoot(projectRoot, projectOverrides);
+			projectPlugins = await collectPluginsAtRoot(projectRoot, projectOverrides, "project");
 		}
 	}
 
@@ -174,7 +182,7 @@ export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {
 	if (userPlugins.length === 0) return projectPlugins;
 
 	// Project entries shadow user entries with the same package name.
-	const merged = new Map<string, InstalledPlugin>();
+	const merged = new Map<string, ScopedInstalledPlugin>();
 	for (const plugin of userPlugins) merged.set(plugin.name, plugin);
 	for (const plugin of projectPlugins) merged.set(plugin.name, plugin);
 	return Array.from(merged.values());

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -50,7 +50,6 @@ function assertRuntimePackageName(name: string): string {
 	return name;
 }
 
-
 // ── Options ──────────────────────────────────────────────────────────────────
 
 export interface MarketplaceManagerOptions {

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -11,6 +11,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { isEnoent, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
+import { normalizePluginRuntimeConfig } from "../runtime-config";
+import type { PluginRuntimeConfig } from "../types";
 
 import { cachePlugin } from "./cache";
 import { classifySource, fetchMarketplace, parseMarketplaceCatalog, promoteCloneToCache } from "./fetcher";
@@ -298,6 +300,9 @@ export class MarketplaceManager {
 			}
 		}
 
+		const packageName = await this.#resolvePluginPackageName(cachePath, name);
+		const previousPackageNames = await this.#resolveInstalledPackageNames(existing ?? [], name);
+
 		// Only now clean up old entries — new cache succeeded, so it is safe to remove old ones.
 		if (existing && existing.length > 0) {
 			// Remove from scope-appropriate registry first, then cross-check refs before disk deletion.
@@ -336,6 +341,13 @@ export class MarketplaceManager {
 		const freshInstReg = await readInstalledPluginsRegistry(registryPath);
 		const newInstReg = addInstalledPlugin(freshInstReg, pluginId, installedEntry);
 		await writeInstalledPluginsRegistry(registryPath, newInstReg);
+
+		for (const previousPackageName of previousPackageNames) {
+			if (previousPackageName !== packageName) {
+				await this.#removeRuntimePlugin(scope, previousPackageName);
+			}
+		}
+		await this.#registerRuntimePlugin(scope, packageName, cachePath, version, wasDisabled ? false : undefined);
 
 		this.#clearCache();
 
@@ -434,6 +446,7 @@ export class MarketplaceManager {
 		const targetEntries = targetScope === "project" ? projectEntries! : userEntries!;
 		const targetReg = targetScope === "project" ? projectReg : userReg;
 		const registryPath = this.#registryPath(targetScope);
+		const packageNames = await this.#resolveInstalledPackageNames(targetEntries, parsed.name);
 
 		const updatedReg = removeInstalledPlugin(targetReg, pluginId);
 		await writeInstalledPluginsRegistry(registryPath, updatedReg);
@@ -451,6 +464,10 @@ export class MarketplaceManager {
 			if (!referenced.has(entry.installPath)) {
 				await fs.rm(entry.installPath, { recursive: true, force: true });
 			}
+		}
+
+		for (const packageName of packageNames) {
+			await this.#removeRuntimePlugin(targetScope, packageName);
 		}
 
 		this.#clearCache();
@@ -538,6 +555,12 @@ export class MarketplaceManager {
 			},
 		};
 		await writeInstalledPluginsRegistry(registryPath, updated);
+
+		const fallbackName = parsePluginId(pluginId)?.name ?? pluginId;
+		const packageNames = await this.#resolveInstalledPackageNames(entries, fallbackName);
+		for (const packageName of packageNames) {
+			await this.#setRuntimePluginEnabled(targetScope, packageName, enabled);
+		}
 
 		this.#clearCache();
 
@@ -700,6 +723,96 @@ export class MarketplaceManager {
 	}
 
 	// ── Private helpers ───────────────────────────────────────────────────────
+
+	#runtimeRoot(scope: "user" | "project"): string {
+		return path.dirname(this.#registryPath(scope));
+	}
+
+	#nodeModulesPath(scope: "user" | "project"): string {
+		return path.join(this.#runtimeRoot(scope), "node_modules");
+	}
+
+	#runtimeLockPath(scope: "user" | "project"): string {
+		return path.join(this.#runtimeRoot(scope), "omp-plugins.lock.json");
+	}
+
+	async #loadRuntimeConfig(scope: "user" | "project"): Promise<PluginRuntimeConfig> {
+		try {
+			return normalizePluginRuntimeConfig(await Bun.file(this.#runtimeLockPath(scope)).json());
+		} catch (err) {
+			if (isEnoent(err)) return normalizePluginRuntimeConfig({});
+			logger.warn("Failed to load marketplace plugin runtime config", {
+				path: this.#runtimeLockPath(scope),
+				error: String(err),
+			});
+			return normalizePluginRuntimeConfig({});
+		}
+	}
+
+	async #writeRuntimeConfig(scope: "user" | "project", config: PluginRuntimeConfig): Promise<void> {
+		await Bun.write(this.#runtimeLockPath(scope), JSON.stringify(config, null, 2));
+	}
+
+	async #resolvePluginPackageName(installPath: string, fallbackName: string): Promise<string> {
+		try {
+			const pkg: { name?: unknown } = await Bun.file(path.join(installPath, "package.json")).json();
+			return typeof pkg.name === "string" && pkg.name.length > 0 ? pkg.name : fallbackName;
+		} catch (err) {
+			if (isEnoent(err)) return fallbackName;
+			throw err;
+		}
+	}
+
+	async #resolveInstalledPackageNames(
+		entries: readonly InstalledPluginEntry[],
+		fallbackName: string,
+	): Promise<Set<string>> {
+		const packageNames = new Set<string>();
+		for (const entry of entries) {
+			packageNames.add(await this.#resolvePluginPackageName(entry.installPath, fallbackName));
+		}
+		return packageNames;
+	}
+
+	async #registerRuntimePlugin(
+		scope: "user" | "project",
+		packageName: string,
+		cachePath: string,
+		version: string,
+		enabled: boolean | undefined,
+	): Promise<void> {
+		const linkPath = path.join(this.#nodeModulesPath(scope), packageName);
+		await fs.mkdir(path.dirname(linkPath), { recursive: true });
+		await fs.rm(linkPath, { recursive: true, force: true });
+		await fs.symlink(cachePath, linkPath, process.platform === "win32" ? "junction" : "dir");
+
+		const config = await this.#loadRuntimeConfig(scope);
+		const previous = config.plugins[packageName];
+		config.plugins[packageName] = {
+			version,
+			enabledFeatures: previous?.enabledFeatures ?? null,
+			enabled: enabled ?? previous?.enabled ?? true,
+		};
+		await this.#writeRuntimeConfig(scope, config);
+	}
+
+	async #removeRuntimePlugin(scope: "user" | "project", packageName: string): Promise<void> {
+		await fs.rm(path.join(this.#nodeModulesPath(scope), packageName), { recursive: true, force: true });
+
+		const config = await this.#loadRuntimeConfig(scope);
+		delete config.plugins[packageName];
+		delete config.settings[packageName];
+		await this.#writeRuntimeConfig(scope, config);
+	}
+
+	async #setRuntimePluginEnabled(scope: "user" | "project", packageName: string, enabled: boolean): Promise<void> {
+		const config = await this.#loadRuntimeConfig(scope);
+		const previous = config.plugins[packageName];
+		if (!previous) return;
+
+		config.plugins[packageName] = { ...previous, enabled };
+		await this.#writeRuntimeConfig(scope, config);
+	}
 
 	#registryPath(scope: "user" | "project"): string {
 		if (scope === "project") {

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -40,6 +40,17 @@ import type {
 } from "./types";
 import { buildPluginId, parsePluginId } from "./types";
 
+const RUNTIME_PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+const MAX_RUNTIME_PACKAGE_NAME_LENGTH = 214;
+
+function assertRuntimePackageName(name: string): string {
+	if (name.length > MAX_RUNTIME_PACKAGE_NAME_LENGTH || !RUNTIME_PACKAGE_NAME_RE.test(name)) {
+		throw new Error(`Invalid marketplace plugin package name: ${JSON.stringify(name)}`);
+	}
+	return name;
+}
+
+
 // ── Options ──────────────────────────────────────────────────────────────────
 
 export interface MarketplaceManagerOptions {
@@ -756,11 +767,22 @@ export class MarketplaceManager {
 	async #resolvePluginPackageName(installPath: string, fallbackName: string): Promise<string> {
 		try {
 			const pkg: { name?: unknown } = await Bun.file(path.join(installPath, "package.json")).json();
-			return typeof pkg.name === "string" && pkg.name.length > 0 ? pkg.name : fallbackName;
+			const name = typeof pkg.name === "string" && pkg.name.length > 0 ? pkg.name : fallbackName;
+			return assertRuntimePackageName(name);
 		} catch (err) {
-			if (isEnoent(err)) return fallbackName;
+			if (isEnoent(err)) return assertRuntimePackageName(fallbackName);
 			throw err;
 		}
+	}
+
+	#runtimePackagePath(scope: "user" | "project", packageName: string): string {
+		const nodeModules = path.resolve(this.#nodeModulesPath(scope));
+		const linkPath = path.resolve(nodeModules, assertRuntimePackageName(packageName));
+		const relative = path.relative(nodeModules, linkPath);
+		if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+			throw new Error(`Marketplace plugin package path escapes node_modules: ${JSON.stringify(packageName)}`);
+		}
+		return linkPath;
 	}
 
 	async #resolveInstalledPackageNames(
@@ -781,7 +803,7 @@ export class MarketplaceManager {
 		version: string,
 		enabled: boolean | undefined,
 	): Promise<void> {
-		const linkPath = path.join(this.#nodeModulesPath(scope), packageName);
+		const linkPath = this.#runtimePackagePath(scope, packageName);
 		await fs.mkdir(path.dirname(linkPath), { recursive: true });
 		await fs.rm(linkPath, { recursive: true, force: true });
 		await fs.symlink(cachePath, linkPath, process.platform === "win32" ? "junction" : "dir");
@@ -797,7 +819,7 @@ export class MarketplaceManager {
 	}
 
 	async #removeRuntimePlugin(scope: "user" | "project", packageName: string): Promise<void> {
-		await fs.rm(path.join(this.#nodeModulesPath(scope), packageName), { recursive: true, force: true });
+		await fs.rm(this.#runtimePackagePath(scope, packageName), { recursive: true, force: true });
 
 		const config = await this.#loadRuntimeConfig(scope);
 		delete config.plugins[packageName];

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -209,6 +209,27 @@ test("installed plugins under `<plugins>/node_modules/` are surfaced (e.g. via `
 	expect(found).toBeDefined();
 });
 
+test("project-scoped installed plugins surface project-level sub-discovery", async () => {
+	const pluginsDir = path.join(project, ".omp", "plugins");
+	const installed = path.join(pluginsDir, "node_modules", "my-project-ext");
+	fs.mkdirSync(installed, { recursive: true });
+	fs.cpSync(ext, installed, { recursive: true });
+	writeFile(
+		path.join(pluginsDir, "omp-plugins.lock.json"),
+		JSON.stringify({
+			plugins: { "my-project-ext": { version: "1.0.0", enabled: true, enabledFeatures: null } },
+			settings: {},
+		}),
+	);
+
+	const skills = await loadFromPlugin<{ name: string; path: string; level: "user" | "project" }>(
+		skillCapability.id,
+		ctx(),
+	);
+	const found = skills.find(s => s.name === "my-skill" && s.path.includes("my-project-ext"));
+	expect(found?.level).toBe("project");
+});
+
 test("disabled installed plugins do not contribute sub-discovery", async () => {
 	const pluginsDir = path.join(home, ".omp", "plugins");
 	const installed = path.join(pluginsDir, "node_modules", "my-disabled-ext");

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import { getEnabledPlugins } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/loader";
 import {
 	MarketplaceManager,
 	readInstalledPluginsRegistry,
@@ -18,6 +19,7 @@ function buildMinimalFixture(): string {
 	const pluginDir = path.join(root, "plugins", "hello-plugin");
 	fs.mkdirSync(path.join(pluginDir, ".claude-plugin"), { recursive: true });
 	fs.mkdirSync(path.join(root, ".claude-plugin"), { recursive: true });
+	fs.mkdirSync(path.join(pluginDir, "extensions"), { recursive: true });
 	fs.writeFileSync(
 		path.join(root, ".claude-plugin", "marketplace.json"),
 		JSON.stringify({
@@ -39,6 +41,15 @@ function buildMinimalFixture(): string {
 		path.join(pluginDir, ".claude-plugin", "plugin.json"),
 		JSON.stringify({ name: "hello-plugin", version: "1.0.0" }),
 	);
+	fs.writeFileSync(
+		path.join(pluginDir, "package.json"),
+		JSON.stringify({
+			name: "hello-plugin",
+			version: "1.0.0",
+			omp: { extensions: ["./extensions"] },
+		}),
+	);
+	fs.writeFileSync(path.join(pluginDir, "extensions", "index.ts"), "export default {};\n");
 	return root;
 }
 
@@ -178,10 +189,41 @@ describe("MarketplaceManager", () => {
 		expect(instEntry.scope).toBe("user");
 		expect(instEntry.version).toBe("1.0.0");
 		expect(fs.existsSync(instEntry.installPath)).toBe(true);
+		const linkPath = path.join(ctx.tmpDir, "node_modules", "hello-plugin");
+		expect(fs.realpathSync(linkPath)).toBe(fs.realpathSync(instEntry.installPath));
+
+		const runtimeConfig = await Bun.file(path.join(ctx.tmpDir, "omp-plugins.lock.json")).json();
+		expect(runtimeConfig.plugins["hello-plugin"]).toEqual({
+			version: "1.0.0",
+			enabledFeatures: null,
+			enabled: true,
+		});
 
 		const installed = await ctx.manager.listInstalledPlugins();
 		expect(installed).toHaveLength(1);
 		expect(installed[0].id).toBe("hello-plugin@test-marketplace");
+	});
+
+	it("installPlugin exposes marketplace package to the runtime loader", async () => {
+		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mgr-home-"));
+		try {
+			const pluginsDir = path.join(tmpHome, ".omp", "plugins");
+			const manager = new MarketplaceManager({
+				marketplacesRegistryPath: path.join(tmpHome, ".omp", "marketplaces.json"),
+				installedRegistryPath: path.join(pluginsDir, "installed_plugins.json"),
+				marketplacesCacheDir: path.join(pluginsDir, "cache", "marketplaces"),
+				pluginsCacheDir: path.join(pluginsDir, "cache", "plugins"),
+			});
+
+			await manager.addMarketplace(FIXTURE_DIR);
+			await manager.installPlugin("hello-plugin", "test-marketplace");
+
+			const enabled = await getEnabledPlugins(ctx.tmpDir, { home: tmpHome });
+			expect(enabled.map(plugin => plugin.name)).toEqual(["hello-plugin"]);
+			expect(enabled[0].path).toBe(path.join(pluginsDir, "node_modules", "hello-plugin"));
+		} finally {
+			fs.rmSync(tmpHome, { recursive: true, force: true });
+		}
 	});
 
 	it("installPlugin embeds config-only marketplace LSP metadata", async () => {
@@ -254,12 +296,16 @@ describe("MarketplaceManager", () => {
 	it("installPlugin with force:true → replaces existing", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		const first = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		await ctx.manager.setPluginEnabled("hello-plugin@test-marketplace", false);
 		const second = await ctx.manager.installPlugin("hello-plugin", "test-marketplace", {
 			force: true,
 		});
 
 		expect(second.installPath).toBe(first.installPath);
 		expect(fs.existsSync(second.installPath)).toBe(true);
+
+		const runtimeConfig = await Bun.file(path.join(ctx.tmpDir, "omp-plugins.lock.json")).json();
+		expect(runtimeConfig.plugins["hello-plugin"].enabled).toBe(false);
 
 		const installed = await ctx.manager.listInstalledPlugins();
 		expect(installed).toHaveLength(1);
@@ -287,6 +333,10 @@ describe("MarketplaceManager", () => {
 		await ctx.manager.uninstallPlugin("hello-plugin@test-marketplace");
 
 		expect(fs.existsSync(instEntry.installPath)).toBe(false);
+		expect(fs.existsSync(path.join(ctx.tmpDir, "node_modules", "hello-plugin"))).toBe(false);
+
+		const runtimeConfig = await Bun.file(path.join(ctx.tmpDir, "omp-plugins.lock.json")).json();
+		expect(runtimeConfig.plugins["hello-plugin"]).toBeUndefined();
 
 		const installed = await ctx.manager.listInstalledPlugins();
 		expect(installed).toHaveLength(0);
@@ -310,9 +360,13 @@ describe("MarketplaceManager", () => {
 
 		const installed = await ctx.manager.listInstalledPlugins();
 		expect(installed[0].entries[0].enabled).toBe(false);
+		let runtimeConfig = await Bun.file(path.join(ctx.tmpDir, "omp-plugins.lock.json")).json();
+		expect(runtimeConfig.plugins["hello-plugin"].enabled).toBe(false);
 
 		await ctx.manager.setPluginEnabled("hello-plugin@test-marketplace", true);
 		const updated = await ctx.manager.listInstalledPlugins();
+		runtimeConfig = await Bun.file(path.join(ctx.tmpDir, "omp-plugins.lock.json")).json();
+		expect(runtimeConfig.plugins["hello-plugin"].enabled).toBe(true);
 		expect(updated[0].entries[0].enabled).toBe(true);
 	});
 

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -226,6 +226,50 @@ describe("MarketplaceManager", () => {
 		}
 	});
 
+	it("installPlugin with scope:project exposes the marketplace package to the runtime loader", async () => {
+		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mgr-home-"));
+		const projectAnchor = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mgr-project-"));
+		try {
+			const userPluginsDir = path.join(tmpHome, ".omp", "plugins");
+			const projectPluginsDir = path.join(projectAnchor, ".omp", "plugins");
+			fs.mkdirSync(projectPluginsDir, { recursive: true });
+			const manager = new MarketplaceManager({
+				marketplacesRegistryPath: path.join(tmpHome, ".omp", "marketplaces.json"),
+				installedRegistryPath: path.join(userPluginsDir, "installed_plugins.json"),
+				projectInstalledRegistryPath: path.join(projectPluginsDir, "installed_plugins.json"),
+				marketplacesCacheDir: path.join(userPluginsDir, "cache", "marketplaces"),
+				pluginsCacheDir: path.join(userPluginsDir, "cache", "plugins"),
+			});
+
+			await manager.addMarketplace(FIXTURE_DIR);
+			await manager.installPlugin("hello-plugin", "test-marketplace", { scope: "project" });
+
+			// Project-scope install must surface via the runtime loader when cwd is inside the anchor.
+			const enabled = await getEnabledPlugins(projectAnchor, { home: tmpHome });
+			expect(enabled.map(plugin => plugin.name)).toEqual(["hello-plugin"]);
+			expect(enabled[0].path).toBe(path.join(projectPluginsDir, "node_modules", "hello-plugin"));
+
+			// The runtime symlink and lockfile must live under the project plugins root.
+			const projectLink = path.join(projectPluginsDir, "node_modules", "hello-plugin");
+			expect(fs.realpathSync(projectLink)).toBe(
+				fs.realpathSync(path.join(userPluginsDir, "cache", "plugins", "test-marketplace___hello-plugin___1.0.0")),
+			);
+			const projectLock = await Bun.file(path.join(projectPluginsDir, "omp-plugins.lock.json")).json();
+			expect(projectLock.plugins["hello-plugin"]).toEqual({
+				version: "1.0.0",
+				enabledFeatures: null,
+				enabled: true,
+			});
+
+			// User-scope tree stays untouched.
+			expect(fs.existsSync(path.join(userPluginsDir, "node_modules", "hello-plugin"))).toBe(false);
+			expect(fs.existsSync(path.join(userPluginsDir, "omp-plugins.lock.json"))).toBe(false);
+		} finally {
+			fs.rmSync(tmpHome, { recursive: true, force: true });
+			fs.rmSync(projectAnchor, { recursive: true, force: true });
+		}
+	});
+
 	it("installPlugin embeds config-only marketplace LSP metadata", async () => {
 		const marketplaceDir = path.join(ctx.tmpDir, "config-only-marketplace");
 		const pluginDir = path.join(marketplaceDir, "plugins", "csharp-lsp");

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -204,6 +204,37 @@ describe("MarketplaceManager", () => {
 		expect(installed[0].id).toBe("hello-plugin@test-marketplace");
 	});
 
+	it("installPlugin rejects package names that escape node_modules", async () => {
+		const marketplaceDir = path.join(ctx.tmpDir, "bad-package-marketplace");
+		const pluginDir = path.join(marketplaceDir, "plugins", "bad-package");
+		fs.mkdirSync(path.join(marketplaceDir, ".claude-plugin"), { recursive: true });
+		fs.mkdirSync(pluginDir, { recursive: true });
+		await Bun.write(
+			path.join(marketplaceDir, ".claude-plugin", "marketplace.json"),
+			`${JSON.stringify(
+				{
+					name: "bad-package-marketplace",
+					owner: { name: "Test Author" },
+					plugins: [{ name: "bad-package", source: "./plugins/bad-package", version: "1.0.0" }],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		await Bun.write(path.join(pluginDir, "package.json"), `${JSON.stringify({ name: "../outside" })}\n`);
+		await Bun.write(path.join(ctx.tmpDir, "outside"), "sentinel\n");
+
+		await ctx.manager.addMarketplace(marketplaceDir);
+		await expect(ctx.manager.installPlugin("bad-package", "bad-package-marketplace")).rejects.toThrow(
+			/Invalid marketplace plugin package name/,
+		);
+
+		expect(await Bun.file(path.join(ctx.tmpDir, "outside")).text()).toBe("sentinel\n");
+		expect(fs.existsSync(path.join(ctx.tmpDir, "node_modules"))).toBe(false);
+		const installed = await ctx.manager.listInstalledPlugins();
+		expect(installed).toHaveLength(0);
+	});
+
 	it("installPlugin exposes marketplace package to the runtime loader", async () => {
 		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mgr-home-"));
 		try {


### PR DESCRIPTION
## Repro
A temp marketplace fixture installed with `MarketplaceManager.installPlugin("hello-plugin", "test-marketplace")` cached the plugin and wrote `installed_plugins.json`, but the runtime plugin root had no `node_modules/hello-plugin`, no `omp-plugins.lock.json`, and `getAllPluginExtensionPaths(process.cwd())` returned `[]`.

## Cause
`packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts` only maintained the Claude-compatible marketplace registry/cache. The runtime loader in `packages/coding-agent/src/extensibility/plugins/loader.ts` discovers plugins from the plugin root `node_modules` tree plus `omp-plugins.lock.json#plugins`, so marketplace installs were invisible even after successful CLI installation.

## Fix
- Added marketplace runtime bookkeeping: install creates/replaces the package symlink or junction and writes `omp-plugins.lock.json` with the previous enabled state preserved.
- Synced marketplace enable/disable and uninstall paths with runtime lockfile state, including removing the runtime symlink and settings on uninstall.
- Added regression coverage that proves marketplace installs are visible to `getEnabledPlugins()` and that uninstall/reinstall/enablement keep runtime state consistent.
- Added the coding-agent changelog entry for #3244.

## Verification
`bun test packages/coding-agent/test/marketplace/manager.test.ts` passed with 39 tests; `bun check` passed; the repro script now reports `nodeModulesLinkExists: true`, `lockfileExists: true`, and a non-empty `extensionPaths` entry through `node_modules/hello-plugin/extensions/index.ts`. Fixes #3244