### PR TITLE
fix(agent): preserve skill URL session context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `skill://` tool resolution losing loaded session skills when a tool runs outside the session-initialization module state. Internal URL resolution now prefers the caller's `session.skills` snapshot before falling back to the process-global skill list, so `read skill://<name>` works across tool execution boundaries. ([#3436](https://github.com/can1357/oh-my-pi/issues/3436))
+
 ## [16.1.18] - 2026-06-25
 
 ### Added

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -13,7 +13,7 @@ import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { getActiveSkills } from "../extensibility/skills";
 import { buildDirectoryResource } from "./filesystem-resource";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 function getContentType(filePath: string): InternalResource["contentType"] {
 	const ext = path.extname(filePath).toLowerCase();
@@ -42,8 +42,8 @@ export class SkillProtocolHandler implements ProtocolHandler {
 	readonly scheme = "skill";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
-		const skills = getActiveSkills();
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const skills = context?.skills ?? getActiveSkills();
 
 		const skillName = url.rawHost || url.hostname;
 		if (!skillName) {

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -5,6 +5,7 @@
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 
+import type { Skill } from "../extensibility/skills";
 import type { LocalProtocolOptions } from "./local-protocol";
 
 /**
@@ -90,6 +91,8 @@ export interface ResolveContext {
 	 * [#1608](https://github.com/can1357/oh-my-pi/issues/1608).
 	 */
 	localProtocolOptions?: LocalProtocolOptions;
+	/** Calling session's loaded skills. Prefer this over process-global skill state. */
+	skills?: readonly Skill[];
 }
 
 /**

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -283,6 +283,7 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				settings: this.session.settings,
 				signal,
 				localProtocolOptions: this.session.localProtocolOptions,
+				skills: this.session.skills,
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -185,6 +185,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				settings: this.session.settings,
 				signal,
 				localProtocolOptions: this.session.localProtocolOptions,
+				skills: this.session.skills,
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -166,6 +166,7 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 					settings: this.session.settings,
 					signal,
 					localProtocolOptions: this.session.localProtocolOptions,
+					skills: this.session.skills,
 				});
 				if (!resource.sourcePath) {
 					throw new ToolError(`Cannot find internal URL without a backing file: ${rawPattern}`);

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { isEnoent } from "@oh-my-pi/pi-utils";
+import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolError } from "./tool-errors";
 
@@ -986,6 +987,8 @@ export interface ToolScopeOptions {
 	signal?: AbortSignal;
 	/** Calling session's `local://` root mapping — pins resolutions to the calling session. */
 	localProtocolOptions?: LocalProtocolOptions;
+	/** Calling session's loaded skills — lets skill:// resolve without process-global state. */
+	skills?: readonly Skill[];
 }
 
 export interface ToolScopeResolution {
@@ -1042,6 +1045,7 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 			settings: opts.settings,
 			signal: opts.signal,
 			localProtocolOptions: opts.localProtocolOptions,
+			skills: opts.skills,
 		});
 		if (!resource.sourcePath) {
 			throw new ToolError(`Cannot ${internalUrlAction} internal URL without a backing file: ${rawPath}`);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2771,6 +2771,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			settings: this.session.settings,
 			signal,
 			localProtocolOptions: this.session.localProtocolOptions,
+			skills: this.session.skills,
 		});
 		const details: ReadToolDetails = { resolvedPath: resource.sourcePath, contentType: resource.contentType };
 

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -579,6 +579,7 @@ async function resolveInternalSearchInputs(opts: {
 	signal?: AbortSignal;
 	archiveDisplayMap: ReadonlyMap<string, string>;
 	localProtocolOptions?: LocalProtocolOptions;
+	skills?: ResolveContext["skills"];
 }): Promise<InternalSearchInputResolution> {
 	const internalRouter = InternalUrlRouter.instance();
 	const paths = opts.resolvedPaths.slice();
@@ -592,6 +593,7 @@ async function resolveInternalSearchInputs(opts: {
 		settings: opts.settings,
 		signal: opts.signal,
 		localProtocolOptions: opts.localProtocolOptions,
+		skills: opts.skills,
 	};
 
 	for (let idx = 0; idx < paths.length; idx++) {
@@ -725,6 +727,7 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 					signal,
 					archiveDisplayMap,
 					localProtocolOptions: this.session.localProtocolOptions,
+					skills: this.session.skills,
 				});
 				const searchablePaths = internalResolution.paths;
 				const { virtualResources, virtualPathSet, virtualInputIndexes } = internalResolution;
@@ -797,6 +800,7 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 						settings: this.session.settings,
 						signal,
 						localProtocolOptions: this.session.localProtocolOptions,
+						skills: this.session.skills,
 					});
 					searchPath = scope.searchPath;
 					isDirectory = scope.isDirectory;

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -136,6 +136,27 @@ describe("SearchTool internal URL resolution", () => {
 		expect(result.details?.resolvedPath).toBe(path.join(skillDir, "references"));
 	});
 
+	it("resolves skill:// through session skills when active skill globals are empty", async () => {
+		const skillDir = await registerSkillDirectory();
+		resetActiveSkillsForTests();
+		const session = createSession({
+			skills: [
+				{
+					name: "demo",
+					description: "demo skill",
+					filePath: path.join(skillDir, "SKILL.md"),
+					baseDir: skillDir,
+					source: "test",
+				},
+			],
+		});
+		const tool = new ReadTool(session);
+
+		const result = await tool.execute("test-call", { path: "skill://demo" });
+
+		expect(getResultText(result)).toContain("# Demo");
+		expect(result.details?.resolvedPath).toBe(path.join(skillDir, "SKILL.md"));
+	});
 	it("walks skill:// directory subpaths for search and find", async () => {
 		await registerSkillDirectory();
 		const session = createSession({ hasEditTool: true });


### PR DESCRIPTION
## Repro
A minimal `ReadTool` session with `session.skills` containing `python` and an empty process-global active skill snapshot fails before the fix: `bun .wt/skill-url-repro.ts` exits with `Unknown skill: python\nAvailable: none`, matching the reported `read skill://python` tool-execution path.

## Cause
`packages/coding-agent/src/internal-urls/skill-protocol.ts` resolved `skill://` only through `getActiveSkills()`, while tool callers like `ReadTool`, `FindTool`, `SearchTool`, and AST tools already carry the loaded `ToolSession.skills` snapshot. When tool execution crossed a module/process boundary, the session snapshot survived but the module-global active skill list was empty.

## Fix
- Added caller `skills` to `ResolveContext` and made `SkillProtocolHandler.resolve()` prefer it before falling back to `getActiveSkills()`.
- Threaded `this.session.skills` through read/find/search/AST internal URL resolution paths.
- Added a regression test covering `read skill://demo` with populated `session.skills` and an empty active-skill global.
- Added the coding-agent changelog entry for #3436.

## Verification
`bun .wt/skill-url-repro.ts` reproduced the failure before the fix and printed `# Python skill` after the fix; `bun test packages/coding-agent/test/tools/search-internal-urls.test.ts` passed with 20 tests; `bun --cwd=packages/coding-agent run check` passed. Fixes #3436