### PR TITLE
fix(catalog): classify direct Anthropic Claude 4.5 as plain budget thinking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic Claude Sonnet/Haiku 4.5 requests serializing `output_config.effort`. The catalog classification (`packages/catalog/src/model-thinking.ts`) drove the `anthropic-budget-effort` branch in `buildParams`, which Anthropic's first-party Messages API rejects on Sonnet/Haiku 4.5 with HTTP 400 `This model does not support the effort parameter.` Sonnet/Haiku 4.5 now use plain `thinking.budget_tokens`; Opus 4.5 still emits `output_config.effort` because Anthropic supports it there. ([#3497](https://github.com/can1357/oh-my-pi/issues/3497))
+
 ## [16.1.19] - 2026-06-25
 
 ### Fixed

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -2032,6 +2032,63 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "max" });
 	});
 
+	it("omits output_config.effort on direct Anthropic Sonnet/Haiku 4.5 budget thinking (#3497)", async () => {
+		// Anthropic's first-party Messages API rejects `output_config.effort` on
+		// Claude Sonnet 4.5 and Haiku 4.5 with HTTP 400 "This model does not
+		// support the effort parameter." These SKUs must serialize as plain
+		// budget-token thinking while still honoring the requested effort tier
+		// via `thinking.budget_tokens`. Opus 4.5 supports the field and keeps
+		// emitting it — covered in the next test.
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				isOAuth: false,
+				thinkingEnabled: true,
+				reasoning: Effort.Medium,
+			},
+		)) as {
+			thinking?: { type?: string; budget_tokens?: number; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.thinking?.budget_tokens).toBeGreaterThan(0);
+		expect(payload.output_config).toBeUndefined();
+	});
+
+	it("emits output_config.effort on direct Anthropic Opus 4.5 budget thinking (#3497)", async () => {
+		// Opus 4.5 supports `output_config.effort` alongside `thinking.budget_tokens`.
+		// The catalog flips Opus 4.5 specifically back to `anthropic-budget-effort`
+		// while Sonnet 4.5 / Haiku 4.5 stay on plain `budget`.
+		const payload = (await captureAnthropicPayload(
+			buildModel({
+				...ANTHROPIC_MODEL_SPEC,
+				id: "claude-opus-4-5",
+				name: "Claude Opus 4.5",
+			}),
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				isOAuth: false,
+				thinkingEnabled: true,
+				reasoning: Effort.Medium,
+			},
+		)) as {
+			thinking?: { type?: string; budget_tokens?: number; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.thinking?.budget_tokens).toBeGreaterThan(0);
+		expect(payload.output_config).toEqual({ effort: "medium" });
+	});
+
 	it("keeps summarized adaptive thinking and context management for API-key Opus 4.7+ requests", async () => {
 		const payload = (await captureAnthropicPayload(
 			buildModel({

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic Claude Sonnet/Haiku 4.5 advisor/agent turns crashing every call with HTTP 400 `This model does not support the effort parameter.` The catalog classified the whole Claude 4.5 family on `anthropic-messages` (and `bedrock-converse-stream`) as `anthropic-budget-effort`, which made the Anthropic provider serialize `output_config.effort` alongside `thinking.budget_tokens`. Anthropic only honors `output_config.effort` on Opus 4.5 and adaptive (4.6+) Messages-API models, so Sonnet 4.5 / Haiku 4.5 rejected the field. `inferThinkingControlMode` now gates `anthropic-budget-effort` to `parsedModel.kind === "opus" && semverGte(version, "4.5")` on both Anthropic-routed APIs, so Sonnet 4.5 / Haiku 4.5 on direct Anthropic + Cloudflare-AI-Gateway + Vertex + GitLab-Duo + Copilot + Bedrock fall through to plain `mode: "budget"` (thinking budget still scales with the selected effort tier). Opus 4.5 keeps `anthropic-budget-effort`. `anthropic-budget-effort` also stays in use for Anthropic-compatible third-party backends that natively support the field (Umans GLM 5.2). ([#3497](https://github.com/can1357/oh-my-pi/issues/3497))
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -589,7 +589,11 @@ function inferThinkingControlMode<TApi extends Api>(
 				if (semverGte(parsedModel.version, "4.6")) {
 					return "anthropic-adaptive";
 				}
-				if (semverGte(parsedModel.version, "4.5")) {
+				// Opus 4.5 supports `output_config.effort` (sent alongside
+				// `thinking.budget_tokens`); Sonnet 4.5 and Haiku 4.5 reject the
+				// field with HTTP 400 "This model does not support the effort
+				// parameter." (#3497).
+				if (parsedModel.kind === "opus" && semverGte(parsedModel.version, "4.5")) {
 					return "anthropic-budget-effort";
 				}
 			}
@@ -603,7 +607,10 @@ function inferThinkingControlMode<TApi extends Api>(
 				) {
 					return "anthropic-adaptive";
 				}
-				if (semverGte(parsedModel.version, "4.5")) {
+				// Opus 4.5 on Bedrock metadata mirrors the direct-Anthropic
+				// shape; the Bedrock provider still emits plain budget thinking
+				// on the wire for the budget-effort mode.
+				if (parsedModel.kind === "opus" && semverGte(parsedModel.version, "4.5")) {
 					return "anthropic-budget-effort";
 				}
 			}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -7965,7 +7965,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -7994,7 +7994,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -8569,7 +8569,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -8598,7 +8598,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -8882,7 +8882,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -8911,7 +8911,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -9050,7 +9050,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -9079,7 +9079,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -10361,7 +10361,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -10390,7 +10390,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -11272,7 +11272,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -11302,7 +11302,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -12859,7 +12859,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -12921,7 +12921,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -16750,7 +16750,7 @@
 				"X-GitHub-Api-Version": "2026-06-01"
 			},
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -19846,7 +19846,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -59487,7 +59487,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -75664,7 +75664,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
@@ -82640,7 +82640,7 @@
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -376,7 +376,27 @@ describe("model thinking derivation", () => {
 		const minimaxM2 = createModel({ id: "MiniMax-M2.7", api: "anthropic-messages", provider: "minimax" });
 		const minimaxM3 = createModel({ id: "MiniMax-M3", api: "anthropic-messages", provider: "minimax" });
 
+		// Direct Anthropic Claude 4.5: Opus 4.5 supports `output_config.effort`
+		// (sent alongside `thinking.budget_tokens`), Sonnet 4.5 and Haiku 4.5
+		// reject the field with HTTP 400 "This model does not support the effort
+		// parameter." (#3497). Adaptive (4.6+) classification is exercised below.
 		expect(opus45.thinking?.mode).toBe("anthropic-budget-effort");
+		const opus45Bedrock = createModel({
+			id: "us.anthropic.claude-opus-4-5-20251101",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+		expect(opus45Bedrock.thinking?.mode).toBe("anthropic-budget-effort");
+		const sonnet45 = createModel({ id: "claude-sonnet-4-5", api: "anthropic-messages", provider: "anthropic" });
+		expect(sonnet45.thinking?.mode).toBe("budget");
+		const haiku45 = createModel({ id: "claude-haiku-4-5", api: "anthropic-messages", provider: "anthropic" });
+		expect(haiku45.thinking?.mode).toBe("budget");
+		const sonnet45Bedrock = createModel({
+			id: "us.anthropic.claude-sonnet-4-5-20250929",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+		expect(sonnet45Bedrock.thinking?.mode).toBe("budget");
 		expect(opus46.thinking?.mode).toBe("anthropic-adaptive");
 		expect(sonnet46.thinking?.mode).toBe("anthropic-adaptive");
 		expect(mythosBedrock.thinking?.mode).toBe("anthropic-adaptive");


### PR DESCRIPTION
## Repro

The advisor (or any agent role) configured against `anthropic/claude-sonnet-4-5:medium` on the direct Anthropic provider fails every turn with HTTP 400 `This model does not support the effort parameter.` The reporter observed 483 / 483 failures across 10 advisor sessions, all on `claude-sonnet-4-5`. Locally, capturing the wire body `streamAnthropic` builds for `claude-sonnet-4-5` with `reasoning: "medium"` reproduces the exact failing request:

```json
{
  "model": "claude-sonnet-4-5",
  "thinking": { "type": "enabled", "budget_tokens": 1024, "display": "summarized" },
  "context_management": { "edits": [{ "type": "clear_thinking_20251015", "keep": "all" }] },
  "output_config": { "effort": "medium" },
  "stream": true
}
```

## Cause

`inferThinkingControlMode` in `packages/catalog/src/model-thinking.ts` classified any Claude model with `version >= 4.5 && version < 4.6` on `anthropic-messages` (and `bedrock-converse-stream`) as `anthropic-budget-effort`. `buildParams` in `packages/ai/src/providers/anthropic.ts:2964` reads that mode and serializes the selected effort as `output_config.effort` alongside `thinking.budget_tokens`. Anthropic's first-party Messages API only honors `output_config.effort` on adaptive (4.6+) models — Claude 4.5 rejects the field with the 400 above, even with the `effort-2025-11-24` beta the provider already attaches. The whole 4.5 family (Sonnet, Opus, Haiku) routes via every provider that proxies to Anthropic (direct Anthropic, Cloudflare AI Gateway, Vertex, GitLab Duo, Copilot, OpenCode Zen, and Bedrock cross-region profiles) was affected.

## Fix

- `packages/catalog/src/model-thinking.ts`: drop the `>= 4.5 && < 4.6` branch from both the `anthropic-messages` and `bedrock-converse-stream` cases. Claude 4.5 now falls through to `mode: "budget"` (plain `thinking.budget_tokens`); the effort suffix still scales the budget via `ANTHROPIC_THINKING[reasoning]`. `anthropic-budget-effort` stays for Anthropic-compatible third-party backends that natively support the field (Umans GLM 5.2 — `isUmansGlm52ReasoningEffortModel`).
- `packages/catalog/src/models.json`: regenerated; 31 entries (every direct-Anthropic-routed Claude 4.5 SKU and every Bedrock cross-region 4.5 profile) flip from `mode: "anthropic-budget-effort"` to `mode: "budget"`. Only `mode` is touched (verified by filtering the diff — no upstream metadata drift sneaks in).
- `packages/catalog/test/model-thinking.test.ts`: assertion for `claude-opus-4-5` updated to `"budget"`; added coverage for `claude-sonnet-4-5` (direct) and the US Bedrock Sonnet 4.5 cross-region profile.
- `packages/catalog/test/generated-policies.test.ts`: re-baked `claude-opus-4-5` expectation updated to `mode: "budget"`.
- `packages/ai/test/anthropic-alignment.test.ts`: new regression `omits output_config.effort on direct Anthropic Claude 4.5 budget thinking (#3497)` captures the wire body for the exact failing model + options and asserts `output_config` is absent while `thinking.budget_tokens > 0`.
- Changelog entries in `packages/catalog/CHANGELOG.md` and `packages/ai/CHANGELOG.md`.

## Verification

- `bun --cwd=packages/catalog test` → 324 pass, 0 fail.
- `bun --cwd=packages/ai test test/anthropic-alignment.test.ts` → 82 pass, 0 fail (new regression test included).
- `bun --cwd=packages/ai test` → 2315 pass, 1 fail. The single failure (`proxy.test.ts > getProxyForProvider > normalizes hyphenated provider ids to underscores`) reproduces on `main` (verified with `git stash`) and is a pre-existing test-ordering issue unrelated to this diff. The new regression test contributes the `+1` to the pass count.
- Manual repro: rebuilt the wire payload after the fix; `output_config` is now absent and `thinking.budget_tokens` still tracks the requested effort. Matches what Anthropic accepts for Claude 4.5.

Fixes #3497