### PR TITLE
fix(ai): send llama.cpp string tool_choice

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed llama.cpp OpenAI-compatible capture follow-ups sending named forced `tool_choice` as an object; the chat-completions encoder now downgrades that shape to string `"required"` for llama.cpp so its parser no longer falls back with `type must be string, but is object`. ([#3593](https://github.com/can1357/oh-my-pi/issues/3593))
+
 ## [16.1.23] - 2026-06-26
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1439,6 +1439,13 @@ function buildParams(
 	if (options?.toolChoice && initialCompat.supportsToolChoice) {
 		params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
 	}
+	if (
+		typeof params.tool_choice === "object" &&
+		params.tool_choice !== null &&
+		!initialCompat.supportsNamedToolChoice
+	) {
+		params.tool_choice = "required";
+	}
 	if (isForcedToolChoice(params.tool_choice) && !initialCompat.supportsForcedToolChoice) {
 		// Some thinking-required OpenAI-compatible models reject forced
 		// `tool_choice` while still accepting tools with the default auto

--- a/packages/ai/test/issue-3593-repro.test.ts
+++ b/packages/ai/test/issue-3593-repro.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, Model, ModelSpec, Tool, ToolChoice } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { z } from "zod/v4";
+
+interface ChatCompletionsPayload {
+	tool_choice?: unknown;
+	tools?: Array<{ type?: string; function?: { name?: string } }>;
+}
+
+const resolveTool: Tool = {
+	name: "resolve",
+	description: "Apply or discard a pending preview",
+	parameters: z.object({ action: z.enum(["apply", "discard"]), reason: z.string() }),
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Resolve the pending preview.", timestamp: 0 }],
+	tools: [resolveTool],
+};
+
+const forcedResolve: ToolChoice = { type: "tool", name: "resolve" };
+
+function model(overrides: Partial<ModelSpec<"openai-completions">>): Model<"openai-completions"> {
+	return buildModel({
+		id: "qwen-3.6-27b",
+		name: "Qwen 3.6 27B",
+		api: "openai-completions",
+		provider: "llama.cpp",
+		baseUrl: "http://localhost:8080/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131_072,
+		maxTokens: 32_768,
+		...overrides,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capturePayload(target: Model<"openai-completions">): Promise<ChatCompletionsPayload> {
+	const { promise, resolve } = Promise.withResolvers<ChatCompletionsPayload>();
+	streamOpenAICompletions(target, context, {
+		apiKey: "test-key",
+		toolChoice: forcedResolve,
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as ChatCompletionsPayload),
+	});
+	return promise;
+}
+
+describe("issue #3593 — llama.cpp string-only tool_choice", () => {
+	it("downgrades named forced tool_choice to required for llama.cpp", async () => {
+		const payload = await capturePayload(model({}));
+
+		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["resolve"]);
+		expect(payload.tool_choice).toBe("required");
+	});
+
+	it("preserves OpenAI's named tool_choice object", async () => {
+		const payload = await capturePayload(
+			model({ provider: "openai", baseUrl: "https://api.openai.com/v1", id: "gpt-4o-mini", name: "GPT-4o mini" }),
+		);
+
+		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "resolve" } });
+	});
+});

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -34,6 +34,7 @@ const compat: ResolvedOpenAICompat = {
 	supportsUsageInStreaming: true,
 	supportsToolChoice: true,
 	supportsForcedToolChoice: true,
+	supportsNamedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -168,6 +168,7 @@ describe("openai-completions compatibility", () => {
 			supportsUsageInStreaming: true,
 			supportsToolChoice: true,
 			supportsForcedToolChoice: true,
+			supportsNamedToolChoice: true,
 			disableReasoningOnForcedToolChoice: false,
 			disableReasoningOnToolChoice: false,
 			maxTokensField: "max_completion_tokens",

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -23,6 +23,7 @@ const compat: ResolvedOpenAICompat = {
 	supportsUsageInStreaming: true,
 	supportsToolChoice: true,
 	supportsForcedToolChoice: true,
+	supportsNamedToolChoice: true,
 	disableReasoningOnForcedToolChoice: false,
 	disableReasoningOnToolChoice: false,
 	maxTokensField: "max_completion_tokens",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `OpenAICompat.supportsNamedToolChoice` so string-only OpenAI-compatible chat servers can keep forced tool use without emitting the named function-object `tool_choice` shape. ([#3593](https://github.com/can1357/oh-my-pi/issues/3593))
+
 ## [16.1.23] - 2026-06-26
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -403,6 +403,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
 		supportsForcedToolChoice: true,
+		supportsNamedToolChoice: provider !== "llama.cpp",
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: isMistral,
@@ -593,6 +594,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
 		supportsToolChoice: true,
 		supportsForcedToolChoice: true,
+		supportsNamedToolChoice: true,
 		reasoningContentField: "reasoning_content",
 		requiresReasoningContentForToolCalls:
 			(isKimiModel || (isDeepseekFamily && reasoningCapable) || (isOpenRouter && reasoningCapable)) &&

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -269,6 +269,14 @@ export interface OpenAICompat {
 	 */
 	supportsForcedToolChoice?: boolean;
 	/**
+	 * Whether the chat-completions endpoint accepts the object form that pins one
+	 * named function (`{ type: "function", function: { name } }`). Some
+	 * OpenAI-compatible hosts such as llama.cpp only accept string
+	 * `tool_choice` values; request builders downgrade a named force to
+	 * `"required"` when this is false. Default: true.
+	 */
+	supportsNamedToolChoice?: boolean;
+	/**
 	 * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
 	 * the request when `tool_choice` forces a tool call. Mirrors the Anthropic
 	 * `disableThinkingIfToolChoiceForced` rule for backends like Kimi that
@@ -465,6 +473,7 @@ export interface ResolvedOpenAISharedCompat {
 	disableReasoningOnToolChoice: boolean;
 	supportsToolChoice: boolean;
 	supportsForcedToolChoice: boolean;
+	supportsNamedToolChoice: boolean;
 	reasoningContentField?: OpenAICompat["reasoningContentField"];
 	requiresReasoningContentForToolCalls: boolean;
 	requiresReasoningContentForAllAssistantTurns: boolean;
@@ -516,6 +525,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "disableReasoningOnToolChoice"
 			| "supportsToolChoice"
 			| "supportsForcedToolChoice"
+			| "supportsNamedToolChoice"
 			| "reasoningContentField"
 			| "requiresReasoningContentForToolCalls"
 			| "requiresReasoningContentForAllAssistantTurns"


### PR DESCRIPTION
## Repro
Reporter's llama.cpp capture-at-stop run shows the follow-up request logging `Wrong type supplied for parameter 'tool_choice'. Expected 'string' ... type must be string, but is object`, then falling back to default tool selection before `forcing full prompt re-processing due to lack of cache data`. I pinned the request shape with `bun test packages/ai/test/issue-3593-repro.test.ts`, covering a forced `resolve` tool choice on a `provider: "llama.cpp"` OpenAI-compatible model.

## Cause
`packages/ai/src/providers/openai-completions.ts` always mapped a named forced `ToolChoice` to OpenAI's object form `{ type: "function", function: { name } }` whenever `supportsForcedToolChoice` was true. `packages/catalog/src/compat/openai.ts` marked llama.cpp as forced-tool-choice capable, but llama.cpp's chat-completions schema only accepts string `tool_choice` values, so auto-learn's capture/resolve path emitted a parser-invalid object and the server ignored the directive.

## Fix
- Added `OpenAICompat.supportsNamedToolChoice` in `packages/catalog/src/types.ts` and defaulted it off for `provider: "llama.cpp"` in `packages/catalog/src/compat/openai.ts`.
- Downgraded named forced chat-completions choices to string `"required"` when the compat profile does not support named object choices.
- Added `packages/ai/test/issue-3593-repro.test.ts` to assert llama.cpp gets string `"required"` while OpenAI still gets the named object form.
- Updated affected resolved-compat test fixtures and changelogs.

## Verification
`bun test packages/ai/test/issue-3593-repro.test.ts packages/ai/test/issue-1701-repro.test.ts packages/ai/test/openai-completions-compat.test.ts` passed: 72 tests. `bun test packages/catalog` passed: 328 tests. `bun check` passed. Fixes #3593