### PR TITLE
fix(mcp): hide Windows stdio server consoles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows stdio MCP server launches showing a separate `cmd.exe` window for direct executable servers; MCP subprocesses now set `windowsHide` on every Windows spawn path. ([#3535](https://github.com/can1357/oh-my-pi/issues/3535))
+
 ## [16.1.21] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveStdioSpawnCommand } from "./stdio";
+
+describe("resolveStdioSpawnCommand", () => {
+	it("hides direct Windows executable MCP servers", async () => {
+		await expect(
+			resolveStdioSpawnCommand(
+				{ command: "server.exe", args: ["--stdio"] },
+				{ cwd: process.cwd(), env: {}, platform: "win32" },
+			),
+		).resolves.toEqual({
+			cmd: ["server.exe", "--stdio"],
+			windowsHide: true,
+		});
+	});
+
+	it("keeps off-Windows spawn options unchanged", async () => {
+		await expect(
+			resolveStdioSpawnCommand(
+				{ command: "server.exe", args: ["--stdio"] },
+				{ cwd: process.cwd(), env: {}, platform: "linux" },
+			),
+		).resolves.toEqual({
+			cmd: ["server.exe", "--stdio"],
+		});
+	});
+});

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -239,12 +239,15 @@ export async function resolveStdioSpawnCommand(
 	// Direct-spawn only when we resolved to a concrete file AND its extension
 	// is not a batch script. Everything else (resolved .cmd/.bat, or an
 	// unresolved extensionless command) goes through cmd.exe so PATHEXT runs.
+	// Every Windows stdio server launch hides its console window; otherwise
+	// direct .exe servers pop a visible cmd window while the MCP server lives.
+	const windowsHide = true;
 	const needsCmdExe = resolved === null || isWindowsBatchCommand(resolvedCommand);
-	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args] };
+	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide };
 
 	return {
 		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],
-		windowsHide: true,
+		windowsHide,
 	};
 }
 


### PR DESCRIPTION
## Repro
On the pre-fix branch, the Windows stdio spawn resolver returned no hidden-window flag for a direct executable MCP server: `bun --eval "const mod = await import('./packages/coding-agent/src/mcp/transports/stdio.ts'); const direct = await mod.resolveStdioSpawnCommand({ command: 'server.exe', args: ['--stdio'] }, { cwd: process.cwd(), env: {}, platform: 'win32' }); console.log(JSON.stringify(direct));"` printed `{"cmd":["server.exe","--stdio"]}`.

## Cause
`packages/coding-agent/src/mcp/transports/stdio.ts` only set `windowsHide: true` for the Windows npm-shim and `cmd.exe /d /s /c` fallback paths. `resolveStdioSpawnCommand()` returned direct `.exe` server launches without `windowsHide`, and `StdioTransport.connect()` forwarded that undefined value to `Bun.spawn()`.

## Fix
- Set `windowsHide: true` for every Windows stdio MCP spawn path, including direct executable launches.
- Added `packages/coding-agent/src/mcp/transports/stdio.test.ts` to pin direct Windows executable behavior while preserving off-Windows spawn options.
- Added a coding-agent changelog entry for the Windows MCP console-window fix.

## Verification
Ran `bun test packages/coding-agent/src/mcp/transports/stdio.test.ts` (2 pass) and `bun run check` in `packages/coding-agent` (passed). After the fix, the resolver prints `{"cmd":["server.exe","--stdio"],"windowsHide":true}` for the direct Windows executable repro. Fixes #3535