### PR TITLE
fix(web-search): Cursor WebSearch alias for grok-composer models

### DIFF
--- a/packages/coding-agent/src/prompts/system/empty-stop-retry.md
+++ b/packages/coding-agent/src/prompts/system/empty-stop-retry.md
@@ -1,4 +1,7 @@
 <system-injection>
 You stopped without completing the task. Continue.
 Attempt #{{retryCount}}/{{maxRetries}}
+{{#if composerWebSearch}}
+Call the `{{webSearchToolName}}` tool now with a concrete `search_term` derived from the user's request. Do not stop with reasoning alone — execute the search, then synthesize the results for the user.
+{{/if}}
 </system-injection>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -197,6 +197,7 @@ import {
 	warmupLspServers,
 } from "./tools";
 import { ToolContextStore } from "./tools/context";
+import { applyComposerWebSearchToolSwap } from "./web/search/composer-surface";
 import { getImageGenTools } from "./tools/image-gen";
 import { wrapToolWithMetaNotice } from "./tools/output-meta";
 import { queueResolveHandler } from "./tools/resolve";
@@ -2344,6 +2345,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			status: "running",
 		});
 		hasRegistered = true;
+
+		initialToolNames = applyComposerWebSearchToolSwap(initialToolNames, model);
 
 		const { systemPrompt } = await logger.time(
 			"buildSystemPrompt",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -260,6 +260,14 @@ import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { normalizeModelContextImages } from "../utils/image-loading";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
+import {
+	applyComposerWebSearchToolSwap,
+	buildComposerWebSearchForceSequence,
+	CURSOR_WEB_SEARCH_TOOL_NAME,
+	normalizeToolNameForRegistry,
+	resolveWebSearchForcedToolName,
+} from "../web/search/composer-surface";
+import { containsWebSearchIntent, findLastUserPromptText } from "../web/search/search-intent";
 import type { AuthStorage } from "./auth-storage";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
 import {
@@ -1832,11 +1840,12 @@ export class AgentSession {
 	 * calls exactly the forced tool once and then cannot call another.
 	 */
 	setForcedToolChoice(toolName: string): void {
-		if (!this.getActiveToolNames().includes(toolName)) {
+		const resolvedToolName = resolveWebSearchForcedToolName(toolName, this.model);
+		if (!this.getActiveToolNames().includes(resolvedToolName)) {
 			throw new Error(`Tool "${toolName}" is not currently active.`);
 		}
 
-		const forced = buildNamedToolChoice(toolName, this.model);
+		const forced = buildNamedToolChoice(resolvedToolName, this.model);
 		if (!forced || typeof forced === "string") {
 			throw new Error("Current model does not support forcing a specific tool.");
 		}
@@ -3948,6 +3957,13 @@ export class AgentSession {
 		const editModeChanged = previousEditMode !== currentEditMode && this.getActiveToolNames().includes("edit");
 		// The system prompt may surface the active model; a switch makes the cached prompt stale.
 		const modelChanged = this.#currentPromptModelKey() !== this.#promptModelKey;
+		if (modelChanged) {
+			const swapped = applyComposerWebSearchToolSwap(this.getActiveToolNames(), this.model);
+			if (swapped.join("\u0001") !== this.getActiveToolNames().join("\u0001")) {
+				await this.#applyActiveToolsByName(swapped, { persistMCPSelection: false });
+				if (!editModeChanged) return;
+			}
+		}
 		if (editModeChanged || modelChanged) {
 			await this.refreshBaseSystemPrompt();
 		}
@@ -4217,7 +4233,10 @@ export class AgentSession {
 		toolNames: string[],
 		options?: { persistMCPSelection?: boolean; previousSelectedMCPToolNames?: string[] },
 	): Promise<void> {
-		toolNames = [...new Set(toolNames.map(name => name.toLowerCase()))];
+		toolNames = applyComposerWebSearchToolSwap(
+			[...new Set(toolNames.map(normalizeToolNameForRegistry))],
+			this.model,
+		);
 		const previousSelectedMCPToolNames = options?.previousSelectedMCPToolNames ?? this.getSelectedMCPToolNames();
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
@@ -5116,6 +5135,15 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
+			const queuedComposerWebSearchForce =
+				!options?.synthetic
+					? buildComposerWebSearchForceSequence(this.model, this.getActiveToolNames(), expandedText)
+					: undefined;
+			if (queuedComposerWebSearchForce) {
+				this.#toolChoiceQueue.pushSequence(queuedComposerWebSearchForce, {
+					label: "composer-web-search-intent",
+				});
+			}
 			return true;
 		}
 
@@ -5125,6 +5153,10 @@ export class AgentSession {
 			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
 		const eagerTaskPrelude =
 			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTaskPrelude(expandedText) : undefined;
+		const composerWebSearchForce =
+			!options?.synthetic && !hasPendingUserDirective
+				? buildComposerWebSearchForceSequence(this.model, this.getActiveToolNames(), expandedText)
+				: undefined;
 		const normalizedImages = await this.#normalizeImagesForModel(options?.images);
 
 		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
@@ -5149,6 +5181,11 @@ export class AgentSession {
 		if (eagerTaskPrelude) {
 			preludeMessages.push(eagerTaskPrelude);
 		}
+		if (composerWebSearchForce) {
+			this.#toolChoiceQueue.pushSequence(composerWebSearchForce, {
+				label: "composer-web-search-intent",
+			});
+		}
 
 		try {
 			await this.#promptWithMessage(message, expandedText, {
@@ -5161,6 +5198,7 @@ export class AgentSession {
 			// Clean up residual eager-todo directive if the prompt never consumed it
 			// (e.g., compaction aborted, validation failed).
 			this.#toolChoiceQueue.removeByLabel("eager-todo");
+			this.#toolChoiceQueue.removeByLabel("composer-web-search-intent");
 		}
 		if (!options?.synthetic) {
 			await this.#enforcePlanModeToolDecision();
@@ -7522,6 +7560,7 @@ export class AgentSession {
 			return true;
 		}
 		this.#removeEmptyStopFromActiveContext(assistantMessage);
+		this.#maybeQueueComposerWebSearchForceOnEmptyStop();
 		this.agent.appendMessage({
 			role: "developer",
 			content: [{ type: "text", text: this.#emptyStopRetryReminder() }],
@@ -7560,6 +7599,31 @@ export class AgentSession {
 		return prompt.render(emptyStopRetryTemplate, {
 			retryCount: this.#emptyStopRetryCount,
 			maxRetries: EMPTY_STOP_MAX_RETRIES,
+			composerWebSearch: this.#shouldUseComposerWebSearchEmptyStopReminder(),
+			webSearchToolName: CURSOR_WEB_SEARCH_TOOL_NAME,
+		});
+	}
+
+	#shouldUseComposerWebSearchEmptyStopReminder(): boolean {
+		const lastUserText = findLastUserPromptText(this.agent.state.messages);
+		if (!lastUserText || !containsWebSearchIntent(lastUserText)) return false;
+		return (
+			buildComposerWebSearchForceSequence(this.model, this.getActiveToolNames(), lastUserText) !== undefined
+		);
+	}
+
+	#maybeQueueComposerWebSearchForceOnEmptyStop(): void {
+		const lastUserText = findLastUserPromptText(this.agent.state.messages);
+		if (!lastUserText) return;
+		const forceSequence = buildComposerWebSearchForceSequence(
+			this.model,
+			this.getActiveToolNames(),
+			lastUserText,
+		);
+		if (!forceSequence) return;
+		if (this.#toolChoiceQueue.inspect().includes("composer-web-search-empty-stop")) return;
+		this.#toolChoiceQueue.pushSequence(forceSequence, {
+			label: "composer-web-search-empty-stop",
 		});
 	}
 	async #handleUnexpectedAssistantStop(assistantMessage: AssistantMessage): Promise<boolean> {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -30,7 +30,8 @@ import { canSpawnAtDepth } from "../task/types";
 import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "../tool-discovery/mode";
 import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../tool-discovery/tool-index";
 import type { EventBus } from "../utils/event-bus";
-import { WebSearchTool } from "../web/search";
+import { CursorWebSearchTool } from "../web/search/cursor-alias";
+import { CURSOR_WEB_SEARCH_TOOL_NAME, WebSearchTool } from "../web/search";
 import type { WorkspaceTree } from "../workspace-tree";
 import { AskTool } from "./ask";
 import { AstEditTool } from "./ast-edit";
@@ -454,6 +455,7 @@ export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	report_tool_issue: s => createReportToolIssueTool(s),
 	resolve: s => new ResolveTool(s),
 	goal: s => new GoalTool(s),
+	[CURSOR_WEB_SEARCH_TOOL_NAME]: s => new CursorWebSearchTool(s),
 };
 
 export type ToolName = BuiltinToolName;
@@ -565,7 +567,9 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "ast_edit") return session.settings.get("astEdit.enabled");
 		if (name === "render_mermaid") return session.settings.get("renderMermaid.enabled");
 		if (name === "inspect_image") return session.settings.get("inspect_image.enabled");
-		if (name === "web_search") return session.settings.get("web_search.enabled");
+		if (name === "web_search" || name === CURSOR_WEB_SEARCH_TOOL_NAME) {
+			return session.settings.get("web_search.enabled");
+		}
 		// search_tool_bm25 is allowed when either legacy mcp.discoveryMode or new tools.discoveryMode is active.
 		if (name === "search_tool_bm25") return discoveryActive;
 		if (name === "browser") return session.settings.get("browser.enabled");
@@ -620,6 +624,20 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Auto-inject report_tool_issue when autoqa is enabled (env or setting).
 	// Injected unconditionally into every agent, regardless of requested tool list.
 	const autoQA = isAutoQaEnabled(session.settings);
+	if (
+		tools.some(tool => tool.name === "web_search") &&
+		!tools.some(tool => tool.name === CURSOR_WEB_SEARCH_TOOL_NAME)
+	) {
+		const cursorWebSearch = await logger.time(
+			`createTools:${CURSOR_WEB_SEARCH_TOOL_NAME}`,
+			HIDDEN_TOOLS[CURSOR_WEB_SEARCH_TOOL_NAME],
+			session,
+		);
+		if (cursorWebSearch) {
+			tools.push(wrapToolWithMetaNotice(cursorWebSearch));
+		}
+	}
+
 	if (autoQA && !tools.some(t => t.name === "report_tool_issue")) {
 		// Build the enum from tools we just constructed via BUILTIN_TOOLS / HIDDEN_TOOLS.
 		// Extension overrides (e.g. a user's custom `bash`) get added later by

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -82,5 +82,14 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	github: githubToolRenderer as ToolRenderer,
 	goal: goalToolRenderer as ToolRenderer,
 	web_search: webSearchToolRenderer as ToolRenderer,
+	WebSearch: {
+		...webSearchToolRenderer,
+		renderCall: (args, options, theme) =>
+			webSearchToolRenderer.renderCall(
+				{ ...args, query: typeof args.query === "string" ? args.query : args.search_term },
+				options,
+				theme,
+			),
+	} as ToolRenderer,
 	write: writeToolRenderer as ToolRenderer,
 };

--- a/packages/coding-agent/src/web/search/composer-surface.ts
+++ b/packages/coding-agent/src/web/search/composer-surface.ts
@@ -1,0 +1,70 @@
+import type { Model, ToolChoice } from "@oh-my-pi/pi-ai";
+import { buildNamedToolChoice } from "../../utils/tool-choice";
+import { containsWebSearchIntent } from "./search-intent";
+
+/** Cursor harness wire name for web search on Composer-family models. */
+export const CURSOR_WEB_SEARCH_TOOL_NAME = "WebSearch" as const;
+
+/** Models that should see the Cursor-style `WebSearch` alias instead of `web_search`. */
+export const COMPOSER_WEB_SEARCH_MODEL_PREFIX = "grok-composer-" as const;
+
+export function normalizeToolNameForRegistry(name: string): string {
+	const trimmed = name.trim();
+	if (trimmed === CURSOR_WEB_SEARCH_TOOL_NAME || trimmed.toLowerCase() === "websearch") {
+		return CURSOR_WEB_SEARCH_TOOL_NAME;
+	}
+	return trimmed.toLowerCase();
+}
+
+export function isComposerWebSearchModel(model: Pick<Model, "id"> | undefined): boolean {
+	return model?.id?.startsWith(COMPOSER_WEB_SEARCH_MODEL_PREFIX) ?? false;
+}
+
+export function applyComposerWebSearchToolSwap(
+	toolNames: readonly string[],
+	model: Pick<Model, "id"> | undefined,
+): string[] {
+	const normalized = toolNames.map(normalizeToolNameForRegistry);
+	const hasBuiltin = normalized.includes("web_search");
+	const hasAlias = normalized.includes(CURSOR_WEB_SEARCH_TOOL_NAME);
+
+	if (isComposerWebSearchModel(model)) {
+		if (!hasBuiltin && !hasAlias) return normalized;
+		const swapped = normalized.filter(name => name !== "web_search" && name !== CURSOR_WEB_SEARCH_TOOL_NAME);
+		swapped.push(CURSOR_WEB_SEARCH_TOOL_NAME);
+		return swapped;
+	}
+
+	if (!hasBuiltin && !hasAlias) return normalized;
+	const swapped = normalized.filter(name => name !== CURSOR_WEB_SEARCH_TOOL_NAME);
+	if (hasAlias && !swapped.includes("web_search")) {
+		swapped.push("web_search");
+	}
+	return swapped;
+}
+
+export function resolveWebSearchForcedToolName(
+	toolName: string,
+	model: Pick<Model, "id"> | undefined,
+): string {
+	const normalized = normalizeToolNameForRegistry(toolName);
+	if (normalized !== "web_search" && normalized !== CURSOR_WEB_SEARCH_TOOL_NAME) {
+		return normalized;
+	}
+	return isComposerWebSearchModel(model) ? CURSOR_WEB_SEARCH_TOOL_NAME : "web_search";
+}
+
+/** One-shot forced tool choice for Composer models when the user asked for web search. */
+export function buildComposerWebSearchForceSequence(
+	model: Pick<Model, "api" | "id"> | undefined,
+	activeToolNames: readonly string[],
+	promptText: string,
+): ToolChoice[] | undefined {
+	if (!containsWebSearchIntent(promptText)) return undefined;
+	if (!isComposerWebSearchModel(model)) return undefined;
+	if (!activeToolNames.includes(CURSOR_WEB_SEARCH_TOOL_NAME)) return undefined;
+
+	const forced = buildNamedToolChoice(CURSOR_WEB_SEARCH_TOOL_NAME, model as Model);
+	if (!forced) return undefined;
+	return [forced, "none"];
+}

--- a/packages/coding-agent/src/web/search/cursor-alias.ts
+++ b/packages/coding-agent/src/web/search/cursor-alias.ts
@@ -1,0 +1,59 @@
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import { z } from "zod/v4";
+import type { ToolSession } from "../../tools";
+import { CURSOR_WEB_SEARCH_TOOL_NAME } from "./composer-surface";
+import { executeSearch } from "./execute-query";
+import type { SearchRenderDetails } from "./render";
+
+/** Cursor Composer wire schema (`search_term` + optional rationale). */
+export const cursorWebSearchSchema = z.object({
+	search_term: z.string().describe("The search term to look up on the web"),
+	explanation: z
+		.string()
+		.describe("One sentence explanation as to why this tool is being used, and how it contributes to the goal.")
+		.optional(),
+});
+
+export type CursorWebSearchParams = z.infer<typeof cursorWebSearchSchema>;
+
+/**
+ * Cursor-style web search alias for Composer-family models.
+ *
+ * Delegates to the shared `web_search` provider chain; only the wire name and
+ * parameter shape differ from the built-in `web_search` tool.
+ */
+export class CursorWebSearchTool implements AgentTool<typeof cursorWebSearchSchema, SearchRenderDetails> {
+	readonly name = CURSOR_WEB_SEARCH_TOOL_NAME;
+	readonly approval = "read" as const;
+	readonly label = "Web Search";
+	readonly hidden = true;
+	readonly description =
+		"Search the web for real-time information about any topic. Use when you need up-to-date facts, documentation, release notes, benchmarks, or news that may be outside your training data.";
+	readonly parameters = cursorWebSearchSchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable";
+	readonly summary = "Search the web for up-to-date information";
+
+	#session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: CursorWebSearchParams,
+		signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<SearchRenderDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<SearchRenderDetails>> {
+		const authStorage =
+			this.#session.authStorage ?? (await import("../../sdk").then(module => module.discoverAuthStorage()));
+		const sessionId = this.#session.getSessionId?.() ?? undefined;
+		return executeSearch(
+			_toolCallId,
+			{ query: params.search_term },
+			{ authStorage, sessionId, signal },
+		);
+	}
+}

--- a/packages/coding-agent/src/web/search/execute-query.ts
+++ b/packages/coding-agent/src/web/search/execute-query.ts
@@ -1,0 +1,200 @@
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { type: "text" };
+import { formatAge } from "../../tools/render-utils";
+import { throwIfAborted } from "../../tools/tool-errors";
+import { getSearchProvider, getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
+import type { SearchRenderDetails } from "./render";
+import type { SearchProviderId, SearchResponse } from "./types";
+import { SearchProviderError } from "./types";
+
+export interface SearchQueryParams {
+	query: string;
+	provider?: SearchProviderId | "auto";
+	recency?: "day" | "week" | "month" | "year";
+	limit?: number;
+	max_tokens?: number;
+	temperature?: number;
+	num_search_results?: number;
+}
+
+function formatProviderError(error: unknown, provider: SearchProvider): string {
+	if (error instanceof SearchProviderError) {
+		if (error.provider === "anthropic" && error.status === 404) {
+			return "Anthropic web search returned 404 (model or endpoint not found).";
+		}
+		if (error.status === 401 || error.status === 403) {
+			if (error.provider === "zai") {
+				return error.message;
+			}
+			return `${getSearchProviderLabel(error.provider)} authorization failed (${error.status}). Check API key or base URL.`;
+		}
+		return error.message;
+	}
+	if (error instanceof Error) return error.message;
+	return `Unknown error from ${provider.label}`;
+}
+
+function truncateText(text: string, maxLen: number): string {
+	if (text.length <= maxLen) return text;
+	return `${text.slice(0, Math.max(0, maxLen - 1))}…`;
+}
+
+function formatCount(label: string, count: number): string {
+	return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+function formatForLLM(response: SearchResponse): string {
+	const parts: string[] = [];
+
+	if (response.answer) {
+		parts.push(response.answer);
+		if (response.sources.length > 0) {
+			parts.push("\n## Sources");
+			parts.push(formatCount("source", response.sources.length));
+		}
+	}
+
+	for (const [i, src] of response.sources.entries()) {
+		const age = formatAge(src.ageSeconds) || src.publishedDate;
+		const agePart = age ? ` (${age})` : "";
+		parts.push(`[${i + 1}] ${src.title}${agePart}\n    ${src.url}`);
+		if (src.snippet) {
+			parts.push(`    ${truncateText(src.snippet, 240)}`);
+		}
+	}
+
+	if (response.citations && response.citations.length > 0) {
+		parts.push("\n## Citations");
+		parts.push(formatCount("citation", response.citations.length));
+		for (const [i, citation] of response.citations.entries()) {
+			const title = citation.title || citation.url;
+			parts.push(`[${i + 1}] ${title}\n    ${citation.url}`);
+			if (citation.citedText) {
+				parts.push(`    ${truncateText(citation.citedText, 240)}`);
+			}
+		}
+	}
+
+	if (response.relatedQuestions && response.relatedQuestions.length > 0) {
+		parts.push("\n## Related");
+		parts.push(formatCount("question", response.relatedQuestions.length));
+		for (const q of response.relatedQuestions) {
+			parts.push(`- ${q}`);
+		}
+	}
+
+	if (response.searchQueries && response.searchQueries.length > 0) {
+		parts.push(`Search queries: ${response.searchQueries.length}`);
+		for (const query of response.searchQueries.slice(0, 3)) {
+			parts.push(`- ${truncateText(query, 120)}`);
+		}
+	}
+
+	return parts.join("\n");
+}
+
+function hasRenderableSearchContent(response: SearchResponse): boolean {
+	if (response.answer?.trim()) return true;
+	if (response.sources.length > 0) return true;
+	if (response.citations?.length) return true;
+	if (response.relatedQuestions?.some(question => question.trim())) return true;
+	if (response.searchQueries?.some(query => query.trim())) return true;
+	return false;
+}
+
+interface ExecuteSearchOptions {
+	authStorage: AuthStorage;
+	sessionId?: string;
+	signal?: AbortSignal;
+}
+
+/** Execute web search */
+export async function executeSearch(
+	_toolCallId: string,
+	params: SearchQueryParams,
+	options: ExecuteSearchOptions,
+): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
+	const { authStorage, sessionId, signal } = options;
+	const providers =
+		params.provider && params.provider !== "auto"
+			? await getSearchProvider(params.provider).then(async provider =>
+					(await provider.isExplicitlyAvailable(authStorage))
+						? [provider]
+						: resolveProviderChain(authStorage, "auto"),
+				)
+			: await resolveProviderChain(authStorage);
+	if (providers.length === 0) {
+		const message = "No web search provider configured.";
+		return {
+			content: [{ type: "text" as const, text: `Error: ${message}` }],
+			details: { response: { provider: "none", sources: [] }, error: message },
+		};
+	}
+
+	const failures: Array<{ provider: SearchProvider; error: unknown }> = [];
+	let lastProvider = providers[0];
+	for (const provider of providers) {
+		lastProvider = provider;
+		try {
+			const response = await provider.search({
+				query: params.query,
+				limit: params.limit,
+				recency: params.recency,
+				systemPrompt: webSearchSystemPrompt,
+				maxOutputTokens: params.max_tokens,
+				numSearchResults: params.num_search_results,
+				temperature: params.temperature,
+				signal,
+				authStorage,
+				sessionId,
+			});
+
+			if (!hasRenderableSearchContent(response)) {
+				throw new SearchProviderError(provider.id, `${provider.label} returned no renderable search content.`, 204);
+			}
+
+			const text = formatForLLM(response);
+
+			return {
+				content: [{ type: "text" as const, text }],
+				details: { response },
+			};
+		} catch (error) {
+			throwIfAborted(signal);
+			failures.push({ provider, error });
+		}
+	}
+
+	const lastFailure = failures[failures.length - 1];
+	const baseMessage = lastFailure
+		? formatProviderError(lastFailure.error, lastFailure.provider)
+		: `Unknown error from ${lastProvider.label}`;
+	const message =
+		providers.length > 1
+			? `All web search providers failed: ${failures
+					.map(f =>
+						f.error instanceof SearchProviderError
+							? f.error.message
+							: `${f.provider.id}: ${formatProviderError(f.error, f.provider)}`,
+					)
+					.join("; ")}`
+			: baseMessage;
+
+	return {
+		content: [{ type: "text" as const, text: `Error: ${message}` }],
+		details: { response: { provider: lastProvider.id, sources: [] }, error: message },
+	};
+}
+
+export async function runSearchQuery(
+	params: SearchQueryParams,
+	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal } = {},
+): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
+	const { discoverAuthStorage } = await import("../../sdk");
+	const authStorage = options.authStorage ?? (await discoverAuthStorage());
+	return executeSearch("cli-web-search", params, {
+		authStorage,
+		sessionId: options.sessionId,
+		signal: options.signal,
+	});
+}

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -10,16 +10,11 @@ import { prompt } from "@oh-my-pi/pi-utils";
 import { z } from "zod/v4";
 import type { CustomTool, CustomToolContext, RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme } from "../../modes/theme/theme";
-import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { type: "text" };
 import webSearchDescription from "../../prompts/tools/web-search.md" with { type: "text" };
 import { discoverAuthStorage } from "../../sdk";
 import type { ToolSession } from "../../tools";
-import { formatAge } from "../../tools/render-utils";
-import { throwIfAborted } from "../../tools/tool-errors";
-import { getSearchProvider, getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
+import { executeSearch, runSearchQuery, type SearchQueryParams } from "./execute-query";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
-import type { SearchProviderId, SearchResponse } from "./types";
-import { SearchProviderError } from "./types";
 
 /** Web search tool parameters schema */
 export const webSearchSchema = z.object({
@@ -33,204 +28,8 @@ export const webSearchSchema = z.object({
 
 export type SearchToolParams = z.infer<typeof webSearchSchema>;
 
-export interface SearchQueryParams extends SearchToolParams {
-	provider?: SearchProviderId | "auto";
-}
-
-function formatProviderError(error: unknown, provider: SearchProvider): string {
-	if (error instanceof SearchProviderError) {
-		if (error.provider === "anthropic" && error.status === 404) {
-			return "Anthropic web search returned 404 (model or endpoint not found).";
-		}
-		if (error.status === 401 || error.status === 403) {
-			if (error.provider === "zai") {
-				return error.message;
-			}
-			return `${getSearchProviderLabel(error.provider)} authorization failed (${error.status}). Check API key or base URL.`;
-		}
-		return error.message;
-	}
-	if (error instanceof Error) return error.message;
-	return `Unknown error from ${provider.label}`;
-}
-
-/** Truncate text for tool output */
-function truncateText(text: string, maxLen: number): string {
-	if (text.length <= maxLen) return text;
-	return `${text.slice(0, Math.max(0, maxLen - 1))}…`;
-}
-
-function formatCount(label: string, count: number): string {
-	return `${count} ${label}${count === 1 ? "" : "s"}`;
-}
-
-/** Format response for LLM consumption */
-function formatForLLM(response: SearchResponse): string {
-	const parts: string[] = [];
-
-	if (response.answer) {
-		parts.push(response.answer);
-		if (response.sources.length > 0) {
-			parts.push("\n## Sources");
-			parts.push(formatCount("source", response.sources.length));
-		}
-	}
-
-	for (const [i, src] of response.sources.entries()) {
-		const age = formatAge(src.ageSeconds) || src.publishedDate;
-		const agePart = age ? ` (${age})` : "";
-		parts.push(`[${i + 1}] ${src.title}${agePart}\n    ${src.url}`);
-		if (src.snippet) {
-			parts.push(`    ${truncateText(src.snippet, 240)}`);
-		}
-	}
-
-	if (response.citations && response.citations.length > 0) {
-		parts.push("\n## Citations");
-		parts.push(formatCount("citation", response.citations.length));
-		for (const [i, citation] of response.citations.entries()) {
-			const title = citation.title || citation.url;
-			parts.push(`[${i + 1}] ${title}\n    ${citation.url}`);
-			if (citation.citedText) {
-				parts.push(`    ${truncateText(citation.citedText, 240)}`);
-			}
-		}
-	}
-
-	if (response.relatedQuestions && response.relatedQuestions.length > 0) {
-		parts.push("\n## Related");
-		parts.push(formatCount("question", response.relatedQuestions.length));
-		for (const q of response.relatedQuestions) {
-			parts.push(`- ${q}`);
-		}
-	}
-
-	if (response.searchQueries && response.searchQueries.length > 0) {
-		parts.push(`Search queries: ${response.searchQueries.length}`);
-		for (const query of response.searchQueries.slice(0, 3)) {
-			parts.push(`- ${truncateText(query, 120)}`);
-		}
-	}
-
-	return parts.join("\n");
-}
-
-function hasRenderableSearchContent(response: SearchResponse): boolean {
-	if (response.answer?.trim()) return true;
-	if (response.sources.length > 0) return true;
-	if (response.citations?.length) return true;
-	if (response.relatedQuestions?.some(question => question.trim())) return true;
-	if (response.searchQueries?.some(query => query.trim())) return true;
-	return false;
-}
-
-interface ExecuteSearchOptions {
-	authStorage: AuthStorage;
-	sessionId?: string;
-	signal?: AbortSignal;
-}
-
-/** Execute web search */
-async function executeSearch(
-	_toolCallId: string,
-	params: SearchQueryParams,
-	options: ExecuteSearchOptions,
-): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const { authStorage, sessionId, signal } = options;
-	const providers =
-		params.provider && params.provider !== "auto"
-			? await getSearchProvider(params.provider).then(async provider =>
-					(await provider.isExplicitlyAvailable(authStorage))
-						? [provider]
-						: resolveProviderChain(authStorage, "auto"),
-				)
-			: await resolveProviderChain(authStorage);
-	if (providers.length === 0) {
-		const message = "No web search provider configured.";
-		return {
-			content: [{ type: "text" as const, text: `Error: ${message}` }],
-			details: { response: { provider: "none", sources: [] }, error: message },
-		};
-	}
-
-	const failures: Array<{ provider: SearchProvider; error: unknown }> = [];
-	let lastProvider = providers[0];
-	for (const provider of providers) {
-		lastProvider = provider;
-		try {
-			const response = await provider.search({
-				query: params.query,
-				limit: params.limit,
-				recency: params.recency,
-				systemPrompt: webSearchSystemPrompt,
-				maxOutputTokens: params.max_tokens,
-				numSearchResults: params.num_search_results,
-				temperature: params.temperature,
-				signal,
-				authStorage,
-				sessionId,
-			});
-
-			if (!hasRenderableSearchContent(response)) {
-				throw new SearchProviderError(provider.id, `${provider.label} returned no renderable search content.`, 204);
-			}
-
-			const text = formatForLLM(response);
-
-			return {
-				content: [{ type: "text" as const, text }],
-				details: { response },
-			};
-		} catch (error) {
-			// Surface user-initiated cancellation immediately so the session sees
-			// a clean abort instead of a generic "all providers failed" message.
-			// Without this, an AbortError from `fetch()` is treated as a provider
-			// failure and the loop falls through to the next provider (or to the
-			// summary error), masking the cancellation.
-			throwIfAborted(signal);
-			failures.push({ provider, error });
-		}
-	}
-
-	const lastFailure = failures[failures.length - 1];
-	const baseMessage = lastFailure
-		? formatProviderError(lastFailure.error, lastFailure.provider)
-		: `Unknown error from ${lastProvider.label}`;
-	const message =
-		providers.length > 1
-			? `All web search providers failed: ${failures
-					.map(f =>
-						f.error instanceof SearchProviderError
-							? f.error.message
-							: `${f.provider.id}: ${formatProviderError(f.error, f.provider)}`,
-					)
-					.join("; ")}`
-			: baseMessage;
-
-	return {
-		content: [{ type: "text" as const, text: `Error: ${message}` }],
-		details: { response: { provider: lastProvider.id, sources: [] }, error: message },
-	};
-}
-
-/**
- * Execute a web search query for CLI/testing workflows.
- *
- * `authStorage` may be omitted; in that case we discover one via the standard
- * factory (`discoverAuthStorage`), which honours `OMP_AUTH_BROKER_URL` and
- * otherwise opens the local SQLite credential store.
- */
-export async function runSearchQuery(
-	params: SearchQueryParams,
-	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal } = {},
-): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const authStorage = options.authStorage ?? (await discoverAuthStorage());
-	return executeSearch("cli-web-search", params, {
-		authStorage,
-		sessionId: options.sessionId,
-		signal: options.signal,
-	});
-}
+export type { SearchQueryParams };
+export { runSearchQuery };
 
 /**
  * Web search tool implementation.
@@ -299,6 +98,9 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 export function getSearchTools(): CustomTool<any, any>[] {
 	return [webSearchCustomTool];
 }
+
+export * from "./composer-surface";
+export * from "./search-intent";
 
 export { getSearchProvider, setExcludedSearchProviders, setPreferredSearchProvider } from "./provider";
 export type { SearchProviderId as SearchProvider, SearchResponse } from "./types";

--- a/packages/coding-agent/src/web/search/search-intent.ts
+++ b/packages/coding-agent/src/web/search/search-intent.ts
@@ -1,0 +1,45 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+const WEB_SEARCH_INTENT_EN =
+	/\b(?:web\s*search(?:es|ing)?|search\s+the\s+web|look\s+up\s+online|search\s+online)\b/i;
+
+const WEB_SEARCH_INTENT_VIA = /(?:through|via)\s+web\s+search/i;
+
+const WEB_SEARCH_INTENT_KO =
+	/(?:웹\s*서치|웹서치|웹\s*검색|인터넷\s+(?:에서\s+)?검색|웹서치\s*(?:로|통해|해서))/;
+
+const WEB_SEARCH_REQUEST_KO =
+	/(?:검색해(?:줘|주세요|서|)|리서치(?:해(?:줘|주세요|서|))?|최신\s*(?:정보|뉴스|리뷰|자료))/;
+
+const WEB_SEARCH_FOR_RE = /\bweb\s+search\s+for\b/i;
+
+/** Whether the user explicitly asked for a live web search. */
+export function containsWebSearchIntent(text: string): boolean {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) return false;
+
+	return (
+		WEB_SEARCH_INTENT_EN.test(trimmed) ||
+		WEB_SEARCH_INTENT_VIA.test(trimmed) ||
+		WEB_SEARCH_INTENT_KO.test(trimmed) ||
+		WEB_SEARCH_REQUEST_KO.test(trimmed) ||
+		WEB_SEARCH_FOR_RE.test(trimmed)
+	);
+}
+
+export function extractUserPromptText(message: AgentMessage): string | undefined {
+	if (message.role !== "user") return undefined;
+	if (typeof message.content === "string") return message.content;
+	return message.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map(block => block.text)
+		.join("\n");
+}
+
+export function findLastUserPromptText(messages: readonly AgentMessage[]): string | undefined {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const text = extractUserPromptText(messages[index]!);
+		if (text !== undefined) return text;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/test/agent-session-composer-websearch.test.ts
+++ b/packages/coding-agent/test/agent-session-composer-websearch.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { z } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { CursorWebSearchTool } from "@oh-my-pi/pi-coding-agent/web/search/cursor-alias";
+import { CURSOR_WEB_SEARCH_TOOL_NAME } from "@oh-my-pi/pi-coding-agent/web/search/composer-surface";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const FAKE_SESSION = {} as ConstructorParameters<typeof CursorWebSearchTool>[0];
+
+type Harness = {
+	session: AgentSession;
+	mock: ReturnType<typeof createMockModel>;
+	authStorage: AuthStorage;
+	tempDir: TempDir;
+};
+
+const activeHarnesses: Harness[] = [];
+
+function thinkingOnlyStop(): MockResponse {
+	return {
+		content: [{ type: "thinking", thinking: "I should call WebSearch next." }],
+		stopReason: "stop",
+		usage: { output: 1, cacheRead: 100 },
+	};
+}
+
+function reminderMessages(messages: AgentMessage[]): AgentMessage[] {
+	return messages.filter(message => {
+		if (message.role !== "developer") return false;
+		return typeof message.content === "string"
+			? message.content.includes("<system-injection>")
+			: message.content.some(content => content.type === "text" && content.text.includes("<system-injection>"));
+	});
+}
+
+async function createComposerHarness(responses: MockResponse[]): Promise<Harness> {
+	const tempDir = TempDir.createSync("@pi-composer-websearch-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("mock", "test-key");
+
+	const mock = createMockModel({ id: "grok-composer-2.5-fast", provider: "mock", responses });
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"retry.enabled": false,
+		"todo.enabled": false,
+		"todo.eager": "default",
+	});
+	settings.setModelRole("default", `mock/${mock.id}`);
+
+	const webSearchTool = new CursorWebSearchTool(FAKE_SESSION);
+	const recordTool: AgentTool = {
+		name: "record",
+		label: "Record",
+		description: "Record a value",
+		parameters: z.object({ value: z.string() }),
+		async execute(_toolCallId, params) {
+			return {
+				content: [{ type: "text", text: `recorded:${params.value}` }],
+				details: { value: params.value },
+			};
+		},
+	};
+
+	const sessionManager = SessionManager.inMemory(tempDir.path());
+	const tools = [recordTool, webSearchTool];
+	let session: AgentSession;
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		getToolChoice: () => session.nextToolChoice(),
+		initialState: {
+			model: mock,
+			systemPrompt: ["Test"],
+			tools,
+			messages: [],
+		},
+		convertToLlm,
+		streamFn: mock.stream,
+	});
+
+	session = new AgentSession({
+		agent,
+		sessionManager,
+		settings,
+		modelRegistry,
+		toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+	});
+	agent.setModel({ ...mock, api: "openai-responses" });
+	await session.setActiveToolsByName(["record", CURSOR_WEB_SEARCH_TOOL_NAME]);
+
+	const harness = { session, mock, authStorage, tempDir };
+	activeHarnesses.push(harness);
+	return harness;
+}
+
+afterEach(async () => {
+	for (const harness of activeHarnesses.splice(0)) {
+		await harness.session.dispose();
+		harness.authStorage.close();
+		harness.tempDir.removeSync();
+	}
+});
+
+describe("AgentSession composer web search phase 2", () => {
+	it("forces WebSearch on search-intent user prompts", async () => {
+		const { session, mock } = await createComposerHarness([
+			{
+				content: [
+					{
+						type: "toolCall",
+						id: "call-websearch",
+						name: CURSOR_WEB_SEARCH_TOOL_NAME,
+						arguments: { search_term: "glm 5.2 review" },
+					},
+				],
+				stopReason: "toolUse",
+			},
+			{ content: ["done"], stopReason: "stop" },
+		]);
+
+		await session.prompt("web search for glm 5.2 review");
+		await session.waitForIdle();
+
+		expect(mock.calls[0]?.options?.toolChoice).toEqual({
+			type: "function",
+			name: CURSOR_WEB_SEARCH_TOOL_NAME,
+		});
+	});
+
+	it("adds composer-specific empty-stop guidance after thinking-only stops", async () => {
+		const { session } = await createComposerHarness([
+			thinkingOnlyStop(),
+			{
+				content: [
+					{
+						type: "toolCall",
+						id: "call-websearch",
+						name: CURSOR_WEB_SEARCH_TOOL_NAME,
+						arguments: { search_term: "glm 5.2 review" },
+					},
+				],
+				stopReason: "toolUse",
+			},
+			{ content: ["done"], stopReason: "stop" },
+		]);
+
+		await session.prompt("web search for glm 5.2 review");
+		await session.waitForIdle();
+
+		const reminderText = reminderMessages(session.agent.state.messages)
+			.flatMap(message =>
+				typeof message.content === "string"
+					? [message.content]
+					: message.content.flatMap(content => (content.type === "text" ? [content.text] : [])),
+			)
+			.join("\n");
+
+		expect(reminderText).toContain(CURSOR_WEB_SEARCH_TOOL_NAME);
+		expect(reminderText).toContain("search_term");
+	});
+});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -81,6 +81,7 @@ describe("createTools", () => {
 		expect(names).toContain("task");
 		expect(names).toContain("todo");
 		expect(names).toContain("web_search");
+		expect(names).toContain("WebSearch");
 		expect(names).toContain("resolve");
 		expect(names).not.toContain("fetch");
 		expect(names).not.toContain("vim");
@@ -267,6 +268,7 @@ describe("createTools", () => {
 
 	it("HIDDEN_TOOLS contains review tools and goal", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual([
+			"WebSearch",
 			"goal",
 			"report_finding",
 			"report_tool_issue",

--- a/packages/coding-agent/test/web/search/composer-surface.test.ts
+++ b/packages/coding-agent/test/web/search/composer-surface.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import {
+	applyComposerWebSearchToolSwap,
+	buildComposerWebSearchForceSequence,
+	CURSOR_WEB_SEARCH_TOOL_NAME,
+	normalizeToolNameForRegistry,
+	resolveWebSearchForcedToolName,
+} from "@oh-my-pi/pi-coding-agent/web/search/composer-surface";
+
+const composerModel = { id: "grok-composer-2.5-fast", api: "openai-responses" } as Model;
+const defaultModel = { id: "grok-4.20-0309-non-reasoning", api: "openai-responses" } as Model;
+
+describe("composer web search surface", () => {
+	it("preserves the Cursor wire name when normalizing tool names", () => {
+		expect(normalizeToolNameForRegistry("WebSearch")).toBe(CURSOR_WEB_SEARCH_TOOL_NAME);
+		expect(normalizeToolNameForRegistry("websearch")).toBe(CURSOR_WEB_SEARCH_TOOL_NAME);
+		expect(normalizeToolNameForRegistry("web_search")).toBe("web_search");
+	});
+
+	it("swaps web_search to WebSearch on composer models", () => {
+		expect(applyComposerWebSearchToolSwap(["read", "web_search", "bash"], composerModel)).toEqual([
+			"read",
+			"bash",
+			CURSOR_WEB_SEARCH_TOOL_NAME,
+		]);
+	});
+
+	it("restores web_search when leaving composer models", () => {
+		expect(applyComposerWebSearchToolSwap(["read", CURSOR_WEB_SEARCH_TOOL_NAME], defaultModel)).toEqual([
+			"read",
+			"web_search",
+		]);
+	});
+
+	it("maps forced web_search to WebSearch on composer models", () => {
+		expect(resolveWebSearchForcedToolName("web_search", composerModel)).toBe(CURSOR_WEB_SEARCH_TOOL_NAME);
+		expect(resolveWebSearchForcedToolName("web_search", defaultModel)).toBe("web_search");
+		expect(resolveWebSearchForcedToolName("write", composerModel)).toBe("write");
+	});
+
+	it("builds a one-shot WebSearch force sequence for composer search intent", () => {
+		expect(
+			buildComposerWebSearchForceSequence(composerModel, ["read", CURSOR_WEB_SEARCH_TOOL_NAME], "web search for glm 5.2 review"),
+		).toEqual([{ type: "function", name: CURSOR_WEB_SEARCH_TOOL_NAME }, "none"]);
+		expect(
+			buildComposerWebSearchForceSequence(defaultModel, ["web_search"], "web search for glm 5.2 review"),
+		).toBeUndefined();
+		expect(
+			buildComposerWebSearchForceSequence(composerModel, ["read"], "fix the hero section"),
+		).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/web/search/cursor-alias.test.ts
+++ b/packages/coding-agent/test/web/search/cursor-alias.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { CursorWebSearchTool } from "@oh-my-pi/pi-coding-agent/web/search/cursor-alias";
+import * as provider from "@oh-my-pi/pi-coding-agent/web/search/provider";
+import type { SearchProviderId, SearchResponse } from "@oh-my-pi/pi-coding-agent/web/search/types";
+
+const FAKE_SESSION = {} as ToolSession;
+
+function fakeResponse(providerId: SearchProviderId): SearchResponse {
+	return {
+		provider: providerId,
+		sources: [{ title: "Example", url: "https://example.com", snippet: "snippet" }],
+	};
+}
+
+describe("CursorWebSearchTool", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("uses the Cursor wire name and maps search_term to the shared search pipeline", async () => {
+		const tool = new CursorWebSearchTool(FAKE_SESSION);
+		expect(tool.name).toBe("WebSearch");
+
+		const searchSpy = vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			{
+				id: "searxng",
+				label: "SearXNG",
+				search: async () => fakeResponse("searxng"),
+				isExplicitlyAvailable: async () => true,
+			},
+		]);
+
+		const result = await tool.execute("call-1", {
+			search_term: "GLM 5.2 review",
+			explanation: "Need recent community reactions.",
+		});
+
+		expect(searchSpy).toHaveBeenCalled();
+		expect(result.content[0]?.type).toBe("text");
+		expect(result.content[0]?.text).toContain("https://example.com");
+	});
+});

--- a/packages/coding-agent/test/web/search/search-intent.test.ts
+++ b/packages/coding-agent/test/web/search/search-intent.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import {
+	containsWebSearchIntent,
+	extractUserPromptText,
+	findLastUserPromptText,
+} from "@oh-my-pi/pi-coding-agent/web/search/search-intent";
+
+describe("containsWebSearchIntent", () => {
+	it("detects explicit English web search requests", () => {
+		expect(containsWebSearchIntent("web search for glm 5.2 review")).toBe(true);
+		expect(containsWebSearchIntent("Please search the web for release notes")).toBe(true);
+		expect(containsWebSearchIntent("research via web search")).toBe(true);
+	});
+
+	it("detects Korean web search requests", () => {
+		expect(containsWebSearchIntent("웹서치로 GLM 5.2 리뷰 찾아줘")).toBe(true);
+		expect(containsWebSearchIntent("최신 리뷰 검색해줘")).toBe(true);
+	});
+
+	it("ignores unrelated prompts", () => {
+		expect(containsWebSearchIntent("grep the repo for web_search")).toBe(false);
+		expect(containsWebSearchIntent("fix the resume hero section")).toBe(false);
+		expect(containsWebSearchIntent("hi")).toBe(false);
+	});
+});
+
+describe("findLastUserPromptText", () => {
+	it("returns the latest user message text", () => {
+		const messages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "first" }], timestamp: 1 },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }], api: "mock", provider: "mock", model: "m", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+			{ role: "user", content: [{ type: "text", text: "web search for glm 5.2 review" }], timestamp: 3 },
+		];
+
+		expect(extractUserPromptText(messages[0]!)).toBe("first");
+		expect(findLastUserPromptText(messages)).toBe("web search for glm 5.2 review");
+	});
+});

--- a/packages/collab-web/src/tool-render/registry.ts
+++ b/packages/collab-web/src/tool-render/registry.ts
@@ -80,6 +80,7 @@ const RENDERERS: Record<string, ToolRenderer> = {
 	task: taskRenderer,
 	todo: todoRenderer,
 	web_search: webSearchRenderer,
+	WebSearch: webSearchRenderer,
 	write: writeRenderer,
 	yield: yieldRenderer,
 };

--- a/scripts/verify-composer-websearch.ts
+++ b/scripts/verify-composer-websearch.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+/**
+ * Quick smoke check: composer model should expose WebSearch (not web_search).
+ * Run from repo root:
+ *   bun scripts/verify-composer-websearch.ts
+ */
+import { applyComposerWebSearchToolSwap, CURSOR_WEB_SEARCH_TOOL_NAME } from "../packages/coding-agent/src/web/search/composer-surface.ts";
+import { createTools } from "../packages/coding-agent/src/tools/index.ts";
+import { Settings } from "../packages/coding-agent/src/config/settings.ts";
+
+const composerModel = { id: "grok-composer-2.5-fast" } as const;
+const defaultModel = { id: "grok-4.20-0309-non-reasoning" } as const;
+
+const session = {
+	cwd: process.cwd(),
+	hasUI: false,
+	getSessionFile: () => null,
+	getSessionSpawns: () => "*" as const,
+	settings: Settings.isolated({ "web_search.enabled": true }),
+};
+
+const tools = await createTools(session);
+const names = tools.map(t => t.name);
+
+if (!names.includes("web_search")) throw new Error("registry missing web_search");
+if (!names.includes(CURSOR_WEB_SEARCH_TOOL_NAME)) throw new Error("registry missing WebSearch alias");
+
+const composerActive = applyComposerWebSearchToolSwap(
+	["read", "bash", "web_search", "find"],
+	composerModel,
+);
+if (!composerActive.includes(CURSOR_WEB_SEARCH_TOOL_NAME) || composerActive.includes("web_search")) {
+	throw new Error(`composer swap failed: ${composerActive.join(", ")}`);
+}
+
+const restored = applyComposerWebSearchToolSwap(composerActive, defaultModel);
+if (!restored.includes("web_search") || restored.includes(CURSOR_WEB_SEARCH_TOOL_NAME)) {
+	throw new Error(`restore swap failed: ${restored.join(", ")}`);
+}
+
+console.log("OK: WebSearch alias registered and composer surface swap works");
+console.log(`  registry tools: ${names.filter(n => n === "web_search" || n === CURSOR_WEB_SEARCH_TOOL_NAME).join(", ")}`);
+console.log(`  composer active: ${composerActive.join(", ")}`);


### PR DESCRIPTION
## Problem

`grok-composer-*` models (e.g. `grok-composer-2.5-fast` via `xai-oauth` / `openai-responses`) are trained on Cursor's harness, which exposes web search as **`WebSearch`** with a **`search_term`** argument. omp only registered **`web_search`** with **`query`**.

In practice the model often:
1. Emits **thinking-only** assistant turns (“I'll use web_search…”)
2. Stops with `stopReason: "stop"` and **no tool call**
3. Triggers the generic empty-stop retry loop (max 3×) without recovering

Repro session: user prompt `web search for glm 5.2 review` → **0** `web_search` / `WebSearch` tool calls; SearXNG and `omp search` CLI were healthy (infra was not the issue).

## Solution

### Phase 1 — Cursor wire alias
- Register hidden `WebSearch` tool (`cursor-alias.ts`) delegating to the existing `executeSearch` provider chain
- Swap active tool names for `grok-composer-*`: `web_search` → `WebSearch` (`composer-surface.ts`)
- Hook swap on session init, model change, and `setForcedToolChoice` / `setActiveToolsByName`
- Extract `execute-query.ts` to avoid circular imports when loading natives

### Phase 2 — Recovery when the model still stops empty
- Detect explicit web-search intent (EN/KO) in user prompts (`search-intent.ts`)
- Queue a one-shot forced `WebSearch` tool choice on search-intent turns
- On empty-stop retry for composer + search intent: inject `WebSearch` / `search_term` guidance and re-force the tool

## Tests

- `search-intent.test.ts` — intent detection
- `composer-surface.test.ts` — tool name swap + force sequence
- `cursor-alias.test.ts` — `search_term` → shared pipeline
- `agent-session-composer-websearch.test.ts` — forced tool choice + empty-stop reminder
- `tools/index.test.ts` — registry exposes both names when `web_search` enabled

```bash
cd packages/coding-agent
bun test test/web/search/search-intent.test.ts \
         test/web/search/composer-surface.test.ts \
         test/web/search/cursor-alias.test.ts \
         test/agent-session-composer-websearch.test.ts \
         test/tools/index.test.ts
```

Smoke script: `bun scripts/verify-composer-websearch.ts`

## Manual verification

- `grok-composer-2.5-fast` + SearXNG: `web search for glm 5.2 review` → `WebSearch` tool call succeeds
- Built binary: `packages/coding-agent && bun run build`

## Notes

- Non-composer models are unchanged (`WebSearch` hidden; `web_search` remains the active name).
- Intent forcing is scoped to explicit search phrasing to avoid false positives on repo `grep`/`search` tasks.