### PR TITLE
fix(coding-agent): hide marketplace plugins from duplicate plugin lists

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed marketplace-installed plugins appearing in both the npm plugin list and the OMP extension-package status provider. ([#3628](https://github.com/can1357/oh-my-pi/issues/3628))
+
 ## [16.2.1] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -22,6 +22,7 @@ import { readDirEntries, readFile } from "../capability/fs";
 import type { LoadContext } from "../capability/types";
 import { getEnabledPlugins } from "../extensibility/plugins/loader";
 import { expandTilde } from "../tools/path-utils";
+import { listClaudePluginRoots } from "./helpers";
 
 /** A resolved extension package directory wired into the discovery surfaces. */
 export interface OmpExtensionRoot {
@@ -123,9 +124,9 @@ async function isDirectory(p: string): Promise<boolean> {
  * 1. CLI roots injected via {@link injectOmpExtensionCliRoots}
  * 2. Project `<cwd>/.omp/settings.json#extensions`
  * 3. User `~/.omp/agent/settings.json#extensions`
- * 4. Enabled plugins installed under `<plugins>/node_modules/` (e.g. via
- *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`)
- *
+ * 4. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
+ *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`). Marketplace
+ *    installs are loaded by the `claude-plugins` provider and are excluded here.
  * Only entries that resolve to a directory on disk are returned; file
  * entrypoints contribute zero sub-discovery surface and are filtered out.
  * Installed-plugin enumeration failures (missing lockfile, unreadable
@@ -167,20 +168,44 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 }
 
 /**
- * Enumerate every enabled installed plugin's package directory so its
- * conventional `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`,
- * `prompts/`, and `.mcp.json` are wired into discovery — mirrors how
- * `getAllPluginExtensionPaths` already feeds the extension factory loader.
+ * Enumerate every enabled npm/link plugin's package directory so its conventional
+ * `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`, `prompts/`, and
+ * `.mcp.json` are wired into discovery — mirrors how `getAllPluginExtensionPaths`
+ * already feeds the extension factory loader.
  *
- * Marketplace and `omp plugin link` installs write to the plugin manager's
- * `node_modules` (or symlink into it) rather than to `extensions:` in
- * settings; without this branch the sub-discovery provider would still miss
- * everything those install paths produce.
+ * Marketplace installs also create runtime symlinks for enable-state persistence,
+ * but their resources are discovered through the `claude-plugins` provider.
+ * Filtering them here prevents `/status` from showing the same plugin under both
+ * "Claude Code Marketplace" and "OMP Extension Packages".
  */
+async function realpathOrResolved(p: string): Promise<string> {
+	try {
+		return await fs.realpath(p);
+	} catch (err) {
+		if (isEnoent(err)) return path.resolve(p);
+		throw err;
+	}
+}
+
 async function listInstalledPluginRoots(ctx: LoadContext): Promise<InjectedRoot[]> {
 	try {
-		const plugins = await getEnabledPlugins(ctx.cwd, { home: ctx.home });
-		return plugins.map(({ path: p, scope }) => ({ path: p, level: scope }));
+		const [plugins, marketplaceRoots] = await Promise.all([
+			getEnabledPlugins(ctx.cwd, { home: ctx.home }),
+			listClaudePluginRoots(ctx.home, ctx.cwd),
+		]);
+		const marketplaceRealpaths = new Set(
+			await Promise.all(marketplaceRoots.roots.map(root => realpathOrResolved(root.path))),
+		);
+		const installedRoots = await Promise.all(
+			plugins.map(async plugin => ({
+				path: plugin.path,
+				scope: plugin.scope,
+				realpath: await realpathOrResolved(plugin.path),
+			})),
+		);
+		return installedRoots
+			.filter(root => !marketplaceRealpaths.has(root.realpath))
+			.map(({ path: p, scope }) => ({ path: p, level: scope }));
 	} catch (err) {
 		logger.debug("listInstalledPluginRoots: enumeration failed", { error: String(err) });
 		return [];

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -15,6 +15,7 @@ import { type GitSource, parseGitUrl } from "./git-url";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "./legacy-pi-compat";
 import { resolvePluginManifestEntries } from "./loader";
 import { getInstalledPluginsRegistryPath, readInstalledPluginsRegistry } from "./marketplace/registry";
+import { parsePluginId } from "./marketplace/types";
 import { extractPackageName, parsePluginSpec } from "./parser";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type {
@@ -223,26 +224,38 @@ export class PluginManager {
 		const registry = await readInstalledPluginsRegistry(getInstalledPluginsRegistryPath());
 		const packageRealpaths = new Map<string, Set<string>>();
 		await Promise.all(
-			Object.values(registry.plugins)
-				.flat()
-				.map(async entry => {
+			Object.entries(registry.plugins).flatMap(([pluginId, entries]) =>
+				entries.map(async entry => {
 					if (entry.scope !== "user") return;
 					const packageJsonPath = path.join(entry.installPath, "package.json");
+					const parsedId = parsePluginId(pluginId);
+					let packageName = parsedId?.name ?? pluginId;
 					try {
 						const pkg: RuntimePackageJson = await Bun.file(packageJsonPath).json();
+						if (typeof pkg.name === "string" && pkg.name.length > 0) {
+							packageName = pkg.name;
+						}
+					} catch (err) {
+						if (!isEnoent(err)) {
+							logger.debug("Failed to inspect marketplace plugin package path", {
+								path: entry.installPath,
+								error: String(err),
+							});
+							return;
+						}
+					}
+
+					try {
 						const installRealpath = await fs.promises.realpath(entry.installPath);
-						if (typeof pkg.name !== "string" || pkg.name.length === 0) return;
-						const realpaths = packageRealpaths.get(pkg.name) ?? new Set<string>();
+						const realpaths = packageRealpaths.get(packageName) ?? new Set<string>();
 						realpaths.add(installRealpath);
-						packageRealpaths.set(pkg.name, realpaths);
+						packageRealpaths.set(packageName, realpaths);
 					} catch (err) {
 						if (isEnoent(err)) return;
-						logger.debug("Failed to inspect marketplace plugin package path", {
-							path: entry.installPath,
-							error: String(err),
-						});
+						throw err;
 					}
 				}),
+			),
 		);
 		return packageRealpaths;
 	}

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -14,6 +14,7 @@ import {
 import { type GitSource, parseGitUrl } from "./git-url";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "./legacy-pi-compat";
 import { resolvePluginManifestEntries } from "./loader";
+import { getInstalledPluginsRegistryPath, readInstalledPluginsRegistry } from "./marketplace/registry";
 import { extractPackageName, parsePluginSpec } from "./parser";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type {
@@ -106,6 +107,9 @@ interface PluginPackageSnapshot {
 	readonly backupPath: string;
 }
 
+interface RuntimePackageJson {
+	name?: unknown;
+}
 // =============================================================================
 // Plugin Manager
 // =============================================================================
@@ -214,6 +218,31 @@ export class PluginManager {
 			installedNames.add(name);
 		}
 		return installedNames;
+	}
+	async #collectMarketplaceRuntimePackageNames(): Promise<Set<string>> {
+		const registry = await readInstalledPluginsRegistry(getInstalledPluginsRegistryPath());
+		const packageNames = new Set<string>();
+		await Promise.all(
+			Object.values(registry.plugins)
+				.flat()
+				.map(async entry => {
+					if (entry.scope !== "user") return;
+					const packageJsonPath = path.join(entry.installPath, "package.json");
+					try {
+						const pkg: RuntimePackageJson = await Bun.file(packageJsonPath).json();
+						if (typeof pkg.name === "string" && pkg.name.length > 0) {
+							packageNames.add(pkg.name);
+						}
+					} catch (err) {
+						if (isEnoent(err)) return;
+						logger.debug("Failed to inspect marketplace plugin package name", {
+							path: packageJsonPath,
+							error: String(err),
+						});
+					}
+				}),
+		);
+		return packageNames;
 	}
 
 	async #snapshotInstalledPackage(actualName: string | undefined): Promise<PluginPackageSnapshot | null> {
@@ -569,12 +598,15 @@ export class PluginManager {
 			if (!isEnoent(err)) throw err;
 		}
 
-		const projectOverrides = await this.#loadProjectOverrides();
-		const config = await this.#ensureConfigLoaded();
+		const [projectOverrides, config, marketplaceRuntimeNames] = await Promise.all([
+			this.#loadProjectOverrides(),
+			this.#ensureConfigLoaded(),
+			this.#collectMarketplaceRuntimePackageNames(),
+		]);
 		const plugins: InstalledPlugin[] = [];
 		const installedNames = this.#collectInstalledNames(deps, config);
-
 		for (const name of installedNames) {
+			if (!(name in deps) && marketplaceRuntimeNames.has(name)) continue;
 			const pluginPath = path.join(getPluginsNodeModules(), name);
 			const pluginPkgPath = path.join(pluginPath, "package.json");
 			let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
@@ -816,10 +848,14 @@ export class PluginManager {
 		});
 
 		const deps = pkg.dependencies || {};
-		const config = await this.#ensureConfigLoaded();
+		const [config, marketplaceRuntimeNames] = await Promise.all([
+			this.#ensureConfigLoaded(),
+			this.#collectMarketplaceRuntimePackageNames(),
+		]);
 		const installedNames = this.#collectInstalledNames(deps, config);
 
 		for (const name of installedNames) {
+			if (!(name in deps) && marketplaceRuntimeNames.has(name)) continue;
 			const pluginPath = path.join(nodeModulesPath, name);
 			const pluginPkgPath = path.join(pluginPath, "package.json");
 			const fromDependencies = name in deps;

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -219,9 +219,9 @@ export class PluginManager {
 		}
 		return installedNames;
 	}
-	async #collectMarketplaceRuntimePackageNames(): Promise<Set<string>> {
+	async #collectMarketplaceRuntimePackageRealpaths(): Promise<Map<string, Set<string>>> {
 		const registry = await readInstalledPluginsRegistry(getInstalledPluginsRegistryPath());
-		const packageNames = new Set<string>();
+		const packageRealpaths = new Map<string, Set<string>>();
 		await Promise.all(
 			Object.values(registry.plugins)
 				.flat()
@@ -230,19 +230,38 @@ export class PluginManager {
 					const packageJsonPath = path.join(entry.installPath, "package.json");
 					try {
 						const pkg: RuntimePackageJson = await Bun.file(packageJsonPath).json();
-						if (typeof pkg.name === "string" && pkg.name.length > 0) {
-							packageNames.add(pkg.name);
-						}
+						const installRealpath = await fs.promises.realpath(entry.installPath);
+						if (typeof pkg.name !== "string" || pkg.name.length === 0) return;
+						const realpaths = packageRealpaths.get(pkg.name) ?? new Set<string>();
+						realpaths.add(installRealpath);
+						packageRealpaths.set(pkg.name, realpaths);
 					} catch (err) {
 						if (isEnoent(err)) return;
-						logger.debug("Failed to inspect marketplace plugin package name", {
-							path: packageJsonPath,
+						logger.debug("Failed to inspect marketplace plugin package path", {
+							path: entry.installPath,
 							error: String(err),
 						});
 					}
 				}),
 		);
-		return packageNames;
+		return packageRealpaths;
+	}
+
+	async #isMarketplaceRuntimeLink(
+		name: string,
+		deps: Record<string, string>,
+		marketplaceRuntimeRealpaths: Map<string, Set<string>>,
+		pluginPath: string,
+	): Promise<boolean> {
+		if (name in deps) return false;
+		const realpaths = marketplaceRuntimeRealpaths.get(name);
+		if (!realpaths) return false;
+		try {
+			return realpaths.has(await fs.promises.realpath(pluginPath));
+		} catch (err) {
+			if (isEnoent(err)) return false;
+			throw err;
+		}
 	}
 
 	async #snapshotInstalledPackage(actualName: string | undefined): Promise<PluginPackageSnapshot | null> {
@@ -598,16 +617,16 @@ export class PluginManager {
 			if (!isEnoent(err)) throw err;
 		}
 
-		const [projectOverrides, config, marketplaceRuntimeNames] = await Promise.all([
+		const [projectOverrides, config, marketplaceRuntimeRealpaths] = await Promise.all([
 			this.#loadProjectOverrides(),
 			this.#ensureConfigLoaded(),
-			this.#collectMarketplaceRuntimePackageNames(),
+			this.#collectMarketplaceRuntimePackageRealpaths(),
 		]);
 		const plugins: InstalledPlugin[] = [];
 		const installedNames = this.#collectInstalledNames(deps, config);
 		for (const name of installedNames) {
-			if (!(name in deps) && marketplaceRuntimeNames.has(name)) continue;
 			const pluginPath = path.join(getPluginsNodeModules(), name);
+			if (await this.#isMarketplaceRuntimeLink(name, deps, marketplaceRuntimeRealpaths, pluginPath)) continue;
 			const pluginPkgPath = path.join(pluginPath, "package.json");
 			let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
 			try {
@@ -848,15 +867,15 @@ export class PluginManager {
 		});
 
 		const deps = pkg.dependencies || {};
-		const [config, marketplaceRuntimeNames] = await Promise.all([
+		const [config, marketplaceRuntimeRealpaths] = await Promise.all([
 			this.#ensureConfigLoaded(),
-			this.#collectMarketplaceRuntimePackageNames(),
+			this.#collectMarketplaceRuntimePackageRealpaths(),
 		]);
 		const installedNames = this.#collectInstalledNames(deps, config);
 
 		for (const name of installedNames) {
-			if (!(name in deps) && marketplaceRuntimeNames.has(name)) continue;
 			const pluginPath = path.join(nodeModulesPath, name);
+			if (await this.#isMarketplaceRuntimeLink(name, deps, marketplaceRuntimeRealpaths, pluginPath)) continue;
 			const pluginPkgPath = path.join(pluginPath, "package.json");
 			const fromDependencies = name in deps;
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -226,7 +226,9 @@ export class PluginManager {
 		await Promise.all(
 			Object.entries(registry.plugins).flatMap(([pluginId, entries]) =>
 				entries.map(async entry => {
-					if (entry.scope !== "user") return;
+					// Legacy registries written before `scope` was added omit the field;
+					// `listClaudePluginRoots` treats those as user-scoped, so do the same.
+					if ((entry.scope ?? "user") !== "user") return;
 					const packageJsonPath = path.join(entry.installPath, "package.json");
 					const parsedId = parsePluginId(pluginId);
 					let packageName = parsedId?.name ?? pluginId;

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -427,6 +427,18 @@ describe("MarketplaceManager", () => {
 				},
 			},
 		});
+
+		const spies = mockPluginManagerPaths(ctx.tmpDir);
+		try {
+			const manager = new PluginManager(ctx.tmpDir);
+			const plugins = await manager.list();
+			const checks = await manager.doctor();
+
+			expect(plugins.map(plugin => plugin.name)).toEqual([]);
+			expect(checks.filter(check => check.name.includes("csharp-lsp"))).toEqual([]);
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
 	});
 
 	it("installPlugin embeds config-only marketplace DAP metadata", async () => {

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -1,13 +1,16 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import { listOmpExtensionRoots } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
 import { getEnabledPlugins } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/loader";
+import { PluginManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/manager";
 import {
 	MarketplaceManager,
 	readInstalledPluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import * as piUtils from "@oh-my-pi/pi-utils";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 // Minimal marketplace fixture, built once into a temp dir (see beforeAll). It carries only
@@ -253,6 +256,48 @@ describe("MarketplaceManager", () => {
 			const enabled = await getEnabledPlugins(ctx.tmpDir, { home: tmpHome });
 			expect(enabled.map(plugin => plugin.name)).toEqual(["hello-plugin"]);
 			expect(enabled[0].path).toBe(path.join(pluginsDir, "node_modules", "hello-plugin"));
+		} finally {
+			fs.rmSync(tmpHome, { recursive: true, force: true });
+		}
+	});
+
+	it("installPlugin keeps marketplace packages out of the npm plugin list", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+
+		const spies = [
+			spyOn(piUtils, "getPluginsDir").mockReturnValue(ctx.tmpDir),
+			spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(path.join(ctx.tmpDir, "node_modules")),
+			spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(ctx.tmpDir, "package.json")),
+			spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(ctx.tmpDir, "omp-plugins.lock.json")),
+			spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(
+				path.join(ctx.tmpDir, "plugin-overrides.json"),
+			),
+		];
+		try {
+			const plugins = await new PluginManager(ctx.tmpDir).list();
+			expect(plugins.map(plugin => plugin.name)).toEqual([]);
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
+	});
+
+	it("installPlugin keeps marketplace packages out of OMP extension roots", async () => {
+		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mgr-home-"));
+		try {
+			const pluginsDir = path.join(tmpHome, ".omp", "plugins");
+			const manager = new MarketplaceManager({
+				marketplacesRegistryPath: path.join(tmpHome, ".omp", "marketplaces.json"),
+				installedRegistryPath: path.join(pluginsDir, "installed_plugins.json"),
+				marketplacesCacheDir: path.join(pluginsDir, "cache", "marketplaces"),
+				pluginsCacheDir: path.join(pluginsDir, "cache", "plugins"),
+			});
+
+			await manager.addMarketplace(FIXTURE_DIR);
+			await manager.installPlugin("hello-plugin", "test-marketplace");
+
+			const roots = await listOmpExtensionRoots({ cwd: tmpHome, home: tmpHome, repoRoot: null });
+			expect(roots.map(root => root.name)).toEqual([]);
 		} finally {
 			fs.rmSync(tmpHome, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -93,6 +93,16 @@ function createTestContext(): TestContext {
 	return { manager, tmpDir, clearCount: () => count };
 }
 
+function mockPluginManagerPaths(root: string) {
+	return [
+		spyOn(piUtils, "getPluginsDir").mockReturnValue(root),
+		spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(path.join(root, "node_modules")),
+		spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(root, "package.json")),
+		spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(root, "omp-plugins.lock.json")),
+		spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(root, "plugin-overrides.json")),
+	];
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("MarketplaceManager", () => {
@@ -265,18 +275,45 @@ describe("MarketplaceManager", () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
 
-		const spies = [
-			spyOn(piUtils, "getPluginsDir").mockReturnValue(ctx.tmpDir),
-			spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(path.join(ctx.tmpDir, "node_modules")),
-			spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(ctx.tmpDir, "package.json")),
-			spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(ctx.tmpDir, "omp-plugins.lock.json")),
-			spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(
-				path.join(ctx.tmpDir, "plugin-overrides.json"),
-			),
-		];
+		const spies = mockPluginManagerPaths(ctx.tmpDir);
 		try {
 			const plugins = await new PluginManager(ctx.tmpDir).list();
 			expect(plugins.map(plugin => plugin.name)).toEqual([]);
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
+	});
+
+	it("installPlugin keeps same-name local runtime links visible", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+
+		const localPlugin = path.join(ctx.tmpDir, "local-dev-plugin");
+		await Bun.write(
+			path.join(localPlugin, "package.json"),
+			`${JSON.stringify({
+				name: "hello-plugin",
+				version: "9.9.9",
+				omp: { tools: "tools" },
+			})}\n`,
+		);
+		fs.mkdirSync(path.join(localPlugin, "tools"), { recursive: true });
+		const linkPath = path.join(ctx.tmpDir, "node_modules", "hello-plugin");
+		fs.rmSync(linkPath, { recursive: true, force: true });
+		fs.symlinkSync(localPlugin, linkPath, "dir");
+
+		const spies = mockPluginManagerPaths(ctx.tmpDir);
+		try {
+			const manager = new PluginManager(ctx.tmpDir);
+			const plugins = await manager.list();
+			const checks = await manager.doctor();
+
+			expect(plugins.map(plugin => `${plugin.name}@${plugin.version}`)).toEqual(["hello-plugin@9.9.9"]);
+			expect(checks).toContainEqual({
+				name: "plugin:hello-plugin",
+				status: "ok",
+				message: "v9.9.9",
+			});
 		} finally {
 			for (const spy of spies) spy.mockRestore();
 		}

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -284,6 +284,35 @@ describe("MarketplaceManager", () => {
 		}
 	});
 
+	it("hides legacy marketplace entries that pre-date the scope field", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+
+		const registryPath = path.join(ctx.tmpDir, "installed_plugins.json");
+		const registry = (await Bun.file(registryPath).json()) as {
+			version: number;
+			plugins: Record<string, Array<Record<string, unknown>>>;
+		};
+		for (const entries of Object.values(registry.plugins)) {
+			for (const entry of entries) {
+				delete entry.scope;
+			}
+		}
+		await Bun.write(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+
+		const spies = mockPluginManagerPaths(ctx.tmpDir);
+		try {
+			const manager = new PluginManager(ctx.tmpDir);
+			const plugins = await manager.list();
+			const checks = await manager.doctor();
+
+			expect(plugins.map(plugin => plugin.name)).toEqual([]);
+			expect(checks.filter(check => check.name.includes("hello-plugin"))).toEqual([]);
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
+	});
+
 	it("installPlugin keeps same-name local runtime links visible", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");


### PR DESCRIPTION
## Repro
A temp `~/.omp/plugins` tree with an OMP marketplace `installed_plugins.json` entry, matching runtime symlink, and `omp-plugins.lock.json` entry reproduced the duplicate surfaces: `bun .wt/repro-3628.ts` returned `hello-package` from both `PluginManager.list()` and `listOmpExtensionRoots()` before the fix.

## Cause
`PluginManager.list()` in `packages/coding-agent/src/extensibility/plugins/manager.ts` treated every config-only `omp-plugins.lock.json#plugins` entry as an npm/plugin-manager install, including entries created by `MarketplaceManager.#registerRuntimePlugin`. `listInstalledPluginRoots()` in `packages/coding-agent/src/discovery/omp-extension-roots.ts` then fed the same marketplace runtime symlinks into the `omp-plugins` provider even though `claude-plugins` already discovers those marketplace roots from `installed_plugins.json`.

## Fix
- Filter marketplace-managed runtime packages out of `PluginManager.list()` and plugin doctor enumeration unless the package is also explicitly present in `package.json#dependencies`.
- Filter marketplace realpaths out of OMP extension-package roots so `/status` no longer shows the same marketplace resources under `Claude Code Marketplace` and `OMP Extension Packages`.
- Added marketplace regressions covering the npm list and OMP extension-root duplicate paths, plus a coding-agent changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/marketplace/manager.test.ts` (45 pass), `bun .wt/repro-3628.ts` (now reports empty `npmPlugins` and `ompExtensionRoots`), and `bun check` (passed). Fixes #3628