### PR TITLE
fix(ai): use code login for xAI OAuth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Enabled the manual code-paste login flow for the xAI Grok OAuth (`xai-oauth`) provider when its fixed loopback port is unavailable. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without changing xAI's allowlisted redirect URI.
+- Changed the xAI Grok OAuth (`xai-oauth`) provider to use manual code-paste login by default. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without starting a local callback listener.
 - Renamed the xAI Grok OAuth provider in login and credential prompts to "xAI Grok OAuth (SuperGrok or X Premium+)".
 
 ## [16.1.11] - 2026-06-21

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Enabled the manual code-paste login flow for the xAI Grok OAuth (`xai-oauth`) provider when its fixed loopback port is unavailable. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without changing xAI's allowlisted redirect URI.
+- Renamed the xAI Grok OAuth provider in login and credential prompts to "xAI Grok OAuth (SuperGrok or X Premium+)".
+
 ## [16.1.11] - 2026-06-21
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
+++ b/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
@@ -70,13 +70,15 @@ describe("XAIOAuthFlow", () => {
 		expect(flow.redirectUri).toBe("http://127.0.0.1:56121/callback");
 	});
 
-	it("continues manual-paste login when the fixed callback port is unavailable", async () => {
+	it("uses pasted-code login without starting a callback server", async () => {
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(() => {
-			throw new Error("port busy");
+			throw new Error("callback server should not start");
 		});
+		let authUrl = "";
+		let tokenRequestBody = "";
 		const progress: string[] = [];
-		const fetchMock = vi.fn(async (input: string | URL) => {
-			const url = typeof input === "string" ? input : input.toString();
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
 			if (url.includes("/.well-known/openid-configuration")) {
 				return new Response(
 					JSON.stringify({
@@ -86,6 +88,7 @@ describe("XAIOAuthFlow", () => {
 					{ status: 200, headers: { "Content-Type": "application/json" } },
 				);
 			}
+			tokenRequestBody = init?.body instanceof URLSearchParams ? init.body.toString() : String(init?.body ?? "");
 			return new Response(
 				JSON.stringify({
 					access_token: "access-token",
@@ -98,15 +101,26 @@ describe("XAIOAuthFlow", () => {
 
 		const flow = new XAIOAuthFlow({
 			fetch: fetchMock as unknown as typeof fetch,
-			onAuth: () => {},
-			onManualCodeInput: async () => "code-xyz",
+			onAuth: info => {
+				authUrl = info.url;
+			},
+			onManualCodeInput: async () => {
+				const parsed = new URL(authUrl);
+				const redirectUri = parsed.searchParams.get("redirect_uri") ?? "";
+				const state = parsed.searchParams.get("state") ?? "";
+				return `${redirectUri}?code=code-xyz&state=${encodeURIComponent(state)}`;
+			},
 			onProgress: message => progress.push(message),
 		});
 
 		const credentials = await flow.login();
+		const authorizeUrl = new URL(authUrl);
+		const tokenParams = new URLSearchParams(tokenRequestBody);
 
-		expect(serveSpy).toHaveBeenCalledTimes(1);
-		expect(progress).toContain("OAuth callback port 56121 unavailable; waiting for pasted authorization code.");
+		expect(serveSpy).not.toHaveBeenCalled();
+		expect(authorizeUrl.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:56121/callback");
+		expect(progress).toContain("Waiting for pasted authorization code...");
+		expect(tokenParams.get("code")).toBe("code-xyz");
 		expect(credentials.access).toBe("access-token");
 		expect(credentials.refresh).toBe("refresh-token");
 	});

--- a/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
+++ b/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
@@ -69,6 +69,47 @@ describe("XAIOAuthFlow", () => {
 
 		expect(flow.redirectUri).toBe("http://127.0.0.1:56121/callback");
 	});
+
+	it("continues manual-paste login when the fixed callback port is unavailable", async () => {
+		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(() => {
+			throw new Error("port busy");
+		});
+		const progress: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url.includes("/.well-known/openid-configuration")) {
+				return new Response(
+					JSON.stringify({
+						authorization_endpoint: "https://auth.x.ai/oauth/authorize",
+						token_endpoint: "https://auth.x.ai/oauth/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					access_token: "access-token",
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const flow = new XAIOAuthFlow({
+			fetch: fetchMock as unknown as typeof fetch,
+			onAuth: () => {},
+			onManualCodeInput: async () => "code-xyz",
+			onProgress: message => progress.push(message),
+		});
+
+		const credentials = await flow.login();
+
+		expect(serveSpy).toHaveBeenCalledTimes(1);
+		expect(progress).toContain("OAuth callback port 56121 unavailable; waiting for pasted authorization code.");
+		expect(credentials.access).toBe("access-token");
+		expect(credentials.refresh).toBe("refresh-token");
+	});
 });
 
 describe("XAIOAuthFlow.exchangeToken", () => {

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -25,7 +25,7 @@ export interface OAuthCallbackFlowOptions {
 	callbackHostname?: string;
 	/** Exact redirect URI advertised to the provider; disables port fallback. */
 	redirectUri?: string;
-	manualInputOnPortBusy?: boolean;
+	fallbackToManualInputOnBindFailure?: boolean;
 }
 
 /**
@@ -37,7 +37,7 @@ export abstract class OAuthCallbackFlow {
 	callbackPath: string;
 	callbackHostname: string;
 	redirectUri?: string;
-	manualInputOnPortBusy?: boolean;
+	fallbackToManualInputOnBindFailure?: boolean;
 	#callbackResolve?: (result: CallbackResult) => void;
 	#callbackReject?: (error: string) => void;
 
@@ -58,7 +58,7 @@ export abstract class OAuthCallbackFlow {
 		this.callbackPath = preferredPortOrOptions.callbackPath ?? CALLBACK_PATH;
 		this.callbackHostname = preferredPortOrOptions.callbackHostname ?? DEFAULT_HOSTNAME;
 		this.redirectUri = preferredPortOrOptions.redirectUri;
-		this.manualInputOnPortBusy = preferredPortOrOptions.manualInputOnPortBusy;
+		this.fallbackToManualInputOnBindFailure = preferredPortOrOptions.fallbackToManualInputOnBindFailure;
 	}
 
 	/**
@@ -126,7 +126,7 @@ export abstract class OAuthCallbackFlow {
 			return { server, redirectUri };
 		} catch {
 			if (this.redirectUri) {
-				if (this.manualInputOnPortBusy && this.ctrl.onManualCodeInput) {
+				if (this.fallbackToManualInputOnBindFailure && this.ctrl.onManualCodeInput) {
 					this.ctrl.onProgress?.(
 						`OAuth callback port ${this.preferredPort} unavailable; waiting for pasted authorization code.`,
 					);

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -25,7 +25,7 @@ export interface OAuthCallbackFlowOptions {
 	callbackHostname?: string;
 	/** Exact redirect URI advertised to the provider; disables port fallback. */
 	redirectUri?: string;
-	fallbackToManualInputOnBindFailure?: boolean;
+	manualInputOnly?: boolean;
 }
 
 /**
@@ -37,7 +37,7 @@ export abstract class OAuthCallbackFlow {
 	callbackPath: string;
 	callbackHostname: string;
 	redirectUri?: string;
-	fallbackToManualInputOnBindFailure?: boolean;
+	#manualInputOnly: boolean;
 	#callbackResolve?: (result: CallbackResult) => void;
 	#callbackReject?: (error: string) => void;
 
@@ -51,6 +51,7 @@ export abstract class OAuthCallbackFlow {
 			this.preferredPort = preferredPortOrOptions;
 			this.callbackPath = callbackPath;
 			this.callbackHostname = DEFAULT_HOSTNAME;
+			this.#manualInputOnly = false;
 			return;
 		}
 
@@ -58,7 +59,7 @@ export abstract class OAuthCallbackFlow {
 		this.callbackPath = preferredPortOrOptions.callbackPath ?? CALLBACK_PATH;
 		this.callbackHostname = preferredPortOrOptions.callbackHostname ?? DEFAULT_HOSTNAME;
 		this.redirectUri = preferredPortOrOptions.redirectUri;
-		this.fallbackToManualInputOnBindFailure = preferredPortOrOptions.fallbackToManualInputOnBindFailure;
+		this.#manualInputOnly = preferredPortOrOptions.manualInputOnly ?? false;
 	}
 
 	/**
@@ -95,13 +96,19 @@ export abstract class OAuthCallbackFlow {
 	async login(): Promise<OAuthCredentials> {
 		const state = this.generateState();
 
-		const { server, redirectUri } = await this.#startCallbackServer(state);
+		const { server, redirectUri } = this.#manualInputOnly
+			? { redirectUri: this.#buildRedirectUri() }
+			: await this.#startCallbackServer(state);
 
 		try {
 			const { url: authUrl, instructions } = await this.generateAuthUrl(state, redirectUri);
 
 			this.ctrl.onAuth?.({ url: authUrl, instructions });
-			this.ctrl.onProgress?.("Waiting for browser authentication...");
+			this.ctrl.onProgress?.(
+				this.#manualInputOnly
+					? "Waiting for pasted authorization code..."
+					: "Waiting for browser authentication...",
+			);
 
 			const { code } = await this.#waitForCallback(state);
 
@@ -113,25 +120,19 @@ export abstract class OAuthCallbackFlow {
 		}
 	}
 
+	#buildRedirectUri(): string {
+		return this.redirectUri ?? `http://${this.callbackHostname}:${this.preferredPort}${this.callbackPath}`;
+	}
+
 	/**
 	 * Start callback server, trying preferred port first, falling back to random.
 	 */
 	async #startCallbackServer(expectedState: string): Promise<{ server?: Bun.Server<unknown>; redirectUri: string }> {
 		try {
 			const server = this.#createServer(this.preferredPort, expectedState);
-			if (this.redirectUri) {
-				return { server, redirectUri: this.redirectUri };
-			}
-			const redirectUri = `http://${this.callbackHostname}:${this.preferredPort}${this.callbackPath}`;
-			return { server, redirectUri };
+			return { server, redirectUri: this.#buildRedirectUri() };
 		} catch {
 			if (this.redirectUri) {
-				if (this.fallbackToManualInputOnBindFailure && this.ctrl.onManualCodeInput) {
-					this.ctrl.onProgress?.(
-						`OAuth callback port ${this.preferredPort} unavailable; waiting for pasted authorization code.`,
-					);
-					return { redirectUri: this.redirectUri };
-				}
 				throw new Error(
 					`OAuth callback port ${this.preferredPort} unavailable; cannot fall back to a random port when oauth.redirectUri is set`,
 				);
@@ -212,15 +213,14 @@ export abstract class OAuthCallbackFlow {
 		const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT);
 		const signal = this.ctrl.signal ? AbortSignal.any([this.ctrl.signal, timeoutSignal]) : timeoutSignal;
 
-		const callbackPromise = new Promise<CallbackResult>((resolve, reject) => {
-			this.#callbackResolve = resolve;
-			this.#callbackReject = reject;
+		const { promise: callbackPromise, resolve, reject } = Promise.withResolvers<CallbackResult>();
+		this.#callbackResolve = resolve;
+		this.#callbackReject = reject;
 
-			signal.addEventListener("abort", () => {
-				this.#callbackResolve = undefined;
-				this.#callbackReject = undefined;
-				reject(new Error(`OAuth callback cancelled: ${signal.reason}`));
-			});
+		signal.addEventListener("abort", () => {
+			this.#callbackResolve = undefined;
+			this.#callbackReject = undefined;
+			reject(new Error(`OAuth callback cancelled: ${signal.reason}`));
 		});
 
 		// Manual input race (if supported)

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -25,6 +25,7 @@ export interface OAuthCallbackFlowOptions {
 	callbackHostname?: string;
 	/** Exact redirect URI advertised to the provider; disables port fallback. */
 	redirectUri?: string;
+	manualInputOnPortBusy?: boolean;
 }
 
 /**
@@ -36,6 +37,7 @@ export abstract class OAuthCallbackFlow {
 	callbackPath: string;
 	callbackHostname: string;
 	redirectUri?: string;
+	manualInputOnPortBusy?: boolean;
 	#callbackResolve?: (result: CallbackResult) => void;
 	#callbackReject?: (error: string) => void;
 
@@ -56,6 +58,7 @@ export abstract class OAuthCallbackFlow {
 		this.callbackPath = preferredPortOrOptions.callbackPath ?? CALLBACK_PATH;
 		this.callbackHostname = preferredPortOrOptions.callbackHostname ?? DEFAULT_HOSTNAME;
 		this.redirectUri = preferredPortOrOptions.redirectUri;
+		this.manualInputOnPortBusy = preferredPortOrOptions.manualInputOnPortBusy;
 	}
 
 	/**
@@ -92,32 +95,28 @@ export abstract class OAuthCallbackFlow {
 	async login(): Promise<OAuthCredentials> {
 		const state = this.generateState();
 
-		// Start callback server first to get actual redirect URI
 		const { server, redirectUri } = await this.#startCallbackServer(state);
 
 		try {
-			// Generate auth URL with the ACTUAL redirect URI (may differ from expected if port was busy)
 			const { url: authUrl, instructions } = await this.generateAuthUrl(state, redirectUri);
 
-			// Notify controller that auth is ready
 			this.ctrl.onAuth?.({ url: authUrl, instructions });
 			this.ctrl.onProgress?.("Waiting for browser authentication...");
 
-			// Wait for callback or manual input
 			const { code } = await this.#waitForCallback(state);
 
 			this.ctrl.onProgress?.("Exchanging authorization code for tokens...");
 
 			return await this.exchangeToken(code, state, redirectUri);
 		} finally {
-			server.stop();
+			server?.stop();
 		}
 	}
 
 	/**
 	 * Start callback server, trying preferred port first, falling back to random.
 	 */
-	async #startCallbackServer(expectedState: string): Promise<{ server: Bun.Server<unknown>; redirectUri: string }> {
+	async #startCallbackServer(expectedState: string): Promise<{ server?: Bun.Server<unknown>; redirectUri: string }> {
 		try {
 			const server = this.#createServer(this.preferredPort, expectedState);
 			if (this.redirectUri) {
@@ -127,6 +126,12 @@ export abstract class OAuthCallbackFlow {
 			return { server, redirectUri };
 		} catch {
 			if (this.redirectUri) {
+				if (this.manualInputOnPortBusy && this.ctrl.onManualCodeInput) {
+					this.ctrl.onProgress?.(
+						`OAuth callback port ${this.preferredPort} unavailable; waiting for pasted authorization code.`,
+					);
+					return { redirectUri: this.redirectUri };
+				}
 				throw new Error(
 					`OAuth callback port ${this.preferredPort} unavailable; cannot fall back to a random port when oauth.redirectUri is set`,
 				);

--- a/packages/ai/src/registry/oauth/xai-oauth.ts
+++ b/packages/ai/src/registry/oauth/xai-oauth.ts
@@ -192,7 +192,7 @@ export class XAIOAuthFlow extends OAuthCallbackFlow {
 			callbackPath: XAI_OAUTH_REDIRECT_PATH,
 			callbackHostname: XAI_OAUTH_REDIRECT_HOST,
 			redirectUri: `http://${XAI_OAUTH_REDIRECT_HOST}:${XAI_OAUTH_REDIRECT_PORT}${XAI_OAUTH_REDIRECT_PATH}`,
-			manualInputOnPortBusy: true,
+			fallbackToManualInputOnBindFailure: true,
 		} satisfies OAuthCallbackFlowOptions);
 		this.#fetch = ctrl.fetch ?? fetch;
 	}

--- a/packages/ai/src/registry/oauth/xai-oauth.ts
+++ b/packages/ai/src/registry/oauth/xai-oauth.ts
@@ -3,7 +3,8 @@
 /**
  * xAI Grok (SuperGrok or X Premium+) OAuth flow.
  *
- * Loopback PKCE flow on `127.0.0.1:56121/callback`. One token unlocks Grok-4.x
+ * Manual-code PKCE flow using `127.0.0.1:56121/callback` as the allowlisted
+ * redirect URI. One token unlocks Grok-4.x
  * chat, Grok Imagine image generation, and Grok Voice TTS via subsequent
  * commits. Endpoint discovery is hardened against MITM via
  * {@link validateXAIEndpoint}: any non-HTTPS or non-`x.ai`/`*.x.ai` host is
@@ -177,10 +178,7 @@ function buildXAIAuthorizeUrl(opts: BuildXAIAuthorizeUrlOptions): string {
 }
 
 /**
- * xAI Grok OAuth loopback flow (Hermes `_xai_oauth_loopback_login` L5315-5469).
- *
- * Uses a fixed redirect URI so the callback server fails fast instead of
- * falling back to a random port that xAI's redirect_uri allowlist rejects.
+ * xAI Grok OAuth code flow (Hermes `_xai_oauth_loopback_login` L5315-5469).
  */
 export class XAIOAuthFlow extends OAuthCallbackFlow {
 	#verifier: string = "";
@@ -192,7 +190,7 @@ export class XAIOAuthFlow extends OAuthCallbackFlow {
 			callbackPath: XAI_OAUTH_REDIRECT_PATH,
 			callbackHostname: XAI_OAUTH_REDIRECT_HOST,
 			redirectUri: `http://${XAI_OAUTH_REDIRECT_HOST}:${XAI_OAUTH_REDIRECT_PORT}${XAI_OAUTH_REDIRECT_PATH}`,
-			fallbackToManualInputOnBindFailure: true,
+			manualInputOnly: true,
 		} satisfies OAuthCallbackFlowOptions);
 		this.#fetch = ctrl.fetch ?? fetch;
 	}

--- a/packages/ai/src/registry/oauth/xai-oauth.ts
+++ b/packages/ai/src/registry/oauth/xai-oauth.ts
@@ -1,7 +1,7 @@
 // Ported from NousResearch/hermes-agent (MIT) — hermes_cli/auth.py xAI sections (L93-111, L2979-3160, L5286-5469).
 
 /**
- * xAI Grok (SuperGrok Subscription) OAuth flow.
+ * xAI Grok (SuperGrok or X Premium+) OAuth flow.
  *
  * Loopback PKCE flow on `127.0.0.1:56121/callback`. One token unlocks Grok-4.x
  * chat, Grok Imagine image generation, and Grok Voice TTS via subsequent
@@ -192,6 +192,7 @@ export class XAIOAuthFlow extends OAuthCallbackFlow {
 			callbackPath: XAI_OAUTH_REDIRECT_PATH,
 			callbackHostname: XAI_OAUTH_REDIRECT_HOST,
 			redirectUri: `http://${XAI_OAUTH_REDIRECT_HOST}:${XAI_OAUTH_REDIRECT_PORT}${XAI_OAUTH_REDIRECT_PATH}`,
+			manualInputOnPortBusy: true,
 		} satisfies OAuthCallbackFlowOptions);
 		this.#fetch = ctrl.fetch ?? fetch;
 	}
@@ -212,7 +213,7 @@ export class XAIOAuthFlow extends OAuthCallbackFlow {
 
 		return {
 			url,
-			instructions: `Complete login in your browser for xAI Grok (SuperGrok). Docs: ${XAI_OAUTH_DOCS_URL}`,
+			instructions: `Complete login in your browser for xAI Grok (SuperGrok or X Premium+). Docs: ${XAI_OAUTH_DOCS_URL}`,
 		};
 	}
 
@@ -275,9 +276,6 @@ export class XAIOAuthFlow extends OAuthCallbackFlow {
 	}
 }
 
-/**
- * Login with xAI Grok OAuth (SuperGrok Subscription).
- */
 export async function loginXAIOAuth(ctrl: OAuthController): Promise<OAuthCredentials> {
 	return new XAIOAuthFlow(ctrl).login();
 }

--- a/packages/ai/src/registry/xai-oauth.ts
+++ b/packages/ai/src/registry/xai-oauth.ts
@@ -14,6 +14,5 @@ export const xaiOauthProvider = {
 		const { refreshXAIOAuthToken } = await import("./oauth/xai-oauth");
 		return refreshXAIOAuthToken(credentials.refresh);
 	},
-	callbackPort: 56121,
 	pasteCodeFlow: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/xai-oauth.ts
+++ b/packages/ai/src/registry/xai-oauth.ts
@@ -15,6 +15,5 @@ export const xaiOauthProvider = {
 		return refreshXAIOAuthToken(credentials.refresh);
 	},
 	callbackPort: 56121,
-	// Headless/remote: also accept a pasted code / loopback redirect URL (raced with the callback).
 	pasteCodeFlow: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/xai-oauth.ts
+++ b/packages/ai/src/registry/xai-oauth.ts
@@ -3,7 +3,7 @@ import type { ProviderDefinition } from "./types";
 
 export const xaiOauthProvider = {
 	id: "xai-oauth",
-	name: "xAI Grok OAuth (SuperGrok Subscription)",
+	name: "xAI Grok OAuth (SuperGrok or X Premium+)",
 	login: async (cb: OAuthLoginCallbacks) => {
 		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
 		const { loginXAIOAuth } = await import("./oauth/xai-oauth");
@@ -14,4 +14,7 @@ export const xaiOauthProvider = {
 		const { refreshXAIOAuthToken } = await import("./oauth/xai-oauth");
 		return refreshXAIOAuthToken(credentials.refresh);
 	},
+	callbackPort: 56121,
+	// Headless/remote: also accept a pasted code / loopback redirect URL (raced with the callback).
+	pasteCodeFlow: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
-import { PASTE_CODE_LOGIN_PROVIDERS, PROVIDER_REGISTRY } from "@oh-my-pi/pi-ai/registry";
+import { PASTE_CODE_LOGIN_PROVIDERS } from "@oh-my-pi/pi-ai/registry";
 import {
 	getOAuthProviders,
 	refreshOAuthToken,
@@ -69,11 +69,6 @@ describe("provider registry auth surface", () => {
 			["anthropic", "gitlab-duo", "google-antigravity", "google-gemini-cli", "openai-codex", "xai-oauth"].sort(),
 		);
 		expect(PASTE_CODE_LOGIN_PROVIDERS.has("zenmux")).toBe(false);
-	});
-
-	test("xAI OAuth advertises its fixed loopback callback port for auth-broker tunnels", () => {
-		const xaiOauth = PROVIDER_REGISTRY.find(provider => provider.id === "xai-oauth");
-		expect(xaiOauth?.callbackPort).toBe(56121);
 	});
 
 	test("refresh dispatch returns api-key providers unchanged and routes real refreshers", async () => {

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
-import { PASTE_CODE_LOGIN_PROVIDERS } from "@oh-my-pi/pi-ai/registry";
+import { PASTE_CODE_LOGIN_PROVIDERS, PROVIDER_REGISTRY } from "@oh-my-pi/pi-ai/registry";
 import {
 	getOAuthProviders,
 	refreshOAuthToken,
@@ -66,9 +66,14 @@ describe("provider registry auth surface", () => {
 
 	test("paste-code login set is derived from pasteCodeFlow", () => {
 		expect([...PASTE_CODE_LOGIN_PROVIDERS].sort()).toEqual(
-			["anthropic", "gitlab-duo", "google-antigravity", "google-gemini-cli", "openai-codex"].sort(),
+			["anthropic", "gitlab-duo", "google-antigravity", "google-gemini-cli", "openai-codex", "xai-oauth"].sort(),
 		);
 		expect(PASTE_CODE_LOGIN_PROVIDERS.has("zenmux")).toBe(false);
+	});
+
+	test("xAI OAuth advertises its fixed loopback callback port for auth-broker tunnels", () => {
+		const xaiOauth = PROVIDER_REGISTRY.find(provider => provider.id === "xai-oauth");
+		expect(xaiOauth?.callbackPort).toBe(56121);
 	});
 
 	test("refresh dispatch returns api-key providers unchanged and routes real refreshers", async () => {

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1275,7 +1275,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 				const xaiCreds = await resolveXAIHttpCredentials(ctx.modelRegistry, resolvedModel);
 				if (!xaiCreds) {
 					throw new Error(
-						"No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok Subscription) or set XAI_API_KEY.",
+						"No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok or X Premium+) or set XAI_API_KEY.",
 					);
 				}
 

--- a/packages/coding-agent/src/tools/tts.ts
+++ b/packages/coding-agent/src/tools/tts.ts
@@ -102,7 +102,7 @@ async function synthesizeXai(
 			content: [
 				{
 					type: "text",
-					text: "No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok Subscription) or set XAI_API_KEY.",
+					text: "No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok or X Premium+) or set XAI_API_KEY.",
 				},
 			],
 		};


### PR DESCRIPTION
## What

Use manual code-paste login as the default xAI Grok OAuth path. The flow still sends xAI's allowlisted `http://127.0.0.1:56121/callback` redirect URI, but it no longer starts a local callback listener or advertises an auth-broker callback port.

Also keep the login label as `xAI Grok OAuth (SuperGrok or X Premium+)`, and let RPC hosts answer post-auth OAuth code prompts so xAI login can complete over `RpcClient.login()`.

## Why

xAI login should work in normal terminal, remote, port-occupied, and RPC-hosted sessions without relying on a loopback callback server. The user completes browser auth, then pastes the returned code or redirect URL back into `/login` or the RPC login prompt.

## Testing

```text
$ bun test packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts packages/ai/test/provider-registry.test.ts packages/coding-agent/test/oauth-flow.test.ts
38 pass, 0 fail

$ bun check
passed

$ OMP_SKIP_SETUP=1 PI_CODING_AGENT_DIR=/tmp/omp-xai-slash-code-* BUN_OPTIONS=--preload=/tmp/omp-xai-oauth-preload.ts bun packages/coding-agent/src/cli.ts --no-extensions --no-skills --no-rules --no-title
Setup: port 56121 occupied; XAI_API_KEY and XAI_OAUTH_TOKEN unset
Input: /login xai-oauth; /login manual-code
Output excerpt:
Complete login in your browser for xAI Grok (SuperGrok or X Premium+). Docs:
Tip: You can complete pairing with /login <redirect URL>.
Waiting for pasted authorization code...
https://auth.x.ai/oauth/authorize?response_type=code&client_id=b1a00492-073a-4
Exchanging authorization code for tokens...
✔ Successfully logged in to xai-oauth
Credentials saved to /tmp/omp-xai-slash-code-*/agent.db
OAuth callback received; completing login…
```

The `BUN_OPTIONS` preload above only stubbed xAI network responses so the source CLI flow could complete without account credentials; the UI, slash commands, auth URL generation, manual-code wait, and credential persistence path were the real `omp` flow.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)