### PR TITLE
fix(tui): @-path autocomplete on Windows for paths outside cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `@`-path autocomplete failing on Windows for paths outside the cwd. Windows absolute paths (e.g. `C:\\Users\\...`) were not detected as absolute — only `/` was checked — so they were incorrectly joined with the base directory, producing invalid search paths and empty suggestions. Path-join calls also introduced backslashes into suggestion values, breaking round-trip insertion. Absolute path detection now uses `path.isAbsolute()` (handles drive letters) and suggestion paths are normalized to forward slashes (valid on all platforms).
+
 ## [16.1.10] - 2026-06-21
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -682,19 +682,23 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			// (C:\tmp\foo) work with the /-based splitting/joining below.
 			expandedPrefix = expandedPrefix.replace(/\\/g, "/");
 
+			// Capture the pre-expansion prefix so root checks can still
+			// detect bare "~" and "~/" after #expandHomePath rewrites them.
+			const preExpand = expandedPrefix;
+
 			// Handle home directory expansion
 			if (expandedPrefix.startsWith("~")) {
 				expandedPrefix = this.#expandHomePath(expandedPrefix);
 			}
 
 			const isRootPrefix =
-				expandedPrefix === "" ||
-				rawPrefix === "./" ||
-				expandedPrefix === "../" ||
-				expandedPrefix === "~" ||
-				expandedPrefix === "~/" ||
-				expandedPrefix === "/" ||
-				(isAtPrefix && expandedPrefix === "");
+				preExpand === "" ||
+				preExpand === "./" ||
+				preExpand === "../" ||
+				preExpand === "~" ||
+				preExpand === "~/" ||
+				preExpand === "/" ||
+				(isAtPrefix && preExpand === "");
 
 			if (isRootPrefix) {
 				// Complete from specified position

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -761,14 +761,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 						const homeRelativeDir = displayPrefix.slice(2); // Remove ~/
 						const dir = path.dirname(homeRelativeDir);
 						relativePath = `~/${dir === "." ? name : path.join(dir, name)}`;
-					} else if (displayPrefix.startsWith("/")) {
-						// Absolute path - construct properly
-						const dir = path.dirname(displayPrefix);
-						if (dir === "/") {
-							relativePath = `/${name}`;
-						} else {
-							relativePath = `${dir}/${name}`;
-						}
+					} else if (path.isAbsolute(displayPrefix)) {
+						// Absolute path — covers both /unix/paths and Windows C:/drive/paths.
+						// Use string concat with / instead of path.join (which uses platform-native
+						// separators and produces drive-relative results like "C:alpha" when
+						// dirname returns "C:" without a trailing slash).
+						const dir = displayPrefix.slice(0, displayPrefix.lastIndexOf("/"));
+						relativePath = dir === "" || dir === "/" ? `/${name}` : `${dir}/${name}`;
 					} else {
 						relativePath = path.join(path.dirname(displayPrefix), name);
 						if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -688,25 +688,25 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			}
 
 			const isRootPrefix =
-				rawPrefix === "" ||
+				expandedPrefix === "" ||
 				rawPrefix === "./" ||
