### PR TITLE
fix(tui): deliver notifications under tmux via DCS passthrough + BEL fallback

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed desktop notifications being silently lost under tmux on the common stack of tmux + kitty/ghostty/wezterm/iTerm2. `TERMINAL_ID` resolves to the inner terminal (whose markers leak into the tmux session env), which maps to `NotifyProtocol.Osc9` / `NotifyProtocol.Osc99`, and `sendNotification()` wrote that raw OSC straight to stdout — tmux dropped it on the floor and `monitor-bell` / `monitor-activity` never fired, so a backgrounded omp pane had no way to flag completion or `ask` blockage. Under `TMUX`, OSC-protocol notifications are now wrapped in tmux's `\x1bPtmux;…\x1b\\` DCS passthrough envelope (so users with `set -g allow-passthrough on` still get the real toast on the outer terminal) and followed by a `\x07` BEL (so `set -g monitor-bell on` reliably flags the window otherwise). The OSC 99 capability probe in `terminal.ts` is wrapped the same way so rich notifications keep working across tmux. `NotifyProtocol.Bell` paths are unchanged. ([#3395](https://github.com/can1357/oh-my-pi/issues/3395))
+
 ## [16.1.10] - 2026-06-21
 
 ### Fixed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -98,8 +98,47 @@ export class TerminalInfo {
 
 	sendNotification(message: string | TerminalNotification): void {
 		if (isNotificationSuppressed() || isTerminalHeadless()) return;
-		process.stdout.write(this.formatNotification(message));
+		const formatted = this.formatNotification(message);
+		// Under tmux, terminals whose notify protocol is OSC 9 / OSC 99 would
+		// otherwise lose the notification entirely: tmux does not forward bare
+		// OSC 9/99 to the outer terminal, and the bare sequence does not flag
+		// tmux's own `monitor-bell` / `monitor-activity`. Wrap the OSC in tmux's
+		// DCS passthrough envelope so users with `allow-passthrough on` still
+		// get the desktop toast, then append a BEL so `monitor-bell` flags the
+		// pane/window for everyone else — the only signal a backgrounded pane
+		// has that the agent finished or is waiting for input. `Bell` protocol
+		// already self-flags via tmux's bell monitoring, so leave it alone.
+		if (this.notifyProtocol !== NotifyProtocol.Bell && isInsideTmux()) {
+			process.stdout.write(`${wrapTmuxPassthrough(formatted)}\x07`);
+			return;
+		}
+		process.stdout.write(formatted);
 	}
