### PR TITLE
fix(web-search): pace exa search requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Exa web search requests firing back-to-back with no client-side pacing by adding a configurable `exa.searchDelayMs` delay (default 1000ms) between Exa search requests. ([#3271](https://github.com/can1357/oh-my-pi/issues/3271))
+
 ## [16.1.15] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4479,6 +4479,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"exa.searchDelayMs": {
+		type: "number",
+		default: 1_000,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Exa Search Delay",
+			description: "Minimum delay between Exa web search requests in milliseconds; set 0 to disable pacing",
+		},
+	},
+
 	"exa.enableResearcher": {
 		type: "boolean",
 		default: false,
@@ -4785,6 +4796,7 @@ export interface TtsrSettings {
 export interface ExaSettings {
 	enabled: boolean;
 	enableSearch: boolean;
+	searchDelayMs: number;
 	enableResearcher: boolean;
 	enableWebsets: boolean;
 }

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -32,6 +32,40 @@ function configuredExaSearchDelayMs(): number {
 	}
 }
 
+function rejectWithAbortReason(reject: (reason?: unknown) => void, signal: AbortSignal): void {
+	try {
+		signal.throwIfAborted();
+		reject(new DOMException("The operation was aborted.", "AbortError"));
+	} catch (error) {
+		reject(error);
+	}
+}
+
+function abortableSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+	if (ms <= 0) return Promise.resolve();
+	signal?.throwIfAborted();
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	let timer: NodeJS.Timeout | undefined;
+	const cleanup = (): void => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+		signal?.removeEventListener("abort", onAbort);
+	};
+	const onAbort = (): void => {
+		cleanup();
+		if (signal) rejectWithAbortReason(reject, signal);
+	};
+	timer = setTimeout(() => {
+		cleanup();
+		resolve();
+	}, ms);
+	signal?.addEventListener("abort", onAbort, { once: true });
+	if (signal?.aborted) onAbort();
+	return promise;
+}
+
 async function waitForExaSearchSlot(signal: AbortSignal | undefined): Promise<void> {
 	const delayMs = configuredExaSearchDelayMs();
 	if (delayMs <= 0) return;
@@ -41,7 +75,7 @@ async function waitForExaSearchSlot(signal: AbortSignal | undefined): Promise<vo
 		signal?.throwIfAborted();
 		const waitMs = Math.max(0, nextExaSearchRequestAt - Date.now());
 		if (waitMs > 0) {
-			await Bun.sleep(waitMs);
+			await abortableSleep(waitMs, signal);
 		}
 		signal?.throwIfAborted();
 		nextExaSearchRequestAt = Date.now() + delayMs;

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -7,7 +7,7 @@
  * them into a combined `answer` string on the SearchResponse.
  */
 import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
-import { settings } from "../../../config/settings";
+import { getDefault, settings } from "../../../config/settings";
 import { findApiKey, isSearchResponse } from "../../../exa/mcp-client";
 import { parseSSE } from "../../../mcp/json-rpc";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
@@ -18,6 +18,43 @@ import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const EXA_API_URL = "https://api.exa.ai/search";
+const DEFAULT_EXA_SEARCH_DELAY_MS = getDefault("exa.searchDelayMs");
+
+let nextExaSearchRequestAt = 0;
+let exaSearchThrottle = Promise.resolve();
+
+function configuredExaSearchDelayMs(): number {
+	try {
+		const delayMs = settings.get("exa.searchDelayMs");
+		return Number.isFinite(delayMs) && delayMs > 0 ? Math.floor(delayMs) : 0;
+	} catch {
+		return DEFAULT_EXA_SEARCH_DELAY_MS;
+	}
+}
+
+async function waitForExaSearchSlot(signal: AbortSignal | undefined): Promise<void> {
+	const delayMs = configuredExaSearchDelayMs();
+	if (delayMs <= 0) return;
+
+	const prior = exaSearchThrottle.catch(() => {});
+	const current = prior.then(async () => {
+		signal?.throwIfAborted();
+		const waitMs = Math.max(0, nextExaSearchRequestAt - Date.now());
+		if (waitMs > 0) {
+			await Bun.sleep(waitMs);
+		}
+		signal?.throwIfAborted();
+		nextExaSearchRequestAt = Date.now() + delayMs;
+	});
+	exaSearchThrottle = current.catch(() => {});
+	await current;
+}
+
+/** Reset Exa request pacing state for isolated provider tests. */
+export function resetExaSearchThrottleForTest(): void {
+	nextExaSearchRequestAt = 0;
+	exaSearchThrottle = Promise.resolve();
+}
 
 type ExaSearchType = "neural" | "fast" | "auto" | "deep";
 
@@ -224,6 +261,7 @@ async function callExaSearch(apiKey: string, params: ExaSearchParams): Promise<E
 	const body = buildExaRequestBody(params);
 
 	const fetchImpl = params.fetch ?? fetch;
+	await waitForExaSearchSlot(params.signal);
 	const response = await fetchImpl(EXA_API_URL, {
 		method: "POST",
 		headers: {
@@ -260,6 +298,7 @@ async function callExaMcpSearch(params: ExaSearchParams): Promise<ExaSearchRespo
 	if (apiKey) query.set("exaApiKey", apiKey);
 	query.set("tools", "web_search_exa");
 	const fetchImpl = params.fetch ?? fetch;
+	await waitForExaSearchSlot(params.signal);
 	const response = await fetchImpl(`https://mcp.exa.ai/mcp?${query.toString()}`, {
 		method: "POST",
 		headers: {

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -66,12 +66,23 @@ function abortableSleep(ms: number, signal: AbortSignal | undefined): Promise<vo
 	return promise;
 }
 
+function waitUntilDoneOrAborted<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+	if (!signal) return promise;
+	signal.throwIfAborted();
+	const { promise: aborted, reject } = Promise.withResolvers<never>();
+	const onAbort = (): void => rejectWithAbortReason(reject, signal);
+	signal.addEventListener("abort", onAbort, { once: true });
+	return Promise.race([promise, aborted]).finally(() => {
+		signal.removeEventListener("abort", onAbort);
+	});
+}
+
 async function waitForExaSearchSlot(signal: AbortSignal | undefined): Promise<void> {
 	const delayMs = configuredExaSearchDelayMs();
 	if (delayMs <= 0) return;
 
 	const prior = exaSearchThrottle.catch(() => {});
-	const current = prior.then(async () => {
+	const queued = prior.then(async () => {
 		signal?.throwIfAborted();
 		const waitMs = Math.max(0, nextExaSearchRequestAt - Date.now());
 		if (waitMs > 0) {
@@ -80,8 +91,8 @@ async function waitForExaSearchSlot(signal: AbortSignal | undefined): Promise<vo
 		signal?.throwIfAborted();
 		nextExaSearchRequestAt = Date.now() + delayMs;
 	});
-	exaSearchThrottle = current.catch(() => {});
-	await current;
+	exaSearchThrottle = queued.catch(() => {});
+	await waitUntilDoneOrAborted(queued, signal);
 }
 
 /** Reset Exa request pacing state for isolated provider tests. */

--- a/packages/coding-agent/test/tools/web-search-exa.test.ts
+++ b/packages/coding-agent/test/tools/web-search-exa.test.ts
@@ -322,6 +322,33 @@ describe("searchExa", () => {
 		expect(requestTimes[1] - requestTimes[0]).toBeGreaterThanOrEqual(20);
 	});
 
+	it("aborts while waiting for the configured Exa request delay", async () => {
+		resetSettingsForTest();
+		resetExaSearchThrottleForTest();
+		await Settings.init({ inMemory: true, overrides: { "exa.searchDelayMs": 1_000 } });
+		let fetchCount = 0;
+		const fetchMock: FetchImpl = () => {
+			fetchCount += 1;
+			return Promise.resolve(
+				new Response(JSON.stringify(makeMockExaResponse()), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		};
+
+		await searchExa({ query: "first request", fetch: fetchMock });
+		const controller = new AbortController();
+		const startedAt = Date.now();
+		const pending = searchExa({ query: "cancelled request", fetch: fetchMock, signal: controller.signal });
+		await Bun.sleep(0);
+		controller.abort(new Error("cancelled Exa throttle wait"));
+
+		await expect(pending).rejects.toThrow("cancelled Exa throttle wait");
+		expect(Date.now() - startedAt).toBeLessThan(250);
+		expect(fetchCount).toBe(1);
+	});
+
 	it("prefers summary over text for snippet field", async () => {
 		const result = await searchExa({
 			query: "snippet test",

--- a/packages/coding-agent/test/tools/web-search-exa.test.ts
+++ b/packages/coding-agent/test/tools/web-search-exa.test.ts
@@ -3,11 +3,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
 	buildExaRequestBody,
 	ExaProvider,
 	normalizeSearchType,
+	resetExaSearchThrottleForTest,
 	searchExa,
 	synthesizeAnswer,
 } from "@oh-my-pi/pi-coding-agent/web/search/providers/exa";
@@ -214,13 +216,18 @@ function makeMockExaResponse(overrides: Record<string, unknown> = {}) {
 describe("searchExa", () => {
 	let capturedRequestBody: Record<string, unknown> | null = null;
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		resetExaSearchThrottleForTest();
+		await Settings.init({ inMemory: true, overrides: { "exa.searchDelayMs": 0 } });
 		capturedRequestBody = null;
 		process.env.EXA_API_KEY = "test-key-123";
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		resetExaSearchThrottleForTest();
+		resetSettingsForTest();
 		delete process.env.EXA_API_KEY;
 	});
 
@@ -288,6 +295,31 @@ describe("searchExa", () => {
 			type: "neural",
 			contents: { summary: { query: "shape test" } },
 		});
+	});
+
+	it("paces consecutive Exa API requests by the configured delay", async () => {
+		resetSettingsForTest();
+		resetExaSearchThrottleForTest();
+		await Settings.init({ inMemory: true, overrides: { "exa.searchDelayMs": 25 } });
+		const requestTimes: number[] = [];
+		const fetchMock: FetchImpl = (_url, init) => {
+			requestTimes.push(Date.now());
+			if (init?.body) {
+				capturedRequestBody = JSON.parse(init.body as string);
+			}
+			return Promise.resolve(
+				new Response(JSON.stringify(makeMockExaResponse()), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		};
+
+		await searchExa({ query: "first paced request", fetch: fetchMock });
+		await searchExa({ query: "second paced request", fetch: fetchMock });
+
+		expect(requestTimes).toHaveLength(2);
+		expect(requestTimes[1] - requestTimes[0]).toBeGreaterThanOrEqual(20);
 	});
 
 	it("prefers summary over text for snippet field", async () => {

--- a/packages/coding-agent/test/tools/web-search-exa.test.ts
+++ b/packages/coding-agent/test/tools/web-search-exa.test.ts
@@ -349,6 +349,38 @@ describe("searchExa", () => {
 		expect(fetchCount).toBe(1);
 	});
 
+	it("aborts while queued behind another Exa throttle wait", async () => {
+		resetSettingsForTest();
+		resetExaSearchThrottleForTest();
+		await Settings.init({ inMemory: true, overrides: { "exa.searchDelayMs": 1_000 } });
+		let fetchCount = 0;
+		const fetchMock: FetchImpl = () => {
+			fetchCount += 1;
+			return Promise.resolve(
+				new Response(JSON.stringify(makeMockExaResponse()), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		};
+
+		await searchExa({ query: "first request", fetch: fetchMock });
+		const secondController = new AbortController();
+		const thirdController = new AbortController();
+		const second = searchExa({ query: "second request", fetch: fetchMock, signal: secondController.signal });
+		const startedAt = Date.now();
+		const third = searchExa({ query: "third request", fetch: fetchMock, signal: thirdController.signal });
+		await Bun.sleep(0);
+		thirdController.abort(new Error("cancelled queued Exa throttle wait"));
+
+		await expect(third).rejects.toThrow("cancelled queued Exa throttle wait");
+		expect(Date.now() - startedAt).toBeLessThan(250);
+		expect(fetchCount).toBe(1);
+
+		secondController.abort(new Error("cleanup second Exa throttle wait"));
+		await expect(second).rejects.toThrow("cleanup second Exa throttle wait");
+	});
+
 	it("prefers summary over text for snippet field", async () => {
 		const result = await searchExa({
 			query: "snippet test",


### PR DESCRIPTION
## Repro
Two sequential Exa searches were allowed to hit the Exa transport back-to-back. Reproduced with `cd packages/coding-agent && bun -e 'import { searchExa } from "@oh-my-pi/pi-coding-agent/web/search/providers/exa"; process.env.EXA_API_KEY = "test-key"; const times = []; const fetch = async () => { times.push(Date.now()); return new Response(JSON.stringify({ requestId: "r", results: [{ title: "ok", url: "https://example.com", summary: "ok" }] }), { status: 200, headers: { "Content-Type": "application/json" } }); }; await searchExa({ query: "one", fetch }); await searchExa({ query: "two", fetch }); const gap = times[1] - times[0]; console.log(`request count=${times.length}`); console.log(`gap_ms=${gap}`); if (gap < 250) { console.log("REPRO: Exa requests are allowed in burst succession"); process.exit(1); } console.log("OK: throttled");'`, which reported `gap_ms=0` before the fix.

## Cause
`packages/coding-agent/src/web/search/providers/exa.ts` called `fetchImpl()` directly in `callExaSearch()` and `callExaMcpSearch()` with no shared pacing state, so repeated `web_search` tool calls could start consecutive Exa API/MCP requests in the same millisecond.

## Fix
- Added a process-local Exa search throttle that spaces Exa API and MCP request starts by `exa.searchDelayMs`.
- Added the configurable `exa.searchDelayMs` setting with a 1000ms default and `0` as an opt-out.
- Added an Exa provider regression test covering configured request pacing.
- Added an Unreleased changelog entry for the Exa pacing fix.

## Verification
`bun test test/tools/web-search-exa.test.ts` passed with 42 tests; `bun check` passed; the repro command now reports `gap_ms=1001` and `OK: throttled`. Fixes #3271