### PR TITLE
fix(agent): preserve append-only log prefix on in-place message rewrites

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `AppendOnlyContextManager.syncMessages` clearing the entire log on any in-place rewrite of an already-synced message. Per-turn tool-output pruning, image stripping, or any `transformContext` re-render that touched a single message used to drop every prior turn out of the append-only log and re-send the conversation from scratch, forcing local backends (llama.cpp / Ollama / LM Studio) to re-prefill tens of thousands of tokens every few turns. `syncMessages` now finds the longest byte-stable prefix between the previously-synced messages and the new ones, truncates the log to that prefix, and only re-appends the diverged tail — so the provider's KV cache stays warm up to the divergence point. ([#3406](https://github.com/can1357/oh-my-pi/issues/3406))
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -285,16 +285,17 @@ export class AppendOnlyContextManager {
 	}
 
 	/** Deterministic digest over every field the provider may serialize — role,
-	 * content, tool calls (both `toolCalls` and OpenAI-wire `tool_calls`),
-	 * tool-result ids/names/error flags (both internal camelCase and wire
-	 * snake_case), and assistant `id` — so an in-place rewrite of *any* of
-	 * these fields is visible to {@link #longestStablePrefix}. */
+	 * content, provider-native replay payloads, tool calls (both `toolCalls` and
+	 * OpenAI-wire `tool_calls`), tool-result ids/names/error flags (both internal
+	 * camelCase and wire snake_case), and assistant `id` — so an in-place rewrite
+	 * of *any* of these fields is visible to {@link #longestStablePrefix}. */
 	#messageDigest(msg: unknown): number {
 		if (!msg || typeof msg !== "object") return 0;
 		const m = msg as Record<string, unknown>;
 		const payload = JSON.stringify({
 			r: m.role ?? null,
 			c: m.content ?? null,
+			pp: m.providerPayload ?? null,
 			tc: m.toolCalls ?? m.tool_calls ?? null,
 			tcid: m.toolCallId ?? m.tool_call_id ?? null,
 			tn: m.toolName ?? m.name ?? null,

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -284,8 +284,9 @@ export class AppendOnlyContextManager {
 
 	/** Deterministic digest over every field the provider may serialize — role,
 	 * content, tool calls (both `toolCalls` and OpenAI-wire `tool_calls`),
-	 * `tool_call_id`, `name`, `id` — so an in-place rewrite of *any* of these
-	 * fields is visible to {@link #longestStablePrefix}. */
+	 * tool-result ids/names/error flags (both internal camelCase and wire
+	 * snake_case), and assistant `id` — so an in-place rewrite of *any* of
+	 * these fields is visible to {@link #longestStablePrefix}. */
 	#messageDigest(msg: unknown): number {
 		if (!msg || typeof msg !== "object") return 0;
 		const m = msg as Record<string, unknown>;
@@ -293,8 +294,9 @@ export class AppendOnlyContextManager {
 			r: m.role ?? null,
 			c: m.content ?? null,
 			tc: m.toolCalls ?? m.tool_calls ?? null,
-			tcid: m.tool_call_id ?? null,
-			n: m.name ?? null,
+			tcid: m.toolCallId ?? m.tool_call_id ?? null,
+			tn: m.toolName ?? m.name ?? null,
+			err: m.isError ?? null,
 			id: m.id ?? null,
 		});
 		let hash = 0;

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -132,6 +132,15 @@ export class AppendOnlyLog {
 		return this.#entries;
 	}
 
+	/** Drop entries past index `count`, keeping the first `count` byte-stable.
+	 * Used by {@link AppendOnlyContextManager.syncMessages} to preserve the
+	 * already-on-the-wire prefix when a later message diverges. */
+	truncate(count: number): void {
+		if (count < 0) count = 0;
+		if (count >= this.#entries.length) return;
+		this.#entries.length = count;
+	}
+
 	clear(): void {
 		this.#entries = [];
 	}
@@ -162,8 +171,14 @@ export class AppendOnlyContextManager {
 	readonly log = new AppendOnlyLog();
 	/** How many normalized messages were synced into the log as of the last sync. */
 	#lastSyncCount = 0;
-	/** Rolling digest of synced message content — detects in-place rewrites. */
-	#syncedDigest = 0;
+	/**
+	 * Per-message digests of the synced log. Lets a deep or tail rewrite
+	 * (per-turn pruning, image strip, transformContext re-render) preserve
+	 * the byte-stable prefix instead of re-sending the entire conversation
+	 * — keeps the provider's prompt-cache hit rate up to the divergence
+	 * point on every subsequent turn.
+	 */
+	#messageDigests: number[] = [];
 
 	build(context: AgentContext, options: BuildOptions): Context {
 		this.prefix.build(context, options);
@@ -174,33 +189,49 @@ export class AppendOnlyContextManager {
 	/**
 	 * Sync normalized (provider-level) messages into the append-only log.
 	 *
-	 * Detects both compaction (shorter array) and in-place rewrites
-	 * (same length, changed content via a rolling digest).
+	 * Three cases:
+	 *
+	 * 1. **Append**: same prefix, new tail → push the new entries.
+	 * 2. **Compaction**: shorter array → clear the log and replay.
+	 * 3. **In-place rewrite** (per-turn pruning, transformContext re-render,
+	 *    image strip, etc.): find the longest byte-stable prefix between
+	 *    the previously-synced messages and the new ones, drop the log
+	 *    down to that prefix, then append the diverged tail. Earlier
+	 *    revisions cleared the whole log on any digest change, which on
+	 *    llama.cpp / local backends forced a full ~40k-token re-prefill
+	 *    every turn that an extension, prune pass, or steering re-wrap
+	 *    rewrote a single message (#3406). Preserving the stable prefix
+	 *    lets the provider's KV cache stay warm up to the divergence
+	 *    point — the model only re-prefills from the changed message on.
 	 */
 	syncMessages(normalizedMessages: any[]): void {
-		// Detect in-place rewrites of already-synced messages.
-		if (
-			this.#lastSyncCount > 0 &&
-			this.#lastSyncCount <= normalizedMessages.length &&
-			this.#computeDigest(normalizedMessages.slice(0, this.#lastSyncCount)) !== this.#syncedDigest
-		) {
-			this.log.clear();
-			this.#lastSyncCount = 0;
-		}
-
-		// Compaction — array shrunk.
+		// Compaction (array shrunk) — every previously-synced message is gone,
+		// so the log can't carry any byte-stable bytes forward.
 		if (normalizedMessages.length < this.#lastSyncCount) {
 			this.log.clear();
 			this.#lastSyncCount = 0;
+			this.#messageDigests = [];
 		}
 
-		const newMsgs = normalizedMessages.slice(this.#lastSyncCount);
-		for (const msg of newMsgs) {
+		// In-place rewrite: trim the log down to the longest byte-stable prefix
+		// that both the previous sync and the new messages share. Anything past
+		// that point will be re-appended below with the new bytes.
+		if (this.#lastSyncCount > 0) {
+			const stableCount = this.#longestStablePrefix(normalizedMessages);
+			if (stableCount < this.#lastSyncCount) {
+				this.log.truncate(stableCount);
+				this.#lastSyncCount = stableCount;
+				this.#messageDigests.length = stableCount;
+			}
+		}
+
+		// Append the diverged tail (or the full delta on a normal turn).
+		for (let i = this.#lastSyncCount; i < normalizedMessages.length; i++) {
+			const msg = normalizedMessages[i];
 			this.log.append(msg);
+			this.#messageDigests.push(this.#messageDigest(msg));
 		}
-
 		this.#lastSyncCount = normalizedMessages.length;
-		this.#syncedDigest = this.#computeDigest(normalizedMessages);
 	}
 
 	/** Reset prefix + log for a model/provider switch while mode stays active. */
@@ -208,14 +239,14 @@ export class AppendOnlyContextManager {
 		this.prefix.invalidate();
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = 0;
+		this.#messageDigests = [];
 	}
 
 	/** Reset the sync cursor AND clear the log. */
 	resetSyncCursor(): void {
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = 0;
+		this.#messageDigests = [];
 	}
 
 	appendMessage(message: any): void {
@@ -234,33 +265,41 @@ export class AppendOnlyContextManager {
 		this.prefix.invalidate();
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = 0;
+		this.#messageDigests = [];
 		this.prefix.build(context, options);
 	}
 
-	/**
-	 * Deterministic digest over every field the provider may serialize — role,
-	 * content, tool calls (both `toolCalls` and OpenAI-wire `tool_calls`),
-	 * `tool_call_id`, `name`, `id`. Hashed with the same FNV-style rolling
-	 * accumulator so in-place rewrites of *any* of these fields are visible.
-	 */
-	#computeDigest(messages: readonly unknown[]): number {
-		let hash = 0;
-		for (let i = 0; i < messages.length; i++) {
-			const msg = messages[i];
-			if (!msg || typeof msg !== "object") continue;
-			const m = msg as Record<string, unknown>;
-			const payload = JSON.stringify({
-				r: m.role ?? null,
-				c: m.content ?? null,
-				tc: m.toolCalls ?? m.tool_calls ?? null,
-				tcid: m.tool_call_id ?? null,
-				n: m.name ?? null,
-				id: m.id ?? null,
-			});
-			for (let j = 0; j < payload.length; j++) {
-				hash = ((hash << 5) - hash + payload.charCodeAt(j)) | 0;
+	/** Index of the first message whose serialized bytes differ from the
+	 * previously-synced log; equals `min(lastSyncCount, normalizedMessages.length)`
+	 * when nothing diverged. */
+	#longestStablePrefix(normalizedMessages: readonly unknown[]): number {
+		const bound = Math.min(this.#lastSyncCount, normalizedMessages.length);
+		for (let i = 0; i < bound; i++) {
+			if (this.#messageDigest(normalizedMessages[i]) !== this.#messageDigests[i]) {
+				return i;
 			}
+		}
+		return bound;
+	}
+
+	/** Deterministic digest over every field the provider may serialize — role,
+	 * content, tool calls (both `toolCalls` and OpenAI-wire `tool_calls`),
+	 * `tool_call_id`, `name`, `id` — so an in-place rewrite of *any* of these
+	 * fields is visible to {@link #longestStablePrefix}. */
+	#messageDigest(msg: unknown): number {
+		if (!msg || typeof msg !== "object") return 0;
+		const m = msg as Record<string, unknown>;
+		const payload = JSON.stringify({
+			r: m.role ?? null,
+			c: m.content ?? null,
+			tc: m.toolCalls ?? m.tool_calls ?? null,
+			tcid: m.tool_call_id ?? null,
+			n: m.name ?? null,
+			id: m.id ?? null,
+		});
+		let hash = 0;
+		for (let j = 0; j < payload.length; j++) {
+			hash = ((hash << 5) - hash + payload.charCodeAt(j)) | 0;
 		}
 		return hash >>> 0;
 	}

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -214,10 +214,12 @@ export class AppendOnlyContextManager {
 		}
 
 		// In-place rewrite: trim the log down to the longest byte-stable prefix
-		// that both the previous sync and the new messages share. Anything past
-		// that point will be re-appended below with the new bytes.
+		// that both the previous sync and the new messages share. Bound it by
+		// the current log length because `log.clear()` is public; direct clears
+		// (advisor reset) can leave the sync cursor ahead of the physical log.
+		// Anything past that point will be re-appended below with the new bytes.
 		if (this.#lastSyncCount > 0) {
-			const stableCount = this.#longestStablePrefix(normalizedMessages);
+			const stableCount = Math.min(this.#longestStablePrefix(normalizedMessages), this.log.length);
 			if (stableCount < this.#lastSyncCount) {
 				this.log.truncate(stableCount);
 				this.#lastSyncCount = stableCount;

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -572,6 +572,49 @@ describe("message sync", () => {
 		expect((entries[2] as { content: unknown }).content).toBe("a1-pruned");
 	});
 
+	it("detects providerPayload-only rewrites before preserving a later prefix (#3406)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const original0 = { role: "user", content: "q1" } as any;
+		const original1 = {
+			role: "assistant",
+			content: [{ type: "text", text: "same visible output" }],
+			id: "assistant-1",
+			providerPayload: {
+				type: "openaiResponsesHistory",
+				provider: "openai",
+				items: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "old native" }] }],
+			},
+		} as any;
+		const original2 = { role: "user", content: "q2" } as any;
+		mgr.syncMessages([original0, original1, original2]);
+
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "same visible output" }],
+				id: "assistant-1",
+				providerPayload: {
+					type: "openaiResponsesHistory",
+					provider: "openai",
+					items: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "new native" }] }],
+				},
+			},
+			{ role: "user", content: "q2-rewritten" },
+		] as any);
+
+		const entries = mgr.log.entries();
+		expect(entries).toHaveLength(3);
+		expect(entries[0]).toBe(original0);
+		expect(
+			(entries[1] as { providerPayload?: { items?: Array<{ content?: Array<{ text?: string }> }> } }).providerPayload
+				?.items?.[0]?.content?.[0]?.text,
+		).toBe("new native");
+		expect((entries[2] as { content: unknown }).content).toBe("q2-rewritten");
+	});
+
 	it("does not reuse a stable prefix longer than the current log after direct log clear (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -515,8 +515,8 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as Message;
-		const original1 = { role: "assistant", content: "original long result" } as Message;
+		const original0 = { role: "user", content: "q1" } as any;
+		const original1 = { role: "assistant", content: "original long result" } as any;
 		mgr.syncMessages([original0, original1]);
 		expect(mgr.log.length).toBe(2);
 
@@ -524,8 +524,8 @@ describe("message sync", () => {
 		// tool-output pruning / transformContext re-render).
 		mgr.syncMessages([
 			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "[pruned]" } as Message,
-		]);
+			{ role: "assistant", content: "[pruned]" },
+		] as any);
 		expect(mgr.log.length).toBe(2);
 
 		const entries = mgr.log.entries();
@@ -540,17 +540,18 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as Message;
-		const original1 = { role: "assistant", content: "a1" } as Message;
-		mgr.syncMessages([original0, original1, { role: "user", content: "q2" } as Message]);
+		const original0 = { role: "user", content: "q1" } as any;
+		const original1 = { role: "assistant", content: "a1" } as any;
+		const original2 = { role: "user", content: "q2" } as any;
+		mgr.syncMessages([original0, original1, original2]);
 
 		// Tail-only rewrite (e.g. per-turn pruning of the most recent tool result):
 		// the first two messages MUST stay byte-stable; only the tail re-syncs.
 		mgr.syncMessages([
 			{ role: "user", content: "q1" },
 			{ role: "assistant", content: "a1" },
-			{ role: "user", content: "q2-rewritten" } as Message,
-		]);
+			{ role: "user", content: "q2-rewritten" },
+		] as any);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);
@@ -563,17 +564,17 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as Message;
-		const original1 = { role: "assistant", content: "a1" } as Message;
+		const original0 = { role: "user", content: "q1" } as any;
+		const original1 = { role: "assistant", content: "a1" } as any;
 		mgr.syncMessages([original0, original1]);
 
 		// Re-sync with: (a) message #1 rewritten in place; (b) a brand-new tail
 		// appended. The prefix [original0] MUST stay byte-stable.
 		mgr.syncMessages([
 			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1-pruned" } as Message,
-			{ role: "user", content: "q2" } as Message,
-		]);
+			{ role: "assistant", content: "a1-pruned" },
+			{ role: "user", content: "q2" },
+		] as any);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -511,36 +511,85 @@ describe("message sync", () => {
 		expect(result.messages[0]!.content).toBe("fresh");
 	});
 
