### PR TITLE
fix(ai): preserve 3p thinking blocks across cross-API switches

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cross-API 3p ↔ 3p mid-session switches (Z.AI Anthropic → Z.AI OpenAI, Kimi Anthropic → Kimi OpenAI, custom `models.yaml` provider switches that cross API types) demoting every prior `thinking` block to plain text on the cross-API path of `transformMessages`, so the next request shipped the reasoning chain as conversation text instead of structured `reasoning_content`. `transformMessages` now preserves the prior reasoning as a native, signature-stripped `thinking` block whenever the `openai-completions` target accepts `reasoning_content` as a continuation hint (`requiresReasoningContentForToolCalls` or `thinkingFormat: "zai"`), and the `openai-completions` encoder now surfaces those preserved blocks via `reasoningContentField` for Z.AI-format hosts that don't strictly require the field. Other cross-API targets (encrypted reasoning blobs, signed thought parts) still demote to text so reasoning survives at minimum as visible conversation context. ([#3434](https://github.com/can1357/oh-my-pi/issues/3434))
+
 ## [16.1.18] - 2026-06-25
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1793,6 +1793,17 @@ export function convertMessages(
 					if (wireField) {
 						assistantMsg[wireField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
 					}
+				} else if (compat.thinkingFormat === "zai" && model.reasoning) {
+					// Z.AI / Zhipu / Moonshot Kimi (native) / Xiaomi MiMo accept
+					// `reasoning_content` as a continuation hint even when they don't
+					// strictly require it. Surfacing the preserved thinking text here
+					// keeps cross-API replays (Z.AI Anthropic → Z.AI OpenAI, etc.)
+					// shipping reasoning as structured `reasoning_content` rather than
+					// folded into conversation text (#3434). Signature is irrelevant on
+					// this path: `transform-messages` strips the source wire-format
+					// signature on cross-API replays before the block reaches us.
+					const reasoningField = compat.reasoningContentField ?? "reasoning_content";
+					assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
 				}
 			}
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1766,6 +1766,13 @@ export function convertMessages(
 			const thinkingBlocks = msg.content.filter(b => b.type === "thinking") as ThinkingContent[];
 			// Filter out empty thinking blocks to avoid API validation errors
 			const nonEmptyThinkingBlocks = thinkingBlocks.filter(b => b.thinking && b.thinking.trim().length > 0);
+			// Source identity: same-model history is replay we MUST NOT mutate
+			// beyond what the existing per-compat branches do. In particular,
+			// markup-healed thinking (MiniMax `<think>…</think>` and similar)
+			// arrives with `thinkingSignature: undefined` for same-model turns;
+			// it is private reasoning the model emitted, not cross-API preserved
+			// reasoning, and must not be promoted into visible `content`.
+			const isSameModelHistory = msg.api === model.api && msg.provider === model.provider && msg.model === model.id;
 			if (nonEmptyThinkingBlocks.length > 0) {
 				if (compat.requiresThinkingAsText) {
 					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
@@ -1804,18 +1811,26 @@ export function convertMessages(
 					// signature on cross-API replays before the block reaches us.
 					const reasoningField = compat.reasoningContentField ?? "reasoning_content";
 					assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
-				} else if (nonEmptyThinkingBlocks.every(b => !b.thinkingSignature)) {
+				} else if (!isSameModelHistory && nonEmptyThinkingBlocks.every(b => !b.thinkingSignature)) {
 					// Cross-API preserved thinking (signature stripped by
-					// `transform-messages`) that reached an encoder branch which can't
-					// surface `reasoning_content` for THIS request — most often an
-					// OpenCode-hosted reasoning model in thinking-disabled mode, where
-					// the resolved base compat must keep the field off to dodge the
-					// `Extra inputs are not permitted` 400 (#1071). Fold the reasoning
-					// into the visible content (same shape as `requiresThinkingAsText`)
-					// so the next turn at least sees the prior plan as conversation
-					// context, matching the pre-#3434 cross-API text-demotion behavior.
-					// Same-model replays preserve the streaming signature and never
-					// land here.
+					// `transform-messages` on a non-same-model replay) that reached an
+					// encoder branch which can't surface `reasoning_content` for THIS
+					// request — most often an OpenCode-hosted reasoning model in
+					// thinking-disabled mode, where the resolved base compat must
+					// keep the field off to dodge the `Extra inputs are not permitted`
+					// 400 (#1071). Fold the reasoning into the visible content (same
+					// shape as `requiresThinkingAsText`) so the next turn at least sees
+					// the prior plan as conversation context, matching the pre-#3434
+					// cross-API text-demotion behavior.
+					//
+					// Gated on `!isSameModelHistory` because some same-model streams
+					// also produce unsigned thinking blocks — notably markup-healed
+					// `<think>…</think>` runs (MiniMax M3 on opencode-zen and the
+					// other `getStreamMarkupHealingPattern === "thinking"` hosts).
+					// That reasoning is PRIVATE to the source turn and must never be
+					// promoted into the next request's visible content; same-model
+					// history therefore keeps the legacy silently-dropped behavior
+					// when no per-compat branch above consumes it.
 					const thinkingText = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n\n");
 					assistantMsg.content =
 						typeof assistantMsg.content === "string" && assistantMsg.content.length > 0

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1804,6 +1804,23 @@ export function convertMessages(
 					// signature on cross-API replays before the block reaches us.
 					const reasoningField = compat.reasoningContentField ?? "reasoning_content";
 					assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+				} else if (nonEmptyThinkingBlocks.every(b => !b.thinkingSignature)) {
+					// Cross-API preserved thinking (signature stripped by
+					// `transform-messages`) that reached an encoder branch which can't
+					// surface `reasoning_content` for THIS request — most often an
+					// OpenCode-hosted reasoning model in thinking-disabled mode, where
+					// the resolved base compat must keep the field off to dodge the
+					// `Extra inputs are not permitted` 400 (#1071). Fold the reasoning
+					// into the visible content (same shape as `requiresThinkingAsText`)
+					// so the next turn at least sees the prior plan as conversation
+					// context, matching the pre-#3434 cross-API text-demotion behavior.
+					// Same-model replays preserve the streaming signature and never
+					// land here.
+					const thinkingText = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n\n");
+					assistantMsg.content =
+						typeof assistantMsg.content === "string" && assistantMsg.content.length > 0
+							? `${thinkingText}\n\n${assistantMsg.content}`
+							: thinkingText;
 				}
 			}
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -143,6 +143,34 @@ function isAnthropicMessagesModel(model: Model): model is Model<"anthropic-messa
 	return model.api === "anthropic-messages";
 }
 
+function isOpenAICompletionsModel(model: Model): model is Model<"openai-completions"> {
+	return model.api === "openai-completions";
+}
+
+/**
+ * Cross-API targets that accept a prior turn's reasoning as a native,
+ * signature-stripped `thinking` block. Anthropic's same-API path
+ * (`replayUnsignedThinking`) covers `anthropic-messages` targets directly;
+ * this predicate is the analogue for the `openai-completions` branch of the
+ * cross-API path (#3434). 3p ↔ 3p replays between an Anthropic-compatible
+ * source (Z.AI Anthropic, Kimi Anthropic, …) and an OpenAI-compat reasoning
+ * target on the same vendor must keep reasoning as structured
+ * `reasoning_content` instead of degrading it to conversation text.
+ *
+ * The downstream encoder MUST then surface the preserved block on the wire
+ * via `reasoningContentField` — see `openai-completions.ts` for the matching
+ * branch.
+ */
+function openAICompletionsReplaysUnsignedThinking(model: Model<"openai-completions">): boolean {
+	if (!model.reasoning) return false;
+	const compat = model.compat;
+	if (compat.requiresThinkingAsText) return false;
+	// Hosts that REQUIRE `reasoning_content` on tool-call turns already accept
+	// it elsewhere; same for Z.AI-format hosts (Z.AI, Zhipu, Moonshot Kimi,
+	// Xiaomi MiMo), which advertise `reasoning_content` as a continuation hint.
+	return compat.requiresReasoningContentForToolCalls || compat.thinkingFormat === "zai";
+}
+
 const ANTHROPIC_TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 
 function isValidAnthropicToolCallId(id: string): boolean {
@@ -316,13 +344,34 @@ export function transformMessages<TApi extends Api>(
 						}
 						return sanitized;
 					}
-					// Cross-API target: keep the existing text-demotion fallback.
-					// For same model: keep thinking blocks with signatures (needed for replay)
-					// even if the thinking text is empty (OpenAI encrypted reasoning)
+					// Cross-API target: same-model replay keeps signatures untouched
+					// (the encoder needs them for native replay; an OpenAI encrypted
+					// reasoning blob has empty text but a load-bearing signature).
 					if (isSameModel && sanitized.thinkingSignature) return sanitized;
-					// Skip empty thinking blocks, convert others to plain text
+					// Nothing left for the next turn to replay: drop empty/no-anchor
+					// thinking blocks before the cross-model paths.
 					if (!sanitized.thinking || sanitized.thinking.trim() === "") return [];
 					if (isSameModel) return sanitized;
+					// Cross-model + cross-API: preserve as a native, signature-stripped
+					// `thinking` block whenever the target encoder can re-emit it on the
+					// wire (today: `openai-completions` reasoning targets that accept
+					// `reasoning_content` as a continuation hint — Z.AI, Zhipu, DeepSeek
+					// reasoning, Kimi native, MiMo, OpenRouter reasoning, …). The source
+					// signature is always dropped because it is bound to the source
+					// wire-format (Anthropic crypto sig / OpenAI Responses encrypted
+					// blob) and would be rejected by the target. Without this branch
+					// every cross-API 3p ↔ 3p switch (Z.AI Anthropic → Z.AI OpenAI,
+					// Kimi Anthropic → Kimi OpenAI, etc.) demoted prior reasoning to
+					// conversation text and lost it as structured reasoning context
+					// (#3434).
+					if (isOpenAICompletionsModel(model) && openAICompletionsReplaysUnsignedThinking(model)) {
+						return sanitized.thinkingSignature ? { ...sanitized, thinkingSignature: undefined } : sanitized;
+					}
+					// Other cross-API targets (openai-responses encrypted blobs, google
+					// signed thought parts, anthropic-target from a non-Anthropic source,
+					// or any reasoning-disabled target) can't usefully replay an unsigned
+					// thinking block. Demote to text so the reasoning survives at least
+					// as visible conversation context.
 					return {
 						type: "text" as const,
 						text: sanitized.thinking,

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -157,13 +157,29 @@ function isOpenAICompletionsModel(model: Model): model is Model<"openai-completi
  * target on the same vendor must keep reasoning as structured
  * `reasoning_content` instead of degrading it to conversation text.
  *
+ * Considers both the base compat view AND `compat.whenThinking` because the
+ * latter is the resolved compat the request actually runs against when
+ * thinking is engaged on hosts like OpenCode (`opencode-go`/`opencode-zen`),
+ * where the base compat intentionally suppresses `requiresReasoningContentForToolCalls`
+ * to dodge the thinking-off `Extra inputs are not permitted` 400 (#1071) and
+ * the `whenThinking` policy reactivates it for thinking-on requests to dodge
+ * the `thinking is enabled but reasoning_content is missing` 400 (#1484).
+ * Ignoring `whenThinking` would re-open #1484 for every cross-API switch into
+ * an OpenCode-hosted reasoning model.
+ *
  * The downstream encoder MUST then surface the preserved block on the wire
  * via `reasoningContentField` — see `openai-completions.ts` for the matching
  * branch.
  */
 function openAICompletionsReplaysUnsignedThinking(model: Model<"openai-completions">): boolean {
 	if (!model.reasoning) return false;
-	const compat = model.compat;
+	const base = model.compat;
+	if (acceptsReasoningContentReplay(base)) return true;
+	const whenThinking = base.whenThinking;
+	return whenThinking !== undefined && acceptsReasoningContentReplay(whenThinking);
+}
+
+function acceptsReasoningContentReplay(compat: Model<"openai-completions">["compat"]): boolean {
 	if (compat.requiresThinkingAsText) return false;
 	// Hosts that REQUIRE `reasoning_content` on tool-call turns already accept
 	// it elsewhere; same for Z.AI-format hosts (Z.AI, Zhipu, Moonshot Kimi,

--- a/packages/ai/test/issue-3434-repro.test.ts
+++ b/packages/ai/test/issue-3434-repro.test.ts
@@ -303,4 +303,50 @@ describe("cross-API 3p ↔ 3p thinking-block preservation (#3434)", () => {
 		expect(content).toContain("Read README and answer.");
 		expect(content).toContain("Done.");
 	});
+
+	it("does not promote markup-healed same-model thinking into visible content", () => {
+		// Markup-healed streams (MiniMax `<think>…</think>`, Kimi K2 healed
+		// reasoning, …) record thinking blocks with `thinkingSignature: undefined`
+		// because the healer reconstructs them from raw text deltas. On a
+		// same-model continuation those blocks are PRIVATE reasoning the source
+		// emitted, not cross-API preserved reasoning. The text-fold fallback for
+		// signature-stripped blocks MUST therefore skip same-model history,
+		// otherwise it would leak the hidden chain-of-thought into the next
+		// request's visible `content`.
+		const target = opencodeGoKimiTarget();
+		const compat = target.compat;
+		const sameModelAssistant: AssistantMessage = {
+			role: "assistant",
+			api: target.api,
+			provider: target.provider,
+			model: target.id,
+			content: [
+				{ type: "thinking", thinking: "hidden chain-of-thought, must not leak" },
+				{ type: "text", text: "Visible answer." },
+			],
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 0,
+		};
+		const messages: Message[] = [userMessage("Plan it."), sameModelAssistant, userMessage("Continue.")];
+
+		const wire = convertMessages(target, { messages }, compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		// Visible content stays exactly what the model produced on the last turn.
+		expect(assistant.content).toBe("Visible answer.");
+		// And the private reasoning is not promoted anywhere on the wire.
+		expect(assistant.reasoning_content).toBeUndefined();
+		expect(assistant.reasoning).toBeUndefined();
+		expect(assistant.reasoning_text).toBeUndefined();
+	});
 });

--- a/packages/ai/test/issue-3434-repro.test.ts
+++ b/packages/ai/test/issue-3434-repro.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression guard for cross-API 3p ↔ 3p thinking-block preservation (#3434).
+ *
+ * Mid-session switches between an Anthropic-compatible 3p provider and an
+ * OpenAI-compatible 3p provider on the same vendor (Z.AI Anthropic → Z.AI
+ * OpenAI, Kimi Anthropic → Kimi OpenAI, …) used to demote every prior
+ * `thinking` block to plain text on the cross-API path of `transformMessages`:
+ *
+ *     // Cross-API target: keep the existing text-demotion fallback.
+ *     return { type: "text", text: sanitized.thinking };
+ *
+ * The next request shipped the reasoning chain as conversation text instead
+ * of structured `reasoning_content`, so the target model lost the prior
+ * reasoning context and the user paid twice — once to generate the thinking
+ * on the source endpoint, once again to re-derive it on the target.
+ *
+ * The fix has two halves:
+ *
+ *  1. `transformMessages` preserves the prior thinking text as a native,
+ *     signature-stripped `thinking` block whenever the target encoder can
+ *     re-emit it on the wire (today: `openai-completions` reasoning targets
+ *     that accept `reasoning_content` as a continuation hint).
+ *  2. The `openai-completions` encoder surfaces those preserved blocks via
+ *     `reasoningContentField` even for hosts that don't strictly require
+ *     `reasoning_content` — specifically `thinkingFormat: "zai"` targets.
+ *
+ * This file pins the wire output for the canonical scenarios.
+ */
+import { describe, expect, it } from "bun:test";
+import { convertMessages } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { AssistantMessage, Message, Model, ModelSpec, UserMessage } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function findAssistantMessage(messages: readonly unknown[]): Record<string, unknown> | undefined {
+	for (const message of messages) {
+		if (isPlainObject(message) && message.role === "assistant") return message;
+	}
+	return undefined;
+}
+
+const ZAI_OPAQUE_SIGNATURE = "Ev0CCkYIBhgCKkArbase64sigfromzai==";
+
+function zaiAnthropicMessage(thinkingText: string): AssistantMessage {
+	// Z.AI's Anthropic-format 3p endpoint (api.z.ai/api/anthropic). The source
+	// signature looks like an Anthropic continuation hint but is opaque to any
+	// other API — the cross-API path MUST strip it before the encoder reads it.
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "zai",
+		model: "glm-5.2",
+		content: [
+			{ type: "thinking", thinking: thinkingText, thinkingSignature: ZAI_OPAQUE_SIGNATURE },
+			{ type: "text", text: "Done." },
+		],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function userMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: 0 };
+}
+
+function zaiOpenAITarget(): Model<"openai-completions"> {
+	// Z.AI's OpenAI-format endpoint (api.z.ai/api/coding/paas/v4 — same vendor
+	// catalog entry as the Anthropic source above). thinkingFormat resolves to
+	// "zai"; requiresReasoningContentForToolCalls is false.
+	return buildModel({
+		id: "glm-5.2",
+		name: "GLM-5.2",
+		api: "openai-completions",
+		provider: "zhipu-coding-plan",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 131_072,
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function deepseekReasoningTarget(): Model<"openai-completions"> {
+	// DeepSeek-family reasoning target: requiresReasoningContentForToolCalls is
+	// true here, so the preserved block reaches reasoning_content via the
+	// existing recovery branch. Guards the other half of the fix from regressing.
+	return buildModel({
+		id: "deepseek-v4-flash",
+		name: "DeepSeek V4 Flash",
+		api: "openai-completions",
+		provider: "deepseek",
+		baseUrl: "https://api.deepseek.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function openAIGpt4oTarget(): Model<"openai-completions"> {
+	// Official OpenAI Chat Completions, non-reasoning. Thinking blocks must
+	// still demote to text — this target can't usefully emit `reasoning_content`.
+	return buildModel({
+		id: "gpt-4o-mini",
+		name: "GPT-4o mini",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+describe("cross-API 3p ↔ 3p thinking-block preservation (#3434)", () => {
+	it("emits reasoning_content on Z.AI Anthropic → Z.AI OpenAI cross-API switch", () => {
+		const target = zaiOpenAITarget();
+		const messages: Message[] = [
+			userMessage("Build a plan"),
+			zaiAnthropicMessage("Step 1 explore. Step 2 patch. Step 3 verify."),
+			userMessage("Continue the same plan on the other endpoint."),
+		];
+
+		const wire = convertMessages(target, { messages }, target.compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		// The reasoning chain rides as structured `reasoning_content` on the
+		// next request, not folded into the visible `content` text.
+		expect(assistant.reasoning_content).toBe("Step 1 explore. Step 2 patch. Step 3 verify.");
+		expect(assistant.content).toBe("Done.");
+	});
+
+	it("strips the source signature on the preserved cross-API thinking block", () => {
+		// The Z.AI Anthropic signature is bound to the Anthropic wire-format and
+		// useless to the OpenAI target. The preserved block surfaces only the
+		// reasoning text; no opaque signature may leak onto the wire as a stray
+		// field name.
+		const target = zaiOpenAITarget();
+		const messages: Message[] = [
+			userMessage("Plan it."),
+			zaiAnthropicMessage("opaque continuation metadata payload"),
+			userMessage("Continue."),
+		];
+
+		const wire = convertMessages(target, { messages }, target.compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		expect(ZAI_OPAQUE_SIGNATURE in assistant).toBe(false);
+		expect(assistant.reasoning_content).toBe("opaque continuation metadata payload");
+	});
+
+	it("emits reasoning_content on Anthropic 3p → DeepSeek cross-API switch", () => {
+		// DeepSeek-family reasoning targets reach reasoning_content via the
+		// existing `requiresReasoningContentForToolCalls` recovery branch. This
+		// pin guards against a regression in either fix half that would drop
+		// the preserved block before recovery runs.
+		const target = deepseekReasoningTarget();
+		const messages: Message[] = [
+			userMessage("Inspect README"),
+			zaiAnthropicMessage("Read README and answer."),
+			userMessage("Continue on DeepSeek."),
+		];
+
+		const wire = convertMessages(target, { messages }, target.compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		expect(assistant.reasoning_content).toBe("Read README and answer.");
+	});
+
+	it("demotes thinking to text when the target cannot replay reasoning_content", () => {
+		// Anthropic 3p → official OpenAI non-reasoning model: the encoder
+		// cannot emit `reasoning_content` here (the field would be ignored and
+		// strict OpenAI-compat shims would reject it). Reasoning must survive
+		// at minimum as visible conversation text so the next turn still sees
+		// the prior plan.
+		const target = openAIGpt4oTarget();
+		const messages: Message[] = [
+			userMessage("Plan it."),
+			zaiAnthropicMessage("Explore the repo, then patch it."),
+			userMessage("Continue."),
+		];
+
+		const wire = convertMessages(target, { messages }, target.compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		expect(assistant.reasoning_content).toBeUndefined();
+		const content = assistant.content;
+		expect(typeof content).toBe("string");
+		if (typeof content !== "string") throw new Error("content not a string");
+		expect(content).toContain("Explore the repo, then patch it.");
+		expect(content).toContain("Done.");
+	});
+});

--- a/packages/ai/test/issue-3434-repro.test.ts
+++ b/packages/ai/test/issue-3434-repro.test.ts
@@ -115,6 +115,29 @@ function deepseekReasoningTarget(): Model<"openai-completions"> {
 	} satisfies ModelSpec<"openai-completions">);
 }
 
+function opencodeGoKimiTarget(): Model<"openai-completions"> {
+	// OpenCode Go's reasoning-enabled Kimi. Base compat keeps
+	// `requiresReasoningContentForToolCalls: false` to dodge the
+	// `Extra inputs are not permitted` 400 (#1071); only the resolved
+	// `whenThinking` policy reactivates it (#1484). The predicate that
+	// gates cross-API preservation MUST consult `whenThinking`, otherwise
+	// the prior thinking is demoted to text and the next thinking-on
+	// request 400s with `thinking is enabled but reasoning_content is
+	// missing in assistant tool call message at index N`.
+	return buildModel({
+		id: "kimi-k2.6",
+		name: "Kimi K2.6",
+		api: "openai-completions",
+		provider: "opencode-go",
+		baseUrl: "https://opencode.ai/zen/go/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256_000,
+		maxTokens: 16_384,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
 function openAIGpt4oTarget(): Model<"openai-completions"> {
 	// Official OpenAI Chat Completions, non-reasoning. Thinking blocks must
 	// still demote to text — this target can't usefully emit `reasoning_content`.
@@ -216,6 +239,68 @@ describe("cross-API 3p ↔ 3p thinking-block preservation (#3434)", () => {
 		expect(typeof content).toBe("string");
 		if (typeof content !== "string") throw new Error("content not a string");
 		expect(content).toContain("Explore the repo, then patch it.");
+		expect(content).toContain("Done.");
+	});
+
+	it("preserves cross-API thinking for OpenCode reasoning targets that gate replay via compat.whenThinking", () => {
+		// OpenCode (`opencode-go`, `opencode-zen`) reasoning models keep
+		// `requiresReasoningContentForToolCalls: false` on the base compat
+		// (dodges the thinking-off `Extra inputs are not permitted` 400 — #1071)
+		// and reactivate the flag on `compat.whenThinking` for thinking-engaged
+		// requests (dodges the `thinking is enabled but reasoning_content is
+		// missing` 400 — #1484). Before this guard, the cross-API preservation
+		// predicate only read the base compat, so prior thinking was demoted
+		// to text and the next thinking-on request re-triggered #1484.
+		const target = opencodeGoKimiTarget();
+		const messages: Message[] = [
+			userMessage("Plan it."),
+			zaiAnthropicMessage("Read README and answer."),
+			userMessage("Continue on OpenCode."),
+		];
+
+		// Resolve the thinking-engaged compat the way `streamOpenAICompletions`
+		// does for a request with reasoning effort set, then hand it to
+		// `convertMessages` directly so the test exercises the same encoder
+		// configuration the live wire would.
+		const compat = target.compat.whenThinking ?? target.compat;
+		expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+
+		const wire = convertMessages(target, { messages }, compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		expect(assistant.reasoning_content).toBe("Read README and answer.");
+	});
+
+	it("folds preserved thinking into content when the OpenCode base compat (thinking off) cannot surface reasoning_content", () => {
+		// Companion of the prior test: same OpenCode target, but the request
+		// runs against the BASE compat (thinking disabled, the path that bars
+		// `reasoning_content` per #1071). Without the encoder fallback,
+		// transform-messages would preserve the native thinking block and the
+		// encoder would silently drop it — a regression vs. the pre-#3434
+		// text-demotion behavior. The fallback folds the reasoning into the
+		// visible content so the next turn still sees the prior plan.
+		const target = opencodeGoKimiTarget();
+		const compat = target.compat;
+		expect(compat.requiresReasoningContentForToolCalls).toBe(false);
+
+		const messages: Message[] = [
+			userMessage("Plan it."),
+			zaiAnthropicMessage("Read README and answer."),
+			userMessage("Continue with thinking off."),
+		];
+
+		const wire = convertMessages(target, { messages }, compat);
+		const assistant = findAssistantMessage(wire);
+		expect(assistant).toBeDefined();
+		if (!assistant) throw new Error("assistant message missing");
+
+		expect(assistant.reasoning_content).toBeUndefined();
+		const content = assistant.content;
+		expect(typeof content).toBe("string");
+		if (typeof content !== "string") throw new Error("content not a string");
+		expect(content).toContain("Read README and answer.");
 		expect(content).toContain("Done.");
 	});
 });


### PR DESCRIPTION
## Repro

Switch a session from an Anthropic-compatible 3p endpoint to an OpenAI-compatible 3p endpoint on the same vendor (e.g. Z.AI Anthropic → Z.AI OpenAI, Kimi Anthropic → Kimi OpenAI, or any cross-API switch via `models.yaml`). On the very next request `transformMessages` demotes every prior `thinking` block to plain `text`, so the wire body carries the reasoning chain in `content` instead of structured `reasoning_content`. The target model never sees the prior reasoning as reasoning context, and the source-side reasoning tokens are paid for twice. Reproduced by the new test file:

```
bun test packages/ai/test/issue-3434-repro.test.ts
# on main: 3 of 4 tests fail
#   reasoning_content undefined for Z.AI Anthropic → Z.AI OpenAI
#   reasoning_content undefined for the signature-strip pin
#   reasoning_content empty for Anthropic 3p → DeepSeek
```

## Cause

`packages/ai/src/providers/transform-messages.ts` — the cross-API branch of the `thinking` block path unconditionally text-demotes anything that isn't a same-model replay. There is no 3p ↔ 3p preservation branch: the only check is `isSameModel`, and once it's false the block is converted to `{ type: "text", text: sanitized.thinking }` regardless of whether both endpoints are 3p.

`packages/ai/src/providers/openai-completions.ts` — the encoder only surfaces preserved thinking on the wire via `reasoning_content` when the streaming signature is one of `reasoning_content` / `reasoning` / `reasoning_text` (recognized OpenAI-compat field names) **and** `compat.requiresReasoningContentForToolCalls` is true. Z.AI / Zhipu (`thinkingFormat: "zai"`, `requiresReasoningContentForToolCalls: false`) fall through every branch and drop the block silently — so even if `transformMessages` preserved it, the encoder still wouldn't put it on the wire.

## Fix

Two-half fix, both halves required to make the wire ship `reasoning_content`:

- `transform-messages.ts`: new `openAICompletionsReplaysUnsignedThinking(model)` predicate plus a new branch in the cross-API thinking path. When the target is an `openai-completions` reasoning model that accepts `reasoning_content` as a continuation hint (`requiresReasoningContentForToolCalls` **or** `thinkingFormat: "zai"`), the prior reasoning is kept as a native, signature-stripped `thinking` block. Source signature is always stripped because it's bound to the source wire format (Anthropic crypto sig / OpenAI Responses encrypted blob) and useless to a foreign target. Other cross-API targets (openai-responses encrypted blobs, google signed thought parts, anthropic-from-foreign-source) still text-demote so reasoning at least survives as visible conversation context.
- `openai-completions.ts`: new `else if (compat.thinkingFormat === "zai" && model.reasoning)` branch in the thinking-block handler. Surfaces preserved thinking via `compat.reasoningContentField ?? "reasoning_content"` for Z.AI-format hosts (Z.AI, Zhipu, Moonshot Kimi native, Xiaomi MiMo) that don't require the field but do accept it. Signature is irrelevant — `transformMessages` strips it before the block reaches the encoder.

## Verification

- `bun test packages/ai/test/issue-3434-repro.test.ts` — 4/4 pass (all 4 are net-new regression pins; 3 of them fail on `main` against the exact same diff).
- `bun test packages/ai/test/anthropic-prior-turn-thinking.test.ts packages/ai/test/anthropic-thinking-only-length-truncated.test.ts packages/ai/test/deepseek-reasoning-content.test.ts packages/ai/test/openai-completions-compat.test.ts packages/ai/test/transform-messages-dedup.test.ts packages/ai/test/duplicate-tool-results.test.ts packages/ai/test/anthropic-prefill.test.ts` — 118/118 pass (every existing test in the thinking-block / cross-API neighborhood).
- `bun test packages/ai` — 2294 pass / 1 fail. The lone failure (`proxy.test.ts > normalizes hyphenated provider ids to underscores`) reads `Bun.env.PI_PROXY_GITHUB_COPILOT` set by a sibling test, fails identically on `main` (4 fails there, three of which are the new repro tests), and isn't reachable from this diff.
- `bun check` — passes.

Fixes #3434