### PR TITLE
fix(coding-agent): surface transcript search paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concise `history://` transcript rendering for `find` and `search` so scoped `paths` arguments are visible instead of being hidden behind JSON fallback output or omitted when a search `pattern` is present. ([#3482](https://github.com/can1357/oh-my-pi/issues/3482))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -53,6 +53,7 @@ const PRIMARY_ARG_KEYS = [
 	"command",
 	"cmd",
 	"pattern",
+	"paths",
 	"url",
 	"query",
 	"prompt",
@@ -86,6 +87,14 @@ function lineCount(text: string): number {
 	return text.split("\n").length;
 }
 
+function primaryArgValue(value: unknown): string {
+	if (typeof value === "string" && value.length > 0) return value;
+	if (Array.isArray(value) && value.length > 0 && value.every(v => typeof v === "string")) {
+		return value.join(", ");
+	}
+	return "";
+}
+
 /** Pick the most informative scalar argument of a tool call. */
 function primaryArg(name: string, args: Record<string, unknown> | undefined): string {
 	if (!args || typeof args !== "object") return "";
@@ -97,12 +106,17 @@ function primaryArg(name: string, args: Record<string, unknown> | undefined): st
 		if (note) return oneLine(note);
 		if (severity) return oneLine(severity);
 	}
+	if (name === "search") {
+		const pattern = primaryArgValue(args.pattern);
+		const paths = primaryArgValue(args.paths);
+		if (pattern && paths) return oneLine(`${pattern} @ ${paths}`);
+		if (pattern) return oneLine(pattern);
+		if (paths) return oneLine(paths);
+	}
 	for (const key of PRIMARY_ARG_KEYS) {
 		const value = args[key];
-		if (typeof value === "string" && value.length > 0) return oneLine(value);
-		if (Array.isArray(value) && value.length > 0 && value.every(v => typeof v === "string")) {
-			return oneLine(value.join(", "));
-		}
+		const summary = primaryArgValue(value);
+		if (summary) return oneLine(summary);
 	}
 	// Fallback: first non-intent string arg, then a compact JSON of the args.
 	const rest: Record<string, unknown> = {};

--- a/packages/coding-agent/test/session/session-history-format.test.ts
+++ b/packages/coding-agent/test/session/session-history-format.test.ts
@@ -167,7 +167,9 @@ describe("formatSessionHistoryMarkdown", () => {
 			},
 		]);
 
-		expect(output).toContain("→ search(PRIMARY_ARG_KEYS @ packages/coding-agent/src/session) ⇒ error · 1 line — timed out");
+		expect(output).toContain(
+			"→ search(PRIMARY_ARG_KEYS @ packages/coding-agent/src/session) ⇒ error · 1 line — timed out",
+		);
 	});
 
 	it("renders tool intent comments immediately before tool call lines when includeToolIntent is true", () => {

--- a/packages/coding-agent/test/session/session-history-format.test.ts
+++ b/packages/coding-agent/test/session/session-history-format.test.ts
@@ -115,6 +115,61 @@ describe("formatSessionHistoryMarkdown", () => {
 		expect(output).toContain("→ search() ⇒ ok · 1 line");
 	});
 
+	it("renders find paths without falling back to JSON arguments", () => {
+		const output = formatSessionHistoryMarkdown([
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "tc-find",
+						name: "find",
+						arguments: { paths: ["packages/coding-agent/src/**/*.ts"] },
+					},
+				],
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "tc-find",
+				toolName: "find",
+				content: [{ type: "text", text: "session-history-format.ts" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+
+		expect(output).toContain("→ find(packages/coding-agent/src/**/*.ts) ⇒ ok · 1 line");
+		expect(output).not.toContain('{"paths"');
+	});
+
+	it("renders search path scope alongside the pattern", () => {
+		const output = formatSessionHistoryMarkdown([
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "tc-search",
+						name: "search",
+						arguments: { pattern: "PRIMARY_ARG_KEYS", paths: ["packages/coding-agent/src/session"] },
+					},
+				],
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "tc-search",
+				toolName: "search",
+				content: [{ type: "text", text: "timed out" }],
+				isError: true,
+				timestamp: 2,
+			},
+		]);
+
+		expect(output).toContain("→ search(PRIMARY_ARG_KEYS @ packages/coding-agent/src/session) ⇒ error · 1 line — timed out");
+	});
+
 	it("renders tool intent comments immediately before tool call lines when includeToolIntent is true", () => {
 		const messages = [
 			{


### PR DESCRIPTION
## Repro
Added regression coverage in `packages/coding-agent/test/session/session-history-format.test.ts` and ran `bun test packages/coding-agent/test/session/session-history-format.test.ts`; before the fix, `find` rendered `→ find({"paths":[...]})` and `search` rendered only `→ search(PRIMARY_ARG_KEYS)`, hiding the scoped `paths` value.

## Cause
`packages/coding-agent/src/session/session-history-format.ts` selected concise tool-call arguments through `PRIMARY_ARG_KEYS`, which omitted `paths`; `find` therefore fell through to compact JSON rendering, while `search` stopped at `pattern` and never exposed `paths`.

## Fix
- Added `paths` to the primary argument preference list so path arrays render as concise scope text.
- Added a `search`-specific summary that keeps `pattern` first and appends the scoped `paths` value when present.
- Added transcript-format regression tests for `find` JSON fallback avoidance and `search` scope visibility.
- Added a `packages/coding-agent` changelog entry.

## Verification
`bun test packages/coding-agent/test/session/session-history-format.test.ts` passed: 8 tests, 28 assertions. `gh_push_branch` completed the repository pre-publish gate before pushing. Fixes #3482