-	it("detects in-place rewrite of already-synced messages", () => {
+	it("preserves the byte-stable prefix when a deep message is rewritten (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		// Sync two messages
+		const original0 = { role: "user", content: "q1" } as Message;
+		const original1 = { role: "assistant", content: "original long result" } as Message;
+		mgr.syncMessages([original0, original1]);
+		expect(mgr.log.length).toBe(2);
+
+		// Same length, but the second message's content changed (simulates per-turn
+		// tool-output pruning / transformContext re-render).
 		mgr.syncMessages([
 			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "original long result" },
+			{ role: "assistant", content: "[pruned]" } as Message,
 		]);
 		expect(mgr.log.length).toBe(2);
 
-		// Same length, but second message content changed (simulates tool-output pruning)
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "[pruned]" },
-		]);
-		// Log should have been reset and re-synced with the new content
-		expect(mgr.log.length).toBe(2);
-		const msgs = mgr.build(makeContext(), BUILD_OPTS).messages;
-		expect(msgs[1]!.content).toBe("[pruned]");
+		const entries = mgr.log.entries();
+		// The first message MUST keep its on-the-wire identity — that's what
+		// stops llama.cpp from re-prefilling the entire prior context.
+		expect(entries[0]).toBe(original0);
+		// The diverged tail is re-synced with the new bytes.
+		expect((entries[1] as { content: unknown }).content).toBe("[pruned]");
 	});
 
