### PR TITLE
fix(ai): preserve cross-api reasoning replay

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1629,6 +1629,7 @@ export function convertMessages(
 		id => normalizeToolCallId(id),
 		maxNormalizedToolCallIdLength,
 		duplicateToolCallIdSuffixPrefix,
+		compat,
 	);
 
 	const remappedToolCallIds = new Map<string, string[]>();

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -143,6 +143,20 @@ function isAnthropicMessagesModel(model: Model): model is Model<"anthropic-messa
 	return model.api === "anthropic-messages";
 }
 
+function isOpenAICompletionsReasoningReplayTarget(model: Model): boolean {
+	const compat = model.compat;
+	return (
+		model.api === "openai-completions" &&
+		compat !== undefined &&
+		"requiresReasoningContentForToolCalls" in compat &&
+		compat.requiresReasoningContentForToolCalls === true
+	);
+}
+
+function isOpenAICompletionsReasoningField(signature: string | undefined): boolean {
+	return signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text";
+}
+
 const ANTHROPIC_TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 
 function isValidAnthropicToolCallId(id: string): boolean {
@@ -248,6 +262,7 @@ export function transformMessages<TApi extends Api>(
 			// `reasoning && !official` case in the compat builder). Used to keep
 			// `redacted_thinking` siblings beside unsigned visible thinking on
 			// targets that won't text-demote it.
+			const isOpenAICompletionsReasoningReplay = isOpenAICompletionsReasoningReplayTarget(model);
 			const replaysUnsignedAnthropicThinking = isAnthropicTarget && model.compat.replayUnsignedThinking;
 			// Thinking signatures can be untrustworthy for two distinct reasons with very
 			// different blast radii:
@@ -315,6 +330,17 @@ export function transformMessages<TApi extends Api>(
 							return [];
 						}
 						return sanitized;
+					}
+					// Cross-API OpenAI-compatible reasoning targets can replay the text
+					// through their configured reasoning field; strip unrecognized foreign
+					// signatures so the encoder falls back instead of leaking them.
+					if (isOpenAICompletionsReasoningReplay) {
+						const signature = sanitized.thinkingSignature;
+						if (!sanitized.thinking || sanitized.thinking.trim() === "") {
+							return isOpenAICompletionsReasoningField(signature) ? sanitized : [];
+						}
+						if (isOpenAICompletionsReasoningField(signature)) return sanitized;
+						return { ...sanitized, thinkingSignature: undefined };
 					}
 					// Cross-API target: keep the existing text-demotion fallback.
 					// For same model: keep thinking blocks with signatures (needed for replay)

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -143,8 +143,7 @@ function isAnthropicMessagesModel(model: Model): model is Model<"anthropic-messa
 	return model.api === "anthropic-messages";
 }
 
