### PR TITLE
fix(inspect_image): resolve internal URIs before loading images

### DIFF
--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -16,8 +16,10 @@ import {
 	MAX_IMAGE_INPUT_BYTES,
 	webpExclusionForModel,
 } from "../utils/image-loading";
+import { InternalUrlRouter } from "../internal-urls/router";
 import type { ToolSession } from "./index";
 import { ToolError } from "./tool-errors";
+import { isInternalUrlPath } from "./path-utils";
 
 const inspectImageSchema = type({
 	path: type("string").describe("image file path, Image #N label, or attachment://N URI"),
@@ -182,6 +184,19 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 		const autoResize = this.session.settings.get("images.autoResize");
 		const excludeWebP = webpExclusionForModel(model);
 		const attachmentReference = parseImageAttachmentReference(params.path);
+		let resolvedPathOverride: string | undefined;
+		if (isInternalUrlPath(params.path)) {
+			const router = InternalUrlRouter.instance();
+			if (router.canHandle(params.path)) {
+				const resource = await router.resolve(params.path, {
+					cwd: this.session.cwd,
+					signal,
+					localProtocolOptions: this.session.localProtocolOptions,
+				});
+				resolvedPathOverride = resource.sourcePath;
+			}
+		}
+
 		try {
 			if (attachmentReference) {
 				imageInput = await loadAttachmentReferenceInput({
@@ -198,6 +213,7 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 					autoResize,
 					maxBytes: MAX_IMAGE_INPUT_BYTES,
 					excludeWebP,
+					resolvedPath: resolvedPathOverride,
 				});
 			}
 		} catch (error) {


### PR DESCRIPTION
## Problem

`inspect_image` rejects `/Users/xxx/2026-06-26T05-57-33-935Z_019f0281-446f-7000-bfc2-86498218b633/local` URIs with error: "must be resolved through the proper protocol handler". It only calls `resolveReadPath()` for filesystem path resolution, while the `read` tool properly delegates to `InternalUrlRouter`.

## Root Cause

In `packages/coding-agent/src/utils/image-loading.ts`, `loadImageInput()` does:
```typescript
const resolvedPath = options.resolvedPath ?? resolveReadPath(options.path, options.cwd);
```

`resolveReadPath()` handles `~`, relative paths, and macOS filename quirks — but NOT internal URLs. The `InternalUrlRouter` (which handles `/Users/xxxx/2026-06-26T05-57-33-935Z_019f0281-446f-7000-bfc2-86498218b633/local`, `agent://`, `skill://`, etc.) is never consulted.

## Fix

In `inspect-image.ts` execute(), before calling `loadImageInput`:
1. Check if the path looks like an internal URL via `isInternalUrlPath()`
2. If yes, resolve it through `InternalUrlRouter.instance().resolve()` 
3. Pass the underlying `sourcePath` as the `resolvedPath` override to `loadImageInput`

This makes `inspect_image path=/Users/xxx/2026-06-26T05-57-33-935Z_019f0281-446f-7000-bfc2-86498218b633/local/image-xxx.webp` work transparently, matching `read` tool behavior.

## Changes

`packages/coding-agent/src/tools/inspect-image.ts` — 16 insertions, 0 deletions