### PR TITLE
[codex] add extension rule registration API

### DIFF
--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -342,6 +342,16 @@ export class TtsrManager {
 	}
 
 	/**
+	 * Remove a previously-added rule by name. Returns true if a rule was removed.
+	 * Lets callers update a rule's content (remove + re-add, since `addRule`
+	 * no-ops on an existing name) or drop rules whose source set shrank — needed
+	 * for runtime rule re-projection via `ExtensionAPI.replaceRules`.
+	 */
+	removeRule(name: string): boolean {
+		return this.#rules.delete(name);
+	}
+
+	/**
 	 * Add a stream chunk to its scoped buffer and return matching rules.
 	 *
 	 * Buffers are isolated by source/tool key so matches don't bleed across

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -12,6 +12,7 @@ import { Type } from "arktype";
 import * as zodModule from "zod/v4";
 import { type ExtensionModule, extensionModuleCapability } from "../../capability/extension-module";
 import { type Hook, hookCapability } from "../../capability/hook";
+import type { Rule } from "../../capability/rule";
 import { loadCapability } from "../../discovery";
 import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
@@ -62,6 +63,8 @@ export class ExtensionRuntimeNotInitializedError extends Error {
 export class ExtensionRuntime implements IExtensionRuntime {
 	flagValues = new Map<string, boolean | string>();
 	pendingProviderRegistrations: Array<{ name: string; config: ProviderConfig; sourceId: string }> = [];
+	/** Set by the session host after loading; re-syncs the live TtsrManager on runtime rule changes. */
+	onRulesChanged?: () => void;
 
 	sendMessage(): void {
 		throw new ExtensionRuntimeNotInitializedError();
@@ -152,6 +155,19 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 			definition: tool,
 			extensionPath: this.extension.path,
 		});
+	}
+
+	registerRule(rule: Rule): void {
+		this.extension.rules.set(rule.name, rule);
+		this.runtime.onRulesChanged?.();
+	}
+
+	replaceRules(rules: Rule[]): void {
+		this.extension.rules.clear();
+		for (const rule of rules) {
+			this.extension.rules.set(rule.name, rule);
+		}
+		this.runtime.onRulesChanged?.();
 	}
 
 	registerCommand(
@@ -274,6 +290,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		resolvedPath,
 		handlers: new Map(),
 		tools: new Map(),
+		rules: new Map(),
 		assistantThinkingRenderers: [],
 		messageRenderers: new Map(),
 		commands: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -5,6 +5,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
+import type { Rule } from "../../capability/rule";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { MemoryRuntimeContext } from "../../memory-backend";
@@ -344,6 +345,17 @@ export class ExtensionRunner {
 			}
 		}
 		return tools;
