### PR TITLE
fix(mcp): wrap unresolvable Windows commands in cmd.exe for PATHEXT lookup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP stdio servers failing on Windows when the launcher's PATH walk can't pin down a bare `npx`/`yarn`/pnpm-style shim (empty `Bun.env.PATH` under a restricted parent process, UNC mounts that reject `fs.access`, locked-down shells). `resolveStdioSpawnCommand` used to fall back to the bare command name, which `Bun.spawn` → `CreateProcess` can only resolve as `<name>.exe` — never `.cmd`/`.bat` — so `npx -y …` died ~140ms after spawn with `ENOENT`/`EINVAL`. The Windows resolver now routes any unresolvable bare command through `cmd.exe /d /s /c` so Windows's own PATHEXT search picks up the shim. The reporter's diagnosis ("process.env not merged") was incorrect — the merge happens at `transports/stdio.ts:316-319` — but the symptom they hit is real ([#3250](https://github.com/can1357/oh-my-pi/issues/3250)).
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -212,7 +212,18 @@ function buildCmdExeCommand(command: string, args: readonly string[]): string {
 	return `"${quotedCommand}"`;
 }
 
-/** Resolve the subprocess argv used to launch an MCP stdio server. */
+/**
+ * Resolve the subprocess argv used to launch an MCP stdio server.
+ *
+ * On Windows, our PATH/PATHEXT walk may return `null` for a bare command
+ * (e.g. `npx`) — `Bun.env.PATH` empty under a restricted parent process,
+ * UNC/network mounts that reject `fs.access`, locked-down shells. The
+ * legacy fallback handed `Bun.spawn` the bare name, but `CreateProcess`
+ * only appends `.exe` for extensionless names — `.cmd`/`.bat` are never
+ * tried, so `npx` (which exists only as `npx.cmd` on Windows) crashes the
+ * subprocess immediately. When the resolver can't pin the command down,
+ * route through `cmd.exe /d /s /c` so Windows's own PATHEXT lookup runs.
+ */
 export async function resolveStdioSpawnCommand(
 	config: MCPStdioServerConfig,
 	options: ResolveStdioSpawnOptions,
@@ -220,11 +231,16 @@ export async function resolveStdioSpawnCommand(
 	const args = config.args ?? [];
 	if (options.platform !== "win32") return { cmd: [config.command, ...args] };
 
-	const resolvedCommand =
-		(await resolveWindowsCommandPath(config.command, options.cwd, options.env)) ?? config.command;
+	const resolved = await resolveWindowsCommandPath(config.command, options.cwd, options.env);
+	const resolvedCommand = resolved ?? config.command;
 	const npmShimCommand = await resolveWindowsNpmShimCommand(resolvedCommand, args, options.cwd);
 	if (npmShimCommand) return npmShimCommand;
-	if (!isWindowsBatchCommand(resolvedCommand)) return { cmd: [resolvedCommand, ...args] };
+
+	// Direct-spawn only when we resolved to a concrete file AND its extension
+	// is not a batch script. Everything else (resolved .cmd/.bat, or an
+	// unresolved extensionless command) goes through cmd.exe so PATHEXT runs.
+	const needsCmdExe = resolved === null || isWindowsBatchCommand(resolvedCommand);
+	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args] };
 
 	return {
 		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -287,6 +287,38 @@ describe("resolveStdioSpawnCommand", () => {
 		expect(result.windowsHide).toBe(true);
 	});
 
+	it("routes unresolvable bare Windows commands through cmd.exe so PATHEXT can find a .cmd shim (#3250)", async () => {
+		// Bun.spawn -> CreateProcess only appends `.exe` to extensionless names.
+		// Commands shipped as `.cmd` shims (`npx`, `yarn`, most pnpm-installed
+		// binaries on Windows) cannot be launched directly. When our PATH walk
+		// finds nothing — empty PATH under a restricted parent, locked-down
+		// shell, UNC mounts that reject `fs.access` — we must delegate to
+		// cmd.exe so its native PATHEXT lookup runs. The legacy fallback
+		// handed `Bun.spawn` the bare name and the subprocess died ~140ms
+		// after spawn with ENOENT/EINVAL (issue #3250).
+		const result = await resolveStdioSpawnCommand(
+			{ type: "stdio", command: "npx", args: ["-y", "cloakbrowser-mcp@latest"] },
+			{
+				cwd: "C:\\project",
+				env: {
+					COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+					PATH: "",
+					PATHEXT: ".COM;.EXE;.BAT;.CMD",
+				},
+				platform: "win32",
+			},
+		);
+
+		expect(result.cmd).toEqual([
+			"C:\\Windows\\System32\\cmd.exe",
+			"/d",
+			"/s",
+			"/c",
+			`""npx" "-y" "cloakbrowser-mcp@latest""`,
+		]);
+		expect(result.windowsHide).toBe(true);
+	});
+
 	it("leaves non-Windows commands untouched", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },


### PR DESCRIPTION
## Repro

On Windows, MCP stdio servers configured with `command: "npx"` (and similar `.cmd`-shim binaries — `yarn`, most pnpm-installed CLIs) die ~140 ms after spawn with `ENOENT`/`EINVAL`, even though the same `npx -y …` works from cmd.exe and works under other MCP clients. The reporter's `mcp.json`:

```json
{ "mcpServers": { "cloakbrowser": { "type": "stdio", "command": "npx",
    "args": ["-y", "cloakbrowser-mcp@latest"] } } }
```

## Cause

The reporter's stated cause ("`process.env` not merged with config `env`") is incorrect — the merge has been in place at [`packages/coding-agent/src/mcp/transports/stdio.ts:316-319`](packages/coding-agent/src/mcp/transports/stdio.ts#L316-L319) since well before 16.1.14, and all 20 existing `resolveStdioSpawnCommand` tests pass on HEAD. The real defect is one layer up, in `resolveStdioSpawnCommand`:

```ts
const resolvedCommand =
    (await resolveWindowsCommandPath(config.command, options.cwd, options.env)) ?? config.command;
// …
if (!isWindowsBatchCommand(resolvedCommand)) return { cmd: [resolvedCommand, ...args] };
```

When the Windows PATH/PATHEXT walk can't pin down the command (empty `Bun.env.PATH` under a restricted parent process, UNC mounts that reject `fs.access`, locked-down shells), `resolveWindowsCommandPath` returns `null` and we fall back to the bare string `"npx"`. `isWindowsBatchCommand("npx")` is `false` (no `.cmd`/`.bat` suffix), so `Bun.spawn` is handed `cmd: ["npx", …]`. On Windows, `Bun.spawn` → `CreateProcess` only appends `.exe` to extensionless names — `.cmd`/`.bat` are never tried — so the subprocess dies before any I/O.

## Fix

- `resolveStdioSpawnCommand` now treats `resolveWindowsCommandPath` returning `null` the same as resolving to a `.cmd`/`.bat` file: route through `cmd.exe /d /s /c` so Windows's own PATHEXT search runs natively. Direct-spawn fast path is preserved for `.exe`/`.com` resolutions and the existing `.cmd`/`.bat` wrap is unchanged.
- Comment on `resolveStdioSpawnCommand` documents the failure mode and references this issue.
- Regression test asserts the cmd.exe wrap for the reporter's exact `command: "npx"` config with an empty PATH on `platform: "win32"`.

## Verification

`bun test packages/coding-agent/test/mcp-stdio-transport.test.ts` — 21 pass, 0 fail (was 20 before; +1 regression test).

`bun test packages/coding-agent/test/mcp-*.test.ts` — 126 pass, 1 unrelated pre-existing failure (`mcp-render-status.test.ts` errors with `Cannot find module './tool-views.generated.js'`; same failure reproduces with my diff stashed, so it's not caused by this change).

Fixes #3250