### PR TITLE
fix(auth): accept cross-host MCP OAuth issuers on fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed MCP OAuth discovery rejecting Atlassian-style cross-host issuer metadata during the resource-server fallback probe; issuer matching now remains enforced for advertised auth-server candidates but no longer blocks fallback metadata where the resource host and authorization-server issuer differ. ([#3551](https://github.com/can1357/oh-my-pi/issues/3551))
+
 - Fixed the `eval` Julia kernel showing only runner-internal backtrace frames (`at top-level scope (./none:N)`, `at main (…runner-…jl:635)`) with no exception type or message, making cell errors undebuggable. The host renderer (`packages/coding-agent/src/eval/kernel-base.ts`) displays a non-empty `traceback` verbatim and only falls back to `ename: evalue` when it is empty; the Python and Ruby runners embed the rendered error in `traceback`, but the Julia runner (`packages/coding-agent/src/eval/jl/runner.jl`) built `traceback` from stack frames only, so the message was dropped. `emit_error` now seeds `traceback` with the `showerror` output (matching the REPL's `ERROR:` text) ahead of the frames.
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -433,7 +433,8 @@ export async function discoverOAuthEndpoints(
 						// cross-host issuer metadata.
 						const requireIssuerMatch =
 							base.issuerCandidate &&
-							(path === "/.well-known/oauth-authorization-server" || path === "/.well-known/openid-configuration");
+							(path === "/.well-known/oauth-authorization-server" ||
+								path === "/.well-known/openid-configuration");
 						const issuerOk = requireIssuerMatch ? issuerMatchesBase(metadata.issuer, base.url) : true;
 						const endpoints = issuerOk ? findEndpoints(metadata) : null;
 						if (endpoints) return endpoints;

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -308,10 +308,15 @@ export async function discoverOAuthEndpoints(
 		"/.mcp/auth",
 		"/authorize", // Some MCP servers expose OAuth config here
 	];
-	const urlsToQuery: string[] = [];
+	const urlsToQuery: Array<{ url: string; issuerCandidate: boolean }> = [];
 	const visitedAuthServers = new Set<string>();
 
 	let protectedResource = opts?.protectedResource;
+	const addDiscoveryBase = (url: string | undefined, issuerCandidate: boolean): void => {
+		if (!url || visitedAuthServers.has(url)) return;
+		urlsToQuery.push({ url, issuerCandidate });
+		visitedAuthServers.add(url);
+	};
 
 	// Step 1: If a resource_metadata URL was provided, fetch it to discover auth servers.
 	// This follows the RFC 9728 chain: resource_metadata → authorization_servers.
@@ -332,10 +337,7 @@ export async function discoverOAuthEndpoints(
 					? meta.authorization_servers.filter((entry): entry is string => typeof entry === "string")
 					: [];
 				for (const s of authServers) {
-					if (!visitedAuthServers.has(s)) {
-						urlsToQuery.push(s);
-						visitedAuthServers.add(s);
-					}
+					addDiscoveryBase(s, true);
 				}
 			}
 		} catch {
@@ -343,13 +345,9 @@ export async function discoverOAuthEndpoints(
 		}
 	}
 
-	// Step 2: Add explicit authServerUrl and serverUrl (deduped against visited)
-	for (const url of [authServerUrl, serverUrl].filter((v): v is string => Boolean(v))) {
-		if (!visitedAuthServers.has(url)) {
-			urlsToQuery.push(url);
-			visitedAuthServers.add(url);
-		}
-	}
+	// Step 2: Add explicit authServerUrl as an issuer candidate, then the resource server fallback.
+	addDiscoveryBase(authServerUrl, true);
+	addDiscoveryBase(serverUrl, false);
 
 	const findEndpoints = (metadata: Record<string, unknown>): OAuthEndpoints | null => {
 		if (metadata.authorization_endpoint && metadata.token_endpoint) {
@@ -414,10 +412,10 @@ export async function discoverOAuthEndpoints(
 		return null;
 	};
 
-	for (const baseUrl of urlsToQuery) {
+	for (const base of urlsToQuery) {
 		for (const path of wellKnownPaths) {
 			// Try each well-known path at both the absolute origin and relative
-			const urlsToTry = buildWellKnownUrls(path, baseUrl);
+			const urlsToTry = buildWellKnownUrls(path, base.url);
 			for (const url of urlsToTry) {
 				try {
 					const response = await fetchImpl(url.toString(), {
@@ -429,13 +427,14 @@ export async function discoverOAuthEndpoints(
 					if (response.ok) {
 						const metadata = (await response.json()) as Record<string, unknown>;
 						// Authorization-server / OpenID Connect metadata documents carry an
-						// `issuer` field that MUST equal the queried base URL (RFC 8414 §3.3,
-						// OIDC Discovery §4.3). Protected-resource and nonstandard paths use a
-						// different schema, so the issuer check only gates the two official
-						// auth-server documents.
+						// `issuer` field that MUST equal the queried base URL only when that
+						// URL came from an auth-server source (RFC 8414 §3.3, OIDC Discovery
+						// §4.3). Resource-server fallback probes can legitimately return
+						// cross-host issuer metadata.
 						const requireIssuerMatch =
-							path === "/.well-known/oauth-authorization-server" || path === "/.well-known/openid-configuration";
-						const issuerOk = requireIssuerMatch ? issuerMatchesBase(metadata.issuer, baseUrl) : true;
+							base.issuerCandidate &&
+							(path === "/.well-known/oauth-authorization-server" || path === "/.well-known/openid-configuration");
+						const issuerOk = requireIssuerMatch ? issuerMatchesBase(metadata.issuer, base.url) : true;
 						const endpoints = issuerOk ? findEndpoints(metadata) : null;
 						if (endpoints) return endpoints;
 

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -317,6 +317,38 @@ describe("relative Mcp-Auth-Server URL", () => {
 });
 
 describe("RFC 8414 §3.3 issuer validation", () => {
+	it("accepts cross-host issuer metadata on resource-server fallback (Atlassian regression)", async () => {
+		const calls: string[] = [];
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			calls.push(url);
+
+			if (url === "https://mcp.atlassian.com/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://cf.mcp.atlassian.com",
+						authorization_endpoint: "https://mcp.atlassian.com/v1/authorize",
+						token_endpoint: "https://cf.mcp.atlassian.com/v1/token",
+						registration_endpoint: "https://cf.mcp.atlassian.com/v1/register",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints("https://mcp.atlassian.com/v1/mcp", undefined, undefined, {
+			fetch: fetchImpl,
+		});
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://mcp.atlassian.com/v1/authorize",
+			tokenUrl: "https://cf.mcp.atlassian.com/v1/token",
+		});
+		expect(calls[0]).toBe("https://mcp.atlassian.com/.well-known/oauth-authorization-server");
+	});
+
 	it("rejects origin-root metadata whose issuer mismatches the path-scoped auth server (Plane regression)", async () => {
 		// Plane hosts both a root issuer (`https://mcp.plane.so/`) at the
 		// origin-root well-known *and* a path-scoped issuer


### PR DESCRIPTION
## Repro
Atlassian-shaped resource fallback discovery fails when the resource URL is `https://mcp.atlassian.com/v1/mcp` and `https://mcp.atlassian.com/.well-known/oauth-authorization-server` advertises issuer `https://cf.mcp.atlassian.com`; the focused repro command `bun test packages/coding-agent/test/oauth-discovery.test.ts -t Atlassian` returned `null` before the fix.

## Cause
`packages/coding-agent/src/mcp/oauth-discovery.ts` stored every discovery base URL as a plain string, so `discoverOAuthEndpoints` applied `issuerMatchesBase` to both advertised authorization-server candidates and the bare resource-server fallback. That made the RFC 8414 issuer guard reject valid fallback metadata where the resource host and authorization-server issuer differ.

## Fix
- Track whether each discovery base URL is an issuer candidate or the resource-server fallback.
- Keep issuer matching for protected-resource `authorization_servers`, `Mcp-Auth-Server`, and recursive auth-server discovery.
- Skip issuer matching only for the resource-server fallback probe.
- Add an Atlassian-shaped regression test and changelog entry.

## Verification
`bun test packages/coding-agent/test/oauth-discovery.test.ts` passed with 14 tests. `gh_push_branch` completed the pre-publish gate and pushed `farm/d1145a36/mcp-oauth-cross-host-issuer`. Fixes #3551