### PR TITLE
fix(internal-urls): reject binary `local://` reads before `Bun.file().text()` OOMs the host

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed `local://` reads decoding binary attachments (videos, archives, images) via `Bun.file().text()`, causing OMP to hang and grow memory by 100+ MiB per read. `LocalProtocolHandler.resolve` now sniffs the first 8 KiB for NUL bytes and rejects binary content with a clear notice, and caps inline text resources at 10 MiB so a single oversized log can't allocate the whole file twice. `sourcePath` stays populated so callers like `find`, `search`, and bash `local://` expansion keep working. ([#3449](https://github.com/can1357/oh-my-pi/issues/3449))
 - Fixed `skill://` tool resolution losing loaded session skills when a tool runs outside the session-initialization module state. Internal URL resolution now prefers the caller's `session.skills` snapshot before falling back to the process-global skill list, so `read skill://<name>` works across tool execution boundaries. ([#3436](https://github.com/can1357/oh-my-pi/issues/3436))
 
 ## [16.1.18] - 2026-06-25

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isEnoent } from "@oh-my-pi/pi-utils";
+import { formatBytes, isEnoent } from "@oh-my-pi/pi-utils";
 import { AgentRegistry } from "../registry/agent-registry";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { parseInternalUrl } from "./parse";
@@ -27,6 +27,24 @@ function toLocalValidationError(error: unknown): Error {
 	const message = error instanceof Error ? error.message : String(error);
 	return new Error(message.replace("skill://", "local://"));
 }
