### PR TITLE
fix(web-search): retry empty Tavily recency results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Tavily web search with recency filters to retry once without `time_range` when Tavily returns HTTP 200 with no renderable content. ([#3633](https://github.com/can1357/oh-my-pi/issues/3633))
+
 ## [16.2.1] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/web/search/providers/tavily.ts
+++ b/packages/coding-agent/src/web/search/providers/tavily.ts
@@ -120,25 +120,7 @@ async function callTavilySearch(apiKey: string, params: TavilySearchParams): Pro
 	return (await response.json()) as TavilySearchResponse;
 }
 
-/** Execute Tavily web search. */
-export async function searchTavily(params: SearchParams): Promise<SearchResponse> {
-	const tavilyParams: TavilySearchParams = {
-		query: params.query,
-		num_results: params.numSearchResults ?? params.limit,
-		recency: params.recency,
-		signal: params.signal,
-		fetch: params.fetch,
-	};
-	const keyOrResolver: ApiKey = params.authStorage.resolver("tavily", {
-		sessionId: params.sessionId,
-	});
-
-	const numResults = clampNumResults(tavilyParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
-	const response = await withAuth(keyOrResolver, key => callTavilySearch(key, tavilyParams), {
-		signal: params.signal,
-		missingKeyMessage:
-			'Tavily credentials not found. Set TAVILY_API_KEY or configure an API key for provider "tavily".',
-	});
+function toSearchResponse(response: TavilySearchResponse, numResults: number): SearchResponse {
 	const sources: SearchSource[] = [];
 
 	for (const result of response.results ?? []) {
@@ -159,6 +141,41 @@ export async function searchTavily(params: SearchParams): Promise<SearchResponse
 		requestId: response.request_id ?? undefined,
 		authMode: "api_key",
 	};
+}
+
+function hasRenderableResponse(response: SearchResponse): boolean {
+	if (response.answer?.trim()) return true;
+	return response.sources.length > 0;
+}
+
+/** Execute Tavily web search. */
+export async function searchTavily(params: SearchParams): Promise<SearchResponse> {
+	const tavilyParams: TavilySearchParams = {
+		query: params.query,
+		num_results: params.numSearchResults ?? params.limit,
+		recency: params.recency,
+		signal: params.signal,
+		fetch: params.fetch,
+	};
+	const keyOrResolver: ApiKey = params.authStorage.resolver("tavily", {
+		sessionId: params.sessionId,
+	});
+
+	const numResults = clampNumResults(tavilyParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	const authOptions = {
+		signal: params.signal,
+		missingKeyMessage:
+			'Tavily credentials not found. Set TAVILY_API_KEY or configure an API key for provider "tavily".',
+	};
+	const callWithAuth = (searchParams: TavilySearchParams) =>
+		withAuth(keyOrResolver, key => callTavilySearch(key, searchParams), authOptions);
+
+	const response = toSearchResponse(await callWithAuth(tavilyParams), numResults);
+	if (!tavilyParams.recency || hasRenderableResponse(response)) {
+		return response;
+	}
+
+	return toSearchResponse(await callWithAuth({ ...tavilyParams, recency: undefined }), numResults);
 }
 
 /** Search provider for Tavily web search. */

--- a/packages/coding-agent/test/tools/web-search-tavily.test.ts
+++ b/packages/coding-agent/test/tools/web-search-tavily.test.ts
@@ -99,6 +99,68 @@ describe("Tavily web search provider", () => {
 		expect(response.sources[0]?.ageSeconds).toBeTypeOf("number");
 	});
 
+	it("retries recency-filtered empty responses without time_range", async () => {
+		const requestBodies: Record<string, unknown>[] = [];
+		const responses = [
+			new Response(JSON.stringify({ answer: "", request_id: "empty-month", results: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+			new Response(
+				JSON.stringify({
+					answer: "Fallback Tavily answer",
+					request_id: "fallback-without-time-range",
+					results: [
+						{
+							title: "Latest release notes",
+							url: "https://example.com/release-notes",
+							content: "Release note snippet",
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		];
+
+		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			requestBodies.push(JSON.parse(String(init?.body ?? "null")) as Record<string, unknown>);
+			const response = responses.shift();
+			if (!response) throw new Error("unexpected extra Tavily request");
+			return response;
+		};
+
+		const response = await searchTavily({
+			...makeParams("Oh My Pi omp latest release notes advisor"),
+			numSearchResults: 5,
+			recency: "month",
+			fetch: fetchMock,
+		});
+
+		expect(requestBodies).toHaveLength(2);
+		expect(requestBodies[0]).toMatchObject({
+			query: "Oh My Pi omp latest release notes advisor",
+			max_results: 5,
+			time_range: "month",
+		});
+		expect(requestBodies[1]).toMatchObject({
+			query: "Oh My Pi omp latest release notes advisor",
+			max_results: 5,
+		});
+		expect(requestBodies[1]).not.toHaveProperty("time_range");
+		expect(response).toMatchObject({
+			provider: "tavily",
+			answer: "Fallback Tavily answer",
+			requestId: "fallback-without-time-range",
+			sources: [
+				{
+					title: "Latest release notes",
+					url: "https://example.com/release-notes",
+					snippet: "Release note snippet",
+				},
+			],
+		});
+	});
+
 	it("surfaces structured API errors", async () => {
 		const fetchMock = (): Promise<Response> =>
 			Promise.resolve(


### PR DESCRIPTION
## Repro
A focused provider repro stubbed Tavily to return HTTP 200 with `answer: ""` and `results: []` for `Oh My Pi omp latest release notes advisor` while OMP sent `time_range: "month"`; `searchTavily` returned no answer and `sources: []`, matching the no-renderable-content failure seen by `omp search "Oh My Pi omp latest release notes advisor" --provider=tavily --recency=month -l 5 --compact`.

## Cause
`packages/coding-agent/src/web/search/providers/tavily.ts` passed `recency` directly as Tavily `time_range` and returned the 200 response as-is even when it contained no answer or usable results; `packages/coding-agent/src/web/search/index.ts` then rejected that provider response because `hasRenderableSearchContent` had no answer, sources, citations, related questions, or search queries to render.

## Fix
- Map Tavily API responses through a reusable response adapter before returning.
- Detect Tavily recency-filtered responses that have no renderable answer or source.
- Retry those Tavily searches once without `time_range`, preserving the filtered result when it contains renderable content.
- Added a regression test covering the first request with `time_range: "month"` and the fallback request without `time_range`.

## Verification
`bun test packages/coding-agent/test/tools/web-search-tavily.test.ts` passed with 4 tests and 11 assertions; `gh_push_branch` completed the repository pre-publish gate before pushing. Fixes #3633