### PR TITLE
fix(agent): stop replaying provider refusals

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed API-level provider refusals being replayed as assistant dialogue on later requests, which could anchor repeated refusals after a single blocked turn. ([#3592](https://github.com/can1357/oh-my-pi/issues/3592))
+
 ## [16.1.23] - 2026-06-26
 
 ### Changed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -36,6 +36,7 @@ import {
 	resolveOwnedDialectFromEnv,
 } from "./agent-loop";
 import type { AppendOnlyContextManager } from "./append-only-context";
+import { isProviderRefusalMessage } from "./replay-policy";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -54,10 +55,13 @@ import { isSoftToolRequirement } from "./types";
 import { EventLoopKeepalive } from "./utils/yield";
 
 /**
- * Default convertToLlm: Keep only LLM-compatible messages, convert attachments.
+ * Default convertToLlm: Keep only LLM-compatible replay messages.
  */
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
-	return messages.filter((m): m is Message => m.role === "user" || m.role === "assistant" || m.role === "toolResult");
+	return messages.filter((m): m is Message => {
+		if (m.role === "assistant") return !isProviderRefusalMessage(m);
+		return m.role === "user" || m.role === "toolResult";
+	});
 }
 
 const ANTHROPIC_OUTPUT_BLOCKED_PREFIX = "Output blocked by conten";

