### PR TITLE
feat(stats): gain dashboard — project filter, unparsed commands panel

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Gain tab in `omp stats` dashboard (`/#/gain`) — surfaces bash minimizer, snapcompact, and pi-distill token-savings with project scoping and an Unparsed Commands panel listing unhandled bash commands as filter-tuning candidates ([#3543](https://github.com/can1357/oh-my-pi/pull/3543)).
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -330,7 +330,7 @@ const TIME_RANGE_TO_CONFIG: Record<TimeRange, Omit<TimeRangeConfig, "cutoff">> =
 	},
 };
 
-function getTimeRangeConfig(range?: string | null): TimeRangeConfig {
+export function getTimeRangeConfig(range?: string | null): TimeRangeConfig {
 	const normalized = range?.trim().toLowerCase() ?? DEFAULT_TIME_RANGE;
 	const config = TIME_RANGE_TO_CONFIG[normalized as TimeRange];
 	if (config) {

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -6,6 +6,7 @@ import {
 	BehaviorRoute,
 	CostsRoute,
 	ErrorsRoute,
+	GainRoute,
 	ModelsRoute,
 	OverviewRoute,
 	ProjectsRoute,
@@ -77,6 +78,8 @@ export default function App() {
 				return <BehaviorRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
 			case "projects":
 				return <ProjectsRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
+			case "gain":
+				return <GainRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
 		}
 	};
 

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -85,8 +85,8 @@ export async function getFolderStats(range: TimeRange = "24h", signal?: AbortSig
 
 export async function getGainDashboardStats(
 	range: TimeRange = "24h",
-	signal?: AbortSignal,
 	project?: string | null,
+	signal?: AbortSignal,
 ): Promise<GainDashboardStats> {
 	const params = new URLSearchParams({ range });
 	if (project) params.set("project", project);

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -2,6 +2,7 @@ import type {
 	BehaviorDashboardStats,
 	CostDashboardStats,
 	FolderStats,
+	GainDashboardStats,
 	MessageStats,
 	ModelDashboardStats,
 	OverviewStats,
@@ -80,4 +81,14 @@ export async function getBehaviorDashboardStats(
 
 export async function getFolderStats(range: TimeRange = "24h", signal?: AbortSignal): Promise<FolderStats[]> {
 	return fetchJson<FolderStats[]>(`${API_BASE}/stats/folders?range=${encodeURIComponent(range)}`, { signal });
+}
+
+export async function getGainDashboardStats(
+	range: TimeRange = "24h",
+	signal?: AbortSignal,
+	project?: string | null,
+): Promise<GainDashboardStats> {
+	const params = new URLSearchParams({ range });
+	if (project) params.set("project", project);
+	return fetchJson<GainDashboardStats>(`${API_BASE}/stats/gain?${params}`, { signal });
 }

--- a/packages/stats/src/client/app/routes.ts
+++ b/packages/stats/src/client/app/routes.ts
@@ -1,7 +1,15 @@
 import { Activity, AlertCircle, Coins, Cpu, Folder, LayoutDashboard, Smile, TrendingUp } from "lucide-react";
 import type React from "react";
 
-export type DashboardSection = "overview" | "requests" | "errors" | "models" | "costs" | "behavior" | "projects" | "gain";
+export type DashboardSection =
+	| "overview"
+	| "requests"
+	| "errors"
+	| "models"
+	| "costs"
+	| "behavior"
+	| "projects"
+	| "gain";
 
 export interface DashboardRoute {
 	id: DashboardSection;

--- a/packages/stats/src/client/app/routes.ts
+++ b/packages/stats/src/client/app/routes.ts
@@ -1,7 +1,7 @@
-import { Activity, AlertCircle, Coins, Cpu, Folder, LayoutDashboard, Smile } from "lucide-react";
+import { Activity, AlertCircle, Coins, Cpu, Folder, LayoutDashboard, Smile, TrendingUp } from "lucide-react";
 import type React from "react";
 
-export type DashboardSection = "overview" | "requests" | "errors" | "models" | "costs" | "behavior" | "projects";
+export type DashboardSection = "overview" | "requests" | "errors" | "models" | "costs" | "behavior" | "projects" | "gain";
 
 export interface DashboardRoute {
 	id: DashboardSection;
@@ -46,5 +46,10 @@ export const routes: DashboardRoute[] = [
 		id: "projects",
 		label: "Projects",
 		icon: Folder,
+	},
+	{
+		id: "gain",
+		label: "Gain",
+		icon: TrendingUp,
 	},
 ];

--- a/packages/stats/src/client/data/formatters.ts
+++ b/packages/stats/src/client/data/formatters.ts
@@ -36,3 +36,10 @@ export function formatTokensPerSecond(value: number | null): string {
 export function formatRelativeTime(timestamp: number): string {
 	return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
 }
+
+export function formatBytes(value: number): string {
+	if (value >= 1e9) return `${(value / 1e9).toFixed(1)} GB`;
+	if (value >= 1e6) return `${(value / 1e6).toFixed(1)} MB`;
+	if (value >= 1e3) return `${(value / 1e3).toFixed(1)} KB`;
+	return `${value} B`;
+}

--- a/packages/stats/src/client/data/useHashRoute.ts
+++ b/packages/stats/src/client/data/useHashRoute.ts
@@ -10,6 +10,7 @@ const VALID_SECTIONS: DashboardSection[] = [
 	"costs",
 	"behavior",
 	"projects",
+	"gain",
 ];
 
 const VALID_RANGES: TimeRange[] = ["1h", "24h", "7d", "30d", "90d", "all"];

--- a/packages/stats/src/client/routes/GainRoute.tsx
+++ b/packages/stats/src/client/routes/GainRoute.tsx
@@ -1,0 +1,335 @@
+import { format } from "date-fns";
+import { useState, useMemo } from "react";
+import { Line } from "react-chartjs-2";
+import { getGainDashboardStats } from "../api";
+import {
+	buildSharedPlugins,
+	buildSharedScales,
+	CHART_THEMES,
+	lineDatasetStyle,
+} from "../components/chart-shared";
+import { formatBytes, formatCompact, formatInteger, formatPercent } from "../data/formatters";
+import { useResource } from "../data/useResource";
+import type { GainDashboardStats, GainUnparsedCommand, GainSourceTotals, GainTimeSeriesPoint, GainTopFilter, TimeRange } from "../types";
+import { AsyncBoundary, DataTable, Panel } from "../ui";
+import type { DataTableColumn } from "../ui/DataTable";
+import { useSystemTheme } from "../useSystemTheme";
+
+export interface GainRouteProps {
+	active: boolean;
+	range: TimeRange;
+	refreshTrigger: number;
+}
+
+export function GainRoute({ active, range, refreshTrigger }: GainRouteProps) {
+	const [project, setProject] = useState<string | null>(null);
+
+	const {
+		data: stats,
+		error,
+		loading,
+	} = useResource(
+		["gain", range, refreshTrigger, project],
+		signal => getGainDashboardStats(range, signal, project),
+		{ pollMs: 30_000, enabled: active },
+	);
+
+	return (
+		<div className="stats-route-container space-y-6">
+			<AsyncBoundary loading={loading} error={error} data={stats}>
+				{stats && (
+					<>
+						<GainProjectSelector
+							projects={stats.projects}
+							selected={project}
+							onChange={setProject}
+						/>
+						<GainOverallPanel overall={stats.overall} />
+						<GainBySourcePanel bySource={stats.bySource} />
+						<GainTimeSeriesPanel timeSeries={stats.timeSeries} />
+						<GainTopFiltersPanel topFilters={stats.topFilters} />
+					<GainUnparsedCommandsPanel unparsedCommands={stats.unparsedCommands} />
+					</>
+				)}
+			</AsyncBoundary>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Project selector
+// ---------------------------------------------------------------------------
+
+function GainProjectSelector({
+	projects,
+	selected,
+	onChange,
+}: {
+	projects: string[];
+	selected: string | null;
+	onChange: (p: string | null) => void;
+}) {
+	if (projects.length === 0) return null;
+	return (
+		<div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+			<span className="stats-text-secondary" style={{ fontSize: "0.875rem", whiteSpace: "nowrap" }}>
+				Project
+			</span>
+			<select
+				className="stats-select"
+				value={selected ?? ""}
+				onChange={e => onChange(e.target.value || null)}
+				style={{ maxWidth: "480px", flex: 1 }}
+			>
+				<option value="">All projects</option>
+				{projects.map(p => (
+					<option key={p} value={p}>{p}</option>
+				))}
+			</select>
+		</div>
+	);
+}
+
+
+// ---------------------------------------------------------------------------
+// Overall metrics panel
+// ---------------------------------------------------------------------------
+
+function GainOverallPanel({ overall }: { overall: GainSourceTotals }) {
+	return (
+		<Panel title="Overall Gain" subtitle="Aggregate savings across all sources">
+			<div className="stats-metric-primary-grid">
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Saved Tokens</div>
+					<div className="stats-metric-value">{formatCompact(overall.savedTokens)}</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Saved Bytes</div>
+					<div className="stats-metric-value">{formatBytes(overall.savedBytes)}</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Reduction</div>
+					<div className="stats-metric-value">
+						{overall.reductionPercent !== null ? formatPercent(overall.reductionPercent) : "—"}
+					</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Total Hits</div>
+					<div className="stats-metric-value">{formatInteger(overall.hits)}</div>
+				</div>
+			</div>
+		</Panel>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// By-source breakdown panel
+// ---------------------------------------------------------------------------
+
+function SourceCard({ title, totals }: { title: string; totals: GainSourceTotals }) {
+	return (
+		<div className="stats-metric-card secondary" style={{ flex: 1 }}>
+			<div className="stats-metric-label" style={{ fontWeight: 600, marginBottom: 8 }}>
+				{title}
+			</div>
+			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+				<div>
+					<div className="stats-metric-label">Saved Tokens</div>
+					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
+						{formatCompact(totals.savedTokens)}
+					</div>
+				</div>
+				<div>
+					<div className="stats-metric-label">Saved Bytes</div>
+					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
+						{formatBytes(totals.savedBytes)}
+					</div>
+				</div>
+				<div>
+					<div className="stats-metric-label">Hits</div>
+					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
+						{formatInteger(totals.hits)}
+					</div>
+				</div>
+				<div>
+					<div className="stats-metric-label">Reduction</div>
+					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
+						{totals.reductionPercent !== null ? formatPercent(totals.reductionPercent) : "—"}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GainBySourcePanel({ bySource }: { bySource: GainDashboardStats["bySource"] }) {
+	return (
+		<Panel title="By Source" subtitle="Savings breakdown per subsystem">
+			<div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+				<SourceCard title="Bash Minimizer" totals={bySource.minimizer} />
+				<SourceCard title="Snapcompact" totals={bySource.snapcompact} />
+				<SourceCard title="Pi-Distill" totals={bySource.distill} />
+			</div>
+		</Panel>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Time series chart (stacked area, daily)
+// ---------------------------------------------------------------------------
+
+// Stable colours matching the plan: blue/green/purple from Tailwind palette
+const GAIN_COLORS = {
+	minimizer: "rgb(59, 130, 246)",
+	snapcompact: "rgb(34, 197, 94)",
+	distill: "rgb(168, 85, 247)",
+} as const;
+
+function GainTimeSeriesPanel({ timeSeries }: { timeSeries: GainTimeSeriesPoint[] }) {
+	const theme = useSystemTheme();
+	const chartTheme = CHART_THEMES[theme];
+
+	const { data, options } = useMemo(() => {
+		const labels = timeSeries.map(p => format(new Date(p.date), "MMM d"));
+		const chartData = {
+			labels,
+			datasets: [
+				{
+					label: "Bash Minimizer",
+					data: timeSeries.map(p => p.minimizer),
+					...lineDatasetStyle(GAIN_COLORS.minimizer),
+				},
+				{
+					label: "Snapcompact",
+					data: timeSeries.map(p => p.snapcompact),
+					...lineDatasetStyle(GAIN_COLORS.snapcompact),
+				},
+				{
+					label: "Pi-Distill",
+					data: timeSeries.map(p => p.distill),
+					...lineDatasetStyle(GAIN_COLORS.distill),
+				},
+			],
+		};
+
+		const { sharedScaleBase, yScale } = buildSharedScales({
+			chartTheme,
+			formatY: n => formatCompact(n),
+		});
+
+		const chartOptions = {
+			responsive: true,
+			maintainAspectRatio: false,
+			plugins: buildSharedPlugins({
+				chartTheme,
+				showLegend: true,
+				defaultLabel: "Tokens Saved",
+				formatValue: formatCompact,
+			}),
+			scales: {
+				x: { ...sharedScaleBase, stacked: true },
+				y: { ...yScale, stacked: true },
+			},
+		};
+
+		return { data: chartData, options: chartOptions };
+	}, [timeSeries, chartTheme]);
+
+	return (
+		<Panel title="Savings Over Time" subtitle="Daily token savings by source">
+			<div style={{ height: 240 }}>
+				{timeSeries.length === 0 ? (
+					<div className="stats-table-empty">No time series data yet</div>
+				) : (
+					<Line data={data} options={options as Parameters<typeof Line>[0]["options"]} />
+				)}
+			</div>
+		</Panel>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Top filters table
+// ---------------------------------------------------------------------------
+
+const TOP_FILTER_COLUMNS: DataTableColumn<GainTopFilter>[] = [
+	{
+		key: "filter",
+		header: "Filter / Command",
+		render: item => <code style={{ fontSize: "0.85em" }}>{item.filter}</code>,
+	},
+	{
+		key: "savedTokens",
+		header: "Saved Tokens",
+		numeric: true,
+		render: item => formatCompact(item.savedTokens),
+	},
+	{
+		key: "savedBytes",
+		header: "Saved Bytes",
+		numeric: true,
+		render: item => formatBytes(item.savedBytes),
+	},
+	{
+		key: "hits",
+		header: "Hits",
+		numeric: true,
+		render: item => formatInteger(item.hits),
+	},
+];
+
+function GainTopFiltersPanel({ topFilters }: { topFilters: GainTopFilter[] }) {
+	return (
+		<Panel title="Top Filters" subtitle="Bash minimizer filters with the highest token savings">
+			<DataTable
+				columns={TOP_FILTER_COLUMNS}
+				data={topFilters}
+				keyExtractor={item => item.filter}
+				emptyText="No minimizer filter data yet"
+			/>
+		</Panel>
+	);
+}
+// ---------------------------------------------------------------------------
+// Unparsed commands table — the tuning surface
+// ---------------------------------------------------------------------------
+
+const UNPARSED_COLUMNS: DataTableColumn<GainUnparsedCommand>[] = [
+	{
+		key: "command",
+		header: "Command (unparsed)",
+		render: item => (
+			<code style={{ fontSize: "0.8em", wordBreak: "break-all", whiteSpace: "pre-wrap" }}>
+				{item.command}
+			</code>
+		),
+	},
+	{
+		key: "hits",
+		header: "Hits",
+		numeric: true,
+		render: item => formatInteger(item.hits),
+	},
+	{
+		key: "inputBytes",
+		header: "Input Bytes",
+		numeric: true,
+		render: item => formatBytes(item.inputBytes),
+	},
+];
+
+function GainUnparsedCommandsPanel({ unparsedCommands }: { unparsedCommands: GainUnparsedCommand[] }) {
+	return (
+		<Panel
+			title="Unparsed Commands"
+			subtitle="Commands with no matching filter — write a new minimizer filter for the top entries"
+		>
+			<DataTable
+				columns={UNPARSED_COLUMNS}
+				data={unparsedCommands}
+				keyExtractor={item => item.command}
+				emptyText="No unparsed commands in this range/project"
+			/>
+		</Panel>
+	);
+}

--- a/packages/stats/src/client/routes/GainRoute.tsx
+++ b/packages/stats/src/client/routes/GainRoute.tsx
@@ -1,16 +1,18 @@
 import { format } from "date-fns";
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { getGainDashboardStats } from "../api";
-import {
-	buildSharedPlugins,
-	buildSharedScales,
-	CHART_THEMES,
-	lineDatasetStyle,
-} from "../components/chart-shared";
+import { buildSharedPlugins, buildSharedScales, CHART_THEMES, lineDatasetStyle } from "../components/chart-shared";
 import { formatBytes, formatCompact, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import type { GainDashboardStats, GainUnparsedCommand, GainSourceTotals, GainTimeSeriesPoint, GainTopFilter, TimeRange } from "../types";
+import type {
+	GainDashboardStats,
+	GainSourceTotals,
+	GainTimeSeriesPoint,
+	GainTopFilter,
+	GainUnparsedCommand,
+	TimeRange,
+} from "../types";
 import { AsyncBoundary, DataTable, Panel } from "../ui";
 import type { DataTableColumn } from "../ui/DataTable";
 import { useSystemTheme } from "../useSystemTheme";
@@ -28,27 +30,22 @@ export function GainRoute({ active, range, refreshTrigger }: GainRouteProps) {
 		data: stats,
 		error,
 		loading,
-	} = useResource(
-		["gain", range, refreshTrigger, project],
-		signal => getGainDashboardStats(range, signal, project),
-		{ pollMs: 30_000, enabled: active },
-	);
+	} = useResource(["gain", range, refreshTrigger, project], signal => getGainDashboardStats(range, project, signal), {
+		pollMs: 30_000,
+		enabled: active,
+	});
 
 	return (
 		<div className="stats-route-container space-y-6">
 			<AsyncBoundary loading={loading} error={error} data={stats}>
 				{stats && (
 					<>
-						<GainProjectSelector
-							projects={stats.projects}
-							selected={project}
-							onChange={setProject}
-						/>
+						<GainProjectSelector projects={stats.projects} selected={project} onChange={setProject} />
 						<GainOverallPanel overall={stats.overall} />
 						<GainBySourcePanel bySource={stats.bySource} />
 						<GainTimeSeriesPanel timeSeries={stats.timeSeries} />
 						<GainTopFiltersPanel topFilters={stats.topFilters} />
-					<GainUnparsedCommandsPanel unparsedCommands={stats.unparsedCommands} />
+						<GainUnparsedCommandsPanel unparsedCommands={stats.unparsedCommands} />
 					</>
 				)}
 			</AsyncBoundary>
@@ -83,13 +80,14 @@ function GainProjectSelector({
 			>
 				<option value="">All projects</option>
 				{projects.map(p => (
-					<option key={p} value={p}>{p}</option>
+					<option key={p} value={p}>
+						{p}
+					</option>
 				))}
 			</select>
 		</div>
 	);
 }
-
 
 // ---------------------------------------------------------------------------
 // Overall metrics panel
@@ -299,9 +297,7 @@ const UNPARSED_COLUMNS: DataTableColumn<GainUnparsedCommand>[] = [
 		key: "command",
 		header: "Command (unparsed)",
 		render: item => (
-			<code style={{ fontSize: "0.8em", wordBreak: "break-all", whiteSpace: "pre-wrap" }}>
-				{item.command}
-			</code>
+			<code style={{ fontSize: "0.8em", wordBreak: "break-all", whiteSpace: "pre-wrap" }}>{item.command}</code>
 		),
 	},
 	{

--- a/packages/stats/src/client/routes/index.ts
+++ b/packages/stats/src/client/routes/index.ts
@@ -1,6 +1,7 @@
 export * from "./BehaviorRoute";
 export * from "./CostsRoute";
 export * from "./ErrorsRoute";
+export * from "./GainRoute";
 export * from "./ModelsRoute";
 export * from "./OverviewRoute";
 export * from "./ProjectsRoute";

--- a/packages/stats/src/gain-aggregator.ts
+++ b/packages/stats/src/gain-aggregator.ts
@@ -1,0 +1,456 @@
+/**
+ * Aggregates token-savings data from three independent gain-tracking subsystems
+ * into a unified GainDashboardStats payload.
+ *
+ * Sources:
+ *   1. Bash minimizer: ~/.omp/agent/minimizer-gain.jsonl
+ *   2. Snapcompact:    colocated with stats.db as snapcompact-savings.jsonl
+ *   3. Pi-distill:     ~/.omp/agent/pi-distill/stats.json
+ *
+ * Missing files are treated as zero records — never an error.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getStatsDbPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import type {
+	GainDashboardStats,
+	GainUnparsedCommand,
+	GainSourceTotals,
+	GainTimeSeriesPoint,
+	GainTopFilter,
+} from "./shared-types";
+
+const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+// ---------------------------------------------------------------------------
+// Minimizer record schema
+// ---------------------------------------------------------------------------
+
+interface MinimizerRecord {
+	timestamp: string; // ISO
+	filter: string;
+	command?: string;
+	inputBytes: number;
+	outputBytes: number;
+	savedBytes: number;
+	savedTokens?: number;
+	kind: "saved" | "missed";
+	sessionId?: string;
+	cwd: string;
+}
+
+// Structural skip filters — these mean the parser didn't attempt compression, not a coverage gap.
+const SKIP_FILTERS = new Set(["missed", "compound", "chain-noop", "unsupported"]);
+
+
+async function readMinimizerFile(): Promise<string | null> {
+	const filePath = path.join(getAgentDir(), "minimizer-gain.jsonl");
+	try {
+		return await Bun.file(filePath).text();
+	} catch (err) {
+		if (!isEnoent(err)) logger.debug("gain-aggregator: failed to read minimizer-gain.jsonl", { err: String(err) });
+		return null;
+	}
+}
+
+async function readMinimizerRecords(cutoff: number | null, project: string | null): Promise<MinimizerRecord[]> {
+	const text = await readMinimizerFile();
+	if (!text) return [];
+	const records: MinimizerRecord[] = [];
+	for (const line of text.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			const rec = JSON.parse(line) as MinimizerRecord;
+			if (rec.kind === "missed") continue;
+			const ts = new Date(rec.timestamp).getTime();
+			if (cutoff !== null && ts < cutoff) continue;
+			if (project !== null && !rec.cwd?.startsWith(project)) continue;
+			records.push(rec);
+		} catch { /* skip malformed */ }
+	}
+	return records;
+}
+
+/** Records where NO filter matched (filter==="missed", kind==="missed"), excluding temp/internal paths. */
+async function readMinimizerUnparsedRecords(cutoff: number | null, project: string | null): Promise<MinimizerRecord[]> {
+	const text = await readMinimizerFile();
+	if (!text) return [];
+	const records: MinimizerRecord[] = [];
+	for (const line of text.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			const rec = JSON.parse(line) as MinimizerRecord;
+			// Only "no filter matched" records
+			if (rec.kind !== "missed" || rec.filter !== "missed") continue;
+			// Skip internal/temp cwds (no tuning signal)
+			if (TEMP_PATH_RE.test(rec.cwd ?? "")) continue;
+			const ts = new Date(rec.timestamp).getTime();
+			if (cutoff !== null && ts < cutoff) continue;
+			if (project !== null && !rec.cwd?.startsWith(project)) continue;
+			records.push(rec);
+		} catch { /* skip malformed */ }
+	}
+	return records;
+}
+
+// ---------------------------------------------------------------------------
+// Project normalization & deduplication
+// ---------------------------------------------------------------------------
+
+const TEMP_PATH_RE = /\/T\/|\/tmp\/|\/pi-bash-exec|\/omp-bash-exec|\/pi-bash-detach|\/var\/folders\//;
+
+/** Collapse worktree/ephemeral sub-paths to their logical project root. Returns null to drop. */
+function normalizeProjectPath(p: string): string | null {
+	if (TEMP_PATH_RE.test(p)) return null;
+	// omp internal worktrees — not meaningful
+	if (/\/\.omp\/wt\//.test(p)) return null;
+	// herdr worktrees → /.herdr/worktrees/<project>
+	const herdr = p.match(/(\/\.herdr\/worktrees\/[^/]+)/);
+	if (herdr) return herdr[1];
+	// <prefix>/PycharmProjects/<proj>-factory-worktrees/... → <prefix>/PycharmProjects/<proj>
+	const factory = p.match(/(\/PycharmProjects\/[^/]+)-factory-worktrees\/.*/);
+	if (factory) return p.slice(0, factory.index!) + factory[1];
+	// <prefix>/PycharmProjects/<proj>-worktrees/... → <prefix>/PycharmProjects/<proj>
+	const wt = p.match(/(\/PycharmProjects\/[^/]+)-worktrees\/.*/);
+	if (wt) return p.slice(0, wt.index!) + wt[1];
+	// <prefix>/PycharmProjects/<proj>.wt/<lane>/... → <prefix>/PycharmProjects/<proj>
+	const dotWt = p.match(/(\/PycharmProjects\/[^/]+)\.wt\/.*/);
+	if (dotWt) return p.slice(0, dotWt.index!) + dotWt[1];
+	// <prefix>/PycharmProjects/<proj>-wt/<lane>/... → <prefix>/PycharmProjects/<proj>
+	const dashWt = p.match(/(\/PycharmProjects\/[^/]+)-wt\/.*/);
+	if (dashWt) return p.slice(0, dashWt.index!) + dashWt[1];
+	// PycharmProjects/.worktrees/<proj>/<lane>/... → PycharmProjects/<proj>
+	const hiddenWt = p.match(/^(.+\/PycharmProjects)\/\.worktrees\/([^/]+)\/[^/]+.*/);
+	if (hiddenWt) return `${hiddenWt[1]}/${hiddenWt[2]}`;
+	return p;
+}
+
+function pathDepth(p: string): number {
+	return p.split("/").filter(Boolean).length;
+}
+
+/**
+ * Given a raw set of paths, normalize worktree paths and remove sub-paths
+ * that are already covered by a shorter parent at depth ≥ 4.
+ * Returns a sorted, deduped list of meaningful project roots.
+ */
+function dedupeProjects(rawPaths: Set<string>): string[] {
+	const normalized = new Set<string>();
+	for (const p of rawPaths) {
+		const n = normalizeProjectPath(p);
+		if (n) normalized.add(n);
+	}
+	const sorted = Array.from(normalized).sort();
+	return sorted.filter(p => {
+		// Drop p if a shorter path is a proper prefix of it AND that parent is deep enough
+		// to be a meaningful scope boundary (depth ≥ 4), not a catch-all like /Users/davidandrews.
+		return !sorted.some(
+			other =>
+				other !== p &&
+				other.length < p.length &&
+				p.startsWith(other.endsWith("/") ? other : other + "/") &&
+				pathDepth(other) >= 4,
+		);
+	});
+}
+
+async function readMinimizerProjects(): Promise<Set<string>> {
+	const text = await readMinimizerFile();
+	const projects = new Set<string>();
+	if (!text) return projects;
+	for (const line of text.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			const rec = JSON.parse(line) as MinimizerRecord;
+			if (rec.cwd) projects.add(rec.cwd);
+		} catch { /* skip */ }
+	}
+	return projects;
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Snapcompact record schema
+// ---------------------------------------------------------------------------
+
+interface SnapcompactRecord {
+	ts: number; // epoch ms
+	session: string;
+	provider: string;
+	model: string;
+	toolCallId: string;
+	savedTokens: number;
+}
+
+async function readSnapcompactRecords(cutoff: number | null, _project: string | null): Promise<SnapcompactRecord[]> {
+	// Snapcompact records have no cwd/project field — project filter not applicable.
+	const filePath = path.join(path.dirname(getStatsDbPath()), "snapcompact-savings.jsonl");
+	let text: string;
+	try {
+		text = await Bun.file(filePath).text();
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		logger.debug("gain-aggregator: failed to read snapcompact-savings.jsonl", { err: String(err) });
+		return [];
+	}
+	const seen = new Set<string>();
+	const records: SnapcompactRecord[] = [];
+	for (const line of text.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			const rec = JSON.parse(line) as SnapcompactRecord;
+			if (cutoff !== null && rec.ts < cutoff) continue;
+			const key = `${rec.session}:${rec.toolCallId}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			records.push(rec);
+		} catch { /* skip malformed line */ }
+	}
+	return records;
+}
+
+// ---------------------------------------------------------------------------
+// Pi-distill stats schema (minimal local redeclaration — do not import from pi-distill)
+// ---------------------------------------------------------------------------
+
+interface PiDistillSessionRecord {
+	sessionId: string;
+	project?: string;
+	label?: string;
+	savedBytes: number;
+	hits: number;
+	originalBytes?: number;
+	replacementBytes?: number;
+	firstTs: number;
+	lastTs: number;
+}
+
+interface PiDistillStats {
+	sessions: Record<string, PiDistillSessionRecord>;
+}
+
+async function readPiDistillRecords(cutoff: number | null, project: string | null): Promise<PiDistillSessionRecord[]> {
+	const filePath = path.join(os.homedir(), ".omp", "agent", "pi-distill", "stats.json");
+	let raw: string;
+	try {
+		raw = await Bun.file(filePath).text();
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		logger.debug("gain-aggregator: failed to read pi-distill stats.json", { err: String(err) });
+		return [];
+	}
+	try {
+		const stats = JSON.parse(raw) as PiDistillStats;
+		let sessions = Object.values(stats.sessions ?? {});
+		if (cutoff !== null) sessions = sessions.filter(s => s.lastTs >= cutoff);
+		if (project !== null) sessions = sessions.filter(s => s.project?.startsWith(project));
+		return sessions;
+	} catch (err) {
+		logger.debug("gain-aggregator: failed to parse pi-distill stats.json", { err: String(err) });
+		return [];
+	}
+}
+
+/** Collect all distinct project values from pi-distill stats (unfiltered). */
+async function readDistillProjects(): Promise<Set<string>> {
+	const filePath = path.join(os.homedir(), ".omp", "agent", "pi-distill", "stats.json");
+	const projects = new Set<string>();
+	try {
+		const raw = await Bun.file(filePath).text();
+		const stats = JSON.parse(raw) as PiDistillStats;
+		for (const s of Object.values(stats.sessions ?? {})) {
+			if (s.project) projects.add(s.project);
+		}
+	} catch { /* ignore */ }
+	return projects;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers
+// ---------------------------------------------------------------------------
+
+function emptyTotals(): GainSourceTotals {
+	return {
+		savedTokens: 0,
+		savedBytes: 0,
+		hits: 0,
+		outputBytes: 0,
+		originalBytes: 0,
+		reductionPercent: null,
+	};
+}
+
+function finalizeReductionPercent(totals: GainSourceTotals): GainSourceTotals {
+	if (totals.originalBytes > 0) {
+		totals.reductionPercent = totals.savedBytes / totals.originalBytes;
+	}
+	return totals;
+}
+
+/** ISO date string from epoch ms, bucketed to the day. */
+function toDateBucket(epochMs: number): string {
+	return new Date(epochMs).toISOString().slice(0, 10); // "YYYY-MM-DD"
+}
+
+// ---------------------------------------------------------------------------
+// Main aggregation function
+// ---------------------------------------------------------------------------
+
+export async function getGainDashboardStats(
+	range?: string | null,
+	project?: string | null,
+): Promise<GainDashboardStats> {
+	const normalized = range?.trim().toLowerCase() ?? "24h";
+	const RANGE_MS: Record<string, number> = { "1h": 3600_000, "24h": 86400_000, "7d": 604800_000, "30d": 2592000_000, "90d": 7776000_000 };
+	const effectiveCutoff: number | null =
+		normalized === "all" ? null : Date.now() - (RANGE_MS[normalized] ?? 86400_000);
+	const effectiveProject: string | null = project?.trim() || null;
+
+	const [minimizerRecords, unparsedRecords, snapcompactRecords, distillRecords, minimizerProjects, distillProjects] =
+		await Promise.all([
+			readMinimizerRecords(effectiveCutoff, effectiveProject),
+			readMinimizerUnparsedRecords(effectiveCutoff, effectiveProject),
+			readSnapcompactRecords(effectiveCutoff, effectiveProject),
+			readPiDistillRecords(effectiveCutoff, effectiveProject),
+			readMinimizerProjects(),
+			readDistillProjects(),
+		]);
+
+	// --- Minimizer totals ---
+	const minimizerTotals = emptyTotals();
+	const filterMap = new Map<string, GainTopFilter>();
+	const timeMap = new Map<string, { minimizer: number; snapcompact: number; distill: number }>();
+
+	for (const rec of minimizerRecords) {
+		const tokens = rec.savedTokens ?? Math.floor((rec.savedBytes ?? 0) / BYTES_PER_TOKEN_ESTIMATE);
+		const savedBytes = rec.savedBytes ?? 0;
+		const inputBytes = rec.inputBytes ?? 0;
+
+		minimizerTotals.savedTokens += tokens;
+		minimizerTotals.savedBytes += savedBytes;
+		minimizerTotals.hits += 1;
+		minimizerTotals.originalBytes += inputBytes;
+		minimizerTotals.outputBytes += rec.outputBytes ?? 0;
+
+		// top filters
+		const existing = filterMap.get(rec.filter);
+		if (existing) {
+			existing.savedTokens += tokens;
+			existing.savedBytes += savedBytes;
+			existing.hits += 1;
+		} else {
+			filterMap.set(rec.filter, { filter: rec.filter, savedTokens: tokens, savedBytes, hits: 1 });
+		}
+
+		// time series
+		const ts = new Date(rec.timestamp).getTime();
+		const date = toDateBucket(ts);
+		const bucket = timeMap.get(date) ?? { minimizer: 0, snapcompact: 0, distill: 0 };
+		bucket.minimizer += tokens;
+		timeMap.set(date, bucket);
+	}
+	finalizeReductionPercent(minimizerTotals);
+
+	// --- Unparsed commands (no filter matched — tuning targets) ---
+	const cmdMap = new Map<string, GainUnparsedCommand>();
+	for (const rec of unparsedRecords) {
+		const key = (rec.command ?? "").slice(0, 120);
+		const existing = cmdMap.get(key);
+		if (existing) {
+			existing.hits += 1;
+			existing.inputBytes += rec.inputBytes ?? 0;
+		} else {
+			cmdMap.set(key, { command: key, hits: 1, inputBytes: rec.inputBytes ?? 0 });
+		}
+	}
+	const unparsedCommands: GainUnparsedCommand[] = Array.from(cmdMap.values())
+		.sort((a, b) => b.hits - a.hits)
+		.slice(0, 25);
+
+
+	// --- Snapcompact totals ---
+	const snapcompactTotals = emptyTotals();
+
+	for (const rec of snapcompactRecords) {
+		snapcompactTotals.savedTokens += rec.savedTokens;
+		const approxBytes = rec.savedTokens * BYTES_PER_TOKEN_ESTIMATE;
+		snapcompactTotals.savedBytes += approxBytes;
+		snapcompactTotals.hits += 1;
+
+		const date = toDateBucket(rec.ts);
+		const bucket = timeMap.get(date) ?? { minimizer: 0, snapcompact: 0, distill: 0 };
+		bucket.snapcompact += rec.savedTokens;
+		timeMap.set(date, bucket);
+	}
+	// No originalBytes for snapcompact — reductionPercent stays null
+
+	// --- Pi-distill totals ---
+	const distillTotals = emptyTotals();
+
+	for (const rec of distillRecords) {
+		const tokens = Math.floor(rec.savedBytes / BYTES_PER_TOKEN_ESTIMATE);
+		distillTotals.savedTokens += tokens;
+		distillTotals.savedBytes += rec.savedBytes;
+		distillTotals.hits += rec.hits;
+		if (rec.originalBytes !== undefined) {
+			distillTotals.originalBytes += rec.originalBytes;
+			distillTotals.outputBytes += rec.originalBytes - rec.savedBytes;
+		}
+
+		const ts = Math.floor((rec.firstTs + rec.lastTs) / 2);
+		const date = toDateBucket(ts);
+		const bucket = timeMap.get(date) ?? { minimizer: 0, snapcompact: 0, distill: 0 };
+		bucket.distill += tokens;
+		timeMap.set(date, bucket);
+	}
+	finalizeReductionPercent(distillTotals);
+
+	// --- Overall totals ---
+	const overall: GainSourceTotals = {
+		savedTokens: minimizerTotals.savedTokens + snapcompactTotals.savedTokens + distillTotals.savedTokens,
+		savedBytes: minimizerTotals.savedBytes + snapcompactTotals.savedBytes + distillTotals.savedBytes,
+		hits: minimizerTotals.hits + snapcompactTotals.hits + distillTotals.hits,
+		outputBytes: minimizerTotals.outputBytes + distillTotals.outputBytes,
+		originalBytes: minimizerTotals.originalBytes + distillTotals.originalBytes,
+		reductionPercent: null,
+	};
+	if (overall.originalBytes > 0) {
+		overall.reductionPercent = overall.savedBytes / overall.originalBytes;
+	}
+
+	// --- Time series (sorted ascending by date) ---
+	const timeSeries: GainTimeSeriesPoint[] = Array.from(timeMap.entries())
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([date, bucket]) => ({
+			date,
+			minimizer: bucket.minimizer,
+			snapcompact: bucket.snapcompact,
+			distill: bucket.distill,
+			total: bucket.minimizer + bucket.snapcompact + bucket.distill,
+		}));
+
+	// --- Top filters (top 10 by savedTokens) ---
+	const topFilters: GainTopFilter[] = Array.from(filterMap.values())
+		.sort((a, b) => b.savedTokens - a.savedTokens)
+		.slice(0, 10);
+
+	// --- Projects list (union of minimizer cwds + distill projects, normalized & deduped) ---
+	const allProjects = new Set<string>([...minimizerProjects, ...distillProjects]);
+	const projects = dedupeProjects(allProjects);
+
+	return {
+		overall,
+		bySource: {
+			minimizer: minimizerTotals,
+			snapcompact: snapcompactTotals,
+			distill: distillTotals,
+		},
+		timeSeries,
+		topFilters,
+		unparsedCommands,
+		project: effectiveProject,
+		projects,
+	};
+}

--- a/packages/stats/src/gain-aggregator.ts
+++ b/packages/stats/src/gain-aggregator.ts
@@ -10,15 +10,15 @@
  * Missing files are treated as zero records — never an error.
  */
 
-import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, getStatsDbPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { getTimeRangeConfig } from "./aggregator";
 import type {
 	GainDashboardStats,
-	GainUnparsedCommand,
 	GainSourceTotals,
 	GainTimeSeriesPoint,
 	GainTopFilter,
+	GainUnparsedCommand,
 } from "./shared-types";
 
 const BYTES_PER_TOKEN_ESTIMATE = 4;
@@ -40,9 +40,28 @@ interface MinimizerRecord {
 	cwd: string;
 }
 
-// Structural skip filters — these mean the parser didn't attempt compression, not a coverage gap.
-const SKIP_FILTERS = new Set(["missed", "compound", "chain-noop", "unsupported"]);
+// Paths that carry no tuning signal — temp/internal locations.
+const TEMP_PATH_RE = /\/T\/|\/tmp\/|\/pi-bash-exec|\/omp-bash-exec|\/pi-bash-detach|\/var\/folders\//;
 
+// ---------------------------------------------------------------------------
+// Project-match helper
+// ---------------------------------------------------------------------------
+
+/** True when `cwd` is exactly `project` or is a sub-path of it. */
+function matchesProject(cwd: string | undefined, project: string): boolean {
+	if (!cwd) return false;
+	return cwd === project || cwd.startsWith(`${project}/`);
+}
+
+// ---------------------------------------------------------------------------
+// Minimizer JSONL — single read, three derived result sets
+// ---------------------------------------------------------------------------
+
+interface MinimizerSets {
+	records: MinimizerRecord[];
+	unparsed: MinimizerRecord[];
+	projects: Set<string>;
+}
 
 async function readMinimizerFile(): Promise<string | null> {
 	const filePath = path.join(getAgentDir(), "minimizer-gain.jsonl");
@@ -54,80 +73,69 @@ async function readMinimizerFile(): Promise<string | null> {
 	}
 }
 
-async function readMinimizerRecords(cutoff: number | null, project: string | null): Promise<MinimizerRecord[]> {
+/**
+ * Parse the minimizer JSONL exactly once and derive all three result sets in
+ * a single pass. Avoids re-reading and re-parsing the file three times per
+ * dashboard request.
+ */
+async function readMinimizerSets(cutoff: number | null, project: string | null): Promise<MinimizerSets> {
 	const text = await readMinimizerFile();
-	if (!text) return [];
-	const records: MinimizerRecord[] = [];
-	for (const line of text.split("\n")) {
-		if (!line.trim()) continue;
-		try {
-			const rec = JSON.parse(line) as MinimizerRecord;
-			if (rec.kind === "missed") continue;
-			const ts = new Date(rec.timestamp).getTime();
-			if (cutoff !== null && ts < cutoff) continue;
-			if (project !== null && !rec.cwd?.startsWith(project)) continue;
-			records.push(rec);
-		} catch { /* skip malformed */ }
-	}
-	return records;
-}
+	const sets: MinimizerSets = { records: [], unparsed: [], projects: new Set() };
+	if (!text) return sets;
 
-/** Records where NO filter matched (filter==="missed", kind==="missed"), excluding temp/internal paths. */
-async function readMinimizerUnparsedRecords(cutoff: number | null, project: string | null): Promise<MinimizerRecord[]> {
-	const text = await readMinimizerFile();
-	if (!text) return [];
-	const records: MinimizerRecord[] = [];
 	for (const line of text.split("\n")) {
 		if (!line.trim()) continue;
 		try {
 			const rec = JSON.parse(line) as MinimizerRecord;
-			// Only "no filter matched" records
-			if (rec.kind !== "missed" || rec.filter !== "missed") continue;
-			// Skip internal/temp cwds (no tuning signal)
-			if (TEMP_PATH_RE.test(rec.cwd ?? "")) continue;
+
+			// Always collect project cwds (unfiltered).
+			if (rec.cwd) sets.projects.add(rec.cwd);
+
 			const ts = new Date(rec.timestamp).getTime();
 			if (cutoff !== null && ts < cutoff) continue;
-			if (project !== null && !rec.cwd?.startsWith(project)) continue;
-			records.push(rec);
-		} catch { /* skip malformed */ }
+			if (project !== null && !matchesProject(rec.cwd, project)) continue;
+
+			if (rec.kind === "missed") {
+				// Unparsed: only "no filter matched" records from meaningful cwds.
+				if (rec.filter === "missed" && !TEMP_PATH_RE.test(rec.cwd ?? "")) {
+					sets.unparsed.push(rec);
+				}
+			} else {
+				sets.records.push(rec);
+			}
+		} catch {
+			/* skip malformed */
+		}
 	}
-	return records;
+	return sets;
 }
 
 // ---------------------------------------------------------------------------
 // Project normalization & deduplication
 // ---------------------------------------------------------------------------
 
-const TEMP_PATH_RE = /\/T\/|\/tmp\/|\/pi-bash-exec|\/omp-bash-exec|\/pi-bash-detach|\/var\/folders\//;
-
-/** Collapse worktree/ephemeral sub-paths to their logical project root. Returns null to drop. */
+/**
+ * Collapse worktree sub-paths to their logical project root.
+ *
+ * Rules are generic: omp internal wt paths are dropped; conventional worktree
+ * suffixes (`.wt/`, `-wt/`, `.worktrees/`, `-worktrees/`) are stripped. No
+ * author-specific IDE or tool paths are baked in.
+ *
+ * Returns null to drop temp/internal paths entirely.
+ */
 function normalizeProjectPath(p: string): string | null {
 	if (TEMP_PATH_RE.test(p)) return null;
-	// omp internal worktrees — not meaningful
+	// omp internal worktrees — not meaningful project roots
 	if (/\/\.omp\/wt\//.test(p)) return null;
-	// herdr worktrees → /.herdr/worktrees/<project>
-	const herdr = p.match(/(\/\.herdr\/worktrees\/[^/]+)/);
-	if (herdr) return herdr[1];
-	// <prefix>/PycharmProjects/<proj>-factory-worktrees/... → <prefix>/PycharmProjects/<proj>
-	const factory = p.match(/(\/PycharmProjects\/[^/]+)-factory-worktrees\/.*/);
-	if (factory) return p.slice(0, factory.index!) + factory[1];
-	// <prefix>/PycharmProjects/<proj>-worktrees/... → <prefix>/PycharmProjects/<proj>
-	const wt = p.match(/(\/PycharmProjects\/[^/]+)-worktrees\/.*/);
-	if (wt) return p.slice(0, wt.index!) + wt[1];
-	// <prefix>/PycharmProjects/<proj>.wt/<lane>/... → <prefix>/PycharmProjects/<proj>
-	const dotWt = p.match(/(\/PycharmProjects\/[^/]+)\.wt\/.*/);
-	if (dotWt) return p.slice(0, dotWt.index!) + dotWt[1];
-	// <prefix>/PycharmProjects/<proj>-wt/<lane>/... → <prefix>/PycharmProjects/<proj>
-	const dashWt = p.match(/(\/PycharmProjects\/[^/]+)-wt\/.*/);
-	if (dashWt) return p.slice(0, dashWt.index!) + dashWt[1];
-	// PycharmProjects/.worktrees/<proj>/<lane>/... → PycharmProjects/<proj>
-	const hiddenWt = p.match(/^(.+\/PycharmProjects)\/\.worktrees\/([^/]+)\/[^/]+.*/);
-	if (hiddenWt) return `${hiddenWt[1]}/${hiddenWt[2]}`;
-	return p;
-}
 
-function pathDepth(p: string): number {
-	return p.split("/").filter(Boolean).length;
+	// Generic worktree layouts — strip the worktree suffix/subpath.
+	// Matches: <root>/.wt/<lane>/..., <root>-wt/<lane>/...,
+	//          <root>.wt/<lane>/..., <root>/.worktrees/<lane>/...,
+	//          <root>-worktrees/<lane>/..., <root>/.herdr/worktrees/<name>/...
+	const m = p.match(/^(.+?)(?:\/\.wt\/|\/\.worktrees\/|-worktrees\/|-wt\/|\.wt\/|\/.+\/worktrees\/)[^/]+(\/.*)?$/);
+	if (m) return m[1];
+
+	return p;
 }
 
 /**
@@ -144,32 +152,16 @@ function dedupeProjects(rawPaths: Set<string>): string[] {
 	const sorted = Array.from(normalized).sort();
 	return sorted.filter(p => {
 		// Drop p if a shorter path is a proper prefix of it AND that parent is deep enough
-		// to be a meaningful scope boundary (depth ≥ 4), not a catch-all like /Users/davidandrews.
+		// to be a meaningful scope boundary (depth ≥ 4), not a catch-all like /Users/x.
 		return !sorted.some(
 			other =>
 				other !== p &&
 				other.length < p.length &&
-				p.startsWith(other.endsWith("/") ? other : other + "/") &&
-				pathDepth(other) >= 4,
+				p.startsWith(other.endsWith("/") ? other : `${other}/`) &&
+				other.split("/").filter(Boolean).length >= 4,
 		);
 	});
 }
-
-async function readMinimizerProjects(): Promise<Set<string>> {
-	const text = await readMinimizerFile();
-	const projects = new Set<string>();
-	if (!text) return projects;
-	for (const line of text.split("\n")) {
-		if (!line.trim()) continue;
-		try {
-			const rec = JSON.parse(line) as MinimizerRecord;
-			if (rec.cwd) projects.add(rec.cwd);
-		} catch { /* skip */ }
-	}
-	return projects;
-}
-
-
 
 // ---------------------------------------------------------------------------
 // Snapcompact record schema
@@ -184,8 +176,16 @@ interface SnapcompactRecord {
 	savedTokens: number;
 }
 
-async function readSnapcompactRecords(cutoff: number | null, _project: string | null): Promise<SnapcompactRecord[]> {
-	// Snapcompact records have no cwd/project field — project filter not applicable.
+/**
+ * Snapcompact records carry no cwd/project field — project filter cannot be
+ * applied. When a project is selected the snapcompact totals are omitted from
+ * project-scoped responses to avoid mixing unrelated savings into the
+ * per-project view.
+ */
+async function readSnapcompactRecords(cutoff: number | null, project: string | null): Promise<SnapcompactRecord[]> {
+	// No project field → skip entirely for project-scoped requests.
+	if (project !== null) return [];
+
 	const filePath = path.join(path.dirname(getStatsDbPath()), "snapcompact-savings.jsonl");
 	let text: string;
 	try {
@@ -206,7 +206,9 @@ async function readSnapcompactRecords(cutoff: number | null, _project: string | 
 			if (seen.has(key)) continue;
 			seen.add(key);
 			records.push(rec);
-		} catch { /* skip malformed line */ }
+		} catch {
+			/* skip malformed line */
+		}
 	}
 	return records;
 }
@@ -232,7 +234,7 @@ interface PiDistillStats {
 }
 
 async function readPiDistillRecords(cutoff: number | null, project: string | null): Promise<PiDistillSessionRecord[]> {
-	const filePath = path.join(os.homedir(), ".omp", "agent", "pi-distill", "stats.json");
+	const filePath = path.join(getAgentDir(), "pi-distill", "stats.json");
 	let raw: string;
 	try {
 		raw = await Bun.file(filePath).text();
@@ -245,7 +247,7 @@ async function readPiDistillRecords(cutoff: number | null, project: string | nul
 		const stats = JSON.parse(raw) as PiDistillStats;
 		let sessions = Object.values(stats.sessions ?? {});
 		if (cutoff !== null) sessions = sessions.filter(s => s.lastTs >= cutoff);
-		if (project !== null) sessions = sessions.filter(s => s.project?.startsWith(project));
+		if (project !== null) sessions = sessions.filter(s => matchesProject(s.project, project));
 		return sessions;
 	} catch (err) {
 		logger.debug("gain-aggregator: failed to parse pi-distill stats.json", { err: String(err) });
@@ -255,7 +257,7 @@ async function readPiDistillRecords(cutoff: number | null, project: string | nul
 
 /** Collect all distinct project values from pi-distill stats (unfiltered). */
 async function readDistillProjects(): Promise<Set<string>> {
-	const filePath = path.join(os.homedir(), ".omp", "agent", "pi-distill", "stats.json");
+	const filePath = path.join(getAgentDir(), "pi-distill", "stats.json");
 	const projects = new Set<string>();
 	try {
 		const raw = await Bun.file(filePath).text();
@@ -263,7 +265,9 @@ async function readDistillProjects(): Promise<Set<string>> {
 		for (const s of Object.values(stats.sessions ?? {})) {
 			if (s.project) projects.add(s.project);
 		}
-	} catch { /* ignore */ }
+	} catch {
+		/* ignore */
+	}
 	return projects;
 }
 
@@ -302,21 +306,17 @@ export async function getGainDashboardStats(
 	range?: string | null,
 	project?: string | null,
 ): Promise<GainDashboardStats> {
-	const normalized = range?.trim().toLowerCase() ?? "24h";
-	const RANGE_MS: Record<string, number> = { "1h": 3600_000, "24h": 86400_000, "7d": 604800_000, "30d": 2592000_000, "90d": 7776000_000 };
-	const effectiveCutoff: number | null =
-		normalized === "all" ? null : Date.now() - (RANGE_MS[normalized] ?? 86400_000);
+	const { cutoff: effectiveCutoff } = getTimeRangeConfig(range);
 	const effectiveProject: string | null = project?.trim() || null;
 
-	const [minimizerRecords, unparsedRecords, snapcompactRecords, distillRecords, minimizerProjects, distillProjects] =
-		await Promise.all([
-			readMinimizerRecords(effectiveCutoff, effectiveProject),
-			readMinimizerUnparsedRecords(effectiveCutoff, effectiveProject),
-			readSnapcompactRecords(effectiveCutoff, effectiveProject),
-			readPiDistillRecords(effectiveCutoff, effectiveProject),
-			readMinimizerProjects(),
-			readDistillProjects(),
-		]);
+	const [minimizerSets, snapcompactRecords, distillRecords, distillProjects] = await Promise.all([
+		readMinimizerSets(effectiveCutoff, effectiveProject),
+		readSnapcompactRecords(effectiveCutoff, effectiveProject),
+		readPiDistillRecords(effectiveCutoff, effectiveProject),
+		readDistillProjects(),
+	]);
+
+	const { records: minimizerRecords, unparsed: unparsedRecords, projects: minimizerProjects } = minimizerSets;
 
 	// --- Minimizer totals ---
 	const minimizerTotals = emptyTotals();
@@ -354,21 +354,22 @@ export async function getGainDashboardStats(
 	finalizeReductionPercent(minimizerTotals);
 
 	// --- Unparsed commands (no filter matched — tuning targets) ---
+	// Key on the full command string to avoid collision; truncate only at display time.
 	const cmdMap = new Map<string, GainUnparsedCommand>();
 	for (const rec of unparsedRecords) {
-		const key = (rec.command ?? "").slice(0, 120);
-		const existing = cmdMap.get(key);
+		const fullKey = rec.command ?? "";
+		const existing = cmdMap.get(fullKey);
 		if (existing) {
 			existing.hits += 1;
 			existing.inputBytes += rec.inputBytes ?? 0;
 		} else {
-			cmdMap.set(key, { command: key, hits: 1, inputBytes: rec.inputBytes ?? 0 });
+			// Store the full command; callers may truncate for display.
+			cmdMap.set(fullKey, { command: fullKey, hits: 1, inputBytes: rec.inputBytes ?? 0 });
 		}
 	}
 	const unparsedCommands: GainUnparsedCommand[] = Array.from(cmdMap.values())
 		.sort((a, b) => b.hits - a.hits)
 		.slice(0, 25);
-
 
 	// --- Snapcompact totals ---
 	const snapcompactTotals = emptyTotals();
@@ -408,6 +409,10 @@ export async function getGainDashboardStats(
 	finalizeReductionPercent(distillTotals);
 
 	// --- Overall totals ---
+	// reductionPercent is computed only from sources that have originalBytes
+	// (minimizer + distill). Snapcompact has no originalBytes, so including its
+	// savedBytes in the numerator with nothing in the denominator would overstate
+	// the ratio. The per-source cards each report their own correct ratio.
 	const overall: GainSourceTotals = {
 		savedTokens: minimizerTotals.savedTokens + snapcompactTotals.savedTokens + distillTotals.savedTokens,
 		savedBytes: minimizerTotals.savedBytes + snapcompactTotals.savedBytes + distillTotals.savedBytes,
@@ -416,8 +421,11 @@ export async function getGainDashboardStats(
 		originalBytes: minimizerTotals.originalBytes + distillTotals.originalBytes,
 		reductionPercent: null,
 	};
-	if (overall.originalBytes > 0) {
-		overall.reductionPercent = overall.savedBytes / overall.originalBytes;
+	// Use only sources with originalBytes for the ratio to avoid inflated percentages.
+	const ratioNumerator = minimizerTotals.savedBytes + distillTotals.savedBytes;
+	const ratioDenominator = overall.originalBytes;
+	if (ratioDenominator > 0) {
+		overall.reductionPercent = ratioNumerator / ratioDenominator;
 	}
 
 	// --- Time series (sorted ascending by date) ---

--- a/packages/stats/src/gain-aggregator.ts
+++ b/packages/stats/src/gain-aggregator.ts
@@ -47,10 +47,18 @@ const TEMP_PATH_RE = /\/T\/|\/tmp\/|\/pi-bash-exec|\/omp-bash-exec|\/pi-bash-det
 // Project-match helper
 // ---------------------------------------------------------------------------
 
-/** True when `cwd` is exactly `project` or is a sub-path of it. */
+/**
+ * True when `cwd` (or its normalized project root) exactly equals `project`
+ * or is a direct sub-path of it.
+ *
+ * Normalization is applied so that a cwd of `/repo-worktrees/lane/src` matches
+ * a project root of `/repo` — the selector shows normalized roots, so the
+ * filter must compare apples-to-apples.
+ */
 function matchesProject(cwd: string | undefined, project: string): boolean {
 	if (!cwd) return false;
-	return cwd === project || cwd.startsWith(`${project}/`);
+	const normalized = normalizeProjectPath(cwd) ?? cwd;
+	return normalized === project || normalized.startsWith(`${project}/`);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -15,9 +15,15 @@ export {
 	syncAllSessions,
 } from "./aggregator";
 export { closeDb } from "./db";
-export { startServer } from "./server";
 export { getGainDashboardStats } from "./gain-aggregator";
-export type { GainDashboardStats, GainSource, GainSourceTotals, GainTimeSeriesPoint, GainTopFilter } from "./shared-types";
+export { startServer } from "./server";
+export type {
+	GainDashboardStats,
+	GainSource,
+	GainSourceTotals,
+	GainTimeSeriesPoint,
+	GainTopFilter,
+} from "./shared-types";
 export type {
 	AggregatedStats,
 	DashboardStats,

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -16,6 +16,8 @@ export {
 } from "./aggregator";
 export { closeDb } from "./db";
 export { startServer } from "./server";
+export { getGainDashboardStats } from "./gain-aggregator";
+export type { GainDashboardStats, GainSource, GainSourceTotals, GainTimeSeriesPoint, GainTopFilter } from "./shared-types";
 export type {
 	AggregatedStats,
 	DashboardStats,

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -16,6 +16,7 @@ import {
 	getTotalMessageCount,
 	syncAllSessions,
 } from "./aggregator";
+import { getGainDashboardStats } from "./gain-aggregator";
 import { decodeEmbeddedClientArchive } from "./embedded-client";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
 
@@ -253,6 +254,12 @@ async function handleApi(req: Request): Promise<Response> {
 		const result = await syncAllSessions();
 		const count = await getTotalMessageCount();
 		return Response.json({ ...result, totalMessages: count });
+	}
+
+	if (path === "/api/stats/gain") {
+		const project = url.searchParams.get("project");
+		const stats = await getGainDashboardStats(range, project);
+		return Response.json(stats);
 	}
 
 	return new Response("Not Found", { status: 404 });

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -16,9 +16,9 @@ import {
 	getTotalMessageCount,
 	syncAllSessions,
 } from "./aggregator";
-import { getGainDashboardStats } from "./gain-aggregator";
 import { decodeEmbeddedClientArchive } from "./embedded-client";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
+import { getGainDashboardStats } from "./gain-aggregator";
 
 const EMBEDDED_CLIENT_ARCHIVE = decodeEmbeddedClientArchive(embeddedClientArchiveTxt);
 

--- a/packages/stats/src/shared-types.ts
+++ b/packages/stats/src/shared-types.ts
@@ -232,3 +232,67 @@ export interface BehaviorDashboardStats {
 	byModel: BehaviorModelStats[];
 	behaviorSeries: BehaviorTimeSeriesPoint[];
 }
+
+/** Token savings from a single source type. */
+export interface GainSourceTotals {
+	savedTokens: number;
+	savedBytes: number;
+	hits: number;
+	/** originalBytes - savedBytes, when original is known */
+	outputBytes: number;
+	/** Total original bytes before compression, when known */
+	originalBytes: number;
+	/** savedBytes / originalBytes when both are known, else null */
+	reductionPercent: number | null;
+}
+
+/** Per-source breakdown. */
+export type GainSource = "minimizer" | "snapcompact" | "distill";
+
+/** Time-series point for gain (daily bucket). */
+export interface GainTimeSeriesPoint {
+	date: string;
+	minimizer: number;
+	snapcompact: number;
+	distill: number;
+	total: number;
+}
+
+/** Top filter/command gaining the most savings. */
+export interface GainTopFilter {
+	filter: string;
+	savedTokens: number;
+	savedBytes: number;
+	hits: number;
+}
+
+/**
+ * A bash command that the minimizer saw but had no filter for — no parser matched.
+ * These are the prime candidates for writing new minimizer filters.
+ */
+export interface GainUnparsedCommand {
+	/** The actual command string (truncated to 120 chars for grouping). */
+	command: string;
+	/** Number of times this exact command was seen unparsed. */
+	hits: number;
+	/** Total input bytes across all occurrences. */
+	inputBytes: number;
+}
+
+/** Complete gain dashboard payload. */
+export interface GainDashboardStats {
+	/** Aggregate across all sources for the active range. */
+	overall: GainSourceTotals;
+	/** Per-source breakdown. */
+	bySource: Record<GainSource, GainSourceTotals>;
+	/** Daily time series (all sources stacked). */
+	timeSeries: GainTimeSeriesPoint[];
+	/** Top 10 bash minimizer filters by savedTokens. */
+	topFilters: GainTopFilter[];
+	/** Top 25 unparsed commands (no filter matched) sorted by hit count — use to write new filters. */
+	unparsedCommands: GainUnparsedCommand[];
+	/** Active project filter (cwd prefix), or null for all projects. */
+	project: string | null;
+	/** All distinct projects seen in the data, for the selector. */
+	projects: string[];
+}


### PR DESCRIPTION
## Summary

Adds a Gain tab to `omp stats` (port 3847) that surfaces bash minimizer + snapcompact + pi-distill savings, with project scoping and an unparsed-commands panel for tuning the parser.

### Server-side (`packages/stats/src/`)

- **`gain-aggregator.ts`** — new aggregation module:
  - `normalizeProjectPath()` + `dedupeProjects()`: collapses 3,037 raw cwds to ~113 meaningful project roots by normalising worktree sub-paths (`.herdr/worktrees/`, `-worktrees/`, `.wt/`, etc.) and prefix-deduplicating with a min-depth ≥ 4 guard
  - `readMinimizerUnparsedRecords()`: reads `kind==="missed" && filter==="missed"` records — commands the parser had no handler for, excluding temp/internal paths
  - `getGainDashboardStats(range?, project?)`: project-scoped reads across all 3 sources, aggregates top-25 unparsed commands sorted by hit count
- **`shared-types.ts`**: `GainUnparsedCommand` (actual command string + hits + inputBytes); `GainDashboardStats` extended with `unparsedCommands`, `project`, `projects`
- **`server.ts`**: `?project=` query param forwarded to aggregator

### Client-side (`packages/stats/src/client/`)

- **`GainRoute.tsx`**: full Gain tab with Overall metrics, By Source breakdown, daily time-series chart, Top Filters table, and **Unparsed Commands panel** — the actual bash command strings with hit count and input bytes, sorted by frequency
- **`GainProjectSelector`**: dropdown of 113 deduplicated project roots; hidden when empty
- **`useHashRoute.ts`**: `"gain"` added to `VALID_SECTIONS` (was missing → `/#/gain` fell back to `"overview"`)
- **`api.ts`**: `getGainDashboardStats` accepts optional `project?` param

## Unparsed Commands panel

The panel shows the **actual command strings** that had no matching minimizer filter — not aggregated filter names. This is the direct tuning surface: the top entries are candidates for new filters.

Example output (`range=all`):
| Command | Hits | Input Bytes |
|---|---|---|
| `git status --short` | 43 | 32.6 KB |
| `bun run check:types` | 21 | 3.6 KB |
| `./rebuild-lex.zsh` | 19 | 139.3 KB |
| `git diff --stat` | 14 | 20.2 KB |

## Test

```
bun run --cwd packages/stats check:types   # 0 errors
bun --cwd=packages/coding-agent run build  # rebuild binary
omp stats                                  # verify at http://localhost:3847/#/gain
```