### PR TITLE
feat(coding-agent): add vcs read protocol

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -95,6 +95,8 @@ A `WATCHDOG.yml` roster entry may broaden this with `tools: [...]`, selecting an
 
 Advisor grants are not routed through the primary agent's approval wrapper. The advisor pool is built from the built-in tool factories against its own `-advisor` `ToolSession` and then filtered by `WATCHDOG.yml`; it is not the primary `toolRegistry` wrapped with `ExtensionToolWrapper`. Granting write- or exec-tier tools therefore lets the advisor invoke those tools directly, subject to the tool's own runtime guards but not to `tools.approvalMode` / `tools.approval.<tool>` prompts. Keep mutating grants narrow and trusted.
 
+VCS inspection uses the `read` tool's internal protocol instead of an advisor-only tool. `vcs://state` reports changed files, stat output, and untracked files; `vcs://diff[/path]` returns patch text. Both support `base=<ref>`, `staged=true`, and repeated `file=<path>` query params. The protocol sets `DiffOptions.noExternal` so git reads cannot run repo-configured external diff or textconv commands, validates `base` through `git.ref.commit`, and normalizes path scopes from the caller cwd before passing them to git.
+
 The `advise` tool accepts one note and an optional severity:
 
 | Severity | Delivery | Intended use |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
