### PR TITLE
fix(ai): surface Ollama usage accounts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Redesigned the OAuth callback page (`oauth.html`) to match the oh-my-pi web brand language: OKLCH purple-tinted dark neutrals, magenta→iris→cyan brand gradient on the wordmark, frosted-glass card over an ascii grid backdrop, and a colored status halo around the success/error icon. All assets are inlined; the `__OAUTH_STATE__` injection contract and success/error JS logic are unchanged.
 
+### Fixed
+
+- Fixed `omp usage` silently omitting Ollama and Ollama Cloud accounts by registering placeholder usage providers for both until an upstream quota endpoint is available. ([#3555](https://github.com/can1357/oh-my-pi/issues/3555))
+
 ## [16.1.22] - 2026-06-26
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -39,6 +39,7 @@ import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
+import { ollamaCloudUsageProvider, ollamaUsageProvider } from "./usage/ollama";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import {
 	type CodexResetConsumeCode,
@@ -496,6 +497,8 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	kimiUsageProvider,
 	antigravityUsageProvider,
 	googleGeminiCliUsageProvider,
+	ollamaUsageProvider,
+	ollamaCloudUsageProvider,
 	claudeUsageProvider,
 	zaiUsageProvider,
 	opencodeGoUsageProvider,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -34,6 +34,7 @@ export * from "./usage/github-copilot";
 export * from "./usage/google-antigravity";
 export * from "./usage/kimi";
 export * from "./usage/minimax-code";
+export * from "./usage/ollama";
 export * from "./usage/openai-codex";
 export * from "./usage/openai-codex-reset";
 export * from "./usage/opencode-go";

--- a/packages/ai/src/usage/ollama.ts
+++ b/packages/ai/src/usage/ollama.ts
@@ -1,0 +1,41 @@
+import type { UsageFetchContext, UsageFetchParams, UsageProvider, UsageReport } from "../usage";
+
+const OLLAMA_PROVIDER = "ollama";
+const OLLAMA_CLOUD_PROVIDER = "ollama-cloud";
+
+async function fetchOllamaUsage(params: UsageFetchParams, _ctx: UsageFetchContext): Promise<UsageReport | null> {
+	if (params.provider !== OLLAMA_PROVIDER && params.provider !== OLLAMA_CLOUD_PROVIDER) {
+		return null;
+	}
+
+	const metadata: Record<string, unknown> = {};
+	if (params.credential.email) metadata.email = params.credential.email;
+	if (params.credential.accountId) metadata.accountId = params.credential.accountId;
+	if (params.credential.projectId) metadata.projectId = params.credential.projectId;
+
+	return {
+		provider: params.provider,
+		fetchedAt: Date.now(),
+		limits: [],
+		notes: [
+			"Ollama does not expose a standalone quota usage API; per-response token usage is reported during requests.",
+		],
+		metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+	};
+}
+
+/** Registers Ollama accounts with usage views even though no quota endpoint is exposed. */
+export const ollamaUsageProvider: UsageProvider = {
+	id: OLLAMA_PROVIDER,
+	fetchUsage: fetchOllamaUsage,
+	supports: params => params.provider === OLLAMA_PROVIDER,
+	validatesCredentials: false,
+};
+
+/** Registers Ollama Cloud accounts with usage views until a quota endpoint is available. */
+export const ollamaCloudUsageProvider: UsageProvider = {
+	id: OLLAMA_CLOUD_PROVIDER,
+	fetchUsage: fetchOllamaUsage,
+	supports: params => params.provider === OLLAMA_CLOUD_PROVIDER,
+	validatesCredentials: false,
+};

--- a/packages/ai/test/issue-3555-repro.test.ts
+++ b/packages/ai/test/issue-3555-repro.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { type AuthCredentialStore, AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+
+describe("issue 3555 Ollama usage registration", () => {
+	it("registers Ollama and Ollama Cloud in the default usage resolver", async () => {
+		const store: AuthCredentialStore = {
+			close() {},
+			listAuthCredentials() {
+				return [];
+			},
+			updateAuthCredential() {},
+			deleteAuthCredential() {},
+			tryDisableAuthCredentialIfMatches() {
+				return false;
+			},
+			replaceAuthCredentialsForProvider() {
+				return [];
+			},
+			upsertAuthCredentialForProvider() {
+				return [];
+			},
+			deleteAuthCredentialsForProvider() {},
+			getCache() {
+				return null;
+			},
+			setCache() {},
+			cleanExpiredCache() {},
+		};
+		const storage = new AuthStorage(store);
+		await storage.reload();
+
+		try {
+			expect(storage.usageProviderFor("ollama")).toBeDefined();
+			const cloudProvider = storage.usageProviderFor("ollama-cloud");
+			expect(cloudProvider).toBeDefined();
+			if (!cloudProvider) throw new Error("expected Ollama Cloud usage provider");
+
+			const report = await cloudProvider.fetchUsage(
+				{
+					provider: "ollama-cloud",
+					credential: { type: "oauth", email: "cloud@example.test" },
+				},
+				{ fetch: globalThis.fetch },
+			);
+			expect(report).toMatchObject({
+				provider: "ollama-cloud",
+				limits: [],
+				metadata: { email: "cloud@example.test" },
+			});
+			expect(report?.notes?.[0]).toContain("does not expose a standalone quota usage API");
+		} finally {
+			storage.close();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
`bun test packages/ai/test/issue-3555-repro.test.ts` failed because `AuthStorage.usageProviderFor("ollama")` returned `undefined`, matching `omp usage` filtering Ollama/Ollama Cloud accounts out before unreported-account rendering.

## Cause
`packages/ai/src/auth-storage.ts` built `DEFAULT_USAGE_PROVIDER_MAP` only from registered `UsageProvider.id` values, and no provider in `packages/ai/src/usage/` used the `ollama` or `ollama-cloud` ids. `packages/coding-agent/src/cli/usage-cli.ts` relies on `AuthStorage.usageProviderFor` in `selectReportableAccounts`, so both account types were culled as providers with no usage concept.

## Fix
- Added placeholder Ollama and Ollama Cloud usage providers in `packages/ai/src/usage/ollama.ts` that return empty reports with a no-standalone-quota-API note and do not claim credential validation.
- Registered both providers in `DEFAULT_USAGE_PROVIDERS` and exported them from the ai package barrel.
- Added a regression test covering default resolver registration and the placeholder Ollama Cloud report shape.
- Added the ai changelog entry for #3555.

## Verification
`bun test packages/ai/test/issue-3555-repro.test.ts` passes. `bun run check` passes in `packages/ai`. Pre-publish `gh_push_branch` completed its gate and pushed `6547caeffae8`. Fixes #3555