### PR TITLE
Add workspace identifier modes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added experimental workspace identifier modes for sharing default sessions and per-project memories by Git remote or root commit.
+
 ### Fixed
 
 - Fixed all extension loading silently failing on the cross-compiled `omp-darwin-arm64` release binary (downloaded directly or via a Homebrew tap wrapper) because `__computeBunfsPackageRoot` mis-handled `import.meta.dir = "//root/omp-darwin-arm64"`. Bun 1.3.14 reports `<bunfs-root>/<binary-name>` for the compiled entry's `import.meta.dir`, but the pre-fix function joined `metaDir + "packages"` and produced `/root/omp-darwin-arm64/packages` — the binary basename was baked into every bunfs path, so the TypeBox/legacy-pi shims and every `@oh-my-pi/pi-*` package-root override failed `existsSync` validation and `resolveCanonicalPiSpecifier` fell through to a bunfs `Bun.resolveSync` that also could not find the module. The function now detects the bunfs-root + binary-basename shape (`path.basename(path.dirname(metaDir)) === "root"`) and strips the trailing binary segment by slicing the original `metaDir`; the production bunfs shim join path also preserves Bun's bunfs-native `//root` / `B:\~BUN\root` prefix that `path.join` would otherwise collapse. ([#3329](https://github.com/can1357/oh-my-pi/issues/3329))

--- a/packages/coding-agent/src/commands/complete.ts
+++ b/packages/coding-agent/src/commands/complete.ts
@@ -10,6 +10,7 @@
  */
 import { type GeneratedProvider, getBundledModels, getBundledProviders } from "@oh-my-pi/pi-catalog/models";
 import { Command } from "@oh-my-pi/pi-utils/cli";
+import { Settings } from "../config/settings";
 import { SessionManager } from "../session/session-manager";
 
 export default class Complete extends Command {
@@ -55,7 +56,10 @@ function completeModels(prefix: string): void {
 }
 
 async function completeSessions(prefix: string): Promise<void> {
-	const sessions = await SessionManager.list(process.cwd());
+	const cwd = process.cwd();
+	const settings = await Settings.init({ cwd });
+	const mode = settings.get("workspace.identifier");
+	const sessions = await SessionManager.list(cwd, undefined, undefined, mode);
 	const lines: string[] = [];
 	for (const session of sessions) {
 		if (prefix && !session.id.startsWith(prefix)) continue;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -34,6 +34,7 @@ import {
 	TTS_LOCAL_VOICE_VALUES,
 } from "../tts/models";
 import { EDIT_MODES } from "../utils/edit-mode";
+import { WORKSPACE_IDENTIFIER_MODES } from "../utils/workspace-storage-identifier";
 import { SEARCH_PROVIDER_OPTIONS, SEARCH_PROVIDER_PREFERENCES, type SearchProviderId } from "../web/search/types";
 
 /** Unified settings schema - single source of truth for all settings.
@@ -1871,6 +1872,37 @@ export const SETTINGS_SCHEMA = {
 			label: "Elide Uneventful Results",
 			description:
 				"Prune tool results flagged contextually useless (no matches, timed-out waits) once consumed (cache-aware)",
+		},
+	},
+
+	"workspace.identifier": {
+		type: "enum",
+		values: WORKSPACE_IDENTIFIER_MODES,
+		default: "path",
+		ui: {
+			tab: "context",
+			group: "Experimental",
+			label: "Workspace Identifier (experimental)",
+			description:
+				"Controls how default sessions and per-project memories are keyed. Git modes fall back to path outside Git or when git is unavailable.",
+			options: [
+				{
+					value: "path",
+					label: "Path",
+					description: "Current behavior: key by normalized project path.",
+				},
+				{
+					value: "git-remote",
+					label: "Git remote",
+					description:
+						"Use origin URL, or the first configured remote URL, so worktrees for one fork share storage.",
+				},
+				{
+					value: "git-root",
+					label: "Git root commit",
+					description: "Use the first reachable commit hash so forks and hosting platforms share storage.",
+				},
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -19,9 +19,13 @@ export function memoryRootsFromRegistry(): string[] {
 	const agentDir = getAgentDir();
 	const roots: string[] = [];
 	for (const ref of AgentRegistry.global().list()) {
-		const sm = ref.session?.sessionManager;
-		if (!sm) continue;
-		const root = getMemoryRoot(agentDir, sm.getCwd());
+		const session = ref.session;
+		if (!session?.sessionManager) continue;
+		const root = getMemoryRoot(
+			agentDir,
+			session.sessionManager.getCwd(),
+			session.settings.get("workspace.identifier"),
+		);
 		if (root && !roots.includes(root)) roots.push(root);
 	}
 	return roots;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -83,6 +83,7 @@ import {
 	writeLastChangelogVersion,
 } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
+import type { WorkspaceIdentifierMode } from "./utils/workspace-storage-identifier";
 
 type RunAcpMode = (createSession: AcpSessionFactory) => Promise<never>;
 type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promise<void>;
@@ -358,7 +359,12 @@ export interface AcpSessionFactoryOptions {
 export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
 	return async cwd => {
 		const nextSettings = await args.settings.cloneForCwd(cwd);
-		const nextSessionManager = SessionManager.create(cwd, args.sessionDir);
+		const nextSessionManager = SessionManager.create(
+			cwd,
+			args.sessionDir,
+			undefined,
+			nextSettings.get("workspace.identifier"),
+		);
 		const agentId = `acp:${nextSessionManager.getSessionId()}`;
 		const { session: nextSession } = await args.createSession({
 			...args.baseOptions,
@@ -567,6 +573,7 @@ async function moveMissingCwdSessionIfNeeded(
 	session: SessionInfo,
 	cwd: string,
 	sessionDir: string | undefined,
+	workspaceIdentifierMode: WorkspaceIdentifierMode,
 	askToMoveSession: SessionPrompt,
 ): Promise<MissingCwdMoveResult> {
 	const sourceCwd = session.cwd;
@@ -588,11 +595,37 @@ async function moveMissingCwdSessionIfNeeded(
 	// to the launch cwd, which would make the `moveTo` below a no-op whenever the
 	// move target equals the current project dir. moveTo never chdirs, so the
 	// stale cwd is only a relocation source, not a directory we enter.
-	const manager = await SessionManager.open(session.path, sessionDir, undefined, { initialCwd: sourceCwd });
+	const manager = await SessionManager.open(session.path, sessionDir, undefined, {
+		initialCwd: sourceCwd,
+		workspaceIdentifierMode,
+	});
 	await manager.moveTo(cwd, sessionDir);
 	return { status: "moved", manager };
 }
 
+// Shared git-identifier buckets can return a session whose header cwd belongs
+// to another existing worktree. Match the startup picker: adopt that project
+// before the AgentSession is built so settings, plugins, and capabilities are
+// scoped to the resumed session rather than the launch directory.
+async function rescopeStartupToManagerCwd(
+	manager: SessionManager,
+	activeSettings: Settings,
+	beforeProjectDirChange: () => Promise<void> = async () => {},
+): Promise<SessionManager> {
+	const targetCwd = manager.getCwd();
+	if (
+		targetCwd &&
+		normalizePathForComparison(targetCwd) !== normalizePathForComparison(getProjectDir()) &&
+		(await directoryExists(targetCwd))
+	) {
+		await beforeProjectDirChange();
+		setProjectDir(targetCwd);
+		clearPluginRootsAndCaches();
+		resetCapabilities();
+		await activeSettings.reloadForCwd(getProjectDir());
+	}
+	return manager;
+}
 async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
 	if (parsed.continue || parsed.resume) {
 		return undefined;
@@ -630,23 +663,29 @@ export async function createSessionManager(
 	activeSettings: Settings = settings,
 	askToForkSession: SessionPrompt = promptForkSession,
 	askToMoveSession: SessionPrompt = promptMoveSession,
+	beforeProjectDirChange: () => Promise<void> = async () => {},
 ): Promise<SessionManager | undefined> {
+	const workspaceMode = activeSettings.get("workspace.identifier");
 	if (parsed.fork) {
 		if (parsed.noSession) {
 			throw new SessionResolutionError("--fork requires session persistence");
 		}
 		const forkSource = parsed.fork;
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
-			return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
+			return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir, undefined, {
+				workspaceIdentifierMode: workspaceMode,
+			});
 		}
-		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir, undefined, workspaceMode);
 		if (!match) {
 			throw new SessionResolutionError(
 				`Session "${forkSource}" not found.`,
 				"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
 			);
 		}
-		return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
+		return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir, undefined, {
+			workspaceIdentifierMode: workspaceMode,
+		});
 	}
 
 	if (parsed.noSession) {
@@ -655,9 +694,15 @@ export async function createSessionManager(
 	if (typeof parsed.resume === "string") {
 		const sessionArg = parsed.resume;
 		if (sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl")) {
-			return await SessionManager.open(sessionArg, parsed.sessionDir);
+			return await rescopeStartupToManagerCwd(
+				await SessionManager.open(sessionArg, parsed.sessionDir, undefined, {
+					workspaceIdentifierMode: workspaceMode,
+				}),
+				activeSettings,
+				beforeProjectDirChange,
+			);
 		}
-		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir, undefined, workspaceMode);
 		if (!match) {
 			throw new SessionResolutionError(
 				`Session "${sessionArg}" not found.`,
@@ -670,6 +715,7 @@ export async function createSessionManager(
 				match.session,
 				cwd,
 				parsed.sessionDir,
+				workspaceMode,
 				askToMoveSession,
 			);
 			if (moveResult.status === "moved") {
@@ -688,6 +734,7 @@ export async function createSessionManager(
 					match.session,
 					cwd,
 					parsed.sessionDir,
+					workspaceMode,
 					askToMoveSession,
 				);
 				if (moveResult.status === "moved") {
@@ -708,25 +755,42 @@ export async function createSessionManager(
 					// by checking `typeof parsed.resume === "string"`.
 					return undefined;
 				}
-				return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
+				return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir, undefined, {
+					workspaceIdentifierMode: workspaceMode,
+				});
 			}
 		}
-		return await SessionManager.open(match.session.path, parsed.sessionDir);
+		return await rescopeStartupToManagerCwd(
+			await SessionManager.open(match.session.path, parsed.sessionDir, undefined, {
+				initialCwd: match.session.cwd || cwd,
+				workspaceIdentifierMode: workspaceMode,
+			}),
+			activeSettings,
+			beforeProjectDirChange,
+		);
 	}
 	if (parsed.continue) {
-		return await SessionManager.continueRecent(cwd, parsed.sessionDir);
+		return await rescopeStartupToManagerCwd(
+			await SessionManager.continueRecent(cwd, parsed.sessionDir, undefined, workspaceMode),
+			activeSettings,
+			beforeProjectDirChange,
+		);
 	}
 	// --resume without value is handled separately (needs picker UI)
 	// If --session-dir provided without --continue/--resume, create new session there
 	if (parsed.sessionDir) {
-		return SessionManager.create(cwd, parsed.sessionDir);
+		return SessionManager.create(cwd, parsed.sessionDir, undefined, workspaceMode);
 	}
 	// Auto-resume: behave like --continue if the setting is enabled and a prior
 	// session exists. When a prior session is resumed, mark parsed.continue so
 	// buildSessionOptions restores the session's model/thinking instead of
 	// overriding them with CLI defaults.
 	if (activeSettings.get("autoResume")) {
-		const manager = await SessionManager.continueRecent(cwd, parsed.sessionDir);
+		const manager = await rescopeStartupToManagerCwd(
+			await SessionManager.continueRecent(cwd, parsed.sessionDir, undefined, workspaceMode),
+			activeSettings,
+			beforeProjectDirChange,
+		);
 		if (manager.getEntries().length > 0) {
 			parsed.continue = true;
 		}
@@ -1115,6 +1179,11 @@ export async function runRootCommand(
 			parsedArgs,
 			cwd,
 			settingsInstance,
+			promptForkSession,
+			promptMoveSession,
+			async () => {
+				await pluginPreloadPromise.catch(() => {});
+			},
 		);
 	} catch (error: unknown) {
 		if (error instanceof SessionResolutionError) {
@@ -1126,6 +1195,7 @@ export async function runRootCommand(
 		}
 		throw error;
 	}
+	cwd = getProjectDir();
 
 	// User declined the cross-project fork prompt — exit cleanly with a friendly
 	// message rather than letting the decline bubble up as an uncaught exception
@@ -1138,7 +1208,15 @@ export async function runRootCommand(
 
 	// Handle --resume (no value): show session picker
 	if (parsedArgs.resume === true && !parsedArgs.fork) {
-		const folderSessions = await logger.time("SessionManager.list", SessionManager.list, cwd, parsedArgs.sessionDir);
+		const workspaceMode = settingsInstance.get("workspace.identifier");
+		const folderSessions = await logger.time(
+			"SessionManager.list",
+			SessionManager.list,
+			cwd,
+			parsedArgs.sessionDir,
+			undefined,
+			workspaceMode,
+		);
 		let preloadedAllSessions: SessionInfo[] | undefined;
 		if (folderSessions.length === 0) {
 			// Probe globally so we can exit fast when the user has no sessions at
@@ -1192,7 +1270,9 @@ export async function runRootCommand(
 			// project in place so the session is built with its configuration.
 			await settingsInstance.reloadForCwd(cwd);
 		}
-		sessionManager = await SessionManager.open(selected.path);
+		sessionManager = await SessionManager.open(selected.path, undefined, undefined, {
+			workspaceIdentifierMode: settingsInstance.get("workspace.identifier"),
+		});
 	}
 
 	await pluginPreloadPromise;

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -17,6 +17,8 @@ import readPathTemplate from "../prompts/memories/read-path.md" with { type: "te
 import stageOneInputTemplate from "../prompts/memories/stage_one_input.md" with { type: "text" };
 import stageOneSystemTemplate from "../prompts/memories/stage_one_system.md" with { type: "text" };
 import type { AgentSession } from "../session/agent-session";
+import type { WorkspaceIdentifierMode } from "../utils/workspace-storage-identifier";
+import { resolveWorkspaceStorageIdentity } from "../utils/workspace-storage-identifier";
 import {
 	claimStage1Jobs,
 	clearMemoryData as clearMemoryDataInDb,
@@ -156,7 +158,7 @@ export async function buildMemoryToolDeveloperInstructions(
 ): Promise<string | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd(), settings.get("workspace.identifier"));
 
 	let summary = "";
 	try {
@@ -188,23 +190,33 @@ export async function buildMemoryToolDeveloperInstructions(
 /**
  * Clear all persisted memory state and generated artifacts.
  */
-export async function clearMemoryData(agentDir: string, cwd: string): Promise<void> {
+export async function clearMemoryData(
+	agentDir: string,
+	cwd: string,
+	mode: WorkspaceIdentifierMode = "path",
+): Promise<void> {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
 		clearMemoryDataInDb(db);
 	} finally {
 		closeMemoryDb(db);
 	}
-	await fs.rm(getMemoryRoot(agentDir, cwd), { recursive: true, force: true });
+	await fs.rm(getMemoryRoot(agentDir, cwd, mode), { recursive: true, force: true });
 }
 
 /**
  * Force-enqueue global consolidation maintenance work.
  */
-export function enqueueMemoryConsolidation(agentDir: string, cwd: string, sourceUpdatedAt = unixNow()): void {
+export function enqueueMemoryConsolidation(
+	agentDir: string,
+	cwd: string,
+	sourceUpdatedAt = unixNow(),
+	mode: WorkspaceIdentifierMode = "path",
+): void {
+	const scopeKey = getMemoryScopeKey(cwd, mode);
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
-		enqueueGlobalWatermark(db, sourceUpdatedAt, cwd, { forceDirtyWhenNotAdvanced: true });
+		enqueueGlobalWatermark(db, sourceUpdatedAt, scopeKey, { forceDirtyWhenNotAdvanced: true });
 	} finally {
 		closeMemoryDb(db);
 	}
@@ -229,15 +241,16 @@ async function runPhase1(options: {
 	agentDir: string;
 	config: MemoryRuntimeConfig;
 }): Promise<void> {
-	const { session, modelRegistry, agentDir, config } = options;
+	const { session, settings, modelRegistry, agentDir, config } = options;
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, session.sessionManager.getCwd());
+	const mode = settings.get("workspace.identifier");
+	const memoryRoot = getMemoryRoot(agentDir, session.sessionManager.getCwd(), mode);
 	const currentThreadId = session.sessionManager.getSessionId();
 
 	try {
-		const threads = await collectThreads(session, currentThreadId);
+		const threads = await collectThreads(session, currentThreadId, mode);
 		upsertThreads(db, threads);
 
 		const phase1Model = await resolveMemoryModel({
@@ -307,13 +320,15 @@ async function runPhase1(options: {
 				return;
 			}
 
+			const scopeKey = claim.cwd ?? "";
+
 			if (result.kind === "no_output") {
 				markStage1SucceededNoOutput(db, {
 					threadId: claim.threadId,
 					ownershipToken: claim.ownershipToken,
 					sourceUpdatedAt: claim.sourceUpdatedAt,
 					nowSec: unixNow(),
-					cwd: claim.cwd,
+					cwd: scopeKey,
 				});
 				stats.succeededNoOutput += 1;
 				return;
@@ -327,7 +342,7 @@ async function runPhase1(options: {
 				rolloutSummary: result.output.rolloutSummary,
 				rolloutSlug: result.output.rolloutSlug,
 				nowSec: unixNow(),
-				cwd: claim.cwd,
+				cwd: scopeKey,
 			});
 			stats.succeeded += 1;
 			stats.produced += 1;
@@ -361,24 +376,26 @@ async function runPhase2(options: {
 	agentDir: string;
 	config: MemoryRuntimeConfig;
 }): Promise<void> {
-	const { session, modelRegistry, agentDir, config } = options;
+	const { session, settings, modelRegistry, agentDir, config } = options;
 	const cwd = session.sessionManager.getCwd();
+	const mode = settings.get("workspace.identifier");
+	const scopeKey = getMemoryScopeKey(cwd, mode);
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, cwd);
+	const memoryRoot = getMemoryRoot(agentDir, cwd, mode);
 
 	try {
 		const claimResult = tryClaimGlobalPhase2Job(db, {
 			workerId,
 			leaseSeconds: config.phase2LeaseSeconds,
 			nowSec,
-			cwd,
+			cwd: scopeKey,
 		});
 		if (claimResult.kind !== "claimed") return;
 
 		const claim = claimResult.claim;
-		const outputs = listStage1OutputsForGlobal(db, config.maxRawMemoriesForGlobal, cwd);
+		const outputs = listStage1OutputsForGlobal(db, config.maxRawMemoriesForGlobal, scopeKey);
 		const newWatermark = computeCompletionWatermark(claim.inputWatermark, outputs);
 
 		await syncPhase2Artifacts(memoryRoot, outputs);
@@ -388,7 +405,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				newWatermark,
 				nowSec: unixNow(),
-				cwd,
+				cwd: scopeKey,
 			});
 			if (!marked) {
 				logger.warn("Phase2 empty-input completion lost ownership", { memoryRoot });
@@ -407,7 +424,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: "No model available for phase2",
 				memoryRoot,
-				cwd,
+				scopeKey,
 			});
 			return;
 		}
@@ -418,7 +435,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: "No API key available for phase2",
 				memoryRoot,
-				cwd,
+				scopeKey,
 			});
 			return;
 		}
@@ -429,7 +446,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				leaseSeconds: config.phase2LeaseSeconds,
 				nowSec: unixNow(),
-				cwd,
+				cwd: scopeKey,
 			});
 			if (!ok) {
 				heartbeatLostOwnership = true;
@@ -452,7 +469,7 @@ async function runPhase2(options: {
 				ownershipToken: claim.ownershipToken,
 				newWatermark,
 				nowSec: unixNow(),
-				cwd,
+				cwd: scopeKey,
 			});
 			if (!marked) {
 				throw new Error("Phase2 could not mark success: ownership lost");
@@ -463,7 +480,7 @@ async function runPhase2(options: {
 				retryDelaySeconds: config.phase2RetryDelaySeconds,
 				reason: String(error),
 				memoryRoot,
-				cwd,
+				scopeKey,
 				error,
 			});
 		} finally {
@@ -481,18 +498,18 @@ function markPhase2FailureWithFallback(
 		retryDelaySeconds: number;
 		reason: string;
 		memoryRoot: string;
-		cwd: string;
+		scopeKey: string;
 		error?: unknown;
 	},
 ): void {
-	const { claim, retryDelaySeconds, reason, memoryRoot, cwd, error } = params;
+	const { claim, retryDelaySeconds, reason, memoryRoot, scopeKey, error } = params;
 	const nowSec = unixNow();
 	const strictFailed = markGlobalPhase2Failed(db, {
 		ownershipToken: claim.ownershipToken,
 		retryDelaySeconds,
 		reason,
 		nowSec,
-		cwd,
+		cwd: scopeKey,
 	});
 	if (strictFailed) return;
 
@@ -500,7 +517,7 @@ function markPhase2FailureWithFallback(
 		retryDelaySeconds,
 		reason,
 		nowSec,
-		cwd,
+		cwd: scopeKey,
 	});
 	if (!unownedFailed) {
 		logger.warn("Phase2 could not mark failure (ownership lost and unowned fallback skipped)", {
@@ -512,10 +529,15 @@ function markPhase2FailureWithFallback(
 	}
 }
 
-async function collectThreads(session: AgentSession, currentThreadId?: string): Promise<MemoryThread[]> {
+async function collectThreads(
+	session: AgentSession,
+	currentThreadId: string | undefined,
+	mode: WorkspaceIdentifierMode,
+): Promise<MemoryThread[]> {
 	const sessionDir = session.sessionManager.getSessionDir();
 	const files = await fs.readdir(sessionDir);
 	const threads: MemoryThread[] = [];
+	const scopeKeysByCwd = new Map<string, string>();
 	for (const name of files) {
 		if (!name.endsWith(".jsonl")) continue;
 		const fullPath = path.join(sessionDir, name);
@@ -541,11 +563,22 @@ async function collectThreads(session: AgentSession, currentThreadId?: string): 
 		}
 
 		if (currentThreadId && id === currentThreadId) continue;
+		let scopeKey = "";
+		if (cwd) {
+			const cachedScopeKey = scopeKeysByCwd.get(cwd);
+			if (cachedScopeKey !== undefined) {
+				scopeKey = cachedScopeKey;
+			} else {
+				scopeKey = getMemoryScopeKey(cwd, mode);
+				scopeKeysByCwd.set(cwd, scopeKey);
+			}
+		}
+
 		threads.push({
 			id,
 			updatedAt: Math.floor(stat.mtimeMs / 1000),
 			rolloutPath: fullPath,
-			cwd,
+			cwd: scopeKey,
 			sourceKind: "cli",
 		});
 	}
@@ -1133,8 +1166,16 @@ function loadMemoryConfig(settings: Settings): MemoryRuntimeConfig {
 	};
 }
 
-export function getMemoryRoot(agentDir: string, cwd: string): string {
-	return path.join(getMemoriesDir(agentDir), encodeProjectPath(cwd));
+export function getMemoryRoot(agentDir: string, cwd: string, mode: WorkspaceIdentifierMode = "path"): string {
+	const fallbackSegment = encodeProjectPath(cwd);
+	const identity = resolveWorkspaceStorageIdentity(cwd, mode, fallbackSegment);
+	return path.join(getMemoriesDir(agentDir), identity.segment);
+}
+
+export function getMemoryScopeKey(cwd: string, mode: WorkspaceIdentifierMode = "path"): string {
+	if (mode === "path") return cwd;
+	const identity = resolveWorkspaceStorageIdentity(cwd, mode, encodeProjectPath(cwd));
+	return identity.fallback ? cwd : identity.key;
 }
 
 /**
@@ -1195,6 +1236,7 @@ export async function saveLearnedLesson(
 	agentDir: string,
 	cwd: string,
 	input: MemoryBackendSaveInput,
+	mode: WorkspaceIdentifierMode = "path",
 ): Promise<MemoryBackendSaveResult> {
 	const content = normalizeLearnedText(input.content, MAX_LEARNED_CONTENT_CHARS);
 	if (!content) {
@@ -1202,7 +1244,7 @@ export async function saveLearnedLesson(
 	}
 	const context = input.context ? normalizeLearnedText(input.context, MAX_LEARNED_CONTEXT_CHARS) : "";
 	const line = context ? `- ${content} _(context: ${context})_` : `- ${content}`;
-	const filePath = path.join(getMemoryRoot(agentDir, cwd), LEARNED_LESSONS_FILE);
+	const filePath = path.join(getMemoryRoot(agentDir, cwd, mode), LEARNED_LESSONS_FILE);
 
 	// Serialize the read-modify-write per file: parallel `learn` calls (sibling
 	// subagents, or two shared tool calls in one turn) share the project memory

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -37,7 +37,9 @@ const GLOBAL_KIND = "memory_consolidate_global";
 const DEFAULT_RETRY_REMAINING = 3;
 
 /**
- * Per-project job key so Phase 2 consolidation is isolated to a single cwd.
+ * Per-project job key so Phase 2 consolidation is isolated to a single workspace scope.
+ * The `cwd` parameter and derived job key are legacy names: git modes pass the
+ * workspace scope key here.
  * Previously a single "global" key caused cross-project memory contamination.
  */
 function globalJobKey(cwd: string): string {
@@ -487,7 +489,9 @@ WHERE kind = ? AND job_key = ? AND status = 'running' AND ownership_token = ?
 	return Number(result.changes ?? 0) > 0;
 }
 
-// Filter by cwd so each project only consolidates its own thread outputs.
+// Filter by workspace scope so each project only consolidates its own thread outputs.
+// The `cwd` column/parameter and job key are legacy names; git modes store/pass
+// the workspace scope key.
 // Before this filter existed, whichever project ran Phase 2 first got every
 // project's data written into its memory directory (see #369).
 export function listStage1OutputsForGlobal(db: Database, limit: number, cwd: string): Stage1OutputRow[] {

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -1,3 +1,4 @@
+import type { Settings } from "../config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
 	clearMemoryData,
@@ -5,7 +6,17 @@ import {
 	saveLearnedLesson,
 	startMemoryStartupTask,
 } from "../memories";
-import type { MemoryBackend } from "./types";
+import type { MemoryBackend, MemoryBackendOperationContext } from "./types";
+
+interface LocalMemoryOperationSession {
+	settings: Settings;
+}
+
+interface LocalMemoryOperationContext {
+	agentDir: string;
+	cwd: string;
+	session?: LocalMemoryOperationSession;
+}
 
 /**
  * Wraps the existing `memories/` module as a `MemoryBackend`.
@@ -15,7 +26,7 @@ import type { MemoryBackend } from "./types";
  * `learned.md` (so `status()` reports `writable: true`); structured search is
  * still unavailable.
  */
-export const localBackend: MemoryBackend = {
+export const localBackend = {
 	id: "local",
 	start(options) {
 		startMemoryStartupTask(options);
@@ -23,16 +34,19 @@ export const localBackend: MemoryBackend = {
 	async buildDeveloperInstructions(agentDir, settings) {
 		return buildMemoryToolDeveloperInstructions(agentDir, settings);
 	},
-	async clear(agentDir, cwd) {
-		await clearMemoryData(agentDir, cwd);
+	async clear(agentDir, cwd, session) {
+		const mode = session?.settings.get("workspace.identifier") ?? "path";
+		await clearMemoryData(agentDir, cwd, mode);
 	},
-	async enqueue(agentDir, cwd) {
-		enqueueMemoryConsolidation(agentDir, cwd);
+	async enqueue(agentDir, cwd, session) {
+		const mode = session?.settings.get("workspace.identifier") ?? "path";
+		enqueueMemoryConsolidation(agentDir, cwd, undefined, mode);
 	},
-	async save(context, input) {
-		return saveLearnedLesson(context.agentDir, context.cwd, input);
+	async save(context: LocalMemoryOperationContext, input) {
+		const mode = context.session?.settings.get("workspace.identifier") ?? "path";
+		return saveLearnedLesson(context.agentDir, context.cwd, input, mode);
 	},
-	async status() {
+	async status(_context: MemoryBackendOperationContext) {
 		return {
 			backend: "local" as const,
 			active: true,
@@ -42,4 +56,4 @@ export const localBackend: MemoryBackend = {
 				"Local rollout-summary memory is active; lessons from the `learn` tool are saved to learned.md. Structured search is not available.",
 		};
 	},
-};
+} satisfies MemoryBackend;

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
+import { resolveWorkspaceStorageIdentity, type WorkspaceIdentifierMode } from "../utils/workspace-storage-identifier";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
 
@@ -44,10 +45,13 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 	const configuredDbPath = settings.get("mnemopi.dbPath");
 	const cwd = settings.getCwd();
 	const scoping = settings.get("mnemopi.scoping");
+	const configuredBank = settings.get("mnemopi.bank");
 	const dbPath = configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db");
-	const scope = computeMnemopiBankScope(settings.get("mnemopi.bank"), cwd, scoping);
+	const scope = computeMnemopiBankScope(configuredBank, cwd, scoping, settings.get("workspace.identifier"));
 	const recallBanks =
-		scoping === "global" ? scope.recallBanks : extendRecallWithLegacyBanks(scope.recallBanks, dbPath, cwd);
+		scoping === "global"
+			? scope.recallBanks
+			: extendRecallWithLegacyBanks(scope.recallBanks, dbPath, cwd, configuredBank);
 	const llmMode = settings.get("mnemopi.llmMode");
 	const embeddingOverride = settings.get("mnemopi.embeddingModel");
 	const embeddingVariant = settings.get("mnemopi.embeddingVariant");
@@ -127,8 +131,9 @@ export function computeMnemopiBankScope(
 	configured: string | undefined,
 	cwd: string,
 	scoping: MnemopiScoping,
+	mode: WorkspaceIdentifierMode = "path",
 ): MnemopiBankScope {
-	const project = projectBank(configured, cwd);
+	const project = projectBank(configured, cwd, mode);
 	const globalBank = sharedBank(configured);
 	switch (scoping) {
 		case "global":
@@ -163,17 +168,17 @@ function sharedBank(configured: string | undefined): string {
 }
 
 /**
- * Derive the per-project bank id from `cwd` alone.
+ * Derive the per-project bank id from the selected workspace identity.
  *
- * Earlier versions resolved the enclosing git root before hashing, which
- * made the bank id unstable: removing or adding a `.git` anywhere above the
- * cwd repointed the same conversation directory to a different bank and
- * fragmented memories (#2412). The git lookup is gone here; the rescue path
- * for already-fragmented installs lives in {@link extendRecallWithLegacyBanks}.
+ * The default `path` mode still hashes the resolved cwd only, preserving the
+ * #2412 stability contract: adding or removing a `.git` marker above cwd must
+ * not repoint the same conversation directory to a different bank. Git modes
+ * explicitly opt into stable Git identities; the rescue path for old
+ * path-derived banks remains in {@link extendRecallWithLegacyBanks}.
  */
-function projectBank(configured: string | undefined, cwd: string): string {
-	const projectRoot = path.resolve(cwd || ".");
-	const project = projectBankSegment(projectRoot);
+function projectBank(configured: string | undefined, cwd: string, mode: WorkspaceIdentifierMode): string {
+	const identity = resolveWorkspaceStorageIdentity(cwd, mode, path.resolve(cwd || "."));
+	const project = projectBankSegment(identity.key);
 	const base = sanitizeBankName(configured);
 	return limitBankName(base ? `${base}-${project}` : project);
 }
@@ -190,6 +195,10 @@ function projectBankSegment(projectRoot: string): string {
  * previous, less-stable bank derivation (#2412) without recalling mixed-cwd
  * legacy banks wholesale under per-project isolation.
  *
+ * When `mnemopi.bank` is configured, rescue is confined to that configured
+ * namespace (`<base>` and `<base>-*`) so two explicit bank namespaces for the
+ * same cwd cannot recall each other's legacy banks.
+ *
  * Robust by design: a missing banks directory, unreadable bank dir, or
  * corrupt SQLite file is silently skipped. Scanning is capped at
  * {@link LEGACY_BANK_SCAN_LIMIT} to bound startup cost.
@@ -198,6 +207,7 @@ export function extendRecallWithLegacyBanks(
 	resolved: readonly string[],
 	dbPath: string,
 	cwd: string,
+	configured?: string,
 ): readonly string[] {
 	const banksDir = path.join(path.dirname(dbPath), "banks");
 	const cwdAbs = path.resolve(cwd || ".");
@@ -208,16 +218,28 @@ export function extendRecallWithLegacyBanks(
 		return resolved;
 	}
 	const have = new Set(resolved);
+	const configuredBase = configuredBankNamespace(configured);
 	const extras: string[] = [];
 	let scanned = 0;
 	for (const entry of entries) {
-		if (!entry.isDirectory() || have.has(entry.name)) continue;
+		if (!entry.isDirectory() || have.has(entry.name) || !isInConfiguredBankNamespace(entry.name, configuredBase))
+			continue;
 		if (scanned >= LEGACY_BANK_SCAN_LIMIT) break;
 		scanned++;
 		const candidate = path.join(banksDir, entry.name, "mnemopi.db");
 		if (bankOnlyHasCwd(candidate, cwdAbs)) extras.push(entry.name);
 	}
 	return extras.length === 0 ? resolved : [...resolved, ...extras];
+}
+
+function configuredBankNamespace(configured: string | undefined): string | undefined {
+	if (configured === undefined || configured.trim() === "") return undefined;
+	return sharedBank(configured);
+}
+
+function isInConfiguredBankNamespace(candidate: string, configuredBase: string | undefined): boolean {
+	if (configuredBase === undefined) return true;
+	return candidate === configuredBase || candidate.startsWith(`${configuredBase}-`);
 }
 
 function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -80,6 +80,7 @@ import {
 	TTS_LOCAL_VOICE_OPTIONS,
 } from "../../tts/models";
 import { canonicalizeMessage } from "../../utils/thinking-display";
+import type { WorkspaceIdentifierMode } from "../../utils/workspace-storage-identifier";
 import { createAcpClientBridge } from "./acp-client-bridge";
 import {
 	buildToolCallStartUpdate,
@@ -954,7 +955,7 @@ export class AcpAgent implements Agent {
 				const cwd = typeof params.cwd === "string" ? (params.cwd as string) : undefined;
 				if (!cwd) throw new Error("cwd required");
 				const limit = typeof params.limit === "number" ? Math.max(1, Math.min(500, params.limit as number)) : 100;
-				const sessions = await SessionManager.list(cwd);
+				const sessions = await this.#listStoredSessions(cwd);
 				const sorted = sessions.sort((l, r) => r.modified.getTime() - l.modified.getTime()).slice(0, limit);
 				return { sessions: sorted.map(s => this.#toSessionInfo(s)) };
 			}
@@ -1844,8 +1845,29 @@ export class AcpAgent implements Agent {
 		return usage;
 	}
 
+	#activeSettings(cwd?: string): Settings | undefined {
+		if (cwd) {
+			for (const record of this.#sessions.values()) {
+				if (record.session.sessionManager.getCwd() === cwd) {
+					return record.session.settings;
+				}
+			}
+		}
+		const [firstRecord] = this.#sessions.values();
+		return this.#initialSession?.settings ?? firstRecord?.session.settings;
+	}
+
+	async #workspaceIdentifierModeForCwd(cwd: string): Promise<WorkspaceIdentifierMode> {
+		const baseSettings = this.#activeSettings(cwd);
+		if (!baseSettings) return "path";
+		const scopedSettings = await baseSettings.cloneForCwd(cwd);
+		return scopedSettings.get("workspace.identifier");
+	}
+
 	async #listStoredSessions(cwd?: string): Promise<StoredSessionInfo[]> {
-		const sessions = cwd ? await SessionManager.list(cwd) : await SessionManager.listAll();
+		const sessions = cwd
+			? await SessionManager.list(cwd, undefined, undefined, await this.#workspaceIdentifierModeForCwd(cwd))
+			: await SessionManager.listAll();
 		return sessions.sort((left, right) => right.modified.getTime() - left.modified.getTime());
 	}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1153,6 +1153,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		: logger.time("discoverSlashCommands", discoverSlashCommands, cwd);
 	slashCommandsPromise.catch(() => {});
 	const skillsSettings = settings.getGroup("skills");
+	const workspaceMode = settings.get("workspace.identifier");
 	const disabledExtensionIds = settings.get("disabledExtensions") ?? [];
 	const discoveredSkillsPromise =
 		options.skills === undefined
@@ -1181,9 +1182,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const sessionManager =
 		options.sessionManager ??
-		logger.time("sessionManager", () =>
-			SessionManager.create(cwd, SessionManager.getDefaultSessionDir(cwd, agentDir)),
-		);
+		logger.time("sessionManager", () => {
+			const computedDir = SessionManager.getDefaultSessionDir(cwd, agentDir, undefined, workspaceMode);
+			return SessionManager.create(cwd, computedDir, undefined, workspaceMode);
+		});
 	const providerSessionId = options.providerSessionId ?? sessionManager.getSessionId();
 	// Startup model *selection* only needs to know whether auth is configured for
 	// a candidate's provider — never the resolved key bytes. Use the synchronous,

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -2,6 +2,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Message, TextContent } from "@oh-my-pi/pi-ai";
 import { getAgentDir as getDefaultAgentDir, logger, parseJsonlLenient, toError } from "@oh-my-pi/pi-utils";
+import type { WorkspaceIdentifierMode } from "../utils/workspace-storage-identifier";
 import { computeDefaultSessionDir } from "./session-paths";
 import { FileSessionStorage, type SessionStorage } from "./session-storage";
 
@@ -566,8 +567,9 @@ export async function resolveResumableSession(
 	cwd: string,
 	sessionDir?: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	mode: WorkspaceIdentifierMode = "path",
 ): Promise<ResolvedSessionMatch | undefined> {
-	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage);
+	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage, undefined, mode);
 	const localSessions = await listSessions(localSessionDir, storage);
 	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (localMatch) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -10,6 +10,7 @@ import {
 	logger,
 	toError,
 } from "@oh-my-pi/pi-utils";
+import type { WorkspaceIdentifierMode } from "../utils/workspace-storage-identifier";
 import { ArtifactManager } from "./artifacts";
 import { type BlobPutOptions, type BlobPutResult, BlobStore } from "./blob-store";
 import {
@@ -330,6 +331,7 @@ export class SessionManager {
 	#sessionDir: string;
 	readonly #persist: boolean;
 	readonly #storage: SessionStorage;
+	readonly #workspaceIdentifierMode: WorkspaceIdentifierMode;
 	readonly #blobs: BlobStore;
 
 	#sessionId = "";
@@ -376,11 +378,18 @@ export class SessionManager {
 	#suppressBreadcrumb = false;
 	#sessionNameChangedCallbacks = new Set<() => void>();
 
-	private constructor(cwd: string, sessionDir: string, persist: boolean, storage: SessionStorage) {
+	private constructor(
+		cwd: string,
+		sessionDir: string,
+		persist: boolean,
+		storage: SessionStorage,
+		workspaceIdentifierMode: WorkspaceIdentifierMode = "path",
+	) {
 		this.#cwd = cwd;
 		this.#sessionDir = sessionDir;
 		this.#persist = persist;
 		this.#storage = storage;
+		this.#workspaceIdentifierMode = workspaceIdentifierMode;
 		this.#blobs = new BlobStore(getBlobsDir());
 
 		if (persist && sessionDir) this.#storage.ensureDirSync(sessionDir);
@@ -840,12 +849,12 @@ export class SessionManager {
 			return;
 		}
 
-		const managedRoot = resolveManagedSessionRoot(this.#sessionDir, this.#cwd);
+		const managedRoot = resolveManagedSessionRoot(this.#sessionDir, this.#cwd, this.#workspaceIdentifierMode);
 		const nextSessionDir =
 			resolvedTargetDir ??
 			(managedRoot
-				? computeDefaultSessionDir(resolvedCwd, this.#storage, managedRoot)
-				: computeDefaultSessionDir(resolvedCwd, this.#storage));
+				? computeDefaultSessionDir(resolvedCwd, this.#storage, managedRoot, this.#workspaceIdentifierMode)
+				: computeDefaultSessionDir(resolvedCwd, this.#storage, undefined, this.#workspaceIdentifierMode));
 
 		let sessionFileExisted = false;
 
@@ -1507,8 +1516,9 @@ export class SessionManager {
 		cwd: string,
 		agentDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
+		mode: WorkspaceIdentifierMode = "path",
 	): string {
-		return computeDefaultSessionDir(cwd, storage, getSessionsDir(agentDir));
+		return computeDefaultSessionDir(cwd, storage, getSessionsDir(agentDir), mode);
 	}
 
 	/**
@@ -1516,9 +1526,14 @@ export class SessionManager {
 	 * @param cwd Working directory (stored in the session header)
 	 * @param sessionDir Optional session directory; defaults to the cwd-derived dir.
 	 */
-	static create(cwd: string, sessionDir?: string, storage: SessionStorage = new FileSessionStorage()): SessionManager {
-		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
-		const manager = new SessionManager(cwd, dir, true, storage);
+	static create(
+		cwd: string,
+		sessionDir?: string,
+		storage: SessionStorage = new FileSessionStorage(),
+		mode: WorkspaceIdentifierMode = "path",
+	): SessionManager {
+		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage, mode);
+		const manager = new SessionManager(cwd, dir, true, storage, mode);
 		manager.#resetToNewSession();
 		return manager;
 	}
@@ -1537,10 +1552,15 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { suppressBreadcrumb?: boolean; sessionFile?: string },
+		options?: {
+			suppressBreadcrumb?: boolean;
+			sessionFile?: string;
+			workspaceIdentifierMode?: WorkspaceIdentifierMode;
+		},
 	): Promise<SessionManager> {
-		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
-		const manager = new SessionManager(cwd, dir, true, storage);
+		const mode = options?.workspaceIdentifierMode ?? "path";
+		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage, mode);
+		const manager = new SessionManager(cwd, dir, true, storage, mode);
 		manager.#suppressBreadcrumb = options?.suppressBreadcrumb === true;
 
 		const sourceEntries = structuredClone(await loadEntriesFromFile(sourcePath, storage)) as FileEntry[];
@@ -1571,8 +1591,13 @@ export class SessionManager {
 		filePath: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { initialCwd?: string; suppressBreadcrumb?: boolean },
+		options?: {
+			initialCwd?: string;
+			suppressBreadcrumb?: boolean;
+			workspaceIdentifierMode?: WorkspaceIdentifierMode;
+		},
 	): Promise<SessionManager> {
+		const mode = options?.workspaceIdentifierMode ?? "path";
 		const loaded = await loadEntriesFromFile(filePath, storage);
 		const header = loaded.find(entry => entry.type === "session") as SessionHeader | undefined;
 		// Resume into the session's recorded cwd only when that directory still
@@ -1586,9 +1611,9 @@ export class SessionManager {
 		const dir =
 			sessionDir ??
 			(recordedCwd && !recordedCwdUsable
-				? SessionManager.getDefaultSessionDir(cwd, undefined, storage)
+				? SessionManager.getDefaultSessionDir(cwd, undefined, storage, mode)
 				: path.dirname(path.resolve(filePath)));
-		const manager = new SessionManager(cwd, dir, true, storage);
+		const manager = new SessionManager(cwd, dir, true, storage, mode);
 		manager.#suppressBreadcrumb = options?.suppressBreadcrumb === true;
 		await manager.setSessionFile(filePath);
 		return manager;
@@ -1655,8 +1680,9 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
+		mode: WorkspaceIdentifierMode = "path",
 	): Promise<SessionManager> {
-		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
+		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage, mode);
 		const resolvedCwd = path.resolve(cwd);
 		const breadcrumb = await readTerminalBreadcrumbEntry();
 		let chosenSession: string | null | undefined;
@@ -1681,7 +1707,7 @@ export class SessionManager {
 				let currentProjectAlreadyHasSession = false;
 
 				if (breadcrumbCwdMissing && newestIsBreadcrumb) {
-					const localSession = (await SessionManager.list(cwd, dir, storage)).find(
+					const localSession = (await SessionManager.list(cwd, dir, storage, mode)).find(
 						session =>
 							path.resolve(session.path) !== breadcrumbFile &&
 							session.cwd &&
@@ -1703,6 +1729,7 @@ export class SessionManager {
 					// recorded cwd, which would no-op moveTo when it equals `cwd`.
 					const manager = await SessionManager.open(breadcrumb.sessionFile, undefined, storage, {
 						initialCwd: breadcrumbCwd,
+						workspaceIdentifierMode: mode,
 					});
 					await manager.moveTo(cwd, sessionDir);
 					return manager;
@@ -1714,7 +1741,7 @@ export class SessionManager {
 
 		if (chosenSession === undefined) chosenSession = await findMostRecentSession(dir, storage);
 
-		const manager = new SessionManager(cwd, dir, true, storage);
+		const manager = new SessionManager(cwd, dir, true, storage, mode);
 		if (chosenSession) await manager.setSessionFile(chosenSession);
 		else manager.#resetToNewSession();
 		return manager;
@@ -1725,7 +1752,7 @@ export class SessionManager {
 		cwd: string = getProjectDir(),
 		storage: SessionStorage = new MemorySessionStorage(),
 	): SessionManager {
-		const manager = new SessionManager(cwd, "", false, storage);
+		const manager = new SessionManager(cwd, "", false, storage, "path");
 		manager.#resetToNewSession();
 		return manager;
 	}
@@ -1738,8 +1765,9 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
+		mode: WorkspaceIdentifierMode = "path",
 	): Promise<SessionInfo[]> {
-		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
+		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage, mode);
 		return listSessions(dir, storage);
 	}
 

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
 import { getSessionsDir, getTerminalSessionsDir, isEnoent, logger, resolveEquivalentPath } from "@oh-my-pi/pi-utils";
+import { resolveWorkspaceStorageIdentity, type WorkspaceIdentifierMode } from "../utils/workspace-storage-identifier";
 import type { SessionStorage } from "./session-storage";
 
 const migratedSessionRoots = new Set<string>();
@@ -111,10 +112,15 @@ function migrateLegacyAbsoluteSessionDir(cwd: string, sessionDir: string, sessio
 	}
 }
 
-export function resolveManagedSessionRoot(sessionDir: string, cwd: string): string | undefined {
+export function resolveManagedSessionRoot(
+	sessionDir: string,
+	cwd: string,
+	mode: WorkspaceIdentifierMode = "path",
+): string | undefined {
 	const currentDirName = path.basename(sessionDir);
-	const { encodedDirName } = getDefaultSessionDirName(cwd);
-	if (currentDirName !== encodedDirName && currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)) {
+	const { encodedDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
+	const identity = resolveWorkspaceStorageIdentity(resolvedCwd, mode, encodedDirName);
+	if (currentDirName !== identity.segment && currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)) {
 		return undefined;
 	}
 	return path.dirname(sessionDir);
@@ -129,11 +135,13 @@ export function computeDefaultSessionDir(
 	cwd: string,
 	storage: SessionStorage,
 	sessionsRoot: string = getSessionsDir(),
+	mode: WorkspaceIdentifierMode = "path",
 ): string {
 	const { encodedDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
-	migrateHomeSessionDirs(sessionsRoot);
-	const sessionDir = path.join(sessionsRoot, encodedDirName);
-	migrateLegacyAbsoluteSessionDir(resolvedCwd, sessionDir, sessionsRoot);
+	const identity = resolveWorkspaceStorageIdentity(resolvedCwd, mode, encodedDirName);
+	if (identity.mode === "path") migrateHomeSessionDirs(sessionsRoot);
+	const sessionDir = path.join(sessionsRoot, identity.segment);
+	if (identity.mode === "path") migrateLegacyAbsoluteSessionDir(resolvedCwd, sessionDir, sessionsRoot);
 	storage.ensureDirSync(sessionDir);
 	return sessionDir;
 }

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -80,8 +80,17 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 			}
 		} else if (backend === "local") {
 			const result = await localBackend.save?.(
-				{ agentDir: this.session.settings.getAgentDir(), cwd: this.session.settings.getCwd() },
-				{ content: params.memory, context: params.context, source: "coding-agent-learn", importance: 0.8 },
+				{
+					agentDir: this.session.settings.getAgentDir(),
+					cwd: this.session.settings.getCwd(),
+					session: this.session,
+				},
+				{
+					content: params.memory,
+					context: params.context,
+					source: "coding-agent-learn",
+					importance: 0.8,
+				},
 			);
 			if (!result || result.stored === 0) {
 				throw new Error("Lesson was empty after sanitization; nothing stored.");

--- a/packages/coding-agent/src/utils/workspace-storage-identifier.ts
+++ b/packages/coding-agent/src/utils/workspace-storage-identifier.ts
@@ -1,0 +1,262 @@
+import * as path from "node:path";
+import { $which, WhichCachePolicy } from "@oh-my-pi/pi-utils";
+
+export const WORKSPACE_IDENTIFIER_MODES = ["path", "git-remote", "git-root"] as const;
+export type WorkspaceIdentifierMode = (typeof WORKSPACE_IDENTIFIER_MODES)[number];
+
+export interface WorkspaceStorageIdentity {
+	requestedMode: WorkspaceIdentifierMode;
+	mode: WorkspaceIdentifierMode;
+	key: string;
+	segment: string;
+	fallback: boolean;
+}
+
+interface GitCommandResult {
+	exitCode: number;
+	stdout: string;
+}
+
+const GIT_READ_ONLY_ARGS = [
+	"--no-optional-locks",
+	"-c",
+	"core.fsmonitor=false",
+	"-c",
+	"core.untrackedCache=false",
+] as const;
+const ROOT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const REMOTE_SLUG_MAX_LENGTH = 72;
+
+export function resolveWorkspaceStorageIdentity(
+	cwd: string,
+	requestedMode: WorkspaceIdentifierMode,
+	pathFallbackSegment: string,
+): WorkspaceStorageIdentity {
+	const resolvedCwd = path.resolve(cwd || ".");
+	if (requestedMode === "path") {
+		return pathIdentity(resolvedCwd, requestedMode, pathFallbackSegment, false);
+	}
+
+	const git = $which("git", { cache: WhichCachePolicy.Fresh, PATH: process.env.PATH });
+	if (!git) {
+		return pathIdentity(resolvedCwd, requestedMode, pathFallbackSegment, true);
+	}
+
+	if (requestedMode === "git-remote") {
+		const remote = resolveGitRemoteIdentifier(git, resolvedCwd);
+		if (!remote) {
+			return pathIdentity(resolvedCwd, requestedMode, pathFallbackSegment, true);
+		}
+
+		const key = `git-remote:${remote}`;
+		return {
+			requestedMode,
+			mode: "git-remote",
+			key,
+			segment: `git-remote-${remoteSlug(remote)}-${hash12(key)}`,
+			fallback: false,
+		};
+	}
+
+	const rootCommit = resolveGitRootCommit(git, resolvedCwd);
+	if (!rootCommit) {
+		return pathIdentity(resolvedCwd, requestedMode, pathFallbackSegment, true);
+	}
+
+	const key = `git-root:${rootCommit}`;
+	return {
+		requestedMode,
+		mode: "git-root",
+		key,
+		segment: `git-root-${rootCommit}`,
+		fallback: false,
+	};
+}
+
+export function normalizeGitRemoteIdentifier(rawUrl: string, cwd: string): string | null {
+	const trimmed = rawUrl.trim();
+	if (!trimmed) return null;
+
+	const scpRemote = parseScpRemote(trimmed);
+	if (scpRemote) {
+		return remoteHostPathIdentifier(scpRemote.host, scpRemote.remotePath);
+	}
+
+	const parsed = parseRemoteUrl(trimmed);
+	if (parsed) {
+		if (parsed.protocol === "file:") {
+			return localRemoteIdentifier(decodeUriPath(parsed.pathname), cwd);
+		}
+
+		if (!parsed.hostname) return null;
+		return remoteHostPathIdentifier(
+			parsed.hostname.toLowerCase() + (parsed.port ? `:${parsed.port}` : ""),
+			decodeUriPath(parsed.pathname),
+		);
+	}
+
+	return localRemoteIdentifier(trimmed, cwd);
+}
+
+function pathIdentity(
+	resolvedCwd: string,
+	requestedMode: WorkspaceIdentifierMode,
+	segment: string,
+	fallback: boolean,
+): WorkspaceStorageIdentity {
+	return {
+		requestedMode,
+		mode: "path",
+		key: resolvedCwd,
+		segment,
+		fallback,
+	};
+}
+
+function resolveGitRemoteIdentifier(git: string, cwd: string): string | null {
+	const origin = runGit(git, cwd, ["remote", "get-url", "origin"]);
+	const originUrl = firstLine(origin);
+	if (origin.exitCode === 0 && originUrl) {
+		const normalized = normalizeGitRemoteIdentifier(originUrl, cwd);
+		if (normalized) return normalized;
+	}
+
+	const remotes = runGit(git, cwd, ["remote"]);
+	if (remotes.exitCode !== 0) return null;
+
+	for (const remoteName of remotes.stdout
+		.split(/\r?\n/)
+		.map(remote => remote.trim())
+		.filter(Boolean)) {
+		const remote = runGit(git, cwd, ["remote", "get-url", remoteName]);
+		const remoteUrl = firstLine(remote);
+		if (remote.exitCode !== 0 || !remoteUrl) continue;
+
+		const normalized = normalizeGitRemoteIdentifier(remoteUrl, cwd);
+		if (normalized) return normalized;
+	}
+
+	return null;
+}
+
+function resolveGitRootCommit(git: string, cwd: string): string | null {
+	const shallow = isShallowRepository(git, cwd);
+	if (shallow !== false) return null;
+
+	const result = runGit(git, cwd, ["rev-list", "--max-parents=0", "--reverse", "HEAD"]);
+	if (result.exitCode !== 0) return null;
+
+	for (const line of result.stdout.split(/\r?\n/)) {
+		const candidate = line.trim().toLowerCase();
+		if (ROOT_COMMIT_PATTERN.test(candidate)) return candidate;
+	}
+
+	return null;
+}
+
+function isShallowRepository(git: string, cwd: string): boolean | null {
+	const result = runGit(git, cwd, ["rev-parse", "--is-shallow-repository"]);
+	if (result.exitCode !== 0) return null;
+
+	const value = firstLine(result);
+	if (value === "true") return true;
+	if (value === "false") return false;
+	return null;
+}
+
+function runGit(git: string, cwd: string, args: readonly string[]): GitCommandResult {
+	try {
+		const result = Bun.spawnSync([git, ...GIT_READ_ONLY_ARGS, ...args], {
+			cwd,
+			env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+		});
+
+		return {
+			exitCode: result.exitCode ?? 0,
+			stdout: new TextDecoder().decode(result.stdout),
+		};
+	} catch {
+		return { exitCode: 1, stdout: "" };
+	}
+}
+
+function firstLine(result: GitCommandResult): string | null {
+	const line = result.stdout
+		.split(/\r?\n/)
+		.map(value => value.trim())
+		.find(Boolean);
+	return line ?? null;
+}
+
+function parseScpRemote(rawUrl: string): { host: string; remotePath: string } | null {
+	if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return null;
+
+	const match = /^(?:[^@\s]+@)?([^:/\s]+):(.+)$/.exec(rawUrl);
+	if (!match) return null;
+
+	return {
+		host: match[1].toLowerCase(),
+		remotePath: match[2],
+	};
+}
+
+function parseRemoteUrl(rawUrl: string): URL | null {
+	try {
+		return new URL(rawUrl);
+	} catch {
+		return null;
+	}
+}
+
+function remoteHostPathIdentifier(host: string, rawPath: string): string | null {
+	const normalizedPath = trimTrailingGit(trimSlashes(rawPath));
+	if (!host || !normalizedPath) return null;
+
+	return `${host}/${normalizedPath}`;
+}
+
+function localRemoteIdentifier(rawPath: string, cwd: string): string | null {
+	const trimmed = rawPath.trim();
+	if (!trimmed) return null;
+
+	const resolved = path.resolve(cwd || ".", trimmed);
+	const withoutTrailingSlash = trimTrailingSlashes(resolved);
+	return `file:${trimTrailingSlashes(trimTrailingGit(withoutTrailingSlash))}`;
+}
+
+function decodeUriPath(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function trimSlashes(value: string): string {
+	return trimTrailingSlashes(value).replace(/^\/+/, "");
+}
+
+function trimTrailingSlashes(value: string): string {
+	let output = value;
+	while (output.length > 1 && output.endsWith("/")) {
+		output = output.slice(0, -1);
+	}
+	return output;
+}
+
+function trimTrailingGit(value: string): string {
+	return value.replace(/\.git$/i, "");
+}
+
+function remoteSlug(remote: string): string {
+	const slug = remote.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+	const capped = (slug || "remote").slice(0, REMOTE_SLUG_MAX_LENGTH).replace(/-+$/g, "");
+	return capped || "remote";
+}
+
+function hash12(key: string): string {
+	return Bun.hash(key).toString(16).padStart(16, "0").slice(-12);
+}

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -164,6 +164,17 @@ describe("learned-lesson read-back", () => {
 		expect(out).toContain("- File-backed lesson");
 	});
 
+	it("reads lessons saved from a linked worktree in git-remote mode", async () => {
+		const { repoCwd, worktreeCwd } = await createLinkedWorktree(tmp);
+		await saveLearnedLesson(agentDir, repoCwd, { content: "Shared lesson" }, "git-remote");
+		const settings = Settings.isolated({ "memory.backend": "local", "workspace.identifier": "git-remote" });
+		spyOn(settings, "getCwd").mockReturnValue(worktreeCwd);
+
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+
+		expect(out).toContain("Shared lesson");
+	});
+
 	it("injects both the summary and lessons when both exist", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		const root = getMemoryRoot(agentDir, settings.getCwd());
@@ -231,12 +242,14 @@ describe("learn tool (local backend)", () => {
 		await fs.rm(tmp, { recursive: true, force: true });
 	});
 
-	function localSession(): ToolSession {
-		const settings = Settings.isolated({ "autolearn.enabled": true, "memory.backend": "local" });
+	function localSession(
+		settings = Settings.isolated({ "autolearn.enabled": true, "memory.backend": "local" }),
+		cwd = projCwd,
+	): ToolSession {
 		spyOn(settings, "getAgentDir").mockReturnValue(agentDir);
-		spyOn(settings, "getCwd").mockReturnValue(projCwd);
+		spyOn(settings, "getCwd").mockReturnValue(cwd);
 		return {
-			cwd: projCwd,
+			cwd,
 			hasUI: false,
 			skipPythonPreflight: true,
 			getSessionFile: () => null,
@@ -258,8 +271,58 @@ describe("learn tool (local backend)", () => {
 		expect(await Bun.file(learnedFile).text()).toContain("- A local tool lesson");
 	});
 
+	it("execute saves git-remote lessons into the shared worktree bucket", async () => {
+		const { repoCwd, worktreeCwd } = await createLinkedWorktree(tmp);
+		const repoSettings = Settings.isolated({
+			"autolearn.enabled": true,
+			"memory.backend": "local",
+			"workspace.identifier": "git-remote",
+		});
+		await new LearnTool(localSession(repoSettings, repoCwd)).execute("git-remote", {
+			memory: "A git-remote tool lesson",
+		});
+		const worktreeSettings = Settings.isolated({ "memory.backend": "local", "workspace.identifier": "git-remote" });
+		spyOn(worktreeSettings, "getCwd").mockReturnValue(worktreeCwd);
+
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, worktreeSettings);
+
+		expect(out).toContain("A git-remote tool lesson");
+	});
+
 	it("execute throws when the lesson is empty after sanitization", async () => {
 		await expect(new LearnTool(localSession()).execute("2", { memory: "   " })).rejects.toThrow(/empty/i);
 		expect(await Bun.file(learnedFile).exists()).toBe(false);
 	});
 });
+
+async function createLinkedWorktree(root: string): Promise<{ repoCwd: string; worktreeCwd: string }> {
+	const repoCwd = path.join(root, "repo");
+	const worktreeCwd = path.join(root, "repo-linked");
+	await runGit(root, ["init", repoCwd]);
+	await runGit(repoCwd, ["config", "user.email", "test@example.com"]);
+	await runGit(repoCwd, ["config", "user.name", "Test User"]);
+	await Bun.write(path.join(repoCwd, "README.md"), "fixture\n");
+	await runGit(repoCwd, ["add", "README.md"]);
+	await runGit(repoCwd, ["-c", "commit.gpgsign=false", "commit", "-m", "initial"]);
+	await runGit(repoCwd, ["remote", "add", "origin", "git@github.com:owner/project.git"]);
+	await runGit(repoCwd, ["worktree", "add", "-b", "linked", worktreeCwd]);
+	return { repoCwd, worktreeCwd };
+}
+
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+	const child = Bun.spawn(["git", ...args], {
+		cwd,
+		env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1", GIT_OPTIONAL_LOCKS: "0" },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout as ReadableStream<Uint8Array>).text(),
+		new Response(child.stderr as ReadableStream<Uint8Array>).text(),
+		child.exited,
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed (${exitCode}): ${stderr || stdout}`);
+	}
+	return stdout;
+}

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -20,6 +20,9 @@ import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-list
 import * as sessionListingModule from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
 
 function buildArgs(resume: string, sessionDir?: string): Args {
 	return {
@@ -50,7 +53,91 @@ function buildGlobalMatch(cwd: string): { session: SessionInfo; scope: "global" 
 	};
 }
 
-const stubSettings = { get: () => undefined } as unknown as Settings;
+const stubSettings = { get: () => undefined, reloadForCwd: async () => {} } as unknown as Settings;
+
+describe("createSessionManager — shared-bucket local resume", () => {
+	let tempRoot: string;
+	let launchProject: string;
+	let existingProject: string;
+	let sessionDir: string;
+
+	beforeEach(async () => {
+		tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-shared-resume-"));
+		launchProject = path.join(tempRoot, "launch");
+		existingProject = path.join(tempRoot, "existing");
+		sessionDir = path.join(tempRoot, "sessions");
+		await fsp.mkdir(launchProject, { recursive: true });
+		await fsp.mkdir(existingProject, { recursive: true });
+		setProjectDir(launchProject);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		setProjectDir(originalProjectDir);
+		await fsp.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("rescopes startup to an existing different cwd from a local git-identifier resume match", async () => {
+		const persisted = SessionManager.create(existingProject, sessionDir);
+		persisted.appendMessage({ role: "user", content: "shared bucket resume", timestamp: 1 });
+		await persisted.ensureOnDisk();
+		await persisted.flush();
+		const sessionFile = persisted.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		const sessionId = persisted.getSessionId();
+		await persisted.close();
+
+		const resolveSpy = vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue({
+			scope: "local",
+			session: {
+				path: sessionFile,
+				id: sessionId,
+				cwd: existingProject,
+				title: "shared-bucket",
+				created: new Date(0),
+				modified: new Date(0),
+				messageCount: 1,
+				size: 0,
+				firstMessage: "shared bucket resume",
+				allMessagesText: "shared bucket resume",
+			},
+		});
+		const reloadForCwd = vi.fn(async () => {});
+		const gitModeSettings = {
+			get: (key: string) => (key === "workspace.identifier" ? "git-remote" : undefined),
+			reloadForCwd,
+		} as unknown as Settings;
+		const openSpy = vi.spyOn(SessionManager, "open");
+
+		const result = await createSessionManager(buildArgs(sessionId.slice(0, 8)), launchProject, gitModeSettings);
+
+		if (!result) throw new Error("Expected resumed session manager");
+		try {
+			expect(result.getCwd()).toBe(path.resolve(existingProject));
+			expect(getProjectDir()).toBe(path.resolve(existingProject));
+			expect(reloadForCwd).toHaveBeenCalledTimes(1);
+			expect(reloadForCwd).toHaveBeenCalledWith(path.resolve(existingProject));
+			expect(openSpy).toHaveBeenCalledWith(
+				sessionFile,
+				undefined,
+				undefined,
+				expect.objectContaining({
+					initialCwd: path.resolve(existingProject),
+					workspaceIdentifierMode: "git-remote",
+				}),
+			);
+			expect(resolveSpy).toHaveBeenCalledWith(
+				sessionId.slice(0, 8),
+				launchProject,
+				undefined,
+				undefined,
+				"git-remote",
+			);
+		} finally {
+			await result.close();
+		}
+	});
+});
 
 describe("createSessionManager — cross-project --resume cancellation (#1668)", () => {
 	// An existing directory so the match is treated as a genuinely different

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -100,6 +100,33 @@ describe("computeMnemopiBankScope (#2412)", () => {
 		expect(here).toEqual(there);
 		expect(here.bank).toBe("default");
 	});
+
+	it("shares per-project banks across linked worktrees in git-remote mode", async () => {
+		const fixture = await createGitFixture("@mnemopi-git-worktree-");
+		try {
+			const repo = computeMnemopiBankScope(undefined, fixture.repoCwd, "per-project", "git-remote");
+			const worktree = computeMnemopiBankScope(undefined, fixture.worktreeCwd, "per-project", "git-remote");
+
+			expect(worktree.bank).toBe(repo.bank);
+		} finally {
+			await fixture.root.remove();
+		}
+	});
+
+	it("separates fork remotes but shares root commits when requested", async () => {
+		const fixture = await createGitFixture("@mnemopi-git-fork-");
+		try {
+			const remoteRepo = computeMnemopiBankScope(undefined, fixture.repoCwd, "per-project", "git-remote");
+			const remoteFork = computeMnemopiBankScope(undefined, fixture.cloneCwd, "per-project", "git-remote");
+			const rootRepo = computeMnemopiBankScope(undefined, fixture.repoCwd, "per-project", "git-root");
+			const rootFork = computeMnemopiBankScope(undefined, fixture.cloneCwd, "per-project", "git-root");
+
+			expect(remoteFork.bank).not.toBe(remoteRepo.bank);
+			expect(rootFork.bank).toBe(rootRepo.bank);
+		} finally {
+			await fixture.root.remove();
+		}
+	});
 });
 
 describe("extendRecallWithLegacyBanks (#2412)", () => {
@@ -121,6 +148,26 @@ describe("extendRecallWithLegacyBanks (#2412)", () => {
 		]);
 		const extended = extendRecallWithLegacyBanks(["active-bank"], mainDbPath, childCwd);
 		expect(extended).not.toContain("mixed-cwd-legacy");
+	});
+
+	it("keeps configured-bank legacy rescue inside the configured namespace", () => {
+		const cwd = path.join(rootDir.path(), "projects", "configured-namespace");
+		createBankFixture("alpha-bank", [{ cwd }]);
+		createBankFixture("alpha-bank-legacy", [{ cwd }]);
+		createBankFixture("beta-bank", [{ cwd }]);
+		createBankFixture("beta-bank-legacy", [{ cwd }]);
+
+		const alpha = extendRecallWithLegacyBanks(["alpha-bank-active"], mainDbPath, cwd, "alpha bank");
+		expect(alpha).toContain("alpha-bank");
+		expect(alpha).toContain("alpha-bank-legacy");
+		expect(alpha).not.toContain("beta-bank");
+		expect(alpha).not.toContain("beta-bank-legacy");
+
+		const beta = extendRecallWithLegacyBanks(["beta-bank-active"], mainDbPath, cwd, "beta bank");
+		expect(beta).toContain("beta-bank");
+		expect(beta).toContain("beta-bank-legacy");
+		expect(beta).not.toContain("alpha-bank");
+		expect(beta).not.toContain("alpha-bank-legacy");
 	});
 });
 
@@ -147,3 +194,48 @@ describe("extendRecallWithLegacyBanks edge cases", () => {
 		expect(out).not.toContain("corrupt-C");
 	});
 });
+
+interface GitFixture {
+	cloneCwd: string;
+	repoCwd: string;
+	root: TempDir;
+	worktreeCwd: string;
+}
+
+async function createGitFixture(prefix: string): Promise<GitFixture> {
+	const root = await TempDir.create(prefix);
+	const repoCwd = root.join("repo");
+	const worktreeCwd = root.join("repo-linked");
+	const cloneCwd = root.join("repo-clone");
+
+	await runGit(root.path(), ["init", repoCwd]);
+	await runGit(repoCwd, ["config", "user.email", "test@example.com"]);
+	await runGit(repoCwd, ["config", "user.name", "Test User"]);
+	await Bun.write(path.join(repoCwd, "README.md"), "fixture\n");
+	await runGit(repoCwd, ["add", "README.md"]);
+	await runGit(repoCwd, ["-c", "commit.gpgsign=false", "commit", "-m", "initial"]);
+	await runGit(repoCwd, ["remote", "add", "origin", "git@github.com:owner/project.git"]);
+	await runGit(repoCwd, ["worktree", "add", "-b", "linked", worktreeCwd]);
+	await runGit(root.path(), ["clone", repoCwd, cloneCwd]);
+	await runGit(cloneCwd, ["remote", "set-url", "origin", "https://gitlab.example/fork/project.git"]);
+
+	return { cloneCwd, repoCwd, root, worktreeCwd };
+}
+
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+	const child = Bun.spawn(["git", ...args], {
+		cwd,
+		env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1", GIT_OPTIONAL_LOCKS: "0" },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout as ReadableStream<Uint8Array>).text(),
+		new Response(child.stderr as ReadableStream<Uint8Array>).text(),
+		child.exited,
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed (${exitCode}): ${stderr || stdout}`);
+	}
+	return stdout;
+}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -85,6 +85,11 @@ describe("Settings", () => {
 				"minimax",
 			]);
 		});
+
+		it("exposes workspace identifier modes", () => {
+			expect(getDefault("workspace.identifier")).toBe("path");
+			expect(getEnumValues("workspace.identifier")).toEqual(["path", "git-remote", "git-root"]);
+		});
 	});
 
 	describe("get()", () => {

--- a/packages/coding-agent/test/workspace-storage-identifier.test.ts
+++ b/packages/coding-agent/test/workspace-storage-identifier.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
+import { computeMnemopiBankScope } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import {
+	normalizeGitRemoteIdentifier,
+	resolveWorkspaceStorageIdentity,
+} from "@oh-my-pi/pi-coding-agent/utils/workspace-storage-identifier";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const tempDirs: TempDir[] = [];
+const originalPath = process.env.PATH;
+
+interface GitFixture {
+	agentDir: string;
+	cloneCwd: string;
+	repoCwd: string;
+	worktreeCwd: string;
+}
+
+async function makeTempDir(prefix: string): Promise<TempDir> {
+	const dir = await TempDir.create(prefix);
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	if (originalPath === undefined) {
+		delete process.env.PATH;
+		delete Bun.env.PATH;
+	} else {
+		process.env.PATH = originalPath;
+		Bun.env.PATH = originalPath;
+	}
+	await Promise.all(tempDirs.splice(0).map(dir => dir.remove()));
+});
+
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+	const child = Bun.spawn(["git", ...args], {
+		cwd,
+		env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1", GIT_OPTIONAL_LOCKS: "0" },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout as ReadableStream<Uint8Array>).text(),
+		new Response(child.stderr as ReadableStream<Uint8Array>).text(),
+		child.exited,
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed (${exitCode}): ${stderr || stdout}`);
+	}
+	return stdout;
+}
+
+async function createFixture(prefix: string): Promise<GitFixture> {
+	const root = await makeTempDir(prefix);
+	const repoCwd = root.join("repo");
+	const worktreeCwd = root.join("repo-linked");
+	const cloneCwd = root.join("repo-clone");
+	const agentDir = root.join("agent");
+
+	await runGit(root.path(), ["init", repoCwd]);
+	await runGit(repoCwd, ["config", "user.email", "test@example.com"]);
+	await runGit(repoCwd, ["config", "user.name", "Test User"]);
+	await Bun.write(path.join(repoCwd, "README.md"), "fixture\n");
+	await runGit(repoCwd, ["add", "README.md"]);
+	await runGit(repoCwd, ["-c", "commit.gpgsign=false", "commit", "-m", "initial"]);
+	await runGit(repoCwd, ["remote", "add", "origin", "git@github.com:owner/project.git"]);
+	await runGit(repoCwd, ["worktree", "add", "-b", "linked", worktreeCwd]);
+	await runGit(root.path(), ["clone", repoCwd, cloneCwd]);
+	await runGit(cloneCwd, ["remote", "set-url", "origin", "https://gitlab.example/fork/project.git"]);
+
+	return { agentDir, cloneCwd, repoCwd, worktreeCwd };
+}
+
+describe("workspace storage identity", () => {
+	it("falls back to the supplied path segment outside a Git repository", async () => {
+		const dir = await makeTempDir("@workspace-identity-nonrepo-");
+		const identity = resolveWorkspaceStorageIdentity(dir.path(), "git-remote", "path-bucket");
+
+		expect(identity).toEqual({
+			requestedMode: "git-remote",
+			mode: "path",
+			key: path.resolve(dir.path()),
+			segment: "path-bucket",
+			fallback: true,
+		});
+	});
+
+	it("falls back when git cannot be found on PATH", async () => {
+		const fixture = await createFixture("@workspace-identity-path-");
+		const emptyPath = await makeTempDir("@workspace-identity-empty-path-");
+		process.env.PATH = emptyPath.path();
+		Bun.env.PATH = emptyPath.path();
+
+		const identity = resolveWorkspaceStorageIdentity(fixture.repoCwd, "git-root", "path-bucket");
+
+		expect(identity.requestedMode).toBe("git-root");
+		expect(identity.mode).toBe("path");
+		expect(identity.segment).toBe("path-bucket");
+		expect(identity.fallback).toBe(true);
+	});
+
+	it("falls back for shallow repositories in git-root mode", async () => {
+		const root = await makeTempDir("@workspace-identity-shallow-");
+		const repoCwd = root.join("repo");
+		const shallowCwd = root.join("shallow");
+
+		await runGit(root.path(), ["init", repoCwd]);
+		await runGit(repoCwd, ["config", "user.email", "test@example.com"]);
+		await runGit(repoCwd, ["config", "user.name", "Test User"]);
+		await Bun.write(path.join(repoCwd, "README.md"), "first\n");
+		await runGit(repoCwd, ["add", "README.md"]);
+		await runGit(repoCwd, ["-c", "commit.gpgsign=false", "commit", "-m", "initial"]);
+		await Bun.write(path.join(repoCwd, "README.md"), "second\n");
+		await runGit(repoCwd, ["add", "README.md"]);
+		await runGit(repoCwd, ["-c", "commit.gpgsign=false", "commit", "-m", "second"]);
+		await runGit(root.path(), [
+			"-c",
+			"protocol.file.allow=always",
+			"clone",
+			"--depth=1",
+			`file://${repoCwd}`,
+			shallowCwd,
+		]);
+
+		const identity = resolveWorkspaceStorageIdentity(shallowCwd, "git-root", "path-bucket");
+
+		expect(identity.requestedMode).toBe("git-root");
+		expect(identity.mode).toBe("path");
+		expect(identity.key).toBe(path.resolve(shallowCwd));
+		expect(identity.segment).toBe("path-bucket");
+		expect(identity.fallback).toBe(true);
+	});
+
+	it("normalizes remote URL variants without credentials", () => {
+		const scp = normalizeGitRemoteIdentifier("git@github.com:Owner/repo.git", "/tmp");
+		const ssh = normalizeGitRemoteIdentifier("ssh://git@github.com/Owner/repo.git", "/tmp");
+		const https = normalizeGitRemoteIdentifier("https://token@github.com/Owner/repo", "/tmp");
+
+		expect(scp).toBe("github.com/Owner/repo");
+		expect(ssh).toBe(scp);
+		expect(https).toBe(scp);
+	});
+
+	it("normalizes local .git remotes to the worktree path identity", async () => {
+		const dir = await makeTempDir("@workspace-identity-local-remote-");
+		const repoCwd = dir.join("project");
+		const worktreeRemote = normalizeGitRemoteIdentifier(repoCwd, "/tmp");
+		const dotGitRemote = normalizeGitRemoteIdentifier(`${repoCwd}/.git`, "/tmp");
+		const dotGitSlashRemote = normalizeGitRemoteIdentifier(`${repoCwd}/.git/`, "/tmp");
+		const suffixGitRemote = normalizeGitRemoteIdentifier(`${repoCwd}.git`, "/tmp");
+		const suffixGitSlashRemote = normalizeGitRemoteIdentifier(`${repoCwd}.git/`, "/tmp");
+		const fileSuffixGitSlashRemote = normalizeGitRemoteIdentifier(`file://${repoCwd}.git/`, "/tmp");
+		const fileDotGitSlashRemote = normalizeGitRemoteIdentifier(`file://${repoCwd}/.git/`, "/tmp");
+
+		expect(worktreeRemote).toBe(`file:${repoCwd}`);
+		expect(dotGitRemote).toBe(worktreeRemote);
+		expect(dotGitSlashRemote).toBe(worktreeRemote);
+		expect(suffixGitRemote).toBe(worktreeRemote);
+		expect(suffixGitSlashRemote).toBe(worktreeRemote);
+		expect(fileSuffixGitSlashRemote).toBe(worktreeRemote);
+		expect(fileDotGitSlashRemote).toBe(worktreeRemote);
+	});
+
+	it("shares session, local memory, and Mnemopi buckets across linked worktrees by remote", async () => {
+		const fixture = await createFixture("@workspace-identity-worktree-");
+
+		expect(SessionManager.getDefaultSessionDir(fixture.repoCwd, fixture.agentDir, undefined, "git-remote")).toBe(
+			SessionManager.getDefaultSessionDir(fixture.worktreeCwd, fixture.agentDir, undefined, "git-remote"),
+		);
+		expect(getMemoryRoot(fixture.agentDir, fixture.repoCwd, "git-remote")).toBe(
+			getMemoryRoot(fixture.agentDir, fixture.worktreeCwd, "git-remote"),
+		);
+		expect(computeMnemopiBankScope(undefined, fixture.repoCwd, "per-project", "git-remote").bank).toBe(
+			computeMnemopiBankScope(undefined, fixture.worktreeCwd, "per-project", "git-remote").bank,
+		);
+	});
+
+	it("keeps fork remotes separate but shares fork roots by first commit", async () => {
+		const fixture = await createFixture("@workspace-identity-fork-");
+
+		expect(SessionManager.getDefaultSessionDir(fixture.repoCwd, fixture.agentDir, undefined, "git-remote")).not.toBe(
+			SessionManager.getDefaultSessionDir(fixture.cloneCwd, fixture.agentDir, undefined, "git-remote"),
+		);
+		expect(SessionManager.getDefaultSessionDir(fixture.repoCwd, fixture.agentDir, undefined, "git-root")).toBe(
+			SessionManager.getDefaultSessionDir(fixture.cloneCwd, fixture.agentDir, undefined, "git-root"),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds an experimental `workspace.identifier` setting so default sessions and per-project memories can be keyed by project path, Git remote, or Git root commit.

The original request was to let parallel worktrees share session and memory storage without forcing every workspace layout to collapse into one bucket. `git-remote` shares worktrees for the same fork while keeping forks separate; `git-root` shares across forks and hosting platforms when the repository root commit is known. Both Git modes fall back to the existing path-derived behavior outside usable Git repositories.

## Changes

- Added `workspace.identifier` with `path`, `git-remote`, and `git-root` modes.
- Added a shared workspace storage identity resolver with remote canonicalization, shallow-repo fallback, root commit fallback, and deterministic filesystem segments.
- Wired the identifier through default session dirs, resume/list/create/open flows, shell completion, SDK startup, and ACP session listing.
- Wired the identifier through local memory roots, memory DB scope keys, `memory://root`, learned lessons, and Mnemopi per-project banks.
- Added regression coverage for linked worktrees, fork separation/sharing, missing Git fallbacks, shallow repositories, local remote normalization, local learned-memory sharing, and Mnemopi configured-bank isolation.

## Testing

- `bun test packages/coding-agent/test/workspace-storage-identifier.test.ts packages/coding-agent/test/autolearn-learn-local.test.ts packages/coding-agent/test/mnemopi-bank-derivation.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/main-cross-project-resume.test.ts`
- `bun --cwd=packages/coding-agent run check`

Final review pass: four specialist reviewers agreed there are no blocking concerns after fixes.