+### Added
+
+- Added `read` support for `vcs://state` and `vcs://diff[/path]`, giving the advisor and other read-only sessions a safe way to inspect git state and patch text without introducing an advisor-only `git` tool. The protocol validates `base` refs, normalizes path scopes from the caller cwd, rejects repo escapes, and disables external diff/textconv commands for VCS reads ([#3416](https://github.com/can1357/oh-my-pi/pull/3416) by [@wolfiesch](https://github.com/wolfiesch)).
+- Added an opt-in `DiffOptions.noExternal` flag to `utils/git` that passes `--no-ext-diff --no-textconv`, so a diff cannot execute a repo-configured `diff.external`/`GIT_EXTERNAL_DIFF` or per-driver `textconv` program. `vcs://diff` and `vcs://state` set it; existing callers (commit/changelog prompts) are unchanged and keep honoring configured textconv ([#3416](https://github.com/can1357/oh-my-pi/pull/3416) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -24,4 +24,5 @@ export * from "./skill-protocol";
 export * from "./ssh-protocol";
 export type * from "./types";
 export * from "./vault-protocol";
+export * from "./vcs-protocol";
 export * from "./xd-protocol";

--- a/packages/coding-agent/src/internal-urls/router.ts
+++ b/packages/coding-agent/src/internal-urls/router.ts
@@ -1,5 +1,5 @@
 /**
- * Internal URL router for internal protocols (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, `vault://`, and `xd://`).
+ * Internal URL router for internal protocols (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, `vault://`, `vcs://`, and `xd://`).
  *
  * One process-global router with one handler per scheme. Access via
  * `InternalUrlRouter.instance()`. Handlers are stateless; per-session and
@@ -26,6 +26,7 @@ import type {
 	WriteContext,
 } from "./types";
 import { VaultProtocolHandler } from "./vault-protocol";
+import { VcsProtocolHandler } from "./vcs-protocol";
 import { XdProtocolHandler } from "./xd-protocol";
 
 export class InternalUrlRouter {
@@ -39,6 +40,7 @@ export class InternalUrlRouter {
 		this.register(new ArtifactProtocolHandler());
 		this.register(new MemoryProtocolHandler());
 		this.register(new LocalProtocolHandler());
+		this.register(new VcsProtocolHandler());
 		this.register(new VaultProtocolHandler());
 		this.register(new SkillProtocolHandler());
 		this.register(new RuleProtocolHandler());

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the internal URL routing system.
  *
- * Internal URLs (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, `vault://`, and `xd://`) are resolved by tools like read,
+ * Internal URLs (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, `vault://`, `vcs://`, and `xd://`) are resolved by tools like read,
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 

--- a/packages/coding-agent/src/internal-urls/vcs-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/vcs-protocol.ts
@@ -1,0 +1,476 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { shortenPath } from "../tools/render-utils";
+import * as git from "../utils/git";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext } from "./types";
+
+type VcsOperation = "state" | "diff";
+
+type ParsedVcsRequest = {
+	operation: VcsOperation;
+	pathScopes: string[];
+	fileScopes: string[];
+	base?: string;
+	staged?: boolean;
+};
+
+const SUPPORTED_QUERY_PARAMS: Record<string, true> = { base: true, file: true, staged: true };
+
+function requireSingleParam(params: URLSearchParams, name: "base" | "staged"): string | undefined {
+	const values = params.getAll(name);
+	if (values.length > 1) throw new Error(`vcs:// ${name} may be provided at most once.`);
+	return values[0];
+}
+
+function decodePathScope(url: InternalUrl): string | undefined {
+	const rawPath = url.rawPathname ?? url.pathname;
+	if (!rawPath || rawPath === "/") return undefined;
+	try {
+		const decoded = decodeURIComponent(rawPath.slice(1));
+		return decoded === "" ? undefined : decoded;
+	} catch {
+		throw new Error(`Invalid URL encoding in vcs:// path: ${url.href}`);
+	}
+}
+
+function parseVcsUrl(url: InternalUrl): ParsedVcsRequest {
+	const operation = url.rawHost || url.hostname;
+	if (operation !== "state" && operation !== "diff") {
+		throw new Error("Invalid vcs:// URL. Expected vcs://state or vcs://diff[/path].");
+	}
+
+	for (const key of url.searchParams.keys()) {
+		if (!Object.hasOwn(SUPPORTED_QUERY_PARAMS, key)) {
+			throw new Error(`Invalid vcs:// query parameter '${key}'. Supported: base, staged, file.`);
+		}
+	}
+
+	const base = requireSingleParam(url.searchParams, "base");
+	const stagedValue = requireSingleParam(url.searchParams, "staged");
+	let staged: boolean | undefined;
+	if (stagedValue !== undefined) {
+		if (stagedValue === "true") staged = true;
+		else if (stagedValue === "false") staged = false;
+		else throw new Error(`Invalid vcs:// staged value '${stagedValue}'. Use true or false.`);
+	}
+
+	const fileScopes = url.searchParams.getAll("file").map(scope => {
+		if (scope === "") throw new Error("vcs:// file query parameters must be non-empty.");
+		return scope;
+	});
+	const pathScope = decodePathScope(url);
+	return {
+		operation,
+		pathScopes: pathScope ? [pathScope] : [],
+		fileScopes,
+		...(base !== undefined ? { base } : {}),
+		...(staged !== undefined ? { staged } : {}),
+	};
+}
+
+function toGitPath(scope: string): string {
+	return path.sep === "/" ? scope : scope.split(path.sep).join("/");
+}
+
+/**
+ * Canonicalize an absolute path so containment checks compare physical paths,
+ * matching the physical repo root Git reports. Symlinks are resolved segment by
+ * segment BEFORE `..` is applied — `fs.realpath` (and `path.resolve`) collapse
+ * `/repo/link/../x` lexically to `/repo/x`, which would mask a physical escape
+ * when `link` points outside the repository. Nonexistent segments cannot be
+ * symlinks, so they are appended verbatim and popped lexically by `..`; once
+ * `..` backs out of the whole nonexistent suffix, the prefix is canonical and
+ * existing again, and later segments resume symlink resolution.
+ */
+function realpathExisting(target: string): string {
+	const root = path.parse(target).root;
+	let resolved = root;
+	let missingDepth = 0;
+	// Windows path syntax accepts `/` and `\` interchangeably (URL-derived scopes
+	// commonly use `/`); on POSIX a backslash is an ordinary filename byte and
+	// must not split a segment.
+	const segments =
+		path.sep === "\\" ? target.slice(root.length).split(/[\\/]/) : target.slice(root.length).split(path.sep);
+	for (const part of segments) {
+		if (part === "" || part === ".") continue;
+		if (part === "..") {
+			// The parent of a canonical path is canonical; popping a missing
+			// segment restores the deeper (possibly existing) prefix.
+			resolved = path.dirname(resolved);
+			if (missingDepth > 0) missingDepth--;
+			continue;
+		}
+		const candidate = path.join(resolved, part);
+		if (missingDepth === 0) {
+			try {
+				// `candidate` is a canonical prefix plus one plain segment (no `.`/`..`),
+				// so realpath only has the final symlink hop left to resolve.
+				resolved = fs.realpathSync(candidate);
+				continue;
+			} catch (err) {
+				// Only a genuinely missing suffix (ENOENT) may be appended unresolved.
+				// ENOTDIR means a prefix segment is a file — backing out with `..`
+				// could collapse the scope onto its parent and broaden the pathspec.
+				// EACCES/ELOOP/etc. mean the segment could not be canonicalized, so
+				// containment cannot be proven — propagate all of them.
+				if (!isEnoent(err)) throw err;
+			}
+		}
+		missingDepth++;
+		resolved = candidate;
+	}
+	return resolved;
+}
+
+function resolveGitCwd(repoRoot: string, cwdPrefix: string): string {
+	const normalizedPrefix = cwdPrefix.replace(/\/+$/, "");
+	if (normalizedPrefix === "") return repoRoot;
+	return path.join(repoRoot, ...normalizedPrefix.split("/"));
+}
+
+function normalizePathspecs(cwdPrefix: string, repoRoot: string, scopes: readonly string[]): string[] | undefined {
+	if (scopes.length === 0) return undefined;
+	const result: string[] = [];
+	const seen = new Set<string>();
+	const normalizedPrefix = toGitPath(cwdPrefix).replace(/\/+$/, "");
+	let physicalRoot: string | undefined;
+	for (const scope of scopes) {
+		let repoRelative: string;
+		if (path.isAbsolute(scope)) {
+			physicalRoot ??= realpathExisting(repoRoot);
+			// Feed the raw absolute scope to realpath so symlinks resolve before
+			// `..` collapses: a lexical `path.resolve` of `/repo/link/../x` with
+			// `link -> /outside/dir` would yield `/repo/x` and mask a physical escape.
+			const absolute = realpathExisting(scope);
+			const fsRelative = path.relative(physicalRoot, absolute);
+			if (fsRelative === ".." || fsRelative.startsWith(`..${path.sep}`) || path.isAbsolute(fsRelative)) {
+				throw new Error(`Requested file resolves outside the repository: "${scope}".`);
+			}
+			repoRelative = fsRelative === "" ? "." : toGitPath(fsRelative);
+		} else {
+			repoRelative = path.posix.normalize(path.posix.join(normalizedPrefix, toGitPath(scope)));
+			if (repoRelative === ".." || repoRelative.startsWith("../") || path.posix.isAbsolute(repoRelative)) {
+				throw new Error(`Requested file resolves outside the repository: "${scope}".`);
+			}
+		}
+		const pathspec = repoRelative === "." ? "." : `:(literal)${repoRelative}`;
+		if (!seen.has(pathspec)) {
+			seen.add(pathspec);
+			result.push(pathspec);
+		}
+	}
+	return result;
+}
+
+function dedupe<T>(items: readonly T[]): T[] {
+	const result: T[] = [];
+	const seen = new Set<T>();
+	for (const item of items) {
+		if (seen.has(item)) continue;
+		seen.add(item);
+		result.push(item);
+	}
+	return result;
+}
+
+function rebaseRepoPath(cwd: string, repoRoot: string, repoRelative: string): string {
+	const absolute = path.join(repoRoot, repoRelative);
+	const relative = path.relative(cwd, absolute);
+	return (relative === "" ? "." : relative.split(path.sep).join("/")) || ".";
+}
+
+type RenameStatPath = {
+	oldPath: string;
+	newPath: string;
+	braced: boolean;
+};
+
+function parseRenameStatPath(pathColumn: string): RenameStatPath | undefined {
+	const repoRelative = pathColumn.trimEnd();
+	const braceStart = repoRelative.indexOf("{");
+	if (braceStart !== -1) {
+		const braceEnd = repoRelative.indexOf("}", braceStart + 1);
+		if (braceEnd !== -1) {
+			const inner = repoRelative.slice(braceStart + 1, braceEnd);
+			const arrow = inner.indexOf(" => ");
+			if (arrow !== -1) {
+				const oldPart = inner.slice(0, arrow);
+				const newPart = inner.slice(arrow + " => ".length);
+				if (oldPart !== "" && newPart !== "") {
+					const prefix = repoRelative.slice(0, braceStart);
+					const suffix = repoRelative.slice(braceEnd + 1);
+					return {
+						oldPath: `${prefix}${oldPart}${suffix}`,
+						newPath: `${prefix}${newPart}${suffix}`,
+						braced: true,
+					};
+				}
+			}
+		}
+	}
+
+	const arrow = repoRelative.indexOf(" => ");
+	if (arrow === -1) return undefined;
+	const oldPath = repoRelative.slice(0, arrow);
+	const newPath = repoRelative.slice(arrow + " => ".length);
+	if (oldPath === "" || newPath === "") return undefined;
+	return { oldPath, newPath, braced: false };
+}
+
+function formatBracedRenameStatPath(oldPath: string, newPath: string): string {
+	const oldParts = oldPath.split("/");
+	const newParts = newPath.split("/");
+	let prefixLength = 0;
+	while (
+		prefixLength < oldParts.length &&
+		prefixLength < newParts.length &&
+		oldParts[prefixLength] === newParts[prefixLength]
+	) {
+		prefixLength++;
+	}
+
+	let oldEnd = oldParts.length;
+	let newEnd = newParts.length;
+	while (oldEnd > prefixLength && newEnd > prefixLength && oldParts[oldEnd - 1] === newParts[newEnd - 1]) {
+		oldEnd--;
+		newEnd--;
+	}
+
+	const oldMiddle = oldParts.slice(prefixLength, oldEnd).join("/");
+	const newMiddle = newParts.slice(prefixLength, newEnd).join("/");
+	if (oldMiddle === "" || newMiddle === "") return `${oldPath} => ${newPath}`;
+
+	const prefix = prefixLength === 0 ? "" : `${oldParts.slice(0, prefixLength).join("/")}/`;
+	const suffix = oldEnd === oldParts.length ? "" : `/${oldParts.slice(oldEnd).join("/")}`;
+	return `${prefix}{${oldMiddle} => ${newMiddle}}${suffix}`;
+}
+
+function rebaseStatPaths(cwd: string, repoRoot: string, stat: string, repoPaths: readonly string[]): string {
+	return stat
+		.split(/\r?\n/)
+		.map(line => rebaseStatPath(cwd, repoRoot, line, repoPaths))
+		.join("\n");
+}
+
+function rebaseStatPath(cwd: string, repoRoot: string, line: string, repoPaths: readonly string[]): string {
+	const separator = line.lastIndexOf(" | ");
+	if (separator === -1) return line;
+	const pathColumn = line.slice(0, separator);
+	const rawRepoRelative = pathColumn.trimEnd();
+	if (rawRepoRelative === "") return line;
+	const unpaddedRepoRelative = rawRepoRelative.startsWith(" ") ? rawRepoRelative.slice(1) : rawRepoRelative;
+	const exactRepoRelative = repoPaths.find(
+		repoPath =>
+			repoPath === rawRepoRelative ||
+			repoPath === unpaddedRepoRelative ||
+			repoPath.trimStart() === unpaddedRepoRelative,
+	);
+	const repoRelative = exactRepoRelative ?? unpaddedRepoRelative;
+	const trailing = pathColumn.slice(rawRepoRelative.length);
+	const rename = exactRepoRelative === undefined ? parseRenameStatPath(repoRelative) : undefined;
+	if (rename) {
+		const oldPath = rebaseRepoPath(cwd, repoRoot, rename.oldPath);
+		const newPath = rebaseRepoPath(cwd, repoRoot, rename.newPath);
+		const rebasedPath = rename.braced ? formatBracedRenameStatPath(oldPath, newPath) : `${oldPath} => ${newPath}`;
+		return `${rebasedPath}${trailing}${line.slice(separator)}`;
+	}
+	return `${rebaseRepoPath(cwd, repoRoot, repoRelative)}${trailing}${line.slice(separator)}`;
+}
+
+function formatReadPath(file: string): string {
+	const display = escapeControlChars(file);
+	const quotedPath = JSON.stringify(file).replace(/[\x7f-\x9f]/g, char => {
+		return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+	});
+	return display === file ? display : `${display} [read path: ${quotedPath}]`;
+}
+
+function formatVcsScope(file: string): string {
+	const display = escapeControlChars(file);
+	return display === file ? display : `${display} [scope: vcs://diff?file=${encodeURIComponent(file)}]`;
+}
+
+function formatUntrackedDiffHint(cwd: string, repoRoot: string, untracked: readonly string[]): string {
+	return [
+		"Untracked files are not included in git diff. Read them directly:",
+		...untracked.map(file => `  ${formatReadPath(rebaseRepoPath(cwd, repoRoot, file))}`),
+	].join("\n");
+}
+
+function trimStat(stat: string, empty: string): string {
+	const lines = stat.split(/\r?\n/);
+	while (lines[0] === "") lines.shift();
+	while (lines.at(-1) === "") lines.pop();
+	return lines.length === 0 ? empty : lines.join("\n");
+}
+
+async function resolveBaseCommit(
+	repoRoot: string,
+	base: string | undefined,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	if (base === undefined) return undefined;
+	if (base.length === 0 || base.length > 256 || base.startsWith("-") || base.includes("\0")) {
+		throw new Error(
+			`Invalid base ref "${base}". Provide a plain branch, tag, or commit (no leading '-' or option-like values).`,
+		);
+	}
+	const commit = await git.ref.commit(repoRoot, base, signal);
+	if (!commit) throw new Error(`Base "${base}" does not resolve to a commit, tag, or branch in this repository.`);
+	return commit;
+}
+
+function viewLabel(baseCommit: string | undefined, staged: boolean | undefined): string {
+	if (baseCommit) return staged ? `staged vs base ${baseCommit.slice(0, 12)}` : `base ${baseCommit.slice(0, 12)}`;
+	if (staged === true) return "staged";
+	if (staged === false) return "working-tree";
+	return "working-tree + staged";
+}
+
+export class VcsProtocolHandler implements ProtocolHandler {
+	readonly scheme = "vcs";
+	readonly immutable = true;
+
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const cwd = context?.cwd ?? process.cwd();
+		const signal = context?.signal;
+		const request = parseVcsUrl(url);
+		const repoRoot = await git.repo.root(cwd, signal);
+		if (!repoRoot) throw new Error("Not inside a git repository.");
+
+		const cwdPrefix = await git.show.prefix(cwd, signal);
+		const displayCwd = resolveGitCwd(repoRoot, cwdPrefix);
+		const baseCommit = await resolveBaseCommit(repoRoot, request.base, signal);
+		const files = normalizePathspecs(cwdPrefix, repoRoot, [...request.pathScopes, ...request.fileScopes]);
+		const diffOptions: git.DiffOptions = {
+			noExternal: true,
+			literalPaths: true,
+			cached: request.staged,
+			...(baseCommit ? { base: baseCommit } : {}),
+			...(files ? { files } : {}),
+			signal,
+		};
+
+		const content =
+			request.operation === "state"
+				? await this.#resolveState(displayCwd, repoRoot, baseCommit, request.staged, files, diffOptions, signal)
+				: await this.#resolveDiff(displayCwd, repoRoot, baseCommit, request.staged, files, diffOptions, signal);
+
+		return {
+			url: url.href,
+			content,
+			contentType: "text/plain",
+		};
+	}
+
+	async #resolveDiff(
+		cwd: string,
+		repoRoot: string,
+		baseCommit: string | undefined,
+		staged: boolean | undefined,
+		files: string[] | undefined,
+		diffOptions: git.DiffOptions,
+		signal?: AbortSignal,
+	): Promise<string> {
+		const sections: string[] = [];
+		if (!baseCommit && staged === undefined) {
+			const [stagedDiff, unstagedDiff, untracked] = await Promise.all([
+				git.diff(repoRoot, { ...diffOptions, cached: true }),
+				git.diff(repoRoot, { ...diffOptions, cached: false }),
+				git.ls.untracked(repoRoot, { files, literalPaths: true, signal, z: true }),
+			]);
+			if (stagedDiff.trim() !== "") sections.push(stagedDiff.trimEnd());
+			if (unstagedDiff.trim() !== "") sections.push(unstagedDiff.trimEnd());
+			if (untracked.length > 0) sections.push(formatUntrackedDiffHint(cwd, repoRoot, untracked));
+			return sections.length === 0 ? "No changes for the requested diff." : sections.join("\n\n");
+		}
+
+		const diffText = await git.diff(repoRoot, diffOptions);
+		if (diffText.trim() !== "") sections.push(diffText.trimEnd());
+		if (staged !== true) {
+			const untracked = await git.ls.untracked(repoRoot, { files, literalPaths: true, signal, z: true });
+			if (untracked.length > 0) sections.push(formatUntrackedDiffHint(cwd, repoRoot, untracked));
+		}
+		return sections.length === 0 ? "No changes for the requested diff." : sections.join("\n\n");
+	}
+
+	async #resolveState(
+		cwd: string,
+		repoRoot: string,
+		baseCommit: string | undefined,
+		staged: boolean | undefined,
+		files: string[] | undefined,
+		diffOptions: git.DiffOptions,
+		signal?: AbortSignal,
+	): Promise<string> {
+		const headState = await git.head.resolve(repoRoot, signal);
+		let changedFiles: string[];
+		let statSection: string[];
+
+		if (baseCommit || staged !== undefined) {
+			const [names, stat] = await Promise.all([
+				git.diff(repoRoot, { ...diffOptions, nameOnly: true, z: true }),
+				git.diff(repoRoot, { ...diffOptions, stat: true }),
+			]);
+			const changedNames = gitSplitLines(names);
+			changedFiles = changedNames.map(name => rebaseRepoPath(cwd, repoRoot, name));
+			statSection = [trimStat(rebaseStatPaths(cwd, repoRoot, stat, changedNames), "No tracked changes.")];
+		} else {
+			const [unstagedNamesText, unstagedStat, stagedNamesText, stagedStat] = await Promise.all([
+				git.diff(repoRoot, { ...diffOptions, cached: false, nameOnly: true, z: true }),
+				git.diff(repoRoot, { ...diffOptions, cached: false, stat: true }),
+				git.diff(repoRoot, { ...diffOptions, cached: true, nameOnly: true, z: true }),
+				git.diff(repoRoot, { ...diffOptions, cached: true, stat: true }),
+			]);
+			const unstagedNames = gitSplitLines(unstagedNamesText);
+			const stagedNames = gitSplitLines(stagedNamesText);
+			changedFiles = dedupe([...stagedNames, ...unstagedNames]).map(name => rebaseRepoPath(cwd, repoRoot, name));
+			statSection = [
+				"Staged:",
+				trimStat(rebaseStatPaths(cwd, repoRoot, stagedStat, stagedNames), "No staged changes."),
+				"Unstaged:",
+				trimStat(rebaseStatPaths(cwd, repoRoot, unstagedStat, unstagedNames), "No unstaged changes."),
+			];
+		}
+
+		const untracked =
+			staged === true
+				? []
+				: (await git.ls.untracked(repoRoot, { files, literalPaths: true, signal, z: true })).map(name =>
+						rebaseRepoPath(cwd, repoRoot, name),
+					);
+
+		const lines = [`repo: ${escapeControlChars(shortenPath(repoRoot))}`];
+		if (headState?.kind === "ref" && headState.branchName) lines.push(`branch: ${headState.branchName}`);
+		if (headState?.commit) lines.push(`head: ${headState.commit.slice(0, 12)}`);
+		lines.push(`view: ${viewLabel(baseCommit, staged)}`, "", `Changed files (${changedFiles.length}):`);
+		lines.push(
+			...(changedFiles.length === 0 ? ["  (none)"] : changedFiles.map(file => `  ${formatVcsScope(file)}`)),
+			"Stat:",
+			...statSection,
+		);
+		if (untracked.length > 0) {
+			lines.push("", `Untracked (${untracked.length}):`, ...untracked.map(file => `  ${formatReadPath(file)}`));
+		}
+		return lines.join("\n");
+	}
+}
+
+function gitSplitLines(text: string): string[] {
+	const records = text.includes("\0") ? text.split("\0") : text.split(/\r?\n/);
+	return records.filter(record => record.length > 0);
+}
+function escapeControlChars(p: string): string {
+	return p.replace(/[\x00-\x1f\x7f-\x9f]/g, c => {
+		const map: Record<string, string> = {
+			"\b": "\\b",
+			"\f": "\\f",
+			"\n": "\\n",
+			"\r": "\\r",
+			"\t": "\\t",
+			"\v": "\\v",
+		};
+		return map[c] ?? `\\x${c.charCodeAt(0).toString(16).padStart(2, "0")}`;
+	});
+}

--- a/packages/coding-agent/src/prompts/advisor/system.md
+++ b/packages/coding-agent/src/prompts/advisor/system.md
@@ -15,6 +15,7 @@ Offer that view before they sink work into the wrong direction.
 <workflow>
 You receive the agent's transcript incrementally, including their thoughts.
 Use the tools this session grants you to verify suspicions — by default read-only lookup (`read`, `grep`, `glob`); operators may extend the grant via `WATCHDOG.yml`. Advising is your primary channel; touch mutating tools (when granted) only when a verify step genuinely needs them.
+When reviewing workspace changes, use `read` with `vcs://state` and `vcs://diff/...` to inspect the current repository state and patch.
 Keep exploration lean:
 - 2–3 tool calls per advise.
 - Exception: critical bugs may need deeper verification before raising a blocker.

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -19,6 +19,7 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 - Documents → extracted text. Notebooks → editable cells. Images → {{#if INSPECT_IMAGE_ENABLED}}metadata; call `inspect_image`{{else}}decoded inline{{/if}}. `:raw` bypasses converters.
 - URLs → reader-mode clean text/markdown; `:raw` → untouched HTML. Bare `host:port` needs trailing slash.
 - Internal URIs — all schemes take selectors. `artifact://<id>` recovers spilled output; page with `:N-M`/`:raw:N-M`.
+- `vcs://state` — changed files + stat + untracked for the current repo; `vcs://diff[/path]` — patch text. Paths are caller-cwd-relative; query: `base=<ref>`, `staged=true`, repeated `file=<path>`. `:raw` for exact patch bytes; line selectors page large diffs.
 - `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts; also `write`/`search`-able.
   Literal `:`, `?`, `#` → percent-encode (`%3A`/`%3F`/`%23`). Requires POSIX shell (else `ssh` tool).
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -43,6 +43,7 @@ const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	rule: true,
 	skill: true,
 	ssh: true,
+	vcs: true,
 	vault: true,
 };
 // Schemes whose resource URIs are server-defined and may legitimately end
@@ -63,6 +64,7 @@ const TOP_LEVEL_INTERNAL_URL_PREFIXES = [
 	"mcp://",
 	"ssh://",
 	"vault://",
+	"vcs://",
 ] as const;
 
 function normalizeUnicodeSpaces(str: string): string {
@@ -402,7 +404,14 @@ export function splitInternalUrlSel(rawPath: string): { path: string; sel?: stri
 	if (scheme === "ssh" && rawPath.indexOf("/", schemeEnd) === -1) {
 		return { path: rawPath };
 	}
-	let path = rawPath;
+	const selectorEnd =
+		scheme === "vcs"
+			? [rawPath.indexOf("?", schemeEnd), rawPath.indexOf("#", schemeEnd)]
+					.filter(index => index !== -1)
+					.reduce((first, index) => Math.min(first, index), rawPath.length)
+			: rawPath.length;
+	const suffix = rawPath.slice(selectorEnd);
+	let path = rawPath.slice(0, selectorEnd);
 	const chunks: string[] = [];
 	while (true) {
 		const colon = path.lastIndexOf(":");
@@ -414,7 +423,7 @@ export function splitInternalUrlSel(rawPath: string): { path: string; sel?: stri
 		path = path.slice(0, colon);
 	}
 	if (chunks.length === 0) return { path: rawPath };
-	return { path, sel: chunks.join(":") };
+	return { path: `${path}${suffix}`, sel: chunks.join(":") };
 }
 
 /**

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -58,13 +58,25 @@ export interface DiffOptions {
 	readonly binary?: boolean;
 	readonly cached?: boolean;
 	readonly env?: Record<string, string | undefined>;
+	readonly literalPaths?: boolean;
 	readonly files?: readonly string[];
 	readonly head?: string;
 	readonly nameOnly?: boolean;
+	/**
+	 * Pass `--no-ext-diff --no-textconv --no-color` so the diff cannot run a
+	 * repo-configured `diff.external`/`GIT_EXTERNAL_DIFF` or per-driver
+	 * `textconv` program, and cannot inherit forced color from repo/global config.
+	 * Opt-in (default off) to preserve existing behavior for callers that
+	 * intentionally surface textconv'd or colored diffs (e.g. commit/changelog
+	 * prompts); set by callers that must read plain, inert patch bytes from
+	 * untrusted repo config, such as the `vcs://` read protocol.
+	 */
+	readonly noExternal?: boolean;
 	readonly noIndex?: { left: string; right: string };
 	readonly numstat?: boolean;
 	readonly signal?: AbortSignal;
 	readonly stat?: boolean;
+	readonly z?: boolean;
 }
 
 export interface StatusOptions {
@@ -358,6 +370,7 @@ async function collectSubprocessResult(
 
 interface CommandOptions {
 	readonly env?: Record<string, string | undefined>;
+	readonly config?: readonly (readonly [key: string, value: string])[];
 	readonly maxOutputBytes?: number;
 	readonly readOnly?: boolean;
 	readonly signal?: AbortSignal;
@@ -400,7 +413,8 @@ function formatCommandFailure(
 }
 
 async function git(cwd: string, args: readonly string[], options: CommandOptions = {}): Promise<GitCommandResult> {
-	const commandArgs = withShortLivedGitConfig(options.readOnly ? withNoOptionalLocks(args) : [...args]);
+	const baseArgs = withShortLivedGitConfig(options.readOnly ? withNoOptionalLocks(args) : [...args]);
+	const commandArgs = options.config ? withGitConfig(baseArgs, options.config) : baseArgs;
 	const child = Bun.spawn(["git", ...commandArgs], {
 		cwd,
 		env: buildGitEnv(options.env),
@@ -422,6 +436,15 @@ function withNoOptionalLocks(args: readonly string[]): string[] {
 function withShortLivedGitConfig(args: readonly string[]): string[] {
 	const prefix: string[] = [];
 	for (const [key, value] of SHORT_LIVED_GIT_CONFIG) {
+		if (hasGitConfig(args, key, value)) continue;
+		prefix.push("-c", `${key}=${value}`);
+	}
+	return [...prefix, ...args];
+}
+
+function withGitConfig(args: readonly string[], config: readonly (readonly [key: string, value: string])[]): string[] {
+	const prefix: string[] = [];
+	for (const [key, value] of config) {
 		if (hasGitConfig(args, key, value)) continue;
 		prefix.push("-c", `${key}=${value}`);
 	}
@@ -518,8 +541,8 @@ export async function withRepoLock<T>(cwd: string, fn: () => Promise<T>, signal?
 function splitLines(text: string): string[] {
 	return text
 		.split("\n")
-		.map(line => line.trim())
-		.filter(Boolean);
+		.map(line => (line.endsWith("\r") ? line.slice(0, -1) : line))
+		.filter(line => line.length > 0);
 }
 
 function trimScalar(text: string | undefined): string | undefined {
@@ -533,11 +556,19 @@ function trimScalar(text: string | undefined): string | undefined {
 
 function buildDiffArgs(options: DiffOptions): string[] {
 	const args = ["diff"];
+	// Opt-in: `--no-ext-diff`/`--no-textconv` override any repo-config
+	// `diff.external`, `GIT_EXTERNAL_DIFF`, or per-driver textconv program, while
+	// `--no-color` overrides forced `color.ui`/`color.diff`. Hardened, read-only
+	// diff callers then receive plain patch bytes and never execute arbitrary
+	// external commands from untrusted repo config. Off by default so callers that
+	// rely on configured textconv or color (commit/changelog prompts) are unchanged.
+	if (options.noExternal) args.push("--no-ext-diff", "--no-textconv", "--no-color");
 	if (options.binary) args.push("--binary");
 	if (options.cached) args.push("--cached");
 	if (options.nameOnly) args.push("--name-only");
 	if (options.stat) args.push("--stat");
 	if (options.numstat) args.push("--numstat");
+	if (options.z) args.push("-z");
 	if (options.noIndex) {
 		args.push("--no-index", options.noIndex.left, options.noIndex.right);
 		return args;
@@ -1179,16 +1210,17 @@ function parseStatusPorcelain(text: string): GitStatusSummary {
 export const diff = Object.assign(
 	async function diff(cwd: string, options: DiffOptions = {}): Promise<string> {
 		const args = buildDiffArgs(options);
+		const config = options.literalPaths ? ([["core.quotePath", "false"]] as const) : undefined;
 		if (options.allowFailure) {
-			return (await git(cwd, args, { env: options.env, readOnly: true, signal: options.signal })).stdout;
+			return (await git(cwd, args, { config, env: options.env, readOnly: true, signal: options.signal })).stdout;
 		}
-		return runText(cwd, args, { env: options.env, readOnly: true, signal: options.signal });
+		return runText(cwd, args, { config, env: options.env, readOnly: true, signal: options.signal });
 	},
 	{
 		/** List changed file paths. */
 		async changedFiles(
 			cwd: string,
-			options: Pick<DiffOptions, "cached" | "files" | "signal"> = {},
+			options: Pick<DiffOptions, "cached" | "files" | "literalPaths" | "signal"> = {},
 		): Promise<string[]> {
 			return splitLines(await diff(cwd, { ...options, nameOnly: true }));
 		},
@@ -1635,7 +1667,7 @@ export const show = Object.assign(
 	{
 		/** Get the path prefix of the current directory relative to the repo root. */
 		async prefix(cwd: string, signal?: AbortSignal): Promise<string> {
-			return (await runText(cwd, ["rev-parse", "--show-prefix"], { readOnly: true, signal })).trim();
+			return (await runText(cwd, ["rev-parse", "--show-prefix"], { readOnly: true, signal })).replace(/\r?\n$/, "");
 		},
 	},
 );
@@ -1805,6 +1837,23 @@ export const ref = {
 		const repository = await resolveRepository(cwd);
 		if (repository && refName.startsWith("refs/")) return readRef(repository, refName, signal);
 		const result = await git(cwd, ["rev-parse", refName], { readOnly: true, signal });
+		if (result.exitCode !== 0) return null;
+		return result.stdout.trim() || null;
+	},
+
+	/**
+	 * Resolve a user-supplied ref to a commit SHA, requiring it to actually name
+	 * a commit-ish. Uses `rev-parse --verify <ref>^{commit}`, so a value that is
+	 * only a path (e.g. `main` when no `main` branch exists but a `main` file
+	 * does) fails instead of being silently reinterpreted as a pathspec, and a
+	 * tree/blob ref is rejected. `--end-of-options` prevents a leading `-` from
+	 * being parsed as an option. Returns `null` when the ref does not resolve.
+	 */
+	async commit(cwd: string, refName: string, signal?: AbortSignal): Promise<string | null> {
+		const result = await git(cwd, ["rev-parse", "--verify", "--quiet", "--end-of-options", `${refName}^{commit}`], {
+			readOnly: true,
+			signal,
+		});
 		if (result.exitCode !== 0) return null;
 		return result.stdout.trim() || null;
 	},
@@ -2162,17 +2211,38 @@ export const ls = {
 	/** List files tracked or untracked by git. */
 	async files(
 		cwd: string,
-		options: { others?: boolean; excludeStandard?: boolean; signal?: AbortSignal } = {},
+		options: {
+			others?: boolean;
+			excludeStandard?: boolean;
+			files?: readonly string[];
+			literalPaths?: boolean;
+			signal?: AbortSignal;
+			z?: boolean;
+		} = {},
 	): Promise<string[]> {
 		const args = ["ls-files"];
 		if (options.others) args.push("--others");
 		if (options.excludeStandard) args.push("--exclude-standard");
-		return splitLines(await runText(cwd, args, { readOnly: true, signal: options.signal }));
+		if (options.z) args.push("-z");
+		if (options.files?.length) args.push("--", ...options.files);
+		const config = options.literalPaths ? ([["core.quotePath", "false"]] as const) : undefined;
+		const text = await runText(cwd, args, { config, readOnly: true, signal: options.signal });
+		return (options.z ? text.split("\0") : splitLines(text)).filter(record => record.length > 0);
 	},
 
-	/** List untracked files (excludes ignored). */
-	async untracked(cwd: string, signal?: AbortSignal): Promise<string[]> {
-		return ls.files(cwd, { others: true, excludeStandard: true, signal });
+	/** List untracked files (excludes ignored), optionally scoped to pathspecs. */
+	async untracked(
+		cwd: string,
+		options: { files?: readonly string[]; literalPaths?: boolean; signal?: AbortSignal; z?: boolean } = {},
+	): Promise<string[]> {
+		return ls.files(cwd, {
+			others: true,
+			excludeStandard: true,
+			files: options.files,
+			literalPaths: options.literalPaths,
+			signal: options.signal,
+			z: options.z,
+		});
 	},
 
 	/** List paths present in a ref, optionally filtered to specific paths. */

--- a/packages/coding-agent/test/git-process-config.test.ts
+++ b/packages/coding-agent/test/git-process-config.test.ts
@@ -69,6 +69,45 @@ describe("git subprocess config", () => {
 		]);
 	});
 
+	it("adds external diff hardening only when requested", async () => {
+		const spawnCalls: SpawnCall[] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(createSpawnMock(spawnCalls));
+
+		await git.diff("/work/pi", { noExternal: true });
+
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.cmd).toEqual([
+			"git",
+			"-c",
+			"core.fsmonitor=false",
+			"-c",
+			"core.untrackedCache=false",
+			"--no-optional-locks",
+			"diff",
+			"--no-ext-diff",
+			"--no-textconv",
+			"--no-color",
+		]);
+	});
+
+	it("leaves external diff and textconv enabled by default", async () => {
+		const spawnCalls: SpawnCall[] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(createSpawnMock(spawnCalls));
+
+		await git.diff("/work/pi");
+
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.cmd).toEqual([
+			"git",
+			"-c",
+			"core.fsmonitor=false",
+			"-c",
+			"core.untrackedCache=false",
+			"--no-optional-locks",
+			"diff",
+		]);
+	});
+
 	it("disables fsmonitor and untracked cache for mutating commands", async () => {
 		const spawnCalls: SpawnCall[] = [];
 		vi.spyOn(Bun, "spawn").mockImplementation(createSpawnMock(spawnCalls));

--- a/packages/coding-agent/test/internal-urls/vcs-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/vcs-protocol.test.ts
@@ -1,0 +1,664 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import type { ReadToolDetails } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+
+const GIT_ENV = {
+	...process.env,
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+	GIT_CONFIG_NOSYSTEM: "1",
+	GIT_TERMINAL_PROMPT: "0",
+	GIT_AUTHOR_NAME: "Test User",
+	GIT_AUTHOR_EMAIL: "test@example.com",
+	GIT_COMMITTER_NAME: "Test User",
+	GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+const tmpDirs: string[] = [];
+
+function runGit(cwd: string, args: string[]): void {
+	const result = Bun.spawnSync(["git", ...args], { cwd, env: GIT_ENV, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${new TextDecoder().decode(result.stderr)}`);
+	}
+}
+
+function textOfRead(result: AgentToolResult<ReadToolDetails>): string {
+	return result.content
+		.filter(c => c.type === "text")
+		.map(c => c.text)
+		.join("\n");
+}
+
+function session(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		hasEditTool: false,
+		getSessionFile: () => null,
+		getArtifactsDir: () => null,
+		getSessionSpawns: () => null,
+		settings: Settings.isolated({ readLineNumbers: false }),
+	} as unknown as ToolSession;
+}
+
+async function mkTmp(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+async function makeRepo(): Promise<string> {
+	const dir = await mkTmp("vcs-protocol-");
+	runGit(dir, ["init", "-q", "-b", "main"]);
+	await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\n");
+	runGit(dir, ["add", "-A"]);
+	runGit(dir, ["commit", "-q", "-m", "init"]);
+	return dir;
+}
+
+async function resolveVcs(cwd: string, url: string): Promise<string> {
+	return (await InternalUrlRouter.instance().resolve(url, { cwd })).content;
+}
+
+function singleChangedPath(text: string): string {
+	const match = text.match(/Changed files \(1\):\n {2}([^\n]+)/);
+	if (!match) throw new Error(`Expected exactly one changed path in VCS state:\n${text}`);
+	return match[1];
+}
+
+describe("vcs:// internal URL protocol", () => {
+	afterEach(async () => {
+		InternalUrlRouter.resetForTests();
+		await Promise.all(tmpDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+	});
+
+	it("vcs://state reports modified tracked files and untracked files", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		await Bun.write(path.join(dir, "new.txt"), "fresh\n");
+
+		const text = await resolveVcs(dir, "vcs://state");
+
+		expect(text).toContain("view: working-tree + staged");
+		expect(text).toContain("Changed files (1):\n  a.txt");
+		expect(text).toContain("Unstaged:");
+		expect(text).toContain("a.txt");
+		expect(text).toContain("Untracked (1):\n  new.txt");
+	});
+
+	it("vcs://state/<path> scopes tracked changes and matching untracked files", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		await Bun.write(path.join(dir, "b.txt"), "bee\n");
+		runGit(dir, ["add", "b.txt"]);
+		runGit(dir, ["commit", "-q", "-m", "add b"]);
+		await Bun.write(path.join(dir, "b.txt"), "bee\nbuzz\n");
+		await Bun.write(path.join(dir, "new.txt"), "fresh\n");
+		await Bun.write(path.join(dir, "other.txt"), "ignore me\n");
+
+		const text = await resolveVcs(dir, "vcs://state/a.txt?file=new.txt");
+
+		expect(text).toContain("Changed files (1):\n  a.txt");
+		expect(text).toContain("Untracked (1):\n  new.txt");
+		expect(text).not.toContain("b.txt");
+		expect(text).not.toContain("other.txt");
+	});
+
+	it("default vcs://state surfaces staged-only files", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		runGit(dir, ["add", "a.txt"]);
+
+		const text = await resolveVcs(dir, "vcs://state");
+
+		expect(text).toContain("Changed files (1):\n  a.txt");
+		expect(text).toContain("Staged:");
+		expect(text).toContain("a.txt");
+		expect(text).toContain("Unstaged:\nNo unstaged changes.");
+	});
+
+	it("default vcs://diff includes staged-only patches", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		runGit(dir, ["add", "a.txt"]);
+
+		const text = await resolveVcs(dir, "vcs://diff/a.txt");
+
+		expect(text).toContain("diff --git a/a.txt b/a.txt");
+		expect(text).toContain("+four");
+	});
+
+	it("vcs://diff/<path> returns patch text scoped to that path", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		await Bun.write(path.join(dir, "b.txt"), "bee\n");
+
+		const text = await resolveVcs(dir, "vcs://diff/a.txt");
+
+		expect(text).toContain("diff --git a/a.txt b/a.txt");
+		expect(text).toContain("+four");
+		expect(text).not.toContain("b.txt");
+	});
+
+	it("vcs://diff and vcs://state return plain text when Git color is forced", async () => {
+		const dir = await makeRepo();
+		runGit(dir, ["config", "color.ui", "always"]);
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		const diffText = await resolveVcs(dir, "vcs://diff/a.txt");
+		const stateText = await resolveVcs(dir, "vcs://state/a.txt");
+
+		expect(diffText).toContain("+four");
+		expect(stateText).toContain("a.txt |");
+		expect(diffText).not.toMatch(/\x1B\[[0-9;]*m/);
+		expect(stateText).not.toMatch(/\x1B\[[0-9;]*m/);
+	});
+
+	it("vcs://diff/<path> reports matching untracked files with a read hint", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "new.txt"), "fresh\n");
+		await Bun.write(path.join(dir, "other.txt"), "ignore me\n");
+
+		const text = await resolveVcs(dir, "vcs://diff/new.txt");
+
+		expect(text).toContain("Untracked files are not included in git diff. Read them directly:");
+		expect(text).toContain("  new.txt");
+		expect(text).not.toContain("other.txt");
+	});
+
+	it("vcs://diff?base=main&staged=true diffs staged changes against a base ref", async () => {
+		const dir = await makeRepo();
+		runGit(dir, ["checkout", "-q", "-b", "feature"]);
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		runGit(dir, ["add", "a.txt"]);
+
+		const text = await resolveVcs(dir, "vcs://diff?base=main&staged=true");
+
+		expect(text).toContain("+four");
+	});
+
+	it("rejects option-like base refs", async () => {
+		const dir = await makeRepo();
+
+		await expect(resolveVcs(dir, "vcs://diff?base=--output%3D%2Ftmp%2Fpwn")).rejects.toThrow("Invalid base ref");
+	});
+
+	it("rejects a base that exists only as a tracked path", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "nope"), "i am a file\n");
+		runGit(dir, ["add", "nope"]);
+		runGit(dir, ["commit", "-q", "-m", "add nope"]);
+
+		await expect(resolveVcs(dir, "vcs://diff?base=nope")).rejects.toThrow("does not resolve to a commit");
+	});
+
+	it("rejects vcs://state outside a git repository", async () => {
+		const dir = await mkTmp("vcs-nogit-");
+
+		await expect(resolveVcs(dir, "vcs://state")).rejects.toThrow("Not inside a git repository");
+	});
+
+	it("resolves URL path scopes relative to a session cwd inside the repo", async () => {
+		const dir = await makeRepo();
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\n");
+		await Bun.write(path.join(dir, "c.txt"), "root\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add c files"]);
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\nsea\n");
+		await Bun.write(path.join(dir, "c.txt"), "root\nwrong\n");
+
+		const text = await resolveVcs(path.join(dir, "pkg"), "vcs://diff/c.txt");
+
+		expect(text).toContain("+sea");
+		expect(text).toContain("pkg/c.txt");
+		expect(text).not.toContain("+wrong");
+	});
+
+	it("resolves URL path scopes relative to a symlinked session cwd inside the repo", async () => {
+		const dir = await makeRepo();
+		const linkDir = await mkTmp("vcs-symlink-parent-");
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\n");
+		await Bun.write(path.join(dir, "c.txt"), "root\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add c files"]);
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\nsea\n");
+		await Bun.write(path.join(dir, "c.txt"), "root\nwrong\n");
+		const symlinkCwd = path.join(linkDir, "pkg-link");
+		await fs.symlink(path.join(dir, "pkg"), symlinkCwd, "dir");
+
+		const text = await resolveVcs(symlinkCwd, "vcs://diff/c.txt");
+
+		expect(text).toContain("+sea");
+		expect(text).toContain("pkg/c.txt");
+		expect(text).not.toContain("+wrong");
+	});
+
+	it("vcs://state paths from a symlinked cwd round-trip to vcs://diff", async () => {
+		const dir = await makeRepo();
+		const linkDir = await mkTmp("vcs-symlink-state-parent-");
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add nested file"]);
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\nsea\n");
+		const symlinkCwd = path.join(linkDir, "pkg-link");
+		await fs.symlink(path.join(dir, "pkg"), symlinkCwd, "dir");
+
+		const stateText = await resolveVcs(symlinkCwd, "vcs://state");
+		const changedPath = singleChangedPath(stateText);
+		const diffText = await resolveVcs(symlinkCwd, `vcs://diff/${encodeURIComponent(changedPath)}`);
+
+		expect(changedPath).toBe("c.txt");
+		expect(stateText).toContain("c.txt |");
+		expect(diffText).toContain("+sea");
+		expect(diffText).toContain("pkg/c.txt");
+	});
+
+	it("vcs://state and vcs://diff display non-ASCII paths literally", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "é.txt"), "accent\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add unicode file"]);
+		await Bun.write(path.join(dir, "é.txt"), "accent\nchanged\n");
+
+		const stateText = await resolveVcs(dir, "vcs://state");
+		const diffText = await resolveVcs(dir, "vcs://diff/%C3%A9.txt");
+
+		expect(stateText).toContain("Changed files (1):\n  é.txt");
+		expect(stateText).toContain("é.txt |");
+		expect(diffText).toContain("diff --git a/é.txt b/é.txt");
+		expect(stateText).not.toContain("\\303");
+		expect(diffText).not.toContain("\\303");
+	});
+
+	it("vcs://state preserves leading whitespace in changed and untracked paths", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, " leading.txt"), "space\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add leading-space file"]);
+		await Bun.write(path.join(dir, " leading.txt"), "space\nchanged\n");
+		await Bun.write(path.join(dir, " fresh.txt"), "new\n");
+
+		const stateText = await resolveVcs(dir, "vcs://state");
+		const diffText = await resolveVcs(dir, "vcs://diff/%20leading.txt");
+
+		expect(stateText).toContain("Changed files (1):\n   leading.txt");
+		expect(stateText).toContain(" leading.txt |");
+		expect(stateText).toContain("Untracked (1):\n   fresh.txt");
+		expect(diffText).toContain("diff --git a/ leading.txt b/ leading.txt");
+		expect(diffText).toContain("+changed");
+	});
+
+	it("rebases vcs://state stat paths relative to a session cwd inside the repo", async () => {
+		const dir = await makeRepo();
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add nested file"]);
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\nsea\n");
+
+		const text = await resolveVcs(path.join(dir, "pkg"), "vcs://state");
+
+		expect(text).toContain("Changed files (1):\n  c.txt");
+		expect(text).toContain("c.txt |");
+		expect(text).not.toContain("pkg/c.txt |");
+	});
+
+	it("rebases stat paths containing the stat delimiter sequence", async () => {
+		const dir = await makeRepo();
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "a | b.txt"), "one\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add delimiter path"]);
+		await Bun.write(path.join(dir, "pkg", "a | b.txt"), "one\ntwo\n");
+
+		const text = await resolveVcs(path.join(dir, "pkg"), "vcs://state");
+
+		expect(text).toContain("Changed files (1):\n  a | b.txt");
+		expect(text).toContain("a | b.txt |");
+		expect(text).not.toContain("../a | b.txt");
+	});
+
+	it("rebases git rename stat paths relative to a session cwd inside the repo", async () => {
+		const dir = await makeRepo();
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "old.txt"), "see\nsea\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add nested file"]);
+		await fs.rename(path.join(dir, "pkg", "old.txt"), path.join(dir, "pkg", "new.txt"));
+		runGit(dir, ["add", "-A"]);
+
+		const text = await resolveVcs(path.join(dir, "pkg"), "vcs://state");
+
+		expect(text).toContain("Changed files (1):\n  new.txt");
+		expect(text).toContain("{old.txt => new.txt} |");
+		expect(text).not.toContain("pkg/{old.txt => new.txt} |");
+	});
+
+	it("vcs://state literal-arrow paths round-trip from a subdirectory cwd", async () => {
+		const dir = await makeRepo();
+		const pkg = path.join(dir, "pkg");
+		const filename = "literal => arrow.txt";
+		await fs.mkdir(pkg, { recursive: true });
+		await Bun.write(path.join(pkg, filename), "before\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add literal-arrow file"]);
+		await Bun.write(path.join(pkg, filename), "before\nafter\n");
+
+		const stateText = await resolveVcs(pkg, "vcs://state");
+		const changedPath = singleChangedPath(stateText);
+		const diffText = await resolveVcs(pkg, `vcs://diff/${encodeURIComponent(changedPath)}`);
+
+		expect(changedPath).toBe(filename);
+		expect(stateText).toContain(`${filename} |`);
+		expect(stateText).not.toContain(`../literal => arrow.txt |`);
+		expect(diffText).toContain(`diff --git a/pkg/${filename} b/pkg/${filename}`);
+		expect(diffText).toContain("+after");
+	});
+
+	it("treats scoped paths as literal Git pathspecs", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, ":(exclude)b.txt"), "literal\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add magic-looking path"]);
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nunrelated\n");
+		await Bun.write(path.join(dir, ":(exclude)b.txt"), "literal\nsafe\n");
+
+		const pathText = await resolveVcs(dir, "vcs://diff/%3A%28exclude%29b.txt");
+		const queryText = await resolveVcs(dir, "vcs://state?file=%3A%28exclude%29b.txt");
+
+		expect(pathText).toContain("+safe");
+		expect(pathText).not.toContain("+unrelated");
+		expect(queryText).toContain("Changed files (1):\n  :(exclude)b.txt");
+		expect(queryText).not.toContain("a.txt");
+	});
+
+	it("rejects scopes that escape the repository", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		await expect(resolveVcs(dir, "vcs://diff/../../etc/passwd")).rejects.toThrow(
+			"Requested file resolves outside the repository",
+		);
+		await expect(resolveVcs(dir, "vcs://diff?file=../../etc/passwd")).rejects.toThrow(
+			"Requested file resolves outside the repository",
+		);
+	});
+
+	it("base comparisons still surface untracked files in vcs://state and vcs://diff", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		await Bun.write(path.join(dir, "new.txt"), "fresh\n");
+
+		const state = await resolveVcs(dir, "vcs://state?base=main");
+		expect(state).toContain("Changed files (1):\n  a.txt");
+		expect(state).toContain("Untracked (1):\n  new.txt");
+
+		const diff = await resolveVcs(dir, "vcs://diff?base=main");
+		expect(diff).toContain("+four");
+		expect(diff).toContain("Untracked files are not included in git diff.");
+		expect(diff).toContain("new.txt");
+
+		const stagedState = await resolveVcs(dir, "vcs://state?base=main&staged=true");
+		expect(stagedState).not.toContain("Untracked");
+		const stagedDiff = await resolveVcs(dir, "vcs://diff?base=main&staged=true");
+		expect(stagedDiff).not.toContain("new.txt");
+	});
+
+	it("accepts absolute scopes that reach the repo through a symlink", async () => {
+		const dir = await makeRepo();
+		const linkParent = await mkTmp("vcs-abs-symlink-");
+		const link = path.join(linkParent, "repo-link");
+		await fs.symlink(dir, link);
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		const encoded = encodeURIComponent(path.join(link, "a.txt"));
+		const text = await resolveVcs(dir, `vcs://diff?file=${encoded}`);
+		expect(text).toContain("+four");
+
+		await expect(
+			resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(path.join(link, "..", "outside.txt"))}`),
+		).rejects.toThrow("Requested file resolves outside the repository");
+	});
+
+	it("accepts absolute scopes through a symlinked repo subdirectory", async () => {
+		const dir = await makeRepo();
+		const linkParent = await mkTmp("vcs-abs-subdir-symlink-");
+		const link = path.join(linkParent, "pkg-link");
+		await fs.mkdir(path.join(dir, "pkg"), { recursive: true });
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\n");
+		runGit(dir, ["add", "-A"]);
+		runGit(dir, ["commit", "-q", "-m", "add pkg"]);
+		await fs.symlink(path.join(dir, "pkg"), link);
+		await Bun.write(path.join(dir, "pkg", "c.txt"), "see\nsea\n");
+
+		const encoded = encodeURIComponent(path.join(link, "c.txt"));
+		const text = await resolveVcs(dir, `vcs://diff?file=${encoded}`);
+		expect(text).toContain("+sea");
+	});
+
+	it("rejects absolute scopes whose `..` escapes through an in-repo symlink", async () => {
+		const dir = await makeRepo();
+		const outside = await mkTmp("vcs-escape-target-");
+		await fs.mkdir(path.join(outside, "sub"), { recursive: true });
+		await Bun.write(path.join(outside, "secret.txt"), "outside\n");
+		await fs.symlink(path.join(outside, "sub"), path.join(dir, "link"));
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		// Raw `..` after a symlink must resolve physically (to `outside/`), not
+		// collapse lexically back inside the repo.
+		const escapePath = `${dir}${path.sep}link${path.sep}..${path.sep}secret.txt`;
+		await expect(resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(escapePath)}`)).rejects.toThrow(
+			"Requested file resolves outside the repository",
+		);
+
+		// A symlink-free `..` that stays inside the repo is still accepted.
+		const inside = `${dir}${path.sep}pkg${path.sep}..${path.sep}a.txt`;
+		const text = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(inside)}`);
+		expect(text).toContain("+four");
+	});
+
+	it("re-resolves symlinks after `..` backs out of a nonexistent segment", async () => {
+		const dir = await makeRepo();
+		const outside = await mkTmp("vcs-escape-missing-");
+		await fs.mkdir(path.join(outside, "sub"), { recursive: true });
+		await Bun.write(path.join(outside, "sub", "file.txt"), "outside\n");
+		await fs.symlink(path.join(outside, "sub"), path.join(dir, "link"));
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		// `missing` does not exist, so `..` pops it lexically and `link` must
+		// then resolve physically (to `outside/sub`), not be appended verbatim.
+		const escapePath = `${dir}${path.sep}missing${path.sep}..${path.sep}link${path.sep}file.txt`;
+		await expect(resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(escapePath)}`)).rejects.toThrow(
+			"Requested file resolves outside the repository",
+		);
+
+		// Backing out of a nonexistent segment onto a real in-repo file still works.
+		const inside = `${dir}${path.sep}missing${path.sep}..${path.sep}a.txt`;
+		const text = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(inside)}`);
+		expect(text).toContain("+four");
+
+		// An ordinary nonexistent trailing path is preserved and stays in scope.
+		const gone = `${dir}${path.sep}nope${path.sep}gone.txt`;
+		const noChanges = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(gone)}`);
+		expect(noChanges).toContain("No changes for the requested diff.");
+	});
+
+	it("accepts forward-slash absolute scopes on Windows", async () => {
+		// Windows-only: URL-derived scopes commonly arrive with `/` separators,
+		// which must still be canonicalized segment by segment.
+		if (process.platform === "win32") {
+			const dir = await makeRepo();
+			await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+			const forward = `${dir.replaceAll("\\", "/")}/a.txt`;
+			const text = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(forward)}`);
+			expect(text).toContain("+four");
+
+			const escapePath = `${dir.replaceAll("\\", "/")}/../outside.txt`;
+			await expect(resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(escapePath)}`)).rejects.toThrow(
+				"Requested file resolves outside the repository",
+			);
+		}
+	});
+
+	it("preserves literal backslash filenames in absolute scopes on POSIX", async () => {
+		// POSIX-only: backslash is an ordinary filename byte, not a separator.
+		if (process.platform !== "win32") {
+			const dir = await makeRepo();
+			const filename = "back\\slash.txt";
+			await Bun.write(path.join(dir, filename), "one\n");
+			runGit(dir, ["add", "-A"]);
+			runGit(dir, ["commit", "-q", "-m", "add backslash file"]);
+			await Bun.write(path.join(dir, filename), "one\ntwo\n");
+
+			const text = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(path.join(dir, filename))}`);
+			expect(text).toContain("+two");
+		}
+	});
+
+	it("propagates non-missing canonicalization failures instead of passing containment", async () => {
+		// POSIX-only: a self-referencing symlink makes realpath fail with ELOOP,
+		// which must surface as an error rather than being appended unresolved.
+		if (process.platform !== "win32") {
+			const dir = await makeRepo();
+			const loop = path.join(dir, "loop");
+			await fs.symlink(loop, loop);
+
+			const scope = `${dir}${path.sep}loop${path.sep}file.txt`;
+			await expect(resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(scope)}`)).rejects.toThrow(
+				/ELOOP|too many/i,
+			);
+		}
+	});
+
+	it("rejects scopes that traverse a file as if it were a directory", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		// `a.txt` is a file, so `a.txt/missing/../..` must fail with ENOTDIR
+		// rather than backing out to `.` and broadening the diff to the whole repo.
+		const scope = `${dir}${path.sep}a.txt${path.sep}missing${path.sep}..${path.sep}..`;
+		await expect(resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(scope)}`)).rejects.toThrow(
+			/ENOTDIR|not a directory/i,
+		);
+	});
+
+	it("treats vcs://diff/. from the repo root as a whole-repo scope", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+
+		const text = await resolveVcs(dir, "vcs://diff/.");
+
+		expect(text).toContain("+four");
+	});
+
+	it("accepts base refs with plus signs and UTF-8 characters", async () => {
+		const dir = await makeRepo();
+		runGit(dir, ["checkout", "-q", "-b", "feature+api/日本語"]);
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		runGit(dir, ["add", "a.txt"]);
+		runGit(dir, ["commit", "-m", "add files"]);
+
+		// Verify we can resolve it using the branch name containing + and UTF-8
+		const text = await resolveVcs(dir, "vcs://diff?base=feature%2Bapi/%E6%97%A5%E6%9C%AC%E8%AA%9E");
+		expect(text).toContain("No changes");
+	});
+
+	it("rejects base refs containing NUL bytes", async () => {
+		const dir = await makeRepo();
+		await expect(resolveVcs(dir, "vcs://diff?base=main%00")).rejects.toThrow("Invalid base ref");
+	});
+
+	it("escapes control characters in file paths in vcs://state", async () => {
+		// Only run on non-Windows since newlines in filenames are POSIX-only
+		if (process.platform !== "win32") {
+			const dir = await makeRepo();
+			const filename = "file\nwith\nnewline.txt";
+			const filePath = path.join(dir, filename);
+			await Bun.write(filePath, "new file content");
+
+			const stateText1 = await resolveVcs(dir, "vcs://state");
+			expect(stateText1).toContain('file\\nwith\\nnewline.txt [read path: "file\\nwith\\nnewline.txt"]');
+
+			// Track and commit it
+			runGit(dir, ["add", filename]);
+			runGit(dir, ["commit", "-m", "commit newline file"]);
+
+			// Modify it to create unstaged changes
+			await Bun.write(filePath, "modified file content");
+
+			const stateText2 = await resolveVcs(dir, "vcs://state");
+			expect(stateText2).toContain("file\\nwith\\nnewline.txt [scope: vcs://diff?file=file%0Awith%0Anewline.txt]");
+			const scopedDiff = await resolveVcs(dir, `vcs://diff?file=${encodeURIComponent(filename)}`);
+			expect(scopedDiff).toContain("+modified file content");
+		}
+	});
+
+	it("escapes control characters in vcs://diff untracked hints", async () => {
+		// Only run on non-Windows since newlines in filenames are POSIX-only
+		if (process.platform !== "win32") {
+			const dir = await makeRepo();
+			await Bun.write(path.join(dir, "new\twith\nctrl.txt"), "fresh\n");
+			await Bun.write(path.join(dir, "del\u007fctrl.txt"), "del\n");
+
+			const text = await resolveVcs(dir, "vcs://diff");
+			expect(text).toContain("Untracked files are not included in git diff.");
+			expect(text).toContain('new\\twith\\nctrl.txt [read path: "new\\twith\\nctrl.txt"]');
+			expect(text).not.toContain("new\twith\nctrl.txt");
+			expect(text).toContain('del\\x7fctrl.txt [read path: "del\\u007fctrl.txt"]');
+			expect(text).not.toContain("del\u007fctrl.txt");
+		}
+	});
+
+	it("escapes control characters in the vcs://state repository path", async () => {
+		// Only run on non-Windows since control characters in directory names are POSIX-only
+		if (process.platform !== "win32") {
+			const parent = await mkTmp("vcs-ctrl-parent-");
+			const dir = path.join(parent, "repo\twith\ttabs");
+			await fs.mkdir(dir, { recursive: true });
+			runGit(dir, ["init", "-q", "-b", "main"]);
+			await Bun.write(path.join(dir, "a.txt"), "one\n");
+			runGit(dir, ["add", "-A"]);
+			runGit(dir, ["commit", "-q", "-m", "init"]);
+
+			const text = await resolveVcs(dir, "vcs://state");
+			const repoLine = text.split("\n").find(line => line.startsWith("repo: "));
+			expect(repoLine).toBeDefined();
+			expect(repoLine).toContain("repo\\twith\\ttabs");
+			expect(repoLine).not.toContain("\t");
+		}
+	});
+
+	it("rejects unknown query parameters", async () => {
+		const dir = await makeRepo();
+
+		await expect(resolveVcs(dir, "vcs://diff?files=a.txt")).rejects.toThrow(
+			"Invalid vcs:// query parameter 'files'. Supported: base, staged, file.",
+		);
+		await expect(resolveVcs(dir, "vcs://diff?constructor=a.txt")).rejects.toThrow(
+			"Invalid vcs:// query parameter 'constructor'. Supported: base, staged, file.",
+		);
+	});
+
+	it("ReadTool routes vcs://diff selectors through the protocol", async () => {
+		const dir = await makeRepo();
+		await Bun.write(path.join(dir, "a.txt"), "one\ntwo\nthree\nfour\n");
+		const tool = new ReadTool(session(dir));
+
+		const text = textOfRead(await tool.execute("read-vcs", { path: "vcs://diff/a.txt:raw" }));
+
+		expect(text).toContain("+four");
+		expect(text).toContain("diff --git a/a.txt b/a.txt");
+	});
+});

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -113,6 +113,19 @@ describe("splitInternalUrlSel", () => {
 		});
 	});
 
