### PR TITLE
refactor(cursor): eliminate as-any casts on ToolCallState field deletion

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Made `index`, `partialJson`, and `kind` optional on Cursor's `ToolCallState` type, eliminating `as any` casts when deleting these runtime-only fields before pushing tool-call events.
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -563,8 +563,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			if (state.currentToolCall) {
 				const idx = output.content.indexOf(state.currentToolCall);
 				state.currentToolCall.arguments = parseStreamingJson(state.currentToolCall.partialJson);
-				delete (state.currentToolCall as any).partialJson;
-				delete (state.currentToolCall as any).index;
+				delete state.currentToolCall.partialJson;
+				delete state.currentToolCall.index;
 				stream.push({
 					type: "toolcall_end",
 					contentIndex: idx,
@@ -606,7 +606,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 	return stream;
 };
 
-export type ToolCallState = ToolCall & { index: number; partialJson?: string; kind: "mcp" | "todo" };
+export type ToolCallState = ToolCall & { index?: number; partialJson?: string; kind?: "mcp" | "todo" };
 
 export interface BlockState {
 	currentTextBlock: (TextContent & { index: number }) | null;
@@ -2113,9 +2113,9 @@ export function processInteractionUpdate(
 				}
 			}
 			const idx = output.content.indexOf(state.currentToolCall);
-			delete (state.currentToolCall as any).partialJson;
-			delete (state.currentToolCall as any).index;
-			delete (state.currentToolCall as any).kind;
+			delete state.currentToolCall.partialJson;
+			delete state.currentToolCall.index;
+			delete state.currentToolCall.kind;
 			stream.push({ type: "toolcall_end", contentIndex: idx, toolCall: state.currentToolCall, partial: output });
 			state.setToolCall(null);
 		}


### PR DESCRIPTION
## Summary

Eliminates 5 `as any` casts across 2 deletion sites in `packages/ai/src/providers/cursor.ts`.

## Problem

`ToolCallState = ToolCall & { index: number; partialJson?: string; kind: "mcp" | "todo" }` extends `ToolCall` with runtime-only tracking fields (`index`, `partialJson`, `kind`). Before pushing the object as a `toolCall` in stream events, these fields are deleted via `delete (state.currentToolCall as any).partialJson/index/kind` — the `as any` was needed because `index` and `kind` were non-optional, and TypeScript doesn't allow `delete` on non-optional properties.

## Fix

Made `index`, `partialJson`, and `kind` optional (`index?: number`, `kind?: "mcp" | "todo"`) on `ToolCallState`. These are runtime tracking fields that are always set at creation time but deleted before the object leaves the `ToolCallState` context. Making them optional allows `delete` without any cast.

The 5 `as any` casts at lines 566-567 and 2116-2118 are replaced with direct property deletion: `delete state.currentToolCall.partialJson`, etc.

## Verification
- `bun check` passes
- 22 cursor tests pass (cursor-streaming-args, cursor-exec-handlers)