### PR TITLE
fix(ai): enable OpenRouter Anthropic Responses caching

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter Anthropic models on the Responses path omitting `cache_control`, so prompt caching engages without forcing Chat Completions. ([#3397](https://github.com/can1357/oh-my-pi/issues/3397))
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed OpenRouter Anthropic models on the Responses path omitting `cache_control`, so prompt caching engages without forcing Chat Completions. ([#3397](https://github.com/can1357/oh-my-pi/issues/3397))
+- Fixed OpenRouter Anthropic models on the Responses path omitting `cache_control`, so prompt caching engages without forcing Chat Completions. `cacheRetention: "long"` now upgrades the breakpoint to `ttl: "1h"`. ([#3397](https://github.com/can1357/oh-my-pi/issues/3397))
 
 ## [16.1.16] - 2026-06-23
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -325,7 +325,7 @@ function markOpenAIResponsesChainZeroDataRetention(chain: OpenAIResponsesChainSt
 	});
 }
 
-type OpenRouterAnthropicCacheControl = { type: "ephemeral" };
+type OpenRouterAnthropicCacheControl = { type: "ephemeral"; ttl?: "1h" };
 
 type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	top_p?: number;
@@ -346,7 +346,8 @@ function maybeAddOpenRouterAnthropicCacheControl(
 	cacheRetention: CacheRetention,
 ): void {
 	if (cacheRetention === "none" || !isOpenRouterAnthropicModel(model)) return;
-	params.cache_control ??= { type: "ephemeral" };
+	if (params.cache_control != null) return;
+	params.cache_control = cacheRetention === "long" ? { type: "ephemeral", ttl: "1h" } : { type: "ephemeral" };
 }
 
 /**

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -3,6 +3,7 @@ import { $flag, extractHttpStatusFromError, logger, structuredCloneJSON } from "
 import { getEnvApiKey } from "../stream";
 import type {
 	AssistantMessage,
+	CacheRetention,
 	Context,
 	Model,
 	OpenAICompat,
@@ -324,6 +325,8 @@ function markOpenAIResponsesChainZeroDataRetention(chain: OpenAIResponsesChainSt
 	});
 }
 
+type OpenRouterAnthropicCacheControl = { type: "ephemeral" };
+
 type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	top_p?: number;
 	top_k?: number;
@@ -334,7 +337,17 @@ type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	stream_options?: { include_obfuscation?: boolean };
 	provider?: OpenAICompat["openRouterRouting"];
 	reasoning?: { effort?: string } | { enabled: false };
+	cache_control?: OpenRouterAnthropicCacheControl;
 };
+
+function maybeAddOpenRouterAnthropicCacheControl(
+	params: OpenAIResponsesSamplingParams,
+	model: Model<"openai-responses">,
+	cacheRetention: CacheRetention,
+): void {
+	if (cacheRetention === "none" || !isOpenRouterAnthropicModel(model)) return;
+	params.cache_control ??= { type: "ephemeral" };
+}
 
 /**
  * Generate function for OpenAI Responses API
@@ -823,6 +836,7 @@ export function buildParams(
 		store: false,
 		stream_options: model.compat.supportsObfuscationOptOut ? { include_obfuscation: false } : undefined,
 	};
+	maybeAddOpenRouterAnthropicCacheControl(params, model, cacheRetention);
 	const outputToken = resolveOpenAIOutputTokenParam({
 		field: "max_output_tokens",
 		maxTokens: options?.maxTokens,

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -269,6 +269,15 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.cache_control).toEqual({ type: "ephemeral" });
 	});
 
+	it("upgrades to 1h ttl when cacheRetention is long for OpenRouter Anthropic Responses requests", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "workflow-123", cacheRetention: "long" },
+			openRouterAnthropicResponsesModel,
+		);
+
+		expect(captured.body?.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+	});
+
 	it("lets explicit headers override OpenRouter Responses defaults", async () => {
 		const captured = await captureOpenAIResponseHeaders(
 			{

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -19,6 +19,19 @@ const openRouterResponsesModel: Model<"openai-responses"> = {
 		baseUrl: "https://openrouter.ai/api/v1",
 	}),
 };
+const openRouterAnthropicResponsesModel: Model<"openai-responses"> = {
+	...model,
+	id: "anthropic/claude-sonnet-4.5",
+	name: "OpenRouter Claude Sonnet 4.5",
+	provider: "openrouter",
+	baseUrl: "https://openrouter.ai/api/v1",
+	compat: buildOpenAIResponsesCompat({
+		id: "anthropic/claude-sonnet-4.5",
+		name: "OpenRouter Claude Sonnet 4.5",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+	}),
+};
 const xaiOAuthResponsesModel: Model<"openai-responses"> = {
 	...model,
 	id: "grok-build",
@@ -247,6 +260,14 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.session_id).toBe("workflow-123");
 		expect(captured.body?.prompt_cache_key).toBe("cache-key-123");
 	});
+	it("sets Anthropic cache control for OpenRouter Anthropic Responses requests", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "workflow-123" },
+			openRouterAnthropicResponsesModel,
+		);
+
+		expect(captured.body?.cache_control).toEqual({ type: "ephemeral" });
+	});
 
 	it("lets explicit headers override OpenRouter Responses defaults", async () => {
 		const captured = await captureOpenAIResponseHeaders(
@@ -437,10 +458,11 @@ describe("openai-responses cache affinity", () => {
 	it("omits OpenRouter Responses session_id when cache retention is disabled", async () => {
 		const captured = await captureOpenAIResponseHeaders(
 			{ cacheRetention: "none", sessionId: "workflow-123" },
-			openRouterResponsesModel,
+			openRouterAnthropicResponsesModel,
 		);
 
 		expect(captured.body?.session_id).toBeUndefined();
 		expect(captured.body?.prompt_cache_key).toBeUndefined();
+		expect(captured.body?.cache_control).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Repro
OpenRouter Anthropic models routed through the default Responses path omitted the Anthropic `cache_control` hint. I reproduced this with `bun test packages/ai/test/openai-responses-cache-affinity.test.ts -t "sets Anthropic cache control"`, which failed because the captured request body had `cache_control: undefined`.

## Cause
`packages/ai/src/providers/openai-responses.ts` only populated OpenAI cache-affinity fields (`prompt_cache_key` and OpenRouter `session_id`) when building Responses payloads. The Anthropic cache marker existed only in the Chat Completions request shaper, so OpenRouter could not translate Responses requests for `anthropic/*` models into Anthropic prompt caching.

## Fix
- Added OpenRouter Anthropic Responses request shaping that emits top-level `cache_control: { type: "ephemeral" }` unless cache retention is disabled.
- Added request-capture coverage for the Anthropic Responses cache marker and the `cacheRetention: "none"` opt-out.
- Added the package changelog entry for the prompt-caching fix.

## Verification
`bun test packages/ai/test/openai-responses-cache-affinity.test.ts` passed: 16 tests, 49 expectations. `bun check` passed for the workspace. Fixes #3397