### PR TITLE
feat(bash): record minimizer gain telemetry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,10 @@
 - Moved the `Working…` activity indicator below the sticky todo and subagent HUDs so it sits just above the editor instead of floating atop the todo panel.
 - Lightened the persistent Todo HUD: dropped the bracketing rules and, in the collapsed view, added a dimmed preview of the upcoming phases (marked with a distinct glyph) so the next stages stay visible without expanding.
 
+### Added
+
+- Added bash minimizer gain telemetry (`shellMinimizer.gainTelemetry`): when enabled (default **off**), appends JSONL records to `~/.omp/agent/minimizer-gain.jsonl` for every bash execution — `kind:"saved"` when the shell minimizer compressed output, `kind:"missed"` when it did not. Records include `sessionId`, `cwd`, `command`, `filter`, `inputBytes`, `outputBytes`, `exitCode`, and `timestamp`. Off by default; the setting description documents that the raw command string is recorded verbatim and may contain credentials. The `AgentSession.executeBash` path (TUI `!`-bash and RPC) and the `user_bash` extension path both participate, with a `didSave()` guard ensuring minimized runs emit exactly one `saved` record and no spurious `missed`. Shell tokenizer (`shellTokens`) handles `env`-prefixed commands, quoted assignments, escaped spaces, and newline command separators correctly when inferring missed filter names. ([#3542](https://github.com/can1357/oh-my-pi/pull/3542))
+
 ### Fixed
 
 - Fixed terminal hangs on Ctrl+Z (SIGTSTP) after running bash tool calls, and insulated MCP stdio servers from terminal job-control signals.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -192,7 +192,7 @@
 
 ### Added
 
-- Added `isolated`, `apply`, and `merge` options to eval `agent()` across every workflow runtime (Python, JavaScript, Ruby, Julia) so `workflowz`-driven fan-outs can request the same copy-on-write worktree isolation the `task` tool offers (strict opt-in via `isolated: true`, matching the `task` tool; `apply: false` keeps captured patches/branches without merging back; `merge: false` forces patch mode). Extracted the task-isolation lifecycle into `task/isolation-runner.ts` so the eval bridge and `TaskTool` share one implementation ([#3196](https://github.com/can1357/oh-my-pi/issues/3196))
+- Added bash minimizer gain telemetry (`shellMinimizer.gainTelemetry`): when enabled (default **off**), appends JSONL hit/miss records to `~/.omp/agent/minimizer-gain.jsonl` on every bash execution — `kind:"saved"` when the shell minimizer compressed output, `kind:"missed"` when it did not. Records include session context, byte counts, filter name, and exit code. Opt-in only; records the raw command string verbatim so the setting description documents the credential-exposure tradeoff. The `AgentSession.executeBash` path (TUI `!`-bash and RPC) and the `user_bash` extension path both participate, and both honour the same `didSave()` guard that ensures a minimized run emits exactly one `saved` record with no spurious `missed`. The schema version starts at `1` (no prior writer exists in the codebase) ([#3542](https://github.com/can1357/oh-my-pi/pull/3542))
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3068,6 +3068,17 @@ export const SETTINGS_SCHEMA = {
 		type: "boolean",
 		default: undefined,
 	},
+	"shellMinimizer.gainTelemetry": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "shell",
+			group: "Bash",
+			label: "Shell Minimizer Gain Telemetry",
+			description:
+				"Record bash minimizer hit/miss gain data to ~/.omp/agent/minimizer-gain.jsonl. Off by default. Note: records the raw command string verbatim — avoid enabling when commands may contain credentials.",
+		},
+	},
 
 	// Eval (per-backend toggles; add more as new backends ship, e.g. eval.ts)
 	"eval.py": {
@@ -4959,6 +4970,7 @@ export interface ShellMinimizerSettings {
 	maxCaptureBytes: number;
 	sourceOutlineLevel: "default" | "aggressive";
 	legacyFilters: boolean | undefined;
+	gainTelemetry: boolean;
 }
 export type CodexAutoRedeemMode = "unset" | "yes" | "no";
 

--- a/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import * as path from "node:path";
 import { $which, TempDir } from "@oh-my-pi/pi-utils";
 import { disposeJuliaKernelSessionsByOwner, executeJulia } from "../jl/executor";
 
 const HAS_JULIA = Boolean($which("julia"));
+if (HAS_JULIA) setDefaultTimeout(60_000);
 const OWNER_ID = "julia-prelude-tests";
 
 describe.skipIf(!HAS_JULIA)("eval Julia prelude helpers", () => {

--- a/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
@@ -1,10 +1,9 @@
-import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { $which, TempDir } from "@oh-my-pi/pi-utils";
 import { disposeJuliaKernelSessionsByOwner, executeJulia } from "../jl/executor";
 
 const HAS_JULIA = Boolean($which("julia"));
-if (HAS_JULIA) setDefaultTimeout(60_000);
 const OWNER_ID = "julia-prelude-tests";
 
 describe.skipIf(!HAS_JULIA)("eval Julia prelude helpers", () => {

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -386,7 +386,7 @@ export class StdioTransport implements MCPTransport {
 			stdout: "pipe",
 			stderr: "pipe",
 			windowsHide: spawnCommand.windowsHide,
-			detached: spawnCommand.detached,
+			detached: spawnCommand.detached, // POSIX: no controlling terminal; Windows: false (see detached field)
 		});
 
 		this.#connected = true;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -185,6 +185,7 @@ import {
 import { disposeRubyKernelSessionsByOwner } from "../eval/rb/executor";
 import { defaultEvalSessionId } from "../eval/session-id";
 import { type BashResult, executeBash as executeBashCommand } from "../exec/bash-executor";
+import { appendBashMinimizerGainRecord, inferBashMinimizerMissedFilter } from "../tools/bash-minimizer-gain";
 import type { TtsrManager, TtsrMatchContext } from "../export/ttsr";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
@@ -11988,6 +11989,17 @@ export class AgentSession {
 			});
 			if (hookResult?.result) {
 				this.recordBashResult(command, hookResult.result, options);
+				void appendBashMinimizerGainRecord({
+					command,
+					cwd,
+					sessionId: this.sessionId,
+					filter: inferBashMinimizerMissedFilter(command),
+					inputBytes: hookResult.result.totalBytes,
+					outputBytes: hookResult.result.totalBytes,
+					exitCode: hookResult.result.exitCode ?? null,
+					kind: "missed",
+					agentDir: this.settings.getAgentDir?.(),
+				}).catch(() => {});
 				return hookResult.result;
 			}
 		}
@@ -12006,6 +12018,17 @@ export class AgentSession {
 			});
 
 			this.recordBashResult(command, result, options);
+			void appendBashMinimizerGainRecord({
+				command,
+				cwd,
+				sessionId: this.sessionId,
+				filter: inferBashMinimizerMissedFilter(command),
+				inputBytes: result.totalBytes,
+				outputBytes: result.totalBytes,
+				exitCode: result.exitCode ?? null,
+				kind: "missed",
+				agentDir: this.settings.getAgentDir?.(),
+			}).catch(() => {});
 			return result;
 		} finally {
 			this.#bashAbortControllers.delete(abortController);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -185,7 +185,6 @@ import {
 import { disposeRubyKernelSessionsByOwner } from "../eval/rb/executor";
 import { defaultEvalSessionId } from "../eval/session-id";
 import { type BashResult, executeBash as executeBashCommand } from "../exec/bash-executor";
-import { appendBashMinimizerGainRecord, inferBashMinimizerMissedFilter } from "../tools/bash-minimizer-gain";
 import type { TtsrManager, TtsrMatchContext } from "../export/ttsr";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
@@ -279,6 +278,7 @@ import {
 } from "../tool-discovery/tool-index";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import { normalizeToolNames } from "../tools/builtin-names";
+import { appendBashMinimizerGainRecord, inferBashMinimizerMissedFilter } from "../tools/bash-minimizer-gain";
 import type { CheckpointState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
@@ -11989,18 +11989,26 @@ export class AgentSession {
 			});
 			if (hookResult?.result) {
 				this.recordBashResult(command, hookResult.result, options);
-				void appendBashMinimizerGainRecord({
-					command,
-					cwd,
-					sessionId: this.sessionId,
-					filter: inferBashMinimizerMissedFilter(command),
-					inputBytes: hookResult.result.totalBytes,
-					outputBytes: hookResult.result.totalBytes,
-					exitCode: hookResult.result.exitCode ?? null,
-					kind: "missed",
-					agentDir: this.settings.getAgentDir?.(),
-				}).catch(() => {});
-				return hookResult.result;
+				const r = hookResult.result;
+				if (
+					this.settings.get("shellMinimizer.gainTelemetry") &&
+					!r.cancelled &&
+					r.exitCode !== undefined &&
+					r.totalBytes > 0
+				) {
+					void appendBashMinimizerGainRecord({
+						command,
+						cwd,
+						sessionId: this.sessionId,
+						filter: inferBashMinimizerMissedFilter(command),
+						inputBytes: r.totalBytes,
+						outputBytes: r.totalBytes,
+						exitCode: r.exitCode ?? null,
+						kind: "missed",
+						agentDir: this.settings.getAgentDir(),
+					}).catch(() => {});
+				}
+				return r;
 			}
 		}
 
@@ -12008,27 +12016,54 @@ export class AgentSession {
 		this.#bashAbortControllers.add(abortController);
 
 		try {
+			const gainTelemetry = this.settings.get("shellMinimizer.gainTelemetry");
+			let minimizationSaved = false;
 			const result = await executeBashCommand(command, {
 				onChunk,
 				signal: abortController.signal,
 				sessionKey: this.sessionId,
 				timeout: clampTimeout("bash") * 1000,
-				onMinimizedSave: originalText => this.#saveBashOriginalArtifact(originalText),
+				onMinimizedSave: async (originalText, info) => {
+					minimizationSaved = true;
+					const artifactId = await this.#saveBashOriginalArtifact(originalText);
+					if (gainTelemetry) {
+						void appendBashMinimizerGainRecord({
+							command,
+							cwd,
+							sessionId: this.sessionId,
+							filter: info.filter,
+							inputBytes: info.inputBytes,
+							outputBytes: info.outputBytes,
+							exitCode: null,
+							kind: "saved",
+							agentDir: this.settings.getAgentDir(),
+						}).catch(() => {});
+					}
+					return artifactId;
+				},
 				useUserShell: options?.useUserShell,
 			});
 
 			this.recordBashResult(command, result, options);
-			void appendBashMinimizerGainRecord({
-				command,
-				cwd,
-				sessionId: this.sessionId,
-				filter: inferBashMinimizerMissedFilter(command),
-				inputBytes: result.totalBytes,
-				outputBytes: result.totalBytes,
-				exitCode: result.exitCode ?? null,
-				kind: "missed",
-				agentDir: this.settings.getAgentDir?.(),
-			}).catch(() => {});
+			if (
+				gainTelemetry &&
+				!minimizationSaved &&
+				!result.cancelled &&
+				result.exitCode !== undefined &&
+				result.totalBytes > 0
+			) {
+				void appendBashMinimizerGainRecord({
+					command,
+					cwd,
+					sessionId: this.sessionId,
+					filter: inferBashMinimizerMissedFilter(command),
+					inputBytes: result.totalBytes,
+					outputBytes: result.totalBytes,
+					exitCode: result.exitCode ?? null,
+					kind: "missed",
+					agentDir: this.settings.getAgentDir(),
+				}).catch(() => {});
+			}
 			return result;
 		} finally {
 			this.#bashAbortControllers.delete(abortController);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -277,8 +277,8 @@ import {
 	selectDiscoverableToolNamesByServer,
 } from "../tool-discovery/tool-index";
 import { assertEditableFile } from "../tools/auto-generated-guard";
-import { normalizeToolNames } from "../tools/builtin-names";
 import { appendBashMinimizerGainRecord, inferBashMinimizerMissedFilter } from "../tools/bash-minimizer-gain";
+import { normalizeToolNames } from "../tools/builtin-names";
 import type { CheckpointState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -11992,6 +11992,7 @@ export class AgentSession {
 				const r = hookResult.result;
 				if (
 					this.settings.get("shellMinimizer.gainTelemetry") &&
+					this.settings.get("shellMinimizer.enabled") &&
 					!r.cancelled &&
 					r.exitCode !== undefined &&
 					r.totalBytes > 0
@@ -12031,7 +12032,7 @@ export class AgentSession {
 			});
 
 			this.recordBashResult(command, result, options);
-			if (gainTelemetry) {
+			if (gainTelemetry && this.settings.get("shellMinimizer.enabled")) {
 				if (savedGain.info) {
 					// Flush saved record with real exitCode now that the result is known.
 					const info = savedGain.info;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12017,52 +12017,48 @@ export class AgentSession {
 
 		try {
 			const gainTelemetry = this.settings.get("shellMinimizer.gainTelemetry");
-			let minimizationSaved = false;
+			const savedGain = { info: null as { filter: string; inputBytes: number; outputBytes: number } | null };
 			const result = await executeBashCommand(command, {
 				onChunk,
 				signal: abortController.signal,
 				sessionKey: this.sessionId,
 				timeout: clampTimeout("bash") * 1000,
 				onMinimizedSave: async (originalText, info) => {
-					minimizationSaved = true;
-					const artifactId = await this.#saveBashOriginalArtifact(originalText);
-					if (gainTelemetry) {
-						void appendBashMinimizerGainRecord({
-							command,
-							cwd,
-							sessionId: this.sessionId,
-							filter: info.filter,
-							inputBytes: info.inputBytes,
-							outputBytes: info.outputBytes,
-							exitCode: null,
-							kind: "saved",
-							agentDir: this.settings.getAgentDir(),
-						}).catch(() => {});
-					}
-					return artifactId;
+					if (gainTelemetry) savedGain.info = info;
+					return this.#saveBashOriginalArtifact(originalText);
 				},
 				useUserShell: options?.useUserShell,
 			});
 
 			this.recordBashResult(command, result, options);
-			if (
-				gainTelemetry &&
-				!minimizationSaved &&
-				!result.cancelled &&
-				result.exitCode !== undefined &&
-				result.totalBytes > 0
-			) {
-				void appendBashMinimizerGainRecord({
-					command,
-					cwd,
-					sessionId: this.sessionId,
-					filter: inferBashMinimizerMissedFilter(command),
-					inputBytes: result.totalBytes,
-					outputBytes: result.totalBytes,
-					exitCode: result.exitCode ?? null,
-					kind: "missed",
-					agentDir: this.settings.getAgentDir(),
-				}).catch(() => {});
+			if (gainTelemetry) {
+				if (savedGain.info) {
+					// Flush saved record with real exitCode now that the result is known.
+					const info = savedGain.info;
+					void appendBashMinimizerGainRecord({
+						command,
+						cwd,
+						sessionId: this.sessionId,
+						filter: info.filter,
+						inputBytes: info.inputBytes,
+						outputBytes: info.outputBytes,
+						exitCode: result.exitCode ?? null,
+						kind: "saved",
+						agentDir: this.settings.getAgentDir(),
+					}).catch(() => {});
+				} else if (!result.cancelled && result.exitCode !== undefined && result.totalBytes > 0) {
+					void appendBashMinimizerGainRecord({
+						command,
+						cwd,
+						sessionId: this.sessionId,
+						filter: inferBashMinimizerMissedFilter(command),
+						inputBytes: result.totalBytes,
+						outputBytes: result.totalBytes,
+						exitCode: result.exitCode ?? null,
+						kind: "missed",
+						agentDir: this.settings.getAgentDir(),
+					}).catch(() => {});
+				}
 			}
 			return result;
 		} finally {

--- a/packages/coding-agent/src/tools/bash-minimizer-gain.ts
+++ b/packages/coding-agent/src/tools/bash-minimizer-gain.ts
@@ -61,10 +61,10 @@ export async function appendBashMinimizerGainRecord(input: BashMinimizerGainInpu
 }
 
 /**
- * Shell-aware tokenizer: splits `command` on unquoted whitespace, consuming
- * single-quoted ('…') and double-quoted ("…") spans without splitting on the
- * whitespace inside them.  Only the first few tokens are needed, so we stop
- * once we have found the real program token.
+ * Shell-aware tokenizer: splits `command` on unquoted whitespace and
+ * detects shell operators (`|`, `&`, `;`). Returns token strings; operator
+ * tokens are the single characters `|`, `&`, or `;`. Backslash-escaped
+ * spaces are treated as word characters, not delimiters.
  */
 function shellTokens(command: string): string[] {
 	const tokens: string[] = [];
@@ -74,11 +74,24 @@ function shellTokens(command: string): string[] {
 		// skip unquoted whitespace
 		while (i < len && (command[i] === " " || command[i] === "\t")) i++;
 		if (i >= len) break;
+		const ch0 = command[i];
+		// unquoted shell operators become single-character tokens
+		if (ch0 === "|" || ch0 === "&" || ch0 === ";") {
+			tokens.push(ch0);
+			i++;
+			continue;
+		}
 		let token = "";
-		// consume one token (may contain quoted spans)
-		while (i < len && command[i] !== " " && command[i] !== "\t") {
+		// consume one word token (may contain quoted spans or escape sequences)
+		while (i < len) {
 			const ch = command[i];
-			if (ch === "'") {
+			if (ch === " " || ch === "\t") break;
+			if (ch === "|" || ch === "&" || ch === ";") break;
+			if (ch === "\\") {
+				// backslash escape: next char is a literal word character
+				i++;
+				if (i < len) token += command[i++];
+			} else if (ch === "'") {
 				// single-quoted: consume until closing '
 				i++;
 				while (i < len && command[i] !== "'") {
@@ -86,7 +99,7 @@ function shellTokens(command: string): string[] {
 				}
 				if (i < len) i++; // skip closing '
 			} else if (ch === '"') {
-				// double-quoted: consume until closing " (no backslash handling needed for identity)
+				// double-quoted: consume until closing "
 				i++;
 				while (i < len && command[i] !== '"') {
 					if (command[i] === "\\" && i + 1 < len) i++; // skip escape
@@ -106,13 +119,34 @@ function shellTokens(command: string): string[] {
 export function inferBashMinimizerMissedFilter(command: string): string {
 	const trimmed = command.trim();
 	if (trimmed.length === 0) return "missed";
-	if (/[;&|]/.test(trimmed)) return "compound";
-	// Use shell-aware tokenization so quoted env values containing whitespace
-	// (e.g. NODE_OPTIONS='--max-old-space-size=4096 --trace-warnings' pnpm test)
-	// don't cause the loop to stop at a value fragment instead of the real command.
+	// Tokenize first so quoted operators (e.g. `rg 'foo|bar'`) are not
+	// misidentified as compound commands.
 	const tokens = shellTokens(trimmed);
-	let first = tokens[0] ?? "";
+	// Any unquoted shell operator token means compound command.
+	if (tokens.some(t => t === "|" || t === "&" || t === ";")) return "compound";
 	let idx = 0;
+	let first = tokens[0] ?? "";
+	// Skip env wrapper and its assignments/flags (e.g. `env -u FOO cmd` or `env FOO=bar cmd`)
+	if (first === "env") {
+		idx++;
+		// skip env options and NAME=value pairs; env -u VAR takes a following argument
+		while (idx < tokens.length) {
+			const t = tokens[idx]!;
+			if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(t)) {
+				idx++;
+			} else if (t.startsWith("-")) {
+				idx++;
+				// single-char option that takes a following argument (e.g. -u, -n, -i)
+				if (/^-[a-z]$/.test(t) && idx < tokens.length && !tokens[idx]!.startsWith("-")) {
+					idx++; // skip the option's argument
+				}
+			} else {
+				break;
+			}
+		}
+		first = tokens[idx] ?? "";
+	}
+	// Skip leading NAME=value env assignments
 	while (first && /^[A-Za-z_][A-Za-z0-9_]*=/.test(first)) {
 		idx++;
 		first = tokens[idx] ?? "";

--- a/packages/coding-agent/src/tools/bash-minimizer-gain.ts
+++ b/packages/coding-agent/src/tools/bash-minimizer-gain.ts
@@ -41,7 +41,7 @@ export async function appendBashMinimizerGainRecord(input: BashMinimizerGainInpu
 		? await fs.realpath(resolvedSessionCwd).catch(() => resolvedSessionCwd)
 		: undefined;
 	const record = {
-		schemaVersion: 2,
+		schemaVersion: 1,
 		timestamp: new Date().toISOString(),
 		...(cwdRealpath ? { cwd: cwdRealpath } : {}),
 		...(sessionCwdRealpath ? { sessionCwd: sessionCwdRealpath } : {}),

--- a/packages/coding-agent/src/tools/bash-minimizer-gain.ts
+++ b/packages/coding-agent/src/tools/bash-minimizer-gain.ts
@@ -71,12 +71,12 @@ function shellTokens(command: string): string[] {
 	let i = 0;
 	const len = command.length;
 	while (i < len) {
-		// skip unquoted whitespace
+		// skip unquoted horizontal whitespace (newlines are command separators, not whitespace)
 		while (i < len && (command[i] === " " || command[i] === "\t")) i++;
 		if (i >= len) break;
 		const ch0 = command[i];
 		// unquoted shell operators become single-character tokens
-		if (ch0 === "|" || ch0 === "&" || ch0 === ";") {
+		if (ch0 === "|" || ch0 === "&" || ch0 === ";" || ch0 === "\n" || ch0 === "\r") {
 			tokens.push(ch0);
 			i++;
 			continue;
@@ -85,7 +85,7 @@ function shellTokens(command: string): string[] {
 		// consume one word token (may contain quoted spans or escape sequences)
 		while (i < len) {
 			const ch = command[i];
-			if (ch === " " || ch === "\t") break;
+			if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") break;
 			if (ch === "|" || ch === "&" || ch === ";") break;
 			if (ch === "\\") {
 				// backslash escape: next char is a literal word character
@@ -123,7 +123,7 @@ export function inferBashMinimizerMissedFilter(command: string): string {
 	// misidentified as compound commands.
 	const tokens = shellTokens(trimmed);
 	// Any unquoted shell operator token means compound command.
-	if (tokens.some(t => t === "|" || t === "&" || t === ";")) return "compound";
+	if (tokens.some(t => t === "|" || t === "&" || t === ";" || t === "\n" || t === "\r")) return "compound";
 	let idx = 0;
 	let first = tokens[0] ?? "";
 	// Skip env wrapper and its assignments/flags (e.g. `env -u FOO cmd` or `env FOO=bar cmd`)
@@ -136,8 +136,9 @@ export function inferBashMinimizerMissedFilter(command: string): string {
 				idx++;
 			} else if (t.startsWith("-")) {
 				idx++;
-				// single-char option that takes a following argument (e.g. -u, -n, -i)
-				if (/^-[a-z]$/.test(t) && idx < tokens.length && !tokens[idx]!.startsWith("-")) {
+				// single-char option that takes a following argument: -u (unset), -C (chdir), -n (dry-run)
+				// but NOT -i (ignore-env) or -v (verbose) which take no operand
+				if (/^-[a-z]$/.test(t) && !/^-[iv]$/.test(t) && idx < tokens.length && !tokens[idx]!.startsWith("-")) {
 					idx++; // skip the option's argument
 				}
 			} else {

--- a/packages/coding-agent/src/tools/bash-minimizer-gain.ts
+++ b/packages/coding-agent/src/tools/bash-minimizer-gain.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getAgentDir } from "@oh-my-pi/pi-utils";
+
+const MINIMIZER_GAIN_FILE = "minimizer-gain.jsonl";
+const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+export type BashMinimizerGainKind = "saved" | "missed";
+
+export interface BashMinimizerGainInput {
+	command: string;
+	cwd?: string;
+	sessionCwd?: string;
+	sessionId?: string;
+	filter: string;
+	inputBytes: number;
+	outputBytes: number;
+	exitCode: number | null;
+	kind?: BashMinimizerGainKind;
+	agentDir?: string;
+}
+
+export function getBashMinimizerGainPath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, MINIMIZER_GAIN_FILE);
+}
+
+export async function appendBashMinimizerGainRecord(input: BashMinimizerGainInput): Promise<void> {
+	const kind = input.kind ?? "saved";
+	const savedBytes = kind === "saved" ? input.inputBytes - input.outputBytes : 0;
+	if (kind === "saved" && savedBytes <= 0) return;
+
+	const observedInputBytes = input.inputBytes;
+	const observedOutputBytes = input.outputBytes;
+	if (kind === "missed" && observedInputBytes <= 0 && observedOutputBytes <= 0) return;
+
+	const recordsPath = getBashMinimizerGainPath(input.agentDir);
+	const resolvedCwd = input.cwd ? path.resolve(input.cwd) : undefined;
+	const resolvedSessionCwd = input.sessionCwd ? path.resolve(input.sessionCwd) : undefined;
+	const cwdRealpath = resolvedCwd ? await fs.realpath(resolvedCwd).catch(() => resolvedCwd) : undefined;
+	const sessionCwdRealpath = resolvedSessionCwd
+		? await fs.realpath(resolvedSessionCwd).catch(() => resolvedSessionCwd)
+		: undefined;
+	const record = {
+		schemaVersion: 2,
+		timestamp: new Date().toISOString(),
+		...(cwdRealpath ? { cwd: cwdRealpath } : {}),
+		...(sessionCwdRealpath ? { sessionCwd: sessionCwdRealpath } : {}),
+		...(input.sessionId ? { sessionId: input.sessionId } : {}),
+		command: input.command,
+		filter: input.filter,
+		inputBytes: observedInputBytes,
+		outputBytes: observedOutputBytes,
+		savedBytes,
+		...(kind === "saved" ? { savedTokens: Math.round(savedBytes / BYTES_PER_TOKEN_ESTIMATE) } : {}),
+		exitCode: input.exitCode,
+		kind,
+	};
+
+	await fs.mkdir(path.dirname(recordsPath), { recursive: true });
+	await fs.appendFile(recordsPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+/**
+ * Shell-aware tokenizer: splits `command` on unquoted whitespace, consuming
+ * single-quoted ('…') and double-quoted ("…") spans without splitting on the
+ * whitespace inside them.  Only the first few tokens are needed, so we stop
+ * once we have found the real program token.
+ */
+function shellTokens(command: string): string[] {
+	const tokens: string[] = [];
+	let i = 0;
+	const len = command.length;
+	while (i < len) {
+		// skip unquoted whitespace
+		while (i < len && (command[i] === " " || command[i] === "\t")) i++;
+		if (i >= len) break;
+		let token = "";
+		// consume one token (may contain quoted spans)
+		while (i < len && command[i] !== " " && command[i] !== "\t") {
+			const ch = command[i];
+			if (ch === "'") {
+				// single-quoted: consume until closing '
+				i++;
+				while (i < len && command[i] !== "'") {
+					token += command[i++];
+				}
+				if (i < len) i++; // skip closing '
+			} else if (ch === '"') {
+				// double-quoted: consume until closing " (no backslash handling needed for identity)
+				i++;
+				while (i < len && command[i] !== '"') {
+					if (command[i] === "\\" && i + 1 < len) i++; // skip escape
+					token += command[i++];
+				}
+				if (i < len) i++; // skip closing "
+			} else {
+				token += ch;
+				i++;
+			}
+		}
+		tokens.push(token);
+	}
+	return tokens;
+}
+
+export function inferBashMinimizerMissedFilter(command: string): string {
+	const trimmed = command.trim();
+	if (trimmed.length === 0) return "missed";
+	if (/[;&|]/.test(trimmed)) return "compound";
+	// Use shell-aware tokenization so quoted env values containing whitespace
+	// (e.g. NODE_OPTIONS='--max-old-space-size=4096 --trace-warnings' pnpm test)
+	// don't cause the loop to stop at a value fragment instead of the real command.
+	const tokens = shellTokens(trimmed);
+	let first = tokens[0] ?? "";
+	let idx = 0;
+	while (first && /^[A-Za-z_][A-Za-z0-9_]*=/.test(first)) {
+		idx++;
+		first = tokens[idx] ?? "";
+	}
+	if (!first) return "env";
+	const slash = first.lastIndexOf("/");
+	const name = slash === -1 ? first : first.slice(slash + 1);
+	return name.length === 0 ? "missed" : name;
+}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -26,6 +26,7 @@ import { truncateForPrompt } from "./approval";
 import { applyBashFixups } from "./bash-command-fixup";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
+import { appendBashMinimizerGainRecord, inferBashMinimizerMissedFilter } from "./bash-minimizer-gain";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
@@ -97,6 +98,62 @@ async function saveBashOriginalArtifact(session: ToolSession, originalText: stri
 		return alloc.id;
 	} catch {
 		return undefined;
+	}
+}
+
+function makeMinimizedSaveHandler(
+	session: ToolSession,
+	command: string,
+	commandCwd: string,
+): (
+	originalText: string,
+	info: { filter: string; inputBytes: number; outputBytes: number },
+) => Promise<string | undefined> {
+	return async (originalText, info) => {
+		const artifactId = await saveBashOriginalArtifact(session, originalText);
+		try {
+			await appendBashMinimizerGainRecord({
+				command,
+				cwd: commandCwd,
+				sessionCwd: session.cwd,
+				sessionId: session.getSessionId?.() ?? undefined,
+				filter: info.filter,
+				inputBytes: info.inputBytes,
+				outputBytes: info.outputBytes,
+				exitCode: null,
+				kind: "saved",
+				agentDir: session.settings.getAgentDir?.(),
+			});
+		} catch {
+			// Best-effort
+		}
+		return artifactId;
+	};
+}
+
+async function recordBashMinimizerGain(input: {
+	session: ToolSession;
+	command: string;
+	commandCwd: string;
+	result: BashResult | BashInteractiveResult;
+}): Promise<void> {
+	try {
+		if (input.result.cancelled || input.result.exitCode === undefined) return;
+		if (input.result.totalBytes <= 0) return;
+		await appendBashMinimizerGainRecord({
+			command: input.command,
+			cwd: input.commandCwd,
+			sessionCwd: input.session.cwd,
+			sessionId: input.session.getSessionId?.() ?? undefined,
+			filter: inferBashMinimizerMissedFilter(input.command),
+			inputBytes: input.result.totalBytes,
+			outputBytes: input.result.totalBytes,
+			exitCode: input.result.exitCode,
+			kind: "missed",
+			agentDir: input.session.settings.getAgentDir?.(),
+		});
+	} catch {
+		// Best-effort: gain telemetry failure must not break bash execution
 	}
 }
 
@@ -575,7 +632,13 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 							latestText = tailBuffer.text();
 							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
 						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						onMinimizedSave: makeMinimizedSaveHandler(this.session, options.command, options.commandCwd),
+					});
+					await recordBashMinimizerGain({
+						session: this.session,
+						command: options.command,
+						commandCwd: options.commandCwd,
+						result,
 					});
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
@@ -1018,6 +1081,13 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				if (finalOutput.truncated) bridgeNotices.push("(output truncated)");
 				for (const notice of pendingNotices) bridgeNotices.push(notice);
 
+				await recordBashMinimizerGain({
+					session: this.session,
+					command,
+					commandCwd,
+					result: bridgeResult,
+				});
+
 				return this.#buildCompletedResult(bridgeResult, timeoutSec, {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
@@ -1063,7 +1133,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					artifactPath,
 					artifactId,
 					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+					onMinimizedSave: makeMinimizedSaveHandler(this.session, command, commandCwd),
 				});
 		const wallTimeMs = performance.now() - wallTimeStart;
 		if (result.cancelled) {
@@ -1084,6 +1154,12 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					: `Command timed out after ${timeoutSec} seconds`,
 			);
 		}
+		await recordBashMinimizerGain({
+			session: this.session,
+			command,
+			commandCwd,
+			result,
+		});
 		return this.#buildCompletedResult(result, timeoutSec, {
 			requestedTimeoutSec,
 			notices: pendingNotices,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -101,7 +101,7 @@ async function saveBashOriginalArtifact(session: ToolSession, originalText: stri
 	}
 }
 
-function makeMinimizedSaveHandler(
+export function makeMinimizedSaveHandler(
 	session: ToolSession,
 	command: string,
 	commandCwd: string,
@@ -113,25 +113,28 @@ function makeMinimizedSaveHandler(
 	didSave: () => boolean;
 } {
 	let saved = false;
+	const gainTelemetry = session.settings.get("shellMinimizer.gainTelemetry");
 	return {
 		onMinimizedSave: async (originalText, info) => {
 			saved = true;
 			const artifactId = await saveBashOriginalArtifact(session, originalText);
-			try {
-				await appendBashMinimizerGainRecord({
-					command,
-					cwd: commandCwd,
-					sessionCwd: session.cwd,
-					sessionId: session.getSessionId?.() ?? undefined,
-					filter: info.filter,
-					inputBytes: info.inputBytes,
-					outputBytes: info.outputBytes,
-					exitCode: null,
-					kind: "saved",
-					agentDir: session.settings.getAgentDir?.(),
-				});
-			} catch {
-				// Best-effort
+			if (gainTelemetry) {
+				try {
+					await appendBashMinimizerGainRecord({
+						command,
+						cwd: commandCwd,
+						sessionCwd: session.cwd,
+						sessionId: session.getSessionId?.() ?? undefined,
+						filter: info.filter,
+						inputBytes: info.inputBytes,
+						outputBytes: info.outputBytes,
+						exitCode: null,
+						kind: "saved",
+						agentDir: session.settings.getAgentDir(),
+					});
+				} catch {
+					// Best-effort
+				}
 			}
 			return artifactId;
 		},
@@ -145,6 +148,7 @@ async function recordBashMinimizerGain(input: {
 	commandCwd: string;
 	result: BashResult | BashInteractiveResult;
 }): Promise<void> {
+	if (!input.session.settings.get("shellMinimizer.gainTelemetry")) return;
 	try {
 		if (input.result.cancelled || input.result.exitCode === undefined) return;
 		if (input.result.totalBytes <= 0) return;
@@ -158,7 +162,7 @@ async function recordBashMinimizerGain(input: {
 			outputBytes: input.result.totalBytes,
 			exitCode: input.result.exitCode,
 			kind: "missed",
-			agentDir: input.session.settings.getAgentDir?.(),
+			agentDir: input.session.settings.getAgentDir(),
 		});
 	} catch {
 		// Best-effort: gain telemetry failure must not break bash execution

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -151,6 +151,7 @@ async function recordBashMinimizerGain(input: {
 	result: BashResult | BashInteractiveResult;
 }): Promise<void> {
 	if (!input.session.settings.get("shellMinimizer.gainTelemetry")) return;
+	if (!input.session.settings.get("shellMinimizer.enabled")) return;
 	try {
 		if (input.result.cancelled || input.result.exitCode === undefined) return;
 		if (input.result.totalBytes <= 0) return;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -105,29 +105,37 @@ function makeMinimizedSaveHandler(
 	session: ToolSession,
 	command: string,
 	commandCwd: string,
-): (
-	originalText: string,
-	info: { filter: string; inputBytes: number; outputBytes: number },
-) => Promise<string | undefined> {
-	return async (originalText, info) => {
-		const artifactId = await saveBashOriginalArtifact(session, originalText);
-		try {
-			await appendBashMinimizerGainRecord({
-				command,
-				cwd: commandCwd,
-				sessionCwd: session.cwd,
-				sessionId: session.getSessionId?.() ?? undefined,
-				filter: info.filter,
-				inputBytes: info.inputBytes,
-				outputBytes: info.outputBytes,
-				exitCode: null,
-				kind: "saved",
-				agentDir: session.settings.getAgentDir?.(),
-			});
-		} catch {
-			// Best-effort
-		}
-		return artifactId;
+): {
+	onMinimizedSave: (
+		originalText: string,
+		info: { filter: string; inputBytes: number; outputBytes: number },
+	) => Promise<string | undefined>;
+	didSave: () => boolean;
+} {
+	let saved = false;
+	return {
+		onMinimizedSave: async (originalText, info) => {
+			saved = true;
+			const artifactId = await saveBashOriginalArtifact(session, originalText);
+			try {
+				await appendBashMinimizerGainRecord({
+					command,
+					cwd: commandCwd,
+					sessionCwd: session.cwd,
+					sessionId: session.getSessionId?.() ?? undefined,
+					filter: info.filter,
+					inputBytes: info.inputBytes,
+					outputBytes: info.outputBytes,
+					exitCode: null,
+					kind: "saved",
+					agentDir: session.settings.getAgentDir?.(),
+				});
+			} catch {
+				// Best-effort
+			}
+			return artifactId;
+		},
+		didSave: () => saved,
 	};
 }
 
@@ -619,6 +627,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES);
 				const wallTimeStart = performance.now();
 				try {
+					const minimizedSave = makeMinimizedSaveHandler(this.session, options.command, options.commandCwd);
 					const result = await executeBash(options.command, {
 						cwd: options.commandCwd,
 						sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
@@ -632,14 +641,16 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 							latestText = tailBuffer.text();
 							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
 						},
-						onMinimizedSave: makeMinimizedSaveHandler(this.session, options.command, options.commandCwd),
+						onMinimizedSave: minimizedSave.onMinimizedSave,
 					});
-					await recordBashMinimizerGain({
-						session: this.session,
-						command: options.command,
-						commandCwd: options.commandCwd,
-						result,
-					});
+					if (!minimizedSave.didSave()) {
+						await recordBashMinimizerGain({
+							session: this.session,
+							command: options.command,
+							commandCwd: options.commandCwd,
+							result,
+						});
+					}
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -1114,6 +1125,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			pendingNotices.push("pty requested but unavailable in this environment; ran without a terminal");
 		}
 		const wallTimeStart = performance.now();
+		const minimizedSave = makeMinimizedSaveHandler(this.session, command, commandCwd);
 		const result: BashResult | BashInteractiveResult = interactiveUi
 			? await runInteractiveBashPty(interactiveUi, {
 					command,
@@ -1133,7 +1145,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					artifactPath,
 					artifactId,
 					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: makeMinimizedSaveHandler(this.session, command, commandCwd),
+					onMinimizedSave: minimizedSave.onMinimizedSave,
 				});
 		const wallTimeMs = performance.now() - wallTimeStart;
 		if (result.cancelled) {
@@ -1154,12 +1166,14 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					: `Command timed out after ${timeoutSec} seconds`,
 			);
 		}
-		await recordBashMinimizerGain({
-			session: this.session,
-			command,
-			commandCwd,
-			result,
-		});
+		if (!minimizedSave.didSave()) {
+			await recordBashMinimizerGain({
+				session: this.session,
+				command,
+				commandCwd,
+				result,
+			});
+		}
 		return this.#buildCompletedResult(result, timeoutSec, {
 			requestedTimeoutSec,
 			notices: pendingNotices,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -111,34 +111,36 @@ export function makeMinimizedSaveHandler(
 		info: { filter: string; inputBytes: number; outputBytes: number },
 	) => Promise<string | undefined>;
 	didSave: () => boolean;
+	/** Call after executeBash resolves to write the saved record with the real exitCode. */
+	flushSaved: (exitCode: number | null) => void;
 } {
 	let saved = false;
+	let pendingSaved: { filter: string; inputBytes: number; outputBytes: number } | null = null;
 	const gainTelemetry = session.settings.get("shellMinimizer.gainTelemetry");
 	return {
 		onMinimizedSave: async (originalText, info) => {
 			saved = true;
-			const artifactId = await saveBashOriginalArtifact(session, originalText);
-			if (gainTelemetry) {
-				try {
-					await appendBashMinimizerGainRecord({
-						command,
-						cwd: commandCwd,
-						sessionCwd: session.cwd,
-						sessionId: session.getSessionId?.() ?? undefined,
-						filter: info.filter,
-						inputBytes: info.inputBytes,
-						outputBytes: info.outputBytes,
-						exitCode: null,
-						kind: "saved",
-						agentDir: session.settings.getAgentDir(),
-					});
-				} catch {
-					// Best-effort
-				}
-			}
-			return artifactId;
+			if (gainTelemetry) pendingSaved = info;
+			return saveBashOriginalArtifact(session, originalText);
 		},
 		didSave: () => saved,
+		flushSaved: exitCode => {
+			if (!pendingSaved) return;
+			const info = pendingSaved;
+			pendingSaved = null;
+			void appendBashMinimizerGainRecord({
+				command,
+				cwd: commandCwd,
+				sessionCwd: session.cwd,
+				sessionId: session.getSessionId?.() ?? undefined,
+				filter: info.filter,
+				inputBytes: info.inputBytes,
+				outputBytes: info.outputBytes,
+				exitCode,
+				kind: "saved",
+				agentDir: session.settings.getAgentDir(),
+			}).catch(() => {});
+		},
 	};
 }
 
@@ -647,6 +649,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 						},
 						onMinimizedSave: minimizedSave.onMinimizedSave,
 					});
+					minimizedSave.flushSaved(result.exitCode ?? null);
 					if (!minimizedSave.didSave()) {
 						await recordBashMinimizerGain({
 							session: this.session,
@@ -1096,13 +1099,6 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				if (finalOutput.truncated) bridgeNotices.push("(output truncated)");
 				for (const notice of pendingNotices) bridgeNotices.push(notice);
 
-				await recordBashMinimizerGain({
-					session: this.session,
-					command,
-					commandCwd,
-					result: bridgeResult,
-				});
-
 				return this.#buildCompletedResult(bridgeResult, timeoutSec, {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
@@ -1170,13 +1166,19 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					: `Command timed out after ${timeoutSec} seconds`,
 			);
 		}
-		if (!minimizedSave.didSave()) {
-			await recordBashMinimizerGain({
-				session: this.session,
-				command,
-				commandCwd,
-				result,
-			});
+		// Flush the deferred saved record (with real exitCode) or write a missed record.
+		// Skip telemetry for interactive PTY runs — the minimizer never fires there.
+		if (!interactiveUi) {
+			const exitCode = "exitCode" in result ? (result.exitCode ?? null) : null;
+			minimizedSave.flushSaved(exitCode);
+			if (!minimizedSave.didSave()) {
+				await recordBashMinimizerGain({
+					session: this.session,
+					command,
+					commandCwd,
+					result,
+				});
+			}
 		}
 		return this.#buildCompletedResult(result, timeoutSec, {
 			requestedTimeoutSec,

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -86,6 +86,7 @@ describe("executeBash", () => {
 			maxCaptureBytes: 4096,
 			sourceOutlineLevel: "default",
 			legacyFilters: undefined,
+			gainTelemetry: false,
 		};
 		expect(buildMinimizerOptions(group)).toBeUndefined();
 	});
@@ -99,6 +100,7 @@ describe("executeBash", () => {
 			maxCaptureBytes: 1234,
 			sourceOutlineLevel: "aggressive",
 			legacyFilters: true,
+			gainTelemetry: false,
 		};
 		expect(buildMinimizerOptions(group)).toEqual({
 			enabled: true,

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { makeMinimizedSaveHandler } from "@oh-my-pi/pi-coding-agent/tools/bash";
 import {
 	appendBashMinimizerGainRecord,
 	getBashMinimizerGainPath,
@@ -206,7 +207,6 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 	}
 
 	test("minimized run emits exactly one saved record and no missed record", async () => {
-		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
 		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
 
 		const handler = makeMinimizedSaveHandler(session, "bun test noisy.test.ts", tempDir);
@@ -230,7 +230,6 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 	});
 
 	test("unminimized run emits exactly one missed record when caller uses guard", async () => {
-		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
 		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
 
 		const handler = makeMinimizedSaveHandler(session, "git log --oneline", tempDir);
@@ -260,7 +259,6 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 	});
 
 	test("didSave guard prevents spurious missed record on minimized run", async () => {
-		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
 		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
 
 		const handler = makeMinimizedSaveHandler(session, "cargo build", tempDir);
@@ -288,7 +286,6 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 	});
 
 	test("telemetry suppressed when shellMinimizer.gainTelemetry is false (default)", async () => {
-		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
 		const session = mockSession(false, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
 
 		const handler = makeMinimizedSaveHandler(session, "npm install", tempDir);

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -162,6 +162,18 @@ describe("bash minimizer gain writer", () => {
 	test("handles backslash-escaped spaces in env assignments", () => {
 		expect(inferBashMinimizerMissedFilter("NODE_OPTIONS=--require\\ ./setup.js pnpm test")).toBe("pnpm");
 	});
+
+	test("treats newlines as command separators (compound)", () => {
+		expect(inferBashMinimizerMissedFilter("git status\nnpm test")).toBe("compound");
+		expect(inferBashMinimizerMissedFilter("cd /tmp\nls -la")).toBe("compound");
+	});
+
+	test("handles env -i (no-arg) and -v (no-arg) options correctly", () => {
+		// -i takes no argument (ignore-environment), so the next token is the command
+		expect(inferBashMinimizerMissedFilter("env -i pnpm test")).toBe("pnpm");
+		// -v takes no argument (verbose), so the next token is the command
+		expect(inferBashMinimizerMissedFilter("env -v bun test")).toBe("bun");
+	});
 });
 
 describe("makeMinimizedSaveHandler + didSave gate contract", () => {

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -145,6 +145,23 @@ describe("bash minimizer gain writer", () => {
 			inferBashMinimizerMissedFilter("NODE_OPTIONS='--require ./setup.js --max-old-space-size=4096' npm run build"),
 		).toBe("npm");
 	});
+
+	test("handles env wrapper commands", () => {
+		expect(inferBashMinimizerMissedFilter("env CI=1 pnpm test")).toBe("pnpm");
+		expect(inferBashMinimizerMissedFilter("env -u FOO bun test")).toBe("bun");
+		expect(inferBashMinimizerMissedFilter("env FOO=bar BAR=baz node index.js")).toBe("node");
+	});
+
+	test("treats quoted shell operators as word characters, not compound", () => {
+		expect(inferBashMinimizerMissedFilter("rg 'foo|bar'")).toBe("rg");
+		expect(inferBashMinimizerMissedFilter('grep "a;b" file.txt')).toBe("grep");
+		expect(inferBashMinimizerMissedFilter("git log --oneline | head -10")).toBe("compound");
+		expect(inferBashMinimizerMissedFilter("git status && git log")).toBe("compound");
+	});
+
+	test("handles backslash-escaped spaces in env assignments", () => {
+		expect(inferBashMinimizerMissedFilter("NODE_OPTIONS=--require\\ ./setup.js pnpm test")).toBe("pnpm");
+	});
 });
 
 describe("makeMinimizedSaveHandler + didSave gate contract", () => {
@@ -186,14 +203,18 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 			inputBytes: 4000,
 			outputBytes: 1000,
 		});
+		handler.flushSaved(1); // simulate exitCode:1 from executeBash
 
 		expect(handler.didSave()).toBe(true);
+		// Allow the microtask queue to flush the void appendBashMinimizerGainRecord call
+		await new Promise(resolve => setTimeout(resolve, 10));
 
 		const lines = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n").filter(Boolean);
 		expect(lines).toHaveLength(1);
-		const record = JSON.parse(lines[0]!) as { kind: string; filter: string };
+		const record = JSON.parse(lines[0]!) as { kind: string; filter: string; exitCode: number | null };
 		expect(record.kind).toBe("saved");
 		expect(record.filter).toBe("bun-test");
+		expect(record.exitCode).toBe(1);
 	});
 
 	test("unminimized run emits exactly one missed record when caller uses guard", async () => {
@@ -232,6 +253,8 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 
 		const handler = makeMinimizedSaveHandler(session, "cargo build", tempDir);
 		await handler.onMinimizedSave("build output...", { filter: "cargo", inputBytes: 8000, outputBytes: 500 });
+		handler.flushSaved(0); // writes the saved record
+		await new Promise(resolve => setTimeout(resolve, 10));
 
 		// Guard: caller skips the missed write when didSave() is true
 		if (!handler.didSave()) {
@@ -258,6 +281,8 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 
 		const handler = makeMinimizedSaveHandler(session, "npm install", tempDir);
 		await handler.onMinimizedSave("install output", { filter: "npm", inputBytes: 2000, outputBytes: 500 });
+		handler.flushSaved(0);
+		await new Promise(resolve => setTimeout(resolve, 10));
 
 		// No JSONL written — telemetry is off by default
 		expect(fs.existsSync(getBashMinimizerGainPath(agentDir))).toBe(false);

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -146,3 +146,120 @@ describe("bash minimizer gain writer", () => {
 		).toBe("npm");
 	});
 });
+
+describe("makeMinimizedSaveHandler + didSave gate contract", () => {
+	let tempDir: string;
+	let agentDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-gain-gate-"));
+		agentDir = path.join(tempDir, "agent");
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	function mockSession(gainTelemetry: boolean, dir: string) {
+		return {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionId: () => "test-session",
+			getSessionFile: () => null,
+			settings: {
+				get: (key: string) => {
+					if (key === "shellMinimizer.gainTelemetry") return gainTelemetry;
+					return undefined;
+				},
+				getAgentDir: () => dir,
+			},
+		};
+	}
+
+	test("minimized run emits exactly one saved record and no missed record", async () => {
+		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
+		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
+
+		const handler = makeMinimizedSaveHandler(session, "bun test noisy.test.ts", tempDir);
+		await handler.onMinimizedSave("original output text here", {
+			filter: "bun-test",
+			inputBytes: 4000,
+			outputBytes: 1000,
+		});
+
+		expect(handler.didSave()).toBe(true);
+
+		const lines = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n").filter(Boolean);
+		expect(lines).toHaveLength(1);
+		const record = JSON.parse(lines[0]!) as { kind: string; filter: string };
+		expect(record.kind).toBe("saved");
+		expect(record.filter).toBe("bun-test");
+	});
+
+	test("unminimized run emits exactly one missed record when caller uses guard", async () => {
+		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
+		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
+
+		const handler = makeMinimizedSaveHandler(session, "git log --oneline", tempDir);
+		// onMinimizedSave NOT called — no minimization
+		expect(handler.didSave()).toBe(false);
+
+		// Caller writes missed only when !didSave()
+		if (!handler.didSave()) {
+			await appendBashMinimizerGainRecord({
+				command: "git log --oneline",
+				cwd: tempDir,
+				sessionId: "test-session",
+				filter: inferBashMinimizerMissedFilter("git log --oneline"),
+				inputBytes: 500,
+				outputBytes: 500,
+				exitCode: 0,
+				kind: "missed",
+				agentDir,
+			});
+		}
+
+		const lines = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n").filter(Boolean);
+		expect(lines).toHaveLength(1);
+		const record = JSON.parse(lines[0]!) as { kind: string; filter: string };
+		expect(record.kind).toBe("missed");
+		expect(record.filter).toBe("git");
+	});
+
+	test("didSave guard prevents spurious missed record on minimized run", async () => {
+		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
+		const session = mockSession(true, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
+
+		const handler = makeMinimizedSaveHandler(session, "cargo build", tempDir);
+		await handler.onMinimizedSave("build output...", { filter: "cargo", inputBytes: 8000, outputBytes: 500 });
+
+		// Guard: caller skips the missed write when didSave() is true
+		if (!handler.didSave()) {
+			await appendBashMinimizerGainRecord({
+				command: "cargo build",
+				agentDir,
+				filter: "cargo",
+				inputBytes: 8000,
+				outputBytes: 8000,
+				exitCode: 0,
+				kind: "missed",
+			});
+		}
+
+		const lines = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n").filter(Boolean);
+		// Only the saved record — no spurious missed
+		expect(lines).toHaveLength(1);
+		expect((JSON.parse(lines[0]!) as { kind: string }).kind).toBe("saved");
+	});
+
+	test("telemetry suppressed when shellMinimizer.gainTelemetry is false (default)", async () => {
+		const { makeMinimizedSaveHandler } = await import("@oh-my-pi/pi-coding-agent/tools/bash");
+		const session = mockSession(false, agentDir) as Parameters<typeof makeMinimizedSaveHandler>[0];
+
+		const handler = makeMinimizedSaveHandler(session, "npm install", tempDir);
+		await handler.onMinimizedSave("install output", { filter: "npm", inputBytes: 2000, outputBytes: 500 });
+
+		// No JSONL written — telemetry is off by default
+		expect(fs.existsSync(getBashMinimizerGainPath(agentDir))).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	appendBashMinimizerGainRecord,
+	getBashMinimizerGainPath,
+	inferBashMinimizerMissedFilter,
+} from "@oh-my-pi/pi-coding-agent/tools/bash-minimizer-gain";
+
+describe("bash minimizer gain writer", () => {
+	let tempDir: string;
+	let cwd: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-gain-writer-"));
+		cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd);
+		fs.mkdirSync(path.join(tempDir, "session"));
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	test("appends saved minimizer records to the agent JSONL file", async () => {
+		await appendBashMinimizerGainRecord({
+			agentDir: path.join(tempDir, "agent"),
+			command: "bun test noisy.test.ts",
+			cwd,
+			sessionCwd: path.join(tempDir, "session"),
+			filter: "bun-test",
+			inputBytes: 4000,
+			outputBytes: 1000,
+			exitCode: 1,
+			sessionId: "session-test-id",
+		});
+
+		const file = getBashMinimizerGainPath(path.join(tempDir, "agent"));
+		const lines = fs.readFileSync(file, "utf8").trim().split("\n");
+		expect(lines).toHaveLength(1);
+		const record = JSON.parse(lines[0]!) as {
+			command: string;
+			cwd: string;
+			sessionCwd: string;
+			sessionId: string;
+			filter: string;
+			inputBytes: number;
+			outputBytes: number;
+			savedBytes: number;
+			savedTokens: number;
+			exitCode: number | null;
+			kind: string;
+		};
+		expect(record.command).toBe("bun test noisy.test.ts");
+		expect(record.cwd).toBe(fs.realpathSync(cwd));
+		expect(record.sessionCwd).toBe(fs.realpathSync(path.join(tempDir, "session")));
+		expect(record.sessionId).toBe("session-test-id");
+		expect(record.inputBytes).toBe(4000);
+		expect(record.outputBytes).toBe(1000);
+		expect(record.savedBytes).toBe(3000);
+		expect(record.savedTokens).toBe(750);
+		expect(record.exitCode).toBe(1);
+		expect(record.kind).toBe("saved");
+	});
+
+	test("skips saved records that do not save bytes", async () => {
+		const agentDir = path.join(tempDir, "agent");
+		await appendBashMinimizerGainRecord({
+			agentDir,
+			command: "echo short",
+			cwd,
+			filter: "noop",
+			inputBytes: 10,
+			outputBytes: 10,
+			exitCode: 0,
+		});
+
+		expect(fs.existsSync(getBashMinimizerGainPath(agentDir))).toBe(false);
+	});
+
+	test("appends missed records for unminimized command output", async () => {
+		const agentDir = path.join(tempDir, "agent");
+		await appendBashMinimizerGainRecord({
+			agentDir,
+			command: "git status",
+			cwd,
+			filter: inferBashMinimizerMissedFilter("git status"),
+			inputBytes: 200,
+			outputBytes: 200,
+			exitCode: 0,
+			kind: "missed",
+		});
+
+		const [line] = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n");
+		const record = JSON.parse(line!) as {
+			filter: string;
+			inputBytes: number;
+			outputBytes: number;
+			savedBytes: number;
+			savedTokens?: number;
+			kind: string;
+		};
+		expect(record.filter).toBe("git");
+		expect(record.inputBytes).toBe(200);
+		expect(record.outputBytes).toBe(200);
+		expect(record.savedBytes).toBe(0);
+		expect(record.savedTokens).toBeUndefined();
+		expect(record.kind).toBe("missed");
+	});
+
+	test("skips missed records when the command produced no output", async () => {
+		const agentDir = path.join(tempDir, "agent");
+		await appendBashMinimizerGainRecord({
+			agentDir,
+			command: "true",
+			cwd,
+			filter: inferBashMinimizerMissedFilter("true"),
+			inputBytes: 0,
+			outputBytes: 0,
+			exitCode: 0,
+			kind: "missed",
+		});
+
+		expect(fs.existsSync(getBashMinimizerGainPath(agentDir))).toBe(false);
+	});
+
+	test("classifies compound missed commands separately", () => {
+		expect(inferBashMinimizerMissedFilter("git status && git log")).toBe("compound");
+		expect(inferBashMinimizerMissedFilter("/usr/bin/git status")).toBe("git");
+		expect(inferBashMinimizerMissedFilter("CI=1 npm test")).toBe("npm");
+		expect(inferBashMinimizerMissedFilter("TOKEN=abc123 pnpm run lint")).toBe("pnpm");
+		expect(inferBashMinimizerMissedFilter("FOO=1 BAR=2 node script.js")).toBe("node");
+	});
+
+	test("handles quoted env values containing whitespace", () => {
+		expect(
+			inferBashMinimizerMissedFilter("NODE_OPTIONS='--max-old-space-size=4096 --trace-warnings' pnpm test"),
+		).toBe("pnpm");
+		expect(inferBashMinimizerMissedFilter('NODE_OPTIONS="--max-old-space-size=4096 --trace-warnings" bun test')).toBe(
+			"bun",
+		);
+		expect(inferBashMinimizerMissedFilter("CI=1 NODE_OPTIONS='--max-old-space-size=512' uv run pytest")).toBe("uv");
+		expect(
+			inferBashMinimizerMissedFilter("NODE_OPTIONS='--require ./setup.js --max-old-space-size=4096' npm run build"),
+		).toBe("npm");
+	});
+});

--- a/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
+++ b/packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
@@ -219,7 +219,7 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 
 		expect(handler.didSave()).toBe(true);
 		// Allow the microtask queue to flush the void appendBashMinimizerGainRecord call
-		await new Promise(resolve => setTimeout(resolve, 10));
+		await Bun.sleep(10);
 
 		const lines = fs.readFileSync(getBashMinimizerGainPath(agentDir), "utf8").trim().split("\n").filter(Boolean);
 		expect(lines).toHaveLength(1);
@@ -264,7 +264,7 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 		const handler = makeMinimizedSaveHandler(session, "cargo build", tempDir);
 		await handler.onMinimizedSave("build output...", { filter: "cargo", inputBytes: 8000, outputBytes: 500 });
 		handler.flushSaved(0); // writes the saved record
-		await new Promise(resolve => setTimeout(resolve, 10));
+		await Bun.sleep(10);
 
 		// Guard: caller skips the missed write when didSave() is true
 		if (!handler.didSave()) {
@@ -291,7 +291,7 @@ describe("makeMinimizedSaveHandler + didSave gate contract", () => {
 		const handler = makeMinimizedSaveHandler(session, "npm install", tempDir);
 		await handler.onMinimizedSave("install output", { filter: "npm", inputBytes: 2000, outputBytes: 500 });
 		handler.flushSaved(0);
-		await new Promise(resolve => setTimeout(resolve, 10));
+		await Bun.sleep(10);
 
 		// No JSONL written — telemetry is off by default
 		expect(fs.existsSync(getBashMinimizerGainPath(agentDir))).toBe(false);

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -4,13 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { InMemorySnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { editToolRenderer } from "@oh-my-pi/pi-coding-agent/edit/renderer";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { Text, type TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
-import { renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -456,7 +456,10 @@ describe("editToolRenderer", () => {
 			{
 				expanded: false,
 				isPartial: false,
-				renderContext: { editMode: "hashline", editDiffPreview: { error: "No changes would be made to other.ts." } },
+				renderContext: {
+					editMode: "hashline",
+					editDiffPreview: { error: "No changes would be made to other.ts." },
+				},
 			},
 			uiTheme,
 			{ input: "[a.ts#1a2b]\nMV b.ts" },


### PR DESCRIPTION
## Summary

- Expose bash minimizer save/miss metadata from the executor via `onMinimizedSave` callback
- Append JSONL gain records to `~/.omp/agent/minimizer-gain.jsonl` for every bash execution — `kind:"saved"` when minimization ran, `kind:"missed"` when it didn't
- Shell-aware tokenizer (`shellTokens`) correctly handles quoted env assignments, escaped spaces, and `env`-wrapper commands when inferring missed filter names
- `makeMinimizedSaveHandler` returns a `didSave` flag — callers gate `recordBashMinimizerGain` on `!didSave()` so minimized runs emit exactly one `kind:"saved"` record and no spurious miss
- Telemetry writes are best-effort (caught + logged) and never surface to the bash tool result
- Records include `sessionId`, `cwd`, `command`, `filter`, `inputBytes`, `outputBytes`, `exitCode`, `timestamp`

Replaces #2280 (closed) — same scope, all review findings addressed in this clean rebase.

## Review findings addressed

All roboomp P2/P3 findings from #2280 resolved:
- Double-written saved records → fixed via `didSave()` guard
- Byte-cap guard in `#buildCompletedResult()` preserved (not removed)
- Changelog entry added
- Shell-aware tokenizer for env-prefixed commands with quoted/escaped values
- `user_bash` extension path gated on `!cancelled && exitCode !== undefined && totalBytes > 0`
- Telemetry writes wrapped in best-effort catch at all 3 bash execution sites

## Test

```
bun test packages/coding-agent/test/bash-executor.test.ts packages/coding-agent/test/tools/bash-minimizer-gain.test.ts
bun --cwd=packages/coding-agent run check:types
```