### PR TITLE
fix(providers): initialize Z.AI MCP search session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### Fixed
 
+- Fixed Z.AI web search to initialize the Streamable HTTP MCP session before calling `web_search_prime`, preserving the returned session ID for authenticated tool calls. ([#3619](https://github.com/can1357/oh-my-pi/issues/3619))
+
 - Fixed terminal hangs on Ctrl+Z (SIGTSTP) after running bash tool calls, and insulated MCP stdio servers from terminal job-control signals.
 - Fixed macOS `Cmd+V` silently dropping image-only clipboard pastes in supported terminals.
 - Fixed an infinite loop in auto-compaction when a single recent turn exceeded the compaction threshold.

--- a/packages/coding-agent/src/web/search/providers/zai.ts
+++ b/packages/coding-agent/src/web/search/providers/zai.ts
@@ -5,7 +5,7 @@
  * the unified SearchResponse shape used by the web search tool.
  */
 import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
-import { asRecord, asString } from "../../../web/scrapers/utils";
+import { isRecord } from "@oh-my-pi/pi-utils";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { dateToAgeSeconds } from "../utils";
@@ -54,49 +54,24 @@ interface JsonRpcPayload {
 	error?: JsonRpcError;
 }
 
-/** Resolve Z.AI API credentials through the unified auth storage pipeline. */
-export async function findApiKey(
-	authStorage: AuthStorage,
-	sessionId?: string,
-	signal?: AbortSignal,
-): Promise<string | null> {
-	return (await authStorage.getApiKey("zai", sessionId, { signal })) ?? null;
+interface ZaiMcpPostResult {
+	parsed?: unknown;
+	sessionId?: string;
 }
 
-async function callZaiTool(
-	apiKey: string,
-	args: Record<string, unknown>,
-	signal: AbortSignal | undefined,
-	fetchImpl: FetchImpl,
-): Promise<unknown> {
-	const response = await fetchImpl(ZAI_MCP_URL, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"Content-Type": "application/json",
-			Accept: "application/json, text/event-stream",
-		},
-		body: JSON.stringify({
-			jsonrpc: "2.0",
-			id: crypto.randomUUID(),
-			method: "tools/call",
-			params: {
-				name: ZAI_TOOL_NAME,
-				arguments: args,
-			},
-		}),
-		signal: withHardTimeout(signal),
-	});
+const ZAI_MCP_PROTOCOL_VERSION = "2025-03-26";
+const ZAI_MCP_CLIENT_INFO = {
+	name: "omp-coding-agent",
+	version: "1.0.0",
+};
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		const classified = classifyProviderHttpError("zai", response.status, errorText);
-		if (classified) throw classified;
-		throw new SearchProviderError("zai", `Z.AI MCP error (${response.status}): ${errorText}`, response.status);
-	}
+function asString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
 
-	const rawText = await response.text();
-
+function parseZaiMcpResponse(rawText: string): unknown {
 	const parsedMessages: unknown[] = [];
 	for (const line of rawText.split("\n")) {
 		const trimmed = line.trim();
@@ -118,8 +93,64 @@ async function callZaiTool(
 		}
 	}
 
-	const parsed = parsedMessages[parsedMessages.length - 1];
-	const parsedRecord = asRecord(parsed);
+	return parsedMessages[parsedMessages.length - 1];
+}
+
+async function postZaiMcp(
+	apiKey: string,
+	method: string,
+	params: Record<string, unknown>,
+	sessionId: string | undefined,
+	signal: AbortSignal | undefined,
+	fetchImpl: FetchImpl,
+	expectResponse: boolean,
+): Promise<ZaiMcpPostResult> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${apiKey}`,
+		"Content-Type": "application/json",
+		Accept: "application/json, text/event-stream",
+	};
+	if (sessionId) {
+		headers["Mcp-Session-Id"] = sessionId;
+	}
+
+	const body: Record<string, unknown> = {
+		jsonrpc: "2.0",
+		method,
+		params,
+	};
+	if (expectResponse) {
+		body.id = crypto.randomUUID();
+	}
+
+	const response = await fetchImpl(ZAI_MCP_URL, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(body),
+		signal: withHardTimeout(signal),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("zai", response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError("zai", `Z.AI MCP error (${response.status}): ${errorText}`, response.status);
+	}
+
+	const nextSessionId = response.headers.get("Mcp-Session-Id") ?? sessionId;
+	if (!expectResponse) {
+		await response.body?.cancel();
+		return { sessionId: nextSessionId };
+	}
+
+	return {
+		parsed: parseZaiMcpResponse(await response.text()),
+		sessionId: nextSessionId,
+	};
+}
+
+function readJsonRpcPayload(parsed: unknown): JsonRpcPayload {
+	const parsedRecord = isRecord(parsed) ? parsed : null;
 	const directErrorCode = typeof parsedRecord?.code === "number" ? parsedRecord.code : undefined;
 	const directErrorSuccess = parsedRecord?.success;
 	const directErrorMessage =
@@ -132,6 +163,10 @@ async function callZaiTool(
 		);
 	}
 
+	if (!isRecord(parsed)) {
+		throw new SearchProviderError("zai", "Failed to parse Z.AI MCP response", 500);
+	}
+
 	const payload = parsed as JsonRpcPayload;
 	if (payload.error) {
 		const status = typeof payload.error.code === "number" ? payload.error.code : 400;
@@ -142,11 +177,64 @@ async function callZaiTool(
 		);
 	}
 
-	const resultRecord = asRecord(payload.result);
+	return payload;
+}
+
+/** Resolve Z.AI API credentials through the unified auth storage pipeline. */
+export async function findApiKey(
+	authStorage: AuthStorage,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<string | null> {
+	return (await authStorage.getApiKey("zai", sessionId, { signal })) ?? null;
+}
+
+async function callZaiTool(
+	apiKey: string,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	fetchImpl: FetchImpl,
+): Promise<unknown> {
+	const initialized = await postZaiMcp(
+		apiKey,
+		"initialize",
+		{
+			protocolVersion: ZAI_MCP_PROTOCOL_VERSION,
+			capabilities: {},
+			clientInfo: ZAI_MCP_CLIENT_INFO,
+		},
+		undefined,
+		signal,
+		fetchImpl,
+		true,
+	);
+	if (initialized.parsed !== undefined) {
+		readJsonRpcPayload(initialized.parsed);
+	}
+
+	await postZaiMcp(apiKey, "notifications/initialized", {}, initialized.sessionId, signal, fetchImpl, false);
+
+	const toolCall = await postZaiMcp(
+		apiKey,
+		"tools/call",
+		{
+			name: ZAI_TOOL_NAME,
+			arguments: args,
+		},
+		initialized.sessionId,
+		signal,
+		fetchImpl,
+		true,
+	);
+	const payload = readJsonRpcPayload(toolCall.parsed);
+	const resultRecord = isRecord(payload.result) ? payload.result : null;
 	if (resultRecord?.isError === true) {
 		const content = Array.isArray(resultRecord.content) ? resultRecord.content : [];
 		const errorText = content
-			.map(item => asString(asRecord(item)?.text))
+			.map(item => {
+				if (!isRecord(item)) return null;
+				return asString(item.text);
+			})
 			.filter((text): text is string => text != null)
 			.join("\n")
 			.trim();
@@ -159,7 +247,7 @@ async function callZaiTool(
 		return payload.result;
 	}
 
-	return parsed;
+	return toolCall.parsed;
 }
 
 async function callZaiSearch(apiKey: string, params: ZaiSearchParams): Promise<unknown> {
@@ -204,8 +292,8 @@ function getSearchResults(value: unknown): ZaiSearchResult[] {
 	if (Array.isArray(value)) {
 		return value as ZaiSearchResult[];
 	}
-	const obj = asRecord(value);
-	if (!obj) return [];
+	if (!isRecord(value)) return [];
+	const obj = value;
 
 	const searchResult = obj.search_result;
 	if (Array.isArray(searchResult)) return searchResult as ZaiSearchResult[];
@@ -224,17 +312,15 @@ function parseSearchPayload(rawResult: unknown): {
 	const candidates: unknown[] = [rawResult];
 	const textParts: string[] = [];
 
-	const root = asRecord(rawResult);
-	if (root) {
-		if (root.structuredContent) candidates.push(root.structuredContent);
-		if (root.data) candidates.push(root.data);
-		if (root.result) candidates.push(root.result);
+	if (isRecord(rawResult)) {
+		if (rawResult.structuredContent) candidates.push(rawResult.structuredContent);
+		if (rawResult.data) candidates.push(rawResult.data);
+		if (rawResult.result) candidates.push(rawResult.result);
 
-		const content = root.content;
+		const content = rawResult.content;
 		if (Array.isArray(content)) {
 			for (const part of content) {
-				const partObj = asRecord(part);
-				const text = asString(partObj?.text);
+				const text = isRecord(part) ? asString(part.text) : null;
 				if (!text) continue;
 				textParts.push(text);
 				try {
@@ -249,7 +335,7 @@ function parseSearchPayload(rawResult: unknown): {
 	for (const candidate of candidates) {
 		const results = getSearchResults(candidate);
 		if (results.length > 0) {
-			const obj = asRecord(candidate) as ZaiWebSearchResponse | null;
+			const obj = isRecord(candidate) ? (candidate as ZaiWebSearchResponse) : null;
 			return {
 				results,
 				answer: textParts.length > 0 ? textParts.join("\n\n") : undefined,

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -4,13 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { InMemorySnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { editToolRenderer } from "@oh-my-pi/pi-coding-agent/edit/renderer";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { Text, type TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
-import { renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -456,7 +456,10 @@ describe("editToolRenderer", () => {
 			{
 				expanded: false,
 				isPartial: false,
-				renderContext: { editMode: "hashline", editDiffPreview: { error: "No changes would be made to other.ts." } },
+				renderContext: {
+					editMode: "hashline",
+					editDiffPreview: { error: "No changes would be made to other.ts." },
+				},
 			},
 			uiTheme,
 			{ input: "[a.ts#1a2b]\nMV b.ts" },

--- a/packages/coding-agent/test/web/search/zai.test.ts
+++ b/packages/coding-agent/test/web/search/zai.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { searchZai } from "@oh-my-pi/pi-coding-agent/web/search/providers/zai";
+
+interface CapturedRequest {
+	method: string | undefined;
+	headers: Headers;
+	body: Record<string, unknown>;
+}
+
+describe("Z.AI web search provider", () => {
+	it("initializes a Streamable HTTP MCP session before calling web_search_prime", async () => {
+		const capturedRequests: CapturedRequest[] = [];
+		const fetchImpl: FetchImpl = (_input, init) => {
+			const request = {
+				method: init?.method,
+				headers: new Headers(init?.headers),
+				body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+			};
+			capturedRequests.push(request);
+
+			if (request.body.method === "initialize") {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							jsonrpc: "2.0",
+							id: request.body.id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "zai-web-search", version: "test" },
+							},
+						}),
+						{
+							status: 200,
+							headers: { "Content-Type": "application/json", "Mcp-Session-Id": "zai-session-1" },
+						},
+					),
+				);
+			}
+
+			if (request.body.method === "notifications/initialized") {
+				return Promise.resolve(new Response(null, { status: 202 }));
+			}
+
+			expect(request.body.method).toBe("tools/call");
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						jsonrpc: "2.0",
+						id: request.body.id,
+						result: {
+							content: [
+								{
+									type: "text",
+									text: JSON.stringify({
+										search_result: [
+											{
+												title: "Z.AI search result",
+												content: "Search result content",
+												link: "https://example.com/zai",
+												media: "Example",
+											},
+										],
+									}),
+								},
+							],
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+		};
+		const authStorage = {
+			resolver(provider: string, options?: { sessionId?: string }) {
+				expect(provider).toBe("zai");
+				expect(options?.sessionId).toBe("session-zai-test");
+				return async () => "zai-test-key";
+			},
+			hasAuth(provider: string) {
+				return provider === "zai";
+			},
+		} as unknown as AuthStorage;
+
+		const response = await searchZai({
+			query: "omp z.ai search",
+			authStorage,
+			fetch: fetchImpl,
+			sessionId: "session-zai-test",
+		});
+
+		expect(capturedRequests.map(request => request.body.method)).toEqual([
+			"initialize",
+			"notifications/initialized",
+			"tools/call",
+		]);
+		expect(capturedRequests[0]?.headers.get("Authorization")).toBe("Bearer zai-test-key");
+		expect(capturedRequests[1]?.headers.get("Mcp-Session-Id")).toBe("zai-session-1");
+		expect(capturedRequests[2]?.headers.get("Mcp-Session-Id")).toBe("zai-session-1");
+		expect(response.sources).toEqual([
+			{
+				title: "Z.AI search result",
+				url: "https://example.com/zai",
+				snippet: "Search result content",
+				publishedDate: undefined,
+				ageSeconds: undefined,
+				author: "Example",
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Repro
`searchZai` was exercised with a fake Z.AI Streamable HTTP MCP endpoint using `cd packages/coding-agent && bun test test/web/search/zai.test.ts`; before the fix the first captured JSON-RPC method was `tools/call`, not `initialize`, matching the reported authenticated tool-call failure.

## Cause
`packages/coding-agent/src/web/search/providers/zai.ts` called Z.AI's `web_search_prime` MCP endpoint directly with `tools/call` and only a bearer token. Z.AI binds tool authentication to the Streamable HTTP MCP session created by `initialize`, so the direct call never sent the required `Mcp-Session-Id` on the tool request.

## Fix
- Added Z.AI MCP session setup: `initialize`, `notifications/initialized`, then `tools/call` with the returned `Mcp-Session-Id`.
- Reused the provider's injected `fetch` path and hard timeout for every Z.AI MCP POST.
- Added regression coverage for the request order, bearer header, session header, and parsed search response.
- Added the coding-agent changelog entry for #3619.

## Verification
Passed: `cd packages/coding-agent && bun test test/web/search/zai.test.ts`; `cd packages/coding-agent && bun biome check src/web/search/providers/zai.ts test/web/search/zai.test.ts CHANGELOG.md`; LSP diagnostics for `packages/coding-agent/src/web/search/providers/zai.ts` and `packages/coding-agent/test/web/search/zai.test.ts`. Skipped pre-publish gate: `bun check` fails on `main` after `bun run fix` for unrelated existing type/linkage errors in coding-agent CLI/model-registry files and the TypeScript edit benchmark package. Fixes #3619