### PR TITLE
fix(tui): recognize Warp terminal capabilities

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recognized Warp (`TERM_PROGRAM=WarpTerminal`) as a first-class terminal, enabling Kitty inline images on macOS/Linux while keeping Warp's unsafe OSC 8 hyperlinks and Windows Kitty graphics disabled ([#3471](https://github.com/can1357/oh-my-pi/issues/3471)).
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -21,7 +21,16 @@ export enum NotifyProtocol {
 	Osc9 = "\x1b]9;",
 }
 
-export type TerminalId = "kitty" | "ghostty" | "wezterm" | "iterm2" | "vscode" | "alacritty" | "base" | "trueColor";
+export type TerminalId =
+	| "kitty"
+	| "ghostty"
+	| "wezterm"
+	| "iterm2"
+	| "vscode"
+	| "alacritty"
+	| "warp"
+	| "base"
+	| "trueColor";
 
 function hasNeedleBefore(line: string, needle: string, limit: number): boolean {
 	const index = line.indexOf(needle);
@@ -251,9 +260,9 @@ export function shouldEnableSynchronizedOutputByDefault(
 		case "vscode":
 			return true;
 		default:
-			// VTE family, GNU screen, Apple Terminal, legacy native console host
-			// (no WT_SESSION), and bare/unknown xterm profiles stay off until the
-			// DECRQM probe proves support.
+			// VTE family, GNU screen, Apple Terminal, Warp, legacy native console
+			// host (no WT_SESSION), and bare/unknown xterm profiles stay off until
+			// the DECRQM probe proves support.
 			return false;
 	}
 }
@@ -374,6 +383,12 @@ function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null 
 	}
 	return null;
 }