+	}
+
+	/** Get all rules registered programmatically across all extensions. */
+	getAllRegisteredRules(): Rule[] {
+		const rules: Rule[] = [];
+		for (const ext of this.extensions) {
+			for (const rule of ext.rules.values()) {
+				rules.push(rule);
+			}
+		}
+		return rules;
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -34,6 +34,7 @@ import type { AutocompleteItem, Component, EditorTheme, KeyId, TUI } from "@oh-m
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
 import type { Type as arktype } from "arktype";
 import type * as zod from "zod/v4";
+import type { Rule } from "../../capability/rule";
 import type { KeybindingsManager } from "../../config/keybindings";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { EditToolDetails } from "../../edit";
@@ -1031,6 +1032,27 @@ export interface ExtensionAPI {
 	registerTool<TParams extends TSchema = TSchema, TDetails = unknown>(tool: ToolDefinition<TParams, TDetails>): void;
 
 	// =========================================================================
+	// Rule Registration (programmatic TTSR / advisory rules)
+	// =========================================================================
+
+	/**
+	 * Register a TTSR/advisory rule programmatically. Rules with a `condition`
+	 * or `astCondition` flow into the TtsrManager and abort the stream on match,
+	 * exactly like file-discovered `.omp/rules/*.md`. Lets an external governance
+	 * system inject rules from its extension factory (which runs after the
+	 * filesystem rule-discovery window). Mirrors `registerTool`.
+	 */
+	registerRule(rule: Rule): void;
+
+	/**
+	 * Replace the full set of rules previously registered by THIS extension.
+	 * Use for runtime re-projection (e.g. a governance daemon whose rule set
+	 * changes mid-session): removes this extension's stale rules from the live
+	 * TtsrManager and (re)adds the new set. Idempotent on unchanged content.
+	 */
+	replaceRules(rules: Rule[]): void;
+
+	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================
 
@@ -1312,6 +1334,13 @@ export interface ExtensionRuntimeState {
 	flagValues: Map<string, boolean | string>;
 	/** Provider registrations queued during extension loading, processed during session initialization */
 	pendingProviderRegistrations: Array<{ name: string; config: ProviderConfig; sourceId: string }>;
+	/**
+	 * Set by the session host. Invoked when an extension mutates its rule set at
+	 * runtime (registerRule/replaceRules) so the host can re-sync the live
+	 * TtsrManager. Undefined during factory execution (initial rules are drained
+	 * by the host after loading).
+	 */
+	onRulesChanged?: () => void;
 }
 
 /** Action implementations for ExtensionAPI methods. */
@@ -1368,6 +1397,8 @@ export interface Extension {
 	label?: string;
 	handlers: Map<string, HandlerFn[]>;
 	tools: Map<string, RegisteredTool<any, any>>;
+	/** Rules registered programmatically by this extension (keyed by rule name). */
+	rules: Map<string, Rule>;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
 	messageRenderers: Map<string, MessageRenderer>;
 	commands: Map<string, RegisteredCommand>;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2028,6 +2028,29 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings,
 		);
 
+		// Programmatic extension rules (ExtensionAPI.registerRule/replaceRules) →
+		// live TtsrManager. Extensions whose rules are only known after their
+		// factory runs (e.g. a governance daemon that projects rules on bind)
+		// miss the filesystem rule-discovery window; drain them here and re-sync
+		// whenever an extension mutates its set at runtime. Mirrors how
+		// file-discovered rules reach the TtsrManager via bucketRules.
+		let syncedExtensionRuleNames = new Set<string>();
+		const syncExtensionRules = () => {
+			for (const name of syncedExtensionRuleNames) {
+				ttsrManager.removeRule(name);
+			}
+			syncedExtensionRuleNames = new Set<string>();
+			for (const rule of extensionRunner.getAllRegisteredRules()) {
+				const hasTtsrCondition = (rule.condition?.length ?? 0) > 0 || (rule.astCondition?.length ?? 0) > 0;
+				if (hasTtsrCondition && ttsrManager.addRule(rule)) {
+					syncedExtensionRuleNames.add(rule.name);
+				}
+			}
+			setActiveRules([...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()]);
+		};
+		syncExtensionRules();
+		extensionsResult.runtime.onRulesChanged = syncExtensionRules;
+
 		credentialDisabledTarget = extensionRunner;
 		for (const event of startupCredentialDisabledEvents.splice(0)) {
 			// Discard return: any handler error is routed through runner.onError listeners.

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -237,6 +237,49 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("rule collection", () => {
+		it("collects final programmatic rule sets from extensions", async () => {
+			const ruleCode = (name: string) => `
+				const source = { provider: "test", providerName: "Test", path: "/tmp/${name}.md", level: "project" };
+
+				export default function(pi) {
+					pi.registerRule({
+						name: "${name}_stale",
+						path: "/tmp/${name}-stale.md",
+						content: "stale",
+						condition: ["stale"],
+						_source: source,
+					});
+					pi.replaceRules([
+						{
+							name: "${name}",
+							path: "/tmp/${name}.md",
+							content: "active",
+							condition: ["active"],
+							_source: source,
+						},
+					]);
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "rules-a.ts"), ruleCode("rule_a"));
+			fs.writeFileSync(path.join(extensionsDir, "rules-b.ts"), ruleCode("rule_b"));
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const rules = runner.getAllRegisteredRules();
+
+			expect(rules.map(rule => rule.name).sort()).toEqual(["rule_a", "rule_b"]);
+			expect(rules.map(rule => rule.content)).toEqual(["active", "active"]);
+			expect(rules.some(rule => rule.name.endsWith("_stale"))).toBe(false);
+		});
+	});
+
 	describe("command collection", () => {
 		it("collects commands from multiple extensions", async () => {
 			const cmdCode = (name: string) => `

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -500,6 +500,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 					],
 				]),
 				tools: new Map(),
+				rules: new Map(),
 				assistantThinkingRenderers: [],
 				messageRenderers: new Map(),
 				commands: new Map(),


### PR DESCRIPTION
## Summary
- Adds `ExtensionAPI.registerRule` and `replaceRules` for programmatic TTSR/advisory rules.
- Stores extension-local rule sets and exposes runner aggregation for session setup.
- Re-syncs extension rules into `TtsrManager` after extension load and runtime replacement, including stale rule removal.
- Adds a runner regression test for final `replaceRules` behavior.

## Checks
- `bun check`
- `bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts`