### PR TITLE
Add loop engineering runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ eval "$(omp completions bash)"
 omp completions fish > ~/.config/fish/completions/omp.fish
 ```
 
+### Loop engineering
+
+`omp loop` adds durable loop specs for recurring one-shot agent runs: initialize `.omp/loops/*.loop.yaml`, check readiness, run one scheduled-safe iteration, execute verifier commands, and append JSONL/Markdown run logs. See [docs/loop-engineering.md](docs/loop-engineering.md).
+
 ## Every tool, _benchmaxxed_.
 
 Edits that land on the first attempt. Reads that summarize files instead of dumping their content. Searches that return instantly. Pick any model — omp will get it right.

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -78,7 +78,7 @@ loop:
     budget: loop-budget.md
 ```
 
-Verifier commands must be argv arrays (or objects with an `argv` array) and, by default, must use package-script forms such as `["bun", "run", "check"]`, `["pnpm", "run", "test"]`, or `["npm", "test"]`. Shell strings, shell executables, custom binaries, and arbitrary absolute paths are intentionally not accepted. Treat loop specs as trusted executable configuration: do not run specs modified by untrusted PRs or branches.
+Verifier commands must be argv arrays (or objects with an `argv` array) and, by default, must use package-script forms such as `["bun", "run", "check"]`, `["pnpm", "run", "test"]`, or `["npm", "test"]`. Shell strings, shell executables, custom binaries, and arbitrary absolute paths are intentionally not accepted. OMP reads the selected package script, validates it fail-closed, snapshots verifier inputs, then executes the parsed local runtime command directly with a minimal verifier environment and sanitized `PATH` instead of delegating to package-manager script `PATH` lookup. The selected package script must execute a local verifier entrypoint through an approved runtime such as `node verify.js` or `bun ./verify.ts`; selected `pre<name>`/`post<name>` lifecycle hooks, nested package-manager invocations, runner subcommands, pre-entrypoint flags, shell metacharacters, bare package imports, dynamic import/require forms, dangerous builtins, dynamic-code APIs, process-execution APIs, URL operands, directories, symlinks, unsafe `PATH` values, and verifier references that escape the project are rejected before the agent runs. Treat loop specs and their package scripts as trusted executable configuration: do not run specs modified by untrusted PRs or branches.
 
 ## Exit codes and guardrails
 

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -41,7 +41,7 @@ Schedulers stay outside OMP. Use cron, launchd, GitHub Actions, PM2, or another 
 
 ## Safety levels
 
-- `report` — report-only loops. OMP disables MCP, extension discovery, and project custom-tool discovery, restricts active tools to read/search/find/web search, and does not run verifier commands.
+- `report` — report-only loops. OMP disables MCP, extension discovery, and project custom-tool discovery, restricts active tools to read/grep/glob/web search, and does not run verifier commands.
 - `assisted` — may make bounded local changes, but verifier commands and approval gates are required.
 - `autonomous` — requires verifier results, explicit human-approval guardrails for protected actions, and a clean observable git worktree.
 

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -1,0 +1,88 @@
+# OMP Loop Engineering
+
+`omp loop` is an out-of-process loop runtime for scheduled-safe agent iterations. It is inspired by [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering), but the templates and runtime here are OMP-native and written for this repository.
+
+It does not replace the interactive `/loop` slash command. `/loop` repeats the next prompt inside a live TUI session. `omp loop ...` manages durable loop specs, readiness checks, one-shot scheduled runs, verifier commands, and run logs that an external scheduler can call repeatedly.
+
+## Commands
+
+```bash
+omp loop init daily-triage
+omp loop check daily-triage
+omp loop run daily-triage --dry-run
+omp loop run daily-triage
+omp loop status --json
+```
+
+## Files
+
+`omp loop init <name>` creates:
+
+- `.omp/loops/<name>.loop.yaml` — machine-readable loop spec
+- `LOOP.md` — human-readable loop contract
+- `STATE.md` — durable state/handoff notes
+- `loop-budget.md` — caps and kill switch
+- `loop-run-log.md` — append-only Markdown run log
+
+`omp loop run <name>` also appends JSONL records under `.omp/loop-runs/<name>.jsonl`.
+
+## Runtime model
+
+One `omp loop run <name>` call performs exactly one iteration:
+
+1. Parse and validate `.omp/loops/<name>.loop.yaml`.
+2. Build the agent prompt from a static Markdown template.
+3. Run one OMP agent turn in-process.
+4. Run verifier commands from the loop spec for assisted/autonomous loops only.
+5. Inspect changed files since the pre-run git baseline for scope, max-file, and denylist guardrails.
+6. Append redacted durable JSONL and Markdown run records.
+
+Schedulers stay outside OMP. Use cron, launchd, GitHub Actions, PM2, or another supervisor to repeat `omp loop run <name>` on a cadence. Use single-flight scheduler settings so two runs never share the same worktree at once.
+
+## Safety levels
+
+- `report` — report-only loops. OMP disables MCP, extension discovery, and project custom-tool discovery, restricts active tools to read/search/find/web search, and does not run verifier commands.
+- `assisted` — may make bounded local changes, but verifier commands and approval gates are required.
+- `autonomous` — requires verifier results, explicit human-approval guardrails for protected actions, and a clean observable git worktree.
+
+## Spec shape
+
+```yaml
+loop:
+  name: ci-sweeper
+  goal: Fix one failing CI issue and report the result.
+  level: assisted
+  non_goals:
+    - Do not deploy.
+  scope:
+    paths: ["."]
+  trigger:
+    type: manual
+    cadence: daily
+  runner:
+    prompt: Inspect CI and make one safe fix.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "check"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+    require_human_approval:
+      - protected_paths
+      - push
+      - deploy
+  state:
+    file: STATE.md
+    run_log: loop-run-log.md
+    budget: loop-budget.md
+```
+
+Verifier commands must be argv arrays (or objects with an `argv` array) and, by default, must use package-script forms such as `["bun", "run", "check"]`, `["pnpm", "run", "test"]`, or `["npm", "test"]`. Shell strings, shell executables, custom binaries, and arbitrary absolute paths are intentionally not accepted. Treat loop specs as trusted executable configuration: do not run specs modified by untrusted PRs or branches.
+
+## Exit codes and guardrails
+
+- `passed` and `dry_run` exit 0.
+- `failed` and `needs_approval` exit non-zero so external schedulers can page or stop.
+- Assisted/autonomous loops require git status visibility. A missing git worktree, unobservable changed-file status, out-of-scope edit, denylist hit, or dirty pre-run baseline moves the run to `needs_approval`.
+- State paths and verifier working directories must stay inside the project. Markdown run logs are limited to `loop-run-log.md` or `.omp/loop-runs/*.md`, and run logs reject symlink targets.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -73,6 +73,12 @@
 - Fixed marketplace-installed plugins incorrectly appearing in both the npm plugin list and the extension-package status provider.
 - Fixed inconsistent OpenRouter prompt-cache hits on `/advisor` turns by ensuring advisor agents inherit the same provider-shaping options, hooks, and settings as the main agent.
 - Fixed path-scoped TTSR (Targeted Tool Safety Rules) evaluation for `hashline` and `apply_patch` edit streams, ensuring rules are correctly applied to file paths parsed from section headers and envelope markers without leaking across file scopes.
+- Prevented auto-generated session titles from accidentally re-shouting user all-caps text
+- Fixed auto-generated session titles re-shouting emphatic ALL-CAPS from the user's message. `reconcileTitleCasing` (`packages/coding-agent/src/tiny/text.ts`) restored any source token with interior/repeated uppercase, so shouting like "unify ALL ERROR HANDLING" turned the model's clean sentence case ("Unify error handling…") back into "Unify ERROR HANDLING…". Casing is now restored only from mixed-case identifiers the user typed deliberately (`TinyVMM`, `iOS`, `IDs`); pure all-caps is left to the model's own output.
+- Fixed Tavily web search with recency filters to retry once without `time_range` when Tavily returns HTTP 200 with no renderable content. ([#3633](https://github.com/can1357/oh-my-pi/issues/3633))
+- Fixed TUI thought stream stalling and `ui.loop-blocked` warnings during subagent-heavy runs by replacing the mid-run compaction persistence check's O(n²) branch rebuild + per-pair `JSON.stringify` content compare with a one-shot persistence-key snapshot. Content equality is preserved as the rare collision tiebreaker. ([#3629](https://github.com/can1357/oh-my-pi/issues/3629))
+- Fixed marketplace-installed plugins appearing in both the npm plugin list and the OMP extension-package status provider. ([#3628](https://github.com/can1357/oh-my-pi/issues/3628))
+- Added `omp loop` scaffolding and iteration runtime for durable loop-engineering workflows, including spec parsing, readiness checks, verifier execution, scoped approval guardrails, run logs, and documentation templates.
 
 ## [16.2.1] - 2026-06-27
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -29,6 +29,7 @@ export const commands: CommandEntry[] = [
 	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
 	{ name: "install", load: () => import("./commands/install").then(m => m.default) },
 	{ name: "join", load: () => import("./commands/join").then(m => m.default) },
+	{ name: "loop", load: () => import("./commands/loop").then(m => m.default) },
 	{ name: "models", load: () => import("./commands/models").then(m => m.default) },
 	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "say", load: () => import("./commands/say").then(m => m.default) },

--- a/packages/coding-agent/src/commands/loop.ts
+++ b/packages/coding-agent/src/commands/loop.ts
@@ -1,0 +1,48 @@
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { runLoopCli } from "../loop-engineering/cli";
+
+export default class Loop extends Command {
+	static description = "Initialize, check, and run OMP loop-engineering specs";
+
+	static args = {
+		action: Args.string({
+			description: "init, check, status, or run",
+			required: false,
+			options: ["init", "check", "status", "run"],
+			default: "status",
+		}),
+		target: Args.string({
+			description: "Loop name or .loop.yaml path",
+			required: false,
+		}),
+	};
+
+	static flags = {
+		dir: Flags.string({ description: "Project directory containing .omp/loops", default: process.cwd() }),
+		pattern: Flags.string({ description: "Starter pattern for init (daily-triage or ci-sweeper)" }),
+		force: Flags.boolean({ char: "f", description: "Overwrite existing starter files during init", default: false }),
+		"dry-run": Flags.boolean({
+			description: "Build the run prompt without calling the agent or verifier",
+			default: false,
+		}),
+		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
+	};
+
+	static examples = [
+		"omp loop init daily-triage",
+		"omp loop check daily-triage",
+		"omp loop run daily-triage --dry-run",
+		"omp loop status --json",
+	];
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Loop);
+		await runLoopCli(args.action ?? "status", args.target, {
+			cwd: flags.dir ?? process.cwd(),
+			json: flags.json ?? false,
+			force: flags.force ?? false,
+			dryRun: flags["dry-run"] ?? false,
+			pattern: flags.pattern,
+		});
+	}
+}

--- a/packages/coding-agent/src/loop-engineering/cli.ts
+++ b/packages/coding-agent/src/loop-engineering/cli.ts
@@ -1,0 +1,96 @@
+import * as path from "node:path";
+import { listLoopSpecs, loadLoopSpec } from "./paths";
+import { assessLoopReadiness } from "./readiness";
+import { executeLoopIteration } from "./runner";
+import { scaffoldLoopProject } from "./scaffold";
+
+export interface LoopCliOptions {
+	cwd: string;
+	json?: boolean;
+	force?: boolean;
+	dryRun?: boolean;
+	pattern?: string;
+}
+
+export async function runLoopCli(action: string, target: string | undefined, options: LoopCliOptions): Promise<void> {
+	if (action === "init") {
+		const result = await scaffoldLoopProject({
+			cwd: options.cwd,
+			name: target || options.pattern || "daily-triage",
+			pattern: options.pattern,
+			force: options.force,
+		});
+		writeOutput(options.json, result, `Created loop ${result.name} (${result.created.length} files)\n`);
+		return;
+	}
+	if (action === "check") {
+		const spec = await loadLoopSpec(options.cwd, target);
+		const assessment = assessLoopReadiness(spec);
+		writeOutput(
+			options.json,
+			{ spec, assessment },
+			renderAssessment(spec.name, assessment.score, assessment.issues, assessment.warnings),
+		);
+		if (!assessment.ready) process.exitCode = 1;
+		return;
+	}
+	if (action === "run") {
+		const spec = await loadLoopSpec(options.cwd, target);
+		const result = await executeLoopIteration(spec, { cwd: options.cwd, dryRun: options.dryRun });
+		writeOutput(
+			options.json,
+			result,
+			renderRunResult(result.status, result.loop, result.jsonlPath, result.markdownLogPath),
+		);
+		if (result.status === "failed" || result.status === "needs_approval") process.exitCode = 1;
+		return;
+	}
+	const specs = await listLoopSpecs(options.cwd);
+	const rows = specs.map(spec => {
+		const assessment = assessLoopReadiness(spec);
+		return {
+			name: spec.name,
+			level: spec.level,
+			score: assessment.score,
+			ready: assessment.ready,
+			path: spec.sourcePath,
+		};
+	});
+	writeOutput(options.json, rows, renderStatus(rows));
+}
+
+function writeOutput(json: boolean | undefined, value: unknown, text: string): void {
+	process.stdout.write(json ? `${JSON.stringify(value, null, 2)}\n` : text);
+}
+
+function renderAssessment(name: string, score: number, issues: string[], warnings: string[]): string {
+	const lines = [`Loop ${name}: readiness ${score}/100`];
+	for (const issue of issues) lines.push(`Issue: ${issue}`);
+	for (const warning of warnings) lines.push(`Warning: ${warning}`);
+	if (issues.length === 0) lines.push("Ready for one scheduled-safe iteration.");
+	return `${lines.join("\n")}\n`;
+}
+
+function renderRunResult(
+	status: string,
+	name: string,
+	jsonlPath: string | null,
+	markdownLogPath: string | null,
+): string {
+	const lines = [`Loop ${name}: ${status}`];
+	if (jsonlPath) lines.push(`State: ${jsonlPath}`);
+	if (markdownLogPath) lines.push(`Run log: ${markdownLogPath}`);
+	return `${lines.join("\n")}\n`;
+}
+
+function renderStatus(
+	rows: Array<{ name: string; level: string; score: number; ready: boolean; path?: string }>,
+): string {
+	if (rows.length === 0) return "No loop specs found. Run `omp loop init daily-triage` first.\n";
+	return `${rows
+		.map(
+			row =>
+				`${row.ready ? "✓" : "!"} ${row.name} ${row.level} readiness=${row.score}/100 ${row.path ? path.relative(process.cwd(), row.path) : ""}`,
+		)
+		.join("\n")}\n`;
+}

--- a/packages/coding-agent/src/loop-engineering/paths.ts
+++ b/packages/coding-agent/src/loop-engineering/paths.ts
@@ -1,0 +1,141 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { normalizeName, parseLoopSpec } from "./schema";
+import type { LoopSpec } from "./types";
+
+export async function loadLoopSpec(cwd: string, target: string | undefined): Promise<LoopSpec> {
+	const specPath = await resolveLoopSpecPath(cwd, target);
+	const content = await Bun.file(specPath).text();
+	return parseLoopSpec(content, specPath);
+}
+
+export async function listLoopSpecs(cwd: string): Promise<LoopSpec[]> {
+	const dir = await resolveInsideProject(cwd, path.join(".omp", "loops"), "loop specs directory");
+	let entries: string[];
+	try {
+		await assertNotSymlink(dir, "loop specs directory");
+		entries = await fs.readdir(dir);
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return [];
+		throw error;
+	}
+	const specs: LoopSpec[] = [];
+	for (const entry of entries.sort()) {
+		if (!entry.endsWith(".loop.yaml") && !entry.endsWith(".loop.yml")) continue;
+		const specPath = await resolveInsideProject(cwd, path.join(".omp", "loops", entry), "loop spec path");
+		await assertNotSymlink(specPath, "loop spec path");
+		specs.push(parseLoopSpec(await Bun.file(specPath).text(), specPath));
+	}
+	return specs;
+}
+
+export async function resolveLoopSpecPath(cwd: string, target: string | undefined): Promise<string> {
+	if (target && (target.includes(path.sep) || target.endsWith(".yaml") || target.endsWith(".yml"))) {
+		const specPath = await resolveInsideProject(cwd, target, "loop spec path");
+		await assertNotSymlink(specPath, "loop spec path");
+		return specPath;
+	}
+	const name = normalizeName(target || "daily-triage");
+	const yamlPath = await resolveInsideProject(cwd, path.join(".omp", "loops", `${name}.loop.yaml`), "loop spec path");
+	try {
+		await assertNotSymlink(yamlPath, "loop spec path");
+		return yamlPath;
+	} catch (error) {
+		if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;
+	}
+	const ymlPath = await resolveInsideProject(cwd, path.join(".omp", "loops", `${name}.loop.yml`), "loop spec path");
+	await assertNotSymlink(ymlPath, "loop spec path");
+	return ymlPath;
+}
+
+export async function resolveInsideProject(cwd: string, relativePath: string, label: string): Promise<string> {
+	const normalized = normalizeRelativeProjectPath(relativePath, label);
+	const rootReal = await fs.realpath(cwd);
+	const resolved = path.resolve(rootReal, normalized);
+	await assertParentInsideProject(rootReal, resolved, label);
+	await assertExistingTargetInsideProject(rootReal, resolved, label);
+	return resolved;
+}
+
+export function normalizeRelativeProjectPath(relativePath: string, label: string): string {
+	if (path.isAbsolute(relativePath)) throw new Error(`${label} must be relative to the project`);
+	const normalized = path.normalize(relativePath);
+	if (normalized === "." || normalized.startsWith("..") || path.isAbsolute(normalized)) {
+		throw new Error(`${label} must stay inside the project`);
+	}
+	return normalized;
+}
+
+export async function assertSafeProjectWrite(cwd: string, filePath: string, label: string): Promise<void> {
+	const rootReal = await fs.realpath(cwd);
+	const parent = path.dirname(filePath);
+	await assertParentInsideProject(rootReal, filePath, label);
+	await rejectSymlinkPath(rootReal, parent, label);
+	try {
+		const targetStat = await fs.lstat(filePath);
+		if (targetStat.isSymbolicLink()) throw new Error(`${label} must not be a symlink`);
+	} catch (error) {
+		if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;
+	}
+}
+
+async function assertNotSymlink(filePath: string, label: string): Promise<void> {
+	const stat = await fs.lstat(filePath);
+	if (stat.isSymbolicLink()) throw new Error(`${label} must not be a symlink`);
+}
+
+async function assertParentInsideProject(rootReal: string, filePath: string, label: string): Promise<void> {
+	let parentReal: string;
+	try {
+		parentReal = await fs.realpath(path.dirname(filePath));
+	} catch (error) {
+		if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;
+		parentReal = await nearestExistingParentReal(path.dirname(filePath));
+	}
+	const relative = path.relative(rootReal, parentReal);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new Error(`${label} must stay inside the project`);
+	}
+}
+
+async function assertExistingTargetInsideProject(rootReal: string, filePath: string, label: string): Promise<void> {
+	try {
+		const targetReal = await fs.realpath(filePath);
+		const relative = path.relative(rootReal, targetReal);
+		if (relative.startsWith("..") || path.isAbsolute(relative)) {
+			throw new Error(`${label} must stay inside the project`);
+		}
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return;
+		throw error;
+	}
+}
+async function nearestExistingParentReal(dir: string): Promise<string> {
+	let current = dir;
+	for (;;) {
+		try {
+			return await fs.realpath(current);
+		} catch (error) {
+			if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;
+			const parent = path.dirname(current);
+			if (parent === current) throw error;
+			current = parent;
+		}
+	}
+}
+
+async function rejectSymlinkPath(rootReal: string, targetDir: string, label: string): Promise<void> {
+	const relative = path.relative(rootReal, path.resolve(targetDir));
+	if (relative.startsWith("..") || path.isAbsolute(relative)) throw new Error(`${label} must stay inside the project`);
+	let current = rootReal;
+	for (const segment of relative.split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		try {
+			const stat = await fs.lstat(current);
+			if (stat.isSymbolicLink()) throw new Error(`${label} must not pass through a symlink`);
+		} catch (error) {
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return;
+			throw error;
+		}
+	}
+}

--- a/packages/coding-agent/src/loop-engineering/readiness.ts
+++ b/packages/coding-agent/src/loop-engineering/readiness.ts
@@ -1,0 +1,46 @@
+import type { LoopReadinessAssessment, LoopSpec } from "./types";
+
+export function assessLoopReadiness(spec: LoopSpec): LoopReadinessAssessment {
+	const issues: string[] = [];
+	const warnings: string[] = [];
+
+	if (spec.goal.length === 0) issues.push("loop.goal is required");
+	if (spec.nonGoals.length === 0) issues.push("loop.non_goals must list at least one explicit non-goal");
+	if (spec.runner.prompt.length === 0) issues.push("loop.runner.prompt is required");
+	if (!spec.verifier.separate) {
+		issues.push("loop.verifier.separate must be true so implementer and verifier stay split");
+	}
+	if (!spec.state.runLog) issues.push("loop.state.run_log is required for durable audit history");
+	if (spec.level !== "report" && spec.verifier.commands.length === 0) {
+		issues.push("loop.verifier.commands must include at least one check for assisted/autonomous loops");
+	}
+	if (spec.level === "report" && spec.verifier.commands.length > 0) {
+		issues.push("loop.verifier.commands must be empty for report loops");
+	}
+	if (spec.level !== "report" && spec.guardrails.maxIterations === null) {
+		issues.push("loop.guardrails.max_iterations is required for assisted/autonomous loops");
+	}
+
+	if (spec.scope.paths.length === 0) warnings.push("loop.scope.paths is empty; the loop has no watched scope");
+	if (!spec.state.file) warnings.push("loop.state.file is not set; durable handoff context may be weak");
+	if (!spec.state.budget && spec.level !== "report") {
+		warnings.push("loop.state.budget is not set; budget caps should be explicit before unattended use");
+	}
+	if (spec.guardrails.maxFilesChanged === null && spec.level !== "report") {
+		warnings.push("loop.guardrails.max_files_changed is not set");
+	}
+	if (spec.guardrails.requireHumanApproval.length === 0 && spec.level === "autonomous") {
+		issues.push("loop.guardrails.require_human_approval is required for autonomous loops");
+	}
+	if (spec.trigger.type === "manual") {
+		warnings.push("loop.trigger.type is manual; use cron, launch-agent, or github-actions for recurring runs");
+	}
+
+	const score = Math.max(0, 100 - issues.length * 20 - warnings.length * 5);
+	return {
+		ready: issues.length === 0,
+		score,
+		issues,
+		warnings,
+	};
+}

--- a/packages/coding-agent/src/loop-engineering/runner.ts
+++ b/packages/coding-agent/src/loop-engineering/runner.ts
@@ -1979,7 +1979,7 @@ async function resolveVerifierFilePath(rootReal: string, filePath: string): Prom
 		throw new Error("verifier referenced file must stay inside the project");
 	}
 	await rejectSymlinkPathComponents(rootReal, filePath, "verifier referenced file");
-	let stat: Awaited<ReturnType<typeof fs.lstat>>;
+	let stat: nodeFs.Stats;
 	try {
 		stat = await fs.lstat(filePath);
 	} catch (error) {

--- a/packages/coding-agent/src/loop-engineering/runner.ts
+++ b/packages/coding-agent/src/loop-engineering/runner.ts
@@ -3,6 +3,7 @@ import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import { builtinModules } from "node:module";
 import * as path from "node:path";
+import { parse } from "@babel/parser";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import { createAgentSession } from "../sdk";
@@ -19,11 +20,11 @@ import type {
 } from "./types";
 
 const OUTPUT_LIMIT = 8_000;
-const REPORT_LOOP_TOOLS = ["read", "search", "find", "web_search"];
+const REPORT_LOOP_TOOLS = ["read", "grep", "glob", "web_search"];
 const VERIFIER_TIMEOUT_MS = 120_000;
 const SHELL_EXECUTABLES = new Set(["bash", "cmd", "fish", "powershell", "pwsh", "sh", "zsh"]);
 const PACKAGE_SCRIPT_RUNNERS = new Set(["bun", "npm", "pnpm", "yarn"]);
-const VERIFIER_SCRIPT_OPERAND_RUNNERS = new Set(["bun", "deno", "node", "tsx", "ts-node"]);
+const VERIFIER_SCRIPT_OPERAND_RUNNERS = new Set(["bun", "deno", "node"]);
 const NODE_BUILTIN_MODULES = new Set(builtinModules.flatMap(name => [name, `node:${name.replace(/^node:/, "")}`]));
 const VERIFIER_DENIED_NODE_BUILTINS = new Set([
 	"child_process",
@@ -34,10 +35,12 @@ const VERIFIER_DENIED_NODE_BUILTINS = new Set([
 	"node:cluster",
 	"node:inspector",
 	"node:module",
+	"node:process",
 	"node:repl",
 	"node:vm",
 	"node:worker_threads",
 	"repl",
+	"process",
 	"vm",
 	"worker_threads",
 ]);
@@ -88,8 +91,6 @@ const VERIFIER_SCRIPT_VALUE_FLAGS = new Map([
 	],
 	["python", new Set(["-c", "-m", "-W", "-X"])],
 	["python3", new Set(["-c", "-m", "-W", "-X"])],
-	["tsx", new Set(["--require", "-r", "--tsconfig"])],
-	["ts-node", new Set(["--compiler", "-C", "--project", "-P", "--require", "-r", "--transpiler"])],
 ]);
 const STATUS_OUTPUT_LIMIT = 1_000_000;
 const VERIFIER_REFERENCE_EXTENSIONS = new Set([
@@ -121,6 +122,7 @@ const PACKAGE_MANAGER_CONFIG_FILES = [
 	"yarn.lock",
 ];
 const VERIFIER_DEPENDENCY_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
+const VERIFIER_UNSAFE_DEPENDENCY_EXTENSIONS = new Set([".node", ".wasm"]);
 const VERIFIER_CONFIG_FILES = [
 	"biome.json",
 	"biome.jsonc",
@@ -200,7 +202,7 @@ export async function executeLoopIteration(spec: LoopSpec, options: LoopRunOptio
 		const runAgent = options.runAgent ?? ((text, cwd) => runAgentInProcess(text, cwd, spec));
 		const result = await runAgent(promptText, options.cwd);
 		agentExitCode = result.exitCode;
-		agentOutput = truncate(result.output);
+		agentOutput = redactAndTruncate(result.output);
 	} catch (err) {
 		agentExitCode = 1;
 		error = err instanceof Error ? err.message : String(err);
@@ -304,6 +306,8 @@ interface VerifierScriptSnapshot {
 	packageJsonDigest: string;
 	scriptName: string;
 	scriptValue: string;
+	runtimePath: string;
+	runtimeDigest: string;
 	referencedFiles: VerifierReferencedFileSnapshot[];
 	error: string | null;
 }
@@ -327,6 +331,8 @@ async function captureVerifierScriptSnapshots(
 				packageJsonDigest: "",
 				scriptName: "",
 				scriptValue: "",
+				runtimePath: "",
+				runtimeDigest: "",
 				referencedFiles: [],
 				error: invalidReason,
 			});
@@ -339,6 +345,11 @@ async function captureVerifierScriptSnapshots(
 			const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : rootReal;
 			await rejectSymlinkPathComponents(rootReal, commandCwd, "verifier cwd");
 			const script = await readVerifierPackageScript(command, commandCwd);
+			const runtimePath =
+				script.error === null
+					? await resolveVerifierRuntimePath(script.scriptValue, verifierRuntimePath(cwd, rootReal), cwd, rootReal)
+					: "";
+			const runtimeDigest = runtimePath ? await verifierFileState(runtimePath) : "";
 			const referencedFiles =
 				script.error === null ? await captureVerifierReferencedFiles(rootReal, commandCwd, script.scriptValue) : [];
 			snapshots.push(
@@ -348,10 +359,12 @@ async function captureVerifierScriptSnapshots(
 							packageJsonDigest: "",
 							scriptName: "",
 							scriptValue: "",
+							runtimePath: "",
+							runtimeDigest: "",
 							referencedFiles: [],
 							error: script.error,
 						}
-					: { ...script, referencedFiles },
+					: { ...script, runtimePath, runtimeDigest, referencedFiles },
 			);
 		} catch (error) {
 			snapshots.push({
@@ -359,6 +372,8 @@ async function captureVerifierScriptSnapshots(
 				packageJsonDigest: "",
 				scriptName: "",
 				scriptValue: "",
+				runtimePath: "",
+				runtimeDigest: "",
 				referencedFiles: [],
 				error: error instanceof Error ? error.message : String(error),
 			});
@@ -378,6 +393,12 @@ async function verifierScriptsChanged(snapshots: VerifierScriptSnapshot[]): Prom
 		if (current.error) return current.error;
 		if (current.scriptValue !== snapshot.scriptValue) {
 			return `verifier package.json script ${snapshot.scriptName} changed before verifier execution`;
+		}
+		if (snapshot.runtimePath) {
+			const currentRuntimeDigest = await verifierFileState(snapshot.runtimePath);
+			if (currentRuntimeDigest !== snapshot.runtimeDigest) {
+				return "verifier runtime changed before verifier execution";
+			}
 		}
 		for (const file of snapshot.referencedFiles) {
 			const currentDigest = await verifierFileState(file.filePath);
@@ -428,7 +449,12 @@ async function captureVerifierFileAndDependencies(
 		displayPath: path.relative(commandReal, filePath) || path.basename(filePath),
 		digest,
 	});
-	if (digest === "missing" || !shouldScanVerifierDependencies(filePath)) return;
+	if (digest === "missing") return;
+	if (!shouldScanVerifierDependencies(filePath)) {
+		if (VERIFIER_UNSAFE_DEPENDENCY_EXTENSIONS.has(path.extname(filePath)))
+			throw new Error("verifier dependencies must not use native or WebAssembly files");
+		return;
+	}
 	let content: string;
 	try {
 		content = await Bun.file(filePath).text();
@@ -447,6 +473,8 @@ async function captureVerifierFileAndDependencies(
 	if (hasBareVerifierDependency(content)) throw new Error("verifier dependencies must use relative or node: imports");
 	const importerDir = path.dirname(filePath);
 	for (const dependencySpecifier of verifierStaticDependencySpecifiers(content)) {
+		if (path.extname(dependencySpecifier).length === 0)
+			throw new Error("verifier dependencies must use explicit file extensions");
 		const dependencyPath = await resolveVerifierDependencyPath(rootReal, importerDir, dependencySpecifier);
 		if (!dependencyPath) throw new Error(`verifier dependency ${dependencySpecifier} could not be resolved`);
 		await captureVerifierFileAndDependencies(rootReal, commandReal, dependencyPath, snapshots, seen);
@@ -484,7 +512,7 @@ function hasDeniedVerifierBuiltinDependency(content: string): boolean {
 }
 
 function hasVerifierDynamicCodeApi(content: string): boolean {
-	return /\b(?:constructor|eval|Function|SharedWorker|Worker)\b/.test(content);
+	return /\b(?:constructor|eval|Function|SharedWorker|WebAssembly|Worker)\b/.test(content);
 }
 
 function hasVerifierEscapedIdentifier(content: string): boolean {
@@ -492,15 +520,1302 @@ function hasVerifierEscapedIdentifier(content: string): boolean {
 }
 
 function hasVerifierDynamicPropertyAccess(content: string): boolean {
-	const gap = verifierJsGap();
-	return new RegExp(`(?:\\b[A-Za-z_$][\\w$]*|\\)|\\])${gap}(?:\\?\\.${gap})?\\[${gap}(?!\\d+${gap}\\])`).test(content);
+	let ast: unknown;
+	try {
+		ast = parse(content, { sourceType: "unambiguous", plugins: ["typescript", "jsx"] });
+	} catch {
+		return true;
+	}
+	const globalAliases = collectGlobalAliases(ast);
+	return hasUnsafeDynamicPropertyNode(ast, globalAliases);
+}
+
+function hasUnsafeDynamicPropertyNode(node: unknown, globalAliases = new Set<string>()): boolean {
+	if (!node || typeof node !== "object") return false;
+	if (Array.isArray(node)) return node.some(item => hasUnsafeDynamicPropertyNode(item, globalAliases));
+	const record = node as Record<string, unknown>;
+	if (isComputedMemberExpression(record) && !isNumericLiteralNode(record.property)) return true;
+	if (isUnsafeReflectivePropertyAccess(record, globalAliases)) return true;
+	if (record.type === "ObjectPattern" && hasComputedPatternProperty(record.properties)) return true;
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end") continue;
+		if (hasUnsafeDynamicPropertyNode(value, globalAliases)) return true;
+	}
+	return false;
+}
+
+function isComputedMemberExpression(record: Record<string, unknown>): boolean {
+	return (
+		(record.type === "MemberExpression" || record.type === "OptionalMemberExpression") && record.computed === true
+	);
+}
+
+function isUnsafeReflectivePropertyAccess(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	const reflectCall = reflectedBuiltinCall(
+		record,
+		"Reflect",
+		new Set(["get", "getOwnPropertyDescriptor"]),
+		globalAliases,
+	);
+	if (reflectCall) {
+		if (reflectCall.unknownApply) return true;
+		const target = reflectCall.args[0];
+		const targetIsProcess = isIdentifierNamed(target, "process");
+		const targetIsGlobalObject = isGlobalObjectExpression(target, globalAliases);
+		const reflectedProperty = reflectedPropertyKeyName(reflectCall.args[1]);
+		return targetIsProcess || (targetIsGlobalObject && isUnsafeGlobalReflectedProperty(reflectedProperty));
+	}
+	const objectCall = reflectedBuiltinCall(
+		record,
+		"Object",
+		new Set(["values", "entries", "assign", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors"]),
+		globalAliases,
+	);
+	if (!objectCall) return false;
+	if (objectCall.unknownApply) return true;
+	const target =
+		objectCall.method === "assign"
+			? objectCall.args.find(arg => isGlobalObjectExpression(arg, globalAliases))
+			: objectCall.args[0];
+	const targetIsProcess = isIdentifierNamed(target, "process");
+	const targetIsGlobalObject = isGlobalObjectExpression(target, globalAliases);
+	if (objectCall.method === "getOwnPropertyDescriptor") {
+		const reflectedProperty = reflectedPropertyKeyName(objectCall.args[1]);
+		return targetIsProcess || (targetIsGlobalObject && isUnsafeGlobalReflectedProperty(reflectedProperty));
+	}
+	return targetIsProcess || targetIsGlobalObject;
+}
+
+function isUnsafeGlobalReflectedProperty(property: string | null): boolean {
+	return property === null || property === "process" || property === "Bun" || property === "Deno";
+}
+
+function isNumericLiteralNode(node: unknown): boolean {
+	return (
+		!!node &&
+		typeof node === "object" &&
+		((node as Record<string, unknown>).type === "NumericLiteral" ||
+			(node as Record<string, unknown>).type === "NumberLiteral")
+	);
+}
+
+function hasComputedPatternProperty(properties: unknown): boolean {
+	if (!Array.isArray(properties)) return false;
+	return properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const record = property as Record<string, unknown>;
+		return record.computed === true || hasUnsafeDynamicPropertyNode(record);
+	});
 }
 
 function hasVerifierProcessExecutionApi(content: string): boolean {
-	const gap = verifierJsGap();
-	return new RegExp(
-		`\\bBun\\b|\\bDeno\\b|\\bprocess${gap}(?:(?:\\?\\.|\\.)${gap}(?:binding|dlopen)\\b|(?:\\?\\.${gap})?\\[${gap}["'](?:binding|dlopen)["']${gap}\\])`,
-	).test(content);
+	let ast: unknown;
+	try {
+		ast = parse(content, { sourceType: "unambiguous", plugins: ["typescript", "jsx"] });
+	} catch {
+		return true;
+	}
+	const globalAliases = collectGlobalAliases(ast);
+	const processAliases = collectProcessAliases(ast, new Set<string>(), globalAliases);
+	return hasUnsafeProcessApiNode(ast, processAliases, globalAliases);
+}
+
+function collectProcessAliases(
+	node: unknown,
+	aliases = new Set<string>(),
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+	visibleProcessAliases = aliases,
+): Set<string> {
+	if (!node || typeof node !== "object") return aliases;
+	if (Array.isArray(node)) {
+		for (const item of node)
+			collectProcessAliases(item, aliases, globalAliases, shadowBareProcess, visibleProcessAliases);
+		return aliases;
+	}
+	const record = node as Record<string, unknown>;
+	const params = isFunctionLikeExpression(record) && Array.isArray(record.params) ? record.params : [];
+	const nestedProcessAliases = aliasesWithoutBoundParams(visibleProcessAliases, params);
+	const nestedGlobalAliases = aliasesWithoutBoundParams(globalAliases, params);
+	const nestedShadowBareProcess = shadowBareProcess || params.some(param => patternBindsIdentifier(param, "process"));
+	if (isFunctionLikeExpression(record)) {
+		for (const [key, value] of Object.entries(record)) {
+			if (key === "loc" || key === "start" || key === "end" || key === "body" || key === "params") continue;
+			collectProcessAliases(value, aliases, globalAliases, shadowBareProcess, visibleProcessAliases);
+		}
+		return aliases;
+	}
+	if (
+		record.type === "VariableDeclarator" &&
+		isIdentifierNode(record.id) &&
+		isProcessExpression(record.init, visibleProcessAliases, globalAliases, shadowBareProcess)
+	) {
+		const aliasName = String((record.id as Record<string, unknown>).name);
+		aliases.add(aliasName);
+		visibleProcessAliases.add(aliasName);
+	}
+	if (
+		record.type === "AssignmentExpression" &&
+		isIdentifierNode(record.left) &&
+		isProcessExpression(record.right, visibleProcessAliases, globalAliases, shadowBareProcess)
+	) {
+		const aliasName = String((record.left as Record<string, unknown>).name);
+		aliases.add(aliasName);
+		visibleProcessAliases.add(aliasName);
+	}
+	if (
+		record.type === "AssignmentExpression" &&
+		isGlobalProcessDestructurePattern(record.left, record.right, globalAliases)
+	) {
+		addGlobalProcessDestructureAliases(record.left, aliases);
+		if (visibleProcessAliases !== aliases) addGlobalProcessDestructureAliases(record.left, visibleProcessAliases);
+	}
+	if (
+		record.type === "VariableDeclarator" &&
+		isGlobalProcessDestructurePattern(record.id, record.init, globalAliases)
+	) {
+		addGlobalProcessDestructureAliases(record.id, aliases);
+		if (visibleProcessAliases !== aliases) addGlobalProcessDestructureAliases(record.id, visibleProcessAliases);
+	}
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || (isFunctionLikeExpression(record) && key === "params"))
+			continue;
+		collectProcessAliases(value, aliases, nestedGlobalAliases, nestedShadowBareProcess, nestedProcessAliases);
+	}
+	return aliases;
+}
+
+function collectGlobalAliases(node: unknown, aliases = new Set<string>()): Set<string> {
+	if (!node || typeof node !== "object") return aliases;
+	if (Array.isArray(node)) {
+		for (const item of node) collectGlobalAliases(item, aliases);
+		return aliases;
+	}
+	const record = node as Record<string, unknown>;
+	if (isFunctionLikeExpression(record)) {
+		for (const [key, value] of Object.entries(record)) {
+			if (key === "loc" || key === "start" || key === "end" || key === "body" || key === "params") continue;
+			collectGlobalAliases(value, aliases);
+		}
+		return aliases;
+	}
+	if (
+		record.type === "VariableDeclarator" &&
+		isIdentifierNode(record.id) &&
+		isGlobalObjectExpression(record.init, aliases)
+	)
+		aliases.add(String((record.id as Record<string, unknown>).name));
+	if (
+		record.type === "AssignmentExpression" &&
+		isIdentifierNode(record.left) &&
+		isGlobalObjectExpression(record.right, aliases)
+	)
+		aliases.add(String((record.left as Record<string, unknown>).name));
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end") continue;
+		collectGlobalAliases(value, aliases);
+	}
+	return aliases;
+}
+
+function hasUnsafeProcessApiNode(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (!node || typeof node !== "object") return false;
+	if (Array.isArray(node))
+		return node.some(item => hasUnsafeProcessApiNode(item, processAliases, globalAliases, shadowBareProcess));
+	const record = node as Record<string, unknown>;
+	if (isIdentifierNamed(record, "Bun") || isIdentifierNamed(record, "Deno")) return true;
+	if (isGlobalRuntimeObjectExpression(record, globalAliases)) return true;
+	if (isUnsafeGlobalObjectReflectionCall(record, globalAliases)) return true;
+	if (
+		record.type === "WithStatement" &&
+		isProcessExpression(record.object, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isIdentifierNode(record.left) &&
+		isProcessExpression(record.right, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isIdentifierNode(record.left) &&
+		isGlobalObjectExpression(record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isIdentifierNode(record.left) &&
+		(isSensitiveReflectionMethodExpression(record.right, globalAliases) ||
+			isSensitiveReflectionMethodBindExpression(record.right, globalAliases) ||
+			containsSensitiveReflectionObjectValue(record.right, globalAliases))
+	)
+		return true;
+	if (
+		record.type === "VariableDeclarator" &&
+		isIdentifierNode(record.id) &&
+		(isSensitiveReflectionMethodExpression(record.init, globalAliases) ||
+			isSensitiveReflectionMethodBindExpression(record.init, globalAliases) ||
+			containsSensitiveReflectionObjectValue(record.init, globalAliases))
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isSensitiveReflectionMethodDestructurePattern(record.left, record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "VariableDeclarator" &&
+		isSensitiveReflectionMethodDestructurePattern(record.id, record.init, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "VariableDeclarator" &&
+		isProcessBindingPattern(record.id, record.init, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (record.type === "VariableDeclarator" && isGlobalProcessBindingPattern(record.id, record.init, globalAliases))
+		return true;
+	if (record.type === "VariableDeclarator" && isGlobalRuntimeDestructurePattern(record.id, record.init, globalAliases))
+		return true;
+	if (record.type === "VariableDeclarator" && isGlobalObjectDestructurePattern(record.id, record.init, globalAliases))
+		return true;
+	if (record.type === "VariableDeclarator" && containsGlobalObjectContainerValue(record.init, globalAliases))
+		return true;
+	if (
+		record.type === "VariableDeclarator" &&
+		containsProcessContainerValue(record.init, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isProcessBindingPattern(record.left, record.right, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isGlobalProcessBindingPattern(record.left, record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isGlobalProcessDestructurePattern(record.left, record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isGlobalRuntimeDestructurePattern(record.left, record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		isGlobalObjectDestructurePattern(record.left, record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		!isIdentifierNode(record.left) &&
+		containsGlobalObjectValue(record.right, globalAliases)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		!isIdentifierNode(record.left) &&
+		(isSensitiveReflectionMethodExpression(record.right, globalAliases) ||
+			isSensitiveReflectionMethodBindExpression(record.right, globalAliases) ||
+			containsSensitiveReflectionObjectValue(record.right, globalAliases))
+	)
+		return true;
+	if (record.type === "AssignmentExpression" && containsGlobalObjectContainerValue(record.right, globalAliases))
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		containsProcessContainerValue(record.right, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (
+		record.type === "AssignmentExpression" &&
+		!isIdentifierNode(record.left) &&
+		isProcessExpression(record.right, processAliases, globalAliases, shadowBareProcess)
+	)
+		return true;
+	if (isFunctionLikeExpression(record)) {
+		const params = Array.isArray(record.params) ? record.params : [];
+		if (
+			params.some(
+				param =>
+					parameterDefaultContainsProcessValue(param, processAliases, globalAliases, shadowBareProcess) ||
+					parameterDefaultContainsGlobalObjectValue(param, globalAliases),
+			)
+		)
+			return true;
+		const nestedProcessAliases = aliasesWithoutBoundParams(processAliases, params);
+		const nestedGlobalAliases = aliasesWithoutBoundParams(globalAliases, params);
+		const nestedShadowBareProcess =
+			shadowBareProcess || params.some(param => patternBindsIdentifier(param, "process"));
+		const scopedGlobalAliases = collectGlobalAliases(record.body, new Set(nestedGlobalAliases));
+		const scopedProcessAliases = collectProcessAliases(
+			record.body,
+			new Set(nestedProcessAliases),
+			scopedGlobalAliases,
+			nestedShadowBareProcess,
+		);
+		if (
+			functionExposesProcessValue(record, processAliases, globalAliases, shadowBareProcess) ||
+			functionExposesGlobalObjectValue(record, globalAliases)
+		)
+			return true;
+		return hasUnsafeProcessApiNode(record.body, scopedProcessAliases, scopedGlobalAliases, nestedShadowBareProcess);
+	}
+	if (isUnsafeProcessMemberAccess(record, processAliases, globalAliases, shadowBareProcess)) return true;
+	if (isUnsafeProcessMemberCall(record, processAliases, globalAliases, shadowBareProcess)) return true;
+	if (isUnsafeProcessReflectionCall(record, processAliases, globalAliases, shadowBareProcess)) return true;
+	if (isProcessValueCallArgument(record, processAliases, globalAliases, shadowBareProcess)) return true;
+	if (isGlobalObjectValueCallArgument(record, globalAliases)) return true;
+	if (
+		(record.type === "ThrowStatement" || record.type === "YieldExpression") &&
+		(containsProcessValue(record.argument, processAliases, globalAliases, shadowBareProcess) ||
+			containsGlobalObjectValue(record.argument, globalAliases))
+	)
+		return true;
+	if (
+		isClassFieldRecord(record) &&
+		(containsProcessValue(record.value, processAliases, globalAliases, shadowBareProcess) ||
+			containsGlobalObjectValue(record.value, globalAliases))
+	)
+		return true;
+	if (
+		record.type === "ExportDefaultDeclaration" &&
+		(containsProcessValue(record.declaration, processAliases, globalAliases, shadowBareProcess) ||
+			containsGlobalObjectValue(record.declaration, globalAliases))
+	)
+		return true;
+	if (
+		record.type === "ExportSpecifier" &&
+		(containsProcessValue(record.local, processAliases, globalAliases, shadowBareProcess) ||
+			containsGlobalObjectValue(record.local, globalAliases))
+	)
+		return true;
+	if (
+		record.type === "SpreadElement" &&
+		(isProcessExpression(record.argument, processAliases, globalAliases, shadowBareProcess) ||
+			containsGlobalObjectValue(record.argument, globalAliases))
+	)
+		return true;
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || isNonComputedMemberProperty(record, key)) continue;
+		if (hasUnsafeProcessApiNode(value, processAliases, globalAliases, shadowBareProcess)) return true;
+	}
+	return false;
+}
+
+function isUnsafeProcessMemberAccess(
+	record: Record<string, unknown>,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (
+		!isMemberLikeNode(record) ||
+		!isProcessExpression(record.object, processAliases, globalAliases, shadowBareProcess)
+	)
+		return false;
+	const property = staticMemberPropertyName(record);
+	return property === "binding" || property === "dlopen" || property === "getBuiltinModule";
+}
+
+function isUnsafeProcessMemberCall(
+	record: Record<string, unknown>,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression") return false;
+	const callee = record.callee;
+	if (!callee || typeof callee !== "object") return false;
+	const member = callee as Record<string, unknown>;
+	if (
+		!isMemberLikeNode(member) ||
+		!isProcessExpression(member.object, processAliases, globalAliases, shadowBareProcess)
+	)
+		return false;
+	const property = staticMemberPropertyName(member);
+	return property === "binding" || property === "dlopen" || property === "getBuiltinModule";
+}
+
+function isUnsafeProcessReflectionCall(
+	record: Record<string, unknown>,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression") return false;
+	const callee = record.callee;
+	if (!callee || typeof callee !== "object") return false;
+	const member = callee as Record<string, unknown>;
+	if (!isMemberLikeNode(member)) return false;
+	const objectName = identifierName(member.object);
+	const property = staticMemberPropertyName(member);
+	const args = Array.isArray(record.arguments) ? record.arguments : [];
+	if (objectName === "Reflect" && property === "get")
+		return args.some(arg => isProcessExpression(arg, processAliases, globalAliases, shadowBareProcess));
+	if (
+		objectName === "Object" &&
+		(property === "values" ||
+			property === "entries" ||
+			property === "assign" ||
+			property === "getOwnPropertyDescriptor" ||
+			property === "getOwnPropertyDescriptors")
+	) {
+		return args.some(arg => isProcessExpression(arg, processAliases, globalAliases, shadowBareProcess));
+	}
+	return false;
+}
+function isProcessValueCallArgument(
+	record: Record<string, unknown>,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (record.type === "TaggedTemplateExpression") {
+		const quasi = record.quasi as Record<string, unknown> | undefined;
+		const expressions = Array.isArray(quasi?.expressions) ? quasi.expressions : [];
+		return expressions.some(expression =>
+			containsProcessValue(expression, processAliases, globalAliases, shadowBareProcess),
+		);
+	}
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression" && record.type !== "NewExpression")
+		return false;
+	const args = Array.isArray(record.arguments) ? record.arguments : [];
+	return args.some(arg => containsProcessValue(arg, processAliases, globalAliases, shadowBareProcess));
+}
+
+function containsProcessValue(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (shadowBareProcess && isIdentifierNamed(node, "process") && !processAliases.has("process")) return false;
+	if (isProcessExpression(node, processAliases, globalAliases, shadowBareProcess)) return true;
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (
+		record.type === "CallExpression" ||
+		record.type === "OptionalCallExpression" ||
+		record.type === "NewExpression"
+	) {
+		const callee = record.callee;
+		return isFunctionLikeExpression(callee as Record<string, unknown>)
+			? functionExposesProcessValue(
+					callee as Record<string, unknown>,
+					processAliases,
+					globalAliases,
+					shadowBareProcess,
+				)
+			: false;
+	}
+
+	if (isMemberLikeNode(record)) {
+		return (
+			isProcessExpression(record, processAliases, globalAliases, shadowBareProcess) ||
+			isUnsafeProcessMemberAccess(record, processAliases, globalAliases, shadowBareProcess)
+		);
+	}
+	if (record.type === "SpreadElement")
+		return containsProcessValue(record.argument, processAliases, globalAliases, shadowBareProcess);
+	if (record.type === "ArrayExpression" && Array.isArray(record.elements))
+		return record.elements.some(element =>
+			containsProcessValue(element, processAliases, globalAliases, shadowBareProcess),
+		);
+	if (isFunctionLikeExpression(record)) {
+		const params = Array.isArray(record.params) ? record.params : [];
+		if (
+			params.some(param =>
+				parameterDefaultContainsProcessValue(param, processAliases, globalAliases, shadowBareProcess),
+			)
+		)
+			return true;
+		return functionExposesProcessValue(record, processAliases, globalAliases, shadowBareProcess);
+	}
+	if (record.type === "ObjectExpression" && Array.isArray(record.properties)) {
+		return record.properties.some(property => {
+			if (!property || typeof property !== "object") return false;
+			const propertyRecord = property as Record<string, unknown>;
+			if (propertyRecord.type === "SpreadElement")
+				return containsProcessValue(propertyRecord.argument, processAliases, globalAliases, shadowBareProcess);
+			if (isFunctionLikeExpression(propertyRecord))
+				return containsProcessValue(propertyRecord, processAliases, globalAliases, shadowBareProcess);
+			return containsProcessValue(propertyRecord.value, processAliases, globalAliases, shadowBareProcess);
+		});
+	}
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || isNonComputedMemberProperty(record, key)) continue;
+		if (containsProcessValue(value, processAliases, globalAliases, shadowBareProcess)) return true;
+	}
+	return false;
+}
+
+function isGlobalObjectValueCallArgument(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	if (isSafeGlobalObjectReadCall(record, globalAliases)) return false;
+	if (record.type === "TaggedTemplateExpression") {
+		const quasi = record.quasi as Record<string, unknown> | undefined;
+		const expressions = Array.isArray(quasi?.expressions) ? quasi.expressions : [];
+		return expressions.some(expression => containsGlobalObjectValue(expression, globalAliases));
+	}
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression" && record.type !== "NewExpression")
+		return false;
+	const args = Array.isArray(record.arguments) ? record.arguments : [];
+	return args.some(arg => containsGlobalObjectValue(arg, globalAliases));
+}
+
+function isSafeGlobalObjectReadCall(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	const reflectCall = reflectedBuiltinCall(record, "Reflect", new Set(["get"]), globalAliases);
+	if (reflectCall && !reflectCall.unknownApply) {
+		const reflectedProperty = reflectedPropertyKeyName(reflectCall.args[1]);
+		return (
+			reflectedProperty !== null &&
+			isGlobalObjectExpression(reflectCall.args[0], globalAliases) &&
+			!isUnsafeGlobalReflectedProperty(reflectedProperty)
+		);
+	}
+	const objectCall = reflectedBuiltinCall(record, "Object", new Set(["getOwnPropertyDescriptor"]), globalAliases);
+	if (!objectCall || objectCall.unknownApply) return false;
+	const reflectedProperty = reflectedPropertyKeyName(objectCall.args[1]);
+	return (
+		reflectedProperty !== null &&
+		isGlobalObjectExpression(objectCall.args[0], globalAliases) &&
+		!isUnsafeGlobalReflectedProperty(reflectedProperty)
+	);
+}
+
+function isFunctionLikeExpression(record: Record<string, unknown>): boolean {
+	return (
+		record.type === "FunctionDeclaration" ||
+		record.type === "FunctionExpression" ||
+		record.type === "ArrowFunctionExpression" ||
+		record.type === "ObjectMethod" ||
+		record.type === "ClassMethod" ||
+		record.type === "ClassPrivateMethod"
+	);
+}
+
+function aliasesWithoutBoundParams(aliases: Set<string>, params: unknown[]): Set<string> {
+	let narrowed: Set<string> | null = null;
+	for (const alias of aliases) {
+		if (!params.some(param => patternBindsIdentifier(param, alias))) continue;
+		if (!narrowed) narrowed = new Set(aliases);
+		narrowed.delete(alias);
+	}
+	return narrowed ?? aliases;
+}
+
+function functionExposesProcessValue(
+	record: Record<string, unknown>,
+	processAliases: Set<string>,
+	globalAliases: Set<string>,
+	shadowBareProcess = false,
+): boolean {
+	const params = Array.isArray(record.params) ? record.params : [];
+	const nestedProcessAliases = aliasesWithoutBoundParams(processAliases, params);
+	const nestedGlobalAliases = aliasesWithoutBoundParams(globalAliases, params);
+	const shadowsProcess = shadowBareProcess || params.some(param => patternBindsIdentifier(param, "process"));
+	const body = record.body;
+	if (!body || typeof body !== "object") return false;
+	const scopedGlobalAliases = collectGlobalAliases(body, new Set(nestedGlobalAliases));
+	const scopedProcessAliases = collectProcessAliases(
+		body,
+		new Set(nestedProcessAliases),
+		scopedGlobalAliases,
+		shadowsProcess,
+	);
+	const bodyRecord = body as Record<string, unknown>;
+	if (bodyRecord.type !== "BlockStatement")
+		return containsProcessValue(body, scopedProcessAliases, scopedGlobalAliases, shadowsProcess);
+	const statements = Array.isArray(bodyRecord.body) ? bodyRecord.body : [];
+	return statements.some(statement =>
+		returnStatementExposesProcess(statement, scopedProcessAliases, scopedGlobalAliases, shadowsProcess),
+	);
+}
+
+function returnStatementExposesProcess(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases: Set<string>,
+	shadowBareProcess: boolean,
+): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (isFunctionLikeExpression(record)) return false;
+	if (record.type === "ReturnStatement")
+		return containsProcessValue(record.argument, processAliases, globalAliases, shadowBareProcess);
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end") continue;
+		if (returnStatementExposesProcess(value, processAliases, globalAliases, shadowBareProcess)) return true;
+	}
+	return false;
+}
+
+function functionExposesGlobalObjectValue(record: Record<string, unknown>, globalAliases: Set<string>): boolean {
+	const params = Array.isArray(record.params) ? record.params : [];
+	const nestedGlobalAliases = aliasesWithoutBoundParams(globalAliases, params);
+	const body = record.body;
+	if (!body || typeof body !== "object") return false;
+	const scopedGlobalAliases = collectGlobalAliases(body, new Set(nestedGlobalAliases));
+	const bodyRecord = body as Record<string, unknown>;
+	if (bodyRecord.type !== "BlockStatement") return containsGlobalObjectValue(body, scopedGlobalAliases);
+	const statements = Array.isArray(bodyRecord.body) ? bodyRecord.body : [];
+	return statements.some(statement => returnStatementExposesGlobalObject(statement, scopedGlobalAliases));
+}
+
+function returnStatementExposesGlobalObject(node: unknown, globalAliases: Set<string>): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (isFunctionLikeExpression(record)) return false;
+	if (record.type === "ReturnStatement") return containsGlobalObjectValue(record.argument, globalAliases);
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end") continue;
+		if (returnStatementExposesGlobalObject(value, globalAliases)) return true;
+	}
+	return false;
+}
+
+function patternBindsIdentifier(node: unknown, name: string): boolean {
+	if (isIdentifierNamed(node, name)) return true;
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (record.type === "AssignmentPattern") return patternBindsIdentifier(record.left, name);
+	if (record.type === "RestElement") return patternBindsIdentifier(record.argument, name);
+	if (record.type === "ObjectProperty") return patternBindsIdentifier(record.value, name);
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || key === "right") continue;
+		if (patternBindsIdentifier(value, name)) return true;
+	}
+	return false;
+}
+
+function parameterDefaultContainsProcessValue(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases: Set<string>,
+	shadowBareProcess = false,
+): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (record.type === "AssignmentPattern")
+		return containsProcessValue(record.right, processAliases, globalAliases, shadowBareProcess);
+	if (record.type === "ObjectProperty")
+		return parameterDefaultContainsProcessValue(record.value, processAliases, globalAliases, shadowBareProcess);
+	if (record.type === "RestElement") return false;
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || key === "key") continue;
+		if (parameterDefaultContainsProcessValue(value, processAliases, globalAliases, shadowBareProcess)) return true;
+	}
+	return false;
+}
+
+function parameterDefaultContainsGlobalObjectValue(node: unknown, globalAliases: Set<string>): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (record.type === "AssignmentPattern") return containsGlobalObjectValue(record.right, globalAliases);
+	if (record.type === "ObjectProperty") return parameterDefaultContainsGlobalObjectValue(record.value, globalAliases);
+	if (record.type === "RestElement") return false;
+	for (const [key, value] of Object.entries(record)) {
+		if (key === "loc" || key === "start" || key === "end" || key === "key") continue;
+		if (parameterDefaultContainsGlobalObjectValue(value, globalAliases)) return true;
+	}
+	return false;
+}
+
+function containsProcessContainerValue(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (record.type !== "SpreadElement" && record.type !== "ArrayExpression" && record.type !== "ObjectExpression")
+		return false;
+	return containsProcessValue(record, processAliases, globalAliases, shadowBareProcess);
+}
+
+function containsGlobalObjectContainerValue(node: unknown, globalAliases = new Set<string>()): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (record.type !== "SpreadElement" && record.type !== "ArrayExpression" && record.type !== "ObjectExpression")
+		return false;
+	return containsGlobalObjectValue(record, globalAliases);
+}
+
+function containsGlobalObjectValue(node: unknown, globalAliases = new Set<string>()): boolean {
+	if (isGlobalObjectExpression(node, globalAliases)) return true;
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (
+		record.type === "CallExpression" ||
+		record.type === "OptionalCallExpression" ||
+		record.type === "NewExpression"
+	) {
+		if (isGlobalObjectWrapperExpression(record, globalAliases)) return true;
+		const callee = record.callee;
+		return callee && typeof callee === "object"
+			? isFunctionLikeExpression(callee as Record<string, unknown>) &&
+					functionExposesGlobalObjectValue(callee as Record<string, unknown>, globalAliases)
+			: false;
+	}
+	if (record.type === "SpreadElement") return containsGlobalObjectValue(record.argument, globalAliases);
+	if (record.type === "ArrayExpression" && Array.isArray(record.elements))
+		return record.elements.some(element => containsGlobalObjectValue(element, globalAliases));
+	if (isFunctionLikeExpression(record)) return functionExposesGlobalObjectValue(record, globalAliases);
+	if (record.type === "ObjectExpression" && Array.isArray(record.properties)) {
+		return record.properties.some(property => {
+			if (!property || typeof property !== "object") return false;
+			const propertyRecord = property as Record<string, unknown>;
+			if (propertyRecord.type === "SpreadElement")
+				return containsGlobalObjectValue(propertyRecord.argument, globalAliases);
+			return containsGlobalObjectValue(propertyRecord.value, globalAliases);
+		});
+	}
+	return false;
+}
+
+function containsSensitiveReflectionObjectValue(node: unknown, globalAliases = new Set<string>()): boolean {
+	if (!node || typeof node !== "object") return false;
+	const unwrapped = unwrapStaticExpression(node);
+	if (
+		isSensitiveReflectionMethodExpression(unwrapped, globalAliases) ||
+		isSensitiveReflectionMethodBindExpression(unwrapped, globalAliases) ||
+		isSensitiveBuiltinObjectExpression(unwrapped, "Reflect", globalAliases) ||
+		isSensitiveBuiltinObjectExpression(unwrapped, "Object", globalAliases)
+	)
+		return true;
+	if (!unwrapped || typeof unwrapped !== "object") return false;
+	const record = unwrapped as Record<string, unknown>;
+	if (record.type === "SpreadElement") return containsSensitiveReflectionObjectValue(record.argument, globalAliases);
+	if (record.type === "ArrayExpression" && Array.isArray(record.elements))
+		return record.elements.some(element => containsSensitiveReflectionObjectValue(element, globalAliases));
+	if (record.type === "ObjectExpression" && Array.isArray(record.properties)) {
+		return record.properties.some(property => {
+			if (!property || typeof property !== "object") return false;
+			const propertyRecord = property as Record<string, unknown>;
+			if (propertyRecord.type === "SpreadElement")
+				return containsSensitiveReflectionObjectValue(propertyRecord.argument, globalAliases);
+			return containsSensitiveReflectionObjectValue(propertyRecord.value, globalAliases);
+		});
+	}
+	return false;
+}
+
+function isProcessBindingPattern(
+	pattern: unknown,
+	init: unknown,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (
+		!isProcessExpression(init, processAliases, globalAliases, shadowBareProcess) ||
+		!pattern ||
+		typeof pattern !== "object"
+	)
+		return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		if (propertyRecord.type === "RestElement") return true;
+		const key = propertyRecord.key;
+		return isUnsafeProcessStaticProperty(key);
+	});
+}
+
+function isGlobalProcessBindingPattern(pattern: unknown, init: unknown, globalAliases = new Set<string>()): boolean {
+	if (!isGlobalObjectExpression(init, globalAliases) || !pattern || typeof pattern !== "object") return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		if (propertyRecord.type === "RestElement") return true;
+		if (staticPropertyKeyName(propertyRecord.key) !== "process") return false;
+		const value = unwrapAssignmentPattern(propertyRecord.value);
+		if (!value || typeof value !== "object") return false;
+		const valueRecord = value as Record<string, unknown>;
+		if (valueRecord.type !== "ObjectPattern" || !Array.isArray(valueRecord.properties)) return false;
+		return valueRecord.properties.some(nestedProperty => {
+			if (!nestedProperty || typeof nestedProperty !== "object") return false;
+			const nestedRecord = nestedProperty as Record<string, unknown>;
+			if (nestedRecord.type === "RestElement") return true;
+			return isUnsafeProcessStaticProperty(nestedRecord.key);
+		});
+	});
+}
+
+function isUnsafeProcessStaticProperty(key: unknown): boolean {
+	const property = staticPropertyKeyName(key);
+	return property === "binding" || property === "dlopen" || property === "getBuiltinModule";
+}
+function isGlobalProcessDestructurePattern(
+	pattern: unknown,
+	init: unknown,
+	globalAliases = new Set<string>(),
+): boolean {
+	if (!isGlobalObjectExpression(init, globalAliases) || !pattern || typeof pattern !== "object") return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		return (
+			staticPropertyKeyName(propertyRecord.key) === "process" &&
+			bindingTargetIdentifierName(propertyRecord.value) !== null
+		);
+	});
+}
+
+function isGlobalRuntimeDestructurePattern(
+	pattern: unknown,
+	init: unknown,
+	globalAliases = new Set<string>(),
+): boolean {
+	if (!isGlobalObjectExpression(init, globalAliases) || !pattern || typeof pattern !== "object") return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		if (propertyRecord.type === "RestElement") return true;
+		const key = staticPropertyKeyName(propertyRecord.key);
+		return key === "Bun" || key === "Deno";
+	});
+}
+
+function isGlobalObjectDestructurePattern(pattern: unknown, init: unknown, globalAliases = new Set<string>()): boolean {
+	if (!isGlobalObjectExpression(init, globalAliases) || !pattern || typeof pattern !== "object") return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		if (propertyRecord.type === "RestElement") return true;
+		const key = staticPropertyKeyName(propertyRecord.key);
+		return key === "globalThis" || key === "global";
+	});
+}
+
+function addGlobalProcessDestructureAliases(pattern: unknown, aliases: Set<string>): void {
+	if (!pattern || typeof pattern !== "object") return;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return;
+	for (const property of record.properties) {
+		if (!property || typeof property !== "object") continue;
+		const propertyRecord = property as Record<string, unknown>;
+		if (staticPropertyKeyName(propertyRecord.key) !== "process") continue;
+		const aliasName = bindingTargetIdentifierName(propertyRecord.value);
+		if (aliasName) aliases.add(aliasName);
+	}
+}
+
+function bindingTargetIdentifierName(node: unknown): string | null {
+	if (isIdentifierNode(node)) return String((node as Record<string, unknown>).name);
+	if (!node || typeof node !== "object") return null;
+	const record = node as Record<string, unknown>;
+	if (record.type === "AssignmentPattern") return bindingTargetIdentifierName(record.left);
+	return null;
+}
+
+function unwrapAssignmentPattern(node: unknown): unknown {
+	if (!node || typeof node !== "object") return node;
+	const record = node as Record<string, unknown>;
+	return record.type === "AssignmentPattern" ? record.left : node;
+}
+
+function unwrapStaticExpression(node: unknown): unknown {
+	if (!node || typeof node !== "object") return node;
+	const record = node as Record<string, unknown>;
+	if (record.type === "SequenceExpression" && Array.isArray(record.expressions)) {
+		return unwrapStaticExpression(record.expressions.at(-1));
+	}
+	if (
+		record.type === "ParenthesizedExpression" ||
+		record.type === "ChainExpression" ||
+		record.type === "TSAsExpression" ||
+		record.type === "TSTypeAssertion" ||
+		record.type === "TSNonNullExpression"
+	) {
+		return unwrapStaticExpression(record.expression);
+	}
+	return node;
+}
+
+function isGlobalObjectExpression(node: unknown, globalAliases = new Set<string>()): boolean {
+	const unwrapped = unwrapStaticExpression(node);
+	if (isIdentifierNamed(unwrapped, "globalThis") || isIdentifierNamed(unwrapped, "global")) return true;
+	const name = identifierName(unwrapped);
+	if (name && globalAliases.has(name)) return true;
+	if (!unwrapped || typeof unwrapped !== "object") return false;
+	const record = unwrapped as Record<string, unknown>;
+	if (isGlobalObjectWrapperExpression(record, globalAliases)) return true;
+	if (isMemberLikeNode(record) && isGlobalObjectExpression(record.object, globalAliases)) {
+		const property = staticMemberPropertyName(record);
+		if (property === "globalThis" || property === "global") return true;
+	}
+	return false;
+}
+
+function isGlobalObjectWrapperExpression(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression" && record.type !== "NewExpression")
+		return false;
+	const args = Array.isArray(record.arguments) ? record.arguments : [];
+	const callee = record.callee;
+	if (isIdentifierNamed(callee, "Object")) return isGlobalObjectExpression(args[0], globalAliases);
+	if (!callee || typeof callee !== "object") return false;
+	const calleeRecord = callee as Record<string, unknown>;
+	return (
+		isMemberLikeNode(calleeRecord) &&
+		isIdentifierNamed(calleeRecord.object, "Object") &&
+		staticMemberPropertyName(calleeRecord) === "create" &&
+		isGlobalObjectExpression(args[0], globalAliases)
+	);
+}
+
+function isGlobalRuntimeObjectExpression(node: unknown, globalAliases = new Set<string>()): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (isReflectGlobalRuntimeLookup(record, globalAliases)) return true;
+	if (isGlobalRuntimeDescriptorProperty(record, globalAliases)) return true;
+	if (!isMemberLikeNode(record) || !isGlobalObjectExpression(record.object, globalAliases)) return false;
+	const property = staticMemberPropertyName(record);
+	return property === "Bun" || property === "Deno";
+}
+
+function isProcessExpression(
+	node: unknown,
+	processAliases: Set<string>,
+	globalAliases = new Set<string>(),
+	shadowBareProcess = false,
+): boolean {
+	if (!node || typeof node !== "object") return false;
+	const record = node as Record<string, unknown>;
+	if (isIdentifierNamed(record, "process")) return processAliases.has("process") || !shadowBareProcess;
+	const name = identifierName(record);
+	if (name && processAliases.has(name)) return true;
+	if (record.type === "LogicalExpression")
+		return (
+			isProcessExpression(record.left, processAliases, globalAliases, shadowBareProcess) ||
+			isProcessExpression(record.right, processAliases, globalAliases, shadowBareProcess)
+		);
+	if (record.type === "ConditionalExpression")
+		return (
+			isProcessExpression(record.consequent, processAliases, globalAliases, shadowBareProcess) ||
+			isProcessExpression(record.alternate, processAliases, globalAliases, shadowBareProcess)
+		);
+	if (record.type === "SequenceExpression" && Array.isArray(record.expressions))
+		return isProcessExpression(record.expressions.at(-1), processAliases, globalAliases, shadowBareProcess);
+	if (
+		record.type === "ParenthesizedExpression" ||
+		record.type === "ChainExpression" ||
+		record.type === "TSAsExpression" ||
+		record.type === "TSTypeAssertion" ||
+		record.type === "TSNonNullExpression"
+	)
+		return isProcessExpression(record.expression, processAliases, globalAliases, shadowBareProcess);
+	if (isReflectGlobalProcessLookup(record, globalAliases)) return true;
+	if (!isMemberLikeNode(record)) return false;
+	return isGlobalObjectExpression(record.object, globalAliases) && staticMemberPropertyName(record) === "process";
+}
+
+function isReflectGlobalProcessLookup(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	const reflectCall = reflectedBuiltinCall(record, "Reflect", new Set(["get"]), globalAliases);
+	if (!reflectCall) return false;
+	if (reflectCall.unknownApply) return true;
+	return (
+		isGlobalObjectExpression(reflectCall.args[0], globalAliases) &&
+		isUnsafeGlobalReflectedProperty(reflectedPropertyKeyName(reflectCall.args[1]))
+	);
+}
+
+function isReflectGlobalRuntimeLookup(record: Record<string, unknown>, globalAliases = new Set<string>()): boolean {
+	const reflectCall = reflectedBuiltinCall(
+		record,
+		"Reflect",
+		new Set(["get", "getOwnPropertyDescriptor"]),
+		globalAliases,
+	);
+	if (!reflectCall) return false;
+	if (reflectCall.unknownApply) return true;
+	const property = reflectedPropertyKeyName(reflectCall.args[1]);
+	return isGlobalObjectExpression(reflectCall.args[0], globalAliases) && isUnsafeGlobalReflectedProperty(property);
+}
+
+function isGlobalRuntimeDescriptorProperty(
+	record: Record<string, unknown>,
+	globalAliases = new Set<string>(),
+): boolean {
+	if (!isMemberLikeNode(record)) return false;
+	const property = staticMemberPropertyName(record);
+	if (property !== "Bun" && property !== "Deno") return false;
+	const object = record.object;
+	if (!object || typeof object !== "object") return false;
+	const objectRecord = object as Record<string, unknown>;
+	if (objectRecord.type !== "CallExpression" && objectRecord.type !== "OptionalCallExpression") return false;
+	const callee = objectRecord.callee;
+	if (!callee || typeof callee !== "object") return false;
+	const member = callee as Record<string, unknown>;
+	if (!isMemberLikeNode(member) || identifierName(member.object) !== "Object") return false;
+	if (staticMemberPropertyName(member) !== "getOwnPropertyDescriptors") return false;
+	const args = Array.isArray(objectRecord.arguments) ? objectRecord.arguments : [];
+	return isGlobalObjectExpression(args[0], globalAliases);
+}
+
+function isUnsafeGlobalObjectReflectionCall(
+	record: Record<string, unknown>,
+	globalAliases = new Set<string>(),
+): boolean {
+	const objectCall = reflectedBuiltinCall(
+		record,
+		"Object",
+		new Set(["values", "entries", "assign", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors"]),
+		globalAliases,
+	);
+	if (!objectCall) return false;
+	if (objectCall.unknownApply) return true;
+	if (objectCall.method === "assign") return objectCall.args.some(arg => isGlobalObjectExpression(arg, globalAliases));
+
+	if (!isGlobalObjectExpression(objectCall.args[0], globalAliases)) return false;
+	if (
+		objectCall.method === "values" ||
+		objectCall.method === "entries" ||
+		objectCall.method === "getOwnPropertyDescriptors"
+	)
+		return true;
+	if (objectCall.method !== "getOwnPropertyDescriptor") return false;
+	const reflectedProperty = reflectedPropertyKeyName(objectCall.args[1]);
+	return isUnsafeGlobalReflectedProperty(reflectedProperty);
+}
+
+function isSensitiveReflectionMethodExpression(node: unknown, globalAliases = new Set<string>()): boolean {
+	const unwrapped = unwrapStaticExpression(node);
+	if (!unwrapped || typeof unwrapped !== "object") return false;
+	const record = unwrapped as Record<string, unknown>;
+	if (!isMemberLikeNode(record)) return false;
+	const property = staticMemberPropertyName(record);
+	return (
+		(isSensitiveBuiltinObjectExpression(record.object, "Reflect", globalAliases) &&
+			(property === "get" || property === "getOwnPropertyDescriptor")) ||
+		(isSensitiveBuiltinObjectExpression(record.object, "Object", globalAliases) &&
+			(property === "values" ||
+				property === "entries" ||
+				property === "assign" ||
+				property === "getOwnPropertyDescriptor" ||
+				property === "getOwnPropertyDescriptors"))
+	);
+}
+
+function isSensitiveReflectionMethodDestructurePattern(
+	pattern: unknown,
+	init: unknown,
+	globalAliases = new Set<string>(),
+): boolean {
+	if (!pattern || typeof pattern !== "object" || !init || typeof init !== "object") return false;
+	const objectName = isSensitiveBuiltinObjectExpression(init, "Reflect", globalAliases)
+		? "Reflect"
+		: isSensitiveBuiltinObjectExpression(init, "Object", globalAliases)
+			? "Object"
+			: null;
+	if (objectName === null) return false;
+	const record = pattern as Record<string, unknown>;
+	if (record.type !== "ObjectPattern" || !Array.isArray(record.properties)) return false;
+	return record.properties.some(property => {
+		if (!property || typeof property !== "object") return false;
+		const propertyRecord = property as Record<string, unknown>;
+		if (propertyRecord.type === "RestElement") return true;
+		const key = staticPropertyKeyName(propertyRecord.key);
+		return (
+			(objectName === "Reflect" && (key === "get" || key === "getOwnPropertyDescriptor")) ||
+			(objectName === "Object" &&
+				(key === "values" ||
+					key === "entries" ||
+					key === "assign" ||
+					key === "getOwnPropertyDescriptor" ||
+					key === "getOwnPropertyDescriptors"))
+		);
+	});
+}
+
+function isSensitiveBuiltinObjectExpression(
+	node: unknown,
+	objectName: "Object" | "Reflect",
+	globalAliases = new Set<string>(),
+): boolean {
+	const unwrapped = unwrapStaticExpression(node);
+	if (isIdentifierNamed(unwrapped, objectName)) return true;
+	if (!unwrapped || typeof unwrapped !== "object") return false;
+	const record = unwrapped as Record<string, unknown>;
+	return (
+		isMemberLikeNode(record) &&
+		isGlobalObjectExpression(record.object, globalAliases) &&
+		staticMemberPropertyName(record) === objectName
+	);
+}
+
+function isSensitiveReflectionMethodBindExpression(node: unknown, globalAliases = new Set<string>()): boolean {
+	return (
+		boundSensitiveReflectionMethod(node, "Reflect", new Set(["get", "getOwnPropertyDescriptor"]), globalAliases) !==
+			null ||
+		boundSensitiveReflectionMethod(
+			node,
+			"Object",
+			new Set(["values", "entries", "assign", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors"]),
+			globalAliases,
+		) !== null
+	);
+}
+
+function isClassFieldRecord(record: Record<string, unknown>): boolean {
+	return (
+		record.type === "ClassProperty" ||
+		record.type === "ClassPrivateProperty" ||
+		record.type === "PropertyDefinition" ||
+		record.type === "ClassAccessorProperty"
+	);
+}
+
+function boundSensitiveReflectionMethod(
+	node: unknown,
+	objectName: "Object" | "Reflect",
+	methods: Set<string>,
+	globalAliases = new Set<string>(),
+): string | null {
+	const unwrapped = unwrapStaticExpression(node);
+	if (!unwrapped || typeof unwrapped !== "object") return null;
+	const record = unwrapped as Record<string, unknown>;
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression") return null;
+	const callee = unwrapStaticExpression(record.callee);
+	if (!callee || typeof callee !== "object") return null;
+	const member = callee as Record<string, unknown>;
+	if (!isMemberLikeNode(member) || staticMemberPropertyName(member) !== "bind") return null;
+	const target = unwrapStaticExpression(member.object);
+	if (!target || typeof target !== "object") return null;
+	const targetMember = target as Record<string, unknown>;
+	if (
+		!isMemberLikeNode(targetMember) ||
+		!isSensitiveBuiltinObjectExpression(targetMember.object, objectName, globalAliases)
+	)
+		return null;
+	const method = staticMemberPropertyName(targetMember);
+	return method && methods.has(method) ? method : null;
+}
+
+function sensitiveReflectionTargetMethod(
+	node: unknown,
+	objectName: "Object" | "Reflect",
+	methods: Set<string>,
+	globalAliases = new Set<string>(),
+): string | null {
+	const boundMethod = boundSensitiveReflectionMethod(node, objectName, methods, globalAliases);
+	if (boundMethod) return boundMethod;
+	const unwrapped = unwrapStaticExpression(node);
+	if (!unwrapped || typeof unwrapped !== "object") return null;
+	const record = unwrapped as Record<string, unknown>;
+	if (!isMemberLikeNode(record) || !isSensitiveBuiltinObjectExpression(record.object, objectName, globalAliases)) {
+		return null;
+	}
+	const method = staticMemberPropertyName(record);
+	return method && methods.has(method) ? method : null;
+}
+
+function reflectedBuiltinCall(
+	record: Record<string, unknown>,
+	objectName: "Object" | "Reflect",
+	methods: Set<string>,
+	globalAliases = new Set<string>(),
+): { method: string; args: unknown[]; unknownApply?: boolean } | null {
+	if (record.type !== "CallExpression" && record.type !== "OptionalCallExpression") return null;
+	const callee = unwrapStaticExpression(record.callee);
+	if (!callee || typeof callee !== "object") return null;
+	const boundMethod = boundSensitiveReflectionMethod(callee, objectName, methods, globalAliases);
+	if (boundMethod) {
+		const args = Array.isArray(record.arguments) ? record.arguments : [];
+		return { method: boundMethod, args };
+	}
+	const member = callee as Record<string, unknown>;
+	if (!isMemberLikeNode(member)) return null;
+	const directMethod = staticMemberPropertyName(member);
+	const rawArgs = Array.isArray(record.arguments) ? record.arguments : [];
+	if (isSensitiveBuiltinObjectExpression(member.object, "Reflect", globalAliases) && directMethod === "apply") {
+		const method = sensitiveReflectionTargetMethod(rawArgs[0], objectName, methods, globalAliases);
+		if (!method) return null;
+		const applyArgs = rawArgs[2];
+		if (
+			!applyArgs ||
+			typeof applyArgs !== "object" ||
+			(applyArgs as Record<string, unknown>).type !== "ArrayExpression"
+		)
+			return { method, args: [], unknownApply: true };
+		const elements = (applyArgs as Record<string, unknown>).elements;
+		return { method, args: Array.isArray(elements) ? elements : [] };
+	}
+	if (
+		isSensitiveBuiltinObjectExpression(member.object, objectName, globalAliases) &&
+		directMethod &&
+		methods.has(directMethod)
+	) {
+		return { method: directMethod, args: rawArgs };
+	}
+	if (directMethod !== "call" && directMethod !== "apply") return null;
+	const method = sensitiveReflectionTargetMethod(member.object, objectName, methods, globalAliases);
+	if (!method) return null;
+	if (directMethod === "call") return { method, args: rawArgs.slice(1) };
+	const applyArgs = rawArgs[1];
+	if (!applyArgs || typeof applyArgs !== "object" || (applyArgs as Record<string, unknown>).type !== "ArrayExpression")
+		return { method, args: [], unknownApply: true };
+	const elements = (applyArgs as Record<string, unknown>).elements;
+	return { method, args: Array.isArray(elements) ? elements : [] };
+}
+
+function isMemberLikeNode(record: Record<string, unknown>): boolean {
+	return record.type === "MemberExpression" || record.type === "OptionalMemberExpression";
+}
+
+function isNonComputedMemberProperty(record: Record<string, unknown>, key: string): boolean {
+	return key === "property" && isMemberLikeNode(record) && record.computed !== true;
+}
+
+function staticMemberPropertyName(record: Record<string, unknown>): string | null {
+	return staticPropertyKeyName(record.property);
+}
+
+function reflectedPropertyKeyName(node: unknown): string | null {
+	if (isIdentifierNode(node)) return null;
+	return staticPropertyKeyName(node);
+}
+
+function staticPropertyKeyName(node: unknown): string | null {
+	if (!node || typeof node !== "object") return null;
+	const record = node as Record<string, unknown>;
+	if (typeof record.name === "string") return record.name;
+	if (typeof record.value === "string") return record.value;
+	return null;
+}
+
+function isIdentifierNode(node: unknown): boolean {
+	return !!node && typeof node === "object" && (node as Record<string, unknown>).type === "Identifier";
+}
+
+function isIdentifierNamed(node: unknown, name: string): boolean {
+	return isIdentifierNode(node) && (node as Record<string, unknown>).name === name;
+}
+
+function identifierName(node: unknown): string | null {
+	return isIdentifierNode(node) ? String((node as Record<string, unknown>).name) : null;
 }
 
 function hasDynamicVerifierDependency(content: string): boolean {
@@ -708,6 +2023,44 @@ function verifierRuntimePath(projectCwd: string, projectRootReal: string): strin
 	return sanitizedVerifierPath(inheritedPathValue(), projectCwd, projectRootReal);
 }
 
+async function resolveVerifierRuntimePath(
+	scriptValue: string,
+	runtimePath: string,
+	projectCwd: string,
+	projectRootReal: string,
+): Promise<string> {
+	const runtimeToken = tokenizeVerifierScript(scriptValue)[0] ?? "";
+	if (
+		!runtimeToken ||
+		runtimeToken !== path.basename(runtimeToken) ||
+		runtimeToken.includes("/") ||
+		runtimeToken.includes("\\")
+	)
+		throw new Error("verifier runtime must be a bare executable name");
+	for (const segment of runtimePath.split(path.delimiter)) {
+		if (!segment) continue;
+		const candidate = path.join(segment, runtimeToken);
+		try {
+			const stat = await fs.stat(candidate);
+			if (!stat.isFile()) continue;
+			await fs.access(candidate, nodeFs.constants.X_OK);
+			const realCandidate = await fs.realpath(candidate);
+			if (isUnsafeVerifierRuntimeLocation(realCandidate, projectCwd, projectRootReal)) continue;
+			return realCandidate;
+		} catch (error) {
+			if (
+				error &&
+				typeof error === "object" &&
+				"code" in error &&
+				(error.code === "ENOENT" || error.code === "ENOTDIR" || error.code === "EACCES" || error.code === "EPERM")
+			)
+				continue;
+			throw error;
+		}
+	}
+	throw new Error(`verifier runtime ${runtimeToken} could not be resolved from sanitized PATH`);
+}
+
 function verifierSafePathError(projectCwd: string, projectRootReal: string): string | null {
 	return verifierRuntimePath(projectCwd, projectRootReal).split(path.delimiter).some(Boolean)
 		? null
@@ -729,6 +2082,15 @@ function verifierRuntimeEnv(
 }
 
 function sanitizedVerifierPath(rawPath: string, projectCwd: string, projectRootReal: string): string {
+	return rawPath
+		.split(path.delimiter)
+		.filter(segment => segment.length > 0 && path.isAbsolute(segment))
+		.filter(segment => !isUnsafeVerifierRuntimeLocation(segment, projectCwd, projectRootReal))
+		.join(path.delimiter);
+}
+
+function isUnsafeVerifierRuntimeLocation(targetPath: string, projectCwd: string, projectRootReal: string): boolean {
+	if (!path.isAbsolute(targetPath)) return true;
 	const normalizedRoots = [
 		...new Set(
 			[path.resolve(projectCwd), path.resolve(projectRootReal), ...normalizedPathAliases(projectRootReal)].map(
@@ -736,26 +2098,17 @@ function sanitizedVerifierPath(rawPath: string, projectCwd: string, projectRootR
 			),
 		),
 	];
-	return rawPath
-		.split(path.delimiter)
-		.filter(segment => {
-			if (segment.length === 0 || !path.isAbsolute(segment)) return false;
-			const normalizedSegments = normalizedPathAliases(segment).map(candidate => candidate.toLowerCase());
-			if (
-				normalizedSegments.some(normalizedSegment =>
-					normalizedRoots.some(
-						normalizedRoot =>
-							normalizedSegment === normalizedRoot ||
-							normalizedSegment.startsWith(`${normalizedRoot}${path.sep}`),
-					),
-				)
-			)
-				return false;
-			return !normalizedSegments.some(normalizedSegment =>
-				normalizedSegment.split(path.sep).includes("node_modules"),
-			);
-		})
-		.join(path.delimiter);
+	const normalizedSegments = normalizedPathAliases(targetPath).map(candidate => candidate.toLowerCase());
+	if (
+		normalizedSegments.some(normalizedSegment =>
+			normalizedRoots.some(
+				normalizedRoot =>
+					normalizedSegment === normalizedRoot || normalizedSegment.startsWith(`${normalizedRoot}${path.sep}`),
+			),
+		)
+	)
+		return true;
+	return normalizedSegments.some(normalizedSegment => normalizedSegment.split(path.sep).includes("node_modules"));
 }
 
 function normalizedPathAliases(targetPath: string): string[] {
@@ -808,14 +2161,15 @@ async function runVerifierCommands(
 	verifierScripts: VerifierScriptSnapshot[],
 ): Promise<LoopVerifierResult[]> {
 	const results: LoopVerifierResult[] = [];
-	for (const command of commands) {
+	for (const [index, command] of commands.entries()) {
+		const snapshot = verifierScripts[index];
 		let started = Date.now();
 		const beforeReason = await verifierScriptsChanged(verifierScripts);
 		if (beforeReason) {
 			results.push(verifierError(command, beforeReason, started));
 			break;
 		}
-		results.push(await runCommand(command, cwd));
+		results.push(await runCommand(command, cwd, snapshot));
 		started = Date.now();
 		const afterReason = await verifierScriptsChanged(verifierScripts);
 		if (afterReason) {
@@ -826,7 +2180,11 @@ async function runVerifierCommands(
 	return results;
 }
 
-async function runCommand(command: LoopCommandSpec, cwd: string): Promise<LoopVerifierResult> {
+async function runCommand(
+	command: LoopCommandSpec,
+	cwd: string,
+	snapshot?: VerifierScriptSnapshot,
+): Promise<LoopVerifierResult> {
 	const started = Date.now();
 	const invalidReason = validateVerifierCommand(command);
 	if (invalidReason) return verifierError(command, invalidReason, started);
@@ -839,25 +2197,39 @@ async function runCommand(command: LoopCommandSpec, cwd: string): Promise<LoopVe
 		const script = await readVerifierPackageScript(command, commandCwd);
 		if (script.error) return verifierError(command, script.error, started);
 		const verifierArgv = tokenizeVerifierScript(script.scriptValue);
+		const runtimePath =
+			snapshot?.runtimePath ||
+			(await resolveVerifierRuntimePath(script.scriptValue, verifierRuntimePath(cwd, rootReal), cwd, rootReal));
+		verifierArgv[0] = runtimePath;
 		const proc = Bun.spawn(verifierArgv, {
 			cwd: commandCwd,
 			env: verifierRuntimeEnv(cwd, rootReal),
 			stdout: "pipe",
 			stderr: "pipe",
 		});
-		let killTimer: ReturnType<typeof setTimeout> | null = null;
+		let sigkillTimer: NodeJS.Timeout | undefined;
 		const outputPromise = Promise.all([readLimited(proc.stdout), readLimited(proc.stderr), proc.exited]);
-		const timeoutPromise = new Promise<"timeout">(resolve => {
-			killTimer = setTimeout(() => {
-				proc.kill("SIGTERM");
-				setTimeout(() => proc.kill("SIGKILL"), 1_000);
-				resolve("timeout");
-			}, VERIFIER_TIMEOUT_MS);
-		});
-		const result = await Promise.race([outputPromise, timeoutPromise]);
-		if (killTimer) clearTimeout(killTimer);
+		const timeout = Promise.withResolvers<"timeout">();
+		const killTimer: NodeJS.Timeout = setTimeout(() => {
+			proc.kill("SIGTERM");
+			sigkillTimer = setTimeout(() => proc.kill("SIGKILL"), 1_000);
+			timeout.resolve("timeout");
+		}, VERIFIER_TIMEOUT_MS);
+		const result = await Promise.race([outputPromise, timeout.promise]);
+		clearTimeout(killTimer);
 		if (result === "timeout") {
-			outputPromise.catch(() => undefined);
+			const exitWait = Promise.withResolvers<void>();
+			const abandonTimer = setTimeout(() => {
+				proc.kill("SIGKILL");
+				exitWait.resolve();
+			}, 2_000);
+			outputPromise.then(
+				() => exitWait.resolve(),
+				() => exitWait.resolve(),
+			);
+			await exitWait.promise;
+			clearTimeout(abandonTimer);
+			if (sigkillTimer) clearTimeout(sigkillTimer);
 			return {
 				command: command.argv,
 				exitCode: null,
@@ -866,6 +2238,7 @@ async function runCommand(command: LoopCommandSpec, cwd: string): Promise<LoopVe
 				durationMs: Date.now() - started,
 			};
 		}
+		if (sigkillTimer) clearTimeout(sigkillTimer);
 		const [stdout, stderr, exitCode] = result;
 		return {
 			command: command.argv,
@@ -928,7 +2301,15 @@ async function readVerifierPackageScript(
 	const script = await readPackageScript(packageJsonPath, scriptName);
 	return script.error
 		? verifierScriptError(script.error)
-		: { ...script, packageJsonPath, packageJsonDigest, referencedFiles: [], error: null };
+		: {
+				...script,
+				packageJsonPath,
+				packageJsonDigest,
+				runtimePath: "",
+				runtimeDigest: "",
+				referencedFiles: [],
+				error: null,
+			};
 }
 
 async function validateVerifierPackageJson(packageJsonPath: string): Promise<string | null> {
@@ -1057,6 +2438,7 @@ function looksLikeDirectVerifierFileOperand(operand: string): boolean {
 	) {
 		return false;
 	}
+	if (VERIFIER_UNSAFE_DEPENDENCY_EXTENSIONS.has(path.extname(operand))) return false;
 	return (
 		operand.startsWith("./") || operand.startsWith("../") || VERIFIER_REFERENCE_EXTENSIONS.has(path.extname(operand))
 	);
@@ -1084,7 +2466,16 @@ function containsUnsupportedVerifierRunnerSubcommand(scriptValue: string): boole
 }
 
 function verifierScriptError(error: string): VerifierScriptSnapshot {
-	return { packageJsonPath: "", packageJsonDigest: "", scriptName: "", scriptValue: "", referencedFiles: [], error };
+	return {
+		packageJsonPath: "",
+		packageJsonDigest: "",
+		scriptName: "",
+		scriptValue: "",
+		runtimePath: "",
+		runtimeDigest: "",
+		referencedFiles: [],
+		error,
+	};
 }
 
 function verifierError(command: LoopCommandSpec, message: string, started: number): LoopVerifierResult {
@@ -1323,14 +2714,15 @@ function redactRunRecord(record: LoopRunRecord): LoopRunRecord {
 	return {
 		...record,
 		prompt: redactSecrets(record.prompt),
-		agentOutput: redactSecrets(record.agentOutput),
+		agentOutput: redactAndTruncate(record.agentOutput),
 		approvalReasons: record.approvalReasons.map(redactSecrets),
 		error: record.error ? redactSecrets(record.error) : null,
+		changedFiles: record.changedFiles.map(redactSecrets),
 		verifierResults: record.verifierResults.map(result => ({
 			...result,
 			command: redactCommandArgs(result.command),
-			stdout: redactSecrets(result.stdout),
-			stderr: redactSecrets(result.stderr),
+			stdout: redactAndTruncate(result.stdout),
+			stderr: redactAndTruncate(result.stderr),
 		})),
 	};
 }
@@ -1365,6 +2757,7 @@ function isSecretFlag(value: string): boolean {
 function redactSecrets(value: string): string {
 	return value
 		.replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[REDACTED_SECRET]")
+		.replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*$/g, "[REDACTED_SECRET]")
 		.replace(/\b(?:ghp|github_pat|npm|xox[baprs])[-_][A-Za-z0-9_/-]{10,}\b/g, "[REDACTED_SECRET]")
 		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED_SECRET]")
 		.replace(/\b(Authorization\s*:\s*Bearer\s+)["']?[^"'\s]+/gi, "$1[REDACTED_SECRET]")
@@ -1376,8 +2769,12 @@ function redactSecrets(value: string): string {
 			/\b(--?[A-Za-z0-9_-]*(?:token|key|secret|password|credential)[A-Za-z0-9_-]*=)["']?[^"'\s]+/gi,
 			"$1[REDACTED_SECRET]",
 		)
-		.replace(/\b(sk-[A-Za-z0-9_-]{16,})\b/g, "[REDACTED_SECRET]")
+		.replace(/\b(sk-[A-Za-z0-9_-]{3,})\b/g, "[REDACTED_SECRET]")
 		.replace(/\b([A-Za-z0-9._%+-]+:[A-Za-z0-9/+=._-]{16,})\b/g, "[REDACTED_SECRET]");
+}
+
+function redactAndTruncate(value: string): string {
+	return truncate(redactSecrets(value));
 }
 
 function truncate(value: string): string {

--- a/packages/coding-agent/src/loop-engineering/runner.ts
+++ b/packages/coding-agent/src/loop-engineering/runner.ts
@@ -1,0 +1,655 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { prompt, sanitizeText } from "@oh-my-pi/pi-utils";
+import { createAgentSession } from "../sdk";
+import { assertSafeProjectWrite, resolveInsideProject } from "./paths";
+import { assessLoopReadiness } from "./readiness";
+import runPromptTemplate from "./templates/run-prompt.md" with { type: "text" };
+import type {
+	LoopCommandSpec,
+	LoopRunOptions,
+	LoopRunRecord,
+	LoopRunResult,
+	LoopSpec,
+	LoopVerifierResult,
+} from "./types";
+
+const OUTPUT_LIMIT = 8_000;
+const REPORT_LOOP_TOOLS = ["read", "search", "find", "web_search"];
+const VERIFIER_TIMEOUT_MS = 120_000;
+const SHELL_EXECUTABLES = new Set(["bash", "cmd", "fish", "powershell", "pwsh", "sh", "zsh"]);
+const PACKAGE_SCRIPT_RUNNERS = new Set(["bun", "npm", "pnpm", "yarn"]);
+const STATUS_OUTPUT_LIMIT = 1_000_000;
+
+export function buildLoopRunPrompt(spec: LoopSpec): string {
+	return prompt.render(runPromptTemplate, {
+		name: spec.name,
+		level: spec.level,
+		goal: spec.goal,
+		non_goals: spec.nonGoals,
+		scope_paths: spec.scope.paths,
+		max_files_changed: spec.guardrails.maxFilesChanged ?? "not set",
+		max_iterations: spec.guardrails.maxIterations ?? "not set",
+		denylist_paths: spec.guardrails.denylistPaths,
+		state_file: spec.state.file,
+		budget_file: spec.state.budget,
+		run_log: spec.state.runLog,
+		runner_prompt: spec.runner.prompt,
+	});
+}
+
+export async function executeLoopIteration(spec: LoopSpec, options: LoopRunOptions): Promise<LoopRunResult> {
+	const started = options.now?.() ?? new Date();
+	const promptText = buildLoopRunPrompt(spec);
+	const baseRecord = createBaseRecord(spec, started, promptText);
+	if (options.dryRun) {
+		return {
+			...baseRecord,
+			status: "dry_run",
+			finishedAt: started.toISOString(),
+			jsonlPath: null,
+			markdownLogPath: null,
+		};
+	}
+
+	const readiness = assessLoopReadiness(spec);
+	if (!readiness.ready) {
+		const finishedAt = options.now?.() ?? new Date();
+		const record: LoopRunRecord = {
+			...baseRecord,
+			status: "failed",
+			finishedAt: finishedAt.toISOString(),
+			durationMs: finishedAt.getTime() - started.getTime(),
+			error: readiness.issues.join("; "),
+		};
+		return persistRunRecord(spec, options.cwd, record);
+	}
+
+	const baselineChangedFiles = await listChangedFiles(options.cwd);
+	const verifierScripts =
+		spec.level === "report" ? [] : await captureVerifierScriptSnapshots(spec.verifier.commands, options.cwd);
+	const verifierPreflightError = verifierScripts.find(script => script.error)?.error ?? null;
+	if (verifierPreflightError) {
+		const finishedAt = options.now?.() ?? new Date();
+		const record: LoopRunRecord = {
+			...baseRecord,
+			status: "failed",
+			finishedAt: finishedAt.toISOString(),
+			durationMs: finishedAt.getTime() - started.getTime(),
+			error: verifierPreflightError,
+		};
+		return persistRunRecord(spec, options.cwd, record);
+	}
+
+	let agentExitCode: number | null = null;
+	let agentOutput = "";
+	let error: string | null = null;
+	try {
+		const runAgent = options.runAgent ?? ((text, cwd) => runAgentInProcess(text, cwd, spec));
+		const result = await runAgent(promptText, options.cwd);
+		agentExitCode = result.exitCode;
+		agentOutput = truncate(result.output);
+	} catch (err) {
+		agentExitCode = 1;
+		error = err instanceof Error ? err.message : String(err);
+	}
+
+	const verifierMutationReason =
+		agentExitCode === 0 && spec.level !== "report" ? await verifierScriptsChanged(verifierScripts) : null;
+	const verifierResults =
+		agentExitCode === 0 && spec.level !== "report" && !verifierMutationReason
+			? await runVerifierCommands(spec.verifier.commands, options.cwd)
+			: [];
+	const observedChangedFiles = await listChangedFiles(options.cwd);
+	const changedFiles = changedFilesSinceBaseline(baselineChangedFiles, observedChangedFiles);
+	const approvalReasons = approvalReasonsFor(spec, changedFiles, verifierResults, {
+		canObserveChangedFiles: baselineChangedFiles !== null && observedChangedFiles !== null,
+		baselineChangedFileCount: baselineChangedFiles?.length ?? null,
+	});
+	if (verifierMutationReason) approvalReasons.push(verifierMutationReason);
+	const failedVerifier = verifierResults.some(result => result.exitCode !== 0);
+	const finishedAt = options.now?.() ?? new Date();
+	const status =
+		error || agentExitCode !== 0 || failedVerifier
+			? "failed"
+			: approvalReasons.length > 0
+				? "needs_approval"
+				: "passed";
+	const record: LoopRunRecord = {
+		...baseRecord,
+		status,
+		finishedAt: finishedAt.toISOString(),
+		durationMs: finishedAt.getTime() - started.getTime(),
+		agentExitCode,
+		agentOutput,
+		verifierResults,
+		changedFiles,
+		approvalReasons,
+		error,
+	};
+	return persistRunRecord(spec, options.cwd, record);
+}
+
+async function runAgentInProcess(
+	promptText: string,
+	cwd: string,
+	spec: LoopSpec,
+): Promise<{ exitCode: number | null; output: string }> {
+	const reportMode = spec.level === "report";
+	const { session, modelFallbackMessage } = await createAgentSession({
+		cwd,
+		customTools: reportMode ? [] : undefined,
+		disableExtensionDiscovery: reportMode,
+		enableMCP: reportMode ? false : undefined,
+		preloadedCustomToolPaths: reportMode ? [] : undefined,
+		strictToolNames: reportMode,
+		toolNames: reportMode ? REPORT_LOOP_TOOLS : undefined,
+	});
+	try {
+		if (modelFallbackMessage) process.stderr.write(`${modelFallbackMessage}\n`);
+		await session.prompt(promptText);
+		const lastMessage = session.state.messages[session.state.messages.length - 1];
+		if (lastMessage?.role !== "assistant")
+			return { exitCode: 1, output: "Loop agent did not produce an assistant message." };
+		const assistantMessage = lastMessage as AssistantMessage;
+		const output = assistantMessage.content
+			.filter(part => part.type === "text")
+			.map(part => part.text)
+			.join("\n");
+		const failed = assistantMessage.stopReason === "error" || assistantMessage.stopReason === "aborted";
+		return { exitCode: failed ? 1 : 0, output: assistantMessage.errorMessage ?? output };
+	} finally {
+		await session.dispose();
+	}
+}
+
+function createBaseRecord(spec: LoopSpec, started: Date, promptText: string): LoopRunRecord {
+	return {
+		id: `${started.toISOString().replace(/[^0-9TZ]/g, "")}-${spec.name}`,
+		loop: spec.name,
+		status: "dry_run",
+		startedAt: started.toISOString(),
+		finishedAt: started.toISOString(),
+		durationMs: 0,
+		level: spec.level,
+		prompt: promptText,
+		agentExitCode: null,
+		agentOutput: "",
+		verifierResults: [],
+		changedFiles: [],
+		approvalReasons: [],
+		error: null,
+	};
+}
+
+interface VerifierScriptSnapshot {
+	packageJsonPath: string;
+	scriptName: string;
+	scriptValue: string;
+	error: string | null;
+}
+
+async function captureVerifierScriptSnapshots(
+	commands: LoopCommandSpec[],
+	cwd: string,
+): Promise<VerifierScriptSnapshot[]> {
+	const snapshots: VerifierScriptSnapshot[] = [];
+	for (const command of commands) {
+		const invalidReason = validateVerifierCommand(command);
+		if (invalidReason) {
+			snapshots.push({ packageJsonPath: "", scriptName: "", scriptValue: "", error: invalidReason });
+			continue;
+		}
+		try {
+			const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : cwd;
+			const script = await readVerifierPackageScript(command, commandCwd);
+			snapshots.push(
+				script.error ? { packageJsonPath: "", scriptName: "", scriptValue: "", error: script.error } : script,
+			);
+		} catch (error) {
+			snapshots.push({
+				packageJsonPath: "",
+				scriptName: "",
+				scriptValue: "",
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+	return snapshots;
+}
+
+async function verifierScriptsChanged(snapshots: VerifierScriptSnapshot[]): Promise<string | null> {
+	for (const snapshot of snapshots) {
+		if (snapshot.error) return snapshot.error;
+		const current = await readPackageScript(snapshot.packageJsonPath, snapshot.scriptName);
+		if (current.error) return current.error;
+		if (current.scriptValue !== snapshot.scriptValue) {
+			return `verifier package.json script ${snapshot.scriptName} changed before verifier execution`;
+		}
+	}
+	return null;
+}
+
+async function runVerifierCommands(commands: LoopCommandSpec[], cwd: string): Promise<LoopVerifierResult[]> {
+	const results: LoopVerifierResult[] = [];
+	for (const command of commands) {
+		results.push(await runCommand(command, cwd));
+	}
+	return results;
+}
+
+async function runCommand(command: LoopCommandSpec, cwd: string): Promise<LoopVerifierResult> {
+	const started = Date.now();
+	const invalidReason = validateVerifierCommand(command);
+	if (invalidReason) return verifierError(command, invalidReason, started);
+	try {
+		const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : cwd;
+		const scriptError = await validateVerifierPackageScriptTarget(command, commandCwd);
+		if (scriptError) return verifierError(command, scriptError, started);
+		const proc = Bun.spawn(command.argv, {
+			cwd: commandCwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		let killTimer: ReturnType<typeof setTimeout> | null = null;
+		const outputPromise = Promise.all([readLimited(proc.stdout), readLimited(proc.stderr), proc.exited]);
+		const timeoutPromise = new Promise<"timeout">(resolve => {
+			killTimer = setTimeout(() => {
+				proc.kill("SIGTERM");
+				setTimeout(() => proc.kill("SIGKILL"), 1_000);
+				resolve("timeout");
+			}, VERIFIER_TIMEOUT_MS);
+		});
+		const result = await Promise.race([outputPromise, timeoutPromise]);
+		if (killTimer) clearTimeout(killTimer);
+		if (result === "timeout") {
+			outputPromise.catch(() => undefined);
+			return {
+				command: command.argv,
+				exitCode: null,
+				stdout: "",
+				stderr: `Verifier timed out after ${VERIFIER_TIMEOUT_MS}ms`,
+				durationMs: Date.now() - started,
+			};
+		}
+		const [stdout, stderr, exitCode] = result;
+		return {
+			command: command.argv,
+			exitCode,
+			stdout,
+			stderr,
+			durationMs: Date.now() - started,
+		};
+	} catch (error) {
+		return verifierError(command, error instanceof Error ? error.message : String(error), started);
+	}
+}
+
+function validateVerifierCommand(command: LoopCommandSpec): string | null {
+	const executable = command.argv[0];
+	if (!executable || executable.trim().length === 0) return "verifier argv[0] is required";
+	if (executable !== path.basename(executable) || executable.includes("/") || executable.includes("\\")) {
+		return "verifier executable must be a bare package runner name";
+	}
+	const executableName = path.basename(executable).toLowerCase();
+	if (SHELL_EXECUTABLES.has(executableName)) {
+		return `verifier executable ${executable} is not allowed; use argv commands without a shell`;
+	}
+	if (!isAllowedVerifierPackageScript(executableName, command.argv)) {
+		return "verifier commands must use a package-script form like `bun run check`";
+	}
+	return null;
+}
+
+function isAllowedVerifierPackageScript(executableName: string, argv: string[]): boolean {
+	if (!PACKAGE_SCRIPT_RUNNERS.has(executableName)) return false;
+	if (executableName === "npm" && argv[1] === "test") return true;
+	return argv[1] === "run" && typeof argv[2] === "string" && argv[2].length > 0 && !argv[2].startsWith("-");
+}
+
+async function validateVerifierPackageScriptTarget(
+	command: LoopCommandSpec,
+	commandCwd: string,
+): Promise<string | null> {
+	const script = await readVerifierPackageScript(command, commandCwd);
+	return script.error;
+}
+
+async function readVerifierPackageScript(
+	command: LoopCommandSpec,
+	commandCwd: string,
+): Promise<VerifierScriptSnapshot> {
+	if (command.argv[0] === "npm" && command.argv[1] === "test" && command.argv.length > 2) {
+		return verifierScriptError("verifier package scripts do not accept extra argv by default");
+	}
+	if (!(command.argv[0] === "npm" && command.argv[1] === "test") && command.argv.length > 3) {
+		return verifierScriptError("verifier package scripts do not accept extra argv by default");
+	}
+	const scriptName = command.argv[0] === "npm" && command.argv[1] === "test" ? "test" : command.argv[2];
+	if (
+		!scriptName ||
+		scriptName.includes("/") ||
+		scriptName.includes("\\") ||
+		scriptName === "." ||
+		scriptName === ".."
+	) {
+		return verifierScriptError("verifier script name must be a package.json script key");
+	}
+	const packageJsonPath = await resolveInsideProject(commandCwd, "package.json", "verifier package.json");
+	const script = await readPackageScript(packageJsonPath, scriptName);
+	return script.error ? verifierScriptError(script.error) : { ...script, packageJsonPath, error: null };
+}
+
+async function readPackageScript(
+	packageJsonPath: string,
+	scriptName: string,
+): Promise<{ scriptName: string; scriptValue: string; error: string | null }> {
+	let parsed: { scripts?: Record<string, unknown> };
+	try {
+		parsed = JSON.parse(await Bun.file(packageJsonPath).text()) as { scripts?: Record<string, unknown> };
+	} catch (error) {
+		return {
+			scriptName,
+			scriptValue: "",
+			error: `verifier package.json could not be read: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	const scriptValue = parsed.scripts?.[scriptName];
+	if (typeof scriptValue !== "string") {
+		return { scriptName, scriptValue: "", error: `verifier script ${scriptName} is not defined in package.json` };
+	}
+	return { scriptName, scriptValue, error: null };
+}
+
+function verifierScriptError(error: string): VerifierScriptSnapshot {
+	return { packageJsonPath: "", scriptName: "", scriptValue: "", error };
+}
+
+function verifierError(command: LoopCommandSpec, message: string, started: number): LoopVerifierResult {
+	return {
+		command: command.argv,
+		exitCode: null,
+		stdout: "",
+		stderr: message,
+		durationMs: Date.now() - started,
+	};
+}
+
+async function readLimited(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+	if (!stream) return "";
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let output = "";
+	let truncated = false;
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const chunk = decoder.decode(value, { stream: true });
+			const remaining = OUTPUT_LIMIT - output.length;
+			if (remaining > 0) output += chunk.slice(0, remaining);
+			if (chunk.length > remaining) {
+				truncated = true;
+				await reader.cancel();
+				break;
+			}
+		}
+		output += decoder.decode();
+	} finally {
+		reader.releaseLock();
+	}
+	return truncated ? `${output}\n... truncated ...` : output;
+}
+
+async function readStatusOutput(stream: ReadableStream<Uint8Array> | null): Promise<string | null> {
+	if (!stream) return "";
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let output = "";
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const chunk = decoder.decode(value, { stream: true });
+			if (output.length + chunk.length > STATUS_OUTPUT_LIMIT) {
+				await reader.cancel();
+				return null;
+			}
+			output += chunk;
+		}
+		return output + decoder.decode();
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function appendLine(value: string, line: string): string {
+	return value.length > 0 ? `${value}\n${line}` : line;
+}
+
+async function listChangedFiles(cwd: string): Promise<string[] | null> {
+	try {
+		const proc = Bun.spawn(["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+			cwd,
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const [stdout, exitCode] = await Promise.all([readStatusOutput(proc.stdout), proc.exited]);
+		if (exitCode !== 0 || stdout === null) return null;
+		return parsePorcelainStatusZ(stdout);
+	} catch {
+		return null;
+	}
+}
+
+export function parsePorcelainStatusZ(stdout: string): string[] {
+	const records = stdout.split("\0").filter(Boolean);
+	const files: string[] = [];
+	for (let index = 0; index < records.length; index++) {
+		const record = records[index];
+		if (record.length < 4) continue;
+		const status = record.slice(0, 2);
+		files.push(record.slice(3));
+		if (status.includes("R") || status.includes("C")) {
+			const previousPath = records[index + 1];
+			if (previousPath) files.push(previousPath);
+			index++;
+		}
+	}
+	return [...new Set(files)];
+}
+
+function changedFilesSinceBaseline(baseline: string[] | null, observed: string[] | null): string[] {
+	if (!baseline || !observed) return [];
+	const before = new Set(baseline);
+	return observed.filter(file => !before.has(file));
+}
+
+interface ApprovalContext {
+	canObserveChangedFiles: boolean;
+	baselineChangedFileCount: number | null;
+}
+
+function approvalReasonsFor(
+	spec: LoopSpec,
+	changedFiles: string[],
+	verifierResults: LoopVerifierResult[],
+	context: ApprovalContext,
+): string[] {
+	const reasons: string[] = [];
+	if (!context.canObserveChangedFiles && spec.level !== "report") {
+		reasons.push("changed files could not be observed with git status");
+	}
+	if (context.baselineChangedFileCount && context.baselineChangedFileCount > 0 && spec.level !== "report") {
+		reasons.push(`worktree had ${context.baselineChangedFileCount} pre-existing changed files before loop run`);
+	}
+	if (spec.guardrails.maxFilesChanged !== null && changedFiles.length > spec.guardrails.maxFilesChanged) {
+		reasons.push(`changed ${changedFiles.length} files, above max_files_changed ${spec.guardrails.maxFilesChanged}`);
+	}
+	const outsideScope = changedFiles.find(file => !spec.scope.paths.some(scope => pathWithinScope(scope, file)));
+	if (outsideScope) reasons.push(`changed out-of-scope path ${outsideScope}`);
+	const denylistHit = changedFiles.find(file =>
+		spec.guardrails.denylistPaths.some(pattern => pathMatches(pattern, file)),
+	);
+	if (denylistHit) reasons.push(`changed denylisted path ${denylistHit}`);
+	if (spec.level === "autonomous" && verifierResults.length === 0)
+		reasons.push("autonomous loop has no verifier command result");
+	return reasons;
+}
+
+function pathWithinScope(scope: string, filePath: string): boolean {
+	const normalizedScope = normalizeRepoPath(scope);
+	const normalizedFile = normalizeRepoPath(filePath);
+	if (normalizedScope === "." || normalizedScope === "") return true;
+	if (normalizedScope.includes("*")) return pathMatches(normalizedScope, normalizedFile);
+	return normalizedFile === normalizedScope || normalizedFile.startsWith(`${normalizedScope}/`);
+}
+
+export function pathMatches(pattern: string, filePath: string): boolean {
+	const normalizedPattern = normalizeRepoPath(pattern);
+	const normalizedFile = normalizeRepoPath(filePath);
+	if (normalizedPattern === "." || normalizedPattern === normalizedFile) return true;
+	if (normalizedPattern.startsWith("**/") && pathMatches(normalizedPattern.slice(3), normalizedFile)) return true;
+	if (normalizedPattern.endsWith("/**") && !normalizedPattern.slice(0, -3).includes("*")) {
+		const base = normalizedPattern.slice(0, -3);
+		return normalizedFile === base || normalizedFile.startsWith(`${base}/`);
+	}
+	if (!normalizedPattern.includes("/")) {
+		return (
+			globRegex(normalizedPattern).test(path.basename(normalizedFile)) ||
+			globRegex(normalizedPattern).test(normalizedFile)
+		);
+	}
+	if (!normalizedPattern.includes("*")) return false;
+	return globRegex(normalizedPattern).test(normalizedFile);
+}
+
+function normalizeRepoPath(value: string): string {
+	return (
+		value
+			.replaceAll("\\", "/")
+			.replace(/^\.\/+/, "")
+			.replace(/\/+$/, "") || "."
+	);
+}
+
+function globRegex(pattern: string): RegExp {
+	let source = "^";
+	for (let index = 0; index < pattern.length; index++) {
+		const char = pattern[index];
+		const next = pattern[index + 1];
+		const afterNext = pattern[index + 2];
+		if (char === "*" && next === "*" && afterNext === "/") {
+			source += "(?:.*/)?";
+			index += 2;
+			continue;
+		}
+		if (char === "*" && next === "*") {
+			source += ".*";
+			index++;
+			continue;
+		}
+		if (char === "*") {
+			source += "[^/]*";
+			continue;
+		}
+		source += escapeRegex(char);
+	}
+	return new RegExp(`${source}$`);
+}
+
+async function persistRunRecord(spec: LoopSpec, cwd: string, record: LoopRunRecord): Promise<LoopRunResult> {
+	const redactedRecord = redactRunRecord(record);
+	const jsonlPath = await resolveInsideProject(
+		cwd,
+		path.join(".omp", "loop-runs", `${spec.name}.jsonl`),
+		"loop JSONL log",
+	);
+	await assertSafeProjectWrite(cwd, jsonlPath, "loop JSONL log");
+	await fs.mkdir(path.dirname(jsonlPath), { recursive: true });
+	await fs.appendFile(jsonlPath, `${JSON.stringify(redactedRecord)}\n`, { encoding: "utf8", mode: 0o600 });
+	let markdownLogPath: string | null = null;
+	if (spec.state.runLog) {
+		markdownLogPath = await resolveInsideProject(cwd, spec.state.runLog, "loop markdown log");
+		await assertSafeProjectWrite(cwd, markdownLogPath, "loop markdown log");
+		await fs.mkdir(path.dirname(markdownLogPath), { recursive: true });
+		await fs.appendFile(markdownLogPath, markdownLine(redactedRecord), { encoding: "utf8", mode: 0o600 });
+	}
+	return { ...redactedRecord, jsonlPath, markdownLogPath };
+}
+
+function markdownLine(record: LoopRunRecord): string {
+	const summary =
+		record.error ?? (record.approvalReasons.join("; ") || record.agentOutput.split("\n")[0] || "completed");
+	return `| ${record.finishedAt} | ${record.status} | ${record.loop}: ${markdownCell(summary)} |\n`;
+}
+
+function redactRunRecord(record: LoopRunRecord): LoopRunRecord {
+	return {
+		...record,
+		prompt: redactSecrets(record.prompt),
+		agentOutput: redactSecrets(record.agentOutput),
+		approvalReasons: record.approvalReasons.map(redactSecrets),
+		error: record.error ? redactSecrets(record.error) : null,
+		verifierResults: record.verifierResults.map(result => ({
+			...result,
+			command: redactCommandArgs(result.command),
+			stdout: redactSecrets(result.stdout),
+			stderr: redactSecrets(result.stderr),
+		})),
+	};
+}
+
+function markdownCell(value: string): string {
+	return sanitizeText(redactSecrets(value))
+		.replace(/[\r\n\t]+/g, " ")
+		.replace(/[\p{Cc}\p{Cf}]/gu, " ")
+		.replaceAll("|", "\\|")
+		.slice(0, 500);
+}
+
+function redactCommandArgs(argv: string[]): string[] {
+	const redacted: string[] = [];
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index] ?? "";
+		if (isSecretFlag(arg) && index + 1 < argv.length) {
+			redacted.push(arg);
+			redacted.push("[REDACTED_SECRET]");
+			index++;
+			continue;
+		}
+		redacted.push(redactSecrets(arg));
+	}
+	return redacted;
+}
+
+function isSecretFlag(value: string): boolean {
+	return /^--?[A-Za-z0-9_-]*(token|key|secret|password|credential)[A-Za-z0-9_-]*$/i.test(value);
+}
+
+function redactSecrets(value: string): string {
+	return value
+		.replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[REDACTED_SECRET]")
+		.replace(/\b(?:ghp|github_pat|npm|xox[baprs])_[A-Za-z0-9_/-]{10,}\b/g, "[REDACTED_SECRET]")
+		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED_SECRET]")
+		.replace(/\b(Authorization\s*:\s*Bearer\s+)["']?[^"'\s]+/gi, "$1[REDACTED_SECRET]")
+		.replace(
+			/\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*[:=]\s*)["']?[^"'\s]{6,}/gi,
+			"$1[REDACTED_SECRET]",
+		)
+		.replace(
+			/\b(--?[A-Za-z0-9_-]*(?:token|key|secret|password|credential)[A-Za-z0-9_-]*=)["']?[^"'\s]+/gi,
+			"$1[REDACTED_SECRET]",
+		)
+		.replace(/\b(sk-[A-Za-z0-9_-]{16,})\b/g, "[REDACTED_SECRET]")
+		.replace(/\b([A-Za-z0-9._%+-]+:[A-Za-z0-9/+=._-]{16,})\b/g, "[REDACTED_SECRET]");
+}
+
+function truncate(value: string): string {
+	return value.length > OUTPUT_LIMIT ? `${value.slice(0, OUTPUT_LIMIT)}\n[… truncated …]` : value;
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/coding-agent/src/loop-engineering/runner.ts
+++ b/packages/coding-agent/src/loop-engineering/runner.ts
@@ -1,4 +1,7 @@
+import { createHash } from "node:crypto";
+import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
+import { builtinModules } from "node:module";
 import * as path from "node:path";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { prompt, sanitizeText } from "@oh-my-pi/pi-utils";
@@ -20,7 +23,115 @@ const REPORT_LOOP_TOOLS = ["read", "search", "find", "web_search"];
 const VERIFIER_TIMEOUT_MS = 120_000;
 const SHELL_EXECUTABLES = new Set(["bash", "cmd", "fish", "powershell", "pwsh", "sh", "zsh"]);
 const PACKAGE_SCRIPT_RUNNERS = new Set(["bun", "npm", "pnpm", "yarn"]);
+const VERIFIER_SCRIPT_OPERAND_RUNNERS = new Set(["bun", "deno", "node", "tsx", "ts-node"]);
+const NODE_BUILTIN_MODULES = new Set(builtinModules.flatMap(name => [name, `node:${name.replace(/^node:/, "")}`]));
+const VERIFIER_DENIED_NODE_BUILTINS = new Set([
+	"child_process",
+	"cluster",
+	"inspector",
+	"module",
+	"node:child_process",
+	"node:cluster",
+	"node:inspector",
+	"node:module",
+	"node:repl",
+	"node:vm",
+	"node:worker_threads",
+	"repl",
+	"vm",
+	"worker_threads",
+]);
+const VERIFIER_ENV_ALLOWLIST = new Set([
+	"CI",
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"LOGNAME",
+	"PATH",
+	"SYSTEMROOT",
+	"TEMP",
+	"TERM",
+	"TMP",
+	"TMPDIR",
+	"USER",
+	"WINDIR",
+]);
+const VERIFIER_SCRIPT_RUNNER_SUBCOMMANDS = new Map([
+	["bun", new Set(["add", "build", "create", "fig", "help", "init", "install", "pm", "remove", "run", "test", "x"])],
+	[
+		"deno",
+		new Set(["bench", "bundle", "check", "compile", "doc", "fmt", "info", "install", "lint", "run", "task", "test"]),
+	],
+]);
+const VERIFIER_SCRIPT_VALUE_FLAGS = new Map([
+	["bun", new Set(["--define", "--origin", "--preload", "--tsconfig-override", "--user-agent"])],
+	[
+		"deno",
+		new Set(["--cert", "--config", "--env-file", "--import-map", "--location", "--node-modules-dir", "--vendor"]),
+	],
+	[
+		"node",
+		new Set([
+			"--conditions",
+			"-C",
+			"--eval",
+			"-e",
+			"--experimental-loader",
+			"--import",
+			"--loader",
+			"--print",
+			"-p",
+			"--require",
+			"-r",
+		]),
+	],
+	["python", new Set(["-c", "-m", "-W", "-X"])],
+	["python3", new Set(["-c", "-m", "-W", "-X"])],
+	["tsx", new Set(["--require", "-r", "--tsconfig"])],
+	["ts-node", new Set(["--compiler", "-C", "--project", "-P", "--require", "-r", "--transpiler"])],
+]);
 const STATUS_OUTPUT_LIMIT = 1_000_000;
+const VERIFIER_REFERENCE_EXTENSIONS = new Set([
+	".cjs",
+	".cts",
+	".js",
+	".json",
+	".jsonc",
+	".jsx",
+	".mjs",
+	".mts",
+	".py",
+	".sh",
+	".toml",
+	".ts",
+	".tsx",
+	".yaml",
+	".yml",
+]);
+const PACKAGE_MANAGER_CONFIG_FILES = [
+	".npmrc",
+	".yarnrc",
+	".yarnrc.yml",
+	"bun.lock",
+	"bunfig.toml",
+	"package-lock.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"yarn.lock",
+];
+const VERIFIER_DEPENDENCY_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
+const VERIFIER_CONFIG_FILES = [
+	"biome.json",
+	"biome.jsonc",
+	"eslint.config.cjs",
+	"eslint.config.js",
+	"eslint.config.mjs",
+	"tsconfig.json",
+	"tsconfig.build.json",
+	"vitest.config.mts",
+	"vitest.config.ts",
+];
 
 export function buildLoopRunPrompt(spec: LoopSpec): string {
 	return prompt.render(runPromptTemplate, {
@@ -99,8 +210,12 @@ export async function executeLoopIteration(spec: LoopSpec, options: LoopRunOptio
 		agentExitCode === 0 && spec.level !== "report" ? await verifierScriptsChanged(verifierScripts) : null;
 	const verifierResults =
 		agentExitCode === 0 && spec.level !== "report" && !verifierMutationReason
-			? await runVerifierCommands(spec.verifier.commands, options.cwd)
+			? await runVerifierCommands(spec.verifier.commands, options.cwd, verifierScripts)
 			: [];
+	const postVerifierMutationReason =
+		verifierResults.length > 0 && agentExitCode === 0 && spec.level !== "report"
+			? await verifierScriptsChanged(verifierScripts)
+			: null;
 	const observedChangedFiles = await listChangedFiles(options.cwd);
 	const changedFiles = changedFilesSinceBaseline(baselineChangedFiles, observedChangedFiles);
 	const approvalReasons = approvalReasonsFor(spec, changedFiles, verifierResults, {
@@ -108,6 +223,7 @@ export async function executeLoopIteration(spec: LoopSpec, options: LoopRunOptio
 		baselineChangedFileCount: baselineChangedFiles?.length ?? null,
 	});
 	if (verifierMutationReason) approvalReasons.push(verifierMutationReason);
+	if (postVerifierMutationReason) approvalReasons.push(postVerifierMutationReason);
 	const failedVerifier = verifierResults.some(result => result.exitCode !== 0);
 	const finishedAt = options.now?.() ?? new Date();
 	const status =
@@ -185,9 +301,17 @@ function createBaseRecord(spec: LoopSpec, started: Date, promptText: string): Lo
 
 interface VerifierScriptSnapshot {
 	packageJsonPath: string;
+	packageJsonDigest: string;
 	scriptName: string;
 	scriptValue: string;
+	referencedFiles: VerifierReferencedFileSnapshot[];
 	error: string | null;
+}
+
+interface VerifierReferencedFileSnapshot {
+	filePath: string;
+	displayPath: string;
+	digest: string;
 }
 
 async function captureVerifierScriptSnapshots(
@@ -198,20 +322,44 @@ async function captureVerifierScriptSnapshots(
 	for (const command of commands) {
 		const invalidReason = validateVerifierCommand(command);
 		if (invalidReason) {
-			snapshots.push({ packageJsonPath: "", scriptName: "", scriptValue: "", error: invalidReason });
+			snapshots.push({
+				packageJsonPath: "",
+				packageJsonDigest: "",
+				scriptName: "",
+				scriptValue: "",
+				referencedFiles: [],
+				error: invalidReason,
+			});
 			continue;
 		}
 		try {
-			const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : cwd;
+			const rootReal = await fs.realpath(cwd);
+			const pathError = verifierSafePathError(cwd, rootReal);
+			if (pathError) throw new Error(pathError);
+			const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : rootReal;
+			await rejectSymlinkPathComponents(rootReal, commandCwd, "verifier cwd");
 			const script = await readVerifierPackageScript(command, commandCwd);
+			const referencedFiles =
+				script.error === null ? await captureVerifierReferencedFiles(rootReal, commandCwd, script.scriptValue) : [];
 			snapshots.push(
-				script.error ? { packageJsonPath: "", scriptName: "", scriptValue: "", error: script.error } : script,
+				script.error
+					? {
+							packageJsonPath: "",
+							packageJsonDigest: "",
+							scriptName: "",
+							scriptValue: "",
+							referencedFiles: [],
+							error: script.error,
+						}
+					: { ...script, referencedFiles },
 			);
 		} catch (error) {
 			snapshots.push({
 				packageJsonPath: "",
+				packageJsonDigest: "",
 				scriptName: "",
 				scriptValue: "",
+				referencedFiles: [],
 				error: error instanceof Error ? error.message : String(error),
 			});
 		}
@@ -222,19 +370,458 @@ async function captureVerifierScriptSnapshots(
 async function verifierScriptsChanged(snapshots: VerifierScriptSnapshot[]): Promise<string | null> {
 	for (const snapshot of snapshots) {
 		if (snapshot.error) return snapshot.error;
+		const currentPackageJsonDigest = await verifierFileState(snapshot.packageJsonPath);
+		if (currentPackageJsonDigest !== snapshot.packageJsonDigest) {
+			return "verifier package.json changed before verifier execution";
+		}
 		const current = await readPackageScript(snapshot.packageJsonPath, snapshot.scriptName);
 		if (current.error) return current.error;
 		if (current.scriptValue !== snapshot.scriptValue) {
 			return `verifier package.json script ${snapshot.scriptName} changed before verifier execution`;
 		}
+		for (const file of snapshot.referencedFiles) {
+			const currentDigest = await verifierFileState(file.filePath);
+			if (currentDigest !== file.digest) {
+				return `verifier referenced file ${file.displayPath} changed before verifier execution`;
+			}
+		}
 	}
 	return null;
 }
 
-async function runVerifierCommands(commands: LoopCommandSpec[], cwd: string): Promise<LoopVerifierResult[]> {
+async function captureVerifierReferencedFiles(
+	projectCwd: string,
+	commandCwd: string,
+	scriptValue: string,
+): Promise<VerifierReferencedFileSnapshot[]> {
+	const snapshots: VerifierReferencedFileSnapshot[] = [];
+	const rootReal = await fs.realpath(projectCwd);
+	const commandReal = await fs.realpath(commandCwd);
+	const candidates = new Set(verifierScriptLocalPathTokens(scriptValue));
+	for (const candidate of candidates) {
+		const filePath = await resolveVerifierReferencePath(rootReal, commandReal, candidate);
+		await captureVerifierFileAndDependencies(rootReal, commandReal, filePath, snapshots, new Set());
+	}
+	for (const configPath of verifierConfigPaths(rootReal, commandReal)) {
+		const filePath = await resolveVerifierFilePath(rootReal, configPath);
+		snapshots.push({
+			filePath,
+			displayPath: path.relative(commandReal, filePath) || path.basename(filePath),
+			digest: await verifierFileState(filePath),
+		});
+	}
+	return snapshots;
+}
+
+async function captureVerifierFileAndDependencies(
+	rootReal: string,
+	commandReal: string,
+	filePath: string,
+	snapshots: VerifierReferencedFileSnapshot[],
+	seen: Set<string>,
+): Promise<void> {
+	if (seen.has(filePath)) return;
+	seen.add(filePath);
+	const digest = await verifierFileState(filePath);
+	snapshots.push({
+		filePath,
+		displayPath: path.relative(commandReal, filePath) || path.basename(filePath),
+		digest,
+	});
+	if (digest === "missing" || !shouldScanVerifierDependencies(filePath)) return;
+	let content: string;
+	try {
+		content = await Bun.file(filePath).text();
+	} catch {
+		return;
+	}
+	if (hasDynamicVerifierDependency(content)) throw new Error("verifier dependencies must use literal imports");
+	if (hasDeniedVerifierBuiltinDependency(content))
+		throw new Error("verifier dependencies must not import dangerous builtins");
+	if (hasVerifierDynamicCodeApi(content)) throw new Error("verifier dependencies must not use dynamic code APIs");
+	if (hasVerifierEscapedIdentifier(content)) throw new Error("verifier dependencies must not use escaped identifiers");
+	if (hasVerifierProcessExecutionApi(content))
+		throw new Error("verifier dependencies must not use process execution APIs");
+	if (hasVerifierDynamicPropertyAccess(content))
+		throw new Error("verifier dependencies must not use dynamic property access");
+	if (hasBareVerifierDependency(content)) throw new Error("verifier dependencies must use relative or node: imports");
+	const importerDir = path.dirname(filePath);
+	for (const dependencySpecifier of verifierStaticDependencySpecifiers(content)) {
+		const dependencyPath = await resolveVerifierDependencyPath(rootReal, importerDir, dependencySpecifier);
+		if (!dependencyPath) throw new Error(`verifier dependency ${dependencySpecifier} could not be resolved`);
+		await captureVerifierFileAndDependencies(rootReal, commandReal, dependencyPath, snapshots, seen);
+	}
+}
+
+function shouldScanVerifierDependencies(filePath: string): boolean {
+	const extension = path.extname(filePath);
+	return extension.length === 0 || VERIFIER_DEPENDENCY_EXTENSIONS.has(extension);
+}
+
+function verifierStaticDependencySpecifiers(content: string): string[] {
+	const specifiers = new Set<string>();
+	for (const match of content.matchAll(verifierDependencyPattern())) {
+		specifiers.add(match[1] ?? match[2] ?? match[3] ?? "");
+	}
+	specifiers.delete("");
+	return [...specifiers];
+}
+
+function hasBareVerifierDependency(content: string): boolean {
+	for (const match of content.matchAll(verifierAnyLiteralDependencyPattern())) {
+		const specifier = match[1] ?? match[2] ?? match[3] ?? "";
+		if (specifier && !specifier.startsWith(".") && !NODE_BUILTIN_MODULES.has(specifier)) return true;
+	}
+	return false;
+}
+
+function hasDeniedVerifierBuiltinDependency(content: string): boolean {
+	for (const match of content.matchAll(verifierAnyLiteralDependencyPattern())) {
+		const specifier = match[1] ?? match[2] ?? match[3] ?? "";
+		if (VERIFIER_DENIED_NODE_BUILTINS.has(specifier)) return true;
+	}
+	return false;
+}
+
+function hasVerifierDynamicCodeApi(content: string): boolean {
+	return /\b(?:constructor|eval|Function|SharedWorker|Worker)\b/.test(content);
+}
+
+function hasVerifierEscapedIdentifier(content: string): boolean {
+	return /\\(?:u\{?[0-9a-fA-F]+}?|x[0-9a-fA-F]{2})/.test(content);
+}
+
+function hasVerifierDynamicPropertyAccess(content: string): boolean {
+	const gap = verifierJsGap();
+	return new RegExp(`(?:\\b[A-Za-z_$][\\w$]*|\\)|\\])${gap}(?:\\?\\.${gap})?\\[${gap}(?!\\d+${gap}\\])`).test(content);
+}
+
+function hasVerifierProcessExecutionApi(content: string): boolean {
+	const gap = verifierJsGap();
+	return new RegExp(
+		`\\bBun\\b|\\bDeno\\b|\\bprocess${gap}(?:(?:\\?\\.|\\.)${gap}(?:binding|dlopen)\\b|(?:\\?\\.${gap})?\\[${gap}["'](?:binding|dlopen)["']${gap}\\])`,
+	).test(content);
+}
+
+function hasDynamicVerifierDependency(content: string): boolean {
+	const requireRemainder = content.replace(verifierApprovedRequireLiteralPattern(), "");
+	const importRemainder = content.replace(verifierApprovedDynamicImportLiteralPattern(), "");
+	return (
+		/createRequire\b/.test(content) ||
+		/(?:\b|\.)require\b/.test(requireRemainder) ||
+		verifierAnyDynamicImportPattern().test(importRemainder)
+	);
+}
+
+function verifierDependencyPattern(): RegExp {
+	const gap = verifierJsGap();
+	const requireCall = verifierRequireCallPrefix();
+	return new RegExp(
+		`(?:import|export)${gap}(?:[^"']*?${gap}from${gap})?["'](\\.{1,2}\\/[^"']+)["']|import${gap}\\(${gap}["'](\\.{1,2}\\/[^"']+)["']${gap}\\)|${requireCall}${gap}["'](\\.{1,2}\\/[^"']+)["']${gap}\\)`,
+		"g",
+	);
+}
+
+function verifierAnyLiteralDependencyPattern(): RegExp {
+	const gap = verifierJsGap();
+	const requireCall = verifierRequireCallPrefix();
+	return new RegExp(
+		`(?:import|export)${gap}(?:[^"']*?${gap}from${gap})?["']([^"']+)["']|import${gap}\\(${gap}["']([^"']+)["']${gap}\\)|${requireCall}${gap}["']([^"']+)["']${gap}\\)`,
+		"g",
+	);
+}
+
+function verifierAnyDynamicImportPattern(): RegExp {
+	const gap = verifierJsGap();
+	return new RegExp(`\\bimport${gap}\\(`);
+}
+
+function verifierRequireCallPrefix(): string {
+	const gap = verifierJsGap();
+	return `(?:\\b|\\.)require${gap}(?:\\?\\.${gap})?\\(${gap}`;
+}
+
+function verifierApprovedRequireLiteralPattern(): RegExp {
+	const gap = verifierJsGap();
+	return new RegExp(`${verifierRequireCallPrefix()}["'][^"']+["']${gap}\\)`, "g");
+}
+
+function verifierApprovedDynamicImportLiteralPattern(): RegExp {
+	const gap = verifierJsGap();
+	return new RegExp(`\\bimport${gap}\\(${gap}["'][^"']+["']${gap}\\)`, "g");
+}
+
+function verifierJsGap(): string {
+	return String.raw`(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*(?:\n|$))*`;
+}
+
+async function resolveVerifierDependencyPath(
+	rootReal: string,
+	importerDir: string,
+	specifier: string,
+): Promise<string | null> {
+	for (const candidate of verifierDependencyCandidates(specifier)) {
+		try {
+			const filePath = await resolveVerifierReferencePath(rootReal, importerDir, candidate);
+			if ((await verifierFileState(filePath)) !== "missing") return filePath;
+		} catch (error) {
+			if (error instanceof Error && error.message === "verifier referenced file must be a file") continue;
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") continue;
+			throw error;
+		}
+	}
+	return null;
+}
+
+function verifierDependencyCandidates(specifier: string): string[] {
+	if (path.extname(specifier).length > 0) return [specifier];
+	const candidates = [specifier];
+	for (const extension of VERIFIER_DEPENDENCY_EXTENSIONS) candidates.push(`${specifier}${extension}`);
+	for (const extension of VERIFIER_DEPENDENCY_EXTENSIONS) candidates.push(path.join(specifier, `index${extension}`));
+	return candidates;
+}
+
+function verifierScriptLocalPathTokens(scriptValue: string): string[] {
+	const tokens = new Set<string>();
+	for (const rawToken of scriptValue.match(/(?:\.{0,2}\/)?[A-Za-z0-9_@+./-]+\.[A-Za-z0-9]+/g) ?? []) {
+		addVerifierPathToken(tokens, rawToken, true);
+	}
+	for (const match of scriptValue.matchAll(
+		/(?:^|[\s"'(])((?:\.{1,2}\/|[A-Za-z0-9_@+-]+\/)[A-Za-z0-9_@+./-]+)(?=$|[\s"')\],;&|])/g,
+	)) {
+		addVerifierPathToken(tokens, match[1] ?? "", false);
+	}
+	const words = tokenizeVerifierScript(scriptValue);
+	for (const [index, word] of words.entries()) {
+		const runnerName = path.basename(word).toLowerCase();
+		if (!VERIFIER_SCRIPT_OPERAND_RUNNERS.has(runnerName)) continue;
+		for (const operand of verifierRunnerOperands(runnerName, words, index + 1)) {
+			if (isVerifierRunnerSubcommand(runnerName, operand)) continue;
+			addVerifierPathToken(tokens, operand, false);
+		}
+	}
+	return [...tokens];
+}
+
+function addVerifierPathToken(tokens: Set<string>, rawToken: string, requireKnownExtension: boolean): void {
+	const token = rawToken.replace(/^['"({[]+|['")}\],;]+$/g, "");
+	if (token.length === 0 || token.startsWith("-")) return;
+	const extension = path.extname(token);
+	if (extension.length > 0 && !VERIFIER_REFERENCE_EXTENSIONS.has(extension)) return;
+	if (requireKnownExtension && extension.length === 0) return;
+	tokens.add(token);
+}
+
+function tokenizeVerifierScript(scriptValue: string): string[] {
+	return [...scriptValue.matchAll(/"([^"]*)"|'([^']*)'|[^\s"';&|()]+/g)].map(
+		match => match[1] ?? match[2] ?? match[0],
+	);
+}
+
+function verifierRunnerOperands(runnerName: string, words: string[], start: number): string[] {
+	const operands: string[] = [];
+	for (let index = start; index < words.length; index++) {
+		const word = words[index] ?? "";
+		if (word.length === 0) continue;
+		if (word === "--") {
+			operands.push(...words.slice(index + 1).filter(value => value.length > 0));
+			break;
+		}
+		if (word.startsWith("-")) {
+			if (verifierRunnerFlagConsumesValue(runnerName, word)) index++;
+			continue;
+		}
+		operands.push(word);
+	}
+	return operands;
+}
+
+function firstVerifierRunnerOperand(runnerName: string, words: string[], start: number): string | null {
+	return verifierRunnerOperands(runnerName, words, start)[0] ?? null;
+}
+
+function verifierRunnerFlagConsumesValue(runnerName: string, word: string): boolean {
+	const flag = word.split("=", 1)[0] ?? word;
+	return !word.includes("=") && (VERIFIER_SCRIPT_VALUE_FLAGS.get(runnerName)?.has(flag) ?? false);
+}
+
+function isVerifierRunnerSubcommand(runnerName: string, operand: string): boolean {
+	return VERIFIER_SCRIPT_RUNNER_SUBCOMMANDS.get(runnerName)?.has(operand) ?? false;
+}
+
+async function resolveVerifierReferencePath(
+	rootReal: string,
+	commandReal: string,
+	relativePath: string,
+): Promise<string> {
+	if (path.isAbsolute(relativePath)) throw new Error("verifier referenced file must be relative to the project");
+	return resolveVerifierFilePath(rootReal, path.resolve(commandReal, relativePath));
+}
+
+async function resolveVerifierFilePath(rootReal: string, filePath: string): Promise<string> {
+	const lexicalContainment = path.relative(rootReal, filePath);
+	if (lexicalContainment.startsWith("..") || path.isAbsolute(lexicalContainment)) {
+		throw new Error("verifier referenced file must stay inside the project");
+	}
+	await rejectSymlinkPathComponents(rootReal, filePath, "verifier referenced file");
+	let stat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		stat = await fs.lstat(filePath);
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return filePath;
+		throw error;
+	}
+	if (stat.isSymbolicLink()) throw new Error("verifier referenced file must not be a symlink");
+	if (!stat.isFile()) throw new Error("verifier referenced file must be a file");
+	const targetReal = await fs.realpath(filePath);
+	const containment = path.relative(rootReal, targetReal);
+	if (containment.startsWith("..") || path.isAbsolute(containment)) {
+		throw new Error("verifier referenced file must stay inside the project");
+	}
+	return targetReal;
+}
+async function rejectSymlinkPathComponents(rootReal: string, targetPath: string, label: string): Promise<void> {
+	const relative = path.relative(rootReal, targetPath);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) throw new Error(`${label} must stay inside the project`);
+	let current = rootReal;
+	for (const part of relative.split(path.sep)) {
+		if (!part) continue;
+		current = path.join(current, part);
+		try {
+			const stat = await fs.lstat(current);
+			if (stat.isSymbolicLink()) throw new Error(`${label} must not pass through a symlink`);
+		} catch (error) {
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return;
+			throw error;
+		}
+	}
+}
+
+function inheritedPathValue(): string {
+	for (const [key, value] of Object.entries(process.env)) {
+		if (key.toUpperCase() === "PATH" && typeof value === "string") return value;
+	}
+	return "";
+}
+
+function verifierRuntimePath(projectCwd: string, projectRootReal: string): string {
+	return sanitizedVerifierPath(inheritedPathValue(), projectCwd, projectRootReal);
+}
+
+function verifierSafePathError(projectCwd: string, projectRootReal: string): string | null {
+	return verifierRuntimePath(projectCwd, projectRootReal).split(path.delimiter).some(Boolean)
+		? null
+		: "verifier PATH has no safe absolute runtime entries";
+}
+
+function verifierRuntimeEnv(
+	projectCwd: string,
+	projectRootReal: string = path.resolve(projectCwd),
+): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		const envKey = key.toUpperCase();
+		if (envKey === "PATH" || typeof value !== "string" || !VERIFIER_ENV_ALLOWLIST.has(envKey)) continue;
+		env[key] = value;
+	}
+	env.PATH = verifierRuntimePath(projectCwd, projectRootReal);
+	return env;
+}
+
+function sanitizedVerifierPath(rawPath: string, projectCwd: string, projectRootReal: string): string {
+	const normalizedRoots = [
+		...new Set(
+			[path.resolve(projectCwd), path.resolve(projectRootReal), ...normalizedPathAliases(projectRootReal)].map(
+				root => root.toLowerCase(),
+			),
+		),
+	];
+	return rawPath
+		.split(path.delimiter)
+		.filter(segment => {
+			if (segment.length === 0 || !path.isAbsolute(segment)) return false;
+			const normalizedSegments = normalizedPathAliases(segment).map(candidate => candidate.toLowerCase());
+			if (
+				normalizedSegments.some(normalizedSegment =>
+					normalizedRoots.some(
+						normalizedRoot =>
+							normalizedSegment === normalizedRoot ||
+							normalizedSegment.startsWith(`${normalizedRoot}${path.sep}`),
+					),
+				)
+			)
+				return false;
+			return !normalizedSegments.some(normalizedSegment =>
+				normalizedSegment.split(path.sep).includes("node_modules"),
+			);
+		})
+		.join(path.delimiter);
+}
+
+function normalizedPathAliases(targetPath: string): string[] {
+	const resolved = path.resolve(targetPath);
+	const aliases = [resolved];
+	try {
+		aliases.push(nodeFs.realpathSync(resolved));
+	} catch {
+		// Nonexistent PATH segments are compared lexically only.
+	}
+	return [...new Set(aliases)];
+}
+
+function verifierConfigPaths(rootReal: string, commandReal: string): string[] {
+	const paths: string[] = [];
+	for (let current = commandReal; ; current = path.dirname(current)) {
+		for (const configFile of [...VERIFIER_CONFIG_FILES, ...PACKAGE_MANAGER_CONFIG_FILES])
+			paths.push(path.join(current, configFile));
+		if (current === rootReal) break;
+		const relative = path.relative(rootReal, path.dirname(current));
+		if (relative.startsWith("..") || path.isAbsolute(relative)) break;
+	}
+	return paths;
+}
+
+async function hashFile(filePath: string): Promise<string> {
+	return createHash("sha256")
+		.update(await fs.readFile(filePath))
+		.digest("hex");
+}
+
+async function verifierFileState(filePath: string): Promise<string> {
+	try {
+		const stat = await fs.lstat(filePath);
+		if (stat.isSymbolicLink()) return "symlink";
+		if (!stat.isFile()) return "non-file";
+		return `sha256:${await hashFile(filePath)}`;
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error) {
+			const code = error.code;
+			if (code === "ENOENT" || code === "ENOTDIR" || code === "EISDIR") return "missing";
+		}
+		throw error;
+	}
+}
+
+async function runVerifierCommands(
+	commands: LoopCommandSpec[],
+	cwd: string,
+	verifierScripts: VerifierScriptSnapshot[],
+): Promise<LoopVerifierResult[]> {
 	const results: LoopVerifierResult[] = [];
 	for (const command of commands) {
+		let started = Date.now();
+		const beforeReason = await verifierScriptsChanged(verifierScripts);
+		if (beforeReason) {
+			results.push(verifierError(command, beforeReason, started));
+			break;
+		}
 		results.push(await runCommand(command, cwd));
+		started = Date.now();
+		const afterReason = await verifierScriptsChanged(verifierScripts);
+		if (afterReason) {
+			results.push(verifierError(command, afterReason, started));
+			break;
+		}
 	}
 	return results;
 }
@@ -244,11 +831,17 @@ async function runCommand(command: LoopCommandSpec, cwd: string): Promise<LoopVe
 	const invalidReason = validateVerifierCommand(command);
 	if (invalidReason) return verifierError(command, invalidReason, started);
 	try {
-		const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : cwd;
-		const scriptError = await validateVerifierPackageScriptTarget(command, commandCwd);
-		if (scriptError) return verifierError(command, scriptError, started);
-		const proc = Bun.spawn(command.argv, {
+		const rootReal = await fs.realpath(cwd);
+		const pathError = verifierSafePathError(cwd, rootReal);
+		if (pathError) return verifierError(command, pathError, started);
+		const commandCwd = command.cwd ? await resolveInsideProject(cwd, command.cwd, "verifier cwd") : rootReal;
+		await rejectSymlinkPathComponents(rootReal, commandCwd, "verifier cwd");
+		const script = await readVerifierPackageScript(command, commandCwd);
+		if (script.error) return verifierError(command, script.error, started);
+		const verifierArgv = tokenizeVerifierScript(script.scriptValue);
+		const proc = Bun.spawn(verifierArgv, {
 			cwd: commandCwd,
+			env: verifierRuntimeEnv(cwd, rootReal),
 			stdout: "pipe",
 			stderr: "pipe",
 		});
@@ -308,14 +901,6 @@ function isAllowedVerifierPackageScript(executableName: string, argv: string[]):
 	return argv[1] === "run" && typeof argv[2] === "string" && argv[2].length > 0 && !argv[2].startsWith("-");
 }
 
-async function validateVerifierPackageScriptTarget(
-	command: LoopCommandSpec,
-	commandCwd: string,
-): Promise<string | null> {
-	const script = await readVerifierPackageScript(command, commandCwd);
-	return script.error;
-}
-
 async function readVerifierPackageScript(
 	command: LoopCommandSpec,
 	commandCwd: string,
@@ -337,8 +922,24 @@ async function readVerifierPackageScript(
 		return verifierScriptError("verifier script name must be a package.json script key");
 	}
 	const packageJsonPath = await resolveInsideProject(commandCwd, "package.json", "verifier package.json");
+	const packageJsonError = await validateVerifierPackageJson(packageJsonPath);
+	if (packageJsonError) return verifierScriptError(packageJsonError);
+	const packageJsonDigest = await verifierFileState(packageJsonPath);
 	const script = await readPackageScript(packageJsonPath, scriptName);
-	return script.error ? verifierScriptError(script.error) : { ...script, packageJsonPath, error: null };
+	return script.error
+		? verifierScriptError(script.error)
+		: { ...script, packageJsonPath, packageJsonDigest, referencedFiles: [], error: null };
+}
+
+async function validateVerifierPackageJson(packageJsonPath: string): Promise<string | null> {
+	try {
+		const stat = await fs.lstat(packageJsonPath);
+		if (stat.isSymbolicLink()) return "verifier package.json must not be a symlink";
+		if (!stat.isFile()) return "verifier package.json must be a file";
+		return null;
+	} catch (error) {
+		return `verifier package.json could not be read: ${error instanceof Error ? error.message : String(error)}`;
+	}
 }
 
 async function readPackageScript(
@@ -359,11 +960,131 @@ async function readPackageScript(
 	if (typeof scriptValue !== "string") {
 		return { scriptName, scriptValue: "", error: `verifier script ${scriptName} is not defined in package.json` };
 	}
+	const safetyError = validateVerifierPackageScriptSafety(scriptName, scriptValue, parsed.scripts ?? {});
+	if (safetyError) return { scriptName, scriptValue: "", error: safetyError };
 	return { scriptName, scriptValue, error: null };
 }
 
+function validateVerifierPackageScriptSafety(
+	scriptName: string,
+	scriptValue: string,
+	scripts: Record<string, unknown>,
+): string | null {
+	for (const lifecycleScriptName of [`pre${scriptName}`, `post${scriptName}`]) {
+		if (typeof scripts[lifecycleScriptName] === "string") {
+			return `verifier lifecycle script ${lifecycleScriptName} is not allowed`;
+		}
+	}
+	if (containsUnsafeVerifierShellSyntax(scriptValue)) {
+		return "verifier package scripts must not use shell expansion, escaping, or metacharacters";
+	}
+	if (containsNodePackageScriptDelegation(scriptValue)) {
+		return "verifier package scripts must not delegate through node --run";
+	}
+	if (containsNestedPackageRunner(scriptValue)) {
+		return "verifier package scripts must not invoke nested package scripts";
+	}
+	if (containsUnsupportedVerifierRunnerSubcommand(scriptValue)) {
+		return "verifier package scripts must not use runner subcommands";
+	}
+	if (!usesApprovedLocalVerifierEntrypoint(scriptValue)) {
+		return "verifier package scripts must execute a local verifier file through an approved runtime";
+	}
+	return null;
+}
+
+function containsUnsafeVerifierShellSyntax(scriptValue: string): boolean {
+	return /["'\\`$*?[\]{}<>;&|\r\n]/.test(scriptValue) || /:\/\/|(?:^|\s)[A-Za-z][A-Za-z0-9+.-]*:/.test(scriptValue);
+}
+
+function containsNodePackageScriptDelegation(scriptValue: string): boolean {
+	const words = tokenizeVerifierScript(scriptValue);
+	for (const [index, word] of words.entries()) {
+		if (path.basename(word).toLowerCase() !== "node") continue;
+		if (words.slice(index + 1).some(value => value === "--run" || value.startsWith("--run="))) return true;
+	}
+	return false;
+}
+
+function usesApprovedLocalVerifierEntrypoint(scriptValue: string): boolean {
+	const words = tokenizeVerifierScript(scriptValue);
+	const runtimeToken = words[0] ?? "";
+	if (
+		runtimeToken !== path.basename(runtimeToken) ||
+		runtimeToken.includes("/") ||
+		runtimeToken.includes("\\") ||
+		path.isAbsolute(runtimeToken)
+	) {
+		return false;
+	}
+	const runnerName = runtimeToken.toLowerCase();
+	if (!VERIFIER_SCRIPT_OPERAND_RUNNERS.has(runnerName)) return false;
+	if (hasEntrypointBlockingFlag(words, 1)) return false;
+	const operand = firstVerifierRunnerOperand(runnerName, words, 1);
+	return !!operand && !isVerifierRunnerSubcommand(runnerName, operand) && looksLikeDirectVerifierFileOperand(operand);
+}
+
+function hasEntrypointBlockingFlag(words: string[], start: number): boolean {
+	for (let index = start; index < words.length; index++) {
+		const word = words[index] ?? "";
+		if (word.length === 0) continue;
+		if (word === "--") return false;
+		return word.startsWith("-");
+	}
+	return false;
+}
+
+function containsNestedPackageRunner(scriptValue: string): boolean {
+	const words = tokenizeVerifierScript(scriptValue);
+	for (const [index, word] of words.entries()) {
+		const runnerName = path.basename(word).toLowerCase();
+		if (!PACKAGE_SCRIPT_RUNNERS.has(runnerName)) continue;
+		if (runnerName !== "bun") return true;
+		const operand = firstVerifierRunnerOperand(runnerName, words, index + 1);
+		if (!operand || isVerifierRunnerSubcommand(runnerName, operand) || !looksLikeDirectVerifierFileOperand(operand)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function looksLikeDirectVerifierFileOperand(operand: string): boolean {
+	if (
+		operand.includes("://") ||
+		/^[A-Za-z][A-Za-z0-9+.-]*:/.test(operand) ||
+		path.isAbsolute(operand) ||
+		operand.startsWith("-")
+	) {
+		return false;
+	}
+	return (
+		operand.startsWith("./") || operand.startsWith("../") || VERIFIER_REFERENCE_EXTENSIONS.has(path.extname(operand))
+	);
+}
+
+function looksLikeExplicitVerifierFileOperand(operand: string): boolean {
+	return (
+		looksLikeDirectVerifierFileOperand(operand) &&
+		(operand.startsWith("./") ||
+			operand.startsWith("../") ||
+			VERIFIER_REFERENCE_EXTENSIONS.has(path.extname(operand)))
+	);
+}
+
+function containsUnsupportedVerifierRunnerSubcommand(scriptValue: string): boolean {
+	const words = tokenizeVerifierScript(scriptValue);
+	for (const [index, word] of words.entries()) {
+		const runnerName = path.basename(word).toLowerCase();
+		if (!VERIFIER_SCRIPT_RUNNER_SUBCOMMANDS.has(runnerName)) continue;
+		const operand = firstVerifierRunnerOperand(runnerName, words, index + 1);
+		if (runnerName === "deno" && operand && !looksLikeExplicitVerifierFileOperand(operand)) return true;
+		if (operand && !looksLikeDirectVerifierFileOperand(operand)) return true;
+	}
+	return false;
+}
+
 function verifierScriptError(error: string): VerifierScriptSnapshot {
-	return { packageJsonPath: "", scriptName: "", scriptValue: "", error };
+	return { packageJsonPath: "", packageJsonDigest: "", scriptName: "", scriptValue: "", referencedFiles: [], error };
 }
 
 function verifierError(command: LoopCommandSpec, message: string, started: number): LoopVerifierResult {
@@ -422,10 +1143,6 @@ async function readStatusOutput(stream: ReadableStream<Uint8Array> | null): Prom
 	} finally {
 		reader.releaseLock();
 	}
-}
-
-function appendLine(value: string, line: string): string {
-	return value.length > 0 ? `${value}\n${line}` : line;
 }
 
 async function listChangedFiles(cwd: string): Promise<string[] | null> {
@@ -566,17 +1283,34 @@ async function persistRunRecord(spec: LoopSpec, cwd: string, record: LoopRunReco
 		path.join(".omp", "loop-runs", `${spec.name}.jsonl`),
 		"loop JSONL log",
 	);
-	await assertSafeProjectWrite(cwd, jsonlPath, "loop JSONL log");
-	await fs.mkdir(path.dirname(jsonlPath), { recursive: true });
-	await fs.appendFile(jsonlPath, `${JSON.stringify(redactedRecord)}\n`, { encoding: "utf8", mode: 0o600 });
+	await appendRunLogLine(cwd, jsonlPath, "loop JSONL log", `${JSON.stringify(redactedRecord)}\n`);
 	let markdownLogPath: string | null = null;
 	if (spec.state.runLog) {
 		markdownLogPath = await resolveInsideProject(cwd, spec.state.runLog, "loop markdown log");
-		await assertSafeProjectWrite(cwd, markdownLogPath, "loop markdown log");
-		await fs.mkdir(path.dirname(markdownLogPath), { recursive: true });
-		await fs.appendFile(markdownLogPath, markdownLine(redactedRecord), { encoding: "utf8", mode: 0o600 });
+		await appendRunLogLine(cwd, markdownLogPath, "loop markdown log", markdownLine(redactedRecord));
 	}
 	return { ...redactedRecord, jsonlPath, markdownLogPath };
+}
+
+async function appendRunLogLine(cwd: string, logPath: string, label: string, line: string): Promise<void> {
+	await assertSafeProjectWrite(cwd, logPath, label);
+	await fs.mkdir(path.dirname(logPath), { recursive: true });
+	await assertSafeProjectWrite(cwd, logPath, label);
+	const rootReal = await fs.realpath(cwd);
+	await rejectSymlinkPathComponents(rootReal, logPath, label);
+	const noFollow = "O_NOFOLLOW" in nodeFs.constants ? nodeFs.constants.O_NOFOLLOW : 0;
+	const fd = nodeFs.openSync(
+		logPath,
+		nodeFs.constants.O_WRONLY | nodeFs.constants.O_CREAT | nodeFs.constants.O_APPEND | noFollow,
+		0o600,
+	);
+	try {
+		const stat = nodeFs.fstatSync(fd);
+		if (!stat.isFile()) throw new Error(`${label} must be a file`);
+		nodeFs.writeFileSync(fd, line, { encoding: "utf8" });
+	} finally {
+		nodeFs.closeSync(fd);
+	}
 }
 
 function markdownLine(record: LoopRunRecord): string {
@@ -631,7 +1365,7 @@ function isSecretFlag(value: string): boolean {
 function redactSecrets(value: string): string {
 	return value
 		.replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[REDACTED_SECRET]")
-		.replace(/\b(?:ghp|github_pat|npm|xox[baprs])_[A-Za-z0-9_/-]{10,}\b/g, "[REDACTED_SECRET]")
+		.replace(/\b(?:ghp|github_pat|npm|xox[baprs])[-_][A-Za-z0-9_/-]{10,}\b/g, "[REDACTED_SECRET]")
 		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED_SECRET]")
 		.replace(/\b(Authorization\s*:\s*Bearer\s+)["']?[^"'\s]+/gi, "$1[REDACTED_SECRET]")
 		.replace(

--- a/packages/coding-agent/src/loop-engineering/scaffold.ts
+++ b/packages/coding-agent/src/loop-engineering/scaffold.ts
@@ -1,0 +1,87 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { assertSafeProjectWrite, resolveInsideProject } from "./paths";
+import { normalizeName } from "./schema";
+import loopDocTemplate from "./templates/LOOP.md" with { type: "text" };
+import budgetTemplate from "./templates/loop-budget.md" with { type: "text" };
+import runLogTemplate from "./templates/loop-run-log.md" with { type: "text" };
+import specTemplate from "./templates/loop-spec.loop.yaml" with { type: "text" };
+import stateTemplate from "./templates/STATE.md" with { type: "text" };
+
+export interface ScaffoldLoopOptions {
+	cwd: string;
+	name: string;
+	pattern?: string;
+	force?: boolean;
+}
+
+export interface ScaffoldLoopResult {
+	name: string;
+	created: string[];
+	skipped: string[];
+}
+
+export async function scaffoldLoopProject(options: ScaffoldLoopOptions): Promise<ScaffoldLoopResult> {
+	const name = normalizeName(options.name);
+	const context = buildScaffoldContext(name, options.pattern ?? "daily-triage");
+	const files = [
+		{ relativePath: path.join(".omp", "loops", `${name}.loop.yaml`), content: prompt.render(specTemplate, context) },
+		{ relativePath: "LOOP.md", content: prompt.render(loopDocTemplate, context) },
+		{ relativePath: "STATE.md", content: prompt.render(stateTemplate, context) },
+		{ relativePath: "loop-budget.md", content: prompt.render(budgetTemplate, context) },
+		{ relativePath: "loop-run-log.md", content: prompt.render(runLogTemplate, context) },
+	];
+
+	const created: string[] = [];
+	const skipped: string[] = [];
+	for (const file of files) {
+		const absolutePath = await resolveInsideProject(options.cwd, file.relativePath, file.relativePath);
+		if (!options.force && (await fileExists(absolutePath))) {
+			throw new Error(`${file.relativePath} already exists; pass --force to overwrite loop starter files`);
+		}
+		if (options.force && (await fileExists(absolutePath))) skipped.push(absolutePath);
+		await assertSafeProjectWrite(options.cwd, absolutePath, file.relativePath);
+		await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+		await Bun.write(absolutePath, file.content);
+		created.push(absolutePath);
+	}
+	return { name, created, skipped };
+}
+
+function buildScaffoldContext(name: string, pattern: string): Record<string, unknown> {
+	const title = titleCase(name);
+	const isCi = pattern === "ci-sweeper" || name.includes("ci");
+	return {
+		name,
+		title,
+		goal: isCi
+			? "Find one actionable CI failure, fix it when safe, and report verifier results."
+			: "Triage repository activity and report the most important next actions.",
+		level: isCi ? "assisted" : "report",
+		non_goals: ["Do not deploy, push, merge, or comment publicly without explicit approval."],
+		scope_paths: ["."],
+		max_iterations: isCi ? 3 : 1,
+		verifier_command: isCi,
+		max_files_changed: isCi ? 8 : 0,
+		run_log: "loop-run-log.md",
+	};
+}
+
+function titleCase(value: string): string {
+	return value
+		.split("-")
+		.filter(part => part.length > 0)
+		.map(part => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+		.join(" ");
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/loop-engineering/schema.ts
+++ b/packages/coding-agent/src/loop-engineering/schema.ts
@@ -1,0 +1,193 @@
+import * as path from "node:path";
+import type {
+	LoopCommandSpec,
+	LoopGuardrails,
+	LoopLevel,
+	LoopScope,
+	LoopSpec,
+	LoopStateSpec,
+	LoopTrigger,
+	LoopTriggerType,
+	LoopVerifierSpec,
+} from "./types";
+
+const DEFAULT_DENYLIST_PATHS = [
+	".env",
+	".env.*",
+	"**/secrets/**",
+	"**/credentials/**",
+	"**/*_key*",
+	"**/*_secret*",
+	".terraform/**",
+	"k8s/production/**",
+	"**/migrations/**",
+];
+
+const LOOP_LEVELS: Record<LoopLevel, true> = { autonomous: true, assisted: true, report: true };
+const TRIGGER_TYPES: Record<LoopTriggerType, true> = {
+	cron: true,
+	"github-actions": true,
+	"launch-agent": true,
+	manual: true,
+};
+
+export function parseLoopSpec(content: string, sourcePath?: string): LoopSpec {
+	const raw = Bun.YAML.parse(content) as unknown;
+	const root = asRecord(raw);
+	const loop = root ? asRecord(root.loop) : null;
+	if (!loop) throw new Error("Loop spec must have a top-level 'loop' object");
+
+	const level = stringValue(loop.level) || "report";
+	if (!LOOP_LEVELS[level as LoopLevel]) {
+		throw new Error("loop.level must be one of: report, assisted, autonomous");
+	}
+
+	return {
+		name: normalizeName(stringValue(loop.name) || "loop"),
+		goal: stringValue(loop.goal) || "",
+		level: level as LoopLevel,
+		nonGoals: stringArray(loop.non_goals),
+		scope: parseScope(loop.scope),
+		trigger: parseTrigger(loop.trigger),
+		runner: { prompt: stringValue(asRecord(loop.runner)?.prompt) || "" },
+		verifier: parseVerifier(loop.verifier),
+		guardrails: parseGuardrails(loop.guardrails),
+		state: parseState(loop.state),
+		sourcePath,
+	};
+}
+
+export function normalizeName(name: string): string {
+	const normalized = name
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized || "loop";
+}
+
+export function defaultDenylistPaths(): string[] {
+	return [...DEFAULT_DENYLIST_PATHS];
+}
+
+function parseScope(value: unknown): LoopScope {
+	const scope = asRecord(value);
+	return {
+		paths: stringArray(scope?.paths, ["."]),
+		branches: stringArray(scope?.branches),
+		repos: stringArray(scope?.repos),
+	};
+}
+
+function parseTrigger(value: unknown): LoopTrigger {
+	const trigger = asRecord(value);
+	const type = stringValue(trigger?.type) || "manual";
+	return {
+		type: TRIGGER_TYPES[type as LoopTriggerType] ? (type as LoopTriggerType) : "manual",
+		cadence: stringValue(trigger?.cadence),
+		fireImmediately: booleanValue(trigger?.fire_immediately) ?? false,
+	};
+}
+
+function parseVerifier(value: unknown): LoopVerifierSpec {
+	const verifier = asRecord(value);
+	return {
+		separate: booleanValue(verifier?.separate) ?? false,
+		commands: commandArray(verifier?.commands),
+	};
+}
+
+function parseGuardrails(value: unknown): LoopGuardrails {
+	const guardrails = asRecord(value);
+	return {
+		maxIterations: positiveInteger(guardrails?.max_iterations),
+		maxFilesChanged: nonNegativeInteger(guardrails?.max_files_changed),
+		maxAutoPrsPerDay: nonNegativeInteger(guardrails?.max_auto_prs_per_day),
+		requireHumanApproval: stringArray(guardrails?.require_human_approval),
+		denylistPaths: [...new Set([...DEFAULT_DENYLIST_PATHS, ...stringArray(guardrails?.denylist_paths)])],
+	};
+}
+
+function parseState(value: unknown): LoopStateSpec {
+	const state = asRecord(value);
+	return {
+		file: projectRelativePath(state?.file, "loop.state.file"),
+		runLog: safeRunLogPath(state?.run_log),
+		budget: projectRelativePath(state?.budget, "loop.state.budget"),
+	};
+}
+
+function commandArray(value: unknown): LoopCommandSpec[] {
+	if (!Array.isArray(value)) return [];
+	const commands: LoopCommandSpec[] = [];
+	for (const item of value) {
+		if (Array.isArray(item)) {
+			commands.push({ argv: parseArgv(item) });
+			continue;
+		}
+		const record = asRecord(item);
+		if (!record) throw new Error("loop.verifier.commands entries must be argv arrays or objects with argv arrays");
+		if (!Array.isArray(record.argv))
+			throw new Error("loop.verifier.commands object entries must include an argv array");
+		const cwd = record.cwd === undefined ? undefined : stringValue(record.cwd);
+		if (record.cwd !== undefined && !cwd) throw new Error("loop.verifier.commands cwd must be a non-empty string");
+		commands.push({ argv: parseArgv(record.argv), cwd: cwd ?? undefined });
+	}
+	return commands;
+}
+
+function parseArgv(value: unknown[]): string[] {
+	if (value.length === 0) throw new Error("loop.verifier.commands argv must not be empty");
+	return value.map(part => {
+		if (typeof part !== "string" || part.length === 0) {
+			throw new Error("loop.verifier.commands argv entries must be non-empty strings");
+		}
+		return part;
+	});
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function projectRelativePath(value: unknown, label: string): string | null {
+	const raw = stringValue(value);
+	if (!raw) return null;
+	if (path.isAbsolute(raw)) throw new Error(`${label} must be relative to the project`);
+	const normalized = path.normalize(raw);
+	if (normalized === "." || normalized.startsWith("..") || path.isAbsolute(normalized)) {
+		throw new Error(`${label} must stay inside the project`);
+	}
+	return normalized;
+}
+
+function safeRunLogPath(value: unknown): string | null {
+	const raw = projectRelativePath(value, "loop.state.run_log");
+	if (!raw) return null;
+	const normalized = raw.replaceAll("\\", "/");
+	if (normalized === "loop-run-log.md") return raw;
+	if (normalized.startsWith(".omp/loop-runs/") && normalized.endsWith(".md")) return raw;
+	throw new Error("loop.state.run_log must be loop-run-log.md or a Markdown file under .omp/loop-runs/");
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function booleanValue(value: unknown): boolean | null {
+	return typeof value === "boolean" ? value : null;
+}
+
+function stringArray(value: unknown, fallback: string[] = []): string[] {
+	if (!Array.isArray(value)) return [...fallback];
+	return value.filter(item => typeof item === "string" && item.trim().length > 0).map(item => item.trim());
+}
+
+function positiveInteger(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : null;
+}

--- a/packages/coding-agent/src/loop-engineering/templates/LOOP.md
+++ b/packages/coding-agent/src/loop-engineering/templates/LOOP.md
@@ -1,0 +1,33 @@
+# {{title}} Loop
+
+Inspired by cobusgreyling/loop-engineering: https://github.com/cobusgreyling/loop-engineering
+
+## Goal
+
+{{goal}}
+
+## Non-goals
+
+{{#each non_goals}}
+- {{this}}
+{{/each}}
+
+## Operating level
+
+{{level}}
+
+## Scope
+
+{{#each scope_paths}}
+- {{this}}
+{{/each}}
+
+## Budget and stop rules
+
+- Max iterations per run: {{max_iterations}}
+- Max files changed: {{max_files_changed}}
+- Human approval required for protected paths, pushes, deploys, and ambiguous instructions.
+
+## Verifier contract
+
+The implementer cannot mark its own work done. `omp loop run {{name}}` runs verifier commands after the agent iteration and records the outcome in `{{run_log}}`.

--- a/packages/coding-agent/src/loop-engineering/templates/STATE.md
+++ b/packages/coding-agent/src/loop-engineering/templates/STATE.md
@@ -1,0 +1,17 @@
+# {{title}} State
+
+## Current status
+
+Not started.
+
+## Decisions
+
+- Created by `omp loop init {{name}}`.
+
+## Open questions
+
+- None yet.
+
+## Escalations
+
+- None yet.

--- a/packages/coding-agent/src/loop-engineering/templates/loop-budget.md
+++ b/packages/coding-agent/src/loop-engineering/templates/loop-budget.md
@@ -1,0 +1,11 @@
+# {{title}} Budget
+
+## Caps
+
+- Max iterations per run: {{max_iterations}}
+- Max files changed per run: {{max_files_changed}}
+- Max auto PRs per day: 0
+
+## Kill switch
+
+Pause this loop by removing its scheduler entry or setting `loop.trigger.type: manual` in `.omp/loops/{{name}}.loop.yaml`.

--- a/packages/coding-agent/src/loop-engineering/templates/loop-run-log.md
+++ b/packages/coding-agent/src/loop-engineering/templates/loop-run-log.md
@@ -1,0 +1,6 @@
+# {{title}} Run Log
+
+Append-only history for `{{name}}`.
+
+| Time | Status | Summary |
+| --- | --- | --- |

--- a/packages/coding-agent/src/loop-engineering/templates/loop-spec.loop.yaml
+++ b/packages/coding-agent/src/loop-engineering/templates/loop-spec.loop.yaml
@@ -1,0 +1,46 @@
+# OMP loop spec. Source inspiration: https://github.com/cobusgreyling/loop-engineering
+loop:
+  name: {{name}}
+  goal: {{goal}}
+  level: {{level}}
+  non_goals:
+    - Do not deploy, push, merge, or comment publicly without explicit approval.
+  scope:
+    paths:
+      - .
+    branches:
+      - main
+  trigger:
+    type: manual
+    cadence: daily
+    fire_immediately: false
+  runner:
+    prompt: |
+      Follow LOOP.md and STATE.md. Complete one {{title}} iteration, then stop with a concise report.
+  verifier:
+    separate: true
+    commands:{{#if verifier_command}}
+      - ["bun", "run", "check"]{{else}} []{{/if}}
+  guardrails:
+    max_iterations: {{max_iterations}}
+    max_files_changed: {{max_files_changed}}
+    max_auto_prs_per_day: 0
+    require_human_approval:
+      - protected_paths
+      - push
+      - deploy
+      - external_comments
+    denylist_paths:
+      - .env
+      - .env.*
+      - "**/secrets/**"
+      - "**/credentials/**"
+      - "**/*_key*"
+      - "**/*_secret*"
+      - ".terraform/**"
+      - "k8s/production/**"
+      - "**/migrations/**"
+  state:
+    file: STATE.md
+    run_log: loop-run-log.md
+    budget: loop-budget.md

--- a/packages/coding-agent/src/loop-engineering/templates/run-prompt.md
+++ b/packages/coding-agent/src/loop-engineering/templates/run-prompt.md
@@ -1,0 +1,37 @@
+You are running one scheduled-safe OMP loop-engineering iteration.
+
+Loop: {{name}}
+Level: {{level}}
+Goal: {{goal}}
+
+Non-goals:
+{{#each non_goals}}
+- {{this}}
+{{/each}}
+
+Watched scope:
+{{#each scope_paths}}
+- {{this}}
+{{/each}}
+
+Guardrails:
+- Max files changed: {{max_files_changed}}
+- Max iterations per run: {{max_iterations}}
+{{#each denylist_paths}}
+- Denylist: {{this}}
+{{/each}}
+
+State files:
+{{#if state_file}}- State: {{state_file}}{{/if}}
+{{#if budget_file}}- Budget: {{budget_file}}{{/if}}
+{{#if run_log}}- Run log: {{run_log}}{{/if}}
+
+Instructions:
+1. Read the loop spec and state files before acting.
+2. Perform exactly one loop iteration.
+3. Stay within the watched scope and guardrails.
+4. Do not push, deploy, merge, or comment externally unless the spec and user explicitly allow it.
+5. End with a concise summary containing: outcome, files changed, verification performed, and any escalation needed.
+
+Runner prompt:
+{{runner_prompt}}

--- a/packages/coding-agent/src/loop-engineering/types.ts
+++ b/packages/coding-agent/src/loop-engineering/types.ts
@@ -1,0 +1,101 @@
+export type LoopLevel = "report" | "assisted" | "autonomous";
+export type LoopTriggerType = "manual" | "cron" | "github-actions" | "launch-agent";
+export type LoopRunStatus = "dry_run" | "passed" | "failed" | "needs_approval";
+
+export interface LoopCommandSpec {
+	argv: string[];
+	cwd?: string;
+}
+
+export interface LoopScope {
+	paths: string[];
+	branches: string[];
+	repos: string[];
+}
+
+export interface LoopTrigger {
+	type: LoopTriggerType;
+	cadence: string | null;
+	fireImmediately: boolean;
+}
+
+export interface LoopRunnerSpec {
+	prompt: string;
+}
+
+export interface LoopVerifierSpec {
+	separate: boolean;
+	commands: LoopCommandSpec[];
+}
+
+export interface LoopGuardrails {
+	maxIterations: number | null;
+	maxFilesChanged: number | null;
+	maxAutoPrsPerDay: number | null;
+	requireHumanApproval: string[];
+	denylistPaths: string[];
+}
+
+export interface LoopStateSpec {
+	file: string | null;
+	runLog: string | null;
+	budget: string | null;
+}
+
+export interface LoopSpec {
+	name: string;
+	goal: string;
+	level: LoopLevel;
+	nonGoals: string[];
+	scope: LoopScope;
+	trigger: LoopTrigger;
+	runner: LoopRunnerSpec;
+	verifier: LoopVerifierSpec;
+	guardrails: LoopGuardrails;
+	state: LoopStateSpec;
+	sourcePath?: string;
+}
+
+export interface LoopReadinessAssessment {
+	ready: boolean;
+	score: number;
+	issues: string[];
+	warnings: string[];
+}
+
+export interface LoopRunRecord {
+	id: string;
+	loop: string;
+	status: LoopRunStatus;
+	startedAt: string;
+	finishedAt: string;
+	durationMs: number;
+	level: LoopLevel;
+	prompt: string;
+	agentExitCode: number | null;
+	agentOutput: string;
+	verifierResults: LoopVerifierResult[];
+	changedFiles: string[];
+	approvalReasons: string[];
+	error: string | null;
+}
+
+export interface LoopVerifierResult {
+	command: string[];
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	durationMs: number;
+}
+
+export interface LoopRunResult extends LoopRunRecord {
+	jsonlPath: string | null;
+	markdownLogPath: string | null;
+}
+
+export interface LoopRunOptions {
+	cwd: string;
+	dryRun?: boolean;
+	now?: () => Date;
+	runAgent?: (prompt: string, cwd: string) => Promise<{ exitCode: number | null; output: string }>;
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -482,6 +482,8 @@ export interface CreateAgentSessionOptions {
 	skipPythonPreflight?: boolean;
 	/** Tool names explicitly requested (enables disabled-by-default tools) */
 	toolNames?: string[];
+	/** Honor toolNames exactly without auto-activating MCP, extension, or custom tools. */
+	strictToolNames?: boolean;
 
 	/** Output schema for structured completion (subagents) */
 	outputSchema?: unknown;
@@ -1813,8 +1815,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// re-bind under their own `CustomToolAPI` while skipping the FS scan.
 		toolSession.customToolPaths = customToolPaths;
 
+		if (options.strictToolNames && options.toolNames) {
+			const strictToolNameSet = new Set(options.toolNames.map(name => name.toLowerCase()));
+			for (let index = customTools.length - 1; index >= 0; index--) {
+				if (!strictToolNameSet.has(customTools[index]?.name.toLowerCase() ?? "")) customTools.splice(index, 1);
+			}
+		}
+
 		const inlineExtensions: ExtensionFactory[] = options.extensions ? [...options.extensions] : [];
-		inlineExtensions.push((await import("./autoresearch")).createAutoresearchExtension);
+		if (!options.strictToolNames) inlineExtensions.push((await import("./autoresearch")).createAutoresearchExtension);
 		if (customTools.length > 0) {
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}
@@ -2319,7 +2328,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// exactly the builtins createTools built (`builtInToolNames` — provenance, so a
 		// same-named custom/extension tool is never force-activated when auto-learn is
 		// off) to keep guidance, controller, and the active set consistent.
-		if (explicitlyRequestedToolNames) {
+		if (!options.strictToolNames && explicitlyRequestedToolNames) {
 			for (const name of ["manage_skill", "learn"]) {
 				if (builtInToolNames.includes(name) && !explicitlyRequestedToolNames.includes(name)) {
 					explicitlyRequestedToolNames.push(name);
@@ -2371,18 +2380,24 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			];
 		}
 
-		// Custom tools and extension-registered tools are always included regardless of toolNames filter
-		const alwaysInclude: string[] = [
-			...sdkCustomTools.map(t => (isCustomTool(t) ? t.name : t.name)),
-			...registeredTools.filter(t => !t.definition.defaultInactive).map(t => t.definition.name),
-		];
-		for (const name of alwaysInclude) {
-			if (mcpDiscoveryEnabled && name.startsWith("mcp__")) {
-				continue;
+		if (!options.strictToolNames) {
+			// Custom tools and extension-registered tools are always included regardless of toolNames filter.
+			const alwaysInclude: string[] = [
+				...sdkCustomTools.map(t => (isCustomTool(t) ? t.name : t.name)),
+				...registeredTools.filter(t => !t.definition.defaultInactive).map(t => t.definition.name),
+			];
+			for (const name of alwaysInclude) {
+				if (mcpDiscoveryEnabled && name.startsWith("mcp__")) {
+					continue;
+				}
+				if (toolRegistry.has(name) && !initialToolNames.includes(name)) {
+					initialToolNames.push(name);
+				}
 			}
-			if (toolRegistry.has(name) && !initialToolNames.includes(name)) {
-				initialToolNames.push(name);
-			}
+		} else if (options.toolNames) {
+			initialToolNames = initialToolNames.filter(name => requestedToolNameSet.has(name));
+			initialSelectedMCPToolNames = initialSelectedMCPToolNames.filter(name => requestedToolNameSet.has(name));
+			defaultSelectedMCPToolNames = defaultSelectedMCPToolNames.filter(name => requestedToolNameSet.has(name));
 		}
 
 		// When tools.discoveryMode === "all", hide non-essential built-in discoverable tools

--- a/packages/coding-agent/test/issue-983-multi-file-extension.test.ts
+++ b/packages/coding-agent/test/issue-983-multi-file-extension.test.ts
@@ -1,22 +1,44 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { discoverAndLoadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getPluginsDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const TOOL_NAME = "legacy-multi-file-tool";
+const XDG_VARS = ["XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"] as const;
 
 describe("issue #983: multi-file legacy Pi extensions", () => {
 	const tempDirs: string[] = [];
+	const originalAgentDir = getAgentDir();
+	const originalXdg = new Map<string, string | undefined>();
 
 	afterEach(async () => {
+		spyOn(os, "homedir").mockRestore();
+		for (const [key, value] of originalXdg) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		originalXdg.clear();
+		setAgentDir(originalAgentDir);
 		await Promise.all(tempDirs.splice(0).map(dir => removeWithRetries(dir)));
 	});
 
 	it("loads legacy Pi extensions whose sibling TypeScript files import each other via relative paths", async () => {
 		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-issue-983-project-"));
 		tempDirs.push(projectDir);
+		const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-issue-983-home-"));
+		tempDirs.push(tempHome);
+		for (const key of XDG_VARS) {
+			originalXdg.set(key, process.env[key]);
+			delete process.env[key];
+		}
+		spyOn(os, "homedir").mockReturnValue(tempHome);
+		setAgentDir(path.join(tempHome, ".omp", "agent"));
+		const pluginsDir = getPluginsDir();
+		if (!pluginsDir.startsWith(tempHome + path.sep)) {
+			throw new Error(`plugin isolation failed: getPluginsDir() resolved outside the temp home: ${pluginsDir}`);
+		}
 		const extensionDir = path.join(projectDir, "legacy-pi-multi-file-extension");
 
 		await fs.mkdir(extensionDir, { recursive: true });

--- a/packages/coding-agent/test/loop-engineering.test.ts
+++ b/packages/coding-agent/test/loop-engineering.test.ts
@@ -1,0 +1,621 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { commands, isSubcommand } from "../src/cli-commands";
+import { assessLoopReadiness } from "../src/loop-engineering/readiness";
+import { executeLoopIteration, parsePorcelainStatusZ, pathMatches } from "../src/loop-engineering/runner";
+import { scaffoldLoopProject } from "../src/loop-engineering/scaffold";
+import { parseLoopSpec } from "../src/loop-engineering/schema";
+
+async function makeTempDir(prefix = "@pi-loop-engineering-"): Promise<TempDir> {
+	return TempDir.create(prefix);
+}
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+	const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stdout}${stderr}`);
+}
+
+async function initCleanGitRepo(cwd: string): Promise<void> {
+	await runGit(cwd, ["init"]);
+	await runGit(cwd, ["config", "user.email", "loop-test@example.com"]);
+	await runGit(cwd, ["config", "user.name", "Loop Test"]);
+	await Bun.write(path.join(cwd, "baseline.txt"), "baseline\n");
+	await runGit(cwd, ["add", "."]);
+	await runGit(cwd, ["commit", "-m", "baseline"]);
+}
+
+describe("loop CLI registration", () => {
+	it("registers loop as a top-level subcommand instead of leaking to launch prompts", () => {
+		expect(commands.some(command => command.name === "loop")).toBe(true);
+		expect(isSubcommand("loop")).toBe(true);
+	});
+});
+
+describe("loop-engineering spec parsing", () => {
+	it("normalizes an OMP loop spec with safe defaults", () => {
+		const spec = parseLoopSpec(`
+loop:
+  name: daily-triage
+  goal: Report repository issues that need human attention.
+  level: assisted
+  non_goals:
+    - Do not edit code.
+  scope:
+    paths: ["."]
+  trigger:
+    type: manual
+  runner:
+    prompt: Summarize open risks.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "check"]
+  guardrails:
+    max_iterations: 2
+    max_files_changed: 0
+  state:
+    file: STATE.md
+    run_log: loop-run-log.md
+    budget: loop-budget.md
+`);
+
+		expect(spec.name).toBe("daily-triage");
+		expect(spec.level).toBe("assisted");
+		expect(spec.guardrails.maxIterations).toBe(2);
+		expect(spec.guardrails.denylistPaths).toContain(".env");
+		expect(spec.verifier.commands).toEqual([{ argv: ["bun", "run", "check"] }]);
+	});
+
+	it("parses NUL-delimited git porcelain paths including renames and spaces", () => {
+		expect(parsePorcelainStatusZ("R  new name.ts\0old name.ts\0?? .env\0")).toEqual([
+			"new name.ts",
+			"old name.ts",
+			".env",
+		]);
+	});
+
+	it("matches default denylist glob patterns at root and nested paths", () => {
+		expect(pathMatches("**/secrets/**", "secrets/token")).toBe(true);
+		expect(pathMatches("**/secrets/**", "src/secrets/token")).toBe(true);
+		expect(pathMatches("**/credentials/**", "src/credentials/key")).toBe(true);
+		expect(pathMatches("**/*_secret*", "api_secret.txt")).toBe(true);
+		expect(pathMatches("k8s/production/**", "k8s/production-old/file")).toBe(false);
+	});
+
+	it("flags verifier commands on report-only loops", () => {
+		const spec = parseLoopSpec(`
+loop:
+  name: report-with-command
+  goal: Report only.
+  level: report
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Summarize.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "check"]
+  state:
+    run_log: loop-run-log.md
+`);
+		expect(assessLoopReadiness(spec).issues).toContain("loop.verifier.commands must be empty for report loops");
+	});
+
+	it("rejects malformed verifier argv entries instead of silently rewriting commands", () => {
+		expect(() =>
+			parseLoopSpec(`
+loop:
+  name: malformed-verifier
+  goal: Test command validation.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", 123]
+  state:
+    run_log: loop-run-log.md
+`),
+		).toThrow(/argv entries/);
+	});
+
+	it("rejects shell-string verifier commands and unsafe run-log targets", () => {
+		expect(() =>
+			parseLoopSpec(`
+loop:
+  name: string-verifier
+  goal: Test command validation.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - "bun run check"
+  state:
+    run_log: loop-run-log.md
+`),
+		).toThrow(/entries must be argv arrays/);
+		expect(() =>
+			parseLoopSpec(`
+loop:
+  name: unsafe-log
+  goal: Test state validation.
+  level: report
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Report.
+  verifier:
+    separate: true
+  state:
+    run_log: .env
+`),
+		).toThrow(/loop.state.run_log/);
+		expect(() =>
+			parseLoopSpec(`
+loop:
+  name: traversing-log
+  goal: Test state validation.
+  level: report
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Report.
+  verifier:
+    separate: true
+  state:
+    run_log: .omp/loop-runs/../../package.md
+`),
+		).toThrow(/loop.state.run_log/);
+	});
+
+	it("reports concrete validation issues for unsafe incomplete specs", () => {
+		const spec = parseLoopSpec(`
+loop:
+  name: risky
+  runner:
+    prompt: Fix everything.
+`);
+		const assessment = assessLoopReadiness(spec);
+
+		expect(assessment.ready).toBe(false);
+		expect(assessment.issues).toContain("loop.goal is required");
+		expect(assessment.issues).toContain("loop.non_goals must list at least one explicit non-goal");
+		expect(assessment.issues).toContain("loop.verifier.separate must be true so implementer and verifier stay split");
+		expect(assessment.issues).toContain("loop.state.run_log is required for durable audit history");
+	});
+
+	it("requires explicit human approval guardrails for autonomous loops", () => {
+		const spec = parseLoopSpec(`
+loop:
+  name: autonomous
+  goal: Make safe fixes.
+  level: autonomous
+  non_goals: ["Do not deploy."]
+  runner:
+    prompt: Fix one thing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "check"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 1
+  state:
+    run_log: loop-run-log.md
+`);
+		expect(assessLoopReadiness(spec).issues).toContain(
+			"loop.guardrails.require_human_approval is required for autonomous loops",
+		);
+	});
+});
+
+describe("loop-engineering scaffold", () => {
+	it("writes source-inspired OMP-native starter files and refuses accidental overwrite", async () => {
+		const dir = await makeTempDir();
+		try {
+			const result = await scaffoldLoopProject({ cwd: dir.path(), name: "daily-triage", pattern: "daily-triage" });
+			const root = await fs.realpath(dir.path());
+			expect(result.created.map(item => path.relative(root, item)).sort()).toEqual([
+				path.join(".omp", "loops", "daily-triage.loop.yaml"),
+				"LOOP.md",
+				"STATE.md",
+				"loop-budget.md",
+				"loop-run-log.md",
+			]);
+
+			const loopDoc = await Bun.file(path.join(dir.path(), "LOOP.md")).text();
+			expect(loopDoc).toContain("Inspired by cobusgreyling/loop-engineering");
+			const parsed = parseLoopSpec(
+				await Bun.file(path.join(dir.path(), ".omp", "loops", "daily-triage.loop.yaml")).text(),
+			);
+			expect(parsed.name).toBe("daily-triage");
+			expect(parsed.level).toBe("report");
+			expect(parsed.verifier.commands).toEqual([]);
+
+			await expect(
+				scaffoldLoopProject({ cwd: dir.path(), name: "daily-triage", pattern: "daily-triage" }),
+			).rejects.toThrow(/already exists/);
+		} finally {
+			await dir.remove();
+		}
+	});
+});
+
+describe("loop-engineering iteration runner", () => {
+	it("runs one scheduled-safe iteration, verifier command, and durable logs", async () => {
+		const dir = await makeTempDir();
+		try {
+			const verifier = path.join(dir.path(), "verify.ts");
+			await Bun.write(verifier, "await Bun.write('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "bun verify.ts" } }),
+			);
+			const spec = parseLoopSpec(`
+loop:
+  name: ci-sweeper
+  goal: Fix one failing CI issue and report the result.
+  level: assisted
+  non_goals:
+    - Do not deploy.
+  scope:
+    paths: ["."]
+  trigger:
+    type: manual
+  runner:
+    prompt: Inspect CI and make one safe fix.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    file: STATE.md
+    run_log: loop-run-log.md
+    budget: loop-budget.md
+`);
+			await Bun.write(path.join(dir.path(), "STATE.md"), "# State\n");
+			await Bun.write(path.join(dir.path(), "loop-budget.md"), "# Budget\n");
+			await initCleanGitRepo(dir.path());
+
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async promptText => {
+					expect(promptText).toContain("Fix one failing CI issue");
+					await Bun.write(path.join(dir.path(), "agent-output.txt"), "done");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "verified.txt")).text()).toBe("ok");
+			const jsonl = await Bun.file(path.join(dir.path(), ".omp", "loop-runs", "ci-sweeper.jsonl")).text();
+			expect(jsonl).toContain('"status":"passed"');
+			const markdownLog = await Bun.file(path.join(dir.path(), "loop-run-log.md")).text();
+			expect(markdownLog).toContain("ci-sweeper");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("persists a failed run when a verifier executable is missing", async () => {
+		const dir = await makeTempDir();
+		try {
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: missing-verifier
+  goal: Exercise verifier failure logging.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["definitely-not-a-real-loop-verifier"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("package-script form");
+			const jsonl = await Bun.file(path.join(dir.path(), ".omp", "loop-runs", "missing-verifier.jsonl")).text();
+			expect(jsonl).toContain('"status":"failed"');
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval for out-of-scope and denylisted changes from the iteration", async () => {
+		const dir = await makeTempDir();
+		try {
+			const verifier = path.join(dir.path(), "noop.ts");
+			await Bun.write(verifier, "process.exit(0);\n");
+			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: guarded
+  goal: Make a bounded safe change.
+  level: assisted
+  non_goals: ["Do not edit secrets."]
+  scope:
+    paths: ["src/**"]
+  runner:
+    prompt: Change only scoped files.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "README.md"), "outside\n");
+					await fs.mkdir(path.join(dir.path(), "secrets"), { recursive: true });
+					await Bun.write(path.join(dir.path(), "secrets", "token"), "api_key=SECRET_TOKEN_123456\n");
+					return {
+						exitCode: 0,
+						output:
+							"agent completed with api_key=SECRET_TOKEN_123456 Authorization: Bearer ghp_1234567890abcdef1234567890abcdef1234 AWS_SECRET_ACCESS_KEY=ABCDEFGHIJKLMNOPQRST",
+					};
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain("changed out-of-scope path README.md");
+			expect(result.approvalReasons).toContain("changed denylisted path secrets/token");
+			const jsonl = await Bun.file(path.join(dir.path(), ".omp", "loop-runs", "guarded.jsonl")).text();
+			expect(jsonl).toContain("[REDACTED_SECRET]");
+			expect(jsonl).not.toContain("SECRET_TOKEN_123456");
+			expect(jsonl).not.toContain("ghp_1234567890");
+			expect(jsonl).not.toContain("ABCDEFGHIJKLMNOPQRST");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval when assisted loops start from a dirty baseline", async () => {
+		const dir = await makeTempDir();
+		try {
+			const verifier = path.join(dir.path(), "noop.ts");
+			await Bun.write(verifier, "process.exit(0);\n");
+			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await initCleanGitRepo(dir.path());
+			await Bun.write(path.join(dir.path(), "already-dirty.txt"), "dirty\n");
+			const spec = parseLoopSpec(`
+loop:
+  name: dirty-baseline
+  goal: Do nothing when dirty.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons[0]).toContain("pre-existing changed files");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent changes verifier package scripts before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "noop.ts"), "process.exit(0);\n");
+			await Bun.write(path.join(dir.path(), "changed.ts"), "await Bun.write('should-not-run.txt', 'bad');\n");
+			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-mutated
+  goal: Do not trust mutated verifiers.
+  level: assisted
+  non_goals: ["Do not edit verifier scripts."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(
+						path.join(dir.path(), "package.json"),
+						JSON.stringify({ scripts: { verify: "bun changed.ts" } }),
+					);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier package.json script verify changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "should-not-run.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects shell verifier executables without running them", async () => {
+		const dir = await makeTempDir();
+		try {
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: shell-verifier
+  goal: Reject shell verifier.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["sh", "-lc", "touch should-not-exist"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("not allowed");
+			await expect(fs.stat(path.join(dir.path(), "should-not-exist"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects absolute verifier runner paths", async () => {
+		const dir = await makeTempDir();
+		try {
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: absolute-verifier
+  goal: Reject absolute verifier runner.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["${process.execPath}", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("bare package runner");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects verifier package script extra argv by default", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "noop.ts"), "process.exit(0);\n");
+			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-extra-args
+  goal: Reject verifier arg mutation.
+  level: assisted
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify", "--token", "ghp_1234567890abcdef1234567890abcdef1234"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("extra argv");
+			const jsonl = await Bun.file(path.join(dir.path(), ".omp", "loop-runs", "verifier-extra-args.jsonl")).text();
+			expect(jsonl).not.toContain("ghp_1234567890");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("dry-run builds the prompt without touching durable state", async () => {
+		const dir = await makeTempDir();
+		try {
+			const spec = parseLoopSpec(`
+loop:
+  name: report
+  goal: Report only.
+  level: report
+  non_goals: ["Do not edit code."]
+  runner:
+    prompt: Summarize.
+  verifier:
+    separate: true
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				dryRun: true,
+				runAgent: async () => {
+					throw new Error("dry-run should not call the agent");
+				},
+			});
+
+			expect(result.status).toBe("dry_run");
+			expect(result.prompt).toContain("Report only.");
+			await expect(fs.stat(path.join(dir.path(), ".omp", "loop-runs", "report.jsonl"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/loop-engineering.test.ts
+++ b/packages/coding-agent/test/loop-engineering.test.ts
@@ -255,11 +255,14 @@ describe("loop-engineering iteration runner", () => {
 	it("runs one scheduled-safe iteration, verifier command, and durable logs", async () => {
 		const dir = await makeTempDir();
 		try {
-			const verifier = path.join(dir.path(), "verify.ts");
-			await Bun.write(verifier, "await Bun.write('verified.txt', 'ok');\n");
+			const verifier = path.join(dir.path(), "verify.js");
+			await Bun.write(
+				verifier,
+				"const expected = ['ok'];\nrequire('fs').writeFileSync('verified.txt', expected[0]);\n",
+			);
 			await Bun.write(
 				path.join(dir.path(), "package.json"),
-				JSON.stringify({ scripts: { verify: "bun verify.ts" } }),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
 			);
 			const spec = parseLoopSpec(`
 loop:
@@ -310,6 +313,218 @@ loop:
 		}
 	});
 
+	it("ignores project-local runtime shims created before verifier execution", async () => {
+		const dir = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: runtime-shim
+  goal: Do not trust local runtime shims.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.PATH = [".", "bin", originalPath ?? ""].join(path.delimiter);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					for (const shim of [
+						path.join(dir.path(), "node"),
+						path.join(dir.path(), "bin", "node"),
+						path.join(dir.path(), "node_modules", ".bin", "node"),
+					]) {
+						await fs.mkdir(path.dirname(shim), { recursive: true });
+						await Bun.write(shim, "#!/bin/sh\necho hijacked > hijacked.txt\n");
+						await fs.chmod(shim, 0o755);
+					}
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "verified.txt")).text()).toBe("ok");
+			await expect(fs.stat(path.join(dir.path(), "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await dir.remove();
+		}
+	});
+
+	it("ignores project-local runtime shims when launched through a symlinked project cwd", async () => {
+		const dir = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			const real = path.join(dir.path(), "real");
+			const link = path.join(dir.path(), "link");
+			await fs.mkdir(real, { recursive: true });
+			await fs.symlink("real", link, "dir");
+			await Bun.write(path.join(real, "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(path.join(real, "package.json"), JSON.stringify({ scripts: { verify: "node verify.js" } }));
+			await initCleanGitRepo(real);
+			const spec = parseLoopSpec(`
+loop:
+  name: symlink-cwd-runtime-shim
+  goal: Do not trust local runtime shims from real cwd paths.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.PATH = [path.join(real, "bin"), originalPath ?? ""].join(path.delimiter);
+			const result = await executeLoopIteration(spec, {
+				cwd: link,
+				runAgent: async () => {
+					const shim = path.join(real, "bin", "node");
+					await fs.mkdir(path.dirname(shim), { recursive: true });
+					await Bun.write(shim, "#!/bin/sh\necho hijacked > hijacked.txt\n");
+					await fs.chmod(shim, 0o755);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(real, "verified.txt")).text()).toBe("ok");
+			await expect(fs.stat(path.join(real, "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await dir.remove();
+		}
+	});
+
+	it("scrubs verifier runtime option environment variables before execution", async () => {
+		const dir = await makeTempDir();
+		const originalNodeOptions = process.env.NODE_OPTIONS;
+		try {
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: env-injection
+  goal: Do not trust parent runtime option env vars.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.NODE_OPTIONS = "--require ./hijack.js";
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(
+						path.join(dir.path(), "hijack.js"),
+						"require('fs').writeFileSync('hijacked.txt', 'bad');\n",
+					);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "verified.txt")).text()).toBe("ok");
+			await expect(fs.stat(path.join(dir.path(), "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+			else process.env.NODE_OPTIONS = originalNodeOptions;
+			await dir.remove();
+		}
+	});
+
+	it("fails closed before the agent when verifier PATH has no safe runtime entries", async () => {
+		const dir = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: empty-safe-path
+  goal: Do not spawn verifiers without a safe PATH.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.PATH = dir.path();
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "node"), "#!/bin/sh\necho hijacked > hijacked.txt\n");
+					await fs.chmod(path.join(dir.path(), "node"), 0o755);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("verifier PATH has no safe absolute runtime entries");
+			await expect(fs.stat(path.join(dir.path(), "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await dir.remove();
+		}
+	});
+
 	it("persists a failed run when a verifier executable is missing", async () => {
 		const dir = await makeTempDir();
 		try {
@@ -348,9 +563,12 @@ loop:
 	it("requires approval for out-of-scope and denylisted changes from the iteration", async () => {
 		const dir = await makeTempDir();
 		try {
-			const verifier = path.join(dir.path(), "noop.ts");
+			const verifier = path.join(dir.path(), "noop.js");
 			await Bun.write(verifier, "process.exit(0);\n");
-			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
 			await initCleanGitRepo(dir.path());
 			const spec = parseLoopSpec(`
 loop:
@@ -378,10 +596,10 @@ loop:
 					await Bun.write(path.join(dir.path(), "README.md"), "outside\n");
 					await fs.mkdir(path.join(dir.path(), "secrets"), { recursive: true });
 					await Bun.write(path.join(dir.path(), "secrets", "token"), "api_key=SECRET_TOKEN_123456\n");
+					const slackToken = ["xoxb", "1234567890", "123456789012", "abcdefghijklmnopqrstuvwx"].join("-");
 					return {
 						exitCode: 0,
-						output:
-							"agent completed with api_key=SECRET_TOKEN_123456 Authorization: Bearer ghp_1234567890abcdef1234567890abcdef1234 AWS_SECRET_ACCESS_KEY=ABCDEFGHIJKLMNOPQRST",
+						output: `agent completed with api_key=SECRET_TOKEN_123456 Authorization: Bearer ghp_1234567890abcdef1234567890abcdef1234 AWS_SECRET_ACCESS_KEY=ABCDEFGHIJKLMNOPQRST SLACK_BOT_TOKEN=${slackToken} bare_slack ${slackToken}`,
 					};
 				},
 			});
@@ -394,6 +612,7 @@ loop:
 			expect(jsonl).not.toContain("SECRET_TOKEN_123456");
 			expect(jsonl).not.toContain("ghp_1234567890");
 			expect(jsonl).not.toContain("ABCDEFGHIJKLMNOPQRST");
+			expect(jsonl).not.toContain(["xoxb", "1234567890"].join("-"));
 		} finally {
 			await dir.remove();
 		}
@@ -402,9 +621,12 @@ loop:
 	it("requires approval when assisted loops start from a dirty baseline", async () => {
 		const dir = await makeTempDir();
 		try {
-			const verifier = path.join(dir.path(), "noop.ts");
+			const verifier = path.join(dir.path(), "noop.js");
 			await Bun.write(verifier, "process.exit(0);\n");
-			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
 			await initCleanGitRepo(dir.path());
 			await Bun.write(path.join(dir.path(), "already-dirty.txt"), "dirty\n");
 			const spec = parseLoopSpec(`
@@ -440,9 +662,15 @@ loop:
 	it("requires approval if the agent changes verifier package scripts before verification", async () => {
 		const dir = await makeTempDir();
 		try {
-			await Bun.write(path.join(dir.path(), "noop.ts"), "process.exit(0);\n");
-			await Bun.write(path.join(dir.path(), "changed.ts"), "await Bun.write('should-not-run.txt', 'bad');\n");
-			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await Bun.write(path.join(dir.path(), "noop.js"), "process.exit(0);\n");
+			await Bun.write(
+				path.join(dir.path(), "changed.js"),
+				"require('fs').writeFileSync('should-not-run.txt', 'bad');\n",
+			);
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
 			await initCleanGitRepo(dir.path());
 			const spec = parseLoopSpec(`
 loop:
@@ -467,17 +695,889 @@ loop:
 				runAgent: async () => {
 					await Bun.write(
 						path.join(dir.path(), "package.json"),
-						JSON.stringify({ scripts: { verify: "bun changed.ts" } }),
+						JSON.stringify({ scripts: { verify: "node changed.js" } }),
 					);
 					return { exitCode: 0, output: "agent completed" };
 				},
 			});
 
 			expect(result.status).toBe("needs_approval");
-			expect(result.approvalReasons).toContain(
-				"verifier package.json script verify changed before verifier execution",
-			);
+			expect(result.approvalReasons).toContain("verifier package.json changed before verifier execution");
 			await expect(fs.stat(path.join(dir.path(), "should-not-run.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent changes verifier implementation files before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-file-mutated
+  goal: Do not trust mutated verifier files.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "verify.js"), "process.exit(0);\n");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file verify.js changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent changes verifier helper dependencies before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(
+				path.join(dir.path(), "verify.js"),
+				"require('./helper');\nrequire('fs').writeFileSync('verified.txt', 'ok');\n",
+			);
+			await Bun.write(path.join(dir.path(), "helper.js"), "module.exports = true;\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-helper-mutated
+  goal: Do not trust mutated verifier helpers.
+  level: assisted
+  non_goals: ["Do not edit verifier helpers."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "helper.js"), "module.exports = false;\n");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file helper.js changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent changes extensionless verifier implementation files", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "scripts"), { recursive: true });
+			await Bun.write(
+				path.join(dir.path(), "scripts", "check.js"),
+				"require('fs').writeFileSync('verified.txt', 'ok');\n",
+			);
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node scripts/check.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-extensionless-mutated
+  goal: Do not trust extensionless verifier files.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "scripts", "check.js"), "process.exit(0);\n");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file scripts/check.js changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent changes bare extensionless verifier operands", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "check.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node check.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-bare-extensionless-mutated
+  goal: Do not trust bare verifier operands.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "check.js"), "process.exit(0);\n");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file check.js changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects pre-entrypoint runner flags before running an agent", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(
+				path.join(dir.path(), "loader.mjs"),
+				"export async function resolve(s,c,n){return n(s,c);} export async function load(u,c,n){return n(u,c);}\n",
+			);
+			await Bun.write(path.join(dir.path(), "check.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node --loader ./loader.mjs check" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-flagged-bare-mutated
+  goal: Do not trust bare verifier operands hidden behind flags.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					throw new Error("agent should not run after verifier preflight failure");
+				},
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain(
+				"verifier package scripts must execute a local verifier file through an approved runtime",
+			);
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent creates an absent verifier implementation file before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "scripts"), { recursive: true });
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node scripts/check.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-absent-file-created
+  goal: Do not trust newly created verifier files.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "scripts", "check.js"), "process.exit(0);\n");
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file scripts/check.js changed before verifier execution",
+			);
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent adds verifier lifecycle hooks before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "noop.js"), "process.exit(0);\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-hook-mutated
+  goal: Do not trust mutated verifier hooks.
+  level: assisted
+  non_goals: ["Do not edit verifier scripts."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(
+						path.join(dir.path(), "package.json"),
+						JSON.stringify({ scripts: { preverify: "node should-not-run.js", verify: "node noop.js" } }),
+					);
+					await Bun.write(
+						path.join(dir.path(), "should-not-run.js"),
+						"require('fs').writeFileSync('hook-ran.txt', 'bad');\n",
+					);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain("verifier package.json changed before verifier execution");
+			await expect(fs.stat(path.join(dir.path(), "hook-ran.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects unsafe package verifier script shapes before running an agent", async () => {
+		const cases: Array<{
+			name: string;
+			scripts: Record<string, string>;
+			files?: Record<string, string>;
+			dirs?: string[];
+			error: string;
+		}> = [
+			{
+				name: "existing-lifecycle",
+				scripts: { preverify: "node precheck.js", verify: "node noop.js" },
+				files: { "noop.js": "process.exit(0);\n", "precheck.js": "process.exit(0);\n" },
+				error: "verifier lifecycle script preverify is not allowed",
+			},
+			{
+				name: "relative-runtime",
+				scripts: { verify: "./node verify.js" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "absolute-runtime",
+				scripts: { verify: "/tmp/node verify.js" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "dynamic-require",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const helper = './helper.js';\nrequire(helper);\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-import",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const helper = './helper.js';\nawait import(helper);\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-computed-import",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "await import('./' + 'helper.mjs');\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-commented-require",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const helper = './helper.js';\nrequire/**/(helper);\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-commented-import",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const helper = './helper.js';\nawait import/**/(helper);\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "module-require",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "module.require('./helper.js');\n" },
+				error: "verifier dependency ./helper.js could not be resolved",
+			},
+			{
+				name: "dynamic-optional-require",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const helper = './helper.js';\nrequire?.(helper);\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-bracket-require",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "module['require']('./helper.js');\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dynamic-require-call",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "require.call(null, './helper.js');\n" },
+				error: "verifier dependencies must use literal imports",
+			},
+			{
+				name: "dangerous-builtin",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": "require('child_process').execFileSync('node', ['./helper.js']);\n",
+				},
+				error: "verifier dependencies must not import dangerous builtins",
+			},
+			{
+				name: "dynamic-code-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "Function('return 1')();\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "dynamic-code-api-comment",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "eval/**/('1');\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "dynamic-code-api-optional",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "Function?.('return 1')();\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "dynamic-code-api-call",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "eval.call(null, '1');\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "dynamic-code-constructor",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "({}).constructor.constructor('return 1')();\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "escaped-dynamic-code-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "\\u0065val('1');\n" },
+				error: "verifier dependencies must not use escaped identifiers",
+			},
+			{
+				name: "dynamic-property-global",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "globalThis?.['Fun' + 'ction']('return 1')();\n" },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "dynamic-property-variable-key",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const key = 'Fun' + 'ction';\nglobalThis[key]('return 1')();\n" },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "dynamic-code-worker",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": "new Worker('./helper.js');\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "process-binding-optional-bracket-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "process?.['binding']('spawn_sync');\n" },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-comment-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "process/**/.binding('spawn_sync');\n" },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-execution-api",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": "Bun?.spawnSync(['node', './helper.js']);\n" },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "process?.binding('spawn_sync');\n" },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "nested-package-runner",
+				scripts: { verify: "bun run check", check: "node scripts/check.js" },
+				files: { "scripts/check.js": "process.exit(0);\n" },
+				error: "verifier package scripts must not invoke nested package scripts",
+			},
+			{
+				name: "directory-operand",
+				scripts: { verify: "node ./scripts" },
+				dirs: ["scripts"],
+				files: { "scripts/index.js": "process.exit(0);\n" },
+				error: "verifier referenced file must be a file",
+			},
+			{
+				name: "unsupported-runner-subcommand",
+				scripts: { verify: "deno unknown" },
+				error: "verifier package scripts must not use runner subcommands",
+			},
+			{
+				name: "glob-expansion",
+				scripts: { verify: "node scripts/*.js" },
+				error: "verifier package scripts must not use shell expansion, escaping, or metacharacters",
+			},
+			{
+				name: "escaped-path",
+				scripts: { verify: "node verify\\.js" },
+				error: "verifier package scripts must not use shell expansion, escaping, or metacharacters",
+			},
+			{
+				name: "node-run-delegation",
+				scripts: { verify: "node --run check", check: "node check.js" },
+				error: "verifier package scripts must not delegate through node --run",
+			},
+			{
+				name: "node-eval-short-circuit",
+				scripts: { verify: "node -e 0 verify.js" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "node-double-dash-dash-script",
+				scripts: { verify: "node -- -e verify.js" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "newline-command",
+				scripts: { verify: "node verify.js\nnode other.js" },
+				error: "verifier package scripts must not use shell expansion, escaping, or metacharacters",
+			},
+			{
+				name: "extensionless-entrypoint",
+				scripts: { verify: "node check" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "bare-package-import",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "require('left-pad');\n" },
+				error: "verifier dependencies must use relative or node: imports",
+			},
+			{
+				name: "bare-tool-command",
+				scripts: { verify: "biome check" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "url-bun-operand",
+				scripts: { verify: "bun https://example.com/check.js" },
+				error: "verifier package scripts must not use shell expansion, escaping, or metacharacters",
+			},
+		];
+
+		for (const testCase of cases) {
+			const dir = await makeTempDir();
+			try {
+				for (const relativeDir of testCase.dirs ?? []) {
+					await fs.mkdir(path.join(dir.path(), relativeDir), { recursive: true });
+				}
+				for (const [relativeFile, content] of Object.entries(testCase.files ?? {})) {
+					await fs.mkdir(path.dirname(path.join(dir.path(), relativeFile)), { recursive: true });
+					await Bun.write(path.join(dir.path(), relativeFile), content);
+				}
+				await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: testCase.scripts }));
+				await initCleanGitRepo(dir.path());
+				const spec = parseLoopSpec(`
+loop:
+  name: ${testCase.name}
+  goal: Reject unsafe verifier script shapes.
+  level: assisted
+  non_goals: ["Do not edit verifier scripts."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+				const result = await executeLoopIteration(spec, {
+					cwd: dir.path(),
+					runAgent: async () => {
+						throw new Error("agent should not run after verifier preflight failure");
+					},
+				});
+
+				expect(result.status).toBe("failed");
+				expect(result.error).toContain(testCase.error);
+			} finally {
+				await dir.remove();
+			}
+		}
+	});
+
+	it("requires approval if a subpackage verifier root config changes before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "pkg", "scripts"), { recursive: true });
+			await Bun.write(path.join(dir.path(), "biome.json"), JSON.stringify({ formatter: { enabled: true } }));
+			await Bun.write(
+				path.join(dir.path(), "pkg", "scripts", "check"),
+				"require('fs').writeFileSync('verified.txt', 'ok');\n",
+			);
+			await Bun.write(
+				path.join(dir.path(), "pkg", "package.json"),
+				JSON.stringify({ scripts: { verify: "node scripts/check.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-root-config-mutated
+  goal: Do not trust mutated root verifier config.
+  level: assisted
+  non_goals: ["Do not edit verifier config."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - argv: ["bun", "run", "verify"]
+        cwd: pkg
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "biome.json"), JSON.stringify({ formatter: { enabled: false } }));
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file ../biome.json changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "pkg", "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("requires approval if the agent adds an absent root verifier config before verification", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "pkg", "scripts"), { recursive: true });
+			await Bun.write(
+				path.join(dir.path(), "pkg", "scripts", "check"),
+				"require('fs').writeFileSync('verified.txt', 'ok');\n",
+			);
+			await Bun.write(
+				path.join(dir.path(), "pkg", "package.json"),
+				JSON.stringify({ scripts: { verify: "node scripts/check.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-root-config-created
+  goal: Do not trust newly created root verifier config.
+  level: assisted
+  non_goals: ["Do not edit verifier config."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - argv: ["bun", "run", "verify"]
+        cwd: pkg
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 2
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(path.join(dir.path(), "biome.json"), JSON.stringify({ formatter: { enabled: false } }));
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain(
+				"verifier referenced file ../biome.json changed before verifier execution",
+			);
+			await expect(fs.stat(path.join(dir.path(), "pkg", "verified.txt"))).rejects.toThrow();
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects symlinked verifier package.json before running an agent", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(path.join(dir.path(), "noop.js"), "process.exit(0);\n");
+			await Bun.write(
+				path.join(dir.path(), "real-package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
+			await fs.symlink("real-package.json", path.join(dir.path(), "package.json"));
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-package-symlink
+  goal: Reject symlinked verifier package.
+  level: assisted
+  non_goals: ["Do not edit verifier package."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					throw new Error("agent should not run after verifier preflight failure");
+				},
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("verifier package.json must not be a symlink");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects symlinked verifier cwd before running an agent", async () => {
+		const dir = await makeTempDir();
+		try {
+			const realPkg = path.join(dir.path(), "pkg");
+			await fs.mkdir(realPkg, { recursive: true });
+			await Bun.write(path.join(realPkg, "noop.js"), "process.exit(0);\n");
+			await Bun.write(path.join(realPkg, "package.json"), JSON.stringify({ scripts: { verify: "node noop.js" } }));
+			await fs.symlink("pkg", path.join(dir.path(), "pkg-link"), "dir");
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-cwd-symlink
+  goal: Reject symlinked verifier cwd.
+  level: assisted
+  non_goals: ["Do not edit verifier cwd."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - argv: ["bun", "run", "verify"]
+        cwd: pkg-link
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					throw new Error("agent should not run after verifier preflight failure");
+				},
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("verifier cwd must not pass through a symlink");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("allows verifier cwd scripts to reference files elsewhere inside the project", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "pkg"), { recursive: true });
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "pkg", "package.json"),
+				JSON.stringify({ scripts: { verify: "node ../verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-cwd
+  goal: Support package cwd verifiers.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - argv: ["bun", "run", "verify"]
+        cwd: pkg
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "pkg", "verified.txt")).text()).toBe("ok");
+		} finally {
+			await dir.remove();
+		}
+	});
+
+	it("rejects verifier script references that escape the project even when absent", async () => {
+		const dir = await makeTempDir();
+		try {
+			await fs.mkdir(path.join(dir.path(), "pkg"), { recursive: true });
+			await Bun.write(
+				path.join(dir.path(), "pkg", "package.json"),
+				JSON.stringify({ scripts: { verify: "node ../../outside.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: verifier-outside-reference
+  goal: Reject outside verifier references.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - argv: ["bun", "run", "verify"]
+        cwd: pkg
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					throw new Error("agent should not run after verifier preflight failure");
+				},
+			});
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toContain("verifier referenced file must stay inside the project");
 		} finally {
 			await dir.remove();
 		}
@@ -553,8 +1653,11 @@ loop:
 	it("rejects verifier package script extra argv by default", async () => {
 		const dir = await makeTempDir();
 		try {
-			await Bun.write(path.join(dir.path(), "noop.ts"), "process.exit(0);\n");
-			await Bun.write(path.join(dir.path(), "package.json"), JSON.stringify({ scripts: { verify: "bun noop.ts" } }));
+			await Bun.write(path.join(dir.path(), "noop.js"), "process.exit(0);\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node noop.js" } }),
+			);
 			await initCleanGitRepo(dir.path());
 			const spec = parseLoopSpec(`
 loop:

--- a/packages/coding-agent/test/loop-engineering.test.ts
+++ b/packages/coding-agent/test/loop-engineering.test.ts
@@ -258,8 +258,24 @@ describe("loop-engineering iteration runner", () => {
 			const verifier = path.join(dir.path(), "verify.js");
 			await Bun.write(
 				verifier,
-				"const expected = ['ok'];\nrequire('fs').writeFileSync('verified.txt', expected[0]);\n",
+				[
+					"const data = require('./fixture.json');",
+					"const fs = require('fs');",
+					"const path = require('path');",
+					"const expected = ['ok'];",
+					"const label = 'binding';",
+					"const config = { binding: true };",
+					"const { process: proc } = globalThis;",
+					"proc.cwd();",
+					"function binding() { return label; }",
+					"binding();",
+					"if (true) { ['o', 'k'].join(''); }",
+					"const outputPath = path.join(process.cwd(), 'verified.txt');",
+					"fs.writeFileSync(outputPath, data.expected || ['o', 'k'].join('') || expected[0] || config.binding);",
+					"",
+				].join("\n"),
 			);
+			await Bun.write(path.join(dir.path(), "fixture.json"), JSON.stringify({ expected: "ok" }));
 			await Bun.write(
 				path.join(dir.path(), "package.json"),
 				JSON.stringify({ scripts: { verify: "node verify.js" } }),
@@ -419,6 +435,169 @@ loop:
 		} finally {
 			if (originalPath === undefined) delete process.env.PATH;
 			else process.env.PATH = originalPath;
+			await dir.remove();
+		}
+	});
+
+	it("freezes verifier runtime path before agents can add external PATH shims", async () => {
+		const dir = await makeTempDir();
+		const external = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: external-path-runtime-shim
+  goal: Do not trust external runtime shims created by an agent.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			const nonExecutableShim = path.join(external.path(), "node");
+			await Bun.write(nonExecutableShim, "#!/bin/sh\necho should-not-run > hijacked.txt\n");
+			await fs.chmod(nonExecutableShim, 0o644);
+			process.env.PATH = [external.path(), originalPath ?? ""].join(path.delimiter);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					const shim = path.join(external.path(), "node");
+					await Bun.write(shim, "#!/bin/sh\necho hijacked > hijacked.txt\n");
+					await fs.chmod(shim, 0o755);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "verified.txt")).text()).toBe("ok");
+			await expect(fs.stat(path.join(dir.path(), "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await external.remove();
+			await dir.remove();
+		}
+	});
+
+	it("skips external runtime symlinks that resolve back into the project", async () => {
+		const dir = await makeTempDir();
+		const external = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			const localRuntime = path.join(dir.path(), "node");
+			await Bun.write(localRuntime, "#!/bin/sh\necho hijacked > hijacked.txt\n");
+			await fs.chmod(localRuntime, 0o755);
+			await fs.symlink(localRuntime, path.join(external.path(), "node"));
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: project-runtime-symlink
+  goal: Ignore PATH runtimes that resolve back into the project.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.PATH = [external.path(), originalPath ?? ""].join(path.delimiter);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.status).toBe("passed");
+			expect(await Bun.file(path.join(dir.path(), "verified.txt")).text()).toBe("ok");
+			await expect(fs.stat(path.join(dir.path(), "hijacked.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await external.remove();
+			await dir.remove();
+		}
+	});
+
+	it("rejects verifier runtime paths replaced after preflight", async () => {
+		const dir = await makeTempDir();
+		const external = await makeTempDir();
+		const originalPath = process.env.PATH;
+		try {
+			const runtimeShim = path.join(external.path(), "bun");
+			await Bun.write(runtimeShim, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`);
+			await fs.chmod(runtimeShim, 0o755);
+			await Bun.write(path.join(dir.path(), "verify.js"), "require('fs').writeFileSync('verified.txt', 'ok');\n");
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "bun verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: replaced-runtime-shim
+  goal: Fail if an agent mutates the resolved verifier runtime.
+  level: assisted
+  non_goals: ["Do not edit verifier files."]
+  scope:
+    paths: ["."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+    max_files_changed: 5
+  state:
+    run_log: loop-run-log.md
+`);
+			process.env.PATH = [external.path(), originalPath ?? ""].join(path.delimiter);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => {
+					await Bun.write(runtimeShim, "#!/bin/sh\necho hijacked > hijacked.txt\n");
+					await fs.chmod(runtimeShim, 0o755);
+					return { exitCode: 0, output: "agent completed" };
+				},
+			});
+
+			expect(result.status).toBe("needs_approval");
+			expect(result.approvalReasons).toContain("verifier runtime changed before verifier execution");
+			await expect(fs.stat(path.join(dir.path(), "verified.txt"))).rejects.toThrow();
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			await external.remove();
 			await dir.remove();
 		}
 	});
@@ -759,7 +938,7 @@ loop:
 		try {
 			await Bun.write(
 				path.join(dir.path(), "verify.js"),
-				"require('./helper');\nrequire('fs').writeFileSync('verified.txt', 'ok');\n",
+				"require('./helper.js');\nrequire('fs').writeFileSync('verified.txt', 'ok');\n",
 			);
 			await Bun.write(path.join(dir.path(), "helper.js"), "module.exports = true;\n");
 			await Bun.write(
@@ -1126,6 +1305,18 @@ loop:
 				error: "verifier dependencies must not import dangerous builtins",
 			},
 			{
+				name: "process-builtin-require-binding-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const p = require('process');\np.binding('spawn_sync');\n" },
+				error: "verifier dependencies must not import dangerous builtins",
+			},
+			{
+				name: "node-process-builtin-require-binding-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "const p = require('node:process');\np.binding('spawn_sync');\n" },
+				error: "verifier dependencies must not import dangerous builtins",
+			},
+			{
 				name: "dynamic-code-api",
 				scripts: { verify: "node verify.js" },
 				files: { "verify.js": "Function('return 1')();\n" },
@@ -1174,9 +1365,25 @@ loop:
 				error: "verifier dependencies must not use dynamic property access",
 			},
 			{
+				name: "dynamic-property-unicode-receiver",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const π = process;\nπ["bind" + "ing"]("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
 				name: "dynamic-code-worker",
 				scripts: { verify: "bun verify.js" },
 				files: { "verify.js": "new Worker('./helper.js');\n" },
+				error: "verifier dependencies must not use dynamic code APIs",
+			},
+			{
+				name: "dynamic-code-webassembly",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						"const fs = require('fs');\n(async () => WebAssembly.instantiate(await fs.promises.readFile('./addon.wasm')))();\n",
+					"addon.wasm": "",
+				},
 				error: "verifier dependencies must not use dynamic code APIs",
 			},
 			{
@@ -1192,6 +1399,713 @@ loop:
 				error: "verifier dependencies must not use process execution APIs",
 			},
 			{
+				name: "process-binding-reflect-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'Reflect.get(process, "binding")("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-descriptor-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'Object.getOwnPropertyDescriptor(process, "binding")?.value("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const p = process;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-logical-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const p = process || {};\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-conditional-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const p = true ? globalThis.process : {};\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const p = Reflect.get(globalThis, "process");\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((p) => p.binding("spawn_sync"))(process);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-named-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'function f(p) { p.binding("spawn_sync"); }\nf(process);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-parameter-destructure-call-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'function f({ binding }) { binding("spawn_sync"); }\nf(process);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-spread-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((p) => p.binding("spawn_sync"))(...[process]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-array-alias-spread-call-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const a = [process];\nfunction f(p) { p.binding("spawn_sync"); }\nf(...a);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-wrapped-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((o) => o.p.binding("spawn_sync"))({ p: process });\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-function-return-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((get) => get().binding("spawn_sync"))(() => process);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-function-local-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'function f() { const p = process; p.binding("spawn_sync"); }\nf();\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-shadow-reassigned-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'function f(process) { process = globalThis.process; process.binding("spawn_sync"); }\nf({});\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-shadow-closure-reassigned-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'function f(process) { const assign = () => { process = globalThis.process; }; assign(); process.binding("spawn_sync"); }\nf({});\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-shadow-closure-local-reassigned-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'function f(process) { let p = {}; const assign = () => { p = globalThis.process; }; assign(); p.binding("spawn_sync"); }\nf({});\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-shadow-closure-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'function f() { let p; const assign = () => { ({ process: p } = globalThis); }; assign(); p.binding("spawn_sync"); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-closure-reassigned-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'function f(g) { const assign = () => { g = globalThis; }; assign(); g.process.binding("spawn_sync"); }\nf({});\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-method-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((o) => o.get().binding("spawn_sync"))({ get() { return process; } });\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-parameter-default-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '((fn) => fn().binding("spawn_sync"))((x = process) => x);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const g = globalThis;\ng.process.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-object-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { globalThis: { process: p } } = globalThis;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-self-property-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'globalThis.globalThis.process.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-bun-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'globalThis.Bun.spawnSync(["true"]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-deno-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'globalThis.Deno.Command("true").outputSync();\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": 'const g = globalThis;\nReflect.get(g, "Bun").spawnSync(["true"]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-reflect-global-bun-api",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": 'const g = globalThis;\nglobalThis.Reflect.get(g, "Bun").spawnSync(["true"]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-apply-global-process-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'Reflect.apply(Reflect.get, Reflect, [globalThis, "process"]).binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-get-sequence-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": '(0, Reflect.get)(globalThis, "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-get-sequence-target-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'Reflect.get((0, globalThis), "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "dynamic-constructor-chain-computed-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": '({})["con" + "structor"]["con" + "structor"]("return 1")();\n',
+				},
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-global-object-container-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'const holder = { g: globalThis };\nholder.g.process.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-return-function-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const getGlobal = () => globalThis;\ngetGlobal().Bun.spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-call-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": '((g) => g.process.binding("spawn_sync"))(globalThis);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-throw-global-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'try { throw globalThis; } catch (g) { g.Bun.spawnSync(["true"]); }\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-global-wrapper-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'Object(globalThis).process.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-global-bun-wrapper-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'Object(globalThis).Bun.spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-create-global-wrapper-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'Object.create(globalThis).process.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-parameter-default-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": '((g = globalThis) => g.process.binding("spawn_sync"))();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-tagged-template-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": ['((_, g) => g.Bun.spawnSync(["true"]))`', "$", "{globalThis}", "`;\n"].join(""),
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-bun-literal-destructure-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const { "Bun": b } = globalThis;\nb.spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-deno-assignment-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'let d;\n({ Deno: d } = globalThis);\nd.Command("true").outputSync();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-member-assignment-container-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'const holder = {};\nholder.g = globalThis;\nholder.g.process.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-array-assignment-container-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const holder = [];\nholder[0] = globalThis;\nholder[0].Bun.spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-method-member-assignment-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'const holder = {};\nholder.get = Reflect.get;\nholder.get(globalThis, "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-method-container-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'const holder = { get: Reflect.get };\nholder.get(globalThis, "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-object-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'const R = Reflect;\nR.get(globalThis, "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-object-container-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const holder = { R: Reflect };\nholder.R.get(globalThis, "Bun").spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-object-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'const O = Object;\nO.getOwnPropertyDescriptor(globalThis, "process").value.getBuiltinModule("child_process").execSync("true");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-tagged-template-process-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": [
+						'((_, p) => p.getBuiltinModule("child_process").execSync("true"))`',
+						"$",
+						"{process}",
+						"`;\n",
+					].join(""),
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-throw-process-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'try { throw process; } catch (p) { p.getBuiltinModule("child_process").execSync("true"); }\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-yield-process-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'function* leak(){ yield process; }\nleak().next().value.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-class-field-process-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'class Leak { static p = process; }\nLeak.p.binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-exported-process-dependency-api",
+				scripts: { verify: "node verify.mjs" },
+				files: {
+					"verify.mjs": 'import p from "./proc.mjs";\np.binding("spawn_sync");\n',
+					"proc.mjs": "export default process;\n",
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-get-sequence-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'const get = (0, Reflect.get);\nget(globalThis, "process").binding("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-dynamic-key-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const g = globalThis;\nconst key = "Bun";\nReflect.get(g, key).spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-method-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const g = globalThis;\nconst get = Reflect.get;\nget(g, "Bun").spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptor-global-bun-method-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; const desc = Object.getOwnPropertyDescriptor; desc(g, "Bun").value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-method-destructure-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js": 'const g = globalThis;\nconst { get } = Reflect;\nget(g, "Bun").spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-reflect-method-destructure-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'const g = globalThis;\nconst { get } = globalThis.Reflect;\nget(g, "Bun").spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptor-global-bun-method-destructure-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; const { getOwnPropertyDescriptor: desc } = Object; desc(g, "Bun").value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-call-api",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": 'const g = globalThis;\nReflect.get.call(Reflect, g, "Bun").spawnSync(["true"]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-bind-api",
+				scripts: { verify: "bun verify.js" },
+				files: { "verify.js": 'const g = globalThis;\nReflect.get.bind(Reflect)(g, "Bun").spawnSync(["true"]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptor-global-bun-bind-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.getOwnPropertyDescriptor.bind(Object)(g, "Bun").value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-global-bun-apply-args-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'const g = globalThis;\nconst args = [g, "Bun"];\nReflect.get.apply(Reflect, args).spawnSync(["true"]);\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptor-global-bun-apply-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.getOwnPropertyDescriptor.apply(Object, [g, "Bun"]).value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-descriptor-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Reflect.getOwnPropertyDescriptor(g, "Bun").value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptor-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.getOwnPropertyDescriptor(g, "Bun").value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptors-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.getOwnPropertyDescriptors(g).Bun.value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-descriptors-map-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; const d = Object.getOwnPropertyDescriptors(g); d.Bun.value.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-values-global-bun-alias-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.values(g).find(v => v?.spawnSync)?.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-assign-global-bun-source-api",
+				scripts: { verify: "bun verify.js" },
+				files: {
+					"verify.js":
+						'function f() { const g = globalThis; Object.assign({}, g).Bun.spawnSync(["true"]); }\nf();\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-alias-process-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const g = globalThis;\nconst p = g.process;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-member-assignment-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const o = {};\no.p = process;\no.p.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-named-supplier-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const get = () => process;\nget().binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-function-declaration-supplier-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'function get() { return process; }\nget().binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-reflect-apply-argument-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const fn = (p) => p.binding("spawn_sync");\nReflect.apply(fn, null, [process]);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-object-call-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'Object(process).binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { binding } = process;\nbinding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-computed-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { ["bind" + "ing"]: b } = process;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-computed-global-this-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { ["bind" + "ing"]: b } = globalThis.process;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-computed-global-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { ["bind" + "ing"]: b } = global.process;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-computed-nested-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: { ["bind" + "ing"]: b } } = globalThis;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-global-destructure-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: p } = globalThis;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-global-destructure-default-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: p = null } = globalThis;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-assignment-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'let p;\np = globalThis.process;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-destructure-assignment-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'let p;\n({ process: p } = globalThis);\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-direct-destructure-assignment-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'let binding;\n({ binding } = process);\nbinding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-nested-global-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: { binding } } = globalThis;\nbinding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-nested-global-default-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: { binding } = {} } = globalThis;\nbinding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-rest-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { ...p } = process;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-nested-global-rest-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { process: { ...p } } = globalThis;\np.binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-computed-after-nested-object-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const { env: {}, ["bind" + "ing"]: b } = process;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-binding-computed-parameter-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'function f({ ["bind" + "ing"]: b }) { b("spawn_sync"); }\nf(process);\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-computed-bracket-string-destructure-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js": 'const { ["bind]".replace("]", "") + "ing"]: b } = process;\nb("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use dynamic property access",
+			},
+			{
+				name: "process-get-builtin-module-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "process.getBuiltinModule('child_process').execSync('true');\n" },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
 				name: "process-execution-api",
 				scripts: { verify: "bun verify.js" },
 				files: { "verify.js": "Bun?.spawnSync(['node', './helper.js']);\n" },
@@ -1202,6 +2116,63 @@ loop:
 				scripts: { verify: "node verify.js" },
 				files: { "verify.js": "process?.binding('spawn_sync');\n" },
 				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-member-alias-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'const b = process.binding;\nb("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-sequence-call-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": '(0, process.binding)("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-call-method-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'process.binding.call(process, "spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-with-api",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": 'with (process) binding("spawn_sync");\n' },
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "process-binding-enumeration-api",
+				scripts: { verify: "node verify.js" },
+				files: {
+					"verify.js":
+						'const fn = Object.values(process).find(value => value?.name === "bind" + "ing");\nfn("spawn_sync");\n',
+				},
+				error: "verifier dependencies must not use process execution APIs",
+			},
+			{
+				name: "native-verifier-dependency",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "require('./addon.node');\n", "addon.node": "" },
+				error: "verifier dependencies must not use native or WebAssembly files",
+			},
+			{
+				name: "wasm-verifier-dependency",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "require('./addon.wasm');\n", "addon.wasm": "" },
+				error: "verifier dependencies must not use native or WebAssembly files",
+			},
+			{
+				name: "native-verifier-entrypoint",
+				scripts: { verify: "node ./addon.node" },
+				files: { "addon.node": "" },
+				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "wasm-verifier-entrypoint",
+				scripts: { verify: "bun ./addon.wasm" },
+				files: { "addon.wasm": "" },
+				error: "verifier package scripts must not invoke nested package scripts",
 			},
 			{
 				name: "nested-package-runner",
@@ -1255,6 +2226,12 @@ loop:
 				name: "extensionless-entrypoint",
 				scripts: { verify: "node check" },
 				error: "verifier package scripts must execute a local verifier file through an approved runtime",
+			},
+			{
+				name: "extensionless-verifier-dependency",
+				scripts: { verify: "node verify.js" },
+				files: { "verify.js": "require('./pkg');\n", "pkg/index.js": "module.exports = true;\n" },
+				error: "verifier dependencies must use explicit file extensions",
 			},
 			{
 				name: "bare-package-import",
@@ -1316,7 +2293,60 @@ loop:
 				await dir.remove();
 			}
 		}
-	});
+	}, 60_000);
+
+	it("allows verifier scripts to shadow process and global aliases in local parameters", async () => {
+		const dir = await makeTempDir();
+		try {
+			await Bun.write(
+				path.join(dir.path(), "verify.js"),
+				[
+					"function local(process) { return process.binding('spawn_sync'); }",
+					"const p = process;",
+					"function localAlias(p) { const q = p; return q.binding('spawn_sync'); }",
+					"const g = globalThis;",
+					"function localGlobal(g) { return g.process.binding('spawn_sync'); }",
+					"function outer() { function nested(process) { return process.binding('spawn_sync'); } return 'ok'; }",
+					"Object.getOwnPropertyDescriptor(globalThis, 'fetch');",
+					"const result = local({ binding: () => 'ok' }) + localAlias({ binding: () => 'ok' }) + localGlobal({ process: { binding: () => 'ok' } }) + outer();",
+					"require('fs').writeFileSync('verified.txt', result);",
+					"",
+				].join("\n"),
+			);
+			await Bun.write(
+				path.join(dir.path(), "package.json"),
+				JSON.stringify({ scripts: { verify: "node verify.js" } }),
+			);
+			await initCleanGitRepo(dir.path());
+			const spec = parseLoopSpec(`
+loop:
+  name: process-shadow-local-param
+  goal: Allow local parameter names without exposing global process.
+  level: assisted
+  non_goals: ["Do not edit verifier scripts."]
+  runner:
+    prompt: Try nothing.
+  verifier:
+    separate: true
+    commands:
+      - ["bun", "run", "verify"]
+  guardrails:
+    max_iterations: 1
+  state:
+    run_log: loop-run-log.md
+`);
+			const result = await executeLoopIteration(spec, {
+				cwd: dir.path(),
+				runAgent: async () => ({ exitCode: 0, output: "agent completed" }),
+			});
+
+			expect(result.error).toBeNull();
+			expect(result.status).toBe("passed");
+			await expect(Bun.file(path.join(dir.path(), "verified.txt")).text()).resolves.toBe("okokokok");
+		} finally {
+			await dir.remove();
+		}
+	}, 15000);
 
 	it("requires approval if a subpackage verifier root config changes before verification", async () => {
 		const dir = await makeTempDir();


### PR DESCRIPTION
## Summary
- Add an OMP-native `omp loop` command for initializing, checking, and running one scheduled-safe loop iteration.
- Add loop spec parsing/readiness checks, scoped durable run logs, verifier execution guardrails, and starter templates.
- Harden report-mode sessions, path containment, package-script verifier validation, lifecycle-hook/config/file tamper detection, and durable log redaction.

## Verification
- `bunx biome check --write packages/coding-agent/src/loop-engineering/runner.ts packages/coding-agent/test/loop-engineering.test.ts`
- `bun test packages/coding-agent/test/loop-engineering.test.ts` (27 pass)
- `bun --cwd=packages/coding-agent run check`
- CLI smoke: `loop init`, `loop check`, `loop run --dry-run`

## CI
- GitHub Actions run 28223671744 is `action_required` with no jobs/logs, likely awaiting maintainer approval for the fork PR.