### PR TITLE
fix(utils): handle truncated JSON gracefully in readSseJson

### DIFF
--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -217,10 +217,136 @@ interface JsonLevel {
 	state?: "expect_key" | "expect_colon" | "expect_value" | "expect_comma_or_close";
 }
 
+interface ScanResult {
+	stack: JsonLevel[];
+	inString: boolean;
+}
+
+function scanJsonState(trimmed: string): ScanResult | null {
+	const stack: JsonLevel[] = [];
+	let inString = false;
+	let escaped = false;
+
+	for (let i = 0; i < trimmed.length; i++) {
+		const char = trimmed[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === '"') {
+			inString = !inString;
+			if (stack.length > 0) {
+				const top = stack[stack.length - 1];
+				if (inString) {
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				} else {
+					if (top.type === "object" && top.state === "expect_key") {
+						top.state = "expect_colon";
+					}
+				}
+			}
+			continue;
+		}
+		if (!inString) {
+			if (char === "{") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+				stack.push({ type: "object", state: "expect_key" });
+			} else if (char === "[") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+				stack.push({ type: "array", state: "expect_value" });
+			} else if (char === "}") {
+				if (stack.length === 0 || stack[stack.length - 1].type !== "object") {
+					return null;
+				}
+				stack.pop();
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+			} else if (char === "]") {
+				if (stack.length === 0 || stack[stack.length - 1].type !== "array") {
+					return null;
+				}
+				stack.pop();
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+			} else if (char === ":") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_colon") {
+						top.state = "expect_value";
+					} else {
+						return null;
+					}
+				} else {
+					return null;
+				}
+			} else if (char === ",") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_comma_or_close") {
+						top.state = "expect_key";
+					} else {
+						return null;
+					}
+				} else {
+					return null;
+				}
+			} else if (char !== " " && char !== "\t" && char !== "\n" && char !== "\r") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+			}
+		}
+	}
+
+	if (inString) {
+		if (stack.length > 0) {
+			const top = stack[stack.length - 1];
+			if (top.type === "object") {
+				if (top.state === "expect_key") {
+					top.state = "expect_colon";
+				} else if (top.state === "expect_value") {
+					top.state = "expect_comma_or_close";
+				}
+			}
+		}
+	}
+
+	return { stack, inString };
+}
+
 function hasValidPredecessorForComma(trimmed: string): boolean {
 	if (!trimmed.endsWith(",")) return false;
 	const beforeComma = trimmed.slice(0, -1).trim();
-	return /["}\]\d]$|[elEL]$/.test(beforeComma);
+	const scan = scanJsonState(beforeComma);
+	if (!scan || scan.stack.length === 0) return false;
+	return scan.stack[scan.stack.length - 1].state === "expect_comma_or_close";
 }
 
 function getClosingSuffix(data: string): string | null {
@@ -232,6 +358,17 @@ function getClosingSuffix(data: string): string | null {
 	if (hasValidPredecessorForComma(trimmed)) {
 		trimmed = trimmed.slice(0, -1).trim();
 	}
+
+	const scan = scanJsonState(trimmed);
+	if (!scan) return null;
+
+	const { stack, inString } = scan;
+	let suffix = "";
+
+	if (inString) {
+		suffix += '"';
+	}
+
 	let literalCompletion = "";
 	const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
 	if (match) {
@@ -251,108 +388,7 @@ function getClosingSuffix(data: string): string | null {
 		literalCompletion = completions[partial] ?? "";
 	}
 
-	let suffix = literalCompletion;
-
-	const stack: JsonLevel[] = [];
-	let inString = false;
-	let escaped = false;
-
-	for (let i = 0; i < trimmed.length; i++) {
-		const char = trimmed[i];
-		if (escaped) {
-			escaped = false;
-			continue;
-		}
-		if (char === "\\") {
-			escaped = true;
-			continue;
-		}
-		if (char === '"') {
-			inString = !inString;
-			if (stack.length > 0) {
-				const top = stack[stack.length - 1];
-				if (top.type === "object") {
-					if (!inString) {
-						if (top.state === "expect_key") {
-							top.state = "expect_colon";
-						} else if (top.state === "expect_value") {
-							top.state = "expect_comma_or_close";
-						}
-					}
-				}
-			}
-			continue;
-		}
-		if (!inString) {
-			if (char === "{") {
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_value") {
-						top.state = "expect_comma_or_close";
-					}
-				}
-				stack.push({ type: "object", state: "expect_key" });
-			} else if (char === "[") {
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_value") {
-						top.state = "expect_comma_or_close";
-					}
-				}
-				stack.push({ type: "array" });
-			} else if (char === "}") {
-				if (stack.length === 0 || stack[stack.length - 1].type !== "object") {
-					return null;
-				}
-				stack.pop();
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_value") {
-						top.state = "expect_comma_or_close";
-					}
-				}
-			} else if (char === "]") {
-				if (stack.length === 0 || stack[stack.length - 1].type !== "array") {
-					return null;
-				}
-				stack.pop();
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_value") {
-						top.state = "expect_comma_or_close";
-					}
-				}
-			} else if (char === ":") {
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_colon") {
-						top.state = "expect_value";
-					}
-				}
-			} else if (char === ",") {
-				if (stack.length > 0) {
-					const top = stack[stack.length - 1];
-					if (top.type === "object" && top.state === "expect_comma_or_close") {
-						top.state = "expect_key";
-					}
-				}
-			}
-		}
-	}
-
-	if (inString) {
-		suffix += '"';
-		if (stack.length > 0) {
-			const top = stack[stack.length - 1];
-			if (top.type === "object") {
-				if (top.state === "expect_key") {
-					top.state = "expect_colon";
-				} else if (top.state === "expect_value") {
-					top.state = "expect_comma_or_close";
-				}
-			}
-		}
-	}
+	suffix += literalCompletion;
 
 	for (let i = stack.length - 1; i >= 0; i--) {
 		const level = stack[i];

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -307,7 +307,7 @@ function scanJsonState(trimmed: string): ScanResult | null {
 				if (stack.length > 0) {
 					const top = stack[stack.length - 1];
 					if (top.state === "expect_comma_or_close") {
-						top.state = "expect_key";
+						top.state = top.type === "object" ? "expect_key" : "expect_value";
 					} else {
 						return null;
 					}

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -346,7 +346,7 @@ function hasValidPredecessorForComma(trimmed: string): boolean {
 	if (!trimmed.endsWith(",")) return false;
 	const beforeComma = trimmed.slice(0, -1).trim();
 	const scan = scanJsonState(beforeComma);
-	if (!scan || scan.stack.length === 0) return false;
+	if (!scan || scan.stack.length === 0 || scan.inString) return false;
 	return scan.stack[scan.stack.length - 1].state === "expect_comma_or_close";
 }
 

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -370,22 +370,24 @@ function getClosingSuffix(data: string): string | null {
 	}
 
 	let literalCompletion = "";
-	const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
-	if (match) {
-		const partial = match[0].toLowerCase();
-		const completions: Record<string, string> = {
-			t: "rue",
-			tr: "ue",
-			tru: "e",
-			f: "alse",
-			fa: "lse",
-			fal: "se",
-			fals: "e",
-			n: "ull",
-			nu: "ll",
-			nul: "l",
-		};
-		literalCompletion = completions[partial] ?? "";
+	if (!inString) {
+		const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
+		if (match) {
+			const partial = match[0].toLowerCase();
+			const completions: Record<string, string> = {
+				t: "rue",
+				tr: "ue",
+				tru: "e",
+				f: "alse",
+				fa: "lse",
+				fal: "se",
+				fals: "e",
+				n: "ull",
+				nu: "ll",
+				nul: "l",
+			};
+			literalCompletion = completions[partial] ?? "";
+		}
 	}
 
 	suffix += literalCompletion;

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -217,16 +217,21 @@ interface JsonLevel {
 	state?: "expect_key" | "expect_colon" | "expect_value" | "expect_comma_or_close";
 }
 
+function hasValidPredecessorForComma(trimmed: string): boolean {
+	if (!trimmed.endsWith(",")) return false;
+	const beforeComma = trimmed.slice(0, -1).trim();
+	return /["}\]\d]$|[elEL]$/.test(beforeComma);
+}
+
 function getClosingSuffix(data: string): string | null {
 	let trimmed = data.trim();
 	if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
 		return null;
 	}
 
-	if (trimmed.endsWith(",")) {
+	if (hasValidPredecessorForComma(trimmed)) {
 		trimmed = trimmed.slice(0, -1).trim();
 	}
-
 	let literalCompletion = "";
 	const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
 	if (match) {
@@ -388,7 +393,7 @@ function getClosingSuffix(data: string): string | null {
 
 function isJsonTruncated(data: string): boolean {
 	let trimmed = data.trim();
-	if (trimmed.endsWith(",")) {
+	if (hasValidPredecessorForComma(trimmed)) {
 		trimmed = trimmed.slice(0, -1).trim();
 	}
 	const suffix = getClosingSuffix(data);

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -1,3 +1,5 @@
+const trailingEvents = new WeakSet<ServerSentEvent>();
+
 import { abortableSource } from "./abortable";
 
 const LF = 0x0a;
@@ -210,19 +212,122 @@ function notifySseEventObserver(observer: SseEventObserver | undefined, event: S
 	}
 }
 
+function getClosingSuffix(data: string): string | null {
+	let trimmed = data.trim();
+	if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+		return null;
+	}
+
+	let suffix = "";
+	if (trimmed.endsWith(",")) {
+		trimmed = trimmed.slice(0, -1).trim();
+	}
+
+	if (trimmed.endsWith(":")) {
+		suffix = "null";
+	} else {
+		const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
+		if (match) {
+			const partial = match[0].toLowerCase();
+			const completions: Record<string, string> = {
+				t: "rue",
+				tr: "ue",
+				tru: "e",
+				f: "alse",
+				fa: "lse",
+				fal: "se",
+				fals: "e",
+				n: "ull",
+				nu: "ll",
+				nul: "l",
+			};
+			if (completions[partial]) {
+				suffix = completions[partial];
+			}
+		}
+	}
+
+	const stack: string[] = [];
+	let inString = false;
+	let escaped = false;
+
+	for (let i = 0; i < trimmed.length; i++) {
+		const char = trimmed[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === '"') {
+			inString = !inString;
+			continue;
+		}
+		if (!inString) {
+			if (char === "{" || char === "[") {
+				stack.push(char);
+			} else if (char === "}") {
+				if (stack.pop() !== "{") return null;
+			} else if (char === "]") {
+				if (stack.pop() !== "[") return null;
+			}
+		}
+	}
+
+	if (inString) {
+		return `"${stack
+			.reverse()
+			.map(c => (c === "{" ? "}" : "]"))
+			.join("")}`;
+	}
+	return (
+		suffix +
+		stack
+			.reverse()
+			.map(c => (c === "{" ? "}" : "]"))
+			.join("")
+	);
+}
+
+function isJsonTruncated(data: string): boolean {
+	let trimmed = data.trim();
+	if (trimmed.endsWith(",")) {
+		trimmed = trimmed.slice(0, -1).trim();
+	}
+	const suffix = getClosingSuffix(data);
+	if (suffix === null || suffix === "") return false;
+
+	try {
+		JSON.parse(trimmed + suffix);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export async function* readSseJson<T>(
 	stream: ReadableStream<Uint8Array>,
 	signal?: AbortSignal,
 	onEvent?: SseEventObserver,
 ): AsyncGenerator<T> {
 	for await (const sse of readSseEvents(stream, signal)) {
+		const isTrailing = trailingEvents.has(sse);
 		notifySseEventObserver(onEvent, sse);
 		const data = sse.data;
 		if (data === "" || data === "[DONE]") {
 			if (data === "[DONE]") return;
 			continue;
 		}
-		yield JSON.parse(data) as T;
+		try {
+			yield JSON.parse(data) as T;
+		} catch (err) {
+			if (err instanceof SyntaxError && isTrailing && isJsonTruncated(data)) {
+				return;
+			}
+			throw err;
+		}
 	}
 }
 
@@ -353,12 +458,18 @@ export async function* readSseEvents(
 			if (tail) {
 				lineBuffer.clear();
 				const event = pushSseLine(tail, state);
-				if (event) yield event;
+				if (event) {
+					trailingEvents.add(event);
+					yield event;
+				}
 			}
 		}
 		// Real services don't always close on a blank line — flush any pending event.
 		const trailing = flushSseEvent(state);
-		if (trailing) yield trailing;
+		if (trailing) {
+			trailingEvents.add(trailing);
+			yield trailing;
+		}
 	} catch (err) {
 		if (signal?.aborted) return;
 		throw err;

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -220,6 +220,7 @@ interface JsonLevel {
 interface ScanResult {
 	stack: JsonLevel[];
 	inString: boolean;
+	escaped: boolean;
 }
 
 function scanJsonState(trimmed: string): ScanResult | null {
@@ -338,7 +339,7 @@ function scanJsonState(trimmed: string): ScanResult | null {
 		}
 	}
 
-	return { stack, inString };
+	return { stack, inString, escaped };
 }
 
 function hasValidPredecessorForComma(trimmed: string): boolean {
@@ -362,10 +363,22 @@ function getClosingSuffix(data: string): string | null {
 	const scan = scanJsonState(trimmed);
 	if (!scan) return null;
 
-	const { stack, inString } = scan;
+	const { stack, inString, escaped } = scan;
 	let suffix = "";
 
 	if (inString) {
+		if (escaped) {
+			suffix += "\\";
+		} else {
+			const match = trimmed.match(/(\\+)u([0-9a-fA-F]{0,3})$/);
+			if (match) {
+				const backslashes = match[1].length;
+				if (backslashes % 2 === 1) {
+					const digits = match[2].length;
+					suffix += "0".repeat(4 - digits);
+				}
+			}
+		}
 		suffix += '"';
 	}
 

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -212,42 +212,43 @@ function notifySseEventObserver(observer: SseEventObserver | undefined, event: S
 	}
 }
 
+interface JsonLevel {
+	type: "object" | "array";
+	state?: "expect_key" | "expect_colon" | "expect_value" | "expect_comma_or_close";
+}
+
 function getClosingSuffix(data: string): string | null {
 	let trimmed = data.trim();
 	if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
 		return null;
 	}
 
-	let suffix = "";
 	if (trimmed.endsWith(",")) {
 		trimmed = trimmed.slice(0, -1).trim();
 	}
 
-	if (trimmed.endsWith(":")) {
-		suffix = "null";
-	} else {
-		const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
-		if (match) {
-			const partial = match[0].toLowerCase();
-			const completions: Record<string, string> = {
-				t: "rue",
-				tr: "ue",
-				tru: "e",
-				f: "alse",
-				fa: "lse",
-				fal: "se",
-				fals: "e",
-				n: "ull",
-				nu: "ll",
-				nul: "l",
-			};
-			if (completions[partial]) {
-				suffix = completions[partial];
-			}
-		}
+	let literalCompletion = "";
+	const match = trimmed.match(/(t|tr|tru|f|fa|fal|fals|n|nu|nul)$/i);
+	if (match) {
+		const partial = match[0].toLowerCase();
+		const completions: Record<string, string> = {
+			t: "rue",
+			tr: "ue",
+			tru: "e",
+			f: "alse",
+			fa: "lse",
+			fal: "se",
+			fals: "e",
+			n: "ull",
+			nu: "ll",
+			nul: "l",
+		};
+		literalCompletion = completions[partial] ?? "";
 	}
 
-	const stack: string[] = [];
+	let suffix = literalCompletion;
+
+	const stack: JsonLevel[] = [];
 	let inString = false;
 	let escaped = false;
 
@@ -263,32 +264,126 @@ function getClosingSuffix(data: string): string | null {
 		}
 		if (char === '"') {
 			inString = !inString;
+			if (stack.length > 0) {
+				const top = stack[stack.length - 1];
+				if (top.type === "object") {
+					if (!inString) {
+						if (top.state === "expect_key") {
+							top.state = "expect_colon";
+						} else if (top.state === "expect_value") {
+							top.state = "expect_comma_or_close";
+						}
+					}
+				}
+			}
 			continue;
 		}
 		if (!inString) {
-			if (char === "{" || char === "[") {
-				stack.push(char);
+			if (char === "{") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+				stack.push({ type: "object", state: "expect_key" });
+			} else if (char === "[") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+				stack.push({ type: "array" });
 			} else if (char === "}") {
-				if (stack.pop() !== "{") return null;
+				if (stack.length === 0 || stack[stack.length - 1].type !== "object") {
+					return null;
+				}
+				stack.pop();
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
 			} else if (char === "]") {
-				if (stack.pop() !== "[") return null;
+				if (stack.length === 0 || stack[stack.length - 1].type !== "array") {
+					return null;
+				}
+				stack.pop();
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_value") {
+						top.state = "expect_comma_or_close";
+					}
+				}
+			} else if (char === ":") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_colon") {
+						top.state = "expect_value";
+					}
+				}
+			} else if (char === ",") {
+				if (stack.length > 0) {
+					const top = stack[stack.length - 1];
+					if (top.type === "object" && top.state === "expect_comma_or_close") {
+						top.state = "expect_key";
+					}
+				}
 			}
 		}
 	}
 
 	if (inString) {
-		return `"${stack
-			.reverse()
-			.map(c => (c === "{" ? "}" : "]"))
-			.join("")}`;
+		suffix += '"';
+		if (stack.length > 0) {
+			const top = stack[stack.length - 1];
+			if (top.type === "object") {
+				if (top.state === "expect_key") {
+					top.state = "expect_colon";
+				} else if (top.state === "expect_value") {
+					top.state = "expect_comma_or_close";
+				}
+			}
+		}
 	}
-	return (
-		suffix +
-		stack
-			.reverse()
-			.map(c => (c === "{" ? "}" : "]"))
-			.join("")
-	);
+
+	for (let i = stack.length - 1; i >= 0; i--) {
+		const level = stack[i];
+		if (level.type === "array") {
+			suffix += "]";
+		} else {
+			let state = level.state;
+			if (state === "expect_value") {
+				const lower = trimmed.toLowerCase();
+				if (
+					literalCompletion !== "" ||
+					lower.endsWith("true") ||
+					lower.endsWith("false") ||
+					lower.endsWith("null") ||
+					/\d$/.test(trimmed) ||
+					trimmed.endsWith('"') ||
+					trimmed.endsWith("}") ||
+					trimmed.endsWith("]")
+				) {
+					state = "expect_comma_or_close";
+				}
+			}
+
+			if (state === "expect_key") {
+				suffix += "}";
+			} else if (state === "expect_colon") {
+				suffix += ":null}";
+			} else if (state === "expect_value") {
+				suffix += "null}";
+			} else if (state === "expect_comma_or_close") {
+				suffix += "}";
+			}
+		}
+	}
+
+	return suffix;
 }
 
 function isJsonTruncated(data: string): boolean {

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -296,6 +296,7 @@ describe("readSseJson", () => {
 			'data: {"b":2,}', // balanced but malformed trailing comma
 			'data: {"b":,', // invalid predecessor before comma
 			"data: [,,", // invalid predecessor before comma
+			'data: {"b",', // invalid predecessor after key
 		];
 		for (const dataChunk of testCases) {
 			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -248,6 +248,7 @@ describe("readSseJson", () => {
 			'data: {"id":"x", "name":',
 			'data: {"id":"x", "name": "y',
 			'data: {"id":"x",',
+			"data: [1,2,",
 		];
 		for (const dataChunk of testCases) {
 			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -302,6 +302,7 @@ describe("readSseJson", () => {
 			'data: {"b":,', // invalid predecessor before comma
 			"data: [,,", // invalid predecessor before comma
 			'data: {"b",', // invalid predecessor after key
+			'data: {"s":"\\u12,', // comma inside unterminated string
 		];
 		for (const dataChunk of testCases) {
 			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -239,6 +239,167 @@ describe("readSseJson", () => {
 		const output = await collectAsync(readSseJson(stream));
 		expect(output).toEqual([{ a: 1 }]);
 	});
+
+	it("completes cleanly when the final data chunk is truncated JSON", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b":2')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readSseJson(stream));
+		expect(output).toEqual([{ a: 1 }]);
+	});
+
+	it("completes cleanly when the final data chunk is cut inside a JSON literal at EOF", async () => {
+		const testCases = ['data: {"finish_reason":nul', 'data: {"ok":tru', "data: [fal"];
+		for (const dataChunk of testCases) {
+			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (const chunk of chunks) controller.enqueue(chunk);
+					controller.close();
+				},
+			});
+
+			const output = await collectAsync(readSseJson(stream));
+			expect(output).toEqual([{ a: 1 }]);
+		}
+	});
+
+	it("throws SyntaxError when a middle data chunk is malformed JSON", async () => {
+		const chunks = [encoder.encode('data: {"a":1\n\n'), encoder.encode('data: {"b":2}\n\n')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event is complete but malformed JSON", async () => {
+		const chunks = [
+			encoder.encode('data: {"a":1}\n\n'),
+			encoder.encode('data: {"b":2,}'), // balanced but malformed trailing comma
+		];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event is plain text", async () => {
+		const chunks = [
+			encoder.encode('data: {"a":1}\n\n'),
+			encoder.encode("data: Internal Server Error"), // plain text (not JSON)
+		];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event is malformed with missing colons but balanced braces", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b" 2}')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event is malformed with mismatched brackets/braces", async () => {
+		const chunks = [
+			encoder.encode('data: {"a":1}\n\n'),
+			encoder.encode("data: [{]"), // mismatched closer
+		];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event is malformed with syntax errors after values", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b": true garbage')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event has invalid characters", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b": @')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event has mismatched closers", async () => {
+		const chunks = [
+			encoder.encode('data: {"a":1}\n\n'),
+			encoder.encode('data: {"b": ]'), // mismatched closer
+		];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event has unbalanced braces but internal syntax errors", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b":1 "c":2')];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
+
+	it("throws SyntaxError when a final event has unbalanced braces but has complete invalid text inside", async () => {
+		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode("data: {unterminated}")];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+	});
 });
 
 function bytesStreamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -292,18 +292,22 @@ describe("readSseJson", () => {
 	});
 
 	it("throws SyntaxError when a final event is complete but malformed JSON", async () => {
-		const chunks = [
-			encoder.encode('data: {"a":1}\n\n'),
-			encoder.encode('data: {"b":2,}'), // balanced but malformed trailing comma
+		const testCases = [
+			'data: {"b":2,}', // balanced but malformed trailing comma
+			'data: {"b":,', // invalid predecessor before comma
+			"data: [,,", // invalid predecessor before comma
 		];
-		const stream = new ReadableStream<Uint8Array>({
-			start(controller) {
-				for (const chunk of chunks) controller.enqueue(chunk);
-				controller.close();
-			},
-		});
+		for (const dataChunk of testCases) {
+			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (const chunk of chunks) controller.enqueue(chunk);
+					controller.close();
+				},
+			});
 
-		await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+			await expect(collectAsync(readSseJson(stream))).rejects.toThrow(SyntaxError);
+		}
 	});
 
 	it("throws SyntaxError when a final event is plain text", async () => {

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -249,6 +249,8 @@ describe("readSseJson", () => {
 			'data: {"id":"x", "name": "y',
 			'data: {"id":"x",',
 			"data: [1,2,",
+			'data: {"s":"n',
+			'data: {"n',
 		];
 		for (const dataChunk of testCases) {
 			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -241,16 +241,26 @@ describe("readSseJson", () => {
 	});
 
 	it("completes cleanly when the final data chunk is truncated JSON", async () => {
-		const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode('data: {"b":2')];
-		const stream = new ReadableStream<Uint8Array>({
-			start(controller) {
-				for (const chunk of chunks) controller.enqueue(chunk);
-				controller.close();
-			},
-		});
+		const testCases = [
+			'data: {"b":2',
+			'data: {"id":"x", "na',
+			'data: {"id":"x", "name"',
+			'data: {"id":"x", "name":',
+			'data: {"id":"x", "name": "y',
+			'data: {"id":"x",',
+		];
+		for (const dataChunk of testCases) {
+			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (const chunk of chunks) controller.enqueue(chunk);
+					controller.close();
+				},
+			});
 
-		const output = await collectAsync(readSseJson(stream));
-		expect(output).toEqual([{ a: 1 }]);
+			const output = await collectAsync(readSseJson(stream));
+			expect(output).toEqual([{ a: 1 }]);
+		}
 	});
 
 	it("completes cleanly when the final data chunk is cut inside a JSON literal at EOF", async () => {

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -251,6 +251,8 @@ describe("readSseJson", () => {
 			"data: [1,2,",
 			'data: {"s":"n',
 			'data: {"n',
+			'data: {"s":"abc\\',
+			'data: {"s":"\\u12',
 		];
 		for (const dataChunk of testCases) {
 			const chunks = [encoder.encode('data: {"a":1}\n\n'), encoder.encode(dataChunk)];


### PR DESCRIPTION
When an SSE connection is aborted or interrupted mid-stream, the final chunk can be truncated and result in malformed JSON (e.g. unterminated strings). This wraps the JSON parse in a try/catch, returning gracefully on SyntaxError instead of crashing the turn.