### PR TITLE
fix(agent): queue input during manual compact startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed manual `/compact` leaving `session.isCompacting` false while active-turn abort teardown awaited, so the first steer/follow-up typed during compaction startup now routes through the compaction queue instead of being lost. ([#3485](https://github.com/can1357/oh-my-pi/issues/3485))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6813,7 +6813,12 @@ export class AgentSession {
 	 * the transcript can distinguish a deliberate user interrupt from an opaque
 	 * abort. Omit it for internal/lifecycle aborts.
 	 */
-	async abort(options?: { goalReason?: "interrupted" | "internal"; reason?: string }): Promise<void> {
+	async abort(options?: {
+		goalReason?: "interrupted" | "internal";
+		reason?: string;
+		/** Internal `/compact` startup keeps the manual-compaction marker alive while aborting the active turn. */
+		preserveCompaction?: boolean;
+	}): Promise<void> {
 		const userInterrupt = options?.reason === USER_INTERRUPT_LABEL;
 		if (userInterrupt) this.#advisorAutoResumeSuppressed = true;
 		// Pull advisor concerns out of the steer/follow-up queues before any await so
@@ -6828,7 +6833,7 @@ export class AgentSession {
 			this.abortRetry();
 			this.#promptGeneration++;
 			this.#scheduledHiddenNextTurnGeneration = undefined;
-			this.abortCompaction();
+			if (!options?.preserveCompaction) this.abortCompaction();
 			this.abortHandoff();
 			this.abortBash();
 			this.abortEval();
@@ -7801,12 +7806,12 @@ export class AgentSession {
 		if (compactMode?.rejectsFocus && customInstructions) {
 			throw new Error(`/compact ${compactMode.name} does not take focus instructions.`);
 		}
-		this.#disconnectFromAgent();
-		await this.abort({ goalReason: "internal" });
 		const compactionAbortController = new AbortController();
 		this.#compactionAbortController = compactionAbortController;
 
 		try {
+			this.#disconnectFromAgent();
+			await this.abort({ goalReason: "internal", preserveCompaction: true });
 			if (!this.model) {
 				throw new Error("No model selected");
 			}

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -215,6 +215,48 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
 	});
 
+	it("marks manual compaction active before abort teardown can yield", async () => {
+		session.settings.set("compaction.keepRecentTokens", 1);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		sessionManager.appendMessage({
+			role: "user",
+			content: "second turn",
+			timestamp: Date.now(),
+		});
+
+		const abortEntered = Promise.withResolvers<void>();
+		const releaseAbort = Promise.withResolvers<void>();
+		let compactingDuringAbort: boolean | undefined;
+		vi.spyOn(session, "abort").mockImplementation(async () => {
+			compactingDuringAbort = session.isCompacting;
+			abortEntered.resolve();
+			await releaseAbort.promise;
+		});
+
+		const compactPromise = session.compact();
+		await abortEntered.promise;
+		releaseAbort.resolve();
+		await compactPromise;
+
+		expect(compactingDuringAbort).toBe(true);
+	});
+
 	it("runs threshold compaction for active goal turns that end with yield", async () => {
 		const now = Date.now();
 		session.setGoalModeState({


### PR DESCRIPTION
## Repro
A focused regression test in `packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts` mocked manual compact abort teardown and reproduced `session.isCompacting === false` while `AgentSession.compact()` awaited that teardown. Command: `bun --cwd=packages/collab-web run build:tool-views && bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts -t "marks manual compaction active"` failed before the fix with `Expected: true, Received: false`.

## Cause
`packages/coding-agent/src/session/agent-session.ts` installed `#compactionAbortController`, which backs `AgentSession.isCompacting`, only after `this.abort({ goalReason: "internal" })` completed. `abort()` awaits active-turn teardown, so the TUI input controller could observe an idle session during manual `/compact` startup and route the first steer/follow-up outside the compaction queue.

## Fix
- Install the manual compaction abort controller before disconnecting and awaiting active-turn abort teardown.
- Let that internal abort preserve the just-installed manual compaction marker instead of aborting it via `abortCompaction()`.
- Add regression coverage for the manual compact starting window and update the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts packages/coding-agent/test/input-controller-compaction-image.test.ts` passed: 20 tests, 46 assertions. `bun --cwd=packages/coding-agent run check` passed. Pre-publish `gh_push_branch` completed its formatter/check gate and pushed `farm/c702d827/manual-compact-queues-steer` at `d380a9e7235b`. Fixes #3485