### PR TITLE
feat(statusline): make git segment jj-aware

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Changed the `inlineToolDescriptors` setting ("Inline Tool Descriptors") from a boolean to a three-way enum (`auto` | `on` | `off`), defaulting to `auto`. `auto` inlines tool descriptors into the system prompt (and strips them from provider tool schemas) only for Gemini models, leaving them in the schemas otherwise; `on`/`off` force the behavior regardless of model. Existing `true`/`false` configs migrate to `on`/`off`.
 - Replaced `as string | undefined` inline casts with `typeof` guards in the TUI usage renderer's account identity resolution (`formatAccountLabel`, `formatUnlimitedReportLabel`, reset-credits label, and unlimited-plan tier), so empty-string metadata values fall through to the next fallback instead of being displayed
 
+### Added
+
+- Made the `git` statusline segment jj-aware: in a colocated jj repo (git HEAD parked detached) or a secondary jj workspace (no git), it now shows the jj working-copy label (bookmarks + short change-id) instead of `detached`/nothing. The jj query is read-only (`--ignore-working-copy`) and throttled, and the segment is unchanged in plain git repos. ([#3582](https://github.com/can1357/oh-my-pi/issues/3582))
+
 ### Fixed
 
 - Fixed `snapcompact` compaction silently falling back to an LLM summary when local preflight rejects the archive; manual and auto snapcompact now fail locally with the blocker instead of making provider calls. ([#3599](https://github.com/can1357/oh-my-pi/issues/3599))

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -14,6 +14,7 @@ import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/sessio
 import { sanitizeStatusText } from "../../shared";
 import { theme } from "../../theme/theme";
 import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
+import { findJjRoot, JJ_BRANCH_TTL_MS, queryJjBranch } from "./jj-info";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -200,6 +201,11 @@ export class StatusLineComponent implements Component {
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
 	#gitStatusLastFetch = 0;
 	#gitStatusInFlight = false;
+	#jjRoot: string | null | undefined = undefined;
+	#jjRootCwd: string | undefined = undefined;
+	#cachedJjBranch: string | null = null;
+	#jjBranchLastFetch = 0;
+	#jjBranchInFlight = false;
 
 	// PR lookup caching (invalidated on branch/repo context changes)
 	#cachedPr: { number: number; url: string } | null | undefined = undefined;
@@ -382,6 +388,7 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedBranchCwd = undefined;
 		this.#cachedPrContext = undefined;
+		this.#jjBranchLastFetch = 0;
 	}
 	#getCurrentBranch(): string | null {
 		if (!this.#gitEnabled()) return null;
@@ -403,6 +410,37 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranch = head.kind === "ref" ? (head.branchName ?? head.ref) : "detached";
 
 		return this.#cachedBranch ?? null;
+	}
+
+	/**
+	 * Colocated-jj label for the `git` segment: the working-copy bookmarks +
+	 * change-id, used in place of git's detached-HEAD label. Throttled and
+	 * cached like {@link #getGitStatus} — returns the cached value immediately
+	 * and refreshes in the background; the jj root is detected once per cwd.
+	 */
+	#getJjBranch(): string | null {
+		const cwd = getProjectDir();
+		if (this.#jjRoot === undefined || this.#jjRootCwd !== cwd) {
+			this.#jjRootCwd = cwd;
+			this.#jjRoot = findJjRoot(cwd);
+			this.#cachedJjBranch = null;
+			this.#jjBranchLastFetch = 0;
+		}
+		const root = this.#jjRoot;
+		if (!root) return null;
+		if (this.#jjBranchInFlight || Date.now() - this.#jjBranchLastFetch < JJ_BRANCH_TTL_MS) {
+			return this.#cachedJjBranch;
+		}
+		this.#jjBranchInFlight = true;
+		(async () => {
+			try {
+				this.#cachedJjBranch = await queryJjBranch(root);
+			} finally {
+				this.#jjBranchLastFetch = Date.now();
+				this.#jjBranchInFlight = false;
+			}
+		})();
+		return this.#cachedJjBranch;
 	}
 
 	#isDefaultBranch(branch: string): boolean {
@@ -788,7 +826,13 @@ export class StatusLineComponent implements Component {
 			contextPercent = collabState.contextUsage.percent ?? contextPercent;
 		}
 
-		const gitBranch = includeGit || includePr ? this.#getCurrentBranch() : null;
+		// Under jj the git `branch` is unhelpful: a colocated repo parks git HEAD
+		// detached, and a secondary jj workspace has no git at all. In both cases
+		// surface the jj working-copy label (bookmarks + change-id) in the `git` slot.
+		let gitBranch = includeGit || includePr ? this.#getCurrentBranch() : null;
+		if (includeGit && (gitBranch === "detached" || gitBranch === null)) {
+			gitBranch = this.#getJjBranch() ?? gitBranch;
+		}
 		const gitStatus = includeGit ? this.#getGitStatus() : null;
 		const gitPr = includePr ? this.#lookupPr() : null;
 

--- a/packages/coding-agent/src/modes/components/status-line/jj-info.ts
+++ b/packages/coding-agent/src/modes/components/status-line/jj-info.ts
@@ -1,0 +1,71 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { $ } from "bun";
+
+/**
+ * Throttle for the working-copy jj query. The statusline calls into jj only
+ * while the `git` segment is shown in a colocated jj repo (where git HEAD is
+ * parked detached), so a moderate TTL keeps the subprocess rate negligible
+ * while a HEAD change still forces an immediate refresh (see
+ * `#invalidateGitCaches`).
+ */
+export const JJ_BRANCH_TTL_MS = 5000;
+
+/**
+ * jj template for the working-copy label: local bookmarks on `@` (space marker
+ * formatting preserved) plus the shortest unique change-id prefix. `separate`
+ * drops the empty bookmark part, so a working copy with no bookmark renders as
+ * just the change-id.
+ */
+const JJ_BRANCH_TEMPLATE = 'separate(" ", bookmarks, change_id.shortest(8))';
+
+/**
+ * Walk up from `cwd` to the colocated jj workspace root — the nearest ancestor
+ * directory holding a `.jj` entry. Returns `null` when none exists. Sync on
+ * purpose: it feeds the synchronous statusline render path and is cached per
+ * cwd by the caller, so it runs at most once per directory.
+ */
+export function findJjRoot(cwd: string): string | null {
+	let dir = path.resolve(cwd);
+	for (;;) {
+		if (fs.existsSync(path.join(dir, ".jj"))) return dir;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/** Collapse a raw jj template line into a single display token, or `null` when empty. */
+export function formatJjBranch(raw: string): string | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	return trimmed.replace(/\s+/g, " ");
+}
+
+/** Runs the jj query in `root`; injectable so the parse boundary is testable without jj. */
+export type JjRunner = (root: string) => Promise<{ exitCode: number; stdout: string }>;
+
+const defaultRunner: JjRunner = async root => {
+	// `--ignore-working-copy` keeps the query read-only (never snapshots the
+	// working copy), so it is safe to run on every refresh.
+	const res = await $`jj log --no-graph --ignore-working-copy --color never -r @ -T ${JJ_BRANCH_TEMPLATE}`
+		.cwd(root)
+		.quiet()
+		.nothrow();
+	return { exitCode: res.exitCode, stdout: res.text() };
+};
+
+/**
+ * Query the jj working-copy label (bookmarks + change-id) for `root`. Returns
+ * `null` on any failure — non-zero exit (not a jj repo) or a missing `jj`
+ * binary — so the caller cleanly falls back to git's detached-HEAD label.
+ */
+export async function queryJjBranch(root: string, runner: JjRunner = defaultRunner): Promise<string | null> {
+	try {
+		const res = await runner(root);
+		if (res.exitCode !== 0) return null;
+		return formatJjBranch(res.stdout);
+	} catch {
+		return null;
+	}
+}

--- a/packages/coding-agent/test/status-line-jj-info.test.ts
+++ b/packages/coding-agent/test/status-line-jj-info.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	findJjRoot,
+	formatJjBranch,
+	queryJjBranch,
+} from "@oh-my-pi/pi-coding-agent/modes/components/status-line/jj-info";
+
+describe("formatJjBranch", () => {
+	test("trims and collapses internal whitespace to a single token", () => {
+		expect(formatJjBranch("  feature-x   kvisqosn  \n")).toBe("feature-x kvisqosn");
+	});
+
+	test("returns the change-id alone when there is no bookmark", () => {
+		expect(formatJjBranch("kvisqosn\n")).toBe("kvisqosn");
+	});
+
+	test("returns null for empty or whitespace-only output", () => {
+		expect(formatJjBranch("")).toBeNull();
+		expect(formatJjBranch("  \n\t ")).toBeNull();
+	});
+});
+
+describe("findJjRoot", () => {
+	test("walks up to the nearest ancestor holding .jj", async () => {
+		const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "jj-root-"));
+		try {
+			await fs.promises.mkdir(path.join(root, ".jj"));
+			const nested = path.join(root, "packages", "coding-agent");
+			await fs.promises.mkdir(nested, { recursive: true });
+			expect(findJjRoot(nested)).toBe(root);
+			expect(findJjRoot(root)).toBe(root);
+		} finally {
+			await fs.promises.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null when no .jj ancestor exists", async () => {
+		const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "no-jj-"));
+		try {
+			expect(findJjRoot(dir)).toBeNull();
+		} finally {
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("queryJjBranch", () => {
+	test("formats runner stdout on success", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({ exitCode: 0, stdout: "feat-x kvisqosn\n" }));
+		expect(desc).toBe("feat-x kvisqosn");
+	});
+
+	test("returns null on non-zero exit (not a jj repo)", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({ exitCode: 1, stdout: "" }));
+		expect(desc).toBeNull();
+	});
+
+	test("returns null when the runner throws (jj binary absent)", async () => {
+		const desc = await queryJjBranch("/repo", async () => {
+			throw new Error("spawn jj ENOENT");
+		});
+		expect(desc).toBeNull();
+	});
+
+	test("treats empty successful output as null", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({ exitCode: 0, stdout: "\n" }));
+		expect(desc).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

Make the `git` statusline segment jj-aware. When the working directory is a jj repo, the segment shows the jj working-copy label (local bookmarks on `@` plus the short change-id) instead of git's unhelpful `detached` (colocated repo) or nothing (secondary jj workspace with no git).

New `jj-info.ts` supplies the label — `findJjRoot` (walk up to the nearest `.jj`), a read-only injectable `queryJjBranch` (`jj log --no-graph --ignore-working-copy --color never -r @ -T 'separate(" ", bookmarks, change_id.shortest(8))'`), and `formatJjBranch`. `component.ts` overlays it onto `ctx.git.branch` only when the git branch is `detached`/`null` (jj is in play) and the `git` segment is shown, throttled (5s TTL) and cached like `#getGitStatus` and force-refreshed on the git-HEAD watcher. No change to `segments.ts`, so it lights up in every preset with no config; plain git repos (HEAD on a branch) and non-jj directories are untouched (the overlay never runs, or the jj query returns `null` and the git label stands).

## Why

Fixes #3582. In a colocated jj repo, jj parks git `HEAD` detached, so the `git` segment renders `detached`. In a secondary jj workspace there is no `.git` at all, so the segment renders nothing. Either way the statusline shows no useful VCS position under jj. The segment set is a closed enum and extensions can only render on a separate line (`setStatus`), so the fix lives in the built-in segment's context provider.

## Testing

- New `status-line-jj-info.test.ts` (9 tests): `formatJjBranch` (trim/collapse, change-id-only, empty -> null), `findJjRoot` (walk-up hit, no-`.jj` -> null), `queryJjBranch` (success format, non-zero exit -> null, runner throw -> null, empty -> null).
- Verified the real `jj log` template against a live jj workspace (returns the change-id).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)