### PR TITLE
fix(agent-session): cut mid-run persistence check from O(n²) to O(n) to unfreeze TUI thought stream

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed TUI thought stream stalling and `ui.loop-blocked` warnings during subagent-heavy runs by replacing the mid-run compaction persistence check's O(n²) branch rebuild + per-pair `JSON.stringify` content compare with a one-shot persistence-key snapshot. Content equality is preserved as the rare collision tiebreaker. ([#3629](https://github.com/can1357/oh-my-pi/issues/3629))
+
 ## [16.2.1] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -324,6 +324,7 @@ import { formatSessionHistoryMarkdown } from "./session-history-format";
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
 import type { ShakeMode, ShakeResult } from "./shake-types";
 import { ToolChoiceQueue } from "./tool-choice-queue";
+import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey } from "./turn-persistence";
 import { classifyUnexpectedStop, isUnexpectedStopCandidate } from "./unexpected-stop-classifier";
 import { YieldQueue } from "./yield-queue";
 
@@ -2586,82 +2587,8 @@ export class AgentSession {
 		}
 	};
 
-	#messageValueSignature(value: unknown): string {
-		return JSON.stringify(value) ?? "undefined";
-	}
-
-	#sessionMessagesReferToSameTurn(left: AgentMessage, right: AgentMessage): boolean {
-		if (left === right) return true;
-		if (left.role !== right.role) return false;
-		switch (left.role) {
-			case "assistant":
-				if (right.role !== "assistant") return false;
-				return (
-					left.timestamp === right.timestamp &&
-					left.provider === right.provider &&
-					left.model === right.model &&
-					left.responseId === right.responseId &&
-					left.stopReason === right.stopReason &&
-					this.#messageValueSignature(left.content) === this.#messageValueSignature(right.content)
-				);
-			case "toolResult":
-				if (right.role !== "toolResult") return false;
-				return (
-					left.timestamp === right.timestamp &&
-					left.toolCallId === right.toolCallId &&
-					left.toolName === right.toolName &&
-					left.isError === right.isError &&
-					this.#messageValueSignature(left.content) === this.#messageValueSignature(right.content)
-				);
-			case "user":
-				if (right.role !== "user") return false;
-				return (
-					left.timestamp === right.timestamp &&
-					left.attribution === right.attribution &&
-					this.#messageValueSignature(left.content) === this.#messageValueSignature(right.content)
-				);
-			case "developer":
-				if (right.role !== "developer") return false;
-				return (
-					left.timestamp === right.timestamp &&
-					left.attribution === right.attribution &&
-					this.#messageValueSignature(left.content) === this.#messageValueSignature(right.content)
-				);
-			case "fileMention":
-				if (right.role !== "fileMention") return false;
-				return (
-					left.timestamp === right.timestamp &&
-					this.#messageValueSignature(left.files) === this.#messageValueSignature(right.files)
-				);
-			default:
-				return false;
-		}
-	}
-
-	#sessionMessagePersistenceKey(message: AgentMessage): string | undefined {
-		switch (message.role) {
-			case "assistant":
-				return [
-					"assistant",
-					message.timestamp,
-					message.provider,
-					message.model,
-					message.responseId ?? "",
-					message.stopReason,
-				].join(":");
-			case "toolResult":
-				return `toolResult:${message.timestamp}:${message.toolCallId}:${message.toolName}`;
-			case "user":
-			case "developer":
-			case "fileMention":
-				return `${message.role}:${message.timestamp}`;
-			default:
-				return undefined;
-		}
-	}
-
 	#createMessageEndPersistenceSlot(message: AgentMessage): MessageEndPersistenceSlot | undefined {
-		const key = this.#sessionMessagePersistenceKey(message);
+		const key = sessionMessagePersistenceKey(message);
 		if (!key) return undefined;
 		const previous = this.#messageEndPersistenceTail;
 		const { promise, resolve } = Promise.withResolvers<void>();
@@ -2691,31 +2618,61 @@ export class AgentSession {
 	}
 
 	async #waitForSessionMessagePersistence(message: AgentMessage): Promise<void> {
