### PR TITLE
feat(coding-agent): add GitLab CLI tool

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3356,6 +3356,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"gitlab.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "GitLab CLI",
+			description:
+				"Enable the gitlab tool (op-based dispatch for project, issue, merge request, and CI/CD workflows through glab)",
+		},
+	},
+
 	"github.cache.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/prompts/tools/gitlab.md
+++ b/packages/coding-agent/src/prompts/tools/gitlab.md
@@ -1,0 +1,16 @@
+Op-based `glab` wrapper: repositories, issues, merge requests, and CI/CD pipeline status/listing.
+
+<instruction>
+Pick op via `op`. Beyond the field descriptions, per op:
+- `repo_view` — omit `repo` to view the current GitLab checkout; `repo` accepts `GROUP/PROJECT`, nested namespaces, full URL, or Git URL.
+- `issue_view` / `mr_view` — require `issue` or `mr`.
+- `issue_list` / `mr_list` — `query` maps to `glab --search`; `limit` maps to the first page via `--per-page` and is capped at 100; `state: "all"` includes all states.
+- `mr_create` — `head`/`sourceBranch` selects the source branch; `base`/`targetBranch` selects the target branch; `fill: true` uses commit history and pushes through glab.
+- `mr_checkout` — checks out an open merge request in the current worktree; use `branch` to override the local branch name.
+- `pipeline_status` — reads current/latest pipeline status; `branch` selects the ref.
+- `pipeline_list` — lists pipelines; `branch` maps to `--ref`, and `status` maps to GitLab pipeline status.
+</instruction>
+
+<output>
+Concise markdown summary per op with source URLs when `glab` returns them.
+</output>

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -9,6 +9,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"eval",
 	"ssh",
 	"github",
+	"gitlab",
 	"find",
 	"search",
 	"lsp",