--- a/packages/agent/src/compaction/messages.ts
+++ b/packages/agent/src/compaction/messages.ts
@@ -7,7 +7,6 @@ import type {
 	ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
-import { isProviderRefusalMessage } from "../replay-policy";
 import type { AgentMessage } from "../types";
 import branchSummaryContextPrompt from "./prompts/branch-summary-context.md" with { type: "text" };
 import compactionSummaryContextPrompt from "./prompts/compaction-summary-context.md" with { type: "text" };
@@ -214,7 +213,7 @@ export function convertMessageToLlm(message: AgentMessage): Message | undefined 
 		case "developer":
 			return { ...message, attribution: message.attribution ?? "agent" };
 		case "assistant":
-			return isProviderRefusalMessage(message) ? undefined : message;
+			return message;
 		case "toolResult":
 			return {
 				...message,

--- a/packages/agent/src/compaction/messages.ts
+++ b/packages/agent/src/compaction/messages.ts
@@ -1,5 +1,4 @@
 import type {
-	AssistantMessage,
 	ImageContent,
 	Message,
 	MessageAttribution,
@@ -8,6 +7,7 @@ import type {
 	ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
+import { isProviderRefusalMessage } from "../replay-policy";
 import type { AgentMessage } from "../types";
 import branchSummaryContextPrompt from "./prompts/branch-summary-context.md" with { type: "text" };
 import compactionSummaryContextPrompt from "./prompts/compaction-summary-context.md" with { type: "text" };
@@ -214,7 +214,7 @@ export function convertMessageToLlm(message: AgentMessage): Message | undefined 
 		case "developer":
 			return { ...message, attribution: message.attribution ?? "agent" };
 		case "assistant":
-			return message as AssistantMessage;
+			return isProviderRefusalMessage(message) ? undefined : message;
 		case "toolResult":
 			return {
 				...message,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,6 +8,8 @@ export * from "./append-only-context";
 export * from "./compaction";
 // Proxy utilities
 export * from "./proxy";
+// Replay policy
+export * from "./replay-policy";
 // Run-level telemetry collector + aggregators
 export * from "./run-collector";
 // Telemetry

--- a/packages/agent/src/replay-policy.ts
+++ b/packages/agent/src/replay-policy.ts
@@ -1,8 +1,13 @@
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Message } from "@oh-my-pi/pi-ai";
 
 /** Detects API-level provider refusals that are terminal errors, not dialogue to replay. */
 export function isProviderRefusalMessage(message: AssistantMessage): boolean {
 	if (message.stopReason !== "error") return false;
 	const stopType = message.stopDetails?.type;
 	return stopType === "refusal" || stopType === "sensitive";
+}
+
+/** Removes API-level provider refusals from live provider replay while preserving other messages. */
+export function filterProviderReplayMessages(messages: readonly Message[]): Message[] {
+	return messages.filter(message => message.role !== "assistant" || !isProviderRefusalMessage(message));
 }

--- a/packages/agent/src/replay-policy.ts
+++ b/packages/agent/src/replay-policy.ts
@@ -1,0 +1,8 @@
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+
+/** Detects API-level provider refusals that are terminal errors, not dialogue to replay. */
+export function isProviderRefusalMessage(message: AssistantMessage): boolean {
+	if (message.stopReason !== "error") return false;
+	const stopType = message.stopDetails?.type;
+	return stopType === "refusal" || stopType === "sensitive";
+}

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -112,6 +112,33 @@ describe("Agent", () => {
 		expect(agent.state.messages[agent.state.messages.length - 1].role).toBe("assistant");
 	});
 
+	it("keeps Anthropic refusal errors out of the next provider context", async () => {
+		const mock = createMockModel({
+			responses: [
+				{
+					content: ["I can't assist with that request."],
+					stopReason: "error",
+					stopDetails: { type: "refusal", category: "bio", explanation: "policy refusal" },
+					errorMessage: "Refusal (bio): policy refusal",
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		await agent.prompt("trigger refusal");
+		await agent.prompt("next request");
+
+		expect(mock.calls).toHaveLength(2);
+		const replayedMessages = mock.calls[1].context.messages;
+		expect(replayedMessages.map(message => message.role)).toEqual(["user", "user"]);
+		expect(JSON.stringify(replayedMessages)).not.toContain("Refusal (bio)");
+		expect(JSON.stringify(replayedMessages)).not.toContain("I can't assist");
+	});
+
 	it("prompt() emits assistant error lifecycle for Anthropic output-blocked stream errors before assistant start", async () => {
 		const mock = createMockModel({ responses: [] });
 		const errorText = "Output blocked by content filtering policy";

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude API refusals polluting the replayed session context and causing later prompts to refuse again. ([#3592](https://github.com/can1357/oh-my-pi/issues/3592))
+
 ## [16.1.23] - 2026-06-26
 
 ### Added

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -5,6 +5,7 @@ import {
 	type AgentTelemetryConfig,
 	type AgentTool,
 	AppendOnlyContextManager,
+	filterProviderReplayMessages,
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
 import {
@@ -2449,9 +2450,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		};
 
-		// Final convertToLlm: chain block-images filter with secret obfuscation
+		// Final convertToLlm: live provider replay drops API-level refusal errors,
+		// then applies secret obfuscation to the remaining outbound context.
 		const convertToLlmFinal = (messages: AgentMessage[]): Message[] => {
-			const converted = convertToLlmWithBlockImages(messages);
+			const converted = filterProviderReplayMessages(convertToLlmWithBlockImages(messages));
 			if (!obfuscator?.hasSecrets()) return converted;
 			return obfuscateMessages(obfuscator, converted);
 		};

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentMessage, filterProviderReplayMessages } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
 import { inferCopilotInitiator } from "@oh-my-pi/pi-ai/providers/github-copilot-headers";
 import { convertToLlm, wrapSteeringForModel } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -54,8 +54,8 @@ describe("convertToLlm compaction summary", () => {
 	});
 });
 
-describe("convertToLlm assistant replay policy", () => {
-	it("drops API-level Anthropic refusals from provider replay", () => {
+describe("assistant refusal replay policy", () => {
+	it("preserves API-level Anthropic refusals for summaries but drops them from provider replay", () => {
 		const messages: AgentMessage[] = [
 			{ role: "user", content: [{ type: "text", text: "trigger" }], timestamp: 1 },
 			{
@@ -82,8 +82,12 @@ describe("convertToLlm assistant replay policy", () => {
 
 		const converted = convertToLlm(messages);
 
-		expect(converted.map(message => message.role)).toEqual(["user", "user"]);
-		expect(JSON.stringify(converted)).not.toContain("Refusal (bio)");
+		expect(converted.map(message => message.role)).toEqual(["user", "assistant", "user"]);
+		expect(JSON.stringify(converted)).toContain("Refusal (bio)");
+
+		const replayed = filterProviderReplayMessages(converted);
+		expect(replayed.map(message => message.role)).toEqual(["user", "user"]);
+		expect(JSON.stringify(replayed)).not.toContain("Refusal (bio)");
 	});
 });
 

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -54,6 +54,39 @@ describe("convertToLlm compaction summary", () => {
 	});
 });
 
+describe("convertToLlm assistant replay policy", () => {
+	it("drops API-level Anthropic refusals from provider replay", () => {
+		const messages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "trigger" }], timestamp: 1 },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "I can't assist with that request." }],
+				stopReason: "error",
+				stopDetails: { type: "refusal", category: "bio", explanation: "policy refusal" },
+				errorMessage: "Refusal (bio): policy refusal",
+				api: "anthropic",
+				provider: "anthropic",
+				model: "claude-opus-4",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: 2,
+			},
+			{ role: "user", content: [{ type: "text", text: "recover" }], timestamp: 3 },
+		];
+
+		const converted = convertToLlm(messages);
+
+		expect(converted.map(message => message.role)).toEqual(["user", "user"]);
+		expect(JSON.stringify(converted)).not.toContain("Refusal (bio)");
+	});
+});
+
 describe("convertToLlm custom message mapping", () => {
 	it("maps custom messages to developer role with explicit agent attribution", () => {
 		const messages: AgentMessage[] = [


### PR DESCRIPTION
## Repro
A focused core-agent regression test reproduces the failure: `bun test packages/agent/test/agent.test.ts --test-name-pattern refusal` previously showed the next provider request roles as `["user", "assistant", "user"]`, meaning the Anthropic `Refusal (bio)` assistant error was replayed between user turns.

## Cause
`packages/agent/src/agent.ts` and `packages/agent/src/compaction/messages.ts` converted every assistant message into provider replay context, including Anthropic API-level refusal/safety stops surfaced as `AssistantMessage.stopReason === "error"` with `stopDetails.type === "refusal"` or `"sensitive"`.

## Fix
- Added `packages/agent/src/replay-policy.ts` to classify API-level provider refusals as non-replayable terminal errors.
- Updated the core `Agent` replay converter and compaction message converter to drop those refusal assistant messages from provider context while leaving normal assistant messages and unrelated errors intact.
- Added regression coverage in `packages/agent/test/agent.test.ts` and `packages/coding-agent/test/session-messages.test.ts`.

## Verification
`bun test packages/agent/test/agent.test.ts --test-name-pattern refusal` passed; `bun test packages/coding-agent/test/session-messages.test.ts --test-name-pattern "assistant replay"` passed; `bun test packages/agent/test/agent.test.ts` passed; `bun test packages/coding-agent/test/session-messages.test.ts` passed; `bun run check` passed in `packages/agent` and `packages/coding-agent`. Fixes #3592