### PR TITLE
feat: add RPC session discovery

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -130,6 +130,9 @@ Important edge behavior from runtime:
 ### Session
 
 - `{ id?, type: "get_session_stats" }`
+- `{ id?, type: "list_sessions", cwd?: string }`
+- `{ id?, type: "list_all_sessions" }`
+- `{ id?, type: "resolve_session", session: string, cwd?: string }`
 - `{ id?, type: "export_html", outputPath?: string }`
 - `{ id?, type: "switch_session", sessionPath: string }`
 - `{ id?, type: "branch", entryId: string }`
@@ -225,6 +228,79 @@ Local-only slash commands may emit `command_output` frames before completing via
   }
 }
 ```
+
+### Session listing and resolution payloads
+
+`list_sessions` lists sessions for the current or specified workspace:
+
+```json
+{
+  "id": "req_sessions",
+  "type": "response",
+  "command": "list_sessions",
+  "success": true,
+  "data": {
+    "cwd": "/repo",
+    "sessionDir": "/home/user/.omp/agent/sessions/-repo",
+    "sessions": [
+      {
+        "path": "/home/user/.omp/agent/sessions/-repo/session.jsonl",
+        "id": "session",
+        "cwd": "/repo",
+        "title": "Fix tests",
+        "parentSessionPath": "/home/user/.omp/agent/sessions/-repo/parent.jsonl",
+        "created": "2026-06-25T12:00:00.000Z",
+        "modified": "2026-06-25T12:05:00.000Z",
+        "messageCount": 4,
+        "size": 1234,
+        "firstMessage": "Run tests",
+        "allMessagesText": "Run tests\nFix the failure",
+        "status": "complete"
+      }
+    ]
+  }
+}
+```
+
+If `cwd` is omitted, the current session workspace is used. The response
+`sessionDir` is derived from that workspace or the active RPC session; callers
+cannot provide arbitrary session directories.
+
+`list_all_sessions` lists every configured agent session directory and returns
+`data.sessions` with newest sessions first.
+
+`resolve_session` resolves a session id/prefix/path against the safe local scope
+first, then the configured global session directories:
+
+```json
+{
+  "id": "req_resolve",
+  "type": "response",
+  "command": "resolve_session",
+  "success": true,
+  "data": {
+    "match": {
+      "scope": "local",
+      "session": {
+        "path": "/home/user/.omp/agent/sessions/-repo/session.jsonl",
+        "id": "session",
+        "cwd": "/repo",
+        "created": "2026-06-25T12:00:00.000Z",
+        "modified": "2026-06-25T12:05:00.000Z",
+        "messageCount": 4,
+        "size": 1234,
+        "firstMessage": "Run tests",
+        "allMessagesText": "Run tests\nFix the failure",
+        "status": "complete"
+      }
+    }
+  }
+}
+```
+
+If no session matches, `match` is `null`. `scope` is `"local"` for the current
+workspace/default session directory and `"global"` for all configured session
+directories.
 
 ### `set_todos` payload
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -23,7 +23,10 @@ import type {
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
+	RpcListSessionsResult,
+	RpcResolveSessionResult,
 	RpcResponse,
+	RpcSessionInfo,
 	RpcSessionState,
 	RpcSubagentEventFrame,
 	RpcSubagentLifecycleFrame,
@@ -464,6 +467,34 @@ export class RpcClient {
 	async getState(): Promise<RpcSessionState> {
 		const response = await this.#send({ type: "get_state" });
 		return this.#getData(response);
+	}
+
+	/**
+	 * List sessions for the current or specified workspace.
+	 */
+	async listSessions(options?: { cwd?: string }): Promise<RpcListSessionsResult> {
+		const response = await this.#send({ type: "list_sessions", cwd: options?.cwd });
+		return this.#getData(response);
+	}
+
+	/**
+	 * List all sessions across workspaces.
+	 */
+	async listAllSessions(): Promise<RpcSessionInfo[]> {
+		const response = await this.#send({ type: "list_all_sessions" });
+		return this.#getData<{ sessions: RpcSessionInfo[] }>(response).sessions;
+	}
+
+	/**
+	 * Resolve a session id/prefix/path against the current or specified workspace.
+	 */
+	async resolveSession(session: string, options?: { cwd?: string }): Promise<RpcResolveSessionResult["match"]> {
+		const response = await this.#send({
+			type: "resolve_session",
+			session,
+			cwd: options?.cwd,
+		});
+		return this.#getData<RpcResolveSessionResult>(response).match;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -33,6 +33,7 @@ import type { EventBus } from "../../utils/event-bus";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import { listAllRpcSessions, listRpcSessions, resolveRpcSession } from "./rpc-session-listing";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -801,6 +802,18 @@ export async function runRpcMode(
 					contextUsage: session.getContextUsage(),
 				};
 				return success(id, "get_state", state);
+			}
+
+			case "list_sessions": {
+				return success(id, "list_sessions", await listRpcSessions(session, command));
+			}
+
+			case "list_all_sessions": {
+				return success(id, "list_all_sessions", await listAllRpcSessions());
+			}
+
+			case "resolve_session": {
+				return success(id, "resolve_session", await resolveRpcSession(session, command));
 			}
 
 			case "get_available_commands": {

--- a/packages/coding-agent/src/modes/rpc/rpc-session-listing.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-session-listing.ts
@@ -1,0 +1,106 @@
+import * as path from "node:path";
+import type { AgentSession } from "../../session/agent-session";
+import { resolveResumableSession, type SessionInfo } from "../../session/session-listing";
+import { SessionManager } from "../../session/session-manager";
+import type { RpcListSessionsResult, RpcResolveSessionResult, RpcSessionInfo } from "./rpc-types";
+
+export interface RpcListSessionsOptions {
+	cwd?: string;
+}
+
+export interface RpcResolveSessionOptions extends RpcListSessionsOptions {
+	session: string;
+}
+
+export function toRpcSessionInfo(info: SessionInfo): RpcSessionInfo {
+	const modified = toIsoString(info.modified, info.created);
+	return {
+		path: info.path,
+		id: info.id,
+		cwd: info.cwd,
+		title: info.title,
+		parentSessionPath: info.parentSessionPath,
+		created: toIsoString(info.created, info.modified),
+		modified,
+		messageCount: info.messageCount,
+		size: info.size,
+		firstMessage: info.firstMessage,
+		allMessagesText: info.allMessagesText,
+		status: info.status,
+	};
+}
+
+function toIsoString(date: Date, fallback: Date): string {
+	if (Number.isFinite(date.getTime())) return date.toISOString();
+	if (Number.isFinite(fallback.getTime())) return fallback.toISOString();
+	return new Date(0).toISOString();
+}
+
+export async function listRpcSessions(
+	session: Pick<AgentSession, "sessionManager">,
+	options: RpcListSessionsOptions = {},
+): Promise<RpcListSessionsResult> {
+	const cwd = options.cwd ?? session.sessionManager.getCwd();
+	const sessionDir = resolveListSessionDir(session, cwd);
+	const sessions = await SessionManager.list(cwd, sessionDir);
+	return { cwd, sessionDir, sessions: sessions.map(toRpcSessionInfo) };
+}
+
+export async function listAllRpcSessions(): Promise<{ sessions: RpcSessionInfo[] }> {
+	const sessions = await SessionManager.listAll();
+	return { sessions: sessions.map(toRpcSessionInfo) };
+}
+
+export async function resolveRpcSession(
+	session: Pick<AgentSession, "sessionManager">,
+	options: RpcResolveSessionOptions,
+): Promise<RpcResolveSessionResult> {
+	const cwd = options.cwd ?? session.sessionManager.getCwd();
+	const sessionArg = options.session;
+	if (sessionArg.trim() === "") return { match: null };
+	const currentSessionDir = resolveResumeSessionDir(session, cwd);
+	const currentMatch =
+		currentSessionDir === undefined
+			? undefined
+			: ((await resolveRpcSessionPath(sessionArg, cwd, currentSessionDir)) ??
+				(await resolveResumableSession(sessionArg, cwd, currentSessionDir)));
+	const match =
+		currentMatch ??
+		(await resolveRpcSessionPath(sessionArg, cwd, undefined)) ??
+		(await resolveResumableSession(sessionArg, cwd));
+	return match === undefined
+		? { match: null }
+		: { match: { scope: match.scope, session: toRpcSessionInfo(match.session) } };
+}
+
+async function resolveRpcSessionPath(
+	sessionArg: string,
+	cwd: string,
+	sessionDir: string | undefined,
+): Promise<{ session: SessionInfo; scope: "local" | "global" } | undefined> {
+	if (!path.isAbsolute(sessionArg)) return undefined;
+	const normalizedPath = path.resolve(sessionArg);
+	const localSessionDir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd);
+	const localSessions = await SessionManager.list(cwd, localSessionDir);
+	const localMatch = localSessions.find(session => path.resolve(session.path) === normalizedPath);
+	if (localMatch) return { session: localMatch, scope: "local" };
+	if (sessionDir !== undefined) return undefined;
+
+	const globalSessions = await SessionManager.listAll();
+	const globalMatch = globalSessions.find(session => path.resolve(session.path) === normalizedPath);
+	if (globalMatch) return { session: globalMatch, scope: "global" };
+	return undefined;
+}
+
+function resolveListSessionDir(session: Pick<AgentSession, "sessionManager">, cwd: string): string {
+	const currentSessionDir = session.sessionManager.getSessionDir();
+	if (cwd === session.sessionManager.getCwd() && currentSessionDir !== "") return currentSessionDir;
+	return SessionManager.getDefaultSessionDir(cwd);
+}
+
+function resolveResumeSessionDir(session: Pick<AgentSession, "sessionManager">, cwd: string): string | undefined {
+	const currentSessionDir = session.sessionManager.getSessionDir();
+	if (cwd !== session.sessionManager.getCwd() || currentSessionDir === "") return undefined;
+	const defaultSessionDir = SessionManager.getDefaultSessionDir(cwd);
+	return path.resolve(currentSessionDir) === path.resolve(defaultSessionDir) ? undefined : currentSessionDir;
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -11,6 +11,7 @@ import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
 import type { FileEntry } from "../../session/session-entries";
+import type { SessionStatus } from "../../session/session-listing";
 import type { AvailableSlashCommandSource } from "../../slash-commands/available-commands";
 import type {
 	AgentProgress,
@@ -71,6 +72,9 @@ export type RpcCommand =
 
 	// Session
 	| { id?: string; type: "get_session_stats" }
+	| { id?: string; type: "list_sessions"; cwd?: string }
+	| { id?: string; type: "list_all_sessions" }
+	| { id?: string; type: "resolve_session"; session: string; cwd?: string }
 	| { id?: string; type: "export_html"; outputPath?: string }
 	| { id?: string; type: "switch_session"; sessionPath: string }
 	| { id?: string; type: "branch"; entryId: string }
@@ -160,6 +164,36 @@ export interface RpcSubagentMessagesResult {
 	reset: boolean;
 	entries: FileEntry[];
 	messages: AgentMessage[];
+}
+
+export interface RpcSessionInfo {
+	path: string;
+	id: string;
+	/** Working directory where the session was started. Empty string for old sessions. */
+	cwd: string;
+	title?: string;
+	/** Path to the parent session (if this session was forked). */
+	parentSessionPath?: string;
+	/** ISO 8601 timestamp. */
+	created: string;
+	/** ISO 8601 timestamp. */
+	modified: string;
+	messageCount: number;
+	/** File size in bytes on disk; used for compact list rendering. */
+	size: number;
+	firstMessage: string;
+	allMessagesText: string;
+	status?: SessionStatus;
+}
+
+export interface RpcListSessionsResult {
+	cwd: string;
+	sessionDir: string;
+	sessions: RpcSessionInfo[];
+}
+
+export interface RpcResolveSessionResult {
+	match: { session: RpcSessionInfo; scope: "local" | "global" } | null;
 }
 
 // ============================================================================
@@ -263,6 +297,15 @@ export type RpcResponse =
 	// Session
 	| { id?: string; type: "response"; command: "get_session_stats"; success: true; data: SessionStats }
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
+	| { id?: string; type: "response"; command: "list_sessions"; success: true; data: RpcListSessionsResult }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_all_sessions";
+			success: true;
+			data: { sessions: RpcSessionInfo[] };
+	  }
+	| { id?: string; type: "response"; command: "resolve_session"; success: true; data: RpcResolveSessionResult }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }
 	| { id?: string; type: "response"; command: "branch"; success: true; data: { text: string; cancelled: boolean } }
 	| {

--- a/packages/coding-agent/src/session/indexed-session-storage.ts
+++ b/packages/coding-agent/src/session/indexed-session-storage.ts
@@ -17,6 +17,7 @@ export interface SessionStorageBackend {
 	truncate(path: string, mtimeMs: number): Promise<void>;
 	remove(paths: string[]): Promise<void>;
 	move(src: string, dst: string, mtimeMs: number): Promise<void>;
+	moveIfAbsent(src: string, dst: string, mtimeMs: number): Promise<boolean>;
 }
 
 interface IndexEntry {
@@ -195,6 +196,32 @@ export class IndexedSessionStorage implements SessionStorage {
 		}
 	}
 
+	async renameIfAbsent(src: string, dst: string): Promise<boolean> {
+		await this.#awaitPath(src);
+		await this.#awaitPath(dst);
+		const entry = this.#index.get(src);
+		if (!entry) throw enoent(src);
+		const dstPrevious = this.#index.get(dst);
+		if (dstPrevious) return false;
+		this.#index.delete(src);
+		this.#index.set(dst, { ...entry });
+		try {
+			const moved = await this.#enqueuePaths([src, dst], () => this.#backend.moveIfAbsent(src, dst, entry.mtimeMs), {
+				trackDrain: false,
+			});
+			if (!moved) {
+				this.#index.delete(dst);
+				this.#index.set(src, entry);
+			}
+			return moved;
+		} catch (err) {
+			this.#index.delete(dst);
+			this.#restoreIndex(dst, dstPrevious);
+			this.#index.set(src, entry);
+			throw toError(err);
+		}
+	}
+
 	async unlink(path: string): Promise<void> {
 		await this.#awaitPath(path);
 		const previous = this.#index.get(path);
@@ -305,11 +332,11 @@ export class IndexedSessionStorage implements SessionStorage {
 		return next;
 	}
 
-	#enqueuePath(path: string, task: () => Promise<void>, options: EnqueueOptions): Promise<void> {
+	#enqueuePath<T>(path: string, task: () => Promise<T>, options: EnqueueOptions): Promise<T> {
 		return this.#enqueuePaths([path], task, options);
 	}
 
-	#enqueuePaths(paths: readonly string[], task: () => Promise<void>, options: EnqueueOptions): Promise<void> {
+	#enqueuePaths<T>(paths: readonly string[], task: () => Promise<T>, options: EnqueueOptions): Promise<T> {
 		const unique = uniquePaths(paths);
 		const previous = unique.map(path => this.#pathTails.get(path) ?? RESOLVED);
 		const operation = Promise.all(previous).then(task);
@@ -318,29 +345,30 @@ export class IndexedSessionStorage implements SessionStorage {
 			if (options.trackDrain && !this.#firstDrainError) this.#firstDrainError = error;
 			throw error;
 		});
-		const tail = tracked.catch(() => {});
+		const trackedVoid = tracked.then(() => undefined);
+		const tail = trackedVoid.catch(() => {});
 		for (const path of unique) {
 			this.#pathTails.set(path, tail);
-			this.#pathPending.set(path, tracked);
+			this.#pathPending.set(path, trackedVoid);
 		}
 		tail.finally(() => {
 			for (const path of unique) {
 				if (this.#pathTails.get(path) === tail) this.#pathTails.delete(path);
 			}
 		});
-		tracked
+		trackedVoid
 			.finally(() => {
 				for (const path of unique) {
-					if (this.#pathPending.get(path) === tracked) this.#pathPending.delete(path);
+					if (this.#pathPending.get(path) === trackedVoid) this.#pathPending.delete(path);
 				}
 			})
 			.catch(() => {});
 		tracked.catch(() => {});
 		if (options.trackDrain) {
-			this.#drainPending.add(tracked);
-			tracked
+			this.#drainPending.add(trackedVoid);
+			trackedVoid
 				.finally(() => {
-					this.#drainPending.delete(tracked);
+					this.#drainPending.delete(trackedVoid);
 				})
 				.catch(() => {});
 		}

--- a/packages/coding-agent/src/session/redis-session-storage.ts
+++ b/packages/coding-agent/src/session/redis-session-storage.ts
@@ -19,10 +19,24 @@ export interface RedisSessionStorageClient {
 	append(key: string, value: string): Promise<number>;
 	del(...keys: string[]): Promise<number>;
 	rename(src: string, dst: string): Promise<unknown>;
+	renamenx(src: string, dst: string): Promise<number>;
 	scan(cursor: string, ...args: string[]): Promise<[string, string[]]>;
 	hset(key: string, field: string, value: string): Promise<unknown>;
 	hgetall(key: string): Promise<Record<string, string>>;
 	hdel(key: string, ...fields: string[]): Promise<unknown>;
+}
+
+function enoent(path: string): NodeJS.ErrnoException {
+	const err = new Error(`ENOENT: no such file, '${path}'`) as NodeJS.ErrnoException;
+	err.code = "ENOENT";
+	err.errno = -2;
+	err.path = path;
+	err.syscall = "rename";
+	return err;
+}
+
+function isRedisMissingKeyError(err: unknown): boolean {
+	return /\bno such key\b/i.test(toError(err).message);
 }
 
 export interface RedisSessionStorageOptions {
@@ -158,6 +172,28 @@ class RedisSessionStorageBackend implements SessionStorageBackend {
 				error: toError(err).message,
 			});
 		}
+	}
+
+	async moveIfAbsent(src: string, dst: string, mtimeMs: number): Promise<boolean> {
+		let moved: number;
+		try {
+			moved = await this.#client.renamenx(this.#fileKey(src), this.#fileKey(dst));
+		} catch (err) {
+			if (isRedisMissingKeyError(err)) throw enoent(src);
+			throw err;
+		}
+		if (moved === 0) return false;
+		try {
+			await this.#client.hdel(this.#metaKey(), src);
+			await this.#client.hset(this.#metaKey(), dst, String(mtimeMs));
+		} catch (err) {
+			logger.warn("Redis session storage meta rename failed", {
+				src,
+				dst,
+				error: toError(err).message,
+			});
+		}
+		return true;
 	}
 
 	#fileKey(path: string): string {

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -464,9 +464,9 @@ export async function recoverOrphanedBackups(sessionDir: string, storage: Sessio
 		}
 	}
 	for (const [primaryPath, { backup }] of candidates) {
-		if (storage.existsSync(primaryPath)) continue;
 		try {
-			await storage.rename(backup, primaryPath);
+			const recovered = await storage.renameIfAbsent(backup, primaryPath);
+			if (!recovered) continue;
 			logger.warn("Recovered orphaned session backup", {
 				sessionFile: primaryPath,
 				backupPath: backup,
@@ -507,6 +507,12 @@ export function listSessions(sessionDir: string, storage: SessionStorage): Promi
 export async function listAllSessions(storage: SessionStorage = new FileSessionStorage()): Promise<SessionInfo[]> {
 	const sessionsRoot = path.join(getDefaultAgentDir(), "sessions");
 	try {
+		const backupDirs = new Set<string>();
+		for await (const name of new Bun.Glob("*/*.bak").scan(sessionsRoot)) {
+			backupDirs.add(path.dirname(path.join(sessionsRoot, name)));
+		}
+		await Promise.all(Array.from(backupDirs, dir => recoverOrphanedBackups(dir, storage)));
+
 		const files = await Array.fromAsync(new Bun.Glob("*/*.jsonl").scan(sessionsRoot), name =>
 			path.join(sessionsRoot, name),
 		);

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -5,6 +5,15 @@ import { hasFsCode, isEnoent, logger, peekFileEnds, Snowflake, toError } from "@
 
 const utf8Decoder = new TextDecoder("utf-8");
 
+function enoent(p: string): NodeJS.ErrnoException {
+	const err = new Error(`ENOENT: no such file, '${p}'`) as NodeJS.ErrnoException;
+	err.code = "ENOENT";
+	err.errno = -2;
+	err.path = p;
+	err.syscall = "open";
+	return err;
+}
+
 export interface SessionStorageStat {
 	size: number;
 	mtimeMs: number;
@@ -41,6 +50,8 @@ export interface SessionStorage {
 	writeText(path: string, content: string): Promise<void>;
 	writeTextAtomic(path: string, content: string): Promise<void>;
 	rename(path: string, nextPath: string): Promise<void>;
+	/** Move `path` to `nextPath` only when `nextPath` is absent. Returns false without overwriting. */
+	renameIfAbsent(path: string, nextPath: string): Promise<boolean>;
 	unlink(path: string): Promise<void>;
 	deleteSessionWithArtifacts(sessionPath: string): Promise<void>;
 	openWriter(path: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }): SessionStorageWriter;
@@ -280,6 +291,54 @@ export class FileSessionStorage implements SessionStorage {
 		}
 	}
 
+	async renameIfAbsent(path: string, nextPath: string): Promise<boolean> {
+		const verifySourceExists = async (): Promise<void> => {
+			try {
+				await fs.promises.access(path, fs.constants.F_OK);
+			} catch (err) {
+				throw toError(err);
+			}
+		};
+
+		try {
+			await fs.promises.link(path, nextPath);
+		} catch (err) {
+			if (hasFsCode(err, "EEXIST")) {
+				await verifySourceExists();
+				return false;
+			}
+			if (!hasFsCode(err, "EXDEV") && !hasFsCode(err, "EPERM") && !hasFsCode(err, "ENOTSUP")) {
+				throw toError(err);
+			}
+			try {
+				await fs.promises.copyFile(path, nextPath, fs.constants.COPYFILE_EXCL);
+			} catch (copyErr) {
+				if (hasFsCode(copyErr, "EEXIST")) {
+					await verifySourceExists();
+					return false;
+				}
+				throw toError(copyErr);
+			}
+		}
+		try {
+			await fs.promises.unlink(path);
+		} catch (err) {
+			try {
+				await fs.promises.unlink(nextPath);
+			} catch (rollbackErr) {
+				if (!isEnoent(rollbackErr)) {
+					logger.warn("Failed to roll back no-clobber rename target", {
+						sourcePath: path,
+						targetPath: nextPath,
+						error: toError(rollbackErr).message,
+					});
+				}
+			}
+			throw toError(err);
+		}
+		return true;
+	}
+
 	unlink(path: string): Promise<void> {
 		return fs.promises.unlink(path);
 	}
@@ -510,7 +569,7 @@ export class MemorySessionStorage implements SessionStorage {
 
 	#requireEntry(path: string): MemoryFileEntry {
 		const entry = this.#files.get(path);
-		if (!entry) throw new Error(`File not found: ${path}`);
+		if (!entry) throw enoent(path);
 		return entry;
 	}
 
@@ -569,15 +628,20 @@ export class MemorySessionStorage implements SessionStorage {
 	}
 
 	readText(path: string): Promise<string> {
-		const entry = this.#files.get(path);
-		if (!entry) return Promise.reject(new Error(`File not found: ${path}`));
-		return Promise.resolve(materializeMemoryEntry(entry));
+		try {
+			return Promise.resolve(materializeMemoryEntry(this.#requireEntry(path)));
+		} catch (err) {
+			return Promise.reject(err);
+		}
 	}
 
 	readTextSlices(path: string, prefixBytes: number, suffixBytes: number): Promise<[string, string]> {
-		const entry = this.#files.get(path);
-		if (!entry) return Promise.reject(new Error(`File not found: ${path}`));
-		return Promise.resolve([sliceChunksHead(entry, prefixBytes), sliceChunksTail(entry, suffixBytes)]);
+		try {
+			const entry = this.#requireEntry(path);
+			return Promise.resolve([sliceChunksHead(entry, prefixBytes), sliceChunksTail(entry, suffixBytes)]);
+		} catch (err) {
+			return Promise.reject(err);
+		}
 	}
 
 	writeText(path: string, content: string): Promise<void> {
@@ -592,10 +656,19 @@ export class MemorySessionStorage implements SessionStorage {
 
 	rename(path: string, nextPath: string): Promise<void> {
 		const entry = this.#files.get(path);
-		if (!entry) return Promise.reject(new Error(`File not found: ${path}`));
+		if (!entry) return Promise.reject(enoent(path));
 		this.#files.set(nextPath, entry);
 		this.#files.delete(path);
 		return Promise.resolve();
+	}
+
+	renameIfAbsent(path: string, nextPath: string): Promise<boolean> {
+		const entry = this.#files.get(path);
+		if (!entry) return Promise.reject(enoent(path));
+		if (this.#files.has(nextPath)) return Promise.resolve(false);
+		this.#files.set(nextPath, entry);
+		this.#files.delete(path);
+		return Promise.resolve(true);
 	}
 
 	unlink(path: string): Promise<void> {

--- a/packages/coding-agent/src/session/sql-session-storage.ts
+++ b/packages/coding-agent/src/session/sql-session-storage.ts
@@ -63,6 +63,10 @@ interface DialectQueries {
 	delete: string;
 	/** Move a row from one path to another (caller deletes any conflicting destination first). */
 	rename: string;
+	/** Move a row only when the destination path is absent. Returns zero affected rows on conflict. */
+	renameIfAbsent: string;
+	/** Lightweight source existence check after a no-op conditional move. */
+	exists: string;
 	/** Warm the synchronous index without transferring full content. */
 	loadIndex: string;
 	/** Read the full content for the async `readText` surface. */
@@ -129,6 +133,10 @@ function buildQueries(adapter: SqlSessionStorageAdapter, table: string): Dialect
 				`ON DUPLICATE KEY UPDATE content = CONCAT(content, VALUES(content)), mtime_ms = VALUES(mtime_ms)`,
 			delete: `DELETE FROM ${table} WHERE path = ?`,
 			rename: `UPDATE ${table} SET path = ?, mtime_ms = ? WHERE path = ?`,
+			renameIfAbsent:
+				`UPDATE ${table} AS src LEFT JOIN ${table} AS dst ON dst.path = ? ` +
+				`SET src.path = ?, src.mtime_ms = ? WHERE src.path = ? AND dst.path IS NULL`,
+			exists: `SELECT path FROM ${table} WHERE path = ?`,
 			loadIndex: `SELECT path, mtime_ms, length(content) AS byte_len FROM ${table}`,
 			readFull: `SELECT content AS content FROM ${table} WHERE path = ?`,
 			readSlices:
@@ -169,6 +177,11 @@ function buildQueries(adapter: SqlSessionStorageAdapter, table: string): Dialect
 			`ON CONFLICT (path) DO UPDATE SET content = ${tableQualifier} || excluded.content, mtime_ms = excluded.mtime_ms`,
 		delete: `DELETE FROM ${table} WHERE path = ${placeholder(1)}`,
 		rename: `UPDATE ${table} SET path = ${placeholder(1)}, mtime_ms = ${placeholder(2)} WHERE path = ${placeholder(3)}`,
+		renameIfAbsent:
+			`UPDATE ${table} SET path = ${placeholder(1)}, mtime_ms = ${placeholder(2)} ` +
+			`WHERE path = ${placeholder(3)} AND NOT EXISTS (SELECT 1 FROM ${table} WHERE path = ${placeholder(1)}) ` +
+			`RETURNING path`,
+		exists: `SELECT path FROM ${table} WHERE path = ${placeholder(1)}`,
 		loadIndex: `SELECT path, mtime_ms, ${byteLengthExpr} AS byte_len FROM ${table}`,
 		readFull: `SELECT content AS content FROM ${table} WHERE path = ${placeholder(1)}`,
 		readSlices,
@@ -187,6 +200,35 @@ function decodeSqlBytes(value: unknown): string {
 	if (value instanceof Uint8Array) return utf8Decoder.decode(value);
 	if (value instanceof ArrayBuffer) return utf8Decoder.decode(new Uint8Array(value));
 	return String(value);
+}
+
+function affectedRowCount(rows: unknown[]): number {
+	const metadata = rows as unknown as { affectedRows?: unknown; count?: unknown };
+	const count = Number(metadata.affectedRows ?? metadata.count ?? rows.length);
+	return Number.isFinite(count) ? count : rows.length;
+}
+
+function isDuplicateKeyError(err: unknown): boolean {
+	if (err == null) return false;
+	const value = err as {
+		code?: unknown;
+		errno?: unknown;
+		sqlState?: unknown;
+		message?: unknown;
+	};
+	const candidates = [value.code, value.errno, value.sqlState].map(item => String(item ?? ""));
+	const duplicateCodes = new Set([
+		"23505",
+		"1062",
+		"ER_DUP_ENTRY",
+		"SQLITE_CONSTRAINT_PRIMARYKEY",
+		"SQLITE_CONSTRAINT_UNIQUE",
+	]);
+	if (candidates.some(code => duplicateCodes.has(code))) return true;
+	const message = String(value.message ?? "").toLowerCase();
+	const hasDuplicateMessage = message.includes("duplicate entry") || message.includes("unique constraint");
+	if (candidates.includes("SQLITE_CONSTRAINT")) return hasDuplicateMessage;
+	return hasDuplicateMessage;
 }
 
 /**
@@ -310,5 +352,24 @@ class SqlSessionStorageBackend implements SessionStorageBackend {
 	async move(src: string, dst: string, mtimeMs: number): Promise<void> {
 		await this.#client.unsafe(this.#q.delete, [dst]);
 		await this.#client.unsafe(this.#q.rename, [dst, mtimeMs, src]);
+	}
+
+	async moveIfAbsent(src: string, dst: string, mtimeMs: number): Promise<boolean> {
+		const values =
+			this.#adapter === "mysql"
+				? [dst, dst, mtimeMs, src]
+				: this.#adapter === "postgres"
+					? [dst, mtimeMs, src]
+					: [dst, mtimeMs, src, dst];
+		try {
+			const rows = await this.#client.unsafe(this.#q.renameIfAbsent, values);
+			if (this.#adapter === "mysql" ? affectedRowCount(rows) > 0 : rows.length > 0) return true;
+			const sourceRows = await this.#client.unsafe(this.#q.exists, [src]);
+			if (sourceRows.length === 0) throw enoent(src);
+			return false;
+		} catch (err) {
+			if (isDuplicateKeyError(err)) return false;
+			throw err;
+		}
 	}
 }

--- a/packages/coding-agent/test/rpc-session-listing.test.ts
+++ b/packages/coding-agent/test/rpc-session-listing.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	listAllRpcSessions,
+	listRpcSessions,
+	resolveRpcSession,
+	toRpcSessionInfo,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-session-listing";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import {
+	__resetProfileSnapshotForTests,
+	getActiveProfile,
+	getAgentDir,
+	setAgentDir,
+	setProfile,
+} from "@oh-my-pi/pi-utils";
+
+const USER_MESSAGE = { role: "user" as const, content: "hello from rpc listing", timestamp: 0 };
+
+describe("RPC session listing", () => {
+	it("serializes SessionInfo dates as explicit ISO strings", () => {
+		const created = new Date("2026-06-25T12:00:00.000Z");
+		const modified = new Date("2026-06-25T12:05:00.000Z");
+
+		expect(
+			toRpcSessionInfo({
+				path: "/tmp/session.jsonl",
+				id: "session-1",
+				cwd: "/tmp/project",
+				title: "Session One",
+				parentSessionPath: "/tmp/parent.jsonl",
+				created,
+				modified,
+				messageCount: 3,
+				size: 1234,
+				firstMessage: "hello",
+				allMessagesText: "hello\nworld",
+				status: "complete",
+			}),
+		).toEqual({
+			path: "/tmp/session.jsonl",
+			id: "session-1",
+			cwd: "/tmp/project",
+			title: "Session One",
+			parentSessionPath: "/tmp/parent.jsonl",
+			created: created.toISOString(),
+			modified: modified.toISOString(),
+			messageCount: 3,
+			size: 1234,
+			firstMessage: "hello",
+			allMessagesText: "hello\nworld",
+			status: "complete",
+		});
+	});
+
+	it("falls back to modified when a session has an invalid created date", () => {
+		const modified = new Date("2026-06-25T12:05:00.000Z");
+
+		const result = toRpcSessionInfo({
+			path: "/tmp/session.jsonl",
+			id: "session-1",
+			cwd: "/tmp/project",
+			title: "Session One",
+			created: new Date(""),
+			modified,
+			messageCount: 3,
+			size: 1234,
+			firstMessage: "hello",
+			allMessagesText: "hello\nworld",
+			status: "complete",
+		});
+
+		expect(result.created).toBe(modified.toISOString());
+		expect(result.modified).toBe(modified.toISOString());
+	});
+
+	it("does not resolve an empty session selector", async () => {
+		const fixture = await createSessionFixture();
+		try {
+			const result = await resolveRpcSession(fakeSession(fixture.manager), { session: "" });
+
+			expect(result.match).toBeNull();
+		} finally {
+			await fixture.dispose();
+		}
+	});
+
+	it("lists sessions from the current RPC session directory by default", async () => {
+		const fixture = await createSessionFixture();
+		try {
+			const result = await listRpcSessions(fakeSession(fixture.manager));
+
+			expect(result.cwd).toBe(fixture.cwd);
+			expect(result.sessionDir).toBe(fixture.sessionDir);
+			expect(result.sessions).toHaveLength(1);
+			expect(result.sessions[0]?.id).toBe(fixture.manager.getSessionId());
+			expect(result.sessions[0]?.created).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+			expect(typeof result.sessions[0]?.modified).toBe("string");
+		} finally {
+			await fixture.dispose();
+		}
+	});
+
+	it("resolves a resumable session by id prefix", async () => {
+		const fixture = await createSessionFixture();
+		try {
+			const idPrefix = fixture.manager.getSessionId().slice(0, 8);
+			const result = await resolveRpcSession(fakeSession(fixture.manager), { session: idPrefix });
+
+			expect(result.match?.scope).toBe("local");
+			expect(result.match?.session.id).toBe(fixture.manager.getSessionId());
+		} finally {
+			await fixture.dispose();
+		}
+	});
+
+	it("resolves a resumable session by absolute path", async () => {
+		const fixture = await createSessionFixture();
+		try {
+			const sessionFile = fixture.manager.getSessionFile();
+			expect(sessionFile).toBeDefined();
+			const result = await resolveRpcSession(fakeSession(fixture.manager), { session: sessionFile! });
+
+			expect(result.match?.scope).toBe("local");
+			expect(result.match?.session.path).toBe(sessionFile);
+		} finally {
+			await fixture.dispose();
+		}
+	});
+
+	it("ignores caller-provided sessionDir fields", async () => {
+		const fixture = await createSessionFixture();
+		const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-sessiondir-"));
+		try {
+			const outsideCwd = path.join(outsideRoot, "project");
+			const outsideDir = path.join(outsideRoot, "sessions");
+			await fs.mkdir(outsideCwd, { recursive: true });
+			const outsideManager = SessionManager.create(outsideCwd, outsideDir);
+			outsideManager.appendMessage({ ...USER_MESSAGE, content: "outside session" });
+			await outsideManager.ensureOnDisk();
+
+			const unsafeListOptions = { sessionDir: outsideDir } as unknown as Parameters<typeof listRpcSessions>[1];
+			const list = await listRpcSessions(fakeSession(fixture.manager), unsafeListOptions);
+			expect(list.sessionDir).toBe(fixture.sessionDir);
+			expect(list.sessions.map(session => session.id)).not.toContain(outsideManager.getSessionId());
+
+			const unsafeResolveOptions = {
+				session: outsideManager.getSessionId(),
+				sessionDir: outsideDir,
+			} as unknown as Parameters<typeof resolveRpcSession>[1];
+			const resolved = await resolveRpcSession(fakeSession(fixture.manager), unsafeResolveOptions);
+			expect(resolved.match).toBeNull();
+		} finally {
+			await fixture.dispose();
+			await fs.rm(outsideRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to configured global sessions after custom session directory misses", async () => {
+		await withIsolatedAgentDir(async root => {
+			const target = await createDefaultSessionFixture(root, "target-project");
+			const currentCwd = path.join(root, "current-project");
+			const currentSessionDir = path.join(root, "custom-sessions");
+			await fs.mkdir(currentCwd, { recursive: true });
+			const currentManager = SessionManager.create(currentCwd, currentSessionDir);
+			currentManager.appendMessage({ ...USER_MESSAGE, content: "current custom session" });
+			await currentManager.ensureOnDisk();
+
+			const byId = await resolveRpcSession(fakeSession(currentManager), { session: target.manager.getSessionId() });
+			expect(byId.match?.scope).toBe("global");
+			expect(byId.match?.session.id).toBe(target.manager.getSessionId());
+
+			const targetFile = target.manager.getSessionFile();
+			expect(targetFile).toBeDefined();
+			const byPath = await resolveRpcSession(fakeSession(currentManager), { session: targetFile! });
+			expect(byPath.match?.scope).toBe("global");
+			expect(byPath.match?.session.path).toBe(targetFile);
+		});
+	});
+
+	it("lists all sessions from the configured agent directory", async () => {
+		await withIsolatedAgentDir(async root => {
+			const first = await createDefaultSessionFixture(root, "project-one");
+			const second = await createDefaultSessionFixture(root, "project-two");
+
+			const result = await listAllRpcSessions();
+
+			expect(result.sessions.map(session => session.id).sort()).toEqual(
+				[first.manager.getSessionId(), second.manager.getSessionId()].sort(),
+			);
+		});
+	});
+
+	it("recovers orphaned backup sessions when listing all configured sessions", async () => {
+		await withIsolatedAgentDir(async root => {
+			const fixture = await createDefaultSessionFixture(root, "backup-project");
+			const sessionFile = fixture.manager.getSessionFile();
+			expect(sessionFile).toBeDefined();
+			await fs.rename(sessionFile!, `${sessionFile}.123456.bak`);
+
+			const result = await listAllRpcSessions();
+
+			expect(result.sessions.map(session => session.id)).toContain(fixture.manager.getSessionId());
+			expect(
+				await fs.stat(sessionFile!).then(
+					() => true,
+					() => false,
+				),
+			).toBe(true);
+		});
+	});
+
+	it("does not clobber a recreated primary during orphaned backup recovery", async () => {
+		await withIsolatedAgentDir(async root => {
+			const fixture = await createDefaultSessionFixture(root, "backup-race");
+			const sessionFile = fixture.manager.getSessionFile();
+			expect(sessionFile).toBeDefined();
+			const backupContent = await fs.readFile(sessionFile!, "utf8");
+			const currentContent = backupContent.replace("backup-race", "current-primary");
+			await fs.rename(sessionFile!, `${sessionFile}.123456.bak`);
+			await fs.writeFile(sessionFile!, currentContent);
+
+			await listAllRpcSessions();
+
+			expect(await fs.readFile(sessionFile!, "utf8")).toBe(currentContent);
+		});
+	});
+
+	it("resolves global sessions when using the default session directory", async () => {
+		await withIsolatedAgentDir(async root => {
+			const target = await createDefaultSessionFixture(root, "target-project");
+			const current = await createDefaultSessionFixture(root, "current-project");
+			const result = await resolveRpcSession(fakeSession(current.manager), {
+				session: target.manager.getSessionId(),
+			});
+
+			expect(result.match?.scope).toBe("global");
+			expect(result.match?.session.id).toBe(target.manager.getSessionId());
+		});
+	});
+});
+
+async function createSessionFixture(): Promise<{
+	cwd: string;
+	sessionDir: string;
+	manager: SessionManager;
+	dispose: () => Promise<void>;
+}> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-session-listing-"));
+	const cwd = path.join(root, "project");
+	const sessionDir = path.join(root, "sessions");
+	await fs.mkdir(cwd, { recursive: true });
+	const manager = SessionManager.create(cwd, sessionDir);
+	manager.appendMessage(USER_MESSAGE);
+	await manager.ensureOnDisk();
+	return {
+		cwd,
+		sessionDir,
+		manager,
+		dispose: () => fs.rm(root, { recursive: true, force: true }),
+	};
+}
+
+async function withIsolatedAgentDir<T>(run: (root: string) => Promise<T>): Promise<T> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-agent-dir-"));
+	const originalAgentDir = getAgentDir();
+	const originalProfile = getActiveProfile();
+	const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+	const originalOmpProfileEnv = process.env.OMP_PROFILE;
+	const originalPiProfileEnv = process.env.PI_PROFILE;
+	setAgentDir(path.join(root, "agent"));
+	try {
+		return await run(root);
+	} finally {
+		if (originalProfile) {
+			setProfile(originalProfile);
+		} else {
+			setAgentDir(originalAgentDir);
+		}
+		restoreEnv("OMP_PROFILE", originalOmpProfileEnv);
+		restoreEnv("PI_PROFILE", originalPiProfileEnv);
+		restoreEnv("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+		__resetProfileSnapshotForTests();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+async function createDefaultSessionFixture(
+	root: string,
+	projectName: string,
+): Promise<{ cwd: string; manager: SessionManager }> {
+	const cwd = path.join(root, projectName);
+	await fs.mkdir(cwd, { recursive: true });
+	const manager = SessionManager.create(cwd);
+	manager.appendMessage({ ...USER_MESSAGE, content: `${USER_MESSAGE.content} ${projectName}` });
+	await manager.ensureOnDisk();
+	return { cwd, manager };
+}
+
+function restoreEnv(name: "OMP_PROFILE" | "PI_PROFILE" | "PI_CODING_AGENT_DIR", value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+		return;
+	}
+	process.env[name] = value;
+}
+
+function fakeSession(manager: SessionManager): Pick<AgentSession, "sessionManager"> {
+	return { sessionManager: manager };
+}

--- a/packages/coding-agent/test/session-manager-close-race.test.ts
+++ b/packages/coding-agent/test/session-manager-close-race.test.ts
@@ -106,6 +106,9 @@ class CloseHoldingStorage implements SessionStorage {
 	rename(p: string, nextPath: string): Promise<void> {
 		return this.#inner.rename(p, nextPath);
 	}
+	renameIfAbsent(p: string, nextPath: string): Promise<boolean> {
+		return this.#inner.renameIfAbsent(p, nextPath);
+	}
 	unlink(p: string): Promise<void> {
 		return this.#inner.unlink(p);
 	}

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -82,3 +82,67 @@ describe("FileSessionStorage.writeTextSync", () => {
 		expect(await Bun.file(sessionPath).text()).toBe("second\n");
 	});
 });
+
+describe("FileSessionStorage.renameIfAbsent", () => {
+	let tempDir: string;
+	let storage: FileSessionStorage;
+
+	beforeEach(async () => {
+		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-session-storage-"));
+		storage = new FileSessionStorage();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await fsp.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("throws ENOENT when destination exists but source is missing", async () => {
+		const sourcePath = path.join(tempDir, "missing.jsonl");
+		const targetPath = path.join(tempDir, "target.jsonl");
+
+		await fsp.writeFile(targetPath, "target\n");
+
+		await expect(storage.renameIfAbsent(sourcePath, targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await Bun.file(targetPath).text()).toBe("target\n");
+	});
+
+	it("rolls back the destination when source cleanup reports ENOENT", async () => {
+		const sourcePath = path.join(tempDir, "source.jsonl");
+		const targetPath = path.join(tempDir, "target.jsonl");
+		const realUnlink = fs.promises.unlink.bind(fs.promises);
+
+		await fsp.writeFile(sourcePath, "source\n");
+		vi.spyOn(fs.promises, "unlink").mockImplementation(async (target: fs.PathLike) => {
+			if (String(target) === sourcePath) {
+				await realUnlink(sourcePath);
+				const err = Object.assign(new Error("mock unlink missing"), { code: "ENOENT" });
+				throw err;
+			}
+			await realUnlink(target);
+		});
+
+		await expect(storage.renameIfAbsent(sourcePath, targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(fs.existsSync(sourcePath)).toBe(false);
+		expect(fs.existsSync(targetPath)).toBe(false);
+	});
+
+	it("rolls back the destination when source cleanup fails", async () => {
+		const sourcePath = path.join(tempDir, "source.jsonl");
+		const targetPath = path.join(tempDir, "target.jsonl");
+		const realUnlink = fs.promises.unlink.bind(fs.promises);
+
+		await fsp.writeFile(sourcePath, "source\n");
+		vi.spyOn(fs.promises, "unlink").mockImplementation(async (target: fs.PathLike) => {
+			if (String(target) === sourcePath) {
+				const err = Object.assign(new Error("mock unlink failure"), { code: "EACCES" });
+				throw err;
+			}
+			await realUnlink(target);
+		});
+
+		await expect(storage.renameIfAbsent(sourcePath, targetPath)).rejects.toMatchObject({ code: "EACCES" });
+		expect(await Bun.file(sourcePath).text()).toBe("source\n");
+		expect(fs.existsSync(targetPath)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/session/redis-session-storage-manager.test.ts
+++ b/packages/coding-agent/test/session/redis-session-storage-manager.test.ts
@@ -74,6 +74,13 @@ function createFakeRedis(): FakeRedis {
 			strings.delete(src);
 			return "OK";
 		},
+		async renamenx(src, dst) {
+			if (!strings.has(src)) throw new Error("ERR no such key");
+			if (strings.has(dst)) return 0;
+			strings.set(dst, strings.get(src) as string);
+			strings.delete(src);
+			return 1;
+		},
 		async scan(_cursor, ...rest) {
 			let pattern = "*";
 			for (let i = 0; i < rest.length; i++) {

--- a/packages/coding-agent/test/session/redis-session-storage.test.ts
+++ b/packages/coding-agent/test/session/redis-session-storage.test.ts
@@ -120,6 +120,17 @@ function createFakeRedis(): FakeRedis {
 			strings.delete(src);
 			return "OK";
 		},
+		async renamenx(src, dst) {
+			record("renamenx", [src, dst]);
+			checkFailure("renamenx");
+			if (!strings.has(src)) {
+				throw new Error("ERR no such key");
+			}
+			if (strings.has(dst)) return 0;
+			strings.set(dst, strings.get(src) as string);
+			strings.delete(src);
+			return 1;
+		},
 		async scan(cursor, ...rest) {
 			record("scan", [cursor, ...rest]);
 			checkFailure("scan");
@@ -292,6 +303,22 @@ describe("RedisSessionStorage", () => {
 		expect(redis.strings.has("omp:sessions:file:/sessions/p/orig.jsonl")).toBe(false);
 	});
 
+	it("renameIfAbsent keeps the existing destination and uses RENAMENX", async () => {
+		const storage = await RedisSessionStorage.create({ client: redis });
+		await storage.writeText("/sessions/p/a.jsonl", "from-a\n");
+		await storage.writeText("/sessions/p/b.jsonl", "from-b\n");
+
+		expect(await storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/b.jsonl")).toBe(false);
+		expect(await storage.readText("/sessions/p/a.jsonl")).toBe("from-a\n");
+		expect(await storage.readText("/sessions/p/b.jsonl")).toBe("from-b\n");
+		expect(redis.calls.some(call => call.method === "renamenx")).toBe(false);
+
+		expect(await storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/c.jsonl")).toBe(true);
+		expect(storage.existsSync("/sessions/p/a.jsonl")).toBe(false);
+		expect(await storage.readText("/sessions/p/c.jsonl")).toBe("from-a\n");
+		expect(redis.calls.some(call => call.method === "renamenx")).toBe(true);
+	});
+
 	it("rename rolls back the index when Redis RENAME fails", async () => {
 		const storage = await RedisSessionStorage.create({ client: redis });
 		await storage.writeText("/sessions/p/a.jsonl", "keep\n");
@@ -303,6 +330,35 @@ describe("RedisSessionStorage", () => {
 
 		expect(storage.existsSync("/sessions/p/a.jsonl")).toBe(true);
 		expect(storage.existsSync("/sessions/p/b.jsonl")).toBe(false);
+	});
+
+	it("renameIfAbsent keeps the moved content when Redis metadata update fails", async () => {
+		const storage = await RedisSessionStorage.create({ client: redis });
+		await storage.writeText("/sessions/p/a.jsonl", "from-a\n");
+		redis.failNext("hdel", new Error("ERR redis rejected metadata update"));
+
+		await expect(storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/b.jsonl")).resolves.toBe(true);
+
+		expect(storage.existsSync("/sessions/p/a.jsonl")).toBe(false);
+		expect(storage.existsSync("/sessions/p/b.jsonl")).toBe(true);
+		expect(redis.strings.has("omp:sessions:file:/sessions/p/a.jsonl")).toBe(false);
+		expect(redis.strings.get("omp:sessions:file:/sessions/p/b.jsonl")).toBe("from-a\n");
+	});
+
+	it("renameIfAbsent rejects ENOENT before no-clobber when the indexed source key is missing", async () => {
+		const storage = await RedisSessionStorage.create({ client: redis });
+		await storage.writeText("/sessions/p/a.jsonl", "from-a\n");
+		await storage.writeText("/sessions/p/b.jsonl", "from-b\n");
+		redis.strings.delete("omp:sessions:file:/sessions/p/a.jsonl");
+
+		await expect(storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/b.jsonl")).rejects.toMatchObject({
+			code: "ENOENT",
+			path: "/sessions/p/a.jsonl",
+		});
+
+		expect(storage.existsSync("/sessions/p/a.jsonl")).toBe(true);
+		expect(storage.existsSync("/sessions/p/b.jsonl")).toBe(true);
+		expect(redis.strings.get("omp:sessions:file:/sessions/p/b.jsonl")).toBe("from-b\n");
 	});
 
 	it("refresh() reloads the metadata index from Redis after out-of-band writes", async () => {

--- a/packages/coding-agent/test/session/sql-session-storage.test.ts
+++ b/packages/coding-agent/test/session/sql-session-storage.test.ts
@@ -189,6 +189,21 @@ describe("SqlSessionStorage (SQLite backend)", () => {
 		await client.end();
 	});
 
+	it("renameIfAbsent keeps an existing destination without clobbering content", async () => {
+		const { client, storage } = await createSqlite();
+		await storage.writeText("/sessions/p/a.jsonl", "from-a\n");
+		await storage.writeText("/sessions/p/b.jsonl", "from-b\n");
+
+		expect(await storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/b.jsonl")).toBe(false);
+		expect(await storage.readText("/sessions/p/a.jsonl")).toBe("from-a\n");
+		expect(await storage.readText("/sessions/p/b.jsonl")).toBe("from-b\n");
+
+		expect(await storage.renameIfAbsent("/sessions/p/a.jsonl", "/sessions/p/c.jsonl")).toBe(true);
+		expect(storage.existsSync("/sessions/p/a.jsonl")).toBe(false);
+		expect(await storage.readText("/sessions/p/c.jsonl")).toBe("from-a\n");
+		await client.end();
+	});
+
 	it("refresh() reloads the mirror from SQL after out-of-band writes", async () => {
 		const { client, storage } = await createSqlite();
 		// Simulate a peer process inserting directly.
@@ -317,6 +332,14 @@ function capturingClient(adapter: "postgres" | "mysql"): {
 		options: { adapter },
 		async unsafe(sql, values) {
 			queries.push({ sql, values });
+			if (
+				values?.length === 1 &&
+				sql.startsWith("SELECT path FROM") &&
+				!sql.includes("byte_len") &&
+				!sql.includes("content")
+			) {
+				return [{ path: values[0] }];
+			}
 			return [];
 		},
 	};
@@ -370,6 +393,96 @@ describe("SqlSessionStorage (dialect-specific SQL)", () => {
 		expect(append?.sql).not.toContain("$1");
 
 		expect(storage.adapter).toBe("mysql");
+	});
+
+	it("renders no-clobber rename statements with dialect-specific bind order", async () => {
+		const pg = capturingClient("postgres");
+		const pgStorage = await SqlSessionStorage.create({ client: pg.client });
+		await pgStorage.writeText("/s/a.jsonl", "a");
+		await pgStorage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl");
+		const pgRename = pg.queries.find(q => q.sql.includes("RETURNING path"));
+		expect(pgRename?.sql).toContain("$1");
+		expect(pgRename?.values).toEqual(["/s/b.jsonl", expect.any(Number), "/s/a.jsonl"]);
+
+		const mysql = capturingClient("mysql");
+		const mysqlStorage = await SqlSessionStorage.create({ client: mysql.client });
+		await mysqlStorage.writeText("/s/a.jsonl", "a");
+		await mysqlStorage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl");
+		const mysqlRename = mysql.queries.find(q => q.sql.includes("LEFT JOIN"));
+		expect(mysqlRename?.sql).toContain("dst.path = ?");
+		expect(mysqlRename?.values).toEqual(["/s/b.jsonl", "/s/b.jsonl", expect.any(Number), "/s/a.jsonl"]);
+	});
+
+	it("normalizes duplicate-key races during renameIfAbsent to false", async () => {
+		const client: SqlSessionStorageClient = {
+			options: { adapter: "postgres" },
+			async unsafe(sql) {
+				if (sql.includes("RETURNING path")) {
+					const err = new Error("duplicate key value violates unique constraint") as Error & { code: string };
+					err.code = "23505";
+					throw err;
+				}
+				return [];
+			},
+		};
+		const storage = await SqlSessionStorage.create({ client });
+		await storage.writeText("/s/a.jsonl", "a");
+
+		expect(await storage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl")).toBe(false);
+		expect(storage.existsSync("/s/a.jsonl")).toBe(true);
+		expect(storage.existsSync("/s/b.jsonl")).toBe(false);
+	});
+
+	it("rethrows message-only primary-key errors during renameIfAbsent", async () => {
+		const client: SqlSessionStorageClient = {
+			options: { adapter: "postgres" },
+			async unsafe(sql) {
+				if (sql.includes("RETURNING path")) {
+					throw new Error("primary key lookup failed while moving session");
+				}
+				return [];
+			},
+		};
+		const storage = await SqlSessionStorage.create({ client });
+		await storage.writeText("/s/a.jsonl", "a");
+
+		await expect(storage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl")).rejects.toThrow(
+			"primary key lookup failed while moving session",
+		);
+		expect(storage.existsSync("/s/a.jsonl")).toBe(true);
+		expect(storage.existsSync("/s/b.jsonl")).toBe(false);
+	});
+
+	it("rethrows null duplicate-key probes during renameIfAbsent", async () => {
+		const client: SqlSessionStorageClient = {
+			options: { adapter: "postgres" },
+			async unsafe(sql) {
+				if (sql.includes("RETURNING path")) throw null;
+				return [];
+			},
+		};
+		const storage = await SqlSessionStorage.create({ client });
+		await storage.writeText("/s/a.jsonl", "a");
+
+		await expect(storage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl")).rejects.toThrow("null");
+		expect(storage.existsSync("/s/a.jsonl")).toBe(true);
+		expect(storage.existsSync("/s/b.jsonl")).toBe(false);
+	});
+
+	it("throws ENOENT when a no-op conditional rename lost the source row", async () => {
+		const client: SqlSessionStorageClient = {
+			options: { adapter: "postgres" },
+			async unsafe() {
+				return [];
+			},
+		};
+		const storage = await SqlSessionStorage.create({ client });
+		await storage.writeText("/s/a.jsonl", "a");
+
+		await expect(storage.renameIfAbsent("/s/a.jsonl", "/s/b.jsonl")).rejects.toMatchObject({
+			code: "ENOENT",
+			path: "/s/a.jsonl",
+		});
 	});
 
 	it("rejects clients reporting an unknown adapter without an override", async () => {


### PR DESCRIPTION
## Summary
- add RPC `list_sessions`, `list_all_sessions`, and `resolve_session` commands
- add session listing helpers for current/default/global session directories
- harden no-clobber session recovery across file, memory, indexed, Redis, and SQL storage backends
- document new session discovery RPC payloads

## Verification
- `bun run --cwd packages/coding-agent check`
- code review subagent FinalReview8: APPROVED, no findings

Draft because this is an integration-enabling seam for pi-web/OMP and may need maintainer feedback before final polish.