### PR TITLE
refactor: remove redundant as-any casts in event-stream and agent

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed unnecessary `as any` casts when accessing `errorMessage` on `AssistantMessage` in `Agent` turn-end handling — the field is already on the type.
+
 ## [16.1.16] - 2026-06-23
 
 ### Added

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1202,8 +1202,8 @@ export class Agent {
 						break;
 
 					case "turn_end":
-						if (event.message.role === "assistant" && (event.message as any).errorMessage) {
-							this.#state.error = (event.message as any).errorMessage;
+						if (event.message.role === "assistant" && event.message.errorMessage) {
+							this.#state.error = event.message.errorMessage;
 						}
 						break;
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed redundant `undefined as any` casts in `EventStream.end()` and `endWaiting()` — `IteratorResult<T>` already allows `undefined` for the `value` field when `done: true`.
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Removed redundant `undefined as any` casts in `EventStream.end()` and `endWaiting()` — `IteratorResult<T>` already allows `undefined` for the `value` field when `done: true`.
+- Removed redundant `undefined as any` casts in `EventStream.end()` and `endWaiting()`. The waiter type is now explicitly `IteratorResult<T, undefined>` (instead of the default `IteratorResult<T, any>`), so the `undefined` value is type-checked without relying on the implicit `any` for `TReturn`.
 
 ## [16.1.16] - 2026-06-23
 

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -3,7 +3,7 @@ import type { AssistantMessage, AssistantMessageEvent } from "../types";
 // Generic event stream class for async iteration
 export class EventStream<T, R = T> implements AsyncIterable<T> {
 	queue: T[] = [];
-	waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (err: unknown) => void }> = [];
+	waiting: Array<{ resolve: (value: IteratorResult<T, undefined>) => void; reject: (err: unknown) => void }> = [];
 	done = false;
 	/** True once finalResultPromise has been resolved or rejected. */
 	resultSettled = false;
@@ -101,7 +101,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 			} else if (this.done) {
 				return;
 			} else {
-				const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
+				const result = await new Promise<IteratorResult<T, undefined>>((resolve, reject) =>
 					this.waiting.push({ resolve, reject }),
 				);
 				if (result.done) return;

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -68,14 +68,14 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Notify all waiting consumers that we're done
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 
 	endWaiting(): void {
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 


### PR DESCRIPTION
## Summary

Removes 3 redundant `as any` casts across two packages:

### `packages/ai/src/utils/event-stream.ts`
`EventStream.end()` and `endWaiting()` resolved waiting consumers with `{ value: undefined as any, done: true }`. The `as any` cast is unnecessary — `IteratorResult<T>` is `IteratorYieldResult<T> | IteratorReturnResult<TReturn>` where `TReturn` defaults to `any`, so `undefined` is assignable to the `value` field when `done: true`.

### `packages/agent/src/agent.ts`
The `turn_end` handler accessed `errorMessage` via `(event.message as any).errorMessage`. The `errorMessage` field is already on the `AssistantMessage` interface (`packages/ai/src/types.ts:524`), so the cast is unnecessary.

## Verification
- `bun check` passes
- 81 tests pass across `agent.test.ts`, `agent-loop.test.ts`, `yield.test.ts`, `proxy-stream-disconnect.test.ts`