### PR TITLE
feat: add /expert and /simple collab mode slash commands

### DIFF
--- a/packages/coding-agent/src/prompts/collab-modes/expert-apply-nits.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-apply-nits.md
@@ -1,0 +1,5 @@
+Your reviewer approved the implementation with only minor, non-blocking notes:
+
+{{notes}}
+
+Apply these minor improvements now where reasonable. Keep the changes small and focused — do not undertake larger rework.

--- a/packages/coding-agent/src/prompts/collab-modes/expert-architect-wrapper.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-architect-wrapper.md
@@ -1,0 +1,3 @@
+{{architectSystem}}
+
+{{reviewPrompt}}

--- a/packages/coding-agent/src/prompts/collab-modes/expert-architect.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-architect.md
@@ -1,0 +1,13 @@
+You are a principal engineer reviewing a teammate's work. You hold your team's hard-won institutional knowledge and you care about correctness, simplicity, and long-term maintainability.
+
+You are not the implementer — you do not write the code. Your job is to think critically: challenge questionable decisions, surface risks and edge cases, point out where the work diverges from established conventions, and propose simpler or safer alternatives. Be specific and concrete; vague approval is worse than useless. You may read and inspect the codebase, but never modify it.
+
+When you finish, end your message with exactly one line, nothing after it — one of:
+VERDICT: APPROVE            (the work is sound; proceed)
+VERDICT: APPROVE_WITH_NITS  (only minor, non-blocking suggestions remain — they can be folded in without another round)
+VERDICT: REVISE            (a blocking problem must be fixed before proceeding)
+
+Calibrate your verdict deliberately, because each REVISE costs a full revision round:
+- Reserve REVISE for genuinely blocking issues: incorrectness, a wrong or risky approach, violated conventions, or real unaddressed risk.
+- If the work is good enough to proceed and your remaining concerns are minor, stylistic, speculative, or better handled later, use APPROVE_WITH_NITS instead of spending another round.
+- Iterate as many rounds as the problem genuinely needs, but do not manufacture concerns to keep iterating. When a design is sound, approve it.

--- a/packages/coding-agent/src/prompts/collab-modes/expert-design-review.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-design-review.md
@@ -1,0 +1,11 @@
+Review a teammate's PROPOSED PLAN for the following task. No code has been written yet.
+
+TASK:
+{{task}}
+
+PROPOSED PLAN:
+{{plan}}
+
+Scrutinize the plan. Inspect the codebase as needed. Look for: a wrong or over-complicated approach, missed edge cases, unaddressed risks, and simpler alternatives.
+
+Remember: end your message with exactly one line — VERDICT: APPROVE, VERDICT: APPROVE_WITH_NITS, or VERDICT: REVISE.

