### PR TITLE
feat(omp): ssh:// URL support for read, search, and write

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ssh://host/path` support to `read`, `search`, and `write` for single text files on pre-configured SSH hosts (or `~/.ssh/config` aliases); UTF-8 text only, up to 1 MiB.
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `ssh://host/path` support to `read`, `search`, and `write` for single text files on pre-configured SSH hosts (or `~/.ssh/config` aliases); UTF-8 text only, up to 1 MiB.
+- Added `ssh://host/path` support to `read`, `search`, and `write` for single text files on pre-configured SSH hosts (or `~/.ssh/config` aliases); UTF-8 text only, up to 1 MiB. Requires the same approval as the `ssh` tool, rejects argument-injecting hosts/usernames (leading `-`), validates the entire file as UTF-8, peels read selectors so `write` targets the same file `read` does, and replaces (rather than writes through) a symlinked write destination via a uniquely named remote temp.
 
 ## [16.1.19] - 2026-06-25
 

--- a/packages/coding-agent/src/internal-urls/__tests__/ssh-protocol.test.ts
+++ b/packages/coding-agent/src/internal-urls/__tests__/ssh-protocol.test.ts
@@ -84,6 +84,17 @@ describe("SshProtocolHandler", () => {
 		await expect(handler.resolve(parseInternalUrl("ssh://icaro/bin/true"))).rejects.toThrow(/binary or non-UTF-8/);
 	});
 
