### PR TITLE
Add advisor evidence investigation sidecar

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -80,6 +80,12 @@ The advisor receives a hard-isolated read-only tool set:
 
 The read/search/find tools are built against a distinct `ToolSession` whose session id is suffixed with `-advisor`. The advisor therefore does not share the primary agent's file snapshots, seen-lines tracking, conflict state, summary cache, or edit/yield capabilities.
 
+### Out-of-band investigations
+
+When `advisor.investigations.enabled` is on, the advisor also gets `request_investigation`. This tool does not give the advisor execution powers. It queues a durable evidence request and returns immediately; a separate sidecar worker performs docs/web/source research or, when `advisor.investigations.exec` is enabled, empirical probes in an isolated disposable repo snapshot.
+
+Investigation results are written as `artifact://...` evidence files under the owning session. Later advisor turns see only a concise investigation update and can advise the main agent with the artifact pointer if the evidence changes guidance. The advisor itself still cannot run commands, edit files, approve actions, or mutate session state.
+
 The `advise` tool accepts one note and an optional severity:
 
 | Severity | Delivery | Intended use |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a GitLab CLI tool for `glab`-backed project, issue, merge request, and pipeline operations, including TUI rendering and discovery support.
+- Added advisor investigations as an out-of-band evidence sidecar that writes durable artifacts without giving the advisor execution tools.
+
 ## [16.1.20] - 2026-06-25
 
 ### Fixed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -960,6 +960,154 @@ describe("advisor", () => {
 			expect(promptInputs[1]).toContain("new-conversation");
 			expect(promptInputs[1]).not.toContain("old-conversation");
 		});
