### PR TITLE
fix(ai): append api key logins

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed API-key `/login` providers replacing sibling credentials instead of appending new keys for the same provider. ([#3265](https://github.com/can1357/oh-my-pi/issues/3265))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1845,14 +1845,9 @@ export class AuthStorage {
 				return;
 			}
 			const newCredential: ApiKeyCredential = { type: "api_key", key: result };
-			const appendApiKeyLogin = "appendApiKeyLogin" in def && def.appendApiKeyLogin === true;
-			const stored = appendApiKeyLogin
-				? this.#store.upsertAuthCredentialRemote
-					? await this.#store.upsertAuthCredentialRemote(provider, newCredential)
-					: this.#store.upsertAuthCredentialForProvider(provider, newCredential)
-				: this.#store.replaceAuthCredentialsRemote
-					? await this.#store.replaceAuthCredentialsRemote(provider, [newCredential])
-					: this.#store.replaceAuthCredentialsForProvider(provider, [newCredential]);
+			const stored = this.#store.upsertAuthCredentialRemote
+				? await this.#store.upsertAuthCredentialRemote(provider, newCredential)
+				: this.#store.upsertAuthCredentialForProvider(provider, newCredential);
 			this.#setStoredCredentials(
 				provider,
 				stored.map(entry => ({ id: entry.id, credential: entry.credential })),

--- a/packages/ai/src/registry/nvidia.ts
+++ b/packages/ai/src/registry/nvidia.ts
@@ -58,5 +58,4 @@ export const nvidiaProvider = {
 	id: "nvidia",
 	name: "NVIDIA",
 	login: (cb: OAuthLoginCallbacks) => loginNvidia(cb),
-	appendApiKeyLogin: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/types.ts
+++ b/packages/ai/src/registry/types.ts
@@ -44,8 +44,6 @@ export interface ProviderDefinition {
 	readonly envKeys?: KeyResolver;
 	// --- interactive login (OAuthProviderInterface-compatible) ---
 	readonly login?: (callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials | string>;
-	/** String-returning login appends API keys instead of replacing the provider's existing key. */
-	readonly appendApiKeyLogin?: boolean;
 	readonly refreshToken?: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
 	readonly getApiKey?: (credentials: OAuthCredentials) => string;
 	/** Store OAuth credentials under a different provider id (e.g. `openai-codex-device` ⇒ `openai-codex`). */

--- a/packages/ai/test/auth-storage-api-key-login.test.ts
+++ b/packages/ai/test/auth-storage-api-key-login.test.ts
@@ -36,7 +36,7 @@ function countCredentialRowsByDisabledState(dbPath: string, provider: string, di
 	}
 }
 
-describe("AuthStorage api-key login replacement", () => {
+describe("AuthStorage api-key login upsert", () => {
 	let tempDir = "";
 	let dbPath = "";
 	let store: SqliteAuthCredentialStore | null = null;
@@ -91,6 +91,32 @@ describe("AuthStorage api-key login replacement", () => {
 		expect(stored.credential.key).toBe("same-kagi-key");
 		expect(store.getApiKey("kagi")).toBe("same-kagi-key");
 		expect(await authStorage.getApiKey("kagi", "session-kagi-relogin")).toBe("same-kagi-key");
+	});
+
+	it("appends a different api-key row when re-login returns a new key", async () => {
+		if (!store || !authStorage || !dbPath) throw new Error("test setup failed");
+
+		loginKagiSpy.mockResolvedValueOnce("first-kagi-key").mockResolvedValueOnce("second-kagi-key");
+
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => "",
+		};
+
+		await authStorage.login("kagi", controller);
+		await authStorage.login("kagi", controller);
+
+		expect(countCredentialRows(dbPath, "kagi")).toBe(2);
+		expect(countCredentialRowsByDisabledState(dbPath, "kagi", false)).toBe(2);
+		expect(countCredentialRowsByDisabledState(dbPath, "kagi", true)).toBe(0);
+
+		const credentials = store.listAuthCredentials("kagi");
+		expect(credentials.map(entry => entry.credential)).toEqual([
+			{ type: "api_key", key: "first-kagi-key" },
+			{ type: "api_key", key: "second-kagi-key" },
+		]);
+		const rotatedKeys = [await authStorage.getApiKey("kagi"), await authStorage.getApiKey("kagi")].sort();
+		expect(rotatedKeys).toEqual(["first-kagi-key", "second-kagi-key"]);
 	});
 
 	it("hard-deletes superseded api-key rows when a different key replaces them", () => {


### PR DESCRIPTION
## Repro
Repeated API-key logins for the same provider reproduced the bug: a two-step `AuthStorage.login("kagi", ...)` simulation entered `sk-aaaa` and then `sk-bbbb`; before the fix, the verification query returned `{"active":1,"disabled":0}` and exited 1 because two active rows were expected.

## Cause
`packages/ai/src/auth-storage.ts` handled string-returning provider logins as replace operations unless the provider opted into `appendApiKeyLogin`, so most API-key login providers routed through `replaceAuthCredentialsForProvider()` and removed sibling credentials for that provider.

## Fix
- Changed string-returning `/login` results in `AuthStorage.login()` to always upsert the API-key credential, matching OAuth append behavior.
- Removed the one-off `appendApiKeyLogin` provider flag and its NVIDIA-only use.
- Added regression coverage proving repeated API-key logins keep both active keys and non-session lookup can rotate across them.
- Added the `packages/ai` changelog entry.

## Verification
Repro command now returns `{"active":2,"disabled":0}`. Ran `bun test packages/ai/test/auth-storage-api-key-login.test.ts` → 5 pass, 0 fail. Ran `bun --cwd=packages/ai run check:types` → `tsgo -p tsconfig.json --noEmit` completed successfully. Fixes #3265