### PR TITLE
fix(cli): keep tiny-model downloads alive

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `omp tiny-models download` exiting before its unref'd worker subprocess could install the runtime or download model weights. The tiny-model client now references the worker while requests are pending so standalone CLI downloads wait for `Downloaded ...` / `Failed ...` completion. ([#3291](https://github.com/can1357/oh-my-pi/issues/3291))
 - Fixed streaming output blocks incorrectly calculating preview height, preventing flickering banners
 - Fixed streaming `bash`/`eval` tool output duplicating its `… (N earlier lines, showing 10 of M) (ctrl+o to expand)` preview into native scrollback. The collapsed output is a sliding tail window fixed at 10 lines, so when the box outgrew the live viewport (a tall command/output under a still-live predecessor such as a parallel tool) its mutating tail scrolled above the commit window and the renderer re-committed a fresh snapshot every frame, stacking dozens of stale preview banners and chunks. The output preview is now clamped to the viewport tail (`Math.min(10, previewWindowRows())`) and measured in visual rows at the box's inner content width (via the new `outputBlockContentWidth` helper), so on short terminals the volatile tail shrinks to stay on-screen and is never committed. Fixes the duplication introduced when scroll-off commits were made loss-free.
 - Prevented `/handoff` from executing while a response is streaming to avoid session corruption

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -5,12 +5,12 @@ import {
 	createWorkerHandle,
 	createWorkerSubprocess,
 	logWorkerMessage,
+	type RefCountedWorkerHandle,
 	resolveWorkerSpawnCmd,
 	SMOKE_TEST_TIMEOUT_MS,
 	type SpawnedSubprocess,
 	smokeTestWorker,
 	spawnWorkerOrUnavailable,
-	type WorkerHandle,
 	workerEnvFromParent,
 } from "../subprocess/worker-client";
 import { safeSend } from "../utils/ipc";
@@ -128,33 +128,60 @@ export function createTinyTitleSubprocess(): SpawnedSubprocess<TinyTitleWorkerOu
 
 function wrapSubprocess(
 	spawned: SpawnedSubprocess<TinyTitleWorkerOutbound>,
-): WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
+): RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
 	const { proc } = spawned;
-	return createWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>(spawned, message =>
-		safeSend(proc, message, "tiny-title"),
-	);
+	return {
+		...createWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>(spawned, message =>
+			safeSend(proc, message, "tiny-title"),
+		),
+		ref() {
+			try {
+				proc.ref();
+			} catch {
+				// Already gone.
+			}
+		},
+		unref() {
+			try {
+				proc.unref();
+			} catch {
+				// Already gone.
+			}
+		},
+	};
 }
 
