### PR TITLE
fix(coding-agent): queue manual compact steers during teardown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the first steering/follow-up message submitted during a manual `/compact` being silently dropped before the compaction controller finished installing; manual compaction now reports as compacting through abort teardown so input queues for post-compaction delivery.
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1182,6 +1182,10 @@ export class AgentSession {
 	#acpPermissionDecisions: Map<string, "allow_always" | "reject_always"> = new Map();
 
 	// Compaction state
+	// Manual compact() starts by aborting the active turn before installing the
+	// real compaction controller; this flag keeps user input routed to the
+	// compaction queue during that teardown window.
+	#compactionStarting = false;
 	#compactionAbortController: AbortController | undefined = undefined;
 	#autoCompactionAbortController: AbortController | undefined = undefined;
 
@@ -5261,9 +5265,13 @@ export class AgentSession {
 		);
 	}
 
-	/** Whether auto-compaction is currently running */
+	/** Whether any manual or auto compaction is currently running or starting */
 	get isCompacting(): boolean {
-		return this.#autoCompactionAbortController !== undefined || this.#compactionAbortController !== undefined;
+		return (
+			this.#compactionStarting ||
+			this.#autoCompactionAbortController !== undefined ||
+			this.#compactionAbortController !== undefined
+		);
 	}
 
 	/**
@@ -7801,12 +7809,14 @@ export class AgentSession {
 		if (compactMode?.rejectsFocus && customInstructions) {
 			throw new Error(`/compact ${compactMode.name} does not take focus instructions.`);
 		}
-		this.#disconnectFromAgent();
-		await this.abort({ goalReason: "internal" });
-		const compactionAbortController = new AbortController();
-		this.#compactionAbortController = compactionAbortController;
+		this.#compactionStarting = true;
+		let compactionAbortController: AbortController | undefined;
 
 		try {
+			this.#disconnectFromAgent();
+			await this.abort({ goalReason: "internal" });
+			compactionAbortController = new AbortController();
+			this.#compactionAbortController = compactionAbortController;
 			if (!this.model) {
 				throw new Error("No model selected");
 			}
@@ -8046,9 +8056,10 @@ export class AgentSession {
 			options?.onError?.(err);
 			throw error;
 		} finally {
-			if (this.#compactionAbortController === compactionAbortController) {
+			if (compactionAbortController && this.#compactionAbortController === compactionAbortController) {
 				this.#compactionAbortController = undefined;
 			}
+			this.#compactionStarting = false;
 			this.#reconnectToAgent();
 		}
 	}

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -143,7 +143,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 	});
 
 	it("reports manual compaction as active before abort teardown settles", async () => {
-		const compacting = session.compact().catch(() => {});
+		const compacting = session.compact();
 
 		// The input controller routes steers/follow-ups through the compaction
 		// queue based on this getter. Manual compact() aborts the active turn before
@@ -151,8 +151,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		// teardown window.
 		expect(session.isCompacting).toBe(true);
 
-		vi.advanceTimersByTime(200);
-		await compacting;
+		await expect(compacting).rejects.toThrow("Nothing to compact");
 
 		expect(session.isCompacting).toBe(false);
 	});

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -142,6 +142,21 @@ describe("AgentSession auto-compaction queue resume", () => {
 		}
 	});
 
+	it("reports manual compaction as active before abort teardown settles", async () => {
+		const compacting = session.compact().catch(() => {});
+
+		// The input controller routes steers/follow-ups through the compaction
+		// queue based on this getter. Manual compact() aborts the active turn before
+		// installing the controller, so the getter must already be true in that
+		// teardown window.
+		expect(session.isCompacting).toBe(true);
+
+		vi.advanceTimersByTime(200);
+		await compacting;
+
+		expect(session.isCompacting).toBe(false);
+	});
+
 	it("resumes after threshold compaction when only agent-level queued messages exist", async () => {
 		session.agent.followUp({
 			role: "custom",


### PR DESCRIPTION
## Summary

- make manual `compact()` report `isCompacting` before it awaits active-turn abort teardown
- keep steers/follow-ups typed in that window routed to the compaction queue
- add regression coverage for the manual compact starting window

Closes #3485

## Verification

- `bun test test/agent-session-auto-compaction-queue.test.ts`
- `bun check`