### PR TITLE
fix(tui): make pasted file path attachments optional

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `skill://` tool resolution losing loaded session skills when a tool runs outside the session-initialization module state. Internal URL resolution now prefers the caller's `session.skills` snapshot before falling back to the process-global skill list, so `read skill://<name>` works across tool execution boundaries. ([#3436](https://github.com/can1357/oh-my-pi/issues/3436))
+- Fixed bracketed pasted file paths always being auto-attached; they now stay as source paths by default, with `paste.autoAttachFilePaths` restoring image attachment and non-image `local://attachment-*` copies for users who want them. The gate lives in `CustomEditor.shouldInterceptPathPaste` so pastes fall through to the editor's normal text handling — original separators and shell escaping (e.g. `src/a.ts src/b.ts`, `/tmp/my\ file.txt`) are preserved instead of being replayed as normalized single tokens. ([#3452](https://github.com/can1357/oh-my-pi/issues/3452))
 
 ## [16.1.18] - 2026-06-25
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1385,6 +1385,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"paste.autoAttachFilePaths": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Auto-Attach Pasted File Paths",
+			description:
+				"When bracketed paste contains an explicit file path, attach image paths or copy non-image files to local:// instead of pasting the original path.",
+		},
+	},
+
 	"startup.quiet": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -103,6 +103,26 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(await pasted.promise).toBe("/tmp/report.csv");
 		expect(editor.getText()).toBe("");
 	});
