### PR TITLE
Add mid-turn auto-compaction for tool loops

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -55,13 +55,14 @@ while `custom` messages pass through as developer messages with their raw conten
 
 ### Triggers
 
-Compaction/context maintenance can run in five ways:
+Compaction/context maintenance can run in six ways:
 
 1. **Manual context compaction**: `/compact [instructions]` calls `AgentSession.compact(...)`.
 2. **Automatic overflow recovery**: after a same-model assistant error that matches context overflow.
 3. **Automatic incomplete-output recovery**: after a same-model assistant message ends with `stopReason === "length"` (OpenAI/Codex `response.incomplete`).
 4. **Automatic threshold maintenance**: after a successful turn when context exceeds the resolved threshold.
-5. **Idle maintenance**: `runIdleCompaction()` can invoke the same auto-maintenance path with reason `"idle"`.
+5. **Mid-turn threshold maintenance**: at safe tool-loop boundaries before the next provider request when `compaction.midTurnEnabled` is true.
+6. **Idle maintenance**: `runIdleCompaction()` can invoke the same auto-maintenance path with reason `"idle"`.
 
 ### Compaction shape (visual)
 
@@ -121,8 +122,9 @@ The automatic paths are intentionally different:
   - Tool-output pruning can reduce the measured token count before threshold comparison.
   - Context promotion is tried before compaction.
   - If promotion is unavailable, auto maintenance runs with `reason: "threshold"` and `willRetry: false`.
-  - With `compaction.strategy: "handoff"`, threshold maintenance normally schedules a post-prompt auto-handoff task instead of writing a compaction entry; pre-prompt checks run it inline to avoid racing the next turn. If handoff returns no document without aborting, it falls back to context-full compaction.
+  - With `compaction.strategy: "handoff"`, threshold maintenance normally schedules a post-prompt auto-handoff task instead of writing a compaction entry; pre-prompt and mid-turn checks run it inline to avoid racing the next provider request. If handoff returns no document without aborting, it falls back to context-full compaction.
   - On success, if `compaction.autoContinue !== false`, schedules an agent-authored developer auto-continue prompt from `prompts/system/auto-continue.md`.
+  - Mid-turn threshold maintenance runs from `AgentSession.#maintainContextMidRun` after tool results are paired and before the loop can send another provider request. It splices the rebuilt compacted context back into the live message array and suppresses separate auto-continue scheduling because the current loop already owns continuation.
 
 - **Idle maintenance**
   - Trigger: `runIdleCompaction()` when not streaming or already compacting.
@@ -405,6 +407,7 @@ From `settings-schema.ts`:
 
 - `compaction.enabled` = `true`
 - `compaction.strategy` = `"snapcompact"` (`"context-full"`, `"handoff"`, `"shake"`, and `"off"` are also supported)
+- `compaction.midTurnEnabled` = `true`
 - `compaction.reserveTokens` = `16384`
 - `compaction.keepRecentTokens` = `20000`
 - `compaction.autoContinue` = `true`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -503,6 +503,7 @@ contextPromotion:
 compaction:
   enabled: true
   strategy: snapcompact     # context-full, handoff, shake, snapcompact, off
+  midTurnEnabled: true        # check thresholds between tool-loop provider requests
   thresholdPercent: -1       # -1 = default reserve-based behavior
   thresholdTokens: -1        # fixed token limit when > 0
   remoteEnabled: true
@@ -516,6 +517,7 @@ memory:
 | `contextPromotion.enabled` | boolean | `true` | Promote relevant earlier context. |
 | `compaction.enabled` | boolean | `true` | Automatic conversation compaction. |
 | `compaction.strategy` | enum | `snapcompact` | `context-full`, `handoff`, `shake`, `snapcompact`, `off`. |
+| `compaction.midTurnEnabled` | boolean | `true` | Check thresholds at safe mid-turn tool-loop boundaries before the next provider request. |
 | `compaction.thresholdPercent` | number | `-1` | Percent-of-context trigger; `-1` = reserve-based default. |
 | `compaction.thresholdTokens` | number | `-1` | Fixed token trigger when `> 0`. |
 | `compaction.reserveTokens` | number | `16384` | Tokens reserved for the next turn. |

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -150,6 +150,7 @@ export interface CompactionSettings {
 	thresholdTokens?: number;
 	reserveTokens: number;
 	keepRecentTokens: number;
+	midTurnEnabled?: boolean;
 	autoContinue?: boolean;
 	remoteEnabled?: boolean;
 	remoteEndpoint?: string;
@@ -162,6 +163,7 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 	thresholdTokens: -1,
 	reserveTokens: 16384,
 	keepRecentTokens: 20000,
+	midTurnEnabled: true,
 	autoContinue: true,
 	remoteEnabled: true,
 };

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1699,6 +1699,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Automatically compact context when it gets too large",
 		},
 	},
