### PR TITLE
fix(agent): stop stale snapcompact state leaking into context-full

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -658,6 +658,35 @@ export interface SummaryOptions {
 	fetch?: FetchImpl;
 }
 
+function formatPreviousSnapcompactArchive(archiveText: string): string {
+	return `Previous snapcompact archive source text:\n\n${archiveText}`;
+}
+
+function mergePreviousSummaryWithSnapcompactArchive(
+	previousSummary: string | undefined,
+	archiveText: string | undefined,
+): string | undefined {
+	if (!archiveText) return previousSummary;
+	const archiveSummary = formatPreviousSnapcompactArchive(archiveText);
+	return previousSummary ? `${previousSummary}\n\n${archiveSummary}` : archiveSummary;
+}
+
+function createSnapcompactArchiveMigrationMessage(archiveText: string): Message {
+	return {
+		role: "user",
+		content: [{ type: "text", text: formatPreviousSnapcompactArchive(archiveText) }],
+		timestamp: Date.now(),
+	};
+}
+
+function stripSnapcompactPreserveData(
+	preserveData: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!preserveData || !(snapcompact.PRESERVE_KEY in preserveData)) return preserveData;
+	const { [snapcompact.PRESERVE_KEY]: _removed, ...rest } = preserveData;
+	return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
 export async function generateSummary(
 	currentMessages: AgentMessage[],
 	model: Model,
@@ -1101,10 +1130,27 @@ export async function compact(
 		fetch: options?.fetch,
 	};
 
+	const previousSnapcompactArchive = snapcompact.getPreservedArchive(previousPreserveData);
+	const previousSnapcompactArchiveText = previousSnapcompactArchive
+		? snapcompact.archiveSourceText(previousSnapcompactArchive)
+		: undefined;
+	const previousSummaryForCompaction = mergePreviousSummaryWithSnapcompactArchive(
+		previousSummary,
+		previousSnapcompactArchiveText,
+	);
+	const snapcompactArchiveMigrationMessage = previousSnapcompactArchiveText
+		? createSnapcompactArchiveMigrationMessage(previousSnapcompactArchiveText)
+		: undefined;
+
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
 	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model)) {
 		const previousRemoteCompaction = getPreservedOpenAiRemoteCompactionData(previousPreserveData);
-		const remoteMessages = [...messagesToSummarize, ...turnPrefixMessages, ...recentMessages];
+		const remoteMessages: AgentMessage[] = [
+			...(snapcompactArchiveMigrationMessage ? [snapcompactArchiveMigrationMessage] : []),
+			...messagesToSummarize,
+			...turnPrefixMessages,
+			...recentMessages,
+		];
 		const previousReplacementHistory =
 			previousRemoteCompaction?.provider === model.provider
 				? previousRemoteCompaction.replacementHistory
@@ -1150,7 +1196,7 @@ export async function compact(
 	if (isSplitTurn && turnPrefixMessages.length > 0) {
 		// Generate both summaries in parallel
 		const [historyResult, turnPrefixResult] = await Promise.all([
-			messagesToSummarize.length > 0
+			messagesToSummarize.length > 0 || previousSummaryForCompaction
 				? generateSummary(
 						messagesToSummarize,
 						model,
@@ -1158,7 +1204,7 @@ export async function compact(
 						apiKey,
 						signal,
 						customInstructions,
-						previousSummary,
+						previousSummaryForCompaction,
 						summaryOptions,
 					)
 				: Promise.resolve("No prior history."),
@@ -1175,12 +1221,12 @@ export async function compact(
 			apiKey,
 			signal,
 			customInstructions,
-			previousSummary,
+			previousSummaryForCompaction,
 			summaryOptions,
 		);
-	} else if (previousSummary) {
+	} else if (previousSummaryForCompaction) {
 		// No new messages to summarize, preserve previous summary
-		summary = previousSummary;
+		summary = previousSummaryForCompaction;
 	} else {
 		// No messages and no previous summary
 		summary = "No prior history.";
@@ -1214,13 +1260,15 @@ export async function compact(
 		throw new Error("First kept entry has no ID - session may need migration");
 	}
 
+	const finalPreserveData = previousSnapcompactArchive ? stripSnapcompactPreserveData(preserveData) : preserveData;
+
 	return {
 		summary,
 		shortSummary,
 		firstKeptEntryId,
 		tokensBefore,
 		details: { readFiles, modifiedFiles } as CompactionDetails,
-		preserveData,
+		preserveData: finalPreserveData,
 	};
 }
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -44,6 +44,7 @@ import compactionSummaryPrompt from "./prompts/compaction-summary.md" with { typ
 import compactionTurnPrefixPrompt from "./prompts/compaction-turn-prefix.md" with { type: "text" };
 import compactionUpdateSummaryPrompt from "./prompts/compaction-update-summary.md" with { type: "text" };
 import handoffDocumentPrompt from "./prompts/handoff-document.md" with { type: "text" };
+import snapcompactArchiveContextPrompt from "./prompts/snapcompact-archive-context.md" with { type: "text" };
 
 import {
 	computeFileLists,
@@ -659,7 +660,7 @@ export interface SummaryOptions {
 }
 
 function formatPreviousSnapcompactArchive(archiveText: string): string {
-	return `Previous snapcompact archive source text:\n\n${archiveText}`;
+	return prompt.render(snapcompactArchiveContextPrompt, { archiveText });
 }
 
 function mergePreviousSummaryWithSnapcompactArchive(

--- a/packages/agent/src/compaction/prompts/snapcompact-archive-context.md
+++ b/packages/agent/src/compaction/prompts/snapcompact-archive-context.md
@@ -1,0 +1,3 @@
+Previous snapcompact archive source text:
+
+{{archiveText}}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1117,6 +1117,22 @@ function toRestoredQueuedMessage(message: AgentMessage): RestoredQueuedMessage {
 	return { text: queueChipText(message), images: queuedImageContent(message) };
 }
 
+function stripSnapcompactPreserveData(
+	preserveData: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!preserveData || !(snapcompact.PRESERVE_KEY in preserveData)) return preserveData;
+	const { [snapcompact.PRESERVE_KEY]: _removed, ...rest } = preserveData;
+	return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+function mergeLlmCompactionPreserveData(
+	hookPreserveData: Record<string, unknown> | undefined,
+	resultPreserveData: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	const preserveData = { ...(hookPreserveData ?? {}), ...(resultPreserveData ?? {}) };
+	return stripSnapcompactPreserveData(Object.keys(preserveData).length > 0 ? preserveData : undefined);
+}
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -8020,7 +8036,7 @@ export class AgentSession {
 					firstKeptEntryId = result.firstKeptEntryId;
 					tokensBefore = result.tokensBefore;
 					details = result.details;
-					preserveData = { ...(compactionPrep.preserveData ?? {}), ...(result.preserveData ?? {}) };
+					preserveData = mergeLlmCompactionPreserveData(compactionPrep.preserveData, result.preserveData);
 				} catch (err) {
 					if (err instanceof CompactionCancelledError) {
 						throw err;
@@ -10246,7 +10262,7 @@ export class AgentSession {
 				firstKeptEntryId = compactResult.firstKeptEntryId;
 				tokensBefore = compactResult.tokensBefore;
 				details = compactResult.details;
-				preserveData = { ...(compactionPrep.preserveData ?? {}), ...(compactResult.preserveData ?? {}) };
+				preserveData = mergeLlmCompactionPreserveData(compactionPrep.preserveData, compactResult.preserveData);
 			}
 
 			if (autoCompactionSignal.aborted) {

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -13,6 +13,7 @@ import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import * as snapcompact from "@oh-my-pi/snapcompact";
 
 const HANDOFF_SECRET = "HANDOFF_SECRET_TOKEN_12345";
 
@@ -315,6 +316,147 @@ describe("AgentSession handoff", () => {
 		// Opaque provider-replay state (encrypted_content / replacementHistory) must pass through
 		// byte-identical — rewriting it would corrupt OpenAI remote-compaction replay.
 		expect(call[0].previousPreserveData).toBe(fixedPreparation.previousPreserveData);
+	});
+
+	it("strips hook-supplied snapcompact data when persisting context-full compaction", async () => {
+		const localTempDir = TempDir.createSync("@pi-context-full-preserve-data-");
+		const localSessionManager = SessionManager.inMemory(localTempDir.path());
+		const firstKeptEntryId = localSessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "kept" }],
+			timestamp: Date.now(),
+		});
+		const fixedPreparation: compactionModule.CompactionPreparation = {
+			firstKeptEntryId,
+			messagesToSummarize: [{ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { ...compactionModule.DEFAULT_COMPACTION_SETTINGS, strategy: "context-full" },
+		};
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "session.compacting"),
+			emit: vi.fn(async (event: { type: string }) =>
+				event.type === "session.compacting"
+					? {
+							preserveData: {
+								otherState: "keep-me",
+								[snapcompact.PRESERVE_KEY]: { frames: [], totalChars: 0, truncatedChars: 0 },
+							},
+						}
+					: undefined,
+			),
+		} as unknown as ExtensionRunner;
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(fixedPreparation);
+		vi.spyOn(compactionModule, "compact").mockResolvedValue({
+			summary: "context-full summary",
+			shortSummary: undefined,
+			firstKeptEntryId,
+			tokensBefore: 100,
+			details: {},
+			preserveData: { resultState: "keep-result" },
+		});
+		const localAgent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const localSession = new AgentSession({
+			agent: localAgent,
+			sessionManager: localSessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": true,
+				"compaction.autoContinue": false,
+				"compaction.strategy": "context-full",
+			}),
+			modelRegistry,
+			extensionRunner,
+		});
+
+		try {
+			await localSession.compact();
+			const compactionEntry = localSessionManager.getEntries().find(entry => entry.type === "compaction");
+			if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
+			expect(compactionEntry.preserveData).toEqual({
+				otherState: "keep-me",
+				resultState: "keep-result",
+			});
+			expect(compactionEntry.preserveData).not.toHaveProperty(snapcompact.PRESERVE_KEY);
+		} finally {
+			await localSession.dispose();
+			await localTempDir.remove();
+		}
+	});
+
+	it("strips hook-supplied snapcompact data when persisting auto context-full compaction", async () => {
+		const localTempDir = TempDir.createSync("@pi-auto-context-full-preserve-data-");
+		const localSessionManager = SessionManager.inMemory(localTempDir.path());
+		const firstKeptEntryId = localSessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "kept" }],
+			timestamp: Date.now(),
+		});
+		const fixedPreparation: compactionModule.CompactionPreparation = {
+			firstKeptEntryId,
+			messagesToSummarize: [{ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { ...compactionModule.DEFAULT_COMPACTION_SETTINGS, strategy: "context-full" },
+		};
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "session.compacting"),
+			emit: vi.fn(async (event: { type: string }) =>
+				event.type === "session.compacting"
+					? {
+							preserveData: {
+								otherState: "keep-me",
+								[snapcompact.PRESERVE_KEY]: { frames: [], totalChars: 0, truncatedChars: 0 },
+							},
+						}
+					: undefined,
+			),
+		} as unknown as ExtensionRunner;
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(fixedPreparation);
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockResolvedValue({
+			summary: "auto context-full summary",
+			shortSummary: undefined,
+			firstKeptEntryId,
+			tokensBefore: 100,
+			details: {},
+			preserveData: { resultState: "keep-result" },
+		});
+		const localAgent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const localSession = new AgentSession({
+			agent: localAgent,
+			sessionManager: localSessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": true,
+				"compaction.autoContinue": false,
+				"compaction.strategy": "context-full",
+			}),
+			modelRegistry,
+			extensionRunner,
+		});
+
+		try {
+			await localSession.runIdleCompaction();
+			expect(compactSpy).toHaveBeenCalledTimes(1);
+			const compactionEntry = localSessionManager.getEntries().find(entry => entry.type === "compaction");
+			if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
+			expect(compactionEntry.preserveData).toEqual({
+				otherState: "keep-me",
+				resultState: "keep-result",
+			});
+			expect(compactionEntry.preserveData).not.toHaveProperty(snapcompact.PRESERVE_KEY);
+		} finally {
+			await localSession.dispose();
+			await localTempDir.remove();
+		}
 	});
 
 	it("runs context maintenance before sending an oversized pending prompt", async () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -786,6 +786,230 @@ describe("remote compaction setting", () => {
 
 		expect(result.preserveData).toEqual({ otherState: "keep-me" });
 	});
+
+	it("summarizes snapcompact archive text locally and stops carrying frames", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected anthropic/claude-sonnet-4-5 model to exist");
+
+		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
+		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
+		const previousCompaction = createCompactionEntry("Snapcompact frame summary", oldAssistant.id);
+		previousCompaction.preserveData = {
+			otherState: "keep-me",
+			snapcompact: {
+				frames: [{ data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 }],
+				totalChars: 31,
+				truncatedChars: 0,
+				text: "Archived snapcompact source",
+			},
+		};
+
+		const entries: SessionEntry[] = [
+			oldUser,
+			oldAssistant,
+			previousCompaction,
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createAssistantMessage("Answer 1", createMockUsage(0, 100, 4000, 0))),
+			createMessageEntry(createUserMessage("Turn 2")),
+			createMessageEntry(createAssistantMessage("Answer 2", createMockUsage(0, 100, 9000, 0))),
+		];
+
+		const preparation = prepareCompaction(entries, {
+			...DEFAULT_COMPACTION_SETTINGS,
+			keepRecentTokens: 1000,
+			remoteEnabled: true,
+		});
+		if (!preparation) throw new Error("Expected compaction preparation");
+
+		const completeSimpleSpy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage("History summary"));
+
+		const result = await compact(preparation, model, "test-api-key");
+		const promptText = completeSimpleSpy.mock.calls
+			.map(call => {
+				const context = call[1] as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+				return context.messages?.[0]?.content?.[0]?.text ?? "";
+			})
+			.join("\n");
+
+		expect(promptText).toContain("Previous snapcompact archive source text:");
+		expect(promptText).toContain("Archived snapcompact source");
+		expect(result.preserveData).toEqual({ otherState: "keep-me" });
+	});
+
+	it("keeps snapcompact archive text when only split-turn prefix is summarized", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected anthropic/claude-sonnet-4-5 model to exist");
+
+		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
+		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
+		const previousCompaction = createCompactionEntry("Split snapcompact frame summary", oldAssistant.id);
+		previousCompaction.preserveData = {
+			otherState: "keep-me",
+			snapcompact: {
+				frames: [{ data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 }],
+				totalChars: 34,
+				truncatedChars: 0,
+				text: "Archived split snapcompact source",
+			},
+		};
+
+		const entries: SessionEntry[] = [
+			oldUser,
+			oldAssistant,
+			previousCompaction,
+			createMessageEntry(createUserMessage("Turn after archive")),
+			createMessageEntry(createAssistantMessage("Prefix answer")),
+			createMessageEntry(createAssistantMessage("Kept answer")),
+		];
+
+		const preparation = prepareCompaction(entries, {
+			...DEFAULT_COMPACTION_SETTINGS,
+			keepRecentTokens: 1,
+			remoteEnabled: true,
+		});
+		if (!preparation) throw new Error("Expected compaction preparation");
+		expect(preparation.isSplitTurn).toBe(true);
+		expect(preparation.messagesToSummarize).toHaveLength(0);
+		expect(preparation.turnPrefixMessages.length).toBeGreaterThan(0);
+
+		const completeSimpleSpy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce(createAssistantMessage("Archived history summary"))
+			.mockResolvedValueOnce(createAssistantMessage("Turn prefix summary"))
+			.mockResolvedValueOnce(createAssistantMessage("Short summary"));
+
+		const result = await compact(preparation, model, "test-api-key");
+		const promptText = completeSimpleSpy.mock.calls
+			.map(call => {
+				const context = call[1] as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+				return context.messages?.[0]?.content?.[0]?.text ?? "";
+			})
+			.join("\n");
+
+		expect(promptText).toContain("Archived split snapcompact source");
+		expect(result.summary).toContain("Archived history summary");
+		expect(result.summary).toContain("Turn prefix summary");
+		expect(result.summary).not.toContain("Archived split snapcompact source");
+		expect(result.summary).not.toContain("No prior history.");
+		expect(result.preserveData).toEqual({ otherState: "keep-me" });
+	});
+
+	it("strips legacy frame-only snapcompact archives during local compaction", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected anthropic/claude-sonnet-4-5 model to exist");
+
+		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
+		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
+		const previousCompaction = createCompactionEntry("Legacy snapcompact frame summary", oldAssistant.id);
+		previousCompaction.preserveData = {
+			otherState: "keep-me",
+			snapcompact: {
+				frames: [{ data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 }],
+				totalChars: 4,
+				truncatedChars: 0,
+			},
+		};
+
+		const entries: SessionEntry[] = [
+			oldUser,
+			oldAssistant,
+			previousCompaction,
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createAssistantMessage("Answer 1", createMockUsage(0, 100, 4000, 0))),
+			createMessageEntry(createUserMessage("Turn 2")),
+			createMessageEntry(createAssistantMessage("Answer 2", createMockUsage(0, 100, 9000, 0))),
+		];
+
+		const preparation = prepareCompaction(entries, {
+			...DEFAULT_COMPACTION_SETTINGS,
+			keepRecentTokens: 1000,
+			remoteEnabled: true,
+		});
+		if (!preparation) throw new Error("Expected compaction preparation");
+
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("History summary"));
+
+		const result = await compact(preparation, model, "test-api-key");
+
+		expect(result.preserveData).toEqual({ otherState: "keep-me" });
+	});
+
+	it("sends snapcompact archive text to OpenAI remote compaction and strips frames", async () => {
+		const model = getBundledModel("openai", "gpt-5.1");
+		if (!model) throw new Error("Expected openai/gpt-5.1 model to exist");
+
+		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
+		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
+		const previousCompaction = createCompactionEntry("Snapcompact frame summary", oldAssistant.id);
+		previousCompaction.preserveData = {
+			otherState: "keep-me",
+			snapcompact: {
+				frames: [{ data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 }],
+				totalChars: 38,
+				truncatedChars: 0,
+				text: "Archived remote snapcompact source",
+			},
+		};
+
+		const entries: SessionEntry[] = [
+			oldUser,
+			oldAssistant,
+			previousCompaction,
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createOpenAiAssistantMessage("Answer 1", model, createMockUsage(0, 100, 4000, 0))),
+			createMessageEntry(createUserMessage("Turn 2")),
+			createMessageEntry(createOpenAiAssistantMessage("Answer 2", model, createMockUsage(0, 100, 9000, 0))),
+		];
+
+		const preparation = prepareCompaction(entries, {
+			...DEFAULT_COMPACTION_SETTINGS,
+			keepRecentTokens: 1000,
+			remoteEnabled: true,
+		});
+		if (!preparation) throw new Error("Expected compaction preparation");
+
+		const remoteOutput = [
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "Compacted retained user" }] },
+			{ type: "compaction", encrypted_content: "new_encrypted" },
+		];
+		const fetchHandler = vi.fn(
+			async (_input, _init) =>
+				new Response(JSON.stringify({ output: remoteOutput }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		const fetchSpy = mockFetch(fetchHandler);
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("History summary"));
+
+		const result = await compact(preparation, model, "test-api-key", undefined, undefined, { fetch: fetchSpy });
+		const requestBody = JSON.parse(String(fetchHandler.mock.calls[0]?.[1]?.body)) as {
+			input: Array<{ type?: string; role?: string; content?: Array<{ type?: string; text?: string }> }>;
+		};
+		const archiveMessage = requestBody.input.find(
+			item =>
+				item.type === "message" &&
+				item.role === "user" &&
+				item.content?.some(
+					block =>
+						block.type === "input_text" &&
+						typeof block.text === "string" &&
+						block.text.includes("Archived remote snapcompact source"),
+				),
+		);
+
+		expect(archiveMessage).toBeDefined();
+		expect(result.preserveData).toEqual({
+			otherState: "keep-me",
+			openaiRemoteCompaction: {
+				provider: "openai",
+				replacementHistory: remoteOutput,
+				compactionItem: { type: "compaction", encrypted_content: "new_encrypted" },
+			},
+		});
+	});
 });
 
 describe("findCutPoint", () => {

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -1290,6 +1290,16 @@ export function getPreservedArchive(preserveData: Record<string, unknown> | unde
 	};
 }
 
+/** Extract persisted archive source text as plain text for LLM summarization. */
+export function archiveSourceText(archive: Archive): string | undefined {
+	const text =
+		archive.text ??
+		[archive.textHead, archive.textTail]
+			.filter((part): part is string => typeof part === "string" && part.length > 0)
+			.join(NEWLINE_GLYPH);
+	return text.length > 0 ? toPlainText(text) : undefined;
+}
+
 /** Convert archive frames into LLM image blocks (oldest first). */
 export function images(archive: Archive): ImageContent[] {
 	return archive.frames.map(frame => ({


### PR DESCRIPTION
   ## Root issue                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Switching `compaction.strategy` from `snapcompact` to `context-full` only changed which compaction strategy runs next. It did not remove the latest compaction entry’s persisted `preserveData.snapcompact`.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   That meant context-full could still rebuild context with old snapcompact archive frames attached, even though the active strategy was no longer snapcompact. Practical effects:                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - context-full was not actually isolated after a prior snapcompact pass                                                                                                                                                                                                                                                                                                                                                                
   - old snapcompact image frames could keep contributing to context/token usage                                                                                                                                                                                                                                                                                                                                                          
   - sessions could look like they were compacting early, e.g. around ~60% apparent window use                                                                                                                                                                                                                                                                                                                                            
   - text-only models/providers could still inherit stale image-frame baggage from the previous mode                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Fix                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - When context-full sees prior `preserveData.snapcompact`, fold available snapcompact archive plaintext into the LLM summary input first.                                                                                                                                                                                                                                                                                              
   - Strip `preserveData.snapcompact` from the new context-full compaction entry.                                                                                                                                                                                                                                                                                                                                                         
   - Apply the same strip at AgentSession manual/auto LLM save paths after hook/result preserve data is merged, so stale snapcompact state cannot be reintroduced at save time.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Behavior after fix                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - Normal snapcompact behavior is unchanged.                                                                                                                                                                                                                                                                                                                                                                                            
   - Context-full from the beginning of a session is unchanged.                                                                                                                                                                                                                                                                                                                                                                           
   - Snapcompact → context-full changes only for the first context-full compaction after the switch:                                                                                                                                                                                                                                                                                                                                      
     - available snapcompact archive text is migrated into the summary                                                                                                                                                                                                                                                                                                                                                                    
     - old snapcompact archive state is removed                                                                                                                                                                                                                                                                                                                                                                                           
   - Subsequent context-full compactions behave like normal context-full.                                                                                                                                                                                                                                                                                                                                                                 
   - Legacy frame-only snapcompact archives have no plaintext source to migrate, so they are stripped to stop stale frames from continuing to affect context-full.                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Verification                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - `bun test packages/coding-agent/test/compaction.test.ts`                                                                                                                                                                                                                                                                                                                                                                             
     - 42 pass, 1 skip, 0 fail       