### PR TITLE
feat(tui): recognize Warp as a first-class terminal

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Recognized Warp (`TERM_PROGRAM=WarpTerminal`) as a first-class terminal. Inline images now negotiate the Kitty graphics protocol on macOS/Linux (direct placement — Warp has no Unicode-placeholder support); the protocol is dropped on Windows, where Warp ships without Kitty support and the APC sequences would render as visible garbage. True color is enabled. OSC 8 hyperlinks stay off by default because Warp's renderer prints the escape as literal text rather than a clickable link (opt in with `PI_FORCE_HYPERLINKS=1` once Warp lands real support), and synchronized output remains gated on the runtime DECRQM probe ([#3471](https://github.com/can1357/oh-my-pi/issues/3471)).
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -412,7 +412,7 @@ const spacer = new Spacer(2); // 2 empty lines (default: 1)
 
 ### Image
 
-Renders images inline for terminals that support the Kitty graphics protocol (Kitty, Ghostty, WezTerm) or iTerm2 inline images. Falls back to a text placeholder on unsupported terminals.
+Renders images inline for terminals that support the Kitty graphics protocol (Kitty, Ghostty, WezTerm, and Warp on macOS/Linux) or iTerm2 inline images. Falls back to a text placeholder on unsupported terminals.
 
 ```typescript
 interface ImageTheme {

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -21,7 +21,16 @@ export enum NotifyProtocol {
 	Osc9 = "\x1b]9;",
 }
 
-export type TerminalId = "kitty" | "ghostty" | "wezterm" | "iterm2" | "vscode" | "alacritty" | "base" | "trueColor";
+export type TerminalId =
+	| "kitty"
+	| "ghostty"
+	| "wezterm"
+	| "iterm2"
+	| "vscode"
+	| "alacritty"
+	| "warp"
+	| "base"
+	| "trueColor";
 
 function hasNeedleBefore(line: string, needle: string, limit: number): boolean {
 	const index = line.indexOf(needle);
@@ -374,6 +383,19 @@ function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null 
 	}
 	return null;
 }
+
+/**
+ * Warp implements the Kitty graphics protocol only on macOS/Linux; its Windows
+ * build ships without it, so the same APC sequences render as visible garbage
+ * there (warpdotdev/Warp#26 landed Mac/Linux only). Warp is marked Kitty-capable
+ * in {@link KNOWN_TERMINALS}; the {@link TERMINAL} builder calls this to drop the
+ * protocol on win32. Kept pure (platform injected) so the carve-out is testable
+ * without mutating `process.platform`.
+ */
+export function resolveWarpImageProtocol(platform: NodeJS.Platform = process.platform): ImageProtocol | null {
+	return platform === "win32" ? null : ImageProtocol.Kitty;
+}
+
 const KNOWN_TERMINALS = Object.freeze({
 	// Fallback terminals
 	base: new TerminalInfo("base", null, false, false, NotifyProtocol.Bell),
@@ -385,6 +407,13 @@ const KNOWN_TERMINALS = Object.freeze({
 	iterm2: new TerminalInfo("iterm2", ImageProtocol.Iterm2, true, true, NotifyProtocol.Osc9),
 	vscode: new TerminalInfo("vscode", null, true, true, NotifyProtocol.Bell),
 	alacritty: new TerminalInfo("alacritty", null, true, true, NotifyProtocol.Bell),
+	// Warp identifies via TERM_PROGRAM=WarpTerminal and ships the Kitty graphics
+	// protocol on macOS/Linux (direct placement only — no Unicode placeholders, so
+	// detectKittyUnicodePlaceholdersSupport correctly excludes it). It does not
+	// honor OSC 8 yet (the escape renders as visible text), so hyperlinks stay off;
+	// the win32 Kitty carve-out lives in the TERMINAL builder via
+	// resolveWarpImageProtocol.
+	warp: new TerminalInfo("warp", ImageProtocol.Kitty, true, false, NotifyProtocol.Bell),
 });
 
 export const TERMINAL_ID: TerminalId = (() => {
@@ -418,6 +447,7 @@ export const TERMINAL_ID: TerminalId = (() => {
 		if (caseEq(TERM_PROGRAM, "iterm.app")) return "iterm2";
 		if (caseEq(TERM_PROGRAM, "vscode")) return "vscode";
 		if (caseEq(TERM_PROGRAM, "alacritty")) return "alacritty";
+		if (caseEq(TERM_PROGRAM, "warpterminal")) return "warp";
 	}
 
 	if (TERM?.toLowerCase().includes("ghostty")) return "ghostty";
@@ -448,6 +478,9 @@ export const TERMINAL: RuntimeTerminal = (() => {
 	const forcedImageProtocol = getForcedImageProtocol();
 	if (forcedImageProtocol !== undefined) {
 		resolved.imageProtocol = forcedImageProtocol;
+	} else if (resolved.id === "warp") {
+		// Warp advertises Kitty graphics on macOS/Linux only; drop it on win32.
+		resolved.imageProtocol = resolveWarpImageProtocol();
 	} else if (!resolved.imageProtocol) {
 		const fallbackImageProtocol = getFallbackImageProtocol(resolved.id);
 		if (fallbackImageProtocol) resolved.imageProtocol = fallbackImageProtocol;

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
+	getTerminalInfo,
 	hyperlinksUserOverride,
+	ImageProtocol,
+	NotifyProtocol,
+	resolveWarpImageProtocol,
 	shouldEnableHyperlinksByDefault,
 	shouldEnableSynchronizedOutputByDefault,
 	synchronizedOutputUserOverride,
@@ -257,5 +261,28 @@ describe("shouldEnableHyperlinksByDefault", () => {
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "base")).toBe(true);
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", TMUX: "1" }, "wezterm")).toBe(true);
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", STY: "1.pts-0" }, "kitty")).toBe(true);
+	});
+});
+
+describe("Warp terminal capabilities", () => {
+	it("is Kitty-capable with true color but no OSC 8 hyperlinks", () => {
+		const warp = getTerminalInfo("warp");
+		expect(warp.imageProtocol).toBe(ImageProtocol.Kitty);
+		expect(warp.trueColor).toBe(true);
+		expect(warp.hyperlinks).toBe(false);
+		expect(warp.notifyProtocol).toBe(NotifyProtocol.Bell);
+		expect(warp.textSizing).toBe(false);
+	});
+
+	it("keeps Kitty inline images on macOS/Linux but drops them on Windows", () => {
+		expect(resolveWarpImageProtocol("darwin")).toBe(ImageProtocol.Kitty);
+		expect(resolveWarpImageProtocol("linux")).toBe(ImageProtocol.Kitty);
+		expect(resolveWarpImageProtocol("win32")).toBeNull();
+	});
+
+	it("leaves OSC 8 hyperlinks off by default since Warp renders the escape as literal text", () => {
+		expect(shouldEnableHyperlinksByDefault({}, "warp")).toBe(false);
+		// The shared force-on override still wins for users on a Warp build that adds support.
+		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "warp")).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

Recognize Warp (`TERM_PROGRAM=WarpTerminal`) as a first-class terminal in the TUI capability layer (`packages/tui`), so omp negotiates Warp's real capabilities instead of the `base` fallback.

- Add `warp` to the `TerminalId` union and `KNOWN_TERMINALS` (Kitty image protocol, true color, OSC 8 off, BEL notifications).
- Detect Warp via `TERM_PROGRAM=WarpTerminal` in `TERMINAL_ID`.
- Add a pure, testable `resolveWarpImageProtocol(platform)` helper and a win32 carve-out in the `TERMINAL` builder — Warp ships Kitty on macOS/Linux only, and the APC sequences render as visible garbage on the Windows build.
- README + CHANGELOG updated.

## Why

Warp shipped the Kitty graphics protocol on macOS/Linux (v0.2025.04, direct placement) but was unrecognized, so inline images fell back to text placeholders and Warp was treated as a lowest-common-denominator terminal. OSC 8 stays off by default because Warp's renderer prints the escape as literal text rather than a clickable link (tracked upstream in warpdotdev/Warp#4194 / #6393 / #6541); `PI_FORCE_HYPERLINKS=1` opts in. Synchronized output is left to the runtime DECRQM probe (Warp lacks DEC Mode 2031). `reportsSizeOnAltScreenToggle` intentionally keeps reading `TERM_PROGRAM` live, since the existing Warp resize tests depend on that.

Fixes #3471

## Testing

- `bun test packages/tui/test/terminal-capabilities.test.ts` → 32 pass, 0 fail (3 new Warp contract tests: capability shape, macOS/Linux-vs-Windows image protocol, OSC 8 off-by-default).
- `tsgo -p tsconfig.json --noEmit` for `packages/tui` is clean.
- No Unicode-placeholder / DECCARA / OSC 66 changes needed — the existing Kitty-only detectors already exclude Warp.

---

- [ ] `bun check` passes — `packages/tui` type-check (`tsgo`) and tests pass; repo-wide `bun check` currently fails *before* type-checking on a pre-existing `biome.json` error (`unknown key "preset"`) unrelated to this change.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
