### PR TITLE
fix(tui): stop OSC 11 poll from wiping text selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the 30-second OSC 11 background-color poll that ran on terminals without DEC Mode 2031 support (macOS Terminal.app, Warp, VS Code's built-in terminal, older Alacritty/WezTerm). Each poll's OSC 11 + DA1 write wiped the user's active text selection on several of those terminals, causing intermittent "can't copy" failures whenever a poll fired mid-drag — most visibly during the Ask tool dialog when the user wants to quote text back from the conversation ([#3297](https://github.com/can1357/oh-my-pi/issues/3297)). Theme detection now relies on the initial startup probe plus Mode 2031 push notifications; affected terminals pick up OS-theme changes on next launch.
+
 ## [16.1.10] - 2026-06-21
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -435,7 +435,6 @@ export class ProcessTerminal implements Terminal {
 	#inBandResizeBuffer = "";
 	#reportedColumns?: number;
 	#reportedRows?: number;
-	#osc11PollTimer?: Timer;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: Timer;
 
@@ -527,24 +526,18 @@ export class ProcessTerminal implements Terminal {
 		// actual background color (following Neovim convention) with 100ms debounce.
 		this.#safeWrite("\x1b[?2031h");
 
-		// Start periodic OSC 11 re-query for terminals without Mode 2031
-		// (Warp, Alacritty, older WezTerm). Stops once Mode 2031 support is
-		// confirmed via DECRQM (probed below) or a Mode 2031 change notification
-		// fires — push notifications supersede polling, and the poll's repeated
-		// OSC 11/DA1 writes clear the user's active text selection on some
-		// terminals (copy breaks every 2s).
-		// Windows Terminal under WSL has been observed to close the hosting tab
-		// after repeated OSC 11/DA1 probes. Keep the initial/event-driven probes,
-		// but avoid background polling there.
-		const isWSL = process.platform === "linux" && (!!$env.WSL_DISTRO_NAME || !!$env.WSL_INTEROP);
-		if (!isWSL) {
-			this.#startOsc11Poll();
-		}
+		// Theme detection relies on (1) the startup OSC 11 probe above and
+		// (2) DEC Mode 2031 push notifications. Terminals without Mode 2031
+		// (macOS Terminal.app, Warp, VS Code's built-in, older Alacritty/
+		// WezTerm) detect the appearance once at startup and pick up later OS
+		// theme changes on next launch. Earlier builds polled OSC 11 every 30 s
+		// here for those terminals, but each poll's OSC 11/DA1 write wiped the
+		// user's active text selection on several of them (#3297).
 
 		// Probe DEC private-mode support via DECRQM. 2026 (synchronized output)
 		// gates the renderer's begin/end markers; 2048 (in-band resize) is enabled
 		// only after the terminal confirms support; 2031 (appearance change
-		// notifications) stops the OSC 11 poll once confirmed. Xterm ?1010/?1011
+		// notifications) drives mid-session theme tracking. Xterm ?1010/?1011
 		// are disabled while OMP owns the TTY so typing in the editor does not
 		// force a reader scrolled into native history back to the tail. Each probe
 		// rides the shared DA1 sentinel, so terminals that ignore DECRQM resolve as
@@ -869,7 +862,6 @@ export class ProcessTerminal implements Terminal {
 			// (Neovim convention — coalesces rapid notifications during transitions)
 			const appearanceMatch = sequence.match(appearanceDsrPattern);
 			if (appearanceMatch) {
-				this.#stopOsc11Poll();
 				if (this.#mode2031DebounceTimer) clearTimeout(this.#mode2031DebounceTimer);
 				this.#mode2031DebounceTimer = setTimeout(() => {
 					this.#mode2031DebounceTimer = undefined;
@@ -985,32 +977,6 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	/**
-	 * Start periodic OSC 11 re-queries for terminals without Mode 2031 (Warp, Alacritty, WezTerm).
-	 * Self-disables once Mode 2031 fires (push-based is better than polling).
-	 * The interval is deliberately long: each poll's OSC 11 + DA1 write clears
-	 * an active text selection on several terminals, so polling exists only to
-	 * eventually notice a rare OS theme switch, not to track it promptly.
-	 */
-	#startOsc11Poll(): void {
-		this.#stopOsc11Poll();
-		this.#osc11PollTimer = setInterval(() => {
-			if (this.#dead) {
-				this.#stopOsc11Poll();
-				return;
-			}
-			this.#queryBackgroundColor();
-		}, 30_000);
-		this.#osc11PollTimer.unref();
-	}
-
-	#stopOsc11Poll(): void {
-		if (this.#osc11PollTimer) {
-			clearInterval(this.#osc11PollTimer);
-			this.#osc11PollTimer = undefined;
-		}
-	}
-
-	/**
 	 * Query terminal for Kitty keyboard protocol support and enable if available.
 	 *
 	 * Sends CSI ? u to query current flags. If terminal responds with CSI ? <flags> u,
@@ -1060,9 +1026,7 @@ export class ProcessTerminal implements Terminal {
 	/**
 	 * Record DECRQM support for a private mode (idempotent — first result wins)
 	 * and notify subscribers. Enables DEC 2048 in-band resize when 2048 resolves
-	 * supported, and stops the OSC 11 poll when 2031 resolves supported (Mode 2031
-	 * push notifications make periodic re-querying redundant — and the poll's
-	 * OSC 11/DA1 writes clobber active text selections on some terminals).
+	 * supported.
 	 */
 	#resolvePrivateMode(mode: number, supported: boolean): void {
 		if (this.#privateModeSupport.has(mode)) return;
@@ -1075,7 +1039,6 @@ export class ProcessTerminal implements Terminal {
 			}
 		}
 		if (mode === 2048 && supported) this.#enableInBandResize();
-		if (mode === 2031 && supported) this.#stopOsc11Poll();
 	}
 
 	#disableXtermScrollToBottomMode(mode: number): void {
@@ -1224,7 +1187,6 @@ export class ProcessTerminal implements Terminal {
 			this.#safeWrite("\x1b[?2048l");
 			this.#inBandResizeActive = false;
 		}
-		this.#stopOsc11Poll();
 		if (this.#mode2031DebounceTimer) {
 			clearTimeout(this.#mode2031DebounceTimer);
 			this.#mode2031DebounceTimer = undefined;

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -190,72 +190,31 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		terminal.stop();
 	});
 
-	it("poll timer self-disables when Mode 2031 fires outside WSL", () => {
+	it("does not periodically re-query OSC 11 once startup probes complete (#3297)", () => {
 		vi.useFakeTimers();
 		const { terminal, queryCount } = setupTerminal();
 
-		// Complete initial OSC 11 + DA1 cycle. Two DA1 sentinels are in flight at
-		// startup (keyboard probe + OSC 11), so emit two DA1 replies.
+		// Drain the startup OSC 11 + DA1 (keyboard probe + OSC 11 sentinels).
 		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
 		process.stdin.emit("data", "\x1b[?1;2c");
 		process.stdin.emit("data", "\x1b[?1;2c");
 
 		const afterInitial = queryCount();
 
-		// Advance one poll interval — poll should fire and send another query
-		vi.advanceTimersByTime(30_000);
-		expect(queryCount()).toBe(afterInitial + 1);
+		// Advance well past the previous 30 s poll interval. Earlier builds
+		// fired an OSC 11 + DA1 probe every 30 s here, which wiped the user's
+		// active text selection on several terminals (Terminal.app, Warp, VS
+		// Code, older Alacritty/WezTerm) — the report in #3297. No periodic
+		// query may fire now; mid-session theme tracking is delegated entirely
+		// to Mode 2031 push notifications.
+		vi.advanceTimersByTime(10 * 60_000);
 
-		// Complete poll's OSC 11 + DA1 (only one DA1 sentinel — keyboard probe is one-shot)
-		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
-		process.stdin.emit("data", "\x1b[?1;2c");
-		// Send Mode 2031 notification — this activates push mode and stops polling
-		process.stdin.emit("data", "\x1b[?997;1n");
-		vi.advanceTimersByTime(100);
-
-		// Complete Mode 2031's re-query
-		process.stdin.emit("data", "\x1b]11;rgb:0000/0000/0000\x07");
-		process.stdin.emit("data", "\x1b[?1;2c");
-
-		const afterMode2031 = queryCount();
-
-		// Advance two more poll intervals — no additional poll queries should fire
-		vi.advanceTimersByTime(60_000);
-		expect(queryCount()).toBe(afterMode2031);
+		expect(queryCount()).toBe(afterInitial);
 
 		terminal.stop();
 	});
 
-	it("poll timer stops once DECRQM confirms Mode 2031 support", () => {
-		vi.useFakeTimers();
-		const { terminal, queryCount } = setupTerminal();
-
-		// Complete initial OSC 11 + DA1 cycle (keyboard + OSC 11 sentinels).
-		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
-		process.stdin.emit("data", "\x1b[?1;2c");
-		process.stdin.emit("data", "\x1b[?1;2c");
-
-		// Poll fires at the first interval while Mode 2031 support is still unknown.
-		const afterInitial = queryCount();
-		vi.advanceTimersByTime(30_000);
-		expect(queryCount()).toBe(afterInitial + 1);
-		// Drain the poll's OSC 11 reply so it is no longer pending.
-		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
-
-		// DECRQM confirms Mode 2031 support — push notifications supersede polling,
-		// so the poll must stop (its repeated OSC 11/DA1 writes otherwise clobber
-		// the user's active text selection on every poll).
-		process.stdin.emit("data", "\x1b[?2031;3$y");
-		const afterConfirm = queryCount();
-
-		// Advance well past several poll intervals — no further OSC 11 queries fire.
-		vi.advanceTimersByTime(90_000);
-		expect(queryCount()).toBe(afterConfirm);
-
-		terminal.stop();
-	});
-
-	it("does not start the OSC 11 poll timer under WSL", () => {
+	it("does not periodically re-query OSC 11 under WSL either (#3297)", () => {
 		vi.useFakeTimers();
 		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
 		Bun.env.WSL_INTEROP = "/run/WSL/1_interop";
@@ -266,7 +225,7 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		process.stdin.emit("data", "\x1b[?1;2c");
 		const afterInitial = queryCount();
 
-		vi.advanceTimersByTime(90_000);
+		vi.advanceTimersByTime(10 * 60_000);
 
 		expect(queryCount()).toBe(afterInitial);
 


### PR DESCRIPTION
## Fixes #3297

## Problem

`ProcessTerminal.start()` armed a 30-second OSC 11 + DA1 background-color poll on every non-WSL terminal so OS theme switches could be picked up mid-session on terminals without DEC Mode 2031 push notifications. Each poll's `\x1b]11;?\x07\x1b[c` write **wipes the user's active text selection** on several terminals (macOS Terminal.app, Warp, VS Code's built-in, older Alacritty/WezTerm).

Any drag-select that straddles the 30-second boundary gets wiped — matching the "sometimes can't copy" pattern reported in #3297. The Ask tool dialog is where users notice it most because that's when they want to quote text back from the conversation.

## Fix

Removed the poll outright:
- `#startOsc11Poll()` / `#stopOsc11Poll()` methods
- `#osc11PollTimer` field
- `isWSL`-gated startup call
- All `#stopOsc11Poll()` calls in the Mode 2031 handler, `#resolvePrivateMode`, and `stop()`

**Theme detection** now relies on:
1. The existing startup OSC 11 probe (runs once at startup)
2. DEC Mode 2031 push notifications (for terminals that support it)

Terminals without Mode 2031 detect the appearance once at startup and pick up OS theme changes on next launch. This is an acceptable tradeoff — the poll existed only to eventually notice a rare OS theme switch, and its cost (wiping selections) far outweighed its benefit.

## Tests

Replaced three poll-asserting tests with two regression tests:
- `does not periodically re-query OSC 11 once startup probes complete (#3297)` — advances fake timers 10 minutes, asserts zero additional OSC 11 queries fire (non-WSL path)
- `does not periodically re-query OSC 11 under WSL either (#3297)` — same assertion on the WSL path

```
bun test packages/tui/test/terminal-appearance.test.ts
34 pass, 0 fail
```

## Verification

- `bun check` passes
- All 34 terminal-appearance tests pass
