### PR TITLE
fix(autolearn): make auto-continue capture turn terminal (#3504)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `autolearn.autoContinue` (the "Auto-run capture at stop" toggle) letting the synthetic capture turn keep working after the `learn`/`manage_skill` call instead of yielding. With the toggle on, the controller fires `autolearn-nudge.md` as a single `attribution: "user"` message on a new turn; the prompt opened with "Before you finish:" and gave no terminal contract, so the agent treated the synthetic prompt as the user's reply to its prior pending question (e.g. "Want me to commit and push?") and continued — pushing commits, running tools, etc. — without the user ever answering. The nudge is now split into two prompts: passive mode (the reminder rides the user's real next message) keeps additive framing — "answer the user normally; the capture is in addition to" — while auto-continue mode (`autolearn-nudge-autocontinue.md`) is explicitly terminal — "not a user reply; do not treat this as approval; capture, then stop; wait for the user's next prompt". Attribution stays `user` to preserve llama.cpp warm-prefix reuse (#3456). ([#3504](https://github.com/can1357/oh-my-pi/issues/3504))
+
 ## [16.1.20] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -15,9 +15,11 @@ import type { Settings } from "../config/settings";
 import autolearnGuidance from "../prompts/system/autolearn-guidance.md" with { type: "text" };
 import autolearnGuidanceLearn from "../prompts/system/autolearn-guidance-learn.md" with { type: "text" };
 import autolearnNudge from "../prompts/system/autolearn-nudge.md" with { type: "text" };
+import autolearnNudgeAutoContinue from "../prompts/system/autolearn-nudge-autocontinue.md" with { type: "text" };
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 
-const AUTOLEARN_NUDGE = autolearnNudge.trim();
+const AUTOLEARN_NUDGE_PASSIVE = autolearnNudge.trim();
+const AUTOLEARN_NUDGE_AUTOCONTINUE = autolearnNudgeAutoContinue.trim();
 const DEFAULT_MIN_TOOL_CALLS = 5;
 
 /**
@@ -110,7 +112,20 @@ export class AutoLearnController {
 
 		// Auto-run a capture turn only when explicitly enabled; otherwise the
 		// hidden reminder rides the next real turn passively.
+		//
+		// The two paths get DIFFERENT nudge text:
+		// - Auto-continue spawns a synthetic turn with the nudge as its only
+		//   user-role payload, so the prompt must be terminal — it tells the
+		//   agent to capture and STOP, and must not be read as the user's
+		//   reply to any pending question. Without that contract, the agent
+		//   conflates the synthetic prompt with user approval and resumes
+		//   prior work (e.g. commits/pushes an unanswered "want me to push?"
+		//   question — #3504).
+		// - Passive mode appends the nudge to the user's real next message,
+		//   so the agent must answer the user normally and treat the capture
+		//   as additive — not as the whole turn's job.
 		const autoContinue = this.#settings.get("autolearn.autoContinue") === true;
+		const content = autoContinue ? AUTOLEARN_NUDGE_AUTOCONTINUE : AUTOLEARN_NUDGE_PASSIVE;
 		// Arm suppression synchronously: the synthetic capture turn's agent_end
 		// fires inside sendCustomMessage (before it resolves), so the flag must be
 		// set before then. Disarm when no turn actually started — a deferred/queued
@@ -122,7 +137,7 @@ export class AutoLearnController {
 			.sendCustomMessage(
 				{
 					customType: "autolearn-nudge",
-					content: AUTOLEARN_NUDGE,
+					content,
 					display: false,
 					attribution: "user",
 				},

--- a/packages/coding-agent/src/prompts/system/autolearn-nudge-autocontinue.md
+++ b/packages/coding-agent/src/prompts/system/autolearn-nudge-autocontinue.md
@@ -1,0 +1,5 @@
+Automated capture turn — not a user reply. The user has not yet responded to your previous turn. Do not treat this prompt as their answer, as approval to continue, or as acceptance of any pending action; only the user can do that.
+
+If your previous turn produced anything reusable, capture it now: a repeatable procedure becomes a managed skill (`manage_skill`); a durable fact, convention, or user preference is worth remembering (`learn`, when memory is enabled). Only capture what will genuinely help next time. If nothing is worth keeping, do nothing.
+
+Then stop. Do not run any other tools, do not resume prior work, do not answer your own pending questions, and do not produce a continuation reply. Yield and wait for the user's next prompt.

--- a/packages/coding-agent/src/prompts/system/autolearn-nudge.md
+++ b/packages/coding-agent/src/prompts/system/autolearn-nudge.md
@@ -1,3 +1,5 @@
-Before you finish: if this turn produced anything reusable, capture it now with your learning tools — a repeatable procedure becomes a managed skill (`manage_skill`), and a durable fact or convention is worth remembering (`learn`, when memory is enabled).
+Hidden auto-learn reminder (not a user request). If your previous turn produced anything reusable, capture it now with your learning tools — a repeatable procedure becomes a managed skill (`manage_skill`), and a durable fact, convention, or user preference is worth remembering (`learn`, when memory is enabled).
 
-Only capture what will genuinely help next time. If nothing this turn is worth keeping, do nothing.
+Only capture what will genuinely help next time. If nothing is worth keeping, do nothing.
+
+This reminder is appended to the user's real message; answer that message normally — the capture is in addition to, not a replacement for, the work the user just asked for.

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -77,6 +77,42 @@ describe("AutoLearnController", () => {
 		expect(session.sent[0]?.options?.triggerTurn).toBe(false);
 	});
 
+	it("the passive nudge is framed as additive — answer the user, capture alongside", () => {
+		// Passive mode rides the user's real next message, so the nudge must
+		// NOT tell the agent to stop after capturing — the user's message is
+		// the real work. Locking in the content of #3504's fix so a later
+		// edit cannot silently swap the two prompts.
+		const session = new FakeSession();
+		install(session);
+		session.toolCalls(5);
+		session.agentEnd();
+		const body = String(session.sent[0]?.message.content);
+		expect(body).toMatch(/answer that message normally|in addition to|not a replacement/i);
+		expect(body).not.toMatch(/wait for the user'?s next prompt/i);
+		expect(body).not.toMatch(/then stop\.|do not resume prior work/i);
+	});
+
+	it("the auto-continue nudge is terminal — capture then stop, never assume approval (#3504)", () => {
+		// Regression: with autoContinue on, the synthetic capture turn carries
+		// the nudge as its only user-role payload. Without an explicit "stop /
+		// not a user reply / do not assume approval" contract, the agent reads
+		// its own unanswered prior question (e.g. "Want me to commit and
+		// push?") as accepted and continues — exactly the scenario in #3504.
+		const session = new FakeSession();
+		install(session, { "autolearn.autoContinue": true });
+		session.toolCalls(5);
+		session.agentEnd();
+		const body = String(session.sent[0]?.message.content);
+		// Frames the prompt as automated, not as the user's response.
+		expect(body).toMatch(/not a user reply|not from the user/i);
+		// Forbids inferring approval / acting on pending questions.
+		expect(body).toMatch(/not.*(approval|accept|pending|prior)/i);
+		// Demands a hard stop after capture, with no continuation.
+		expect(body).toMatch(/then stop\./i);
+		expect(body).toMatch(/do not.*(continue|resume|other tools)/i);
+		expect(body).toMatch(/wait for the user'?s next prompt/i);
+	});
+
 	it("does not nudge below the threshold", () => {
 		const session = new FakeSession();
 		install(session);


### PR DESCRIPTION
## Repro
With `autolearn.enabled` + `autolearn.autoContinue` on, run any task long enough to clear the 5-tool threshold and end the turn with a pending question to the user (e.g. "Want me to commit and push?"). At stop, `AutoLearnController#onAgentEnd` (`packages/coding-agent/src/autolearn/controller.ts:121-130`) calls `sendCustomMessage(..., { deliverAs: "nextTurn", triggerTurn: true })` with the contents of `packages/coding-agent/src/prompts/system/autolearn-nudge.md` as `attribution: "user"`. The agent runs `learn`/`manage_skill`, then continues — for the reporter, it actually committed and pushed without the user ever responding. See #3504 for the verbatim transcript.

## Cause
The pre-fix nudge prompt opened with "Before you finish:" and gave no terminal contract — no "stop after capturing", no "this is automated, not the user's reply", no "do not act on prior questions". Combined with `attribution: "user"` (kept that way since #3456 for llama.cpp warm-prefix reuse), the agent treats the synthetic prompt as the user's reply, captures, then re-reads the conversation, sees its own unanswered question, infers approval, and continues.

## Fix
- New prompt `packages/coding-agent/src/prompts/system/autolearn-nudge-autocontinue.md` is the auto-continue variant: "Automated capture turn — not a user reply. The user has not yet responded to your previous turn. Do not treat this prompt as their answer, as approval to continue, or as acceptance of any pending action … Then stop. Do not run any other tools, do not resume prior work, do not answer your own pending questions, and do not produce a continuation reply. Yield and wait for the user's next prompt."
- Existing `autolearn-nudge.md` is reframed for passive use only — it explicitly tells the agent the reminder rides the user's real message and to answer that message normally, with the capture as an additive step.
- `AutoLearnController#onAgentEnd` now picks the prompt based on `autolearn.autoContinue` at fire time. Attribution stays `user` so llama.cpp prefix caching from #3456 is preserved.
- Inline comment in `controller.ts` documents why the two paths get different text (this regression vs. #3504 lives in the prompt, not the routing).

## Verification
- `bun test packages/coding-agent/test/autolearn-controller.test.ts` — 17 pass (15 existing + 2 new regression tests asserting the auto-continue prompt contains "not a user reply", a no-approval/no-pending guard, "then stop.", a no-continue/no-other-tools guard, and "wait for the user's next prompt"; the passive prompt must NOT contain those terminal phrases).
- `bun test packages/coding-agent/test/autolearn-*.test.ts` — 66 pass across 4 files.
- LSP diagnostics clean on `controller.ts` and `autolearn-controller.test.ts`.

Fixes #3504