### PR TITLE
fix(coding-agent): stop Perplexity auto-chain from hijacking OpenRouter auth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Perplexity web-search provider hijacking the auto fallback chain when only OpenRouter auth was configured. `PerplexityProvider.isAvailable()` accepted `hasAuth("openrouter")` as a credential, so any user with an OpenRouter key (for LLM access) had every `webSearch: auto` request silently routed through OpenRouter's `perplexity/sonar-pro` — bypassing downstream providers like Gemini and producing unexpected OpenRouter billing. Auto-chain admission now requires a direct Perplexity credential (`PERPLEXITY_COOKIES`, OAuth, or `PERPLEXITY_API_KEY`); users who want the OpenRouter-backed Perplexity path can still opt in explicitly with `webSearch: perplexity` ([#3251](https://github.com/can1357/oh-my-pi/issues/3251))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/web/search/providers/perplexity.ts
+++ b/packages/coding-agent/src/web/search/providers/perplexity.ts
@@ -833,16 +833,28 @@ export class PerplexityProvider extends SearchProvider {
 	readonly id = "perplexity";
 	readonly label = "Perplexity";
 
+	/**
+	 * Auto-chain admission. Requires a direct Perplexity credential
+	 * (`PERPLEXITY_COOKIES`, OAuth session, or `PERPLEXITY_API_KEY`).
+	 *
+	 * OpenRouter auth is intentionally NOT accepted here: silently using
+	 * OpenRouter's `perplexity/sonar-pro` whenever any OpenRouter key is
+	 * configured surprises users (and bills them) for a path they never
+	 * asked for. The auto chain skips Perplexity in that case and falls
+	 * through to the next configured provider. Users who DO want the
+	 * OpenRouter-backed Perplexity path can still opt in by setting
+	 * `webSearch: perplexity` explicitly — see {@link isExplicitlyAvailable}.
+	 */
 	isAvailable(authStorage: AuthStorage): boolean {
-		return (
-			!!$env.PERPLEXITY_COOKIES?.trim() || authStorage.hasAuth("perplexity") || authStorage.hasAuth("openrouter")
-		);
+		return !!$env.PERPLEXITY_COOKIES?.trim() || authStorage.hasAuth("perplexity");
 	}
 
 	/**
-	 * Perplexity accepts anonymous browser-style ask requests, but keep auto
-	 * provider selection credential-gated so a configured provider keeps priority
-	 * over the anonymous fallback.
+	 * Perplexity accepts anonymous browser-style ask requests, and the
+	 * OpenRouter-backed `perplexity/sonar-pro` path is opt-in through
+	 * explicit selection. Keep auto-chain admission credential-gated so a
+	 * configured provider keeps priority over the anonymous/OpenRouter
+	 * fallbacks.
 	 */
 	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;

--- a/packages/coding-agent/test/web/search/perplexity.test.ts
+++ b/packages/coding-agent/test/web/search/perplexity.test.ts
@@ -431,6 +431,70 @@ describe("Perplexity anonymous fallback", () => {
 	});
 });
 
