### PR TITLE
refactor: remove redundant type casts from slash command handlers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+### Changed
+
+- Removed 16 redundant type assertions (`as SettingPath`, `as boolean`, `as SettingValue<SettingPath>`) from slash command handlers in `builtin-registry.ts`. The `Settings.get<P>()` and `Settings.set<P>()` methods are already generically typed, making these casts unnecessary
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -5,7 +5,6 @@ import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, setProjectDir } from "@oh-my-pi/pi-utils";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
-import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {
 	clearPluginRootsAndCaches,
@@ -230,7 +229,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[prompt]",
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
-			if (!runtime.ctx.settings.get("plan.enabled" as SettingPath)) return "Plan: disabled in settings";
+			if (!runtime.ctx.settings.get("plan.enabled")) return "Plan: disabled in settings";
 			if (runtime.ctx.planModeEnabled) {
 				const planFile = runtime.ctx.planModePlanFilePath;
 				return `Plan: on${planFile ? ` (${path.basename(planFile)})` : ""}`;
@@ -271,7 +270,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[objective]",
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
-			if (!runtime.ctx.settings.get("goal.enabled" as SettingPath)) return "Goal: disabled in settings";
+			if (!runtime.ctx.settings.get("goal.enabled")) return "Goal: disabled in settings";
 			if (runtime.ctx.planModeEnabled) return "Goal: blocked by plan mode";
 			const state = runtime.ctx.session.getGoalModeState();
 			return state ? `Goal: ${state.goal.status} (${shortDetail(state.goal.objective)})` : "Goal: off";
@@ -772,20 +771,20 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		],
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
-			if (!runtime.ctx.settings.get("browser.enabled" as SettingPath)) return "Browser: disabled";
-			return runtime.ctx.settings.get("browser.headless" as SettingPath) ? "Browser: headless" : "Browser: visible";
+			if (!runtime.ctx.settings.get("browser.enabled")) return "Browser: disabled";
+			return runtime.ctx.settings.get("browser.headless") ? "Browser: headless" : "Browser: visible";
 		},
 		handle: async (command, runtime) => {
 			const arg = command.args.toLowerCase();
-			const enabled = runtime.settings.get("browser.enabled" as SettingPath) as boolean;
+			const enabled = runtime.settings.get("browser.enabled");
 			if (!enabled) return usage("Browser tool is disabled (enable in settings).", runtime);
-			const current = runtime.settings.get("browser.headless" as SettingPath) as boolean;
+			const current = runtime.settings.get("browser.headless");
 			let next = current;
 			if (!arg) next = !current;
 			else if (arg === "headless" || arg === "hidden") next = true;
 			else if (arg === "visible" || arg === "show" || arg === "headful") next = false;
 			else return usage("Usage: /browser [headless|visible]", runtime);
-			runtime.settings.set("browser.headless" as SettingPath, next as SettingValue<SettingPath>);
+			runtime.settings.set("browser.headless", next);
 			const tool = runtime.session.getToolByName("browser");
 			if (tool && "restartForModeChange" in tool) {
 				try {
@@ -804,9 +803,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (command, runtime) => {
 			const arg = command.args.toLowerCase();
-			const current = settings.get("browser.headless" as SettingPath) as boolean;
+			const current = settings.get("browser.headless");
 			let next = current;
-			if (!(settings.get("browser.enabled" as SettingPath) as boolean)) {
+			if (!settings.get("browser.enabled")) {
 				runtime.ctx.showWarning("Browser tool is disabled (enable in settings)");
 				runtime.ctx.editor.setText("");
 				return;
@@ -822,7 +821,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.editor.setText("");
 				return;
 			}
-			settings.set("browser.headless" as SettingPath, next as SettingValue<SettingPath>);
+			settings.set("browser.headless", next);
 			const tool = runtime.ctx.session.getToolByName("browser");
 			if (tool && "restartForModeChange" in tool) {
 				try {


### PR DESCRIPTION
## Problem

The `Settings` API is already generically typed: `get<P extends SettingPath>(path: P): SettingValue<P>` and `set<P>(path: P, value: SettingValue<P>)`. String literals like `"browser.enabled"` are valid `SettingPath` values (`keyof Schema`), and `SettingValue<"browser.enabled">` resolves to `boolean` via the conditional type. The `as SettingPath` and `as boolean` casts were redundant — they asserted types TypeScript could already infer.

## Changes

Removed 16 redundant type assertions from `builtin-registry.ts`:
- 10× `as SettingPath` on string literal arguments to `settings.get()`/`settings.set()`
- 4× `as boolean` on `settings.get()` return values
- 2× `as SettingValue<SettingPath>` on `settings.set()` values (this one was doubly wrong — it used the bare `SettingPath` union instead of the specific literal)
- Unused `SettingPath, SettingValue` type import

## Tests
- `bun check` passes (all 16 packages)
- Slash command tests pass (6/6)