### PR TITLE
feat(web-search): add AnySearch provider support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 - Fixed Anthropic-compatible thinking requests sending replayed thinking blocks without `context_management.keep: "all"`, preserving multi-turn reasoning context for API-key providers. API-key requests now also advertise the required `context-management-2025-06-27` beta header so the field is honored instead of rejected. Injected SDK clients, GitHub Copilot's Anthropic proxy, and Vertex rawPredict are excluded because this code path cannot add the beta to caller-owned clients, Copilot strips Anthropic betas and demotes thinking blocks to text upstream, and Vertex expects betas in the JSON body rather than the Anthropic HTTP beta header. ([#3288](https://github.com/can1357/oh-my-pi/issues/3288))
 - Fixed OpenRouter Responses native history replay leaking Gemini reasoning item `format` metadata back into follow-up requests, which caused HTTP 400 rejections while preserving encrypted reasoning replay.
+### Added
+
+- Added `anysearch` registry provider definition and interactive credentials login support.
 
 ## [16.1.15] - 2026-06-22
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,16 +19,15 @@
 - Fixed OpenRouter Anthropic Responses follow-up requests replaying prior reasoning items with stale signatures, which caused HTTP 400 `Invalid signature in thinking block` errors after a thinking turn. ([#3399](https://github.com/can1357/oh-my-pi/issues/3399))
 - Fixed OpenRouter Anthropic models on the Responses path omitting `cache_control`, so prompt caching engages without forcing Chat Completions. `cacheRetention: "long"` now upgrades the breakpoint to `ttl: "1h"`. ([#3397](https://github.com/can1357/oh-my-pi/issues/3397))
 
+### Added
+
+- Added `anysearch` registry provider definition and interactive credentials login support.
 ## [16.1.16] - 2026-06-23
 
 ### Fixed
 
 - Fixed Anthropic-compatible thinking requests sending replayed thinking blocks without `context_management.keep: "all"`, preserving multi-turn reasoning context for API-key providers. API-key requests now also advertise the required `context-management-2025-06-27` beta header so the field is honored instead of rejected. Injected SDK clients, GitHub Copilot's Anthropic proxy, and Vertex rawPredict are excluded because this code path cannot add the beta to caller-owned clients, Copilot strips Anthropic betas and demotes thinking blocks to text upstream, and Vertex expects betas in the JSON body rather than the Anthropic HTTP beta header. ([#3288](https://github.com/can1357/oh-my-pi/issues/3288))
 - Fixed OpenRouter Responses native history replay leaking Gemini reasoning item `format` metadata back into follow-up requests, which caused HTTP 400 rejections while preserving encrypted reasoning replay.
-### Added
-
-- Added `anysearch` registry provider definition and interactive credentials login support.
-
 ## [16.1.15] - 2026-06-22
 
 ### Fixed

--- a/packages/ai/src/registry/anysearch.ts
+++ b/packages/ai/src/registry/anysearch.ts
@@ -1,0 +1,19 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { ProviderDefinition } from "./types";
+
+export const loginAnySearch = createApiKeyLogin({
+	providerLabel: "AnySearch",
+	authUrl: "https://anysearch.com/console/api-keys",
+	instructions:
+		"Create or copy your AnySearch API key from the AnySearch console. A key is optional for anonymous search, but recommended for higher rate limits.",
+	promptMessage: "Paste your AnySearch API key",
+	placeholder: "your-api-key",
+	validation: null,
+});
+
+export const anysearchProvider = {
+	id: "anysearch",
+	name: "AnySearch",
+	envKeys: "ANYSEARCH_API_KEY",
+	login: loginAnySearch,
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -3,6 +3,7 @@ import { aimlApiProvider } from "./aimlapi";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan";
 import { amazonBedrockProvider } from "./amazon-bedrock";
 import { anthropicProvider } from "./anthropic";
+import { anysearchProvider } from "./anysearch";
 import { azureProvider } from "./azure";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
@@ -120,6 +121,7 @@ const ALL = [
 	opencodeZenProvider,
 	opencodeGoProvider,
 	tavilyProvider,
+	anysearchProvider,
 	kagiProvider,
 	parallelProvider,
 	ollamaProvider,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Added
 
+- Added `anysearch` web search provider, supporting both credentials-based and anonymous MCP search fallbacks.
 - Added `isolated`, `apply`, and `merge` options to eval `agent()` across every workflow runtime (Python, JavaScript, Ruby, Julia) so `workflowz`-driven fan-outs can request the same copy-on-write worktree isolation the `task` tool offers (strict opt-in via `isolated: true`, matching the `task` tool; `apply: false` keeps captured patches/branches without merging back; `merge: false` forces patch mode). Extracted the task-isolation lifecycle into `task/isolation-runner.ts` so the eval bridge and `TaskTool` share one implementation ([#3196](https://github.com/can1357/oh-my-pi/issues/3196))
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Fixed scripted `eval` `agent()` subagents continuing after a successful `yield` when a trailing empty assistant `stop` arrived after the executor's yield-triggered abort. The session's `agent_end` maintenance compared `#assistantEndedWithSuccessfulYield(msg)` against the trailing empty-stop message — not the prior yield-bearing one — so the empty-stop recovery path appended a retry reminder and scheduled `agent.continue()`, reviving the already-yielded child. The yield handler now sets a sticky `#yieldTerminationPending` flag (cleared on the next `prompt()`) that short-circuits empty-stop / unexpected-stop / compaction continuations for the rest of the run, so a successful yield is terminal regardless of trailing stops ([#3389](https://github.com/can1357/oh-my-pi/issues/3389)).
 - Fixed snapcompact rasterizing transcript frames into requests bound for GitHub Copilot business and enterprise endpoints, which then rejected the session permanently with `400 vision is not supported`. The snapcompact vision gate now also short-circuits whenever `model.provider === "github-copilot"` and the resolved `baseUrl` is not the canonical personal-Copilot host, protecting cached/stale Model specs that still advertise `["text","image"]` on a non-personal endpoint. ([#3387](https://github.com/can1357/oh-my-pi/issues/3387))
 
+### Added
+
+- Added `anysearch` web search provider, supporting both credentials-based and anonymous MCP search fallbacks.
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes
@@ -41,7 +44,6 @@
 
 ### Added
 
-- Added `anysearch` web search provider, supporting both credentials-based and anonymous MCP search fallbacks.
 - Added `isolated`, `apply`, and `merge` options to eval `agent()` across every workflow runtime (Python, JavaScript, Ruby, Julia) so `workflowz`-driven fan-outs can request the same copy-on-write worktree isolation the `task` tool offers (strict opt-in via `isolated: true`, matching the `task` tool; `apply: false` keeps captured patches/branches without merging back; `merge: false` forces patch mode). Extracted the task-isolation lifecycle into `task/isolation-runner.ts` so the eval bridge and `TaskTool` share one implementation ([#3196](https://github.com/can1357/oh-my-pi/issues/3196))
 
 ### Changed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -310,6 +310,7 @@ export function getExtraHelpText(): string {
   PERPLEXITY_API_KEY         - Perplexity web search API key (optional; anonymous fallback)
   PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
   TAVILY_API_KEY             - Tavily web search
+  ANYSEARCH_API_KEY          - AnySearch web search API key (optional; anonymous fallback)
   ANTHROPIC_SEARCH_API_KEY   - Anthropic web search (override; isolates search from main ANTHROPIC_API_KEY)
   ANTHROPIC_SEARCH_BASE_URL  - Anthropic web search base URL (override; pairs with ANTHROPIC_SEARCH_API_KEY)
 

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -94,6 +94,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.searxng,
 		load: async () => new (await import("./providers/searxng")).SearXNGProvider(),
 	},
+	anysearch: {
+		id: "anysearch",
+		label: SEARCH_PROVIDER_LABELS.anysearch,
+		load: async () => new (await import("./providers/anysearch")).AnySearchProvider(),
+	},
 };
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();

--- a/packages/coding-agent/src/web/search/providers/anysearch.ts
+++ b/packages/coding-agent/src/web/search/providers/anysearch.ts
@@ -1,0 +1,220 @@
+import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
+import { parseSSE } from "../../../mcp/json-rpc";
+import { asRecord, asString } from "../../../web/scrapers/utils";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const ANYSEARCH_MCP_URL = "https://api.anysearch.com/mcp";
+const ANYSEARCH_TOOL_NAME = "search";
+const DEFAULT_NUM_RESULTS = 5;
+const MAX_NUM_RESULTS = 10;
+
+export interface AnySearchSearchParams {
+	query: string;
+	num_results?: number;
+	signal?: AbortSignal;
+	fetch?: FetchImpl;
+	authStorage: AuthStorage;
+	sessionId?: string;
+}
+
+interface JsonRpcErrorShape {
+	code?: number;
+	message?: string;
+	data?: unknown;
+}
+
+interface JsonRpcPayload {
+	result?: unknown;
+	error?: JsonRpcErrorShape;
+}
+
+function extractContentText(result: unknown): string {
+	const candidates: unknown[] = [result];
+	const root = asRecord(result);
+	if (root?.structuredContent !== undefined) candidates.push(root.structuredContent);
+	if (root?.data !== undefined) candidates.push(root.data);
+	if (root?.result !== undefined) candidates.push(root.result);
+
+	for (const candidate of candidates) {
+		if (typeof candidate === "string") {
+			const trimmed = candidate.trim();
+			if (trimmed) return trimmed;
+		}
+
+		const obj = asRecord(candidate);
+		const content = Array.isArray(obj?.content) ? obj.content : [];
+		const text = content
+			.map(item => asString(asRecord(item)?.text))
+			.filter((value): value is string => value != null)
+			.join("\n\n")
+			.trim();
+		if (text) return text;
+	}
+
+	return "";
+}
+
+function cleanSnippet(section: string): string | undefined {
+	const snippet = section
+		.split("\n")
+		.map(line => line.trim())
+		.filter(line => line.length > 0 && !/^[*-]\s+\*\*URL\*\*:/i.test(line) && !/^###\s+/.test(line))
+		.map(line => line.replace(/^[*-]\s+/, ""))
+		.join(" ")
+		.trim();
+	return snippet || undefined;
+}
+
+export function parseAnySearchMarkdown(markdown: string): { answer?: string; sources: SearchSource[] } {
+	const normalized = markdown.replace(/\r\n?/g, "\n").trim();
+	if (!normalized) return { sources: [] };
+
+	const firstSection = normalized.search(/(?:^|\n)###\s+/);
+	const preamble = firstSection >= 0 ? normalized.slice(0, firstSection).trim() : normalized;
+	const answer = preamble.replace(/^##\s*Search Results[^\n]*$/m, "").trim() || undefined;
+
+	const sources: SearchSource[] = [];
+	const sectionRegex = /(?:^|\n)###\s+([^\n]+)\n([\s\S]*?)(?=\n###\s+|\s*$)/g;
+	for (const match of normalized.matchAll(sectionRegex)) {
+		const rawTitle = match[1];
+		const title = rawTitle.replace(/^\d+\.\s*/, "").trim() || undefined;
+		const body = match[2].trim();
+		const url =
+			body.match(/(?:^|\n)[*-]\s+\*\*URL\*\*:\s*(https?:\/\/\S+)/i)?.[1] ??
+			body.match(/\[[^\]]+\]\((https?:\/\/[^)]+)\)/)?.[1] ??
+			body.match(/https?:\/\/\S+/)?.[0];
+		if (!url) continue;
+		sources.push({
+			title: title || url,
+			url,
+			snippet: cleanSnippet(body),
+		});
+	}
+
+	if (sources.length > 0) return { answer, sources };
+	if (/no results?/i.test(normalized)) return { answer, sources: [] };
+
+	return {
+		answer: normalized,
+		sources: [],
+	};
+}
+
+async function callAnySearchSearch(apiKey: string | undefined, params: AnySearchSearchParams): Promise<string> {
+	const response = await (params.fetch ?? fetch)(ANYSEARCH_MCP_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: Math.random().toString(36).slice(2),
+			method: "tools/call",
+			params: {
+				name: ANYSEARCH_TOOL_NAME,
+				arguments: {
+					query: params.query,
+					max_results: clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS),
+				},
+			},
+		}),
+		signal: withHardTimeout(params.signal),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("anysearch", response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError(
+			"anysearch",
+			`AnySearch API error (${response.status}): ${errorText}`,
+			response.status,
+		);
+	}
+
+	const payload = parseSSE(await response.text()) as JsonRpcPayload | null;
+	if (!payload) {
+		throw new SearchProviderError("anysearch", "Failed to parse AnySearch MCP response", 500);
+	}
+	if (payload.error) {
+		const rawCode = typeof payload.error.code === "number" ? payload.error.code : undefined;
+		const status = rawCode && rawCode > 0 ? rawCode : 400;
+		throw new SearchProviderError(
+			"anysearch",
+			`AnySearch MCP error${rawCode ? ` (${rawCode})` : ""}: ${payload.error.message ?? "Unknown error"}`,
+			status,
+		);
+	}
+
+	const result = asRecord(payload.result);
+	if (result?.isError === true) {
+		const errorText = Array.isArray(result.content)
+			? result.content
+					.map(item => asString(asRecord(item)?.text))
+					.filter((value): value is string => value != null)
+					.join("\n")
+					.trim()
+			: "";
+		throw new SearchProviderError("anysearch", errorText || "AnySearch MCP tool call failed", 400);
+	}
+
+	const markdown = extractContentText(payload.result);
+	if (!markdown) {
+		throw new SearchProviderError("anysearch", "AnySearch returned no text content", 502);
+	}
+	return markdown;
+}
+
+export async function searchAnySearch(params: SearchParams): Promise<SearchResponse> {
+	const request: AnySearchSearchParams = {
+		query: params.query,
+		num_results: params.numSearchResults ?? params.limit,
+		signal: params.signal,
+		fetch: params.fetch,
+		authStorage: params.authStorage,
+		sessionId: params.sessionId,
+	};
+
+	const envKey = getEnvApiKey("anysearch");
+	const keyOrResolver: ApiKey | undefined = params.authStorage.hasAuth("anysearch")
+		? params.authStorage.resolver("anysearch", { sessionId: params.sessionId })
+		: envKey;
+
+	const markdown = keyOrResolver
+		? await withAuth(keyOrResolver, key => callAnySearchSearch(key, request), { signal: params.signal })
+		: await callAnySearchSearch(undefined, request);
+
+	const parsed = parseAnySearchMarkdown(markdown);
+	const numResults = clampNumResults(request.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+
+	return {
+		provider: "anysearch",
+		answer: parsed.answer,
+		sources: parsed.sources.slice(0, numResults),
+		authMode: keyOrResolver ? "api_key" : "anonymous",
+	};
+}
+
+export class AnySearchProvider extends SearchProvider {
+	readonly id = "anysearch";
+	readonly label = "AnySearch";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("anysearch") || !!getEnvApiKey("anysearch");
+	}
+
+	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+		return true;
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchAnySearch(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/providers/anysearch.ts
+++ b/packages/coding-agent/src/web/search/providers/anysearch.ts
@@ -71,6 +71,21 @@ function cleanSnippet(section: string): string | undefined {
 	return snippet || undefined;
 }
 
+/**
+ * Parses the Markdown response returned by the AnySearch MCP search tool.
+ * The AnySearch server response has the following layout convention:
+ *
+ * ## Search Results (N results, Time)
+ * [Optional preamble/answer text here]
+ *
+ * ### 1. Document Title
+ * - **URL**: https://example.com/url
+ * - Snippet text line 1
+ * - Snippet text line 2
+ *
+ * ### 2. Next Document Title
+ * ...
+ */
 export function parseAnySearchMarkdown(markdown: string): { answer?: string; sources: SearchSource[] } {
 	const normalized = markdown.replace(/\r\n?/g, "\n").trim();
 	if (!normalized) return { sources: [] };
@@ -116,13 +131,13 @@ async function callAnySearchSearch(apiKey: string | undefined, params: AnySearch
 		},
 		body: JSON.stringify({
 			jsonrpc: "2.0",
-			id: Math.random().toString(36).slice(2),
+			id: crypto.randomUUID(),
 			method: "tools/call",
 			params: {
 				name: ANYSEARCH_TOOL_NAME,
 				arguments: {
 					query: params.query,
-					max_results: clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS),
+					max_results: params.num_results,
 				},
 			},
 		}),
@@ -174,9 +189,11 @@ async function callAnySearchSearch(apiKey: string | undefined, params: AnySearch
 }
 
 export async function searchAnySearch(params: SearchParams): Promise<SearchResponse> {
+	const numResults = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+
 	const request: AnySearchSearchParams = {
 		query: params.query,
-		num_results: params.numSearchResults ?? params.limit,
+		num_results: numResults,
 		signal: params.signal,
 		fetch: params.fetch,
 		authStorage: params.authStorage,
@@ -193,7 +210,6 @@ export async function searchAnySearch(params: SearchParams): Promise<SearchRespo
 		: await callAnySearchSearch(undefined, request);
 
 	const parsed = parseAnySearchMarkdown(markdown);
-	const numResults = clampNumResults(request.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
 
 	return {
 		provider: "anysearch",

--- a/packages/coding-agent/src/web/search/providers/anysearch.ts
+++ b/packages/coding-agent/src/web/search/providers/anysearch.ts
@@ -65,6 +65,7 @@ function cleanSnippet(section: string): string | undefined {
 		.map(line => line.trim())
 		.filter(line => line.length > 0 && !/^[*-]\s+\*\*URL\*\*:/i.test(line) && !/^###\s+/.test(line))
 		.map(line => line.replace(/^[*-]\s+/, ""))
+		.map(line => line.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, "$1"))
 		.join(" ")
 		.trim();
 	return snippet || undefined;

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -40,6 +40,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
+	{
+		value: "anysearch",
+		label: "AnySearch",
+		description: "Uses ANYSEARCH_API_KEY when configured; explicit selection falls back to anonymous MCP search",
+	},
 ] as const;
 
 /** Supported web search providers (every option except `auto`). */

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -44,7 +44,7 @@ describe("AnySearch web search provider", () => {
 
 ### 2. DeepMind | Google
 - **URL**: https://deepmind.google/
-- DeepMind is a pioneer in AI research...
+- [Google DeepMind](https://deepmind.google/) is a pioneer in [AI research](https://example.com/ai)...
 `;
 		const parsed = parseAnySearchMarkdown(md);
 		expect(parsed.sources).toHaveLength(2);
@@ -53,7 +53,7 @@ describe("AnySearch web search provider", () => {
 		expect(parsed.sources[0]?.snippet).toBe("OpenAI is an AI research and deployment company...");
 		expect(parsed.sources[1]?.title).toBe("DeepMind | Google");
 		expect(parsed.sources[1]?.url).toBe("https://deepmind.google/");
-		expect(parsed.sources[1]?.snippet).toBe("DeepMind is a pioneer in AI research...");
+		expect(parsed.sources[1]?.snippet).toBe("Google DeepMind is a pioneer in AI research...");
 	});
 
 	it("executes search and returns SearchResponse", async () => {

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { parseAnySearchMarkdown, searchAnySearch } from "@oh-my-pi/pi-coding-agent/web/search/providers/anysearch";
+
+describe("AnySearch web search provider", () => {
+	beforeEach(() => {
+		process.env.ANYSEARCH_API_KEY = "test-anysearch-key";
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.ANYSEARCH_API_KEY;
+	});
+
+	const fakeAuthStorage = {
+		async getApiKey() {
+			return process.env.ANYSEARCH_API_KEY ?? undefined;
+		},
+		hasAuth() {
+			return Boolean(process.env.ANYSEARCH_API_KEY);
+		},
+		resolver(_provider: string) {
+			return async () => process.env.ANYSEARCH_API_KEY ?? undefined;
+		},
+		async rotateSessionCredential() {
+			return false;
+		},
+	} as unknown as AuthStorage;
+
+	function makeParams(query: string) {
+		return {
+			query,
+			authStorage: fakeAuthStorage,
+			systemPrompt: "test system prompt",
+		} as const;
+	}
+
+	it("parses AnySearch Markdown response correctly", () => {
+		const md = `## Search Results (2 results, 1800ms)
+
+### 1. OpenAI | Info
+- **URL**: https://openai.com/
+- OpenAI is an AI research and deployment company...
+
+### 2. DeepMind | Google
+- **URL**: https://deepmind.google/
+- DeepMind is a pioneer in AI research...
+`;
+		const parsed = parseAnySearchMarkdown(md);
+		expect(parsed.sources).toHaveLength(2);
+		expect(parsed.sources[0]?.title).toBe("OpenAI | Info");
+		expect(parsed.sources[0]?.url).toBe("https://openai.com/");
+		expect(parsed.sources[0]?.snippet).toBe("OpenAI is an AI research and deployment company...");
+		expect(parsed.sources[1]?.title).toBe("DeepMind | Google");
+		expect(parsed.sources[1]?.url).toBe("https://deepmind.google/");
+		expect(parsed.sources[1]?.snippet).toBe("DeepMind is a pioneer in AI research...");
+	});
+
+	it("executes search and returns SearchResponse", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		let authHeader: string | null = null;
+
+		const fetchMock = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			if (init?.body) {
+				requestBody = JSON.parse(init.body as string);
+			}
+			if (init?.headers) {
+				authHeader = (init.headers as Record<string, string>).Authorization ?? null;
+			}
+			const md = `## Search Results (1 result)
+
+### 1. seL4 Microkernel
+- **URL**: https://sel4.systems/
+- seL4 is the world's most highly assured kernel.
+`;
+			const payload = {
+				jsonrpc: "2.0",
+				id: 1,
+				result: {
+					content: [{ type: "text", text: md }],
+				},
+			};
+			return new Response(JSON.stringify(payload), { status: 200 });
+		};
+
+		const response = await searchAnySearch({
+			...makeParams("seL4"),
+			fetch: fetchMock,
+		});
+
+		expect(authHeader).toBe("Bearer test-anysearch-key");
+		expect(requestBody).toMatchObject({
+			method: "tools/call",
+			params: {
+				name: "search",
+				arguments: {
+					query: "seL4",
+					max_results: 5,
+				},
+			},
+		});
+		expect(response.provider).toBe("anysearch");
+		expect(response.sources).toHaveLength(1);
+		expect(response.sources[0]?.title).toBe("seL4 Microkernel");
+		expect(response.sources[0]?.url).toBe("https://sel4.systems/");
+		expect(response.sources[0]?.snippet).toBe("seL4 is the world's most highly assured kernel.");
+	});
+
+	it("falls back to anonymous search when key is missing", async () => {
+		delete process.env.ANYSEARCH_API_KEY;
+		const noKeyAuthStorage = {
+			async getApiKey() {
+				return undefined;
+			},
+			hasAuth() {
+				return false;
+			},
+			resolver() {
+				return () => undefined;
+			},
+		} as unknown as AuthStorage;
+
+		let authHeader: string | null = null;
+
+		const fetchMock = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			if (init?.headers) {
+				authHeader = (init.headers as Record<string, string>).Authorization ?? null;
+			}
+			const payload = {
+				jsonrpc: "2.0",
+				id: 1,
+				result: {
+					content: [{ type: "text", text: "## Search Results" }],
+				},
+			};
+			return new Response(JSON.stringify(payload), { status: 200 });
+		};
+
+		const response = await searchAnySearch({
+			query: "test",
+			authStorage: noKeyAuthStorage,
+			systemPrompt: "prompt",
+			fetch: fetchMock,
+		});
+
+		expect(authHeader).toBeNull();
+		expect(response.authMode).toBe("anonymous");
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
-import { parseAnySearchMarkdown, searchAnySearch } from "@oh-my-pi/pi-coding-agent/web/search/providers/anysearch";
+import { parseAnySearchMarkdown, searchAnySearch } from "../../src/web/search/providers/anysearch";
 
 describe("AnySearch web search provider", () => {
 	beforeEach(() => {

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -88,7 +88,7 @@ describe("AnySearch web search provider", () => {
 			fetch: fetchMock,
 		});
 
-		expect(authHeader).toBe("Bearer test-anysearch-key");
+		expect(authHeader as any).toBe("Bearer test-anysearch-key");
 		expect(requestBody).toMatchObject({
 			method: "tools/call",
 			params: {

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -146,4 +146,74 @@ describe("AnySearch web search provider", () => {
 		expect(authHeader).toBeNull();
 		expect(response.authMode).toBe("anonymous");
 	});
+
+	it("throws SearchProviderError on HTTP error status", async () => {
+		const fetchMock = async () => new Response("Internal Server Error", { status: 500 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch API error (500)");
+	});
+
+	it("throws SearchProviderError when JSON-RPC parse fails", async () => {
+		const fetchMock = async () => new Response("invalid sse data", { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Failed to parse AnySearch MCP response");
+	});
+
+	it("throws SearchProviderError when JSON-RPC returns error", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			error: { code: -32603, message: "Internal tool call error" },
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch MCP error (-32603): Internal tool call error");
+	});
+
+	it("throws SearchProviderError when tool result isError is true", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				isError: true,
+				content: [{ type: "text", text: "Database connection failed" }],
+			},
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Database connection failed");
+	});
+
+	it("throws SearchProviderError when tool result contains no text", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				content: [],
+			},
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch returned no text content");
+	});
 });


### PR DESCRIPTION
### Description
This PR integrates AnySearch as a new web search provider into `omp` (oh-my-pi).

### About AnySearch & Privacy Posture
- **Provider**: AnySearch AI (https://anysearch.com)
- **Privacy & ToS**: The API endpoint (`https://api.anysearch.com`) runs a zero-retention search aggregation proxy. It claims zero-knowledge credentials, zero-retention execution, no tracking, no telemetry, and no logging of user queries.
- **Access**: Supports both authenticated access (via `ANYSEARCH_API_KEY`) for higher rate limits and anonymous fallback (no Authorization header sent) when explicit provider selection is requested.

### Changes
1. **Provider Mapping & Registration**:
   - Added `"anysearch"` option to `SEARCH_PROVIDER_OPTIONS` in `packages/coding-agent/src/web/search/types.ts`.
   - Registered `anysearch` in the lazy load registry `PROVIDER_META` in `packages/coding-agent/src/web/search/provider.ts`.
   - Registered `anysearchProvider` in the AI registry `PROVIDER_REGISTRY` in `packages/ai/src/registry/registry.ts`.
2. **API Key & Credentials Handling**:
   - Created `packages/ai/src/registry/anysearch.ts` defining the credential login flow using the unified `createApiKeyLogin` helper, prompting the user for `ANYSEARCH_API_KEY`.
   - Unified support for both authenticated and anonymous MCP search fallbacks.
   - Updated `packages/coding-agent/src/cli/args.ts` to document `ANYSEARCH_API_KEY` under `# Search & Tools` for `omp --help` parity.
3. **Core Provider Implementation**:
   - Created `packages/coding-agent/src/web/search/providers/anysearch.ts` that issues JSON-RPC 2.0 `tools/call` requests directly to `https://api.anysearch.com/mcp`.
   - Implemented a robust Markdown content parser to map the MCP server response to `SearchSource[]`.
   - Added markdown link stripping logic (`[text](url) -> text`) inside search snippets to save context window tokens and keep the terminal TUI representation clean.
   - Hoisted `clampNumResults` and switched JSON-RPC ID generation to `crypto.randomUUID()`.
4. **Testing & Changelog**:
   - Added comprehensive integration tests in `packages/coding-agent/test/tools/web-search-anysearch.test.ts` covering Markdown parsing, API call parameter formatting, and credentialed/anonymous fallback semantics.
   - Added unit tests covering all 5 error/failure paths in `callAnySearchSearch` (HTTP error status, parseSSE failure, JSON-RPC error payload, result isError flag, empty content block). All tests compile and pass.
   - Added `anysearch` entries under `## [Unreleased]` for both `packages/ai/CHANGELOG.md` and `packages/coding-agent/CHANGELOG.md`.