### PR TITLE
fix(tui): include tiered Codex usage limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Fixed Anthropic-compatible thinking requests sending replayed thinking blocks without `context_management.keep: "all"`, preserving multi-turn reasoning context for API-key providers. API-key requests now also advertise the required `context-management-2025-06-27` beta header so the field is honored instead of rejected. Injected SDK clients, GitHub Copilot's Anthropic proxy, and Vertex rawPredict are excluded because this code path cannot add the beta to caller-owned clients, Copilot strips Anthropic betas and demotes thinking blocks to text upstream, and Vertex expects betas in the JSON body rather than the Anthropic HTTP beta header. ([#3288](https://github.com/can1357/oh-my-pi/issues/3288))
 - Fixed OpenRouter Responses native history replay leaking Gemini reasoning item `format` metadata back into follow-up requests, which caused HTTP 400 rejections while preserving encrypted reasoning replay.
+### Fixed
+
+- Fixed Anthropic rate-limit header usage cache entries retaining legacy missing account metadata after refresh.
 
 ## [16.1.15] - 2026-06-22
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2326,8 +2326,13 @@ export class AuthStorage {
 		const last = this.#usageHeaderIngestAt.get(cacheKey);
 		if (last !== undefined && now - last < USAGE_HEADER_INGEST_INTERVAL_MS) return false;
 
-		const report = this.#usageProviderResolver?.(provider)?.parseRateLimitHeaders?.(headers, now);
-		if (!report) return false;
+		const parsedReport = this.#usageProviderResolver?.(provider)?.parseRateLimitHeaders?.(headers, now);
+		if (!parsedReport) return false;
+		const metadata: Record<string, unknown> = { ...(parsedReport.metadata ?? {}) };
+		if (credential.accountId && metadata.accountId === undefined) metadata.accountId = credential.accountId;
+		if (credential.email && metadata.email === undefined) metadata.email = credential.email;
+		if (credential.projectId && metadata.projectId === undefined) metadata.projectId = credential.projectId;
+		const report: UsageReport = { ...parsedReport, metadata };
 
 		const prior = this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value;
 		let merged = report;
@@ -2351,6 +2356,7 @@ export class AuthStorage {
 				fetchedAt: now,
 				limits,
 				metadata: {
+					...(report.metadata ?? {}),
 					...(prior.metadata ?? {}),
 					headersUpdatedAt: now,
 				},

--- a/packages/ai/test/auth-storage-usage-cache.test.ts
+++ b/packages/ai/test/auth-storage-usage-cache.test.ts
@@ -362,8 +362,40 @@ describe("AuthStorage usage cache: header ingestion", () => {
 		const report = requireAnthropicReport(await storage.fetchUsageReports());
 		expect(calls).toBe(0);
 		expect(report.metadata?.source).toBe("ratelimit-headers");
+		expect(report.metadata?.email).toBe("a@example.com");
+		expect(report.metadata?.accountId).toBe("account-1");
 		expect(requireLimit(report, "anthropic:5h").amount.used).toBe(2);
 		expect(requireLimit(report, "anthropic:7d").amount.used).toBe(30);
+	});
+
+	it("merges active credential metadata into existing header cache entries", async () => {
+		const start = Date.now();
+		const now = vi.spyOn(Date, "now").mockReturnValue(start);
+		expect(await storage.getApiKey("anthropic", "legacy-session")).toBe("oat-1");
+		expect(
+			storage.ingestUsageHeaders("anthropic", usageHeaders("0.02", "0.3"), { sessionId: "legacy-session" }),
+		).toBe(true);
+
+		let rewroteLegacyEntry = false;
+		for (const [key, entry] of store.cache) {
+			const payload = JSON.parse(entry.value) as { value?: UsageReport | null };
+			if (payload.value?.metadata?.source !== "ratelimit-headers") continue;
+			payload.value.metadata = { source: "ratelimit-headers" };
+			store.cache.set(key, { value: JSON.stringify(payload), expiresAtSec: entry.expiresAtSec });
+			rewroteLegacyEntry = true;
+		}
+		expect(rewroteLegacyEntry).toBe(true);
+
+		now.mockReturnValue(start + 60_001);
+		expect(
+			storage.ingestUsageHeaders("anthropic", usageHeaders("0.05", "0.6"), { sessionId: "legacy-session" }),
+		).toBe(true);
+
+		const report = requireAnthropicReport(await storage.fetchUsageReports());
+		expect(report.metadata?.source).toBe("ratelimit-headers");
+		expect(report.metadata?.email).toBe("a@example.com");
+		expect(report.metadata?.accountId).toBe("account-1");
+		expect(requireLimit(report, "anthropic:5h").amount.used).toBe(5);
 	});
 
 	it("throttles repeated header ingestion for the same credential cache key", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -506,6 +506,9 @@
 ### Security
 
 - Secured PDF image reads by validating requested image members against the extracted member list before opening files and refusing traversal-style names
+### Fixed
+
+- Fixed status-line `usage` segment ignoring Codex subscription limits that carry a `scope.tier` ([#2877](https://github.com/can1357/oh-my-pi/issues/2877)).
 
 ## [16.0.5] - 2026-06-17
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,12 +1,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { settings } from "../../../config/settings";
 import type { AgentSession } from "../../../session/agent-session";
+import type { OAuthAccountIdentity } from "../../../session/auth-storage";
+import { limitMatchesActiveAccount } from "../../../slash-commands/helpers/active-oauth-account";
 import * as git from "../../../utils/git";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
@@ -207,11 +209,13 @@ export class StatusLineComponent implements Component {
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
 
-	// Anthropic usage caching (5-min TTL, OAuth/sub only)
+	// Provider usage caching (5-min TTL, OAuth/sub only)
 	#cachedUsage: {
+		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 	} | null = null;
+	#cachedUsageContextKey: string | null = null;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
 	#usageStartTimer: Timer | null = null;
@@ -531,15 +535,28 @@ export class StatusLineComponent implements Component {
 		return null;
 	}
 
+	#getUsageContextKey(session: AgentSession): string {
+		const activeProvider = session.state.model?.provider ?? session.model?.provider ?? "";
+		if (!activeProvider) return "";
+		const identity = session.modelRegistry?.authStorage?.getOAuthAccountIdentity(activeProvider, session.sessionId);
+		return [activeProvider, identity?.accountId ?? "", identity?.email ?? "", identity?.projectId ?? ""].join("\0");
+	}
+
 	/**
 	 * Startup redraws only arm a short-delayed task; timeout releases the render
 	 * cadence while a late successful fetch can still refresh the cached segment.
 	 */
 	refreshUsageInBackground(): void {
 		const now = Date.now();
+		const session = this.session;
+		const usageContextKey = this.#getUsageContextKey(session);
+		if (this.#cachedUsageContextKey !== usageContextKey) {
+			this.#cachedUsage = null;
+			this.#usageFetchedAt = 0;
+			this.#cachedUsageContextKey = usageContextKey;
+		}
 		if (this.#usageInFlight || this.#usageStartTimer) return;
 		if (this.#usageFetchedAt > 0 && now - this.#usageFetchedAt < 5 * 60_000) return;
-		const session = this.session;
 		const fetcher = (session as { fetchUsageReports?: (signal?: AbortSignal) => Promise<unknown> }).fetchUsageReports;
 		if (typeof fetcher !== "function") return;
 		this.#usageInFlight = true;
@@ -572,7 +589,12 @@ export class StatusLineComponent implements Component {
 
 	#applyUsageRefreshReports(session: AgentSession, reports: unknown): void {
 		if (this.#disposed || this.session !== session) return;
-		this.#cachedUsage = this.#normalizeUsageReports(reports);
+		const activeProvider = session.state.model?.provider ?? session.model?.provider;
+		const activeIdentity =
+			activeProvider && session.modelRegistry?.authStorage
+				? session.modelRegistry.authStorage.getOAuthAccountIdentity(activeProvider, session.sessionId)
+				: undefined;
+		this.#cachedUsage = this.#normalizeUsageReports(reports, activeProvider, activeIdentity);
 		this.#usageFetchedAt = Date.now();
 	}
 
@@ -599,20 +621,35 @@ export class StatusLineComponent implements Component {
 		}
 	}
 
-	#normalizeUsageReports(reports: unknown): {
+	#normalizeUsageReports(
+		reports: unknown,
+		activeProvider?: string,
+		activeIdentity?: OAuthAccountIdentity,
+	): {
+		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 	} | null {
 		if (!Array.isArray(reports)) return null;
 		let fiveHour: { percent: number; resetMinutes?: number } | undefined;
 		let sevenDay: { percent: number; resetHours?: number } | undefined;
+		let fiveHourTier: string | undefined;
+		let sevenDayTier: string | undefined;
 		const now = Date.now();
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
+			const provider = (report as { provider?: unknown }).provider;
+			if (activeProvider && provider !== activeProvider) continue;
 			const limits = (report as { limits?: unknown }).limits;
 			if (!Array.isArray(limits)) continue;
 			for (const limit of limits) {
 				if (!limit || typeof limit !== "object") continue;
+				if (
+					activeIdentity &&
+					!limitMatchesActiveAccount(report as UsageReport, limit as UsageLimit, activeIdentity)
+				) {
+					continue;
+				}
 				const l = limit as {
 					scope?: { windowId?: string; tier?: string };
 					window?: { resetsAt?: number };
@@ -623,23 +660,30 @@ export class StatusLineComponent implements Component {
 				const windowId = l.scope?.windowId;
 				const tier = l.scope?.tier;
 				const resetsAt = l.window?.resetsAt;
-				if (windowId === "5h" && !tier && !fiveHour) {
+				// Accept tiered limits, but prefer untiered (backward compat with Anthropic).
+				// An untiered limit always replaces a tiered one; among same-tieredness, first wins.
+				if (windowId === "5h" && (!fiveHour || (fiveHourTier !== undefined && !tier))) {
 					fiveHour = {
 						percent: fraction * 100,
 						resetMinutes:
 							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 60_000)) : undefined,
 					};
-				} else if (windowId === "7d" && !tier && !sevenDay) {
+					fiveHourTier = tier || undefined;
+				}
+				if (windowId === "7d" && (!sevenDay || (sevenDayTier !== undefined && !tier))) {
 					sevenDay = {
 						percent: fraction * 100,
 						resetHours:
 							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 3_600_000)) : undefined,
 					};
+					sevenDayTier = tier || undefined;
 				}
 			}
 		}
 		if (!fiveHour && !sevenDay) return null;
-		return { fiveHour, sevenDay };
+		// Single compact label; prefer the five-hour tier if displayed windows ever disagree.
+		const effectiveTier = fiveHourTier ?? sevenDayTier;
+		return { tier: effectiveTier, fiveHour, sevenDay };
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -4,7 +4,7 @@ import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
-import { shortenPath } from "../../../tools/render-utils";
+import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
@@ -551,6 +551,10 @@ const usageSegment: StatusLineSegment = {
 			return { content: "", visible: false };
 		}
 		const parts: string[] = [];
+		if (u.tier) {
+			const tier = truncateToWidth(sanitizeStatusText(u.tier), TRUNCATE_LENGTHS.SHORT);
+			if (tier) parts.push(theme.fg("accent", tier));
+		}
 		if (u.fiveHour) {
 			const pct = u.fiveHour.percent;
 			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -84,6 +84,7 @@ export interface SegmentContext {
 		pr: { number: number; url: string } | null;
 	};
 	usage: {
+		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 	} | null;

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -1,0 +1,333 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+function makeComponent(
+	reports: unknown,
+	options: { provider?: string; activeIdentity?: { accountId?: string; email?: string; projectId?: string } } = {},
+): StatusLineComponent {
+	const component = new StatusLineComponent({
+		state: { messages: [], model: { contextWindow: 1000, provider: options.provider } },
+		model: { contextWindow: 1000, provider: options.provider },
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+		fetchUsageReports: async () => reports,
+		modelRegistry: {
+			authStorage: {
+				getOAuthAccountIdentity: (provider: string) =>
+					provider === options.provider ? options.activeIdentity : undefined,
+			},
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		getContextUsage: () => undefined,
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]);
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: [],
+		rightSegments: ["usage"],
+		sessionAccent: false,
+	});
+	return component;
+}
+
+async function flushUsageRefresh(): Promise<void> {
+	const timer = Promise.withResolvers<void>();
+	setTimeout(timer.resolve, 0);
+	await timer.promise;
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("usage status-line segment", () => {
+	it("renders untiered five-hour and seven-day limits", () => {
+		const result = renderSegment("usage", {
+			usage: { fiveHour: { percent: 24, resetMinutes: 30 }, sevenDay: { percent: 8, resetHours: 141 } },
+		} as unknown as SegmentContext);
+		const content = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).toContain("30m");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+		expect(content).toContain("5d 21h");
+	});
+
+	it("renders tiered usage fetched from provider reports", async () => {
+		const now = Date.now();
+		const component = makeComponent([
+			{
+				limits: [
+					{
+						scope: { windowId: "5h", tier: "prolite" },
+						window: { resetsAt: now + 30 * 60_000 },
+						amount: { usedFraction: 0.24 },
+					},
+					{
+						scope: { windowId: "7d", tier: "prolite" },
+						window: { resetsAt: now + 141 * 3_600_000 },
+						amount: { usedFraction: 0.08 },
+					},
+				],
+			},
+		]);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("prolite");
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+	});
+
+	it("prefers untiered windows and labels the displayed tiered window", async () => {
+		const component = makeComponent([
+			{
+				limits: [
+					{ scope: { windowId: "5h", tier: "stale" }, amount: { usedFraction: 0.5 } },
+					{ scope: { windowId: "5h" }, amount: { usedFraction: 0.24 } },
+					{ scope: { windowId: "7d", tier: "prolite" }, amount: { usedFraction: 0.08 } },
+				],
+			},
+		]);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("prolite");
+		expect(content).not.toContain("stale");
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+	});
+
+	it("scopes fetched usage reports to the active provider and account", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "anthropic",
+					limits: [
+						{ scope: { windowId: "5h" }, amount: { usedFraction: 0.99 } },
+						{ scope: { windowId: "7d" }, amount: { usedFraction: 0.98 } },
+					],
+				},
+				{
+					provider: "openai-codex",
+					metadata: { accountId: "other-account" },
+					limits: [{ scope: { windowId: "5h", tier: "other" }, amount: { usedFraction: 0.66 } }],
+				},
+				{
+					provider: "openai-codex",
+					metadata: { accountId: "active-account" },
+					limits: [
+						{ scope: { windowId: "5h", tier: "prolite" }, amount: { usedFraction: 0.24 } },
+						{ scope: { windowId: "7d", tier: "prolite" }, amount: { usedFraction: 0.08 } },
+					],
+				},
+			],
+			{ provider: "openai-codex", activeIdentity: { accountId: "active-account" } },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("prolite");
+		expect(content).toContain("24%");
+		expect(content).toContain("8%");
+		expect(content).not.toContain("99%");
+		expect(content).not.toContain("98%");
+		expect(content).not.toContain("66%");
+		expect(content).not.toContain("other");
+	});
+
+	it("invalidates cached usage when the active provider changes", async () => {
+		let provider = "openai-codex";
+		const model = { contextWindow: 1000, provider };
+		const reports = [
+			{
+				provider: "anthropic",
+				limits: [{ scope: { windowId: "5h" }, amount: { usedFraction: 0.24 } }],
+			},
+			{
+				provider: "openai-codex",
+				metadata: { accountId: "active-account" },
+				limits: [{ scope: { windowId: "5h", tier: "prolite" }, amount: { usedFraction: 0.8 } }],
+			},
+		];
+		const session = {
+			state: { messages: [], model },
+			model,
+			sessionManager: {
+				getUsageStatistics: () => ({
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
+			},
+			fetchUsageReports: async () => reports,
+			modelRegistry: {
+				authStorage: {
+					getOAuthAccountIdentity: (requestedProvider: string) =>
+						requestedProvider === provider && provider === "openai-codex"
+							? { accountId: "active-account" }
+							: undefined,
+				},
+			},
+			getAsyncJobSnapshot: () => ({ running: [] }),
+			getContextUsage: () => undefined,
+		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["usage"],
+			sessionAccent: false,
+		});
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		expect(stripVTControlCharacters(component.getTopBorder(200).content)).toContain("80%");
+
+		provider = "anthropic";
+		model.provider = provider;
+
+		const immediate = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(immediate).not.toContain("80%");
+		await flushUsageRefresh();
+		const refreshed = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(refreshed).toContain("24%");
+	});
+
+	it("keeps active-provider rate-limit header reports with account metadata", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "anthropic",
+					metadata: { source: "ratelimit-headers", accountId: "other-account" },
+					limits: [{ scope: { windowId: "5h" }, amount: { usedFraction: 0.66 } }],
+				},
+				{
+					provider: "anthropic",
+					metadata: { source: "ratelimit-headers", accountId: "active-account" },
+					limits: [
+						{ scope: { windowId: "5h" }, amount: { usedFraction: 0.24 } },
+						{ scope: { windowId: "7d" }, amount: { usedFraction: 0.08 } },
+					],
+				},
+			],
+			{ provider: "anthropic", activeIdentity: { accountId: "active-account" } },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+		expect(content).not.toContain("66%");
+	});
+
+	it("renders tiered limits with the tier label", () => {
+		const result = renderSegment("usage", {
+			usage: {
+				tier: "prolite",
+				fiveHour: { percent: 50, resetMinutes: 120 },
+				sevenDay: { percent: 10, resetHours: 48 },
+			},
+		} as unknown as SegmentContext);
+		const content = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(content).toContain("prolite");
+		expect(content).toContain("5h");
+		expect(content).toContain("50%");
+		expect(content).toContain("7d");
+		expect(content).toContain("10%");
+	});
+
+	it("sanitizes tier labels before rendering", () => {
+		const result = renderSegment("usage", {
+			usage: {
+				tier: "\u001b[31mbad\t tier\nvalue\u001b[0m",
+				fiveHour: { percent: 50 },
+			},
+		} as unknown as SegmentContext);
+		const content = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(content).toContain("bad tier value");
+		expect(result.content).not.toContain("\u001b[31m");
+		expect(result.content).not.toContain("\t");
+		expect(result.content).not.toContain("\n");
+	});
+
+	it("hides null usage", () => {
+		const result = renderSegment("usage", { usage: null } as unknown as SegmentContext);
+
+		expect(result.visible).toBe(false);
+		expect(result.content).toBe("");
+	});
+
+	it("hides usage without visible windows", () => {
+		const result = renderSegment("usage", { usage: {} } as unknown as SegmentContext);
+
+		expect(result.visible).toBe(false);
+		expect(result.content).toBe("");
+	});
+
+	it("renders five-hour usage without seven-day usage", () => {
+		const result = renderSegment("usage", { usage: { fiveHour: { percent: 80 } } } as unknown as SegmentContext);
+		const content = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(content).toContain("5h");
+		expect(content).toContain("80%");
+		expect(content).not.toContain("7d");
+	});
+
+	it("uses a distinct error color at the eighty-percent threshold", () => {
+		const high = renderSegment("usage", { usage: { fiveHour: { percent: 80 } } } as unknown as SegmentContext);
+		const low = renderSegment("usage", { usage: { fiveHour: { percent: 24 } } } as unknown as SegmentContext);
+		const highWithoutValue = high.content.replace("80%", "PCT");
+		const lowWithoutValue = low.content.replace("24%", "PCT");
+
+		expect(high.visible).toBe(true);
+		expect(low.visible).toBe(true);
+		expect(stripVTControlCharacters(highWithoutValue)).toBe(stripVTControlCharacters(lowWithoutValue));
+		expect(highWithoutValue).not.toBe(lowWithoutValue);
+	});
+});


