### PR TITLE
perf(coding-agent): cache grouped search results for skip pagination

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
+### Fixed
+
+- Fixed paginated plain-filesystem `search` calls with `skip` rerunning the same native grep work for each page; later pages now reuse a short-lived per-session grouped result cache until the query changes, expires, or the session mutates files ([#3263](https://github.com/can1357/oh-my-pi/pull/3263) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.0.6] - 2026-07-20
 
@@ -1696,7 +1699,6 @@
 - Fixed configured model discovery caches to refresh when `models.yml`/`models.json` is newer than the cached row, so updated local model metadata is not shadowed by fresh `models.db` entries. ([#3242](https://github.com/can1357/oh-my-pi/issues/3242))
 - Fixed hide-secrets handling so advisor session updates are redacted before the advisor model sees them and opaque assistant thinking blocks are no longer deobfuscated.
 - Filtered alias definitions brush's whitespace-only expander cannot execute (`(`, `)`, `|`, `&`, `;`, `<`, `>`, `` ` ``) from the bash-tool shell snapshot, so user rc-files containing compound aliases like Fedora's default `which='(alias; declare -f) | /usr/bin/which …'` no longer poison the brush session with `error: command not found: (alias;` ([#3234](https://github.com/can1357/oh-my-pi/issues/3234)).
-
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -163,9 +163,10 @@ export class HashlineFilesystem extends Filesystem {
 				this.session.cwd,
 				[{ filePath: absolutePath, type: FileChangeType.Deleted }],
 				this.#signal,
+				this.session,
 			);
 		}
-		invalidateFsScanAfterWrite(absolutePath);
+		invalidateFsScanAfterWrite(absolutePath, this.session);
 	}
 
 	async move(fromRelative: string, toRelative: string, content?: string): Promise<void> {
@@ -186,10 +187,11 @@ export class HashlineFilesystem extends Filesystem {
 					{ filePath: toAbsolute, type: FileChangeType.Created },
 				],
 				this.#signal,
+				this.session,
 			);
 		}
-		invalidateFsScanAfterWrite(fromAbsolute);
-		invalidateFsScanAfterWrite(toAbsolute);
+		invalidateFsScanAfterWrite(fromAbsolute, this.session);
+		invalidateFsScanAfterWrite(toAbsolute, this.session);
 	}
 
 	async writeText(relativePath: string, content: string): Promise<WriteResult> {
@@ -211,7 +213,7 @@ export class HashlineFilesystem extends Filesystem {
 			this.#batchRequest,
 			dst => (dst === absolutePath ? this.#beginDeferredDiagnosticsForPath(absolutePath) : undefined),
 		);
-		invalidateFsScanAfterWrite(absolutePath);
+		invalidateFsScanAfterWrite(absolutePath, this.session);
 		this.#diagnosticsByPath.set(relativePath, diagnostics);
 		return { text: finalContent };
 	}

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -113,6 +113,7 @@ function createEditWritethrough(session: ToolSession): WritethroughCallback {
 				transformDiagnostics: dedup
 					? (path, result) => getDiagnosticsLedger(session).reduce(path, result)
 					: undefined,
+				owner: session,
 			})
 		: writethroughNoop;
 }

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -1759,6 +1759,7 @@ class LspFileSystem implements FileSystem {
 				this.session.cwd,
 				[{ filePath: path, type: FileChangeType.Deleted }],
 				this.signal,
+				this.session,
 			);
 		}
 	}
@@ -1881,11 +1882,11 @@ export async function executePatchSingle(
 	}
 
 	if (resolvedRename) {
-		invalidateFsScanAfterRename(resolvedPath, resolvedRename);
+		invalidateFsScanAfterRename(resolvedPath, resolvedRename, session);
 	} else if (result.change.type === "delete") {
-		invalidateFsScanAfterDelete(resolvedPath);
+		invalidateFsScanAfterDelete(resolvedPath, session);
 	} else {
-		invalidateFsScanAfterWrite(resolvedPath);
+		invalidateFsScanAfterWrite(resolvedPath, session);
 	}
 	const effectiveRename = result.change.newPath ? rename : undefined;
 

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -1109,7 +1109,7 @@ export async function executeReplaceSingle(
 		diagnostics = await writethrough(absolutePath, finalContent, signal, Bun.file(absolutePath), batchRequest, dst =>
 			dst === absolutePath ? beginDeferredDiagnosticsForPath(absolutePath) : undefined,
 		);
-		invalidateFsScanAfterWrite(absolutePath);
+		invalidateFsScanAfterWrite(absolutePath, session);
 	}
 
 	const diffResult = generateDiffString(normalizedContent, result.content, undefined, { path });

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -102,6 +102,14 @@ export interface CustomToolContext {
 	localProtocolOptions?: LocalProtocolOptions;
 	/** Whether to auto-approve all destructive tool operations (--auto-approve CLI flag) */
 	autoApprove?: boolean;
+	/**
+	 * Invalidate filesystem-derived caches (native scan cache + the owning
+	 * session's cached grouped search pages) for a file this tool wrote.
+	 * Write-capable custom tools MUST call this for every workspace file they
+	 * create or overwrite; read-only tools never call it, so their execution
+	 * cannot evict cached search pagination.
+	 */
+	invalidateFileCaches?: (path: string) => void;
 }
 
 /** Session event passed to onSession callback */

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { isEnoent, logger, postmortem, ptree, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../jsonrpc/message-framing";
+import { clearSearchResultCache, type SearchResultCacheOwner } from "../tools/search-result-cache";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
@@ -437,6 +438,35 @@ async function handleConfigurationRequest(client: LspClient, message: LspJsonRpc
 }
 
 /**
+ * Register a session-scoped search cache owner on a client. Clients are
+ * process-global and typically outlive sessions, so owners are held through
+ * deduplicated WeakRefs; dead refs are pruned on every registration.
+ */
+export function registerSearchCacheOwner(client: LspClient, owner: SearchResultCacheOwner): void {
+	const refs = client.searchCacheOwners ?? new Set<WeakRef<SearchResultCacheOwner>>();
+	client.searchCacheOwners = refs;
+	for (const ref of refs) {
+		const held = ref.deref();
+		if (!held) refs.delete(ref);
+		else if (held === owner) return;
+	}
+	refs.add(new WeakRef(owner));
+}
+
+/**
+ * Clear every live registered owner's search cache and prune refs whose
+ * sessions have been collected. Used whenever the server may have mutated the
+ * workspace, including partially failed `workspace/applyEdit` applications.
+ */
+export function invalidateRegisteredSearchCaches(client: LspClient): void {
+	for (const ref of client.searchCacheOwners ?? []) {
+		const owner = ref.deref();
+		if (owner) clearSearchResultCache(owner);
+		else client.searchCacheOwners?.delete(ref);
+	}
+}
+
+/**
  * Handle workspace/applyEdit requests from the server.
  */
 async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
@@ -451,11 +481,20 @@ async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequ
 		return;
 	}
 
+	let failure: string | undefined;
 	try {
 		await applyWorkspaceEdit(params.edit, client.cwd);
-		await sendResponse(client, message.id, { applied: true }, "workspace/applyEdit");
 	} catch (err) {
-		await sendResponse(client, message.id, { applied: false, failureReason: String(err) }, "workspace/applyEdit");
+		failure = String(err);
+	}
+	// Invalidate BEFORE acknowledging: the server may have mutated the
+	// workspace even when a later operation failed mid-apply, and anything
+	// sequenced after the response must not observe stale cached pages.
+	invalidateRegisteredSearchCaches(client);
+	if (failure === undefined) {
+		await sendResponse(client, message.id, { applied: true }, "workspace/applyEdit");
+	} else {
+		await sendResponse(client, message.id, { applied: false, failureReason: failure }, "workspace/applyEdit");
 	}
 }
 
@@ -752,6 +791,7 @@ export async function getOrCreateClient(
 			activeProgressTokens: new Set(),
 			projectLoaded,
 			resolveProjectLoaded,
+			searchCacheOwners: new Set(),
 		};
 
 		// Register crash recovery - remove client on process exit
