### PR TITLE
fix(compaction): run /goal threshold maintenance mid-run between tool turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/goal` auto-compaction never triggering during long autonomous runs with `compaction.strategy: context-full`. Threshold compaction was only evaluated at `agent_end` and before a fresh prompt, but an active goal driven by a relentless model (e.g. a local `omlx` model) can iterate tool-call turns for the entire goal inside a single agent run that never settles to `agent_end` — so the soft threshold was never checked and context grew unbounded until the provider overflowed or the user aborted. A per-turn `onTurnEnd` maintenance pass now compacts in place between tool-call turns when an active goal run crosses the threshold (mirroring the in-place rewind path), keeping context bounded across the run. [#3147](https://github.com/can1357/oh-my-pi/issues/3147) fixed only the post-yield early-return path; this covers the continuation loop that never yields ([#3174](https://github.com/can1357/oh-my-pi/issues/3174)).
+
 ## [16.1.15] - 2026-06-22
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1619,6 +1619,9 @@ export class AgentSession {
 					await this.#advisorRuntime.waitForCatchup(30000, threshold, signal);
 				}
 			}
+			// Catch unbounded autonomous runs (active /goal) that never settle to an
+			// agent_end where the threshold is otherwise checked (issue #3174).
+			await this.#maintainContextMidRun(messages, signal);
 		});
 		this.yieldQueue = new YieldQueue({
 			isStreaming: () => this.isStreaming,
@@ -8214,6 +8217,79 @@ export class AgentSession {
 	}
 
 	/**
+	 * Mid-run threshold maintenance, invoked from the per-turn `onTurnEnd` hook.
+	 *
+	 * The agent_end / pre-prompt compaction checkpoints only fire when an agent
+	 * run settles (the model stops emitting tool calls) or a fresh prompt is
+	 * submitted. An autonomous run — most visibly an active `/goal` continuation
+	 * driven by a relentless local model — can iterate tool-call turns for the
+	 * entire goal without ever yielding, so neither checkpoint is reached and the
+	 * soft threshold is never evaluated. Context then grows unbounded until the
+	 * provider hard-overflows or the user aborts (issue #3174).
+	 *
+	 * `onTurnEnd` runs at a clean boundary — the just-finished turn's tool results
+	 * are already paired in `activeMessages`, the live array the agent loop reads
+	 * before its next model call. So we compact in place here, mirroring the
+	 * rewind path in {@link #applyRewind}: run compaction (which rewrites session
+	 * history + agent state) and splice the compacted message set back into
+	 * `activeMessages` so the running loop continues on the smaller context. The
+	 * compaction is told to suppress continuation scheduling — the live run is
+	 * already the continuation, and a queued `agent.continue()` would race it.
+	 *
+	 * Scoped to active goals: ordinary interactive runs are user-paced and reach
+	 * `agent_end` between turns, so they don't need (and shouldn't pay for)
+	 * per-turn compaction. Promotion is intentionally skipped — the loop captured
+	 * its model at run start, so a mid-run model switch can't take effect until
+	 * the run ends, which is exactly what never happens here.
+	 */
+	async #maintainContextMidRun(activeMessages: AgentMessage[], signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) return;
+		if (this.#isDisposed || this.isCompacting || this.isGeneratingHandoff) return;
+		// Only autonomous goal continuations get stuck in an unbounded single run.
+		if (!(this.#goalModeState?.enabled === true && this.#goalModeState.goal.status === "active")) return;
+		const model = this.model;
+		const contextWindow = model?.contextWindow ?? 0;
+		if (contextWindow <= 0) return;
+		const compactionSettings = this.settings.getGroup("compaction");
+		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
+
+		// Anchor on the provider-billed context of the just-finished turn (the same
+		// figure the status line shows), floored by the local stored-conversation
+		// estimate so a payload-compression hook can't deflate the trigger.
+		const lastAssistant = [...activeMessages]
+			.reverse()
+			.find((message): message is AssistantMessage => message.role === "assistant");
+		if (!lastAssistant || lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") return;
+		const billedContextTokens = calculateContextTokens(lastAssistant.usage);
+		const contextTokens = compactionContextTokens(billedContextTokens, this.#estimateStoredContextTokens());
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings)) return;
+
+		const messagesBefore = activeMessages.length;
+		await this.#runAutoCompaction("threshold", false, false, false, {
+			autoContinue: false,
+			suppressContinuation: true,
+			triggerContextTokens: contextTokens,
+		});
+
+		if (signal?.aborted) return;
+		// Rewrite the live loop array in place so the next model call in this run
+		// uses the compacted context. `#runAutoCompaction` already swapped agent
+		// state via replaceMessages; mirror that into the array the loop holds
+		// (the loop works on its own copy that replaceMessages does not touch).
+		const compacted = this.agent.state.messages;
+		if (compacted !== activeMessages) {
+			activeMessages.splice(0, activeMessages.length, ...compacted);
+		}
+		logger.debug("Mid-run goal compaction ran between tool-call turns", {
+			contextTokens,
+			contextWindow,
+			strategy: compactionSettings.strategy,
+			messagesBefore,
+			messagesAfter: activeMessages.length,
+		});
+	}
+
+	/**
 	 * Check if context maintenance or promotion is needed and run it.
 	 * Called after agent_end and before prompt submission.
 	 *
@@ -9483,13 +9559,18 @@ export class AgentSession {
 		willRetry: boolean,
 		deferred = false,
 		allowDefer = true,
-		options: { autoContinue?: boolean; triggerContextTokens?: number } = {},
+		options: { autoContinue?: boolean; triggerContextTokens?: number; suppressContinuation?: boolean } = {},
 	): Promise<CompactionCheckResult> {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.strategy === "off") return COMPACTION_CHECK_NONE;
 		if (reason !== "idle" && !compactionSettings.enabled) return COMPACTION_CHECK_NONE;
 		const generation = this.#promptGeneration;
-		const shouldAutoContinue = options.autoContinue !== false && compactionSettings.autoContinue !== false;
+		// Mid-run maintenance (see #maintainContextMidRun) compacts in place while the
+		// agent loop is still iterating; it must not schedule a fresh agent.continue()
+		// or auto-continue prompt that would race the live run it is repairing.
+		const suppressContinuation = options.suppressContinuation === true;
+		const shouldAutoContinue =
+			!suppressContinuation && options.autoContinue !== false && compactionSettings.autoContinue !== false;
 		// Shake runs inline (cheap, no remote LLM). On overflow recovery, if shake
 		// reclaims nothing we fall through to the summary-compaction body below so
 		// the oversized input still gets resolved.
@@ -9500,6 +9581,7 @@ export class AgentSession {
 				generation,
 				shouldAutoContinue,
 				options.triggerContextTokens,
+				suppressContinuation,
 			);
 			if (outcome !== "fallback") return outcome;
 		}
@@ -9953,7 +10035,7 @@ export class AgentSession {
 
 				this.#scheduleAgentContinue({ delayMs: 100, generation });
 				continuationScheduled = true;
-			} else if (this.agent.hasQueuedMessages()) {
+			} else if (!suppressContinuation && this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
 				this.#scheduleAgentContinue({
@@ -10013,6 +10095,7 @@ export class AgentSession {
 		generation: number,
 		autoContinue: boolean,
 		triggerContextTokens?: number,
+		suppressContinuation = false,
 	): Promise<CompactionCheckResult | "fallback"> {
 		const action = "shake";
 		this.#autoCompactionAbortController?.abort();
@@ -10111,7 +10194,7 @@ export class AgentSession {
 				}
 				this.#scheduleAgentContinue({ delayMs: 100, generation });
 				continuationScheduled = true;
-			} else if (this.agent.hasQueuedMessages()) {
+			} else if (!suppressContinuation && this.agent.hasQueuedMessages()) {
 				this.#scheduleAgentContinue({
 					delayMs: 100,
 					generation,

--- a/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+// Issue #3174: an active /goal continuation can iterate tool-call turns for the
+// entire goal in a single agent run. Such a run never settles to an `agent_end`,
+// so the agent_end/pre-prompt threshold checkpoints never fire and context grows
+// unbounded past the configured threshold. The per-turn `onTurnEnd` maintenance
+// pass must catch this and compact in place between tool-call turns.
+
+function activeGoalState(): GoalModeState {
+	const now = Date.now();
+	return {
+		enabled: true,
+		mode: "active",
+		goal: {
+			id: "goal-1",
+			objective: "Ship the release",
+			status: "active",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: now,
+			updatedAt: now,
+		},
+	};
+}
+
+function highUsage(input: number) {
+	return {
+		input,
+		output: 100,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + 100,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+describe("AgentSession mid-run goal compaction (issue #3174)", () => {
+	let tempDir: TempDir;
+	const cleanups: Array<() => Promise<void>> = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-agent-goal-midrun-compaction-");
+		cleanups.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const cleanup of cleanups) await cleanup();
+		cleanups.length = 0;
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	async function createHarness(settingsOverride: Record<string, unknown> = {}): Promise<{
+		session: AgentSession;
+		observedContexts: string[][];
+	}> {
+		const observedContexts: string[][] = [];
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const settings = Settings.isolated({
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			"compaction.autoContinue": true,
+			"compaction.thresholdTokens": 1000,
+			"compaction.thresholdPercent": -1,
+			"todo.enabled": false,
+			"todo.reminders": false,
+			...settingsOverride,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+
+		const mockBashTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock bash tool",
+			parameters: type({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "tool output" }] }),
+		};
+		const toolSession: ToolSession = {
+			cwd: tempDir.path(),
+			hasUI: false,
+			getSessionFile: () => sessionManager.getSessionFile() ?? null,
+			getSessionSpawns: () => "*",
+			settings,
+		};
+		void toolSession;
+
+		// Turn 1: tool-call turn with high usage (drives the threshold). Turn 2+:
+		// a plain text stop so the run finally settles. Without the mid-run fix the
+		// only compaction checkpoint is the final agent_end, which sees turn 2's low
+		// usage and never fires.
+		let call = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [mockBashTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context, _options) => {
+				const index = call++;
+				observedContexts.push(context.messages.map(m => JSON.stringify(m)));
+				const stream = new AssistantMessageEventStream();
+				const isToolTurn = index === 0;
+				const message = isToolTurn
+					? {
+							role: "assistant" as const,
+							content: [
+								{ type: "toolCall" as const, id: `tc-${index}`, name: "bash", arguments: { cmd: "ls" } },
+							],
+							api: "anthropic-messages" as const,
+							provider: "anthropic" as const,
+							model: "claude-sonnet-4-5",
+							usage: highUsage(50_000),
+							stopReason: "toolUse" as const,
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant" as const,
+							content: [{ type: "text" as const, text: "All done." }],
+							api: "anthropic-messages" as const,
+							provider: "anthropic" as const,
+							model: "claude-sonnet-4-5",
+							usage: highUsage(200),
+							stopReason: "stop" as const,
+							timestamp: Date.now(),
+						};
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: message.stopReason as "toolUse" | "stop", message });
+				});
+				return stream;
+			},
+		});
+
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry: new Map<string, AgentTool>([[mockBashTool.name, mockBashTool]]),
+		});
+
+		cleanups.push(async () => {
+			await session.dispose();
+			authStorage.close();
+		});
+		return { session, observedContexts };
+	}
+
+	it("compacts between tool-call turns during an active goal run", async () => {
+		const { session } = await createHarness();
+		session.setGoalModeState(activeGoalState());
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "MID-RUN-COMPACTED",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+
+		await session.prompt("work on the release");
+
+		// Compaction ran mid-run, triggered by the per-turn maintenance pass — not by
+		// a final agent_end (the run never settled until the threshold was relieved).
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not compact mid-run when no goal is active", async () => {
+		const { session } = await createHarness();
+		// No goal mode set — ordinary interactive runs reach agent_end between turns.
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "SHOULD-NOT-RUN",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+
+		await session.prompt("work on the release");
+
+		expect(compactSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Problem

`/goal` auto-compaction never triggers during long autonomous runs with `compaction.strategy: context-full` (issue #3174).

Threshold compaction is only evaluated in two places: the `agent_end` handler and the pre-prompt check before a fresh `session.prompt()`. But an active goal driven by a relentless model — most visibly a local `omlx`/`Nex-N2-mini-4bit` model — can iterate **tool-call turns for the entire goal inside a single agent run** that never settles to `agent_end` (the model just keeps calling tools). Neither checkpoint is reached, so the soft threshold is never checked and context grows unbounded until the provider hard-overflows or the user aborts.

This matches the reporter's diagnostic: during a normal `/goal` continuation **no `agent_end` maintenance fires at all** — routing logs only appear after pressing ESC (which forces the run to end). #3147 fixed only the post-yield early-return path inside `agent_end`; this is the continuation loop that *never yields*.

## Fix

Add a per-turn `onTurnEnd` maintenance pass (`#maintainContextMidRun`). When an active goal run crosses the threshold, it compacts **in place between tool-call turns**, mirroring the existing in-place rewind path (`#applyRewind`):

1. `onTurnEnd` runs at a clean boundary — the just-finished turn's tool results are already paired in the live `messages` array the agent loop reads before its next model call.
2. Run compaction (which rewrites session history + agent state via `replaceMessages`).
3. Splice the compacted message set back into the live loop array — the loop works on its own `currentContext.messages` copy that `replaceMessages` does not touch, so the splice is what actually shrinks the running run's context.

The mid-run compaction suppresses continuation scheduling (new `suppressContinuation` option on `#runAutoCompaction`/`#runAutoShake`) — the live run *is* the continuation, and a queued `agent.continue()` would race it.

Scoped to active goals: ordinary interactive runs are user-paced and reach `agent_end` between turns, so they don't need (and shouldn't pay for) per-turn compaction. Promotion is intentionally skipped — the loop captured its model at run start, so a mid-run model switch can't take effect until the run ends, which is exactly what never happens here.

## Verification

- New regression test `agent-session-goal-midrun-compaction.test.ts`: drives a multi-turn run (tool-call turn with high usage → text stop) and asserts compaction fires **mid-run** for an active goal, and does **not** fire when no goal is active. Confirmed the test fails without the fix (0 calls) and passes with it.
- Manually verified against a real `/goal` session on `omlx/Nex-N2-mini-4bit`: context that previously grew unbounded past 90k now stays bounded and compacts in place between turns (debug log `Mid-run goal compaction ran between tool-call turns`). Note: `thresholdTokens` was lowered to 32768 purely to reproduce/verify faster, so the observed ~34k–47k band reflects that lowered test threshold rather than a default.
- Existing compaction + goals suites pass; typecheck and biome clean.

Relationship to #3175: that PR adjusted the token accounting *inside* the `agent_end` threshold branch, which the reporter confirmed does not fix the issue because that branch isn't reached during a normal goal continuation. This addresses the structural root cause instead.

Fixes #3174