### PR TITLE
fix(release): restored legacy pi-compat --compile entrypoints in release builds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp install` of legacy pi extensions failing with `Cannot find module '/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js'` on every released `omp-<platform>-<arch>` binary. Commit `dc5c93462f` removed worker entrypoints from `scripts/ci-release-build-binaries.ts`; the inline comment then claimed the legacy-shim and package-barrel entrypoints (`typebox.ts`, `legacy-pi-{ai,coding-agent}-shim.ts`, `packages/{agent,natives,tui,utils}/...`) were "still" passed to `bun build --compile`, but they had never been re-added. The release binaries shipped without those files in bunfs, so `legacy-pi-compat.ts` redirected `typebox` imports to a bunfs path that didn't exist. The two build scripts (release CI + local dev) now share `scripts/binary-entrypoints.ts` so the lists cannot drift apart, and `__resolveTypeBoxShimPath` mirrors `__validateLegacyPiPackageRootOverrides` (#2168) by dropping the override when the shim file is missing so future regressions fall through to native `node_modules` resolution instead of emitting a dead bunfs URL ([#3414](https://github.com/can1357/oh-my-pi/issues/3414)).
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -2,6 +2,7 @@
 
 import { createRequire } from "node:module";
 import * as path from "node:path";
+import { LEGACY_COMPAT_BUILD_ENTRYPOINTS } from "../../../scripts/binary-entrypoints";
 
 const packageDir = path.join(import.meta.dir, "..");
 const repoRoot = path.join(packageDir, "..", "..");
@@ -82,22 +83,7 @@ async function main(): Promise<void> {
 					"--root",
 					".",
 					"./packages/coding-agent/src/cli.ts",
-					// Legacy pi-* extension compat entrypoints served by
-					// `legacy-pi-compat.ts`. These are reached via computed bunfs paths
-					// (which `--compile`'s static analyzer cannot trace), so each must be
-					// listed here to land in bunfs at
-					// `/$bunfs/root/packages/<pkg>/<entry>.js`. The coding-agent's own
-					// `./src/index.ts` is intentionally NOT listed: bun --compile silently
-					// breaks the CLI entry when the same package's barrel appears as an
-					// extra entrypoint (issue #1474), so legacy `pi-coding-agent` imports
-					// resolve through `legacy-pi-coding-agent-shim.ts` instead.
-					"./packages/agent/src/index.ts",
-					"./packages/natives/native/index.js",
-					"./packages/tui/src/index.ts",
-					"./packages/utils/src/index.ts",
-					"./packages/coding-agent/src/extensibility/typebox.ts",
-					"./packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts",
-					"./packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts",
+					...LEGACY_COMPAT_BUILD_ENTRYPOINTS,
 					"--outfile",
 					`packages/coding-agent/dist/${outName}`,
 				],

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -189,9 +189,35 @@ function sourceShimPath(file: string): string {
 		: path.resolve(import.meta.dir, "..", file);
 }
 
-const TYPEBOX_SHIM_PATH = BUNFS_PACKAGE_ROOT
-	? bunfsPath("coding-agent", "src", "extensibility", "typebox.js")
-	: sourceShimPath("typebox.ts");
+/**
+ * Resolve the path the TypeBox compatibility shim ships at — bunfs in compiled
+ * mode, on-disk source elsewhere — then drop it when the file is missing.
+ *
+ * Validation mirrors `__validateLegacyPiPackageRootOverrides` (#2168): if the
+ * computed candidate doesn't exist (e.g. a release build silently omitted the
+ * `--compile` entrypoint — issue #3414), `resolveTypeBoxSpecifier` returns
+ * `undefined` and `rewriteLegacyExtensionSource` leaves bare `typebox` /
+ * `@sinclair/typebox` specifiers alone, so Bun falls through to native
+ * resolution against the extension's own `node_modules`.
+ *
+ * Exported for tests; production callers use `TYPEBOX_SHIM_PATH`.
+ */
+export function __resolveTypeBoxShimPath(
+	bunfsRoot: string | null,
+	bundledSelfRoot: string | undefined,
+	metaDir: string,
+	pathExistsSync: (p: string) => boolean = fs.existsSync,
+	pathImpl: typeof path = path,
+): string | null {
+	const candidate = bunfsRoot
+		? __joinBunfsPath(bunfsRoot, ["coding-agent", "src", "extensibility", "typebox.js"], pathImpl)
+		: bundledSelfRoot
+			? pathImpl.join(bundledSelfRoot, "src", "extensibility", "typebox.ts")
+			: pathImpl.resolve(metaDir, "..", "typebox.ts");
+	return pathExistsSync(candidate) ? candidate : null;
+}
+
+const TYPEBOX_SHIM_PATH = __resolveTypeBoxShimPath(BUNFS_PACKAGE_ROOT, BUNDLED_SELF_PACKAGE_ROOT, import.meta.dir);
 
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
 // the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
@@ -341,12 +367,17 @@ const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'
  */
 async function rewriteLegacyExtensionSource(source: string, importerPath: string): Promise<string> {
 	const withPi = rewriteLegacyPiImports(source);
-	const withTypeBox = withPi.replace(
-		TYPEBOX_IMPORT_SPECIFIER_REGEX,
-		(_match, prefix: string, _specifier: string, suffix: string) => {
-			return `${prefix}${toImportSpecifier(TYPEBOX_SHIM_PATH)}${suffix}`;
-		},
-	);
+	// When the TypeBox shim is missing (release build dropped the entrypoint —
+	// issue #3414), leave bare specifiers untouched so Bun resolves a real
+	// `typebox` / `@sinclair/typebox` install from the extension's own
+	// `node_modules`. `resolveTypeBoxSpecifier` mirrors the fall-through.
+	const withTypeBox = TYPEBOX_SHIM_PATH
+		? withPi.replace(
+				TYPEBOX_IMPORT_SPECIFIER_REGEX,
+				(_match, prefix: string, _specifier: string, suffix: string) =>
+					`${prefix}${toImportSpecifier(TYPEBOX_SHIM_PATH)}${suffix}`,
+			)
+		: withPi;
 	return rewriteExtensionPackageImports(withTypeBox, importerPath);
 }
 
@@ -719,8 +750,8 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 	}
 }
 
-function resolveTypeBoxSpecifier(): { path: string } {
-	return { path: TYPEBOX_SHIM_PATH };
+function resolveTypeBoxSpecifier(): { path: string } | undefined {
+	return TYPEBOX_SHIM_PATH ? { path: TYPEBOX_SHIM_PATH } : undefined;
 }
 
 export function installLegacyPiSpecifierShim(): void {

--- a/packages/coding-agent/test/extensibility/legacy-pi-compat-entrypoints.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-compat-entrypoints.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { LEGACY_COMPAT_BUILD_ENTRYPOINTS } from "../../../../scripts/binary-entrypoints";
+
+/**
+ * Regression for issue #3414.
+ *
+ * `legacy-pi-compat.ts` redirects bare `typebox` / `@sinclair/typebox` imports
+ * and the legacy `@(scope)/pi-*` package roots onto computed bunfs paths under
+ * `/$bunfs/root/packages/coding-agent/src/extensibility/` and
+ * `/$bunfs/root/packages/<barrel>/...`. Bun's `--compile` static analyzer
+ * never visits those literals, so each shim must be passed to `bun build` as
+ * an extra entrypoint or it is silently omitted from bunfs and plugin loads
+ * fail with `Cannot find module '/$bunfs/root/.../typebox.js'`.
+ *
+ * Commit `dc5c93462f` removed the worker entrypoints from
+ * `scripts/ci-release-build-binaries.ts` but its inline comment falsely
+ * claimed the legacy-shim entrypoints were "still" listed — they had never
+ * been re-added. Released `omp-darwin-arm64` and `omp-linux-x64` shipped
+ * without the shims, breaking every legacy pi plugin install.
+ *
+ * Contract pinned here:
+ *   - Both build scripts (release CI + local dev) feed the SAME entrypoint
+ *     list to `bun build --compile`, sourced from `binary-entrypoints.ts`.
+ *   - That list covers every shim referenced by `legacy-pi-compat.ts`.
+ */
+describe("legacy pi-compat --compile entrypoints (issue #3414)", () => {
+	const repoRoot = path.resolve(import.meta.dir, "../../../..");
+	const ciScriptPath = path.join(repoRoot, "scripts/ci-release-build-binaries.ts");
+	const devScriptPath = path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts");
+	const compatPath = path.join(repoRoot, "packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts");
+
+	it("declares every shim file legacy-pi-compat redirects to as a --compile entrypoint", () => {
+		// The shared constant must list every bunfs file the resolver hands back
+		// to Bun. Drop one here and the corresponding plugin import breaks at
+		// runtime with `Cannot find module '/$bunfs/root/...'`.
+		expect(LEGACY_COMPAT_BUILD_ENTRYPOINTS).toEqual([
+			"./packages/agent/src/index.ts",
+			"./packages/natives/native/index.js",
+			"./packages/tui/src/index.ts",
+			"./packages/utils/src/index.ts",
+			"./packages/coding-agent/src/extensibility/typebox.ts",
+			"./packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts",
+			"./packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts",
+		]);
+	});
+
+	it("release and dev build scripts both source entrypoints from binary-entrypoints.ts", async () => {
+		const releaseSource = await Bun.file(ciScriptPath).text();
+		const devSource = await Bun.file(devScriptPath).text();
+
+		// Both scripts import the shared constant rather than inlining their
+		// own copy, so the two halves of the contract cannot drift apart.
+		expect(releaseSource).toContain("import { LEGACY_COMPAT_BUILD_ENTRYPOINTS } from");
+		expect(releaseSource).toContain("binary-entrypoints");
+		expect(releaseSource).toContain("...LEGACY_COMPAT_BUILD_ENTRYPOINTS");
+
+		expect(devSource).toContain("import { LEGACY_COMPAT_BUILD_ENTRYPOINTS } from");
+		expect(devSource).toContain("binary-entrypoints");
+		expect(devSource).toContain("...LEGACY_COMPAT_BUILD_ENTRYPOINTS");
+	});
+
+	it("each entrypoint actually exists on disk under the repo root", async () => {
+		// `--compile` silently swallows a missing entrypoint when run without
+		// `--root .` mismatches, then drops the file from bunfs and ships a
+		// broken binary. Make every path a real file so the build fails loudly
+		// if the constant ever lists a stale path.
+		for (const relative of LEGACY_COMPAT_BUILD_ENTRYPOINTS) {
+			const abs = path.join(repoRoot, relative.replace(/^\.\//, ""));
+			expect(await Bun.file(abs).exists()).toBe(true);
+		}
+	});
+
+	it("legacy-pi-compat.ts only redirects to shims declared in the entrypoint list", async () => {
+		// Every `bunfsPath("<pkg>", "<entry>", ..., "<file>.js")` and
+		// `bunfsPath("coding-agent", "src", "extensibility", "<shim>.js")` in
+		// the compat module must have a corresponding `.ts` (or `.js`) entry
+		// in `LEGACY_COMPAT_BUILD_ENTRYPOINTS`. Otherwise a plugin import goes
+		// to a bunfs file that wasn't compiled in.
+		const compatSource = await Bun.file(compatPath).text();
+		const bunfsPathPattern = /bunfsPath\(([^)]+)\)/g;
+		const segmentsList = [...compatSource.matchAll(bunfsPathPattern)]
+			.map(match => match[1])
+			.filter((segment): segment is string => typeof segment === "string");
+		expect(segmentsList.length).toBeGreaterThan(0);
+
+		for (const segmentsExpr of segmentsList) {
+			const segments = [...segmentsExpr.matchAll(/"([^"]+)"/g)]
+				.map(match => match[1])
+				.filter((seg): seg is string => typeof seg === "string");
+			if (segments.length === 0) continue;
+
+			// Convert the bunfs path tail (e.g. `tui/src/index.js`) to the
+			// matching repo-root build entrypoint (`./packages/tui/src/index.{ts,js}`).
+			const bunfsTail = segments.join("/");
+			const matched = LEGACY_COMPAT_BUILD_ENTRYPOINTS.some(entry => {
+				const stripped = entry.replace(/^\.\/packages\//, "").replace(/\.(ts|js)$/, "");
+				const bunfsExpected = bunfsTail.replace(/\.(js|ts)$/, "");
+				return stripped === bunfsExpected;
+			});
+			expect(matched, `bunfsPath(${segmentsExpr}) has no matching --compile entrypoint`).toBe(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/extensibility/legacy-pi-typebox-shim-validation.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-typebox-shim-validation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { __resolveTypeBoxShimPath } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+
+/**
+ * Defensive tier for issue #3414.
+ *
+ * Even with the entrypoint list pinned in `binary-entrypoints.ts`, a future
+ * Bun `--compile` regression (cf. #2168) can silently drop the typebox shim
+ * file from bunfs. Without runtime validation the resolver would emit a
+ * `file://` URL to a path that no longer exists and plugin loads fail with
+ * `Cannot find module '/$bunfs/root/.../typebox.js'`.
+ *
+ * `__resolveTypeBoxShimPath` mirrors the `__validateLegacyPiPackageRootOverrides`
+ * fallback already in place for the legacy package-root overrides: if the
+ * computed candidate is missing, return `null` so the rewriter leaves bare
+ * `typebox` / `@sinclair/typebox` specifiers alone and Bun resolves a real
+ * install from the extension's own `node_modules`.
+ */
+describe("legacy pi-compat typebox shim path validation (issue #3414)", () => {
+	const stubMetaDir = "/repo/packages/coding-agent/src/extensibility/plugins";
+
+	it("returns the bunfs candidate when --compile bundled the shim", () => {
+		const result = __resolveTypeBoxShimPath(
+			"/$bunfs/root/packages",
+			undefined,
+			"/$bunfs/root",
+			() => true,
+			path.posix,
+		);
+		expect(result).toBe("/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js");
+	});
+
+	it("drops the bunfs candidate when --compile silently omitted the shim", () => {
+		const result = __resolveTypeBoxShimPath(
+			"/$bunfs/root/packages",
+			undefined,
+			"/$bunfs/root",
+			() => false,
+			path.posix,
+		);
+		expect(result).toBeNull();
+	});
+
+	it("preserves the double-slash bunfs prefix on cross-compiled darwin-arm64 (issue #3329)", () => {
+		// `BUNFS_PACKAGE_ROOT` on the cross-compiled release is `//root/packages`.
+		// The shim path must keep that exact double-slash mount prefix so Bun's
+		// bunfs lookup matches.
+		const result = __resolveTypeBoxShimPath(
+			"//root/packages",
+			undefined,
+			"//root/omp-darwin-arm64",
+			() => true,
+			path.posix,
+		);
+		expect(result).toBe("//root/packages/coding-agent/src/extensibility/typebox.js");
+	});
+
+	it("returns the npm prebuilt dist path when PI_BUNDLED is set", () => {
+		const bundledRoot = "/home/me/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent";
+		const result = __resolveTypeBoxShimPath(null, bundledRoot, stubMetaDir, () => true, path.posix);
+		expect(result).toBe(`${bundledRoot}/src/extensibility/typebox.ts`);
+	});
+
+	it("returns the dev source path when neither bunfs nor bundled is set", () => {
+		const result = __resolveTypeBoxShimPath(null, undefined, stubMetaDir, () => true, path.posix);
+		expect(result).toBe("/repo/packages/coding-agent/src/extensibility/typebox.ts");
+	});
+
+	it("returns null when the dev source path is missing too", () => {
+		const result = __resolveTypeBoxShimPath(null, undefined, stubMetaDir, () => false, path.posix);
+		expect(result).toBeNull();
+	});
+});

