### PR TITLE
fix(mcp/oauth): skip discovery metadata with mismatched issuer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP OAuth still failing with `Authorization failed: An unexpected error occurred` against Plane's `https://mcp.plane.so/http/mcp` endpoint after #3502. The protected-resource metadata advertised the path-scoped issuer `https://mcp.plane.so/http`, but `discoverOAuthEndpoints` (`packages/coding-agent/src/mcp/oauth-discovery.ts`) probed `/.well-known/oauth-authorization-server` at the *origin root* first and accepted the metadata served there — which describes a *different* issuer (`https://mcp.plane.so/`) whose `/authorize` endpoint rejects every grant. Discovery now honors RFC 8414 §3.3 and skips authorization-server / OpenID Connect well-known documents whose `issuer` field doesn't match the queried base URL (trailing-slash insensitive). Servers that omit `issuer` keep today's permissive behavior, so legacy flows are unaffected. ([#3537](https://github.com/can1357/oh-my-pi/issues/3537))
+
 ## [16.1.21] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -434,8 +434,7 @@ export async function discoverOAuthEndpoints(
 						// different schema, so the issuer check only gates the two official
 						// auth-server documents.
 						const requireIssuerMatch =
-							path === "/.well-known/oauth-authorization-server" ||
-							path === "/.well-known/openid-configuration";
+							path === "/.well-known/oauth-authorization-server" || path === "/.well-known/openid-configuration";
 						const issuerOk = requireIssuerMatch ? issuerMatchesBase(metadata.issuer, baseUrl) : true;
 						const endpoints = issuerOk ? findEndpoints(metadata) : null;
 						if (endpoints) return endpoints;

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -251,6 +251,45 @@ export function analyzeAuthError(error: Error, serverUrl?: string): AuthDetectio
 }
 
 /**
+ * Normalize an OAuth issuer URL for RFC 8414 §3.3 comparison: lowercase
+ * scheme/host (URL parser already does this), drop fragment/query, strip a
+ * trailing slash on the path. The path is otherwise case-sensitive.
+ */
+function normalizeIssuerUrl(value: string): string | undefined {
+	try {
+		const u = new URL(value);
+		const path = u.pathname.replace(/\/+$/, "");
+		return `${u.protocol}//${u.host}${path}`;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * RFC 8414 §3.3: an authorization-server metadata document's `issuer` MUST
+ * equal the URL the client used to construct the metadata URL. When a server
+ * hosts metadata for several issuers under one origin (Plane serves a root
+ * issuer `https://mcp.plane.so/` at `/.well-known/oauth-authorization-server`
+ * *and* a path-scoped issuer `https://mcp.plane.so/http` at the path-prefixed
+ * well-known URL), accepting the first hit silently routes the grant to the
+ * wrong `/authorize` endpoint and produces opaque `server_error` redirects.
+ *
+ * Returns true when the metadata is safe to use:
+ *   - the document has no `issuer` field (nonstandard / legacy servers — keep
+ *     today's permissive behavior), or
+ *   - the issuer matches `baseUrl` after trailing-slash normalization.
+ */
+function issuerMatchesBase(metadataIssuer: unknown, baseUrl: string): boolean {
+	if (typeof metadataIssuer !== "string" || !metadataIssuer.trim()) {
+		return true;
+	}
+	const normalizedIssuer = normalizeIssuerUrl(metadataIssuer);
+	const normalizedBase = normalizeIssuerUrl(baseUrl);
+	if (!normalizedIssuer || !normalizedBase) return true;
+	return normalizedIssuer === normalizedBase;
+}
+
+/**
  * Try to discover OAuth endpoints by querying the server's well-known endpoints.
  * This is a fallback when error responses don't include OAuth metadata.
  */
@@ -389,7 +428,16 @@ export async function discoverOAuthEndpoints(
 
 					if (response.ok) {
 						const metadata = (await response.json()) as Record<string, unknown>;
-						const endpoints = findEndpoints(metadata);
+						// Authorization-server / OpenID Connect metadata documents carry an
+						// `issuer` field that MUST equal the queried base URL (RFC 8414 §3.3,
+						// OIDC Discovery §4.3). Protected-resource and nonstandard paths use a
+						// different schema, so the issuer check only gates the two official
+						// auth-server documents.
+						const requireIssuerMatch =
+							path === "/.well-known/oauth-authorization-server" ||
+							path === "/.well-known/openid-configuration";
+						const issuerOk = requireIssuerMatch ? issuerMatchesBase(metadata.issuer, baseUrl) : true;
+						const endpoints = issuerOk ? findEndpoints(metadata) : null;
 						if (endpoints) return endpoints;
 
 						if (path === "/.well-known/oauth-protected-resource") {

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -315,3 +315,128 @@ describe("relative Mcp-Auth-Server URL", () => {
 		);
 	});
 });
+
+describe("RFC 8414 §3.3 issuer validation", () => {
+	it("rejects origin-root metadata whose issuer mismatches the path-scoped auth server (Plane regression)", async () => {
+		// Plane hosts both a root issuer (`https://mcp.plane.so/`) at the
+		// origin-root well-known *and* a path-scoped issuer
+		// (`https://mcp.plane.so/http`) at the path-prefixed well-known. The
+		// `/http/mcp` endpoint advertises only the path-scoped issuer via
+		// protected-resource metadata, but the discovery loop probes origin-root
+		// first; before the fix it accepted the wrong-issuer metadata and routed
+		// the OAuth flow to `https://mcp.plane.so/authorize`, which rejects every
+		// grant with `server_error`.
+		const calls: string[] = [];
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			calls.push(url);
+
+			if (url === "https://mcp.plane.so/.well-known/oauth-protected-resource/http/mcp") {
+				return new Response(
+					JSON.stringify({
+						resource: "https://mcp.plane.so/http/mcp",
+						authorization_servers: ["https://mcp.plane.so/http"],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === "https://mcp.plane.so/.well-known/oauth-authorization-server") {
+				// Root-issuer metadata served at origin root — wrong issuer for the
+				// `/http` auth server we asked about.
+				return new Response(
+					JSON.stringify({
+						issuer: "https://mcp.plane.so/",
+						authorization_endpoint: "https://mcp.plane.so/authorize",
+						token_endpoint: "https://mcp.plane.so/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === "https://mcp.plane.so/http/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://mcp.plane.so/http",
+						authorization_endpoint: "https://mcp.plane.so/http/authorize",
+						token_endpoint: "https://mcp.plane.so/http/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints(
+			"https://mcp.plane.so/http/mcp",
+			undefined,
+			"https://mcp.plane.so/.well-known/oauth-protected-resource/http/mcp",
+			{ fetch: fetchImpl },
+		);
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://mcp.plane.so/http/authorize",
+			tokenUrl: "https://mcp.plane.so/http/token",
+			resource: "https://mcp.plane.so/http/mcp",
+		});
+		// Wrong-issuer origin-root metadata WAS fetched and skipped.
+		expect(calls).toContain("https://mcp.plane.so/.well-known/oauth-authorization-server");
+		// Path-prefixed well-known is the one that supplied the result.
+		expect(calls).toContain("https://mcp.plane.so/http/.well-known/oauth-authorization-server");
+	});
+
+	it("treats trailing-slash issuer differences as a match", async () => {
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						// Issuer with trailing slash; queried base without.
+						issuer: "https://auth.example.com/",
+						authorization_endpoint: "https://auth.example.com/oauth/authorize",
+						token_endpoint: "https://auth.example.com/oauth/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints("https://mcp.example.com", "https://auth.example.com", undefined, {
+			fetch: fetchImpl,
+		});
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://auth.example.com/oauth/authorize",
+			tokenUrl: "https://auth.example.com/oauth/token",
+		});
+	});
+
+	it("accepts metadata without an issuer field (legacy / nonstandard servers)", async () => {
+		// Some servers omit `issuer` from their well-known document. Keep today's
+		// permissive behavior so this fix never regresses an already-working flow.
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						authorization_endpoint: "https://auth.example.com/oauth",
+						token_endpoint: "https://auth.example.com/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints("https://mcp.example.com", "https://auth.example.com", undefined, {
+			fetch: fetchImpl,
+		});
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://auth.example.com/oauth",
+			tokenUrl: "https://auth.example.com/token",
+		});
+	});
+});