+describe("Perplexity OpenRouter auto-chain admission (issue #3251)", () => {
+	const savedKey = process.env.PERPLEXITY_API_KEY;
+	const savedPplxKey = process.env.PPLX_API_KEY;
+	const savedCookies = process.env.PERPLEXITY_COOKIES;
+
+	beforeEach(() => {
+		delete process.env.PERPLEXITY_API_KEY;
+		delete process.env.PPLX_API_KEY;
+		delete process.env.PERPLEXITY_COOKIES;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (savedKey === undefined) delete process.env.PERPLEXITY_API_KEY;
+		else process.env.PERPLEXITY_API_KEY = savedKey;
+		if (savedPplxKey === undefined) delete process.env.PPLX_API_KEY;
+		else process.env.PPLX_API_KEY = savedPplxKey;
+		if (savedCookies === undefined) delete process.env.PERPLEXITY_COOKIES;
+		else process.env.PERPLEXITY_COOKIES = savedCookies;
+	});
+
+	it("keeps Perplexity out of the auto chain when only OpenRouter auth is configured", () => {
+		const openrouterOnly = {
+			async getOAuthAccess() {
+				return undefined;
+			},
+			async getApiKey() {
+				return undefined;
+			},
+			hasAuth(provider: string) {
+				return provider === "openrouter";
+			},
+		} as unknown as AuthStorage;
+
+		const provider = new PerplexityProvider();
+
+		// Auto chain MUST skip Perplexity so downstream providers (Gemini, ...)
+		// get a chance instead of silently routing through OpenRouter's
+		// `perplexity/sonar-pro` and billing the user for an unrequested path.
+		expect(provider.isAvailable(openrouterOnly)).toBe(false);
+		// Explicit selection still admits the provider so `webSearch: perplexity`
+		// can opt into the OpenRouter-backed path on purpose.
+		expect(provider.isExplicitlyAvailable(openrouterOnly)).toBe(true);
+	});
+
+	it("admits Perplexity to the auto chain when a direct Perplexity credential exists", () => {
+		const perplexityOnly = {
+			async getOAuthAccess() {
+				return undefined;
+			},
+			async getApiKey() {
+				return undefined;
+			},
+			hasAuth(provider: string) {
+				return provider === "perplexity";
+			},
+		} as unknown as AuthStorage;
+
+		const provider = new PerplexityProvider();
+
+		expect(provider.isAvailable(perplexityOnly)).toBe(true);
+	});
+});
+
 describe("Perplexity Authentication order", () => {
 	const savedCookies = Bun.env.PERPLEXITY_COOKIES || process.env.PERPLEXITY_COOKIES;
 


### PR DESCRIPTION
## Repro

Configure only an OpenRouter API key (no Perplexity cookie, OAuth, or `PERPLEXITY_API_KEY`) and run a web search with `webSearch: auto` (or any preference where Perplexity is still chain-eligible). Every search is silently routed through OpenRouter's `perplexity/sonar-pro` model — billed by OpenRouter and bypassing every later provider in the chain (e.g. Gemini). A direct unit probe demonstrates the misclassification:

```
$ bun test/repro_3251.ts
isAvailable(openrouter-only) = true
exit=1
```

## Cause

`PerplexityProvider.isAvailable()` in `packages/coding-agent/src/web/search/providers/perplexity.ts` accepted `authStorage.hasAuth("openrouter")` as a valid Perplexity credential:

```ts
isAvailable(authStorage: AuthStorage): boolean {
    return (
        !!$env.PERPLEXITY_COOKIES?.trim()
            || authStorage.hasAuth("perplexity")
            || authStorage.hasAuth("openrouter") // <-- silent hijack
    );
}
```

`resolveProviderChain` walks providers in `SEARCH_PROVIDER_ORDER` and admits any whose `isAvailable()` returns `true`. Perplexity is first in that order, so an `OPENROUTER_API_KEY`-only setup made Perplexity claim every auto-routed search — `getAvailableAuthMethods` → `getApiConfigs` then picked the OpenRouter API config (model prefix `perplexity/`, base URL `openrouter.ai/api/v1`) and the request never reached Gemini or any later provider.

## Fix

- `packages/coding-agent/src/web/search/providers/perplexity.ts`: drop the `hasAuth("openrouter")` admission leg. `isAvailable()` now requires a direct Perplexity credential (`PERPLEXITY_COOKIES`, Perplexity OAuth/session, or `PERPLEXITY_API_KEY` via `hasAuth("perplexity")`). `isExplicitlyAvailable()` still returns `true`, so users who deliberately want the OpenRouter-backed `perplexity/sonar-pro` path can opt in with `webSearch: perplexity` — `getAvailableAuthMethods` / `getApiConfigs` still emit the OpenRouter config in that explicit path. Updated the JSDoc to document the opt-in.
- `packages/coding-agent/test/web/search/perplexity.test.ts`: added an "OpenRouter auto-chain admission (issue #3251)" describe block that pins the new behavior — OpenRouter-only auth keeps Perplexity out of the auto chain while explicit selection still admits it, and a direct Perplexity credential still admits the auto chain.
- `packages/coding-agent/CHANGELOG.md`: noted the fix under `[Unreleased] → Fixed`.

## Verification

```
$ bun test test/web/search/perplexity.test.ts
 14 pass
 0 fail
 42 expect() calls
```

The two pre-existing failures in `test/web/search/` (`abort-and-timeout.test.ts`, `provider-chain.test.ts`) are unrelated — both fail on `main` against this same checkout with `Cannot find module './tool-views.generated.js' from .../src/export/html/index.ts`, confirmed by stashing the diff and re-running. Not introduced by this PR; left untouched.

Fixes #3251