--- a/packages/coding-agent/src/tools/gitlab-renderer.ts
+++ b/packages/coding-agent/src/tools/gitlab-renderer.ts
@@ -1,0 +1,97 @@
+import { type Component, Text } from "@oh-my-pi/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import { renderStatusLine } from "../tui";
+import { formatErrorDetail, replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "./render-utils";
+
+type GitlabToolRenderArgs = {
+	op?: string;
+	repo?: string;
+	branch?: string;
+	issue?: string;
+	mr?: string;
+	query?: string;
+	title?: string;
+	status?: string;
+};
+
+const OP_TITLES: Record<string, string> = {
+	repo_view: "GitLab Repo",
+	issue_view: "GitLab Issue",
+	mr_view: "GitLab MR",
+	issue_list: "GitLab Issues",
+	mr_list: "GitLab MRs",
+	mr_create: "GitLab MR Create",
+	mr_checkout: "GitLab MR Checkout",
+	pipeline_status: "GitLab Pipeline Status",
+	pipeline_list: "GitLab Pipelines",
+};
+
+function formatOpTitle(op: string | undefined): string {
+	if (!op) return "GitLab";
+	return OP_TITLES[op] ?? `GitLab ${op.replaceAll("_", " ")}`;
+}
+
+function buildMeta(args: GitlabToolRenderArgs | undefined): string[] {
+	const meta: string[] = [];
+	if (!args) return meta;
+	for (const value of [args.repo, args.branch, args.issue, args.mr, args.status]) {
+		if (value) meta.push(truncateToWidth(value, TRUNCATE_LENGTHS.SHORT));
+	}
+	if (args.query) meta.push(truncateToWidth(args.query, TRUNCATE_LENGTHS.CONTENT));
+	if (args.title) meta.push(truncateToWidth(args.title, TRUNCATE_LENGTHS.CONTENT));
+	return meta;
+}
+
+function extractText(content: Array<{ type: string; text?: string }>): string {
+	const parts: string[] = [];
+	for (const item of content) {
+		if (item.type === "text" && item.text) parts.push(item.text);
+	}
+	return parts.join("\n").trim();
+}
+
+function renderPreview(text: string, theme: Theme, maxLines: number): string[] {
+	return text
+		.split("\n")
+		.filter(line => line.trim().length > 0)
+		.slice(0, maxLines)
+		.map(line => theme.fg("toolOutput", truncateToWidth(replaceTabs(line), TRUNCATE_LENGTHS.LINE)));
+}
+
+export const gitlabToolRenderer = {
+	renderCall(args: GitlabToolRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
+		const header = renderStatusLine(
+			{
+				icon: options.spinnerFrame !== undefined ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: formatOpTitle(args?.op),
+				meta: buildMeta(args),
+			},
+			uiTheme,
+		);
+		return new Text(header, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: GitlabToolRenderArgs,
+	): Component {
+		const text = extractText(result.content);
+		const header = renderStatusLine(
+			result.isError
+				? { icon: "error", title: formatOpTitle(args?.op), meta: buildMeta(args) }
+				: {
+						iconOverride: uiTheme.styledSymbol("tool.gh", "accent"),
+						title: formatOpTitle(args?.op),
+						meta: buildMeta(args),
+					},
+			uiTheme,
+		);
+		if (!text) return new Text(header, 0, 0);
+		if (result.isError) return new Text([header, formatErrorDetail(text, uiTheme)].join("\n"), 0, 0);
+		return new Text([header, ...renderPreview(text, uiTheme, options.expanded ? 12 : 4)].join("\n"), 0, 0);
+	},
+};

--- a/packages/coding-agent/src/tools/gitlab.ts
+++ b/packages/coding-agent/src/tools/gitlab.ts
@@ -1,0 +1,601 @@
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ToolApprovalDecision,
+} from "@oh-my-pi/pi-agent-core";
+import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import gitlabDescription from "../prompts/tools/gitlab.md" with { type: "text" };
+import * as git from "../utils/git";
+import type { ToolSession } from ".";
+import type { OutputMeta } from "./output-meta";
+import { ToolError } from "./tool-errors";
+import { toolResult } from "./tool-result";
+
+const GITLAB_READONLY_OPS: Record<string, true> = {
+	repo_view: true,
+	issue_view: true,
+	mr_view: true,
+	issue_list: true,
+	mr_list: true,
+	pipeline_status: true,
+	pipeline_list: true,
+};
+
+const gitlabSchema = type({
+	op: type(
+		"'repo_view' | 'issue_view' | 'mr_view' | 'issue_list' | 'mr_list' | 'mr_create' | 'mr_checkout' | 'pipeline_status' | 'pipeline_list'",
+	).describe("gitlab operation"),
+	"repo?": type("string").describe("group/project, full URL, or Git URL"),
+	"branch?": type("string").describe("branch or ref"),
+	"issue?": type("string").describe("issue id or URL"),
+	"mr?": type("string").describe("merge request id, URL, or branch"),
+	"state?": type("'opened' | 'closed' | 'merged' | 'all'").describe("issue or merge request state"),
+	"query?": type("string").describe("list search query"),
+	"limit?": type("number").describe("max first-page results, capped at 100"),
+	"label?": type("string[]").describe("labels"),
+	"assignee?": type("string[]").describe("assignees"),
+	"reviewer?": type("string[]").describe("reviewers"),
+	"author?": type("string").describe("author username"),
+	"sourceBranch?": type("string").describe("merge request source branch"),
+	"targetBranch?": type("string").describe("merge request target branch"),
+	"title?": type("string").describe("merge request title"),
+	"body?": type("string").describe("merge request description"),
+	"base?": type("string").describe("target branch alias"),
+	"head?": type("string").describe("source branch alias"),
+	"draft?": type("boolean").describe("create draft merge request"),
+	"fill?": type("boolean").describe("auto-fill merge request from commits"),
+	"force?": type("boolean").describe("force checkout reset"),
+	"status?": type("string").describe("pipeline status filter"),
+	"sha?": type("string").describe("commit SHA filter"),
+});
+
+type GitlabInput = typeof gitlabSchema.infer;
+
+export interface GitlabToolDetails {
+	meta?: OutputMeta;
+	artifactId?: string;
+	repo?: string;
+	branch?: string;
+	issueId?: string;
+	mrId?: string;
+	status?: string;
+	url?: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : undefined;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function requireNonEmpty(value: string | null | undefined, label: string): string {
+	const trimmed = normalizeOptionalString(value);
+	if (!trimmed) throw new ToolError(`${label} is required`);
+	return trimmed;
+}
+
+function requireSafePositional(value: string, label: string): string {
+	if (value.startsWith("-")) throw new ToolError(`${label} must not start with '-'`);
+	return value;
+}
+
+function readString(value: unknown, keys: readonly string[]): string | undefined {
+	const record = asRecord(value);
+	if (!record) return undefined;
+	for (const key of keys) {
+		const raw = record[key];
+		if (typeof raw === "string") {
+			const trimmed = raw.trim();
+			if (trimmed) return trimmed;
+		}
+		if (typeof raw === "number" && Number.isFinite(raw)) return String(raw);
+		if (typeof raw === "boolean") return String(raw);
+	}
+	return undefined;
+}
+
+function readNumber(value: unknown, keys: readonly string[]): number | undefined {
+	const record = asRecord(value);
+	if (!record) return undefined;
+	for (const key of keys) {
+		const raw = record[key];
+		if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+		if (typeof raw === "string") {
+			const parsed = Number(raw);
+			if (Number.isFinite(parsed)) return parsed;
+		}
+	}
+	return undefined;
+}
+
+function formatUser(value: unknown): string | undefined {
+	if (typeof value === "string") return normalizeOptionalString(value);
+	return readString(value, ["username", "login", "name"]);
+}
+
+function formatUsers(value: unknown): string | undefined {
+	if (!Array.isArray(value)) return formatUser(value);
+	const users = value.map(formatUser).filter((user): user is string => Boolean(user));
+	return users.length > 0 ? users.join(", ") : undefined;
+}
+
+function formatLabels(value: unknown): string | undefined {
+	if (typeof value === "string") return normalizeOptionalString(value);
+	if (!Array.isArray(value)) return undefined;
+	const labels = value
+		.map(label => (typeof label === "string" ? label : readString(label, ["name", "title"])))
+		.filter((label): label is string => Boolean(label));
+	return labels.length > 0 ? labels.join(", ") : undefined;
+}
+
+function pushLine(lines: string[], label: string, value: string | number | boolean | undefined): void {
+	if (value === undefined || value === "") return;
+	lines.push(`${label}: ${value}`);
+}
+
+function appendBody(lines: string[], value: string | undefined): void {
+	const body = normalizeOptionalString(value);
+	if (!body) return;
+	lines.push("", body);
+}
+
+function sourceUrlOf(data: unknown): string | undefined {
+	return readString(data, ["web_url", "webUrl", "url", "http_url_to_repo", "httpUrlToRepo"]);
+}
+
+function formatRepoView(data: unknown): string {
+	const title = readString(data, [
+		"path_with_namespace",
+		"pathWithNamespace",
+		"full_path",
+		"fullPath",
+		"name_with_owner",
+		"name",
+		"path",
+	]);
+	const lines = [`# ${title ?? "GitLab project"}`];
+	pushLine(lines, "Description", readString(data, ["description"]));
+	pushLine(lines, "URL", sourceUrlOf(data));
+	pushLine(lines, "Default branch", readString(data, ["default_branch", "defaultBranch"]));
+	pushLine(lines, "Visibility", readString(data, ["visibility"]));
+	pushLine(lines, "Stars", readNumber(data, ["star_count", "starCount", "stars"]));
+	pushLine(lines, "Forks", readNumber(data, ["forks_count", "forksCount", "forks"]));
+	pushLine(lines, "Open issues", readNumber(data, ["open_issues_count", "openIssuesCount"]));
+	pushLine(lines, "Archived", readString(data, ["archived"]));
+	pushLine(
+		lines,
+		"Last activity",
+		readString(data, ["last_activity_at", "lastActivityAt", "updated_at", "updatedAt"]),
+	);
+	return lines.join("\n");
+}
+
+function formatIssueView(data: unknown): string {
+	const number = readString(data, ["iid", "number", "id"]);
+	const title = readString(data, ["title"]);
+	const lines = [`# GitLab issue ${number ? `#${number}` : ""}${title ? `: ${title}` : ""}`.trimEnd()];
+	pushLine(lines, "State", readString(data, ["state"]));
+	pushLine(lines, "Author", formatUser(asRecord(data)?.author));
+	pushLine(lines, "Assignees", formatUsers(asRecord(data)?.assignees));
+	pushLine(lines, "Labels", formatLabels(asRecord(data)?.labels));
+	pushLine(lines, "Created", readString(data, ["created_at", "createdAt"]));
+	pushLine(lines, "Updated", readString(data, ["updated_at", "updatedAt"]));
+	pushLine(lines, "URL", sourceUrlOf(data));
+	appendBody(lines, readString(data, ["description", "body"]));
+	return lines.join("\n");
+}
+
+function formatMergeRequestView(data: unknown, heading = "GitLab merge request"): string {
+	const number = readString(data, ["iid", "number", "id"]);
+	const title = readString(data, ["title"]);
+	const lines = [`# ${heading} ${number ? `!${number}` : ""}${title ? `: ${title}` : ""}`.trimEnd()];
+	pushLine(lines, "State", readString(data, ["state"]));
+	pushLine(lines, "Draft", readString(data, ["draft", "work_in_progress", "workInProgress"]));
+	pushLine(lines, "Author", formatUser(asRecord(data)?.author));
+	pushLine(lines, "Assignees", formatUsers(asRecord(data)?.assignees));
+	pushLine(lines, "Reviewers", formatUsers(asRecord(data)?.reviewers));
+	pushLine(lines, "Labels", formatLabels(asRecord(data)?.labels));
+	pushLine(lines, "Source", readString(data, ["source_branch", "sourceBranch"]));
+	pushLine(lines, "Target", readString(data, ["target_branch", "targetBranch"]));
+	pushLine(lines, "Created", readString(data, ["created_at", "createdAt"]));
+	pushLine(lines, "Updated", readString(data, ["updated_at", "updatedAt"]));
+	pushLine(lines, "URL", sourceUrlOf(data));
+	appendBody(lines, readString(data, ["description", "body"]));
+	return lines.join("\n");
+}
+
+function extractItems(value: unknown): unknown[] {
+	if (Array.isArray(value)) return value;
+	const record = asRecord(value);
+	if (!record) return [];
+	for (const key of ["items", "data", "issues", "merge_requests", "mergeRequests", "pipelines"]) {
+		const raw = record[key];
+		if (Array.isArray(raw)) return raw;
+	}
+	return [];
+}
+
+function formatIssueListItem(item: unknown): string[] {
+	const number = readString(item, ["iid", "number", "id"]);
+	const title = readString(item, ["title"]) ?? "(untitled)";
+	const lines = [`- ${number ? `#${number} ` : ""}${title}`];
+	pushLine(lines, "  State", readString(item, ["state"]));
+	pushLine(lines, "  Author", formatUser(asRecord(item)?.author));
+	pushLine(lines, "  Assignees", formatUsers(asRecord(item)?.assignees));
+	pushLine(lines, "  Labels", formatLabels(asRecord(item)?.labels));
+	pushLine(lines, "  Updated", readString(item, ["updated_at", "updatedAt"]));
+	pushLine(lines, "  URL", sourceUrlOf(item));
+	return lines;
+}
+
+function formatMrListItem(item: unknown): string[] {
+	const number = readString(item, ["iid", "number", "id"]);
+	const title = readString(item, ["title"]) ?? "(untitled)";
+	const lines = [`- ${number ? `!${number} ` : ""}${title}`];
+	pushLine(lines, "  State", readString(item, ["state"]));
+	pushLine(lines, "  Draft", readString(item, ["draft", "work_in_progress", "workInProgress"]));
+	pushLine(lines, "  Author", formatUser(asRecord(item)?.author));
+	pushLine(lines, "  Reviewers", formatUsers(asRecord(item)?.reviewers));
+	pushLine(lines, "  Labels", formatLabels(asRecord(item)?.labels));
+	pushLine(lines, "  Source", readString(item, ["source_branch", "sourceBranch"]));
+	pushLine(lines, "  Target", readString(item, ["target_branch", "targetBranch"]));
+	pushLine(lines, "  Updated", readString(item, ["updated_at", "updatedAt"]));
+	pushLine(lines, "  URL", sourceUrlOf(item));
+	return lines;
+}
+
+function formatListResults(
+	title: string,
+	params: GitlabInput,
+	data: unknown,
+	itemFormatter: (item: unknown) => string[],
+): string {
+	const items = extractItems(data);
+	const lines = [`# ${title}`];
+	pushLine(lines, "Query", normalizeOptionalString(params.query));
+	pushLine(lines, "Repository", normalizeOptionalString(params.repo));
+	pushLine(lines, "State", normalizeOptionalString(params.state));
+	if (items.length === 0) {
+		lines.push("", "No results.");
+		return lines.join("\n");
+	}
+	lines.push("");
+	for (const item of items) {
+		lines.push(...itemFormatter(item));
+	}
+	return lines.join("\n");
+}
+
+function formatPipelineItem(item: unknown): string[] {
+	const id = readString(item, ["id", "iid"]);
+	const status = readString(item, ["status"]);
+	const ref = readString(item, ["ref", "branch"]);
+	const sha = readString(item, ["sha"]);
+	const lines = [`- ${id ? `#${id}` : "Pipeline"}${status ? ` ${status}` : ""}`];
+	pushLine(lines, "  Ref", ref);
+	pushLine(lines, "  SHA", sha ? sha.slice(0, 12) : undefined);
+	pushLine(lines, "  Updated", readString(item, ["updated_at", "updatedAt"]));
+	pushLine(lines, "  URL", sourceUrlOf(item));
+	return lines;
+}
+
+function formatPipelineStatus(data: unknown, params: GitlabInput): string {
+	const items = extractItems(data);
+	if (items.length > 0) return formatListResults("GitLab pipeline status", params, items, formatPipelineItem);
+	const lines = ["# GitLab pipeline status"];
+	pushLine(lines, "Status", readString(data, ["status"]));
+	pushLine(lines, "Ref", readString(data, ["ref", "branch"]));
+	pushLine(lines, "SHA", readString(data, ["sha"]));
+	pushLine(lines, "URL", sourceUrlOf(data));
+	return lines.join("\n");
+}
+
+function buildTextResult(
+	text: string,
+	sourceUrl?: string,
+	details?: GitlabToolDetails,
+): AgentToolResult<GitlabToolDetails> {
+	const builder = toolResult<GitlabToolDetails>(details).text(text);
+	if (sourceUrl) builder.sourceUrl(sourceUrl);
+	return builder.done();
+}
+
+function appendRepoFlag(args: string[], repo: string | undefined): void {
+	if (repo) args.push("--repo", repo);
+}
+
+function normalizeStringList(values: string[] | undefined): string[] {
+	return values?.map(value => value.trim()).filter(Boolean) ?? [];
+}
+
+function appendCsvFlag(args: string[], flag: string, values: string[] | undefined): void {
+	const normalized = normalizeStringList(values);
+	if (normalized.length > 0) args.push(flag, normalized.join(","));
+}
+
+function appendFirstStringFlag(args: string[], flag: string, values: string[] | undefined): void {
+	const [first] = normalizeStringList(values);
+	if (first) args.push(flag, first);
+}
+
+function appendScalarFlag(args: string[], flag: string, value: string | undefined): void {
+	if (value) args.push(flag, value);
+}
+
+function appendLimit(args: string[], limit: number | undefined): void {
+	if (limit === undefined) return;
+	if (!Number.isFinite(limit) || limit <= 0) throw new ToolError("limit must be a positive number");
+	args.push("--per-page", String(Math.floor(Math.min(limit, 100))));
+}
+
+function appendIssueState(args: string[], state: GitlabInput["state"]): void {
+	if (!state || state === "opened") return;
+	if (state === "all") {
+		args.push("--all");
+		return;
+	}
+	if (state === "closed") {
+		args.push("--closed");
+		return;
+	}
+	throw new ToolError("issue_list does not support state 'merged'");
+}
+
+function appendMrState(args: string[], state: GitlabInput["state"]): void {
+	if (!state || state === "opened") return;
+	if (state === "all") args.push("--all");
+	else if (state === "closed") args.push("--closed");
+	else if (state === "merged") args.push("--merged");
+}
+
+function extractMrIdFromCreateOutput(output: string): string | undefined {
+	return output.match(/\/-\/merge_requests\/(\d+)/)?.[1] ?? output.match(/!(\d+)\b/)?.[1];
+}
+
+export class GitlabTool implements AgentTool<typeof gitlabSchema, GitlabToolDetails> {
+	readonly name = "gitlab";
+	readonly approval = (args: unknown): ToolApprovalDecision => {
+		const rawOp = (args as Partial<GitlabInput>).op;
+		const op = typeof rawOp === "string" ? rawOp : "";
+		return GITLAB_READONLY_OPS[op] ? "read" : "exec";
+	};
+	readonly summary = "Interact with GitLab issues, merge requests, projects, and CI/CD";
+	readonly loadMode = "discoverable";
+	readonly label = "GitLab";
+	readonly description = prompt.render(gitlabDescription);
+	readonly parameters = gitlabSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	static createIf(session: ToolSession): GitlabTool | null {
+		if (!git.gitlab.available()) return null;
+		return new GitlabTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: GitlabInput,
+		signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<GitlabToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<GitlabToolDetails>> {
+		return untilAborted(signal, async () => {
+			switch (params.op) {
+				case "repo_view":
+					return executeRepoView(this.session, params, signal);
+				case "issue_view":
+					return executeIssueView(this.session, params, signal);
+				case "mr_view":
+					return executeMrView(this.session, params, signal);
+				case "issue_list":
+					return executeIssueList(this.session, params, signal);
+				case "mr_list":
+					return executeMrList(this.session, params, signal);
+				case "mr_create":
+					return executeMrCreate(this.session, params, signal);
+				case "mr_checkout":
+					return executeMrCheckout(this.session, params, signal);
+				case "pipeline_status":
+					return executePipelineStatus(this.session, params, signal);
+				case "pipeline_list":
+					return executePipelineList(this.session, params, signal);
+			}
+		});
+	}
+}
+
+async function executeRepoView(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const branch = normalizeOptionalString(params.branch);
+	const args = ["repo", "view"];
+	if (repo) args.push(requireSafePositional(repo, "repo"));
+	appendScalarFlag(args, "--branch", branch);
+	args.push("--output", "json");
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	const sourceUrl = sourceUrlOf(data);
+	return buildTextResult(formatRepoView(data), sourceUrl, { repo, branch, url: sourceUrl });
+}
+
+async function executeIssueView(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const issue = requireSafePositional(requireNonEmpty(params.issue, "issue"), "issue");
+	const args = ["issue", "view", issue, "--output", "json"];
+	appendRepoFlag(args, repo);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	const sourceUrl = sourceUrlOf(data);
+	return buildTextResult(formatIssueView(data), sourceUrl, { repo, issueId: issue, url: sourceUrl });
+}
+
+async function executeMrView(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const mr = requireSafePositional(requireNonEmpty(params.mr, "mr"), "mr");
+	const args = ["mr", "view", mr, "--output", "json"];
+	appendRepoFlag(args, repo);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	const sourceUrl = sourceUrlOf(data);
+	return buildTextResult(formatMergeRequestView(data), sourceUrl, { repo, mrId: mr, url: sourceUrl });
+}
+
+async function executeIssueList(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const args = ["issue", "list", "--output", "json"];
+	appendRepoFlag(args, repo);
+	appendIssueState(args, params.state);
+	appendScalarFlag(args, "--search", normalizeOptionalString(params.query));
+	appendScalarFlag(args, "--author", normalizeOptionalString(params.author));
+	appendFirstStringFlag(args, "--assignee", params.assignee);
+	appendCsvFlag(args, "--label", params.label);
+	appendLimit(args, params.limit);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	return buildTextResult(formatListResults("GitLab issues", params, data, formatIssueListItem), undefined, { repo });
+}
+
+async function executeMrList(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const args = ["mr", "list", "--output", "json"];
+	appendRepoFlag(args, repo);
+	appendMrState(args, params.state);
+	appendScalarFlag(args, "--search", normalizeOptionalString(params.query));
+	appendScalarFlag(args, "--author", normalizeOptionalString(params.author));
+	appendCsvFlag(args, "--assignee", params.assignee);
+	appendCsvFlag(args, "--reviewer", params.reviewer);
+	appendCsvFlag(args, "--label", params.label);
+	appendScalarFlag(args, "--source-branch", normalizeOptionalString(params.sourceBranch ?? params.head));
+	appendScalarFlag(args, "--target-branch", normalizeOptionalString(params.targetBranch ?? params.base));
+	appendLimit(args, params.limit);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	return buildTextResult(formatListResults("GitLab merge requests", params, data, formatMrListItem), undefined, {
+		repo,
+	});
+}
+
+async function executeMrCreate(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const title = normalizeOptionalString(params.title);
+	const body = params.body ?? "";
+	if (!params.fill && !title) throw new ToolError("title is required unless fill is true");
+
+	const args = ["mr", "create", "--yes"];
+	appendRepoFlag(args, repo);
+	if (params.fill) {
+		args.push("--fill");
+	} else {
+		args.push("--title", title ?? "", "--description", body);
+	}
+	appendScalarFlag(args, "--source-branch", normalizeOptionalString(params.sourceBranch ?? params.head));
+	appendScalarFlag(args, "--target-branch", normalizeOptionalString(params.targetBranch ?? params.base));
+	appendCsvFlag(args, "--assignee", params.assignee);
+	appendCsvFlag(args, "--reviewer", params.reviewer);
+	appendCsvFlag(args, "--label", params.label);
+	if (params.draft) args.push("--draft");
+
+	const output = await git.gitlab.text(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	const mrId = extractMrIdFromCreateOutput(output);
+	if (mrId) {
+		try {
+			const viewArgs = ["mr", "view", mrId, "--output", "json"];
+			appendRepoFlag(viewArgs, repo);
+			const data = await git.gitlab.json<unknown>(session.cwd, viewArgs, signal, { repoProvided: Boolean(repo) });
+			const sourceUrl = sourceUrlOf(data) ?? sourceUrlOf({ web_url: output.match(/https?:\/\/\S+/)?.[0] });
+			return buildTextResult(formatMergeRequestView(data, "Created GitLab merge request"), sourceUrl, {
+				repo,
+				mrId,
+				url: sourceUrl,
+			});
+		} catch {
+			// Creation already succeeded; keep the useful URL instead of failing the whole tool on a follow-up view miss.
+		}
+	}
+	const sourceUrl = output.match(/https?:\/\/\S+/)?.[0];
+	return buildTextResult(`# Created GitLab merge request\n${output}`, sourceUrl, { repo, mrId, url: sourceUrl });
+}
+
+async function executeMrCheckout(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const mr = normalizeOptionalString(params.mr);
+	const branch = normalizeOptionalString(params.branch);
+	const args = ["mr", "checkout"];
+	if (mr) args.push(requireSafePositional(mr, "mr"));
+	appendScalarFlag(args, "--branch", branch);
+	if (params.force) args.push("--force");
+	appendRepoFlag(args, repo);
+	const output = await git.gitlab.text(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	return buildTextResult(`# GitLab merge request checkout\n${output}`, undefined, { repo, branch, mrId: mr });
+}
+
+async function executePipelineStatus(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const branch = normalizeOptionalString(params.branch);
+	const args = ["ci", "status", "--output", "json"];
+	appendScalarFlag(args, "--branch", branch);
+	appendRepoFlag(args, repo);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	return buildTextResult(formatPipelineStatus(data, params), sourceUrlOf(data), {
+		repo,
+		branch,
+		status: readString(data, ["status"]),
+		url: sourceUrlOf(data),
+	});
+}
+
+async function executePipelineList(
+	session: ToolSession,
+	params: GitlabInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GitlabToolDetails>> {
+	const repo = normalizeOptionalString(params.repo);
+	const branch = normalizeOptionalString(params.branch);
+	const args = ["ci", "list", "--output", "json"];
+	appendRepoFlag(args, repo);
+	appendScalarFlag(args, "--ref", branch);
+	appendScalarFlag(args, "--status", normalizeOptionalString(params.status));
+	appendScalarFlag(args, "--sha", normalizeOptionalString(params.sha));
+	appendLimit(args, params.limit);
+	const data = await git.gitlab.json<unknown>(session.cwd, args, signal, { repoProvided: Boolean(repo) });
+	return buildTextResult(formatListResults("GitLab pipelines", params, data, formatPipelineItem), undefined, {
+		repo,
+		branch,
+		status: normalizeOptionalString(params.status),
+	});
+}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -46,6 +46,7 @@ import { EvalTool } from "./eval";
 import { resolveEvalBackends } from "./eval-backends";
 import { FindTool } from "./find";
 import { GithubTool } from "./gh";
+import { GitlabTool } from "./gitlab";
 import { InspectImageTool } from "./inspect-image";
 import { IrcTool, isIrcEnabled } from "./irc";
 import { JobTool } from "./job";
@@ -84,6 +85,7 @@ export * from "./eval";
 export * from "./eval-backends";
 export * from "./find";
 export * from "./gh";
+export * from "./gitlab";
 export * from "./image-gen";
 export * from "./inspect-image";
 export * from "./irc";
@@ -447,6 +449,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	eval: s => new EvalTool(s),
 	ssh: loadSshTool,
 	github: GithubTool.createIf,
+	gitlab: GitlabTool.createIf,
 	find: s => new FindTool(s),
 	search: s => new SearchTool(s),
 	lsp: LspTool.createIf,
@@ -603,6 +606,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "find") return session.settings.get("find.enabled");
 		if (name === "search") return session.settings.get("search.enabled");
 		if (name === "github") return session.settings.get("github.enabled");
+		if (name === "gitlab") return session.settings.get("gitlab.enabled");
 		if (name === "ast_grep") return session.settings.get("astGrep.enabled");
 		if (name === "ast_edit") return session.settings.get("astEdit.enabled");
 		if (name === "inspect_image") return session.settings.get("inspect_image.enabled");

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -20,6 +20,7 @@ import { debugToolRenderer } from "./debug";
 import { evalToolRenderer } from "./eval-render";
 import { findToolRenderer } from "./find";
 import { githubToolRenderer } from "./gh-renderer";
+import { gitlabToolRenderer } from "./gitlab-renderer";
 import { inspectImageToolRenderer } from "./inspect-image-renderer";
 import { ircToolRenderer } from "./irc";
 import { jobToolRenderer } from "./job";
@@ -80,6 +81,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	task: taskToolRenderer as ToolRenderer,
 	todo: todoToolRenderer as ToolRenderer,
 	github: githubToolRenderer as ToolRenderer,
+	gitlab: gitlabToolRenderer as ToolRenderer,
 	goal: goalToolRenderer as ToolRenderer,
 	web_search: webSearchToolRenderer as ToolRenderer,
 	write: writeToolRenderer as ToolRenderer,

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1837,3 +1837,118 @@ export const github = {
 		return result.stdout;
 	},
 };
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: gitlab (GitLab CLI)
+// ════════════════════════════════════════════════════════════════════════════
+
+export interface GlabCommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface GlabCommandOptions {
+	repoProvided?: boolean;
+	trimOutput?: boolean;
+}
+
+function formatGlabFailure(
+	args: readonly string[],
+	stdout: string,
+	stderr: string,
+	options?: GlabCommandOptions,
+): string {
+	const message = (stderr || stdout).trim();
+	if (
+		message.includes("glab auth login") ||
+		message.includes("not authenticated") ||
+		message.includes("No token provided")
+	) {
+		return "GitLab CLI is not authenticated. Run `glab auth login`.";
+	}
+	if (
+		!options?.repoProvided &&
+		(message.includes("not a git repository") ||
+			message.includes("no git remotes found") ||
+			message.includes("could not find any gitlab remotes") ||
+			message.includes("unable to determine current repository"))
+	) {
+		return "GitLab repository context is unavailable. Pass `repo` explicitly or run the tool inside a GitLab checkout.";
+	}
+	if (message.length > 0) return message;
+	return `GitLab CLI command failed: glab ${args.join(" ")}`;
+}
+
+export const gitlab = {
+	/** Check if `glab` CLI is installed. */
+	available(): boolean {
+		return Boolean($which("glab"));
+	},
+
+	/** Run a raw `glab` CLI command. Does not throw on non-zero exit. */
+	async run(
+		cwd: string,
+		args: string[],
+		signal?: AbortSignal,
+		options?: GlabCommandOptions,
+	): Promise<GlabCommandResult> {
+		throwIfAborted(signal);
+		if (!$which("glab")) {
+			throw new ToolError("GitLab CLI (glab) is not installed. Install it from https://gitlab.com/gitlab-org/cli.");
+		}
+		try {
+			const child = Bun.spawn(["glab", ...args], {
+				cwd,
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+				windowsHide: true,
+				signal,
+			});
+			if (!child.stdout || !child.stderr) {
+				throw new ToolError("Failed to capture GitLab CLI output.");
+			}
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+			throwIfAborted(signal);
+			const trim = options?.trimOutput !== false;
+			return {
+				exitCode: exitCode ?? 0,
+				stdout: trim ? stdout.trim() : stdout,
+				stderr: trim ? stderr.trim() : stderr,
+			};
+		} catch (error) {
+			if (signal?.aborted) throw new ToolAbortError();
+			throw error;
+		}
+	},
+
+	/** Run `glab` and parse stdout as JSON. Throws on non-zero exit or invalid JSON. */
+	async json<T>(cwd: string, args: string[], signal?: AbortSignal, options?: GlabCommandOptions): Promise<T> {
+		const result = await gitlab.run(cwd, args, signal, options);
+		if (result.exitCode !== 0) {
+			throw new ToolError(formatGlabFailure(args, result.stdout, result.stderr, options));
+		}
+		if (!result.stdout) {
+			throw new ToolError("GitLab CLI returned empty output.");
+		}
+		try {
+			return JSON.parse(result.stdout) as T;
+		} catch {
+			throw new ToolError("GitLab CLI returned invalid JSON output.");
+		}
+	},
+
+	/** Run `glab` and return stdout as text. Throws on non-zero exit. */
+	async text(cwd: string, args: string[], signal?: AbortSignal, options?: GlabCommandOptions): Promise<string> {
+		const result = await gitlab.run(cwd, args, signal, options);
+		if (result.exitCode !== 0) {
+			throw new ToolError(formatGlabFailure(args, result.stdout, result.stderr, options));
+		}
+		return result.stdout;
+	},
+};

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -8,6 +8,7 @@ import {
 	createTools,
 	DEFAULT_ESSENTIAL_TOOL_NAMES,
 	filterInitialToolsForDiscoveryAll,
+	GitlabTool,
 	IrcTool,
 	JobTool,
 	SshTool,
@@ -20,6 +21,7 @@ const allToolsSettings = Settings.isolated({
 	"find.enabled": true,
 	"search.enabled": true,
 	"github.enabled": true,
+	"gitlab.enabled": true,
 	"lsp.enabled": true,
 	"inspect_image.enabled": true,
 	"web_search.enabled": true,
@@ -48,6 +50,7 @@ async function getToolMetadata(): Promise<Map<string, { loadMode?: string; summa
 	for (const tool of [
 		new AskTool({ ...toolSession, hasUI: true }),
 		new SshTool(toolSession, [], new Map(), ""),
+		new GitlabTool(toolSession),
 		new JobTool(toolSession),
 		new IrcTool(toolSession),
 	]) {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -813,7 +813,9 @@ describe("github tool", () => {
 			const cfg = runGit(fixture.repoRoot, ["config", "--get-regexp", "^branch\\.pr-123\\."]);
 			expect(cfg).toContain("branch.pr-123.pushremote forksrc");
 			expect(cfg).toContain(`branch.pr-123.merge refs/heads/${fixture.headRefName}`);
-			expect(runGit(fixture.repoRoot, ["worktree", "list", "--porcelain"])).toContain(`worktree ${worktreePath}`);
+			expect(runGit(fixture.repoRoot, ["worktree", "list", "--porcelain"]).replaceAll("\\", "/")).toContain(
+				`worktree ${worktreePath.replaceAll("\\", "/")}`,
+			);
 			expect(runGit(worktreePath, ["branch", "--show-current"])).toBe("pr-123");
 		});
 	});

--- a/packages/coding-agent/test/tools/gitlab.test.ts
+++ b/packages/coding-agent/test/tools/gitlab.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { GitlabTool } from "@oh-my-pi/pi-coding-agent/tools/gitlab";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+
+function createSession(cwd: string = "/tmp/test"): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		settings: Settings.isolated({ "gitlab.enabled": true }),
+	};
+}
+
+describe("gitlab tool", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("formats repository metadata and calls glab repo view with JSON output", async () => {
+		const jsonSpy = vi.spyOn(git.gitlab, "json").mockResolvedValue({
+			path_with_namespace: "group/project",
+			description: "Project description",
+			web_url: "https://gitlab.com/group/project",
+			default_branch: "main",
+			visibility: "public",
+			star_count: 42,
+			forks_count: 7,
+			open_issues_count: 3,
+			last_activity_at: "2026-06-01T12:00:00Z",
+		});
+
+		const tool = new GitlabTool(createSession());
+		const result = await tool.execute("repo-view", { op: "repo_view", repo: "group/project", branch: "main" });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(jsonSpy).toHaveBeenCalledWith(
+			"/tmp/test",
+			["repo", "view", "group/project", "--branch", "main", "--output", "json"],
+			undefined,
+			{ repoProvided: true },
+		);
+		expect(text).toContain("# group/project");
+		expect(text).toContain("Project description");
+		expect(text).toContain("Default branch: main");
+		expect(text).toContain("Stars: 42");
+	});
+
+	it("lists issues with repo, search, state, labels, and limit flags", async () => {
+		const jsonSpy = vi.spyOn(git.gitlab, "json").mockResolvedValue([
+			{
+				iid: 12,
+				title: "Fix bug",
+				state: "closed",
+				author: { username: "dev1" },
+				labels: ["bug", "backend"],
+				web_url: "https://gitlab.com/group/project/-/issues/12",
+			},
+		]);
+
+		const tool = new GitlabTool(createSession());
+		const result = await tool.execute("issue-list", {
+			op: "issue_list",
+			repo: "group/project",
+			query: "bug",
+			state: "closed",
+			label: ["bug"],
+			assignee: ["alice", "bob"],
+			limit: 2,
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(jsonSpy).toHaveBeenCalledWith(
+			"/tmp/test",
+			[
+				"issue",
+				"list",
+				"--output",
+				"json",
+				"--repo",
+				"group/project",
+				"--closed",
+				"--search",
+				"bug",
+				"--assignee",
+				"alice",
+				"--label",
+				"bug",
+				"--per-page",
+				"2",
+			],
+			undefined,
+			{ repoProvided: true },
+		);
+		expect(text).toContain("# GitLab issues");
+		expect(text).toContain("Query: bug");
+		expect(text).toContain("- #12 Fix bug");
+		expect(text).toContain("  Labels: bug, backend");
+	});
+
+	it("creates merge requests non-interactively and re-reads the created MR", async () => {
+		const textCalls: string[][] = [];
+		vi.spyOn(git.gitlab, "text").mockImplementation(async (_cwd, args) => {
+			textCalls.push([...args]);
+			return "https://gitlab.com/group/project/-/merge_requests/7";
+		});
+		const jsonCalls: string[][] = [];
+		vi.spyOn(git.gitlab, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			jsonCalls.push([...args]);
+			return {
+				iid: 7,
+				title: "Add widget",
+				state: "opened",
+				draft: true,
+				source_branch: "feature/widget",
+				target_branch: "main",
+				author: { username: "dev1" },
+				labels: ["feature"],
+				description: "Adds a widget.",
+				web_url: "https://gitlab.com/group/project/-/merge_requests/7",
+			} as T;
+		});
+
+		const tool = new GitlabTool(createSession());
+		const result = await tool.execute("mr-create", {
+			op: "mr_create",
+			repo: "group/project",
+			title: "Add widget",
+			body: "Adds a widget.",
+			base: "main",
+			head: "feature/widget",
+			draft: true,
+			reviewer: ["reviewer1"],
+			label: ["feature"],
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		const createArgs = textCalls[0];
+		expect(createArgs.slice(0, 3)).toEqual(["mr", "create", "--yes"]);
+		expect(createArgs).toEqual(expect.arrayContaining(["--repo", "group/project"]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--title", "Add widget"]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--description", "Adds a widget."]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--target-branch", "main"]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--source-branch", "feature/widget"]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--reviewer", "reviewer1"]));
+		expect(createArgs).toEqual(expect.arrayContaining(["--label", "feature"]));
+		expect(createArgs).toContain("--draft");
+		expect(jsonCalls[0]).toEqual(["mr", "view", "7", "--output", "json", "--repo", "group/project"]);
+		expect(text).toContain("# Created GitLab merge request !7: Add widget");
+		expect(text).toContain("Source: feature/widget");
+		expect(text).toContain("Target: main");
+		expect(text).toContain("Adds a widget.");
+	});
+
+	it("rejects mr_create when neither title nor fill is supplied", async () => {
+		const textSpy = vi.spyOn(git.gitlab, "text");
+		const tool = new GitlabTool(createSession());
+
+		await expect(tool.execute("mr-create", { op: "mr_create", repo: "group/project" })).rejects.toThrow(
+			"title is required unless fill is true",
+		);
+		expect(textSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects unsupported merged state for issue_list", async () => {
+		const jsonSpy = vi.spyOn(git.gitlab, "json");
+		const tool = new GitlabTool(createSession());
+
+		await expect(tool.execute("issue-list", { op: "issue_list", state: "merged" })).rejects.toThrow(
+			"issue_list does not support state 'merged'",
+		);
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
+
+	it("lists merged merge requests with reviewers and branch filters", async () => {
+		const jsonSpy = vi.spyOn(git.gitlab, "json").mockResolvedValue([
+			{
+				iid: 31,
+				title: "Ship feature",
+				state: "merged",
+				source_branch: "feature",
+				target_branch: "main",
+				reviewers: [{ username: "reviewer1" }],
+				web_url: "https://gitlab.com/group/project/-/merge_requests/31",
+			},
+		]);
+
+		const tool = new GitlabTool(createSession());
+		const result = await tool.execute("mr-list", {
+			op: "mr_list",
+			repo: "group/project",
+			state: "merged",
+			reviewer: ["reviewer1"],
+			sourceBranch: "feature",
+			targetBranch: "main",
+			limit: 5,
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(jsonSpy).toHaveBeenCalledWith(
+			"/tmp/test",
+			[
+				"mr",
+				"list",
+				"--output",
+				"json",
+				"--repo",
+				"group/project",
+				"--merged",
+				"--reviewer",
+				"reviewer1",
+				"--source-branch",
+				"feature",
+				"--target-branch",
+				"main",
+				"--per-page",
+				"5",
+			],
+			undefined,
+			{ repoProvided: true },
+		);
+		expect(text).toContain("# GitLab merge requests");
+		expect(text).toContain("- !31 Ship feature");
+		expect(text).toContain("  Reviewers: reviewer1");
+	});
+
+	it("checks out merge requests with force and rejects flag-shaped MR ids", async () => {
+		const textSpy = vi.spyOn(git.gitlab, "text").mockResolvedValue("Checked out branch feature");
+		const tool = new GitlabTool(createSession());
+
+		const result = await tool.execute("mr-checkout", {
+			op: "mr_checkout",
+			repo: "group/project",
+			mr: "12",
+			branch: "feature",
+			force: true,
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).toHaveBeenCalledWith(
+			"/tmp/test",
+			["mr", "checkout", "12", "--branch", "feature", "--force", "--repo", "group/project"],
+			undefined,
+			{ repoProvided: true },
+		);
+		expect(text).toContain("# GitLab merge request checkout");
+		await expect(tool.execute("mr-checkout", { op: "mr_checkout", mr: "--force" })).rejects.toThrow(
+			"mr must not start with '-'",
+		);
+		expect(textSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("reads pipeline status and lists pipelines", async () => {
+		const jsonCalls: string[][] = [];
+		vi.spyOn(git.gitlab, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			jsonCalls.push([...args]);
+			if (args[1] === "status") {
+				return { status: "success", ref: "main", sha: "abcdef1234567890" } as T;
+			}
+			return [{ id: 1001, status: "failed", ref: "main", sha: "1234567890abcdef" }] as T;
+		});
+
+		const tool = new GitlabTool(createSession());
+		const status = await tool.execute("pipeline-status", {
+			op: "pipeline_status",
+			repo: "group/project",
+			branch: "main",
+		});
+		const list = await tool.execute("pipeline-list", {
+			op: "pipeline_list",
+			repo: "group/project",
+			branch: "main",
+			status: "failed",
+			sha: "1234567890abcdef",
+			limit: 3,
+		});
+		const statusText = status.content[0]?.type === "text" ? status.content[0].text : "";
+		const listText = list.content[0]?.type === "text" ? list.content[0].text : "";
+
+		expect(jsonCalls[0]).toEqual(["ci", "status", "--output", "json", "--branch", "main", "--repo", "group/project"]);
+		expect(jsonCalls[1]).toEqual([
+			"ci",
+			"list",
+			"--output",
+			"json",
+			"--repo",
+			"group/project",
+			"--ref",
+			"main",
+			"--status",
+			"failed",
+			"--sha",
+			"1234567890abcdef",
+			"--per-page",
+			"3",
+		]);
+		expect(statusText).toContain("Status: success");
+		expect(listText).toContain("# GitLab pipelines");
+		expect(listText).toContain("- #1001 failed");
+	});
+
+	it("classifies read-only and mutating operations for approval", () => {
+		const tool = new GitlabTool(createSession());
+
+		expect(tool.approval({ op: "repo_view" })).toBe("read");
+		expect(tool.approval({ op: "pipeline_list" })).toBe("read");
+		expect(tool.approval({ op: "mr_create" })).toBe("exec");
+		expect(tool.approval({ op: "mr_checkout" })).toBe("exec");
+	});
+});

--- a/packages/collab-web/src/tool-render/registry.ts
+++ b/packages/collab-web/src/tool-render/registry.ts
@@ -56,6 +56,7 @@ const RENDERERS: Record<string, ToolRenderer> = {
 	find: findRenderer,
 	generate_image: generateImageRenderer,
 	github: githubRenderer,
+	gitlab: githubRenderer,
 	goal: goalRenderer,
 	inspect_image: inspectImageRenderer,
 	irc: ircRenderer,


### PR DESCRIPTION
## Summary
- Adds a discoverable `gitlab` built-in tool backed by `glab` for GitLab projects, issues, merge requests, and CI/CD pipelines.
- Wires the tool through the same setup surfaces as `github`: builtin name, factory/export, settings gate (`gitlab.enabled`), prompt docs, TUI renderer, collab-web renderer registry, and discovery tests.
- Adds regression coverage for argv mapping, read/exec approval classification, MR checkout force path, MR list state/filter mapping, pipeline status/list, and issue state validation.

## Parity notes
- Setup/registration parity with the GitHub CLI tool: yes (`createIf` availability gate, discoverable load mode, settings toggle, renderer registration, prompt documentation, tests).
- Operation parity is intentionally GitLab-shaped rather than one-to-one: GitHub-only internals such as `issue://`/`pr://` cache protocols, PR diff cache, `pr_push`, and Actions `run_watch` are not included in this PR.

## Verification
- `bun test packages/coding-agent/test/tools/gh.test.ts packages/coding-agent/test/tools/gitlab.test.ts packages/coding-agent/test/tool-discovery/initial-tools.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/collab-web run check`

## Review
- Internal code review approved after follow-up fixes; no blocking findings remained.