### PR TITLE
fix(coding-agent): evict openai-completions provider session state on backend switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `openai-completions` provider session state surviving `/model` switches across different providers or base URLs. `AgentSession.#closeProviderSessionsForModelSwitch` only evicted `openai-codex-responses` and `openai-responses:<provider>` keys; entries keyed `openai-completions:<provider>:<baseUrl>:<modelId>` (cached strict-tools disable scopes and reasoning-effort fallbacks for the old transport) lingered indefinitely. Moving away from an `openai-completions` backend now evicts every cached entry sharing the previous `(provider, baseUrl)` pair, while same-backend model toggles keep their cached state ([#3260](https://github.com/can1357/oh-my-pi/issues/3260))
+- Fixed `openai-completions` provider session state surviving `/model` switches across different providers or base URLs. `AgentSession.#closeProviderSessionsForModelSwitch` only evicted `openai-codex-responses` and `openai-responses:<provider>` keys; entries keyed `openai-completions:<provider>:<resolvedBaseUrl>:<modelId>` (cached strict-tools disable scopes and reasoning-effort fallbacks for the old transport) lingered indefinitely. Moving away from an `openai-completions` backend now evicts every cached entry for the previous provider, including entries whose base URL was resolved at request time rather than read from the catalog, while same-backend model toggles keep their cached state ([#3260](https://github.com/can1357/oh-my-pi/issues/3260))
 
 ## [16.1.14] - 2026-06-22
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `openai-completions` provider session state surviving `/model` switches across different providers or base URLs. `AgentSession.#closeProviderSessionsForModelSwitch` only evicted `openai-codex-responses` and `openai-responses:<provider>` keys; entries keyed `openai-completions:<provider>:<baseUrl>:<modelId>` (cached strict-tools disable scopes and reasoning-effort fallbacks for the old transport) lingered indefinitely. Moving away from an `openai-completions` backend now evicts every cached entry sharing the previous `(provider, baseUrl)` pair, while same-backend model toggles keep their cached state ([#3260](https://github.com/can1357/oh-my-pi/issues/3260))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9035,9 +9035,7 @@ export class AgentSession {
 		if (currentModel.api === "openai-completions") {
 			const currentScope = `${currentModel.provider}:${currentModel.baseUrl ?? ""}`;
 			const nextScope =
-				nextModel.api === "openai-completions"
-					? `${nextModel.provider}:${nextModel.baseUrl ?? ""}`
-					: undefined;
+				nextModel.api === "openai-completions" ? `${nextModel.provider}:${nextModel.baseUrl ?? ""}` : undefined;
 			if (currentScope !== nextScope) {
 				completionsPrefixToEvict = `openai-completions:${currentScope}:`;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9026,18 +9026,18 @@ export class AgentSession {
 			providerKeys.add(`openai-responses:${nextModel.provider}`);
 		}
 
-		// `openai-completions` sessions are keyed `openai-completions:<provider>:<baseUrl>:<modelId>`
+		// `openai-completions` sessions are keyed `openai-completions:<provider>:<resolvedBaseUrl>:<modelId>`
 		// and cache backend-specific decisions (strict-tools disable scopes, reasoning-effort
-		// fallbacks). When the user moves away from that backend — different `api`, `provider`,
-		// or `baseUrl` — the cached decisions no longer track the active transport. Evict the
-		// full `(provider, baseUrl)` prefix; same-backend model toggles keep their state.
+		// fallbacks). The resolved request base URL can differ from the catalog `model.baseUrl`
+		// (Moonshot env override, Alibaba Coding Plan enterprise URL, Azure deployment URL),
+		// so evict by provider prefix when the user moves away from that completions backend.
 		let completionsPrefixToEvict: string | undefined;
 		if (currentModel.api === "openai-completions") {
 			const currentScope = `${currentModel.provider}:${currentModel.baseUrl ?? ""}`;
 			const nextScope =
 				nextModel.api === "openai-completions" ? `${nextModel.provider}:${nextModel.baseUrl ?? ""}` : undefined;
 			if (currentScope !== nextScope) {
-				completionsPrefixToEvict = `openai-completions:${currentScope}:`;
+				completionsPrefixToEvict = `openai-completions:${currentModel.provider}:`;
 			}
 		}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9026,6 +9026,23 @@ export class AgentSession {
 			providerKeys.add(`openai-responses:${nextModel.provider}`);
 		}
 
+		// `openai-completions` sessions are keyed `openai-completions:<provider>:<baseUrl>:<modelId>`
+		// and cache backend-specific decisions (strict-tools disable scopes, reasoning-effort
+		// fallbacks). When the user moves away from that backend — different `api`, `provider`,
+		// or `baseUrl` — the cached decisions no longer track the active transport. Evict the
+		// full `(provider, baseUrl)` prefix; same-backend model toggles keep their state.
+		let completionsPrefixToEvict: string | undefined;
+		if (currentModel.api === "openai-completions") {
+			const currentScope = `${currentModel.provider}:${currentModel.baseUrl ?? ""}`;
+			const nextScope =
+				nextModel.api === "openai-completions"
+					? `${nextModel.provider}:${nextModel.baseUrl ?? ""}`
+					: undefined;
+			if (currentScope !== nextScope) {
+				completionsPrefixToEvict = `openai-completions:${currentScope}:`;
+			}
+		}
+
 		for (const providerKey of providerKeys) {
 			const state = this.#providerSessionState.get(providerKey);
 			if (!state) continue;
@@ -9040,6 +9057,21 @@ export class AgentSession {
 			}
 
 			this.#providerSessionState.delete(providerKey);
+		}
+
+		if (completionsPrefixToEvict !== undefined) {
+			for (const [key, state] of this.#providerSessionState) {
+				if (!key.startsWith(completionsPrefixToEvict)) continue;
+				try {
+					state.close();
+				} catch (error) {
+					logger.warn("Failed to close provider session state during model switch", {
+						providerKey: key,
+						error: String(error),
+					});
+				}
+				this.#providerSessionState.delete(key);
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts
@@ -92,7 +92,7 @@ describe("AgentSession openai-completions provider session eviction", () => {
 		expect(session.providerSessionState.has(completionsSessionKey(deepseek))).toBe(false);
 	});
 
-	it("evicts every cached entry under the old (provider, baseUrl) prefix", async () => {
+	it("evicts every cached entry under the old provider prefix", async () => {
 		const deepseekPro = completionsModel("deepseek", "deepseek-v4-pro");
 		const deepseekFlash = completionsModel("deepseek", "deepseek-v4-flash");
 		const cerebras = completionsModel("cerebras", "llama3.1-8b");
@@ -117,6 +117,25 @@ describe("AgentSession openai-completions provider session eviction", () => {
 		expect(flashCloseSpy).toHaveBeenCalledTimes(1);
 		expect(session.providerSessionState.has(completionsSessionKey(deepseekPro))).toBe(false);
 		expect(session.providerSessionState.has(completionsSessionKey(deepseekFlash))).toBe(false);
+	});
+
+	it("evicts entries whose base URL was resolved at request time", async () => {
+		const moonshot = completionsModel("moonshot", "kimi-k2-thinking");
+		const cerebras = completionsModel("cerebras", "llama3.1-8b");
+		authStorage.setRuntimeApiKey(cerebras.provider, "cerebras-test-key");
+
+		session = buildSession(moonshot);
+
+		const closeSpy = vi.fn();
+		const resolvedBaseUrlKey = `openai-completions:${moonshot.provider}:https://api.moonshot.cn/v1:${moonshot.id}`;
+		session.providerSessionState.set(resolvedBaseUrlKey, {
+			close: closeSpy,
+		} satisfies ProviderSessionState);
+
+		await session.setModel(cerebras);
+
+		expect(closeSpy).toHaveBeenCalledTimes(1);
+		expect(session.providerSessionState.has(resolvedBaseUrlKey)).toBe(false);
 	});
 
 	it("leaves unrelated provider session state untouched", async () => {

--- a/packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Model, ProviderSessionState } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+// Regression: `#closeProviderSessionsForModelSwitch` historically only handled
+// the `openai-codex-responses` / `openai-responses` keys and left
+// `openai-completions:<provider>:<baseUrl>:<modelId>` entries behind on a
+// /model switch. The cached strict-tools disable scopes and reasoning-effort
+// fallbacks for the old backend then survived indefinitely — repro reported
+// in #3260 (PR #3236).
+
+describe("AgentSession openai-completions provider session eviction", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-completions-eviction-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+		}
+	});
+
+	function completionsModel(provider: string, id: string): Model {
+		const model = modelRegistry.find(provider, id);
+		if (!model) {
+			throw new Error(`expected bundled openai-completions model ${provider}/${id}`);
+		}
+		if (model.api !== "openai-completions") {
+			throw new Error(`expected ${provider}/${id} to use openai-completions, got ${model.api}`);
+		}
+		return model;
+	}
+
+	function completionsSessionKey(model: Model): string {
+		return `openai-completions:${model.provider}:${model.baseUrl ?? ""}:${model.id}`;
+	}
+
+	function buildSession(model: Model): AgentSession {
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	}
+
+	it("evicts stale openai-completions state on provider/baseUrl switch", async () => {
+		const deepseek = completionsModel("deepseek", "deepseek-v4-pro");
+		const cerebras = completionsModel("cerebras", "llama3.1-8b");
+		authStorage.setRuntimeApiKey(cerebras.provider, "cerebras-test-key");
+
+		session = buildSession(deepseek);
+
+		const oldCloseSpy = vi.fn();
+		session.providerSessionState.set(completionsSessionKey(deepseek), {
+			close: oldCloseSpy,
+		} satisfies ProviderSessionState);
+
+		await session.setModel(cerebras);
+
+		expect(session.model?.provider).toBe(cerebras.provider);
+		expect(session.model?.id).toBe(cerebras.id);
+		expect(oldCloseSpy).toHaveBeenCalledTimes(1);
+		expect(session.providerSessionState.has(completionsSessionKey(deepseek))).toBe(false);
+	});
+
+	it("evicts every cached entry under the old (provider, baseUrl) prefix", async () => {
+		const deepseekPro = completionsModel("deepseek", "deepseek-v4-pro");
+		const deepseekFlash = completionsModel("deepseek", "deepseek-v4-flash");
+		const cerebras = completionsModel("cerebras", "llama3.1-8b");
+		authStorage.setRuntimeApiKey(cerebras.provider, "cerebras-test-key");
+
+		session = buildSession(deepseekPro);
+
+		const proCloseSpy = vi.fn();
+		const flashCloseSpy = vi.fn();
+		session.providerSessionState.set(completionsSessionKey(deepseekPro), {
+			close: proCloseSpy,
+		} satisfies ProviderSessionState);
+		// A sibling model on the same backend — set up earlier in the session but
+		// not currently active. Same `(provider, baseUrl)` prefix; must also go.
+		session.providerSessionState.set(completionsSessionKey(deepseekFlash), {
+			close: flashCloseSpy,
+		} satisfies ProviderSessionState);
+
+		await session.setModel(cerebras);
+
+		expect(proCloseSpy).toHaveBeenCalledTimes(1);
+		expect(flashCloseSpy).toHaveBeenCalledTimes(1);
+		expect(session.providerSessionState.has(completionsSessionKey(deepseekPro))).toBe(false);
+		expect(session.providerSessionState.has(completionsSessionKey(deepseekFlash))).toBe(false);
+	});
+
+	it("leaves unrelated provider session state untouched", async () => {
+		const deepseek = completionsModel("deepseek", "deepseek-v4-pro");
+		const cerebras = completionsModel("cerebras", "llama3.1-8b");
+		authStorage.setRuntimeApiKey(cerebras.provider, "cerebras-test-key");
+
+		session = buildSession(deepseek);
+
+		const oldCloseSpy = vi.fn();
+		const unrelatedCloseSpy = vi.fn();
+		const unrelatedKey = "openai-completions:other-provider:https://other.example/v1:other-model";
+		session.providerSessionState.set(completionsSessionKey(deepseek), {
+			close: oldCloseSpy,
+		} satisfies ProviderSessionState);
+		session.providerSessionState.set(unrelatedKey, {
+			close: unrelatedCloseSpy,
+		} satisfies ProviderSessionState);
+
+		await session.setModel(cerebras);
+
+		expect(oldCloseSpy).toHaveBeenCalledTimes(1);
+		expect(unrelatedCloseSpy).not.toHaveBeenCalled();
+		expect(session.providerSessionState.has(unrelatedKey)).toBe(true);
+	});
+
+	it("keeps cached state when switching models on the same (provider, baseUrl)", async () => {
+		const deepseekPro = completionsModel("deepseek", "deepseek-v4-pro");
+		const deepseekFlash = completionsModel("deepseek", "deepseek-v4-flash");
+		expect(deepseekPro.provider).toBe(deepseekFlash.provider);
+		expect(deepseekPro.baseUrl).toBe(deepseekFlash.baseUrl);
+
+		session = buildSession(deepseekPro);
+
+		const proCloseSpy = vi.fn();
+		session.providerSessionState.set(completionsSessionKey(deepseekPro), {
+			close: proCloseSpy,
+		} satisfies ProviderSessionState);
+
+		await session.setModel(deepseekFlash);
+
+		expect(session.model?.id).toBe(deepseekFlash.id);
+		expect(proCloseSpy).not.toHaveBeenCalled();
+		expect(session.providerSessionState.has(completionsSessionKey(deepseekPro))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro

Use an `openai-completions` provider (e.g. a local proxy aggregating multiple upstreams) and `/model` switch to a model on a *different* `(provider, baseUrl)`. The previous model's cached `ProviderSessionState` — strict-tools disable scope and reasoning-effort fallbacks bound to the old transport — stays in the session map. Toggling back to the old backend (or pushing enough traffic across switches) replays those stale decisions against a transport they were never inferred from. Reporter saw empty completions; the underlying leak is unconditional on every cross-backend switch.

Verifying repro in unit form: `bun --cwd packages/coding-agent test test/agent-session-openai-completions-model-switch.test.ts` against `main` fails on 3/4 cases (the same-backend toggle is a no-op either way). With the fix applied, 4/4 pass.

## Cause

`AgentSession.#closeProviderSessionsForModelSwitch` (`packages/coding-agent/src/session/agent-session.ts:9017`) only synthesizes provider keys for `openai-codex-responses` (global key) and `openai-responses:<provider>`. The `openai-completions` provider keys its session state at `openai-completions:<provider>:<baseUrl>:<modelId>` (`packages/ai/src/providers/openai-completions.ts:497`) and was never on the eviction list, so those entries leaked across `/model` switches.

## Fix

- Extend `#closeProviderSessionsForModelSwitch` to compute the current model's `(provider, baseUrl)` scope when `currentModel.api === "openai-completions"`. If the next model's scope differs (different api, provider, or baseUrl), evict every cached entry whose key starts with `openai-completions:<oldProvider>:<oldBaseUrl>:`.
- Same-backend toggles (only `modelId` changes within one `(provider, baseUrl)`) keep their cached state — matches the existing codex/responses semantics for `#closeProviderSessionsForModelSwitch(current, current)` no-op behavior.
- New `packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts` covers four contracts: stale eviction on provider switch, prefix-wide eviction across multiple cached models on the old backend, unrelated entries survive, same-backend toggles keep state.
- CHANGELOG entry under `[Unreleased]` → `### Fixed`.

## Verification

`bun --cwd packages/coding-agent test test/agent-session-openai-completions-model-switch.test.ts test/agent-session-context-promotion.test.ts test/agent-session-fresh.test.ts test/agent-session-openai-responses-replay.test.ts test/agent-session-retry-fallback.test.ts` → 52 pass / 0 fail (300 assertions).

Credit to @hathawayANdRX105 for the original diagnosis and PR #3236.

Fixes #3260