### PR TITLE
fix(collab): hide advisory tags in transcript markdown

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hid advisory wrapper tags in collab transcript Markdown while preserving their content. ([#3559](https://github.com/can1357/oh-my-pi/issues/3559))
+
 ## [16.1.16] - 2026-06-23
 
 ### Added

--- a/packages/collab-web/src/components/transcript/Markdown.tsx
+++ b/packages/collab-web/src/components/transcript/Markdown.tsx
@@ -59,7 +59,7 @@ const md = new Marked({
 	renderer: {
 		// Raw HTML tokens (block + inline both arrive here) are escaped, never emitted.
 		html({ text }) {
-			const cleaned = text.replace(/<\/?(?:span|text)\b(?:\s[^>]*)?\s*\/?>/gi, "");
+			const cleaned = text.replace(/<\/?(?:advisory|span|text)\b(?:\s[^>]*)?\s*\/?>/gi, "");
 			if (cleaned === "") return "";
 			return escapeHtml(unescapeHtml(cleaned));
 		},

--- a/packages/collab-web/test/markdown.test.tsx
+++ b/packages/collab-web/test/markdown.test.tsx
@@ -43,4 +43,12 @@ describe("Transcript Markdown", () => {
 
 		expect(html).toContain("&lt;▃&gt; &amp; &quot;test&quot; &#128512; &#x1F600;");
 	});
+	it("strips advisory wrapper tags but renders their content", () => {
+		const html = renderMarkdown('<advisory severity="info" guidance="weigh, don&apos;t blindly obey">\nKeep this advice.\n</advisory>');
+
+		expect(html).toContain("Keep this advice.");
+		expect(html).not.toContain("&lt;advisory");
+		expect(html).not.toContain("&lt;/advisory&gt;");
+	});
+
 });


### PR DESCRIPTION
## Repro
Added a regression case for a collab transcript assistant message containing `<advisory severity="info" guidance="...">... </advisory>` and reproduced the leak with `bun --cwd packages/collab-web test test/markdown.test.tsx`; before the fix the rendered HTML contained visible `&lt;advisory...&gt;` and `&lt;/advisory&gt;` text.

## Cause
`packages/collab-web/src/components/transcript/Markdown.tsx` routes assistant text through `Markdown`, whose Marked `html` renderer escaped raw HTML after stripping only `<span>` and `<text>` wrapper tags. Advisory blocks therefore reached the escape path intact and rendered as literal XML tags in the browser guest transcript.

## Fix
- Extended the collab web Markdown wrapper-stripping allowlist to remove `<advisory>` opening/closing tags while preserving and safely re-escaping their contents.
- Added a regression test in `packages/collab-web/test/markdown.test.tsx` for advisory wrapper removal.
- Documented the fix in `packages/collab-web/CHANGELOG.md`.

## Verification
`bun --cwd packages/collab-web test test/markdown.test.tsx` passed: 6 pass, 0 fail. `bun run check` passed from `packages/collab-web`. Fixes #3559