### PR TITLE
feat(usage): show expiry dates for banked Codex rate-limit resets

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `credits` field (array of `UsageResetCreditDetail` with `grantedAt`, `expiresAt`, `status`) to `UsageResetCredits`, so display layers can show when banked rate-limit resets expire. The OpenAI Codex usage provider now calls `listCodexResetCredits` to populate individual credit details when `availableCount > 0` ([#3339](https://github.com/can1357/oh-my-pi/issues/3339)).
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -183,8 +183,15 @@ const usageLimitSchema = type({
 	"notes?": "string[]",
 });
 
+const usageResetCreditDetailSchema = type({
+	"grantedAt?": "string",
+	"expiresAt?": "string",
+	"status?": "string",
+});
+
 const usageResetCreditsSchema = type({
 	availableCount: "number",
+	"credits?": usageResetCreditDetailSchema.array(),
 });
 
 const arkUsageReportSchema = type({

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -64,6 +64,23 @@ export interface UsageLimit {
 }
 
 /**
+ * Per-credit detail for a saved/banked rate-limit reset.
+ *
+ * Populated when the provider's listing endpoint returns individual credit
+ * metadata (e.g. OpenAI Codex `wham/rate-limit-reset-credits`). Callers that
+ * only need the count can ignore this; display layers use `expiresAt` to show
+ * when banked resets expire ([#3339](https://github.com/can1357/oh-my-pi/issues/3339)).
+ */
+export interface UsageResetCreditDetail {
+	/** ISO timestamp when the credit was granted. */
+	grantedAt?: string;
+	/** ISO timestamp when the credit expires and can no longer be redeemed. */
+	expiresAt?: string;
+	/** Backend status, e.g. `available`, `redeemed`. */
+	status?: string;
+}
+
+/**
  * Saved/banked rate-limit resets an account can redeem on demand.
  *
  * Surfaced by providers that let users defer a usage-window reset and spend it
@@ -73,6 +90,8 @@ export interface UsageLimit {
 export interface UsageResetCredits {
 	/** Number of resets available to redeem right now. */
 	availableCount: number;
+	/** Individual credit details (expiry dates, etc.) when the provider exposes them. */
+	credits?: UsageResetCreditDetail[];
 }
 
 /** Aggregated usage report for a provider. */
@@ -195,8 +214,15 @@ export const usageLimitSchema = type({
 	"notes?": "string[]",
 });
 
+export const usageResetCreditDetailSchema = type({
+	"grantedAt?": "string",
+	"expiresAt?": "string",
+	"status?": "string",
+});
+
 export const usageResetCreditsSchema = type({
 	availableCount: "number",
+	"credits?": usageResetCreditDetailSchema.array(),
 });
 
 export const usageReportSchema = type({

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -488,6 +488,7 @@ export const openaiCodexUsageProvider: UsageProvider = {
 							expiresAt: c.expiresAt,
 							status: c.status,
 						}));
+					resetCredits.availableCount = list.availableCount;
 				}
 			} catch (error) {
 				ctx.logger?.warn("Codex reset credits detail fetch failed", { error: String(error) });

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -12,6 +12,7 @@ import type {
 	UsageWindow,
 } from "../usage";
 import { isRecord } from "../utils";
+import { listCodexResetCredits } from "./openai-codex-reset";
 import { toNumber } from "./shared";
 
 const CODEX_USAGE_PATH = "wham/usage";
@@ -470,6 +471,28 @@ export const openaiCodexUsageProvider: UsageProvider = {
 		}
 
 		const resetCredits = parseResetCredits(payload);
+		if (resetCredits && resetCredits.availableCount > 0) {
+			try {
+				const list = await listCodexResetCredits({
+					accessToken,
+					accountId,
+					baseUrl: params.baseUrl,
+					fetch: ctx.fetch,
+					signal: params.signal,
+				});
+				if (list?.credits.length) {
+					resetCredits.credits = list.credits
+						.filter(c => (c.status ?? "available") === "available")
+						.map(c => ({
+							grantedAt: c.grantedAt,
+							expiresAt: c.expiresAt,
+							status: c.status,
+						}));
+				}
+			} catch (error) {
+				ctx.logger?.warn("Codex reset credits detail fetch failed", { error: String(error) });
+			}
+		}
 		const report: UsageReport = {
 			provider: "openai-codex",
 			fetchedAt: nowMs,

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -488,6 +488,11 @@ export const openaiCodexUsageProvider: UsageProvider = {
 							expiresAt: c.expiresAt,
 							status: c.status,
 						}));
+				}
+				// Always sync the live count from the detail endpoint — it may report
+				// fewer or zero available credits after expiry/redeem, even when the
+				// /wham/usage payload still has a stale count.
+				if (list) {
 					resetCredits.availableCount = list.availableCount;
 				}
 			} catch (error) {

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -149,4 +149,71 @@ describe("openai-codex usage parser", () => {
 		);
 		expect(report?.resetCredits).toBeUndefined();
 	});
