### PR TITLE
fix(cli): align gallery state labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp gallery --state` accepting lifecycle tokens that did not match displayed state labels and rendering unknown state values as `· undefined`; displayed labels now work as aliases, invalid values fail with a valid-token list, and failed gallery fixtures visibly render failures. ([#3473](https://github.com/can1357/oh-my-pi/issues/3473))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/cli/gallery-cli.ts
+++ b/packages/coding-agent/src/cli/gallery-cli.ts
@@ -21,12 +21,41 @@ import { captureGalleryScreenshots } from "./gallery-screenshot";
 export const GALLERY_STATES = ["streaming", "progress", "success", "error"] as const;
 export type GalleryState = (typeof GALLERY_STATES)[number];
 
-const STATE_LABELS: Record<GalleryState, string> = {
+/** User-facing labels printed above each rendered lifecycle state. */
+export const GALLERY_STATE_LABELS: Record<GalleryState, string> = {
 	streaming: "streaming args",
 	progress: "in progress",
 	success: "done",
 	error: "failed",
 };
+
+const GALLERY_STATE_ALIASES: Record<string, GalleryState> = {
+	streaming: "streaming",
+	"streaming args": "streaming",
+	progress: "progress",
+	"in progress": "progress",
+	success: "success",
+	done: "success",
+	error: "error",
+	failed: "error",
+};
+
+/** Accepted `--state` tokens, including legacy lifecycle names and displayed labels. */
+export const GALLERY_STATE_TOKENS = Object.keys(GALLERY_STATE_ALIASES);
+
+/** Normalize user-provided `--state` tokens to the internal gallery lifecycle states. */
+export function parseGalleryStates(states: readonly string[] | undefined): GalleryState[] | undefined {
+	if (!states || states.length === 0) return undefined;
+	const parsed: GalleryState[] = [];
+	for (const raw of states) {
+		const state = GALLERY_STATE_ALIASES[raw.trim().toLowerCase()];
+		if (!state) {
+			throw new Error(`Invalid --state '${raw}'. Valid values: ${GALLERY_STATE_TOKENS.join(", ")}`);
+		}
+		if (!parsed.includes(state)) parsed.push(state);
+	}
+	return parsed;
+}
 
 export interface GalleryCommandArgs {
 	/** Render width in columns (defaults to terminal width, clamped). */
@@ -166,7 +195,7 @@ async function renderGallerySections(
 		const heading = fixture.label && fixture.label !== name ? `${name} — ${fixture.label}` : name;
 		const lines: string[] = ["", sectionRule(heading, width)];
 		for (const state of states) {
-			lines.push("", theme.fg("dim", `  · ${STATE_LABELS[state]}`));
+			lines.push("", theme.fg("dim", `  · ${GALLERY_STATE_LABELS[state]}`));
 			try {
 				for (const line of await renderGalleryState(name, fixture, state, width, expanded)) lines.push(line);
 			} catch (err) {

--- a/packages/coding-agent/src/cli/gallery-fixtures/agentic.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/agentic.ts
@@ -263,6 +263,11 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 				],
 			} satisfies IrcDetails,
 		},
+		errorResult: {
+			isError: true,
+			content: [{ type: "text", text: "IRC inbox failed: message store unavailable." }],
+			details: { op: "inbox" } satisfies IrcDetails,
+		},
 	},
 
 	irc_list: {
@@ -308,6 +313,11 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 					},
 				],
 			} satisfies IrcDetails,
+		},
+		errorResult: {
+			isError: true,
+			content: [{ type: "text", text: "IRC list failed: agent hub is unavailable." }],
+			details: { op: "list" } satisfies IrcDetails,
 		},
 	},
 
@@ -388,19 +398,18 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 		},
 		errorResult: {
 			isError: true,
-			content: [{ type: "text", text: "Job cancelled by user." }],
+			content: [{ type: "text", text: "1 job failed." }],
 			details: {
 				jobs: [
 					{
 						id: "job_d4",
 						type: "task",
-						status: "cancelled",
+						status: "failed",
 						label: "Refactor the session store to Redis",
 						durationMs: 52_300,
-						errorText: "Aborted: superseded by goal re-scope.",
+						errorText: "Subagent exited 1: Redis connection string is missing.",
 					},
 				],
-				cancelled: [{ id: "job_d4", status: "cancelled" }],
 			},
 		},
 	},

--- a/packages/coding-agent/src/commands/gallery.ts
+++ b/packages/coding-agent/src/commands/gallery.ts
@@ -2,7 +2,7 @@
  * Render every built-in tool's renderer across its lifecycle states.
  */
 import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
-import { GALLERY_STATES, type GalleryState, runGalleryCommand } from "../cli/gallery-cli";
+import { GALLERY_STATE_TOKENS, type GalleryState, parseGalleryStates, runGalleryCommand } from "../cli/gallery-cli";
 
 export default class Gallery extends Command {
 	static description = "Preview tool renderers across streaming, in-progress, success, and failure states";
@@ -12,7 +12,7 @@ export default class Gallery extends Command {
 		state: Flags.string({
 			char: "s",
 			description: "Render only the given lifecycle state(s)",
-			options: [...GALLERY_STATES],
+			options: GALLERY_STATE_TOKENS,
 			multiple: true,
 		}),
 		width: Flags.integer({ char: "w", description: "Render width in columns" }),
@@ -37,9 +37,17 @@ export default class Gallery extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Gallery);
+		let states: GalleryState[] | undefined;
+		try {
+			states = parseGalleryStates(flags.state);
+		} catch (err) {
+			process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+			process.exitCode = 1;
+			return;
+		}
 		await runGalleryCommand({
 			tool: flags.tool,
-			states: flags.state as GalleryState[] | undefined,
+			states,
 			width: flags.width,
 			expanded: flags.expanded,
 			plain: flags.plain,

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -514,6 +514,18 @@ function callMeta(args: IrcRenderArgs | undefined): string[] {
 	return meta;
 }
 
+function renderErrorResult(
+	result: { content: Array<{ type: string; text?: string }> },
+	args: IrcRenderArgs | undefined,
+	theme: Theme,
+): string[] {
+	const text = textContent(result) || "IRC call failed.";
+	return [
+		renderStatusLine({ icon: "error", title: callTitle(args, theme), meta: callMeta(args) }, theme),
+		formatErrorDetail(text, theme),
+	];
+}
+
 /**
  * Display-only transcript card for live IRC traffic: `irc:incoming` DMs
  * delivered to this session, `irc:autoreply` side-channel replies sent on
@@ -743,9 +755,11 @@ function buildResultLines(
 		case "wait":
 			return renderWaitResult(result, details, args, expanded, theme);
 		case "inbox":
-			return renderInboxResult(details, args, expanded, theme);
+			return result.isError
+				? renderErrorResult(result, args, theme)
+				: renderInboxResult(details, args, expanded, theme);
 		case "list":
-			return renderListResult(details, expanded, theme);
+			return result.isError ? renderErrorResult(result, args, theme) : renderListResult(details, expanded, theme);
 		default: {
 			const text = textContent(result) || (result.isError ? "IRC call failed." : "Done.");
 			return [

--- a/packages/coding-agent/test/gallery-cli.test.ts
+++ b/packages/coding-agent/test/gallery-cli.test.ts
@@ -1,5 +1,10 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import { GALLERY_STATES, renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
+import {
+	GALLERY_STATES,
+	parseGalleryStates,
+	renderGalleryState,
+	resolveFixture,
+} from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 import type { GalleryFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-fixtures";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -12,6 +17,22 @@ beforeAll(async () => {
 });
 
 describe("gallery harness", () => {
+	it("accepts displayed gallery state labels and legacy tokens", () => {
+		expect(parseGalleryStates(["streaming args", "in progress", "done", "failed"])).toEqual([
+			"streaming",
+			"progress",
+			"success",
+			"error",
+		]);
+		expect(parseGalleryStates(["streaming", "progress", "success", "error", "failed"])).toEqual([...GALLERY_STATES]);
+	});
+
+	it("rejects unknown gallery state tokens before rendering", () => {
+		expect(() => parseGalleryStates(["bogus"])).toThrow(
+			/Invalid --state 'bogus'.*streaming args.*in progress.*done.*failed/,
+		);
+	});
+
 	it("renders every registered tool in every lifecycle state without throwing", async () => {
 		for (const name in toolRenderers) {
 			const fixture = resolveFixture(name);
@@ -66,6 +87,20 @@ describe("gallery harness", () => {
 		expect(stripped.some(line => line.startsWith(theme.boxRound.topLeft) && line.includes("Task"))).toBe(true);
 		// ...but no standalone "Task" label line precedes it.
 		expect(stripped).not.toContain("Task");
+	});
+
+	it("renders curated failed states as failures", async () => {
+		const cases = [
+			["irc_inbox", "IRC inbox failed: message store unavailable.", "IRC inbox empty"],
+			["irc_list", "IRC list failed: agent hub is unavailable.", "no other agents"],
+			["job", "Subagent exited 1: Redis connection string is missing.", "cancelled"],
+		] as const;
+
+		for (const [name, expected, forbidden] of cases) {
+			const output = Bun.stripANSI((await renderGalleryState(name, resolveFixture(name), "error", 100)).join("\n"));
+			expect(output).toContain(expected);
+			expect(output).not.toContain(forbidden);
+		}
 	});
 
 	it("renders gallery-only read group fixtures", async () => {


### PR DESCRIPTION
## Repro
`bun --cwd=packages/collab-web run build:tool-views` followed by `bun packages/coding-agent/src/cli.ts gallery -t job -s failed --plain` reproduced the bug: the command exited 0 and rendered the state heading as `· undefined` instead of the failed fixture.

## Cause
`packages/coding-agent/src/commands/gallery.ts` passed raw `--state` strings into `runGalleryCommand`, while `packages/coding-agent/src/cli/gallery-cli.ts` only keyed rendering by the internal lifecycle tokens `streaming`, `progress`, `success`, and `error`; displayed labels like `failed` or unknown values therefore bypassed validation and indexed `STATE_LABELS` as `undefined`. The `irc_inbox` and `irc_list` gallery fixtures also had no failed result, and the IRC renderer ignored error results for inbox/list operations.

## Fix
- Added explicit `--state` normalization for displayed labels and legacy lifecycle tokens, with invalid tokens rejected before rendering.
- Updated gallery state tests to cover displayed-label aliases, invalid state rejection, and failed fixture rendering.
- Added visible failed fixtures for `irc_inbox`, `irc_list`, and `job`, and taught the IRC renderer to render inbox/list error results as failures.
- Added the coding-agent changelog entry for this issue.

## Verification
Ran `bun --cwd=packages/collab-web run build:tool-views`, `bun test packages/coding-agent/test/gallery-cli.test.ts` (8 pass), `bun packages/coding-agent/src/cli.ts gallery -t job -s failed --plain` (renders `· failed` with a failed job), `bun packages/coding-agent/src/cli.ts gallery -t job -s bogus --plain` (exits 1 with valid tokens), and `bun --cwd=packages/coding-agent run check` (passed). Fixes #3473