### PR TITLE
refactor(ai): use Promise.withResolvers in EventStream iterator

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `EventStream` async iterator, per the project convention.
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -3,7 +3,7 @@ import type { AssistantMessage, AssistantMessageEvent } from "../types";
 // Generic event stream class for async iteration
 export class EventStream<T, R = T> implements AsyncIterable<T> {
 	queue: T[] = [];
-	waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (err: unknown) => void }> = [];
+	waiting: Array<{ resolve: (value: IteratorResult<T, undefined>) => void; reject: (err: unknown) => void }> = [];
 	done = false;
 	/** True once finalResultPromise has been resolved or rejected. */
 	resultSettled = false;
@@ -68,14 +68,14 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Notify all waiting consumers that we're done
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 
 	endWaiting(): void {
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 
@@ -101,7 +101,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 			} else if (this.done) {
 				return;
 			} else {
-				const { promise, resolve, reject } = Promise.withResolvers<IteratorResult<T>>();
+				const { promise, resolve, reject } = Promise.withResolvers<IteratorResult<T, undefined>>();
 				this.waiting.push({ resolve, reject });
 				const result = await promise;
 				if (result.done) return;

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -101,9 +101,9 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 			} else if (this.done) {
 				return;
 			} else {
-				const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
-					this.waiting.push({ resolve, reject }),
-				);
+				const { promise, resolve, reject } = Promise.withResolvers<IteratorResult<T>>();
+				this.waiting.push({ resolve, reject });
+				const result = await promise;
 				if (result.done) return;
 				yield result.value;
 			}


### PR DESCRIPTION
## Summary

Replaces `new Promise<IteratorResult<T>>((resolve, reject) => this.waiting.push({ resolve, reject }))` with `Promise.withResolvers<T>()` in `EventStream`'s async iterator, per the project convention in AGENTS.md.

The Promise executor only pushed `{ resolve, reject }` to `this.waiting` — exactly the pattern `Promise.withResolvers()` was designed for.

## Verification
- `bun check` passes
- 37 tests pass across `event-stream.test.ts`, `agent.test.ts`, `yield.test.ts`, `proxy-stream-disconnect.test.ts`