### PR TITLE
feat(todo): add blocked status with block/unblock ops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Changed the `inlineToolDescriptors` setting ("Inline Tool Descriptors") from a boolean to a three-way enum (`auto` | `on` | `off`), defaulting to `auto`. `auto` inlines tool descriptors into the system prompt (and strips them from provider tool schemas) only for Gemini models, leaving them in the schemas otherwise; `on`/`off` force the behavior regardless of model. Existing `true`/`false` configs migrate to `on`/`off`.
 - Replaced `as string | undefined` inline casts with `typeof` guards in the TUI usage renderer's account identity resolution (`formatAccountLabel`, `formatUnlimitedReportLabel`, reset-credits label, and unlimited-plan tier), so empty-string metadata values fall through to the next fallback instead of being displayed
 
+### Added
+
+- Added a `blocked` todo status, with `block`/`unblock` operations and an optional blocker note, for tasks that are open but waiting on something the agent can't act on (a user decision, another agent, an external action). Blocked tasks stay in the tracker and survive the markdown round-trip, but are excluded from the stop-time incomplete-todo reminder and from auto-promotion. ([#3581](https://github.com/can1357/oh-my-pi/issues/3581))
+
 ### Fixed
 
 - Fixed `snapcompact` compaction silently falling back to an LLM summary when local preflight rejects the archive; manual and auto snapcompact now fail locally with the blocker instead of making provider calls. ([#3599](https://github.com/can1357/oh-my-pi/issues/3599))

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -334,6 +334,7 @@ const todoStatusMap: Record<TodoStatus, "pending" | "in_progress" | "completed">
 	in_progress: "in_progress",
 	completed: "completed",
 	abandoned: "completed",
+	blocked: "pending",
 };
 
 function mapTodoStatus(status: TodoStatus): "pending" | "in_progress" | "completed" {
@@ -397,7 +398,13 @@ function extractTodoEntries(phases: unknown[]): Array<{ content: string; status:
 }
 
 function isTodoStatus(status: unknown): status is TodoStatus {
-	return status === "pending" || status === "in_progress" || status === "completed" || status === "abandoned";
+	return (
+		status === "pending" ||
+		status === "in_progress" ||
+		status === "completed" ||
+		status === "abandoned" ||
+		status === "blocked"
+	);
 }
 export function buildToolCallStartUpdate(input: {
 	toolCallId: string;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1494,6 +1494,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				return theme.fg("accent", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;
 			case "abandoned":
 				return theme.fg("error", `${prefix}${checkbox.unchecked} ${chalk.strikethrough(todo.content)}`) + marker;
+			case "blocked":
+				return theme.fg("warning", `${prefix}${checkbox.unchecked} ${todo.content} (blocked)`) + marker;
 			default:
 				if (matched) {
 					return theme.fg("accent", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -69,7 +69,7 @@ export type SubmittedUserInput = {
 	started: boolean;
 };
 
-export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
+export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";
 
 export type TodoItem = {
 	content: string;

--- a/packages/coding-agent/src/prompts/tools/todo.md
+++ b/packages/coding-agent/src/prompts/tools/todo.md
@@ -11,6 +11,8 @@ On each completion the earliest still-open task (in phase order) auto-promotes t
 |`start`|`task`|Mark in progress|
 |`done`|`task` or `phase`|Mark completed|
 |`drop`|`task` or `phase`|Mark abandoned|
+|`block`|`task` or `phase`, optional `reason`|Mark **blocked** — open but waiting on external input; excluded from the stop-time incomplete-todo reminder|
+|`unblock`|`task` or `phase`|Return a blocked task to `pending`|
 |`rm`|`task` or `phase` (optional)|Remove task or phase's tasks; omit both to clear the list|
 |`append`|`phase`, `items: string[]`|Append tasks to `phase`; lazily creates phase|
 |`view`|—|Read-only: echo the list, no modify|
@@ -22,7 +24,7 @@ On each completion the earliest still-open task (in phase order) auto-promotes t
 ## Rules
 - Mark tasks done immediately after finishing.
 - Complete phases in order.
-- Blocked? `append` a task to the active phase to unblock, or `drop`.
+- Waiting on something you can't act on (a user decision, another agent, an external service)? `block` the task (optional `reason`) — it stays in the tracker but won't trip the stop reminder; `unblock` when it's actionable again. If the blocker is itself agent-actionable, `append` an unblocking task instead.
 - Keep `task`/`phase` strings stable once introduced.
 - Lost the exact task text? `view` echoes the list — NEVER guess from memory; a mismatched `task` string is an error.
 

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -18,11 +18,13 @@ import { formatErrorDetail, PREVIEW_LIMITS } from "./render-utils";
 // Types
 // =============================================================================
 
-export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
+export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";
 
 export interface TodoItem {
 	content: string;
 	status: TodoStatus;
+	/** When `status === "blocked"`, an optional note on what the task is waiting for. */
+	blocker?: string;
 }
 
 export interface TodoPhase {
@@ -45,7 +47,9 @@ export interface TodoToolDetails {
 // Schema
 // =============================================================================
 
-const TodoOp = type('"init" | "start" | "done" | "rm" | "drop" | "append" | "view"').describe("operation to apply");
+const TodoOp = type('"init" | "start" | "done" | "rm" | "drop" | "block" | "unblock" | "append" | "view"').describe(
+	"operation to apply",
+);
 
 const InitListEntry = type({
 	phase: type("string").describe("phase name"),
@@ -61,6 +65,7 @@ const todoSchema = type({
 	// and both enforce non-empty with op-specific errors. A stray `items: []` on
 	// an op that ignores it (e.g. `view`) must not be a hard schema rejection.
 	"items?": type("string").describe("task content").array().describe("tasks to append"),
+	"reason?": type("string").describe("blocker note (block op)"),
 }).describe("apply a single todo operation");
 
 type TodoParams = TodoSchema;
@@ -85,7 +90,9 @@ function findPhaseByName(phases: TodoPhase[], name: string): TodoPhase | undefin
 }
 
 function cloneTask(task: TodoItem): TodoItem {
-	return { content: task.content, status: task.status };
+	return task.blocker !== undefined
+		? { content: task.content, status: task.status, blocker: task.blocker }
+		: { content: task.content, status: task.status };
 }
 
 function clonePhases(phases: TodoPhase[]): TodoPhase[] {
@@ -391,6 +398,23 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 			}
 			return phases;
 		}
+		case "block": {
+			const reason = entry.reason?.trim() || undefined;
+			for (const task of getTaskTargets(phases, entry, errors)) {
+				task.status = "blocked";
+				task.blocker = reason;
+			}
+			return phases;
+		}
+		case "unblock": {
+			for (const task of getTaskTargets(phases, entry, errors)) {
+				if (task.status === "blocked") {
+					task.status = "pending";
+					task.blocker = undefined;
+				}
+			}
+			return phases;
+		}
 		case "rm":
 			return removeTasks(phases, entry, errors);
 		case "append":
@@ -430,6 +454,7 @@ const STATUS_TO_MARKER: Record<TodoStatus, string> = {
 	in_progress: "/",
 	completed: "x",
 	abandoned: "-",
+	blocked: "!",
 };
 
 export function resolveTodoMarkdownPath(input: string, cwd: string): string {
@@ -460,6 +485,7 @@ const MARKER_TO_STATUS: Record<string, TodoStatus> = {
 	">": "in_progress",
 	"-": "abandoned",
 	"~": "abandoned",
+	"!": "blocked",
 };
 
 /** Parse a Markdown checklist back into todo phases. */
@@ -491,7 +517,7 @@ export function markdownToPhases(md: string): { phases: TodoPhase[]; errors: str
 			const marker = taskMatch[1];
 			const status = MARKER_TO_STATUS[marker];
 			if (!status) {
-				errors.push(`Line ${lineNum + 1}: unknown status marker "[${marker}]" (use [ ], [x], [/], [-])`);
+				errors.push(`Line ${lineNum + 1}: unknown status marker "[${marker}]" (use [ ], [x], [/], [-], [!])`);
 				continue;
 			}
 			currentPhase.tasks.push({ content: taskMatch[2].trim(), status });
@@ -539,6 +565,7 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 	}
 	// Closed = completed + abandoned, mirroring the per-phase `done` count.
 	const closedAll = tasks.filter(task => task.status === "completed" || task.status === "abandoned").length;
+	const blockedAll = tasks.filter(task => task.status === "blocked").length;
 	// The active phase is the EARLIEST one still holding open work, so the
 	// in-progress pointer can sit in a phase whose successors already have
 	// completed tasks. Detect that "worked ahead" case to explain the
@@ -548,7 +575,9 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 		(phase, idx) =>
 			idx > currentIdx && phase.tasks.some(task => task.status === "completed" || task.status === "abandoned"),
 	);
-	lines.push(`Overall: ${closedAll}/${tasks.length} done, ${remainingTasks.length} open.`);
+	lines.push(
+		`Overall: ${closedAll}/${tasks.length} done, ${remainingTasks.length} open${blockedAll > 0 ? `, ${blockedAll} blocked` : ""}.`,
+	);
 	lines.push(
 		`Active phase ${currentIdx + 1}/${phases.length} "${current.name}" (${done}/${current.tasks.length})${
 			workedAhead
@@ -560,7 +589,16 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 		lines.push(`  ${phase.name}:`);
 		for (const task of phase.tasks) {
 			const checkbox = task.status === "completed" ? "[X]" : "[ ]";
-			const tag = task.status === "in_progress" ? " (in progress)" : task.status === "abandoned" ? " (dropped)" : "";
+			const tag =
+				task.status === "in_progress"
+					? " (in progress)"
+					: task.status === "abandoned"
+						? " (dropped)"
+						: task.status === "blocked"
+							? task.blocker
+								? ` (blocked: ${task.blocker})`
+								: " (blocked)"
+							: "";
 			lines.push(`    - ${checkbox} ${task.content}${tag}`);
 		}
 	}

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -4,6 +4,8 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
+	markdownToPhases,
+	phasesToMarkdown,
 	resolveTodoMarkdownPath,
 	selectStickyTodoWindow,
 	TODO_STRIKE_HOLD_FRAMES,
@@ -160,6 +162,54 @@ describe("TodoTool operations", () => {
 			{ content: "First", status: "in_progress" },
 			{ content: "Second", status: "pending" },
 		]);
+	});
+
+	it("blocks a task (excluded from remaining, counted distinctly) and unblocks it", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b"] }] });
+
+		const blocked = await tool.execute("call-2", { op: "block", task: "b", reason: "waiting on sign-off" });
+		const bTask = blocked.details?.phases[0]?.tasks.find(task => task.content === "b");
+		expect(bTask?.status).toBe("blocked");
+		expect(bTask?.blocker).toBe("waiting on sign-off");
+		const summary = blocked.content.find(part => part.type === "text");
+		if (summary?.type !== "text") throw new Error("Expected text summary from todo");
+		// `a` stays the only open item; `b` leaves the remaining/open set but is surfaced as blocked.
+		expect(summary.text).toContain("Remaining items (1):");
+		expect(summary.text).toContain("1 blocked");
+
+		const unblocked = await tool.execute("call-3", { op: "unblock", task: "b" });
+		const bAfter = unblocked.details?.phases[0]?.tasks.find(task => task.content === "b");
+		expect(bAfter?.status).toBe("pending");
+		expect(bAfter?.blocker).toBeUndefined();
+	});
+
+	it("does not auto-promote a blocked task to in_progress", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["only"] }] });
+
+		const result = await tool.execute("call-2", { op: "block", task: "only" });
+
+		// `only` was in_progress; blocking it leaves no pending/in_progress, so normalization must not revive it.
+		expect(result.details?.phases[0]?.tasks[0]?.status).toBe("blocked");
+	});
+
+	it("preserves blocked status across the markdown round-trip", () => {
+		const phases: TodoPhase[] = [
+			{
+				name: "Work",
+				tasks: [
+					{ content: "a", status: "blocked", blocker: "x" },
+					{ content: "b", status: "completed" },
+				],
+			},
+		];
+		const md = phasesToMarkdown(phases);
+		expect(md).toContain("- [!] a");
+
+		const { phases: parsed, errors } = markdownToPhases(md);
+		expect(errors).toEqual([]);
+		expect(parsed[0]?.tasks.find(task => task.content === "a")?.status).toBe("blocked");
 	});
 
 	it("creates a phase when append targets a missing phase", async () => {


### PR DESCRIPTION
## What

Add a `blocked` todo status, with `block`/`unblock` operations and an optional blocker note.

## Why

Fixes #3581. There was no honest status for a task that is open but can't proceed because it waits on something the agent can't act on (a user decision, another agent, an external action). Leaving it `pending`/`in_progress` re-arms the stop-time incomplete-todo reminder every turn; `drop` marks it `abandoned` — wrong, and it leaves the tracker. `blocked` keeps the task visible but excluded from the reminder (via the existing `pending`/`in_progress` allowlist) and from auto-promotion.

## Testing

`packages/coding-agent/test/tools/todo.test.ts` — block/unblock transitions + blocker note; the summary excludes blocked from "remaining/open" and counts it distinctly; the markdown round-trip preserves `blocked` (`[!]` marker); a sole blocked task is not auto-promoted. Existing todo / reminder-loop / command-controller / todo-clear / acp-event-mapper suites pass (52 tests). The mode-layer `TodoStatus`, the ACP status map + `isTodoStatus` guard, the markdown markers, and the renderers were all synced (tsgo-verified exhaustive).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)