### PR TITLE
fix(coding-agent): refuse local binary attachment text reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `skill://` tool resolution losing loaded session skills when a tool runs outside the session-initialization module state. Internal URL resolution now prefers the caller's `session.skills` snapshot before falling back to the process-global skill list, so `read skill://<name>` works across tool execution boundaries. ([#3436](https://github.com/can1357/oh-my-pi/issues/3436))
+- Fixed `local://` binary attachments being decoded with `Bun.file().text()` before read-tool file safeguards could reject or stream them. `read local://...` now routes file-backed resources through the normal filesystem reader, and the protocol handler refuses known binary/container resources without materializing their bytes. ([#3448](https://github.com/can1357/oh-my-pi/issues/3448))
 
 ## [16.1.18] - 2026-06-25
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed `skill://` tool resolution losing loaded session skills when a tool runs outside the session-initialization module state. Internal URL resolution now prefers the caller's `session.skills` snapshot before falling back to the process-global skill list, so `read skill://<name>` works across tool execution boundaries. ([#3436](https://github.com/can1357/oh-my-pi/issues/3436))
-- Fixed `local://` binary attachments being decoded with `Bun.file().text()` before read-tool file safeguards could reject or stream them. `read local://...` now routes file-backed resources through the normal filesystem reader, and the protocol handler refuses known binary/container resources without materializing their bytes. ([#3448](https://github.com/can1357/oh-my-pi/issues/3448))
+- Fixed `local://` binary attachments being decoded with `Bun.file().text()` before read-tool file safeguards could reject or stream them. `read local://...` now routes file-backed resources through the normal filesystem reader, the protocol handler refuses known binary/container resources without materializing their bytes, and the streaming reader's NUL-byte refusal now also covers binary blobs whose first newline lies beyond the byte budget (videos, archives) — those previously bypassed the per-line scan and surfaced as decoded mojibake. ([#3448](https://github.com/can1357/oh-my-pi/issues/3448))
 
 ## [16.1.18] - 2026-06-25
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -49,6 +49,118 @@ function getContentType(filePath: string): InternalResource["contentType"] {
 	return "text/plain";
 }
 
+const LOCAL_TEXT_SNIFF_BYTES = 8 * 1024;
+const LOCAL_TEXT_RESOURCE_MAX_BYTES = 1024 * 1024;
+const BINARY_FILE_EXTENSIONS = new Set([
+	".7z",
+	".avi",
+	".bmp",
+	".bz2",
+	".db",
+	".doc",
+	".docx",
+	".gif",
+	".gz",
+	".ico",
+	".jpeg",
+	".jpg",
+	".m4v",
+	".mkv",
+	".mov",
+	".mp4",
+	".pdf",
+	".png",
+	".ppt",
+	".pptx",
+	".rar",
+	".sqlite",
+	".tgz",
+	".webm",
+	".webp",
+	".wmv",
+	".xls",
+	".xlsx",
+	".xz",
+	".zip",
+]);
+
+function formatLocalByteSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const kib = bytes / 1024;
+	if (kib < 1024) return `${kib.toFixed(1)} KiB`;
+	const mib = kib / 1024;
+	if (mib < 1024) return `${mib.toFixed(1)} MiB`;
+	return `${(mib / 1024).toFixed(1)} GiB`;
+}
+
+function buildNonTextLocalResource(url: InternalUrl, filePath: string, size: number, reason: string): InternalResource {
+	const content = `[Cannot read binary local:// file '${url.href}' (${formatLocalByteSize(size)}): ${reason}. This resource is not text. Use a metadata/key-frame/video-specific workflow instead.]`;
+	return {
+		url: url.href,
+		content,
+		contentType: "text/plain",
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: filePath,
+		notes: [LOCAL_WRITE_NOTE],
+	};
+}
+
+function buildLargeLocalTextResource(url: InternalUrl, filePath: string, size: number): InternalResource {
+	const content = `[Cannot materialize local:// file '${url.href}' as an internal text resource (${formatLocalByteSize(size)} exceeds ${formatLocalByteSize(LOCAL_TEXT_RESOURCE_MAX_BYTES)}). Use the read tool's filesystem path handling or a line selector so content is streamed with file-size safeguards.]`;
+	return {
+		url: url.href,
+		content,
+		contentType: "text/plain",
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: filePath,
+		notes: [LOCAL_WRITE_NOTE],
+	};
+}
+
+async function readFilePrefix(filePath: string, maxBytes: number): Promise<Uint8Array> {
+	if (maxBytes <= 0) return new Uint8Array();
+	const handle = await fs.open(filePath, "r");
+	try {
+		const buffer = Buffer.allocUnsafe(maxBytes);
+		const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+		return buffer.subarray(0, bytesRead);
+	} finally {
+		await handle.close();
+	}
+}
+
+function isUtf8Text(bytes: Uint8Array): boolean {
+	if (bytes.indexOf(0) !== -1) return false;
+	try {
+		new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function buildFileResource(url: InternalUrl, resolved: Extract<ResolvedLocalTarget, { kind: "file" }>): Promise<InternalResource> {
+	if (BINARY_FILE_EXTENSIONS.has(path.extname(resolved.path).toLowerCase())) {
+		return buildNonTextLocalResource(url, resolved.path, resolved.size, "extension is a known binary/container type");
+	}
+	const sniffBytes = await readFilePrefix(resolved.path, Math.min(resolved.size, LOCAL_TEXT_SNIFF_BYTES));
+	if (!isUtf8Text(sniffBytes)) {
+		return buildNonTextLocalResource(url, resolved.path, resolved.size, "content is not valid UTF-8 text");
+	}
+	if (resolved.size > LOCAL_TEXT_RESOURCE_MAX_BYTES) {
+		return buildLargeLocalTextResource(url, resolved.path, resolved.size);
+	}
+	const content = await Bun.file(resolved.path).text();
+	return {
+		url: url.href,
+		content,
+		contentType: getContentType(resolved.path),
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: resolved.path,
+		notes: [LOCAL_WRITE_NOTE],
+	};
+}
+
 async function listFilesRecursively(rootPath: string): Promise<string[]> {
 	const pending = [""];
 	const files: string[] = [];
@@ -336,15 +448,7 @@ export class LocalProtocolHandler implements ProtocolHandler {
 			return buildDirectoryResource(url.href, resolved.path, [LOCAL_WRITE_NOTE]);
 		}
 
-		const content = await Bun.file(resolved.path).text();
-		return {
-			url: url.href,
-			content,
-			contentType: getContentType(resolved.path),
-			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: resolved.path,
-			notes: [LOCAL_WRITE_NOTE],
-		};
+		return buildFileResource(url, resolved);
 	}
 
 	async complete(_query?: string, context?: ResolveContext): Promise<UrlCompletion[]> {

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -139,7 +139,10 @@ function isUtf8Text(bytes: Uint8Array): boolean {
 	}
 }
 
-async function buildFileResource(url: InternalUrl, resolved: Extract<ResolvedLocalTarget, { kind: "file" }>): Promise<InternalResource> {
+async function buildFileResource(
+	url: InternalUrl,
+	resolved: Extract<ResolvedLocalTarget, { kind: "file" }>,
+): Promise<InternalResource> {
 	if (BINARY_FILE_EXTENSIONS.has(path.extname(resolved.path).toLowerCase())) {
 		return buildNonTextLocalResource(url, resolved.path, resolved.size, "extension is a known binary/container type");
 	}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2410,23 +2410,31 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					// counts in `truncation` keep reflecting the source, not the trimmed
 					// view — column truncation surfaces separately via `.limits()`.
 					const rawSelector = isRawSelector(parsed);
-					// Binary sniff: NUL bytes in the collected window mean the file is
-					// not displayable text (binary, or UTF-16 which has NULs in the
-					// ASCII range) — emit a notice instead of mojibake filling the
-					// line budget. `:raw` stays an explicit escape hatch.
+					// Binary sniff: NUL bytes mean the file is not displayable text
+					// (binary, or UTF-16 which has NULs in the ASCII range) — emit a
+					// notice instead of mojibake filling the line budget. `:raw`
+					// stays an explicit escape hatch.
+					//
+					// `collectedLines` covers the common case where at least one
+					// physical line terminates within the byte budget. Binary blobs
+					// without newlines (videos, archives, packed JSON) leave it
+					// empty; their bytes only land in `firstLinePreview`, which the
+					// `firstLineExceedsLimit` branch below would otherwise emit
+					// verbatim. Sniffing the preview here keeps the refusal uniform.
 					if (!rawSelector) {
-						for (const line of collectedLines) {
-							if (line.includes("\u0000")) {
-								return toolResult<ReadToolDetails>({ resolvedPath: absolutePath, suffixResolution })
-									.text(
-										prependSuffixResolutionNotice(
-											`[Cannot read binary file '${formatPathRelativeToCwd(absolutePath, this.session.cwd)}' (${formatBytes(fileSize)}); content contains NUL bytes (binary or UTF-16 encoded)]`,
-											suffixResolution,
-										),
-									)
-									.sourcePath(absolutePath)
-									.done();
-							}
+						const hasNul = (text: string): boolean => text.includes("\u0000");
+						const binaryDetected =
+							collectedLines.some(hasNul) || (firstLinePreview !== undefined && hasNul(firstLinePreview.text));
+						if (binaryDetected) {
+							return toolResult<ReadToolDetails>({ resolvedPath: absolutePath, suffixResolution })
+								.text(
+									prependSuffixResolutionNotice(
+										`[Cannot read binary file '${formatPathRelativeToCwd(absolutePath, this.session.cwd)}' (${formatBytes(fileSize)}); content contains NUL bytes (binary or UTF-16 encoded)]`,
+										suffixResolution,
+									),
+								)
+								.sourcePath(absolutePath)
+								.done();
 						}
 					}
 					const maxColumns = resolveOutputMaxColumns(this.session.settings);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2094,8 +2094,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					skills: this.session.skills,
 				});
 				if (localFile) {
-					readPath =
-						internalTarget.sel === undefined ? localFile.path : `${localFile.path}:${internalTarget.sel}`;
+					readPath = internalTarget.sel === undefined ? localFile.path : `${localFile.path}:${internalTarget.sel}`;
 				} else {
 					return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 				}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2083,7 +2083,25 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					`Invalid selector ':${internalTarget.sel}' on '${internalTarget.path}'. Use :N, :N-M, :N+K, :N- (open-ended), a comma-separated list of ranges, :raw, or a range combined with raw (e.g. :raw:50-100).`,
 				);
 			}
-			return this.#handleInternalUrl(internalTarget.path, parsed, signal);
+			const urlMeta = parseInternalUrl(internalTarget.path);
+			const scheme = urlMeta.protocol.replace(/:$/, "").toLowerCase();
+			if (scheme === "local") {
+				const localFile = await resolveLocalUrlToFile(urlMeta, {
+					cwd: this.session.cwd,
+					settings: this.session.settings,
+					signal,
+					localProtocolOptions: this.session.localProtocolOptions,
+					skills: this.session.skills,
+				});
+				if (localFile) {
+					readPath =
+						internalTarget.sel === undefined ? localFile.path : `${localFile.path}:${internalTarget.sel}`;
+				} else {
+					return this.#handleInternalUrl(internalTarget.path, parsed, signal);
+				}
+			} else {
+				return this.#handleInternalUrl(internalTarget.path, parsed, signal);
+			}
 		}
 
 		// One suffix-glob memo per read call — archive, sqlite, and plain-path

--- a/packages/coding-agent/test/tools/read-local-image.test.ts
+++ b/packages/coding-agent/test/tools/read-local-image.test.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { InternalUrlRouter, LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { InternalUrlRouter, LocalProtocolHandler, parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 
@@ -87,6 +87,28 @@ describe("read local:// images", () => {
 
 		expect(result.content.some(c => c.type === "image")).toBe(false);
 		expect(joinText(result.content)).toContain("hello world");
+	});
+
+	it("rejects a local:// non-image binary without emitting decoded bytes", async () => {
+		await Bun.write(path.join(localRoot, "clip.mp4"), new Uint8Array([0, 1, 2, 3, 4, 5]));
+		const tool = new ReadTool(makeSession(testDir));
+
+		const result = await tool.execute("call", { path: "local://clip.mp4" });
+		const text = joinText(result.content);
+
+		expect(text).toContain("Cannot read binary file");
+		expect(text).toContain("clip.mp4");
+		expect(text).not.toContain("\u0000");
+	});
+
+	it("does not materialize local:// binary resources in the protocol handler", async () => {
+		await Bun.write(path.join(localRoot, "archive.zip"), new Uint8Array([0, 1, 2, 3, 4, 5]));
+
+		const resource = await new LocalProtocolHandler().resolve(parseInternalUrl("local://archive.zip"));
+
+		expect(resource.content).toContain("Cannot read binary local:// file");
+		expect(resource.content).toContain("archive.zip");
+		expect(resource.content).not.toContain("\u0000");
 	});
 
 	it("does not read an image symlinked outside the local root", async () => {

--- a/packages/coding-agent/test/tools/read-local-image.test.ts
+++ b/packages/coding-agent/test/tools/read-local-image.test.ts
@@ -101,6 +101,25 @@ describe("read local:// images", () => {
 		expect(text).not.toContain("\u0000");
 	});
 
+	it("rejects a large local:// binary whose first line exceeds the streaming byte budget", async () => {
+		// The streaming reader's byte budget is `max(DEFAULT_MAX_BYTES, defaultLimit*512)` —
+		// 150 KiB under default settings. A NUL-filled blob larger than that with no 0x0A
+		// byte forces streamLinesFromFile into the firstLineExceedsLimit path: collectedLines
+		// stays empty, so the NUL check that walks collectedLines never sees these bytes.
+		// Without the firstLinePreview guard, the preview would be decoded as UTF-8 and
+		// emitted as text (the reviewer's video/archive case).
+		const blob = new Uint8Array(256 * 1024);
+		await Bun.write(path.join(localRoot, "video.mp4"), blob);
+		const tool = new ReadTool(makeSession(testDir));
+
+		const result = await tool.execute("call", { path: "local://video.mp4" });
+		const text = joinText(result.content);
+
+		expect(text).toContain("Cannot read binary file");
+		expect(text).toContain("video.mp4");
+		expect(text).not.toContain("\u0000");
+	});
+
 	it("does not materialize local:// binary resources in the protocol handler", async () => {
 		await Bun.write(path.join(localRoot, "archive.zip"), new Uint8Array([0, 1, 2, 3, 4, 5]));
 


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/tools/read-local-image.test.ts` reproduced the regression before the fix: `read local://clip.mp4` returned hashlined text containing `\u0000` bytes instead of refusing the binary attachment.

## Cause
`packages/coding-agent/src/tools/read.ts` sent every `local://` file through `LocalProtocolHandler.resolve`, and `packages/coding-agent/src/internal-urls/local-protocol.ts` materialized file resources with `Bun.file(resolved.path).text()` before the read tool's filesystem branch could apply image/document handling, streaming limits, or binary detection.

## Fix
- Route file-backed `local://` reads through the normal filesystem read path after the existing realpath containment check.
- Harden `LocalProtocolHandler.resolve` with extension and UTF-8 prefix checks so binary/container resources return a small metadata-only refusal instead of decoded bytes.
- Add regression coverage for both read-tool `local://` binary reads and direct protocol resolution.
- Document the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/tools/read-local-image.test.ts` passed: 5 tests, 0 failed. `bun --cwd=packages/coding-agent run check:types` passed. Fixes #3448