### PR DESCRIPTION
## Repro

Configure the Plane MCP server with `https://mcp.plane.so/http/mcp` and run `/mcp reauth plane`. The browser flow still fails with `Authorization failed: An unexpected error occurred` even after #3503 landed; the URL OMP renders points at `https://mcp.plane.so/authorize?...` (root) rather than the path-scoped `/http/authorize` Plane advertises.

Verified live against Plane (`client_id=365784f2-fe68-4c63-b946-6c59aa5935b2`, same scopes/PKCE OMP sends):

|Request|Result|
|---|---|
|`GET https://mcp.plane.so/authorize?...&resource=https://mcp.plane.so/http/mcp`|`302 → /callback?error=server_error&error_description=An+unexpected+error+occurred`|
|`GET https://mcp.plane.so/authorize?...` (no `resource`)|`302 → /callback?error=server_error&error_description=An+unexpected+error+occurred`|
|`GET https://mcp.plane.so/http/authorize?...&resource=https://mcp.plane.so/http/mcp`|`302 → /http/consent?txn_id=…`|

`/authorize` is *always* the wrong endpoint for the `/http/mcp` MCP; Plane's protected-resource metadata advertises `authorization_servers: ["https://mcp.plane.so/http"]`, so the correct authorize endpoint is `/http/authorize`.

