### PR TITLE
fix(providers): strip OpenRouter Anthropic reasoning replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter Anthropic Responses follow-up requests replaying prior reasoning items with stale signatures, which caused HTTP 400 `Invalid signature in thinking block` errors after a thinking turn. ([#3399](https://github.com/can1357/oh-my-pi/issues/3399))
+
 ## [16.1.16] - 2026-06-23
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -777,7 +777,7 @@ export function buildParams(
 			replay: shouldReplayNativeHistory,
 			filterReasoning: policy.reasoning.filterReasoningHistory,
 		},
-		includeThinkingSignatures: shouldReplayNativeHistory,
+		includeThinkingSignatures: shouldReplayNativeHistory && !policy.reasoning.filterReasoningHistory,
 		repairOrphanOutputs: true,
 	});
 

--- a/packages/ai/test/openai-responses-openrouter.test.ts
+++ b/packages/ai/test/openai-responses-openrouter.test.ts
@@ -345,7 +345,7 @@ describe("OpenRouter Responses request shape", () => {
 		expect(headers.get("X-OpenRouter-Cache-TTL")).toBe("7");
 	});
 
-	it("replays native Responses history after a pseudo OpenRouter turn", async () => {
+	it("omits native reasoning history for OpenRouter Anthropic turns", async () => {
 		const nativeItem = {
 			type: "reasoning",
 			id: "rs_1",
@@ -416,10 +416,7 @@ describe("OpenRouter Responses request shape", () => {
 			if (event.type === "error") throw event.error;
 		}
 
-		expect(bodies[1]?.input).toEqual([
-			replayItem,
-			{ role: "user", content: [{ type: "input_text", text: "continue" }] },
-		]);
+		expect(bodies[1]?.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "continue" }] }]);
 	});
 });
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter Anthropic compat to strip Responses reasoning history during replay so signed thinking blocks are not sent back to routed Anthropic providers. ([#3399](https://github.com/can1357/oh-my-pi/issues/3399))
+
 ## [16.1.14] - 2026-06-22
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -374,7 +374,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
 		omitReasoningEffort: false,
 		includeEncryptedReasoning: true,
-		filterReasoningHistory: false,
+		filterReasoningHistory: isOpenRouter && isAnthropicModel,
 		thinkingKeep: usesMoonshotKimiPreservedThinking ? "all" : undefined,
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
@@ -480,6 +480,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 	const id = spec.id ?? "";
 	const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] = isOpenRouter ? "openrouter" : "openai";
 	const isKimiModel = id ? isKimiModelId(id) : false;
+	const isAnthropicModel = id ? isClaudeModelId(id) || isAnthropicNamespacedModelId(id) : false;
 	const isDeepseekFamily = id ? isDeepseekModelIdOrName(id) || isDeepseekModelIdOrName(spec.name) : false;
 	const reasoningCapable = Boolean(spec.reasoning);
 
@@ -505,7 +506,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
 		omitReasoningEffort: false,
 		includeEncryptedReasoning: spec.provider !== "xai-oauth",
-		filterReasoningHistory: spec.provider === "xai-oauth",
+		filterReasoningHistory: spec.provider === "xai-oauth" || (isOpenRouter && isAnthropicModel),
 		disableReasoningOnForcedToolChoice: isKimiModel,
 		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
 		supportsToolChoice: true,


### PR DESCRIPTION
## Repro
A focused test reproduces the failing request shape with `bun test packages/ai/test/openai-responses-openrouter.test.ts -t "omits native reasoning history"`: before the fix, the follow-up OpenRouter Anthropic Responses payload included a prior `type: "reasoning"` item before the next user message, matching the reporter's HTTP 400 `Invalid signature in thinking block` failure.

## Cause
`packages/ai/src/providers/openai-responses.ts` always allowed same-session Responses reasoning replay when native history was warm, and `packages/catalog/src/compat/openai.ts` marked OpenRouter Anthropic models with `filterReasoningHistory: false`. That let `buildResponsesInput` replay historical `type: "reasoning"` items from `providerPayload` or parsed `thinkingSignature` blocks back through OpenRouter, where Anthropic upstreams reject stale signed thinking blocks.

## Fix
- Mark OpenRouter Anthropic compat as `filterReasoningHistory: true` in both OpenRouter/chat and Responses compat builders.
- Honor `filterReasoningHistory` for parsed assistant thinking signatures so all Responses reasoning replay paths are stripped, not only raw native-history items.
- Update the OpenRouter Responses regression test and changelogs for `packages/ai` and `packages/catalog`.

## Verification
`bun test packages/ai/test/openai-responses-openrouter.test.ts -t "omits native reasoning history"` failed before the fix and passes after it. `bun test packages/ai/test/openai-responses-openrouter.test.ts packages/ai/test/openai-compat-policy.test.ts` passed. `bun test packages/ai/test/openai-responses-history-payload.test.ts` passed. Fixes #3399