+function getWarpTerminalInfo(platform: NodeJS.Platform): TerminalInfo {
+	return platform === "win32"
+		? new TerminalInfo("warp", null, true, false, NotifyProtocol.Bell)
+		: new TerminalInfo("warp", ImageProtocol.Kitty, true, false, NotifyProtocol.Bell);
+}
+
 const KNOWN_TERMINALS = Object.freeze({
 	// Fallback terminals
 	base: new TerminalInfo("base", null, false, false, NotifyProtocol.Bell),
@@ -385,9 +400,11 @@ const KNOWN_TERMINALS = Object.freeze({
 	iterm2: new TerminalInfo("iterm2", ImageProtocol.Iterm2, true, true, NotifyProtocol.Osc9),
 	vscode: new TerminalInfo("vscode", null, true, true, NotifyProtocol.Bell),
 	alacritty: new TerminalInfo("alacritty", null, true, true, NotifyProtocol.Bell),
+	warp: getWarpTerminalInfo(process.platform),
 });
 
-export const TERMINAL_ID: TerminalId = (() => {
+/** Resolve terminal identity from environment markers used by common emulators. */
+export function detectTerminalId(env: NodeJS.ProcessEnv = Bun.env): TerminalId {
 	function caseEq(a: string, b: string): boolean {
 		return a.toLowerCase() === b.toLowerCase(); // For compiler to pattern match
 	}
@@ -402,7 +419,7 @@ export const TERMINAL_ID: TerminalId = (() => {
 		TERM_PROGRAM,
 		TERM,
 		COLORTERM,
-	} = Bun.env;
+	} = env;
 
 	if (KITTY_WINDOW_ID) return "kitty";
 	if (GHOSTTY_RESOURCES_DIR) return "ghostty";
@@ -418,6 +435,7 @@ export const TERMINAL_ID: TerminalId = (() => {
 		if (caseEq(TERM_PROGRAM, "iterm.app")) return "iterm2";
 		if (caseEq(TERM_PROGRAM, "vscode")) return "vscode";
 		if (caseEq(TERM_PROGRAM, "alacritty")) return "alacritty";
+		if (caseEq(TERM_PROGRAM, "WarpTerminal")) return "warp";
 	}
 
 	if (TERM?.toLowerCase().includes("ghostty")) return "ghostty";
@@ -426,7 +444,9 @@ export const TERMINAL_ID: TerminalId = (() => {
 		if (caseEq(COLORTERM, "truecolor") || caseEq(COLORTERM, "24bit")) return "trueColor";
 	}
 	return "base";
-})();
+}
+
+export const TERMINAL_ID: TerminalId = detectTerminalId(Bun.env);
 
 /**
  * The process-wide {@link TERMINAL} singleton: a {@link TerminalInfo} whose
@@ -504,8 +524,8 @@ export function setTerminalTextSizing(enabled: boolean): void {
 	TERMINAL.textSizing = enabled;
 }
 
-export function getTerminalInfo(terminalId: TerminalId): TerminalInfo {
-	return KNOWN_TERMINALS[terminalId];
+export function getTerminalInfo(terminalId: TerminalId, platform: NodeJS.Platform = process.platform): TerminalInfo {
+	return terminalId === "warp" ? getWarpTerminalInfo(platform) : KNOWN_TERMINALS[terminalId];
 }
 
 export interface CellDimensions {

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -383,8 +383,14 @@ function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null 
 	}
 	return null;
 }
-function getWarpTerminalInfo(platform: NodeJS.Platform): TerminalInfo {
-	return platform === "win32"
+function getWarpTerminalInfo(platform: NodeJS.Platform, env: NodeJS.ProcessEnv = Bun.env): TerminalInfo {
+	// Warp for Windows still drives WSL shells from the Windows renderer, where
+	// the Kitty APC sequences print as visible garbage. Detect that case via the
+	// WSL host markers (Bun reports `process.platform === "linux"` inside WSL)
+	// and treat it the same as native win32.
+	const windowsHost =
+		platform === "win32" || (platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP));
+	return windowsHost
 		? new TerminalInfo("warp", null, true, false, NotifyProtocol.Bell)
 		: new TerminalInfo("warp", ImageProtocol.Kitty, true, false, NotifyProtocol.Bell);
 }
@@ -524,8 +530,12 @@ export function setTerminalTextSizing(enabled: boolean): void {
 	TERMINAL.textSizing = enabled;
 }
 
-export function getTerminalInfo(terminalId: TerminalId, platform: NodeJS.Platform = process.platform): TerminalInfo {
-	return terminalId === "warp" ? getWarpTerminalInfo(platform) : KNOWN_TERMINALS[terminalId];
+export function getTerminalInfo(
+	terminalId: TerminalId,
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = Bun.env,
+): TerminalInfo {
+	return terminalId === "warp" ? getWarpTerminalInfo(platform, env) : KNOWN_TERMINALS[terminalId];
 }
 
 export interface CellDimensions {

--- a/packages/tui/test/kitty-graphics.test.ts
+++ b/packages/tui/test/kitty-graphics.test.ts
@@ -93,6 +93,7 @@ describe("detectKittyUnicodePlaceholdersSupport", () => {
 
 	it("disables for wezterm and other Kitty-protocol paths that treat placeholders as literal PUA glyphs (#1877)", () => {
 		expect(detectKittyUnicodePlaceholdersSupport("wezterm", env())).toBe(false);
+		expect(detectKittyUnicodePlaceholdersSupport("warp", env())).toBe(false);
 		// Tmux/screen fallback: base terminal id with Kitty protocol forced on by
 		// `getFallbackImageProtocol`. The outer terminal need not understand U=1.
 		expect(detectKittyUnicodePlaceholdersSupport("base", env())).toBe(false);

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import {
+	detectTerminalId,
+	getTerminalInfo,
 	hyperlinksUserOverride,
+	ImageProtocol,
 	shouldEnableHyperlinksByDefault,
 	shouldEnableSynchronizedOutputByDefault,
 	synchronizedOutputUserOverride,
 } from "@oh-my-pi/pi-tui/terminal-capabilities";
+
+describe("detectTerminalId", () => {
+	it("recognizes Warp before the true-color fallback", () => {
+		expect(detectTerminalId({ TERM_PROGRAM: "WarpTerminal", COLORTERM: "truecolor" })).toBe("warp");
+	});
+});
 
 describe("synchronizedOutputUserOverride", () => {
 	it("returns null when the user expresses no preference", () => {
@@ -92,6 +101,28 @@ describe("shouldEnableSynchronizedOutputByDefault", () => {
 		expect(
 			shouldEnableSynchronizedOutputByDefault({ PI_FORCE_SYNC_OUTPUT: "1", SSH_CONNECTION: "1 2 3 4" }, "base"),
 		).toBe(true);
+	});
+});
+
+describe("Warp terminal capabilities", () => {
+	it("uses Kitty images on macOS/Linux and disables them on Windows", () => {
+		const mac = getTerminalInfo("warp", "darwin");
+		const linux = getTerminalInfo("warp", "linux");
+		const windows = getTerminalInfo("warp", "win32");
+
+		expect(mac.imageProtocol).toBe(ImageProtocol.Kitty);
+		expect(linux.imageProtocol).toBe(ImageProtocol.Kitty);
+		expect(windows.imageProtocol).toBeNull();
+		expect(linux.trueColor).toBe(true);
+		expect(linux.hyperlinks).toBe(false);
+		expect(linux.deccara).toBe(false);
+		expect(linux.textSizing).toBe(false);
+	});
+
+	it("leaves synchronized output off by default and honors hyperlink force-on", () => {
+		expect(shouldEnableSynchronizedOutputByDefault({}, "warp")).toBe(false);
+		expect(shouldEnableHyperlinksByDefault({}, "warp")).toBe(false);
+		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "warp")).toBe(true);
 	});
 });
 

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -106,9 +106,9 @@ describe("shouldEnableSynchronizedOutputByDefault", () => {
 
 describe("Warp terminal capabilities", () => {
 	it("uses Kitty images on macOS/Linux and disables them on Windows", () => {
-		const mac = getTerminalInfo("warp", "darwin");
-		const linux = getTerminalInfo("warp", "linux");
-		const windows = getTerminalInfo("warp", "win32");
+		const mac = getTerminalInfo("warp", "darwin", {});
+		const linux = getTerminalInfo("warp", "linux", {});
+		const windows = getTerminalInfo("warp", "win32", {});
 
 		expect(mac.imageProtocol).toBe(ImageProtocol.Kitty);
 		expect(linux.imageProtocol).toBe(ImageProtocol.Kitty);
@@ -117,6 +117,16 @@ describe("Warp terminal capabilities", () => {
 		expect(linux.hyperlinks).toBe(false);
 		expect(linux.deccara).toBe(false);
 		expect(linux.textSizing).toBe(false);
+	});
+
+	it("treats WSL as the Windows host so Kitty APC garbage never reaches Warp for Windows", () => {
+		// Bun reports process.platform === "linux" inside WSL even though the
+		// renderer is the Windows Warp build, which lacks Kitty support.
+		const wslDistro = getTerminalInfo("warp", "linux", { WSL_DISTRO_NAME: "Ubuntu" });
+		const wslInterop = getTerminalInfo("warp", "linux", { WSL_INTEROP: "/run/WSL/1_interop" });
+
+		expect(wslDistro.imageProtocol).toBeNull();
+		expect(wslInterop.imageProtocol).toBeNull();
 	});
 
 	it("leaves synchronized output off by default and honors hyperlink force-on", () => {


### PR DESCRIPTION
## Repro
With `TERM_PROGRAM=WarpTerminal COLORTERM=truecolor`, importing `@oh-my-pi/pi-tui/terminal-capabilities` resolved `TERMINAL_ID` to `trueColor`, `TERMINAL.imageProtocol` to `null`, and `TERMINAL.hyperlinks` to `false`, so Warp could not use its Kitty inline-image support.

## Cause
`packages/tui/src/terminal-capabilities.ts` only matched Kitty, Ghostty, WezTerm, iTerm2, VS Code, and Alacritty environment markers. `TERM_PROGRAM=WarpTerminal` missed `TERMINAL_ID`, then fell through to the `COLORTERM=truecolor` fallback before `KNOWN_TERMINALS` could assign an image protocol.

## Fix
- Added `warp` to `TerminalId` and terminal identity detection via `TERM_PROGRAM=WarpTerminal`.
- Added Warp terminal capabilities: Kitty images on macOS/Linux, no image protocol on Windows, true color enabled, OSC 8 hyperlinks disabled by default.
- Kept synchronized output, DECCARA, OSC 66 text sizing, and Kitty Unicode placeholders off unless existing runtime/user probes opt in.
- Added regression tests for Warp detection, platform-specific image capabilities, hyperlink override behavior, and Kitty-placeholder exclusion.
- Added a `packages/tui` changelog entry.

## Verification
`bun test packages/tui/test/terminal-capabilities.test.ts packages/tui/test/kitty-graphics.test.ts` passed with 44 tests / 120 expectations; `bun check` passed. Manual repro now prints `{"terminalId":"warp","imageProtocol":"\u001b_G","trueColor":true,"hyperlinks":false}` for `TERM_PROGRAM=WarpTerminal COLORTERM=truecolor`. Fixes #3471