## Cause

`discoverOAuthEndpoints` (`packages/coding-agent/src/mcp/oauth-discovery.ts`) probes well-known paths against every candidate auth server in `urlsToQuery`. For each candidate it tries the origin-root URL before the path-prefixed and RFC 8414 path-ful variants, then returns on the first metadata document where `findEndpoints` finds an `authorization_endpoint`/`token_endpoint` pair. Plane is unusual: it serves a *root* issuer (`https://mcp.plane.so/`) at `https://mcp.plane.so/.well-known/oauth-authorization-server` *and* a separate *path-scoped* issuer (`https://mcp.plane.so/http`) at `https://mcp.plane.so/http/.well-known/oauth-authorization-server`. Discovery queried the auth-server URL `https://mcp.plane.so/http` (from `oauth-protected-resource`), tried origin-root first, got `200 OK` with the *root issuer's* metadata, accepted it, and stuck OMP's flow on the wrong `/authorize` — whose backend rejects every grant. The reauth callsite never gets a chance to fix this because `oauth.authorizationUrl` is already wrong by the time the resource filter runs.

## Fix

- `packages/coding-agent/src/mcp/oauth-discovery.ts`: in the discovery loop, when the queried well-known is the official `/.well-known/oauth-authorization-server` or `/.well-known/openid-configuration` document, verify that `metadata.issuer` equals the queried base URL (RFC 8414 §3.3, OIDC Discovery §4.3). Trailing slashes are normalized away to match common server behavior; case-sensitive path otherwise.
- Metadata without an `issuer` field is accepted as before, so legacy/nonstandard servers that already work don't regress. Protected-resource metadata and the nonstandard fallback paths (`/oauth/metadata`, `/.mcp/auth`, `/authorize`) are also unchanged.
- With the check in place Plane's origin-root metadata (issuer `https://mcp.plane.so/`) is skipped while we're looking for `https://mcp.plane.so/http`; the path-prefixed well-known then supplies the correct `authorization_endpoint = https://mcp.plane.so/http/authorize`, `token_endpoint = https://mcp.plane.so/http/token`, plus the advertised `resource = https://mcp.plane.so/http/mcp`. The existing #3503 resource-indicator policy preserves the provider-advertised resource unchanged, and Plane accepts the full grant.

## Verification

- New `RFC 8414 §3.3 issuer validation` suite in `packages/coding-agent/test/oauth-discovery.test.ts` (3 tests): Plane regression (origin-root wrong-issuer metadata is skipped, path-prefixed correct-issuer metadata supplies the result), trailing-slash issuer is treated as a match, missing-issuer metadata still accepted.
- `bun --cwd packages/coding-agent test test/oauth-discovery.test.ts` → 13 pass / 0 fail.
- Adjacent OAuth suites unchanged: `bun --cwd packages/coding-agent test test/oauth-flow.test.ts test/mcp-manager-oauth-refresh.test.ts test/oauth-manual-input.test.ts test/active-oauth-account.test.ts` → 45 pass / 6 fail; the 6 failures (`oauth-flow.test.ts` callback-server tests) are pre-existing on `main` from the sandbox's inability to bind localhost callback ports — same baseline failures #3503's PR documented and unrelated to this change.
- End-to-end sanity: replayed the corrected `/http/authorize` URL with OMP's exact PKCE/`prompt=consent`/redirect_uri shape — `302 → https://mcp.plane.so/http/consent?txn_id=…`.

Fixes #3537