### PR TITLE
fix(welcome): replace stale ? shortcut with /hotkeys in tips panel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+- Fixed the welcome panel advertising `? for keyboard shortcuts` after the `?` shortcut was deliberately removed (commit dcf482c4c). The tips section now points users at `/hotkeys` instead. ([#1614](https://github.com/can1357/oh-my-pi/issues/1614))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -330,7 +330,7 @@ export class WelcomeComponent implements Component {
 		// Right column
 		const rightLines = [
 			` ${theme.bold(theme.fg("accent", "Tips"))}`,
-			` ${theme.fg("dim", "?")}${theme.fg("muted", " for keyboard shortcuts")}`,
+			` ${theme.fg("dim", "/hotkeys")}${theme.fg("muted", " for keyboard shortcuts")}`,
 			` ${theme.fg("dim", "#")}${theme.fg("muted", " for prompt actions")}`,
 			` ${theme.fg("dim", "/")}${theme.fg("muted", " for commands")}`,
 			` ${theme.fg("dim", "!")}${theme.fg("muted", " to run bash")}`,


### PR DESCRIPTION
## Problem

The welcome panel advertised `? for keyboard shortcuts` even though the `?` shortcut was deliberately removed in commit `dcf482c4c` ("fix(editor): removed `?` shortcut that opened hotkeys when input was empty"). Users typing `?` on an empty prompt got a literal question mark submitted to the model instead of the help panel they expected.

Fixes #1614

## Changes

- Replaced `? for keyboard shortcuts` with `/hotkeys for keyboard shortcuts` in the welcome panel tips section (`welcome.ts:333`).

This is the narrowest fix (option 1 from the issue discussion): honor the maintainer's 2026-05-31 decision to remove `?` and stop advertising it. Users who want the shortcut reference use `/hotkeys` explicitly.

## Tests
- `bun check` passes
- Welcome component tests pass (8/8)