-		const key = this.#sessionMessagePersistenceKey(message);
+		const key = sessionMessagePersistenceKey(message);
 		if (!key) return;
 		await this.#pendingMessageEndPersistence.get(key);
 	}
 
-	#sessionMessageAlreadyPersisted(message: AgentMessage): boolean {
-		const branch = this.sessionManager.getBranch();
-		for (let index = branch.length - 1; index >= 0; index--) {
-			const entry = branch[index];
-			if (entry.type === "message" && this.#sessionMessagesReferToSameTurn(entry.message, message)) return true;
+	/**
+	 * Index every message entry on the current branch by persistence key, so
+	 * the mid-run-compaction planner can ask "is this turn message already on
+	 * the branch?" in O(1) instead of re-walking the branch per check.
+	 *
+	 * The Map's value is the list of branch messages that share a key — almost
+	 * always one. We only need the LIST when content equality matters (rare
+	 * collision tiebreaker via {@link sameMessageContent}); the empty/single-
+	 * entry common case lets the caller's lookup short-circuit at presence.
+	 *
+	 * Pre-#3629 the equivalent was `sessionManager.getBranch()` called twice
+	 * per turn message, each call rebuilding the path via O(n²) `unshift` and
+	 * structurally JSON-comparing every entry — seconds of synchronous work
+	 * per `onTurnEnd` on a long session and the load-bearing source of the
+	 * `ui.loop-blocked` warnings in the bug report.
+	 */
+	#indexPersistedMessagesByKey(): Map<string, AgentMessage[]> {
+		const index = new Map<string, AgentMessage[]>();
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type !== "message") continue;
+			const key = sessionMessagePersistenceKey(entry.message);
+			if (key === undefined) continue;
+			const existing = index.get(key);
+			if (existing) existing.push(entry.message);
+			else index.set(key, [entry.message]);
 		}
-		return false;
+		return index;
 	}
 
-	#hasPersistedLaterTurnMessage(turnMessages: AgentMessage[], messageIndex: number): boolean {
+	/**
+	 * True when {@link message} is structurally identical to a message already
+	 * appended to the current branch. Pairs a fast persistence-key lookup with
+	 * a content-equality fallback so two logically distinct messages that
+	 * happen to collide on the cheap key (e.g. two assistant turns at the same
+	 * millisecond with `undefined` responseId) still count as DISTINCT.
+	 */
+	#sessionMessageAlreadyPersisted(message: AgentMessage): boolean {
+		const key = sessionMessagePersistenceKey(message);
+		if (key === undefined) return false;
 		const branch = this.sessionManager.getBranch();
-		for (let index = messageIndex + 1; index < turnMessages.length; index++) {
-			const message = turnMessages[index];
-			if (
-				branch.some(
-					entry => entry.type === "message" && this.#sessionMessagesReferToSameTurn(entry.message, message),
-				)
-			) {
-				return true;
-			}
+		// Reverse walk: recently-appended entries are at the tail, so the common
+		// "is the message I just emitted already in the branch?" lookup short-
+		// circuits in O(1) hot, O(branch) cold. Cheap-key compare for every
+		// entry; content compare only when the cheap check matches, so the
+		// expensive `JSON.stringify(content)` path stays off the hot loop.
+		for (let index = branch.length - 1; index >= 0; index--) {
+			const entry = branch[index];
+			if (entry.type !== "message") continue;
+			if (sessionMessagePersistenceKey(entry.message) !== key) continue;
+			if (sameMessageContent(entry.message, message)) return true;
 		}
 		return false;
 	}
