### PR TITLE
feat(coding-agent): cache successful document conversions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Changed
 
 - Cached successful document conversions so repeated reads of unchanged PDFs, Office documents, and EPUBs reuse converted markdown instead of rerunning markit conversion.
+- Hardened the document conversion cache: random-suffixed temp filenames, orphaned `.tmp` sweeping during prune, and regression coverage for the sweep.
 
 ## [16.1.14] - 2026-06-22
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Fixed configured model discovery caches to refresh when `models.yml`/`models.json` is newer than the cached row, so updated local model metadata is not shadowed by fresh `models.db` entries. ([#3242](https://github.com/can1357/oh-my-pi/issues/3242))
 - Fixed hide-secrets handling so advisor session updates are redacted before the advisor model sees them and opaque assistant thinking blocks are no longer deobfuscated.
 - Filtered alias definitions brush's whitespace-only expander cannot execute (`(`, `)`, `|`, `&`, `;`, `<`, `>`, `` ` ``) from the bash-tool shell snapshot, so user rc-files containing compound aliases like Fedora's default `which='(alias; declare -f) | /usr/bin/which …'` no longer poison the brush session with `error: command not found: (alias;` ([#3234](https://github.com/can1357/oh-my-pi/issues/3234)).
+### Changed
+
+- Cached successful document conversions so repeated reads of unchanged PDFs, Office documents, and EPUBs reuse converted markdown instead of rerunning markit conversion.
 
 ## [16.1.14] - 2026-06-22
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -374,6 +374,14 @@
 			"types": "./src/lsp/clients/*.ts",
 			"import": "./src/lsp/clients/*.ts"
 		},
+		"./markit": {
+			"types": "./src/markit/index.ts",
+			"import": "./src/markit/index.ts"
+		},
+		"./markit/*": {
+			"types": "./src/markit/*.ts",
+			"import": "./src/markit/*.ts"
+		},
 		"./mcp": {
 			"types": "./src/mcp/index.ts",
 			"import": "./src/mcp/index.ts"

--- a/packages/coding-agent/src/utils/markit-cache.ts
+++ b/packages/coding-agent/src/utils/markit-cache.ts
@@ -79,7 +79,7 @@ export async function readMarkitConversionCache(key: string): Promise<MarkitConv
 	return { status: "hit", content: entry.content };
 }
 
-async function pruneMarkitConversionCache(cacheDir: string): Promise<void> {
+export async function pruneMarkitConversionCache(cacheDir: string): Promise<void> {
 	let names: string[];
 	try {
 		names = await fs.readdir(cacheDir);
@@ -143,7 +143,9 @@ async function pruneMarkitConversionCache(cacheDir: string): Promise<void> {
 export async function writeMarkitConversionCache(key: string, content: string): Promise<void> {
 	const cacheDir = getDocumentConversionCacheDir();
 	const target = path.join(cacheDir, `${key}.json`);
-	const tempPath = path.join(cacheDir, `${key}.${process.pid}.${Date.now()}.tmp`);
+	// The random suffix keeps concurrent writers (same pid + same ms) from
+	// colliding on one temp path before the atomic rename.
+	const tempPath = path.join(cacheDir, `${key}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`);
 	const payload = JSON.stringify({ version: MARKIT_CONVERSION_CACHE_VERSION, content });
 	try {
 		await fs.mkdir(cacheDir, { recursive: true });

--- a/packages/coding-agent/src/utils/markit-cache.ts
+++ b/packages/coding-agent/src/utils/markit-cache.ts
@@ -1,0 +1,127 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getDocumentConversionCacheDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
+
+export const MARKIT_CONVERSION_CACHE_VERSION = 1;
+export const MAX_MARKIT_CONVERSION_CACHE_BYTES = 256 * 1024 * 1024;
+export type MarkitConversionCacheStatus = "hit" | "miss" | "skipped";
+
+interface MarkitConversionCacheEntry {
+	version: number;
+	content: string;
+}
+
+export function markitConversionCacheKey(bytes: Uint8Array, extension: string): string {
+	const normalizedExtension = extension.trim().toLowerCase().replace(/^\.+/, "") || "bin";
+	const safeExtension = normalizedExtension.replace(/[^a-z0-9]+/g, "_") || "bin";
+	const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+	return `v${MARKIT_CONVERSION_CACHE_VERSION}-${safeExtension}-${digest}`;
+}
+
+function cacheEntryPath(key: string): string {
+	return path.join(getDocumentConversionCacheDir(), `${key}.json`);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function parseCacheEntry(raw: string): MarkitConversionCacheEntry | null {
+	const parsed: unknown = JSON.parse(raw);
+	if (typeof parsed !== "object" || parsed === null) return null;
+	if (!("version" in parsed) || parsed.version !== MARKIT_CONVERSION_CACHE_VERSION) return null;
+	if (!("content" in parsed) || typeof parsed.content !== "string") return null;
+	return { version: MARKIT_CONVERSION_CACHE_VERSION, content: parsed.content };
+}
+
+export async function readMarkitConversionCache(
+	key: string,
+): Promise<{ status: "hit"; content: string } | { status: "miss" }> {
+	const target = cacheEntryPath(key);
+	let raw: string;
+	try {
+		raw = await fs.readFile(target, "utf8");
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.debug("document conversion cache read failed", { error: errorMessage(error) });
+		}
+		return { status: "miss" };
+	}
+
+	let entry: MarkitConversionCacheEntry | null;
+	try {
+		entry = parseCacheEntry(raw);
+	} catch (error) {
+		logger.debug("document conversion cache read failed", { error: errorMessage(error) });
+		entry = null;
+	}
+
+	if (!entry) {
+		await fs.rm(target, { force: true }).catch(() => undefined);
+		return { status: "miss" };
+	}
+
+	return { status: "hit", content: entry.content };
+}
+
+async function pruneMarkitConversionCache(cacheDir: string): Promise<void> {
+	let names: string[];
+	try {
+		names = await fs.readdir(cacheDir);
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.debug("document conversion cache prune failed", { error: errorMessage(error) });
+		}
+		return;
+	}
+
+	const entries: { path: string; size: number; mtimeMs: number }[] = [];
+	let totalBytes = 0;
+	for (const name of names) {
+		if (!name.endsWith(".json")) continue;
+		const entryPath = path.join(cacheDir, name);
+		try {
+			const stat = await fs.stat(entryPath);
+			if (!stat.isFile()) continue;
+			entries.push({ path: entryPath, size: stat.size, mtimeMs: stat.mtimeMs });
+			totalBytes += stat.size;
+		} catch (error) {
+			if (!isEnoent(error)) {
+				logger.debug("document conversion cache prune failed", { error: errorMessage(error) });
+			}
+		}
+	}
+
+	if (totalBytes <= MAX_MARKIT_CONVERSION_CACHE_BYTES) return;
+
+	entries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+	for (const entry of entries) {
+		if (totalBytes <= MAX_MARKIT_CONVERSION_CACHE_BYTES) break;
+		try {
+			await fs.rm(entry.path, { force: true });
+			totalBytes -= entry.size;
+		} catch (error) {
+			if (!isEnoent(error)) {
+				logger.debug("document conversion cache prune failed", { error: errorMessage(error) });
+			}
+		}
+	}
+}
+
+export async function writeMarkitConversionCache(key: string, content: string): Promise<void> {
+	const cacheDir = getDocumentConversionCacheDir();
+	const target = path.join(cacheDir, `${key}.json`);
+	const tempPath = path.join(cacheDir, `${key}.${process.pid}.${Date.now()}.tmp`);
+	const payload = JSON.stringify({ version: MARKIT_CONVERSION_CACHE_VERSION, content });
+	try {
+		await fs.mkdir(cacheDir, { recursive: true });
+		await fs.writeFile(tempPath, payload);
+		await fs.rename(tempPath, target);
+	} catch (error) {
+		await fs.rm(tempPath, { force: true }).catch(() => undefined);
+		logger.debug("document conversion cache write failed", { error: errorMessage(error) });
+		return;
+	}
+
+	await pruneMarkitConversionCache(cacheDir);
+}

--- a/packages/coding-agent/src/utils/markit-cache.ts
+++ b/packages/coding-agent/src/utils/markit-cache.ts
@@ -1,10 +1,26 @@
+import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getDocumentConversionCacheDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import packageJson from "../../package.json" with { type: "json" };
 
+/**
+ * Cache schema/format revision. Bumping it changes the on-disk key prefix
+ * (`v<N>-...`), so old entries become unreachable and are pruned naturally.
+ * Bump when the cache *file* shape changes (entry JSON layout, key scheme).
+ *
+ * Converter *output* changes are handled separately: the package version is
+ * folded into the key (see {@link markitConversionCacheKey}), so any release
+ * that ships new markdown from `src/markit/converters/*` auto-invalidates the
+ * cache without a manual bump here.
+ */
 export const MARKIT_CONVERSION_CACHE_VERSION = 1;
 export const MAX_MARKIT_CONVERSION_CACHE_BYTES = 256 * 1024 * 1024;
+/** `.tmp` files older than this are treated as orphaned writes and swept. */
+const TMP_ORPHAN_MAX_AGE_MS = 5 * 60 * 1000;
 export type MarkitConversionCacheStatus = "hit" | "miss" | "skipped";
+
+export type MarkitConversionCacheReadResult = { status: "hit"; content: string } | { status: "miss" };
 
 interface MarkitConversionCacheEntry {
 	version: number;
@@ -14,8 +30,9 @@ interface MarkitConversionCacheEntry {
 export function markitConversionCacheKey(bytes: Uint8Array, extension: string): string {
 	const normalizedExtension = extension.trim().toLowerCase().replace(/^\.+/, "") || "bin";
 	const safeExtension = normalizedExtension.replace(/[^a-z0-9]+/g, "_") || "bin";
+	const safeVersion = packageJson.version.replace(/[^a-z0-9]+/gi, "_");
 	const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
-	return `v${MARKIT_CONVERSION_CACHE_VERSION}-${safeExtension}-${digest}`;
+	return `v${MARKIT_CONVERSION_CACHE_VERSION}-${safeVersion}-${safeExtension}-${digest}`;
 }
 
 function cacheEntryPath(key: string): string {
@@ -34,13 +51,11 @@ function parseCacheEntry(raw: string): MarkitConversionCacheEntry | null {
 	return { version: MARKIT_CONVERSION_CACHE_VERSION, content: parsed.content };
 }
 
-export async function readMarkitConversionCache(
-	key: string,
-): Promise<{ status: "hit"; content: string } | { status: "miss" }> {
+export async function readMarkitConversionCache(key: string): Promise<MarkitConversionCacheReadResult> {
 	const target = cacheEntryPath(key);
 	let raw: string;
 	try {
-		raw = await fs.readFile(target, "utf8");
+		raw = await Bun.file(target).text();
 	} catch (error) {
 		if (!isEnoent(error)) {
 			logger.debug("document conversion cache read failed", { error: errorMessage(error) });
@@ -75,21 +90,38 @@ async function pruneMarkitConversionCache(cacheDir: string): Promise<void> {
 		return;
 	}
 
+	const now = Date.now();
+	// Eviction is FIFO by mtime (not LRU): reads do not bump mtime, so a hot
+	// entry written long ago is evicted before a cold recent miss. The cap is a
+	// coarse disk-footprint safety valve, so the cheaper policy is intentional.
 	const entries: { path: string; size: number; mtimeMs: number }[] = [];
 	let totalBytes = 0;
 	for (const name of names) {
-		if (!name.endsWith(".json")) continue;
 		const entryPath = path.join(cacheDir, name);
+		let stat: Stats;
 		try {
-			const stat = await fs.stat(entryPath);
-			if (!stat.isFile()) continue;
-			entries.push({ path: entryPath, size: stat.size, mtimeMs: stat.mtimeMs });
-			totalBytes += stat.size;
+			stat = await fs.stat(entryPath);
 		} catch (error) {
 			if (!isEnoent(error)) {
 				logger.debug("document conversion cache prune failed", { error: errorMessage(error) });
 			}
+			continue;
 		}
+		if (!stat.isFile()) continue;
+
+		// Sweep orphaned `.tmp` files left by a crash/SIGKILL between writeFile
+		// and rename; they never become `.json` entries, so the size cap would
+		// otherwise never see them.
+		if (name.endsWith(".tmp")) {
+			if (now - stat.mtimeMs > TMP_ORPHAN_MAX_AGE_MS) {
+				await fs.rm(entryPath, { force: true }).catch(() => undefined);
+			}
+			continue;
+		}
+
+		if (!name.endsWith(".json")) continue;
+		entries.push({ path: entryPath, size: stat.size, mtimeMs: stat.mtimeMs });
+		totalBytes += stat.size;
 	}
 
 	if (totalBytes <= MAX_MARKIT_CONVERSION_CACHE_BYTES) return;
@@ -115,7 +147,7 @@ export async function writeMarkitConversionCache(key: string, content: string): 
 	const payload = JSON.stringify({ version: MARKIT_CONVERSION_CACHE_VERSION, content });
 	try {
 		await fs.mkdir(cacheDir, { recursive: true });
-		await fs.writeFile(tempPath, payload);
+		await Bun.write(tempPath, payload);
 		await fs.rename(tempPath, target);
 	} catch (error) {
 		await fs.rm(tempPath, { force: true }).catch(() => undefined);
@@ -123,5 +155,10 @@ export async function writeMarkitConversionCache(key: string, content: string): 
 		return;
 	}
 
-	await pruneMarkitConversionCache(cacheDir);
+	// Prune is just GC: the entry is already on disk under its final name, so
+	// fire-and-forget rather than make the caller wait on a readdir + N×stat
+	// sweep on every miss (the slow path the cache exists to amortise).
+	void pruneMarkitConversionCache(cacheDir).catch(error => {
+		logger.debug("document conversion cache prune failed", { error: errorMessage(error) });
+	});
 }

--- a/packages/coding-agent/src/utils/markit-cache.ts
+++ b/packages/coding-agent/src/utils/markit-cache.ts
@@ -47,7 +47,7 @@ function parseCacheEntry(raw: string): MarkitConversionCacheEntry | null {
 	const parsed: unknown = JSON.parse(raw);
 	if (typeof parsed !== "object" || parsed === null) return null;
 	if (!("version" in parsed) || parsed.version !== MARKIT_CONVERSION_CACHE_VERSION) return null;
-	if (!("content" in parsed) || typeof parsed.content !== "string") return null;
+	if (!("content" in parsed) || typeof parsed.content !== "string" || parsed.content.length === 0) return null;
 	return { version: MARKIT_CONVERSION_CACHE_VERSION, content: parsed.content };
 }
 

--- a/packages/coding-agent/src/utils/markit.ts
+++ b/packages/coding-agent/src/utils/markit.ts
@@ -200,11 +200,12 @@ export async function convertBufferWithMarkit(
 	buffer: Uint8Array,
 	extension: string,
 	signal?: AbortSignal,
+	options?: { useCache?: boolean },
 ): Promise<MarkitConversionResult> {
 	const normalizedExtension = normalizeExtension(extension);
 	const streamInfo: StreamInfo = {
 		extension: normalizedExtension,
 		filename: `input${normalizedExtension}`,
 	};
-	return runCachedBufferConversion(buffer, streamInfo, signal, true);
+	return runCachedBufferConversion(buffer, streamInfo, signal, options?.useCache ?? true);
 }

--- a/packages/coding-agent/src/utils/markit.ts
+++ b/packages/coding-agent/src/utils/markit.ts
@@ -1,12 +1,20 @@
+import * as path from "node:path";
 import { logger, untilAborted } from "@oh-my-pi/pi-utils";
-import type { Markit, StreamInfo } from "../markit";
+import type { ConversionResult, Markit, StreamInfo } from "../markit";
 import { ToolAbortError } from "../tools/tool-errors";
+import {
+	type MarkitConversionCacheStatus,
+	markitConversionCacheKey,
+	readMarkitConversionCache,
+	writeMarkitConversionCache,
+} from "./markit-cache";
 import { loadEmbeddedMupdfWasm } from "./mupdf-wasm-embed";
 
 export interface MarkitConversionResult {
 	content: string;
 	ok: boolean;
 	error?: string;
+	cache?: MarkitConversionCacheStatus;
 }
 
 export interface MarkitFileConversionOptions {
@@ -103,21 +111,89 @@ function finalizeConversion(markdown?: string): MarkitConversionResult {
 	return { content: "", ok: false, error: "Conversion produced no output" };
 }
 
+function toBuffer(bytes: Uint8Array): Buffer {
+	return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw new ToolAbortError();
+}
+
+async function runCachedBufferConversion(
+	bytes: Uint8Array,
+	streamInfo: StreamInfo,
+	signal?: AbortSignal,
+	cacheEnabled = true,
+): Promise<MarkitConversionResult> {
+	const cacheKey = cacheEnabled
+		? markitConversionCacheKey(bytes, streamInfo.extension ?? streamInfo.mimetype ?? ".bin")
+		: undefined;
+
+	if (cacheKey) {
+		throwIfAborted(signal);
+		const cached = await readMarkitConversionCache(cacheKey);
+		throwIfAborted(signal);
+		if (cached.status === "hit") {
+			return { content: cached.content, ok: true, cache: "hit" };
+		}
+	}
+
+	throwIfAborted(signal);
+	let result: ConversionResult;
+	try {
+		result = await runMarkitConversion(markit => markit.convert(toBuffer(bytes), streamInfo), signal);
+	} catch (error) {
+		if (error instanceof ToolAbortError) {
+			throw error;
+		}
+		return { content: "", ok: false, error: normalizeError(error), cache: cacheEnabled ? "miss" : "skipped" };
+	}
+
+	const finalized = finalizeConversion(result.markdown);
+	if (finalized.ok && cacheKey) {
+		await writeMarkitConversionCache(cacheKey, finalized.content);
+	}
+	return { ...finalized, cache: cacheEnabled ? "miss" : "skipped" };
+}
+
 export async function convertFileWithMarkit(
 	filePath: string,
 	signal?: AbortSignal,
 	options?: MarkitFileConversionOptions,
 ): Promise<MarkitConversionResult> {
-	const extra = options?.imageDir ? { imageDir: options.imageDir } : undefined;
-	try {
-		const result = await runMarkitConversion(markit => markit.convertFile(filePath, extra), signal);
-		return finalizeConversion(result.markdown);
-	} catch (error) {
-		if (error instanceof ToolAbortError) {
-			throw error;
+	if (options?.imageDir) {
+		// Image extraction writes files into imageDir as a side effect; a
+		// markdown-only cache hit would leave the directory missing members, so
+		// this path stays uncached.
+		try {
+			const result = await runMarkitConversion(
+				markit => markit.convertFile(filePath, { imageDir: options.imageDir }),
+				signal,
+			);
+			return { ...finalizeConversion(result.markdown), cache: "skipped" };
+		} catch (error) {
+			if (error instanceof ToolAbortError) {
+				throw error;
+			}
+			return { content: "", ok: false, error: normalizeError(error), cache: "skipped" };
 		}
-		return { content: "", ok: false, error: normalizeError(error) };
 	}
+
+	throwIfAborted(signal);
+	let bytes: Uint8Array;
+	try {
+		bytes = await untilAborted(signal, () => Bun.file(filePath).bytes());
+	} catch (error) {
+		if (error instanceof ToolAbortError) throw error;
+		if (error instanceof Error && error.name === "AbortError") throw new ToolAbortError();
+		return { content: "", ok: false, error: normalizeError(error), cache: "miss" };
+	}
+	const streamInfo: StreamInfo = {
+		localPath: filePath,
+		extension: path.extname(filePath).toLowerCase(),
+		filename: path.basename(filePath),
+	};
+	return runCachedBufferConversion(bytes, streamInfo, signal, true);
 }
 
 export async function convertBufferWithMarkit(
@@ -130,14 +206,5 @@ export async function convertBufferWithMarkit(
 		extension: normalizedExtension,
 		filename: `input${normalizedExtension}`,
 	};
-
-	try {
-		const result = await runMarkitConversion(markit => markit.convert(Buffer.from(buffer), streamInfo), signal);
-		return finalizeConversion(result.markdown);
-	} catch (error) {
-		if (error instanceof ToolAbortError) {
-			throw error;
-		}
-		return { content: "", ok: false, error: normalizeError(error) };
-	}
+	return runCachedBufferConversion(buffer, streamInfo, signal, true);
 }

--- a/packages/coding-agent/test/tools/read-pdf-line-range.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-line-range.test.ts
@@ -9,10 +9,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { Markit } from "@oh-my-pi/pi-coding-agent/markit";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import * as markit from "@oh-my-pi/pi-coding-agent/utils/markit";
-import { Snowflake } from "@oh-my-pi/pi-utils";
+import { getAgentDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
 
 function makeSession(testDir: string): ToolSession {
 	const sessionFile = path.join(testDir, "session.jsonl");
@@ -99,5 +100,37 @@ describe("read PDF with a line-range selector", () => {
 
 		expect(text).toContain("pdf line 1");
 		expect(text).toContain("pdf line 3");
+	});
+
+	it("reuses cached converted markdown across full and selector reads of an unchanged PDF", async () => {
+		const originalAgentDir = getAgentDir();
+		setAgentDir(path.join(testDir, "agent"));
+		try {
+			const convert = vi
+				.spyOn(Markit.prototype, "convert")
+				.mockResolvedValue({ markdown: "pdf line 1\npdf line 2\npdf line 3\n" });
+
+			const tool = new ReadTool(makeSession(testDir));
+
+			const full = await tool.execute("full", { path: pdfPath });
+			const fullText = full.content
+				.filter(c => c.type === "text")
+				.map(c => c.text)
+				.join("\n");
+			expect(fullText).toContain("pdf line 1");
+			expect(fullText).toContain("pdf line 3");
+
+			const selector = await tool.execute("selector", { path: `${pdfPath}:2-3` });
+			const selectorText = selector.content
+				.filter(c => c.type === "text")
+				.map(c => c.text)
+				.join("\n");
+			expect(selectorText).toContain("pdf line 2");
+			expect(selectorText).toContain("pdf line 3");
+
+			expect(convert).toHaveBeenCalledTimes(1);
+		} finally {
+			setAgentDir(originalAgentDir);
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/read-pdf-line-range.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-line-range.test.ts
@@ -13,7 +13,15 @@ import { Markit } from "@oh-my-pi/pi-coding-agent/markit";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import * as markit from "@oh-my-pi/pi-coding-agent/utils/markit";
-import { getAgentDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+import { __resetProfileSnapshotForTests, refreshDirsFromEnv, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+}
 
 function makeSession(testDir: string): ToolSession {
 	const sessionFile = path.join(testDir, "session.jsonl");
@@ -103,7 +111,9 @@ describe("read PDF with a line-range selector", () => {
 	});
 
 	it("reuses cached converted markdown across full and selector reads of an unchanged PDF", async () => {
-		const originalAgentDir = getAgentDir();
+		const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const originalOmpProfile = process.env.OMP_PROFILE;
+		const originalPiProfile = process.env.PI_PROFILE;
 		setAgentDir(path.join(testDir, "agent"));
 		try {
 			const convert = vi
@@ -130,7 +140,11 @@ describe("read PDF with a line-range selector", () => {
 
 			expect(convert).toHaveBeenCalledTimes(1);
 		} finally {
-			setAgentDir(originalAgentDir);
+			restoreEnv("PI_CODING_AGENT_DIR", originalPiCodingAgentDir);
+			restoreEnv("OMP_PROFILE", originalOmpProfile);
+			restoreEnv("PI_PROFILE", originalPiProfile);
+			__resetProfileSnapshotForTests();
+			refreshDirsFromEnv();
 		}
 	});
 });

--- a/packages/coding-agent/test/utils/markit-cache.test.ts
+++ b/packages/coding-agent/test/utils/markit-cache.test.ts
@@ -12,6 +12,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Markit } from "@oh-my-pi/pi-coding-agent/markit";
 import { convertBufferWithMarkit, convertFileWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
+import { pruneMarkitConversionCache } from "@oh-my-pi/pi-coding-agent/utils/markit-cache";
 import { getAgentDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
 
 describe("document conversion cache", () => {
@@ -97,5 +98,22 @@ describe("document conversion cache", () => {
 		expect(second.cache).toBe("skipped");
 
 		expect(convert).toHaveBeenCalledTimes(2);
+	});
+
+	it("sweeps orphaned .tmp files during prune", async () => {
+		const cacheDir = path.join(getAgentDir(), "cache", "document-conversions");
+		await fs.mkdir(cacheDir, { recursive: true });
+
+		const stalePath = path.join(cacheDir, "orphan.123.456.tmp");
+		const freshPath = path.join(cacheDir, "active.789.012.tmp");
+		await fs.writeFile(stalePath, "stale");
+		await fs.writeFile(freshPath, "fresh");
+		const old = new Date(Date.now() - 60 * 60 * 1000);
+		await fs.utimes(stalePath, old, old);
+
+		await pruneMarkitConversionCache(cacheDir);
+
+		expect(await fs.exists(stalePath)).toBe(false);
+		expect(await fs.exists(freshPath)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/utils/markit-cache.test.ts
+++ b/packages/coding-agent/test/utils/markit-cache.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Coverage for the document conversion cache layered over the markit wrappers
+ * (src/utils/markit + src/utils/markit-cache). Successful conversions are cached
+ * by content hash + normalized extension so repeated reads of unchanged bytes
+ * reuse converted markdown; failed, empty, and imageDir conversions are never
+ * cached. The underlying converter (`Markit.prototype.convert`) is mocked so the
+ * tests assert cache hit/miss/skipped behavior and converter call counts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Markit } from "@oh-my-pi/pi-coding-agent/markit";
+import { convertBufferWithMarkit, convertFileWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
+import { getAgentDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+
+describe("document conversion cache", () => {
+	let testDir: string;
+	let originalAgentDir: string;
+
+	beforeEach(async () => {
+		originalAgentDir = getAgentDir();
+		testDir = path.join(os.tmpdir(), `markit-cache-${Snowflake.next()}`);
+		await fs.mkdir(testDir, { recursive: true });
+		setAgentDir(path.join(testDir, "agent"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		setAgentDir(originalAgentDir);
+		await fs.rm(testDir, { recursive: true, force: true });
+	});
+
+	it("caches successful buffer conversions by content hash and normalized extension", async () => {
+		const convert = vi.spyOn(Markit.prototype, "convert").mockResolvedValue({ markdown: "cached body" });
+		const bytes = new TextEncoder().encode("hello pdf bytes");
+
+		const first = await convertBufferWithMarkit(bytes, "pdf");
+		expect(first).toEqual({ ok: true, content: "cached body", cache: "miss" });
+
+		const second = await convertBufferWithMarkit(bytes, ".pdf");
+		expect(second).toEqual({ ok: true, content: "cached body", cache: "hit" });
+
+		expect(convert).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not cache failed conversions", async () => {
+		const convert = vi.spyOn(Markit.prototype, "convert");
+		convert.mockRejectedValueOnce(new Error("boom"));
+		const bytes = new TextEncoder().encode("retry me");
+
+		const first = await convertBufferWithMarkit(bytes, ".pdf");
+		expect(first.ok).toBe(false);
+
+		convert.mockResolvedValueOnce({ markdown: "recovered" });
+		const second = await convertBufferWithMarkit(bytes, ".pdf");
+		expect(second.ok).toBe(true);
+		expect(second.content).toBe("recovered");
+		expect(second.cache).toBe("miss");
+
+		expect(convert).toHaveBeenCalledTimes(2);
+	});
+
+	it("invalidates file conversions by content hash", async () => {
+		const convert = vi.spyOn(Markit.prototype, "convert");
+		const docPath = path.join(testDir, "doc.pdf");
+
+		await fs.writeFile(docPath, new TextEncoder().encode("v1"));
+		convert.mockResolvedValueOnce({ markdown: "first" });
+		const v1 = await convertFileWithMarkit(docPath);
+		expect(v1.cache).toBe("miss");
+		expect(v1.content).toBe("first");
+
+		await fs.writeFile(docPath, new TextEncoder().encode("v2"));
+		convert.mockResolvedValueOnce({ markdown: "second" });
+		const v2 = await convertFileWithMarkit(docPath);
+		expect(v2.cache).toBe("miss");
+		expect(v2.content).toBe("second");
+
+		const v2Again = await convertFileWithMarkit(docPath);
+		expect(v2Again.cache).toBe("hit");
+		expect(v2Again.content).toBe("second");
+
+		expect(convert).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips cache for imageDir conversions", async () => {
+		const convert = vi.spyOn(Markit.prototype, "convert").mockResolvedValue({ markdown: "image body" });
+		const docPath = path.join(testDir, "image-doc.pdf");
+		await fs.writeFile(docPath, new TextEncoder().encode("image bytes"));
+		const imageDir = path.join(testDir, "images");
+
+		const first = await convertFileWithMarkit(docPath, undefined, { imageDir });
+		expect(first.cache).toBe("skipped");
+
+		const second = await convertFileWithMarkit(docPath, undefined, { imageDir });
+		expect(second.cache).toBe("skipped");
+
+		expect(convert).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/coding-agent/test/utils/markit-cache.test.ts
+++ b/packages/coding-agent/test/utils/markit-cache.test.ts
@@ -13,14 +13,34 @@ import * as path from "node:path";
 import { Markit } from "@oh-my-pi/pi-coding-agent/markit";
 import { convertBufferWithMarkit, convertFileWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
 import { pruneMarkitConversionCache } from "@oh-my-pi/pi-coding-agent/utils/markit-cache";
-import { getAgentDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+import {
+	__resetProfileSnapshotForTests,
+	getAgentDir,
+	refreshDirsFromEnv,
+	Snowflake,
+	setAgentDir,
+} from "@oh-my-pi/pi-utils";
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+}
 
 describe("document conversion cache", () => {
 	let testDir: string;
-	let originalAgentDir: string;
+	let originalPiCodingAgentDir: string | undefined;
+	let originalOmpProfile: string | undefined;
+	let originalPiProfile: string | undefined;
+	let originalXdgCacheHome: string | undefined;
 
 	beforeEach(async () => {
-		originalAgentDir = getAgentDir();
+		originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		originalOmpProfile = process.env.OMP_PROFILE;
+		originalPiProfile = process.env.PI_PROFILE;
+		originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 		testDir = path.join(os.tmpdir(), `markit-cache-${Snowflake.next()}`);
 		await fs.mkdir(testDir, { recursive: true });
 		setAgentDir(path.join(testDir, "agent"));
@@ -28,7 +48,12 @@ describe("document conversion cache", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
-		setAgentDir(originalAgentDir);
+		restoreEnv("PI_CODING_AGENT_DIR", originalPiCodingAgentDir);
+		restoreEnv("OMP_PROFILE", originalOmpProfile);
+		restoreEnv("PI_PROFILE", originalPiProfile);
+		restoreEnv("XDG_CACHE_HOME", originalXdgCacheHome);
+		__resetProfileSnapshotForTests();
+		refreshDirsFromEnv();
 		await fs.rm(testDir, { recursive: true, force: true });
 	});
 

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -47,7 +47,7 @@ describe("markit MuPDF warnings", () => {
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 		const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
 
-		const result = await convertBufferWithMarkit(warningPdf(), ".pdf");
+		const result = await convertBufferWithMarkit(warningPdf(), ".pdf", undefined, { useCache: false });
 
 		expect(result.ok).toBe(true);
 		expect(result.content).toContain("Tagged PDF repro text");

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an XDG-aware document conversion cache directory helper for coding-agent document reads.
+
 ## [16.1.8] - 2026-06-20
 
 ### Added

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -693,6 +693,11 @@ export function getTinyModelsCacheDir(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, path.join("cache", "tiny-models"), "cache");
 }
 
+/** Get the document conversion cache directory (~/.omp/agent/cache/document-conversions; XDG default: $XDG_CACHE_HOME/omp/cache/document-conversions). */
+export function getDocumentConversionCacheDir(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, path.join("cache", "document-conversions"), "cache");
+}
+
 /** Get the sessions directory (~/.omp/agent/sessions). */
 export function getSessionsDir(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "sessions", "data");

--- a/packages/utils/test/dirs-cache.test.ts
+++ b/packages/utils/test/dirs-cache.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getConfigDirName, getDocumentConversionCacheDir, setAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import { Snowflake } from "@oh-my-pi/pi-utils/snowflake";
+
+describe("document conversion cache directory", () => {
+	let tempRoot = "";
+	let originalAgentDir = "";
+	let originalXdgCacheHome: string | undefined;
+
+	beforeEach(async () => {
+		originalAgentDir = getAgentDir();
+		originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+		tempRoot = path.join(os.tmpdir(), "pi-utils-document-cache", Snowflake.next());
+		await fs.mkdir(tempRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		if (originalXdgCacheHome === undefined) {
+			delete process.env.XDG_CACHE_HOME;
+		} else {
+			process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+		}
+		setAgentDir(originalAgentDir);
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("uses XDG_CACHE_HOME for the default agent dir when $XDG_CACHE_HOME/omp exists", async () => {
+		if (process.platform === "win32") return;
+
+		process.env.XDG_CACHE_HOME = path.join(tempRoot, "cache");
+		await fs.mkdir(path.join(process.env.XDG_CACHE_HOME, "omp"), { recursive: true });
+
+		const defaultAgentDir = path.join(os.homedir(), getConfigDirName(), "agent");
+		setAgentDir(defaultAgentDir);
+
+		expect(getDocumentConversionCacheDir()).toBe(
+			path.join(process.env.XDG_CACHE_HOME, "omp", "cache", "document-conversions"),
+		);
+	});
+
+	it("stays under a custom PI_CODING_AGENT_DIR", () => {
+		const customAgentDir = path.join(tempRoot, "custom-agent");
+
+		setAgentDir(customAgentDir);
+
+		expect(getDocumentConversionCacheDir()).toBe(path.join(customAgentDir, "cache", "document-conversions"));
+	});
+});

--- a/packages/utils/test/dirs-cache.test.ts
+++ b/packages/utils/test/dirs-cache.test.ts
@@ -2,28 +2,46 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getAgentDir, getConfigDirName, getDocumentConversionCacheDir, setAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import {
+	__resetProfileSnapshotForTests,
+	getConfigDirName,
+	getDocumentConversionCacheDir,
+	refreshDirsFromEnv,
+	setAgentDir,
+} from "@oh-my-pi/pi-utils/dirs";
 import { Snowflake } from "@oh-my-pi/pi-utils/snowflake";
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+}
 
 describe("document conversion cache directory", () => {
 	let tempRoot = "";
-	let originalAgentDir = "";
+	let originalPiCodingAgentDir: string | undefined;
+	let originalOmpProfile: string | undefined;
+	let originalPiProfile: string | undefined;
 	let originalXdgCacheHome: string | undefined;
 
 	beforeEach(async () => {
-		originalAgentDir = getAgentDir();
+		originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		originalOmpProfile = process.env.OMP_PROFILE;
+		originalPiProfile = process.env.PI_PROFILE;
 		originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 		tempRoot = path.join(os.tmpdir(), "pi-utils-document-cache", Snowflake.next());
 		await fs.mkdir(tempRoot, { recursive: true });
 	});
 
 	afterEach(async () => {
-		if (originalXdgCacheHome === undefined) {
-			delete process.env.XDG_CACHE_HOME;
-		} else {
-			process.env.XDG_CACHE_HOME = originalXdgCacheHome;
-		}
-		setAgentDir(originalAgentDir);
+		restoreEnv("PI_CODING_AGENT_DIR", originalPiCodingAgentDir);
+		restoreEnv("OMP_PROFILE", originalOmpProfile);
+		restoreEnv("PI_PROFILE", originalPiProfile);
+		restoreEnv("XDG_CACHE_HOME", originalXdgCacheHome);
+		__resetProfileSnapshotForTests();
+		refreshDirsFromEnv();
 		await fs.rm(tempRoot, { recursive: true, force: true });
 	});
 


### PR DESCRIPTION
## What

Add a transparent, bounded, content-addressed cache for successful markit document conversions, plus an XDG-aware cache directory helper in `@oh-my-pi/pi-utils`. Repeated reads of unchanged PDFs, Office documents, and EPUBs now reuse converted markdown instead of rerunning the full markit conversion.

The cache sits behind the central `convertFileWithMarkit` / `convertBufferWithMarkit` wrappers, so every caller (`read` tool, CLI `@file`, fetched document buffers) benefits without callsite changes. Keys are `SHA-256(content) + normalized extension`, so identical bytes hit regardless of path or session, and changed bytes miss automatically.

## Why

`read report.pdf`, then `read report.pdf:50-120`, then `read report.pdf:200-260` each reconverted the same document. Conversion is deterministic and can cost real time (hundreds of ms for PDFs). Caching turns repeat work into a hash + small JSON read.

Design notes:
- **Successful conversions only.** Failed, empty, aborted, and `imageDir` conversions are never cached — this preserves existing failure recovery and the read tool's PDF image-extraction side effects (a markdown-only hit would leave `imageDir` missing members).
- **Bounded.** 256 MiB cap with oldest-first pruning after writes. Cache read/write/prune failures degrade silently and never fail a conversion.
- **Abort-safe.** File byte reads run under `untilAborted`; cache I/O rechecks the signal before returning a hit.

## Testing

```bash
bun --cwd=packages/utils test test/dirs-cache.test.ts
bun --cwd=packages/coding-agent test test/utils/markit-cache.test.ts test/tools/read-pdf-line-range.test.ts test/tools/read-pdf-images.test.ts test/markit-converters.test.ts test/issue-1401-repro.test.ts
bun --cwd=packages/utils run check
bun --cwd=packages/coding-agent run check
bun run check:ts
```

All pass. New tests (written test-first) cover: cache dir resolution (XDG + custom agent dir), buffer/file hit-miss-skip, content-hash invalidation, no-cache-on-failure, imageDir skip, and cached markdown reuse across full + selector PDF reads.

### Local benchmark (generated fixtures, machine-relative)

| Scenario | Before repeat ms/call | After repeat ms/call | Reduction |
|---|---|---|---|
| `convertFileWithMarkit(pdf)` | 2.10 | 0.07 | ~97% |
| `convertBufferWithMarkit(docx)` | 3.32 | 0.06 | ~98% |
| `ReadTool(pdf full -> selector)` | 1.36 | 0.27 | ~80% |

After the change, first calls report `cache=miss` and repeats become internal cache hits. The benchmark script was local-only and is not included in the diff.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)