### PR TITLE
fix(mcp): stay attached on Windows stdio so nested cmd wrappers keep stdout routed back

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows stdio MCP servers timing out (and popping a visible terminal) when their direct child was a `cmd.exe` wrapper that itself launched a console grandchild — `node` wrappers, `npx.cmd -y mcp-remote`, similar nested shells. `StdioTransport.connect()` unconditionally passed `detached: true` to `Bun.spawn`, but Windows has no SIGTSTP/SIGTTIN to escape; `detached` only maps to `CreateProcess(DETACHED_PROCESS)`, which strips the parent's inherited console. The hidden direct `cmd.exe` lost its console, so the grandchild allocated a brand-new visible conhost whose stdout no longer routed through OMP's pipe — the proxy reported the bridge was up while OMP timed out waiting for the MCP `initialize` response. `resolveStdioSpawnCommand` now returns `detached: false` for every Windows return shape (direct `.exe`, cmd.exe-wrapped batch / unresolvable command, npm cmd-shim launched through node) and keeps `detached: true` on POSIX, where the original SIGTSTP/SIGTTIN reason still holds; `connect()` consumes the resolved flag. ([#3544](https://github.com/can1357/oh-my-pi/issues/3544))
+
 ## [16.1.22] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "bun:test";
 import { resolveStdioSpawnCommand } from "./stdio";
 
 describe("resolveStdioSpawnCommand", () => {
-	it("hides direct Windows executable MCP servers", async () => {
+	it("hides AND stays attached to direct Windows executable MCP servers", async () => {
+		// Hidden so the direct .exe does not pop a console (#3536); attached so
+		// nested console grandchildren do not allocate a new visible conhost
+		// that strips their stdout from our pipe (#3544).
 		await expect(
 			resolveStdioSpawnCommand(
 				{ command: "server.exe", args: ["--stdio"] },
@@ -12,10 +15,11 @@ describe("resolveStdioSpawnCommand", () => {
 		).resolves.toEqual({
 			cmd: ["server.exe", "--stdio"],
 			windowsHide: true,
+			detached: false,
 		});
 	});
 
-	it("keeps off-Windows spawn options unchanged", async () => {
+	it("detaches off-Windows MCP servers so terminal job-control signals cannot stop them", async () => {
 		await expect(
 			resolveStdioSpawnCommand(
 				{ command: "server.exe", args: ["--stdio"] },
@@ -23,6 +27,7 @@ describe("resolveStdioSpawnCommand", () => {
 			),
 		).resolves.toEqual({
 			cmd: ["server.exe", "--stdio"],
+			detached: true,
 		});
 	});
 });

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -22,10 +22,29 @@ import type {
 import { toJsonRpcError } from "../../mcp/types";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
-/** Subprocess argv for launching an MCP stdio server. */
+/** Subprocess argv and platform-derived spawn flags for an MCP stdio server. */
 export interface StdioSpawnCommand {
 	cmd: string[];
 	windowsHide?: boolean;
+	/**
+	 * Run the subprocess in its own session.
+	 *
+	 * POSIX: `true`. Detach → `setsid`, so the MCP process tree has no
+	 * controlling terminal and terminal job-control signals (Ctrl+Z SIGTSTP,
+	 * background-read SIGTTIN) cannot stop stdio servers such as
+	 * `chrome-devtools-mcp` and leave our read loop blocked on silent pipes.
+	 *
+	 * Windows: `false`. There is no SIGTSTP/SIGTTIN to escape, but detaching
+	 * passes `DETACHED_PROCESS` to `CreateProcess`, which strips the parent's
+	 * inherited console. A hidden `cmd.exe` wrapper whose grandchild is a
+	 * console app (`node`, `npx.cmd`, `mcp-remote`) then allocates a brand-new
+	 * visible conhost for that grandchild, and its stdout no longer routes
+	 * back through our pipe — the proxy reports it is up while OMP times out
+	 * waiting for the MCP `initialize` response (#3544). `windowsHide` only
+	 * hides the direct child's console window (#3536); without `detached:
+	 * false` the nested grandchild still pops.
+	 */
+	detached: boolean;
 }
 
 /** Inputs used to resolve platform-specific stdio spawn behavior. */
@@ -177,6 +196,7 @@ async function resolveWindowsNpmShimCommand(
 	return {
 		cmd: [nodeCommand, target, ...args],
 		windowsHide: true,
+		detached: false,
 	};
 }
 
@@ -229,7 +249,7 @@ export async function resolveStdioSpawnCommand(
 	options: ResolveStdioSpawnOptions,
 ): Promise<StdioSpawnCommand> {
 	const args = config.args ?? [];
-	if (options.platform !== "win32") return { cmd: [config.command, ...args] };
+	if (options.platform !== "win32") return { cmd: [config.command, ...args], detached: true };
 
 	const resolved = await resolveWindowsCommandPath(config.command, options.cwd, options.env);
 	const resolvedCommand = resolved ?? config.command;
@@ -239,15 +259,18 @@ export async function resolveStdioSpawnCommand(
 	// Direct-spawn only when we resolved to a concrete file AND its extension
 	// is not a batch script. Everything else (resolved .cmd/.bat, or an
 	// unresolved extensionless command) goes through cmd.exe so PATHEXT runs.
-	// Every Windows stdio server launch hides its console window; otherwise
-	// direct .exe servers pop a visible cmd window while the MCP server lives.
+	// Every Windows stdio server launch hides its console window AND stays
+	// attached: detaching on Windows breaks nested console grandchildren
+	// (see `StdioSpawnCommand.detached`).
 	const windowsHide = true;
+	const detached = false;
 	const needsCmdExe = resolved === null || isWindowsBatchCommand(resolvedCommand);
-	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide };
+	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide, detached };
 
 	return {
 		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],
 		windowsHide,
+		detached,
 	};
 }
 
@@ -343,10 +366,12 @@ export class StdioTransport implements MCPTransport {
 			platform: process.platform,
 		});
 
-		// Spawn in a new session (detached → setsid) so the MCP process tree has
-		// no controlling terminal. Otherwise terminal job-control signals (Ctrl+Z
-		// SIGTSTP, background-read SIGTTIN) can stop stdio servers such as
-		// chrome-devtools-mcp and leave our read loop blocked on silent pipes.
+		// Platform-derived session and console-window handling come from
+		// `resolveStdioSpawnCommand`: POSIX detaches into its own session to
+		// escape terminal job-control signals (SIGTSTP, SIGTTIN); Windows stays
+		// attached and hidden so nested console grandchildren do not allocate a
+		// brand-new conhost that strips their stdout from our pipe. See
+		// `StdioSpawnCommand.detached`.
 		this.#process = spawn({
 			cmd: spawnCommand.cmd,
 			cwd,
@@ -355,7 +380,7 @@ export class StdioTransport implements MCPTransport {
 			stdout: "pipe",
 			stderr: "pipe",
 			windowsHide: spawnCommand.windowsHide,
-			detached: true,
+			detached: spawnCommand.detached,
 		});
 
 		this.#connected = true;

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -33,6 +33,7 @@ describe("resolveStdioSpawnCommand", () => {
 				`""${shim}" "serve" "--mcp""`,
 			]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -62,6 +63,7 @@ describe("resolveStdioSpawnCommand", () => {
 
 			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${localShim}" "serve""`]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(projectDir, { recursive: true, force: true });
 			await fs.rm(globalDir, { recursive: true, force: true });
@@ -112,6 +114,7 @@ describe("resolveStdioSpawnCommand", () => {
 
 			expect(result.cmd).toEqual(["node", entry, "serve", "--mcp"]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -154,6 +157,7 @@ describe("resolveStdioSpawnCommand", () => {
 
 			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${shim}" "serve""`]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -186,6 +190,7 @@ describe("resolveStdioSpawnCommand", () => {
 				`""${shim}" "serve" "--header" "Authorization=^%TOKEN^%""`,
 			]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -218,6 +223,7 @@ describe("resolveStdioSpawnCommand", () => {
 				`""${shim}" "--config" "{^"a^":^"b&c|d^"}""`,
 			]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -258,6 +264,7 @@ describe("resolveStdioSpawnCommand", () => {
 				`""${shim}" "serve" "--mcp""`,
 			]);
 			expect(result.windowsHide).toBe(true);
+			expect(result.detached).toBe(false);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -285,6 +292,7 @@ describe("resolveStdioSpawnCommand", () => {
 			`""codegraph.cmd" "serve" "--mcp""`,
 		]);
 		expect(result.windowsHide).toBe(true);
+		expect(result.detached).toBe(false);
 	});
 
 	it("routes unresolvable bare Windows commands through cmd.exe so PATHEXT can find a .cmd shim (#3250)", async () => {
@@ -317,6 +325,7 @@ describe("resolveStdioSpawnCommand", () => {
 			`""npx" "-y" "cloakbrowser-mcp@latest""`,
 		]);
 		expect(result.windowsHide).toBe(true);
+		expect(result.detached).toBe(false);
 	});
 
 	it("leaves non-Windows commands untouched", async () => {
@@ -327,6 +336,36 @@ describe("resolveStdioSpawnCommand", () => {
 
 		expect(result.cmd).toEqual(["codegraph", "serve", "--mcp"]);
 		expect(result.windowsHide).toBeUndefined();
+		expect(result.detached).toBe(true);
+	});
+
+	it("never detaches Windows stdio launches so nested cmd.exe wrappers keep stdout routed back to the parent pipe (#3544)", async () => {
+		// The reporter's failing shape is `cmd.exe` → `node wrapper` →
+		// `cmd.exe /C npx.cmd -y mcp-remote`. Detaching the direct hidden
+		// `cmd.exe` strips its inherited console; the nested console
+		// grandchildren (`node`, `npx.cmd`, `mcp-remote`) then allocate a
+		// brand-new visible conhost whose stdout no longer routes back through
+		// our pipe — the proxy reports the bridge is up while OMP times out on
+		// the MCP `initialize` response. `windowsHide` only hides the direct
+		// child's window (#3536); the only fix that keeps the grandchild
+		// attached to the same console session is `detached: false`. Pin every
+		// Windows return shape here so the contract cannot regress for the
+		// direct-`cmd.exe` launcher the reporter used.
+		const result = await resolveStdioSpawnCommand(
+			{ type: "stdio", command: "cmd.exe", args: ["/C", "node .codex\\mcp-wrapper.js"] },
+			{
+				cwd: "C:\\project",
+				env: {
+					COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+					PATH: "",
+					PATHEXT: ".COM;.EXE;.BAT;.CMD",
+				},
+				platform: "win32",
+			},
+		);
+
+		expect(result.detached).toBe(false);
+		expect(result.windowsHide).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Repro

On Windows native, a Codex-style stdio MCP server whose `command` is `cmd.exe` and whose argv launches a Node wrapper that in turn spawns `cmd.exe /C npx.cmd -y mcp-remote@latest …` (the reporter's atlassian/mcp-remote setup in #3544) opens a separate visible terminal window during startup. That nested proxy reports a healthy connection (`Local STDIO server running`, `Proxy established successfully…`), but OMP times out waiting for the MCP `initialize` response:

```
MCP server failed to connect: atlassian: Connection to MCP server "atlassian" timed out after 60000ms
```

Reproduced via source inspection (no Windows host on this worker). `grep -n "detached" packages/coding-agent/src/mcp/transports/stdio.ts` shows `StdioTransport.connect()` unconditionally passes `detached: true` to `Bun.spawn` for every platform. Repro transcript recorded in the issue session.

## Cause

`packages/coding-agent/src/mcp/transports/stdio.ts:358` (pre-fix) passed `detached: true` to `Bun.spawn` on every platform. The motivating comment cited POSIX SIGTSTP/SIGTTIN — accurate and load-bearing on POSIX, where the MCP process tree must escape the controlling terminal so a Ctrl+Z or background-read does not stop stdio servers like `chrome-devtools-mcp`.

Windows has no SIGTSTP/SIGTTIN. `detached` on `Bun.spawn` maps to `CreateProcess(DETACHED_PROCESS)`, which strips the parent's inherited console from the child. The earlier fix #3536 set `windowsHide: true` so the *direct* child does not pop a console window, but `windowsHide` does not propagate down to grandchildren. When the direct child is a hidden `cmd.exe` wrapper that itself spawns a console grandchild (`node`, `npx.cmd`, `mcp-remote`), the grandchild has no inherited console to attach to and so allocates a brand-new conhost — visible, with its own stdout/stderr handles that no longer route back through OMP's pipe. The MCP `initialize` response is written to the new conhost's screen buffer and OMP times out.

## Fix

- Add `detached: boolean` to `StdioSpawnCommand` (`packages/coding-agent/src/mcp/transports/stdio.ts`), grouping it with the existing `windowsHide` flag so every platform-derived spawn option is resolved in one place. Doc-comment names the win32 console-stripping behavior and references the issue.
- `resolveStdioSpawnCommand` now returns `detached: true` for the POSIX shape and `detached: false` for every Windows return shape: direct `.exe` fast path, cmd.exe-wrapped batch / unresolvable-command path, and the npm cmd-shim path launched through node. POSIX behavior (SIGTSTP/SIGTTIN escape via `setsid`) is preserved.
- `StdioTransport.connect()` consumes `spawnCommand.detached` instead of hardcoding `detached: true`; the spawn-site comment now points at `StdioSpawnCommand.detached` for the rationale.
- Update both stdio test suites: every existing Windows-path assertion (`src/mcp/transports/stdio.test.ts`, `test/mcp-stdio-transport.test.ts`) now also asserts `detached: false`, and the POSIX case asserts `detached: true`. Add a regression test pinned to the reporter's exact failing shape (`cmd.exe` + `["/C", "node .codex\\mcp-wrapper.js"]`) so the per-path contract cannot regress for the nested-wrapper case specifically.
- Changelog entry under `[Unreleased]` citing #3544 and the `windowsHide`/#3536 relationship.

## Verification

`bun test packages/coding-agent/src/mcp/transports/stdio.test.ts packages/coding-agent/test/mcp-stdio-transport.test.ts packages/coding-agent/test/mcp-json-rpc.test.ts packages/coding-agent/test/mcp-startup-events.test.ts` → 37 pass, 0 fail (92 expect calls). End-to-end Windows runtime verification requires a Windows host, which this worker does not have; the regression tests pin the `detached: false` contract on every Windows return shape so the bug shape cannot reintroduce silently.

Fixes #3544