### PR TITLE
fix(theme): swap wrong nerd-font icons for context and auto

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `nerd` symbol preset rendering the Microsoft Windows brand logo for `icon.context` and a magic wand for `icon.auto` on the status line's `context_pct` segment. `NERD_SYMBOLS` in `packages/coding-agent/src/modes/theme/theme.ts` mapped `icon.context` to `U+E70F` (`nf-dev-windows`) instead of a generic context window, and `icon.auto` to `U+F0068` (`nf-md-auto_fix`) — off-by-two from `U+F006A` (`nf-md-autorenew`), the refresh-loop glyph that matches the `unicode` preset's `⟲` for the same icon. The preset now uses `nf-cod-window` (`U+EB7F`) and `nf-md-autorenew` (`U+F006A`). ([#3481](https://github.com/can1357/oh-my-pi/issues/3481))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -567,8 +567,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.pr": "\uea64",
 	// pick:  | alt: ⊛ ◍ 
 	"icon.tokens": "\ue26b",
-	// pick:  | alt: ◫ ▦
-	"icon.context": "\ue70f",
+	// pick:  (nf-cod-window) | alt:  (nf-md-gauge)  (nf-md-memory) ◫ ▦
+	"icon.context": "\ueb7f",
 	// pick:  | alt: $ ¢
 	"icon.cost": "\uf155",
 	// pick:  | alt: ◷ ◴
@@ -599,8 +599,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.warning": "\uf071",
 	// pick:  | alt:  ↺
 	"icon.rewind": "\uf0e2",
-	// pick: 󰁨 | alt:   
-	"icon.auto": "\u{f0068}",
+	// pick: 󰁪 (nf-md-autorenew) | alt: 󰁨 (nf-md-auto_fix)  
+	"icon.auto": "\u{f006a}",
 	"icon.fast": "\uf0e7",
 	"icon.extensionSkill": "\uf0eb",
 	// pick:  | alt:  

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -599,7 +599,7 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.warning": "\uf071",
 	// pick:  | alt:  ↺
 	"icon.rewind": "\uf0e2",
-	// pick: 󰁪 (nf-md-autorenew) | alt: 󰁨 (nf-md-auto_fix)  
+	// pick: 󰁪 (nf-md-autorenew) | alt: 󰁨 (nf-md-auto_fix)
 	"icon.auto": "\u{f006a}",
 	"icon.fast": "\uf0e7",
 	"icon.extensionSkill": "\uf0eb",

--- a/packages/coding-agent/test/modes/theme/nerd-symbol-icons.test.ts
+++ b/packages/coding-agent/test/modes/theme/nerd-symbol-icons.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	Theme,
-	type ThemeBg,
-	type ThemeColor,
-} from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { Theme, type ThemeBg, type ThemeColor } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 /**
  * Regression contract for issue #3481: the `nerd` symbol preset must not ship

--- a/packages/coding-agent/test/modes/theme/nerd-symbol-icons.test.ts
+++ b/packages/coding-agent/test/modes/theme/nerd-symbol-icons.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import {
+	Theme,
+	type ThemeBg,
+	type ThemeColor,
+} from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+/**
+ * Regression contract for issue #3481: the `nerd` symbol preset must not ship
+ * the Microsoft Windows brand logo as `icon.context`, nor the magic-wand
+ * `nf-md-auto_fix` as `icon.auto`. The intended glyphs are a neutral context
+ * window (`nf-cod-window`, U+EB7F) and a refresh loop (`nf-md-autorenew`,
+ * U+F006A) — the latter matching the `unicode` preset's `⟲`.
+ */
+describe("nerd preset icon glyph mapping (issue #3481)", () => {
+	const fgColors = {} as Record<ThemeColor, string | number>;
+	const bgColors = {} as Record<ThemeBg, string | number>;
+	const t = new Theme(fgColors, bgColors, "truecolor", "nerd", {});
+
+	it("icon.context is nf-cod-window, not nf-dev-windows (the OS brand logo)", () => {
+		expect(t.icon.context).toBe("\ueb7f");
+		expect(t.icon.context).not.toBe("\ue70f");
+	});
+
+	it("icon.auto is nf-md-autorenew, not nf-md-auto_fix (the magic wand)", () => {
+		expect(t.icon.auto).toBe("\u{f006a}");
+		expect(t.icon.auto).not.toBe("\u{f0068}");
+	});
+});


### PR DESCRIPTION
## Repro

With the `nerd` symbol preset active (`omp config set symbolPreset nerd`) and the terminal using a Nerd Font, the status-line `context_pct` segment renders the Microsoft Windows brand logo to the left of the readout and a magic wand to the right when `compaction.enabled` is true:

```
printf 'icon.context (U+E70F): %s\nicon.auto (U+F0068): %s\n' "$(printf '\ue70f')" "$(printf '\U000f0068')"
# icon.context: 
# icon.auto:    󰁨
```

`U+E70F` is `nf-dev-windows` (Devicons / OS brand); `U+F0068` is `nf-md-auto_fix` (a magic wand).

## Cause

`NERD_SYMBOLS` in `packages/coding-agent/src/modes/theme/theme.ts:571,603` mapped `icon.context` to `U+E70F` and `icon.auto` to `U+F0068`. The latter is off-by-two from `U+F006A` (`nf-md-autorenew`), the refresh-loop glyph that matches the `unicode` preset's `⟲` for the same icon — looks like a codepoint slip. The Windows-logo pick on `icon.context` looks plausible at small sizes (Devicons draws it as a four-pane window), but the inline `// pick:` comment's alternatives (`◫ ▦`) show a neutral context window was intended.

## Fix

- `icon.context`: `\ue70f` → `\ueb7f` (`nf-cod-window`).
- `icon.auto`: `\u{f0068}` → `\u{f006a}` (`nf-md-autorenew`).
- Updated adjacent `// pick:` comments to reflect the new picks and their alternatives.
- Added `test/modes/theme/nerd-symbol-icons.test.ts` pinning both codepoints (constructs a `Theme` directly with the nerd preset and asserts `theme.icon.context`/`theme.icon.auto`).

## Verification

```
bun test packages/coding-agent/test/modes/theme/nerd-symbol-icons.test.ts
# 2 pass, 0 fail
```

Pre-publish gate (`bun run fix` + `bun check`) green via `gh_push_branch`.

Fixes #3481