-function isOpenAICompletionsReasoningReplayTarget(model: Model): boolean {
-	const compat = model.compat;
+function isOpenAICompletionsReasoningReplayTarget(model: Model, compat: Model["compat"]): boolean {
 	return (
 		model.api === "openai-completions" &&
 		compat !== undefined &&
@@ -195,6 +194,7 @@ export function transformMessages<TApi extends Api>(
 	normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
 	maxNormalizedToolCallIdLength = MAX_TOOL_CALL_ID_LENGTH,
 	duplicateToolCallIdSuffixPrefix = "_dup",
+	targetCompat: Model<TApi>["compat"] = model.compat,
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
@@ -262,7 +262,7 @@ export function transformMessages<TApi extends Api>(
 			// `reasoning && !official` case in the compat builder). Used to keep
 			// `redacted_thinking` siblings beside unsigned visible thinking on
 			// targets that won't text-demote it.
-			const isOpenAICompletionsReasoningReplay = isOpenAICompletionsReasoningReplayTarget(model);
+			const isOpenAICompletionsReasoningReplay = isOpenAICompletionsReasoningReplayTarget(model, targetCompat);
 			const replaysUnsignedAnthropicThinking = isAnthropicTarget && model.compat.replayUnsignedThinking;
 			// Thinking signatures can be untrustworthy for two distinct reasons with very
 			// different blast radii:

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -327,6 +327,36 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 			// Should have set reasoning_content from the thinking text via the openai path.
 			expect(assistant?.reasoning_content).toBe("some reasoning");
 		});
+		it("replays cross-api thinking with stripped signature through reasoning_content", () => {
+			const model = deepseekModel({
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+				id: "deepseek-v4-flash",
+			});
+			const compat = model.compat;
+			const msg = assistantToolCall(model, [
+				{
+					type: "thinking",
+					thinking: "Need to preserve cross-api reasoning.",
+					thinkingSignature: "sig_from_anthropic",
+				},
+				{
+					type: "toolCall",
+					id: "toolu_cross_api",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			]);
+			msg.api = "anthropic-messages";
+			msg.provider = "zai";
+			msg.model = "claude-compatible";
+
+			const messages = convertMessages(model, { messages: [msg] }, compat);
+			const assistant = findOpenAICompletionAssistantWireMessage(messages);
+			expect(assistant).toBeDefined();
+			expect(assistant?.reasoning_content).toBe("Need to preserve cross-api reasoning.");
+			expect(assistant?.content).toBe("");
+		});
 		it("falls through to empty-string when thinking block has opaque signature and empty text", () => {
 			const model = deepseekModel({
 				provider: "opencode-go",

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1224,6 +1224,75 @@ describe("kimi model detection via detectCompat", () => {
 		expect(assistant?.reasoning).toBeUndefined();
 	});
 
+	it("uses thinking-enabled compat when replaying cross-api reasoning on kimi opencode-go", async () => {
+		const model = kimiOpenCodeModel("kimi-k2.6");
+		expect(model.compat.requiresReasoningContentForToolCalls).toBe(false);
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Need to preserve cross-api reasoning.",
+					thinkingSignature: "sig_from_anthropic",
+				},
+				{
+					type: "toolCall",
+					id: "toolu_cross_api",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "zai",
+			model: "claude-compatible",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const fetchMock = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "toolu_cross_api",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				reasoning: "high",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(assistant?.content).toBe(".");
+		expect(assistant?.reasoning_content).toBe("Need to preserve cross-api reasoning.");
+		expect(assistant?.reasoning).toBeUndefined();
+		expect(assistant?.reasoning_text).toBeUndefined();
+	});
+
 	// #1071 regression guard alongside the #1484 fix: with thinking disabled the
 	// override stays off so the gateway's `Extra inputs are not permitted` error
 	// can never reappear on tool-call replays.


### PR DESCRIPTION
## Repro
A prior `anthropic-messages` assistant tool-call turn with thinking replayed into an `openai-completions` DeepSeek-compatible target was converted into assistant `content` with `reasoning_content: ""` instead of sending the reasoning text through the configured reasoning field. Reproduced with an eval harness calling `convertMessages` for an Anthropic-source assistant turn targeting `opencode-go/deepseek-v4-flash`.

## Cause
`packages/ai/src/providers/transform-messages.ts` always used the cross-API text-demotion fallback for non-Anthropic targets before `packages/ai/src/providers/openai-completions.ts` could encode preserved thinking blocks. OpenAI-compatible reasoning targets therefore received the reasoning text as visible assistant content, while their configured `reasoningContentField` stayed empty.

## Fix
- Preserve non-empty cross-API thinking blocks when the target is an OpenAI completions model that requires reasoning content for tool-call replay.
- Strip unrecognized foreign thinking signatures before replay so the OpenAI completions encoder uses the configured field fallback instead of leaking source signatures.
- Add regression coverage for Anthropic-message history replayed into a DeepSeek-compatible OpenAI completions target.

## Verification
`bun test packages/ai/test/deepseek-reasoning-content.test.ts` passed. `bun test packages/ai/test/anthropic-prior-turn-thinking.test.ts packages/ai/test/anthropic-unsigned-thinking-replay.test.ts` passed. `bun check` passed. Fixes #3433