### PR TITLE
fix(tui): shrink bordered Editor right chrome by cursor overflow cells

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bordered `Editor` rendering 1–2 cells past the terminal width when the end-of-line cursor glyph landed past a wide trailing grapheme (CJK comma `，`, emoji, etc.), wrapping the bottom-right corner (`╯`) to its own row. The right chrome (padding + `─` + corner) now shrinks by the exact cursor overflow cell count instead of a 1-cell boolean, so the box stays inside `width` for any `paddingX` ([#3431](https://github.com/can1357/oh-my-pi/issues/3431)).
+
 ## [16.1.17] - 2026-06-24
 
 ### Added

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -837,7 +837,7 @@ export class Editor implements Component, Focusable {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
 			let displayText = layoutLine.text;
 			let displayWidth = visibleWidth(layoutLine.text);
-			let cursorInPadding = false;
+			let cursorPaddingOverflow = 0;
 			let decorated = false;
 			const showPromptGutter = promptGutter !== undefined && visibleIndex === 0;
 			const gutterText =
@@ -963,7 +963,7 @@ export class Editor implements Component, Focusable {
 						displayWidth += cursorWidth;
 					}
 					if (displayWidth > lineContentWidth && paddingX > 0) {
-						cursorInPadding = true;
+						cursorPaddingOverflow = displayWidth - lineContentWidth;
 					}
 				}
 			}
@@ -982,18 +982,22 @@ export class Editor implements Component, Focusable {
 				continue;
 			}
 
-			// All lines have consistent borders based on padding
+			// All lines have consistent borders based on padding. When the end-of-line cursor
+			// glyph (or a wide trailing grapheme) extends past `lineContentWidth`, shrink the
+			// right chrome by the exact overflow count: drop padding spaces first, then the
+			// trailing `─`, but never the corner/vertical bar itself.
 			const isLastLine = visibleIndex === visibleLayoutLines.length - 1;
-			const rightPaddingWidth = Math.max(0, paddingX - (cursorInPadding ? 1 : 0));
+			const rightChromeCells = Math.max(1, paddingX + 1 - cursorPaddingOverflow);
 			if (isLastLine) {
-				const bottomRightPadding = Math.max(0, paddingX - 1 - (cursorInPadding ? 1 : 0));
+				const rightPad = Math.max(0, rightChromeCells - 2);
+				const includeHorizontal = rightChromeCells >= 2;
 				const bottomRightAdjusted = this.borderColor(
-					`${padding(bottomRightPadding)}${box.horizontal}${box.bottomRight}`,
+					`${padding(rightPad)}${includeHorizontal ? box.horizontal : ""}${box.bottomRight}`,
 				);
 				result.push(`${bottomLeft}${displayText}${linePad}${bottomRightAdjusted}`);
 			} else {
 				const leftBorder = this.borderColor(`${box.vertical}${padding(paddingX)}`);
-				const rightBorder = this.borderColor(`${padding(rightPaddingWidth)}${box.vertical}`);
+				const rightBorder = this.borderColor(`${padding(Math.max(0, rightChromeCells - 1))}${box.vertical}`);
 				result.push(leftBorder + displayText + linePad + rightBorder);
 			}
 		}

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -754,6 +754,28 @@ describe("Editor component", () => {
 			expect(visibleWidth(contentLine)).toBeLessThanOrEqual(width);
 		});
 