@@ -1044,6 +1084,7 @@ export async function notifyWorkspaceWatchedFiles(
 	cwd: string,
 	changes: readonly WatchedFileChange[],
 	signal?: AbortSignal,
+	owner?: SearchResultCacheOwner,
 ): Promise<void> {
 	throwIfAborted(signal);
 	if (changes.length === 0) return;
@@ -1053,6 +1094,12 @@ export async function notifyWorkspaceWatchedFiles(
 		client => client.status === "ready" && path.resolve(client.cwd) === workspace,
 	);
 	if (activeClients.length === 0) return;
+	if (owner) {
+		// A client reached only through write notifications can still push a
+		// later server-initiated workspace/applyEdit; register the session so
+		// that edit can invalidate its cached search pages.
+		for (const client of activeClients) registerSearchCacheOwner(client, owner);
+	}
 
 	const timeoutSignal = AbortSignal.timeout(WATCHED_FILES_NOTIFY_TIMEOUT_MS);
 	const sendSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;

--- a/packages/coding-agent/src/lsp/edits.ts
+++ b/packages/coding-agent/src/lsp/edits.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { formatPathRelativeToCwd } from "../tools/path-utils";
+import { clearSearchResultCache, type SearchResultCacheOwner } from "../tools/search-result-cache";
 import { ToolError } from "../tools/tool-errors";
 import type {
 	CreateFile,
@@ -238,50 +239,63 @@ function planDocumentChanges(documentChanges: NonNullable<WorkspaceEdit["documen
  * Apply a workspace edit (collection of file changes).
  * All text-edit batches are overlap-validated before anything is written so a
  * conflict throws without leaving the workspace half-applied.
+ * When `cacheOwner` is given, its cached grouped search pages are invalidated
+ * whenever any operation mutated the workspace — including a partial apply
+ * where a later operation throws.
  * Returns array of applied change descriptions.
  */
-export async function applyWorkspaceEdit(edit: WorkspaceEdit, cwd: string): Promise<string[]> {
+export async function applyWorkspaceEdit(
+	edit: WorkspaceEdit,
+	cwd: string,
+	cacheOwner?: SearchResultCacheOwner,
+): Promise<string[]> {
 	const applied: string[] = [];
 
-	if (edit.documentChanges) {
-		const ops = planDocumentChanges(edit.documentChanges);
-		for (const op of ops) {
-			if (op.kind === "text") sortAndValidateTextEdits(op.edits);
-		}
-		for (const op of ops) {
-			if (op.kind === "text") {
-				const filePath = uriToFile(op.uri);
-				await applyTextEdits(filePath, op.edits);
-				applied.push(`Applied ${op.edits.length} edit(s) to ${formatPathRelativeToCwd(filePath, cwd)}`);
-			} else if (op.kind === "create") {
-				const filePath = uriToFile(op.uri);
-				await Bun.write(filePath, "");
-				applied.push(`Created ${formatPathRelativeToCwd(filePath, cwd)}`);
-			} else if (op.kind === "rename") {
-				const oldPath = uriToFile(op.oldUri);
-				const newPath = uriToFile(op.newUri);
-				await fs.mkdir(path.dirname(newPath), { recursive: true });
-				await fs.rename(oldPath, newPath);
-				applied.push(`Renamed ${formatPathRelativeToCwd(oldPath, cwd)} → ${formatPathRelativeToCwd(newPath, cwd)}`);
-			} else {
-				const filePath = uriToFile(op.uri);
-				await fs.rm(filePath, { recursive: true });
-				applied.push(`Deleted ${formatPathRelativeToCwd(filePath, cwd)}`);
+	try {
+		if (edit.documentChanges) {
+			const ops = planDocumentChanges(edit.documentChanges);
+			for (const op of ops) {
+				if (op.kind === "text") sortAndValidateTextEdits(op.edits);
+			}
+			for (const op of ops) {
+				if (op.kind === "text") {
+					const filePath = uriToFile(op.uri);
+					await applyTextEdits(filePath, op.edits);
+					applied.push(`Applied ${op.edits.length} edit(s) to ${formatPathRelativeToCwd(filePath, cwd)}`);
+				} else if (op.kind === "create") {
+					const filePath = uriToFile(op.uri);
+					await Bun.write(filePath, "");
+					applied.push(`Created ${formatPathRelativeToCwd(filePath, cwd)}`);
+				} else if (op.kind === "rename") {
+					const oldPath = uriToFile(op.oldUri);
+					const newPath = uriToFile(op.newUri);
+					await fs.mkdir(path.dirname(newPath), { recursive: true });
+					await fs.rename(oldPath, newPath);
+					applied.push(
+						`Renamed ${formatPathRelativeToCwd(oldPath, cwd)} → ${formatPathRelativeToCwd(newPath, cwd)}`,
+					);
+				} else {
+					const filePath = uriToFile(op.uri);
+					await fs.rm(filePath, { recursive: true });
+					applied.push(`Deleted ${formatPathRelativeToCwd(filePath, cwd)}`);
+				}
+			}
+		} else if (edit.changes) {
+			// Legacy changes-map path: validate every file's edits before writing any.
+			const changes = edit.changes;
+			for (const uri in changes) {
+				sortAndValidateTextEdits(changes[uri]);
+			}
+			for (const uri in changes) {
+				const textEdits = changes[uri];
+				if (textEdits.length === 0) continue;
+				const filePath = uriToFile(uri);
+				await applyTextEdits(filePath, textEdits);
+				applied.push(`Applied ${textEdits.length} edit(s) to ${formatPathRelativeToCwd(filePath, cwd)}`);
 			}
 		}
-	} else if (edit.changes) {
-		// Legacy changes-map path: validate every file's edits before writing any.
-		const changes = edit.changes;
-		for (const uri in changes) {
-			sortAndValidateTextEdits(changes[uri]);
-		}
-		for (const uri in changes) {
-			const textEdits = changes[uri];
-			if (textEdits.length === 0) continue;
-			const filePath = uriToFile(uri);
-			await applyTextEdits(filePath, textEdits);
-			applied.push(`Applied ${textEdits.length} edit(s) to ${formatPathRelativeToCwd(filePath, cwd)}`);
-		}
+	} finally {
+		if (applied.length > 0 && cacheOwner) clearSearchResultCache(cacheOwner);
 	}
 
 	return applied;

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -14,6 +14,7 @@ import lspDescription from "../prompts/tools/lsp.md" with { type: "text" };
 import type { ToolSession } from "../tools";
 import { truncateForPrompt } from "../tools/approval";
 import { formatPathRelativeToCwd, resolveToCwd } from "../tools/path-utils";
+import { clearSearchResultCache, type SearchResultCacheOwner } from "../tools/search-result-cache";
 import { ToolAbortError, ToolError, throwIfAborted } from "../tools/tool-errors";
 import { clampTimeout } from "../tools/tool-timeouts";
 import {
@@ -25,6 +26,7 @@ import {
 	notifySaved,
 	notifyWorkspaceWatchedFiles,
 	refreshFile,
+	registerSearchCacheOwner,
 	sendNotification,
 	sendRequest,
 	setIdleTimeout,
@@ -211,6 +213,7 @@ async function syncFileContent(
 	cwd: string,
 	servers: Array<[string, ServerConfig]>,
 	signal?: AbortSignal,
+	owner?: SearchResultCacheOwner,
 ): Promise<void> {
 	throwIfAborted(signal);
 	await Promise.allSettled(
@@ -220,6 +223,7 @@ async function syncFileContent(
 				return;
 			}
 			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
+			if (owner) registerSearchCacheOwner(client, owner);
 			throwIfAborted(signal);
 			await syncContent(client, absolutePath, content, signal);
 		}),
@@ -239,6 +243,7 @@ async function notifyFileSaved(
 	cwd: string,
 	servers: Array<[string, ServerConfig]>,
 	signal?: AbortSignal,
+	owner?: SearchResultCacheOwner,
 ): Promise<void> {
 	throwIfAborted(signal);
 	await Promise.allSettled(
@@ -248,6 +253,7 @@ async function notifyFileSaved(
 				return;
 			}
 			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
+			if (owner) registerSearchCacheOwner(client, owner);
 			await notifySaved(client, absolutePath, signal);
 		}),
 	);
@@ -1042,6 +1048,14 @@ export interface WritethroughOptions {
 	deferredSignal?: AbortSignal;
 	/** Transform diagnostics before surfacing them after a successful fetch. */
 	transformDiagnostics?: (absPath: string, result: FileDiagnosticsResult) => FileDiagnosticsResult;
+	/**
+	 * Session-scoped search cache to register on every LSP client the
+	 * writethrough touches, so later server-initiated workspace edits can
+	 * invalidate it. Accepts a WeakRef directly so callers (and tests) can
+	 * share an existing ref; held weakly throughout — a pending batch in the
+	 * process-global batch map must never extend a session's lifetime.
+	 */
+	owner?: SearchResultCacheOwner | WeakRef<SearchResultCacheOwner>;
 }
 
 /** Internal resolved form of {@link WritethroughOptions} that the writethrough machinery operates on. */
@@ -1049,6 +1063,7 @@ type ResolvedWritethroughOptions = {
 	enableFormat: boolean;
 	enableDiagnostics: boolean;
 	transformDiagnostics?: (absPath: string, result: FileDiagnosticsResult) => FileDiagnosticsResult;
+	owner?: WeakRef<SearchResultCacheOwner>;
 };
 
 /** Per-file deferred LSP diagnostics wiring for {@link WritethroughCallback}. */
@@ -1110,6 +1125,9 @@ function getOrCreateWritethroughBatch(id: string, options: ResolvedWritethroughO
 		existing.options.enableFormat ||= options.enableFormat;
 		existing.options.enableDiagnostics ||= options.enableDiagnostics;
 		existing.options.transformDiagnostics ??= options.transformDiagnostics;
+		// Prefer a LIVE owner: a dead ref left by a collected session must not
+		// shadow the session that is actually continuing this batch.
+		if (!existing.options.owner?.deref()) existing.options.owner = options.owner;
 		return existing;
 	}
 	const batch: LspWritethroughBatchState = {
@@ -1292,6 +1310,10 @@ async function runLspWritethrough(
 	},
 ): Promise<FileDiagnosticsResult | undefined> {
 	const { enableFormat, enableDiagnostics } = options;
+	// Deref once per write: the batch map holds the owner weakly, so a
+	// collected session simply skips registration without changing write or
+	// diagnostic behavior.
+	const owner = options.owner?.deref();
 
 	let finalContent = content;
 	const writeContent = async (value: string) => (file ? file.write(value) : Bun.write(dst, value));
@@ -1301,7 +1323,7 @@ async function runLspWritethrough(
 		if (writeNotified) return;
 		writeNotified = true;
 		try {
-			await notifyWorkspaceWatchedFiles(cwd, [{ filePath: dst, type: changeType }], notifySignal);
+			await notifyWorkspaceWatchedFiles(cwd, [{ filePath: dst, type: changeType }], notifySignal, owner);
 		} catch (error) {
 			if (notifySignal?.aborted && !signal?.aborted) {
 				// The operation budget died mid-notify while the caller is still
@@ -1359,10 +1381,10 @@ async function runLspWritethrough(
 				formatter = finalContent !== content ? FileFormatResult.FORMATTED : FileFormatResult.UNCHANGED;
 				await writeContent(finalContent);
 				await notifyWriteCommitted(operationSignal);
-				await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal);
+				await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal, owner);
 			} else {
 				// 1. Sync original content to LSP servers
-				await syncFileContent(dst, content, cwd, lspServers, operationSignal);
+				await syncFileContent(dst, content, cwd, lspServers, operationSignal, owner);
 
 				// 2. Format in-memory via LSP
 				if (enableFormat) {
@@ -1372,7 +1394,7 @@ async function runLspWritethrough(
 
 				// 3. If formatted, sync formatted content to LSP servers
 				if (finalContent !== content) {
-					await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal);
+					await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal, owner);
 				}
 
 				// 4. Write to disk
@@ -1385,7 +1407,7 @@ async function runLspWritethrough(
 			}
 
 			// 5. Notify saved to LSP servers
-			await notifyFileSaved(dst, cwd, lspServers, operationSignal);
+			await notifyFileSaved(dst, cwd, lspServers, operationSignal, owner);
 		});
 		synced = true;
 	} catch {
@@ -1475,10 +1497,14 @@ async function flushWritethroughBatch(
 
 /** Create a writethrough callback for LSP aware write operations */
 export function createLspWritethrough(cwd: string, options?: WritethroughOptions): WritethroughCallback {
+	const owner = options?.owner;
 	const resolvedOptions: ResolvedWritethroughOptions = {
 		enableFormat: options?.enableFormat ?? false,
 		enableDiagnostics: options?.enableDiagnostics ?? false,
 		transformDiagnostics: options?.transformDiagnostics,
+		// Hold weakly from here on: pending batches live in a process-global map
+		// and must never pin a session.
+		owner: owner === undefined ? undefined : owner instanceof WeakRef ? owner : new WeakRef(owner),
 	};
 	return async (
 		dst: string,
@@ -1997,6 +2023,10 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				}
 			}
 
+			// Invalidate before the first mutation: a failure after any import
+			// rewrite (or between the rewrites and the on-disk rename) must not
+			// leave stale cached search pages behind.
+			clearSearchResultCache(this.session);
 			for (const [uri, bucket] of acceptedByUri) {
 				const filePath = uriToFile(uri);
 				await applyTextEdits(filePath, bucket.edits);
@@ -2346,6 +2376,10 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 
 		try {
 			const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
+			// Server-initiated workspace/applyEdit (e.g. triggered by
+			// workspace/executeCommand below) must invalidate this session's
+			// cached search pages too.
+			registerSearchCacheOwner(client, this.session);
 			const targetFile = resolvedFile;
 			const isRustAnalyzerServer =
 				serverName === "rust-analyzer" ||
@@ -2589,7 +2623,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const appliedAction = await applyCodeAction(selectedAction, {
 							resolveCodeAction: async actionItem =>
 								(await sendRequest(client, "codeAction/resolve", actionItem, signal)) as CodeAction,
-							applyWorkspaceEdit: async edit => applyWorkspaceEdit(edit, this.session.cwd),
+							applyWorkspaceEdit: async edit => applyWorkspaceEdit(edit, this.session.cwd, this.session),
 							executeCommand: async commandItem => {
 								await sendRequest(
 									client,
@@ -2685,7 +2719,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					} else {
 						const shouldApply = apply !== false;
 						if (shouldApply) {
-							const applied = await applyWorkspaceEdit(result, this.session.cwd);
+							const applied = await applyWorkspaceEdit(result, this.session.cwd, this.session);
 							output = `Applied rename:\n${applied.map(a => `  ${a}`).join("\n")}`;
 						} else {
 							const preview = formatWorkspaceEdit(result, this.session.cwd);

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -1,5 +1,6 @@
 import type { ptree } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import type { SearchResultCacheOwner } from "../tools/search-result-cache";
 import { TOOL_TIMEOUTS } from "../tools/tool-timeouts";
 
 // =============================================================================
@@ -421,6 +422,13 @@ export interface LspClient {
 	projectLoaded: Promise<void>;
 	/** Call to signal that project loading has completed */
 	resolveProjectLoaded: () => void;
+	/**
+	 * Deduplicated weak refs to session-scoped search caches to invalidate when
+	 * the server itself applies a workspace edit (`workspace/applyEdit`).
+	 * Weak so this process-global client never extends a session's lifetime;
+	 * register via `registerSearchCacheOwner`, which prunes dead refs.
+	 */
+	searchCacheOwners?: Set<WeakRef<SearchResultCacheOwner>>;
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -190,11 +190,13 @@ import {
 } from "./tools";
 import { isMCPToolName, normalizeToolNames } from "./tools/builtin-names";
 import { ToolContextStore } from "./tools/context";
+import { invalidateFsScanAfterWrite } from "./tools/fs-cache-invalidation";
 import { isIrcEnabled } from "./tools/hub";
 import { getImageGenTools } from "./tools/image-gen";
 import { wrapToolWithMetaNotice } from "./tools/output-meta";
 import { isAutoQaEnabled } from "./tools/report-tool-issue";
 import { queueResolveHandler } from "./tools/resolve";
+import type { SearchResultCacheOwner } from "./tools/search-result-cache";
 import { ttsTool } from "./tools/tts";
 import { resolveActiveRepoContext } from "./utils/active-repo-context";
 import { EventBus } from "./utils/event-bus";
@@ -853,7 +855,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 
 // Internal Helpers
 
-function createCustomToolContext(ctx: ExtensionContext): CustomToolContext {
+function createCustomToolContext(ctx: ExtensionContext, cacheOwner?: SearchResultCacheOwner): CustomToolContext {
 	return {
 		sessionManager: ctx.sessionManager,
 		modelRegistry: ctx.modelRegistry,
@@ -862,6 +864,10 @@ function createCustomToolContext(ctx: ExtensionContext): CustomToolContext {
 		hasQueuedMessages: ctx.hasPendingMessages,
 		abort: ctx.abort,
 		localProtocolOptions: ctx.localProtocolOptions,
+		// Narrow mutation seam for write-capable custom tools (e.g. tts): clear
+		// the owning session's cached search pages for a written file without
+		// touching read-only custom tool behavior.
+		invalidateFileCaches: cacheOwner ? path => invalidateFsScanAfterWrite(path, cacheOwner) : undefined,
 	};
 }
 
@@ -907,7 +913,7 @@ function registerEvalCleanup(): void {
 	postmortem.register("julia-cleanup", disposeAllJuliaKernelSessions);
 }
 
-function customToolToDefinition(tool: CustomTool): ToolDefinition {
+function customToolToDefinition(tool: CustomTool, cacheOwner?: SearchResultCacheOwner): ToolDefinition {
 	const definition: ToolDefinition & { [TOOL_DEFINITION_MARKER]: true } = {
 		name: tool.name,
 		label: tool.label,
@@ -920,8 +926,10 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>
-			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx), signal),
-		onSession: tool.onSession ? (event, ctx) => tool.onSession?.(event, createCustomToolContext(ctx)) : undefined,
+			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx, cacheOwner), signal),
+		onSession: tool.onSession
+			? (event, ctx) => tool.onSession?.(event, createCustomToolContext(ctx, cacheOwner))
+			: undefined,
 		renderCall: tool.renderCall,
 		renderResult: tool.renderResult
 			? (result, options, theme): Component => {
@@ -939,17 +947,17 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 	return definition;
 }
 
-function createCustomToolsExtension(tools: CustomTool[]): ExtensionFactory {
+function createCustomToolsExtension(tools: CustomTool[], cacheOwner?: SearchResultCacheOwner): ExtensionFactory {
 	return api => {
 		for (const tool of tools) {
-			api.registerTool(customToolToDefinition(tool));
+			api.registerTool(customToolToDefinition(tool, cacheOwner));
 		}
 
 		const runOnSession = async (event: CustomToolSessionEvent, ctx: ExtensionContext) => {
 			for (const tool of tools) {
 				if (!tool.onSession) continue;
 				try {
-					await tool.onSession(event, createCustomToolContext(ctx));
+					await tool.onSession(event, createCustomToolContext(ctx, cacheOwner));
 				} catch (err) {
 					logger.warn("Custom tool onSession error", { tool: tool.name, error: String(err) });
 				}
@@ -1931,7 +1939,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			inlineExtensions.push(...(options.extensions ?? []));
 			inlineExtensions.push(createAutoresearchExtension);
 			if (customTools.length > 0) {
-				inlineExtensions.push(createCustomToolsExtension(customTools));
+				inlineExtensions.push(createCustomToolsExtension(customTools, toolSession));
 			}
 		}
 		// Forward the path list (NOT the loaded tools) to subagents so they
@@ -2342,6 +2350,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings,
 			localProtocolOptions,
 			autoApprove: options.autoApprove ?? false,
+			// Same owning session as the built-in tools: write-capable custom
+			// tools resolved through the context store must be able to drop the
+			// session's cached search pages after mutating the workspace.
+			invalidateFileCaches: (writtenPath: string) => invalidateFsScanAfterWrite(writtenPath, toolSession),
 		});
 		const toolContextStore = new ToolContextStore(getSessionContext);
 
@@ -2352,7 +2364,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const allCustomTools = [
 			...registeredTools,
 			...sdkCustomTools.map(tool => {
-				const definition = isCustomTool(tool) ? customToolToDefinition(tool) : tool;
+				const definition = isCustomTool(tool) ? customToolToDefinition(tool, toolSession) : tool;
 				return { definition, extensionPath: "<sdk>" };
 			}),
 		];

--- a/packages/coding-agent/src/tools/acp-bridge.ts
+++ b/packages/coding-agent/src/tools/acp-bridge.ts
@@ -73,9 +73,9 @@ export async function routeWriteThroughBridge(
 		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}
 	if (session.enableLsp ?? true) {
-		await notifyWorkspaceWatchedFiles(session.cwd, [{ filePath: absolutePath, type: changeType }], signal);
+		await notifyWorkspaceWatchedFiles(session.cwd, [{ filePath: absolutePath, type: changeType }], signal, session);
 	}
-	invalidateFsScanAfterWrite(absolutePath);
+	invalidateFsScanAfterWrite(absolutePath, session);
 	session.bumpFileMutationVersion?.(absolutePath);
 	return true;
 }

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -33,6 +33,7 @@ import {
 	PREVIEW_LIMITS,
 } from "./render-utils";
 import { queueResolveHandler } from "./resolve";
+import { clearSearchResultCache } from "./search-result-cache";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 
@@ -437,12 +438,21 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 					label: `AST Edit: ${result.totalReplacements} replacement${previewReplacementPlural} in ${result.filesTouched} file${previewFilePlural}`,
 					sourceToolName: this.name,
 					apply: async (_reason: string) => {
-						const applyResult = await runAstEditOnce(multiTargets, resolvedSearchPath, globFilter, {
-							rewrites: normalizedRewrites,
-							dryRun: false,
-							maxFiles,
-							failOnParseError: false,
-						});
+						let applyResult: AstEditAggregatedResult;
+						try {
+							applyResult = await runAstEditOnce(multiTargets, resolvedSearchPath, globFilter, {
+								rewrites: normalizedRewrites,
+								dryRun: false,
+								maxFiles,
+								failOnParseError: false,
+							});
+						} finally {
+							// The rewrite may have touched files even when a later target
+							// throws (targets apply sequentially) or when the preview went
+							// stale, so cached search pages are conservatively dropped on
+							// every apply attempt — full, partial, or failed.
+							clearSearchResultCache(this.session);
+						}
 						const { errors: cappedApplyParseErrors, total: applyParseErrorsTotal } = capParseErrors(
 							applyResult.parseErrors,
 						);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -16,7 +16,11 @@ import { InternalUrlRouter } from "../internal-urls";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { highlightCode, type Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
-import type { ClientBridgeTerminalExitStatus, ClientBridgeTerminalOutput } from "../session/client-bridge";
+import type {
+	ClientBridgeTerminalExitStatus,
+	ClientBridgeTerminalHandle,
+	ClientBridgeTerminalOutput,
+} from "../session/client-bridge";
 import { DEFAULT_MAX_BYTES, enforceInlineByteCap, streamTailUpdates, TailBuffer } from "../session/streaming-output";
 import { renderStatusLine } from "../tui";
 import { CachedOutputBlock, markFramedBlockComponent, outputBlockContentWidth } from "../tui/output-block";
@@ -43,6 +47,7 @@ import {
 	previewWindowRows,
 	replaceTabs,
 } from "./render-utils";
+import { clearSearchResultCache, suppressSearchResultCaches } from "./search-result-cache";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -617,6 +622,10 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		let latestText = "";
 		let forwardUpdates = options.forwardUpdates;
 		const completion = Promise.withResolvers<ManagedBashJobCompletion>();
+		// A background command can mutate files at any point in its lifetime, so
+		// completion-only invalidation leaves a stale window: drop cached pages at
+		// launch and hold the cache closed until the command itself settles.
+		clearSearchResultCache(this.session);
 
 		const jobId = manager.register(
 			"bash",
@@ -626,21 +635,30 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES);
 				const wallTimeStart = performance.now();
 				try {
-					const result = await executeBash(options.command, {
-						cwd: options.commandCwd,
-						sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
-						timeout: options.timeoutMs ?? 0,
-						signal: runSignal,
-						env: options.resolvedEnv,
-						artifactPath,
-						artifactId,
-						onChunk: chunk => {
-							tailBuffer.append(chunk);
-							latestText = tailBuffer.text();
-							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
-						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
-					});
+					let result: BashResult;
+					// Suppress the session's own workspace AND the job's effective
+					// working directory (a `cwd` override may target a different
+					// workspace whose sibling sessions must not serve stale pages).
+					const releaseSearchCache = suppressSearchResultCaches(this.session, options.commandCwd);
+					try {
+						result = await executeBash(options.command, {
+							cwd: options.commandCwd,
+							sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
+							timeout: options.timeoutMs ?? 0,
+							signal: runSignal,
+							env: options.resolvedEnv,
+							artifactPath,
+							artifactId,
+							onChunk: chunk => {
+								tailBuffer.append(chunk);
+								latestText = tailBuffer.text();
+								void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
+							},
+							onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						});
+					} finally {
+						releaseSearchCache();
+					}
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -927,48 +945,59 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
 			const bridgeWallTimeStart = performance.now();
 			const shellSpawn = wrapShellLineForClientTerminal(command, this.session.settings.getShellConfig());
-			const handle = await clientBridge.createTerminal({
-				command: shellSpawn.command,
-				args: shellSpawn.args,
-				cwd: commandCwd,
-				env: resolvedEnv
-					? Object.entries(resolvedEnv).map(([name, value]) => ({ name, value: value as string }))
-					: undefined,
-				outputByteLimit: DEFAULT_MAX_BYTES,
-			});
-
-			// Emit partial update so the editor can embed the live terminal card.
-			onUpdate?.({ content: [], details: { terminalId: handle.terminalId } });
-
-			const exitPromise = handle.waitForExit();
-			let exitStatus!: ClientBridgeTerminalExitStatus;
-
-			type BridgeRaceResult =
-				| { kind: "exit"; status: ClientBridgeTerminalExitStatus }
-				| { kind: "poll" }
-				| { kind: "timeout" }
-				| { kind: "aborted" };
-
-			// Set up abort listener before entering the poll loop. The listener
-			// kicks off `handle.kill()` synchronously so a `session/cancel`
-			// arriving mid-poll terminates the remote command immediately,
-			// instead of waiting for the next `currentOutput()` to return.
-			const { promise: abortedP, resolve: resolveAborted } = Promise.withResolvers<void>();
-			let killStarted = false;
-			const fireKill = (): Promise<void> => {
-				if (killStarted) return Promise.resolve();
-				killStarted = true;
-				return handle.kill().catch((error: unknown) => {
-					logger.warn("ACP terminal kill failed", { terminalId: handle.terminalId, error });
-				});
-			};
-			const onAbortSignal = () => {
-				resolveAborted();
-				void fireKill();
-			};
-			signal?.addEventListener("abort", onAbortSignal, { once: true });
-
+			// The remote command can mutate the workspace(s) for its whole run:
+			// hold the session's and the effective command cwd's caches closed
+			// until it settles (release is idempotent, called exactly once in the
+			// outer finally, which also covers createTerminal itself rejecting).
+			const releaseSearchCache = suppressSearchResultCaches(this.session, commandCwd);
+			let handle: ClientBridgeTerminalHandle | undefined;
+			let observedExit = false;
+			let killPromise: Promise<void> | undefined;
 			try {
+				handle = await clientBridge.createTerminal({
+					command: shellSpawn.command,
+					args: shellSpawn.args,
+					cwd: commandCwd,
+					env: resolvedEnv
+						? Object.entries(resolvedEnv).map(([name, value]) => ({ name, value: value as string }))
+						: undefined,
+					outputByteLimit: DEFAULT_MAX_BYTES,
+				});
+				const terminal = handle;
+
+				// Emit partial update so the editor can embed the live terminal card.
+				onUpdate?.({ content: [], details: { terminalId: terminal.terminalId } });
+
+				const exitPromise = terminal.waitForExit();
+				let exitStatus!: ClientBridgeTerminalExitStatus;
+
+				type BridgeRaceResult =
+					| { kind: "exit"; status: ClientBridgeTerminalExitStatus }
+					| { kind: "poll" }
+					| { kind: "timeout" }
+					| { kind: "aborted" };
+
+				// Set up abort listener before entering the poll loop. The listener
+				// kicks off `handle.kill()` synchronously so a `session/cancel`
+				// arriving mid-poll terminates the remote command immediately,
+				// instead of waiting for the next `currentOutput()` to return.
+				const { promise: abortedP, resolve: resolveAborted } = Promise.withResolvers<void>();
+				const fireKill = (): Promise<void> => {
+					// Memoize the in-flight kill so EVERY caller (abort listener,
+					// abort/timeout branches, outer finally) awaits the same RPC —
+					// a boolean guard would let a later await return early and race
+					// suppression release against a kill still in flight.
+					killPromise ??= terminal.kill().catch((error: unknown) => {
+						logger.warn("ACP terminal kill failed", { terminalId: terminal.terminalId, error });
+					});
+					return killPromise;
+				};
+				const onAbortSignal = () => {
+					resolveAborted();
+					void fireKill();
+				};
+				signal?.addEventListener("abort", onAbortSignal, { once: true });
+
 				try {
 					if (signal?.aborted) {
 						await fireKill();
@@ -1003,10 +1032,10 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 							await fireKill();
 							let current = { output: "", truncated: false };
 							try {
-								current = await handle.currentOutput();
+								current = await terminal.currentOutput();
 							} catch (error) {
 								logger.warn("ACP terminal final output read failed", {
-									terminalId: handle.terminalId,
+									terminalId: terminal.terminalId,
 									error,
 								});
 							}
@@ -1027,6 +1056,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 
 						if (raced.kind === "exit") {
 							exitStatus = raced.status;
+							observedExit = true;
 							break;
 						}
 
@@ -1034,7 +1064,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 						// Race the read against abort so a stuck `terminal/output` RPC does not
 						// delay cancellation.
 						const pollOutput = await Promise.race([
-							handle.currentOutput(),
+							terminal.currentOutput(),
 							abortedP.then(() => undefined as ClientBridgeTerminalOutput | undefined),
 						]);
 						if (pollOutput === undefined) {
@@ -1044,7 +1074,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 						}
 						onUpdate?.({
 							content: [{ type: "text", text: pollOutput.output }],
-							details: { terminalId: handle.terminalId },
+							details: { terminalId: terminal.terminalId },
 						});
 					}
 				} finally {
@@ -1052,7 +1082,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				}
 
 				// Fetch final output; the terminal is released in the outer finally.
-				const finalOutput = await handle.currentOutput();
+				const finalOutput = await terminal.currentOutput();
 
 				// Map exit status: null exitCode with a signal → treat as signal kill (137).
 				const rawExitCode = exitStatus.exitCode;
@@ -1081,14 +1111,33 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				return this.#buildCompletedResult(bridgeResult, timeoutSec, {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
-					terminalId: handle.terminalId,
+					terminalId: terminal.terminalId,
 					wallTimeMs: performance.now() - bridgeWallTimeStart,
 				});
 			} finally {
 				try {
-					await handle.release();
-				} catch (error) {
-					logger.warn("ACP terminal release failed", { terminalId: handle.terminalId, error });
+					if (handle && !observedExit) {
+						// Exceptional pre-exit path (e.g. waitForExit/currentOutput
+						// transport error): the remote process may still be mutating.
+						// Kill (or join the in-flight kill) and await its settlement
+						// BEFORE reopening caches.
+						const terminal = handle;
+						killPromise ??= terminal.kill().catch((error: unknown) => {
+							logger.warn("ACP terminal kill failed", { terminalId: terminal.terminalId, error });
+						});
+					}
+					if (killPromise) await killPromise;
+				} finally {
+					releaseSearchCache();
+					clearSearchResultCache(this.session);
+					if (commandCwd !== this.session.cwd) clearSearchResultCache({ cwd: commandCwd });
+					if (handle) {
+						try {
+							await handle.release();
+						} catch (error) {
+							logger.warn("ACP terminal release failed", { terminalId: handle.terminalId, error });
+						}
+					}
 				}
 			}
 		}
@@ -1104,27 +1153,39 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			pendingNotices.push("pty requested but unavailable in this environment; ran without a terminal");
 		}
 		const wallTimeStart = performance.now();
-		const result: BashResult | BashInteractiveResult = interactiveUi
-			? await runInteractiveBashPty(interactiveUi, {
-					command,
-					cwd: commandCwd,
-					timeoutMs,
-					signal,
-					env: resolvedEnv,
-					artifactPath,
-					artifactId,
-				})
-			: await executeBash(command, {
-					cwd: commandCwd,
-					sessionKey: this.session.getSessionId?.() ?? undefined,
-					timeout: timeoutMs ?? 0,
-					signal,
-					env: resolvedEnv,
-					artifactPath,
-					artifactId,
-					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
-				});
+		let result: BashResult | BashInteractiveResult;
+		// Foreground direct/PTY execution mutates during the whole run; hold the
+		// shared caches closed for the window instead of clearing only at settle.
+		const releaseSearchCache = suppressSearchResultCaches(this.session, commandCwd);
+		try {
+			result = interactiveUi
+				? await runInteractiveBashPty(interactiveUi, {
+						command,
+						cwd: commandCwd,
+						timeoutMs,
+						signal,
+						env: resolvedEnv,
+						artifactPath,
+						artifactId,
+					})
+				: await executeBash(command, {
+						cwd: commandCwd,
+						sessionKey: this.session.getSessionId?.() ?? undefined,
+						timeout: timeoutMs ?? 0,
+						signal,
+						env: resolvedEnv,
+						artifactPath,
+						artifactId,
+						onChunk: streamTailUpdates(tailBuffer, onUpdate),
+						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+					});
+		} finally {
+			releaseSearchCache();
+			clearSearchResultCache(this.session);
+			// A `cwd` override mutates a different workspace; its sibling
+			// sessions' cached pages are stale too.
+			if (commandCwd !== this.session.cwd) clearSearchResultCache({ cwd: commandCwd });
+		}
 		const wallTimeMs = performance.now() - wallTimeStart;
 		if (result.cancelled) {
 			// A cancelled result is either a timeout (the command's deadline fired)

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -18,6 +18,7 @@ import { truncateForPrompt } from "./approval";
 import { type EvalBackendsAllowance, resolveEvalBackends } from "./eval-backends";
 import { upsertStatusEvent } from "./eval-render";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "./output-meta";
+import { clearSearchResultCache } from "./search-result-cache";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -401,7 +402,13 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		_ctx?: AgentToolContext,
 	): Promise<AgentToolResult<EvalToolDetails | undefined>> {
 		if (this.#proxyExecutor) {
-			return this.#proxyExecutor(params, signal);
+			try {
+				return await this.#proxyExecutor(params, signal);
+			} finally {
+				// The proxied cell runs elsewhere but mutates the same filesystem;
+				// this session's cached search pages cannot be trusted afterwards.
+				if (this.session) clearSearchResultCache(this.session);
+			}
 		}
 
 		if (!this.session) {
@@ -732,6 +739,10 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					.truncationFromSummary(summaryForMeta, { direction: "tail" })
 					.done();
 			} finally {
+				// Eval cells have unrestricted filesystem access (documented `write`
+				// helper, Bun.write, arbitrary Node APIs) and no mutation tracking,
+				// so conservatively drop cached search pages once the cell settles.
+				clearSearchResultCache(session);
 				if (!outputDumped) {
 					try {
 						await finalizeOutput();

--- a/packages/coding-agent/src/tools/fs-cache-invalidation.ts
+++ b/packages/coding-agent/src/tools/fs-cache-invalidation.ts
@@ -1,17 +1,20 @@
 import { invalidateFsScanCache } from "@oh-my-pi/pi-natives";
+import { clearSearchResultCache, type SearchResultCacheOwner } from "./search-result-cache";
 
 /**
  * Invalidate shared filesystem scan caches after a content write/update.
  */
-export function invalidateFsScanAfterWrite(path: string): void {
+export function invalidateFsScanAfterWrite(path: string, owner: SearchResultCacheOwner): void {
 	invalidateFsScanCache(path);
+	clearSearchResultCache(owner);
 }
 
 /**
  * Invalidate shared filesystem scan caches after deleting a file.
  */
-export function invalidateFsScanAfterDelete(path: string): void {
+export function invalidateFsScanAfterDelete(path: string, owner: SearchResultCacheOwner): void {
 	invalidateFsScanCache(path);
+	clearSearchResultCache(owner);
 }
 
 /**
@@ -20,9 +23,10 @@ export function invalidateFsScanAfterDelete(path: string): void {
  * Some watchers care about the disappearance at the old path; others about the
  * appearance at the new one. Bust both to keep callers honest.
  */
-export function invalidateFsScanAfterRename(oldPath: string, newPath: string): void {
+export function invalidateFsScanAfterRename(oldPath: string, newPath: string, owner: SearchResultCacheOwner): void {
 	invalidateFsScanCache(oldPath);
 	if (newPath !== oldPath) {
 		invalidateFsScanCache(newPath);
 	}
+	clearSearchResultCache(owner);
 }

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -9,7 +9,8 @@ import type {
 	AgentToolUpdateCallback,
 	ToolTier,
 } from "@oh-my-pi/pi-agent-core";
-import { type GrepMatch, GrepOutputMode, type GrepResult, grep } from "@oh-my-pi/pi-natives";
+import type { GrepMatch, GrepResult } from "@oh-my-pi/pi-natives";
+import * as piNatives from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
@@ -67,6 +68,7 @@ import {
 	PREVIEW_LIMITS,
 	replaceTabs,
 } from "./render-utils";
+import { type CachedGroupedSearchResult, getSearchResultCache, isPathWithinWorkspace } from "./search-result-cache";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 
@@ -482,7 +484,7 @@ async function nativeChunkedLineIndexes(
 		if (chunkLines.length === 0) return;
 		const scratch = path.resolve(dir, `${resourceIdx}-chunk-${chunkSeq++}`);
 		await writeFile(scratch, chunkLines.join("\n"));
-		const probe = await grep(
+		const probe = await piNatives.grep(
 			{
 				pattern,
 				path: scratch,
@@ -494,7 +496,7 @@ async function nativeChunkedLineIndexes(
 				contextBefore: 0,
 				contextAfter: 0,
 				maxColumns: DEFAULT_MAX_COLUMN,
-				mode: GrepOutputMode.Content,
+				mode: piNatives.GrepOutputMode.Content,
 				signal,
 				timeoutMs: SEARCH_GREP_TIMEOUT_MS,
 			},
@@ -667,7 +669,7 @@ async function searchVirtualResources(
 			} else {
 				const scratch = path.resolve(dir, `${idx}`);
 				await writeFile(scratch, resource.content);
-				const probe = await grep(
+				const probe = await piNatives.grep(
 					{
 						pattern,
 						path: scratch,
@@ -682,7 +684,7 @@ async function searchVirtualResources(
 						contextBefore: 0,
 						contextAfter: 0,
 						maxColumns: DEFAULT_MAX_COLUMN,
-						mode: GrepOutputMode.Content,
+						mode: piNatives.GrepOutputMode.Content,
 						signal,
 						timeoutMs: SEARCH_GREP_TIMEOUT_MS,
 					},
@@ -717,10 +719,16 @@ async function searchVirtualResources(
 	};
 }
 
-function mergeGrepResults(left: GrepResult, right: GrepResult, maxCount: number): GrepResult {
-	if (left.matches.length === 0) return right;
-	if (right.matches.length === 0) return left;
-	const combinedMatches = [...left.matches, ...right.matches];
+/** Merge in left-then-right encounter order under `maxCount`. The cap and
+ * `limitReached` apply even when one side is empty, so an over-cap aggregated
+ * multi-target result cannot bypass the safety ceiling. Exported for tests. */
+export function mergeGrepResults(left: GrepResult, right: GrepResult, maxCount: number): GrepResult {
+	const combinedMatches =
+		left.matches.length === 0
+			? right.matches
+			: right.matches.length === 0
+				? left.matches
+				: [...left.matches, ...right.matches];
 	const matches = combinedMatches.length > maxCount ? combinedMatches.slice(0, maxCount) : combinedMatches;
 	return {
 		matches,
@@ -883,6 +891,46 @@ export interface GrepToolDetails {
 }
 
 type SearchParams = typeof searchSchema.infer;
+
+interface SearchCacheKeyTarget {
+	basePath: string;
+	glob?: string;
+}
+
+interface SearchCacheKeyInput {
+	cwd: string;
+	pattern: string;
+	paths: string[];
+	searchPath: string;
+	scopePath: string;
+	globFilter?: string;
+	exactFilePaths?: string[];
+	multiTargets?: SearchCacheKeyTarget[];
+	isDirectory: boolean;
+	isMultiScope: boolean;
+	ignoreCase: boolean;
+	gitignore: boolean;
+	multiline: boolean;
+	contextBefore: number;
+	contextAfter: number;
+	outputMode: string;
+	maxColumns: number;
+	maxCount: number;
+	maxCountPerFile: number;
+	lineRangeFilters: "none";
+	sourceParticipation: "plain-filesystem";
+	missingPaths: string[];
+}
+
+function buildSearchCacheKey(input: SearchCacheKeyInput): string {
+	return JSON.stringify(input);
+}
+
+function normalizeSearchCacheTargets(
+	targets: readonly ResolvedSearchTarget[] | undefined,
+): SearchCacheKeyTarget[] | undefined {
+	return targets?.map(target => ({ basePath: path.resolve(target.basePath), glob: target.glob }));
+}
 
 export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails> {
 	readonly name = "grep";
@@ -1081,7 +1129,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 				}
 				const baseDisplayMode = resolveFileDisplayMode(this.session);
 
-				const effectiveOutputMode = GrepOutputMode.Content;
+				const effectiveOutputMode = piNatives.GrepOutputMode.Content;
 				const isMultiScope =
 					isDirectory ||
 					Boolean(exactFilePaths) ||
@@ -1101,35 +1149,137 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 					? Math.ceil(INTERNAL_TOTAL_CAP / (perFileMatchCap + 1)) * nativeMaxCountPerFile
 					: INTERNAL_TOTAL_CAP;
 
-				// Run grep
-				let result: GrepResult = {
-					matches: [],
-					totalMatches: 0,
-					filesWithMatches: 0,
-					filesSearched: 0,
-					limitReached: false,
-				};
-				let skippedOversizedCount = 0;
-				try {
-					if (searchablePaths.length > 0) {
-						if (exactFilePaths || multiTargets) {
-							const matches: GrepMatch[] = [];
-							const seenMatchKeys = new Set<string>();
-							let limitReached = false;
-							let totalMatches = 0;
-							let filesSearched = 0;
-							const targets = exactFilePaths
-								? exactFilePaths.map(filePath => ({
-										basePath: filePath,
-										glob: undefined as string | undefined,
-									}))
-								: (multiTargets ?? []);
-							for (const target of targets) {
-								const targetResult = await grep(
+				const hasLineRangeSelector = pathSpecs.some(spec => spec.ranges !== undefined);
+				const hasArchiveParticipation =
+					archiveDisplayMap.size > 0 || archiveDisplaySet.size > 0 || archiveUnreadable.length > 0;
+				const internalRouter = InternalUrlRouter.instance();
+				const hasInternalInput = pathSpecs.some(spec => internalRouter.canHandle(spec.clean));
+				const hasExternalInput = materializedExternalPaths.size > 0;
+				// Cache ownership is registered under the session's workspace, so
+				// mutation fan-out and suppression can only reach it via that key.
+				// A search whose PHYSICAL roots escape the workspace (absolute
+				// sibling repos, `..` scopes, in-workspace symlinks that point
+				// elsewhere) would cache pages no outside mutator can invalidate —
+				// conservatively bypass caching for those. Containment uses the
+				// registry's own canonicalization, so an alias path to the same
+				// physical workspace stays cacheable.
+				const searchRoots = exactFilePaths ?? multiTargets?.map(target => target.basePath) ?? [searchPath];
+				const scopeWithinWorkspace = searchRoots.every(root => isPathWithinWorkspace(this.session.cwd, root));
+				const cacheableFilesystemSearch =
+					!hasLineRangeSelector &&
+					!hasArchiveParticipation &&
+					!hasInternalInput &&
+					!hasExternalInput &&
+					scopeWithinWorkspace;
+				const searchCache = cacheableFilesystemSearch ? getSearchResultCache(this.session) : undefined;
+				const searchCacheKey = cacheableFilesystemSearch
+					? buildSearchCacheKey({
+							cwd: this.session.cwd,
+							pattern: normalizedPattern,
+							paths: searchablePaths.slice(),
+							searchPath,
+							scopePath,
+							globFilter,
+							exactFilePaths: exactFilePaths?.map(filePath => path.resolve(filePath)),
+							multiTargets: normalizeSearchCacheTargets(multiTargets),
+							isDirectory,
+							isMultiScope,
+							ignoreCase,
+							gitignore: useGitignore,
+							multiline: effectiveMultiline,
+							contextBefore: normalizedContextBefore,
+							contextAfter: normalizedContextAfter,
+							outputMode: String(effectiveOutputMode),
+							maxColumns: DEFAULT_MAX_COLUMN,
+							maxCount: INTERNAL_TOTAL_CAP,
+							maxCountPerFile: perFileMatchCap + 1,
+							lineRangeFilters: "none",
+							sourceParticipation: "plain-filesystem",
+							missingPaths: missingPaths.slice(),
+						})
+					: undefined;
+				let groupedSearch: CachedGroupedSearchResult | undefined =
+					normalizedSkip > 0 && searchCacheKey ? searchCache?.get(searchCacheKey) : undefined;
+
+				if (!groupedSearch) {
+					// Run grep
+					let result: GrepResult = {
+						matches: [],
+						totalMatches: 0,
+						filesWithMatches: 0,
+						filesSearched: 0,
+						limitReached: false,
+					};
+					let skippedOversizedCount = 0;
+					try {
+						if (searchablePaths.length > 0) {
+							if (exactFilePaths || multiTargets) {
+								const matches: GrepMatch[] = [];
+								const seenMatchKeys = new Set<string>();
+								let limitReached = false;
+								let totalMatches = 0;
+								let filesSearched = 0;
+								const targets = exactFilePaths
+									? exactFilePaths.map(filePath => ({
+											basePath: filePath,
+											glob: undefined as string | undefined,
+										}))
+									: (multiTargets ?? []);
+								for (const target of targets) {
+									const targetResult = await piNatives.grep(
+										{
+											pattern: normalizedPattern,
+											path: target.basePath,
+											glob: target.glob,
+											ignoreCase,
+											multiline: effectiveMultiline,
+											hidden: true,
+											gitignore: useGitignore,
+											// Range-aware total cap: pre-range matches must not exhaust
+											// the fetch budget before the JS range filter runs.
+											maxCount: nativeMaxCount,
+											contextBefore: normalizedContextBefore,
+											contextAfter: normalizedContextAfter,
+											maxColumns: DEFAULT_MAX_COLUMN,
+											mode: effectiveOutputMode,
+											maxCountPerFile: nativeMaxCountPerFile,
+											signal,
+											timeoutMs: SEARCH_GREP_TIMEOUT_MS,
+										},
+										undefined,
+									);
+									skippedOversizedCount += targetResult.skippedOversized ?? 0;
+									limitReached = limitReached || Boolean(targetResult.limitReached);
+									totalMatches += targetResult.totalMatches;
+									filesSearched += targetResult.filesSearched;
+									for (const match of targetResult.matches) {
+										const absolute = path.resolve(target.basePath, match.path);
+										// Overlapping targets (a directory plus a file nested
+										// inside it) surface the same physical line twice;
+										// keep the first occurrence.
+										const matchKey = `${absolute}\0${match.lineNumber}`;
+										if (seenMatchKeys.has(matchKey)) {
+											totalMatches = Math.max(0, totalMatches - 1);
+											continue;
+										}
+										seenMatchKeys.add(matchKey);
+										const rebased = path.relative(searchPath, absolute).replace(/\\/g, "/");
+										matches.push({ ...match, path: rebased });
+									}
+								}
+								result = {
+									matches,
+									totalMatches: exactFilePaths ? matches.length : totalMatches,
+									filesWithMatches: new Set(matches.map(match => match.path)).size,
+									filesSearched: exactFilePaths ? exactFilePaths.length : filesSearched,
+									limitReached,
+								};
+							} else {
+								result = await piNatives.grep(
 									{
 										pattern: normalizedPattern,
-										path: target.basePath,
-										glob: target.glob,
+										path: searchPath,
+										glob: globFilter,
 										ignoreCase,
 										multiline: effectiveMultiline,
 										hidden: true,
@@ -1145,124 +1295,119 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 									},
 									undefined,
 								);
-								skippedOversizedCount += targetResult.skippedOversized ?? 0;
-								limitReached = limitReached || Boolean(targetResult.limitReached);
-								totalMatches += targetResult.totalMatches;
-								filesSearched += targetResult.filesSearched;
-								for (const match of targetResult.matches) {
-									const absolute = path.resolve(target.basePath, match.path);
-									// Overlapping targets (a directory plus a file nested
-									// inside it) surface the same physical line twice;
-									// keep the first occurrence.
-									const matchKey = `${absolute}\0${match.lineNumber}`;
-									if (seenMatchKeys.has(matchKey)) {
-										totalMatches = Math.max(0, totalMatches - 1);
-										continue;
-									}
-									seenMatchKeys.add(matchKey);
-									const rebased = path.relative(searchPath, absolute).replace(/\\/g, "/");
-									matches.push({ ...match, path: rebased });
-								}
+								skippedOversizedCount = result.skippedOversized ?? 0;
 							}
-							result = {
-								matches,
-								totalMatches: exactFilePaths ? matches.length : totalMatches,
-								filesWithMatches: new Set(matches.map(match => match.path)).size,
-								filesSearched: exactFilePaths ? exactFilePaths.length : filesSearched,
-								limitReached,
-							};
-						} else {
-							result = await grep(
-								{
-									pattern: normalizedPattern,
-									path: searchPath,
-									glob: globFilter,
-									ignoreCase,
-									multiline: effectiveMultiline,
-									hidden: true,
-									gitignore: useGitignore,
-									maxCount: nativeMaxCount,
-									contextBefore: normalizedContextBefore,
-									contextAfter: normalizedContextAfter,
-									maxColumns: DEFAULT_MAX_COLUMN,
-									mode: effectiveOutputMode,
-									maxCountPerFile: nativeMaxCountPerFile,
-									signal,
-									timeoutMs: SEARCH_GREP_TIMEOUT_MS,
-								},
-								undefined,
+						}
+					} catch (err) {
+						if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
+							throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
+						}
+						if (err instanceof Error && err.message.includes("Aborted: Timeout")) {
+							throw new ToolError(
+								`Search timed out after ${SEARCH_GREP_TIMEOUT_MS / 1000}s; narrow paths or pattern, or scope with \`find\` first`,
 							);
-							skippedOversizedCount = result.skippedOversized ?? 0;
 						}
+						throw err;
 					}
-				} catch (err) {
-					if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
-						throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
+					// Apply line-range filtering to filesystem matches BEFORE merging so
+					// out-of-range entries (fetched under the widened native caps) can
+					// never consume merged-cap budget that belongs to eligible matches.
+					if (rangesByAbsPath.size > 0) {
+						const filteredMatches: GrepMatch[] = [];
+						for (const match of result.matches) {
+							const abs = matchAbsolutePath(match.path, searchPath);
+							const ranges = rangesByAbsPath.get(abs);
+							if (!ranges) {
+								// Path has no line-range constraint (e.g. a peer entry without `:N-M`).
+								filteredMatches.push(match);
+								continue;
+							}
+							if (!isLineInRanges(match.lineNumber, ranges)) continue;
+							// Drop context lines that fall outside the allowed ranges; they would
+							// otherwise leak content the caller explicitly excluded.
+							const trimBefore = match.contextBefore?.filter(c => isLineInRanges(c.lineNumber, ranges));
+							const trimAfter = match.contextAfter?.filter(c => isLineInRanges(c.lineNumber, ranges));
+							filteredMatches.push({
+								...match,
+								contextBefore: trimBefore && trimBefore.length > 0 ? trimBefore : undefined,
+								contextAfter: trimAfter && trimAfter.length > 0 ? trimAfter : undefined,
+							});
+						}
+						result = {
+							matches: filteredMatches,
+							totalMatches: filteredMatches.length,
+							filesWithMatches: new Set(filteredMatches.map(match => match.path)).size,
+							filesSearched: result.filesSearched,
+							limitReached: result.limitReached,
+						};
 					}
-					if (err instanceof Error && err.message.includes("Aborted: Timeout")) {
-						throw new ToolError(
-							`Grep timed out after ${SEARCH_GREP_TIMEOUT_MS / 1000}s; narrow paths or pattern, or scope with \`glob\` first`,
+					let virtualResult: GrepResult;
+					try {
+						virtualResult = await searchVirtualResources(
+							virtualResources,
+							normalizedPattern,
+							ignoreCase,
+							effectiveMultiline,
+							normalizedContextBefore,
+							normalizedContextAfter,
+							INTERNAL_TOTAL_CAP,
+							signal,
 						);
-					}
-					throw err;
-				}
-				let virtualResult: GrepResult;
-				try {
-					virtualResult = await searchVirtualResources(
-						virtualResources,
-						normalizedPattern,
-						ignoreCase,
-						effectiveMultiline,
-						normalizedContextBefore,
-						normalizedContextAfter,
-						INTERNAL_TOTAL_CAP,
-						signal,
-					);
-				} catch (err) {
-					if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
-						throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
-					}
-					if (err instanceof SyntaxError) {
-						throw new ToolError(`Invalid regex: ${err.message}`);
-					}
-					throw err;
-				}
-				result = mergeGrepResults(result, virtualResult, nativeMaxCount);
-				if (rangesByAbsPath.size > 0) {
-					const filteredMatches: GrepMatch[] = [];
-					for (const match of result.matches) {
-						const abs = matchAbsolutePath(match.path, searchPath);
-						const ranges = rangesByAbsPath.get(abs);
-						if (!ranges) {
-							// Path has no line-range constraint (e.g. a peer entry without `:N-M`).
-							filteredMatches.push(match);
-							continue;
+					} catch (err) {
+						// Virtual-only scopes never hit the filesystem native-grep catch
+						// above, so normalize the same regex failures here: native RE2
+						// probe errors and JS `RegExp` SyntaxError both surface as the
+						// tool's `Invalid regex: ...` contract.
+						if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
+							throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
 						}
-						if (!isLineInRanges(match.lineNumber, ranges)) continue;
-						// Drop context lines that fall outside the allowed ranges; they would
-						// otherwise leak content the caller explicitly excluded.
-						const trimBefore = match.contextBefore?.filter(c => isLineInRanges(c.lineNumber, ranges));
-						const trimAfter = match.contextAfter?.filter(c => isLineInRanges(c.lineNumber, ranges));
-						filteredMatches.push({
-							...match,
-							contextBefore: trimBefore && trimBefore.length > 0 ? trimBefore : undefined,
-							contextAfter: trimAfter && trimAfter.length > 0 ? trimAfter : undefined,
-						});
+						if (err instanceof SyntaxError) {
+							throw new ToolError(
+								`Invalid regex: ${err.message.replace(/^Invalid regular expression:\s*/i, "")}`,
+							);
+						}
+						throw err;
 					}
-					result = {
-						matches: filteredMatches,
-						totalMatches: filteredMatches.length,
-						filesWithMatches: new Set(filteredMatches.map(match => match.path)).size,
-						filesSearched: result.filesSearched,
-						limitReached: result.limitReached,
-					};
-				}
-				if (archiveDisplayMap.size > 0) {
+					// Both sides are already range-filtered, so the plain safety
+					// ceiling applies to the merged, eligible matches in
+					// filesystem-then-virtual encounter order.
+					result = mergeGrepResults(result, virtualResult, INTERNAL_TOTAL_CAP);
+					if (archiveDisplayMap.size > 0) {
+						for (const match of result.matches) {
+							const abs = matchAbsolutePath(match.path, searchPath);
+							const display = archiveDisplayMap.get(abs);
+							if (display) match.path = display;
+						}
+					}
+
+					// Group matches by file in encounter order. Detect per-file overflow
+					// BEFORE truncation so the renderer can surface that a hot file was
+					// trimmed for diversity.
+					const fileOrder: string[] = [];
+					const matchesByPath = new Map<string, GrepMatch[]>();
 					for (const match of result.matches) {
-						const abs = matchAbsolutePath(match.path, searchPath);
-						const display = archiveDisplayMap.get(abs);
-						if (display) match.path = display;
+						if (!matchesByPath.has(match.path)) {
+							fileOrder.push(match.path);
+							matchesByPath.set(match.path, []);
+						}
+						matchesByPath.get(match.path)!.push(match);
 					}
+					let perFileLimitReached = false;
+					for (const file of fileOrder) {
+						const list = matchesByPath.get(file)!;
+						if (list.length > perFileMatchCap) {
+							perFileLimitReached = true;
+							list.length = perFileMatchCap;
+						}
+					}
+					groupedSearch = {
+						fileOrder,
+						matchesByPath,
+						perFileLimitReached,
+						resultLimitReached: Boolean(result.limitReached),
+						skippedOversizedCount,
+					};
+					if (searchCacheKey) searchCache?.set(searchCacheKey, groupedSearch);
 				}
 
 				const formatPath = (filePath: string): string =>
@@ -1270,30 +1415,12 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 						? filePath
 						: formatResultPath(filePath, isDirectory, searchPath, this.session.cwd);
 
-				// Group matches by file in encounter order. Detect per-file overflow
-				// BEFORE truncation so the renderer can surface that a hot file was
-				// trimmed for diversity.
-				const fileOrder: string[] = [];
-				const matchesByPath = new Map<string, GrepMatch[]>();
-				for (const match of result.matches) {
-					if (!matchesByPath.has(match.path)) {
-						fileOrder.push(match.path);
-						matchesByPath.set(match.path, []);
-					}
-					matchesByPath.get(match.path)!.push(match);
-				}
-				let perFileLimitReached = false;
-				for (const file of fileOrder) {
-					const list = matchesByPath.get(file)!;
-					if (list.length > perFileMatchCap) {
-						perFileLimitReached = true;
-						list.length = perFileMatchCap;
-					}
-				}
+				const { fileOrder, matchesByPath, perFileLimitReached, resultLimitReached, skippedOversizedCount } =
+					groupedSearch;
 				const totalFiles = fileOrder.length;
 				// When native grep stopped at its internal cap, files past the cap were
 				// never surfaced — the file total is only a lower bound.
-				const totalFilesLabel = result.limitReached ? `${totalFiles}+` : `${totalFiles}`;
+				const totalFilesLabel = resultLimitReached ? `${totalFiles}+` : `${totalFiles}`;
 				// Single-file scopes can't paginate — there is one file by definition.
 				const canPaginate = isMultiScope;
 				const skipFiles = canPaginate ? Math.min(normalizedSkip, totalFiles) : 0;
@@ -1503,7 +1630,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 				const output = truncation.content;
 				const displayText = displayLines.join("\n");
 				const truncated = Boolean(
-					fileLimitReached || perFileLimitReached || result.limitReached || truncation.truncated || linesTruncated,
+					fileLimitReached || perFileLimitReached || resultLimitReached || truncation.truncated || linesTruncated,
 				);
 				const details: GrepToolDetails = {
 					scopePath,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -56,6 +56,7 @@ import { MemoryRetainTool } from "./memory-retain";
 import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
+import type { SearchResultCache } from "./search-result-cache";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
 import { isMountableUnderXdev, XdevRegistry } from "./xdev";
@@ -334,6 +335,9 @@ export interface ToolSession {
 	 *  reconstruct the version the model authored anchors against when the
 	 *  file changed out-of-band. Lazily initialized by `getFileSnapshotStore`. */
 	fileSnapshotStore?: InMemorySnapshotStore;
+
+	/** Per-session grouped search result cache used by search skip pagination. */
+	searchResultCache?: SearchResultCache;
 
 	/** Per-session log of unresolved git merge conflict regions surfaced by
 	 *  `read`. Each entry gets a stable id N referenced by `write conflict://N`

--- a/packages/coding-agent/src/tools/search-result-cache.ts
+++ b/packages/coding-agent/src/tools/search-result-cache.ts
@@ -1,0 +1,434 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { GrepMatch } from "@oh-my-pi/pi-natives";
+
+export const SEARCH_RESULT_CACHE_TTL_MS = 45_000;
+export const SEARCH_RESULT_CACHE_MAX_ENTRIES = 8;
+
+export interface CachedGroupedSearchResult {
+	fileOrder: string[];
+	matchesByPath: Map<string, GrepMatch[]>;
+	perFileLimitReached: boolean;
+	resultLimitReached: boolean;
+	skippedOversizedCount: number;
+}
+
+export interface SearchResultCacheOptions {
+	ttlMs?: number;
+	maxEntries?: number;
+	now?: () => number;
+}
+
+interface SearchResultCacheEntry {
+	createdAtMs: number;
+	result: CachedGroupedSearchResult;
+}
+
+/**
+ * Shared per-workspace state: the weakly-held owner set for fan-out
+ * invalidation plus the workspace-wide suppression count. Attached to every
+ * member cache so `get`/`set` observe suppression even for owners that
+ * register mid-flight.
+ */
+interface WorkspaceCacheState {
+	owners: Set<WeakRef<SearchResultCacheOwner>>;
+	suppressions: number;
+}
+
+export class SearchResultCache {
+	#entries = new Map<string, SearchResultCacheEntry>();
+	#maxEntries: number;
+	#now: () => number;
+	#suppressions = 0;
+	#ttlMs: number;
+	#workspace: WorkspaceCacheState | undefined;
+
+	constructor(options: SearchResultCacheOptions = {}) {
+		this.#ttlMs = options.ttlMs ?? SEARCH_RESULT_CACHE_TTL_MS;
+		this.#maxEntries = options.maxEntries ?? SEARCH_RESULT_CACHE_MAX_ENTRIES;
+		this.#now = options.now ?? Date.now;
+	}
+
+	/** Bind this cache to its workspace's shared suppression/owner state. */
+	setWorkspaceState(state: WorkspaceCacheState | undefined): void {
+		this.#workspace = state;
+	}
+
+	#suppressed(): boolean {
+		return this.#suppressions > 0 || (this.#workspace?.suppressions ?? 0) > 0;
+	}
+
+	get(key: string): CachedGroupedSearchResult | undefined {
+		if (this.#suppressed()) return undefined;
+		const entry = this.#entries.get(key);
+		if (!entry) return undefined;
+
+		if (this.#now() - entry.createdAtMs > this.#ttlMs) {
+			this.#entries.delete(key);
+			return undefined;
+		}
+
+		this.#entries.delete(key);
+		this.#entries.set(key, entry);
+		return entry.result;
+	}
+
+	set(key: string, result: CachedGroupedSearchResult): void {
+		if (this.#suppressed()) return;
+		this.#entries.delete(key);
+		this.#entries.set(key, { createdAtMs: this.#now(), result });
+
+		while (this.#entries.size > this.#maxEntries) {
+			const oldestKey = this.#entries.keys().next().value;
+			if (oldestKey === undefined) break;
+			this.#entries.delete(oldestKey);
+		}
+	}
+
+	/**
+	 * Invalidate now and block reuse (`get`) and repopulation (`set`) until the
+	 * returned release is called — used while a background job may still be
+	 * mutating the workspace. Suppressions nest; the cache reopens once every
+	 * holder has released. Instance-scoped: workspace-wide suppression goes
+	 * through {@link suppressSearchResultCaches}.
+	 */
+	suppress(): () => void {
+		this.#suppressions++;
+		this.#entries.clear();
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			this.#suppressions--;
+		};
+	}
+
+	clear(): void {
+		this.#entries.clear();
+	}
+}
+
+export interface SearchResultCacheOwner {
+	searchResultCache?: SearchResultCache;
+	/**
+	 * Owning session's workspace root. Canonicalized (realpath with a
+	 * nearest-existing-ancestor fallback) to key same-workspace fan-out
+	 * invalidation and suppression.
+	 */
+	cwd?: string;
+}
+
+/**
+ * Live cache owners grouped by canonical workspace root, held weakly so this
+ * process-global registry never extends a session's lifetime. Non-isolated
+ * task children share the parent's cwd but carry their own ToolSession cache;
+ * a mutation observed by one session must also drop every sibling's cached
+ * pages for the same workspace, while different-cwd sessions stay untouched.
+ */
+const workspaceStates = new Map<string, WorkspaceCacheState>();
+
+/** Last registration per live owner so a cwd move relocates its entry. */
+const ownerRegistrations = new WeakMap<SearchResultCacheOwner, { key: string; ref: WeakRef<SearchResultCacheOwner> }>();
+
+/**
+ * Shared cleanup for a collected (or simulated-collected) owner ref: run by
+ * the FinalizationRegistry and by the deterministic test seam.
+ */
+function reapCollectedWorkspaceOwner(entry: { key: string; ref: WeakRef<SearchResultCacheOwner> }): void {
+	const state = workspaceStates.get(entry.key);
+	if (!state) return;
+	state.owners.delete(entry.ref);
+	for (const ref of state.owners) {
+		if (!ref.deref()) state.owners.delete(ref);
+	}
+	dropWorkspaceStateIfUnused(entry.key, state);
+}
+
+/** Drop a collected owner's ref and its bucket once truly unused. */
+const ownerFinalizer = new FinalizationRegistry<{ key: string; ref: WeakRef<SearchResultCacheOwner> }>(
+	reapCollectedWorkspaceOwner,
+);
+
+/**
+ * Deterministically exercise the finalizer path for a still-live owner.
+ * Test-only: production collection goes through {@link ownerFinalizer}.
+ */
+export function simulateWorkspaceOwnerCollectionForTests(owner: SearchResultCacheOwner): void {
+	const registration = ownerRegistrations.get(owner);
+	if (!registration) return;
+	ownerFinalizer.unregister(owner);
+	ownerRegistrations.delete(owner);
+	reapCollectedWorkspaceOwner(registration);
+}
+
+function dropWorkspaceStateIfUnused(key: string, state: WorkspaceCacheState): void {
+	if (state.owners.size === 0 && state.suppressions === 0) workspaceStates.delete(key);
+}
+
+/**
+ * Successful realpath results per raw cwd string. Failures (not-yet-existing
+ * paths) are intentionally NOT memoized so a later-created directory converges
+ * on its real canonical key.
+ */
+const canonicalKeyMemo = new Map<string, string>();
+const CANONICAL_KEY_MEMO_LIMIT = 512;
+
+/**
+ * Whether the volume holding `existingDir` treats names case-insensitively,
+ * probed at runtime (same dev+ino when the basename's case is toggled).
+ * Platform alone is NOT trusted: macOS supports case-sensitive APFS/HFS
+ * volumes. Inconclusive probes (no letters in the basename, stat failures)
+ * report case-sensitive so distinct-case paths are never merged wrongly.
+ */
+const caseInsensitiveByDir = new Map<string, boolean>();
+const CASE_PROBE_MEMO_LIMIT = 256;
+
+function isCaseInsensitiveDir(existingDir: string): boolean {
+	const memoized = caseInsensitiveByDir.get(existingDir);
+	if (memoized !== undefined) return memoized;
+	let insensitive = false;
+	const base = path.basename(existingDir);
+	const toggled = base
+		.split("")
+		.map(ch => (ch === ch.toLowerCase() ? ch.toUpperCase() : ch.toLowerCase()))
+		.join("");
+	if (toggled !== base) {
+		try {
+			const original = fs.statSync(existingDir);
+			const alias = fs.statSync(path.join(path.dirname(existingDir), toggled));
+			insensitive = original.dev === alias.dev && original.ino === alias.ino;
+		} catch {
+			insensitive = false;
+		}
+	}
+	if (caseInsensitiveByDir.size >= CASE_PROBE_MEMO_LIMIT) caseInsensitiveByDir.clear();
+	caseInsensitiveByDir.set(existingDir, insensitive);
+	return insensitive;
+}
+
+/**
+ * Uncached canonical form of a path: realpath (collapsing symlink aliases and
+ * yielding on-disk casing) with a nearest-existing-ancestor fallback whose
+ * missing tail folds case only when a runtime probe proves the ancestor's
+ * volume case-insensitive.
+ */
+function canonicalizePath(input: string): string {
+	const resolved = path.resolve(input);
+	try {
+		// Collapses symlink aliases (macOS `/tmp` -> `/private/tmp`) and yields
+		// on-disk casing on case-insensitive filesystems.
+		return fs.realpathSync.native(resolved);
+	} catch {
+		// Not-yet-existing path: canonicalize through the nearest existing
+		// ancestor and keep the missing tail. The tail's case folds only when a
+		// runtime probe proves the ancestor's volume is case-insensitive —
+		// never from the platform name alone.
+		let ancestor = resolved;
+		const tail: string[] = [];
+		while (true) {
+			const parent = path.dirname(ancestor);
+			if (parent === ancestor) return resolved;
+			tail.unshift(path.basename(ancestor));
+			ancestor = parent;
+			try {
+				const realAncestor = fs.realpathSync.native(ancestor);
+				const joinedTail = tail.join(path.sep);
+				const foldedTail = isCaseInsensitiveDir(realAncestor) ? joinedTail.toLowerCase() : joinedTail;
+				return path.join(realAncestor, foldedTail);
+			} catch {
+				// keep walking up
+			}
+		}
+	}
+}
+
+function canonicalWorkspaceKey(cwd: string): string {
+	const memoized = canonicalKeyMemo.get(cwd);
+	if (memoized !== undefined) return memoized;
+	const resolved = path.resolve(cwd);
+	const key = canonicalizePath(resolved);
+	// Memoize only paths that exist NOW (realpath succeeded): fallback keys
+	// for missing paths must converge once the directory is created. Workspace
+	// roots are stable, so memoizing them is safe; arbitrary search targets go
+	// through the uncached canonicalizePath instead.
+	if (fs.existsSync(resolved)) {
+		if (canonicalKeyMemo.size >= CANONICAL_KEY_MEMO_LIMIT) canonicalKeyMemo.clear();
+		canonicalKeyMemo.set(cwd, key);
+	}
+	return key;
+}
+
+/**
+ * Whether `target` physically resolves inside the workspace rooted at
+ * `workspaceCwd`, using the SAME canonicalization as workspace cache keys
+ * (realpath with nearest-existing-ancestor fallback and probed case
+ * semantics). Lexical containment is not enough: an in-workspace symlink can
+ * escape to another workspace (must NOT count as inside), while an alias path
+ * to the same physical workspace must still count as inside. The TARGET is
+ * canonicalized fresh on every call — memoizing it would let a retargeted
+ * symlink keep its stale containment verdict; only the stable workspace root
+ * goes through the memoized key.
+ */
+export function isPathWithinWorkspace(workspaceCwd: string, target: string): boolean {
+	const root = canonicalWorkspaceKey(workspaceCwd);
+	const candidate = canonicalizePath(target);
+	// path.relative instead of a `root + sep` prefix check: a canonical root
+	// that already ends with a separator (filesystem root, Windows drive root)
+	// would otherwise build a double-separator prefix and never match. The
+	// escape test is exactly `..` or a `../` prefix — a bare startsWith("..")
+	// would wrongly reject an in-root child literally named `..foo`.
+	const rel = path.relative(root, candidate);
+	return rel === "" || (rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+/**
+ * Retire an owner's current registration (finalizer token, bucket ref,
+ * WeakMap entry), dropping the old bucket when it becomes unused.
+ */
+function retireOwnerRegistration(owner: SearchResultCacheOwner): void {
+	const prior = ownerRegistrations.get(owner);
+	if (!prior) return;
+	ownerFinalizer.unregister(owner);
+	ownerRegistrations.delete(owner);
+	const priorState = workspaceStates.get(prior.key);
+	if (priorState) {
+		priorState.owners.delete(prior.ref);
+		dropWorkspaceStateIfUnused(prior.key, priorState);
+	}
+}
+
+/**
+ * Reconcile an owner's registration with its CURRENT cwd — registering,
+ * relocating (including to the cwd-less fallback), or leaving it in place —
+ * and return the current workspace state, if any. Shared by every entry point
+ * so a cwd change is honored even when the first post-move operation is a
+ * mutation rather than a cache read.
+ */
+function reconcileWorkspaceOwner(
+	owner: SearchResultCacheOwner,
+	cache: SearchResultCache,
+): WorkspaceCacheState | undefined {
+	if (!owner.cwd) {
+		retireOwnerRegistration(owner);
+		cache.setWorkspaceState(undefined);
+		return undefined;
+	}
+	const key = canonicalWorkspaceKey(owner.cwd);
+	const prior = ownerRegistrations.get(owner);
+	if (prior?.key === key) return workspaceStates.get(key);
+	retireOwnerRegistration(owner);
+	let state = workspaceStates.get(key);
+	if (!state) {
+		state = { owners: new Set(), suppressions: 0 };
+		workspaceStates.set(key, state);
+	}
+	for (const ref of state.owners) {
+		if (!ref.deref()) state.owners.delete(ref);
+	}
+	const ref = new WeakRef(owner);
+	state.owners.add(ref);
+	ownerRegistrations.set(owner, { key, ref });
+	ownerFinalizer.register(owner, { key, ref }, owner);
+	cache.setWorkspaceState(state);
+	return state;
+}
+
+export function getSearchResultCache(owner: SearchResultCacheOwner): SearchResultCache {
+	owner.searchResultCache ??= new SearchResultCache();
+	// Any session that can hold cached pages participates in same-workspace
+	// fan-out invalidation and suppression from that point on.
+	reconcileWorkspaceOwner(owner, owner.searchResultCache);
+	return owner.searchResultCache;
+}
+
+function clearWorkspaceKey(key: string): void {
+	const state = workspaceStates.get(key);
+	if (!state) return;
+	for (const ref of state.owners) {
+		const held = ref.deref();
+		if (!held) {
+			state.owners.delete(ref);
+			continue;
+		}
+		held.searchResultCache?.clear();
+	}
+	dropWorkspaceStateIfUnused(key, state);
+}
+
+export function clearSearchResultCache(owner: SearchResultCacheOwner): void {
+	owner.searchResultCache?.clear();
+	// A mutation can be the first operation after a cwd change: reconcile the
+	// owner's registration before fanning out so the old workspace stops
+	// evicting it and the stale bucket can retire.
+	if (owner.searchResultCache) reconcileWorkspaceOwner(owner, owner.searchResultCache);
+	if (!owner.cwd) return;
+	clearWorkspaceKey(canonicalWorkspaceKey(owner.cwd));
+}
+
+function suppressWorkspaceKey(key: string): () => void {
+	let state = workspaceStates.get(key);
+	if (!state) {
+		// Suppressing a workspace nobody has cached in yet still matters:
+		// owners registering mid-flight attach to this state and stay blocked.
+		state = { owners: new Set(), suppressions: 0 };
+		workspaceStates.set(key, state);
+	}
+	state.suppressions++;
+	for (const ref of state.owners) {
+		const held = ref.deref();
+		if (!held) {
+			state.owners.delete(ref);
+			continue;
+		}
+		held.searchResultCache?.clear();
+	}
+	return () => {
+		state.suppressions--;
+		dropWorkspaceStateIfUnused(key, state);
+	};
+}
+
+/**
+ * Invalidate and hold closed EVERY cache in the affected workspaces —
+ * including owners that register mid-flight — until the returned release is
+ * called. Used while a background job may still be mutating shared files: a
+ * sibling session (e.g. the parent of a non-isolated task child) must neither
+ * serve nor repopulate cached pages during the window. Suppressions nest
+ * across holders.
+ *
+ * `mutationCwd` names the effective working directory of the job when it
+ * differs from the owner's session cwd (e.g. a Bash `cwd` override); its
+ * workspace is suppressed as well WITHOUT relocating the owner's own
+ * registration. The initiating instance cache is always held closed, so
+ * cwd-less owners remain covered.
+ */
+export function suppressSearchResultCaches(owner: SearchResultCacheOwner, mutationCwd?: string): () => void {
+	const cache = getSearchResultCache(owner);
+	const releases: Array<() => void> = [cache.suppress()];
+	const keys = new Set<string>();
+	if (owner.cwd) keys.add(canonicalWorkspaceKey(owner.cwd));
+	if (mutationCwd) keys.add(canonicalWorkspaceKey(mutationCwd));
+	for (const key of keys) {
+		releases.push(suppressWorkspaceKey(key));
+	}
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		for (const release of releases) release();
+	};
+}
+
+/**
+ * Test-only introspection: live-owner count and suppression depth for a cwd,
+ * or undefined once the bucket has been dropped.
+ */
+export function workspaceRegistrySnapshot(cwd: string): { owners: number; suppressions: number } | undefined {
+	const state = workspaceStates.get(canonicalWorkspaceKey(cwd));
+	if (!state) return undefined;
+	let owners = 0;
+	for (const ref of state.owners) {
+		if (ref.deref()) owners++;
+	}
+	return { owners, suppressions: state.suppressions };
+}

--- a/packages/coding-agent/src/tools/tts.ts
+++ b/packages/coding-agent/src/tools/tts.ts
@@ -177,6 +177,8 @@ async function synthesizeXai(
 	}
 	const bytes = new Uint8Array(await response.arrayBuffer());
 	await Bun.write(outputPath, bytes);
+	// The workspace changed: stale cached search pages must not survive.
+	ctx.invalidateFileCaches?.(outputPath);
 	return {
 		content: [
 			{
@@ -190,6 +192,7 @@ async function synthesizeXai(
 
 async function synthesizeLocal(
 	params: TtsSchemaType,
+	ctx: CustomToolContext,
 	cwd: string,
 	outputPath: string,
 	signal: AbortSignal | undefined,
@@ -214,6 +217,8 @@ async function synthesizeLocal(
 	const { wavPath, substituted } = resolveLocalWavPath(outputPath);
 	const wav = encodeWav(audio.pcm, audio.sampleRate);
 	await Bun.write(wavPath, wav);
+	// The workspace changed: stale cached search pages must not survive.
+	ctx.invalidateFileCaches?.(wavPath);
 	const displayPath = formatPathRelativeToCwd(wavPath, cwd);
 	const note = substituted
 		? ` No local MP3 encoder is bundled, so WAV (PCM16) was written instead of the requested container.`
@@ -260,7 +265,7 @@ export const ttsTool: CustomTool<typeof ttsSchema, TtsToolDetails> = {
 			preference === "local" ? false : (await resolveXAIHttpCredentials(ctx.modelRegistry)) !== null;
 		const backend = resolveTtsBackend({ preference, wantsMp3: codec === "mp3", hasXaiCreds });
 
-		if (backend === "local") return synthesizeLocal(params, cwd, outputPath, signal);
+		if (backend === "local") return synthesizeLocal(params, ctx, cwd, outputPath, signal);
 		return synthesizeXai(params, ctx, outputPath, displayPath, codec, signal);
 	},
 };

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -69,6 +69,7 @@ import {
 } from "./render-utils";
 import { dispatchReportIssueDevice, REPORT_ISSUE_DEVICE_NAME, renderReportIssueDeviceCall } from "./report-tool-issue";
 import { dispatchResolutionDevice, isResolutionDeviceName, renderResolutionDeviceCall } from "./resolve";
+import { clearSearchResultCache } from "./search-result-cache";
 import {
 	deleteRowByKey,
 	deleteRowByRowId,
@@ -469,6 +470,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					transformDiagnostics: dedup
 						? (path, result) => getDiagnosticsLedger(session).reduce(path, result)
 						: undefined,
+					owner: session,
 				})
 			: writethroughNoop;
 		this.description = prompt.render(writeDescription);
@@ -556,7 +558,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			throw new ToolError(error instanceof Error ? error.message : String(error));
 		}
 
-		invalidateFsScanAfterWrite(resolvedArchivePath.absolutePath);
+		invalidateFsScanAfterWrite(resolvedArchivePath.absolutePath, this.session);
 		const outputPath = `${formatPathRelativeToCwd(resolvedArchivePath.absolutePath, this.session.cwd)}:${
 			resolvedArchivePath.archiveSubPath
 		}`;
@@ -677,7 +679,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				}
 			}
 
-			invalidateFsScanAfterWrite(resolvedSqlitePath.absolutePath);
+			invalidateFsScanAfterWrite(resolvedSqlitePath.absolutePath, this.session);
 			return toolResult<WriteToolDetails>({ resolvedPath: resolvedSqlitePath.absolutePath })
 				.text(resultText)
 				.sourcePath(resolvedSqlitePath.absolutePath)
@@ -724,7 +726,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		const newContent = splice.text;
 
 		await writethroughNoop(absolutePath, newContent, signal);
-		invalidateFsScanAfterWrite(absolutePath);
+		invalidateFsScanAfterWrite(absolutePath, this.session);
 		this.session.bumpFileMutationVersion?.(absolutePath);
 		this.session.fileSnapshotStore?.invalidate(absolutePath);
 		const history = this.session.conflictHistory;
@@ -903,7 +905,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			}
 
 			await writethroughNoop(absolutePath, text, signal);
-			invalidateFsScanAfterWrite(absolutePath);
+			invalidateFsScanAfterWrite(absolutePath, this.session);
 			this.session.bumpFileMutationVersion?.(absolutePath);
 			this.session.fileSnapshotStore?.invalidate(absolutePath);
 			for (const entry of resolvedEntries) history.invalidate(entry.id);
@@ -1051,6 +1053,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 							},
 						},
 					});
+					clearSearchResultCache(this.session);
 					if (xdResult) return xdResult;
 					let resultText = `Successfully wrote ${cleanContent.length} bytes to ${path}`;
 					if (stripped) {
@@ -1167,7 +1170,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				batchRequest,
 				dst => this.#deferredDiagnostics?.begin(dst),
 			);
-			invalidateFsScanAfterWrite(absolutePath);
+			invalidateFsScanAfterWrite(absolutePath, this.session);
 			if (!this.#deferredDiagnostics || batchRequest?.flush === false) {
 				this.session.bumpFileMutationVersion?.(absolutePath);
 			}

--- a/packages/coding-agent/test/sdk-custom-tool-cache-invalidation.test.ts
+++ b/packages/coding-agent/test/sdk-custom-tool-cache-invalidation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SDK-supplied custom tools (options.customTools) must receive the
+ * `invalidateFileCaches` seam bound to the OWNING session's tool session, so a
+ * workspace write through a custom tool drops that session's cached grouped
+ * search pages — and only that session's.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool, CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import * as piNatives from "@oh-my-pi/pi-natives";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+describe("SDK custom tool search-cache invalidation", () => {
+	const tempDirs: string[] = [];
+	let sharedTempDir: string;
+	let sharedAuthStorage: AuthStorage;
+	let sharedModelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		sharedTempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-sdk-custom-cache-shared-"));
+		sharedAuthStorage = await AuthStorage.create(path.join(sharedTempDir, "auth.db"));
+		sharedModelRegistry = new ModelRegistry(sharedAuthStorage, path.join(sharedTempDir, "models.yml"));
+	});
+
+	afterAll(() => {
+		sharedAuthStorage.close();
+		removeSyncWithRetries(sharedTempDir);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		for (const tempDir of tempDirs.splice(0)) {
+			removeSyncWithRetries(tempDir);
+		}
+		AsyncJobManager.resetForTests();
+	});
+
+	function makeMarkerTool(captured: { ctx?: CustomToolContext }): CustomTool {
+		return {
+			name: "write_marker",
+			label: "Write Marker",
+			description: "Writes a marker file into the workspace (test-only write-capable custom tool).",
+			parameters: type({ file_name: "string", content: "string" }),
+			loadMode: "essential",
+			async execute(_toolCallId, params: { file_name: string; content: string }, _onUpdate, ctx) {
+				const target = path.join(ctx.sessionManager.getCwd(), params.file_name);
+				await Bun.write(target, params.content);
+				captured.ctx = ctx;
+				ctx.invalidateFileCaches?.(target);
+				return { content: [{ type: "text", text: `wrote ${params.file_name}` }] };
+			},
+		} as CustomTool;
+	}
+
+	async function spawnSession(customTools: CustomTool[]) {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-custom-cache-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		fs.mkdirSync(cwd, { recursive: true });
+		for (let idx = 0; idx < 25; idx++) {
+			fs.writeFileSync(path.join(cwd, `file-${idx.toString().padStart(2, "0")}.txt`), `NEEDLE ${idx}\n`);
+		}
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir: path.join(tempDir, "agent"),
+			settings: Settings.isolated({
+				"tools.approvalMode": "yolo",
+				"tools.xdev": false,
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+			}),
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			modelRegistry: sharedModelRegistry,
+			customTools,
+		});
+		const grepTool = session.agent.state.tools.find(tool => tool.name === "grep");
+		if (!grepTool) throw new Error("grep tool not registered");
+		return { session, cwd, grepTool };
+	}
+
+	it("invalidates only the owning session's cached pages after a custom tool write", async () => {
+		const captured: { ctx?: CustomToolContext } = {};
+		const owning = await spawnSession([makeMarkerTool(captured)]);
+		const other = await spawnSession([]);
+		try {
+			const grepSpy = spyOn(piNatives, "grep");
+
+			await owning.grepTool.execute("owning-page-1", { pattern: "NEEDLE", path: "." });
+			await other.grepTool.execute("other-page-1", { pattern: "NEEDLE", path: "." });
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+
+			const markerTool = owning.session.agent.state.tools.find(tool => tool.name === "write_marker");
+			expect(markerTool).toBeDefined();
+			await markerTool!.execute("marker-1", { file_name: "marker.txt", content: "NEEDLE marker\n" });
+
+			// The seam must be wired for SDK-supplied custom tools.
+			expect(captured.ctx?.invalidateFileCaches).toBeDefined();
+			expect(fs.existsSync(path.join(owning.cwd, "marker.txt"))).toBe(true);
+
+			// Owning session: stale page dropped, skip refetches.
+			await owning.grepTool.execute("owning-page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+
+			// Other session: untouched cache still serves its skip page.
+			await other.grepTool.execute("other-page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			await owning.session.dispose();
+			await other.session.dispose();
+		}
+	}, 60_000);
+});

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -133,6 +133,8 @@ describe("LSP diagnostics freshness", () => {
 			tempDir.path(),
 			[{ filePath, type: lspClient.FileChangeType.Created }],
 			undefined,
+			// No owner: this writethrough was created without a session-scoped cache.
+			undefined,
 		);
 	});
 
@@ -156,6 +158,8 @@ describe("LSP diagnostics freshness", () => {
 		expect(notify).toHaveBeenCalledWith(
 			tempDir.path(),
 			[{ filePath, type: lspClient.FileChangeType.Created }],
+			undefined,
+			// No owner: this writethrough was created without a session-scoped cache.
 			undefined,
 		);
 		expect(loadConfig).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import type { AgentToolResult, RenderResultOptions } from "@oh-my-pi/pi-agent-core";
 import { arkToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
-import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
+import { createLspWritethrough, flushLspWritethroughBatch, LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
@@ -43,6 +43,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/lsp/utils";
 import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { getSearchResultCache, type SearchResultCacheOwner } from "@oh-my-pi/pi-coding-agent/tools/search-result-cache";
 import { clampTimeout } from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
 import * as piUtils from "@oh-my-pi/pi-utils";
 import { sanitizeText, TempDir } from "@oh-my-pi/pi-utils";
@@ -303,6 +304,155 @@ describe("lsp regressions", () => {
 			expect(shutdownIndex).toBeGreaterThanOrEqual(0);
 			expect(exitIndex).toBeGreaterThan(shutdownIndex);
 			expect(server.killed).toBe(false);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("registers write-notified sessions so server workspace edits clear their search caches", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-watched-owner-");
+		try {
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["ts"],
+				rootMarkers: [],
+			};
+			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+
+			const targetPath = path.join(tempDir.path(), "watched.ts");
+			fs.writeFileSync(targetPath, "old\n");
+
+			// A session whose ONLY LSP contact is the write-notification path.
+			const sessionOwner: SearchResultCacheOwner = {};
+			const cache = getSearchResultCache(sessionOwner);
+			cache.set("stale", {
+				fileOrder: [],
+				matchesByPath: new Map(),
+				perFileLimitReached: false,
+				resultLimitReached: false,
+				skippedOversizedCount: 0,
+			});
+
+			const notifyChange = () =>
+				lspClient.notifyWorkspaceWatchedFiles(
+					tempDir.path(),
+					[{ filePath: targetPath, type: lspClient.FileChangeType.Changed }],
+					undefined,
+					sessionOwner,
+				);
+			await notifyChange();
+			const refs = Array.from(client.searchCacheOwners ?? []);
+			expect(refs.some(ref => ref.deref() === sessionOwner)).toBe(true);
+			// Re-notification must not accumulate duplicate refs.
+			await notifyChange();
+			expect(client.searchCacheOwners?.size).toBe(1);
+
+			// A later server-initiated workspace/applyEdit must clear the
+			// registered session's cached search pages.
+			server.send({
+				jsonrpc: "2.0",
+				id: 4242,
+				method: "workspace/applyEdit",
+				params: {
+					edit: {
+						changes: {
+							[fileToUri(targetPath)]: [
+								{
+									range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } },
+									newText: "new",
+								},
+							],
+						},
+					},
+				},
+			});
+			const response = await server.waitFor(message => message.id === 4242 && message.method === undefined);
+			expect(response.result).toMatchObject({ applied: true });
+			expect(cache.get("stale")).toBeUndefined();
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("holds batch writethrough owners weakly and registers only live sessions at flush", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-batch-owner-");
+		try {
+			installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["ts"],
+				rootMarkers: [],
+			};
+			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+
+			// Live owner: a flush:false batch defers all LSP work; the explicit
+			// flush must register the still-live session on the client.
+			const liveOwner: SearchResultCacheOwner = {};
+			const liveWritethrough = createLspWritethrough(tempDir.path(), { owner: liveOwner });
+			const livePath = path.join(tempDir.path(), "live.ts");
+			await liveWritethrough(livePath, "export const live = 1;\n", undefined, undefined, {
+				id: "batch-owner-live",
+				flush: false,
+			});
+			expect(Array.from(client.searchCacheOwners ?? []).some(ref => ref.deref() === liveOwner)).toBe(false);
+			await flushLspWritethroughBatch("batch-owner-live", tempDir.path());
+			expect(Array.from(client.searchCacheOwners ?? []).some(ref => ref.deref() === liveOwner)).toBe(true);
+
+			// Dead owner (deterministic stub, no GC): prototype-chained onto
+			// WeakRef so createLspWritethrough shares it instead of re-wrapping,
+			// with deref() overridden to simulate a collected session. The batch
+			// map must hold it weakly and flushing must skip registration while
+			// still writing.
+			const deadRef: WeakRef<SearchResultCacheOwner> = Object.assign(Object.create(WeakRef.prototype), {
+				deref: () => undefined,
+			});
+			const deadWritethrough = createLspWritethrough(tempDir.path(), { owner: deadRef });
+			const deadPath = path.join(tempDir.path(), "dead.ts");
+			await deadWritethrough(deadPath, "export const dead = 1;\n", undefined, undefined, {
+				id: "batch-owner-dead",
+				flush: false,
+			});
+			const sizeBefore = client.searchCacheOwners?.size ?? 0;
+			await flushLspWritethroughBatch("batch-owner-dead", tempDir.path());
+			expect(await Bun.file(deadPath).text()).toBe("export const dead = 1;\n");
+			expect(client.searchCacheOwners?.size ?? 0).toBe(sizeBefore);
+
+			// Merge audit: a dead ref left on a pending batch must not shadow a
+			// live session continuing the same batch.
+			const revivedOwner: SearchResultCacheOwner = {};
+			const deadFirst = createLspWritethrough(tempDir.path(), { owner: deadRef });
+			const mergedPathA = path.join(tempDir.path(), "merged-a.ts");
+			await deadFirst(mergedPathA, "export const a = 1;\n", undefined, undefined, {
+				id: "batch-owner-merge",
+				flush: false,
+			});
+			const liveSecond = createLspWritethrough(tempDir.path(), { owner: revivedOwner });
+			const mergedPathB = path.join(tempDir.path(), "merged-b.ts");
+			await liveSecond(mergedPathB, "export const b = 1;\n", undefined, undefined, {
+				id: "batch-owner-merge",
+				flush: false,
+			});
+			await flushLspWritethroughBatch("batch-owner-merge", tempDir.path());
+			expect(Array.from(client.searchCacheOwners ?? []).some(ref => ref.deref() === revivedOwner)).toBe(true);
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();

--- a/packages/coding-agent/test/tools/search-pagination-cache.test.ts
+++ b/packages/coding-agent/test/tools/search-pagination-cache.test.ts
@@ -1,0 +1,1338 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { disposeAllVmContexts } from "@oh-my-pi/pi-coding-agent/eval/js/context-manager";
+import * as bashExecutor from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import {
+	type InternalResource,
+	type InternalUrl,
+	InternalUrlRouter,
+	type ProtocolHandler,
+} from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { invalidateRegisteredSearchCaches, registerSearchCacheOwner } from "@oh-my-pi/pi-coding-agent/lsp/client";
+import { applyWorkspaceEdit } from "@oh-my-pi/pi-coding-agent/lsp/edits";
+import type { LspClient } from "@oh-my-pi/pi-coding-agent/lsp/types";
+import { ToolChoiceQueue } from "@oh-my-pi/pi-coding-agent/session/tool-choice-queue";
+import { BashTool, GrepTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { AstEditTool } from "@oh-my-pi/pi-coding-agent/tools/ast-edit";
+import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { invalidateFsScanAfterWrite } from "@oh-my-pi/pi-coding-agent/tools/fs-cache-invalidation";
+import { mergeGrepResults } from "@oh-my-pi/pi-coding-agent/tools/grep";
+import {
+	type CachedGroupedSearchResult,
+	clearSearchResultCache,
+	getSearchResultCache,
+	isPathWithinWorkspace,
+	type SearchResultCacheOwner,
+	simulateWorkspaceOwnerCollectionForTests,
+	suppressSearchResultCaches,
+	workspaceRegistrySnapshot,
+} from "@oh-my-pi/pi-coding-agent/tools/search-result-cache";
+import { ttsTool } from "@oh-my-pi/pi-coding-agent/tools/tts";
+import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
+import { ttsClient } from "@oh-my-pi/pi-coding-agent/tts/tts-client";
+import type { GrepResult } from "@oh-my-pi/pi-natives";
+import * as piNatives from "@oh-my-pi/pi-natives";
+
+function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated({ "grep.contextBefore": 0, "grep.contextAfter": 0 }),
+		...overrides,
+	};
+}
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(entry => entry.type === "text")
+		.map(entry => entry.text ?? "")
+		.join("\n");
+}
+
+async function createSearchFixture(rootDir: string): Promise<void> {
+	for (let idx = 0; idx < 50; idx++) {
+		const suffix = idx.toString().padStart(2, "0");
+		await Bun.write(path.join(rootDir, `file-${suffix}.txt`), `NEEDLE file-${suffix}\n`);
+	}
+
+	await fs.mkdir(path.join(rootDir, "other"), { recursive: true });
+	for (let idx = 0; idx < 5; idx++) {
+		const suffix = idx.toString().padStart(2, "0");
+		await Bun.write(path.join(rootDir, "other", `other-${suffix}.txt`), `NEEDLE other-${suffix}\n`);
+	}
+
+	await Bun.write(path.join(rootDir, "alternate.txt"), "OTHER\n");
+}
+
+const BACKING_SCHEME = "search-cache-backing";
+
+describe("search pagination cache", () => {
+	let cwd: string;
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+
+	afterAll(async () => {
+		await disposeAllVmContexts();
+	});
+
+	beforeEach(async () => {
+		cwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-pagination-cache-"));
+		await createSearchFixture(cwd);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		InternalUrlRouter.instance().unregister(BACKING_SCHEME);
+		await fs.rm(cwd, { recursive: true, force: true });
+	});
+
+	it("reuses grouped filesystem results for skip pagination", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		const pageTwo = await new GrepTool(session).execute("page-2", {
+			pattern: "NEEDLE",
+			path: ".",
+			skip: 20,
+		});
+		const text = getText(pageTwo);
+
+		expect(grepSpy).toHaveBeenCalledTimes(1);
+		expect(text).toContain("file-20.txt");
+		expect(text).toContain("file-39.txt");
+		expect(text).toContain("Showing files 21-40 of 55");
+		expect(text).not.toContain("file-19.txt");
+		expect(text).not.toContain("file-40.txt");
+	});
+
+	it("falls back to grep when skip has no prior cache entry", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		const pageTwo = await new GrepTool(session).execute("page-2", {
+			pattern: "NEEDLE",
+			path: ".",
+			skip: 20,
+		});
+		const text = getText(pageTwo);
+
+		expect(grepSpy).toHaveBeenCalledTimes(1);
+		expect(text).toContain("file-20.txt");
+		expect(text).toContain("file-39.txt");
+	});
+
+	it("misses cache when pattern changes", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new GrepTool(session).execute("page-2", { pattern: "OTHER", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("misses cache when path scope changes", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: "other", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears cached search results after a successful write tool mutation", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new WriteTool(session).execute("mutate", {
+			path: "file-49.txt",
+			content: "NEEDLE file-49 changed\n",
+		});
+		await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("fans out mutation invalidation to sibling sessions sharing the workspace", async () => {
+		// A non-isolated task child shares the parent's cwd but owns a separate
+		// ToolSession cache; its mutation must also drop the parent's pages.
+		const parent = createTestSession(cwd);
+		const child = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(parent).execute("parent-page-1", { pattern: "NEEDLE", path: "." });
+		await new WriteTool(child).execute("child-mutate", {
+			path: "file-20.txt",
+			content: "OTHER\n",
+		});
+		const pageTwo = await new GrepTool(parent).execute("parent-page-2", {
+			pattern: "NEEDLE",
+			path: ".",
+			skip: 20,
+		});
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(getText(pageTwo)).not.toContain("file-20.txt");
+	});
+
+	it("does not evict cached pages of sessions in other workspaces", async () => {
+		const otherCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-pagination-other-"));
+		try {
+			await createSearchFixture(otherCwd);
+			const sessionA = createTestSession(cwd);
+			const sessionB = createTestSession(otherCwd);
+			const grepSpy = spyOn(piNatives, "grep");
+
+			await new GrepTool(sessionA).execute("a-page-1", { pattern: "NEEDLE", path: "." });
+			await new GrepTool(sessionB).execute("b-page-1", { pattern: "NEEDLE", path: "." });
+			await new WriteTool(sessionB).execute("b-mutate", {
+				path: "file-20.txt",
+				content: "OTHER\n",
+			});
+
+			// Session A's workspace is untouched: its skip page stays cached.
+			await new GrepTool(sessionA).execute("a-page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			// Session B refetches after its own workspace mutation.
+			await new GrepTool(sessionB).execute("b-page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			await fs.rm(otherCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("clears cached search results after a Bash command completes", async () => {
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+		});
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new BashTool(session).execute("mutate", { command: "rm file-20.txt" });
+		const pageTwo = await new GrepTool(session).execute("page-2", {
+			pattern: "NEEDLE",
+			path: ".",
+			skip: 20,
+		});
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(getText(pageTwo)).not.toContain("file-20.txt");
+	});
+
+	it("clears cached search results after a successful internal URL write mutation", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+		const handler: ProtocolHandler = {
+			scheme: BACKING_SCHEME,
+			immutable: false,
+			async resolve(url: InternalUrl): Promise<InternalResource> {
+				return {
+					url: url.href,
+					content: await Bun.file(path.join(cwd, "file-49.txt")).text(),
+					contentType: "text/plain",
+				};
+			},
+			async write(_url: InternalUrl, content: string): Promise<void> {
+				await Bun.write(path.join(cwd, "file-49.txt"), content);
+			},
+		};
+		InternalUrlRouter.instance().register(handler);
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new WriteTool(session).execute("mutate", {
+			path: `${BACKING_SCHEME}://file-49`,
+			content: "NEEDLE file-49 changed\n",
+		});
+		await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("expires cached grouped results after the TTL window", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+		let now = 1_700_000_000_000;
+		spyOn(Date, "now").mockImplementation(() => now);
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		now += 61_000;
+		await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps nested-scope searches cacheable but bypasses caching outside the session workspace", async () => {
+		const outsideCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-pagination-outside-"));
+		try {
+			await createSearchFixture(outsideCwd);
+			const session = createTestSession(cwd);
+			const grepSpy = spyOn(piNatives, "grep");
+
+			// Nested scope (subdir of the session workspace): cached — every
+			// session-key mutation fans out to it.
+			await new GrepTool(session).execute("nested-1", { pattern: "NEEDLE", path: "other" });
+			await new GrepTool(session).execute("nested-2", { pattern: "NEEDLE", path: "other", skip: 1 });
+			expect(grepSpy).toHaveBeenCalledTimes(1);
+
+			// Sibling/outside scope (absolute path in another workspace): that
+			// workspace's mutators cannot reach a cache owned by this session,
+			// so pagination must recompute instead of caching.
+			await new GrepTool(session).execute("outside-1", { pattern: "NEEDLE", path: outsideCwd });
+			await new GrepTool(session).execute("outside-2", { pattern: "NEEDLE", path: outsideCwd, skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			await fs.rm(outsideCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("bypasses caching for an in-workspace symlink that escapes to another workspace", async () => {
+		const outsideCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-pagination-escape-"));
+		try {
+			await createSearchFixture(outsideCwd);
+			// Lexically inside the session workspace, physically outside it: the
+			// outside workspace's mutators can never invalidate this session's
+			// cache, so pagination must recompute.
+			await fs.symlink(outsideCwd, path.join(cwd, "escape-link"));
+			const session = createTestSession(cwd);
+			const grepSpy = spyOn(piNatives, "grep");
+
+			await new GrepTool(session).execute("escape-1", { pattern: "NEEDLE", path: "escape-link" });
+			await new GrepTool(session).execute("escape-2", { pattern: "NEEDLE", path: "escape-link", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			await fs.rm(outsideCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps caching for a symlink alias inside the same physical workspace", async () => {
+		// An alias to a directory of THIS workspace shares its physical root, so
+		// session-key invalidation reaches the cache — no needless bypass.
+		await fs.symlink(path.join(cwd, "other"), path.join(cwd, "other-alias"));
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("alias-1", { pattern: "NEEDLE", path: "other-alias" });
+		await new GrepTool(session).execute("alias-2", { pattern: "NEEDLE", path: "other-alias", skip: 1 });
+		expect(grepSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-evaluates containment after a symlink is retargeted outside the workspace", async () => {
+		const outsideCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-pagination-retarget-"));
+		try {
+			await createSearchFixture(outsideCwd);
+			const link = path.join(cwd, "swing-link");
+			await fs.symlink(path.join(cwd, "other"), link);
+			const session = createTestSession(cwd);
+			const grepSpy = spyOn(piNatives, "grep");
+
+			// Inside alias: cacheable (memoizing this verdict would be the bug).
+			await new GrepTool(session).execute("swing-1", { pattern: "NEEDLE", path: "swing-link" });
+			await new GrepTool(session).execute("swing-2", { pattern: "NEEDLE", path: "swing-link", skip: 1 });
+			expect(grepSpy).toHaveBeenCalledTimes(1);
+
+			// Retarget the same link outside: containment must be re-resolved
+			// fresh, so pagination recomputes instead of caching an outside scope.
+			await fs.rm(link);
+			await fs.symlink(outsideCwd, link);
+			await new GrepTool(session).execute("swing-3", { pattern: "NEEDLE", path: "swing-link" });
+			await new GrepTool(session).execute("swing-4", { pattern: "NEEDLE", path: "swing-link", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			await fs.rm(outsideCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("workspace containment handles volume roots and dotted children", async () => {
+		// Volume root: a `root + sep` prefix check would build `//` and never match.
+		expect(isPathWithinWorkspace(path.parse(cwd).root, cwd)).toBe(true);
+		// A child literally named `..foo` is inside; a bare startsWith("..")
+		// escape test would wrongly reject it.
+		const dotted = path.join(cwd, "..foo");
+		await fs.mkdir(dotted);
+		expect(isPathWithinWorkspace(cwd, dotted)).toBe(true);
+		expect(isPathWithinWorkspace(cwd, path.dirname(cwd))).toBe(false);
+	});
+
+	it("finds late in-range lines for ranged multi-target searches", async () => {
+		// A `:4000-4000` selector sits far past INTERNAL_TOTAL_CAP (2000) and the
+		// unranged per-file budget (21): only the range-amplified native caps let
+		// the JS range filter see the in-range line in each explicit target.
+		const content = `${Array.from({ length: 3999 }, (_, idx) => `NEEDLE before-${idx}`).join("\n")}\nNEEDLE deep-in-range\n`;
+		await Bun.write(path.join(cwd, "deep-a.txt"), content);
+		await Bun.write(path.join(cwd, "deep-b.txt"), content);
+		const session = createTestSession(cwd);
+
+		const result = await new GrepTool(session).execute("deep-range", {
+			pattern: "NEEDLE",
+			path: "deep-a.txt:4000-4000; deep-b.txt:4000-4000",
+		});
+		const text = getText(result);
+
+		expect(text).toContain("deep-a.txt");
+		expect(text).toContain("deep-b.txt");
+		expect(text.match(/deep-in-range/g)).toHaveLength(2);
+	});
+
+	it("bypasses cache for line-range selectors", async () => {
+		const session = createTestSession(cwd);
+		await Bun.write(path.join(cwd, "range-a.txt"), "NEEDLE a\n");
+		await Bun.write(path.join(cwd, "range-b.txt"), "NEEDLE b\n");
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("range-1", {
+			pattern: "NEEDLE",
+			path: "range-a.txt:1-1; range-b.txt:1-1",
+		});
+		await new GrepTool(session).execute("range-2", {
+			pattern: "NEEDLE",
+			path: "range-a.txt:1-1; range-b.txt:1-1",
+			skip: 1,
+		});
+
+		expect(grepSpy).toHaveBeenCalledTimes(4);
+	});
+	it("scans past out-of-range matches for each file in a fan-out search", async () => {
+		const session = createTestSession(cwd);
+		const content = `${Array.from({ length: 30 }, (_, idx) => `NEEDLE before-${idx}`).join("\n")}\nNEEDLE in-range\n`;
+		await Bun.write(path.join(cwd, "range-a.txt"), content);
+		await Bun.write(path.join(cwd, "range-b.txt"), content);
+
+		const result = await new GrepTool(session).execute("range-fanout", {
+			pattern: "NEEDLE",
+			path: "range-a.txt:31-31; range-b.txt:31-31",
+		});
+		const text = getText(result);
+
+		expect(text).toContain("range-a.txt");
+		expect(text).toContain("range-b.txt");
+		expect(text.match(/in-range/g)).toHaveLength(2);
+	});
+
+	it("does not reuse cached pages while an async Bash job may still mutate files", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": true,
+				"bash.autoBackground.enabled": false,
+			}),
+			asyncJobManager: manager,
+		});
+		// Deterministic stand-in for the shell: mutate immediately, then stay
+		// in-flight until released. No subprocess, no watcher, no wall-clock
+		// dependence (a real `rm … && sleep` flaked under CI load).
+		const bashStarted = Promise.withResolvers<void>();
+		const finishBash = Promise.withResolvers<void>();
+		const executeBashSpy = vi.spyOn(bashExecutor, "executeBash").mockImplementation(async () => {
+			await fs.rm(path.join(cwd, "file-20.txt"));
+			bashStarted.resolve();
+			await finishBash.promise;
+			return {
+				output: "",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				totalLines: 0,
+				totalBytes: 0,
+				outputLines: 0,
+				outputBytes: 0,
+			};
+		});
+		try {
+			const grepSpy = spyOn(piNatives, "grep");
+			await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+
+			// Completion-only invalidation would leave the stale first page
+			// reusable during this window: the job has mutated but not settled.
+			await new BashTool(session).execute("mutate", { command: "rm file-20.txt", async: true });
+			await bashStarted.promise;
+
+			const pageTwo = await new GrepTool(session).execute("page-2", {
+				pattern: "NEEDLE",
+				path: ".",
+				skip: 20,
+			});
+
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			expect(getText(pageTwo)).not.toContain("file-20.txt");
+			expect(executeBashSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			// Release the in-flight job BEFORE disposing so the runner settles
+			// cleanly and no detached continuation outlives the test's cwd.
+			finishBash.resolve();
+			await manager.dispose({ timeoutMs: 1_000 });
+		}
+	});
+
+	it("clears cached search results after an LSP workspace edit applies", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await applyWorkspaceEdit(
+			{
+				changes: {
+					[pathToFileURL(path.join(cwd, "file-20.txt")).href]: [
+						{
+							range: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+							newText: "CHANGED",
+						},
+					],
+				},
+			},
+			cwd,
+			session,
+		);
+		const pageTwo = await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(getText(pageTwo)).not.toContain("file-20.txt");
+	});
+
+	it("clears cached search results when a workspace edit partially fails", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		// Operation one mutates file-20; operation two (text edits against a
+		// missing file) throws. The partial mutation must still invalidate the
+		// cache. (Resource ops are planned before trailing text edits, so the
+		// failing op must also be a text edit to run second.)
+		await expect(
+			applyWorkspaceEdit(
+				{
+					documentChanges: [
+						{
+							textDocument: { uri: pathToFileURL(path.join(cwd, "file-20.txt")).href, version: null },
+							edits: [
+								{
+									range: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+									newText: "CHANGED",
+								},
+							],
+						},
+						{
+							textDocument: { uri: pathToFileURL(path.join(cwd, "missing.txt")).href, version: null },
+							edits: [
+								{
+									range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+									newText: "X",
+								},
+							],
+						},
+					],
+				},
+				cwd,
+				session,
+			),
+		).rejects.toThrow();
+		const pageTwo = await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(getText(pageTwo)).not.toContain("file-20.txt");
+	});
+
+	it("keeps in-range and virtual matches when a widened ranged search merges with virtual results", async () => {
+		const session = createTestSession(cwd);
+		const handler: ProtocolHandler = {
+			scheme: BACKING_SCHEME,
+			immutable: false,
+			async resolve(url: InternalUrl): Promise<InternalResource> {
+				return { url: url.href, content: "NEEDLE virtual-hit\n", contentType: "text/plain" };
+			},
+		};
+		InternalUrlRouter.instance().register(handler);
+		// More pre-range matches than INTERNAL_TOTAL_CAP (2000): a merge that
+		// truncates back to the unwidened cap drops both the in-range line and
+		// the virtual match before the JS range filter runs.
+		const before = Array.from({ length: 2100 }, (_, idx) => `NEEDLE before-${idx}`).join("\n");
+		await Bun.write(path.join(cwd, "huge.txt"), `${before}\nNEEDLE in-range\n`);
+
+		const result = await new GrepTool(session).execute("range-virtual", {
+			pattern: "NEEDLE",
+			path: `huge.txt:2101-2101; ${BACKING_SCHEME}://doc`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("in-range");
+		expect(text).toContain("virtual-hit");
+	});
+
+	it("merge cap keeps encounter order and applies to one-sided results", () => {
+		const makeResult = (pathName: string, count: number): GrepResult => ({
+			matches: Array.from({ length: count }, (_, idx) => ({
+				path: pathName,
+				lineNumber: idx + 1,
+				line: `NEEDLE ${idx}`,
+			})),
+			totalMatches: count,
+			filesWithMatches: 1,
+			filesSearched: 1,
+			limitReached: false,
+		});
+
+		// Two-sided over cap: filesystem matches fill the budget first and the
+		// trailing virtual match is dropped with the limit flagged.
+		const boundary = mergeGrepResults(makeResult("fs.txt", 4), makeResult("virtual://doc", 1), 4);
+		expect(boundary.matches.map(match => match.path)).toEqual(["fs.txt", "fs.txt", "fs.txt", "fs.txt"]);
+		expect(boundary.limitReached).toBe(true);
+		expect(boundary.totalMatches).toBe(5);
+
+		// Under cap: both sides survive in filesystem-then-virtual order.
+		const merged = mergeGrepResults(makeResult("fs.txt", 2), makeResult("virtual://doc", 1), 4);
+		expect(merged.matches.map(match => match.path)).toEqual(["fs.txt", "fs.txt", "virtual://doc"]);
+		expect(merged.limitReached).toBe(false);
+
+		// One-sided over cap must not bypass the ceiling: pre-fix the nonempty
+		// side was returned unchanged and uncapped.
+		const oneSided = mergeGrepResults(makeResult("fs.txt", 6), makeResult("virtual://doc", 0), 4);
+		expect(oneSided.matches).toHaveLength(4);
+		expect(oneSided.limitReached).toBe(true);
+		expect(oneSided.totalMatches).toBe(6);
+	});
+
+	it("caps over-cap aggregated multi-target results even without virtual participation", async () => {
+		const session = createTestSession(cwd);
+		// Two directory targets: each native call stays under its own cap, but
+		// the aggregate (102 files x 21 fetched matches = 2142) exceeds
+		// INTERNAL_TOTAL_CAP, so the merged result must cap and flag the limit.
+		for (const dir of ["cap-a", "cap-b"]) {
+			await fs.mkdir(path.join(cwd, dir), { recursive: true });
+			for (let idx = 0; idx < 51; idx++) {
+				const body = Array.from({ length: 21 }, (_, line) => `NEEDLE ${dir}-${idx}-${line}`).join("\n");
+				await Bun.write(path.join(cwd, dir, `f-${idx.toString().padStart(2, "0")}.txt`), `${body}\n`);
+			}
+		}
+
+		const result = await new GrepTool(session).execute("over-cap", { pattern: "NEEDLE", path: "cap-a; cap-b" });
+		const text = getText(result);
+
+		// The "+" suffix marks the capped lower-bound file total.
+		expect(text).toMatch(/of \d+\+/);
+		expect(text).not.toContain("of 102");
+	});
+
+	it("maps virtual-only regex engine failures to Invalid regex", async () => {
+		const session = createTestSession(cwd);
+		const handler: ProtocolHandler = {
+			scheme: BACKING_SCHEME,
+			immutable: false,
+			async resolve(url: InternalUrl): Promise<InternalResource> {
+				return { url: url.href, content: "irrelevant\n", contentType: "text/plain" };
+			},
+		};
+		InternalUrlRouter.instance().register(handler);
+		// Whether native grep rejects a given pattern depends on the natives
+		// build (newer builds fall back to a literal match instead of erroring),
+		// so drive the error surface directly: a virtual-only scope's ONLY
+		// native call is the scratch probe, and when that probe rejects with a
+		// regex error the tool must surface `Invalid regex: ...`, never the raw
+		// engine error.
+		const grepSpy = spyOn(piNatives, "grep").mockRejectedValue(
+			new Error("regex parse error: unclosed character class"),
+		);
+		await expect(
+			new GrepTool(session).execute("bad-regex", { pattern: "[", path: `${BACKING_SCHEME}://doc` }),
+		).rejects.toThrow(/^Invalid regex: /);
+
+		// JS RegExp SyntaxError (oversized-content fallback path) maps the same way.
+		grepSpy.mockRejectedValue(new SyntaxError("Invalid regular expression: /[/: Unterminated character class"));
+		await expect(
+			new GrepTool(session).execute("bad-regex-js", { pattern: "[", path: `${BACKING_SCHEME}://doc` }),
+		).rejects.toThrow(/^Invalid regex: /);
+	});
+
+	it("clears cached search results after an eval cell completes", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		// Eval cells can mutate the filesystem through arbitrary runtime APIs;
+		// completion must conservatively invalidate cached pages.
+		const target = path.join(cwd, "file-20.txt");
+		await new EvalTool(session).execute("mutate", {
+			language: "js",
+			code: `await Bun.file(${JSON.stringify(target)}).delete();`,
+		});
+		const pageTwo = await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(getText(pageTwo)).not.toContain("file-20.txt");
+	});
+
+	it("clears cached search results when an ast_edit preview is applied", async () => {
+		const queue = new ToolChoiceQueue();
+		const session = createTestSession(cwd, {
+			getToolChoiceQueue: () => queue,
+			buildToolChoice: () => ({ type: "tool" as const, name: "resolve" }),
+			steer: () => {},
+		});
+		await Bun.write(path.join(cwd, "legacy.ts"), "legacyWrap(x, value)\n");
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+		await new AstEditTool(session).execute("preview", {
+			ops: [{ pat: "legacyWrap($A, $B)", out: "modernWrap($A, $B)" }],
+			paths: ["legacy.ts"],
+		});
+		const invoker = queue.peekPendingInvoker()!;
+		await invoker({ action: "apply", reason: "apply previewed AST edit" });
+		const pageTwo = await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+		expect(grepSpy).toHaveBeenCalledTimes(2);
+		expect(await Bun.file(path.join(cwd, "legacy.ts")).text()).toContain("modernWrap");
+		expect(getText(pageTwo)).toContain("file-20.txt");
+	});
+
+	it("clears cached search results after a TTS write", async () => {
+		const session = createTestSession(cwd);
+		const grepSpy = spyOn(piNatives, "grep");
+		spyOn(ttsClient, "synthesize").mockResolvedValue({ pcm: new Float32Array(16), sampleRate: 24_000 });
+		// Force the local backend so no credential lookup or network is involved.
+		const previousProvider = settings.get("providers.tts");
+		settings.set("providers.tts", "local");
+		try {
+			await new GrepTool(session).execute("page-1", { pattern: "NEEDLE", path: "." });
+
+			// Production wiring: sdk.ts binds `invalidateFileCaches` for built-in
+			// write-capable custom tools to the owning tool session.
+			const ttsContext = {
+				sessionManager: { getCwd: () => cwd },
+				isIdle: () => true,
+				hasQueuedMessages: () => false,
+				abort: () => {},
+				invalidateFileCaches: (writtenPath: string) => invalidateFsScanAfterWrite(writtenPath, session),
+			} as unknown as CustomToolContext;
+			await ttsTool.execute(
+				"tts-1",
+				{ text: "hello", voice_id: "eve", language: "en", output_path: "speech.wav" },
+				undefined,
+				ttsContext,
+				undefined,
+			);
+			expect(await Bun.file(path.join(cwd, "speech.wav")).exists()).toBe(true);
+
+			const pageTwo = await new GrepTool(session).execute("page-2", { pattern: "NEEDLE", path: ".", skip: 20 });
+
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			expect(getText(pageTwo)).toContain("file-20.txt");
+		} finally {
+			settings.set("providers.tts", previousProvider);
+		}
+	});
+
+	it("suppresses every same-workspace cache including mid-flight registrants", () => {
+		const makeEntry = (): CachedGroupedSearchResult => ({
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+		const ownerA: SearchResultCacheOwner = { cwd };
+		const ownerB: SearchResultCacheOwner = { cwd };
+		getSearchResultCache(ownerA).set("k", makeEntry());
+		expect(getSearchResultCache(ownerA).get("k")).toBeDefined();
+
+		// Sibling suppression: B's background job closes A's cache too.
+		const release = suppressSearchResultCaches(ownerB);
+		expect(getSearchResultCache(ownerA).get("k")).toBeUndefined();
+		getSearchResultCache(ownerA).set("k", makeEntry());
+		expect(getSearchResultCache(ownerA).get("k")).toBeUndefined();
+
+		// Mid-flight registrant in the same workspace is suppressed as well.
+		const ownerC: SearchResultCacheOwner = { cwd };
+		getSearchResultCache(ownerC).set("k", makeEntry());
+		expect(getSearchResultCache(ownerC).get("k")).toBeUndefined();
+
+		// Nested suppression: the workspace reopens only after every release.
+		const releaseNested = suppressSearchResultCaches(ownerA);
+		release();
+		getSearchResultCache(ownerA).set("k", makeEntry());
+		expect(getSearchResultCache(ownerA).get("k")).toBeUndefined();
+		releaseNested();
+		releaseNested(); // double release is a no-op
+		getSearchResultCache(ownerA).set("k", makeEntry());
+		expect(getSearchResultCache(ownerA).get("k")).toBeDefined();
+		expect(workspaceRegistrySnapshot(cwd)?.suppressions).toBe(0);
+	});
+
+	it("workspace registry dedups owners, relocates moved sessions, and drops empty buckets", async () => {
+		const wsA = path.join(cwd, "reg-a");
+		const wsB = path.join(cwd, "reg-b");
+		await fs.mkdir(wsA, { recursive: true });
+		await fs.mkdir(wsB, { recursive: true });
+
+		const ownerA: SearchResultCacheOwner = { cwd: wsA };
+		getSearchResultCache(ownerA);
+		getSearchResultCache(ownerA);
+		expect(workspaceRegistrySnapshot(wsA)).toEqual({ owners: 1, suppressions: 0 });
+
+		const ownerB: SearchResultCacheOwner = { cwd: wsA };
+		getSearchResultCache(ownerB);
+		expect(workspaceRegistrySnapshot(wsA)?.owners).toBe(2);
+
+		// A live session moving workspaces must leave the old bucket.
+		ownerB.cwd = wsB;
+		getSearchResultCache(ownerB);
+		expect(workspaceRegistrySnapshot(wsA)?.owners).toBe(1);
+		expect(workspaceRegistrySnapshot(wsB)).toEqual({ owners: 1, suppressions: 0 });
+
+		// The last departure drops the empty bucket entirely.
+		ownerA.cwd = wsB;
+		getSearchResultCache(ownerA);
+		expect(workspaceRegistrySnapshot(wsA)).toBeUndefined();
+		expect(workspaceRegistrySnapshot(wsB)?.owners).toBe(2);
+
+		// Old-workspace mutations no longer touch the moved session's cache.
+		getSearchResultCache(ownerA).set("k", {
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+		clearSearchResultCache({ cwd: wsA });
+		expect(getSearchResultCache(ownerA).get("k")).toBeDefined();
+	});
+
+	it("canonicalizes workspace keys across symlinked aliases", async () => {
+		const real = path.join(cwd, "real-ws");
+		const alias = path.join(cwd, "alias-ws");
+		await fs.mkdir(real, { recursive: true });
+		await fs.symlink(real, alias);
+
+		const ownerReal: SearchResultCacheOwner = { cwd: real };
+		const ownerAlias: SearchResultCacheOwner = { cwd: alias };
+		getSearchResultCache(ownerReal).set("k", {
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+		getSearchResultCache(ownerAlias);
+		expect(workspaceRegistrySnapshot(real)?.owners).toBe(2);
+		expect(workspaceRegistrySnapshot(alias)?.owners).toBe(2);
+
+		// A mutation reported through the alias clears the real-path sibling.
+		clearSearchResultCache(ownerAlias);
+		expect(getSearchResultCache(ownerReal).get("k")).toBeUndefined();
+	});
+
+	it("unifies case aliases only when the volume is actually case-insensitive", async () => {
+		const real = path.join(cwd, "case-ws");
+		await fs.mkdir(real, { recursive: true });
+		const upperTail = path.join(cwd, "CASE-WS");
+		// Runtime probe of THIS volume — platform name alone must not decide
+		// (macOS supports case-sensitive APFS/HFS volumes).
+		const volumeInsensitive = await fs.access(upperTail).then(
+			() => true,
+			() => false,
+		);
+
+		const ownerReal: SearchResultCacheOwner = { cwd: real };
+		const ownerUpper: SearchResultCacheOwner = { cwd: upperTail };
+		getSearchResultCache(ownerReal);
+		getSearchResultCache(ownerUpper);
+		expect(workspaceRegistrySnapshot(real)?.owners).toBe(volumeInsensitive ? 2 : 1);
+
+		// Fallback contract: NOT-yet-existing paths differing only by case merge
+		// only when the nearest existing ancestor's volume is case-insensitive —
+		// never by a blind platform-wide lowercase.
+		const missingLower: SearchResultCacheOwner = { cwd: path.join(cwd, "missing-ws") };
+		const missingUpper: SearchResultCacheOwner = { cwd: path.join(cwd, "MISSING-WS") };
+		getSearchResultCache(missingLower);
+		getSearchResultCache(missingUpper);
+		expect(workspaceRegistrySnapshot(path.join(cwd, "missing-ws"))?.owners).toBe(volumeInsensitive ? 2 : 1);
+	});
+
+	it("relocating to a cwd-less fallback retires the old workspace registration", async () => {
+		const wsA = path.join(cwd, "fallback-a");
+		await fs.mkdir(wsA, { recursive: true });
+		const makeEntry = (): CachedGroupedSearchResult => ({
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+
+		const owner: SearchResultCacheOwner = { cwd: wsA };
+		getSearchResultCache(owner);
+		expect(workspaceRegistrySnapshot(wsA)?.owners).toBe(1);
+
+		owner.cwd = undefined;
+		getSearchResultCache(owner).set("k", makeEntry());
+		// Old bucket dropped entirely...
+		expect(workspaceRegistrySnapshot(wsA)).toBeUndefined();
+		// ...and old-workspace invalidation no longer evicts the fallback cache.
+		clearSearchResultCache({ cwd: wsA });
+		expect(getSearchResultCache(owner).get("k")).toBeDefined();
+	});
+
+	it("reconciles a moved owner when the first post-move call is a mutation", async () => {
+		const wsA = path.join(cwd, "move-a");
+		const wsB = path.join(cwd, "move-b");
+		await fs.mkdir(wsA, { recursive: true });
+		await fs.mkdir(wsB, { recursive: true });
+		const makeEntry = (): CachedGroupedSearchResult => ({
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+
+		const owner: SearchResultCacheOwner = { cwd: wsA };
+		getSearchResultCache(owner);
+		owner.cwd = wsB;
+		// First post-move operation is a MUTATION, not a cache read.
+		clearSearchResultCache(owner);
+
+		expect(workspaceRegistrySnapshot(wsA)).toBeUndefined();
+		expect(workspaceRegistrySnapshot(wsB)?.owners).toBe(1);
+		getSearchResultCache(owner).set("k", makeEntry());
+		clearSearchResultCache({ cwd: wsA });
+		expect(getSearchResultCache(owner).get("k")).toBeDefined();
+		clearSearchResultCache({ cwd: wsB });
+		expect(getSearchResultCache(owner).get("k")).toBeUndefined();
+	});
+
+	it("finalized owners are reaped, with bucket drop deferred while suppressed", async () => {
+		const wsX = path.join(cwd, "reap-x");
+		await fs.mkdir(wsX, { recursive: true });
+
+		// Plain collection: last owner reaped drops the bucket immediately.
+		const collected: SearchResultCacheOwner = { cwd: wsX };
+		getSearchResultCache(collected);
+		expect(workspaceRegistrySnapshot(wsX)?.owners).toBe(1);
+		simulateWorkspaceOwnerCollectionForTests(collected);
+		expect(workspaceRegistrySnapshot(wsX)).toBeUndefined();
+
+		// Suppression-active: the bucket must survive the reap until release.
+		const holder: SearchResultCacheOwner = { cwd: wsX };
+		getSearchResultCache(holder);
+		const release = suppressSearchResultCaches(holder);
+		simulateWorkspaceOwnerCollectionForTests(holder);
+		expect(workspaceRegistrySnapshot(wsX)).toEqual({ owners: 0, suppressions: 1 });
+		release();
+		expect(workspaceRegistrySnapshot(wsX)).toBeUndefined();
+	});
+
+	it("async Bash cwd overrides suppress the effective command workspace", async () => {
+		const jobWs = path.join(cwd, "job-ws");
+		await fs.mkdir(jobWs, { recursive: true });
+		for (let idx = 0; idx < 25; idx++) {
+			const suffix = idx.toString().padStart(2, "0");
+			await Bun.write(path.join(jobWs, `job-${suffix}.txt`), `NEEDLE job-${suffix}\n`);
+		}
+		const sibling = createTestSession(jobWs);
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": true,
+				"bash.autoBackground.enabled": false,
+			}),
+			asyncJobManager: manager,
+		});
+		const bashStarted = Promise.withResolvers<void>();
+		const finishBash = Promise.withResolvers<void>();
+		vi.spyOn(bashExecutor, "executeBash").mockImplementation(async () => {
+			await fs.rm(path.join(jobWs, "job-20.txt"));
+			bashStarted.resolve();
+			await finishBash.promise;
+			return {
+				output: "",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				totalLines: 0,
+				totalBytes: 0,
+				outputLines: 0,
+				outputBytes: 0,
+			};
+		});
+		try {
+			const grepSpy = spyOn(piNatives, "grep");
+			await new GrepTool(sibling).execute("sibling-page-1", { pattern: "NEEDLE", path: "." });
+
+			await new BashTool(session).execute("mutate", {
+				command: "rm job-20.txt",
+				cwd: "job-ws",
+				async: true,
+			});
+			await bashStarted.promise;
+
+			// The sibling rooted at the EFFECTIVE command cwd must refetch...
+			const pageTwo = await new GrepTool(sibling).execute("sibling-page-2", {
+				pattern: "NEEDLE",
+				path: ".",
+				skip: 20,
+			});
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			expect(getText(pageTwo)).not.toContain("job-20.txt");
+			// ...and must not repopulate while the job is still running.
+			await new GrepTool(sibling).execute("sibling-page-3", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			finishBash.resolve();
+			await manager.dispose({ timeoutMs: 1_000 });
+		}
+	});
+
+	it("holds sibling caches closed during a foreground Bash run with a cwd override", async () => {
+		const jobWs = path.join(cwd, "fg-ws");
+		await fs.mkdir(jobWs, { recursive: true });
+		for (let idx = 0; idx < 25; idx++) {
+			const suffix = idx.toString().padStart(2, "0");
+			await Bun.write(path.join(jobWs, `fg-${suffix}.txt`), `NEEDLE fg-${suffix}\n`);
+		}
+		const sibling = createTestSession(jobWs);
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+		});
+		const bashStarted = Promise.withResolvers<void>();
+		const finishBash = Promise.withResolvers<void>();
+		vi.spyOn(bashExecutor, "executeBash").mockImplementation(async () => {
+			await fs.rm(path.join(jobWs, "fg-20.txt"));
+			bashStarted.resolve();
+			await finishBash.promise;
+			return {
+				output: "",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				totalLines: 0,
+				totalBytes: 0,
+				outputLines: 0,
+				outputBytes: 0,
+			};
+		});
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(sibling).execute("fg-page-1", { pattern: "NEEDLE", path: "." });
+		const bashPromise = new BashTool(session).execute("fg-mutate", { command: "rm fg-20.txt", cwd: "fg-ws" });
+		try {
+			await bashStarted.promise;
+
+			// Mid-run: the sibling at the effective command cwd must refetch...
+			const pageTwo = await new GrepTool(sibling).execute("fg-page-2", {
+				pattern: "NEEDLE",
+				path: ".",
+				skip: 20,
+			});
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			expect(getText(pageTwo)).not.toContain("fg-20.txt");
+			// ...and must not repopulate while the command is still running.
+			await new GrepTool(sibling).execute("fg-page-3", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			finishBash.resolve();
+			await bashPromise;
+		}
+
+		// After settle the workspace reopens for normal caching.
+		await new GrepTool(sibling).execute("fg-page-4", { pattern: "NEEDLE", path: "." });
+		await new GrepTool(sibling).execute("fg-page-5", { pattern: "NEEDLE", path: ".", skip: 20 });
+		expect(grepSpy).toHaveBeenCalledTimes(4);
+	});
+
+	it("holds sibling caches closed during a client-terminal Bash run with a cwd override", async () => {
+		const termWs = path.join(cwd, "term-ws");
+		await fs.mkdir(termWs, { recursive: true });
+		for (let idx = 0; idx < 25; idx++) {
+			const suffix = idx.toString().padStart(2, "0");
+			await Bun.write(path.join(termWs, `term-${suffix}.txt`), `NEEDLE term-${suffix}\n`);
+		}
+		const sibling = createTestSession(termWs);
+		const terminalCreated = Promise.withResolvers<void>();
+		const exitGate = Promise.withResolvers<void>();
+		const handle = {
+			terminalId: "term-1",
+			waitForExit: () => exitGate.promise.then(() => ({ exitCode: 0, signal: null })),
+			currentOutput: async () => ({ output: "", truncated: false }),
+			kill: async () => {},
+			release: async () => {},
+		};
+		const bridge = {
+			capabilities: { terminal: true },
+			createTerminal: async () => {
+				// The remote command mutates as soon as the terminal spawns.
+				await fs.rm(path.join(termWs, "term-20.txt"));
+				terminalCreated.resolve();
+				return handle;
+			},
+		};
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+			getClientBridge: (() => bridge) as unknown as ToolSession["getClientBridge"],
+		});
+		const grepSpy = spyOn(piNatives, "grep");
+
+		await new GrepTool(sibling).execute("term-page-1", { pattern: "NEEDLE", path: "." });
+		const bashPromise = new BashTool(session).execute("term-mutate", {
+			command: "rm term-20.txt",
+			cwd: "term-ws",
+		});
+		try {
+			await terminalCreated.promise;
+
+			// Mid-run: sibling at the terminal's cwd must refetch...
+			const pageTwo = await new GrepTool(sibling).execute("term-page-2", {
+				pattern: "NEEDLE",
+				path: ".",
+				skip: 20,
+			});
+			expect(grepSpy).toHaveBeenCalledTimes(2);
+			expect(getText(pageTwo)).not.toContain("term-20.txt");
+			// ...and must not repopulate while the terminal is still live.
+			await new GrepTool(sibling).execute("term-page-3", { pattern: "NEEDLE", path: ".", skip: 20 });
+			expect(grepSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			exitGate.resolve();
+			await bashPromise;
+		}
+	});
+
+	it("releases suppression exactly once when client-terminal creation fails", async () => {
+		const failWs = path.join(cwd, "fail-ws");
+		await fs.mkdir(failWs, { recursive: true });
+		const sibling: SearchResultCacheOwner = { cwd: failWs };
+		getSearchResultCache(sibling);
+
+		const bridge = {
+			capabilities: { terminal: true },
+			createTerminal: async () => {
+				throw new Error("terminal create failed");
+			},
+		};
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+			getClientBridge: (() => bridge) as unknown as ToolSession["getClientBridge"],
+		});
+
+		await expect(new BashTool(session).execute("fail-create", { command: "true", cwd: "fail-ws" })).rejects.toThrow(
+			"terminal create failed",
+		);
+
+		// Suppression acquired before createTerminal must be released for BOTH
+		// affected workspaces despite the rejection...
+		expect(workspaceRegistrySnapshot(failWs)?.suppressions).toBe(0);
+		expect(workspaceRegistrySnapshot(cwd)?.suppressions ?? 0).toBe(0);
+		// ...so caching works again in the override workspace.
+		getSearchResultCache(sibling).set("k", {
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+		expect(getSearchResultCache(sibling).get("k")).toBeDefined();
+	});
+
+	it("kills and settles before reopening caches on a bridge transport error", async () => {
+		const twWs = path.join(cwd, "tw-ws");
+		await fs.mkdir(twWs, { recursive: true });
+		const sibling: SearchResultCacheOwner = { cwd: twWs };
+		getSearchResultCache(sibling);
+
+		let killed = false;
+		let suppressionAtKill: { session?: number; job?: number } | undefined;
+		const handle = {
+			terminalId: "tw-1",
+			waitForExit: () => Promise.reject(new Error("transport lost")),
+			currentOutput: async () => ({ output: "", truncated: false }),
+			kill: async () => {
+				killed = true;
+				// The caches must STILL be held closed while the kill settles.
+				suppressionAtKill = {
+					session: workspaceRegistrySnapshot(cwd)?.suppressions,
+					job: workspaceRegistrySnapshot(twWs)?.suppressions,
+				};
+			},
+			release: async () => {},
+		};
+		const bridge = {
+			capabilities: { terminal: true },
+			createTerminal: async () => handle,
+		};
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+			getClientBridge: (() => bridge) as unknown as ToolSession["getClientBridge"],
+		});
+
+		await expect(new BashTool(session).execute("transport-error", { command: "true", cwd: "tw-ws" })).rejects.toThrow(
+			"transport lost",
+		);
+
+		expect(killed).toBe(true);
+		expect(suppressionAtKill).toEqual({ session: 1, job: 1 });
+		// Reopened exactly once after settlement — never negative, never stuck.
+		expect(workspaceRegistrySnapshot(twWs)?.suppressions).toBe(0);
+		expect(workspaceRegistrySnapshot(cwd)?.suppressions ?? 0).toBe(0);
+	});
+
+	it("holds suppression and the handle until an abort-initiated kill settles", async () => {
+		const abWs = path.join(cwd, "ab-ws");
+		await fs.mkdir(abWs, { recursive: true });
+		const sibling: SearchResultCacheOwner = { cwd: abWs };
+		getSearchResultCache(sibling);
+
+		const terminalCreated = Promise.withResolvers<void>();
+		const pollLoopEntered = Promise.withResolvers<void>();
+		const killCalled = Promise.withResolvers<void>();
+		const killGate = Promise.withResolvers<void>();
+		let releaseCalls = 0;
+		const handle = {
+			terminalId: "ab-1",
+			waitForExit: () => {
+				// The tool registers its abort listener synchronously after this
+				// call and then parks in the poll race; resolving here lets the
+				// test abort MID-POLL (through the listener), the racy path.
+				pollLoopEntered.resolve();
+				return new Promise<never>(() => {});
+			},
+			currentOutput: async () => ({ output: "", truncated: false }),
+			kill: () => {
+				killCalled.resolve();
+				return killGate.promise;
+			},
+			release: async () => {
+				releaseCalls++;
+			},
+		};
+		const bridge = {
+			capabilities: { terminal: true },
+			createTerminal: async () => {
+				terminalCreated.resolve();
+				return handle;
+			},
+		};
+		const session = createTestSession(cwd, {
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+			}),
+			getClientBridge: (() => bridge) as unknown as ToolSession["getClientBridge"],
+		});
+
+		const controller = new AbortController();
+		const bashPromise = new BashTool(session).execute(
+			"abort-kill",
+			{ command: "true", cwd: "ab-ws" },
+			controller.signal,
+		);
+		await terminalCreated.promise;
+		await pollLoopEntered.promise;
+		controller.abort();
+		await killCalled.promise;
+		// Give the abort path every microtask turn it could take: with the old
+		// boolean guard the tool's finally ran to completion here (releasing
+		// suppression and the handle) without waiting for the kill RPC. The
+		// fixed code cannot pass `await killPromise`, so nothing below changes.
+		for (let i = 0; i < 25; i++) await Promise.resolve();
+
+		// While the kill RPC is still in flight, both workspaces stay closed and
+		// the handle is not released — a boolean guard raced past this window.
+		expect(workspaceRegistrySnapshot(cwd)?.suppressions).toBe(1);
+		expect(workspaceRegistrySnapshot(abWs)?.suppressions).toBe(1);
+		expect(releaseCalls).toBe(0);
+
+		killGate.resolve();
+		await expect(bashPromise).rejects.toThrow(/aborted/i);
+
+		// Reopened exactly once after settlement.
+		expect(workspaceRegistrySnapshot(cwd)?.suppressions ?? 0).toBe(0);
+		expect(workspaceRegistrySnapshot(abWs)?.suppressions).toBe(0);
+		expect(releaseCalls).toBe(1);
+	});
+});
+
+describe("lsp search cache owner registry", () => {
+	it("deduplicates live owners and prunes dead refs on registration", () => {
+		const client = {} as LspClient;
+		const ownerA: { searchResultCache?: undefined } = {};
+		const ownerB: { searchResultCache?: undefined } = {};
+
+		registerSearchCacheOwner(client, ownerA);
+		registerSearchCacheOwner(client, ownerA);
+		expect(client.searchCacheOwners?.size).toBe(1);
+
+		// A collected session's ref must be dropped instead of accumulating on
+		// the process-global client for its whole lifetime.
+		const deadRef = { deref: () => undefined } as unknown as WeakRef<typeof ownerA>;
+		client.searchCacheOwners?.add(deadRef);
+		registerSearchCacheOwner(client, ownerB);
+
+		expect(client.searchCacheOwners?.has(deadRef)).toBe(false);
+		expect(client.searchCacheOwners?.size).toBe(2);
+		const held = Array.from(client.searchCacheOwners ?? [], ref => ref.deref());
+		expect(held).toContain(ownerA);
+		expect(held).toContain(ownerB);
+	});
+
+	it("invalidates live registered owners and prunes dead refs", () => {
+		const client = {} as LspClient;
+		const owner: { searchResultCache?: undefined } = {};
+		registerSearchCacheOwner(client, owner);
+		const cache = getSearchResultCache(owner);
+		cache.set("key", {
+			fileOrder: [],
+			matchesByPath: new Map(),
+			perFileLimitReached: false,
+			resultLimitReached: false,
+			skippedOversizedCount: 0,
+		});
+		const deadRef = { deref: () => undefined } as unknown as WeakRef<typeof owner>;
+		client.searchCacheOwners?.add(deadRef);
+
+		invalidateRegisteredSearchCaches(client);
+
+		expect(cache.get("key")).toBeUndefined();
+		expect(client.searchCacheOwners?.has(deadRef)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/search-url-paths.test.ts
+++ b/packages/coding-agent/test/tools/search-url-paths.test.ts
@@ -106,6 +106,37 @@ describe("search tools with external URL paths", () => {
 		expect(loadPage).toHaveBeenCalledTimes(2);
 	});
 
+	it("does not reuse stale grouped results for URL pagination", async () => {
+		let body = "first needle\n";
+		const loadPage = vi.spyOn(scrapers, "loadPage").mockImplementation(async requestedUrl => ({
+			ok: true,
+			status: 200,
+			finalUrl: requestedUrl,
+			contentType: "text/plain",
+			content: body,
+		}));
+		await Bun.write(path.join(testDir, "local.txt"), "local needle\n");
+		const tools = await createTools(createSession(testDir));
+		const tool = tools.find(entry => entry.name === "grep");
+		expect(tool).toBeDefined();
+		const pathScope = "local.txt; https://example.com/live.txt";
+
+		await tool!.execute("search-url-page-1", {
+			pattern: "first|second|local",
+			path: pathScope,
+		});
+		body = "second needle\n";
+		const second = await tool!.execute("search-url-page-2", {
+			pattern: "first|second|local",
+			path: pathScope,
+			skip: 1,
+		});
+
+		expect(resultText(second)).toContain("second needle");
+		expect(resultText(second)).not.toContain("first needle");
+		expect(loadPage).toHaveBeenCalledTimes(2);
+	});
+
 	it("search applies URL line-range selectors after materialization", async () => {
 		stubLoadPage("outside before\nremote needle\noutside after\n", "text/plain");
 		const tools = await createTools(createSession(testDir));


### PR DESCRIPTION
## What

- Add a short-lived, bounded, per-session cache for grouped plain-filesystem `search` results so paginated `skip` pages reuse the first page's result instead of repeating the native search.
- Key entries by query, scope, options, and missing-path state. `skip: 0` recomputes and refreshes the entry.
- Clear the per-session cache after successful filesystem mutations from write, replace, patch, hashline, ACP, and internal-URL write paths.
- Bypass the cache for line-range selectors, archive members, internal URLs, and explicit uncached searches.

## Why

Pagination previously repeated the same native search and grouping work for every page. Later pages can reuse the grouped result until the query changes, the 45-second TTL expires, the eight-entry LRU evicts it, or the session mutates files. Search output and pagination semantics remain unchanged.

No timing benchmark was run; this PR makes no user-visible latency or speedup claim.

## Testing

```bash
bun test packages/coding-agent/test/tools/search-pagination-cache.test.ts
bun --cwd=packages/coding-agent run check
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
