### PR TITLE
fix(catalog): preserve Umans bundled effort floor

### DIFF
--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1870,6 +1870,40 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(maxPayload.output_config).toEqual({ effort: "max" });
 	});
 
+	it("maps Umans GLM 5.2 xhigh reasoning to Anthropic max effort", async () => {
+		const payload = (await captureAnthropicPayload(
+			buildModel({
+				...ANTHROPIC_MODEL_SPEC,
+				id: "umans-glm-5.2",
+				name: "Umans GLM 5.2",
+				provider: "umans",
+				baseUrl: "https://api.code.umans.ai",
+				input: ["text"],
+				contextWindow: 405_504,
+				maxTokens: 131_071,
+				thinking: {
+					mode: "budget",
+					efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+				},
+			}),
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.XHigh,
+			},
+		)) as {
+			thinking?: { type?: string; budget_tokens?: number; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.thinking?.budget_tokens).toBeGreaterThan(0);
+		expect(payload.output_config).toEqual({ effort: "max" });
+	});
+
 	it("keeps summarized adaptive thinking by default for API-key Opus 4.7+ requests", async () => {
 		const payload = (await captureAnthropicPayload(
 			buildModel({

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Umans dynamic discovery preserving bundled `umans-glm-5.2` thinking efforts when `/models/info` reports only a subset of levels, including mapping the UI `xhigh` tier to the upstream `max` effort. ([#3286](https://github.com/can1357/oh-my-pi/issues/3286))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -178,11 +178,13 @@ function fillThinkingWireDefaults<TApi extends Api>(
 	thinking: ThinkingConfig,
 ): ThinkingConfig {
 	const parsed = parseKnownModel(spec.id);
+	const normalizedMode = getModelDefinedThinkingMode(spec) ?? thinking.mode;
+	const modeChanged = normalizedMode !== thinking.mode;
 	const normalizedEfforts = getModelDefinedEfforts(spec, compat) ?? thinking.efforts;
 	const effortsChanged = !sameEffortList(normalizedEfforts, thinking.efforts);
 	const effortMap =
 		thinking.effortMap === undefined
-			? inferEffortMap(spec, compat, parsed, thinking.mode, normalizedEfforts)
+			? inferEffortMap(spec, compat, parsed, normalizedMode, normalizedEfforts)
 			: effortsChanged
 				? filterEffortMapToSupportedEfforts(thinking.effortMap, normalizedEfforts)
 				: undefined;
@@ -192,10 +194,13 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
 	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec.id);
-	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort) {
+	if (!modeChanged && !effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort) {
 		return thinking;
 	}
 	const filled: ThinkingConfig = { ...thinking };
+	if (modeChanged) {
+		filled.mode = normalizedMode;
+	}
 	if (effortsChanged) {
 		filled.efforts = normalizedEfforts;
 	}
@@ -321,8 +326,19 @@ function getModelDefinedEfforts<TApi extends Api>(
 		: undefined;
 }
 
+function getModelDefinedThinkingMode<TApi extends Api>(spec: ModelSpec<TApi>): ThinkingConfig["mode"] | undefined {
+	if (isUmansGlm52ReasoningEffortModel(spec)) {
+		return "anthropic-budget-effort";
+	}
+	return undefined;
+}
+
 function isOllamaCloudGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
 	return spec.api === "ollama-chat" && spec.provider === "ollama-cloud" && isGlm52ReasoningEffortModelId(spec.id);
+}
+
+function isUmansGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	return spec.api === "anthropic-messages" && spec.provider === "umans" && isGlm52ReasoningEffortModelId(spec.id);
 }
 
 function isMinimaxReasoningModelOnAnthropicEndpoint<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
@@ -387,6 +403,9 @@ function inferDetectedEffortMap<TApi extends Api>(
 		return ZAI_GLM_52_REASONING_EFFORT_MAP;
 	}
 	if (isOllamaCloudGlm52ReasoningEffortModel(spec)) {
+		return GLM_52_XHIGH_MAX_EFFORT_MAP;
+	}
+	if (isUmansGlm52ReasoningEffortModel(spec)) {
 		return GLM_52_XHIGH_MAX_EFFORT_MAP;
 	}
 	if (isSakanaFuguReasoningModel(spec)) {
@@ -574,6 +593,9 @@ function inferThinkingControlMode<TApi extends Api>(
 				: "budget";
 
 		case "anthropic-messages":
+			if (isUmansGlm52ReasoningEffortModel(spec)) {
+				return "anthropic-budget-effort";
+			}
 			if (isMinimaxReasoningModelOnAnthropicEndpoint(spec)) {
 				return "anthropic-adaptive";
 			}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -620,9 +620,34 @@ function mapUmansReasoningEfforts(value: unknown): readonly Effort[] {
 	return efforts.length > 0 ? efforts : UMANS_DEFAULT_REASONING_EFFORTS;
 }
 
-function mapUmansThinkingConfig(value: unknown): ThinkingConfig | undefined {
+function mergeUmansReasoningEfforts(
+	discoveredEfforts: readonly Effort[],
+	referenceThinking: ThinkingConfig | undefined,
+): readonly Effort[] {
+	const referenceEfforts = referenceThinking?.efforts;
+	if (referenceEfforts === undefined || referenceEfforts.length === 0) {
+		return discoveredEfforts;
+	}
+	const efforts: Effort[] = [];
+	for (const effort of referenceEfforts) {
+		if (!efforts.includes(effort)) {
+			efforts.push(effort);
+		}
+	}
+	for (const effort of discoveredEfforts) {
+		if (!efforts.includes(effort)) {
+			efforts.push(effort);
+		}
+	}
+	return efforts;
+}
+
+function mapUmansThinkingConfig(
+	value: unknown,
+	referenceThinking: ThinkingConfig | undefined,
+): ThinkingConfig | undefined {
 	if (!umansReasoningSupported(value)) return undefined;
-	const efforts = mapUmansReasoningEfforts(value);
+	const efforts = mergeUmansReasoningEfforts(mapUmansReasoningEfforts(value), referenceThinking);
 	const thinking: ThinkingConfig = { mode: "budget", efforts };
 	if (isRecord(value)) {
 		if (value.can_disable === false) {
@@ -647,7 +672,7 @@ function mapUmansModelInfo(
 	if (!modelId) return null;
 	const capabilities = isRecord(raw.capabilities) ? raw.capabilities : {};
 	const supportsTools = capabilities.supports_tools;
-	const thinking = mapUmansThinkingConfig(capabilities.reasoning);
+	const thinking = mapUmansThinkingConfig(capabilities.reasoning, reference?.thinking);
 	return {
 		...reference,
 		id: modelId,

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
@@ -91,6 +92,37 @@ describe("umans provider catalog", () => {
 			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium", requiresEffort: true },
 			compat: { escapeBuiltinToolNames: true },
+		});
+	});
+
+	it("preserves bundled Umans reasoning efforts when discovery reports a subset", async () => {
+		const result = await resolveProviderModels(
+			umansModelManagerOptions({
+				fetch: async () =>
+					new Response(
+						JSON.stringify({
+							"umans-glm-5.2": {
+								display_name: "Umans GLM 5.2",
+								capabilities: {
+									context_window: 405_504,
+									recommended_max_tokens: 131_071,
+									supports_vision: "via-handoff",
+									supports_tools: true,
+									reasoning: { supported: true, levels: ["minimal", "low", "medium"] },
+								},
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+			}),
+			"online",
+		);
+
+		const model = result.models.find(item => item.id === "umans-glm-5.2");
+		expect(model?.thinking).toMatchObject({
+			mode: "anthropic-budget-effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			effortMap: { [Effort.XHigh]: "max" },
 		});
 	});
 


### PR DESCRIPTION
## Repro
A mocked Umans `/models/info` response for `umans-glm-5.2` with `capabilities.reasoning.levels: ["minimal", "low", "medium"]` reproduced the issue: `bun --cwd=packages/catalog test test/umans-provider.test.ts --test-name-pattern "preserves bundled Umans reasoning efforts"` failed because `model.thinking.efforts` omitted `high` and `xhigh`.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` rebuilt Umans `ThinkingConfig` solely from dynamic `capabilities.reasoning.levels`; since Umans is authoritative dynamic discovery, that dynamic subset overwrote the bundled `umans-glm-5.2` five-tier `thinking.efforts` metadata during `resolveProviderModels`.

## Fix
- Merge bundled Umans `thinking.efforts` into discovered reasoning efforts as a floor before returning dynamic `ThinkingConfig`.
- Keep discovery-only Umans models using the endpoint-reported/default effort list when no bundled reference exists.
- Add regression coverage for `umans-glm-5.2` preserving `minimal`, `low`, `medium`, `high`, and `xhigh` when `/models/info` reports only the first three levels.
- Add the catalog changelog entry for #3286.

## Verification
`bun --cwd=packages/catalog run check` passed. `bun --cwd=packages/catalog test test/umans-provider.test.ts` passed with 9 tests / 21 assertions. Fixes #3286