### PR TITLE
refactor: replace new Promise with Promise.withResolvers per AGENTS.md

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `callback-server.ts` and `auth-storage.ts`/`auth-broker/remote-store.ts` race-with-signal helpers, per the project convention.
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `callback-server.ts` and `auth-storage.ts`/`auth-broker/remote-store.ts` race-with-signal helpers, per the project convention.
+- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `callback-server.ts` and `auth-storage.ts`/`auth-broker/remote-store.ts` race-with-signal helpers, per the project convention. ([#3336](https://github.com/can1357/oh-my-pi/pull/3336) by [@oldschoola](https://github.com/oldschoola))
 
 ## [16.1.16] - 2026-06-23
 

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -539,23 +539,23 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 		if (!signal) return promise;
 		if (signal.aborted) return Promise.reject(new Error("auth-broker request aborted"));
-		return new Promise<T>((resolve, reject) => {
-			const onAbort = (): void => {
+		const { promise: raced, resolve, reject } = Promise.withResolvers<T>();
+		const onAbort = (): void => {
+			signal.removeEventListener("abort", onAbort);
+			reject(new Error("auth-broker request aborted"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			value => {
 				signal.removeEventListener("abort", onAbort);
-				reject(new Error("auth-broker request aborted"));
-			};
-			signal.addEventListener("abort", onAbort, { once: true });
-			promise.then(
-				value => {
-					signal.removeEventListener("abort", onAbort);
-					resolve(value);
-				},
-				err => {
-					signal.removeEventListener("abort", onAbort);
-					reject(err);
-				},
-			);
-		});
+				resolve(value);
+			},
+			err => {
+				signal.removeEventListener("abort", onAbort);
+				reject(err);
+			},
+		);
+		return raced;
 	}
 
 	#loadUsageReports(): Promise<UsageReport[] | null> {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -787,23 +787,23 @@ function parseUsageCacheEntry<T>(raw: string): UsageCacheEntry<T> | undefined {
 function raceUsageWithSignal<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
 	if (!signal) return promise;
 	if (signal.aborted) return Promise.reject(new Error("usage fetch aborted"));
-	return new Promise<T>((resolve, reject) => {
-		const onAbort = (): void => {
+	const { promise: raced, resolve, reject } = Promise.withResolvers<T>();
+	const onAbort = (): void => {
+		signal.removeEventListener("abort", onAbort);
+		reject(new Error("usage fetch aborted"));
+	};
+	signal.addEventListener("abort", onAbort, { once: true });
+	promise.then(
+		value => {
 			signal.removeEventListener("abort", onAbort);
-			reject(new Error("usage fetch aborted"));
-		};
-		signal.addEventListener("abort", onAbort, { once: true });
-		promise.then(
-			value => {
-				signal.removeEventListener("abort", onAbort);
-				resolve(value);
-			},
-			err => {
-				signal.removeEventListener("abort", onAbort);
-				reject(err);
-			},
-		);
-	});
+			resolve(value);
+		},
+		err => {
+			signal.removeEventListener("abort", onAbort);
+			reject(err);
+		},
+	);
+	return raced;
 }
 
 function raceCredentialRefreshWithSignal<T>(

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -207,15 +207,14 @@ export abstract class OAuthCallbackFlow {
 		const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT);
 		const signal = this.ctrl.signal ? AbortSignal.any([this.ctrl.signal, timeoutSignal]) : timeoutSignal;
 
-		const callbackPromise = new Promise<CallbackResult>((resolve, reject) => {
-			this.#callbackResolve = resolve;
-			this.#callbackReject = reject;
+		const { promise: callbackPromise, resolve, reject } = Promise.withResolvers<CallbackResult>();
+		this.#callbackResolve = resolve;
+		this.#callbackReject = reject;
 
-			signal.addEventListener("abort", () => {
-				this.#callbackResolve = undefined;
-				this.#callbackReject = undefined;
-				reject(new Error(`OAuth callback cancelled: ${signal.reason}`));
-			});
+		signal.addEventListener("abort", () => {
+			this.#callbackResolve = undefined;
+			this.#callbackReject = undefined;
+			reject(new Error(`OAuth callback cancelled: ${signal.reason}`));
 		});
 
 		// Manual input race (if supported)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+### Changed
+
+- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `print-mode.ts`, per the project convention.
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -207,7 +207,7 @@
 - Changed side-channel turns (`/btw`, `/omfg`, and IRC auto-replies) to forward the main turn's tool catalog to preserve the prompt-cache layout, while injecting a reminder to suppress tool usage and discarding any generated tool calls.
 - Changed `/btw`, `/tan`, `/omfg`, `/memory`, `/rename`, and `/move` to save the typed command text to TUI prompt history so they can be recalled with the up arrow.
 - Changed the temporary model picker to label Alt+P selections as session-only and point users to Alt+M or `/model` for role model assignment. ([#2952](https://github.com/can1357/oh-my-pi/issues/2952))
-- Replaced `new Promise((resolve, reject) => ...)` in `AsyncDrain` with `Promise.withResolvers()` per the repo's promise-construction convention
+- Replaced `new Promise((resolve, reject) => ...)` in `AsyncDrain` with `Promise.withResolvers()` per the repo's promise-construction convention ([#3336](https://github.com/can1357/oh-my-pi/pull/3336) by [@oldschoola](https://github.com/oldschoola))
 - Changed the default advisor interrupt cooldown to 3 turns and the default auto-compaction strategy to snapcompact, with non-vision and over-budget snapcompact runs still falling back to context-full summaries.
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
 ### Changed
 
-- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `print-mode.ts`, per the project convention.
+- Replaced `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in `print-mode.ts`, per the project convention. ([#3336](https://github.com/can1357/oh-my-pi/pull/3336) by [@oldschoola](https://github.com/oldschoola))
 
 ## [16.1.16] - 2026-06-23
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -120,10 +120,14 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// Ensure stdout is fully flushed before returning
 	// This prevents race conditions where the process exits before all output is written
 	const { promise, resolve, reject } = Promise.withResolvers<void>();
-	process.stdout.write("", err => {
-		if (err) reject(err);
-		else resolve();
-	});
+	try {
+		process.stdout.write("", err => {
+			if (err) reject(err);
+			else resolve();
+		});
+	} catch (err) {
+		reject(err);
+	}
 	await promise;
 
 	await session.dispose();

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -119,12 +119,12 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 
 	// Ensure stdout is fully flushed before returning
 	// This prevents race conditions where the process exits before all output is written
-	await new Promise<void>((resolve, reject) => {
-		process.stdout.write("", err => {
-			if (err) reject(err);
-			else resolve();
-		});
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	process.stdout.write("", err => {
+		if (err) reject(err);
+		else resolve();
 	});
+	await promise;
 
 	await session.dispose();
 }


### PR DESCRIPTION
## Summary

Replaces `new Promise((resolve, reject) => ...)` with `Promise.withResolvers()` in 4 files, per the AGENTS.md convention: "use `Promise.withResolvers()` instead of `new Promise((resolve, reject) => ...)`".

## Files changed

- `packages/ai/src/registry/oauth/callback-server.ts` — `#waitForCallback` assigns resolve/reject to instance fields
- `packages/ai/src/auth-storage.ts` — `raceUsageWithSignal` wraps promise + abort signal
- `packages/ai/src/auth-broker/remote-store.ts` — `#raceWithSignal` wraps promise + abort signal
- `packages/coding-agent/src/modes/print-mode.ts` — stdout flush wrapper

## Verification
- `bun check` passes
- 16 tests pass across `auth-broker-refresher`, `auth-storage-usage-cache`, `callback-server-manual-input`