+
+/**
+ * Inline cap for `local://` text reads. `LocalProtocolHandler.resolve` returns
+ * a single in-memory string, so a 100 MB attachment would allocate 100+ MB
+ * (more for non-ASCII bytes, which UTF-8-re-encode as the 3-byte U+FFFD
+ * replacement). 10 MiB comfortably covers planning artifacts, subagent
+ * handoffs, and large generated text while keeping accidental video/archive
+ * reads from sliding the box into paging — see issue #3449.
+ */
+const LOCAL_MAX_TEXT_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Window inspected for NUL bytes before decoding. 8 KiB catches every
+ * mainstream binary container (mp4/mkv/zip/exe/png/...) and UTF-16 text
+ * (which has NULs in the ASCII range). Mirrors the same NUL sniff the plain
+ * file path applies after streaming.
+ */
+const LOCAL_BINARY_SNIFF_BYTES = 8 * 1024;
 const WINDOWS_LOCAL_ROOT_MAX_CHARS = 180;
 
 function safeSessionId(options: LocalProtocolOptions): string {
@@ -175,6 +193,24 @@ type ResolvedLocalTarget =
 	| { kind: "listing"; root: string }
 	| { kind: "directory"; path: string }
 	| { kind: "file"; path: string; size: number };
+
+/**
+ * Wrap a small notice (e.g. "binary file, refusing to decode" or "too large
+ * for inline read") in the same `InternalResource` shape `LocalProtocolHandler.resolve`
+ * returns for normal file reads. `sourcePath` is preserved so callers like
+ * `find` / `path-utils` / `bash-skill-urls` — which only need the on-disk path
+ * — keep functioning even when the file content cannot safely be inlined.
+ */
+function localNoticeResource(url: InternalUrl, sourcePath: string, content: string): InternalResource {
+	return {
+		url: url.href,
+		content,
+		contentType: "text/plain",
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath,
+		notes: [LOCAL_WRITE_NOTE],
+	};
+}
 
 /**
  * Resolve a local:// URL to its on-disk target with realpath + containment
@@ -336,7 +372,37 @@ export class LocalProtocolHandler implements ProtocolHandler {
 			return buildDirectoryResource(url.href, resolved.path, [LOCAL_WRITE_NOTE]);
 		}
 
-		const content = await Bun.file(resolved.path).text();
+		const file = Bun.file(resolved.path);
+
+		// Size guard. A single-string `InternalResource` cannot stream, so any
+		// caller that text-decodes the result would otherwise pay O(size) memory
+		// twice (raw bytes + UTF-8 mojibake). Cap before allocation; the read
+		// tool's range/streaming path on the resolved disk path remains the
+		// escape hatch for genuinely large text artifacts.
+		if (resolved.size > LOCAL_MAX_TEXT_BYTES) {
+			return localNoticeResource(
+				url,
+				resolved.path,
+				`[Cannot inline local:// file '${url.href}' (${formatBytes(resolved.size)}); exceeds ${formatBytes(LOCAL_MAX_TEXT_BYTES)} inline limit. Use the read tool with a range selector (e.g. '${url.href}:1-200') or process the file directly via its on-disk path.]`,
+			);
+		}
+
+		// Binary sniff. A NUL byte in the head window means the file is not
+		// displayable text; decoding it as UTF-8 would produce mojibake and
+		// allocate up to 3x the input size (every lone byte becomes U+FFFD).
+		const sniffEnd = Math.min(resolved.size, LOCAL_BINARY_SNIFF_BYTES);
+		if (sniffEnd > 0) {
+			const head = new Uint8Array(await file.slice(0, sniffEnd).arrayBuffer());
+			if (head.includes(0)) {
+				return localNoticeResource(
+					url,
+					resolved.path,
+					`[Cannot read binary local:// file '${url.href}' (${formatBytes(resolved.size)}); content contains NUL bytes (binary or UTF-16 encoded). This resource is not text — process the file via its on-disk path with a binary-aware workflow.]`,
+				);
+			}
+		}
+
+		const content = await file.text();
 		return {
 			url: url.href,
 			content,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -824,6 +824,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	readonly #autoResizeImages: boolean;
 	readonly #defaultLimit: number;
 	readonly #inspectImageEnabled: boolean;
+	readonly #bridgeBypassCounts = new Map<string, number>();
 
 	constructor(private readonly session: ToolSession) {
 		const displayMode = resolveFileDisplayMode(session);
@@ -1860,10 +1861,25 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 	}
 
+	async #withBridgeBypassForPath<T>(absolutePath: string, run: () => Promise<T>): Promise<T> {
+		const current = this.#bridgeBypassCounts.get(absolutePath) ?? 0;
+		this.#bridgeBypassCounts.set(absolutePath, current + 1);
+		try {
+			return await run();
+		} finally {
+			if (current === 0) {
+				this.#bridgeBypassCounts.delete(absolutePath);
+			} else {
+				this.#bridgeBypassCounts.set(absolutePath, current);
+			}
+		}
+	}
+
 	#routeReadThroughBridge(
 		absolutePath: string,
 		options?: { line?: number; limit?: number },
 	): Promise<string> | undefined {
+		if (this.#bridgeBypassCounts.has(absolutePath)) return undefined;
 		const bridge = this.session.getClientBridge?.();
 		if (!bridge?.capabilities.readTextFile || !bridge.readTextFile) return undefined;
 		return bridge.readTextFile({ path: absolutePath, ...options });
@@ -2092,12 +2108,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					skills: this.session.skills,
 				});
 				if (localFile) {
-					return this.execute(
-						_toolCallId,
-						{ path: `${localFile.path}:${internalTarget.sel}` },
-						signal,
-						_onUpdate,
-						_toolContext,
+					return this.#withBridgeBypassForPath(localFile.path, () =>
+						this.execute(
+							_toolCallId,
+							{ path: `${localFile.path}:${internalTarget.sel}` },
+							signal,
+							_onUpdate,
+							_toolContext,
+						),
 					);
 				}
 			}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2083,6 +2083,18 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					`Invalid selector ':${internalTarget.sel}' on '${internalTarget.path}'. Use :N, :N-M, :N+K, :N- (open-ended), a comma-separated list of ranges, :raw, or a range combined with raw (e.g. :raw:50-100).`,
 				);
 			}
+			if (parsed.kind === "lines" && internalTarget.path.toLowerCase().startsWith("local://")) {
+				const localFile = await resolveLocalUrlToFile(internalTarget.path, {
+					cwd: this.session.cwd,
+					settings: this.session.settings,
+					signal,
+					localProtocolOptions: this.session.localProtocolOptions,
+					skills: this.session.skills,
+				});
+				if (localFile) {
+					return this.execute(_toolCallId, { path: `${localFile.path}:${internalTarget.sel}` }, signal, _onUpdate, _toolContext);
+				}
+			}
 			return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 		}
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2092,7 +2092,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					skills: this.session.skills,
 				});
 				if (localFile) {
-					return this.execute(_toolCallId, { path: `${localFile.path}:${internalTarget.sel}` }, signal, _onUpdate, _toolContext);
+					return this.execute(
+						_toolCallId,
+						{ path: `${localFile.path}:${internalTarget.sel}` },
+						signal,
+						_onUpdate,
+						_toolContext,
+					);
 				}
 			}
 			return this.#handleInternalUrl(internalTarget.path, parsed, signal);

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -194,4 +194,74 @@ describe("LocalProtocolHandler", () => {
 			).rejects.toThrow("Local file not found: local://PLAN.md");
 		});
 	});
+
+	it("returns a notice instead of decoding a binary local file (issue #3449)", async () => {
+		await withTempDir(async tempDir => {
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const localFile = path.join(artifactsDir, "local", "attachment-1.mp4");
+			await fs.mkdir(path.dirname(localFile), { recursive: true });
+			// 1 MiB of structured non-text bytes (NUL in the head triggers the sniff).
+			const buf = Buffer.alloc(1024 * 1024);
+			for (let i = 0; i < buf.length; i += 4) {
+				buf[i] = 0xff;
+				buf[i + 1] = 0xfe;
+				buf[i + 2] = 0x00;
+				buf[i + 3] = i & 0xff;
+			}
+			await Bun.write(localFile, buf);
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "session-binary",
+			});
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("local://attachment-1.mp4");
+
+			// Notice replaces the file content; size matches the notice, not the
+			// 1 MiB source — proves the binary was never decoded into mojibake.
+			expect(resource.content).toContain("Cannot read binary local:// file");
+			expect(resource.content).toContain("local://attachment-1.mp4");
+			expect(resource.content).toContain("NUL bytes");
+			expect(resource.size).toBe(Buffer.byteLength(resource.content, "utf-8"));
+			expect(resource.size).toBeLessThan(1024);
+			// `sourcePath` stays populated so find/search/path-utils still resolve.
+			expect(resource.sourcePath).toBe(await fs.realpath(localFile));
+			expect(resource.contentType).toBe("text/plain");
+		});
+	});
+
+	it("returns a notice instead of materializing an oversized text local file (issue #3449)", async () => {
+		await withTempDir(async tempDir => {
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const localFile = path.join(artifactsDir, "local", "huge.log");
+			await fs.mkdir(path.dirname(localFile), { recursive: true });
+			// 11 MiB of plain ASCII — passes the binary sniff but trips the size cap.
+			const chunk = "a".repeat(1024);
+			const handle = await fs.open(localFile, "w");
+			try {
+				const lineBytes = Buffer.from(`${chunk}\n`, "utf-8");
+				for (let i = 0; i < 11 * 1024; i++) {
+					await handle.write(lineBytes);
+				}
+			} finally {
+				await handle.close();
+			}
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "session-large",
+			});
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("local://huge.log");
+
+			expect(resource.content).toContain("Cannot inline local:// file");
+			expect(resource.content).toContain("local://huge.log");
+			expect(resource.content).toContain("exceeds");
+			expect(resource.content).toContain("inline limit");
+			// Notice mentions a range-selector workaround so the agent knows what to try next.
+			expect(resource.content).toMatch(/local:\/\/huge\.log:1-200/);
+			expect(resource.size).toBeLessThan(1024);
+			expect(resource.sourcePath).toBe(await fs.realpath(localFile));
+		});
+	});
 });

--- a/packages/coding-agent/test/tools/read-local-range.test.ts
+++ b/packages/coding-agent/test/tools/read-local-range.test.ts
@@ -1,13 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter, LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import type { ClientBridge } from "@oh-my-pi/pi-coding-agent/session/client-bridge";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 
-function makeSession(testDir: string): ToolSession {
+function makeSession(testDir: string, bridge?: ClientBridge): ToolSession {
 	const sessionFile = path.join(testDir, "session.jsonl");
 	const artifactsDir = sessionFile.slice(0, -6);
 	return {
@@ -17,6 +18,7 @@ function makeSession(testDir: string): ToolSession {
 		getArtifactsDir: () => artifactsDir,
 		getSessionSpawns: () => null,
 		settings: Settings.isolated({ "images.autoResize": false }),
+		getClientBridge: bridge ? () => bridge : undefined,
 	} as unknown as ToolSession;
 }
 
@@ -25,6 +27,18 @@ function joinText(content: Array<{ type: string; text?: string }>): string {
 		.filter(c => c.type === "text")
 		.map(c => c.text ?? "")
 		.join("\n");
+}
+
+async function writeOversizedLog(localFile: string): Promise<void> {
+	const filler = "x".repeat(1000);
+	const handle = await fs.open(localFile, "w");
+	try {
+		for (let i = 1; i <= 11 * 1024; i++) {
+			await handle.write(`line-${i.toString().padStart(5, "0")} ${filler}\n`);
+		}
+	} finally {
+		await handle.close();
+	}
 }
 
 describe("read local:// ranges", () => {
@@ -52,15 +66,7 @@ describe("read local:// ranges", () => {
 
 	it("streams ranged reads from oversized local text files", async () => {
 		const localFile = path.join(localRoot, "huge.log");
-		const filler = "x".repeat(1000);
-		const handle = await fs.open(localFile, "w");
-		try {
-			for (let i = 1; i <= 11 * 1024; i++) {
-				await handle.write(`line-${i.toString().padStart(5, "0")} ${filler}\n`);
-			}
-		} finally {
-			await handle.close();
-		}
+		await writeOversizedLog(localFile);
 		const tool = new ReadTool(makeSession(testDir));
 
 		const result = await tool.execute("call", { path: "local://huge.log:3-5" });
@@ -70,5 +76,23 @@ describe("read local:// ranges", () => {
 		expect(text).toContain("line-00003");
 		expect(text).toContain("line-00005");
 		expect(text).not.toContain("line-00100");
+	});
+
+	it("bypasses the client bridge for resolved oversized local ranges", async () => {
+		const localFile = path.join(localRoot, "huge.log");
+		await writeOversizedLog(localFile);
+		const bridge: ClientBridge = {
+			capabilities: { readTextFile: true },
+			readTextFile: async () => "bridge materialized the whole file",
+		};
+		const bridgeSpy = spyOn(bridge, "readTextFile");
+		const tool = new ReadTool(makeSession(testDir, bridge));
+
+		const result = await tool.execute("call", { path: "local://huge.log:3-5" });
+		const text = joinText(result.content);
+
+		expect(bridgeSpy).not.toHaveBeenCalled();
+		expect(text).toContain("line-00003");
+		expect(text).not.toContain("bridge materialized");
 	});
 });

--- a/packages/coding-agent/test/tools/read-local-range.test.ts
+++ b/packages/coding-agent/test/tools/read-local-range.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InternalUrlRouter, LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+
+function makeSession(testDir: string): ToolSession {
+	const sessionFile = path.join(testDir, "session.jsonl");
+	const artifactsDir = sessionFile.slice(0, -6);
+	return {
+		cwd: testDir,
+		hasUI: false,
+		getSessionFile: () => sessionFile,
+		getArtifactsDir: () => artifactsDir,
+		getSessionSpawns: () => null,
+		settings: Settings.isolated({ "images.autoResize": false }),
+	} as unknown as ToolSession;
+}
+
+function joinText(content: Array<{ type: string; text?: string }>): string {
+	return content
+		.filter(c => c.type === "text")
+		.map(c => c.text ?? "")
+		.join("\n");
+}
+
+describe("read local:// ranges", () => {
+	let testDir: string;
+	let localRoot: string;
+
+	beforeEach(async () => {
+		LocalProtocolHandler.resetOverrideForTests();
+		InternalUrlRouter.resetForTests();
+		testDir = await fs.mkdtemp(path.join(os.tmpdir(), "read-local-range-"));
+		const artifactsDir = path.join(testDir, "artifacts");
+		localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(localRoot, { recursive: true });
+		LocalProtocolHandler.setOverride({
+			getArtifactsDir: () => artifactsDir,
+			getSessionId: () => "session-local-range",
+		});
+	});
+
+	afterEach(async () => {
+		LocalProtocolHandler.resetOverrideForTests();
+		InternalUrlRouter.resetForTests();
+		await fs.rm(testDir, { recursive: true, force: true });
+	});
+
+	it("streams ranged reads from oversized local text files", async () => {
+		const localFile = path.join(localRoot, "huge.log");
+		const filler = "x".repeat(1000);
+		const handle = await fs.open(localFile, "w");
+		try {
+			for (let i = 1; i <= 11 * 1024; i++) {
+				await handle.write(`line-${i.toString().padStart(5, "0")} ${filler}\n`);
+			}
+		} finally {
+			await handle.close();
+		}
+		const tool = new ReadTool(makeSession(testDir));
+
+		const result = await tool.execute("call", { path: "local://huge.log:3-5" });
+		const text = joinText(result.content);
+
+		expect(text).not.toContain("Cannot inline local:// file");
+		expect(text).toContain("line-00003");
+		expect(text).toContain("line-00005");
+		expect(text).not.toContain("line-00100");
+	});
+});


### PR DESCRIPTION
## Repro

Resolve a binary `local://` attachment through `InternalUrlRouter` (the path the read tool takes for `local://*` URLs). A 32 MiB fake `.mp4` already shows the issue:

```
resolvedSize         49_676_285 bytes   ← larger than the 32 MiB source
contentLengthChars   16_777_215
firstChars           "\u0000\uFEFF\u0400\uFEFF\u0800..."  ← NUL + BOM + replacement glyphs
heapDelta            +13.4 MiB          ← from .text() alone
rssDelta             +63.9 MiB
```

The resource is `text/plain` mojibake larger than the input — every lone byte becomes the 3-byte U+FFFD replacement during UTF-8 re-encoding. Real 100+ MiB videos scale this to hundreds of MB of allocation, matching the reported Windows hang.

## Cause

`packages/coding-agent/src/internal-urls/local-protocol.ts`'s `LocalProtocolHandler.resolve` called `Bun.file(resolved.path).text()` unconditionally before any binary or size guard ran. The read tool's plain-file branch already sniffs for NUL bytes and applies streaming + size limits; the `local://` branch bypassed all of that.

## Fix

- `LocalProtocolHandler.resolve` now sniffs the first 8 KiB for NUL bytes (mirrors the plain-file read's binary check) and returns a clear notice instead of decoding binary content.
- Caps inline text resources at 10 MiB so a single oversized log can't allocate the whole file twice; the notice points the agent at the read tool's range selector (`local://huge.log:1-200`) for the legitimate large-text case.
- New `localNoticeResource()` helper keeps `sourcePath` populated, so callers that only need the on-disk path (`find`, `search`, `path-utils`, bash `local://` expansion) keep working without inspecting the content.
- Updated `packages/coding-agent/CHANGELOG.md` `[Unreleased]`.

## Verification

- `bun test test/internal-urls/local-protocol.test.ts` — 10 pass (8 existing + 2 new: binary sniff + oversize guard, both asserting the notice content, the small `size` field, and that `sourcePath` survives).
- `bun test test/internal-urls/` — 87 pass, 0 fail.
- `bun run check` — passed.
- Manual repro post-fix: `router.resolve("local://attachment-1.mp4")` returns a 226-byte notice, 0 MB heap delta, 0 MB RSS delta (vs +13 MiB / +63 MiB before).

Fixes #3449
