### PR TITLE
fix(tui): queue image-only streaming submissions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed image-only composer submissions while the agent is streaming being treated as empty input, which dropped the image or aborted the active turn when another message was queued. Pending pasted images now count as submit content for Enter and Ctrl+Enter follow-ups. ([#3467](https://github.com/can1357/oh-my-pi/issues/3467))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -534,6 +534,7 @@ export class InputController {
 	setupEditorSubmitHandler(): void {
 		this.ctx.editor.onSubmit = async (text: string) => {
 			text = text.trim();
+			const hasPendingImages = this.ctx.editor.pendingImages.length > 0;
 			if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 
 			// Focused subagent session: the editor is a plain chat box for it.
@@ -546,7 +547,7 @@ export class InputController {
 
 			// Empty submit while streaming with queued messages: abort the active
 			// turn and let the post-unwind drain deliver the agent-core queue.
-			if (!text && this.ctx.session.isStreaming) {
+			if (!text && !hasPendingImages && this.ctx.session.isStreaming) {
 				if (this.ctx.session.queuedMessageCount > 0) {
 					const aborting = this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
 					await aborting;
@@ -556,7 +557,7 @@ export class InputController {
 				return;
 			}
 
-			if (!text) return;
+			if (!text && !hasPendingImages) return;
 
 			// Continue shortcuts: "." or "c" resume the agent with a hidden agent-authored
 			// developer directive (no visible user message) instead of an empty turn, so the
@@ -579,6 +580,7 @@ export class InputController {
 			let inputImages = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 			let inputImageLinks =
 				this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
+			let hasInputImages = (inputImages?.length ?? 0) > 0;
 
 			if (runner?.hasHandlers("input")) {
 				const result = await runner.emitInput(text, inputImages, "interactive");
@@ -596,24 +598,27 @@ export class InputController {
 						this.ctx.sessionManager.putBlob.bind(this.ctx.sessionManager),
 					);
 				}
+				hasInputImages = (inputImages?.length ?? 0) > 0;
 			}
 
-			if (!text) return;
+			if (!text && !hasInputImages) return;
 
 			// Handle built-in slash commands
-			const slashResult = await executeBuiltinSlashCommand(text, {
-				ctx: this.ctx,
-			});
-			if (slashResult === true) {
-				if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
-				return;
-			}
-			if (typeof slashResult === "string") {
-				// Command handled but returned remaining text to use as prompt.
-				// Record the original slash command text so Up Arrow recalls
-				// "/loop 10 fix bug" rather than just "fix bug".
-				if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
-				text = slashResult;
+			if (text) {
+				const slashResult = await executeBuiltinSlashCommand(text, {
+					ctx: this.ctx,
+				});
+				if (slashResult === true) {
+					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
+					return;
+				}
+				if (typeof slashResult === "string") {
+					// Command handled but returned remaining text to use as prompt.
+					// Record the original slash command text so Up Arrow recalls
+					// "/loop 10 fix bug" rather than just "fix bug".
+					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
+					text = slashResult;
+				}
 			}
 
 			// Collab guest: prompts execute on the host; local slash/skill/bash/
@@ -647,7 +652,7 @@ export class InputController {
 			// free-text Enter semantics applied a few lines below at the streaming
 			// branch). Ctrl+Enter routes through `handleFollowUp` and dispatches the
 			// same helper with `"followUp"`.
-			if (await this.#invokeSkillCommand(text, "steer")) {
+			if (text && (await this.#invokeSkillCommand(text, "steer"))) {
 				return;
 			}
 
@@ -833,7 +838,8 @@ export class InputController {
 	/** Submit editor text to the focused subagent session (chat-only focus policy). */
 	async #submitToFocusedSession(text: string, streamingBehavior: "steer" | "followUp"): Promise<void> {
 		const target = this.ctx.viewSession;
-		if (!text) {
+		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
+		if (!text && !images) {
 			if (target.isStreaming && target.queuedMessageCount > 0) {
 				const aborting = target.abort({ reason: USER_INTERRUPT_LABEL });
 				await aborting;
@@ -842,11 +848,10 @@ export class InputController {
 			}
 			return;
 		}
-		if (text.startsWith("/") || text.startsWith("!") || parsePythonCommandInput(text)) {
+		if (text && (text.startsWith("/") || text.startsWith("!") || parsePythonCommandInput(text))) {
 			this.ctx.showStatus("Commands run in the main session — press ←← to return first");
 			return; // editor text not cleared: Editor does not auto-clear on submit
 		}
-		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 		this.ctx.editor.clearDraft(text);
 		try {
 			// prompt() handles idle (new turn) and streaming (queues per streamingBehavior).
@@ -1024,7 +1029,8 @@ export class InputController {
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
 		let text = this.ctx.editor.getText().trim();
-		if (!text) return;
+		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
+		if (!text && !images) return;
 
 		// Focused subagent session: follow-ups go to it; non-chat input is gated.
 		if (this.ctx.focusedAgentId) {
@@ -1044,30 +1050,28 @@ export class InputController {
 			return;
 		}
 
-		const slashResult = await executeBuiltinSlashCommand(text, {
-			ctx: this.ctx,
-		});
-		if (slashResult === true) {
-			if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
-			return;
-		}
-		if (typeof slashResult === "string") {
-			// Command handled but returned remaining text to use as prompt.
-			// Record the original slash command text so Up Arrow recalls it.
-			if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
-			text = slashResult;
+		if (text) {
+			const slashResult = await executeBuiltinSlashCommand(text, {
+				ctx: this.ctx,
+			});
+			if (slashResult === true) {
+				if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
+				return;
+			}
+			if (typeof slashResult === "string") {
+				// Command handled but returned remaining text to use as prompt.
+				// Record the original slash command text so Up Arrow recalls it.
+				if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
+				text = slashResult;
+			}
 		}
 
 		// Skill commands invoke through the custom-message path regardless of
 		// which keybinding submitted them. Enter routes them as `steer`;
 		// Ctrl+Enter (this handler) routes them as `followUp`.
-		if (await this.#invokeSkillCommand(text, "followUp")) {
+		if (text && (await this.#invokeSkillCommand(text, "followUp"))) {
 			return;
 		}
-
-		// Forward any pending clipboard-pasted images alongside the queued text;
-		// otherwise the follow-up would drop the image (mirrors the Enter/steer path).
-		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.clearDraft(text);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -719,11 +719,25 @@ export class InputController {
 				// (a user-role `message_start` event) leaves any draft the user has
 				// typed since queuing intact. Same protection as #783, applied to
 				// the streaming/queue path.
-				await this.ctx.withLocalSubmission(
-					text,
-					() => this.ctx.session.prompt(text, { streamingBehavior: "steer", images }),
-					{ imageCount: images?.length ?? 0 },
-				);
+				try {
+					await this.ctx.withLocalSubmission(
+						text,
+						() => this.ctx.session.prompt(text, { streamingBehavior: "steer", images }),
+						{ imageCount: images?.length ?? 0 },
+					);
+				} catch (error) {
+					// Don't lose the queued steer draft: restore text and images so
+					// the user can retry after dispatch validation/queue failures.
+					this.ctx.editor.setText(text);
+					if (images && images.length > 0) {
+						this.ctx.editor.pendingImages = [...images];
+						this.ctx.editor.pendingImageLinks = inputImageLinks
+							? [...inputImageLinks]
+							: images.map(() => undefined);
+						this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
+					}
+					this.ctx.showError(error instanceof Error ? error.message : String(error));
+				}
 				this.ctx.updatePendingMessagesDisplay();
 				this.ctx.ui.requestRender();
 				return;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1039,6 +1039,8 @@ export class InputController {
 	async handleFollowUp(): Promise<void> {
 		let text = this.ctx.editor.getText().trim();
 		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
+		const imageLinks =
+			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
 		if (!text && !images) return;
 
 		// Focused subagent session: follow-ups go to it; non-chat input is gated.
@@ -1082,13 +1084,30 @@ export class InputController {
 			return;
 		}
 
+		// Hand the message back on dispatch failure (model/API-key validation,
+		// queue rejection): restore both text AND pending images so an image-only
+		// or text+image draft can be retried, mirroring the main submit error path.
+		const restoreOnError = (error: unknown) => {
+			this.ctx.editor.setText(text);
+			if (images && images.length > 0) {
+				this.ctx.editor.pendingImages = [...images];
+				this.ctx.editor.pendingImageLinks = imageLinks ? [...imageLinks] : images.map(() => undefined);
+				this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
+			}
+			this.ctx.showError(error instanceof Error ? error.message : String(error));
+		};
+
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.clearDraft(text);
-			await this.ctx.withLocalSubmission(
-				text,
-				() => this.ctx.session.prompt(text, { streamingBehavior: "followUp", images }),
-				{ imageCount: images?.length ?? 0 },
-			);
+			try {
+				await this.ctx.withLocalSubmission(
+					text,
+					() => this.ctx.session.prompt(text, { streamingBehavior: "followUp", images }),
+					{ imageCount: images?.length ?? 0 },
+				);
+			} catch (error) {
+				restoreOnError(error);
+			}
 			this.ctx.updatePendingMessagesDisplay();
 			this.ctx.ui.requestRender();
 			return;
@@ -1096,9 +1115,13 @@ export class InputController {
 
 		// Not streaming — just submit normally
 		this.ctx.editor.clearDraft(text);
-		await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, { images }), {
-			imageCount: images?.length ?? 0,
-		});
+		try {
+			await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, { images }), {
+				imageCount: images?.length ?? 0,
+			});
+		} catch (error) {
+			restoreOnError(error);
+		}
 	}
 
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -839,6 +839,8 @@ export class InputController {
 	async #submitToFocusedSession(text: string, streamingBehavior: "steer" | "followUp"): Promise<void> {
 		const target = this.ctx.viewSession;
 		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
+		const imageLinks =
+			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
 		if (!text && !images) {
 			if (target.isStreaming && target.queuedMessageCount > 0) {
 				const aborting = target.abort({ reason: USER_INTERRUPT_LABEL });
@@ -859,7 +861,14 @@ export class InputController {
 				imageCount: images?.length ?? 0,
 			});
 		} catch (error) {
-			this.ctx.editor.setText(text); // hand the message back, mirroring the main submit error path
+			// Hand the message back, mirroring the main submit error path: restore
+			// pasted images so the user can retry an image-only or text+image draft.
+			this.ctx.editor.setText(text);
+			if (images && images.length > 0) {
+				this.ctx.editor.pendingImages = [...images];
+				this.ctx.editor.pendingImageLinks = imageLinks ? [...imageLinks] : images.map(() => undefined);
+				this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
+			}
 			this.ctx.showError(error instanceof Error ? error.message : String(error));
 		}
 		this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/test/input-controller-focused-submit-restore.test.ts
+++ b/packages/coding-agent/test/input-controller-focused-submit-restore.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression: when an image-only or text+image submission is delivered to a
+ * focused subagent (`#submitToFocusedSession`) and `viewSession.prompt`
+ * rejects, the controller must restore both `text` AND `pendingImages` /
+ * `pendingImageLinks`. Previously only `text` was handed back, so the pasted
+ * image silently disappeared from the composer on retry.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createContext(opts: { pendingImages: ImageContent[]; pendingImageLinks?: (string | undefined)[] }) {
+	let editorText = "";
+	const prompt = vi.fn(async () => {
+		throw new Error("focused dispatch rejected");
+	});
+	const showError = vi.fn();
+	const updatePendingMessagesDisplay = vi.fn();
+	const requestRender = vi.fn();
+
+	const editor = {
+		setText(text: string) {
+			editorText = text;
+		},
+		getText() {
+			return editorText;
+		},
+		addToHistory: vi.fn(),
+		imageLinks: undefined as (string | undefined)[] | undefined,
+		pendingImages: [...opts.pendingImages],
+		pendingImageLinks:
+			opts.pendingImageLinks !== undefined ? [...opts.pendingImageLinks] : opts.pendingImages.map(() => undefined),
+		clearDraft(historyText?: string) {
+			if (historyText !== undefined) this.addToHistory(historyText);
+			editorText = "";
+			this.imageLinks = undefined;
+			this.pendingImages = [];
+			this.pendingImageLinks = [];
+		},
+	};
+
+	const ctx = {
+		editor,
+		ui: { requestRender },
+		session: { isStreaming: true, isCompacting: false, extensionRunner: undefined, queuedMessageCount: 0 },
+		viewSession: { isStreaming: true, queuedMessageCount: 0, prompt, abort: vi.fn(async () => {}) },
+		focusedAgentId: "Worker",
+		compactionQueuedMessages: [],
+		locallySubmittedUserSignatures: new Set<string>(),
+		showError,
+		updatePendingMessagesDisplay,
+		withLocalSubmission: async <T>(_text: string, fn: () => Promise<T>) => fn(),
+	} as unknown as InteractiveModeContext;
+
+	return { ctx, editor, prompt, showError };
+}
+
+describe("InputController focused submit restore-on-error", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("restores text and pending images when focused prompt rejects", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, editor, prompt, showError } = createContext({
+			pendingImages: [image],
+			pendingImageLinks: ["local://draft.png"],
+		});
+		editor.setText("look at this");
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		await ctx.editor.onSubmit?.("look at this");
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(showError).toHaveBeenCalledWith("focused dispatch rejected");
+		expect(editor.getText()).toBe("look at this");
+		expect(ctx.editor.pendingImages).toEqual([image]);
+		expect(ctx.editor.pendingImageLinks).toEqual(["local://draft.png"]);
+		expect(ctx.editor.imageLinks).toEqual(["local://draft.png"]);
+	});
+
+	it("restores image-only drafts when focused prompt rejects", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, editor, prompt, showError } = createContext({ pendingImages: [image] });
+		editor.setText("");
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		await ctx.editor.onSubmit?.("");
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(showError).toHaveBeenCalledWith("focused dispatch rejected");
+		expect(editor.getText()).toBe("");
+		expect(ctx.editor.pendingImages).toEqual([image]);
+		expect(ctx.editor.pendingImageLinks).toEqual([undefined]);
+		expect(ctx.editor.imageLinks).toEqual([undefined]);
+	});
+});

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -95,6 +95,23 @@ describe("InputController.handleFollowUp image forwarding", () => {
 		expect(ctx.editor.pendingImageLinks).toEqual([]);
 	});
 
+	it("queues image-only follow-ups while streaming", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, editor, prompt } = createContext({ isStreaming: true, pendingImages: [image] });
+
+		const controller = new InputController(ctx);
+		editor.setText("");
+		await controller.handleFollowUp();
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		const call = prompt.mock.calls[0];
+		if (!call) throw new Error("expected session.prompt to be called");
+		expect(call[0]).toBe("");
+		expect(call[1]?.streamingBehavior).toBe("followUp");
+		expect(call[1]?.images).toEqual([image]);
+		expect(ctx.editor.pendingImages).toEqual([]);
+	});
+
 	it("forwards pending images when not streaming", async () => {
 		const image: ImageContent = { type: "image", mimeType: "image/png", data: "d29ybGQ=" };
 		const { ctx, editor, prompt } = createContext({ isStreaming: false, pendingImages: [image] });

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -51,6 +51,7 @@ function createContext(opts: {
 	const prompt = vi.fn(async (_text: string, _options?: PromptOptionsLike) => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
+	const showError = vi.fn();
 
 	const ctx = {
 		editor,
@@ -68,11 +69,11 @@ function createContext(opts: {
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 		updatePendingMessagesDisplay,
-		showError: vi.fn(),
+		showError,
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, prompt, showError: ctx.showError as ReturnType<typeof vi.fn> };
+	return { ctx, editor, prompt, showError };
 }
 
 describe("InputController.handleFollowUp image forwarding", () => {

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -24,7 +24,11 @@ interface PromptOptionsLike {
 	images?: ImageContent[];
 }
 
-function createContext(opts: { isStreaming: boolean; pendingImages: ImageContent[] }) {
+function createContext(opts: {
+	isStreaming: boolean;
+	pendingImages: ImageContent[];
+	pendingImageLinks?: (string | undefined)[];
+}) {
 	let editorText = "";
 	const editor: StubEditor = {
 		setText(text) {
@@ -35,7 +39,7 @@ function createContext(opts: { isStreaming: boolean; pendingImages: ImageContent
 		},
 		addToHistory: vi.fn(),
 		pendingImages: opts.pendingImages,
-		pendingImageLinks: opts.pendingImages.map(() => undefined),
+		pendingImageLinks: opts.pendingImageLinks ? [...opts.pendingImageLinks] : opts.pendingImages.map(() => undefined),
 		clearDraft(text?: string) {
 			if (text !== undefined) this.addToHistory(text);
 			this.setText("");
@@ -64,10 +68,11 @@ function createContext(opts: { isStreaming: boolean; pendingImages: ImageContent
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 		updatePendingMessagesDisplay,
+		showError: vi.fn(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, prompt };
+	return { ctx, editor, prompt, showError: ctx.showError as ReturnType<typeof vi.fn> };
 }
 
 describe("InputController.handleFollowUp image forwarding", () => {
@@ -140,5 +145,48 @@ describe("InputController.handleFollowUp image forwarding", () => {
 		if (!call) throw new Error("expected session.prompt to be called");
 		expect(call[1]?.images).toBeUndefined();
 		expect(call[1]?.streamingBehavior).toBe("followUp");
+	});
+
+	it("restores text and pending images when streaming follow-up dispatch rejects", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aGVsbG8=" };
+		const { ctx, editor, prompt, showError } = createContext({
+			isStreaming: true,
+			pendingImages: [image],
+			pendingImageLinks: ["local://draft.png"],
+		});
+		prompt.mockImplementationOnce(async () => {
+			throw new Error("queue rejected");
+		});
+
+		const controller = new InputController(ctx);
+		editor.setText("[Image #1] look at this");
+		await controller.handleFollowUp();
+
+		expect(showError).toHaveBeenCalledWith("queue rejected");
+		expect(editor.getText()).toBe("[Image #1] look at this");
+		expect(ctx.editor.pendingImages).toEqual([image]);
+		expect(ctx.editor.pendingImageLinks).toEqual(["local://draft.png"]);
+		expect(ctx.editor.imageLinks).toEqual(["local://draft.png"]);
+	});
+
+	it("restores image-only follow-ups when idle dispatch rejects", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, editor, prompt, showError } = createContext({
+			isStreaming: false,
+			pendingImages: [image],
+		});
+		prompt.mockImplementationOnce(async () => {
+			throw new Error("model not configured");
+		});
+
+		const controller = new InputController(ctx);
+		editor.setText("");
+		await controller.handleFollowUp();
+
+		expect(showError).toHaveBeenCalledWith("model not configured");
+		expect(editor.getText()).toBe("");
+		expect(ctx.editor.pendingImages).toEqual([image]);
+		expect(ctx.editor.pendingImageLinks).toEqual([undefined]);
+		expect(ctx.editor.imageLinks).toEqual([undefined]);
 	});
 });

--- a/packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts
+++ b/packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts
@@ -4,7 +4,7 @@ import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/inp
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 
-function createContext() {
+function createContext(options?: { queuedMessageCount?: number; pendingImages?: ImageContent[] }) {
 	let editorText = "";
 	const abort = vi.fn(async () => {});
 	const prompt = vi.fn(async () => {});
@@ -13,6 +13,7 @@ function createContext() {
 	const showError = vi.fn();
 	const ctx = {
 		editor: {
+			imageLinks: undefined as (string | undefined)[] | undefined,
 			setText(text: string) {
 				editorText = text;
 			},
@@ -20,8 +21,8 @@ function createContext() {
 				return editorText;
 			},
 			addToHistory: vi.fn(),
-			pendingImages: [] as ImageContent[],
-			pendingImageLinks: [] as (string | undefined)[],
+			pendingImages: options?.pendingImages ? [...options.pendingImages] : ([] as ImageContent[]),
+			pendingImageLinks: options?.pendingImages?.map(() => undefined) ?? ([] as (string | undefined)[]),
 		},
 		ui: { requestRender },
 		session: {
@@ -29,7 +30,7 @@ function createContext() {
 			isCompacting: false,
 			isBashRunning: false,
 			isEvalRunning: false,
-			queuedMessageCount: 1,
+			queuedMessageCount: options?.queuedMessageCount ?? 1,
 			extensionRunner: undefined,
 			abort,
 			prompt,
@@ -45,6 +46,7 @@ function createContext() {
 		updatePendingMessagesDisplay,
 		showError,
 		hasActiveBtw: () => false,
+		withLocalSubmission: async (_text: string, fn: () => Promise<unknown>) => fn(),
 		hasActiveOmfg: () => false,
 	} as unknown as InteractiveModeContext;
 	return { ctx, abort, prompt, updatePendingMessagesDisplay, requestRender, showError };
@@ -63,5 +65,36 @@ describe("empty submit with queued messages", () => {
 		expect(showError).not.toHaveBeenCalled();
 		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues an image-only steer while streaming", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, abort, prompt, updatePendingMessagesDisplay, requestRender } = createContext({
+			queuedMessageCount: 0,
+			pendingImages: [image],
+		});
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("");
+
+		expect(abort).not.toHaveBeenCalled();
+		expect(prompt).toHaveBeenCalledWith("", { streamingBehavior: "steer", images: [image] });
+		expect(ctx.editor.pendingImages).toEqual([]);
+		expect(ctx.editor.pendingImageLinks).toEqual([]);
+		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues an image-only steer instead of aborting when messages are already queued", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, abort, prompt } = createContext({ queuedMessageCount: 1, pendingImages: [image] });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("");
+
+		expect(abort).not.toHaveBeenCalled();
+		expect(prompt).toHaveBeenCalledWith("", { streamingBehavior: "steer", images: [image] });
 	});
 });

--- a/packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts
+++ b/packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts
@@ -4,7 +4,11 @@ import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/inp
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 
-function createContext(options?: { queuedMessageCount?: number; pendingImages?: ImageContent[] }) {
+function createContext(options?: {
+	queuedMessageCount?: number;
+	pendingImages?: ImageContent[];
+	pendingImageLinks?: (string | undefined)[];
+}) {
 	let editorText = "";
 	const abort = vi.fn(async () => {});
 	const prompt = vi.fn(async () => {});
@@ -22,7 +26,10 @@ function createContext(options?: { queuedMessageCount?: number; pendingImages?: 
 			},
 			addToHistory: vi.fn(),
 			pendingImages: options?.pendingImages ? [...options.pendingImages] : ([] as ImageContent[]),
-			pendingImageLinks: options?.pendingImages?.map(() => undefined) ?? ([] as (string | undefined)[]),
+			pendingImageLinks:
+				options?.pendingImageLinks ??
+				options?.pendingImages?.map(() => undefined) ??
+				([] as (string | undefined)[]),
 		},
 		ui: { requestRender },
 		session: {
@@ -82,6 +89,31 @@ describe("empty submit with queued messages", () => {
 		expect(prompt).toHaveBeenCalledWith("", { streamingBehavior: "steer", images: [image] });
 		expect(ctx.editor.pendingImages).toEqual([]);
 		expect(ctx.editor.pendingImageLinks).toEqual([]);
+		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores an image-only steer when streaming dispatch rejects", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, abort, prompt, showError, updatePendingMessagesDisplay, requestRender } = createContext({
+			queuedMessageCount: 0,
+			pendingImages: [image],
+			pendingImageLinks: ["local://draft.png"],
+		});
+		prompt.mockImplementationOnce(async () => {
+			throw new Error("queue rejected");
+		});
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("");
+
+		expect(abort).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("queue rejected");
+		expect(ctx.editor.getText()).toBe("");
+		expect(ctx.editor.pendingImages).toEqual([image]);
+		expect(ctx.editor.pendingImageLinks).toEqual(["local://draft.png"]);
+		expect(ctx.editor.imageLinks).toEqual(["local://draft.png"]);
 		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
## Repro
Image-only submits while the agent is streaming reproduce after generating the HTML tool-view test asset with `bun run build:tool-views` from `packages/collab-web` and running `bun test packages/coding-agent/test/input-controller-followup-image.test.ts packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts`: before the fix, image-only Ctrl+Enter made zero `session.prompt` calls, image-only Enter made zero `session.prompt` calls, and the queued-message variant called `abort()`.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` treated an empty trimmed editor string as no submit content before reading `editor.pendingImages` in `setupEditorSubmitHandler()`, `#submitToFocusedSession()`, and `handleFollowUp()`. That made image-only submits unreachable from the normal `session.prompt(..., { images })` queue path.

## Fix
- Count pending pasted images as submit content before the empty-text abort/drop gates.
- Skip text-only slash/skill dispatch for image-only submits so they fall through to the normal prompt queue path.
- Add regression coverage for image-only follow-ups, image-only steers, and the queued-message steer case that must not abort.
- Add a coding-agent changelog entry for #3467.

## Verification
`bun test packages/coding-agent/test/input-controller-followup-image.test.ts packages/coding-agent/test/issue-interrupt-and-flush-empty-messages.test.ts` passed with 7 tests / 31 assertions; `bun run check` from `packages/coding-agent` passed. Fixes #3467