### PR TITLE
fix(lsp): invalidate configCache on `reload *` so newly written `.omp/lsp.json` is observed

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the LSP tool's per-cwd config cache (`getConfig` in `packages/coding-agent/src/lsp/index.ts`) never being invalidated, so `.omp/lsp.json`, root markers, and plugin LSP configs added after the first LSP call stayed invisible for the remainder of the process — even after `reload *`. The cached observation persists across chat sessions because OMP is a single-process binary, so users were stuck on `No language servers configured` until they killed the process. The `reload` handler now drops the cwd's cache entry and re-runs `loadConfig` before iterating servers, so the explicit refresh request behaves as the prompt documents. ([#3546](https://github.com/can1357/oh-my-pi/issues/3546))
+
 ## [16.1.22] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -2054,7 +2054,14 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		}
 
 		if (action === "reload" && (isWorkspace || !resolvedFile)) {
-			const servers = getLspServers(config);
+			// `reload *` is the user's explicit request to re-read config from
+			// disk. Drop the per-cwd cache entry so `.omp/lsp.json`, root markers,
+			// and plugin configs added after the first LSP call become visible —
+			// otherwise `getConfig` returns the first observation for the rest of
+			// the process lifetime (#3546).
+			configCache.delete(this.session.cwd);
+			const refreshedConfig = getConfig(this.session.cwd);
+			const servers = getLspServers(refreshedConfig);
 			if (servers.length === 0) {
 				return {
 					content: [{ type: "text", text: "No language server found for this action" }],

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -7,7 +7,7 @@ import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers"
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
-import { getServersForFile, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
+import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { applyTextEditsToString, applyWorkspaceEdit } from "@oh-my-pi/pi-coding-agent/lsp/edits";
 import { renderCall, renderResult } from "@oh-my-pi/pi-coding-agent/lsp/render";
 import type {
@@ -2058,8 +2058,8 @@ describe("lsp regressions", () => {
 		const tempDir = TempDir.createSync("@omp-lsp-config-cache-reload-");
 		try {
 			const cwd = tempDir.path();
-			const empty = { servers: {}, idleTimeoutMs: undefined };
-			const withServer = {
+			const empty: LspConfig = { servers: {}, idleTimeoutMs: undefined };
+			const withServer: LspConfig = {
 				servers: {
 					"fake-pylsp": {
 						command: "true",
@@ -2069,7 +2069,7 @@ describe("lsp regressions", () => {
 					},
 				},
 				idleTimeoutMs: undefined,
-			} satisfies ReturnType<typeof loadConfig>;
+			};
 			const loadConfigSpy = vi
 				.spyOn(lspConfig, "loadConfig")
 				.mockImplementation(() => (loadConfigSpy.mock.calls.length === 1 ? empty : withServer));

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2048,6 +2048,76 @@ describe("lsp regressions", () => {
 		expect(output).toContain("rust-analyzer (configured, not started)");
 		expect(output).toContain("typescript-language-server (ready)");
 	});
+
+	it("reload * invalidates the per-cwd config cache so newly written .omp/lsp.json is observed", async () => {
+		// #3546: `getConfig` caches the first `loadConfig` result per cwd
+		// permanently. Creating `.omp/lsp.json` after the first LSP call left
+		// the tool stuck on "No language servers configured" until the process
+		// restarted. `reload *` (the user's explicit refresh) must invalidate
+		// that cache so subsequent calls observe the fresh config from disk.
+		const tempDir = TempDir.createSync("@omp-lsp-config-cache-reload-");
+		try {
+			const cwd = tempDir.path();
+			const empty = { servers: {}, idleTimeoutMs: undefined };
+			const withServer = {
+				servers: {
+					"fake-pylsp": {
+						command: "true",
+						fileTypes: [".py"],
+						rootMarkers: [".python-root"],
+						resolvedCommand: "/bin/true",
+					},
+				},
+				idleTimeoutMs: undefined,
+			} satisfies ReturnType<typeof loadConfig>;
+			const loadConfigSpy = vi
+				.spyOn(lspConfig, "loadConfig")
+				.mockImplementation(() => (loadConfigSpy.mock.calls.length === 1 ? empty : withServer));
+			// Prevent any real LSP subprocess from spawning when reload iterates
+			// the refreshed server list — the spawn path would race with the
+			// test's teardown.
+			vi.spyOn(lspClient, "getOrCreateClient").mockRejectedValue(new Error("spawn suppressed in test"));
+			vi.spyOn(lspClient, "getActiveClients").mockReturnValue([]);
+
+			const tool = new LspTool({ cwd } as ToolSession);
+
+			const status1 = await tool.execute("cache-1", { action: "status" });
+			const text1 = status1.content
+				.filter(b => b.type === "text")
+				.map(b => b.text)
+				.join("\n");
+			expect(text1).toContain("No language servers configured");
+			expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+
+			// Second status hits the cache — proves caching is the baseline, so
+			// the next assertion measures invalidation, not a missing cache.
+			await tool.execute("cache-2", { action: "status" });
+			expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+
+			// `reload *` MUST drop the cached empty config and re-read from disk.
+			const reload = await tool.execute("cache-3", { action: "reload", file: "*" });
+			expect(loadConfigSpy).toHaveBeenCalledTimes(2);
+			const reloadText = reload.content
+				.filter(b => b.type === "text")
+				.map(b => b.text)
+				.join("\n");
+			// Spawn was suppressed, so the per-server output is the failure line —
+			// the contract under test is that the fresh server was even considered.
+			expect(reloadText).toContain("fake-pylsp");
+
+			// The refreshed config now sits in the cache; status sees the new
+			// server without another disk read.
+			const status3 = await tool.execute("cache-4", { action: "status" });
+			const text3 = status3.content
+				.filter(b => b.type === "text")
+				.map(b => b.text)
+				.join("\n");
+			expect(text3).toContain("fake-pylsp (configured, not started)");
+			expect(loadConfigSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
 });
 
 describe("expert elixir lsp", () => {


### PR DESCRIPTION
## Repro

Programmatic harness against `LspTool`:

1. `new LspTool({ cwd: tempDir })` on an empty dir, call `{ action: "status" }` → `No language servers configured for this project`. The empty `LspConfig` lands in `configCache[tempDir]`.
2. Write `.omp/lsp.json` (+ its root marker) on disk. `loadConfig(tempDir)` called directly now returns `['fake-pylsp']`.
3. Second `{ action: "status" }` on the same `LspTool` → still `No language servers configured for this project`. The cache entry from step 1 is sticky and `reload *` operates on the same stale object, so even the explicit refresh path returns `No language server found for this action`.

Affects anyone who installs an LSP binary, adds a root marker, or writes `.omp/lsp.json` after the first `lsp` call. OMP is a single-process binary, so restarting the chat session does NOT clear it — only killing the process does.

## Cause

`packages/coding-agent/src/lsp/index.ts:256` — `getConfig(cwd)` populates `configCache` on first read and never invalidates. The `reload && (isWorkspace || !resolvedFile)` branch at `index.ts:2056` iterates `getLspServers(config)` against the `config` retrieved at the top of `execute()` (line 1336), so calling `lsp reload *` re-reads zero config files. There is no other invalidation path in the file.

## Fix

- `LspTool.execute` — in the `reload && (isWorkspace || !resolvedFile)` branch, `configCache.delete(this.session.cwd)` before re-running `getConfig(this.session.cwd)`. The refreshed `LspConfig` is what `getLspServers(...)` and the spawn loop see; the new cache entry sticks for subsequent calls until the next explicit `reload *`.
- `packages/coding-agent/test/tools/lsp-regressions.test.ts` — added `reload * invalidates the per-cwd config cache so newly written .omp/lsp.json is observed`. Stubs `loadConfig` with a counter (first call → empty, second → server present) and `getOrCreateClient` to reject, so the spawn loop short-circuits without touching real subprocesses. Asserts: two `status` calls hit the cache (1 `loadConfig` invocation), `reload *` re-reads (2 invocations), the next `status` observes the new server without further reads.
- `packages/coding-agent/CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

## Verification

`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` → 45 pass / 0 fail (the new test included). Bug-side proof: stashing the production diff and re-running the new test fails at the post-`reload *` `loadConfigSpy` count assertion (`Expected: 2 / Received: 1`), confirming the test guards the exact cache-invalidation contract the fix introduces.

Fixes #3546