+}
+
+/**
+ * Whether the agent process is running inside a tmux session. Read fresh on
+ * each call so tests can toggle `Bun.env.TMUX` per case without re-importing
+ * the module and so a tmux session attached/detached mid-run is observed.
+ */
+export function isInsideTmux(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.TMUX);
+}
+
+/**
+ * Wrap a control-sequence payload in tmux's DCS passthrough envelope. Each
+ * ESC byte inside `payload` is doubled per tmux's escape rules. tmux strips
+ * the envelope and forwards the unwrapped payload to the outer terminal only
+ * when the user opts in with `set -g allow-passthrough on`; otherwise tmux
+ * silently consumes the envelope, which is identical to the pre-wrap baseline
+ * (tmux already swallowed the bare OSC).
+ *
+ * Used by `TerminalInfo.sendNotification` and the OSC 99 capability probe in
+ * `terminal.ts` to keep notifications alive for terminals that understand
+ * OSC 9 / OSC 99 (kitty, ghostty, wezterm, iterm2) when running under tmux.
+ */
+export function wrapTmuxPassthrough(payload: string): string {
+	return `\x1bPtmux;${payload.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`;
 }
 
 export function isNotificationSuppressed(): boolean {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -3,7 +3,14 @@ import * as fs from "node:fs";
 import { $env, isBunTestRuntime, isTerminalHeadless, logger } from "@oh-my-pi/pi-utils";
 import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
-import { NotifyProtocol, setCellDimensions, setOsc99Supported, TERMINAL } from "./terminal-capabilities";
+import {
+	isInsideTmux,
+	NotifyProtocol,
+	setCellDimensions,
+	setOsc99Supported,
+	TERMINAL,
+	wrapTmuxPassthrough,
+} from "./terminal-capabilities";
 
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
@@ -936,7 +943,14 @@ export class ProcessTerminal implements Terminal {
 		const id = `omp-probe-${nextOsc99ProbeId++}`;
 		this.#osc99PendingId = id;
 		this.#da1SentinelOwners.push({ kind: "osc99Probe", id });
-		this.#safeWrite(`\x1b]99;i=${id}:p=?;\x1b\\\x1b[c`);
+		// Wrap the probe under tmux so terminals behind `allow-passthrough on`
+		// can still respond (mirroring how `TerminalInfo.sendNotification`
+		// wraps notification deliveries). Without it the probe is swallowed
+		// inside tmux even when the outer terminal speaks OSC 99, and rich
+		// notifications stay permanently downgraded to the single-line fallback.
+		const probe = `\x1b]99;i=${id}:p=?;\x1b\\`;
+		const sequence = isInsideTmux() ? wrapTmuxPassthrough(probe) : probe;
+		this.#safeWrite(`${sequence}\x1b[c`);
 	}
 
 	#handleOsc99CapabilityResponse(metaRaw: string, payload: string): boolean {

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -190,9 +190,7 @@ describe("terminal notifications", () => {
 
 		// Single write — both pieces must reach tmux as one contiguous chunk so a
 		// concurrent renderer cannot interleave between the OSC and the BEL.
-		expect(writes).toEqual([
-			"\x1bPtmux;\x1b\x1b]99;;ping\x1b\x1b\\\x1b\\\x07",
-		]);
+		expect(writes).toEqual(["\x1bPtmux;\x1b\x1b]99;;ping\x1b\x1b\\\x1b\\\x07"]);
 	});
 
 	it("under tmux, Bell-protocol sendNotification stays a plain BEL (no DCS wrap)", () => {

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
 import {
 	getTerminalInfo,
+	isInsideTmux,
 	isOsc99Supported,
 	NotifyProtocol,
 	setOsc99Supported,
 	TERMINAL,
+	wrapTmuxPassthrough,
 } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { setTerminalHeadless } from "@oh-my-pi/pi-utils";
 
@@ -13,6 +15,8 @@ const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isT
 const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalOsc99Probe = Bun.env.PI_TUI_OSC99_PROBE;
+const originalTmux = Bun.env.TMUX;
+const originalPiNotifications = Bun.env.PI_NOTIFICATIONS;
 const mutableTerminal = TERMINAL as unknown as { notifyProtocol: NotifyProtocol };
 const originalNotifyProtocol = mutableTerminal.notifyProtocol;
 
@@ -63,6 +67,13 @@ describe("terminal notifications", () => {
 	beforeEach(() => {
 		setOsc99Supported(false);
 		previousHeadless = setTerminalHeadless(false);
+		// Default the suite to the "outside tmux" baseline so probe/format
+		// assertions never see a stray inherited TMUX leaking the DCS wrap in.
+		delete Bun.env.TMUX;
+		// `PI_NOTIFICATIONS=off` is set in this workspace's CI env, which would
+		// short-circuit `sendNotification` before it writes anything. Clear it
+		// so the delivery-path assertions actually observe stdout writes.
+		delete Bun.env.PI_NOTIFICATIONS;
 	});
 
 	afterEach(() => {
@@ -71,6 +82,8 @@ describe("terminal notifications", () => {
 		setOsc99Supported(false);
 		mutableTerminal.notifyProtocol = originalNotifyProtocol;
 		restoreEnv("PI_TUI_OSC99_PROBE", originalOsc99Probe);
+		restoreEnv("TMUX", originalTmux);
+		restoreEnv("PI_NOTIFICATIONS", originalPiNotifications);
 		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
 		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
 		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
@@ -146,6 +159,79 @@ describe("terminal notifications", () => {
 
 			expect(isOsc99Supported()).toBe(false);
 			expect(received).toEqual([]);
+		} finally {
+			terminal.stop();
+		}
+	});
+
+	it("isInsideTmux reads the TMUX env fresh on each call", () => {
+		expect(isInsideTmux()).toBe(false);
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		expect(isInsideTmux()).toBe(true);
+		delete Bun.env.TMUX;
+		expect(isInsideTmux()).toBe(false);
+	});
+
+	it("wraps an OSC payload in tmux's DCS passthrough envelope with doubled ESCs", () => {
+		const payload = "\x1b]99;;Hello\x1b\\";
+		expect(wrapTmuxPassthrough(payload)).toBe("\x1bPtmux;\x1b\x1b]99;;Hello\x1b\x1b\\\x1b\\");
+	});
+
+	it("under tmux, OSC-protocol sendNotification wraps for passthrough and appends BEL", () => {
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		TERMINAL.sendNotification("ping");
+
+		// Single write — both pieces must reach tmux as one contiguous chunk so a
+		// concurrent renderer cannot interleave between the OSC and the BEL.
+		expect(writes).toEqual([
+			"\x1bPtmux;\x1b\x1b]99;;ping\x1b\x1b\\\x1b\\\x07",
+		]);
+	});
+
+	it("under tmux, Bell-protocol sendNotification stays a plain BEL (no DCS wrap)", () => {
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Bell;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		TERMINAL.sendNotification("ping");
+
+		expect(writes).toEqual(["\x07"]);
+	});
+
+	it("outside tmux, OSC-protocol sendNotification writes the raw OSC unchanged", () => {
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		TERMINAL.sendNotification("ping");
+
+		expect(writes).toEqual(["\x1b]99;;ping\x1b\\"]);
+	});
+
+	it("under tmux, the OSC 99 capability probe is wrapped in DCS passthrough", () => {
+		Bun.env.PI_TUI_OSC99_PROBE = "1";
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const { terminal, writes } = setupProcessTerminal();
+		try {
+			const probe = writes.find(
+				w => w.startsWith("\x1bPtmux;\x1b\x1b]99;i=omp-probe-") && w.endsWith("\x1b\x1b\\\x1b\\\x1b[c"),
+			);
+			expect(probe).toBeDefined();
 		} finally {
 			terminal.stop();
 		}


### PR DESCRIPTION
## Repro

Run omp inside a tmux window backed by kitty / ghostty / wezterm / iTerm2 and trigger a `completion.notify` or `ask.notify`. The desktop toast never appears **and** tmux's `monitor-bell` / `monitor-activity` flags never fire — the notification is silently dropped. Captured against `main` by inspecting the bytes `TerminalInfo.sendNotification()` writes under simulated tmux + inner-terminal env:

```
$ TMUX=… KITTY_WINDOW_ID=1 bun -e '… TERMINAL.sendNotification({title,body}) …'
"\u001b]99;;Session: Complete\u001b\\"
has DCS passthrough: false
has BEL: false
```

A bare OSC 99 sequence: tmux's outer pipe does not forward OSC 9/99 to the wrapping terminal, and there's no `\x07` for `monitor-bell` to latch onto.

## Cause

`packages/tui/src/terminal-capabilities.ts` — `TERMINAL_ID` is derived from inner-terminal env markers (`KITTY_WINDOW_ID`, `GHOSTTY_RESOURCES_DIR`, `WEZTERM_PANE`, `ITERM_SESSION_ID`, …) which survive into the tmux session environment. `KNOWN_TERMINALS` then maps those ids to `NotifyProtocol.Osc99` / `NotifyProtocol.Osc9`, and `sendNotification()` writes the raw OSC straight to `process.stdout` with no tmux awareness. The `\x07` BEL path that tmux *would* catch via `monitor-bell` only fires when the resolved terminal is statically classified `Bell` (`base` / `trueColor` / `vscode` / `alacritty`) — exactly the case that does **not** happen when an inner-terminal marker leaks through tmux. The OSC 99 capability probe in `terminal.ts` (`#queryOsc99Support`) has the same problem: a bare OSC probe never reaches the outer terminal, so rich notifications stay permanently downgraded.

## Fix

- `packages/tui/src/terminal-capabilities.ts`: add `isInsideTmux()` (reads `TMUX` fresh) and `wrapTmuxPassthrough(payload)` (wraps in `\x1bPtmux;…\x1b\\` and doubles every inner `\x1b`).
- `TerminalInfo.sendNotification()`: under `TMUX`, for any non-`Bell` protocol, write `wrapTmuxPassthrough(formatted) + "\x07"` as a single chunk. Passthrough delivers the OSC to the outer terminal when the user has `set -g allow-passthrough on` (real desktop toast preserved); the trailing BEL lets `set -g monitor-bell on` flag the window for everyone else — the standard "this pane needs attention" workflow. `Bell` paths stay untouched (BEL already self-flags via tmux's bell monitoring).
- `packages/tui/src/terminal.ts`: wrap the OSC 99 capability probe in the same DCS envelope when `TMUX` is set so rich-notification confirmation can round-trip across tmux. The `\x1b[c` DA1 sentinel that follows is unchanged (CSI works fine under tmux either way) and still bounds the probe timeout.
- `packages/tui/test/notifications.test.ts`: scope `TMUX` and `PI_NOTIFICATIONS` per test, plus six new cases covering: `isInsideTmux()` freshness, DCS-envelope shape with doubled ESCs, the two-step OSC write under tmux, `Bell` protocol stays a plain BEL, outside-tmux is unchanged, and the OSC 99 probe is wrapped under tmux.
- `packages/tui/CHANGELOG.md`: entry under `## [Unreleased] → Fixed`.

## Verification

- `bun test packages/tui/test/notifications.test.ts` — **12 pass, 0 fail** (3 new positive paths + 3 boundary cases + 6 pre-existing tests).
- `bun test packages/tui` — **1053 pass, 3 skip, 0 fail** across 70 files (no regressions in the wider TUI suite).
- Post-fix repro replay: `TERMINAL.sendNotification({ title: "Session", body: "Complete" })` under `TMUX` + `KITTY_WINDOW_ID=1` now emits `\x1bPtmux;\x1b\x1b]99;;Session: Complete\x1b\x1b\\\x1b\\\x07` — DCS passthrough envelope with doubled inner ESCs and a trailing BEL, exactly what tmux needs to either forward the OSC or flag the window.

Fixes #3395