+		it("keeps the bordered editor inside `width` when the cursor lands past a wide trailing grapheme (#3431)", () => {
+			// Regression: typing a fullwidth char (e.g. CJK comma `，`, U+FF0C) at the end
+			// of the input used to push the bottom-right `─╯` 1–2 cells past the terminal
+			// edge, wrapping `╯` to its own row. The end-of-line cursor glyph + wide grapheme
+			// extends into the right padding zone; the right chrome must shrink by the exact
+			// overflow cell count.
+			for (const paddingX of [1, 2]) {
+				const theme = { ...defaultEditorTheme, editorPaddingX: paddingX };
+				const minContentWidth = 2 * (paddingX + 1) + 3; // chrome + "，" (2) + cursor (1)
+				for (let width = minContentWidth; width <= minContentWidth + 6; width++) {
+					const editor = new Editor(theme);
+					editor.focused = true;
+					for (const c of "asd，") editor.handleInput(c);
+					const lines = editor.render(width);
+					for (const line of lines) {
+						const stripped = line.replaceAll(CURSOR_MARKER, "");
+						expect(visibleWidth(stripped)).toBeLessThanOrEqual(width);
+					}
+				}
+			}
+		});
+
 		it("shows cursor at end before wrap and wraps on next char", () => {
 			for (const paddingX of [0, 1]) {
 				const editor = new Editor({ ...defaultEditorTheme, editorPaddingX: paddingX });


### PR DESCRIPTION
## Repro
On macOS (omp 16.1.15, Bun 1.3.14), typing `asd` then a fullwidth CJK comma `，` (U+FF0C) in the chat input collapses the editor box: the bottom-right `╯` corner wraps to its own row. `visibleWidth("，")` is already 2 cells; the regression sits in the bordered `Editor`'s last-row chrome math, not in width measurement.

Minimal repro on the bordered editor (`paddingX=2`, terminal width 8):
```
L0 (8/8): ╭──────╮
L1 (8/8): │ asd  │
L2 (9/8): ╰─， ─╯       ← 1 cell too wide; `╯` wraps in the user's terminal
```

## Cause
`packages/tui/src/components/editor.ts` tracked cursor-into-padding overflow as a boolean (`cursorInPadding`) that shrank the right padding by exactly one space but always re-emitted `─` before `╯`. When the end-of-line cursor glyph lands past a wide trailing grapheme it extends past `lineContentWidth` by the actual cell count of the inverse-video glyph (1) plus any wide-char overflow already eaten in the same chunk, so:
- `paddingX=1` overflow=1 → right chrome should be `╯` (1 cell), code emits `─╯` (2 cells) → drift 1.
- `paddingX=2` overflow=2 → right chrome should be `╯` (1 cell), code emits `─╯` (2 cells) → drift 1.

`PaddingX=2` width=8 above hits the same path: `asd` wraps to one chunk, last chunk is `，` (2 cells) with the cursor adding 1, overflowing the 4-cell content area by 1 cell while the right chrome only shrinks by 1 space and keeps its `─`.

## Fix
- `packages/tui/src/components/editor.ts`: replace `cursorInPadding: boolean` with `cursorPaddingOverflow: number` (line 840). Set it from the actual `displayWidth - lineContentWidth` at the existing end-of-line-cursor branch (lines 965–967).
- Recompute `rightChromeCells = max(1, paddingX + 1 - cursorPaddingOverflow)` and drive both the `isLastLine` branch (`padding + ─ + ╯`) and the `else` branch (`padding + │`) from it: drop padding spaces first, then the trailing `─`, never the corner/bar.
- Top, bottom-left and topRight chrome are untouched; non-cursor lines retain `cursorPaddingOverflow = 0`, so their chrome is unchanged.

## Verification
- New test `keeps the bordered editor inside `width` when the cursor lands past a wide trailing grapheme (#3431)` in `packages/tui/test/editor.test.ts` sweeps `paddingX ∈ {1,2}` × `width ∈ [minContentWidth … +6]` on `asd，`, asserting every rendered row stays within `width` (32 expectations).
- `bun test packages/tui/test/editor.test.ts` → 142 pass / 0 fail.
- Full TUI suite: 962 pass / 106 fail. The 106 failures are pre-existing and unrelated — they reproduce on `farm/f80f626f/tui-fullwidth-cursor-drift` without this patch (`bun test` after `git stash` of these changes returned the same 961 pass / 106 fail baseline). All failures are `TypeError: nativeSetHangulCompatJamoWidthOverride is not a function` or similar native-module gaps from this worktree's missing `pi-natives` build.

Fixes #3431