+
+		it("prompts investigation updates even without a new primary delta", async () => {
+			const promptInputs: string[] = [];
+			const markDelivered = vi.fn(async (_ids: readonly string[]) => {});
+			let claimed = false;
+			const agent = makeAgent(promptInputs);
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => [],
+				enqueueAdvice: () => {},
+				claimInvestigationUpdates: async () => {
+					if (claimed) return null;
+					claimed = true;
+					return {
+						ids: ["ev-ready", "ev-failed"],
+						text: "- ev-ready: artifact://1\n- ev-failed: worker failed",
+					};
+				},
+				markInvestigationUpdatesDelivered: markDelivered,
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd([]);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain("### Investigation updates");
+			expect(promptInputs[0]).toContain("artifact://1");
+			expect(promptInputs[0]).toContain("worker failed");
+			expect(markDelivered).toHaveBeenCalledWith(["ev-ready", "ev-failed"]);
+		});
+
+		it("marks investigation ids delivered only after the advisor prompt resolves", async () => {
+			const promptInputs: string[] = [];
+			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
+			const { promise: finishPrompt, resolve: resolvePrompt } = Promise.withResolvers<void>();
+			const markDelivered = vi.fn(async (_ids: readonly string[]) => {});
+			let claimed = false;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					startPrompt();
+					await finishPrompt;
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => [],
+				enqueueAdvice: () => {},
+				claimInvestigationUpdates: async () => {
+					if (claimed) return null;
+					claimed = true;
+					return { ids: ["ev-deliver"], text: "- ev-deliver: artifact://2" };
+				},
+				markInvestigationUpdatesDelivered: markDelivered,
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd([]);
+			await promptStarted;
+			expect(promptInputs).toHaveLength(1);
+			expect(markDelivered).not.toHaveBeenCalled();
+
+			resolvePrompt();
+			await Bun.sleep(0);
+			expect(markDelivered).toHaveBeenCalledWith(["ev-deliver"]);
+		});
+
+		it("releases claimed investigation ids when reset aborts the advisor prompt", async () => {
+			const promptInputs: string[] = [];
+			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
+			const releaseClaims = vi.fn(async (_ids: readonly string[]) => {});
+			const markDelivered = vi.fn(async (_ids: readonly string[]) => {});
+			let rejectInFlight: ((err: unknown) => void) | undefined;
+			let claimed = false;
+			const agent: AdvisorAgent = {
+				prompt: input => {
+					promptInputs.push(input);
+					const { promise, reject } = Promise.withResolvers<void>();
+					rejectInFlight = reject;
+					startPrompt();
+					return promise;
+				},
+				abort: () => rejectInFlight?.(new Error("advisor reset")),
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => [],
+				enqueueAdvice: () => {},
+				claimInvestigationUpdates: async () => {
+					if (claimed) return null;
+					claimed = true;
+					return { ids: ["ev-reset"], text: "- ev-reset: artifact://3" };
+				},
+				releaseInvestigationUpdates: releaseClaims,
+				markInvestigationUpdatesDelivered: markDelivered,
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd([]);
+			await promptStarted;
+			runtime.reset();
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(1);
+			expect(releaseClaims).toHaveBeenCalledWith(["ev-reset"]);
+			expect(markDelivered).not.toHaveBeenCalled();
+		});
+
+		it("releases claimed investigation ids when failed advisor prompts are dropped", async () => {
+			const promptInputs: string[] = [];
+			const releaseClaims = vi.fn(async (_ids: readonly string[]) => {});
+			const markDelivered = vi.fn(async (_ids: readonly string[]) => {});
+			let claimed = false;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					throw new Error("fail");
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => [],
+				enqueueAdvice: () => {},
+				claimInvestigationUpdates: async () => {
+					if (claimed) return null;
+					claimed = true;
+					return { ids: ["ev-drop"], text: "- ev-drop: artifact://4" };
+				},
+				releaseInvestigationUpdates: releaseClaims,
+				markInvestigationUpdatesDelivered: markDelivered,
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd([]);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(3);
+			expect(releaseClaims).toHaveBeenCalledWith(["ev-drop"]);
+			expect(markDelivered).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("read-only tool allowlist", () => {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-a
 import { logger } from "@oh-my-pi/pi-utils";
 import { obfuscateToolArguments, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
+import type { AdvisorInvestigationUpdateBatch } from "../evidence/types";
 
 /** Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core `Agent`. */
 export interface AdvisorAgent {
@@ -30,11 +31,15 @@ export interface AdvisorRuntimeHost {
 	 * the primary's next compaction triggers {@link AdvisorRuntime.reset}).
 	 */
 	maintainContext?(incomingTokens: number): Promise<boolean>;
+	claimInvestigationUpdates?(): Promise<AdvisorInvestigationUpdateBatch | null>;
+	releaseInvestigationUpdates?(ids: readonly string[]): Promise<void>;
+	markInvestigationUpdatesDelivered?(ids: readonly string[]): Promise<void>;
 }
 
 interface PendingDelta {
 	text: string;
 	turns: number;
+	investigationIds: string[];
 }
 
 interface CatchupWaiter {
@@ -54,6 +59,7 @@ export class AdvisorRuntime {
 	#seenContext = new Map<string, string>();
 	#pending: PendingDelta[] = [];
 	#busy = false;
+	#drainRequested = false;
 	#backlog = 0;
 	#consecutiveFailures = 0;
 	#latestMessages?: AgentMessage[];
@@ -81,11 +87,11 @@ export class AdvisorRuntime {
 		this.#latestMessages = all;
 		const render = this.#renderDelta(all);
 		if (render) {
-			this.#pending.push({ text: render, turns: 1 });
+			this.#pending.push({ text: render.text, turns: 1, investigationIds: render.investigationIds });
 			this.#backlog++;
 			this.#notifyWaiters();
-			void this.#drain();
 		}
+		void this.#drain();
 	}
 
 	waitForCatchup(maxMs: number, threshold: number, signal?: AbortSignal): Promise<void> {
@@ -111,6 +117,7 @@ export class AdvisorRuntime {
 	dispose(): void {
 		this.disposed = true;
 		this.#epoch++;
+		this.#releaseInvestigationIds(this.#takePendingInvestigationIds());
 		this.#pending = [];
 		this.#backlog = 0;
 		this.#consecutiveFailures = 0;
@@ -122,6 +129,7 @@ export class AdvisorRuntime {
 
 	#resetAdvisorContext(clearBacklog: boolean, wakeWaiters: boolean): void {
 		this.#lastCount = 0;
+		this.#releaseInvestigationIds(this.#takePendingInvestigationIds());
 		this.#pending = [];
 		this.#consecutiveFailures = 0;
 		this.#seenContext.clear();
@@ -158,6 +166,7 @@ export class AdvisorRuntime {
 	 */
 	seedTo(count: number): void {
 		this.#lastCount = count;
+		this.#releaseInvestigationIds(this.#takePendingInvestigationIds());
 		this.#pending = [];
 		this.#backlog = 0;
 		this.#consecutiveFailures = 0;
@@ -165,7 +174,7 @@ export class AdvisorRuntime {
 		this.#wakeAllWaiters();
 	}
 
-	#renderDelta(messages?: AgentMessage[]): string | null {
+	#renderDelta(messages?: AgentMessage[]): { text: string; investigationIds: string[] } | null {
 		const all = messages ?? this.#latestMessages ?? this.host.snapshotMessages();
 		if (all.length < this.#lastCount) {
 			this.#lastCount = all.length;
@@ -174,7 +183,7 @@ export class AdvisorRuntime {
 		}
 		const delta = all
 			.slice(this.#lastCount)
-			.filter(m => !(m.role === "custom" && (m as { customType?: string }).customType === "advisor"))
+			.filter(m => !(customMessageType(m) === "advisor"))
 			.map(m => this.#dedupContextMessage(m));
 		this.#lastCount = all.length;
 		if (delta.length === 0) return null;
@@ -187,7 +196,7 @@ export class AdvisorRuntime {
 			expandPrimaryContext: true,
 		});
 		if (!md.trim()) return null;
-		return `### Session update\n\n${md}`;
+		return { text: `### Session update\n\n${md}`, investigationIds: [] };
 	}
 
 	/**
@@ -199,10 +208,9 @@ export class AdvisorRuntime {
 	 * input shares the live primary transcript and must never be mutated.
 	 */
 	#dedupContextMessage(msg: AgentMessage): AgentMessage {
-		if (msg.role !== "custom") return msg;
-		const type = (msg as { customType?: string }).customType;
+		const type = customMessageType(msg);
 		if (!type || !PRIMARY_CONTEXT_CUSTOM_TYPES.has(type)) return msg;
-		const content = (msg as { content?: unknown }).content;
+		const content = customMessageStringContent(msg);
 		if (typeof content !== "string") return msg;
 		if (this.#seenContext.get(type) === content) {
 			return { ...(msg as object), content: "(unchanged — still in effect)" } as AgentMessage;
@@ -226,17 +234,69 @@ export class AdvisorRuntime {
 		}
 	}
 
+
+	#takePendingInvestigationIds(): string[] {
+		const ids: string[] = [];
+		for (const delta of this.#pending) {
+			ids.push(...delta.investigationIds);
+		}
+		return [...new Set(ids)];
+	}
+
+	#releaseInvestigationIds(ids: readonly string[]): void {
+		if (ids.length === 0) return;
+		void this.host.releaseInvestigationUpdates?.(ids).catch(err => {
+			logger.debug("advisor investigation release failed", { err: String(err) });
+		});
+	}
+
+	async #markInvestigationIdsDelivered(ids: readonly string[]): Promise<void> {
+		if (ids.length === 0) return;
+		try {
+			await this.host.markInvestigationUpdatesDelivered?.(ids);
+		} catch (err) {
+			logger.debug("advisor investigation delivery mark failed", { err: String(err) });
+			this.#releaseInvestigationIds(ids);
+		}
+	}
+
+	#combineBatchText(primaryText: string, investigationText: string | null): string | null {
+		if (primaryText && investigationText) return `${primaryText}\n\n### Investigation updates\n\n${investigationText}`;
+		if (primaryText) return primaryText;
+		if (investigationText) return `### Investigation updates\n\n${investigationText}`;
+		return null;
+	}
 	async #drain(): Promise<void> {
-		if (this.#busy) return;
+		if (this.#busy) {
+			this.#drainRequested = true;
+			return;
+		}
 		this.#busy = true;
 		try {
-			while (!this.disposed && this.#pending.length) {
+			while (!this.disposed) {
+				this.#drainRequested = false;
 				const popped = this.#pending.splice(0);
+				let update: AdvisorInvestigationUpdateBatch | null = null;
+				if (this.host.claimInvestigationUpdates) {
+					try {
+						update = await this.host.claimInvestigationUpdates();
+					} catch (err) {
+						logger.debug("advisor investigation claim failed", { err: String(err) });
+					}
+				}
+				if (popped.length === 0 && update === null) break;
 				const epoch = this.#epoch;
 				// Each delta already opens with a `### Session update` heading, so
 				// join with a blank line rather than a `---` rule.
-				const candidateBatch = popped.map(b => b.text).join("\n\n");
+				const candidatePrimaryText = popped.map(b => b.text).join("\n\n");
+				const investigationText = update?.text ?? null;
+				const combinedIds = [...popped.flatMap(b => b.investigationIds), ...(update?.ids ?? [])];
 				const turnsCovered = popped.reduce((sum, b) => sum + b.turns, 0);
+				const candidateBatch = this.#combineBatchText(candidatePrimaryText, investigationText);
+				if (candidateBatch === null) {
+					this.#releaseInvestigationIds(combinedIds);
+					continue;
+				}
 				const incomingTokens = estimateTokens({
 					role: "user",
 					content: candidateBatch,
@@ -252,7 +312,10 @@ export class AdvisorRuntime {
 					}
 				}
 				// A reset/dispose during context maintenance invalidates this batch.
-				if (this.#epoch !== epoch) continue;
+				if (this.#epoch !== epoch) {
+					this.#releaseInvestigationIds(combinedIds);
+					continue;
+				}
 
 				let batch: string | null;
 				let finalTurns: number;
@@ -260,7 +323,8 @@ export class AdvisorRuntime {
 					// Promotion could not fit the advisor's context — re-prime.
 					const newTurns = this.#pending.reduce((sum, b) => sum + b.turns, 0);
 					this.#resetAdvisorContext(false, false);
-					batch = this.#renderDelta(this.#latestMessages);
+					const rerendered = this.#renderDelta(this.#latestMessages);
+					batch = this.#combineBatchText(rerendered?.text ?? "", investigationText);
 					finalTurns = turnsCovered + newTurns;
 				} else {
 					batch = candidateBatch;
@@ -268,6 +332,7 @@ export class AdvisorRuntime {
 				}
 
 				if (this.disposed || batch === null) {
+					this.#releaseInvestigationIds(combinedIds);
 					this.#backlog = Math.max(0, this.#backlog - finalTurns);
 					this.#notifyWaiters();
 					continue;
@@ -276,6 +341,7 @@ export class AdvisorRuntime {
 				let success = false;
 				try {
 					await this.agent.prompt(batch);
+					if (combinedIds.length > 0) await this.#markInvestigationIdsDelivered(combinedIds);
 					success = true;
 					this.#consecutiveFailures = 0;
 				} catch (err) {
@@ -283,19 +349,23 @@ export class AdvisorRuntime {
 					// reset itself, not a transient advisor failure. Drop the stale batch
 					// (reset already cleared #pending and rewound the cursor) instead of
 					// requeuing it into the post-reset conversation.
-					if (this.#epoch !== epoch) continue;
+					if (this.#epoch !== epoch) {
+						this.#releaseInvestigationIds(combinedIds);
+						continue;
+					}
 					logger.debug("advisor turn failed", { err: String(err) });
 					this.#consecutiveFailures++;
 					if (this.#consecutiveFailures >= 3) {
 						logger.warn("advisor failed consecutively 3 times; dropping backlog to prevent stall");
 						this.#consecutiveFailures = 0;
+						this.#releaseInvestigationIds(combinedIds);
 						// The dropped batch may carry primary-context we never delivered; drop
 						// the seen-state too so the next turn re-expands it instead of marking
 						// it "unchanged" against content the advisor never received.
 						this.#seenContext.clear();
 						success = true;
 					} else {
-						this.#pending.unshift({ text: batch, turns: finalTurns });
+						this.#pending.unshift({ text: batch, turns: finalTurns, investigationIds: combinedIds });
 						await Bun.sleep(this.retryDelayMs);
 					}
 				}
@@ -307,6 +377,9 @@ export class AdvisorRuntime {
 			}
 		} finally {
 			this.#busy = false;
+			if (this.#drainRequested && !this.disposed) {
+				void this.#drain();
+			}
 		}
 	}
 }
@@ -421,6 +494,18 @@ function obfuscateAdvisorMessage(obfuscator: SecretObfuscator, message: AgentMes
 		default:
 			return message;
 	}
+}
+
+function customMessageType(message: AgentMessage): string | undefined {
+	if (message.role !== "custom") return undefined;
+	if (!("customType" in message) || typeof message.customType !== "string") return undefined;
+	return message.customType;
+}
+
+function customMessageStringContent(message: AgentMessage): string | undefined {
+	if (message.role !== "custom") return undefined;
+	if (!("content" in message) || typeof message.content !== "string") return undefined;
+	return message.content;
 }
 
 function obfuscateAdvisorDelta(obfuscator: SecretObfuscator, messages: AgentMessage[]): AgentMessage[] {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -404,6 +404,28 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.investigations.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Investigations",
+			description: "Allow the advisor to request out-of-band evidence artifacts from a separate investigation sidecar.",
+			condition: "advisorEnabled",
+		},
+	},
+	"advisor.investigations.exec": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Code Investigations",
+			description: "Allow advisor investigations that execute code in an isolated disposable repo snapshot.",
+			condition: "advisorEnabled",
+		},
+	},
 	"advisor.syncBacklog": {
 		type: "enum",
 		values: ["off", "1", "3", "5"] as const,

--- a/packages/coding-agent/src/evidence/__tests__/evidence-store.test.ts
+++ b/packages/coding-agent/src/evidence/__tests__/evidence-store.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "bun:test";
+import { EvidenceStore } from "../store";
+import type { InvestigationRequestInput } from "../types";
+
+const baseInput: InvestigationRequestInput = {
+	question: "Which API is correct?",
+	objective: "It could change the advisor guidance.",
+	mode: "docs",
+	risk: "could_change_direction",
+};
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-evidence-store-"));
+	try {
+		return await run(dir);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+function createStore(dir: string, sessionId = "session-1"): EvidenceStore {
+	const store = EvidenceStore.fromArtifactsDir(dir, sessionId);
+	if (!store) throw new Error("store unavailable");
+	return store;
+}
+
+describe("EvidenceStore", () => {
+	it("reconciles running records back to queued", async () => {
+		await withTempDir(async dir => {
+			const store = createStore(dir);
+			const record = await store.create(baseInput);
+			await store.update(record.id, { status: "running" });
+
+			const reconciled = await store.reconcileStale();
+			const updated = reconciled.find(entry => entry.id === record.id);
+			expect(updated?.status).toBe("queued");
+
+			const reloaded = createStore(dir);
+			expect((await reloaded.get(record.id))?.status).toBe("queued");
+		});
+	});
+
+	it("reconciles claimed records back to pending", async () => {
+		await withTempDir(async dir => {
+			const store = createStore(dir);
+			const record = await store.create(baseInput);
+			await store.update(record.id, { status: "ready", summary: "answer" });
+			await store.claimForAdvisor();
+
+			const reconciled = await store.reconcileStale();
+			const updated = reconciled.find(entry => entry.id === record.id);
+			expect(updated?.advisorDelivery).toBe("pending");
+			expect(updated?.status).toBe("ready");
+		});
+	});
+
+	it("release and delivery transitions affect only requested ids", async () => {
+		await withTempDir(async dir => {
+			const store = createStore(dir);
+			const first = await store.create({ ...baseInput, question: "first" });
+			const second = await store.create({ ...baseInput, question: "second" });
+			const third = await store.create({ ...baseInput, question: "third" });
+			await store.update(first.id, { status: "ready", summary: "first" });
+			await store.update(second.id, { status: "ready", summary: "second" });
+			await store.update(third.id, { status: "ready", summary: "third" });
+			await store.claimForAdvisor(2);
+
+			await store.releaseAdvisorClaims([first.id]);
+			let records = await store.list();
+			expect(records.find(entry => entry.id === first.id)?.advisorDelivery).toBe("pending");
+			expect(records.find(entry => entry.id === second.id)?.advisorDelivery).toBe("claimed");
+			expect(records.find(entry => entry.id === third.id)?.advisorDelivery).toBe("pending");
+
+			await store.markDeliveredToAdvisor([first.id, second.id]);
+			records = await store.list();
+			expect(records.find(entry => entry.id === first.id)?.advisorDelivery).toBe("delivered");
+			expect(records.find(entry => entry.id === second.id)?.advisorDelivery).toBe("delivered");
+			expect(records.find(entry => entry.id === third.id)?.advisorDelivery).toBe("pending");
+		});
+	});
+
+	it("serializes concurrent status update and advisor claim", async () => {
+		await withTempDir(async dir => {
+			const store = createStore(dir);
+			const record = await store.create(baseInput);
+
+			const [, batch] = await Promise.all([
+				store.update(record.id, { status: "ready", summary: "done" }),
+				store.claimForAdvisor(),
+			]);
+
+			expect(batch?.ids).toEqual([record.id]);
+			const updated = await store.get(record.id);
+			expect(updated?.status).toBe("ready");
+			expect(updated?.summary).toBe("done");
+			expect(updated?.advisorDelivery).toBe("claimed");
+		});
+	});
+
+	it("persists concurrent worker updates on different ids", async () => {
+		await withTempDir(async dir => {
+			const store = createStore(dir);
+			const first = await store.create({ ...baseInput, question: "first" });
+			const second = await store.create({ ...baseInput, question: "second" });
+
+			await Promise.all([
+				store.update(first.id, { status: "ready", summary: "first ready" }),
+				store.update(second.id, { status: "failed", error: "second failed" }),
+			]);
+
+			const reloaded = createStore(dir);
+			expect((await reloaded.get(first.id))?.summary).toBe("first ready");
+			expect((await reloaded.get(second.id))?.error).toBe("second failed");
+		});
+	});
+});

--- a/packages/coding-agent/src/evidence/__tests__/request-investigation-tool.test.ts
+++ b/packages/coding-agent/src/evidence/__tests__/request-investigation-tool.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "bun:test";
+import { ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE, type EvidenceBroker } from "../broker";
+import { RequestInvestigationTool, type RequestInvestigationParams } from "../request-investigation-tool";
+import type { InvestigationRecord } from "../types";
+
+function makeRecord(args: RequestInvestigationParams): InvestigationRecord {
+	return {
+		...args,
+		id: "ev-test-1",
+		status: "queued",
+		requestedBy: "advisor",
+		createdAt: 1,
+		updatedAt: 1,
+		advisorDelivery: "pending",
+	};
+}
+
+function makeBroker(request: EvidenceBroker["request"]): EvidenceBroker {
+	return { request } as unknown as EvidenceBroker;
+}
+
+describe("RequestInvestigationTool", () => {
+	it("returns queued details from the broker request", async () => {
+		const params: RequestInvestigationParams = {
+			question: "Which docs apply?",
+			objective: "The answer can change guidance.",
+			mode: "docs",
+			risk: "could_change_direction",
+			constraints: ["version 1.2"],
+		};
+		const request = vi.fn(async (input: RequestInvestigationParams) => makeRecord(input));
+		const tool = new RequestInvestigationTool(makeBroker(request));
+
+		const result = await tool.execute("tc-1", params);
+
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(request.mock.calls[0]?.[0]).toEqual(params);
+		expect(result.content).toEqual([
+			{
+				type: "text",
+				text: "Queued investigation ev-test-1. Continue reviewing; a later update will surface the artifact if it changes your guidance.",
+			},
+		]);
+		expect(result.details).toEqual({
+			id: "ev-test-1",
+			status: "queued",
+			mode: "docs",
+			risk: "could_change_direction",
+		});
+		expect(result.useless).toBe(true);
+	});
+
+	it("returns the exact disabled-exec tool error", async () => {
+		const params: RequestInvestigationParams = {
+			question: "Can this command reproduce the bug?",
+			objective: "A repro would change the advice.",
+			mode: "code_experiment",
+			risk: "potential_blocker",
+		};
+		const request = vi.fn(async (_input: RequestInvestigationParams) => {
+			throw new Error(ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE);
+		});
+		const tool = new RequestInvestigationTool(makeBroker(request));
+
+		const result = await tool.execute("tc-1", params);
+
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(result.isError).toBe(true);
+		expect(result.content).toEqual([{ type: "text", text: ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE }]);
+	});
+
+	it("accepts docs, web, and source modes through one broker request each", async () => {
+		const modes = ["docs", "web", "source"] as const;
+		for (const mode of modes) {
+			const params: RequestInvestigationParams = {
+				question: `Question for ${mode}`,
+				objective: "The answer can change guidance.",
+				mode,
+				risk: "background",
+			};
+			const request = vi.fn(async (input: RequestInvestigationParams) => makeRecord(input));
+			const tool = new RequestInvestigationTool(makeBroker(request));
+
+			const result = await tool.execute("tc-1", params);
+
+			expect(result.isError).toBeUndefined();
+			expect(request).toHaveBeenCalledTimes(1);
+			expect(request.mock.calls[0]?.[0]).toEqual(params);
+		}
+	});
+});

--- a/packages/coding-agent/src/evidence/broker.ts
+++ b/packages/coding-agent/src/evidence/broker.ts
@@ -1,0 +1,181 @@
+import type { AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { ModelRegistry } from "../config/model-registry";
+import type { Settings } from "../config/settings";
+import type { LocalProtocolOptions } from "../internal-urls";
+import type { AuthStorage } from "../session/auth-storage";
+import type { ArtifactManager } from "../session/artifacts";
+import type { EventBus } from "../utils/event-bus";
+import { EvidenceStore } from "./store";
+import type { AdvisorInvestigationUpdateBatch, InvestigationMode, InvestigationRecord, InvestigationRequestInput } from "./types";
+import { EvidenceWorkerFailure, runEvidenceWorker } from "./worker";
+
+export interface EvidenceBrokerOptions {
+	cwd: () => string;
+	settings: Settings;
+	artifactManager: ArtifactManager | null;
+	artifactsDir: () => string | null;
+	sessionId: () => string | null;
+	modelRegistry: ModelRegistry;
+	authStorage: AuthStorage;
+	eventBus?: EventBus;
+	localProtocolOptions?: LocalProtocolOptions;
+	parentTelemetry?: AgentTelemetryConfig;
+	onUpdateReady?: () => void;
+}
+
+export const ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE =
+	"Advisor code investigations are disabled. Enable advisor.investigations.exec to run this mode in an isolated snapshot.";
+
+const CODE_EXECUTION_MODES: Record<InvestigationMode, boolean> = {
+	docs: false,
+	web: false,
+	source: false,
+	code_experiment: true,
+	reproduction: true,
+	compatibility: true,
+	benchmark: true,
+	browser_probe: true,
+};
+
+export class EvidenceBroker {
+	readonly #dispatching = new Set<string>();
+	readonly #options: EvidenceBrokerOptions;
+	readonly #store: EvidenceStore;
+
+	private constructor(options: EvidenceBrokerOptions, store: EvidenceStore) {
+		this.#options = options;
+		this.#store = store;
+	}
+
+	static create(options: EvidenceBrokerOptions): EvidenceBroker | null {
+		const store = EvidenceStore.fromArtifactsDir(options.artifactsDir(), options.sessionId() ?? undefined);
+		if (!store) return null;
+		return new EvidenceBroker(options, store);
+	}
+
+	async request(input: InvestigationRequestInput): Promise<InvestigationRecord> {
+		if (CODE_EXECUTION_MODES[input.mode] && !this.#options.settings.get("advisor.investigations.exec")) {
+			throw new Error(ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE);
+		}
+		const record = await this.#store.create(input);
+		this.#scheduleDispatch(record.id);
+		return record;
+	}
+
+	async claimAdvisorUpdates(): Promise<AdvisorInvestigationUpdateBatch | null> {
+		return await this.#store.claimForAdvisor();
+	}
+
+	async releaseAdvisorUpdates(ids: readonly string[]): Promise<void> {
+		await this.#store.releaseAdvisorClaims(ids);
+	}
+
+	async markAdvisorUpdatesDelivered(ids: readonly string[]): Promise<void> {
+		await this.#store.markDeliveredToAdvisor(ids);
+	}
+
+	async reconcile(): Promise<void> {
+		const records = await this.#store.reconcileStale();
+		const queuedIds = records.filter(record => record.status === "queued").map(record => record.id);
+		for (const id of queuedIds) {
+			this.#scheduleDispatch(id);
+		}
+		if (
+			records.some(
+				record =>
+					(record.status === "ready" || record.status === "failed") && record.advisorDelivery === "pending",
+			)
+		) {
+			this.#options.onUpdateReady?.();
+		}
+	}
+
+	#scheduleDispatch(id: string): void {
+		try {
+			void this.#dispatch(id).catch(err => {
+				logger.debug("evidence dispatch scheduling failed", { id, err: String(err) });
+			});
+		} catch (err) {
+			logger.debug("evidence dispatch scheduling failed", { id, err: String(err) });
+		}
+	}
+
+	async #dispatch(id: string): Promise<void> {
+		if (this.#dispatching.has(id)) return;
+		this.#dispatching.add(id);
+		try {
+			const record = await this.#store.get(id);
+			if (!record || record.status !== "queued") return;
+			if (CODE_EXECUTION_MODES[record.mode] && !this.#options.settings.get("advisor.investigations.exec")) {
+				await this.#failRecord(record, ADVISOR_CODE_INVESTIGATIONS_DISABLED_MESSAGE);
+				this.#options.onUpdateReady?.();
+				return;
+			}
+			if (!this.#options.artifactManager) {
+				await this.#store.update(record.id, {
+					status: "failed",
+					error: "Evidence artifact storage is unavailable for this session.",
+					advisorDelivery: "pending",
+				});
+				this.#options.onUpdateReady?.();
+				return;
+			}
+			const running = await this.#store.update(record.id, { status: "running", advisorDelivery: "pending" });
+			if (!running) return;
+			try {
+				const result = await runEvidenceWorker({ ...this.#options, record: running });
+				const artifactId = await this.#options.artifactManager.save(result.artifactBody, "evidence");
+				const patch: Partial<Omit<InvestigationRecord, "id" | "createdAt">> = {
+					status: "ready",
+					artifactId,
+					artifactUrl: `artifact://${artifactId}`,
+					summary: result.summary,
+					advisorDelivery: "pending",
+				};
+				if (result.baseRevision !== undefined) patch.baseRevision = result.baseRevision;
+				await this.#store.update(record.id, patch);
+			} catch (error) {
+				if (error instanceof EvidenceWorkerFailure) {
+					await this.#storeWorkerFailure(record, error);
+				} else {
+					await this.#failRecord(record, error instanceof Error ? error.message : String(error));
+				}
+			}
+			this.#options.onUpdateReady?.();
+		} finally {
+			this.#dispatching.delete(id);
+		}
+	}
+
+	async #storeWorkerFailure(record: InvestigationRecord, failure: EvidenceWorkerFailure): Promise<void> {
+		if (!this.#options.artifactManager) {
+			await this.#failRecord(record, failure.message);
+			return;
+		}
+		try {
+			const artifactId = await this.#options.artifactManager.save(failure.result.artifactBody, "evidence");
+			const patch: Partial<Omit<InvestigationRecord, "id" | "createdAt">> = {
+				status: "failed",
+				artifactId,
+				artifactUrl: `artifact://${artifactId}`,
+				summary: failure.result.summary,
+				error: failure.message,
+				advisorDelivery: "pending",
+			};
+			if (failure.result.baseRevision !== undefined) patch.baseRevision = failure.result.baseRevision;
+			await this.#store.update(record.id, patch);
+		} catch (error) {
+			await this.#failRecord(record, error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	async #failRecord(record: InvestigationRecord, error: string): Promise<void> {
+		await this.#store.update(record.id, {
+			status: "failed",
+			error,
+			summary: error,
+			advisorDelivery: "pending",
+		});
+	}
+}

--- a/packages/coding-agent/src/evidence/index.ts
+++ b/packages/coding-agent/src/evidence/index.ts
@@ -1,0 +1,5 @@
+export * from "./broker";
+export * from "./request-investigation-tool";
+export * from "./store";
+export * from "./types";
+export * from "./worker";

--- a/packages/coding-agent/src/evidence/request-investigation-tool.ts
+++ b/packages/coding-agent/src/evidence/request-investigation-tool.ts
@@ -1,0 +1,68 @@
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+} from "@oh-my-pi/pi-agent-core";
+import { type } from "arktype";
+import requestInvestigationDescription from "../prompts/advisor/request-investigation-tool.md" with { type: "text" };
+import type { EvidenceBroker } from "./broker";
+import type { InvestigationMode, InvestigationRisk, InvestigationStatus } from "./types";
+
+const requestInvestigationSchema = type({
+	question: type("string").describe("The concrete factual or empirical question to answer."),
+	objective: type("string").describe("Why this could change the advisor's guidance to the main agent."),
+	mode: type("'docs' | 'web' | 'source' | 'code_experiment' | 'reproduction' | 'compatibility' | 'benchmark' | 'browser_probe'").describe("The investigation lane."),
+	risk: type("'background' | 'could_change_direction' | 'potential_blocker'").describe("How much the answer could affect the current work."),
+	"constraints?": type("string[]").describe("Concrete limits for the worker, such as package version, URL, command, or platform."),
+});
+
+export type RequestInvestigationParams = typeof requestInvestigationSchema.infer;
+
+export interface RequestInvestigationDetails {
+	id: string;
+	status: InvestigationStatus;
+	mode: InvestigationMode;
+	risk: InvestigationRisk;
+}
+
+export class RequestInvestigationTool implements AgentTool<typeof requestInvestigationSchema, RequestInvestigationDetails> {
+	readonly name = "request_investigation";
+	readonly label = "Request Investigation";
+	readonly description = requestInvestigationDescription;
+	readonly parameters = requestInvestigationSchema;
+	readonly intent = "omit" as const;
+
+	constructor(private readonly broker: EvidenceBroker) {}
+
+	async execute(
+		_toolCallId: string,
+		args: RequestInvestigationParams,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<RequestInvestigationDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<RequestInvestigationDetails>> {
+		try {
+			const input = args.constraints
+				? { question: args.question, objective: args.objective, mode: args.mode, risk: args.risk, constraints: args.constraints }
+				: { question: args.question, objective: args.objective, mode: args.mode, risk: args.risk };
+			const record = await this.broker.request(input);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Queued investigation ${record.id}. Continue reviewing; a later update will surface the artifact if it changes your guidance.`,
+					},
+				],
+				details: { id: record.id, status: record.status, mode: record.mode, risk: record.risk },
+				useless: true,
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				content: [{ type: "text", text: message }],
+				isError: true,
+			};
+		}
+	}
+}

--- a/packages/coding-agent/src/evidence/store.ts
+++ b/packages/coding-agent/src/evidence/store.ts
@@ -1,0 +1,196 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import type {
+	AdvisorInvestigationUpdateBatch,
+	InvestigationRecord,
+	InvestigationRequestInput,
+} from "./types";
+
+let requestCounter = 0;
+let tempCounter = 0;
+
+
+function formatInvestigationUpdate(record: InvestigationRecord): string {
+	const status = record.status === "ready" ? "ready" : "failed";
+	const summary = record.summary ?? record.error ?? "No summary was provided.";
+	const artifact = record.artifactUrl ? ` Artifact: ${record.artifactUrl}` : "";
+	const error = record.error && record.status === "failed" ? ` Error: ${record.error}` : "";
+	return `- ${record.id} (${status}, ${record.mode}, ${record.risk}): ${summary}${artifact}${error}`;
+}
+
+export class EvidenceStore {
+	#lock: Promise<void> = Promise.resolve();
+	readonly #requestsPath: string;
+	readonly #evidenceDir: string;
+
+	constructor(private readonly artifactsDir: string, private readonly sessionId: string | undefined) {
+		this.#evidenceDir = path.join(artifactsDir, "evidence");
+		this.#requestsPath = path.join(this.#evidenceDir, "requests.json");
+	}
+
+	static fromArtifactsDir(artifactsDir: string | null | undefined, sessionId?: string): EvidenceStore | null {
+		if (!artifactsDir) return null;
+		return new EvidenceStore(artifactsDir, sessionId);
+	}
+
+	async create(input: InvestigationRequestInput): Promise<InvestigationRecord> {
+		return await this.#withLock(async () => {
+			const records = await this.#readRecords();
+			const now = Date.now();
+			const record: InvestigationRecord = {
+				...input,
+				id: `ev-${Date.now().toString(36)}-${requestCounter++}`,
+				status: "queued",
+				requestedBy: "advisor",
+				createdAt: now,
+				updatedAt: now,
+				advisorDelivery: "pending",
+			};
+			if (this.sessionId) record.sessionId = this.sessionId;
+			records.push(record);
+			await this.#writeRecords(records);
+			return record;
+		});
+	}
+
+	async update(
+		id: string,
+		patch: Partial<Omit<InvestigationRecord, "id" | "createdAt">>,
+	): Promise<InvestigationRecord | null> {
+		return await this.#withLock(async () => {
+			const records = await this.#readRecords();
+			const index = records.findIndex(record => record.id === id);
+			if (index < 0) return null;
+			const current = records[index];
+			const updated: InvestigationRecord = {
+				...current,
+				...patch,
+				id: current.id,
+				createdAt: current.createdAt,
+				updatedAt: Date.now(),
+			};
+			records[index] = updated;
+			await this.#writeRecords(records);
+			return updated;
+		});
+	}
+
+	async get(id: string): Promise<InvestigationRecord | null> {
+		return await this.#withLock(async () => {
+			const records = await this.#readRecords();
+			return records.find(record => record.id === id) ?? null;
+		});
+	}
+
+	async list(): Promise<InvestigationRecord[]> {
+		return await this.#withLock(async () => await this.#readRecords());
+	}
+
+	async reconcileStale(): Promise<InvestigationRecord[]> {
+		return await this.#withLock(async () => {
+			const records = await this.#readRecords();
+			let changed = false;
+			const now = Date.now();
+			const reconciled = records.map(record => {
+				const status = record.status === "running" ? "queued" : record.status;
+				const advisorDelivery = record.advisorDelivery === "claimed" ? "pending" : record.advisorDelivery;
+				if (status === record.status && advisorDelivery === record.advisorDelivery) return record;
+				changed = true;
+				return { ...record, status, advisorDelivery, updatedAt: now };
+			});
+			if (changed) await this.#writeRecords(reconciled);
+			return reconciled;
+		});
+	}
+
+	async claimForAdvisor(limit?: number): Promise<AdvisorInvestigationUpdateBatch | null> {
+		return await this.#withLock(async () => {
+			const records = await this.#readRecords();
+			const max = limit ?? Number.POSITIVE_INFINITY;
+			const claimed: InvestigationRecord[] = [];
+			const now = Date.now();
+			for (let index = 0; index < records.length && claimed.length < max; index++) {
+				const record = records[index];
+				if ((record.status === "ready" || record.status === "failed") && record.advisorDelivery === "pending") {
+					const updated: InvestigationRecord = { ...record, advisorDelivery: "claimed", updatedAt: now };
+					records[index] = updated;
+					claimed.push(updated);
+				}
+			}
+			if (claimed.length === 0) return null;
+			await this.#writeRecords(records);
+			return {
+				ids: claimed.map(record => record.id),
+				text: claimed.map(formatInvestigationUpdate).join("\n"),
+			};
+		});
+	}
+
+	async releaseAdvisorClaims(ids: readonly string[]): Promise<void> {
+		await this.#withLock(async () => {
+			if (ids.length === 0) return;
+			const idSet = new Set(ids);
+			const records = await this.#readRecords();
+			let changed = false;
+			const now = Date.now();
+			const updated = records.map(record => {
+				if (!idSet.has(record.id) || record.advisorDelivery !== "claimed") return record;
+				changed = true;
+				return { ...record, advisorDelivery: "pending" as const, updatedAt: now };
+			});
+			if (changed) await this.#writeRecords(updated);
+		});
+	}
+
+	async markDeliveredToAdvisor(ids: readonly string[]): Promise<void> {
+		await this.#withLock(async () => {
+			if (ids.length === 0) return;
+			const idSet = new Set(ids);
+			const records = await this.#readRecords();
+			let changed = false;
+			const now = Date.now();
+			const updated = records.map(record => {
+				if (!idSet.has(record.id)) return record;
+				if (record.advisorDelivery !== "claimed" && record.advisorDelivery !== "pending") return record;
+				changed = true;
+				return { ...record, advisorDelivery: "delivered" as const, updatedAt: now };
+			});
+			if (changed) await this.#writeRecords(updated);
+		});
+	}
+
+	async #withLock<T>(work: () => Promise<T>): Promise<T> {
+		const prior = this.#lock;
+		const { promise: next, resolve } = Promise.withResolvers<void>();
+		this.#lock = prior.then(() => next, () => next);
+		await prior;
+		try {
+			return await work();
+		} finally {
+			resolve();
+		}
+	}
+
+	async #readRecords(): Promise<InvestigationRecord[]> {
+		try {
+			const text = await Bun.file(this.#requestsPath).text();
+			if (text.trim().length === 0) return [];
+			return JSON.parse(text) as InvestigationRecord[];
+		} catch (error) {
+			if (isEnoent(error)) return [];
+			throw error;
+		}
+	}
+
+	async #writeRecords(records: readonly InvestigationRecord[]): Promise<void> {
+		await fs.mkdir(this.#evidenceDir, { recursive: true });
+		const tmpPath = `${this.#requestsPath}.${process.pid}.${Date.now()}.${tempCounter++}.tmp`;
+		try {
+			await Bun.write(tmpPath, `${JSON.stringify(records, null, 2)}\n`);
+			await fs.rename(tmpPath, this.#requestsPath);
+		} finally {
+			await fs.rm(tmpPath, { force: true });
+		}
+	}
+}

--- a/packages/coding-agent/src/evidence/types.ts
+++ b/packages/coding-agent/src/evidence/types.ts
@@ -1,0 +1,40 @@
+export type InvestigationMode =
+	| "docs"
+	| "web"
+	| "source"
+	| "code_experiment"
+	| "reproduction"
+	| "compatibility"
+	| "benchmark"
+	| "browser_probe";
+
+export type InvestigationRisk = "background" | "could_change_direction" | "potential_blocker";
+export type InvestigationStatus = "queued" | "running" | "ready" | "failed";
+
+export interface InvestigationRequestInput {
+	question: string;
+	objective: string;
+	mode: InvestigationMode;
+	risk: InvestigationRisk;
+	constraints?: string[];
+}
+
+export interface InvestigationRecord extends InvestigationRequestInput {
+	id: string;
+	status: InvestigationStatus;
+	requestedBy: "advisor";
+	createdAt: number;
+	updatedAt: number;
+	sessionId?: string;
+	baseRevision?: string;
+	artifactId?: string;
+	artifactUrl?: string;
+	summary?: string;
+	error?: string;
+	advisorDelivery: "pending" | "claimed" | "delivered";
+}
+
+export interface AdvisorInvestigationUpdateBatch {
+	ids: readonly string[];
+	text: string;
+}

--- a/packages/coding-agent/src/evidence/worker.ts
+++ b/packages/coding-agent/src/evidence/worker.ts
@@ -1,0 +1,421 @@
+import type { AgentDefinition, SingleResult } from "../task/types";
+import { createSubagentSettings, type ExecutorOptions, runSubprocess } from "../task/executor";
+import { prepareIsolationContext, runIsolatedSubprocess } from "../task/isolation-runner";
+import { getBundledAgent } from "../task/agents";
+import * as git from "../utils/git";
+import { prompt } from "@oh-my-pi/pi-utils";
+import isolatedAssignmentTemplate from "../prompts/evidence/isolated-assignment.md" with { type: "text" };
+import librarianAssignmentTemplate from "../prompts/evidence/librarian-assignment.md" with { type: "text" };
+import type { EvidenceBrokerOptions } from "./broker";
+import type { InvestigationRecord } from "./types";
+
+export interface EvidenceWorkerOptions extends EvidenceBrokerOptions {
+	record: InvestigationRecord;
+}
+
+export interface EvidenceWorkerResult {
+	summary: string;
+	artifactBody: string;
+	baseRevision?: string;
+}
+
+export class EvidenceWorkerFailure extends Error {
+	constructor(
+		message: string,
+		readonly result: EvidenceWorkerResult,
+	) {
+		super(message);
+		this.name = "EvidenceWorkerFailure";
+	}
+}
+
+interface EvidenceSourceEntry {
+	label: string;
+	excerpt: string;
+	url?: string;
+	path?: string;
+	line_start?: number;
+	line_end?: number;
+}
+
+interface EvidenceOutput {
+	answer: string;
+	sources: EvidenceSourceEntry[];
+	commands?: string[];
+	caveats: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function isOptionalNumber(value: unknown): value is number | undefined {
+	return value === undefined || typeof value === "number";
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every(entry => typeof entry === "string");
+}
+
+function isEvidenceSourceEntry(value: unknown): value is EvidenceSourceEntry {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.label === "string" &&
+		typeof value.excerpt === "string" &&
+		isOptionalString(value.url) &&
+		isOptionalString(value.path) &&
+		isOptionalNumber(value.line_start) &&
+		isOptionalNumber(value.line_end)
+	);
+}
+
+function isEvidenceOutput(value: unknown): value is EvidenceOutput {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.answer === "string" &&
+		Array.isArray(value.sources) &&
+		value.sources.every(isEvidenceSourceEntry) &&
+		(value.commands === undefined || isStringArray(value.commands)) &&
+		isStringArray(value.caveats)
+	);
+}
+
+const evidenceOutputSchema = {
+	type: "object",
+	additionalProperties: false,
+	required: ["answer", "sources", "caveats"],
+	properties: {
+		answer: { type: "string" },
+		sources: {
+			type: "array",
+			items: {
+				type: "object",
+				additionalProperties: false,
+				required: ["label", "excerpt"],
+				properties: {
+					label: { type: "string" },
+					url: { type: "string" },
+					path: { type: "string" },
+					line_start: { type: "number" },
+					line_end: { type: "number" },
+					excerpt: { type: "string" },
+				},
+			},
+		},
+		commands: { type: "array", items: { type: "string" } },
+		caveats: { type: "array", items: { type: "string" } },
+	},
+} as const;
+
+const DOCS_MODES: Record<InvestigationRecord["mode"], boolean> = {
+	docs: true,
+	web: true,
+	source: true,
+	code_experiment: false,
+	reproduction: false,
+	compatibility: false,
+	benchmark: false,
+	browser_probe: false,
+};
+
+function constraintsBlock(record: InvestigationRecord): string {
+	if (!record.constraints?.length) return "";
+	return record.constraints.map(constraint => `- ${constraint}`).join("\n");
+}
+
+function assignmentData(record: InvestigationRecord): Record<string, unknown> {
+	return {
+		question: record.question,
+		objective: record.objective,
+		mode: record.mode,
+		risk: record.risk,
+		constraintsBlock: constraintsBlock(record),
+	};
+}
+
+function resolveAgent(name: "librarian" | "task"): AgentDefinition {
+	const agent = getBundledAgent(name);
+	if (agent) return agent;
+	if (name === "librarian") throw new Error("Bundled librarian agent is unavailable");
+	throw new Error("Bundled task agent is unavailable");
+}
+
+function buildWorkerSettings(options: EvidenceBrokerOptions) {
+	return createSubagentSettings(options.settings, {
+		"advisor.enabled": false,
+		"advisor.investigations.enabled": false,
+		"advisor.investigations.exec": false,
+	});
+}
+
+function buildExecutorOptions(args: {
+	options: EvidenceWorkerOptions;
+	agent: AgentDefinition;
+	assignment: string;
+	artifactsDir: string;
+}): ExecutorOptions {
+	const cwd = args.options.cwd();
+	const settings = buildWorkerSettings(args.options);
+	const baseOptions: ExecutorOptions = {
+		cwd,
+		agent: args.agent,
+		task: args.options.record.question,
+		assignment: args.assignment,
+		description: `Evidence investigation ${args.options.record.id}`,
+		role: "Evidence sidecar worker",
+		index: 0,
+		id: args.options.record.id,
+		detached: true,
+		outputSchema: evidenceOutputSchema,
+		artifactsDir: args.artifactsDir,
+		authStorage: args.options.authStorage,
+		modelRegistry: args.options.modelRegistry,
+		settings,
+	};
+	if (args.options.localProtocolOptions) baseOptions.localProtocolOptions = args.options.localProtocolOptions;
+	if (args.options.artifactManager) baseOptions.parentArtifactManager = args.options.artifactManager;
+	if (args.options.parentTelemetry) baseOptions.parentTelemetry = args.options.parentTelemetry;
+	if (args.options.eventBus) baseOptions.eventBus = args.options.eventBus;
+	return baseOptions;
+}
+
+async function readBaseRevision(cwd: string): Promise<string | undefined> {
+	try {
+		return (await git.head.sha(cwd)) ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function formatSources(sources: readonly EvidenceSourceEntry[]): string {
+	if (sources.length === 0) return "No sources were returned.";
+	return sources
+		.map(source => {
+			const locationParts: string[] = [];
+			if (source.url) locationParts.push(source.url);
+			if (source.path) {
+				const lines =
+					source.line_start !== undefined
+						? `:${source.line_start}${source.line_end !== undefined ? `-${source.line_end}` : ""}`
+						: "";
+				locationParts.push(`${source.path}${lines}`);
+			}
+			const location = locationParts.length > 0 ? ` (${locationParts.join(", ")})` : "";
+			return `- ${source.label}${location}\n\n  ${source.excerpt}`;
+		})
+		.join("\n");
+}
+
+function formatCommands(commands: readonly string[] | undefined): string {
+	if (!commands?.length) return "No commands were reported.";
+	return commands.map(command => `- ${command}`).join("\n");
+}
+
+function formatCaveats(caveats: readonly string[]): string {
+	if (caveats.length === 0) return "No caveats were reported.";
+	return caveats.map(caveat => `- ${caveat}`).join("\n");
+}
+
+interface ArtifactBodyArgs {
+	record: InvestigationRecord;
+	answer: string;
+	sources: readonly EvidenceSourceEntry[];
+	commands?: readonly string[];
+	caveats: readonly string[];
+	baseRevision?: string;
+	patchPath?: string;
+	stderr?: string;
+	partialOutput?: string;
+}
+
+
+function buildArtifactBody(args: ArtifactBodyArgs): string {
+	const snapshotLines = [
+		`Base revision: ${args.baseRevision ?? "unavailable"}`,
+		args.patchPath ? `Patch artifact: ${args.patchPath}` : undefined,
+	]
+		.filter((line): line is string => line !== undefined)
+		.join("\n");
+	const resultParts = [args.answer];
+	if (args.commands?.length) resultParts.push(`\nCommands reported:\n${formatCommands(args.commands)}`);
+	if (args.stderr?.trim()) resultParts.push(`\nStderr:\n${args.stderr.trim()}`);
+	if (args.partialOutput?.trim()) resultParts.push(`\nPartial output:\n${args.partialOutput.trim()}`);
+	return [
+		`# Investigation ${args.record.id}`,
+		"## Question",
+		args.record.question,
+		"## Objective",
+		args.record.objective,
+		"## Mode",
+		args.record.mode,
+		"## Result",
+		resultParts.join("\n"),
+		"## Sources",
+		formatSources(args.sources),
+		"## Snapshot",
+		snapshotLines,
+		"## Caveats",
+		formatCaveats(args.caveats),
+	]
+		.join("\n\n")
+		.trimEnd();
+}
+
+function parseWorkerOutput(result: SingleResult): EvidenceOutput {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(result.output);
+	} catch (error) {
+		throw new Error(`Evidence worker returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	if (!isEvidenceOutput(parsed)) {
+		throw new Error("Evidence worker returned structured output that did not match the evidence schema.");
+	}
+	return parsed;
+}
+
+function buildFailureResult(args: {
+	record: InvestigationRecord;
+	baseRevision?: string;
+	message: string;
+	stderr?: string;
+	partialOutput?: string;
+}): EvidenceWorkerResult {
+	const artifactArgs: ArtifactBodyArgs = {
+		record: args.record,
+		answer: args.message,
+		sources: [],
+		caveats: ["Investigation did not complete successfully."],
+	};
+	if (args.baseRevision !== undefined) artifactArgs.baseRevision = args.baseRevision;
+	if (args.stderr !== undefined) artifactArgs.stderr = args.stderr;
+	if (args.partialOutput !== undefined) artifactArgs.partialOutput = args.partialOutput;
+	const result: EvidenceWorkerResult = {
+		summary: args.message,
+		artifactBody: buildArtifactBody(artifactArgs),
+	};
+	if (args.baseRevision !== undefined) result.baseRevision = args.baseRevision;
+	return result;
+}
+
+function failedSingleResult(args: {
+	record: InvestigationRecord;
+	agent: AgentDefinition;
+	assignment: string;
+	message: string;
+}): SingleResult {
+	return {
+		index: 0,
+		id: args.record.id,
+		agent: args.agent.name,
+		agentSource: args.agent.source,
+		task: args.record.question,
+		assignment: args.assignment,
+		description: `Evidence investigation ${args.record.id}`,
+		exitCode: 1,
+		output: "",
+		stderr: args.message,
+		truncated: false,
+		durationMs: 0,
+		tokens: 0,
+		requests: 0,
+		error: args.message,
+	};
+}
+
+function toWorkerResult(record: InvestigationRecord, result: SingleResult, baseRevision?: string): EvidenceWorkerResult {
+	if (result.exitCode !== 0) {
+		const message = result.error ?? (result.stderr.trim() || `Evidence worker exited with code ${result.exitCode}.`);
+		const failureResult = buildFailureResult({
+			record,
+			message,
+			stderr: result.stderr,
+			partialOutput: result.output,
+			...(baseRevision !== undefined ? { baseRevision } : {}),
+		});
+		throw new EvidenceWorkerFailure(message, failureResult);
+	}
+	let output: EvidenceOutput;
+	try {
+		output = parseWorkerOutput(result);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const failureResult = buildFailureResult({
+			record,
+			message,
+			stderr: result.stderr,
+			partialOutput: result.output,
+			...(baseRevision !== undefined ? { baseRevision } : {}),
+		});
+		throw new EvidenceWorkerFailure(message, failureResult);
+	}
+	const caveats = result.error ? [...output.caveats, result.error] : output.caveats;
+	const artifactArgs: ArtifactBodyArgs = {
+		record,
+		answer: output.answer,
+		sources: output.sources,
+		caveats,
+	};
+	if (output.commands !== undefined) artifactArgs.commands = output.commands;
+	if (baseRevision !== undefined) artifactArgs.baseRevision = baseRevision;
+	if (result.patchPath !== undefined) artifactArgs.patchPath = result.patchPath;
+	if (result.stderr) artifactArgs.stderr = result.stderr;
+	const workerResult: EvidenceWorkerResult = {
+		summary: output.answer,
+		artifactBody: buildArtifactBody(artifactArgs),
+	};
+	if (baseRevision !== undefined) workerResult.baseRevision = baseRevision;
+	return workerResult;
+}
+
+export async function runEvidenceWorker(options: EvidenceWorkerOptions): Promise<EvidenceWorkerResult> {
+	const artifactsDir = options.artifactsDir();
+	if (!artifactsDir) {
+		const result = buildFailureResult({
+			record: options.record,
+			message: "Evidence artifact storage is unavailable for this session.",
+		});
+		throw new EvidenceWorkerFailure(result.summary, result);
+	}
+	const cwd = options.cwd();
+	if (DOCS_MODES[options.record.mode]) {
+		const agent = resolveAgent("librarian");
+		const assignment = prompt.render(librarianAssignmentTemplate, assignmentData(options.record));
+		const result = await runSubprocess(buildExecutorOptions({ options, agent, assignment, artifactsDir }));
+		return toWorkerResult(options.record, result, await readBaseRevision(cwd));
+	}
+	const agent = resolveAgent("task");
+	const assignment = prompt.render(isolatedAssignmentTemplate, assignmentData(options.record));
+	let context;
+	try {
+		context = await prepareIsolationContext(cwd);
+	} catch {
+		const result = buildFailureResult({
+			record: options.record,
+			message: "Code-executing investigations require a Git checkout so they can run in an isolated snapshot.",
+		});
+		throw new EvidenceWorkerFailure(result.summary, result);
+	}
+	const baseOptions = buildExecutorOptions({ options, agent, assignment, artifactsDir });
+	const result = await runIsolatedSubprocess({
+		baseOptions,
+		context,
+		preferredBackend: undefined,
+		agentId: options.record.id,
+		mergeMode: "patch",
+		artifactsDir,
+		description: `Evidence investigation ${options.record.id}`,
+		buildFailureResult: err =>
+			failedSingleResult({
+				record: options.record,
+				agent,
+				assignment,
+				message: err instanceof Error ? err.message : String(err),
+			}),
+	});
+	return toWorkerResult(options.record, result, context.baseline.root.headCommit || undefined);
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -138,6 +138,8 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	// they do opt in they get the default tuning rather than the user's local tuning.
 	"advisor.enabled",
 	"advisor.subagents",
+	"advisor.investigations.enabled",
+	"advisor.investigations.exec",
 	"advisor.syncBacklog",
 	"advisor.immuneTurns",
 	"serviceTierAdvisor",

--- a/packages/coding-agent/src/prompts/advisor/request-investigation-tool.md
+++ b/packages/coding-agent/src/prompts/advisor/request-investigation-tool.md
@@ -1,0 +1,9 @@
+Queue an out-of-band investigation when missing external or empirical evidence could change your advice.
+
+Use this only when a concrete docs, web, source, reproduction, compatibility, benchmark, code-experiment, or browser-probe result could materially change your guidance to the main agent.
+
+This tool queues work and returns immediately. Never wait for completion in the same advisor turn. Continue reviewing the current session with the evidence you already have.
+
+A later investigation update will surface the artifact. Call `advise` only after that later update changes your guidance.
+
+Do not request investigations for generic uncertainty, ordinary caution, or user-intent questions. Ask for evidence only when the missing fact is specific, answerable, and likely to affect the advice.

--- a/packages/coding-agent/src/prompts/evidence/isolated-assignment.md
+++ b/packages/coding-agent/src/prompts/evidence/isolated-assignment.md
@@ -1,0 +1,26 @@
+# Evidence investigation in an isolated snapshot
+
+You are running in a disposable repo snapshot. Produce evidence only.
+
+You may mutate only this disposable worktree. Do not attempt to apply changes to the parent repository. Do not create commits, branches, pull requests, or persistent side effects outside this snapshot.
+
+Use the selected empirical lane to answer the question. Run the smallest commands, code experiments, compatibility checks, benchmarks, reproductions, or browser probes that directly answer it.
+
+## Question
+{{question}}
+
+## Objective
+{{objective}}
+
+## Mode
+{{mode}}
+
+## Risk
+{{risk}}
+
+{{#if constraintsBlock}}
+## Constraints
+{{constraintsBlock}}
+{{/if}}
+
+Return only the structured output requested by the runtime. Include concise findings, commands run with observed outputs, sources or paths with excerpts, and caveats. Do not propose applying changes to the parent repo.

--- a/packages/coding-agent/src/prompts/evidence/librarian-assignment.md
+++ b/packages/coding-agent/src/prompts/evidence/librarian-assignment.md
@@ -1,0 +1,22 @@
+# Evidence investigation
+
+Answer the requested question using source-grounded evidence. Use official docs, source files, repository search, or web sources only as needed for the selected mode.
+
+## Question
+{{question}}
+
+## Objective
+{{objective}}
+
+## Mode
+{{mode}}
+
+## Risk
+{{risk}}
+
+{{#if constraintsBlock}}
+## Constraints
+{{constraintsBlock}}
+{{/if}}
+
+Return only the structured output requested by the runtime. Include concise answer text, sources with excerpts, and caveats. Do not make recommendations beyond the evidence.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -139,6 +139,7 @@ import {
 	isInterruptingSeverity,
 	resolveAdvisorDeliveryChannel,
 } from "../advisor";
+import { EvidenceBroker, type EvidenceBrokerOptions, RequestInvestigationTool } from "../evidence";
 import { type AsyncJob, type AsyncJobDeliveryState, AsyncJobManager } from "../async";
 import { classifyDifficulty } from "../auto-thinking/classifier";
 import { reset as resetCapabilities } from "../capability";
@@ -1161,6 +1162,8 @@ export class AgentSession {
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
 	#advisorRuntime?: AdvisorRuntime;
+	#evidenceBroker?: EvidenceBroker;
+	#evidenceBrokerArtifactsDir?: string;
 	#advisorEnabled = false;
 	/** The advisor's own agent, retained so `/dump advisor` can serialize its transcript. Undefined when no advisor is active. */
 	#advisorAgent?: Agent;
@@ -1792,13 +1795,12 @@ export class AgentSession {
 	 * so none of them inject into the new conversation.
 	 */
 	#resetAdvisorSessionState(): void {
-		// Mute the recorder across the re-prime: AdvisorRuntime.reset() aborts the advisor
-		// loop, and that abort can emit an `aborted` message_end we must not attribute to
-		// either session's transcript. Detach, reset, then re-attach the live agent's feed.
-		this.#advisorAgentUnsubscribe?.();
-		this.#advisorAgentUnsubscribe = undefined;
-		this.#advisorRuntime?.reset();
-		this.#attachAdvisorRecorderFeed();
+		// Rebuild advisor tooling across session/artifact boundaries so advisor-only tools
+		// (notably request_investigation) cannot keep writing to the prior session's
+		// evidence store or artifact manager after /new, resume, or branch rewrites.
+		const shouldRebuildAdvisor = this.#advisorRuntime !== undefined;
+		this.#stopAdvisorRuntime();
+		if (shouldRebuildAdvisor) this.#buildAdvisorRuntime(false);
 		this.#advisorPrimaryTurnsCompleted = 0;
 		this.#advisorInterruptImmuneTurnStart = undefined;
 		this.#advisorAutoResumeSuppressed = false;
@@ -1879,6 +1881,37 @@ export class AgentSession {
 
 		const adviseTool = new AdviseTool(enqueueAdvice);
 		const advisorReadOnlyTools = this.#advisorReadOnlyTools ?? [];
+		let evidenceBroker: EvidenceBroker | null = null;
+		if (this.settings.get("advisor.investigations.enabled")) {
+			const evidenceArtifactsDir = this.sessionManager.getArtifactsDir();
+			if (evidenceArtifactsDir && this.#evidenceBroker && this.#evidenceBrokerArtifactsDir === evidenceArtifactsDir) {
+				evidenceBroker = this.#evidenceBroker;
+			} else if (evidenceArtifactsDir) {
+				const evidenceSessionId = this.sessionId ?? null;
+				const brokerOptions: EvidenceBrokerOptions = {
+					cwd: () => this.sessionManager.getCwd(),
+					settings: this.settings,
+					artifactManager: this.sessionManager.getArtifactManager(),
+					artifactsDir: () => evidenceArtifactsDir,
+					sessionId: () => evidenceSessionId,
+					modelRegistry: this.#modelRegistry,
+					authStorage: this.#modelRegistry.authStorage,
+					localProtocolOptions: this.#localProtocolOptions(),
+					onUpdateReady: () => this.#advisorRuntime?.onTurnEnd(this.agent.state.messages),
+				};
+				if (this.agent.telemetry) brokerOptions.parentTelemetry = this.agent.telemetry;
+				evidenceBroker = EvidenceBroker.create(brokerOptions);
+				this.#evidenceBroker = evidenceBroker ?? undefined;
+				this.#evidenceBrokerArtifactsDir = evidenceBroker ? evidenceArtifactsDir : undefined;
+			} else {
+				this.#evidenceBroker = undefined;
+				this.#evidenceBrokerArtifactsDir = undefined;
+			}
+		}
+		const requestInvestigationTool = evidenceBroker ? new RequestInvestigationTool(evidenceBroker) : null;
+		const advisorTools: AgentState["tools"] = requestInvestigationTool
+			? [adviseTool, requestInvestigationTool, ...advisorReadOnlyTools]
+			: [adviseTool, ...advisorReadOnlyTools];
 
 		const appendOnlyContext = new AppendOnlyContextManager();
 		const advisorThinkingLevel = advisorSel.thinkingLevel ?? ThinkingLevel.Medium;
@@ -1920,7 +1953,7 @@ export class AgentSession {
 				systemPrompt,
 				model: advisorSel.model,
 				thinkingLevel: toReasoningEffort(advisorThinkingLevel),
-				tools: [adviseTool, ...advisorReadOnlyTools],
+				tools: advisorTools,
 			},
 			appendOnlyContext,
 			sessionId: advisorSessionId,
@@ -1938,6 +1971,9 @@ export class AgentSession {
 			reset: () => {
 				advisorAgent.reset();
 				appendOnlyContext.log.clear();
+				void this.#evidenceBroker
+					?.reconcile()
+					.catch(err => logger.debug("advisor evidence reconcile failed", { err: String(err) }));
 			},
 			state: advisorAgent.state,
 		};
@@ -1960,9 +1996,16 @@ export class AgentSession {
 			enqueueAdvice,
 			maintainContext: incomingTokens => this.#maintainAdvisorContext(incomingTokens),
 			obfuscator: this.#obfuscator,
+			claimInvestigationUpdates: () => this.#evidenceBroker?.claimAdvisorUpdates() ?? Promise.resolve(null),
+			releaseInvestigationUpdates: ids => this.#evidenceBroker?.releaseAdvisorUpdates(ids) ?? Promise.resolve(),
+			markInvestigationUpdatesDelivered: ids =>
+				this.#evidenceBroker?.markAdvisorUpdatesDelivered(ids) ?? Promise.resolve(),
 		});
 		if (seedToCurrent) {
 			this.#advisorRuntime.seedTo(this.agent.state.messages.length);
+		}
+		if (evidenceBroker) {
+			void evidenceBroker.reconcile().catch(err => logger.debug("advisor evidence reconcile failed", { err: String(err) }));
 		}
 
 		// Batch non-blocking advisor notes into one injected custom message.


### PR DESCRIPTION
## Summary
- add an advisor request_investigation tool backed by a durable evidence queue
- dispatch docs/source work through the librarian lane and empirical probes through isolated workers
- deliver concise artifact pointers back to the advisor runtime

## Verification
- bun test src/advisor/__tests__/advisor.test.ts src/evidence/__tests__/evidence-store.test.ts src/evidence/__tests__/request-investigation-tool.test.ts
- bun run check:types