### PR TITLE
feat(coding-agent): add /clear in-place context reset command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Changed the `inlineToolDescriptors` setting ("Inline Tool Descriptors") from a boolean to a three-way enum (`auto` | `on` | `off`), defaulting to `auto`. `auto` inlines tool descriptors into the system prompt (and strips them from provider tool schemas) only for Gemini models, leaving them in the schemas otherwise; `on`/`off` force the behavior regardless of model. Existing `true`/`false` configs migrate to `on`/`off`.
 - Replaced `as string | undefined` inline casts with `typeof` guards in the TUI usage renderer's account identity resolution (`formatAccountLabel`, `formatUnlimitedReportLabel`, reset-credits label, and unlimited-plan tier), so empty-string metadata values fall through to the next fallback instead of being displayed
 
+### Added
+
+- Added `/clear` to reset the conversation context in place: it drops the current conversation (messages, queued turns, pending tool calls) and rotates provider stream state while keeping the session itself — id, title, cwd, model, and the on-disk transcript all survive, so the next turn starts from just the base system prompt + rules. Distinct from `/new` (mints a new session id and transcript), `/fresh` (provider stream state only), and `/compact`/`/shake` (carry context forward). ([#3580](https://github.com/can1357/oh-my-pi/issues/3580))
+
 ### Fixed
 
 - Fixed `snapcompact` compaction silently falling back to an LLM summary when local preflight rejects the archive; manual and auto snapcompact now fail locally with the blocker instead of making provider calls. ([#3599](https://github.com/can1357/oh-my-pi/issues/3599))

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -875,6 +875,41 @@ export class CommandController {
 		this.ctx.showStatus(`Fresh provider session started (${result.closedProviderSessions} ${stateLabel} pruned).`);
 	}
 
+	async handleClearContextCommand(): Promise<void> {
+		if (this.ctx.session.isCompacting) {
+			this.ctx.session.abortCompaction();
+			while (this.ctx.session.isCompacting) {
+				await Bun.sleep(10);
+			}
+		}
+		const result = await this.ctx.session.clearSessionContext();
+		if (!result) {
+			this.ctx.showWarning("Wait for the current response to finish or abort it before clearing the context.");
+			return;
+		}
+		// Drop the rendered transcript so the UI matches the now-empty model
+		// context (mirrors #runNewSessionFlow's container teardown, minus the
+		// new session — the session id, title, and transcript file all survive).
+		this.ctx.chatContainer.clear();
+		this.ctx.pendingMessagesContainer.clear();
+		this.ctx.compactionQueuedMessages = [];
+		this.ctx.streamingComponent = undefined;
+		this.ctx.streamingMessage = undefined;
+		this.ctx.pendingTools.clear();
+		this.ctx.statusLine.invalidate();
+		this.ctx.updateEditorTopBorder();
+		const noun = result.droppedCount === 1 ? "message" : "messages";
+		this.ctx.present([
+			new Spacer(1),
+			new Text(
+				`${theme.fg("accent", `${theme.status.success} Context cleared — ${result.droppedCount} ${noun} dropped; session continues.`)}`,
+				1,
+				1,
+			),
+		]);
+		this.ctx.ui.requestRender(true, { clearScrollback: true });
+	}
+
 	async handleDropCommand(): Promise<void> {
 		if (!this.ctx.sessionManager.getSessionFile()) {
 			this.ctx.showError("Nothing to drop (in-memory session)");

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3624,6 +3624,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleFreshCommand();
 	}
 
+	handleClearContextCommand(): Promise<void> {
+		return this.#commandController.handleClearContextCommand();
+	}
+
 	handleDropCommand(): Promise<void> {
 		this.#prepareSessionSwitch();
 		return this.#commandController.handleDropCommand();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -317,6 +317,7 @@ export interface InteractiveModeContext {
 	handleDebugTranscriptCommand(): Promise<void>;
 	handleClearCommand(): Promise<void>;
 	handleFreshCommand(): Promise<void>;
+	handleClearContextCommand(): Promise<void>;
 	handleDropCommand(): Promise<void>;
 	handleForkCommand(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -729,6 +729,11 @@ export interface FreshSessionResult {
 	closedProviderSessions: number;
 }
 
+export interface ClearSessionContextResult {
+	/** Number of live messages dropped from the model's context. */
+	droppedCount: number;
+}
+
 /** Internal marker for hook messages queued through the agent loop */
 // ============================================================================
 // Constants
@@ -4797,6 +4802,50 @@ export class AgentSession {
 			sessionId: this.sessionId,
 			closedProviderSessions,
 		};
+	}
+
+	/**
+	 * Reset the current conversation in place: drop every message, queued turn,
+	 * and pending tool call from the model's context while keeping the session
+	 * itself — its id, title, cwd, model, settings, and on-disk transcript all
+	 * survive. The next turn is sent with only the base system prompt plus the
+	 * project rules/AGENTS.md.
+	 *
+	 * This is the in-place sibling of {@link newSession}: it reuses the same
+	 * conversation-boundary teardown (drop the conversation, rotate provider-side
+	 * session state so providers that keep history server-side resume nothing,
+	 * re-prime the advisor, and undo any memory promotion) but skips minting a new
+	 * session id and opening a fresh transcript file. Unlike {@link freshSession}
+	 * (which only rotates provider stream state) it also clears the conversation.
+	 *
+	 * Returns `undefined` without mutating anything while a response is streaming.
+	 */
+	async clearSessionContext(): Promise<ClearSessionContextResult | undefined> {
+		if (this.isStreaming) return undefined;
+		const droppedCount = this.agent.state.messages.length;
+
+		// Drop the conversation: messages, queued steers/follow-ups, pending tool
+		// calls, and error state. agent.reset() keeps the model and system prompt.
+		this.agent.reset();
+		this.#pendingNextTurnMessages = [];
+		this.#scheduledHiddenNextTurnGeneration = undefined;
+
+		// Rotate provider-side session state so a provider that keeps conversation
+		// history server-side starts a brand-new exchange rather than resuming the
+		// context we just dropped (mirrors freshSession).
+		this.#closeAllProviderSessions("clear context");
+		this.#freshProviderSessionId = Bun.randomUUIDv7();
+		this.#syncAgentSessionId();
+		this.#rekeyHindsightMemoryForCurrentSessionId();
+		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.agent.appendOnlyContext?.invalidateForModelChange();
+
+		// Re-prime the advisor across the conversation boundary and undo any memory
+		// promotion so the next turn rebuilds from the base system prompt.
+		this.#resetAdvisorSessionState();
+		await this.#resetMemoryContextForNewTranscript();
+
+		return { droppedCount };
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1319,6 +1319,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "clear",
+		description: "Reset the conversation context in place, keeping the session",
+		getTuiAutocompleteDescription: runtime =>
+			runtime.ctx.session.isStreaming ? "Clear: unavailable while streaming" : "Clear: reset context, keep session",
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleClearContextCommand();
+		},
+	},
+	{
 		name: "drop",
 		description: "Delete the current session and start a new one",
 		handleTui: async (_command, runtime) => {

--- a/packages/coding-agent/test/agent-session-clear-context.test.ts
+++ b/packages/coding-agent/test/agent-session-clear-context.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("AgentSession.clearSessionContext", () => {
+	let tempDir: string;
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-clear-context-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		await fs.promises
+			.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+			.catch(() => undefined);
+		vi.restoreAllMocks();
+	});
+
+	async function createSession(): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["unused"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.create(tempDir, tempDir);
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		return session;
+	}
+
+	function seedConversation(active: AgentSession): void {
+		active.sessionManager.appendMessage({ role: "user", content: "first task", timestamp: Date.now() - 2 });
+		active.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "did the first task" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now() - 1,
+		});
+		active.agent.replaceMessages(active.sessionManager.buildSessionContext().messages);
+	}
+
+	it("drops live context to empty, reports the dropped count, and preserves session identity + transcript", async () => {
+		const active = await createSession();
+		await active.setSessionName("My long-lived session", "user");
+		seedConversation(active);
+		await active.sessionManager.flush();
+
+		const persistentId = active.sessionManager.getSessionId();
+		const title = active.sessionName;
+		const file = active.sessionFile;
+		expect(file).toBeDefined();
+		const liveBefore = active.messages.length;
+		const transcriptBefore = active.sessionManager.buildSessionContext().messages.length;
+		expect(liveBefore).toBeGreaterThan(0);
+		expect(transcriptBefore).toBeGreaterThan(0);
+
+		const result = await active.clearSessionContext();
+
+		// The live conversation is gone and the dropped count is reported.
+		expect(result).toEqual({ droppedCount: liveBefore });
+		expect(active.messages).toHaveLength(0);
+
+		// The session itself survives: persistent id, title, file path, and the
+		// on-disk transcript all remain — clearing context is not deleting history.
+		expect(active.sessionManager.getSessionId()).toBe(persistentId);
+		expect(active.sessionName).toBe(title);
+		expect(active.sessionFile).toBe(file);
+		expect(active.sessionManager.buildSessionContext().messages).toHaveLength(transcriptBefore);
+		const transcriptRaw = fs.readFileSync(file!, "utf8");
+		expect(transcriptRaw).toContain("first task");
+		expect(transcriptRaw).toContain("did the first task");
+	});
+
+	it("is a no-op that returns undefined while a response is streaming", async () => {
+		const active = await createSession();
+		seedConversation(active);
+		const liveBefore = active.messages.length;
+		expect(liveBefore).toBeGreaterThan(0);
+
+		// Drive the real streaming flag rather than spying (Bun's spyOn can't stub
+		// accessor getters); session.isStreaming reads agent.state.isStreaming.
+		active.agent.state.isStreaming = true;
+		const result = await active.clearSessionContext();
+		active.agent.state.isStreaming = false;
+
+		expect(result).toBeUndefined();
+		expect(active.messages).toHaveLength(liveBefore);
+	});
+});

--- a/packages/coding-agent/test/clear-command-dispatch.test.ts
+++ b/packages/coding-agent/test/clear-command-dispatch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { BUILTIN_SLASH_COMMAND_DEFS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+// Defends the discoverability + dispatch contract for /clear: it must be a
+// registered builtin (so TUI autocomplete lists it) and typing it must route to
+// the in-place context-reset handler — neither is covered by the type checker,
+// which cannot catch a wrong command-name string literal.
+function makeCtx() {
+	const handleClearContextCommand = vi.fn(async () => {});
+	let text = "";
+	const editor = {
+		onSubmit: undefined as undefined | ((t: string) => Promise<void>),
+		getText: () => text,
+		setText: (t: string) => {
+			text = t;
+		},
+		addToHistory: vi.fn(),
+		pendingImages: [] as unknown[],
+		pendingImageLinks: [] as unknown[],
+		clearDraft(historyText?: string) {
+			if (historyText !== undefined) editor.addToHistory(historyText);
+			text = "";
+		},
+	};
+	const ctx = {
+		editor,
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			queuedMessageCount: 0,
+			extensionRunner: undefined,
+		},
+		focusedAgentId: undefined,
+		collabGuest: undefined,
+		handleClearContextCommand,
+		showStatus: vi.fn(),
+		ui: { requestRender: vi.fn() },
+	} as unknown as InteractiveModeContext;
+	return { ctx, editor, handleClearContextCommand };
+}
+
+describe("/clear builtin command", () => {
+	it("is registered in the autocomplete command set with a description", () => {
+		const clear = BUILTIN_SLASH_COMMAND_DEFS.find(cmd => cmd.name === "clear");
+		expect(clear).toBeDefined();
+		expect(clear?.description).toBeTruthy();
+	});
+
+	it("routes a typed /clear to the in-place context reset handler", async () => {
+		const { ctx, editor, handleClearContextCommand } = makeCtx();
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("/clear");
+
+		expect(handleClearContextCommand).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What

Add `/clear`: an in-place conversation-context reset for the interactive TUI. It drops the current conversation — messages, queued turns, and pending tool calls — and rotates provider stream state, while keeping the session itself: id, title, cwd, model, settings, and the on-disk transcript all survive. The next turn is sent with just the base system prompt + project rules/AGENTS.md.

`AgentSession.clearSessionContext()` reuses the `/new` conversation-boundary teardown minus the session mint — `agent.reset()` (messages + queued steers/follow-ups + pending tool calls + error, keeping model and system prompt), clear `#pendingNextTurnMessages`, rotate provider-side session state (`#closeAllProviderSessions` + a fresh `#freshProviderSessionId` + rekey + `appendOnlyContext.invalidateForModelChange`, like `/fresh`), `#resetAdvisorSessionState()`, and `#resetMemoryContextForNewTranscript()` — returning `undefined` (no-op) while streaming. It never touches `sessionManager` (id/title/transcript file) or todos. `/clear` is a `handleTui` builtin (like `/new` and `/drop`) with a streaming-aware autocomplete description; ACP/headless `/clear` is intentionally out of scope (matches `/new`).

## Why

Fixes #3580. There was no command to wipe the current session's accumulated context *in place* while keeping the session. The existing reset paths each do something else:

- `/new` mints a new session id and opens a fresh transcript — it discards the id/title, so it's the wrong tool for a long-lived, named session.
- `/fresh` only rotates provider stream state; the conversation stays in context.
- `/compact` and `/shake` carry context forward (summary / heavy-content trim), not a hard reset.

For long sessions full of stale tool output, and for persistent named agents reused across task pickups, the missing primitive is "keep this session, drop its conversation context." `/clear` is that primitive, and an in-place context reset is standard muscle memory in interactive agent CLIs. Clearing context is not deleting history: the transcript stays on disk, so a later `/resume` restores it (the one behavior the issue left unspecified).

## Testing

- `packages/coding-agent/test/agent-session-clear-context.test.ts` — `clearSessionContext` drops the live context to empty and reports the dropped count; the persistent session id, title, file path, and the on-disk transcript all survive (history is not deleted); it is a no-op returning `undefined` while a response is streaming.
- `packages/coding-agent/test/clear-command-dispatch.test.ts` — `/clear` is registered in the autocomplete command set and typing `/clear` routes to the in-place reset handler (guards against a wrong command-name literal the type checker can't catch).
- Adjacent suites green (`available-commands`, `acp-builtins`, `input-controller-slash-history`, `command-controller-hotkeys` — 78 tests). `biome check` clean on all changed files; `tsgo` typecheck passes.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)