### PR TITLE
fix(tui): accept legacy truncate ellipsis strings

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `truncateToWidth` crashing when plugins pass legacy string ellipsis arguments such as `"..."` or `"…"`; the wrapper now maps them before calling the native enum API ([#3492](https://github.com/can1357/oh-my-pi/issues/3492)).
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -15,6 +15,8 @@ export { Ellipsis } from "@oh-my-pi/pi-natives";
 export { DEFAULT_TAB_WIDTH } from "@oh-my-pi/pi-utils";
 
 export type HangulCompatibilityJamoWidth = "platform" | "unicode" | 1 | 2;
+/** Ellipsis selector accepted by {@link truncateToWidth}. */
+export type TruncateEllipsisKind = Ellipsis | string | null;
 
 let hangulCompatibilityJamoWidth: HangulCompatibilityJamoWidth = "platform";
 
@@ -106,10 +108,19 @@ export function sliceWithWidth(line: string, startCol: number, length: number, s
 	return nativeSliceWithWidth(line, startCol, length, strict ?? null, DEFAULT_TAB_WIDTH);
 }
 
+function normalizeTruncateEllipsisKind(ellipsisKind: TruncateEllipsisKind | undefined): Ellipsis {
+	if (ellipsisKind === "" || ellipsisKind === "omit") return Ellipsis.Omit;
+	if (ellipsisKind === "..." || ellipsisKind === "ascii") return Ellipsis.Ascii;
+	if (ellipsisKind === null || ellipsisKind === undefined || typeof ellipsisKind === "string") {
+		return Ellipsis.Unicode;
+	}
+	return ellipsisKind;
+}
+
 export function truncateToWidth(
 	text: string,
 	maxWidth: number,
-	ellipsisKind?: Ellipsis | null | "",
+	ellipsisKind?: TruncateEllipsisKind,
 	pad?: boolean | null,
 ): string {
 	maxWidth = Math.max(0, maxWidth | 0);
@@ -121,7 +132,7 @@ export function truncateToWidth(
 	return nativeTruncateToWidth(
 		text,
 		maxWidth,
-		(ellipsisKind === "" ? Ellipsis.Omit : ellipsisKind) ?? Ellipsis.Unicode,
+		normalizeTruncateEllipsisKind(ellipsisKind),
 		pad ?? false,
 		DEFAULT_TAB_WIDTH,
 	);

--- a/packages/tui/test/issue-848-repro.test.ts
+++ b/packages/tui/test/issue-848-repro.test.ts
@@ -27,8 +27,13 @@ describe("issue #848: truncateToWidth wrapper rejects nullish napi inputs", () =
 	});
 
 	it("maps a legacy empty-string ellipsis argument to omit ellipsis", () => {
-		const result = truncateToWidth("hello world", 5, "" as unknown as Parameters<typeof truncateToWidth>[2]);
+		const result = truncateToWidth("hello world", 5, "" as unknown as Ellipsis);
 		expect(result).toBe("hello");
+	});
+
+	it("maps legacy string ellipsis arguments before calling native code", () => {
+		expect(truncateToWidth("hello world", 8, "..." as unknown as Ellipsis)).toBe("hello...");
+		expect(truncateToWidth("hello world", 8, "…" as unknown as Ellipsis)).toBe("hello w…");
 	});
 	it("returns a string when ellipsisKind / pad are undefined", () => {
 		const result = truncateToWidth("hello world", 80, undefined, undefined);


### PR DESCRIPTION
## Repro
Running a plugin renderer that calls `truncateToWidth('abcdef', 4, '...')` reproduced the reported crash with `Error: Failed to convert napi value into enum Ellipsis`, matching the `/rtk` stack before the modal could render.

## Cause
`packages/tui/src/utils.ts` forwarded the third `truncateToWidth` argument directly to `@oh-my-pi/pi-natives`; external plugins can still pass legacy string ellipsis values like `"..."` or `"…"`, but the native `Ellipsis` parameter only accepts enum numbers.

## Fix
- Added a `TruncateEllipsisKind` wrapper type and normalization path in `packages/tui/src/utils.ts`.
- Mapped `""`/`"omit"`, `"..."`/`"ascii"`, and string Unicode ellipsis values before crossing the napi boundary.
- Added regression coverage in `packages/tui/test/issue-848-repro.test.ts`.
- Added the `packages/tui` changelog entry for #3492.

## Verification
`bun test test/issue-848-repro.test.ts test/truncate-to-width.test.ts` in `packages/tui`: 13 pass, 0 fail. `bun run check:types` in `packages/tui`: passed. Manual smoke: `truncateToWidth('abcdef', 4, '...')` returns `a...` and `truncateToWidth('abcdef', 4, '…')` returns `abc…`, both width 4. Fixes #3492