### PR TITLE
fix(tui): emit BEL under Zellij so notifications flag backgrounded panes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed stray or unmatched HTML tags leaking into rendered output
 - Improved layout consistency by correctly handling HTML block-level tags in various contexts
 - Markdown renderer now handles inline `<code>…</code>` (rendered as themed inline code, identical to a backtick codespan, with HTML entities like `&amp;` decoded), block `<hr>` (rendered as a horizontal rule), and balanced single-line `<blockquote>…</blockquote>` (rendered with the quote border) instead of leaking the raw tags as literal text. Applies to the transcript renderer, table cells, list items, and the inline `renderInlineMarkdown` helper used for option labels; fenced code blocks keep such markup verbatim.
+- Fixed desktop notifications being silently lost under Zellij: `TerminalInfo.sendNotification` now appends a bare `BEL` for OSC-9/99 terminals inside Zellij (which drops OSC 9/99 and has no DCS passthrough), so a backgrounded pane raises Zellij's `[!]` bell flag — matching the existing tmux behavior. ([#3583](https://github.com/can1357/oh-my-pi/issues/3583))
 
 ## [16.1.20] - 2026-06-25
 

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -121,6 +121,13 @@ export class TerminalInfo {
 			process.stdout.write(`${wrapTmuxPassthrough(formatted)}\x07`);
 			return;
 		}
+		// Zellij drops OSC 9/99 and has no DCS passthrough envelope, but raises its
+		// `[!]` bell flag on a bare BEL — the same backgrounded-pane signal tmux
+		// users get. So follow the (Zellij-swallowed) OSC with a plain BEL.
+		if (this.notifyProtocol !== NotifyProtocol.Bell && isInsideZellij()) {
+			process.stdout.write(`${formatted}\x07`);
+			return;
+		}
 		process.stdout.write(formatted);
 	}
 }
@@ -132,6 +139,15 @@ export class TerminalInfo {
  */
 export function isInsideTmux(env: NodeJS.ProcessEnv = Bun.env): boolean {
 	return Boolean(env.TMUX);
+}
+
+/**
+ * Whether the agent process is running inside a Zellij session. Read fresh on
+ * each call (like {@link isInsideTmux}) so a session attached/detached mid-run
+ * is observed and tests can toggle `Bun.env.ZELLIJ` per case.
+ */
+export function isInsideZellij(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.ZELLIJ);
 }
 
 /**

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -3,6 +3,7 @@ import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
 import {
 	getTerminalInfo,
 	isInsideTmux,
+	isInsideZellij,
 	isOsc99Supported,
 	NotifyProtocol,
 	setOsc99Supported,
@@ -16,6 +17,7 @@ const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "i
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalOsc99Probe = Bun.env.PI_TUI_OSC99_PROBE;
 const originalTmux = Bun.env.TMUX;
+const originalZellij = Bun.env.ZELLIJ;
 const originalPiNotifications = Bun.env.PI_NOTIFICATIONS;
 const mutableTerminal = TERMINAL as unknown as { notifyProtocol: NotifyProtocol };
 const originalNotifyProtocol = mutableTerminal.notifyProtocol;
@@ -70,6 +72,7 @@ describe("terminal notifications", () => {
 		// Default the suite to the "outside tmux" baseline so probe/format
 		// assertions never see a stray inherited TMUX leaking the DCS wrap in.
 		delete Bun.env.TMUX;
+		delete Bun.env.ZELLIJ;
 		// `PI_NOTIFICATIONS=off` is set in this workspace's CI env, which would
 		// short-circuit `sendNotification` before it writes anything. Clear it
 		// so the delivery-path assertions actually observe stdout writes.
@@ -83,6 +86,7 @@ describe("terminal notifications", () => {
 		mutableTerminal.notifyProtocol = originalNotifyProtocol;
 		restoreEnv("PI_TUI_OSC99_PROBE", originalOsc99Probe);
 		restoreEnv("TMUX", originalTmux);
+		restoreEnv("ZELLIJ", originalZellij);
 		restoreEnv("PI_NOTIFICATIONS", originalPiNotifications);
 		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
 		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
@@ -218,6 +222,30 @@ describe("terminal notifications", () => {
 		TERMINAL.sendNotification("ping");
 
 		expect(writes).toEqual(["\x1b]99;;ping\x1b\\"]);
+	});
+
+	it("isInsideZellij reads the ZELLIJ env fresh on each call", () => {
+		expect(isInsideZellij()).toBe(false);
+		Bun.env.ZELLIJ = "0";
+		expect(isInsideZellij()).toBe(true);
+		delete Bun.env.ZELLIJ;
+		expect(isInsideZellij()).toBe(false);
+	});
+
+	it("under Zellij, OSC-protocol sendNotification appends a plain BEL (no DCS wrap)", () => {
+		Bun.env.ZELLIJ = "0";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		TERMINAL.sendNotification("ping");
+
+		// Zellij raises its [!] bell flag on a bare BEL; it has no DCS passthrough,
+		// so the OSC (which Zellij drops) is followed by a plain BEL — no wrap.
+		expect(writes).toEqual(["\x1b]99;;ping\x1b\\\x07"]);
 	});
 
 	it("under tmux, the OSC 99 capability probe is wrapped in DCS passthrough", () => {


### PR DESCRIPTION
## What

Add `isInsideZellij()` and a Zellij branch in `sendNotification`: for non-`Bell` protocols inside Zellij, follow the (Zellij-swallowed) OSC with a bare `\x07`, raising Zellij's `[!]` bell flag.

## Why

Fixes #3583. `TerminalInfo.sendNotification` appended a `BEL` only inside tmux. Under Zellij, OSC 9/99 desktop notifications are dropped (Zellij doesn't forward them and has no DCS passthrough) and no `BEL` was emitted, so a backgrounded Zellij pane got no attention indicator when the agent finished a turn or blocked on input. This mirrors the existing tmux behavior; the tmux branch stays first so a nested tmux-inside-Zellij session still takes the passthrough path.

## Testing

`packages/tui/test/notifications.test.ts` — `isInsideZellij` reads `ZELLIJ` fresh; under Zellij an OSC-protocol `sendNotification` writes the OSC followed by a bare `BEL` (no DCS wrap). `ZELLIJ` env is cleaned up per-test alongside the existing `TMUX` handling.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)