### PR TITLE
feat: add Windows ARM64 (win32-arm64) platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
                 "pi-natives-darwin-x64-baseline-h${hash}"
                 "pi-natives-darwin-arm64-h${hash}"
                 "pi-natives-win32-x64-baseline-h${hash}"
+                "pi-natives-win32-arm64-h${hash}"
               )
               linux_x64_run_id=""
               cross_platform_run_id=""
@@ -247,6 +248,7 @@ jobs:
             include:
                - { os: omp-kata, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu }
                - { os: omp-kata, platform: win32, arch: x64, target: x86_64-pc-windows-msvc, variant: baseline }
+               - { os: omp-kata, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc }
       runs-on: ${{ matrix.os }}
       steps:
          - uses: actions/checkout@v4
@@ -603,6 +605,13 @@ jobs:
                     arch: x64,
                     target_id: win32-x64,
                     binary_path: packages/coding-agent/binaries/omp-windows-x64.exe,
+                 }
+               - {
+                    os: ubuntu-22.04,
+                    platform: win32,
+                    arch: arm64,
+                    target_id: win32-arm64,
+                    binary_path: packages/coding-agent/binaries/omp-windows-arm64.exe,
                  }
       runs-on: ${{ matrix.os }}
       permissions:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Windows ARM64 (`win32-arm64`) platform support. The self-updater now recognizes `win32-arm64` as a supported native tag, and the `ffmpegAssetName` helper falls back to the `win32-x64` binary under emulation (ffmpeg-static has no native ARM64 build).
