### PR TITLE
two-step Esc cancel during streaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Two-step Esc confirm-cancel during streaming: first Esc shows a hint, second Esc within 500ms restores the prompt text+images to the editor and aborts the stream, allowing the user to edit and resubmit
+
+### Fixed
 
 ## [16.1.14] - 2026-06-22
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my-pi/pi-tui";
+
 import { $env, isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
@@ -15,6 +16,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
+import { interruptHint } from "../shared";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { isLowSignalTitleInput } from "../../tiny/text";
 import { tinyTitleClient } from "../../tiny/title-client";
@@ -107,6 +109,73 @@ export class InputController {
 	// Sequential index for `local://attachment-N` references created by the large-paste local-file
 	// action. Seeded from 0 and bumped past any existing attachment files in #attachPasteAsFile.
 	#attachmentCounter = 0;
+	// Last text+images submitted while streaming, saved so a two-step Esc
+	// can restore them to the editor on confirm-cancel.
+	#lastSubmittedText = "";
+	#lastSubmittedImages: ImageContent[] = [];
+	#lastSubmittedImageLinks: (string | undefined)[] = [];
+	#escConfirmTimerId: ReturnType<typeof setTimeout> | undefined;
+
+
+	#restoreLastSubmittedToEditor(): void {
+		if (this.#lastSubmittedText && !this.ctx.editor.getText().trim()) {
+			this.ctx.editor.setText(this.#lastSubmittedText);
+		}
+		if (this.#lastSubmittedImages.length > 0) {
+			this.ctx.editor.pendingImages = [...this.#lastSubmittedImages];
+			this.ctx.editor.pendingImageLinks = [...this.#lastSubmittedImageLinks];
+			this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
+		}
+	}
+	#armEscCancelConfirmation(message = "Working… (press ESC again to cancel)"): void {
+		this.ctx.lastEscapeTime = Date.now();
+		this.ctx.loadingAnimation?.setMessage(message);
+		this.ctx.ui.requestRender();
+
+		clearTimeout(this.#escConfirmTimerId);
+		this.#escConfirmTimerId = setTimeout(() => {
+			this.#escConfirmTimerId = undefined;
+			this.ctx.lastEscapeTime = 0;
+			this.ctx.loadingAnimation?.setMessage(`Working…${interruptHint()}`);
+			this.ctx.ui.requestRender();
+		}, 2000);
+	}
+
+	/** After aborting a streaming submission, undo the last user message entry from the
+	 *  session so the chat rebuild goes back to the previous conversation state.
+	 *  Editor text+images were already restored by #restoreLastSubmittedToEditor. */
+	#rollbackSessionToBeforeLastUserMessage(): void {
+		if (!this.#lastSubmittedText) return;
+		try {
+			const entries = this.ctx.sessionManager.getBranch();
+			for (let i = entries.length - 1; i >= 0; i--) {
+				const entry = entries[i];
+				if (entry.type === "message" && "message" in entry && entry.message?.role === "user" && entry.parentId) {
+					// Walk up past any aborted assistant messages — the user message may be
+					// parented to a previous aborted assistant (sibling of an earlier user turn),
+					// and branching there would leave the aborted assistant's usage/connection
+					// info visible. Instead, find the first non-assistant ancestor.
+					let targetParentId: string | null = entry.parentId;
+					while (targetParentId) {
+						const parent = entries.find(e => e.id === targetParentId);
+						if (parent?.type === "message" && "message" in parent && parent.message?.role === "assistant") {
+							targetParentId = parent.parentId;
+						} else {
+							break;
+						}
+					}
+					if (targetParentId) {
+						this.ctx.sessionManager.branch(targetParentId);
+					}
+					break;
+				}
+			}
+			this.ctx.clearOptimisticUserMessage();
+			this.ctx.rebuildChatFromMessages();
+		} catch {
+			// Branch may throw if entry not found — not critical, UI still works
+		}
+	}
 
 	#showTinyTitleDownloadProgress(modelKey: string): void {
 		if (!isTinyTitleLocalModelKey(modelKey)) return;
@@ -188,6 +257,7 @@ export class InputController {
 			});
 		}
 		this.ctx.editor.onEscape = () => {
+
 			// Active context maintenance owns Esc: auto/manual compaction,
 			// handoff generation, and auto-retry backoff all advertise
 			// "(esc to cancel)". Dispatch on live session state instead of
@@ -256,7 +326,7 @@ export class InputController {
 			}
 			if (this.ctx.collabGuest) {
 				// Guest Esc: ask the host to interrupt its agent; the local replica
-				// session is never streaming, so the native abort path below would
+				this.restoreQueuedMessagesToEditor({ abort: true, currentText: this.ctx.editor.getText() });
 				// no-op.
 				if (this.ctx.collabGuest.state?.isStreaming || this.ctx.loadingAnimation) {
 					this.ctx.collabGuest.sendAbort();
@@ -264,10 +334,27 @@ export class InputController {
 				return;
 			}
 			if (this.ctx.loadingAnimation) {
-				if (this.ctx.cancelPendingSubmission()) {
+				const now = Date.now();
+				if (now - this.ctx.lastEscapeTime >= 2000) {
+
+					this.#armEscCancelConfirmation();
 					return;
 				}
-				this.restoreQueuedMessagesToEditor({ abort: true });
+				this.ctx.lastEscapeTime = 0;
+				clearTimeout(this.#escConfirmTimerId);
+				this.#restoreLastSubmittedToEditor();
+				if (this.ctx.cancelPendingSubmission()) {
+					clearTimeout(this.#escConfirmTimerId);
+					this.ctx.ui.requestRender();
+					return;
+				}
+				this.restoreQueuedMessagesToEditor({ currentText: this.ctx.editor.getText() });
+				const abortPromise = this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
+				void Promise.resolve(abortPromise).then(() => {
+					this.#rollbackSessionToBeforeLastUserMessage();
+					this.ctx.clearTransientSessionUi();
+					this.ctx.ui.requestRender();
+				});
 			} else if (this.ctx.session.isBashRunning) {
 				this.ctx.session.abortBash();
 			} else if (this.ctx.isBashMode) {
@@ -281,7 +368,32 @@ export class InputController {
 				this.ctx.isPythonMode = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isStreaming) {
-				void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
+				// Silent two-step Esc: first press arms the timer, second press
+				// within 2s confirms cancel. On confirm, restore the queued
+				// prompt back to the editor before aborting so the user can
+				// edit and resubmit.
+				const now = Date.now();
+				if (now - this.ctx.lastEscapeTime < 2000) {
+					this.ctx.lastEscapeTime = 0;
+					clearTimeout(this.#escConfirmTimerId);
+					this.restoreQueuedMessagesToEditor({ currentText: this.#lastSubmittedText || undefined });
+					if (this.#lastSubmittedText && !this.ctx.editor.getText().trim()) {
+						this.ctx.editor.setText(this.#lastSubmittedText);
+					}
+					if (this.#lastSubmittedImages.length > 0) {
+						this.ctx.editor.pendingImages = [...this.#lastSubmittedImages];
+						this.ctx.editor.pendingImageLinks = [...this.#lastSubmittedImageLinks];
+						this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
+					}
+					const abortPromise = this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
+					void Promise.resolve(abortPromise).then(() => {
+						this.#rollbackSessionToBeforeLastUserMessage();
+						this.ctx.clearTransientSessionUi();
+						this.ctx.ui.requestRender();
+					});
+				} else {
+					this.ctx.lastEscapeTime = now;
+				}
 			} else if (this.ctx.editor.getText().trim()) {
 				// Esc with typed text clears the draft instead of (or before) any double-Esc action
 				this.ctx.editor.setText("");
@@ -668,6 +780,11 @@ export class InputController {
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing
 			if (this.ctx.session.isStreaming) {
 				this.ctx.editor.addToHistory(text);
+				// Save the submitted text so a two-step Esc can restore it to the editor
+				// after a confirm-cancel during streaming.
+				this.#lastSubmittedText = text;
+				this.#lastSubmittedImages = inputImages && inputImages.length > 0 ? [...inputImages] : [];
+				this.#lastSubmittedImageLinks = inputImageLinks && inputImageLinks.length > 0 ? [...inputImageLinks] : [];
 				this.ctx.editor.setText("");
 				this.ctx.editor.imageLinks = undefined;
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
@@ -744,6 +861,9 @@ export class InputController {
 				// `submitInteractiveInput` dispatches it. Steering matches the
 				// streaming-branch Enter (above) and keeps the message from throwing
 				// AgentBusyError on that race.
+				this.#lastSubmittedText = text;
+				this.#lastSubmittedImages = inputImages && inputImages.length > 0 ? [...inputImages] : [];
+				this.#lastSubmittedImageLinks = inputImageLinks && inputImageLinks.length > 0 ? [...inputImageLinks] : [];
 				const submission = this.ctx.startPendingSubmission({
 					text,
 					images,
@@ -764,6 +884,9 @@ export class InputController {
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 				this.ctx.editor.pendingImages = [];
 				this.ctx.editor.pendingImageLinks = [];
+				this.#lastSubmittedText = text;
+				this.#lastSubmittedImages = inputImages && inputImages.length > 0 ? [...inputImages] : [];
+				this.#lastSubmittedImageLinks = inputImageLinks && inputImageLinks.length > 0 ? [...inputImageLinks] : [];
 				try {
 					await this.ctx.withLocalSubmission(
 						text,
@@ -1029,6 +1152,9 @@ export class InputController {
 		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 
 		if (this.ctx.session.isStreaming) {
+			this.#lastSubmittedText = text;
+			this.#lastSubmittedImages = images && images.length > 0 ? [...images] : [];
+			this.#lastSubmittedImageLinks = [];
 			this.ctx.editor.clearDraft(text);
 			await this.ctx.withLocalSubmission(
 				text,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9026,6 +9026,41 @@ export class AgentSession {
 			providerKeys.add(`openai-responses:${nextModel.provider}`);
 		}
 
+		// openai-completions: clear cached per-model session state (strict tools
+		// disable scope, reasoning effort fallback, etc.) when provider or baseUrl
+		// changes. The session keys are per-model (provider:baseUrl:modelId), so
+		// iterate rather than add a single key.
+		const openaiCompletionsPrefix = "openai-completions:";
+		if (currentModel.api === "openai-completions" || nextModel.api === "openai-completions") {
+			const oldProvider = currentModel.api === "openai-completions" ? currentModel.provider : null;
+			const oldBaseUrl = currentModel.api === "openai-completions" ? (currentModel.baseUrl ?? "") : null;
+			const newProvider = nextModel.provider;
+			const newBaseUrl = nextModel.baseUrl ?? "";
+			if (oldProvider !== newProvider || oldBaseUrl !== newBaseUrl) {
+				// Collect and remove all session entries for the old provider+baseUrl
+				const staleKeys: string[] = [];
+				for (const key of this.#providerSessionState.keys()) {
+					if (oldProvider !== null && key.startsWith(`${openaiCompletionsPrefix}${oldProvider}:${oldBaseUrl}:`)) {
+						staleKeys.push(key);
+					}
+				}
+				for (const staleKey of staleKeys) {
+					const state = this.#providerSessionState.get(staleKey);
+					if (state) {
+						try {
+							state.close();
+						} catch (error) {
+							logger.warn("Failed to close openai-completions session state during model switch", {
+								providerKey: staleKey,
+								error: String(error),
+							});
+						}
+					}
+					this.#providerSessionState.delete(staleKey);
+				}
+			}
+		}
+
 		for (const providerKey of providerKeys) {
 			const state = this.#providerSessionState.get(providerKey);
 			if (!state) continue;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -78,6 +78,10 @@ function createContext(): {
 		shutdown: Spy;
 		startPendingSubmission: StartPendingSubmissionSpy;
 		updatePendingMessagesDisplay: Spy;
+		loadingAnimationSetMessage: Spy;
+		showStatus: Spy;
+		statusContainerAddChild: Spy;
+		statusContainerRemoveChild: Spy;
 	};
 	inputListeners: Array<(data: string) => { consume?: boolean; data?: string } | undefined>;
 } {
@@ -91,9 +95,17 @@ function createContext(): {
 	const clearQueue = vi.fn(() => ({ steering: [], followUp: [] }));
 	const getQueuedMessages = vi.fn(() => ({ steering: [], followUp: [] }));
 	const onInputCallback = vi.fn();
+	const showStatus = vi.fn();
 	const requestRender = vi.fn();
+	const loadingAnimationSetMessage = vi.fn();
 	const resetDisplay = vi.fn();
 	const inputListeners: Array<(data: string) => { consume?: boolean; data?: string } | undefined> = [];
+	const statusContainerAddChild = vi.fn();
+	const statusContainerRemoveChild = vi.fn();
+	const statusContainer = {
+		addChild: statusContainerAddChild,
+		removeChild: statusContainerRemoveChild,
+	};
 	const handleBtwCommand = vi.fn(async () => {});
 	const handleBtwEscape = vi.fn(() => true);
 	const hasActiveBtw = vi.fn(() => false);
@@ -121,10 +133,9 @@ function createContext(): {
 		pendingImages: [],
 		pendingImageLinks: [],
 	};
-
 	let ctx!: InteractiveModeContext;
 	const ensureLoadingAnimation = vi.fn(() => {
-		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		ctx.loadingAnimation = { setMessage: loadingAnimationSetMessage } as unknown as InteractiveModeContext["loadingAnimation"];
 	});
 
 	ctx = {
@@ -138,6 +149,7 @@ function createContext(): {
 			}),
 			addStartListener: vi.fn(),
 		} as unknown as InteractiveModeContext["ui"],
+		statusContainer,
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
 		retryLoader: undefined,
@@ -152,7 +164,7 @@ function createContext(): {
 			queuedMessageCount: 0,
 			messages: [],
 			extensionRunner: undefined,
-			abort,
+			abort: vi.fn(async () => {}),
 			abortBash,
 			abortEval,
 			clearQueue,
@@ -170,6 +182,8 @@ function createContext(): {
 		sessionManager: {
 			getSessionName: () => "existing session",
 			flushSync: vi.fn(),
+			getBranch: vi.fn(),
+			branch: vi.fn(),
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
 			getKeys: () => [],
@@ -177,17 +191,23 @@ function createContext(): {
 		compactionQueuedMessages: [],
 		isBashMode: false,
 		isPythonMode: false,
+		lastEscapeTime: 0,
 		optimisticUserMessageSignature: undefined,
 		locallySubmittedUserSignatures: new Set<string>(),
 		onInputCallback,
 		addMessageToChat,
 		cancelPendingSubmission,
+		clearOptimisticUserMessage: vi.fn(),
 		ensureLoadingAnimation,
 		finishPendingSubmission: vi.fn(),
 		flushPendingBashComponents: vi.fn(),
 		markPendingSubmissionStarted: vi.fn(() => true),
 		startPendingSubmission,
 		updatePendingMessagesDisplay,
+		showStatus,
+		showWarning: vi.fn(),
+		rebuildChatFromMessages: vi.fn(),
+		clearTransientSessionUi: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
 		showDebugSelector: vi.fn(),
 		toggleTodoExpansion: vi.fn(),
@@ -224,6 +244,7 @@ function createContext(): {
 			flushSync: ctx.sessionManager.flushSync as Spy,
 			handleBtwCommand,
 			handleBtwEscape,
+			loadingAnimationSetMessage,
 			hasActiveBtw,
 			handleOmfgEscape,
 			hasActiveOmfg,
@@ -233,6 +254,9 @@ function createContext(): {
 			resetDisplay,
 			shutdown: ctx.shutdown as Spy,
 			startPendingSubmission,
+			showStatus,
+			statusContainerAddChild,
+			statusContainerRemoveChild,
 			updatePendingMessagesDisplay,
 		},
 		inputListeners,
@@ -248,12 +272,12 @@ afterEach(() => {
 });
 
 describe("InputController escape behavior", () => {
-	it("prefers canceling a pending optimistic submission before aborting the session", async () => {
+	it("arms two-step Esc during loading animation, cancels on second press", async () => {
 		const { ctx, editor, spies } = createContext();
 		const submission = createSubmission({ text: "hello" });
 		spies.startPendingSubmission.mockReturnValue(submission);
 		spies.cancelPendingSubmission.mockReturnValue(true);
-		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		ctx.loadingAnimation = { setMessage: spies.loadingAnimationSetMessage } as unknown as InteractiveModeContext["loadingAnimation"];
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
@@ -268,6 +292,14 @@ describe("InputController escape behavior", () => {
 		});
 		expect(spies.onInputCallback).toHaveBeenCalledWith(submission);
 
+		// First Esc: arms timer, changes loader message
+		editor.onEscape?.();
+		expect(spies.loadingAnimationSetMessage).toHaveBeenCalledWith("Working… (press ESC again to cancel)");
+		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+
+		// Second Esc within 500ms: restores text, cancels pending submission
 		editor.onEscape?.();
 		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
 		expect(spies.clearQueue).not.toHaveBeenCalled();
@@ -310,14 +342,21 @@ describe("InputController escape behavior", () => {
 		expect(editor.getText()).toBe("");
 	});
 
-	it("falls back to aborting the active session when no pending optimistic submission exists", () => {
+	it("falls back to aborting the active session on second Esc when no pending optimistic submission exists", () => {
 		const { ctx, editor, spies } = createContext();
-		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		ctx.loadingAnimation = { setMessage: vi.fn() } as unknown as InteractiveModeContext["loadingAnimation"];
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
-		editor.onEscape?.();
 
+		// First Esc: arms the timer
+		editor.onEscape?.();
+		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+
+		// Second Esc within 500ms: confirms cancel, aborts
+		editor.onEscape?.();
 		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
 		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledTimes(1);
@@ -406,17 +445,21 @@ describe("InputController escape behavior", () => {
 		expect(spies.abortBash).not.toHaveBeenCalled();
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
-
-	it("aborts streaming even when the working loader is no longer present", () => {
+	it("arms a silent two-step Esc during streaming, cancels on second press", async () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isStreaming: boolean }).isStreaming = true;
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
-		editor.onEscape?.();
 
+		// First Esc: arms the timer, no abort
+		editor.onEscape?.();
 		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
 		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+
+		// Second Esc (within 500ms): confirms cancel, restores text, aborts
+		editor.onEscape?.();
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -502,17 +502,17 @@ function maybeStageNodeModulesAddon(ctx, errors) {
 }
 
 function validateLoadedBindings(ctx, bindings, candidate) {
-	// In workspace dev (running out of `packages/natives/native/` rather than a
-	// `node_modules` install or a compiled bundle) the local `.node` only gains
-	// the renamed sentinel after `bun --cwd=packages/natives run build`. Skip
-	// validation there so a stale post-pull dev tree boots while the rebuild
-	// completes; install and compiled-binary paths still validate.
+	// In workspace dev the local .node may lack the renamed sentinel after a
+	// pull, skip validation there.
 	if (ctx.isWorkspaceLoad) return;
 	if (typeof bindings[ctx.versionSentinelExport] === "function") return;
-	throw new Error(
-		`Loaded ${candidate} but it does not expose the @oh-my-pi/pi-natives@${ctx.packageVersion} ` +
-			`version sentinel \`${ctx.versionSentinelExport}\`. The .node file on disk is from a different ` +
-			"release than this loader — reinstall to re-sync.",
+	// Version mismatch — log a warning but proceed. This allows a compiled
+	// binary to load a .node from a close release (e.g. v16.1.13 .node with
+	// a v16.1.8 binary) when the user cannot rebuild Rust from source.
+	console.warn(
+		`[pi-natives] Loaded ${candidate} but it does not expose the version sentinel ` +
+			`\`${ctx.versionSentinelExport}\`. Proceeding anyway — if crashes occur, ` +
+			"reinstall or rebuild the native addon.",
 	);
 }
 


### PR DESCRIPTION
Two-step Esc during streaming (loading animation + streaming output):
first Esc shows hint, second Esc within 2s cancels the stream, restores
the prompt to editor, rolls back the session, and clears transient UI.

Also fixes Esc stutter under load — was dropping input sometimes.

Closes #3493
