### PR TITLE
fix(utils): increase EBUSY retry delay from 25ms to 50ms (2s total window)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))
+
 ## [16.1.16] - 2026-06-23
 
 ### Breaking Changes

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Increased the EBUSY retry delay from 25ms to 50ms (40 retries × 50ms = 2s total window, up from 1s). Windows can hold file locks on SQLite databases for up to ~1.5s after `close()`, and the previous 1-second window was too short for some test cleanup scenarios — `settings-manager.test.ts` and `sdk-credential-disabled-bridge.test.ts` still failed with EBUSY even when using `removeSyncWithRetries`.
+
 ## [16.1.8] - 2026-06-20
 
 ### Added

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -79,7 +79,10 @@ function normalizePrefix(prefix?: string): string {
 
 const kRemoveOptions = { recursive: true, force: true } as const;
 const kRemoveRetries = 40;
-const kRemoveRetryDelayMs = 25;
+// 50ms × 40 retries = 2s total retry window. Windows holds file locks on
+// SQLite DBs for up to ~1.5s after close(); the previous 25ms (1s total)
+// was too short for some test cleanup scenarios.
+const kRemoveRetryDelayMs = 50;
 const kRetryableRemoveErrorCodes = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
 const kSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
 


### PR DESCRIPTION
## Problem

The retry-on-EBUSY logic in `removeSyncWithRetries`/`removeWithRetries` used 40 retries × 25ms = **1 second total**. Windows can hold file locks on SQLite databases for up to ~1.5s after `close()`, so tests that already used `removeSyncWithRetries` still failed with EBUSY:

```
(fail) Settings > defaults > keeps eight inline images live by default [1266.40ms]
error: EBUSY: resource busy or locked, rm 'C:\Users\james\AppData\Local\Temp\pi-settings-test-GmcF7o'
    at removeSyncWithRetries (C:\tmp\oh-my-pi\packages\utils\src\temp.ts:104:48)
```

## Fix

Increase the retry delay from 25ms to 50ms (40 × 50ms = **2 seconds total** window, up from 1 second).

This only affects Windows — the `shouldRetryRemove` function only retries when `process.platform === "win32"`. Linux CI is completely unaffected.

## Verification

- `bun check` passes
- The change is a single constant: `kRemoveRetryDelayMs = 25` → `kRemoveRetryDelayMs = 50`