+	"compaction.midTurnEnabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "context",
+			group: "Compaction",
+			label: "Mid-Turn Auto-Compact",
+			description: "Check compaction thresholds at safe tool-loop boundaries before the next model request",
+		},
+	},
 
 	"compaction.strategy": {
 		type: "enum",
@@ -4732,6 +4742,7 @@ export interface CompactionSettings {
 	reserveTokens: number;
 	keepRecentTokens: number;
 	handoffSaveToDisk: boolean;
+	midTurnEnabled: boolean;
 	autoContinue: boolean;
 	remoteEnabled: boolean;
 	remoteEndpoint: string | undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8393,20 +8393,31 @@ export class AgentSession {
 		});
 	}
 
+	#assistantMayContinueMidRun(assistantMessage: AssistantMessage): boolean {
+		const hasToolCalls = assistantMessage.content.some((content): content is ToolCall => content.type === "toolCall");
+		if (hasToolCalls) {
+			return (
+				assistantMessage.stopReason === "toolUse" ||
+				assistantMessage.stopReason === "stop" ||
+				assistantMessage.stopReason === "length"
+			);
+		}
+		return assistantMessage.stopReason === "stop" && assistantMessage.stopDetails?.type === "pause_turn";
+	}
+
 	/**
-	 * Compact active `/goal` runs that never settle to `agent_end`.
+	 * Compact runs that have reached a safe boundary but have not settled to `agent_end`.
 	 *
-	 * Long autonomous goals can keep producing tool calls inside one agent run.
-	 * The post-turn `agent_end` threshold check never fires in that shape, so
-	 * context can grow until provider overflow. `onTurnEnd` is the safe boundary:
-	 * tool results for the just-finished turn are already paired in
-	 * `activeMessages`, the live array the agent loop reads before its next
-	 * model call. Run maintenance here and splice the compacted state back into
-	 * that array, mirroring [`AgentSession.#applyRewind`].
+	 * Long tool loops can keep producing provider calls inside one agent run. The
+	 * post-turn `agent_end` threshold check never fires in that shape, so context can
+	 * grow until provider overflow. `onTurnEnd` is the safe boundary: tool results for
+	 * the just-finished turn are already paired in `activeMessages`, and the live
+	 * array is what the agent loop reads before its next model call. Run maintenance
+	 * here and splice the compacted state back into that array, mirroring
+	 * [`AgentSession.#applyRewind`].
 	 */
 	async #maintainContextMidRun(activeMessages: AgentMessage[], signal?: AbortSignal): Promise<void> {
 		if (signal?.aborted || this.#isDisposed || this.isCompacting || this.isGeneratingHandoff) return;
-		if (!(this.#goalModeState?.enabled === true && this.#goalModeState.goal.status === "active")) return;
 
 		const model = this.model;
 		const contextWindow = model?.contextWindow ?? 0;
@@ -8415,10 +8426,14 @@ export class AgentSession {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
 
+		const goalActive = this.#goalModeState?.enabled === true && this.#goalModeState.goal.status === "active";
+		if (!goalActive && compactionSettings.midTurnEnabled === false) return;
+
 		const lastAssistant = [...activeMessages]
 			.reverse()
 			.find((message): message is AssistantMessage => message.role === "assistant");
 		if (!lastAssistant || lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") return;
+		if (!goalActive && !this.#assistantMayContinueMidRun(lastAssistant)) return;
 
 		const billedContextTokens = calculateContextTokens(lastAssistant.usage);
 		const storedContextTokens = this.#estimateStoredContextTokens();
@@ -8437,10 +8452,11 @@ export class AgentSession {
 		if (compactedMessages !== activeMessages) {
 			activeMessages.splice(0, activeMessages.length, ...compactedMessages);
 		}
-		logger.debug("Mid-run goal compaction ran between tool-call turns", {
+		logger.debug("Mid-run compaction ran between provider calls", {
 			contextTokens,
 			contextWindow,
 			strategy: compactionSettings.strategy,
+			goalActive,
 			messagesBefore,
 			messagesAfter: activeMessages.length,
 		});

--- a/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
@@ -164,8 +164,25 @@ describe("AgentSession mid-run goal compaction", () => {
 		expect(observedContexts[1].join("\n")).toContain("MID-RUN-COMPACTED");
 	});
 
-	it("does not compact mid-run when no goal is active", async () => {
-		const { session } = await createHarness();
+	it("compacts in place between tool-call turns outside goal mode", async () => {
+		const { session, observedContexts } = await createHarness();
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "MID-RUN-COMPACTED",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+
+		await session.prompt("work on the release");
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(observedContexts.length).toBeGreaterThanOrEqual(2);
+		expect(observedContexts[1].join("\n")).toContain("MID-RUN-COMPACTED");
+	});
+
+	it("does not compact mid-run outside goal mode when disabled", async () => {
+		const { session } = await createHarness({ "compaction.midTurnEnabled": false });
 		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
 			summary: "SHOULD-NOT-RUN",
 			shortSummary: undefined,


### PR DESCRIPTION
## Summary

- add `compaction.midTurnEnabled` so regular tool-loop runs can compact at safe mid-turn boundaries
- generalize the existing `#maintainContextMidRun` path beyond active goal mode while preserving goal behavior
- document the new setting and mid-turn threshold maintenance path

Closes #3525

## Testing

- `bun test packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/agent-session-*compaction*.test.ts packages/coding-agent/test/agent-session-handoff.test.ts`
