### PR TITLE
Fix MCP optional argument pruning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Fixed
 
+- Fixed MCP tool calls forwarding unused optional placeholder arguments to servers, allowing schema-optional fields to be omitted before `tools/call`.
+
 - Fixed `local://` URLs decoding images as corrupted text (mojibake) instead of showing the image
 - Fixed `omp --resume` hanging instead of exiting when the startup session picker is cancelled (Esc) or there are no sessions to resume. Startup arms long-lived handles (theme/appearance listeners, settings save timer, model registry), so the cancel/empty paths' bare `return` left the event loop alive and the process stuck after the picker cleared the alternate screen. These paths now exit cleanly via `process.exit(0)`, matching the `--version`/`--export` early-exit convention. The in-session `/resume` picker is unaffected — it keeps its own cancel handler that just closes the overlay.
 - Fixed the `/resume` session picker scrolling down after a session is deleted. The delete-confirmation dialog was mounted as a sibling below the picker's bottom border, briefly growing the picker past the terminal height; the TUI committed the picker's header rows into native scrollback to fit, and when the dialog closed `windowTop` stayed pinned at the new commit boundary, leaving the header stranded above the viewport. The picker now hosts the `SessionList` in a single content slot and swaps the dialog INTO that slot (replacing the `SessionList`) while it is open, so the dialog only competes with the `SessionList`'s rendered budget — not the `SessionList` AND the picker chrome — and the picker frame stays inside the viewport. ([#3283](https://github.com/can1357/oh-my-pi/issues/3283))

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -50,12 +50,71 @@ export function isRetriableConnectionError(error: unknown): boolean {
 }
 
 type MCPToolArgs = NonNullable<MCPToolCallParams["arguments"]>;
+type MCPInputSchema = MCPToolDefinition["inputSchema"];
 
 function normalizeToolArgs(value: unknown): MCPToolArgs {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
 		return {};
 	}
-	return value as MCPToolArgs;
+	return { ...(value as Record<string, unknown>) };
+}
+
+function sanitizeToolArgsForSchema(value: unknown, schema: MCPInputSchema): MCPToolArgs {
+	const args = normalizeToolArgs(value);
+	const required = new Set(
+		Array.isArray(schema.required) ? schema.required.filter((key): key is string => typeof key === "string") : [],
+	);
+
+	for (const [key, argValue] of Object.entries(args)) {
+		if (!required.has(key) && isEmptyOptionalMCPValue(argValue)) {
+			delete args[key];
+		}
+	}
+
+	for (const [field, dependency] of collectConditionalFields(schema)) {
+		if (!required.has(field) && Object.hasOwn(args, field) && !Object.hasOwn(args, dependency)) {
+			delete args[field];
+		}
+	}
+
+	return args;
+}
+
+function isEmptyOptionalMCPValue(value: unknown): boolean {
+	return (
+		value === undefined ||
+		value === null ||
+		(typeof value === "string" && value.trim().length === 0) ||
+		(Array.isArray(value) && value.length === 0) ||
+		isPlainEmptyObject(value)
+	);
+}
+
+function isPlainEmptyObject(value: unknown): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.keys(value as Record<string, unknown>).length === 0
+	);
+}
+
+function collectConditionalFields(schema: MCPInputSchema): Map<string, string> {
+	const fields = new Map<string, string>();
+	const properties = schema.properties;
+	if (!properties) return fields;
+
+	for (const [field, property] of Object.entries(properties)) {
+		if (typeof property !== "object" || property === null || Array.isArray(property)) continue;
+		const description = (property as { description?: unknown }).description;
+		if (typeof description !== "string") continue;
+		const match = /Required when using ['"]([^'"]+)['"] parameter/i.exec(description);
+		if (match && Object.hasOwn(properties, match[1])) {
+			fields.set(field, match[1]);
+		}
+	}
+
+	return fields;
 }
 
 /** Details included in MCP tool results for rendering */