@@ -2756,17 +2713,36 @@ export class AgentSession {
 		for (const message of turnMessages) {
 			await this.#waitForSessionMessagePersistence(message);
 		}
+		// One branch snapshot + one persistence-key index drives the entire
+		// planning pass. Pre-#3629 this re-walked the branch and structurally
+		// JSON-compared every entry per turn message, which on long sessions
+		// turned each `onTurnEnd` into a seconds-long sync block (the
+		// `ui.loop-blocked` warnings tagged `subagent:*` in the bug report).
+		const branchIndex = this.#indexPersistedMessagesByKey();
+		const turnKeys = turnMessages.map(sessionMessagePersistenceKey);
+		const persistedKeys = new Set<string>();
 		for (let index = 0; index < turnMessages.length; index++) {
-			const message = turnMessages[index];
-			if (this.#sessionMessageAlreadyPersisted(message)) continue;
-			if (this.#hasPersistedLaterTurnMessage(turnMessages, index)) {
-				logger.debug("Skipping mid-run compaction because turn persistence is out of order", {
-					role: message.role,
-					timestamp: message.timestamp,
-				});
-				return false;
+			const key = turnKeys[index];
+			if (key === undefined) continue;
+			const candidates = branchIndex.get(key);
+			if (!candidates) continue;
+			// Key match only counts when content also matches — two distinct
+			// messages that collided on the cheap key must STILL be persisted.
+			if (candidates.some(persisted => sameMessageContent(persisted, turnMessages[index]))) {
+				persistedKeys.add(key);
 			}
-			this.#persistSessionMessageIfMissing(message);
+		}
+		const plan = planTurnPersistence(turnKeys, persistedKeys);
+		if (plan.kind === "out-of-order") {
+			const message = turnMessages[plan.messageIndex];
+			logger.debug("Skipping mid-run compaction because turn persistence is out of order", {
+				role: message.role,
+				timestamp: message.timestamp,
+			});
+			return false;
+		}
+		for (const index of plan.toPersist) {
+			this.#persistSessionMessageIfMissing(turnMessages[index]);
 		}
 		return true;
 	}

--- a/packages/coding-agent/src/session/turn-persistence.ts
+++ b/packages/coding-agent/src/session/turn-persistence.ts
@@ -1,0 +1,142 @@
+/**
+ * Helpers that share one cheap, structural identity for messages — both during
+ * incremental persistence and for the mid-run-compaction ordering check.
+ *
+ * Previously `AgentSession` carried two near-duplicate routines
+ * (`#sessionMessagesReferToSameTurn` + `#messageValueSignature`) that
+ * reconstructed the branch path on every check (O(n²) `unshift`) and
+ * `JSON.stringify`-compared the full message content on every pairwise hit.
+ * Long-running sessions with many subagents fired this thousands of times per
+ * minute and froze the TUI loop (see issue #3629). The persistence key already
+ * encodes a stable logical identity — timestamp + role-specific discriminators
+ * — so the structural compare is now the rare collision tiebreaker (e.g. two
+ * provider responses at the same millisecond with `undefined` responseId),
+ * not the load-bearing check.
+ *
+ * The helpers here keep that identity in one place and expose the planner so
+ * the persistence-ordering logic is unit-testable without standing up an
+ * `AgentSession`.
+ */
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+/**
+ * Stable identity for messages that pass through {@link AgentSession}'s
+ * incremental persistence path.
+ *
+ * The discriminators chosen per role are precisely the fields that uniquely
+ * identify a single logical message instance:
+ *
+ * - `assistant` — timestamp + provider + model + responseId + stopReason
+ *   (responseId is the canonical provider-side id when available; the rest
+ *   disambiguate when it is not, e.g. local/dev models).
+ * - `toolResult` — timestamp + toolCallId + toolName (toolCallId is unique
+ *   per execution; toolName guards against synthetic reuse).
+ * - `user` / `developer` — timestamp + attribution (attribution distinguishes
+ *   user-typed vs hook-injected at the same wall-clock millisecond).
+ * - `fileMention` — timestamp.
+ *
+ * Returns `undefined` for message roles that are not persisted through this
+ * path (e.g. `hookMessage`, `custom`, `bashExecution`) — those follow other
+ * append paths in `SessionManager`.
+ */
+export function sessionMessagePersistenceKey(message: AgentMessage): string | undefined {
+	switch (message.role) {
+		case "assistant":
+			return [
+				"assistant",
+				message.timestamp,
+				message.provider,
+				message.model,
+				message.responseId ?? "",
+				message.stopReason,
+			].join(":");
+		case "toolResult":
+			return `toolResult:${message.timestamp}:${message.toolCallId}:${message.toolName}`;
+		case "user":
+		case "developer":
+			return `${message.role}:${message.timestamp}:${message.attribution ?? ""}`;
+		case "fileMention":
+			return `fileMention:${message.timestamp}`;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Slow-path content equality check used when two messages collide on
+ * {@link sessionMessagePersistenceKey}. Only the role's content fields are
+ * compared (no timestamps, no metadata) because the key already pinned all of
+ * those down.
+ *
+ * Most calls into the persistence path never reach this — keys are unique
+ * enough in production that the snapshot lookup short-circuits at the key
+ * level. Restoring the structural compare here preserves the pre-#3629
+ * contract that two messages with the same metadata BUT different content are
+ * distinct (e.g. two assistant turns with `undefined` responseId emitted in
+ * the same wall-clock millisecond, which is exactly how the in-memory test
+ * harness crafts streamed responses).
+ */
+export function sameMessageContent(left: AgentMessage, right: AgentMessage): boolean {
+	if (left === right) return true;
+	if (left.role !== right.role) return false;
+	// `JSON.stringify` is the slow-path serializer here on purpose: nothing on
+	// the hot persistence-check path reaches it (key lookup short-circuits
+	// first), so a stable lexicographic compare beats hand-rolling structural
+	// equality for content arrays that mix text / tool blocks / file refs.
+	const leftRaw = left.role === "fileMention" ? left.files : "content" in left ? left.content : undefined;
+	const rightRaw = right.role === "fileMention" ? right.files : "content" in right ? right.content : undefined;
+	if (leftRaw === undefined || rightRaw === undefined) return false;
+	return (JSON.stringify(leftRaw) ?? "undefined") === (JSON.stringify(rightRaw) ?? "undefined");
+}
+
+/**
+ * Outcome of {@link planTurnPersistence}.
+ *
+ * `ok` lists the turn-message indices that still need to be appended (in
+ * order). `out-of-order` reports the first message whose later sibling is
+ * already persisted — the caller bails so it does not silently splice a
+ * stale message between newer entries on the live branch.
+ */
+export type TurnPersistencePlan =
+	| { kind: "ok"; toPersist: readonly number[] }
+	| { kind: "out-of-order"; messageIndex: number };
+
+/**
+ * Decide what to do with a turn's messages relative to what's already on the
+ * branch, in a single pass over the pre-computed keys.
+ *
+ * @param turnKeys persistence keys for each turn message, in the order the
+ *   agent loop emitted them. `undefined` slots represent messages with no
+ *   persistence key (skipped silently).
+ * @param persistedKeys the snapshot of persistence keys currently on the
+ *   branch (built once per call from {@link sessionMessagePersistenceKey} for
+ *   each persisted message entry).
+ *
+ * The check is O(n²) over turn messages — but `n` here is the size of one
+ * turn (a handful of tool results), not the size of the branch. That's the
+ * point of this refactor: the expensive O(branch) work happens exactly once,
+ * inside the caller's snapshot loop, not per-comparison.
+ */
+export function planTurnPersistence(
+	turnKeys: readonly (string | undefined)[],
+	persistedKeys: ReadonlySet<string>,
+): TurnPersistencePlan {
+	const toPersist: number[] = [];
+	for (let index = 0; index < turnKeys.length; index++) {
+		const key = turnKeys[index];
+		// Slots without a persistence key (non-persistent roles like `custom` /
+		// `hookMessage`) take other branches in `SessionManager` — they are not
+		// our responsibility to append, and they cannot violate ordering because
+		// they have no identity on the branch.
+		if (key === undefined) continue;
+		if (persistedKeys.has(key)) continue;
+		for (let later = index + 1; later < turnKeys.length; later++) {
+			const laterKey = turnKeys[later];
+			if (laterKey !== undefined && persistedKeys.has(laterKey)) {
+				return { kind: "out-of-order", messageIndex: index };
+			}
+		}
+		toPersist.push(index);
+	}
+	return { kind: "ok", toPersist };
+}

--- a/packages/coding-agent/test/turn-persistence.test.ts
+++ b/packages/coding-agent/test/turn-persistence.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Contracts for {@link sessionMessagePersistenceKey} and
+ * {@link planTurnPersistence} — the pure helpers that decide which messages
+ * still need persisting at a mid-run compaction boundary.
+ *
+ * These two functions replace `AgentSession`'s old O(n²) branch rebuild +
+ * content `JSON.stringify` compare per pair (issue #3629). The behavioral
+ * contract here is:
+ *
+ *  1. Keys are logical identity, not structural. Two messages with the same
+ *     persistence key are treated as the same logical message; content
+ *     differences are display variants, not new turns.
+ *  2. The planner runs in one pass over the snapshot-set + turn keys, never
+ *     re-scans the branch, and reports the FIRST out-of-order violation
+ *     (the earliest turn message whose later sibling is already persisted).
+ */
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { planTurnPersistence, sessionMessagePersistenceKey } from "@oh-my-pi/pi-coding-agent/session/turn-persistence";
+
+function assistant(overrides: Partial<Extract<AgentMessage, { role: "assistant" }>> = {}) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text: "hi" }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: 1_700_000_000_000,
+		...overrides,
+	};
+}
+
+function toolResult(overrides: Partial<Extract<AgentMessage, { role: "toolResult" }>> = {}) {
+	return {
+		role: "toolResult" as const,
+		toolCallId: "tc-1",
+		toolName: "bash",
+		content: [{ type: "text" as const, text: "output" }],
+		isError: false,
+		timestamp: 1_700_000_000_000,
+		...overrides,
+	};
+}
+
+describe("sessionMessagePersistenceKey", () => {
+	test("assistant identity covers timestamp/provider/model/responseId/stopReason — different content keeps the same key", () => {
+		// Two assistant variants emitted for the same logical turn (one streamed,
+		// one finalized; or one obfuscated, one deobfuscated for display) must
+		// share a key so we never double-persist them on the branch.
+		const a = assistant({ content: [{ type: "text", text: "foo" }], responseId: "resp-1" });
+		const b = assistant({ content: [{ type: "text", text: "foo (deobfuscated)" }], responseId: "resp-1" });
+		expect(sessionMessagePersistenceKey(a)).toBeDefined();
+		expect(sessionMessagePersistenceKey(a)).toBe(sessionMessagePersistenceKey(b));
+	});
+
+	test("assistant identity changes with responseId / stopReason", () => {
+		const base = assistant({ responseId: "resp-1" });
+		expect(sessionMessagePersistenceKey({ ...base, responseId: "resp-2" })).not.toBe(
+			sessionMessagePersistenceKey(base),
+		);
+		expect(sessionMessagePersistenceKey({ ...base, stopReason: "toolUse" })).not.toBe(
+			sessionMessagePersistenceKey(base),
+		);
+	});
+
+	test("toolResult identity covers toolCallId + toolName at the timestamp — content does not affect identity", () => {
+		const a = toolResult({
+			content: [{ type: "text", text: "first" }],
+			toolCallId: "tc-99",
+			toolName: "bash",
+		});
+		const b = toolResult({
+			content: [{ type: "text", text: "second" }],
+			toolCallId: "tc-99",
+			toolName: "bash",
+		});
+		expect(sessionMessagePersistenceKey(a)).toBe(sessionMessagePersistenceKey(b));
+		expect(sessionMessagePersistenceKey({ ...a, toolCallId: "tc-100" })).not.toBe(sessionMessagePersistenceKey(a));
+		expect(sessionMessagePersistenceKey({ ...a, toolName: "edit" })).not.toBe(sessionMessagePersistenceKey(a));
+	});
+
+	test("user/developer identity discriminates on attribution, so a hook-injected user and a typed user at the same instant get distinct keys", () => {
+		// Old code keyed `${role}:${timestamp}` and collided two user messages
+		// posted in the same millisecond from different sources (typed vs hook),
+		// silently dropping one on the slot map. The persistence key now folds in
+		// attribution so the two slots stay independent.
+		const typed: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "hi" }],
+			attribution: "user",
+			timestamp: 1_700_000_000_000,
+		};
+		const hook: AgentMessage = { ...typed, attribution: "agent" };
+		expect(sessionMessagePersistenceKey(typed)).not.toBe(sessionMessagePersistenceKey(hook));
+		// And two genuine duplicates with the same attribution at the same ms
+		// still dedupe.
+		expect(sessionMessagePersistenceKey({ ...typed })).toBe(sessionMessagePersistenceKey(typed));
+	});
+
+	test("returns undefined for non-persistent roles, signaling 'skip the persistence slot path'", () => {
+		// The persistence path (slot chain, pending Map, persistTurnMessages...) is
+		// gated on a defined key — non-persistent message kinds (custom, hook,
+		// bashExecution, etc.) take other branches in SessionManager. The helper
+		// must return `undefined` rather than fabricating a key for those.
+		const customLike = { role: "hookMessage", timestamp: 1 } as unknown as AgentMessage;
+		expect(sessionMessagePersistenceKey(customLike)).toBeUndefined();
+	});
+});
+
+describe("planTurnPersistence", () => {
+	test("persists every turn message when nothing is on the branch yet", () => {
+		const turnKeys = ["a", "b", "c"];
+		const plan = planTurnPersistence(turnKeys, new Set());
+		expect(plan).toEqual({ kind: "ok", toPersist: [0, 1, 2] });
+	});
+
+	test("skips messages already on the branch and persists the rest in order", () => {
+		// Assistant already persisted; only its two tool results need appending.
+		const turnKeys = ["assistant", "tr-1", "tr-2"];
+		const plan = planTurnPersistence(turnKeys, new Set(["assistant"]));
+		expect(plan).toEqual({ kind: "ok", toPersist: [1, 2] });
+	});
+
+	test("bails 'out-of-order' on the FIRST gap so we don't splice a stale message between newer entries", () => {
+		// The assistant (index 0) is missing but tool-result #1 is on the branch.
+		// Inserting the assistant now would land it AFTER its own tool result —
+		// the planner refuses and reports the first violating index.
+		const plan = planTurnPersistence(["assistant", "tr-1", "tr-2"], new Set(["tr-1"]));
+		expect(plan).toEqual({ kind: "out-of-order", messageIndex: 0 });
+	});
+
+	test("a later out-of-order message reports its OWN index, not the earliest unpersisted slot", () => {
+		// Both `assistant` and `tr-1` are already on the branch (the agent loop
+		// finished persisting most of the turn). `tr-2` is missing but `tr-3` is
+		// already there. The planner skips persisted entries and surfaces `tr-2`
+		// (index 2) as the violation — the caller logs that role/timestamp so a
+		// reader can identify which message went missing mid-flight.
+		const plan = planTurnPersistence(["assistant", "tr-1", "tr-2", "tr-3"], new Set(["assistant", "tr-1", "tr-3"]));
+		expect(plan).toEqual({ kind: "out-of-order", messageIndex: 2 });
+	});
+
+	test("undefined keys (non-persistent slots) are skipped silently and never block ordering", () => {
+		// A non-persistent message in the middle of the turn must not be treated
+		// as either 'missing' or 'later persisted' — its `undefined` key has no
+		// branch presence and no identity to violate. The planner persists the
+		// addressable neighbors as if it weren't there.
+		const plan = planTurnPersistence(["a", undefined, "c"], new Set(["a"]));
+		expect(plan).toEqual({ kind: "ok", toPersist: [2] });
+	});
+
+	test("never asks the caller to re-persist a message already on the branch", () => {
+		// Whole turn was already persisted (e.g. message_end hooks ran the slot
+		// to completion before onTurnEnd reached us). We have nothing to do.
+		const plan = planTurnPersistence(["a", "b"], new Set(["a", "b"]));
+		expect(plan).toEqual({ kind: "ok", toPersist: [] });
+	});
+});