-				rawPrefix === "../" ||
-				rawPrefix === "~" ||
-				rawPrefix === "~/" ||
-				rawPrefix === "/" ||
-				(isAtPrefix && rawPrefix === "");
+				expandedPrefix === "../" ||
+				expandedPrefix === "~" ||
+				expandedPrefix === "~/" ||
+				expandedPrefix === "/" ||
+				(isAtPrefix && expandedPrefix === "");
 
 			if (isRootPrefix) {
 				// Complete from specified position
-				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
+				if (expandedPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
 				}
 				searchPrefix = "";
-			} else if (rawPrefix.endsWith("/")) {
+			} else if (expandedPrefix.endsWith("/")) {
 				// If prefix ends with /, show contents of that directory
-				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
+				if (expandedPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -716,7 +716,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// Split into directory and file prefix
 				const dir = path.dirname(expandedPrefix);
 				const file = path.basename(expandedPrefix);
-				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
+				if (expandedPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = dir;
 				} else {
 					searchDir = path.join(this.#basePath, dir);

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -694,7 +694,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			if (isRootPrefix) {
 				// Complete from specified position
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -702,7 +702,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				searchPrefix = "";
 			} else if (rawPrefix.endsWith("/")) {
 				// If prefix ends with /, show contents of that directory
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -712,7 +712,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// Split into directory and file prefix
 				const dir = path.dirname(expandedPrefix);
 				const file = path.basename(expandedPrefix);
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || path.isAbsolute(expandedPrefix)) {
 					searchDir = dir;
 				} else {
 					searchDir = path.join(this.#basePath, dir);
@@ -780,6 +780,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					}
 				}
 
+				// Normalize backslashes to forward slashes so suggestions are consistent
+				// with the user's input (which uses / on all platforms) and work correctly
+				// when inserted back into the editor. Forward slashes are valid on Windows.
+				relativePath = relativePath.replace(/\\/g, "/");
 				const pathValue = isDirectory ? `${relativePath}/` : relativePath;
 				const value = buildCompletionValue(pathValue, {
 					isDirectory,

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -678,6 +678,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const { rawPrefix, isAtPrefix, isQuotedPrefix } = parsePathPrefix(prefix);
 			let expandedPrefix = rawPrefix;
 
+			// Normalize backslashes to forward slashes so Windows native paths
+			// (C:\tmp\foo) work with the /-based splitting/joining below.
+			expandedPrefix = expandedPrefix.replace(/\\/g, "/");
+
 			// Handle home directory expansion
 			if (expandedPrefix.startsWith("~")) {
 				expandedPrefix = this.#expandHomePath(expandedPrefix);
@@ -746,7 +750,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				let relativePath: string;
 				const name = entry.name;
-				const displayPrefix = rawPrefix;
+				const displayPrefix = rawPrefix.replace(/\\/g, "/");
 
 				if (displayPrefix.endsWith("/")) {
 					// If prefix ends with /, append entry to the prefix

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -242,8 +242,11 @@ describe("CombinedAutocompleteProvider", () => {
 			const result = await provider.getSuggestions([line], 0, line.length);
 
 			const values = result?.items.map(item => item.value) ?? [];
-			expect(values).toContain(`@${outsideDir}/alpha/`);
-			expect(values).toContain(`@${outsideDir}/beta/`);
+			// Normalize to forward slashes — the provider normalizes suggestion paths
+			// so they work consistently on all platforms (forward slashes are valid on Windows).
+			const normalizedOutsideDir = outsideDir.replace(/\\/g, "/");
+			expect(values).toContain(`@${normalizedOutsideDir}/alpha/`);
+			expect(values).toContain(`@${normalizedOutsideDir}/beta/`);
 			expect(values.some(value => value.endsWith("nested.ts"))).toBe(false);
 		});
 	});

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -249,7 +249,23 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain(`@${normalizedOutsideDir}/beta/`);
 			expect(values.some(value => value.endsWith("nested.ts"))).toBe(false);
 		});
+
+		it("preserves the full absolute prefix when completing a partial leaf", async () => {
+			fs.mkdirSync(path.join(outsideDir, "alpha"), { recursive: true });
+			fs.mkdirSync(path.join(outsideDir, "beta"), { recursive: true });
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = `@${outsideDir}/a`;
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			const values = result?.items.map(item => item.value) ?? [];
+			const normalizedOutsideDir = outsideDir.replace(/\\/g, "/");
+			expect(values).toContain(`@${normalizedOutsideDir}/alpha/`);
+			// The parent path must be preserved, not stripped to just the leaf name
+			expect(values.some(v => v === "@alpha/")).toBe(false);
+		});
 	});
+
 	describe("dot-slash path completion", () => {
 		let baseDir: string;
 


### PR DESCRIPTION
## Problem

`@`-path autocomplete failed on Windows for paths outside the current working directory. Two cross-platform bugs in `CombinedAutocompleteProvider.#getFileSuggestions`:

1. **Absolute path detection**: Only checked `expandedPrefix.startsWith("/")` — Windows drive-letter paths (e.g., `C:\Users\...`) were not recognized as absolute, so they were incorrectly joined with the base directory via `path.join`, producing invalid search paths and empty suggestions.

2. **Path separator normalization**: `path.join` and `path.dirname` introduce backslashes on Windows, so suggestion values contained backslashes that didn't match the user's forward-slash input and broke round-trip insertion into the editor.

## Fix

- Replaced `expandedPrefix.startsWith("/")` with `path.isAbsolute(expandedPrefix)` in all three path resolution branches (handles drive letters on Windows, `/` on Unix)
- Added `relativePath.replace(/\\/g, "/")` normalization before constructing the suggestion value — forward slashes are valid path separators on all platforms, including Windows

## Tests

Two previously-failing tests now pass on Windows:
- `uses immediate-directory prefix completion for @../` — was getting backslash-separated paths instead of forward slashes
- `lists entries inside an absolute @/abs/ path` — was getting empty results because Windows absolute paths weren't detected

Updated the second test's assertions to normalize `outsideDir` to forward slashes for cross-platform compatibility.

```
bun test packages/tui/test/autocomplete.test.ts
34 pass, 0 fail (was 32 pass, 2 fail)
```

Full TUI suite: 1046 pass, 1 fail (the remaining failure is a pre-existing render-timing test unrelated to this change).

## Verification

- `bun check` passes