+
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -51,6 +51,7 @@ const SUPPORTED_NATIVE_TAGS: ReadonlySet<string> = new Set([
 	"darwin-x64",
 	"darwin-arm64",
 	"win32-x64",
+	"win32-arm64",
 ]);
 
 function currentNativeTag(): string {

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -79,7 +79,9 @@ export function ffmpegAssetName(_version: string, plat: string, architecture: st
 	if (architecture !== "arm64" && architecture !== "x64") return null;
 	if (plat === "darwin") return `ffmpeg-darwin-${architecture}`;
 	if (plat === "linux") return `ffmpeg-linux-${architecture}`;
-	if (plat === "win32") return architecture === "x64" ? "ffmpeg-win32-x64" : null;
+	// ffmpeg-static has no win32-arm64 build; Windows-on-ARM runs the x64 binary
+	// under emulation, so fall back to it rather than reporting no ffmpeg.
+	if (plat === "win32") return "ffmpeg-win32-x64";
 	return null;
 }
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -119,7 +119,7 @@ describe("update-cli bun install command", () => {
 		// file and aborted at validateLoadedBindings with `The .node file on
 		// disk is from a different release than this loader`. See
 		// https://github.com/can1357/oh-my-pi/issues/1824.
-		for (const tag of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]) {
+		for (const tag of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"]) {
 			const args = buildBunInstallArgs("15.9.0", tag);
 			expect(args).toContain("@oh-my-pi/pi-natives@15.9.0");
 			expect(args).toContain(`@oh-my-pi/pi-natives-${tag}@15.9.0`);

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added in-process [uutils](https://github.com/uutils/coreutils)-backed shell builtins to the embedded brush `Shell`: `cat`, `head`, `tail`, `wc`, `sort`, `uniq`, `ls`, `find`, `grep`, `mkdir`, `rm`, and `mv`. These vendored + patched utilities run inside the shell process (no `fork`/`exec`), resolve path operands against the shell working directory, route stdio through the command's (possibly piped/redirected) file descriptors, read the shell's exported environment, and honor abort/timeout cancellation (a blocked `stdin` read unwinds cleanly). `grep` is built on the ripgrep `grep-*` crates and `find` on `uutils/findutils`; the rest are pinned to `uutils/coreutils` 0.8.0 (matching the bundled `uucore`). Registration is gated: set `PI_DISABLE_UUTILS_BUILTINS` to fall back to the system binaries for the whole set, or `PI_DISABLE_UUTILS_DESTRUCTIVE` / `PI_DISABLE_RM_BUILTIN` / `PI_DISABLE_MV_BUILTIN` to disable only the destructive `rm`/`mv` shadows.
+- Added Windows ARM64 (`win32-arm64`) as a supported platform. The native addon loader, npm leaf package generator, and CI build matrix now include `pi_natives.win32-arm64.node`, cross-compiled via `cargo-xwin` targeting `aarch64-pc-windows-msvc`.
+
 
 ## [16.1.17] - 2026-06-24
 

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -31,7 +31,7 @@ import { embeddedAddon } from "./embedded-addon.js";
  * post-build `--reset` stub) is the authoritative compiled-mode signal.
  */
 
-const SUPPORTED_PLATFORMS = ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"];
+const SUPPORTED_PLATFORMS = ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"];
 
 /**
  * Streaming startup marker, enabled by `PI_DEBUG_STARTUP`. Local copy of the

--- a/packages/natives/scripts/gen-npm-packages.ts
+++ b/packages/natives/scripts/gen-npm-packages.ts
@@ -53,6 +53,7 @@ export const LEAF_TARGETS: readonly LeafTarget[] = [
 	{ tag: "darwin-x64", os: "darwin", cpu: "x64" },
 	{ tag: "darwin-arm64", os: "darwin", cpu: "arm64" },
 	{ tag: "win32-x64", os: "win32", cpu: "x64" },
+	{ tag: "win32-arm64", os: "win32", cpu: "arm64" },
 ];
 
 const packageDirDefault = path.join(import.meta.dir, "..");

--- a/packages/natives/test/npm-packages.test.ts
+++ b/packages/natives/test/npm-packages.test.ts
@@ -55,6 +55,7 @@ describe("generated native npm leaf packages", () => {
 				"pi_natives.darwin-x64-baseline.node",
 				"pi_natives.darwin-arm64.node",
 				"pi_natives.win32-x64-baseline.node",
+				"pi_natives.win32-arm64.node",
 			];
 			for (const file of addonFiles) {
 				await Bun.write(path.join(packageDir, "native", file), file);
@@ -67,6 +68,7 @@ describe("generated native npm leaf packages", () => {
 				"darwin-x64",
 				"darwin-arm64",
 				"win32-x64",
+				"win32-arm64",
 			]);
 			const linuxX64 = leaves.find(leaf => leaf.tag === "linux-x64");
 			expect(linuxX64?.files).toEqual(["pi_natives.linux-x64-baseline.node", "pi_natives.linux-x64-modern.node"]);
@@ -95,6 +97,7 @@ describe("generated native npm leaf packages", () => {
 				"linux-arm64",
 				"darwin-x64",
 				"win32-x64",
+				"win32-arm64",
 			]);
 			expect(await Bun.file(path.join(packageDir, "npm/darwin-arm64/package.json")).exists()).toBe(false);
 		} finally {

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -56,6 +56,13 @@ const targets: BinaryTarget[] = [
 		target: "bun-windows-x64-modern",
 		outfile: "packages/coding-agent/binaries/omp-windows-x64.exe",
 	},
+	{
+		id: "win32-arm64",
+		platform: "win32",
+		arch: "arm64",
+		target: "bun-windows-arm64",
+		outfile: "packages/coding-agent/binaries/omp-windows-arm64.exe",
+	},
 ];
 
 function parseRequestedTargets(): Set<string> | null {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,7 +19,13 @@ $ErrorActionPreference = "Stop"
 $Repo = "can1357/oh-my-pi"
 $Package = "@oh-my-pi/pi-coding-agent"
 $InstallDir = if ($env:PI_INSTALL_DIR) { $env:PI_INSTALL_DIR } else { "$env:LOCALAPPDATA\omp" }
-$BinaryName = "omp-windows-x64.exe"
+# OSArchitecture reports the true OS arch even when PowerShell runs under x64
+# emulation on Windows-on-ARM (unlike $env:PROCESSOR_ARCHITECTURE).
+$BinaryName = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq "Arm64") {
+    "omp-windows-arm64.exe"
+} else {
+    "omp-windows-x64.exe"
+}
 $MinimumBunVersion = "1.3.14"
 
 function Test-BunInstalled {


### PR DESCRIPTION
## What

Adds native win32-arm64 builds of native modules.
Turns out that was all that was really needed.

## Why

Having to use wsl2 every time can become frustrating. fixes #1260 and #949 (which 7841ce5 did not resolve)

## Testing

Compiled and tested extensively on my Surface Laptop 7.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