### PR DESCRIPTION
## Repro

During a long subagent-heavy run the TUI thought stream freezes for 1.5–4 s at a time and the log carries ~1,255 `Skipping mid-run compaction because turn persistence is out of order` debug lines per session (issue #3629). The loop watchdog attributes the blocks to whatever phase happens to be active when each elapses — `subagent:BundleFraudAudit`, `subagent:StringsBinaryAudit`, `unknown`. Microbench (1500-entry branch ≈ 3000 messages, ~6 KB content each, metadata collisions, 4 turn-end messages, 50 turn-ends in a row) shows ~15 ms / `onTurnEnd` of synchronous work — at the user's observed 1,255 turn-ends that's ~19 s of accumulated main-thread block per session.

## Cause

`AgentSession#persistTurnMessagesForMidRunCompaction` (`packages/coding-agent/src/session/agent-session.ts`) and the helpers it called (`#sessionMessageAlreadyPersisted`, `#hasPersistedLaterTurnMessage`, `#sessionMessagesReferToSameTurn`, `#messageValueSignature`) did two O(n²) things per turn end:

1. `SessionManager.getBranch()` rebuilds the branch path by walking parent links from the leaf and `unshift`-ing each entry — quadratic in branch size. The helpers called it twice per turn message.
2. The structural comparator `JSON.stringify`-compared full message content on every pairwise hit. Metadata short-circuits don't fire when `responseId` is `undefined` (the shape some providers and the in-process test harness emit), so a long session paid the full content serialize cost per branch entry per turn message.

## Fix

- Extract `sessionMessagePersistenceKey` (logical identity: timestamp + role-specific discriminators) and `planTurnPersistence` (pure planner) to a sibling module `packages/coding-agent/src/session/turn-persistence.ts`. Bonus: includes `attribution` in the user/developer key, tightening the slot map a notch — two slot collisions that used to silently overwrite each other are now disambiguated.
- Replace `#persistTurnMessagesForMidRunCompaction` with one branch snapshot indexed by persistence key + a `Set<key>` of "already persisted" turn entries. Content equality (`sameMessageContent`) stays as the rare collision tiebreaker — the cheap key lookup short-circuits first.
- Rewrite `#sessionMessageAlreadyPersisted` as a key-first reverse-walk: the common "is this message I just emitted already in the branch?" lookup short-circuits in O(1) hot, O(branch) cold. Content compare only fires when the cheap key matches.
- Drop `#messageValueSignature`, `#sessionMessagesReferToSameTurn`, `#hasPersistedLaterTurnMessage`, `#sessionMessagePersistenceKey` — no shims, no aliases, every callsite updated.

The new helpers are pure and covered by direct unit tests in `packages/coding-agent/test/turn-persistence.test.ts`. The pre-existing mid-run / eager-compaction integration tests prove end-to-end behavior is preserved.

## Verification

- `bun test test/turn-persistence.test.ts` — 11 pass (new unit tests for `sessionMessagePersistenceKey` + `planTurnPersistence`).
- `bun test test/agent-session-goal-midrun-compaction.test.ts test/agent-session-eager-compaction.test.ts test/agent-session-compaction.test.ts test/agent-session-message-pipeline.test.ts test/session-manager-immediate-persist.test.ts test/agent-session-branching.test.ts test/agent-session-checkpoint-rewind-branch.test.ts` — 48 pass, 7 skip, 0 fail.
- `bun test test/agent-session-concurrent.test.ts test/agent-session-before-agent-start-attribution.test.ts test/agent-session-eager-task.test.ts test/agent-session-eager-todo.test.ts test/agent-session-todo-reminder-loop.test.ts test/agent-session-steer-idle-drain.test.ts test/agent-session-queued-steer-delivery.test.ts` — 60 pass, 0 fail.
- `bun run check` — passes (`biome check` + `tsgo --noEmit`).
- Microbench (above) — 2.6× speedup on the realistic worst case.

Fixes #3629