+	it("populates resetCredits.credits with expiry dates when available_count > 0", async () => {
+		const usagePayload = { ...makePayload(), rate_limit_reset_credits: { available_count: 2 } };
+		const creditsPayload = {
+			available_count: 2,
+			credits: [
+				{
+					id: "RateLimitResetCredit_1",
+					status: "available",
+					granted_at: "2025-01-15T00:00:00Z",
+					expires_at: "2025-02-14T00:00:00Z",
+				},
+				{
+					id: "RateLimitResetCredit_2",
+					status: "available",
+					granted_at: "2025-01-20T00:00:00Z",
+					expires_at: "2025-02-19T00:00:00Z",
+				},
+				{
+					id: "RateLimitResetCredit_3",
+					status: "redeemed",
+					granted_at: "2025-01-01T00:00:00Z",
+					expires_at: "2025-01-31T00:00:00Z",
+				},
+			],
+		};
+		const fetchImpl: FetchImpl = (async (url: string | URL | Request) => {
+			const path = typeof url === "string" ? url : url.toString();
+			const body = path.includes("rate-limit-reset-credits") ? creditsPayload : usagePayload;
+			return new Response(JSON.stringify(body), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+		const report = await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fetchImpl },
+		);
+		expect(report?.resetCredits?.availableCount).toBe(2);
+		// Redeemed credits are filtered out; only available ones surface
+		expect(report?.resetCredits?.credits).toHaveLength(2);
+		expect(report?.resetCredits?.credits?.[0]?.expiresAt).toBe("2025-02-14T00:00:00Z");
+		expect(report?.resetCredits?.credits?.[1]?.expiresAt).toBe("2025-02-19T00:00:00Z");
+	});
+
+	it("does not call listCodexResetCredits when available_count is 0", async () => {
+		const usagePayload = { ...makePayload(), rate_limit_reset_credits: { available_count: 0 } };
+		let extraFetchCalls = 0;
+		const fetchImpl: FetchImpl = (async (url: string | URL | Request) => {
+			const path = typeof url === "string" ? url : url.toString();
+			if (path.includes("rate-limit-reset-credits")) extraFetchCalls++;
+			return new Response(JSON.stringify(usagePayload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fetchImpl },
+		);
+		expect(extraFetchCalls).toBe(0);
+	});
 });

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -128,13 +128,23 @@ describe("openai-codex usage parser", () => {
 	});
 
 	it("surfaces rate_limit_reset_credits.available_count as report.resetCredits", async () => {
-		const payload = { ...makePayload(), rate_limit_reset_credits: { available_count: 1 } };
+		const usagePayload = { ...makePayload(), rate_limit_reset_credits: { available_count: 1 } };
+		const fetchImpl: FetchImpl = (async (url: string | URL | Request) => {
+			const path = typeof url === "string" ? url : url.toString();
+			// Return an empty credits list for the detail endpoint — the count
+			// from /wham/usage should be synced from the live response.
+			const body = path.includes("rate-limit-reset-credits") ? { available_count: 1, credits: [] } : usagePayload;
+			return new Response(JSON.stringify(body), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
 		const report = await openaiCodexUsageProvider.fetchUsage(
 			{
 				provider: "openai-codex",
 				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
 			},
-			{ fetch: fakeFetch(payload) },
+			{ fetch: fetchImpl },
 		);
 		expect(report?.resetCredits).toEqual({ availableCount: 1 });
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The `/usage` display (TUI, ACP text, and `omp usage` CLI) now shows expiry dates for banked Codex rate-limit resets, so users can plan when to redeem them before they expire ([#3339](https://github.com/can1357/oh-my-pi/issues/3339)).
+
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -326,7 +326,23 @@ function formatAccountHeader(
 	const planType = report.metadata?.planType;
 	if (typeof planType === "string" && planType) header += chalk.dim(` · plan: ${planType}`);
 	const savedResets = report.resetCredits?.availableCount ?? 0;
-	if (savedResets > 0) header += chalk.cyan(` · ✦ ${savedResets} saved reset${savedResets === 1 ? "" : "s"}`);
+	if (savedResets > 0) {
+		header += chalk.cyan(` · ✦ ${savedResets} saved reset${savedResets === 1 ? "" : "s"}`);
+		const credits = report.resetCredits?.credits;
+		if (credits) {
+			const upcoming = credits
+				.filter(c => c.expiresAt)
+				.map(c => ({ date: c.expiresAt!, ms: Date.parse(c.expiresAt!) }))
+				.filter(c => !Number.isNaN(c.ms))
+				.sort((a, b) => a.ms - b.ms)
+				.find(c => c.ms > nowMs);
+			if (upcoming) {
+				header += chalk.dim(
+					` · soonest expires in ${formatDuration(upcoming.ms - nowMs)} (${upcoming.date.slice(0, 10)})`,
+				);
+			}
+		}
+	}
 	if (report.fetchedAt && nowMs - report.fetchedAt > 90_000) {
 		header += chalk.dim(` · fetched ${formatDuration(nowMs - report.fetchedAt)} ago`);
 	}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1598,6 +1598,23 @@ function renderUsageReports(
 			resetAccountLines.push(
 				`    • ${label}: ${count} saved reset${count === 1 ? "" : "s"}${isActive ? " (active)" : ""}`,
 			);
+			const credits = report.resetCredits?.credits;
+			if (credits) {
+				for (const credit of credits) {
+					if (credit.expiresAt) {
+						const expiryMs = Date.parse(credit.expiresAt);
+						if (!Number.isNaN(expiryMs)) {
+							const remaining = expiryMs - nowMs;
+							const expiryDate = credit.expiresAt.slice(0, 10);
+							if (remaining > 0) {
+								resetAccountLines.push(`        expires in ${formatDuration(remaining)} (${expiryDate})`);
+							} else {
+								resetAccountLines.push(`        expired (${expiryDate})`);
+							}
+						}
+					}
+				}
+			}
 		}
 		if (resetAccountLines.length > 0) {
 			lines.push(

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -65,6 +65,22 @@ function renderUsageReports(
 				lines.push(
 					`- ${resetLabel}: ${savedResets} saved rate-limit reset${savedResets === 1 ? "" : "s"} available — /usage reset to spend`,
 				);
+				const credits = report.resetCredits?.credits;
+				if (credits) {
+					for (const credit of credits) {
+						if (credit.expiresAt) {
+							const expiryMs = Date.parse(credit.expiresAt);
+							if (!Number.isNaN(expiryMs)) {
+								const remaining = expiryMs - nowMs;
+								if (remaining > 0) {
+									lines.push(`  expires in ${formatDuration(remaining)} (${credit.expiresAt.slice(0, 10)})`);
+								} else {
+									lines.push(`  expired (${credit.expiresAt.slice(0, 10)})`);
+								}
+							}
+						}
+					}
+				}
 			}
 			if (report.limits.length === 0) {
 				const email = typeof report.metadata?.email === "string" ? report.metadata.email : "account";


### PR DESCRIPTION
## Implements #3339

## Problem

There was no way to know when banked Codex rate-limit resets expire (they last 30 days). Users had to manually track the 30-day window to avoid forgetting to use them.

## Solution

The `/usage` display now shows expiry dates for banked resets across all three rendering paths:

**TUI** (`/usage` in interactive session):
```
  Saved rate-limit resets (/usage reset to spend)
    • user@example.com: 2 saved resets (active)
        expires in 28 days (2025-02-14)
        expires in 15 days (2025-02-01)
```

**ACP text** (`/usage` in chat):
```
- user@example.com: 2 saved rate-limit resets available — /usage reset to spend
  expires in 28 days (2025-02-14)
  expires in 15 days (2025-02-01)
```

**CLI** (`omp usage`):
```
● user@example.com · plan: pro · ✦ 2 saved resets · soonest expires in 15 days (2025-02-01)
```

## Implementation

1. **`packages/ai/src/usage.ts`**: Added `UsageResetCreditDetail` interface (`grantedAt`, `expiresAt`, `status`) and optional `credits` field to `UsageResetCredits`. Updated the ArkType schema.

2. **`packages/ai/src/auth-broker/wire-schemas.ts`**: Updated the wire schema copy to stay in sync.

3. **`packages/ai/src/usage/openai-codex.ts`**: When `availableCount > 0`, calls `listCodexResetCredits` (the separate `wham/rate-limit-reset-credits` endpoint) to fetch individual credit details. Filters out redeemed credits. Errors are logged and swallowed — the count still shows without expiry dates (graceful degradation).

4. **Three UI paths** updated: `command-controller.ts` (TUI), `usage-report.ts` (ACP text), `usage-cli.ts` (CLI).

## Tests

- `bun test packages/ai/test/openai-codex-usage.test.ts` — 8 pass (6 original + 2 new)
  - `populates resetCredits.credits with expiry dates when available_count > 0` — verifies credit details are fetched, redeemed credits filtered out, expiry dates populated
  - `does not call listCodexResetCredits when available_count is 0` — verifies no extra API call when there are no resets

## Verification

- `bun check` passes
- All 8 codex usage tests pass
