### PR TITLE
fix(mcp): expand Claude plugin MCP header env vars

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- Fixed Claude marketplace plugin `.mcp.json` MCP servers to expand environment variables in `url` and `headers` before connecting. ([#3621](https://github.com/can1357/oh-my-pi/issues/3621))
 - Fixed Z.AI web search to initialize the Streamable HTTP MCP session before calling `web_search_prime`, preserving the returned session ID for authenticated tool calls. ([#3619](https://github.com/can1357/oh-my-pi/issues/3619))
 - Fixed terminal hangs on Ctrl+Z (SIGTSTP) after running bash tool calls, and insulated MCP stdio servers from terminal job-control signals.
 - Fixed macOS `Cmd+V` silently dropping image-only clipboard pastes in supported terminals.

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -17,6 +17,7 @@ import type { LoadContext, LoadResult } from "../capability/types";
 import {
 	type ClaudePluginRoot,
 	createSourceMeta,
+	expandEnvVarsDeep,
 	listClaudePluginRoots,
 	loadFilesFromDir,
 	scanSkillsFromDir,
@@ -327,8 +328,8 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				...(raw.args !== undefined && { args: substitutePluginRoot(raw.args, root.path) }),
 				...(raw.env !== undefined && { env: substitutePluginRoot(raw.env, root.path) }),
 				...(raw.cwd !== undefined && { cwd: substitutePluginRoot(raw.cwd, root.path) }),
-				...(raw.url !== undefined && { url: raw.url }),
-				...(raw.headers !== undefined && { headers: raw.headers }),
+				...(raw.url !== undefined && { url: expandEnvVarsDeep(raw.url) }),
+				...(raw.headers !== undefined && { headers: expandEnvVarsDeep(raw.headers) }),
 				...(raw.auth !== undefined && { auth: raw.auth }),
 				...(raw.oauth !== undefined && { oauth: raw.oauth }),
 				...(raw.type !== undefined && { transport: raw.type as MCPServer["transport"] }),

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -13,6 +13,7 @@ import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
+import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
 
@@ -391,6 +392,65 @@ describe("listClaudePluginRoots", () => {
 		expect(skills.all.find(skill => skill.name === "understand")?.frontmatter?.description).toBe(
 			"Build an understanding graph",
 		);
+	});
+
+	test("expands env placeholders in marketplace plugin MCP url and headers", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "context7");
+		const originalApiKey = process.env.OMP_PLUGIN_MCP_API_KEY;
+		const originalUrl = process.env.OMP_PLUGIN_MCP_URL;
+		const envPlaceholder = (name: string): string => ["$", "{", name, ":-}"].join("");
+		process.env.OMP_PLUGIN_MCP_API_KEY = "ctx7sk-test-key";
+		process.env.OMP_PLUGIN_MCP_URL = "https://mcp.context7.example";
+
+		try {
+			await fs.mkdir(pluginsDir, { recursive: true });
+			await fs.mkdir(pluginPath, { recursive: true });
+			await fs.writeFile(
+				path.join(pluginsDir, "installed_plugins.json"),
+				JSON.stringify({
+					version: 2,
+					plugins: {
+						"context7@claude-plugins-official": [
+							{
+								scope: "user",
+								installPath: pluginPath,
+								version: "1.0.0",
+								installedAt: "2026-06-01T00:00:00Z",
+								lastUpdated: "2026-06-01T00:00:00Z",
+							},
+						],
+					},
+				}),
+			);
+			await fs.writeFile(
+				path.join(pluginPath, ".mcp.json"),
+				JSON.stringify({
+					context7: {
+						type: "http",
+						url: `${envPlaceholder("OMP_PLUGIN_MCP_URL")}/mcp`,
+						headers: {
+							CONTEXT7_API_KEY: envPlaceholder("OMP_PLUGIN_MCP_API_KEY"),
+						},
+					},
+				}),
+			);
+
+			const result = await loadCapability<MCPServer>(mcpCapability.id, {
+				cwd: tempDir,
+				providers: ["claude-plugins"],
+			});
+			const server = result.all.find(item => item.name === "context7:context7");
+
+			expect(server).toBeDefined();
+			expect(server?.url).toBe("https://mcp.context7.example/mcp");
+			expect(server?.headers).toEqual({ CONTEXT7_API_KEY: "ctx7sk-test-key" });
+		} finally {
+			if (originalApiKey === undefined) delete process.env.OMP_PLUGIN_MCP_API_KEY;
+			else process.env.OMP_PLUGIN_MCP_API_KEY = originalApiKey;
+			if (originalUrl === undefined) delete process.env.OMP_PLUGIN_MCP_URL;
+			else process.env.OMP_PLUGIN_MCP_URL = originalUrl;
+		}
 	});
 
 	test("reads slash commands directory from plugin manifest slash-commands field", async () => {


### PR DESCRIPTION
## Repro
A focused Claude marketplace plugin fixture with a `.mcp.json` HTTP server using `${OMP_PLUGIN_MCP_URL:-}` and `${OMP_PLUGIN_MCP_API_KEY:-}` failed before the fix: `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts -t "expands env placeholders"` discovered the URL literally as `${OMP_PLUGIN_MCP_URL:-}/mcp`.

## Cause
`packages/coding-agent/src/discovery/claude-plugins.ts` built `MCPServer` entries in `loadMCPServers` by passing `raw.url` and `raw.headers` through unchanged, unlike the project-level `packages/coding-agent/src/discovery/mcp-json.ts` path that already calls `expandEnvVarsDeep` for those fields.

## Fix
- Imported `expandEnvVarsDeep` into the Claude marketplace plugin provider.
- Expanded marketplace plugin MCP `url` and `headers` while constructing each `MCPServer`.
- Added a regression test for a context7-style marketplace plugin `.mcp.json` HTTP server with env-backed URL and API-key header.
- Added a coding-agent changelog entry for the fix.

## Verification
`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts packages/coding-agent/test/discovery/mcp-json.test.ts` passed with 24 tests. `bun check` passed. Fixes #3621