### PR TITLE
fix(mcp): hide windows console on stdio direct-spawn fast path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP stdio servers spawning a visible console window on Windows whenever the resolved command was a `.exe` (node-based servers, absolute `.exe` paths). `StdioTransport.connect()` started passing `detached: true` to defeat terminal job-control signals, but `resolveStdioSpawnCommand`'s direct-spawn fast path returned no `windowsHide` — and on Windows `detached: true` allocates a new console unless `windowsHide: true` rides along. The cmd.exe wrap path was unaffected because it already set the flag. `resolveStdioSpawnCommand` now sets `windowsHide: true` on every win32 return shape. ([#3519](https://github.com/can1357/oh-my-pi/issues/3519))
+
 ## [16.1.20] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -239,8 +239,12 @@ export async function resolveStdioSpawnCommand(
 	// Direct-spawn only when we resolved to a concrete file AND its extension
 	// is not a batch script. Everything else (resolved .cmd/.bat, or an
 	// unresolved extensionless command) goes through cmd.exe so PATHEXT runs.
+	// `windowsHide: true` is set unconditionally on win32 so the subprocess
+	// never materializes a console window — `StdioTransport.connect()` spawns
+	// with `detached: true` to escape terminal job-control signals, and on
+	// Windows that flag would otherwise allocate a new console (issue #3519).
 	const needsCmdExe = resolved === null || isWindowsBatchCommand(resolvedCommand);
-	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args] };
+	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide: true };
 
 	return {
 		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -319,6 +319,44 @@ describe("resolveStdioSpawnCommand", () => {
 		expect(result.windowsHide).toBe(true);
 	});
 
+	it("sets windowsHide on the .exe direct-spawn fast path so detached MCP servers stay headless (#3519)", async () => {
+		// `StdioTransport.connect()` spawns with `detached: true` to escape terminal
+		// job-control signals. On Windows that flag allocates a new console unless
+		// `windowsHide: true` rides along. The cmd.exe wrap path always set the flag,
+		// but the direct-spawn fast path for resolved .exe binaries (node-based
+		// servers, absolute .exe commands) used to drop it — popping a visible
+		// console for the lifetime of the session. Pin the flag on both shapes.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-exe-hide-"));
+		try {
+			const exe = path.join(tempDir, "server.exe");
+			await Bun.write(exe, "MZ");
+
+			const bare = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: "server", args: ["--port", "1234"] },
+				{
+					cwd: tempDir,
+					env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe", PATH: tempDir, PATHEXT: ".exe" },
+					platform: "win32",
+				},
+			);
+			expect(bare.cmd).toEqual([exe, "--port", "1234"]);
+			expect(bare.windowsHide).toBe(true);
+
+			const absolute = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: exe },
+				{
+					cwd: tempDir,
+					env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe", PATHEXT: ".exe" },
+					platform: "win32",
+				},
+			);
+			expect(absolute.cmd).toEqual([exe]);
+			expect(absolute.windowsHide).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("leaves non-Windows commands untouched", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },


### PR DESCRIPTION
## Repro

On Windows, any MCP stdio server whose `command` resolves to a `.exe` opens a visible console window for the lifetime of the session. The two shapes reported:

```jsonc
{ "mcpServers": { "my-server": { "command": "node", "args": ["./server.js"] } } }
{ "mcpServers": { "my-server": { "command": "C:\\path\\to\\server.exe" } } }
```

Servers launched via `npx`/`.cmd`/`.bat` are unaffected because they go through the cmd.exe wrap path. Pinned with a unit test (`test/mcp-stdio-transport.test.ts`) that runs `resolveStdioSpawnCommand` against both shapes under `platform: "win32"` and now asserts `windowsHide === true`.

## Cause

Commit 184f6dd80 added `detached: true` to `StdioTransport.connect()`'s `spawn()` call (`packages/coding-agent/src/mcp/transports/stdio.ts:355`) so terminal job-control signals (SIGTSTP/SIGTTIN) cannot stop stdio servers. On Windows, `detached: true` allocates a new console unless `windowsHide: true` rides along. `resolveStdioSpawnCommand` only set `windowsHide: true` on the cmd.exe wrap branch (line 247); the direct-spawn branch for resolved `.exe` files returned `{ cmd }` with no flag, so the spawn call received `windowsHide: undefined` and Windows allocated a foreground console.

## Fix

- `packages/coding-agent/src/mcp/transports/stdio.ts`: set `windowsHide: true` on the win32 direct-spawn return shape and document the contract inline (any win32 return now sets the flag; the early non-win32 return is unchanged).
- `packages/coding-agent/test/mcp-stdio-transport.test.ts`: add a regression test that creates a `.exe` in PATH and exercises both the bare-name and absolute-path direct-spawn returns, asserting `windowsHide === true`.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] → Fixed` entry citing #3519.

## Verification

`bun test test/mcp-stdio-transport.test.ts` → 22 pass, 0 fail (the new test plus all pre-existing stdio resolver / `writeFrame` / `notify` / `close` cases). `bun test test/issue-3461-repro.test.ts` → 3 pass, 0 fail (the detached-spawn contract from the original SIGTSTP fix still holds). Fixes #3519.