### PR TITLE
fix(tui): preserve bare png filename pastes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bracketed paste treating a bare `.png` filename as an image attachment path instead of normal prompt text. ([#3253](https://github.com/can1357/oh-my-pi/issues/3253))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -3,6 +3,7 @@ import { $ } from "bun";
 import { getEditorTheme, initTheme } from "../theme/theme";
 import {
 	CustomEditor,
+	extractBracketedImagePastePaths,
 	SPACE_HOLD_MECHANICAL_RUN,
 	SPACE_HOLD_RELEASE_MS,
 	SPACE_REPEAT_MAX_GAP_MS,
@@ -21,6 +22,12 @@ function makeEditor() {
 const REPEAT_GAP_MS = 30;
 /** A gap above the threshold — looks like a deliberate keypress. */
 const TAP_GAP_MS = SPACE_REPEAT_MAX_GAP_MS + 80;
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
+
+function bracketedPaste(text: string): string {
+	return `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`;
+}
 
 /** Feed `count` spaces `gapMs` apart on the fake clock. The first space of a run has no prior
  *  space, so its gap is effectively infinite and it always reads as a deliberate tap. */
@@ -63,6 +70,21 @@ describe("CustomEditor placeholder decoration", () => {
 	it("renders linked image placeholders before theme and settings initialization", async () => {
 		const output = await decorateInFreshProcess("[Image #1]", ["/tmp/example.png"]);
 		expect(output).toBe("[Image #1]");
+	});
+});
+
+describe("CustomEditor bracketed image-path paste", () => {
+	it("leaves a pasted bare .png filename on the normal text path", () => {
+		expect(extractBracketedImagePastePaths(bracketedPaste("icon-photo-default.png"))).toBeUndefined();
+	});
+
+	it("extracts explicit local image paths for attachment", () => {
+		expect(extractBracketedImagePastePaths(bracketedPaste("/tmp/icon-photo-default.png"))).toEqual([
+			"/tmp/icon-photo-default.png",
+		]);
+		expect(extractBracketedImagePastePaths(bracketedPaste("C:\\Users\\me\\icon-photo-default.png"))).toEqual([
+			"C:\\Users\\me\\icon-photo-default.png",
+		]);
 	});
 });
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -64,6 +64,9 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const BRACKETED_IMAGE_PATH_REGEX = /\.(?:png|jpe?g|gif|webp)$/i;
 const BRACKETED_IMAGE_PATH_BOUNDARY_REGEX = /\.(?:png|jpe?g|gif|webp)(?=$|["']?\s)/gi;
 const SHELL_ESCAPED_PATH_CHAR_REGEX = /\\([\\\s'"()[\]{}&;<>|?*!$`])/g;
+const URI_SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i;
+const FILE_URI_REGEX = /^file:\/\//i;
+const WINDOWS_DRIVE_PATH_REGEX = /^[a-z]:[\\/]/i;
 
 /** Max gap (ms) between two spaces for the later one to count as OS key auto-repeat rather than a
  *  deliberate press. OS auto-repeat is fast; a deliberate tap (even a fast one) is slower. */
@@ -118,6 +121,12 @@ function normalizePastedImagePath(path: string): string {
 	return unquoted.replace(SHELL_ESCAPED_PATH_CHAR_REGEX, "$1");
 }
 
+function isExplicitPastedImagePath(path: string): boolean {
+	if (WINDOWS_DRIVE_PATH_REGEX.test(path) || FILE_URI_REGEX.test(path)) return true;
+	if (URI_SCHEME_REGEX.test(path)) return false;
+	return path.includes("/") || path.includes("\\");
+}
+
 export function extractBracketedImagePastePaths(data: string): string[] | undefined {
 	if (!data.startsWith(BRACKETED_PASTE_START)) return undefined;
 	const endIndex = data.indexOf(BRACKETED_PASTE_END, BRACKETED_PASTE_START.length);
@@ -139,7 +148,7 @@ export function extractBracketedImagePastePaths(data: string): string[] | undefi
 		if (boundaryEnd === undefined) continue;
 
 		const path = normalizePastedImagePath(pasted.slice(segmentStart, boundaryEnd));
-		if (!path || !BRACKETED_IMAGE_PATH_REGEX.test(path)) return undefined;
+		if (!path || !BRACKETED_IMAGE_PATH_REGEX.test(path) || !isExplicitPastedImagePath(path)) return undefined;
 		paths.push(path);
 
 		segmentStart = boundaryEnd;


### PR DESCRIPTION
## Repro
Pasting `icon-photo-default.png` as a bracketed paste payload reproduces the bug: `bun -e 'import { extractBracketedImagePastePaths } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const paste = "\x1b[200~icon-photo-default.png\x1b[201~"; const paths = extractBracketedImagePastePaths(paste); console.log(JSON.stringify(paths)); process.exit(paths?.[0] === "icon-photo-default.png" ? 1 : 0);'` printed `["icon-photo-default.png"]` and exited 1 before the fix.

## Cause
`packages/coding-agent/src/modes/components/custom-editor.ts` used `extractBracketedImagePastePaths` to classify any bracketed paste segment ending in `.png`, `.jpg`, `.gif`, or `.webp` as an image attachment path. A plain filename such as `icon-photo-default.png` therefore bypassed normal editor text paste and reached `InputController.handleImagePathPaste`, which reported `Image not found at icon-photo-default.png` when no local file existed.

## Fix
- Require image-path paste extraction to see an explicit local path shape: a path separator, Windows drive path, or `file://` URI.
- Keep non-file URI payloads and bare image-like filenames on the normal text paste path.
- Add regression coverage for bare `.png` text and explicit POSIX/Windows image paths.
- Add the coding-agent changelog entry for #3253.

## Verification
`bun test packages/coding-agent/src/modes/components/custom-editor.test.ts` passed with 10 tests. `bun --cwd=packages/coding-agent run check` passed. Fixes #3253