### PR DESCRIPTION
## Summary
- Accept tiered provider usage limits in the status-line `usage` segment while preserving untiered precedence.
- Prefix rendered usage with the tier label for Codex subscription limits.
- Add status-line usage tests for tiered reports, untiered fallback, empty states, and threshold coloring.

Fixes #2877

## Screenshots
No visual change outside the opt-in status-line `usage` segment.

## Testing
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent test test/status-line-usage.test.ts`
- `bun --cwd=packages/coding-agent test test/status-line-cache-hit.test.ts test/status-line-context-cache.test.ts test/status-line-model.test.ts test/status-line-overflow.test.ts test/status-line-settings-cache.test.ts`

## Risk
- Low. The normalizer still prefers untiered limits for Anthropic-style reports; tier labels only render when the displayed usage came from a tiered limit.

## Notes
- Live Codex OAuth status-line rendering was not exercised; fixture reports cover the provider report shape and status-line render path.

## AI Review Report
- Reviewed producer, context type, renderer, and status-line tests for stale tier labels and Anthropic fallback behavior.
- Added an integration-style status-line test that feeds tiered provider reports through `refreshUsageInBackground()`.

## Security Audit
- No credential handling, network target, file access, or command execution behavior changed.
- Tier text comes from existing provider usage metadata and is rendered as plain status-line text.
