### PR TITLE
fix: correct Codex GPT-5.5 context window

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex discovery treating GPT-5.5's 272K prompt budget as its total context window; discovery now uses the largest explicit, reported, or published Codex window and maps GPT-5.5 Codex to the published 400K total window.
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -9,6 +9,10 @@ const COPILOT_PREMIUM_MULTIPLIERS: Record<string, number> = {
 	"github-copilot/grok-code-fast-1": 0.25,
 };
 
+const PUBLISHED_CODEX_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+	"openai-codex/gpt-5.5": 400_000,
+};
+
 import * as path from "node:path";
 import { discoverAuthStorage } from "@oh-my-pi/pi-ai/auth-broker/discover";
 import type { OAuthAccess } from "@oh-my-pi/pi-ai/auth-storage";
@@ -249,6 +253,17 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 			...model,
 			cost: { ...openAICost },
 		};
+	});
+}
+
+function applyPublishedCodexContextWindows(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		const publishedWindow = PUBLISHED_CODEX_CONTEXT_WINDOWS[`${model.provider}/${model.id}`];
+		if (publishedWindow === undefined || model.contextWindow === publishedWindow) {
+			return model;
+		}
+		const contextWindow = Math.max(model.contextWindow ?? 0, publishedWindow);
+		return contextWindow === model.contextWindow ? model : { ...model, contextWindow };
 	});
 }
 
@@ -567,6 +582,7 @@ async function generateModels() {
 		return name === model.name ? model : { ...model, name };
 	});
 	applyGeneratedModelPolicies(allModels);
+	allModels = applyPublishedCodexContextWindows(allModels);
 	linkOpenAIPromotionTargets(allModels);
 	// Collapse effort-tier variants AFTER the policy re-bake: live-discovery
 	// entries are already collapsed (rebake skips them); this pass folds

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -1,11 +1,18 @@
 import { type } from "arktype";
 import type { ModelSpec } from "../types";
-import { isRecord } from "../utils";
 import { CODEX_BASE_URL, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../wire/codex";
 
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
 const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
+// OpenAI publishes GPT-5.5 in Codex as a 400K total window. The Codex
+// `/codex/models` response has historically reported the 272K prompt/input
+// budget in `context_window`; keep OMP's `contextWindow` as the total window
+// and preserve the 128K output cap in `maxTokens`.
+const PUBLISHED_CODEX_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+	"gpt-5.5": 400_000,
+};
+
 const DEFAULT_CODEX_CLIENT_VERSION = "0.99.0";
 const NPM_CODEX_LATEST_URL = "https://registry.npmjs.org/@openai%2Fcodex/latest";
 
