### PR TITLE
fix(coding-agent): report screenshot fallback dimensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed browser screenshots reporting `0x0` dimensions when `Bun.Image` rejects an image whose PNG/JPEG header still exposes real dimensions. ([#3577](https://github.com/can1357/oh-my-pi/issues/3577))
 - Fixed `/resume <session-id>` in the interactive TUI only searching the active cwd's session directory; id-prefix lookup now falls back to sessions from other cwd buckets like CLI `--resume <session-id>`.
 - Fixed plan mode rejecting edits to plan artifacts when models refer to them by bare filenames
 - Fixed absolute paths to session-owned artifacts being incorrectly routed through the editor bridge

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -698,6 +698,9 @@ export function formatScreenshot(opts: {
 		lines.push(`Format: ${opts.resized.mimeType} (${(opts.resized.buffer.length / 1024).toFixed(2)} KB)`);
 		lines.push(`Dimensions: ${opts.resized.width}x${opts.resized.height}`);
 	}
+	if (opts.resized.decodeFailed) {
+		lines.push("Resize: image decoder failed; using original image bytes");
+	}
 	const dimensionNote = formatDimensionNote(opts.resized);
 	if (dimensionNote) {
 		lines.push(dimensionNote);

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -54,10 +54,7 @@ function readUint16BE(buffer: Uint8Array, offset: number): number {
 }
 
 function readUint32BE(buffer: Uint8Array, offset: number): number {
-	return (
-		((buffer[offset] << 24) | (buffer[offset + 1] << 16) | (buffer[offset + 2] << 8) | buffer[offset + 3]) >>>
-		0
-	);
+	return ((buffer[offset] << 24) | (buffer[offset + 1] << 16) | (buffer[offset + 2] << 8) | buffer[offset + 3]) >>> 0;
 }
 
 function readPngHeaderDimensions(buffer: Uint8Array): ImageHeaderDimensions | undefined {

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -18,6 +18,7 @@ export interface ResizedImage {
 	width: number;
 	height: number;
 	wasResized: boolean;
+	decodeFailed?: boolean;
 	get data(): string;
 }
 
@@ -41,6 +42,86 @@ const DEFAULT_OPTIONS: Required<Omit<ImageResizeOptions, "excludeWebP">> = {
 	jpegQuality: 80,
 	minDimension: DEFAULT_MIN_DIMENSION,
 };
+
+interface ImageHeaderDimensions {
+	width: number;
+	height: number;
+	mimeType: string;
+}
+
+function readUint16BE(buffer: Uint8Array, offset: number): number {
+	return (buffer[offset] << 8) | buffer[offset + 1];
+}
+
+function readUint32BE(buffer: Uint8Array, offset: number): number {
+	return (
+		((buffer[offset] << 24) | (buffer[offset + 1] << 16) | (buffer[offset + 2] << 8) | buffer[offset + 3]) >>>
+		0
+	);
+}
+
+function readPngHeaderDimensions(buffer: Uint8Array): ImageHeaderDimensions | undefined {
+	if (buffer.length < 24) return undefined;
+	if (
+		buffer[0] !== 0x89 ||
+		buffer[1] !== 0x50 ||
+		buffer[2] !== 0x4e ||
+		buffer[3] !== 0x47 ||
+		buffer[4] !== 0x0d ||
+		buffer[5] !== 0x0a ||
+		buffer[6] !== 0x1a ||
+		buffer[7] !== 0x0a
+	) {
+		return undefined;
+	}
+	if (readUint32BE(buffer, 8) !== 13) return undefined;
+	if (buffer[12] !== 0x49 || buffer[13] !== 0x48 || buffer[14] !== 0x44 || buffer[15] !== 0x52) return undefined;
+	const width = readUint32BE(buffer, 16);
+	const height = readUint32BE(buffer, 20);
+	if (width === 0 || height === 0) return undefined;
+	return { width, height, mimeType: "image/png" };
+}
+
+function isJpegStartOfFrame(marker: number): boolean {
+	return (
+		(marker >= 0xc0 && marker <= 0xc3) ||
+		(marker >= 0xc5 && marker <= 0xc7) ||
+		(marker >= 0xc9 && marker <= 0xcb) ||
+		(marker >= 0xcd && marker <= 0xcf)
+	);
+}
+
+function readJpegHeaderDimensions(buffer: Uint8Array): ImageHeaderDimensions | undefined {
+	if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) return undefined;
+	let offset = 2;
+	while (offset + 3 < buffer.length) {
+		if (buffer[offset] !== 0xff) {
+			offset++;
+			continue;
+		}
+		while (offset < buffer.length && buffer[offset] === 0xff) offset++;
+		if (offset >= buffer.length) return undefined;
+		const marker = buffer[offset++];
+		if (marker === 0xd9 || marker === 0xda) return undefined;
+		if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+		if (offset + 1 >= buffer.length) return undefined;
+		const segmentLength = readUint16BE(buffer, offset);
+		if (segmentLength < 2) return undefined;
+		if (isJpegStartOfFrame(marker)) {
+			if (offset + 7 >= buffer.length) return undefined;
+			const height = readUint16BE(buffer, offset + 3);
+			const width = readUint16BE(buffer, offset + 5);
+			if (width === 0 || height === 0) return undefined;
+			return { width, height, mimeType: "image/jpeg" };
+		}
+		offset += segmentLength;
+	}
+	return undefined;
+}
+
+function readImageHeaderDimensions(buffer: Uint8Array): ImageHeaderDimensions | undefined {
+	return readPngHeaderDimensions(buffer) ?? readJpegHeaderDimensions(buffer);
+}
 
 /**
  * Read `OMP_NO_WEBP` per-call so runtime toggles take effect.
@@ -298,21 +379,24 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 			},
 		};
 	} catch {
+		const headerDimensions = readImageHeaderDimensions(inputBuffer);
+		const fallbackMimeType = img.mimeType ?? headerDimensions?.mimeType ?? "application/octet-stream";
 		// Bun.Image rejected the input — we cannot decode/re-encode it.
-		// When the caller demanded WebP exclusion AND the original is WebP,
+		// When the caller demanded WebP exclusion AND the source might be WebP,
 		// returning the original buffer would silently violate that contract,
 		// so surface an explicit error instead.
-		if (excludeWebP && (img.mimeType === "image/webp" || !img.mimeType)) {
+		if (excludeWebP && (fallbackMimeType === "image/webp" || (!img.mimeType && !headerDimensions))) {
 			throw new Error("resizeImage: failed to decode image and cannot honor excludeWebP for a WebP source");
 		}
 		return {
 			buffer: inputBuffer,
-			mimeType: img.mimeType,
-			originalWidth: 0,
-			originalHeight: 0,
-			width: 0,
-			height: 0,
+			mimeType: fallbackMimeType,
+			originalWidth: headerDimensions?.width ?? 0,
+			originalHeight: headerDimensions?.height ?? 0,
+			width: headerDimensions?.width ?? 0,
+			height: headerDimensions?.height ?? 0,
 			wasResized: false,
+			decodeFailed: true,
 			get data() {
 				return img.data;
 			},

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -57,6 +57,7 @@ describe("formatScreenshot", () => {
 			wasResized: boolean;
 			buffer: Uint8Array;
 			mimeType: string;
+			decodeFailed: boolean;
 		}>,
 	): {
 		buffer: Uint8Array;
@@ -66,6 +67,7 @@ describe("formatScreenshot", () => {
 		width: number;
 		height: number;
 		wasResized: boolean;
+		decodeFailed?: boolean;
 		get data(): string;
 	} {
 		const buf = overrides?.buffer ?? new Uint8Array(2048);
@@ -77,6 +79,7 @@ describe("formatScreenshot", () => {
 			width: overrides?.width ?? 800,
 			height: overrides?.height ?? 600,
 			wasResized: overrides?.wasResized ?? false,
+			decodeFailed: overrides?.decodeFailed,
 			get data() {
 				return Buffer.from(buf).toString("base64");
 			},
@@ -144,6 +147,20 @@ describe("formatScreenshot", () => {
 				resized,
 			}),
 		).toEqual(["Screenshot captured", "Format: image/webp (3.00 KB)", "Dimensions: 800x600"]);
+	});
+
+	it("surfaces screenshots that could not be resized", () => {
+		const resized = fakeResized({ decodeFailed: true, mimeType: "image/png", buffer: new Uint8Array(4096) });
+
+		expect(
+			formatScreenshot({
+				saveFullRes: false,
+				savedMimeType: "image/png",
+				savedByteLength: 4096,
+				dest: path.join(os.tmpdir(), "omp-sshots-123.png"),
+				resized,
+			}),
+		).toContain("Resize: image decoder failed; using original image bytes");
 	});
 
 	it("appends dimension note when image was resized", () => {

--- a/packages/coding-agent/test/utils/image-resize.test.ts
+++ b/packages/coding-agent/test/utils/image-resize.test.ts
@@ -128,6 +128,28 @@ describe("resizeImage defaults", () => {
 	});
 });
 
+describe("resizeImage decode fallback", () => {
+	it("reports PNG header dimensions when Bun.Image rejects after reading IHDR", async () => {
+		const png = Buffer.alloc(33);
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
+		png.writeUInt32BE(13, 8);
+		png.write("IHDR", 12, "ascii");
+		png.writeUInt32BE(1900, 16);
+		png.writeUInt32BE(2474, 20);
+		png[24] = 8;
+		png[25] = 2;
+
+		const result = await resizeImage({ type: "image", data: png.toBase64(), mimeType: "image/png" });
+
+		expect(result.width).toBe(1900);
+		expect(result.height).toBe(2474);
+		expect(result.originalWidth).toBe(1900);
+		expect(result.originalHeight).toBe(2474);
+		expect(result.wasResized).toBe(false);
+		expect(result.buffer.length).toBe(png.length);
+	});
+});
+
 describe("resizeImage minimum dimension", () => {
 	it("upscales a degenerate 1x1 image up to the 200px floor", async () => {
 		// A 1x1 PNG (e.g. an empty chart render) would sail through the fast path


### PR DESCRIPTION
## Repro
A PNG buffer whose IHDR declares `1900x2474` but whose full `Bun.Image` decode fails goes through `resizeImage`'s catch path. Before the fix, `bun test packages/coding-agent/test/utils/image-resize.test.ts` failed because `result.width` was `0` instead of `1900`.

## Cause
`packages/coding-agent/src/utils/image-resize.ts` returned zeroed dimensions from `resizeImage` whenever `new Bun.Image(inputBuffer).metadata()` or a later re-encode threw. `packages/coding-agent/src/tools/browser/tab-worker.ts` then reported `resized.width`/`resized.height` verbatim for screenshots, so a decodable header with a failed full decode became `Dimensions: 0x0`.

## Fix
- Added PNG IHDR and JPEG SOF header probing in `resizeImage`'s decode-failure fallback.
- Kept returning the original bytes when resize/re-encode is impossible, but preserved real header dimensions and marked the result as a decode fallback.
- Updated screenshot formatting to surface that the image decoder failed and original bytes are being used.
- Added regression coverage for header-dimension fallback and the screenshot warning.

## Verification
`bun test packages/coding-agent/test/utils/image-resize.test.ts packages/coding-agent/test/tools/render-utils.test.ts` passed with 33 tests and 84 assertions. `gh_push_branch` completed the pre-publish `bun run fix` / `bun check` gate and pushed `farm/64a6c4e3/fix-browser-screenshot-dimensions`. Fixes #3577