### PR TITLE
fix(advisor): ground hidden argument warnings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the advisor prompt allowing confident root-cause claims about tool-call arguments absent from its reviewed transcript, so timeout advice now has to cite observed fields instead of inventing mechanisms like `paths[0]` array flattening. ([#3483](https://github.com/can1357/oh-my-pi/issues/3483))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -3,9 +3,9 @@ import type { AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core
 import { type } from "arktype";
 import { createAdvisorMessageCard } from "../../modes/components/advisor-message";
 import { getThemeByName } from "../../modes/theme/theme";
+import advisorSystemPrompt from "../../prompts/advisor/system.md" with { type: "text" };
 import { SecretObfuscator } from "../../secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../../session/session-history-format";
-import advisorSystemPrompt from "../../prompts/advisor/system.md" with { type: "text" };
 import { YieldQueue } from "../../session/yield-queue";
 import {
 	ADVISOR_READONLY_TOOL_NAMES,

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -5,6 +5,7 @@ import { createAdvisorMessageCard } from "../../modes/components/advisor-message
 import { getThemeByName } from "../../modes/theme/theme";
 import { SecretObfuscator } from "../../secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../../session/session-history-format";
+import advisorSystemPrompt from "../../prompts/advisor/system.md" with { type: "text" };
 import { YieldQueue } from "../../session/yield-queue";
 import {
 	ADVISOR_READONLY_TOOL_NAMES,
@@ -21,6 +22,14 @@ import {
 } from "..";
 
 describe("advisor", () => {
+	describe("advisor system prompt", () => {
+		it("forbids concrete claims about hidden arguments", () => {
+			expect(advisorSystemPrompt).toContain("Arguments absent from the rendered transcript are UNKNOWN");
+			expect(advisorSystemPrompt).toContain("NEVER assert concrete values, array indexes");
+			expect(advisorSystemPrompt).toContain("NEVER claim `paths[0]`, array flattening, or malformed `paths`");
+		});
+	});
+
 	describe("formatSessionHistoryMarkdown includeThinking", () => {
 		it("includes thinking text when includeThinking is true", () => {
 			const thinking = "I should check the edge case first.";

--- a/packages/coding-agent/src/prompts/advisor/system.md
+++ b/packages/coding-agent/src/prompts/advisor/system.md
@@ -40,6 +40,11 @@ NEVER advise on intent or process:
 - Intent is the agent's domain; it defaults to informed action.
 - Your lane: correctness, edge cases, design, process.
 
+Cite only transcript evidence or tool output you personally inspected.
+Arguments absent from the rendered transcript are UNKNOWN:
+- NEVER assert concrete values, array indexes, serialization shapes, or caller mistakes for hidden arguments.
+- Hidden/omitted arguments + failure? Say what is observable; suggest inspecting the missing field.
+- Example: if `search` times out and transcript only shows `pattern`, NEVER claim `paths[0]`, array flattening, or malformed `paths`.
 Cite the exact instruction or risk.
 </critical>
 


### PR DESCRIPTION
## Repro
A minimal transcript-rendering repro constructs a `search` call with `paths` plus a `find` call with a `paths` array, then renders the same advisor-visible markdown path: `bun test ./tmp/repro-3483.test.ts`. It confirms `search` shows only `→ search(<pattern>)`, while `find` renders compact JSON and never `paths[0]`.

## Cause
`packages/coding-agent/src/session/session-history-format.ts` intentionally summarizes tool calls through `primaryArg()`, where `search` prefers `pattern` and `paths` is not a primary key; `packages/coding-agent/src/prompts/advisor/system.md` did not prohibit concrete claims about hidden tool arguments, so the advisor could turn a visible timeout into an invented `paths[0]`/array-flattening mechanism.

## Fix
- Added advisor-system guidance requiring claims to cite transcript evidence or advisor-inspected tool output.
- Explicitly forbade concrete values, array indexes, serialization shapes, and caller mistakes for arguments absent from the rendered transcript.
- Added a regression test asserting the advisor prompt contains the hidden-argument guard.
- Added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` passed with 46 tests and 155 assertions. `gh_push_branch` completed the pre-publish gate and pushed `farm/9fbffb6f/advisor-hedge-hidden-args`. Fixes #3483