@@ -18,6 +25,8 @@ const codexModelEntrySchema = type({
 	"id?": "unknown",
 	"display_name?": "unknown",
 	"context_window?": "unknown",
+	"max_context_window?": "unknown",
+	"max_context_window_tokens?": "unknown",
 	"default_reasoning_level?": "unknown",
 	"supported_reasoning_levels?": "unknown",
 	"input_modalities?": "unknown",
@@ -208,6 +217,19 @@ function isAbortError(error: unknown): error is Error {
 	return error instanceof Error && error.name === "AbortError";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveContextWindow(payload: CodexModelEntry, slug: string): number {
+	const explicitTotalWindow =
+		toPositiveInt(payload.max_context_window) ?? toPositiveInt(payload.max_context_window_tokens);
+	const reportedWindow = toPositiveInt(payload.context_window);
+	const publishedWindow = PUBLISHED_CODEX_CONTEXT_WINDOWS[slug.toLowerCase()] ?? null;
+	const contextWindow = Math.max(explicitTotalWindow ?? 0, reportedWindow ?? 0, publishedWindow ?? 0);
+	return contextWindow > 0 ? contextWindow : DEFAULT_CONTEXT_WINDOW;
+}
+
 function normalizeCodexModels(payload: unknown, baseUrl: string): ModelSpec<"openai-codex-responses">[] | null {
 	const parsedResponse = codexModelsResponseSchema(payload);
 	if (parsedResponse instanceof type.errors) {
@@ -251,7 +273,7 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
+	const contextWindow = resolveContextWindow(payload, slug);
 	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -58268,7 +58268,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 272000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 9,

--- a/packages/catalog/test/codex-discovery-context-window.test.ts
+++ b/packages/catalog/test/codex-discovery-context-window.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "bun:test";
+import { fetchCodexModels } from "../src/discovery/codex";
+
+async function discoverCodexModels(payload: unknown) {
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		expect(url).toBe("https://chatgpt.com/backend-api/codex/models?client_version=1.2.3");
+		expect(init?.method).toBe("GET");
+		return new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	});
+
+	const result = await fetchCodexModels({
+		accessToken: "codex-test-token",
+		clientVersion: "1.2.3",
+		fetchFn: fetchMock as unknown as typeof fetch,
+	});
+
+	expect(result).not.toBeNull();
+	return { models: result?.models ?? [], fetchMock };
+}
+
+describe("codex discovery context windows", () => {
+	it("uses an explicit max context window before the prompt budget", async () => {
+		const { models, fetchMock } = await discoverCodexModels({
+			models: [
+				{
+					slug: "gpt-codex-test",
+					display_name: "GPT Codex Test",
+					context_window: 272_000,
+					max_context_window: 400_000,
+					default_reasoning_level: "high",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-codex-test");
+		expect(model).toBeDefined();
+		expect(model?.contextWindow).toBe(400_000);
+		expect(model?.maxTokens).toBe(128_000);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the published GPT-5.5 Codex total window when context_window is the 272K prompt budget", async () => {
+		const { models } = await discoverCodexModels({
+			models: [
+				{
+					slug: "gpt-5.5",
+					display_name: "GPT-5.5",
+					context_window: 272_000,
+					default_reasoning_level: "high",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-5.5");
+		expect(model).toBeDefined();
+		expect(model?.contextWindow).toBe(400_000);
+		expect(model?.maxTokens).toBe(128_000);
+	});
+
+	it("keeps the published GPT-5.5 Codex total window when max_context_window is the 272K prompt budget", async () => {
+		const { models } = await discoverCodexModels({
+			models: [
+				{
+					slug: "gpt-5.5",
+					display_name: "GPT-5.5",
+					context_window: 272_000,
+					max_context_window: 272_000,
+					default_reasoning_level: "high",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-5.5");
+		expect(model).toBeDefined();
+		expect(model?.contextWindow).toBe(400_000);
+		expect(model?.maxTokens).toBe(128_000);
+	});
+	it("keeps other Codex model context_window values unchanged", async () => {
+		const { models } = await discoverCodexModels({
+			models: [
+				{
+					slug: "gpt-5.3-codex-spark",
+					display_name: "GPT-5.3 Codex Spark",
+					context_window: 128_000,
+					default_reasoning_level: "high",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-5.3-codex-spark");
+		expect(model).toBeDefined();
+		expect(model?.contextWindow).toBe(128_000);
+		expect(model?.maxTokens).toBe(128_000);
+	});
+});


### PR DESCRIPTION
## Summary

- Treat GPT-5.5 Codex's published 400K context window as the total `contextWindow` when Codex discovery reports the stale 272K prompt budget.
- Prefer explicit Codex max-context fields when available, and keep generated catalog output aligned for `openai-codex/gpt-5.5`.
- Add regression coverage for max-context fields, the 272K prompt-budget fallback, and Spark/other Codex models staying unchanged.

## Why

OpenAI's GPT-5.5 launch post states that GPT-5.5 in Codex has a 400K context window. The 272K value is the prompt/input budget paired with the 128K output cap, not the total displayed context window.

## Validation

- `bun test packages/catalog/test/codex-discovery-context-window.test.ts`
- `bun --cwd=packages/catalog run check`
- `bun --cwd=packages/catalog run generate-models` (succeeded; unrelated live catalog churn was not included in this focused PR)