+	it("preserves selector-shaped VCS query values while peeling pathname selectors", () => {
+		expect(splitInternalUrlSel("vcs://diff?file=foo:raw")).toEqual({
+			path: "vcs://diff?file=foo:raw",
+		});
+		expect(splitInternalUrlSel("vcs://diff?file=foo:1-5")).toEqual({
+			path: "vcs://diff?file=foo:1-5",
+		});
+		expect(splitInternalUrlSel("vcs://diff/path:raw?file=foo:1-5")).toEqual({
+			path: "vcs://diff/path?file=foo:1-5",
+			sel: "raw",
+		});
+	});
+
 	it("returns the input unchanged for non-URL strings", () => {
 		expect(splitInternalUrlSel("/abs/path:1-50")).toEqual({ path: "/abs/path:1-50" });
 		expect(splitInternalUrlSel("plain-text")).toEqual({ path: "plain-text" });


### PR DESCRIPTION
## What

- Replace the advisor-only `git` tool with read-only `vcs://state` and `vcs://diff[/path]` targets on the existing `read` surface.
- Validate base refs, normalize caller-cwd-relative scopes, reject repository escapes, and disable external diff and text-conversion commands for VCS reads.
- Preserve the advisor's read-only LSP guard, including rejection of workspace-wide diagnostics.
- Preserve literal filenames containing ` => ` when rendering state from a subdirectory while retaining Git rename-stat parsing for actual renames.
- Add protocol coverage for state, diff, path scoping, base refs, staged diffs, real renames, literal-arrow filenames, selector routing, and repository-escape rejection.

## Why

Read-capable sessions can inspect repository state and patch text through one existing protocol without introducing an advisor-specific tool. The server derives the repository root and validates all scopes before executing read-only Git operations.

## Testing

```bash
bun test packages/coding-agent/test/internal-urls/vcs-protocol.test.ts
bun test packages/coding-agent/test/git-process-config.test.ts
bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts
bun --cwd=packages/coding-agent run check
bun --cwd=packages/coding-agent src/cli.ts --help
bun --cwd=packages/coding-agent src/cli.ts read vcs://state
bun --cwd=packages/coding-agent src/cli.ts read vcs://diff:raw
```

Latest review-fix verification: `bun --cwd=packages/coding-agent test test/internal-urls/vcs-protocol.test.ts test/git-process-config.test.ts` (`45 pass, 0 fail`) and `bun --cwd=packages/coding-agent run check:types`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
