### PR TITLE
fix(mcp): hide console window when direct-spawning resolved .exe on Windows

### DIFF
--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -240,7 +240,7 @@ export async function resolveStdioSpawnCommand(
 	// is not a batch script. Everything else (resolved .cmd/.bat, or an
 	// unresolved extensionless command) goes through cmd.exe so PATHEXT runs.
 	const needsCmdExe = resolved === null || isWindowsBatchCommand(resolvedCommand);
-	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args] };
+	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide: true };
 
 	return {
 		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -319,6 +319,37 @@ describe("resolveStdioSpawnCommand", () => {
 		expect(result.windowsHide).toBe(true);
 	});
 
+	it("hides the console window when direct-spawning a resolved .exe on Windows", async () => {
+		// Regression: aa862b8 made resolveWindowsCommandPath return a concrete
+		// .exe path for bare commands (e.g. `uvx` -> `uvx.EXE`), so the direct
+		// spawn branch is taken instead of the cmd.exe wrapper. That branch
+		// omitted windowsHide, so every Console-subsystem child (uvx, uv,
+		// python, etc.) flashed a cmd window on screen at startup.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-exe-"));
+		try {
+			const exe = path.join(tempDir, "uvx.EXE");
+			await Bun.write(exe, "");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: "uvx", args: ["code-review-graph", "serve"] },
+				{
+					cwd: tempDir,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: tempDir,
+						PATHEXT: ".COM;.EXE;.BAT;.CMD",
+					},
+					platform: "win32",
+				},
+			);
+
+			expect(result.cmd).toEqual([exe, "code-review-graph", "serve"]);
+			expect(result.windowsHide).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("leaves non-Windows commands untouched", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },


### PR DESCRIPTION
## Problem

After omp update (16.1.19+), spawning MCP stdio servers that resolve to a concrete `.exe` (e.g. `uvx` → `uvx.EXE`) flashes a cmd console window on screen — one per server instance. With 3 `code-review-graph` instances that's 6 windows.

## Root cause

`aa862b8` ("fix(mcp): launched npm cmd shims directly", #2367) taught `resolveWindowsCommandPath` to return a concrete `.exe` path for bare commands. This made the **direct-spawn branch** of `resolveStdioSpawnCommand` reachable for commands like `uvx`:

```ts
// stdio.ts:243 — the bug
if (!needsCmdExe) return { cmd: [resolvedCommand, ...args] };
//                                     ^^^ no windowsHide
```

Before `aa862b8`, bare commands resolved to `null` and fell through to the `cmd.exe /c` wrapper, which **does** set `windowsHide: true`. Once resolution started succeeding, the direct-spawn branch — which has never set `windowsHide` — was taken instead, and `Bun.spawn` left the console window visible for every Console-subsystem child.

The `cmd.exe` path (line 247) and the npm-shim path (line 150) both set `windowsHide: true`; only the direct-spawn path was missing it.

## Fix

Add `windowsHide: true` to the direct-spawn return so it matches the other two paths:

```ts
if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide: true };
```

## Test

Added a regression test (`hides the console window when direct-spawning a resolved .exe on Windows`) that creates a fake `uvx.EXE`, resolves the bare command `uvx`, and asserts the result is direct-spawned with `windowsHide: true`.

## Note

I'm not yet vouched — happy to go through the vouch process. Started a Discussion to request it.