### PR TITLE
fix(slash-commands): trim args before toLowerCase in /fast and /browser

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+- Fixed `/fast` and `/browser` slash commands ignoring trailing whitespace in arguments — `command.args.toLowerCase()` now consistently uses `.trim().toLowerCase()` matching the pattern in other slash command handlers, so `/fast on ` and `/browser headless ` no longer fail silently.
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -384,7 +384,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => `Fast: ${formatFastModeStatus(runtime.ctx.session)}`,
 		handle: async (command, runtime) => {
-			const arg = command.args.toLowerCase();
+			const arg = command.args.trim().toLowerCase();
 			if (!arg || arg === "toggle") {
 				const enabled = runtime.session.toggleFastMode();
 				await runtime.output(`Fast mode ${enabled ? "enabled" : "disabled"}.`);
@@ -776,7 +776,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return runtime.ctx.settings.get("browser.headless" as SettingPath) ? "Browser: headless" : "Browser: visible";
 		},
 		handle: async (command, runtime) => {
-			const arg = command.args.toLowerCase();
+			const arg = command.args.trim().toLowerCase();
 			const enabled = runtime.settings.get("browser.enabled" as SettingPath) as boolean;
 			if (!enabled) return usage("Browser tool is disabled (enable in settings).", runtime);
 			const current = runtime.settings.get("browser.headless" as SettingPath) as boolean;
@@ -803,7 +803,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
-			const arg = command.args.toLowerCase();
+			const arg = command.args.trim().toLowerCase();
 			const current = settings.get("browser.headless" as SettingPath) as boolean;
 			let next = current;
 			if (!(settings.get("browser.enabled" as SettingPath) as boolean)) {


### PR DESCRIPTION
## Problem

Three slash command handlers used `command.args.toLowerCase()` without a preceding `.trim()`, so trailing whitespace caused silent failures: `/fast on ` (with trailing space) didn't match `"on"`, and `/browser headless ` didn't match `"headless"`.

All other handlers in the same file already use the `.trim().toLowerCase()` pattern. This aligns the three outliers.

## Changes
- `/fast` handler (`builtin-registry.ts:387`): added `.trim()` before `.toLowerCase()`
- `/browser` handler (`builtin-registry.ts:779`): same fix
- `/browser` handleTui (`builtin-registry.ts:806`): same fix

## Tests
- `bun check` passes
- `slash-command-format.test.ts` and `available-commands.test.ts` pass