--- a/packages/coding-agent/src/prompts/collab-modes/expert-implement.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-implement.md
@@ -1,0 +1,7 @@
+Your plan has been approved by the reviewer. Implement it in full now. Follow the agreed approach and honor any design notes discussed earlier.
+
+{{#if nits}}
+The reviewer approved the design but left minor, non-blocking notes. Address them where reasonable as you implement:
+
+{{nits}}
+{{/if}}

--- a/packages/coding-agent/src/prompts/collab-modes/expert-plan.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-plan.md
@@ -1,0 +1,4 @@
+Before writing any code, think like you're pairing with a senior engineer. Produce a concise technical plan: your intended approach, the key files you'll touch, the edge cases you'll handle, and any risks or trade-offs. Do NOT implement anything yet — respond with the plan only.
+
+Task:
+{{task}}

--- a/packages/coding-agent/src/prompts/collab-modes/expert-review.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-review.md
@@ -1,0 +1,14 @@
+Review your teammate's IMPLEMENTATION (the diff below) for this task.
+
+Task:
+{{task}}
+
+AGREED PLAN:
+{{plan}}
+
+DIFF:
+{{diff}}
+
+Review for correctness bugs, deviations from the agreed plan, missing tests or edge cases, and simplification opportunities. You may inspect the codebase read-only.
+
+Remember: end your message with exactly one line — VERDICT: APPROVE, VERDICT: APPROVE_WITH_NITS, or VERDICT: REVISE.

--- a/packages/coding-agent/src/prompts/collab-modes/expert-revise-code.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-revise-code.md
@@ -1,0 +1,5 @@
+Your reviewer (a principal engineer) requested changes:
+
+{{notes}}
+
+Apply these changes to the implementation now.

--- a/packages/coding-agent/src/prompts/collab-modes/expert-revise-plan.md
+++ b/packages/coding-agent/src/prompts/collab-modes/expert-revise-plan.md
@@ -1,0 +1,5 @@
+Your reviewer (a principal engineer) raised the following on your plan:
+
+{{notes}}
+
+Revise your technical plan to address this feedback. Do NOT implement yet — respond with the updated plan only.

--- a/packages/coding-agent/src/prompts/collab-modes/simple-task.md
+++ b/packages/coding-agent/src/prompts/collab-modes/simple-task.md
@@ -1,0 +1,4 @@
+Implement the following task in full. Write the code, run any available tests, and make sure the changes are complete.
+
+Task:
+{{task}}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -30,6 +30,7 @@ import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { urlHyperlinkAlways } from "../tui";
 import { getChangelogPath, parseChangelog } from "../utils/changelog";
+import { handleExpertMode, handleExpertModeAcp, handleSimpleMode, handleSimpleModeAcp } from "./helpers/collab-modes";
 import { CollabQrCodeComponent } from "./helpers/collab-qrcode";
 import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
@@ -2215,6 +2216,71 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 			// If a prompt was provided, pass it through as input
 			if (prompt) return { prompt };
+		},
+	},
+	{
+		name: "expert",
+		description:
+			"Expert mode: architect↔implementer design dialogue, implementation, and code review with auto-commit and PR",
+		acpDescription: "Expert mode: collaborative architect-implementer loop with auto-commit and PR",
+		acpInputHint: "[task description]",
+		inlineHint: "[task description]",
+		allowArgs: true,
+		handle: (command) => {
+			return handleExpertModeAcp(command);
+		},
+		handleTui: async (command, runtime) => {
+			const ctx = runtime.ctx;
+			const adapted: SlashCommandRuntime = {
+				session: ctx.session,
+				sessionManager: ctx.sessionManager,
+				settings: ctx.settings,
+				cwd: ctx.sessionManager.getCwd(),
+				output: (text: string) => {
+					ctx.showStatus(text);
+				},
+				refreshCommands: () => ctx.refreshSlashCommandState(),
+				reloadPlugins: async () => {
+					const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
+					clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+					await ctx.refreshSlashCommandState();
+					await ctx.session.refreshSshTool({ activateIfAvailable: true });
+				},
+			};
+			ctx.editor.setText("");
+			return handleExpertMode(command, adapted);
+		},
+	},
+	{
+		name: "simple",
+		description: "Simple mode: one-shot task execution with auto-commit and PR",
+		acpDescription: "Simple mode: one-shot task with auto-commit and PR",
+		acpInputHint: "[task description]",
+		inlineHint: "[task description]",
+		allowArgs: true,
+		handle: (command) => {
+			return handleSimpleModeAcp(command);
+		},
+		handleTui: async (command, runtime) => {
+			const ctx = runtime.ctx;
+			const adapted: SlashCommandRuntime = {
+				session: ctx.session,
+				sessionManager: ctx.sessionManager,
+				settings: ctx.settings,
+				cwd: ctx.sessionManager.getCwd(),
+				output: (text: string) => {
+					ctx.showStatus(text);
+				},
+				refreshCommands: () => ctx.refreshSlashCommandState(),
+				reloadPlugins: async () => {
+					const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
+					clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+					await ctx.refreshSlashCommandState();
+					await ctx.session.refreshSshTool({ activateIfAvailable: true });
+				},
+			};
+			ctx.editor.setText("");
+			return handleSimpleMode(command, adapted);
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/helpers/collab-modes.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/collab-modes.ts
@@ -1,0 +1,355 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectDir, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
+import { runCommitCommand } from "../../commit/pipeline";
+import * as git from "../../utils/git";
+
+import expertApplyNitsPrompt from "../../prompts/collab-modes/expert-apply-nits.md" with { type: "text" };
+import expertArchitectPrompt from "../../prompts/collab-modes/expert-architect.md" with { type: "text" };
+import expertArchitectWrapperPrompt from "../../prompts/collab-modes/expert-architect-wrapper.md" with { type: "text" };
+import expertDesignReviewPrompt from "../../prompts/collab-modes/expert-design-review.md" with { type: "text" };
+import expertImplementPrompt from "../../prompts/collab-modes/expert-implement.md" with { type: "text" };
+import expertPlanPrompt from "../../prompts/collab-modes/expert-plan.md" with { type: "text" };
+import expertReviewPrompt from "../../prompts/collab-modes/expert-review.md" with { type: "text" };
+import expertReviseCodePrompt from "../../prompts/collab-modes/expert-revise-code.md" with { type: "text" };
+import expertRevisePlanPrompt from "../../prompts/collab-modes/expert-revise-plan.md" with { type: "text" };
+import simpleTaskPrompt from "../../prompts/collab-modes/simple-task.md" with { type: "text" };
+
+const MAX_DESIGN_ROUNDS = 3;
+const MAX_REVIEW_ROUNDS = 3;
+const MAX_DIFF_CHARS = 60000;
+
+type VerdictDecision = "approve" | "nits" | "revise";
+
+interface Verdict {
+	decision: VerdictDecision;
+	notes: string;
+}
+
+function parseVerdict(message: string): Verdict {
+	const match = message.match(/VERDICT:\s*(APPROVE_WITH_NITS|APPROVE|APPROVED|REVISE)/i);
+	let decision: VerdictDecision = "revise";
+	if (match) {
+		const token = match[1].toUpperCase();
+		if (token === "REVISE") decision = "revise";
+		else if (token === "APPROVE_WITH_NITS") decision = "nits";
+		else decision = "approve";
+	}
+	return { decision, notes: message };
+}
+
+function isRepeatConcern(previous: string, current: string): boolean {
+	const tokenize = (s: string): Set<string> =>
+		new Set(
+			s
+				.toLowerCase()
+				.replace(/verdict:\s*\w+/gi, "")
+				.replace(/[^a-z0-9\s]/g, " ")
+				.split(/\s+/)
+				.filter(w => w.length > 3),
+		);
+	const a = tokenize(previous);
+	const b = tokenize(current);
+	if (a.size === 0 || b.size === 0) return false;
+	let intersection = 0;
+	for (const word of a) if (b.has(word)) intersection++;
+	const union = a.size + b.size - intersection;
+	return union > 0 && intersection / union >= 0.85;
+}
+
+function truncateDiff(diff: string): string {
+	if (diff.length <= MAX_DIFF_CHARS) return diff;
+	return (
+		diff.slice(0, MAX_DIFF_CHARS) +
+		`\n\n[... diff truncated at ${MAX_DIFF_CHARS} characters. Read the files directly to review the rest. ...]`
+	);
+}
+
+/**
+ * After the agent finishes implementing, run the omp commit pipeline and
+ * optionally create a PR via the `gh` CLI.
+ *
+ * `runCommitCommand` resolves its cwd from `getProjectDir()`, so we save/restore
+ * the global to ensure it operates in the session's cwd rather than whatever
+ * directory the process was launched from.
+ *
+ * The commit pipeline is run with `push: false` even when a PR is requested,
+ * because `git push` on a branch with no upstream fails. Instead, `gh pr create`
+ * pushes the branch automatically when creating the PR.
+ */
+async function commitAndCreatePr(
+	cwd: string,
+	output: (text: string) => Promise<void> | void,
+	createPr: boolean,
+): Promise<void> {
+	if (createPr) {
+		const currentBranch = await git.branch.current(cwd);
+		const defaultBranch = await git.branch.default(cwd);
+		if (currentBranch && defaultBranch && currentBranch === defaultBranch) {
+			await output(
+				`On default branch '${currentBranch}' — refusing to push directly. Create a feature branch first.`,
+			);
+			return;
+		}
+	}
+
+	const previousProjectDir = getProjectDir();
+	if (previousProjectDir !== cwd) {
+		setProjectDir(cwd);
+	}
+	try {
+		await output("Running commit pipeline...");
+		await runCommitCommand({
+			push: false,
+			dryRun: false,
+			noChangelog: false,
+		});
+	} finally {
+		if (previousProjectDir !== cwd) {
+			setProjectDir(previousProjectDir);
+		}
+	}
+
+	if (createPr) {
+		await output("Creating pull request...");
+		const branch = await git.branch.current(cwd);
+		if (!branch) {
+			await output("Could not determine current branch; skipping PR creation.");
+			return;
+		}
+		const bodyFile = path.join(os.tmpdir(), `omp-pr-body-${Date.now()}.md`);
+		await Bun.write(bodyFile, `Changes on branch ${branch}`);
+		try {
+			const prUrl = await git.github.text(cwd, [
+				"pr",
+				"create",
+				"--body-file",
+				bodyFile,
+				"--title",
+				`Changes from ${branch}`,
+			]);
+			await output(`Pull request created: ${prUrl}`);
+		} catch (err) {
+			await output(`Failed to create PR: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			await Bun.file(bodyFile)
+				.unlink()
+				.catch(() => {});
+		}
+	}
+}
+
+/**
+ * Collect a review diff that includes unstaged, staged, and untracked file
+ * changes. `git diff` alone misses untracked files, so we check `git status
+ * --porcelain` for `??` entries and append their content as pseudo-diff hunks.
+ */
+async function collectReviewDiff(cwd: string): Promise<string> {
+	const unstagedDiff = await git.diff(cwd);
+	const stagedDiff = await git.diff(cwd, { cached: true });
+
+	const statusText = await git.status(cwd, { porcelainV1: true, untrackedFiles: "all" });
+	const untrackedFiles: string[] = [];
+	for (const line of statusText.split("\n")) {
+		if (line.startsWith("?? ")) {
+			untrackedFiles.push(line.slice(3).trim());
+		}
+	}
+
+	let untrackedDiff = "";
+	for (const file of untrackedFiles) {
+		try {
+			const content = await Bun.file(path.join(cwd, file)).text();
+			untrackedDiff += `diff --git a/${file} b/${file}\nnew file mode 100644\n--- /dev/null\n+++ b/${file}\n@@ -0,0 +1,${content.split("\n").length} @@\n`;
+			for (const line of content.split("\n")) {
+				untrackedDiff += `+${line}\n`;
+			}
+		} catch {
+			// Skip binary or unreadable files
+		}
+	}
+
+	return truncateDiff(`${unstagedDiff}\n${stagedDiff}\n${untrackedDiff}`);
+}
+
+/**
+ * Expert mode: runs an architect↔implementer loop with design review,
+ * implementation, and code review phases. After completion, commits and
+ * optionally creates a PR.
+ *
+ * This function is intended for the TUI path where nested `session.prompt()`
+ * calls are safe. ACP/text-mode handlers should return `{ prompt }` instead
+ * to avoid racing with the outer ACP turn lifecycle.
+ */
+export async function handleExpertMode(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const task = command.args.trim();
+	if (!task) {
+		await runtime.output("Usage: /expert <task description>");
+		return { consumed: true };
+	}
+
+	const cwd = runtime.cwd;
+	const session = runtime.session;
+	const architectSystem = prompt.render(expertArchitectPrompt);
+
+	// ----- Phase 1: design dialogue -----
+	await runtime.output("Expert mode: design dialogue");
+	const planPromptText = prompt.render(expertPlanPrompt, { task });
+	await session.prompt(planPromptText, { expandPromptTemplates: false, synthetic: true });
+	let plan = session.getLastAssistantText() ?? "";
+
+	let designNits: string | undefined;
+	let previousDesignConcern: string | undefined;
+
+	for (let round = 1; round <= MAX_DESIGN_ROUNDS; round++) {
+		await runtime.output(`Architect design review (round ${round})`);
+		const designReviewPrompt = prompt.render(expertDesignReviewPrompt, { task, plan });
+		const architectPrompt = prompt.render(expertArchitectWrapperPrompt, {
+			architectSystem,
+			reviewPrompt: designReviewPrompt,
+		});
+		await session.prompt(architectPrompt, { expandPromptTemplates: false, synthetic: true });
+		const reviewText = session.getLastAssistantText() ?? "";
+		const verdict = parseVerdict(reviewText);
+
+		if (verdict.decision === "approve") {
+			await runtime.output("Architect approved the design.");
+			break;
+		}
+		if (verdict.decision === "nits") {
+			await runtime.output("Architect approved the design with minor notes.");
+			designNits = verdict.notes;
+			break;
+		}
+
+		if (round === MAX_DESIGN_ROUNDS) {
+			await runtime.output(
+				`Design still has blocking concerns after ${round} round(s); proceeding with the latest plan.`,
+			);
+			break;
+		}
+		if (previousDesignConcern && isRepeatConcern(previousDesignConcern, verdict.notes)) {
+			await runtime.output("Architect repeated the same unresolved concern; proceeding.");
+			break;
+		}
+		previousDesignConcern = verdict.notes;
+
+		await runtime.output(`Implementer revising plan (round ${round})`);
+		const revisePrompt = prompt.render(expertRevisePlanPrompt, { notes: verdict.notes });
+		await session.prompt(revisePrompt, { expandPromptTemplates: false, synthetic: true });
+		plan = session.getLastAssistantText() ?? plan;
+	}
+
+	// ----- Phase 2: implementation -----
+	await runtime.output("Implementation phase");
+	const implementPromptText = prompt.render(expertImplementPrompt, { nits: designNits ?? "" });
+	await session.prompt(implementPromptText, { expandPromptTemplates: false, synthetic: true });
+
+	// ----- Phase 3: code-review dialogue -----
+	let previousReviewConcern: string | undefined;
+
+	for (let round = 1; round <= MAX_REVIEW_ROUNDS; round++) {
+		const diff = await collectReviewDiff(cwd);
+		if (!diff.trim()) {
+			await runtime.output("No changes to review; skipping code review.");
+			break;
+		}
+
+		await runtime.output(`Architect code review (round ${round})`);
+		const codeReviewPrompt = prompt.render(expertReviewPrompt, { task, plan, diff });
+		const architectCodePrompt = prompt.render(expertArchitectWrapperPrompt, {
+			architectSystem,
+			reviewPrompt: codeReviewPrompt,
+		});
+		await session.prompt(architectCodePrompt, { expandPromptTemplates: false, synthetic: true });
+		const reviewText = session.getLastAssistantText() ?? "";
+		const verdict = parseVerdict(reviewText);
+
+		if (verdict.decision === "approve") {
+			await runtime.output("Architect approved the implementation.");
+			break;
+		}
+		if (verdict.decision === "nits") {
+			await runtime.output("Architect approved with minor notes; applying them.");
+			const applyNitsPromptText = prompt.render(expertApplyNitsPrompt, { notes: verdict.notes });
+			await session.prompt(applyNitsPromptText, { expandPromptTemplates: false, synthetic: true });
+			break;
+		}
+
+		if (round === MAX_REVIEW_ROUNDS) {
+			await runtime.output(`Implementation still has blocking concerns after ${round} round(s); proceeding.`);
+			break;
+		}
+		if (previousReviewConcern && isRepeatConcern(previousReviewConcern, verdict.notes)) {
+			await runtime.output("Architect repeated the same unresolved concern; proceeding.");
+			break;
+		}
+		previousReviewConcern = verdict.notes;
+
+		await runtime.output(`Implementer applying review changes (round ${round})`);
+		const reviseCodePromptText = prompt.render(expertReviseCodePrompt, { notes: verdict.notes });
+		await session.prompt(reviseCodePromptText, { expandPromptTemplates: false, synthetic: true });
+	}
+
+	// ----- Commit and PR -----
+	await commitAndCreatePr(cwd, runtime.output, true);
+
+	return { consumed: true };
+}
+
+/**
+ * Simple mode: one-shot task execution. After the agent finishes, commits
+ * and optionally creates a PR.
+ *
+ * This function is intended for the TUI path where nested `session.prompt()`
+ * calls are safe. ACP/text-mode handlers should return `{ prompt }` instead
+ * to avoid racing with the outer ACP turn lifecycle.
+ */
+export async function handleSimpleMode(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const task = command.args.trim();
+	if (!task) {
+		await runtime.output("Usage: /simple <task description>");
+		return { consumed: true };
+	}
+
+	const session = runtime.session;
+	const taskPrompt = prompt.render(simpleTaskPrompt, { task });
+	await runtime.output("Simple mode: executing task...");
+	await session.prompt(taskPrompt, { expandPromptTemplates: false, synthetic: true });
+
+	await commitAndCreatePr(runtime.cwd, runtime.output, true);
+
+	return { consumed: true };
+}
+
+/**
+ * ACP-safe expert mode handler. Returns `{ prompt }` with the initial task
+ * so the outer ACP turn drives the LLM interaction. The full multi-turn
+ * workflow is only available in the TUI path via `handleExpertMode`.
+ */
+export function handleExpertModeAcp(command: ParsedSlashCommand): SlashCommandResult {
+	const task = command.args.trim();
+	if (!task) {
+		return { consumed: true };
+	}
+	return { prompt: prompt.render(expertPlanPrompt, { task }) };
+}
+
+/**
+ * ACP-safe simple mode handler. Returns `{ prompt }` with the task so the
+ * outer ACP turn drives the LLM interaction.
+ */
+export function handleSimpleModeAcp(command: ParsedSlashCommand): SlashCommandResult {
+	const task = command.args.trim();
+	if (!task) {
+		return { consumed: true };
+	}
+	return { prompt: prompt.render(simpleTaskPrompt, { task }) };
+}


### PR DESCRIPTION
Add two new builtin slash commands for collaborative task execution with auto-commit and PR creation.

## /expert <task>
Runs an architect-implementer loop with three phases:
1. Design dialogue - implementer proposes a plan, architect reviews it (up to 3 rounds with REVISE/APPROVE/APPROVE_WITH_NITS verdicts)
2. Implementation - implementer executes the approved plan
3. Code review - architect reviews the diff, implementer revises if needed (up to 3 rounds)

Then commits and creates a PR via the omp commit pipeline and gh pr create.

## /simple <task>
One-shot task execution with auto-commit and PR creation.

## Implementation details
- Prompt templates: 8 .md files in prompts/collab-modes/ imported via import with type text
- Helper module: slash-commands/helpers/collab-modes.ts with handleExpertMode() and handleSimpleMode()
- Reuses existing infrastructure: AgentSession.prompt() for LLM interaction, runCommitCommand for commits, git.github.text() for gh pr create
- ACP support: Both commands include handle, so they are automatically included in ACP_BUILTIN_SLASH_COMMANDS and ACP_BUILTIN_RESERVED_NAMES

## Files changed
- packages/coding-agent/src/prompts/collab-modes/*.md (8 new files)
- packages/coding-agent/src/slash-commands/helpers/collab-modes.ts (new)
- packages/coding-agent/src/slash-commands/builtin-registry.ts (modified - 2 new command entries)