+
+	it("skips path hooks and preserves raw paste bytes when interception is disabled", () => {
+		const { editor } = makeEditor();
+		const fileHook = vi.fn();
+		const imageHook = vi.fn();
+		editor.onPasteFilePath = fileHook;
+		editor.onPasteImagePath = imageHook;
+		editor.shouldInterceptPathPaste = () => false;
+
+		// Multi-path + shell-escaped-space payloads that the parser would otherwise
+		// normalize into segments — the regressions Codex flagged in #3453.
+		editor.handleInput(bracketedPaste("src/a.ts src/b.ts"));
+		editor.handleInput(bracketedPaste("/tmp/my\\ file.txt"));
+
+		expect(fileHook).not.toHaveBeenCalled();
+		expect(imageHook).not.toHaveBeenCalled();
+		const text = editor.getText();
+		expect(text).toContain("src/a.ts src/b.ts");
+		expect(text).toContain("/tmp/my\\ file.txt");
+	});
 });
 
 describe("CustomEditor space-hold push-to-talk", () => {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -320,6 +320,15 @@ export class CustomEditor extends Editor {
 	onPasteImagePath?: (path: string) => void | Promise<void>;
 	/** Called when a bracketed paste contains one or more non-image file paths. */
 	onPasteFilePath?: (path: string) => void | Promise<void>;
+	/**
+	 * Gate for the bracketed pasted-path interception above. Returning `false`
+	 * skips path parsing entirely and lets the raw paste flow through to the
+	 * editor's normal text-paste handling — original separators and shell
+	 * escaping are preserved, and `onPasteImagePath`/`onPasteFilePath` are not
+	 * invoked. Left undefined = intercept whenever a hook is set (the
+	 * historical default that #3384 introduced).
+	 */
+	shouldInterceptPathPaste?: () => boolean;
 	/** Called when the configured raw text-paste shortcut is pressed. */
 	onPasteTextRaw?: () => void;
 	/** Called when the configured dequeue shortcut is pressed. */
@@ -505,19 +514,21 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		const pastedPaths = extractBracketedPastePaths(data);
-		if (pastedPaths) {
-			const canHandlePaths = pastedPaths.every(path =>
-				isImagePath(path) ? this.onPasteImagePath !== undefined : this.onPasteFilePath !== undefined,
-			);
-			if (canHandlePaths) {
-				void (async () => {
-					for (const path of pastedPaths) {
-						if (isImagePath(path)) await this.onPasteImagePath?.(path);
-						else await this.onPasteFilePath?.(path);
-					}
-				})();
-				return;
+		if (this.shouldInterceptPathPaste?.() !== false) {
+			const pastedPaths = extractBracketedPastePaths(data);
+			if (pastedPaths) {
+				const canHandlePaths = pastedPaths.every(path =>
+					isImagePath(path) ? this.onPasteImagePath !== undefined : this.onPasteFilePath !== undefined,
+				);
+				if (canHandlePaths) {
+					void (async () => {
+						for (const path of pastedPaths) {
+							if (isImagePath(path)) await this.onPasteImagePath?.(path);
+							else await this.onPasteFilePath?.(path);
+						}
+					})();
+					return;
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -393,6 +393,7 @@ export class InputController {
 		this.ctx.editor.onPasteImage = () => this.handleImagePaste();
 		this.ctx.editor.onPasteImagePath = path => this.handleImagePathPaste(path);
 		this.ctx.editor.onPasteFilePath = path => this.handleFilePathPaste(path);
+		this.ctx.editor.shouldInterceptPathPaste = () => this.ctx.settings.get("paste.autoAttachFilePaths");
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.pasteTextRaw",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteTextRaw"),
@@ -1262,6 +1263,12 @@ export class InputController {
 	}
 
 	async handleFilePathPaste(filePath: string): Promise<void> {
+		if (!this.ctx.settings.get("paste.autoAttachFilePaths")) {
+			this.ctx.editor.pasteText(filePath);
+			this.ctx.ui.requestRender();
+			return;
+		}
+
 		try {
 			const resolvedPath = resolvePastedFilePath(filePath, this.ctx.sessionManager.getCwd());
 			const stat = await Bun.file(resolvedPath).stat();
@@ -1293,6 +1300,12 @@ export class InputController {
 	}
 
 	async handleImagePathPaste(path: string): Promise<void> {
+		if (!this.ctx.settings.get("paste.autoAttachFilePaths")) {
+			this.ctx.editor.pasteText(path);
+			this.ctx.ui.requestRender();
+			return;
+		}
+
 		try {
 			const image = await loadImageInput({
 				path,

--- a/packages/coding-agent/test/input-controller-large-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-large-paste.test.ts
@@ -12,7 +12,12 @@ import * as path from "node:path";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
-function createContext(options?: { threshold?: number; choice?: string; artifactsDir?: string }) {
+function createContext(options?: {
+	threshold?: number;
+	choice?: string;
+	artifactsDir?: string;
+	autoAttachFilePaths?: boolean;
+}) {
 	const insertPaste = vi.fn();
 	const insertText = vi.fn();
 	const pasteText = vi.fn();
@@ -20,10 +25,15 @@ function createContext(options?: { threshold?: number; choice?: string; artifact
 	const showStatus = vi.fn();
 	const showError = vi.fn();
 	const showHookSelector = vi.fn(async (_title: string, _options: unknown, _dialog?: unknown) => options?.choice);
+	const getSetting = vi.fn((key: string) => {
+		if (key === "paste.largeMenuThreshold") return options?.threshold ?? 100;
+		if (key === "paste.autoAttachFilePaths") return options?.autoAttachFilePaths ?? false;
+		return undefined;
+	});
 	const ctx = {
 		editor: { insertPaste, insertText, pasteText } as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
-		settings: { get: () => options?.threshold ?? 100 } as unknown as InteractiveModeContext["settings"],
+		settings: { get: getSetting } as unknown as InteractiveModeContext["settings"],
 		sessionManager: {
 			getCwd: () => process.cwd(),
 			getArtifactsDir: () => options?.artifactsDir ?? null,
@@ -36,7 +46,7 @@ function createContext(options?: { threshold?: number; choice?: string; artifact
 	const controller = new InputController(ctx);
 	return {
 		controller,
-		spies: { insertPaste, insertText, pasteText, requestRender, showStatus, showError, showHookSelector },
+		spies: { insertPaste, insertText, pasteText, requestRender, showStatus, showError, showHookSelector, getSetting },
 	};
 }
 
@@ -150,12 +160,31 @@ describe("InputController.presentLargePasteMenu file attachment", () => {
 		expect(await Bun.file(path.join(dir, "local", "attachment-2")).text()).toBe("fresh");
 	});
 
-	it("attaches an existing pasted file as a local:// reference with its extension", async () => {
+	it("pastes an existing file path inline by default", async () => {
 		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-paste-test-"));
 		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-paste-source-"));
 		const sourcePath = path.join(sourceDir, "report.csv");
 		await Bun.write(sourcePath, "name,value\nalpha,1\n");
 		const { controller, spies } = createContext({ artifactsDir: dir });
+
+		try {
+			await controller.handleFilePathPaste(sourcePath);
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+
+		expect(spies.pasteText).toHaveBeenCalledWith(sourcePath);
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.requestRender).toHaveBeenCalled();
+		expect(await Bun.file(path.join(dir, "local", "attachment-1.csv")).exists()).toBe(false);
+	});
+
+	it("attaches an existing pasted file as a local:// reference when enabled", async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-paste-test-"));
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-paste-source-"));
+		const sourcePath = path.join(sourceDir, "report.csv");
+		await Bun.write(sourcePath, "name,value\nalpha,1\n");
+		const { controller, spies } = createContext({ artifactsDir: dir, autoAttachFilePaths: true });
 
 		try {
 			await controller.handleFilePathPaste(sourcePath);
@@ -173,7 +202,7 @@ describe("InputController.presentLargePasteMenu file attachment", () => {
 	it("falls back to inline text when the pasted file path does not exist", async () => {
 		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-paste-test-"));
 		const missing = path.join(dir, "missing.txt");
-		const { controller, spies } = createContext({ artifactsDir: dir });
+		const { controller, spies } = createContext({ artifactsDir: dir, autoAttachFilePaths: true });
 
 		await controller.handleFilePathPaste(missing);
 

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -36,7 +36,7 @@ const ONE_PX_PNG = Buffer.from(
 	"base64",
 );
 
-function createContext() {
+function createContext(options?: { autoAttachFilePaths?: boolean }) {
 	const pasteText = vi.fn();
 	const insertText = vi.fn();
 	const requestRender = vi.fn();
@@ -54,6 +54,12 @@ function createContext() {
 			getCwd: () => process.cwd(),
 			putBlob: async () => ({ hash: "h", path: "/tmp/h.png", displayPath: "/tmp/h.png" }),
 		} as unknown as InteractiveModeContext["sessionManager"],
+		settings: {
+			get: (key: string) => {
+				if (key === "paste.autoAttachFilePaths") return options?.autoAttachFilePaths ?? true;
+				return undefined;
+			},
+		} as unknown as InteractiveModeContext["settings"],
 		showStatus,
 	} as unknown as InteractiveModeContext;
 	return { ctx, spies: { pasteText, insertText, requestRender, showStatus } };
@@ -81,6 +87,19 @@ describe("InputController.handleImagePathPaste (issue #2375)", () => {
 		else process.env.SSH_CLIENT = originalSshClient;
 		resetSettingsForTest();
 		vi.restoreAllMocks();
+	});
+
+	it("pastes image paths inline when auto-attach is disabled", async () => {
+		const { ctx, spies } = createContext({ autoAttachFilePaths: false });
+		const controller = new InputController(ctx, EMPTY_CLIPBOARD);
+		const figure = "/tmp/figure.png";
+
+		await controller.handleImagePathPaste(figure);
+
+		expect(spies.pasteText).toHaveBeenCalledWith(figure);
+		expect(spies.requestRender).toHaveBeenCalled();
+		expect(spies.showStatus).not.toHaveBeenCalled();
+		expect(ctx.editor.pendingImages.length).toBe(0);
 	});
 
 	it("over SSH: never pastes the unreachable path as text and surfaces an SSH-aware status", async () => {


### PR DESCRIPTION
## Repro
A bracketed-paste non-image file path currently routes through `InputController.handleFilePathPaste`; `bun --cwd=packages/collab-web run build:tool-views` followed by `bun test packages/coding-agent/test/input-controller-large-paste.test.ts --test-name-pattern "attaches an existing pasted file"` showed the existing behavior inserts `local://attachment-1.csv ` and copies the source file into the session local root.

## Cause
`packages/coding-agent/src/modes/components/custom-editor.ts` routes explicit bracketed-pasted non-image paths to `InputController.handleFilePathPaste`, and `packages/coding-agent/src/modes/controllers/input-controller.ts` unconditionally attached any existing regular file via `#attachExistingFileAsLocal`; there was no setting gate, so pasting a source path stopped preserving the editable source path.

## Fix
- Added `paste.autoAttachFilePaths` in `packages/coding-agent/src/config/settings-schema.ts`, defaulting to `false`.
- Made `InputController.handleFilePathPaste` paste the original path inline unless that setting is enabled.
- Updated paste tests to cover default inline behavior, opt-in `local://attachment-*` behavior, and missing-file fallback under the enabled path.
- Added the `packages/coding-agent` changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/input-controller-large-paste.test.ts` → 13 pass, 0 fail. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #3452