### PR TITLE
test(eval): raised Julia prelude per-test timeout to 30s

### DIFF
--- a/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
@@ -38,7 +38,7 @@ nothing
 		expect(result.output).toContain("DIFF_DELETE=true");
 		expect(result.output).toContain("DIFF_ADD=true");
 		expect(result.output).toContain("TREE_CHILD=true");
-	});
+	}, 30_000);
 
 	it("supports output ranges, JSON queries, metadata, and ANSI stripping", async () => {
 		using tempDir = TempDir.createSync("@omp-eval-julia-output-");
@@ -73,5 +73,5 @@ nothing
 		expect(result.output).toContain("STRIPPED=red");
 		expect(result.output).toContain("META=alpha:true");
 		expect(result.output).toContain("MULTI=2:alpha:json");
-	});
+	}, 30_000);
 });


### PR DESCRIPTION
## Repro
On a Linux host with Julia installed, `bun test src/eval/__tests__/julia-prelude.test.ts` from `packages/coding-agent` flakes at the default 5000ms per-test timeout because a Julia kernel cold-start (JIT + package precompile) takes ~11–12s. Bumping `--timeout 60000` makes both tests pass at ~11–12s each. The CI `Test coding-agent native/unit (TS)` job is gated on the same path: on `pull_request` it runs on GitHub-hosted `ubuntu-22.04` (Julia preinstalled), so it executes the suite and times out; on `push → main` it runs on `omp-kata` self-hosted (no Julia), so `describe.skipIf(!HAS_JULIA)` hides the failure.

## Cause
`packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts` declares two tests that both use `reset: true`, forcing a fresh Julia kernel boot per test. Each test relied on Bun's default 5000ms per-test timeout, which is below the observed ~11–12s cold-start on the PR-runner class. Latent since `1f5307fde` migrated `pull_request` jobs to `ubuntu-22.04`; surfaced once `33e2594f0` added the Julia prelude tests.

## Fix
- Pass `30_000` as the per-test timeout to both `it(...)` calls in `julia-prelude.test.ts`, matching the in-repo precedent `agent-bridge.test.ts:540` for similar persistent-kernel suites (~2.5× headroom over the observed cold-start).

## Verification
`bun test packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts` on this host (no Julia installed) reports `2 skip / 0 fail` via the existing `describe.skipIf(!HAS_JULIA)` guard, confirming the file still parses and the skip path is unchanged. The reporter has independently verified that with Julia present and a 60s timeout both tests pass at ~11–12s; this change uses the lower 30s ceiling already established for analogous suites. Fixes #3274.