@@ -246,11 +305,11 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	}
 
 	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {
-		return renderMCPCall(normalizeToolArgs(args), theme, this.label);
+		return renderMCPCall(sanitizeToolArgsForSchema(args, this.tool.inputSchema), theme, this.label);
 	}
 
 	renderResult(result: CustomToolResult<MCPToolDetails>, options: RenderResultOptions, theme: Theme, args?: unknown) {
-		return renderMCPResult(result, options, theme, normalizeToolArgs(args));
+		return renderMCPResult(result, options, theme, sanitizeToolArgsForSchema(args, this.tool.inputSchema));
 	}
 
 	async execute(
@@ -261,7 +320,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		signal?: AbortSignal,
 	): Promise<CustomToolResult<MCPToolDetails>> {
 		throwIfAborted(signal);
-		const args = normalizeToolArgs(params);
+		const args = sanitizeToolArgsForSchema(params, this.tool.inputSchema);
 		const provider = this.connection._source?.provider;
 		const providerName = this.connection._source?.providerName;
 
@@ -345,11 +404,11 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	}
 
 	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {
-		return renderMCPCall(normalizeToolArgs(args), theme, this.label);
+		return renderMCPCall(sanitizeToolArgsForSchema(args, this.tool.inputSchema), theme, this.label);
 	}
 
 	renderResult(result: CustomToolResult<MCPToolDetails>, options: RenderResultOptions, theme: Theme, args?: unknown) {
-		return renderMCPResult(result, options, theme, normalizeToolArgs(args));
+		return renderMCPResult(result, options, theme, sanitizeToolArgsForSchema(args, this.tool.inputSchema));
 	}
 
 	async execute(
@@ -360,7 +419,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		signal?: AbortSignal,
 	): Promise<CustomToolResult<MCPToolDetails>> {
 		throwIfAborted(signal);
-		const args = normalizeToolArgs(params);
+		const args = sanitizeToolArgsForSchema(params, this.tool.inputSchema);
 		const provider = this.#fallbackProvider;
 		const providerName = this.#fallbackProviderName;
 

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { MCPReconnect } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import { DeferredMCPTool, isRetriableConnectionError, MCPTool } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
-import type { MCPServerConnection, MCPToolCallResult, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import type {
+	MCPServerConnection,
+	MCPToolCallResult,
+	MCPToolDefinition,
+	MCPTransport,
+} from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 
 // ---------------------------------------------------------------------------
@@ -81,6 +86,129 @@ describe("isRetriableConnectionError", () => {
 		expect(isRetriableConnectionError(null)).toBe(false);
 		expect(isRetriableConnectionError(undefined)).toBe(false);
 		expect(isRetriableConnectionError({ message: "ECONNREFUSED" })).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MCP tool argument sanitization
+// ---------------------------------------------------------------------------
+
+describe("MCP tool argument sanitization", () => {
+	const noop = () => {};
+	const noCtx = {} as Parameters<MCPTool["execute"]>[3];
+
+	const TOOL_DEF_WITH_OPTIONALS: MCPToolDefinition = {
+		name: "search",
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: { type: "string" },
+				cursor: { type: "string" },
+				filters: { type: "object" },
+			},
+		},
+	};
+
+	const CONDITIONAL_DEF: MCPToolDefinition = {
+		name: "lookup",
+		inputSchema: {
+			type: "object",
+			properties: {
+				file: { type: "string" },
+				line: { type: "integer" },
+				column: { type: "integer" },
+				language: {
+					type: "string",
+					enum: ["Java"],
+					description: "Language of the symbol. Required when using 'symbol' parameter.",
+				},
+				symbol: { type: "string" },
+			},
+		},
+	};
+
+	function captureToolCall(definition: MCPToolDefinition, args: Record<string, unknown>) {
+		let capturedParams: Record<string, unknown> | undefined;
+		const captureTransport = mockTransport(async (method, params) => {
+			if (method === "tools/call") {
+				capturedParams = params;
+			}
+			return toolCallResult("ok");
+		});
+
+		const tool = new MCPTool(makeConnection(captureTransport), definition);
+		return tool.execute("call-1", args, noop, noCtx).then(() => capturedParams);
+	}
+
+	it("omits empty optional top-level fields", async () => {
+		const capturedParams = await captureToolCall(TOOL_DEF_WITH_OPTIONALS, {
+			query: "events",
+			cursor: "",
+			filters: {},
+		});
+
+		expect(capturedParams).toEqual({ name: "search", arguments: { query: "events" } });
+	});
+
+	it("omits conditional fields when their trigger field is absent after empty pruning", async () => {
+		const capturedParams = await captureToolCall(CONDITIONAL_DEF, {
+			file: "x.ts",
+			line: 1,
+			column: 1,
+			language: "Java",
+			symbol: "",
+		});
+
+		expect(capturedParams).toEqual({ name: "lookup", arguments: { file: "x.ts", line: 1, column: 1 } });
+	});
+
+	it("preserves conditional fields when their trigger field exists", async () => {
+		const capturedParams = await captureToolCall(CONDITIONAL_DEF, {
+			language: "Java",
+			symbol: "com.example.Service",
+		});
+
+		expect(capturedParams).toEqual({
+			name: "lookup",
+			arguments: { language: "Java", symbol: "com.example.Service" },
+		});
+	});
+
+	it("preserves required empty fields", async () => {
+		const capturedParams = await captureToolCall(
+			{
+				name: "search",
+				inputSchema: {
+					type: "object",
+					required: ["query"],
+					properties: {
+						query: { type: "string" },
+					},
+				},
+			},
+			{ query: "" },
+		);
+
+		expect(capturedParams).toEqual({ name: "search", arguments: { query: "" } });
+	});
+
+	it("preserves numeric and boolean values", async () => {
+		const capturedParams = await captureToolCall(
+			{
+				name: "lookup",
+				inputSchema: {
+					type: "object",
+					properties: {
+						line: { type: "integer" },
+						column: { type: "integer" },
+						enabled: { type: "boolean" },
+					},
+				},
+			},
+			{ line: 0, column: -1, enabled: false },
+		);
+
+		expect(capturedParams).toEqual({ name: "lookup", arguments: { line: 0, column: -1, enabled: false } });
 	});
 });
 


### PR DESCRIPTION
## What

Prunes unused optional MCP tool args before `tools/call`.

## Why

Fixes #3302. MCP servers can reject placeholder optional fields that should be omitted.

## Testing

- `bun test packages/coding-agent/test/mcp-reconnect.test.ts`
- `bunx biome check packages/coding-agent/src/mcp/tool-bridge.ts packages/coding-agent/test/mcp-reconnect.test.ts packages/coding-agent/CHANGELOG.md --no-errors-on-unmatched`
- `bun check` fails on unrelated existing checks: Rust formatting diffs in vendored brush crates plus TypeScript errors in `packages/ai/src/providers/cursor.ts` and `packages/ai/src/providers/devin.ts`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
