### PR TITLE
fix(acp): resolve generated image blob refs in live updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed live ACP `generate_image` updates resolving OMP-internal image blob refs before sending renderable image content to clients. ([#3623](https://github.com/can1357/oh-my-pi/issues/3623))
+
 ## [16.2.0] - 2026-06-27
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -42,7 +42,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import { isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
+import { getBlobsDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import { disableProvider, enableProvider, reset as resetCapabilities } from "../../capability";
 import { Settings } from "../../config/settings";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -62,6 +62,7 @@ import { loadAllExtensions } from "../../modes/components/extensions/state-manag
 import { theme } from "../../modes/theme/theme";
 import { type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
 import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
+import { BlobStore, resolveImageDataSync } from "../../session/blob-store";
 import { isSilentAbort, SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
 import type { UsageStatistics } from "../../session/session-entries";
 import type { SessionInfo as StoredSessionInfo } from "../../session/session-listing";
@@ -445,6 +446,7 @@ export class AcpAgent implements Agent {
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
+	#blobs = new BlobStore(getBlobsDir());
 
 	constructor(connection: AgentSideConnection, createSession: CreateAcpSession, initialSession?: AgentSession) {
 		this.#connection = connection;
@@ -1187,11 +1189,21 @@ export class AcpAgent implements Agent {
 		}
 
 		this.#prepareLiveAssistantMessage(record, event);
+		const imageDataCache = new Map<string, string>();
+		const resolveImageDataForAcp = (data: string, mimeType: string | undefined): string => {
+			const key = `${mimeType ?? ""}\u0000${data}`;
+			const cached = imageDataCache.get(key);
+			if (cached !== undefined) return cached;
+			const resolved = resolveImageDataSync(this.#blobs, data);
+			imageDataCache.set(key, resolved);
+			return resolved;
+		};
 		for (const notification of mapAgentSessionEventToAcpSessionUpdates(event, record.session.sessionId, {
 			getMessageId: message => this.#getLiveMessageId(record, message),
 			getMessageProgress: message => this.#getLiveMessageProgress(record, message),
 			getToolArgs: toolCallId => record.toolArgsById.get(toolCallId),
 			cwd: record.session.sessionManager.getCwd(),
+			resolveImageData: resolveImageDataForAcp,
 		})) {
 			await this.#connection.sessionUpdate(notification);
 		}
@@ -2052,6 +2064,7 @@ export class AcpAgent implements Agent {
 		const notifications = mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, {
 			cwd,
 			getToolArgs: toolCallId => (toolCallId === message.toolCallId ? options.toolArgs : undefined),
+			resolveImageData: (data, _mimeType) => resolveImageDataSync(this.#blobs, data),
 		});
 		if (options.includeStart === false) {
 			return notifications;

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -20,6 +20,7 @@ interface AcpEventMapperOptions {
 	getMessageId?: (message: unknown) => string | undefined;
 	getMessageProgress?: (message: unknown) => MessageProgress | undefined;
 	getToolArgs?: (toolCallId: string) => unknown;
+	resolveImageData?: (data: string, mimeType: string | undefined) => string;
 	/**
 	 * Session cwd. Tool call locations sent to ACP clients must be absolute
 	 * (the editor host needs them to open or focus files). When provided,
@@ -179,7 +180,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 		case "tool_execution_update": {
 			const content = mergeToolUpdateContent(
 				buildToolStartContent(event.toolName, event.args),
-				extractToolCallContent(event.partialResult),
+				extractToolCallContent(event.partialResult, options),
 			);
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
@@ -197,7 +198,10 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_end": {
-			const resultContent = [...extractDiffToolCallContent(event.result), ...extractToolCallContent(event.result)];
+			const resultContent = [
+				...extractDiffToolCallContent(event.result),
+				...extractToolCallContent(event.result, options),
+			];
 			const content = mergeToolUpdateContent(
 				buildToolStartContent(event.toolName, getToolExecutionEndArgs(event, options)),
 				resultContent,
@@ -641,13 +645,15 @@ function terminalToolCallContent(terminalId: string): ToolCallContent {
 	return { type: "terminal", terminalId };
 }
 
-function extractToolCallContent(value: unknown): ToolCallContent[] {
-	const richContent = extractStructuredToolCallContent(value);
+function extractToolCallContent(value: unknown, options: AcpEventMapperOptions): ToolCallContent[] {
+	const richContent = extractStructuredToolCallContent(value, options);
+	const detailsImageContent = extractDetailsImageToolCallContent(value, options, richContent);
+	const combinedContent = [...richContent, ...detailsImageContent];
 	const terminalId = extractTerminalId(value);
 	const content =
-		terminalId && !hasTerminalContent(richContent, terminalId)
-			? [...richContent, terminalToolCallContent(terminalId)]
-			: richContent;
+		terminalId && !hasTerminalContent(combinedContent, terminalId)
+			? [...combinedContent, terminalToolCallContent(terminalId)]
+			: combinedContent;
 	const fallbackText = extractReadableText(value);
 	if (!fallbackText) {
 		return content;
@@ -658,7 +664,7 @@ function extractToolCallContent(value: unknown): ToolCallContent[] {
 	return [...content, textToolCallContent(fallbackText)];
 }
 
-function extractStructuredToolCallContent(value: unknown): ToolCallContent[] {
+function extractStructuredToolCallContent(value: unknown, options: AcpEventMapperOptions): ToolCallContent[] {
 	const blocks = getContentBlocks(value);
 	if (!blocks) {
 		return [];
@@ -666,7 +672,7 @@ function extractStructuredToolCallContent(value: unknown): ToolCallContent[] {
 
 	const content: ToolCallContent[] = [];
 	for (const block of blocks) {
-		const toolCallContent = toToolCallContent(block);
+		const toolCallContent = toToolCallContent(block, options);
 		if (toolCallContent) {
 			content.push(toolCallContent);
 		}
@@ -685,7 +691,7 @@ function getContentBlocks(value: unknown): unknown[] | undefined {
 	return Array.isArray(content) ? content : undefined;
 }
 
-function toToolCallContent(value: unknown): ToolCallContent | undefined {
+function toToolCallContent(value: unknown, options: AcpEventMapperOptions): ToolCallContent | undefined {
 	const type = getContentType(value);
 	if (!type) {
 		return undefined;
@@ -697,21 +703,8 @@ function toToolCallContent(value: unknown): ToolCallContent | undefined {
 			return text ? textToolCallContent(text) : undefined;
 		}
 		case "image":
-		case "audio": {
-			const data = extractStringProperty<BinaryLikeContent>(value, "data");
-			const mimeType = extractStringProperty<BinaryLikeContent>(value, "mimeType");
-			if (!data || !mimeType) {
-				return undefined;
-			}
-			return {
-				type: "content",
-				content: {
-					type,
-					data,
-					mimeType,
-				},
-			};
-		}
+		case "audio":
+			return binaryToolCallContent(type, value, options);
 		case "resource_link": {
 			const uri = extractStringProperty<ResourceLinkLikeContent>(value, "uri");
 			const name = extractStringProperty<ResourceLinkLikeContent>(value, "name");
@@ -767,6 +760,64 @@ function toToolCallContent(value: unknown): ToolCallContent | undefined {
 		default:
 			return undefined;
 	}
+}
+
+function binaryToolCallContent(
+	type: "image" | "audio",
+	value: unknown,
+	options: AcpEventMapperOptions,
+): ToolCallContent | undefined {
+	const data = extractStringProperty<BinaryLikeContent>(value, "data");
+	const mimeType = extractStringProperty<BinaryLikeContent>(value, "mimeType");
+	if (!data || !mimeType) {
+		return undefined;
+	}
+	return {
+		type: "content",
+		content: {
+			type,
+			data: type === "image" ? (options.resolveImageData?.(data, mimeType) ?? data) : data,
+			mimeType,
+		},
+	};
+}
+
+function extractDetailsImageToolCallContent(
+	value: unknown,
+	options: AcpEventMapperOptions,
+	existing: ToolCallContent[],
+): ToolCallContent[] {
+	const images = extractDetailsImages(value);
+	if (!images) {
+		return [];
+	}
+	const seen = new Set(existing.map(imageContentKey).filter((key): key is string => key !== undefined));
+	const content: ToolCallContent[] = [];
+	for (const image of images) {
+		const toolCallContent = binaryToolCallContent("image", image, options);
+		const key = imageContentKey(toolCallContent);
+		if (!toolCallContent || !key || seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		content.push(toolCallContent);
+	}
+	return content;
+}
+
+function extractDetailsImages(value: unknown): unknown[] | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const details = (value as DetailsContainer).details;
+	if (typeof details !== "object" || details === null) return undefined;
+	const images = (details as { images?: unknown }).images;
+	return Array.isArray(images) && images.length > 0 ? images : undefined;
+}
+
+function imageContentKey(value: ToolCallContent | undefined): string | undefined {
+	if (value?.type !== "content" || value.content.type !== "image") {
+		return undefined;
+	}
+	return `${value.content.mimeType}\u0000${value.content.data}`;
 }
 
 function extractEmbeddedResource(
@@ -846,6 +897,12 @@ function extractReadableText(value: unknown): string | undefined {
 		if (text.length > 0) {
 			return normalizeText(text);
 		}
+		if (hasBinaryContentBlock(contentBlocks)) {
+			return undefined;
+		}
+	}
+	if (extractDetailsImages(value)) {
+		return undefined;
 	}
 	if (isTerminalOnlyDetails(value)) {
 		return undefined;
@@ -893,6 +950,13 @@ function getContentType(value: unknown): string | undefined {
 	}
 	const type = (value as TypedValue).type;
 	return typeof type === "string" ? type : undefined;
+}
+
+function hasBinaryContentBlock(blocks: unknown[]): boolean {
+	return blocks.some(block => {
+		const type = getContentType(block);
+		return type === "image" || type === "audio";
+	});
 }
 
 function extractStringProperty<T extends object>(value: unknown, key: keyof T): string | undefined {

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -152,6 +152,17 @@ export class BlobStore {
 		}
 	}
 
+	/** Synchronous variant of {@link get}. */
+	getSync(hash: string): Buffer | null {
+		const blobPath = path.join(this.dir, hash);
+		try {
+			return fs.readFileSync(blobPath);
+		} catch (err) {
+			if (isEnoent(err)) return null;
+			throw err;
+		}
+	}
+
 	/** Check if a blob exists. */
 	async has(hash: string): Promise<boolean> {
 		try {
@@ -250,6 +261,19 @@ export async function resolveImageData(blobStore: BlobStore, data: string): Prom
 	if (!buffer) {
 		logger.warn("Blob not found for image reference", { hash });
 		return data; // Return the ref as-is; downstream will see invalid base64 but won't crash
+	}
+	return buffer.toString("base64");
+}
+
+/** Synchronous variant of {@link resolveImageData}. */
+export function resolveImageDataSync(blobStore: BlobStore, data: string): string {
+	const hash = parseBlobRef(data);
+	if (!hash) return data;
+
+	const buffer = blobStore.getSync(hash);
+	if (!buffer) {
+		logger.warn("Blob not found for image reference", { hash });
+		return data;
 	}
 	return buffer.toString("base64");
 }

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -392,6 +392,53 @@ describe("ACP event mapper", () => {
 		expect(update.locations).toEqual([{ path: "single.ts" }]);
 	});
 
+	it("resolves live image blob refs for ACP content without expanding rawOutput", () => {
+		const blobRef = "blob:sha256:77467fcfe2bbdc034e0eabb4778c9d7de521c0d7c3e0d0a62566468e4d7da3a5";
+		const resolvedImageData = "resolved-webp-base64";
+		const events: AgentSessionEvent[] = [
+			{
+				type: "tool_execution_update",
+				toolCallId: "tc-image-update",
+				toolName: "generate_image",
+				args: {},
+				partialResult: {
+					content: [{ type: "image", data: blobRef, mimeType: "image/webp" }],
+					details: { images: [{ data: blobRef, mimeType: "image/webp" }] },
+				},
+			} as AgentSessionEvent,
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-image-end",
+				toolName: "generate_image",
+				isError: false,
+				result: {
+					content: [{ type: "text", text: "Generated image saved." }],
+					details: { images: [{ data: blobRef, mimeType: "image/webp" }] },
+				},
+			} as AgentSessionEvent,
+		];
+
+		for (const event of events) {
+			const updates = mapAgentSessionEventToAcpSessionUpdates(event, "session-1", {
+				resolveImageData: data => (data === blobRef ? resolvedImageData : data),
+			});
+			const update = updates[0]!.update as {
+				content?: Array<{
+					type: string;
+					content?: { type: string; data?: string; mimeType?: string; text?: string };
+				}>;
+				rawOutput?: unknown;
+			};
+			const images = update.content?.filter(item => item.type === "content" && item.content?.type === "image") ?? [];
+
+			expect(images).toEqual([
+				{ type: "content", content: { type: "image", data: resolvedImageData, mimeType: "image/webp" } },
+			]);
+			expect(JSON.stringify(update.content)).not.toContain("blob:sha256:");
+			expect(JSON.stringify(update.rawOutput)).toContain(blobRef);
+		}
+	});
+
 	it("emits locations on tool_execution_update from args", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{


### PR DESCRIPTION
## Repro
A minimal live ACP `tool_execution_end` for `generate_image` reproduced the issue with `bun .wt/acp-blob-repro.ts`: the emitted `tool_call_update.content[0].content.data` and `rawOutput.details.images[0].data` both remained `blob:sha256:...`, and the compact JSON fallback duplicated that blob ref as visible text.

## Cause
`packages/coding-agent/src/modes/acp/acp-event-mapper.ts` mapped live `event.partialResult` / `event.result` directly into ACP `tool_call_update` content. Session replay uses `session-loader.resolveBlobRefsInEntries(...)`, but the live ACP path in `AcpAgent.#handlePromptEvent` did not provide equivalent blob resolution, and the mapper ignored `details.images[]` entries that lack `type: "image"`.

## Fix
- Added synchronous blob reads/resolution in `packages/coding-agent/src/session/blob-store.ts` for the sync ACP mapper path.
- Passed an ACP image-data resolver from `packages/coding-agent/src/modes/acp/acp-agent.ts` into live and replay mapping.
- Updated `packages/coding-agent/src/modes/acp/acp-event-mapper.ts` to resolve image content blob refs, emit `details.images[]` as ACP image content, dedupe duplicate content/details images, and avoid serializing binary image payloads as fallback text while leaving `rawOutput` compact.
- Added regression coverage in `packages/coding-agent/test/acp-event-mapper.test.ts` and documented the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/session-persistence-images.test.ts` passed with 33 tests / 167 assertions. `bun check` passed before push, and the pre-publish gate in `gh_push_branch` passed. Fixes #3623