--- a/scripts/binary-entrypoints.ts
+++ b/scripts/binary-entrypoints.ts
@@ -1,0 +1,30 @@
+/**
+ * Extra `bun build --compile` entrypoints that must land in bunfs at
+ * `/$bunfs/root/packages/<pkg>/...`.
+ *
+ * `legacy-pi-compat.ts` redirects bare TypeBox imports and the legacy
+ * `@(scope)/pi-*` package roots onto computed bunfs paths — Bun's `--compile`
+ * static analyzer cannot trace those, so each shim and bundled package barrel
+ * must be passed as an explicit additional entrypoint or the file is silently
+ * omitted from bunfs and plugin loads fail with `Cannot find module
+ * '/$bunfs/root/...'` (issue #3414).
+ *
+ * The coding-agent's own `./src/index.ts` is intentionally NOT listed: bun
+ * --compile silently breaks the CLI entry when the same package's barrel
+ * appears as an extra entrypoint (issue #1474), so legacy `pi-coding-agent`
+ * imports resolve through `legacy-pi-coding-agent-shim.ts` instead.
+ *
+ * Repo-root-relative — both `scripts/ci-release-build-binaries.ts` (release)
+ * and `packages/coding-agent/scripts/build-binary.ts` (dev) invoke
+ * `bun build --compile --root .` so the paths land at the same bunfs
+ * locations the runtime computes.
+ */
+export const LEGACY_COMPAT_BUILD_ENTRYPOINTS: readonly string[] = [
+	"./packages/agent/src/index.ts",
+	"./packages/natives/native/index.js",
+	"./packages/tui/src/index.ts",
+	"./packages/utils/src/index.ts",
+	"./packages/coding-agent/src/extensibility/typebox.ts",
+	"./packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts",
+	"./packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts",
+];

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -2,6 +2,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { LEGACY_COMPAT_BUILD_ENTRYPOINTS } from "./binary-entrypoints";
 
 interface BinaryTarget {
 	id: string;
@@ -14,10 +15,14 @@ interface BinaryTarget {
 const repoRoot = path.join(import.meta.dir, "..");
 const binariesDir = path.join(repoRoot, "packages", "coding-agent", "binaries");
 const entrypoint = "./packages/coding-agent/src/cli.ts";
-// Legacy extension shims and package barrels in the build argv below are still
-// explicit `--compile` entrypoints because they are reached via computed bunfs
-// paths. Worker threads spawn `new Worker(Bun.main, { argv })` — they re-enter
-// the binary's own entry module — so no separate worker modules are compiled.
+// Legacy extension shims and package barrels reached via computed bunfs paths.
+// Declared in `binary-entrypoints.ts` so the dev build script
+// (`packages/coding-agent/scripts/build-binary.ts`) and this release script
+// stay in sync — drifting them silently strips the shims from the release
+// `omp-<platform>` assets and breaks `omp install` for legacy pi extensions
+// (issue #3414). Worker threads spawn `new Worker(Bun.main, { argv })` — they
+// re-enter the binary's own entry module — so no separate worker modules
+// are compiled.
 const isDryRun = process.argv.includes("--dry-run");
 const targets: BinaryTarget[] = [
 	{
@@ -110,7 +115,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --minify-identifiers --keep-names --define process.env.PI_COMPILED="true" --root . --target=${target.target} ${entrypoint} --outfile ${target.outfile}`);
+		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --minify-identifiers --keep-names --define process.env.PI_COMPILED="true" --root . --target=${target.target} ${entrypoint} ${LEGACY_COMPAT_BUILD_ENTRYPOINTS.join(" ")} --outfile ${target.outfile}`);
 		return;
 	}
 
@@ -135,6 +140,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 			"--target",
 			target.target,
 			entrypoint,
+			...LEGACY_COMPAT_BUILD_ENTRYPOINTS,
 			"--outfile",
 			target.outfile,
 		],


### PR DESCRIPTION
## Repro

`omp install <legacy-pi-plugin>` on every published `omp-<platform>-<arch>` since `dc5c93462f` (June 2026) fails with `Cannot find module '/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js'`. Tightening on the reporter's case:

```sh
$ omp install @charmland/pi-hyper-provider
✘ Plugin @charmland/pi-hyper-provider extension validation failed:
  …/credits.ts: ResolveMessage: Cannot find module
  '/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js'
  from '…/credits.ts'
```

Confirmed against the actual v16.1.17 release asset:

```
$ strings omp-linux-x64 | grep '^/\$bunfs/root/' | sort -u
/$bunfs/root/
/$bunfs/root/embedded-addons.linux-x64.tar-….gz
/$bunfs/root/mupdf-wasm-….wasm
/$bunfs/root/omp-linux-x64
/$bunfs/root/onnxruntime_binding-….node
/$bunfs/root/tokenizers.linux-x64-gnu-….node
```

No `packages/coding-agent/src/extensibility/typebox.js`, no legacy shims, no `agent`/`natives`/`tui`/`utils` package barrels. Same on `omp-darwin-arm64`.

## Cause

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` redirects bare TypeBox imports and legacy `@(scope)/pi-*` package roots onto bunfs paths computed by `bunfsPath(...)`. Bun's `--compile` static analyzer never visits those literals — every target file must be passed as an extra `bun build` entrypoint or it is silently omitted from bunfs.

The local dev script `packages/coding-agent/scripts/build-binary.ts` listed all seven (typebox shim, two legacy-pi shims, four package barrels). Commit `dc5c93462f` ("rerouted worker subprocesses through the bundled CLI host entrypoint") then dropped the worker entrypoints from `scripts/ci-release-build-binaries.ts` and added an inline comment claiming the legacy-shim entrypoints were *still* listed. They had never been re-added. Every release binary cut after that landed without the shims in bunfs, so `resolveTypeBoxSpecifier` handed Bun a path to a file that wasn't there.

A defensive `__validateLegacyPiPackageRootOverrides` already drops missing entries for the package-root overrides (#2168), but `TYPEBOX_SHIM_PATH` had no equivalent gate, so the resolver always returned the dead bunfs URL.

## Fix

- New `scripts/binary-entrypoints.ts` exports `LEGACY_COMPAT_BUILD_ENTRYPOINTS`, the canonical list of extra `bun build --compile` entrypoints (typebox shim, two legacy-pi shims, `packages/{agent,natives,tui,utils}/...` barrels). Both build scripts now `import` it instead of inlining their own copy.
- `scripts/ci-release-build-binaries.ts` spreads the constant into the `bun build` argv (and the dry-run preview), restoring the release-binary contract.
- `packages/coding-agent/scripts/build-binary.ts` switched to the shared constant too — single source of truth, no more drift.
- `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` introduces `__resolveTypeBoxShimPath`, which mirrors the `#2168` validation: if the bunfs/dev/bundled shim candidate doesn't exist, `TYPEBOX_SHIM_PATH` becomes `null`, `resolveTypeBoxSpecifier` returns `undefined`, and `rewriteLegacyExtensionSource` leaves bare `typebox` / `@sinclair/typebox` imports untouched — so a future regression falls through to native `node_modules` resolution instead of emitting a dead bunfs URL.
- Two new tests pin both halves of the contract:
  - `legacy-pi-compat-entrypoints.test.ts` — release+dev scripts source from the shared constant, every shim path computed in `legacy-pi-compat.ts` has a matching entry, every entry exists on disk.
  - `legacy-pi-typebox-shim-validation.test.ts` — `__resolveTypeBoxShimPath` keeps the bunfs candidate when present, drops it when missing, preserves the double-slash bunfs prefix (#3329), falls back through bundled and dev source layouts.

## Verification

```
$ cd packages/coding-agent && bun test test/extensibility/ test/issue-1150-repro.test.ts
 82 pass / 0 fail (245 expect() calls, 12 files)
$ bun run check
check: passed
```

Then locally rebuilt the binary and verified bunfs now contains all seven shim/barrel entrypoints:

```
$ strings packages/coding-agent/dist/omp | grep '^/\$bunfs/root/packages/' | sort -u
/$bunfs/root/packages/agent/src/index.js
/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.js
/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.js
/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js
/$bunfs/root/packages/natives/native/index.js
/$bunfs/root/packages/tui/src/index.js
/$bunfs/root/packages/utils/src/index.js
```

A typebox-only smoke plugin (`import { Type } from "typebox"`) installs and loads successfully via the rebuilt binary; the reporter's `@charmland/pi-hyper-provider` now clears the typebox error, but its subsequent failure on `@earendil-works/pi-ai/oauth` is a separate Bun-`--compile` resolver limitation (compiled binaries cannot reach external `node_modules` via `Bun.resolveSync`) — not covered by this PR.

Fixes #3414