### PR TITLE
refactor: remove redundant type casts in agent-session and browser tool

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+### Changed
+
+- Removed 3 redundant `as boolean` type casts from `agent-session.ts` and `browser.ts` — `SettingValue<P>` already resolves to `boolean` for paths with `type: "boolean"` and a non-undefined default
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1734,7 +1734,7 @@ export class AgentSession {
 			},
 		});
 
-		this.#advisorEnabled = this.settings.get("advisor.enabled") as boolean;
+		this.#advisorEnabled = this.settings.get("advisor.enabled");
 		if (this.#advisorEnabled) this.#buildAdvisorRuntime();
 
 		// Always subscribe to agent events for internal handling

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -81,12 +81,12 @@ function resolveBrowserKind(params: BrowserParams, session: ToolSession): Browse
 		return { kind: "spawned", path: exe };
 	}
 	const cmuxKind = resolveCmuxKind({
-		settingEnabled: session.settings.get("browser.cmux") as boolean | undefined,
+		settingEnabled: session.settings.get("browser.cmux"),
 	});
 	if (cmuxKind) {
 		return cmuxKind;
 	}
-	const headless = session.settings.get("browser.headless") as boolean;
+	const headless = session.settings.get("browser.headless");
 	return { kind: "headless", headless };
 }
 


### PR DESCRIPTION
## Problem

Three redundant `as boolean` casts on `settings.get()` return values. `SettingValue<P>` already resolves to `boolean` for these paths (they have `type: "boolean"` with a non-`undefined` default in the schema).

## Changes

- `agent-session.ts:1737` — `settings.get("advisor.enabled") as boolean` → `settings.get("advisor.enabled")`
- `browser.ts:84` — `settings.get("browser.cmux") as boolean | undefined` → `settings.get("browser.cmux")` (the `| undefined` was also wrong — the type is `boolean`, not `boolean | undefined`)
- `browser.ts:89` — `settings.get("browser.headless") as boolean` → `settings.get("browser.headless")`

Companion to #3320 which removed 16 redundant casts from `builtin-registry.ts`.

## Tests
- `bun check` passes (all 16 packages)
- Pre-existing test failures (39) are identical on clean main — environment-specific (`gh` CLI, SQLite, etc.)