### PR TITLE
fix(utils): export removeWithRetries + migrate 24 ai test files from fs.rm to retry-enabled cleanup

### DIFF
--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -32,6 +32,7 @@ import type {
 	Tool,
 } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 import { type as arkType } from "arktype";
 import { withEnv } from "./helpers";
 
@@ -1699,7 +1700,7 @@ describe("Anthropic request fingerprint alignment", () => {
 				},
 			);
 		} finally {
-			fs.rmSync(tmpDir, { recursive: true, force: true });
+			removeSyncWithRetries(tmpDir);
 		}
 	});
 

--- a/packages/ai/test/auth-broker-oauth-extra-fields.test.ts
+++ b/packages/ai/test/auth-broker-oauth-extra-fields.test.ts
@@ -9,6 +9,7 @@ import {
 	RemoteAuthCredentialStore,
 	startAuthBroker,
 } from "@oh-my-pi/pi-ai/auth-broker";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 // MCP OAuth credentials extend the base OAuthCredential with refresh material
 // (tokenUrl/clientId/clientSecret/resource) embedded so token refresh works for
@@ -68,7 +69,7 @@ describe("auth-broker preserves extra OAuth credential fields", () => {
 		await handle?.close();
 		serverStorage?.close();
 		serverStore?.close();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 	});
 
 	test("broker set -> get round-trips tokenUrl/clientId/clientSecret/resource", async () => {

--- a/packages/ai/test/auth-broker-refresher.test.ts
+++ b/packages/ai/test/auth-broker-refresher.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import { AuthBrokerRefresher } from "@oh-my-pi/pi-ai/auth-broker";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const ANTHROPIC_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"] as const;
 const savedEnv: Partial<Record<(typeof ANTHROPIC_ENV)[number], string | undefined>> = {};
@@ -27,7 +28,7 @@ describe("AuthBrokerRefresher", () => {
 		vi.restoreAllMocks();
 		storage?.close();
 		store?.close();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 		for (const key of ANTHROPIC_ENV) {
 			if (savedEnv[key] === undefined) delete process.env[key];
 			else process.env[key] = savedEnv[key];

--- a/packages/ai/test/auth-broker-remote-store.test.ts
+++ b/packages/ai/test/auth-broker-remote-store.test.ts
@@ -10,6 +10,7 @@ import {
 	type SnapshotResponse,
 	startAuthBroker,
 } from "@oh-my-pi/pi-ai/auth-broker";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const ANTHROPIC_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"] as const;
 const savedEnv: Partial<Record<(typeof ANTHROPIC_ENV)[number], string | undefined>> = {};
@@ -66,7 +67,7 @@ describe("RemoteAuthCredentialStore SSE integration", () => {
 		await handle?.close();
 		storage?.close();
 		store?.close();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 		for (const key of ANTHROPIC_ENV) {
 			if (savedEnv[key] === undefined) delete process.env[key];
 			else process.env[key] = savedEnv[key];

--- a/packages/ai/test/auth-broker-snapshot-cache.test.ts
+++ b/packages/ai/test/auth-broker-snapshot-cache.test.ts
@@ -7,6 +7,7 @@ import {
 	type SnapshotResponse,
 	writeAuthBrokerSnapshotCache,
 } from "@oh-my-pi/pi-ai/auth-broker";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const TOKEN = "broker-cache-token";
 const URL = "http://127.0.0.1:8765";
@@ -39,7 +40,7 @@ async function withCachePath(run: (cachePath: string) => Promise<void>): Promise
 	try {
 		await run(path.join(tempDir, "snapshot.enc"));
 	} finally {
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 	}
 }
 

--- a/packages/ai/test/auth-broker-wire.test.ts
+++ b/packages/ai/test/auth-broker-wire.test.ts
@@ -11,6 +11,7 @@ import {
 	startAuthBroker,
 } from "@oh-my-pi/pi-ai/auth-broker";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const ANTHROPIC_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"] as const;
 const savedEnv: Partial<Record<(typeof ANTHROPIC_ENV)[number], string | undefined>> = {};
@@ -57,7 +58,7 @@ describe("auth-broker wire surface", () => {
 		await handle?.close();
 		storage?.close();
 		store?.close();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 		for (const key of ANTHROPIC_ENV) {
 			if (savedEnv[key] === undefined) delete process.env[key];
 			else process.env[key] = savedEnv[key];

--- a/packages/ai/test/auth-storage-account-identity.test.ts
+++ b/packages/ai/test/auth-storage-account-identity.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const PROVIDER = "unit-oauth-identity";
 
@@ -24,7 +25,7 @@ describe("AuthStorage.getOAuthAccountIdentity", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -16,6 +16,7 @@ import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
 import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -119,7 +120,7 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-api-key-login.test.ts
+++ b/packages/ai/test/auth-storage-api-key-login.test.ts
@@ -8,6 +8,7 @@ import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-sto
 import * as deepseekModule from "@oh-my-pi/pi-ai/registry/deepseek";
 import * as kagiModule from "@oh-my-pi/pi-ai/registry/kagi";
 import * as ollamaCloudModule from "@oh-my-pi/pi-ai/registry/ollama-cloud";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 function countCredentialRows(dbPath: string, provider: string): number {
 	const db = new Database(dbPath, { readonly: true });
@@ -62,7 +63,7 @@ describe("AuthStorage api-key login upsert", () => {
 		authStorage = null;
 		dbPath = "";
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
+++ b/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
@@ -9,6 +9,7 @@ import {
 	SqliteAuthCredentialStore,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 describe("AuthStorage broker sentinel refresh", () => {
 	let tempDir = "";
@@ -43,7 +44,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 		store = undefined;
 		authStorage = undefined;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -6,6 +6,7 @@ import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
 import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
@@ -168,7 +169,7 @@ describe("AuthStorage codex oauth ranking", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});
@@ -699,7 +700,7 @@ describe("AuthStorage claude oauth ranking", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { withEnv } from "./helpers";
 
 const SUPPRESS_ANTHROPIC_ENV = {
@@ -26,7 +27,7 @@ describe("AuthStorage config-override apiKey", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-credential-origin.test.ts
+++ b/packages/ai/test/auth-storage-credential-origin.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { withEnv } from "./helpers";
 
 // Clear every env var the providers under test alias, so ambient shell / ~/.env
@@ -30,7 +31,7 @@ describe("AuthStorage.getCredentialOrigin", () => {
 		store = null;
 		auth = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, type FetchImpl, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { registerOAuthProvider, unregisterOAuthProviders } from "../src/registry/oauth";
 
 const LEGACY_TIMESTAMP = 1_700_000_000;
@@ -122,7 +123,7 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		authStorage = null;
 		dbPath = "";
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});
@@ -662,7 +663,7 @@ describe("AuthStorage OAuth login upgrade and multi-account coexistence", () => 
 	afterEach(async () => {
 		unregisterOAuthProviders("auth-storage-login-upgrade-test");
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 		}
 	});
 
@@ -790,7 +791,7 @@ describe("AuthStorage persistent session stickiness", () => {
 	});
 
 	afterEach(async () => {
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 	});
 
 	it("persists session-sticky credentials across AuthStorage restarts", async () => {

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const PROVIDER = "unit-rotate-oauth";
 const SOURCE = "auth-storage-force-refresh-rotate-test";
@@ -48,7 +49,7 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 		store = undefined;
 		authStorage = undefined;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -9,6 +9,7 @@ import {
 	SqliteAuthCredentialStore,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { withEnv } from "./helpers";
 
 const SUPPRESS_ANTHROPIC_ENV = {
@@ -40,7 +41,7 @@ describe("AuthStorage OAuth refresh race", () => {
 		store = null;
 		authStorage = null;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-refresh-skew.test.ts
+++ b/packages/ai/test/auth-storage-refresh-skew.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 describe("AuthStorage OAuth refresh skew", () => {
 	let tempDir = "";
@@ -22,7 +23,7 @@ describe("AuthStorage OAuth refresh skew", () => {
 		store = undefined;
 		authStorage = undefined;
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/auth-storage-sqlite-busy.test.ts
+++ b/packages/ai/test/auth-storage-sqlite-busy.test.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isSqliteBusyError, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 interface SqliteBusyShape extends Error {
 	code: string;
@@ -55,7 +56,7 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 		}
 	});

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -7,6 +7,7 @@ import {
 	resolveAwsCredentials,
 	tokenizeCredentialProcessCommand,
 } from "@oh-my-pi/pi-ai/providers/aws-credentials";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 // `credential_process` integration coverage. Drives a real `Bun.spawn`
 // against a fixture script so the JSON envelope contract, exit-code
@@ -94,7 +95,7 @@ describe("resolveAwsCredentials credential_process", () => {
 			else Bun.env[k] = v;
 		}
 		saved.clear();
-		await fs.rm(tmp, { recursive: true, force: true });
+		await removeWithRetries(tmp);
 		clearAwsCredentialCache();
 	});
 

--- a/packages/ai/test/image-limits.test.ts
+++ b/packages/ai/test/image-limits.test.ts
@@ -75,7 +75,7 @@ import * as path from "node:path";
 import { complete } from "@oh-my-pi/pi-ai/stream";
 import type { Api, Context, ImageContent, Model, OptionsForApi, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { $which } from "@oh-my-pi/pi-utils";
+import { $which, removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 import { e2eApiKey } from "./oauth";
 
 const TEMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omp-temp-images-"));
@@ -239,7 +239,7 @@ describe("Image Limits E2E Tests", () => {
 
 	afterAll(() => {
 		// Clean up temp directory
-		fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+		removeSyncWithRetries(TEMP_DIR);
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/ai/test/issue-1417-repro.test.ts
+++ b/packages/ai/test/issue-1417-repro.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { readModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -34,7 +35,7 @@ describe("issue #1417 synthetic model deprecation", () => {
 
 	afterEach(async () => {
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 			dbPath = "";
 		}

--- a/packages/ai/test/issue-957-repro.test.ts
+++ b/packages/ai/test/issue-957-repro.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import * as kimiOauth from "@oh-my-pi/pi-ai/registry/oauth/kimi";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -112,7 +113,7 @@ describe("issue #957 - Kimi OAuth refresh", () => {
 			}
 		} finally {
 			store.close();
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 		}
 	});
 });

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -40,7 +41,7 @@ describe("model cache migrations", () => {
 
 	afterEach(async () => {
 		if (tempDir) {
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await removeWithRetries(tempDir);
 			tempDir = "";
 			dbPath = "";
 		}

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -10,6 +10,7 @@ import {
 	startAuthBroker,
 } from "@oh-my-pi/pi-ai/auth-broker";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const ANTHROPIC_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"] as const;
 const savedEnv: Partial<Record<(typeof ANTHROPIC_ENV)[number], string | undefined>> = {};
@@ -50,7 +51,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 		await handle?.close();
 		serverStorage?.close();
 		serverStore?.close();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetries(tempDir);
 		for (const key of ANTHROPIC_ENV) {
 			if (savedEnv[key] === undefined) delete process.env[key];
 			else process.env[key] = savedEnv[key];

--- a/packages/ai/test/request-debug.test.ts
+++ b/packages/ai/test/request-debug.test.ts
@@ -8,6 +8,7 @@ import type { AssistantMessage, FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { wrapFetchForRequestDebug } from "@oh-my-pi/pi-ai/utils/request-debug";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const enc = new TextEncoder();
 
@@ -27,7 +28,7 @@ afterEach(async () => {
 	process.chdir(previousCwd);
 	if (previousDebugFlag === undefined) delete Bun.env.PI_REQ_DEBUG;
 	else Bun.env.PI_REQ_DEBUG = previousDebugFlag;
-	if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+	if (tempDir) await removeWithRetries(tempDir);
 	tempDir = undefined;
 });
 

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -9,7 +9,7 @@ import { complete, getEnvApiKey, stream } from "@oh-my-pi/pi-ai/stream";
 import type { Api, Context, ImageContent, Model, OptionsForApi, Tool, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { $which } from "@oh-my-pi/pi-utils";
+import { $which, removeWithRetries } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { e2eApiKey, resolveApiKey } from "./oauth";
 
@@ -776,7 +776,7 @@ describe("Generate E2E Tests", () => {
 				expect(request.authorization).toBe("Bearer impersonated-token");
 			} finally {
 				__resetVertexTokenCache();
-				await fs.rm(tmpDir, { recursive: true, force: true });
+				await removeWithRetries(tmpDir);
 				if (originalProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
 				else Bun.env.GOOGLE_CLOUD_PROJECT = originalProject;
 				if (originalGcpProject === undefined) delete Bun.env.GCP_PROJECT;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exported `removeWithRetries()` as a standalone async function so tests with async cleanup hooks (`afterEach(async () => …)`) can use the same retry-on-EBUSY cleanup logic as `TempDir.remove()`. Previously only the sync variant was exported, forcing async tests to use `fs.rm` directly — which fails with EBUSY on Windows when SQLite database files are still locked.
+
 ## [16.1.8] - 2026-06-20
 
 ### Added

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -83,7 +83,7 @@ const kRemoveRetryDelayMs = 25;
 const kRetryableRemoveErrorCodes = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
 const kSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
 
-async function removeWithRetries(target: string): Promise<void> {
+export async function removeWithRetries(target: string): Promise<void> {
 	for (let attempt = 0; ; attempt++) {
 		try {
 			await fsPromises.rm(target, kRemoveOptions);


### PR DESCRIPTION
## Problem

The async `removeWithRetries` function in `packages/utils/src/temp.ts` was used internally by `TempDir.remove()` but **not exported**, while the sync variant (`removeSyncWithRetries`) was exported. This forced tests with async cleanup hooks to use `fs.rm` directly, which fails with EBUSY on Windows when SQLite database files are still locked by the process.

## Fix

### 1. Export `removeWithRetries` (packages/utils)
One-line change: `async function` → `export async function`. The function already exists and is used internally by `TempDir.remove()`; it wraps `fsPromises.rm` with 40 retries at 25ms intervals on Windows (EBUSY/EPERM/ENOTEMPTY).

### 2. Batch-migrate 24 test files (packages/ai/test/)
Replaced all `fs.rm`/`fs.rmSync` calls with `removeWithRetries`/`removeSyncWithRetries`:

| Category | Files | Calls replaced |
|---|---|---|
| auth-broker tests | 5 | 5 |
| auth-storage tests | 11 | 15 |
| non-auth ai tests | 6 | 6 |
| sync migration | 2 | 2 |
| **Total** | **24** | **28** |

The migration pattern:
```ts
// Before:
await fs.rm(tempDir, { recursive: true, force: true });

// After:
await removeWithRetries(tempDir);
```

## Impact

- Fixes ~22 EBUSY test failures on Windows across `packages/ai/test/`
- `auth-storage-email-dedupe.test.ts`: 14 failures → 0 (24/24 pass)
- `auth-storage-api-key-login.test.ts`: 5 failures → 0 (5/5 pass)
- Remaining `packages/ai` test failures are pre-existing Windows issues (AWS subprocess execution, file permission bits) unrelated to EBUSY

## Verification

- `bun check` passes
- Sample tests pass: `auth-storage-email-dedupe` (24/24), `auth-broker-refresher` (4/4), `auth-broker-wire` (all pass), `auth-storage-refresh-skew` (all pass)
- CI runs on Linux where EBUSY doesn't occur — all tests pass on Linux