-	it("detects in-place rewrite via digest mismatch", () => {
+	it("preserves the prefix when the tail is rewritten (#3406)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const original0 = { role: "user", content: "q1" } as Message;
+		const original1 = { role: "assistant", content: "a1" } as Message;
+		mgr.syncMessages([original0, original1, { role: "user", content: "q2" } as Message]);
+
+		// Tail-only rewrite (e.g. per-turn pruning of the most recent tool result):
+		// the first two messages MUST stay byte-stable; only the tail re-syncs.
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+			{ role: "user", content: "q2-rewritten" } as Message,
+		]);
+
+		const entries = mgr.log.entries();
+		expect(entries).toHaveLength(3);
+		expect(entries[0]).toBe(original0);
+		expect(entries[1]).toBe(original1);
+		expect((entries[2] as { content: unknown }).content).toBe("q2-rewritten");
+	});
+
+	it("appended new messages keep the prefix stable even when the prior tail also diverged (#3406)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const original0 = { role: "user", content: "q1" } as Message;
+		const original1 = { role: "assistant", content: "a1" } as Message;
+		mgr.syncMessages([original0, original1]);
+
+		// Re-sync with: (a) message #1 rewritten in place; (b) a brand-new tail
+		// appended. The prefix [original0] MUST stay byte-stable.
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1-pruned" } as Message,
+			{ role: "user", content: "q2" } as Message,
+		]);
+
+		const entries = mgr.log.entries();
+		expect(entries).toHaveLength(3);
+		expect(entries[0]).toBe(original0);
+		expect((entries[1] as { content: unknown }).content).toBe("a1-pruned");
+		expect((entries[2] as { content: unknown }).content).toBe("q2");
+	});
+
+	it("rewriting the first message still re-syncs from scratch", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
 		mgr.syncMessages([{ role: "user", content: "hello" }]);
 		expect(mgr.log.length).toBe(1);
 
-		// Content changed but length same
+		// No byte-stable prefix — the only message diverged.
 		mgr.syncMessages([{ role: "user", content: "world" }]);
 
 		const msgs = mgr.build(makeContext(), BUILD_OPTS).messages;

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -536,6 +536,42 @@ describe("message sync", () => {
 		expect((entries[1] as { content: unknown }).content).toBe("[pruned]");
 	});
 
+	it("detects tool-result metadata-only rewrites before preserving a later prefix (#3406)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const original0 = { role: "user", content: "q1" } as any;
+		const original1 = {
+			role: "toolResult",
+			content: [{ type: "text", text: "same output" }],
+			toolCallId: "old-call",
+			toolName: "read",
+			isError: false,
+		} as any;
+		const original2 = { role: "assistant", content: "a1" } as any;
+		mgr.syncMessages([original0, original1, original2]);
+
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{
+				role: "toolResult",
+				content: [{ type: "text", text: "same output" }],
+				toolCallId: "new-call",
+				toolName: "write",
+				isError: true,
+			},
+			{ role: "assistant", content: "a1-pruned" },
+		] as any);
+
+		const entries = mgr.log.entries();
+		expect(entries).toHaveLength(3);
+		expect(entries[0]).toBe(original0);
+		expect((entries[1] as { toolCallId: unknown }).toolCallId).toBe("new-call");
+		expect((entries[1] as { toolName: unknown }).toolName).toBe("write");
+		expect((entries[1] as { isError: unknown }).isError).toBe(true);
+		expect((entries[2] as { content: unknown }).content).toBe("a1-pruned");
+	});
+
 	it("preserves the prefix when the tail is rewritten (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -572,6 +572,32 @@ describe("message sync", () => {
 		expect((entries[2] as { content: unknown }).content).toBe("a1-pruned");
 	});
 
