### PR TITLE
test(eval): increase Julia prelude test timeout to fix CI flake

### DIFF
--- a/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
@@ -9,7 +9,7 @@ const OWNER_ID = "julia-prelude-tests";
 describe.skipIf(!HAS_JULIA)("eval Julia prelude helpers", () => {
 	afterEach(async () => {
 		await disposeJuliaKernelSessionsByOwner(OWNER_ID);
-	});
+	}, 30_000);
 
 	it("supports output ranges, JSON queries, metadata, and ANSI stripping", async () => {
 		using tempDir = TempDir.createSync("@omp-eval-julia-output-");
@@ -44,5 +44,5 @@ nothing
 		expect(result.output).toContain("STRIPPED=red");
 		expect(result.output).toContain("META=alpha:true");
 		expect(result.output).toContain("MULTI=2:alpha:json");
-	}, 30_000);
+	}, 60_000);
 });


### PR DESCRIPTION
The Julia prelude test times out at 35s on CI because the test timeout (30s) and afterEach hook (default timeout) are too short for Julia kernel startup+shutdown on the CI runner. Increases the test timeout to 60s and adds an explicit 30s timeout to the afterEach hook. This is a pre-existing flaky test that also fails on PRs #3344 and #3346.