+	it("rejects a file whose first invalid byte falls past the old 8 KiB sniff window", async () => {
+		mockHosts();
+		const bytes = new Uint8Array(9001);
+		bytes.fill(0x61); // 9000 'a' bytes — valid UTF-8 within the former 8 KiB window
+		bytes[9000] = 0xff; // lone invalid UTF-8 byte the old prefix sniff never inspected
+		vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({ bytes, truncated: false });
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/var/log/app.log"))).rejects.toThrow(
+			/binary or non-UTF-8/,
+		);
+	});
+
 	it("rejects a file that exceeds the size cap", async () => {
 		mockHosts();
 		vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({

--- a/packages/coding-agent/src/internal-urls/__tests__/ssh-protocol.test.ts
+++ b/packages/coding-agent/src/internal-urls/__tests__/ssh-protocol.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as capability from "../../capability";
+import type { SSHHost } from "../../capability/ssh";
+import type { CapabilityResult, SourceMeta } from "../../capability/types";
+import * as fileTransfer from "../../ssh/file-transfer";
+import { parseInternalUrl } from "../parse";
+import { SshProtocolHandler } from "../ssh-protocol";
+
+const SOURCE: SourceMeta = {
+	provider: "ssh-json",
+	providerName: "SSH Config",
+	path: "/test/ssh.json",
+	level: "user",
+};
+
+function mockHosts(hosts: SSHHost[] = []): void {
+	const result: CapabilityResult<SSHHost> = {
+		items: hosts,
+		all: hosts,
+		warnings: [],
+		providers: hosts.length ? ["ssh-json"] : [],
+	};
+	vi.spyOn(capability, "loadCapability").mockResolvedValue(result as CapabilityResult<unknown>);
+}
+
+function mockReadBytes(text: string, truncated = false) {
+	return vi
+		.spyOn(fileTransfer, "readRemoteFile")
+		.mockResolvedValue({ bytes: new TextEncoder().encode(text), truncated });
+}
+
+describe("SshProtocolHandler", () => {
+	const handler = new SshProtocolHandler();
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("resolves a remote text file byte-exact with no sourcePath", async () => {
+		mockHosts();
+		mockReadBytes("127.0.0.1 a\n");
+		const resource = await handler.resolve(parseInternalUrl("ssh://icaro/etc/hosts"));
+		expect(resource.content).toBe("127.0.0.1 a\n");
+		expect(resource.contentType).toBe("text/plain");
+		// No sourcePath keeps search on the virtual-resource path (stays `ssh://…`).
+		expect(resource.sourcePath).toBeUndefined();
+	});
+
+	it("derives contentType from the file extension", async () => {
+		mockHosts();
+		mockReadBytes("# title\n");
+		expect((await handler.resolve(parseInternalUrl("ssh://icaro/tmp/readme.md"))).contentType).toBe("text/markdown");
+		mockReadBytes("{}\n");
+		expect((await handler.resolve(parseInternalUrl("ssh://icaro/tmp/data.json"))).contentType).toBe(
+			"application/json",
+		);
+	});
+
+	it("rejects user/port overrides on a configured host", async () => {
+		mockHosts([{ _source: SOURCE, name: "icaro", host: "10.0.0.1" }]);
+		mockReadBytes("x");
+		await expect(handler.resolve(parseInternalUrl("ssh://user@icaro:22/x"))).rejects.toThrow(/user\/port overrides/);
+	});
+
+	it("treats an unconfigured authority as an opaque OpenSSH destination", async () => {
+		mockHosts();
+		const spy = mockReadBytes("data\n");
+		await handler.resolve(parseInternalUrl("ssh://bob@h1:2222/x"));
+		expect(spy.mock.calls[0]?.[0]).toMatchObject({ name: "bob@h1:2222", host: "h1", username: "bob", port: 2222 });
+	});
+
+	it("rejects a host-only URL with no file path", async () => {
+		mockHosts();
+		mockReadBytes("x");
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/"))).rejects.toThrow(/absolute file path/);
+	});
+
+	it("rejects a binary / non-UTF-8 file instead of returning a resource", async () => {
+		mockHosts();
+		vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({
+			bytes: new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]),
+			truncated: false,
+		});
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/bin/true"))).rejects.toThrow(/binary or non-UTF-8/);
+	});
+
+	it("rejects a file that exceeds the size cap", async () => {
+		mockHosts();
+		vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({
+			bytes: new TextEncoder().encode("partial"),
+			truncated: true,
+		});
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/big.log"))).rejects.toThrow(/exceeds the 1 MiB limit/);
+	});
+
+	it("writes content byte-exact through writeRemoteFile", async () => {
+		mockHosts();
+		const spy = vi.spyOn(fileTransfer, "writeRemoteFile").mockResolvedValue(undefined);
+		await handler.write(parseInternalUrl("ssh://icaro/tmp/x"), "hi\n\t!\n");
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy.mock.calls[0]?.[2]).toEqual(new TextEncoder().encode("hi\n\t!\n"));
+	});
+});

--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -21,5 +21,6 @@ export * from "./parse";
 export * from "./router";
 export * from "./rule-protocol";
 export * from "./skill-protocol";
+export * from "./ssh-protocol";
 export type * from "./types";
 export * from "./vault-protocol";

--- a/packages/coding-agent/src/internal-urls/router.ts
+++ b/packages/coding-agent/src/internal-urls/router.ts
@@ -1,5 +1,5 @@
 /**
- * Internal URL router for internal protocols (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, and `vault://`).
+ * Internal URL router for internal protocols (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, and `vault://`).
  *
  * One process-global router with one handler per scheme. Access via
  * `InternalUrlRouter.instance()`. Handlers are stateless; per-session and
@@ -16,6 +16,7 @@ import { OmpProtocolHandler } from "./omp-protocol";
 import { parseInternalUrl } from "./parse";
 import { RuleProtocolHandler } from "./rule-protocol";
 import { SkillProtocolHandler } from "./skill-protocol";
+import { SshProtocolHandler } from "./ssh-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 import { VaultProtocolHandler } from "./vault-protocol";
 
@@ -37,6 +38,7 @@ export class InternalUrlRouter {
 		this.register(new IssueProtocolHandler());
 		this.register(new PrProtocolHandler());
 		this.register(new HistoryProtocolHandler());
+		this.register(new SshProtocolHandler());
 	}
 
 	/** Process-global router instance. */

--- a/packages/coding-agent/src/internal-urls/ssh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/ssh-protocol.ts
@@ -26,8 +26,6 @@ import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, Wr
 
 /** Largest remote text file `ssh://` will materialize (mirrors the local:// cap). */
 const SSH_TEXT_MAX_BYTES = 1024 * 1024;
-/** Bytes sniffed to classify text vs binary (mirrors the local:// sniff window). */
-const SSH_TEXT_SNIFF_BYTES = 8 * 1024;
 
 /** POSIX-aware content type from the last path segment's extension. */
 function contentTypeFor(remotePath: string): InternalResource["contentType"] {
@@ -40,14 +38,13 @@ function contentTypeFor(remotePath: string): InternalResource["contentType"] {
 	return "text/plain";
 }
 
-function isUtf8Text(bytes: Uint8Array): boolean {
-	const slice = bytes.length > SSH_TEXT_SNIFF_BYTES ? bytes.subarray(0, SSH_TEXT_SNIFF_BYTES) : bytes;
-	if (slice.indexOf(0) !== -1) return false;
+/** Decode the whole buffer as UTF-8 text, or null if it holds a NUL or invalid byte. */
+function decodeUtf8Text(bytes: Uint8Array): string | null {
+	if (bytes.indexOf(0) !== -1) return null;
 	try {
-		new TextDecoder("utf-8", { fatal: true }).decode(slice);
-		return true;
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 	} catch {
-		return false;
+		return null;
 	}
 }
 
@@ -126,7 +123,8 @@ export class SshProtocolHandler implements ProtocolHandler {
 				`ssh://: ${remotePath} exceeds the 1 MiB limit; ssh:// supports text files up to 1 MiB — use an sshfs mount for larger files`,
 			);
 		}
-		if (!isUtf8Text(bytes)) {
+		const content = decodeUtf8Text(bytes);
+		if (content === null) {
 			throw new Error(
 				`ssh://: ${remotePath} is a binary or non-UTF-8 file; ssh:// supports UTF-8 text only — use the ssh tool or an sshfs mount`,
 			);
@@ -135,7 +133,7 @@ export class SshProtocolHandler implements ProtocolHandler {
 		// displayed/searched resource stays `ssh://…` instead of a temp path.
 		return {
 			url: url.href,
-			content: new TextDecoder().decode(bytes),
+			content,
 			contentType: contentTypeFor(remotePath),
 			size: bytes.length,
 		};

--- a/packages/coding-agent/src/internal-urls/ssh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/ssh-protocol.ts
@@ -1,0 +1,149 @@
+/**
+ * Protocol handler for `ssh://host/path` URLs.
+ *
+ * Resolves a single remote text file on a pre-configured SSH host — or any
+ * destination OpenSSH can resolve itself (e.g. a `~/.ssh/config` alias) — for
+ * the read, search, and write tools, reusing the shared ControlMaster
+ * connection in `../ssh/connection-manager`.
+ *
+ * Text only. Binary/non-UTF-8 files and files larger than 1 MiB are rejected
+ * with an explicit error rather than returned as a resource: this handler
+ * exposes no `sourcePath`, so a note-style resource would make `search` grep the
+ * note text and report "No matches found", hiding the real condition.
+ *
+ * `loadCapability` is imported from `../capability` (not the `../discovery`
+ * barrel) on purpose — pulling the barrel here would route
+ * `path-utils -> internal-urls -> ssh-protocol -> discovery -> path-utils` and
+ * eager-load every provider on any `path-utils` import. Runtime bootstraps the
+ * SSH provider via `import "./discovery"` (sdk.ts) / `initializeWithSettings`
+ * (main.ts) before any tool resolves.
+ */
+import * as capability from "../capability";
+import { type SSHHost, sshCapability } from "../capability/ssh";
+import type { SSHConnectionTarget } from "../ssh/connection-manager";
+import { readRemoteFile, writeRemoteFile } from "../ssh/file-transfer";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, WriteContext } from "./types";
+
+/** Largest remote text file `ssh://` will materialize (mirrors the local:// cap). */
+const SSH_TEXT_MAX_BYTES = 1024 * 1024;
+/** Bytes sniffed to classify text vs binary (mirrors the local:// sniff window). */
+const SSH_TEXT_SNIFF_BYTES = 8 * 1024;
+
+/** POSIX-aware content type from the last path segment's extension. */
+function contentTypeFor(remotePath: string): InternalResource["contentType"] {
+	const slash = remotePath.lastIndexOf("/");
+	const base = slash === -1 ? remotePath : remotePath.slice(slash + 1);
+	const dot = base.lastIndexOf(".");
+	const ext = dot <= 0 ? "" : base.slice(dot).toLowerCase();
+	if (ext === ".md") return "text/markdown";
+	if (ext === ".json") return "application/json";
+	return "text/plain";
+}
+
+function isUtf8Text(bytes: Uint8Array): boolean {
+	const slice = bytes.length > SSH_TEXT_SNIFF_BYTES ? bytes.subarray(0, SSH_TEXT_SNIFF_BYTES) : bytes;
+	if (slice.indexOf(0) !== -1) return false;
+	try {
+		new TextDecoder("utf-8", { fatal: true }).decode(slice);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Remote absolute path from the URL. Uses `rawPathname` (pre-normalization) so
+ * `..`/`//` and percent-escapes survive verbatim to the remote shell; the
+ * authority (host/user/port) stays on the WHATWG fields, which preserve case for
+ * the non-special `ssh` scheme.
+ */
+function remotePathFromUrl(url: InternalUrl): string {
+	const raw = url.rawPathname ?? url.pathname;
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(raw);
+	} catch {
+		throw new Error(`Invalid URL encoding in ssh:// path: ${url.href}`);
+	}
+	if (!decoded || decoded === "/") {
+		throw new Error("ssh:// requires an absolute file path, e.g. ssh://host/etc/hosts");
+	}
+	return decoded;
+}
+
+/**
+ * Resolve the URL authority to an SSH connection target. Prefers an
+ * OMP-discovered host by name; otherwise treats the authority as an opaque
+ * OpenSSH destination so plain `~/.ssh/config` aliases work. User/port overrides
+ * on a configured host name are rejected — the ControlMaster/host-info caches
+ * key on `name` alone, so a different authority under the same alias would
+ * collide.
+ */
+async function resolveTarget(url: InternalUrl, cwd?: string): Promise<SSHConnectionTarget> {
+	const host = url.hostname;
+	if (!host) {
+		throw new Error("ssh:// requires a host: ssh://<host>/<absolute-path>");
+	}
+	const username = url.username || undefined;
+	const port = url.port ? Number(url.port) : undefined;
+
+	const { items } = await capability.loadCapability<SSHHost>(sshCapability.id, { cwd });
+	const match = items.find(entry => entry.name === host);
+
+	if (match) {
+		if (username || port !== undefined) {
+			throw new Error(
+				`ssh://: user/port overrides are not allowed for the configured host "${host}"; use ssh://${host}/<path> or an unconfigured hostname`,
+			);
+		}
+		return {
+			name: match.name,
+			host: match.host,
+			username: match.username,
+			port: match.port,
+			keyPath: match.keyPath,
+			compat: match.compat,
+		};
+	}
+
+	const name = `${username ? `${username}@` : ""}${host}${port !== undefined ? `:${port}` : ""}`;
+	return { name, host, username, port };
+}
+
+export class SshProtocolHandler implements ProtocolHandler {
+	readonly scheme = "ssh";
+	readonly immutable = false;
+
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const target = await resolveTarget(url, context?.cwd);
+		const remotePath = remotePathFromUrl(url);
+		const { bytes, truncated } = await readRemoteFile(target, remotePath, {
+			maxBytes: SSH_TEXT_MAX_BYTES,
+			signal: context?.signal,
+		});
+		if (truncated) {
+			throw new Error(
+				`ssh://: ${remotePath} exceeds the 1 MiB limit; ssh:// supports text files up to 1 MiB — use an sshfs mount for larger files`,
+			);
+		}
+		if (!isUtf8Text(bytes)) {
+			throw new Error(
+				`ssh://: ${remotePath} is a binary or non-UTF-8 file; ssh:// supports UTF-8 text only — use the ssh tool or an sshfs mount`,
+			);
+		}
+		// No `sourcePath`: keeps search on the virtual-resource path so the
+		// displayed/searched resource stays `ssh://…` instead of a temp path.
+		return {
+			url: url.href,
+			content: new TextDecoder().decode(bytes),
+			contentType: contentTypeFor(remotePath),
+			size: bytes.length,
+		};
+	}
+
+	async write(url: InternalUrl, content: string, context?: WriteContext): Promise<void> {
+		const target = await resolveTarget(url, context?.cwd);
+		const remotePath = remotePathFromUrl(url);
+		await writeRemoteFile(target, remotePath, new TextEncoder().encode(content), { signal: context?.signal });
+	}
+}

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the internal URL routing system.
  *
- * Internal URLs (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, and `vault://`) are resolved by tools like read,
+ * Internal URLs (`agent://`, `artifact://`, `history://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, `ssh://`, and `vault://`) are resolved by tools like read,
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -69,7 +69,7 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 
 All URI schemes take the same line selectors. `artifact://<id>` recovers full output a bash/eval/tool result spilled or truncated. `history://<agentId>` = agent transcript; bare `history://` lists agents.
 
-`ssh://host/<absolute-path>` reads a single text file on a pre-configured SSH host or `~/.ssh/config` alias (UTF-8 text only, ≤1 MiB; no binary/recursive/glob). Also writable via `write` and searchable via `search`.
+`ssh://host/<absolute-path>` reads a single text file on a pre-configured SSH host or `~/.ssh/config` alias (UTF-8 text only, ≤1 MiB; no binary/recursive/glob). Also writable via `write` and searchable via `search`. A literal `:` in the remote path must be percent-encoded as `%3A`, since a trailing `:sel` is read as a line selector.
 
 <critical>
 - Line ranges go in the selector: `path="src/foo.ts:50-200"`.

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -7,7 +7,7 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 
 ## Parameters
 
-- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `history://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`, `omp://`, `issue://`, `pr://`), or URL. Append `:<sel>` for ranges/modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `history://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`, `omp://`, `issue://`, `pr://`, `ssh://`), or URL. Append `:<sel>` for ranges/modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
 
 ## Selectors
 
@@ -68,6 +68,8 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 # Internal URIs
 
 All URI schemes take the same line selectors. `artifact://<id>` recovers full output a bash/eval/tool result spilled or truncated. `history://<agentId>` = agent transcript; bare `history://` lists agents.
+
+`ssh://host/<absolute-path>` reads a single text file on a pre-configured SSH host or `~/.ssh/config` alias (UTF-8 text only, ≤1 MiB; no binary/recursive/glob). Also writable via `write` and searchable via `search`.
 
 <critical>
 - Line ranges go in the selector: `path="src/foo.ts:50-200"`.

--- a/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
+++ b/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { buildRemoteCommand, type SSHConnectionTarget } from "../connection-manager";
+
+const TARGET: SSHConnectionTarget = { name: "h", host: "h" };
+
+describe("buildRemoteCommand stdin handling", () => {
+	it("includes -n by default so ssh reads stdin from /dev/null", async () => {
+		const args = await buildRemoteCommand(TARGET, "cat");
+		expect(args).toContain("-n");
+	});
+
+	it("omits -n when allowStdin is set so the remote command reads piped stdin", async () => {
+		const args = await buildRemoteCommand(TARGET, "cat", { allowStdin: true });
+		expect(args).not.toContain("-n");
+	});
+});

--- a/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
+++ b/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { buildRemoteCommand, type SSHConnectionTarget } from "../connection-manager";
+import { buildSshTarget } from "../utils";
 
 const TARGET: SSHConnectionTarget = { name: "h", host: "h" };
 
@@ -12,5 +13,26 @@ describe("buildRemoteCommand stdin handling", () => {
 	it("omits -n when allowStdin is set so the remote command reads piped stdin", async () => {
 		const args = await buildRemoteCommand(TARGET, "cat", { allowStdin: true });
 		expect(args).not.toContain("-n");
+	});
+});
+
+describe("buildSshTarget argument-injection guard", () => {
+	it("rejects a host that begins with '-' (ssh would parse it as an option)", () => {
+		expect(() => buildSshTarget(undefined, "-oProxyCommand=touch /tmp/pwned")).toThrow(/must not begin with/);
+	});
+
+	it("rejects a username that begins with '-'", () => {
+		expect(() => buildSshTarget("-oProxyCommand=x", "host")).toThrow(/must not begin with/);
+	});
+
+	it("renders a normal destination unchanged", () => {
+		expect(buildSshTarget("user", "host")).toBe("user@host");
+		expect(buildSshTarget(undefined, "host")).toBe("host");
+	});
+
+	it("rejects a dash-leading host through the real buildRemoteCommand path", async () => {
+		await expect(buildRemoteCommand({ name: "x", host: "-oProxyCommand=x" }, "cat")).rejects.toThrow(
+			/must not begin with/,
+		);
 	});
 });

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -40,6 +40,8 @@ const hostInfoCache = new Map<string, SSHHostInfo>();
 
 interface SSHArgsOptions {
 	platform?: SshPlatform;
+	/** When true, omit `-n` so the remote command can read from our piped stdin. */
+	allowStdin?: boolean;
 }
 
 function ensureControlDir() {
@@ -87,7 +89,7 @@ async function validateKeyPermissions(keyPath?: string, platform: SshPlatform = 
 }
 
 function buildCommonArgs(host: SSHConnectionTarget, options?: SSHArgsOptions): string[] {
-	const args = ["-n"];
+	const args = options?.allowStdin ? [] : ["-n"];
 
 	if (supportsSshControlMaster(options?.platform)) {
 		args.push("-o", "ControlMaster=auto", "-o", `ControlPath=${CONTROL_PATH}`, "-o", "ControlPersist=3600");

--- a/packages/coding-agent/src/ssh/file-transfer.ts
+++ b/packages/coding-agent/src/ssh/file-transfer.ts
@@ -1,0 +1,82 @@
+/**
+ * Byte-preserving remote file I/O over the shared SSH ControlMaster connection.
+ *
+ * Unlike `executeSSH` (which truncates/sanitizes through an OutputSink) and
+ * `runSshCaptureSync` (which `.trim()`s output), these helpers move raw bytes so
+ * `ssh://` reads/writes round-trip exactly — leading/trailing whitespace, tabs,
+ * and final newlines are preserved.
+ */
+import { ptree } from "@oh-my-pi/pi-utils";
+import { buildRemoteCommand, ensureConnection, type SSHConnectionTarget } from "./connection-manager";
+import { quotePosixPath } from "./utils";
+
+/** Per-operation timeout for remote transfers (matches the ssh tool's grep window). */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface RemoteFileReadOptions {
+	/** Maximum bytes to materialize; the helper fetches one extra byte to detect truncation. */
+	maxBytes: number;
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+export interface RemoteFileReadResult {
+	/** Raw file bytes, capped at `maxBytes`. */
+	bytes: Uint8Array;
+	/** True when the remote file was larger than `maxBytes` (`bytes` is the prefix). */
+	truncated: boolean;
+}
+
+export interface RemoteFileWriteOptions {
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+/**
+ * Read a remote file's raw bytes. Fetches `maxBytes + 1` so the caller can
+ * distinguish an exactly-`maxBytes` file from a larger (truncated) one.
+ *
+ * Throws `ptree.NonZeroExitError` (carrying the remote stderr tail) when the
+ * file is missing/unreadable or the host is unreachable.
+ */
+export async function readRemoteFile(
+	target: SSHConnectionTarget,
+	remotePath: string,
+	opts: RemoteFileReadOptions,
+): Promise<RemoteFileReadResult> {
+	await ensureConnection(target);
+	const command = `head -c ${opts.maxBytes + 1} ${quotePosixPath(remotePath)}`;
+	const args = await buildRemoteCommand(target, command);
+	using child = ptree.spawn(["ssh", ...args], {
+		signal: ptree.combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+	});
+	// Drain stdout before awaiting exit so a full pipe can't deadlock the child.
+	const raw = await child.bytes();
+	await child.exitedCleanly;
+	const truncated = raw.length > opts.maxBytes;
+	return { bytes: truncated ? raw.subarray(0, opts.maxBytes) : raw, truncated };
+}
+
+/**
+ * Write `content` to a remote file byte-exact. Streams stdin into a temp file
+ * and atomically renames it into place so a partial transfer never clobbers the
+ * destination. Throws `ptree.NonZeroExitError` when the remote path is
+ * unwritable or the host is unreachable.
+ */
+export async function writeRemoteFile(
+	target: SSHConnectionTarget,
+	remotePath: string,
+	content: Uint8Array,
+	opts: RemoteFileWriteOptions,
+): Promise<void> {
+	await ensureConnection(target);
+	const dest = quotePosixPath(remotePath);
+	const tmp = quotePosixPath(`${remotePath}.omp-tmp`);
+	const command = `cat > ${tmp} && mv ${tmp} ${dest}`;
+	const args = await buildRemoteCommand(target, command, { allowStdin: true });
+	using child = ptree.spawn(["ssh", ...args], {
+		stdin: content,
+		signal: ptree.combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+	});
+	await child.exitedCleanly;
+}

--- a/packages/coding-agent/src/ssh/file-transfer.ts
+++ b/packages/coding-agent/src/ssh/file-transfer.ts
@@ -58,10 +58,14 @@ export async function readRemoteFile(
 }
 
 /**
- * Write `content` to a remote file byte-exact. Streams stdin into a temp file
- * and atomically renames it into place so a partial transfer never clobbers the
- * destination. Throws `ptree.NonZeroExitError` when the remote path is
- * unwritable or the host is unreachable.
+ * Write `content` to a remote file byte-exact. Streams stdin into a uniquely
+ * named temp file in the destination directory, then atomically renames it into
+ * place so a partial transfer never clobbers the destination and concurrent
+ * writers cannot collide on the temp name. The rename REPLACES a symlink at the
+ * destination with a regular file rather than writing through it (resolving the
+ * link target is not portable across the macOS/Linux hosts this stack supports).
+ * Throws `ptree.NonZeroExitError` when the remote path is unwritable or the host
+ * is unreachable.
  */
 export async function writeRemoteFile(
 	target: SSHConnectionTarget,
@@ -71,7 +75,7 @@ export async function writeRemoteFile(
 ): Promise<void> {
 	await ensureConnection(target);
 	const dest = quotePosixPath(remotePath);
-	const tmp = quotePosixPath(`${remotePath}.omp-tmp`);
+	const tmp = quotePosixPath(`${remotePath}.omp-tmp.${crypto.randomUUID()}`);
 	const command = `cat > ${tmp} && mv ${tmp} ${dest}`;
 	const args = await buildRemoteCommand(target, command, { allowStdin: true });
 	using child = ptree.spawn(["ssh", ...args], {

--- a/packages/coding-agent/src/ssh/utils.ts
+++ b/packages/coding-agent/src/ssh/utils.ts
@@ -4,6 +4,20 @@ export function sanitizeHostName(name: string): string {
 }
 
 export function buildSshTarget(username: string | undefined, host: string): string {
+	// SSH treats a destination starting with "-" as an option, so a host/user of
+	// `-oProxyCommand=...` becomes local command execution. Reject before this
+	// string reaches any `ssh` argv (this is the single render chokepoint for
+	// every connection, transfer, and sshfs mount).
+	if (host.startsWith("-")) {
+		throw new Error(
+			`Invalid SSH host "${host}": an SSH destination must not begin with "-" (argument-injection guard)`,
+		);
+	}
+	if (username?.startsWith("-")) {
+		throw new Error(
+			`Invalid SSH username "${username}": an SSH username must not begin with "-" (argument-injection guard)`,
+		);
+	}
 	return username ? `${username}@${host}` : host;
 }
 

--- a/packages/coding-agent/src/ssh/utils.ts
+++ b/packages/coding-agent/src/ssh/utils.ts
@@ -6,3 +6,13 @@ export function sanitizeHostName(name: string): string {
 export function buildSshTarget(username: string | undefined, host: string): string {
 	return username ? `${username}@${host}` : host;
 }
+
+/**
+ * Single-quote a path for a POSIX remote shell, escaping embedded single quotes.
+ * Mirrors the private `quoteRemotePath` in `tools/ssh.ts`; shared here for the
+ * `ssh://` file-transfer helpers.
+ */
+export function quotePosixPath(value: string): string {
+	if (value.length === 0) return "''";
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -26,7 +26,9 @@ const INTERNAL_URL_SELECTOR_PART_RE = new RegExp(
 );
 // Schemes whose host grammar is identifier-shaped, so any trailing
 // `:<selector-chunk>` is unambiguously a read-tool selector. `mcp://` is
-// excluded because mcp resource URIs may legitimately contain colons.
+// excluded because mcp resource URIs may legitimately contain colons. `ssh://`
+// is included despite an optional `:port` — a selector only ever trails the
+// `/path`, which blocks the port colon from being peeled.
 const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	agent: true,
 	artifact: true,
@@ -37,6 +39,7 @@ const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	pr: true,
 	rule: true,
 	skill: true,
+	ssh: true,
 	vault: true,
 };
 // Schemes whose resource URIs are server-defined and may legitimately end
@@ -55,6 +58,7 @@ const TOP_LEVEL_INTERNAL_URL_PREFIXES = [
 	"rule://",
 	"local://",
 	"mcp://",
+	"ssh://",
 	"vault://",
 ] as const;
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -356,6 +356,27 @@ export function splitInternalUrlSel(rawPath: string): { path: string; sel?: stri
 	return { path, sel: chunks.join(":") };
 }
 
+/**
+ * Peel a read-tool selector off an internal-URL write target so `write` resolves
+ * the same file `read` does (e.g. `ssh://h/f:raw` -> `ssh://h/f`). Only the
+ * whole-file display modes `raw`/`conflicts` are accepted (they do not change
+ * which bytes are written); any other selector-shaped tail `splitInternalUrlSel`
+ * peels — a line range, a compound like `raw:1-20`, or a malformed `:-N` — throws,
+ * because `write` addresses a whole file, not a partial range, and silently
+ * stripping it would write to a path the caller never named. Non-URL paths and
+ * URLs without a selector pass through unchanged.
+ */
+export function peelWriteUrlSelector(rawPath: string): string {
+	const { path, sel } = splitInternalUrlSel(rawPath);
+	if (sel === undefined) return rawPath;
+	// Case-insensitive to match read's selector grammar (parseSel + the /i regexes above).
+	if (/^(?:raw|conflicts)$/i.test(sel)) return path;
+	throw new ToolError(
+		`write does not accept the trailing selector ":${sel}" — it writes a whole file. ` +
+			`Remove ":${sel}", or if the filename truly ends with it, percent-encode the ":" as %3A.`,
+	);
+}
+
 function assertNotInternalUrl(expanded: string, original: string): void {
 	for (const prefix of TOP_LEVEL_INTERNAL_URL_PREFIXES) {
 		if (expanded.startsWith(prefix)) {
@@ -377,6 +398,20 @@ export function isInternalUrlPath(filePath: string): boolean {
 		if (expandedAndNormalized.startsWith(prefix)) return true;
 	}
 	return false;
+}
+
+/**
+ * True when a tool path argument references the `ssh://` scheme anywhere.
+ *
+ * Substring (not anchored) on purpose: it feeds the read/search/write approval
+ * tier, which runs synchronously on the raw args. `search` only flattens a
+ * delimited `paths: "a,ssh://h/x"` into separate entries *after* approval, so an
+ * anchored check would let an embedded `ssh://` slip through at the read tier.
+ * Matching the literal `ssh://` substring also tracks exactly what routes to the
+ * SSH handler; over-matching only over-prompts (fail-closed).
+ */
+export function pathTargetsSsh(path: string): boolean {
+	return /ssh:\/\//i.test(path);
 }
 
 /**

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -3,7 +3,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { formatHashlineHeader, formatNumberedLine, formatNumberedLines } from "@oh-my-pi/hashline";
-import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ToolTier,
+} from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { glob, type SummaryResult, summarizeCode } from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
@@ -83,6 +89,7 @@ import {
 	formatPathRelativeToCwd,
 	type LineRange,
 	parseLineRanges,
+	pathTargetsSsh,
 	resolveReadPath,
 	splitDelimitedPathEntry,
 	splitInternalUrlSel,
@@ -814,7 +821,8 @@ type SuffixMatchCache = Map<string, { absolutePath: string; displayPath: string 
  */
 export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	readonly name = "read";
-	readonly approval = "read" as const;
+	readonly approval = (args: unknown): ToolTier =>
+		pathTargetsSsh(String((args as { path?: unknown }).path ?? "")) ? "exec" : "read";
 	readonly label = "Read";
 	readonly loadMode = "essential";
 	readonly description: string;

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -2,7 +2,13 @@ import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { formatHashlineHeader } from "@oh-my-pi/hashline";
-import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ToolTier,
+} from "@oh-my-pi/pi-agent-core";
 import { type GrepMatch, GrepOutputMode, type GrepResult, grep } from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
@@ -40,6 +46,7 @@ import {
 	isLineInRanges,
 	type LineRange,
 	parseLineRanges,
+	pathTargetsSsh,
 	type ResolvedSearchTarget,
 	resolveReadPath,
 	resolveToolSearchScope,
@@ -668,7 +675,8 @@ type SearchParams = typeof searchSchema.infer;
 
 export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDetails> {
 	readonly name = "search";
-	readonly approval = "read" as const;
+	readonly approval = (args: unknown): ToolTier =>
+		toPathList((args as { paths?: string | string[] }).paths).some(pathTargetsSsh) ? "exec" : "read";
 	readonly label = "Search";
 	readonly loadMode = "discoverable";
 	readonly summary = "Search file contents using ripgrep (fast text search)";

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -3,7 +3,13 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { formatHashlineHeader, stripHashlinePrefixes } from "@oh-my-pi/hashline";
-import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ToolTier,
+} from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { isEnoent, isRecord, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
@@ -41,7 +47,7 @@ import {
 } from "./conflict-detect";
 import { invalidateFsScanAfterWrite } from "./fs-cache-invalidation";
 import { type OutputMeta, outputMeta } from "./output-meta";
-import { formatPathRelativeToCwd, isInternalUrlPath } from "./path-utils";
+import { formatPathRelativeToCwd, isInternalUrlPath, pathTargetsSsh, peelWriteUrlSelector } from "./path-utils";
 import { enforcePlanModeWrite, resolvePlanPath, unwrapHashlineHeaderPath } from "./plan-mode-guard";
 import {
 	cachedRenderedString,
@@ -263,14 +269,22 @@ function parseSqliteWriteTarget(subPath: string, queryString: string): { table: 
  */
 export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails> {
 	readonly name = "write";
-	readonly approval = (args: unknown) => {
+	readonly approval = (args: unknown): ToolTier => {
 		const rawPath = (args as Partial<WriteParams>).path;
-		if (typeof rawPath !== "string" || !isInternalUrlPath(rawPath)) return "write";
+		if (typeof rawPath !== "string") return "write";
+		// Unwrap a hashline `[path#TAG]` wrapper first (parity with execute) so a
+		// wrapped `[ssh://h/x#ABCD]` can't dodge scheme detection and the tier checks below.
+		const path = unwrapHashlineHeaderPath(rawPath);
+		// Remote SSH writes open an outbound connection and run a remote shell —
+		// gate them like the exec-tier `ssh` tool, ahead of the handler-write
+		// logic. Substring match also covers selector-suffixed targets.
+		if (pathTargetsSsh(path)) return "exec";
+		if (!isInternalUrlPath(path)) return "write";
 		// Internal URLs are usually session-local artifacts (read tier), but a
-		// scheme whose handler exposes a `write` hook mutates handler-owned
-		// user data (e.g. vault:// notes, host-owned mcp:// URIs) and must take
-		// the write tier so always-ask mode actually prompts.
-		const match = /^([a-z][a-z0-9+.-]*):\/\//i.exec(rawPath.trim());
+		// scheme whose handler exposes a `write` hook mutates handler-owned user
+		// data (e.g. vault:// notes) and must take the write tier so always-ask
+		// mode actually prompts.
+		const match = /^([a-z][a-z0-9+.-]*):\/\//i.exec(path.trim());
 		const handler = match ? InternalUrlRouter.instance().getHandler(match[1]!.toLowerCase()) : undefined;
 		return handler?.write ? "write" : "read";
 	};
@@ -778,7 +792,9 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		// (which fails on a leading `[`) and the bridge router would send a
 		// `[local://scratch.md#ABCD]` write to the editor instead of the
 		// session-local sandbox.
-		const path = unwrapHashlineHeaderPath(rawPath);
+		// Peel a read-tool selector (`:raw`, `:1-20`, …) so the write target matches
+		// what `read` resolves for the same URL; line-range/malformed selectors throw.
+		const path = peelWriteUrlSelector(unwrapHashlineHeaderPath(rawPath));
 		return untilAborted(signal, async () => {
 			// Strip hashline display prefixes ([PATH#HASH] + LINE:) if the model copied them from read output
 			const { text: cleanContent, stripped } = stripWriteContent(this.session, content);

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { splitInternalUrlSel } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
+import { pathTargetsSsh, peelWriteUrlSelector, splitInternalUrlSel } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 
 describe("splitInternalUrlSel", () => {
 	it("returns the input unchanged when there is no selector tail", () => {
@@ -122,5 +122,56 @@ describe("splitInternalUrlSel", () => {
 		expect(splitInternalUrlSel("http://example.com:1-50")).toEqual({
 			path: "http://example.com:1-50",
 		});
+	});
+});
+
+describe("peelWriteUrlSelector (write/read selector parity)", () => {
+	it("peels whole-file display selectors so write targets the same file read does", () => {
+		expect(peelWriteUrlSelector("ssh://h/f:raw")).toBe("ssh://h/f");
+		expect(peelWriteUrlSelector("ssh://h/f:conflicts")).toBe("ssh://h/f");
+	});
+
+	it("matches read's case-insensitive selector grammar", () => {
+		expect(peelWriteUrlSelector("ssh://h/f:RAW")).toBe("ssh://h/f");
+		expect(peelWriteUrlSelector("ssh://h/f:Conflicts")).toBe("ssh://h/f");
+	});
+
+	it("passes through paths with no peelable selector", () => {
+		expect(peelWriteUrlSelector("ssh://h/f")).toBe("ssh://h/f");
+		expect(peelWriteUrlSelector("vault://note")).toBe("vault://note");
+		// A real filesystem path with a colon is not a scheme:// URL, so it is never peeled.
+		expect(peelWriteUrlSelector("/tmp/local:1-20")).toBe("/tmp/local:1-20");
+	});
+
+	it("applies the same peel to every write-capable internal scheme (intentional, matches read's target)", () => {
+		// vault:// and local:// writes peel display selectors too — write targets
+		// the base resource read resolves, not a note/file literally named `note:raw`.
+		expect(peelWriteUrlSelector("vault://note:raw")).toBe("vault://note");
+		expect(peelWriteUrlSelector("local://foo.txt:conflicts")).toBe("local://foo.txt");
+		expect(() => peelWriteUrlSelector("vault://note:1-20")).toThrow(/whole file/);
+	});
+
+	it("rejects line-range and malformed selectors instead of silently stripping them", () => {
+		expect(() => peelWriteUrlSelector("ssh://h/f:1-20")).toThrow(/whole file/);
+		expect(() => peelWriteUrlSelector("ssh://h/f:-10")).toThrow(/whole file/);
+		expect(() => peelWriteUrlSelector("ssh://h/f:raw:1-20")).toThrow(/whole file/);
+		expect(() => peelWriteUrlSelector("ssh://h/f:conflicts:1-20")).toThrow(/whole file/);
+	});
+});
+
+describe("pathTargetsSsh", () => {
+	it("matches the ssh:// scheme anywhere in the argument (substring, case-insensitive)", () => {
+		expect(pathTargetsSsh("ssh://h/x")).toBe(true);
+		expect(pathTargetsSsh("SSH://h/x")).toBe(true);
+		// A delimited entry that search only splits into separate paths AFTER approval runs.
+		expect(pathTargetsSsh("src,ssh://h/etc/hosts")).toBe(true);
+		// A hashline-wrapped path.
+		expect(pathTargetsSsh("[ssh://h/x#AB12]")).toBe(true);
+	});
+
+	it("does not match local filesystem paths or other internal schemes", () => {
+		expect(pathTargetsSsh("src/foo.ts")).toBe(false);
+		expect(pathTargetsSsh("local://x")).toBe(false);
+		expect(pathTargetsSsh("")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/tools/ssh-url-approval-gate.test.ts
+++ b/packages/coding-agent/test/tools/ssh-url-approval-gate.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+// Exercises the real per-tool approval gate (ExtensionToolWrapper) for read/search/write,
+// proving an `ssh://` target is exec-tier (prompts / is denied without a UI) while the
+// equivalent local-path call runs. ssh:// calls are rejected at the approval gate before any
+// connection, so this suite needs no live ssh.
+const BASE_SETTINGS = {
+	"async.enabled": false,
+	"bash.autoBackground.enabled": false,
+	"bashInterceptor.enabled": false,
+} as const;
+
+const APPROVAL_RE = /requires approval but no interactive UI available/;
+
+describe("ssh:// tools are exec-gated through the production approval wrapper", () => {
+	let tempDir: string;
+	let session: AgentSession;
+
+	beforeAll(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-ssh-approval-${Snowflake.next()}-`));
+		const cwd = path.join(tempDir, "cwd");
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.writeFileSync(path.join(cwd, "local.txt"), "hello-local\n");
+		const sessionManager = SessionManager.create(cwd, path.join(tempDir, "sessions"));
+		const created = await createAgentSession({
+			cwd,
+			agentDir: tempDir,
+			sessionManager,
+			settings: Settings.isolated(BASE_SETTINGS),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			workspaceTree: { rootPath: cwd, rendered: ".\n", truncated: false, totalLines: 1, agentsMdFiles: [] },
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames: ["read", "search", "write"],
+		});
+		session = created.session;
+	});
+
+	afterAll(async () => {
+		await session.dispose();
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup; the OS reclaims the temp dir
+		}
+	});
+
+	function tool(name: "read" | "search" | "write") {
+		const found = session.getToolByName(name);
+		if (!found) throw new Error(`Expected ${name} tool`);
+		return found;
+	}
+
+	function ctx(approvalMode: "always-ask" | "write"): AgentToolContext {
+		return {
+			settings: Settings.isolated({ ...BASE_SETTINGS, "tools.approvalMode": approvalMode }),
+		} as AgentToolContext;
+	}
+
+	it("read: ssh:// requires approval (exec), a local path runs (read)", async () => {
+		await expect(
+			tool("read").execute(
+				"r-ssh",
+				{ path: "ssh://localhost/etc/hostname" },
+				undefined,
+				undefined,
+				ctx("always-ask"),
+			),
+		).rejects.toThrow(APPROVAL_RE);
+		const ok = await tool("read").execute("r-local", { path: "local.txt" }, undefined, undefined, ctx("always-ask"));
+		expect(JSON.stringify(ok.content)).toContain("hello-local");
+	});
+
+	it("search: a delimited ssh:// entry requires approval before path expansion", async () => {
+		// The wrapper sees `paths` verbatim (pre-expansion), so the substring scan must trip exec here.
+		await expect(
+			tool("search").execute(
+				"s-ssh",
+				{ pattern: "x", paths: "local.txt,ssh://localhost/etc/hosts" },
+				undefined,
+				undefined,
+				ctx("always-ask"),
+			),
+		).rejects.toThrow(APPROVAL_RE);
+		const ok = await tool("search").execute(
+			"s-local",
+			{ pattern: "hello", paths: ["."] },
+			undefined,
+			undefined,
+			ctx("always-ask"),
+		);
+		expect(ok).toBeDefined();
+	});
+
+	it("write: ssh:// requires approval (exec), a local write runs (write tier, write mode)", async () => {
+		await expect(
+			tool("write").execute(
+				"w-ssh",
+				{ path: "ssh://localhost/tmp/x", content: "x" },
+				undefined,
+				undefined,
+				ctx("write"),
+			),
+		).rejects.toThrow(APPROVAL_RE);
+		const ok = await tool("write").execute(
+			"w-local",
+			{ path: "out.txt", content: "data\n" },
+			undefined,
+			undefined,
+			ctx("write"),
+		);
+		expect(JSON.stringify(ok.content)).toContain("out.txt");
+	});
+});

--- a/packages/coding-agent/test/tools/ssh-url-approval.test.ts
+++ b/packages/coding-agent/test/tools/ssh-url-approval.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { SearchTool } from "@oh-my-pi/pi-coding-agent/tools/search";
+import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
+
+// Minimal ToolSession stub (block-images.test.ts shape). Approval functions are
+// pure over their args, and the write-execute selector reject throws before any
+// session/SSH access, so no real cwd/fs is needed.
+function createTestToolSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		enableLsp: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+}
+
+function callApproval(tool: { approval?: unknown }, args: unknown): string {
+	const approval = tool.approval;
+	if (typeof approval !== "function") throw new Error("expected a dynamic approval function");
+	return approval(args) as string;
+}
+
+describe("ssh:// tools require exec-tier approval", () => {
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+
+	it("read: ssh:// targets are exec, local paths stay read", () => {
+		const tool = new ReadTool(createTestToolSession(os.tmpdir()));
+		expect(callApproval(tool, { path: "ssh://icaro/etc/hostname" })).toBe("exec");
+		expect(callApproval(tool, { path: "/etc/hostname" })).toBe("read");
+		expect(callApproval(tool, { path: "local://notes" })).toBe("read");
+		expect(callApproval(tool, {})).toBe("read");
+	});
+
+	it("search: an ssh:// entry flattened into a delimited path still trips exec", () => {
+		const tool = new SearchTool(createTestToolSession(os.tmpdir()));
+		// The delimited string is one entry at approval time (expansion happens
+		// later), so an anchored check would miss it — the substring scan must not.
+		expect(callApproval(tool, { paths: "src,ssh://icaro/etc/hosts" })).toBe("exec");
+		expect(callApproval(tool, { paths: ["src", "ssh://icaro/etc/hosts"] })).toBe("exec");
+		expect(callApproval(tool, { paths: ["src", "lib"] })).toBe("read");
+		expect(callApproval(tool, { paths: "src" })).toBe("read");
+		expect(callApproval(tool, {})).toBe("read");
+	});
+
+	it("write: ssh:// is exec even when wrapped in a hashline header", () => {
+		const tool = new WriteTool(createTestToolSession(os.tmpdir()));
+		expect(callApproval(tool, { path: "ssh://icaro/tmp/x" })).toBe("exec");
+		// A pasted `[path#TAG]` wrapper must not let an ssh write dodge the exec tier.
+		expect(callApproval(tool, { path: "[ssh://icaro/tmp/x#ABCD]" })).toBe("exec");
+		expect(callApproval(tool, { path: "/tmp/local-file.txt" })).toBe("write");
+	});
+});
+
+describe("write rejects ssh:// line-range/malformed selectors before connecting", () => {
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+
+	it("execute throws on a line-range or malformed selector without any SSH op", async () => {
+		const tool = new WriteTool(createTestToolSession(os.tmpdir()));
+		await expect(tool.execute("w-range", { path: "ssh://icaro/tmp/f:1-20", content: "x" })).rejects.toThrow(
+			/whole file/,
+		);
+		await expect(tool.execute("w-malformed", { path: "ssh://icaro/tmp/f:-10", content: "x" })).rejects.toThrow(
+			/whole file/,
+		);
+	});
+});

--- a/packages/coding-agent/test/tools/ssh-url-localhost-e2e.test.ts
+++ b/packages/coding-agent/test/tools/ssh-url-localhost-e2e.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as capability from "@oh-my-pi/pi-coding-agent/capability";
+import type { SSHHost } from "@oh-my-pi/pi-coding-agent/capability/ssh";
+import type { CapabilityResult } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
+import { SshProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/ssh-protocol";
+
+// Live integration against `ssh localhost`. Skips automatically where key-based
+// localhost SSH is unavailable (CI without sshd). Capability lookup is mocked
+// empty so "localhost"/"-oProxy…" resolve through the opaque-destination branch,
+// exercising the real connection-manager + file-transfer over a real ssh process.
+const SSH_OK = (() => {
+	try {
+		const r = Bun.spawnSync(["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=4", "localhost", "true"]);
+		return r.exitCode === 0;
+	} catch {
+		return false;
+	}
+})();
+
+function mockEmptyHosts(): void {
+	const result: CapabilityResult<SSHHost> = {
+		items: [],
+		sources: [],
+		diagnostics: [],
+	} as unknown as CapabilityResult<SSHHost>;
+	vi.spyOn(capability, "loadCapability").mockResolvedValue(result as CapabilityResult<unknown>);
+}
+
+const sh = async (script: string) => {
+	await Bun.$`ssh -o BatchMode=yes localhost ${script}`.quiet();
+};
+
+describe.skipIf(!SSH_OK)("ssh:// handler against a real localhost ssh", () => {
+	const handler = new SshProtocolHandler();
+	const TMP = `/tmp/omp-ssh-e2e-${process.pid}`;
+
+	beforeAll(async () => {
+		await sh(`mkdir -p ${TMP}`);
+	});
+
+	afterAll(async () => {
+		await Bun.$`ssh -o BatchMode=yes localhost rm -rf ${TMP}`.nothrow().quiet();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("reads a real remote text file byte-exact", async () => {
+		mockEmptyHosts();
+		await sh(`printf 'alpha\\n\\tbeta\\n' > ${TMP}/read.txt`);
+		const res = await handler.resolve(parseInternalUrl(`ssh://localhost${TMP}/read.txt`));
+		expect(res.content).toBe("alpha\n\tbeta\n");
+	});
+
+	it("rejects an argument-injecting host before spawning ssh (no side effect runs)", async () => {
+		mockEmptyHosts();
+		await sh(`rm -f ${TMP}/PWNED`);
+		// `-oProxyCommand=touch …` would execute locally if it reached ssh's argv.
+		const url = parseInternalUrl(`ssh://-oProxyCommand=touch%20${encodeURIComponent(`${TMP}/PWNED`)}/etc/hostname`);
+		await expect(handler.resolve(url)).rejects.toThrow(/must not begin with/);
+		const pwned = await Bun.$`ssh -o BatchMode=yes localhost test -e ${TMP}/PWNED && echo yes || echo no`.text();
+		expect(pwned.trim()).toBe("no");
+	});
+
+	it("rejects a real binary file via full-buffer validation", async () => {
+		mockEmptyHosts();
+		// 9000 'a' bytes (valid past the old 8 KiB window) then one invalid UTF-8 byte.
+		await sh(`sh -c 'head -c 9000 /dev/zero | tr "\\0" a > ${TMP}/bin; printf "\\377" >> ${TMP}/bin'`);
+		await expect(handler.resolve(parseInternalUrl(`ssh://localhost${TMP}/bin`))).rejects.toThrow(
+			/binary or non-UTF-8/,
+		);
+	});
+
+	it("writes byte-exact, leaves no temp, and the read path round-trips", async () => {
+		mockEmptyHosts();
+		const dest = `${TMP}/write.txt`;
+		await handler.write(parseInternalUrl(`ssh://localhost${dest}`), "hi\n\t!\n");
+		const back = await handler.resolve(parseInternalUrl(`ssh://localhost${dest}`));
+		expect(back.content).toBe("hi\n\t!\n");
+		// The uniquely-named temp must have been renamed away (no leftovers).
+		const leftovers = await Bun.$`ssh -o BatchMode=yes localhost ls ${TMP} | grep -c omp-tmp || true`.text();
+		expect(leftovers.trim()).toBe("0");
+	});
+
+	it("replaces a symlinked destination with a regular file (documented v1 limit)", async () => {
+		mockEmptyHosts();
+		await sh(`sh -c 'printf orig > ${TMP}/sym-target; ln -sf ${TMP}/sym-target ${TMP}/sym-link'`);
+		await handler.write(parseInternalUrl(`ssh://localhost${TMP}/sym-link`), "replaced\n");
+		const isLink =
+			await Bun.$`ssh -o BatchMode=yes localhost test -L ${TMP}/sym-link && echo link || echo regular`.text();
+		expect(isLink.trim()).toBe("regular");
+		const back = await handler.resolve(parseInternalUrl(`ssh://localhost${TMP}/sym-link`));
+		expect(back.content).toBe("replaced\n");
+	});
+});


### PR DESCRIPTION
## Summary

Adds an `ssh://host/<absolute-path>` internal-URL handler so `read`, `search`, and `write` can operate on a single text file on a remote SSH host — either a pre-configured OMP host or any destination OpenSSH can resolve itself (e.g. a `~/.ssh/config` alias). Remote I/O reuses the shared ControlMaster connection in `src/ssh/connection-manager`, and bytes round-trip exactly (no truncation or whitespace munging).

Scope is deliberately narrow: UTF-8 **text only**, **≤ 1 MiB**, single file — no binary, recursive, or glob reads. Larger or binary files are pointed at the `ssh` tool or an sshfs mount.

## Usage

```
read   ssh://web1/etc/nginx/nginx.conf
search "listen " ssh://web1/etc/nginx/nginx.conf
write  ssh://web1/tmp/note.txt
```

## Security & correctness

`ssh://` opens an outbound connection and runs a remote shell, so it is treated with the same care as the `ssh` tool:

- **exec-tier approval** — `read`/`search`/`write` return the `exec` approval tier whenever an `ssh://` target is present (matching the `ssh` tool) instead of the auto-approved read tier. Detection is a fail-closed substring scan, so it also catches `search`'s delimited `paths` (flattened only *after* approval runs) and `write`'s hashline-wrapped paths.
- **argument-injection guard** — an SSH destination/username beginning with `-` (e.g. `-oProxyCommand=…`) is rejected at the single destination-render chokepoint *before* any `ssh` process is spawned, closing a local command-execution vector.
- **full-buffer text validation** — the entire materialized buffer is validated as UTF-8 (fatal decode + NUL scan); binary/non-UTF-8 files are rejected rather than returned lossily.
- **read/write selector parity** — `write` peels the same trailing selectors `read` does (`:raw`, `:conflicts`) so one URL never resolves to two different files; line-range/malformed selectors are rejected (you cannot write a partial range). A literal `:` in a remote path is percent-encoded as `%3A`.
- **byte-exact, crash-safe writes** — content streams into a uniquely named remote temp and is atomically renamed into place. *v1 limit:* a symlink at the write destination is replaced with a regular file rather than written through (resolving the link remotely is not portable across the macOS/Linux hosts this stack supports).

## Tests

- **Unit** — arg-injection guard, full-buffer binary rejection, selector peel/reject (incl. cross-scheme), `ssh://` scheme detection, per-tool approval tiers (incl. hashline-wrapped + delimited inputs).
- **Wrapper-backed integration** — the production `ExtensionToolWrapper` approval gate rejects `ssh://` read/search/write at the exec tier while equivalent local-path calls run.
- **Live `ssh localhost` E2E** (auto-skips where unavailable) — byte-exact read/write, guard blocks before spawn (no side-effect file), real binary rejected, no leftover temp, symlink replacement.

Based cleanly on `main` (0 behind, 2 commits).