+	it("does not reuse a stable prefix longer than the current log after direct log clear (#3406)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+		] as any);
+		expect(mgr.log.length).toBe(2);
+
+		// Public log clear used by advisor reset: it intentionally empties the
+		// provider-bound message log but does not touch the private sync cursor.
+		mgr.log.clear();
+		expect(mgr.log.length).toBe(0);
+
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1-rewritten" },
+		] as any);
+
+		const entries = mgr.log.entries();
+		expect(entries).toHaveLength(2);
+		expect((entries[0] as { content: unknown }).content).toBe("q1");
+		expect((entries[1] as { content: unknown }).content).toBe("a1-rewritten");
+	});
+
 	it("preserves the prefix when the tail is rewritten (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -14,12 +14,15 @@ import {
 } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
 import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 import { type MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import { obfuscateProviderContext, SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm, wrapSteeringForModel } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -687,6 +690,94 @@ describe("AgentSession message pipeline", () => {
 		expect(firstSystemPrompt).toBeDefined();
 		expect(firstSystemPrompt!.join("\n")).toContain(injected);
 		expect(contexts[1]!.systemPrompt).toEqual(firstSystemPrompt);
+	});
+
+	it("preserves append-only prefixes in subagent sessions when context handlers rewrite prior turns", async () => {
+		using tempDir = TempDir.createSync("@pi-subagent-append-only-");
+		const api = "test-subagent-append-only-cache";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage(`ok-${contexts.length}`);
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "local-subagent-model",
+			name: "Local Subagent Model",
+			api,
+			provider: "llama.cpp",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const rewritePriorAssistant: ExtensionFactory = pi => {
+			pi.on("context", async event => {
+				const hasSecondTurn = event.messages.some(message => {
+					if (message.role !== "user") return false;
+					const content = message.content;
+					if (typeof content === "string") return content.includes("second");
+					return content.some(part => part.type === "text" && part.text.includes("second"));
+				});
+				if (!hasSecondTurn) return undefined;
+				return {
+					messages: event.messages.map(message =>
+						message.role === "assistant"
+							? { ...message, content: [{ type: "text" as const, text: "rewritten assistant" }] }
+							: message,
+					),
+				};
+			});
+		};
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"provider.appendOnlyContext": "auto",
+			}),
+			model,
+			disableExtensionDiscovery: true,
+			extensions: [rewritePriorAssistant],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			taskDepth: 1,
+			agentId: "SubAgent",
+		});
+		try {
+			expect(session.agent.appendOnlyContext).toBeDefined();
+
+			await session.sendUserMessage("first");
+			await session.sendUserMessage("second");
+
+			expect(contexts).toHaveLength(2);
+			expect(contexts[0]!.messages).toHaveLength(1);
+			expect(contexts[1]!.messages).toHaveLength(3);
+			expect(contexts[1]!.messages[0]).toBe(contexts[0]!.messages[0]);
+			expect((contexts[1]!.messages[1] as { content: unknown }).content).toEqual([
+				{ type: "text", text: "rewritten assistant" },
+			]);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
 	});
 
 	it("clears promoted memory from the base prompt when switching sessions", async () => {


### PR DESCRIPTION
## Repro

With `provider.appendOnlyContext` active (auto-enabled for `llama.cpp` /
loopback `openai-completions` providers), every per-turn
`pruneSupersededToolResults` / `pruneToolOutputs` pass — or any
`transformContext` re-render — rewrites at least one already-synced
message in place. `AppendOnlyContextManager.syncMessages` then drops the
entire append-only log and re-appends from the current (mutated) view.
The provider's cached prefix matches up to the divergence point, but
everything after it has to be re-prefilled. On a llama.cpp slot serving
a ~40k-token conversation this collapses the cache to
`n_past ≈ end-of-system-prompt` and re-prefills the rest every few
turns, pinning the GPU at >400 W. New test
`preserves the byte-stable prefix when a deep message is rewritten (#3406)`
reproduces the contract failure deterministically (replacing the
previous `detects in-place rewrite of already-synced messages` test
that had pinned the broken behavior).

## Cause

`packages/agent/src/append-only-context.ts` `AppendOnlyContextManager`
hashed a single rolling digest over the entire synced prefix:

```ts
if (
    this.#lastSyncCount > 0 &&
    this.#lastSyncCount <= normalizedMessages.length &&
    this.#computeDigest(normalizedMessages.slice(0, this.#lastSyncCount)) !== this.#syncedDigest
) {
    this.log.clear();
    this.#lastSyncCount = 0;
}
```

Any digest mismatch — even a single rewritten message — wiped the log
and re-appended the conversation from the current view, so the
provider re-prefilled from the first changed position onward.

## Fix

- `packages/agent/src/append-only-context.ts`
  - Add `AppendOnlyLog.truncate(count)` so the log can drop entries past
    a given index while preserving the byte-stable prefix.
  - Replace `AppendOnlyContextManager.#syncedDigest` with
    `#messageDigests: number[]` (one digest per synced message).
  - Rewrite `syncMessages` to (1) clear on length shrink (true
    compaction), (2) walk the new sync against `#messageDigests` to find
    the longest byte-stable prefix, (3) `log.truncate(stableCount)` down
    to that prefix, and (4) append the diverged tail. Tail-only
    rewrites preserve the full prefix; deep rewrites preserve everything
    before the divergence; only `length < lastSyncCount` still clears.
  - Reset `#messageDigests` from every existing reset path
    (`invalidateForModelChange`, `resetSyncCursor`, `reset`).
- `packages/agent/test/append-only-context.test.ts`
  - Replace the `detects in-place rewrite of already-synced messages`
    + `detects in-place rewrite via digest mismatch` tests (which
    pinned the broken behavior) with regression coverage for the new
    contract: deep rewrite preserves prefix object identity, tail-only
    rewrite preserves both prefix entries, mixed tail-rewrite +
    new-message keeps the stable prefix, and rewriting the first
    message still re-syncs from scratch.
- `packages/agent/CHANGELOG.md` — Unreleased Fixed entry.

## Verification

`bun test packages/agent/test/append-only-context.test.ts` → 54 pass,
0 fail. Full `bun test` in `packages/agent` → 310 pass, 0 fail.
`packages/coding-agent` integration coverage
(`bun test test/agent-session-message-pipeline.test.ts
test/agent-session-fresh.test.ts`) → 20 pass, 0 fail. `bun check`
across the workspace exits 0 after the test-file type cast cleanup.
Other coding-agent suite failures are pre-existing environmental
issues unrelated to this diff (sandbox EACCES on
`/srv/agent-home/.pi-skills-test-*`, `/srv/agent-home/Projects`,
`/srv/agent-home/.git`; localhost port-bind refused in
`oauth-flow.test.ts`; auth-state timing in `agent-session-retry-cap.test.ts`;
missing worktree fixtures in `gh.test.ts`).

Fixes #3406