-function spawnTinyTitleWorker(): WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
+function spawnInlineUnavailableWorker(
+	error: unknown,
+): RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
+	return {
+		...createUnavailableWorker<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>(error),
+		ref() {},
+		unref() {},
+	};
+}
+
+function spawnTinyTitleWorker(): RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
 	return spawnWorkerOrUnavailable(
 		() => wrapSubprocess(createTinyTitleSubprocess()),
-		createUnavailableWorker<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>,
+		spawnInlineUnavailableWorker,
 		"Tiny title worker spawn failed; local titles disabled",
 	);
 }
 
 export class TinyTitleClient {
-	#worker: WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> | null = null;
+	#worker: RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> | null = null;
 	#unsubscribeMessage: (() => void) | null = null;
 	#unsubscribeError: (() => void) | null = null;
 	#pending = new Map<string, PendingRequest>();
 	#failedModels = new Set<TinyLocalModelKey>();
 	#progressListeners = new Set<(event: TinyTitleProgressEvent) => void>();
 	#nextRequestId = 0;
-	#spawnWorker: () => WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>;
+	#refed = false;
+	#spawnWorker: () => RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound>;
 
 	constructor(
-		spawnWorker: () => WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> = spawnTinyTitleWorker,
+		spawnWorker: () => RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> = spawnTinyTitleWorker,
 	) {
 		this.#spawnWorker = spawnWorker;
 	}
@@ -179,11 +206,11 @@ export class TinyTitleClient {
 			const worker = this.#ensureWorker();
 			const id = String(++this.#nextRequestId);
 			const { promise, resolve } = Promise.withResolvers<string | null>();
-			this.#pending.set(id, { kind: "generate", modelKey, resolve });
+			this.#addPending(id, { kind: "generate", modelKey, resolve });
 			const abort = (): void => {
 				const pending = this.#pending.get(id);
 				if (pending?.kind !== "generate") return;
-				this.#pending.delete(id);
+				this.#deletePending(id);
 				pending.resolve(null);
 			};
 			options.signal?.addEventListener("abort", abort, { once: true });
@@ -195,7 +222,7 @@ export class TinyTitleClient {
 				return await promise;
 			} finally {
 				options.signal?.removeEventListener("abort", abort);
-				this.#pending.delete(id);
+				this.#deletePending(id);
 			}
 		} catch (error) {
 			logger.debug("tiny-title: local generation failed", {
@@ -218,11 +245,11 @@ export class TinyTitleClient {
 			const worker = this.#ensureWorker();
 			const id = String(++this.#nextRequestId);
 			const { promise, resolve } = Promise.withResolvers<string | null>();
-			this.#pending.set(id, { kind: "complete", modelKey, resolve });
+			this.#addPending(id, { kind: "complete", modelKey, resolve });
 			const abort = (): void => {
 				const pending = this.#pending.get(id);
 				if (pending?.kind !== "complete") return;
-				this.#pending.delete(id);
+				this.#deletePending(id);
 				pending.resolve(null);
 			};
 			options.signal?.addEventListener("abort", abort, { once: true });
@@ -231,7 +258,7 @@ export class TinyTitleClient {
 				return await promise;
 			} finally {
 				options.signal?.removeEventListener("abort", abort);
-				this.#pending.delete(id);
+				this.#deletePending(id);
 			}
 		} catch (error) {
 			logger.debug("tiny-model: local completion failed", {
@@ -251,11 +278,11 @@ export class TinyTitleClient {
 			const worker = this.#ensureWorker();
 			const id = String(++this.#nextRequestId);
 			const { promise, resolve } = Promise.withResolvers<boolean>();
-			this.#pending.set(id, { kind: "download", modelKey, resolve });
+			this.#addPending(id, { kind: "download", modelKey, resolve });
 			const abort = (): void => {
 				const pending = this.#pending.get(id);
 				if (pending?.kind !== "download") return;
-				this.#pending.delete(id);
+				this.#deletePending(id);
 				pending.resolve(false);
 			};
 			options.signal?.addEventListener("abort", abort, { once: true });
@@ -264,7 +291,7 @@ export class TinyTitleClient {
 				return await promise;
 			} finally {
 				options.signal?.removeEventListener("abort", abort);
-				this.#pending.delete(id);
+				this.#deletePending(id);
 			}
 		} catch (error) {
 			logger.debug("tiny-title: local model download failed", {
@@ -290,6 +317,7 @@ export class TinyTitleClient {
 			else pending.resolve(false);
 		}
 		this.#pending.clear();
+		this.#refed = false;
 		try {
 			await worker?.terminate();
 		} catch {
@@ -297,13 +325,39 @@ export class TinyTitleClient {
 		}
 	}
 
-	#ensureWorker(): WorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
+	#ensureWorker(): RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> {
 		if (this.#worker) return this.#worker;
 		const worker = this.#spawnWorker();
 		this.#worker = worker;
 		this.#unsubscribeMessage = worker.onMessage(message => this.#handleMessage(message));
 		this.#unsubscribeError = worker.onError(error => this.#handleWorkerError(error));
 		return worker;
+	}
+
+	/** Register a pending request and keep the worker referenced while work is in flight. */
+	#addPending(id: string, request: PendingRequest): void {
+		this.#pending.set(id, request);
+		this.#syncWorkerRef();
+	}
+
+	/** Drop a pending request and unref the worker once nothing is in flight. */
+	#deletePending(id: string): void {
+		if (this.#pending.delete(id)) this.#syncWorkerRef();
+	}
+
+	/**
+	 * Tiny-model workers are spawned `unref`'d so idle TUI sessions can exit.
+	 * Short-lived CLI downloads need the opposite while awaiting worker IPC, or
+	 * Bun can drain the event loop before the subprocess answers.
+	 */
+	#syncWorkerRef(): void {
+		const worker = this.#worker;
+		if (!worker) return;
+		const shouldRef = this.#pending.size > 0;
+		if (shouldRef === this.#refed) return;
+		this.#refed = shouldRef;
+		if (shouldRef) worker.ref();
+		else worker.unref();
 	}
 
 	#handleMessage(message: TinyTitleWorkerOutbound): void {
@@ -319,7 +373,7 @@ export class TinyTitleClient {
 
 		const pending = this.#pending.get(message.id);
 		if (!pending) return;
-		this.#pending.delete(message.id);
+		this.#deletePending(message.id);
 		if (message.type === "title") {
 			if (pending.kind === "generate") pending.resolve(message.title);
 			return;

--- a/packages/coding-agent/test/issue-1940-repro.test.ts
+++ b/packages/coding-agent/test/issue-1940-repro.test.ts
@@ -4,6 +4,8 @@ import type { TinyTitleWorkerInbound, TinyTitleWorkerOutbound } from "@oh-my-pi/
 
 class FakeTinyWorker {
 	terminated = false;
+	refCalls = 0;
+	unrefCalls = 0;
 	#messageHandlers = new Set<(message: TinyTitleWorkerOutbound) => void>();
 	#errorHandlers = new Set<(error: Error) => void>();
 	#onSend: (message: TinyTitleWorkerInbound, worker: FakeTinyWorker) => void;
@@ -28,6 +30,14 @@ class FakeTinyWorker {
 
 	async terminate(): Promise<void> {
 		this.terminated = true;
+	}
+
+	ref(): void {
+		this.refCalls += 1;
+	}
+
+	unref(): void {
+		this.unrefCalls += 1;
 	}
 
 	emit(message: TinyTitleWorkerOutbound): void {
@@ -138,6 +148,31 @@ describe("issue #1940 — local model failures release the worker process", () =
 			expect(first.terminated).toBe(true);
 			expect(await client.generate("lfm2-350m", "retry title")).toBe("recovered title");
 			expect(nextWorker).toBe(2);
+		} finally {
+			await client.terminate();
+		}
+	});
+});
+
+describe("issue #3291 — tiny-model downloads keep the worker referenced", () => {
+	it("references the worker while a download request is pending", async () => {
+		let downloadRequestId = "";
+		const worker = new FakeTinyWorker(message => {
+			if (message.type === "download") downloadRequestId = message.id;
+		});
+		const client = new TinyTitleClient(() => worker);
+
+		try {
+			const download = client.downloadModel("lfm2-700m");
+
+			expect(downloadRequestId).not.toBe("");
+			expect(worker.refCalls).toBe(1);
+			expect(worker.unrefCalls).toBe(0);
+
+			worker.emit({ type: "downloaded", id: downloadRequestId });
+
+			expect(await download).toBe(true);
+			expect(worker.unrefCalls).toBe(1);
 		} finally {
 			await client.terminate();
 		}


### PR DESCRIPTION
## Repro
`HOME=$(mktemp -d) PI_DEBUG_STARTUP=1 bun packages/coding-agent/src/cli.ts tiny-models download lfm2-700m` printed `Downloading LFM2 700M (lfm2-700m)...`, exited 0 in 484 ms, and created neither `~/.omp/agent/cache/tiny-models` nor `~/.omp/agent/cache/tiny-title-runtime`.

## Cause
`packages/coding-agent/src/tiny/title-client.ts` spawned the shared tiny-model subprocess through `createWorkerSubprocess`, which unrefs the `Bun.spawn` child outside tests. `TinyTitleClient` awaited download IPC without re-referencing that worker while a request was pending, so standalone `packages/coding-agent/src/cli/tiny-models-cli.ts` invocations had no event-loop handle keeping the parent alive.

## Fix
- Changed `TinyTitleClient` to use a ref-counted worker handle for the tiny-model subprocess and unavailable-worker fallback.
- Added pending-request helpers that call `worker.ref()` while generate/complete/download IPC is in flight and `worker.unref()` once the pending map is empty.
- Added issue #3291 regression coverage proving `downloadModel()` references the worker until a `downloaded` response arrives.
- Added a coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/issue-1940-repro.test.ts packages/coding-agent/test/tiny-models-cli.test.ts` passed: 7 pass, 0 fail. `tmp_home=$(mktemp -d) && HOME="$tmp_home" PI_DEBUG_STARTUP=1 timeout 3s bun packages/coding-agent/src/cli.ts tiny-models download lfm2-700m` timed out after 3020 ms instead of exiting 0 immediately, confirming the CLI stays alive past the prior 484 ms early-exit path. `bun --cwd=packages/coding-agent run check` passed. Fixes #3291