### PR TITLE
feat(stats): add session health dashboard

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a Health dashboard to `omp stats` with session-level retry, cancellation, tool-loop, edit-churn, compaction, model-switch, subagent fanout, and large-result analytics. The next sync reparses existing sessions once to backfill the new health table.
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -13,12 +13,17 @@ import {
 	getModelPerformanceSeries,
 	getModelTimeSeries,
 	getOverallStats,
+	getSessionHealthByKind,
+	getSessionHealthByTool,
+	getSessionHealthOverall,
+	getSessionHealthTimeSeries,
 	getStatsByAgentType,
 	getStatsByFolder,
 	getStatsByModel,
 	getTimeSeries,
 	initDb,
 	insertMessageStats,
+	insertSessionHealthStats,
 	insertUserMessageStats,
 	setFileOffset,
 	updateUserMessageLinks,
@@ -29,7 +34,13 @@ import type { SyncWorkerRequest, SyncWorkerResponse } from "./sync-worker";
 // hidden argv mode, so the compiled binary and npm bundle only need one
 // JavaScript entry. Standalone source `omp-stats` keeps using this package's
 // own sync-worker source file.
-import type { BehaviorDashboardStats, DashboardStats, MessageStats, RequestDetails } from "./types";
+import type {
+	BehaviorDashboardStats,
+	DashboardStats,
+	HealthDashboardStats,
+	MessageStats,
+	RequestDetails,
+} from "./types";
 
 /**
  * Apply a freshly parsed result to the database. Runs entirely on the
@@ -38,6 +49,7 @@ import type { BehaviorDashboardStats, DashboardStats, MessageStats, RequestDetai
 function applyParseResult(sessionFile: string, lastModified: number, result: ParseSessionResult): number {
 	if (result.stats.length > 0) insertMessageStats(result.stats);
 	if (result.userStats.length > 0) insertUserMessageStats(result.userStats);
+	if (result.healthStats.length > 0) insertSessionHealthStats(result.healthStats);
 	if (result.userLinks.length > 0) updateUserMessageLinks(result.userLinks);
 	setFileOffset(sessionFile, result.newOffset, lastModified);
 	return result.stats.length + result.userStats.length;
@@ -452,5 +464,16 @@ export async function getBehaviorDashboardStats(range?: string | null): Promise<
 		overall: getBehaviorOverall(cutoff),
 		byModel: getBehaviorByModel(cutoff),
 		behaviorSeries: getBehaviorTimeSeries(cutoff),
+	};
+}
+
+export async function getSessionHealthDashboardStats(range?: string | null): Promise<HealthDashboardStats> {
+	await initDb();
+	const { cutoff } = getTimeRangeConfig(range);
+	return {
+		overall: getSessionHealthOverall(cutoff),
+		byKind: getSessionHealthByKind(cutoff),
+		byTool: getSessionHealthByTool(cutoff),
+		healthSeries: getSessionHealthTimeSeries(cutoff),
 	};
 }

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -7,6 +7,7 @@ import {
 	CostsRoute,
 	ErrorsRoute,
 	GainRoute,
+	HealthRoute,
 	ModelsRoute,
 	OverviewRoute,
 	ProjectsRoute,
@@ -76,6 +77,8 @@ export default function App() {
 				return <CostsRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
 			case "behavior":
 				return <BehaviorRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
+			case "health":
+				return <HealthRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
 			case "projects":
 				return <ProjectsRoute active={isActive} range={range} refreshTrigger={refreshTrigger} />;
 			case "gain":

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -3,6 +3,7 @@ import type {
 	CostDashboardStats,
 	FolderStats,
 	GainDashboardStats,
+	HealthDashboardStats,
 	MessageStats,
 	ModelDashboardStats,
 	OverviewStats,
@@ -75,6 +76,15 @@ export async function getBehaviorDashboardStats(
 	signal?: AbortSignal,
 ): Promise<BehaviorDashboardStats> {
 	return fetchJson<BehaviorDashboardStats>(`${API_BASE}/stats/behavior?range=${encodeURIComponent(range)}`, {
+		signal,
+	});
+}
+
+export async function getSessionHealthDashboardStats(
+	range: TimeRange = "24h",
+	signal?: AbortSignal,
+): Promise<HealthDashboardStats> {
+	return fetchJson<HealthDashboardStats>(`${API_BASE}/stats/health?range=${encodeURIComponent(range)}`, {
 		signal,
 	});
 }

--- a/packages/stats/src/client/app/routes.ts
+++ b/packages/stats/src/client/app/routes.ts
@@ -1,4 +1,14 @@
-import { Activity, AlertCircle, Coins, Cpu, Folder, LayoutDashboard, Smile, TrendingUp } from "lucide-react";
+import {
+	Activity,
+	AlertCircle,
+	Coins,
+	Cpu,
+	Folder,
+	HeartPulse,
+	LayoutDashboard,
+	Smile,
+	TrendingUp,
+} from "lucide-react";
 import type React from "react";
 
 export type DashboardSection =
@@ -8,6 +18,7 @@ export type DashboardSection =
 	| "models"
 	| "costs"
 	| "behavior"
+	| "health"
 	| "projects"
 	| "gain";
 
@@ -49,6 +60,11 @@ export const routes: DashboardRoute[] = [
 		label: "Behavior",
 		shortLabel: "Behavior",
 		icon: Smile,
+	},
+	{
+		id: "health",
+		label: "Health",
+		icon: HeartPulse,
 	},
 	{
 		id: "projects",

--- a/packages/stats/src/client/data/useHashRoute.ts
+++ b/packages/stats/src/client/data/useHashRoute.ts
@@ -9,6 +9,7 @@ const VALID_SECTIONS: DashboardSection[] = [
 	"models",
 	"costs",
 	"behavior",
+	"health",
 	"projects",
 	"gain",
 ];

--- a/packages/stats/src/client/routes/HealthRoute.tsx
+++ b/packages/stats/src/client/routes/HealthRoute.tsx
@@ -1,0 +1,307 @@
+import { useMemo } from "react";
+import { Line } from "react-chartjs-2";
+import { getSessionHealthDashboardStats } from "../api";
+import { buildSharedPlugins, buildSharedScales, CHART_THEMES, lineDatasetStyle } from "../components/chart-shared";
+import { formatBytes, formatCompact, formatInteger } from "../data/formatters";
+import { useResource } from "../data/useResource";
+import type {
+	HealthDimensionStats,
+	HealthEventKind,
+	HealthKindStats,
+	HealthOverallStats,
+	HealthTimeSeriesPoint,
+	TimeRange,
+} from "../types";
+import { AsyncBoundary, DataTable, Panel } from "../ui";
+import { useSystemTheme } from "../useSystemTheme";
+
+export interface HealthRouteProps {
+	active: boolean;
+	range: TimeRange;
+	refreshTrigger: number;
+}
+
+const KIND_LABELS: Record<HealthEventKind, string> = {
+	retry: "Retries",
+	tool_loop: "Tool loops",
+	cancellation: "Cancellations",
+	edit_churn: "Edit churn",
+	compaction: "Compactions",
+	model_switch: "Model switches",
+	subagent_spawn: "Subagent fanout",
+	large_result: "Large results",
+};
+
+const HEALTH_COLORS = {
+	retries: "rgb(236, 72, 153)",
+	cancellations: "rgb(239, 68, 68)",
+	loops: "rgb(168, 85, 247)",
+	edits: "rgb(34, 197, 94)",
+	largeResults: "rgb(14, 165, 233)",
+	fanout: "rgb(245, 158, 11)",
+} as const;
+
+export function HealthRoute({ active, range, refreshTrigger }: HealthRouteProps) {
+	const {
+		data: stats,
+		error,
+		loading,
+	} = useResource(["health", range, refreshTrigger], signal => getSessionHealthDashboardStats(range, signal), {
+		pollMs: 30_000,
+		enabled: active,
+	});
+
+	return (
+		<div className="stats-route-container space-y-6">
+			<AsyncBoundary loading={loading} error={error} data={stats} empty={stats?.overall.totalEvents === 0}>
+				{stats && (
+					<>
+						<HealthSummaryPanel overall={stats.overall} />
+						<HealthTrendPanel healthSeries={stats.healthSeries} />
+						<HealthKindTable rows={stats.byKind} />
+						<HealthDimensionTable rows={stats.byTool} />
+					</>
+				)}
+			</AsyncBoundary>
+		</div>
+	);
+}
+
+function HealthSummaryPanel({ overall }: { overall: HealthOverallStats }) {
+	const editDelta = overall.editLinesAdded + overall.editLinesRemoved;
+	return (
+		<Panel title="Session Health" subtitle="Operational signals extracted from session transcripts">
+			<div className="stats-metric-primary-grid">
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Health Events</div>
+					<div className="stats-metric-value">{formatInteger(overall.totalEvents)}</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Retries</div>
+					<div className="stats-metric-value">{formatInteger(overall.retryCount)}</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Cancellations</div>
+					<div className="stats-metric-value">{formatInteger(overall.cancellationCount)}</div>
+				</div>
+				<div className="stats-metric-card primary">
+					<div className="stats-metric-label">Tool Loop Repeats</div>
+					<div className="stats-metric-value">{formatInteger(overall.toolLoopCount)}</div>
+				</div>
+			</div>
+			<div className="stats-metric-secondary-grid mt-4">
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Files Changed</div>
+					<div className="stats-metric-value">{formatInteger(overall.editFilesChanged)}</div>
+				</div>
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Edit Line Churn</div>
+					<div className="stats-metric-value">{formatInteger(editDelta)}</div>
+				</div>
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Compactions</div>
+					<div className="stats-metric-value">{formatInteger(overall.compactionCount)}</div>
+				</div>
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Model Switches</div>
+					<div className="stats-metric-value">{formatInteger(overall.modelSwitchCount)}</div>
+				</div>
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Subagent Fanout</div>
+					<div className="stats-metric-value">{formatInteger(overall.subagentSpawnCount)}</div>
+				</div>
+				<div className="stats-metric-card secondary">
+					<div className="stats-metric-label">Large Result Bytes</div>
+					<div className="stats-metric-value">{formatBytes(overall.largeResultBytes)}</div>
+				</div>
+			</div>
+		</Panel>
+	);
+}
+
+function HealthTrendPanel({ healthSeries }: { healthSeries: HealthTimeSeriesPoint[] }) {
+	const theme = useSystemTheme();
+	const chartTheme = CHART_THEMES[theme];
+
+	const { data, options } = useMemo(() => {
+		const labelFormatter = new Intl.DateTimeFormat(undefined, {
+			month: "short",
+			day: "numeric",
+			timeZone: "UTC",
+		});
+		const labels = healthSeries.map(point => labelFormatter.format(new Date(point.timestamp)));
+		const chartData = {
+			labels,
+			datasets: [
+				{
+					label: "Retries",
+					data: healthSeries.map(point => point.retryCount),
+					...lineDatasetStyle(HEALTH_COLORS.retries),
+				},
+				{
+					label: "Cancellations",
+					data: healthSeries.map(point => point.cancellationCount),
+					...lineDatasetStyle(HEALTH_COLORS.cancellations),
+				},
+				{
+					label: "Tool loops",
+					data: healthSeries.map(point => point.toolLoopCount),
+					...lineDatasetStyle(HEALTH_COLORS.loops),
+				},
+				{
+					label: "Edit lines",
+					data: healthSeries.map(point => point.editLinesAdded + point.editLinesRemoved),
+					...lineDatasetStyle(HEALTH_COLORS.edits),
+				},
+				{
+					label: "Large results",
+					data: healthSeries.map(point => point.largeResultCount),
+					...lineDatasetStyle(HEALTH_COLORS.largeResults),
+				},
+				{
+					label: "Subagents",
+					data: healthSeries.map(point => point.subagentSpawnCount),
+					...lineDatasetStyle(HEALTH_COLORS.fanout),
+				},
+			],
+		};
+		const plugins = buildSharedPlugins({
+			chartTheme,
+			showLegend: true,
+			defaultLabel: "Events",
+			formatValue: formatCompact,
+		});
+		const { sharedScaleBase, yScale } = buildSharedScales({ chartTheme, formatY: formatCompact });
+		return {
+			data: chartData,
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				interaction: { mode: "index" as const, intersect: false },
+				plugins,
+				scales: { x: sharedScaleBase, y: yScale },
+			},
+		};
+	}, [healthSeries, chartTheme]);
+
+	return (
+		<Panel title="Health Trends" subtitle="Daily operational signals">
+			{healthSeries.length > 0 ? (
+				<div style={{ height: 320 }}>
+					<Line data={data} options={options} />
+				</div>
+			) : (
+				<div className="stats-table-empty">No health events in this range</div>
+			)}
+		</Panel>
+	);
+}
+
+function HealthKindTable({ rows }: { rows: HealthKindStats[] }) {
+	const columns = useMemo(
+		() => [
+			{ key: "kind", header: "Kind", render: (row: HealthKindStats) => KIND_LABELS[row.kind] },
+			{
+				key: "events",
+				header: "Events",
+				render: (row: HealthKindStats) => formatInteger(row.totalEvents),
+				numeric: true,
+			},
+			{
+				key: "retries",
+				header: "Retries",
+				render: (row: HealthKindStats) => formatInteger(row.retryCount),
+				numeric: true,
+			},
+			{
+				key: "loops",
+				header: "Loops",
+				render: (row: HealthKindStats) => formatInteger(row.toolLoopCount),
+				numeric: true,
+			},
+			{
+				key: "cancellations",
+				header: "Cancels",
+				render: (row: HealthKindStats) => formatInteger(row.cancellationCount),
+				numeric: true,
+			},
+			{
+				key: "edit",
+				header: "Edit Δ",
+				render: (row: HealthKindStats) => formatInteger(row.editLinesAdded + row.editLinesRemoved),
+				numeric: true,
+			},
+			{
+				key: "large",
+				header: "Large",
+				render: (row: HealthKindStats) => formatInteger(row.largeResultCount),
+				numeric: true,
+			},
+		],
+		[],
+	);
+	return (
+		<Panel title="Health by Kind" subtitle="Aggregate event categories">
+			<DataTable columns={columns} data={rows} keyExtractor={row => row.kind} emptyText="No health events" />
+		</Panel>
+	);
+}
+
+function dimensionLabel(row: HealthDimensionStats): string {
+	if (row.toolName) return row.toolName;
+	if (row.provider && row.model) return `${row.provider}/${row.model}`;
+	return row.model ?? row.provider ?? "—";
+}
+
+function HealthDimensionTable({ rows }: { rows: HealthDimensionStats[] }) {
+	const columns = useMemo(
+		() => [
+			{ key: "kind", header: "Kind", render: (row: HealthDimensionStats) => KIND_LABELS[row.kind] },
+			{ key: "dimension", header: "Tool / Model", render: dimensionLabel },
+			{
+				key: "events",
+				header: "Events",
+				render: (row: HealthDimensionStats) => formatInteger(row.totalEvents),
+				numeric: true,
+			},
+			{
+				key: "signals",
+				header: "Signals",
+				render: (row: HealthDimensionStats) => signalSummary(row),
+			},
+			{
+				key: "largeBytes",
+				header: "Large Bytes",
+				render: (row: HealthDimensionStats) => formatBytes(row.largeResultBytes),
+				numeric: true,
+			},
+		],
+		[],
+	);
+	return (
+		<Panel title="Tool and Model Drilldown" subtitle="Loop, churn, large-result, retry, and model-switch dimensions">
+			<DataTable
+				columns={columns}
+				data={rows}
+				keyExtractor={row => `${row.kind}:${row.toolName ?? ""}:${row.provider ?? ""}:${row.model ?? ""}`}
+				emptyText="No dimensional health events"
+			/>
+		</Panel>
+	);
+}
+
+function signalSummary(row: HealthDimensionStats): string {
+	const parts: string[] = [];
+	if (row.retryCount) parts.push(`${formatInteger(row.retryCount)} retries`);
+	if (row.toolLoopCount) parts.push(`${formatInteger(row.toolLoopCount)} loops`);
+	if (row.cancellationCount) parts.push(`${formatInteger(row.cancellationCount)} cancels`);
+	if (row.editFilesChanged) parts.push(`${formatInteger(row.editFilesChanged)} files`);
+	if (row.editLinesAdded || row.editLinesRemoved) {
+		parts.push(`+${formatInteger(row.editLinesAdded)} / -${formatInteger(row.editLinesRemoved)}`);
+	}
+	if (row.compactionCount) parts.push(`${formatInteger(row.compactionCount)} compactions`);
+	if (row.modelSwitchCount) parts.push(`${formatInteger(row.modelSwitchCount)} switches`);
+	if (row.subagentSpawnCount) parts.push(`${formatInteger(row.subagentSpawnCount)} spawns`);
+	if (row.largeResultCount) parts.push(`${formatInteger(row.largeResultCount)} large`);
+	return parts.join(" · ") || "—";
+}

--- a/packages/stats/src/client/routes/index.ts
+++ b/packages/stats/src/client/routes/index.ts
@@ -2,6 +2,7 @@ export * from "./BehaviorRoute";
 export * from "./CostsRoute";
 export * from "./ErrorsRoute";
 export * from "./GainRoute";
+export * from "./HealthRoute";
 export * from "./ModelsRoute";
 export * from "./OverviewRoute";
 export * from "./ProjectsRoute";

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -14,10 +14,15 @@ import type {
 	BehaviorTimeSeriesPoint,
 	CostTimeSeriesPoint,
 	FolderStats,
+	HealthDimensionStats,
+	HealthKindStats,
+	HealthOverallStats,
+	HealthTimeSeriesPoint,
 	MessageStats,
 	ModelPerformancePoint,
 	ModelStats,
 	ModelTimeSeriesPoint,
+	SessionHealthStats,
 	TimeSeriesPoint,
 	UserMessageLink,
 	UserMessageStats,
@@ -46,6 +51,7 @@ const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
 const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 const AGENT_TYPE_BACKFILL_KEY = "agent_type_v1";
 const FORK_DEDUPE_KEY = "fork_dedupe_v1";
+const SESSION_HEALTH_BACKFILL_KEY = "session_health_v1";
 function shouldResetBackfill(value: string | undefined): boolean {
 	return value !== BACKFILL_COMPLETE && value !== BACKFILL_PENDING;
 }
@@ -135,6 +141,37 @@ export async function initDb(): Promise<Database> {
 		CREATE INDEX IF NOT EXISTS idx_user_messages_timestamp ON user_messages(timestamp);
 		CREATE INDEX IF NOT EXISTS idx_user_messages_timestamp_model ON user_messages(timestamp, model, provider);
 
+
+		CREATE TABLE IF NOT EXISTS session_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_file TEXT NOT NULL,
+			entry_id TEXT NOT NULL,
+			folder TEXT NOT NULL,
+			timestamp INTEGER NOT NULL,
+			agent_type TEXT NOT NULL DEFAULT 'main',
+			kind TEXT NOT NULL,
+			tool_name TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			tool_loop_count INTEGER NOT NULL DEFAULT 0,
+			cancellation_count INTEGER NOT NULL DEFAULT 0,
+			edit_files_changed INTEGER NOT NULL DEFAULT 0,
+			edit_lines_added INTEGER NOT NULL DEFAULT 0,
+			edit_lines_removed INTEGER NOT NULL DEFAULT 0,
+			compaction_count INTEGER NOT NULL DEFAULT 0,
+			compaction_tokens_before INTEGER NOT NULL DEFAULT 0,
+			model_switch_count INTEGER NOT NULL DEFAULT 0,
+			subagent_spawn_count INTEGER NOT NULL DEFAULT 0,
+			large_result_count INTEGER NOT NULL DEFAULT 0,
+			large_result_bytes INTEGER NOT NULL DEFAULT 0,
+			large_result_lines INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(session_file, entry_id, kind, tool_name, model, provider, agent_type)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_session_health_timestamp ON session_health(timestamp);
+		CREATE INDEX IF NOT EXISTS idx_session_health_kind_timestamp ON session_health(kind, timestamp);
+		CREATE INDEX IF NOT EXISTS idx_session_health_tool_timestamp ON session_health(tool_name, timestamp);
 		CREATE TABLE IF NOT EXISTS meta (
 			key TEXT PRIMARY KEY,
 			value TEXT NOT NULL
@@ -216,6 +253,7 @@ export async function initDb(): Promise<Database> {
 	}
 	backfillUserMessages(db);
 	repairUserMessageLinks(db);
+	backfillSessionHealth(db);
 	backfillPriorityPremiumRequests(db);
 	backfillAgentType(db);
 	backfillMissingCatalogCosts(db);
@@ -407,6 +445,83 @@ export function insertMessageStats(stats: MessageStats[]): number {
 		}
 	});
 
+	insert();
+	return inserted;
+}
+
+/**
+ * Insert session-health stats. Idempotent via
+ * UNIQUE(session_file, entry_id, kind, tool_name, model, provider, agent_type).
+ * The fork guard mirrors request/user inserts so branched transcripts copied
+ * from the same parent do not double-count health events for the same agent.
+ */
+export function insertSessionHealthStats(stats: SessionHealthStats[]): number {
+	if (!db || stats.length === 0) return 0;
+
+	const stmt = db.prepare(`
+		INSERT OR IGNORE INTO session_health (
+			session_file, entry_id, folder, timestamp, agent_type, kind,
+			tool_name, model, provider,
+			retry_count, tool_loop_count, cancellation_count,
+			edit_files_changed, edit_lines_added, edit_lines_removed,
+			compaction_count, compaction_tokens_before, model_switch_count,
+			subagent_spawn_count, large_result_count, large_result_bytes, large_result_lines
+		)
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		WHERE NOT EXISTS (
+			SELECT 1 FROM session_health
+			WHERE entry_id = ?
+				AND timestamp = ?
+				AND kind = ?
+				AND tool_name = ?
+				AND model = ?
+				AND provider = ?
+				AND agent_type = ?
+				AND session_file <> ?
+		)
+	`);
+
+	let inserted = 0;
+	const insert = db.transaction(() => {
+		for (const s of stats) {
+			const toolName = s.toolName ?? "";
+			const model = s.model ?? "";
+			const provider = s.provider ?? "";
+			const result = stmt.run(
+				s.sessionFile,
+				s.entryId,
+				s.folder,
+				s.timestamp,
+				s.agentType,
+				s.kind,
+				toolName,
+				model,
+				provider,
+				s.retryCount,
+				s.toolLoopCount,
+				s.cancellationCount,
+				s.editFilesChanged,
+				s.editLinesAdded,
+				s.editLinesRemoved,
+				s.compactionCount,
+				s.compactionTokensBefore,
+				s.modelSwitchCount,
+				s.subagentSpawnCount,
+				s.largeResultCount,
+				s.largeResultBytes,
+				s.largeResultLines,
+				s.entryId,
+				s.timestamp,
+				s.kind,
+				toolName,
+				model,
+				provider,
+				s.agentType,
+				s.sessionFile,
+			);
+			if (result.changes > 0) inserted++;
+		}
+	});
 	insert();
 	return inserted;
 }
@@ -882,6 +997,25 @@ function backfillUserMessages(database: Database): void {
 }
 
 /**
+ * One-shot wipe of `file_offsets` so the next sync re-parses every session and
+ * populates `session_health` from transcript entries that were ignored before
+ * the table existed. Existing health rows are discarded because every event is
+ * append-only and keyed by transcript entry + dimensions.
+ */
+function backfillSessionHealth(database: Database): void {
+	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(SESSION_HEALTH_BACKFILL_KEY) as
+		| { value: string }
+		| undefined;
+	if (!shouldResetBackfill(row?.value)) return;
+
+	database.run("DELETE FROM session_health");
+	database.run("DELETE FROM file_offsets");
+	database
+		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+		.run(SESSION_HEALTH_BACKFILL_KEY, BACKFILL_PENDING);
+}
+
+/**
  * Reclassify pre-existing `messages` rows by agent type once, after the
  * `agent_type` column is added to an older database (every prior row defaulted
  * to 'main' on the ALTER). Classification is purely path-based — derived from
@@ -1274,5 +1408,204 @@ export function getBehaviorByModel(cutoff?: number | null): BehaviorModelStats[]
 		totalBlame: row.total_blame ?? 0,
 		totalChars: row.total_chars ?? 0,
 		lastTimestamp: row.last_timestamp ?? 0,
+	}));
+}
+
+interface HealthAggregateRow {
+	total_events: number;
+	retry_count: number | null;
+	tool_loop_count: number | null;
+	cancellation_count: number | null;
+	edit_files_changed: number | null;
+	edit_lines_added: number | null;
+	edit_lines_removed: number | null;
+	compaction_count: number | null;
+	compaction_tokens_before: number | null;
+	model_switch_count: number | null;
+	subagent_spawn_count: number | null;
+	large_result_count: number | null;
+	large_result_bytes: number | null;
+	large_result_lines: number | null;
+	first_timestamp: number | null;
+	last_timestamp: number | null;
+}
+
+interface HealthKindRow extends HealthAggregateRow {
+	kind: HealthKindStats["kind"];
+}
+
+interface HealthDimensionRow extends HealthAggregateRow {
+	kind: HealthDimensionStats["kind"];
+	tool_name: string;
+	model: string;
+	provider: string;
+}
+
+interface HealthSeriesRow {
+	bucket: number;
+	retry_count: number | null;
+	tool_loop_count: number | null;
+	cancellation_count: number | null;
+	edit_files_changed: number | null;
+	edit_lines_added: number | null;
+	edit_lines_removed: number | null;
+	compaction_count: number | null;
+	compaction_tokens_before: number | null;
+	model_switch_count: number | null;
+	subagent_spawn_count: number | null;
+	large_result_count: number | null;
+	large_result_bytes: number | null;
+	large_result_lines: number | null;
+}
+
+const EMPTY_HEALTH_OVERALL: HealthOverallStats = {
+	totalEvents: 0,
+	retryCount: 0,
+	toolLoopCount: 0,
+	cancellationCount: 0,
+	editFilesChanged: 0,
+	editLinesAdded: 0,
+	editLinesRemoved: 0,
+	compactionCount: 0,
+	compactionTokensBefore: 0,
+	modelSwitchCount: 0,
+	subagentSpawnCount: 0,
+	largeResultCount: 0,
+	largeResultBytes: 0,
+	largeResultLines: 0,
+	firstTimestamp: 0,
+	lastTimestamp: 0,
+};
+
+function rowToHealthOverall(row: HealthAggregateRow | undefined): HealthOverallStats {
+	if (!row?.total_events) return EMPTY_HEALTH_OVERALL;
+	return {
+		totalEvents: row.total_events,
+		retryCount: row.retry_count ?? 0,
+		toolLoopCount: row.tool_loop_count ?? 0,
+		cancellationCount: row.cancellation_count ?? 0,
+		editFilesChanged: row.edit_files_changed ?? 0,
+		editLinesAdded: row.edit_lines_added ?? 0,
+		editLinesRemoved: row.edit_lines_removed ?? 0,
+		compactionCount: row.compaction_count ?? 0,
+		compactionTokensBefore: row.compaction_tokens_before ?? 0,
+		modelSwitchCount: row.model_switch_count ?? 0,
+		subagentSpawnCount: row.subagent_spawn_count ?? 0,
+		largeResultCount: row.large_result_count ?? 0,
+		largeResultBytes: row.large_result_bytes ?? 0,
+		largeResultLines: row.large_result_lines ?? 0,
+		firstTimestamp: row.first_timestamp ?? 0,
+		lastTimestamp: row.last_timestamp ?? 0,
+	};
+}
+
+function healthAggregateSelect(): string {
+	return `
+		COUNT(*) as total_events,
+		SUM(retry_count) as retry_count,
+		SUM(tool_loop_count) as tool_loop_count,
+		SUM(cancellation_count) as cancellation_count,
+		SUM(edit_files_changed) as edit_files_changed,
+		SUM(edit_lines_added) as edit_lines_added,
+		SUM(edit_lines_removed) as edit_lines_removed,
+		SUM(compaction_count) as compaction_count,
+		SUM(compaction_tokens_before) as compaction_tokens_before,
+		SUM(model_switch_count) as model_switch_count,
+		SUM(subagent_spawn_count) as subagent_spawn_count,
+		SUM(large_result_count) as large_result_count,
+		SUM(large_result_bytes) as large_result_bytes,
+		SUM(large_result_lines) as large_result_lines,
+		MIN(timestamp) as first_timestamp,
+		MAX(timestamp) as last_timestamp
+	`;
+}
+
+export function getSessionHealthOverall(cutoff?: number | null): HealthOverallStats {
+	if (!db) return EMPTY_HEALTH_OVERALL;
+	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
+	const stmt = db.prepare(`
+		SELECT ${healthAggregateSelect()}
+		FROM session_health
+		${hasCutoff ? "WHERE timestamp >= ?" : ""}
+	`);
+	const row = (hasCutoff ? stmt.get(cutoff) : stmt.get()) as HealthAggregateRow | undefined;
+	return rowToHealthOverall(row);
+}
+
+export function getSessionHealthByKind(cutoff?: number | null): HealthKindStats[] {
+	if (!db) return [];
+	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
+	const stmt = db.prepare(`
+		SELECT kind, ${healthAggregateSelect()}
+		FROM session_health
+		${hasCutoff ? "WHERE timestamp >= ?" : ""}
+		GROUP BY kind
+		ORDER BY total_events DESC
+	`);
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as HealthKindRow[];
+	return rows.map(row => ({ kind: row.kind, ...rowToHealthOverall(row) }));
+}
+
+export function getSessionHealthByTool(cutoff?: number | null): HealthDimensionStats[] {
+	if (!db) return [];
+	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
+	const stmt = db.prepare(`
+		SELECT kind, tool_name, model, provider, ${healthAggregateSelect()}
+		FROM session_health
+		WHERE (tool_name <> '' OR model <> '' OR provider <> '')
+		${hasCutoff ? "AND timestamp >= ?" : ""}
+		GROUP BY kind, tool_name, model, provider
+		ORDER BY total_events DESC, large_result_bytes DESC
+	`);
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as HealthDimensionRow[];
+	return rows.map(row => ({
+		kind: row.kind,
+		toolName: row.tool_name || null,
+		model: row.model || null,
+		provider: row.provider || null,
+		...rowToHealthOverall(row),
+	}));
+}
+
+export function getSessionHealthTimeSeries(cutoff?: number | null): HealthTimeSeriesPoint[] {
+	if (!db) return [];
+	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
+	const stmt = db.prepare(`
+		SELECT
+			(timestamp / 86400000) * 86400000 as bucket,
+			SUM(retry_count) as retry_count,
+			SUM(tool_loop_count) as tool_loop_count,
+			SUM(cancellation_count) as cancellation_count,
+			SUM(edit_files_changed) as edit_files_changed,
+			SUM(edit_lines_added) as edit_lines_added,
+			SUM(edit_lines_removed) as edit_lines_removed,
+			SUM(compaction_count) as compaction_count,
+			SUM(compaction_tokens_before) as compaction_tokens_before,
+			SUM(model_switch_count) as model_switch_count,
+			SUM(subagent_spawn_count) as subagent_spawn_count,
+			SUM(large_result_count) as large_result_count,
+			SUM(large_result_bytes) as large_result_bytes,
+			SUM(large_result_lines) as large_result_lines
+		FROM session_health
+		${hasCutoff ? "WHERE timestamp >= ?" : ""}
+		GROUP BY bucket
+		ORDER BY bucket ASC
+	`);
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as HealthSeriesRow[];
+	return rows.map(row => ({
+		timestamp: row.bucket,
+		retryCount: row.retry_count ?? 0,
+		toolLoopCount: row.tool_loop_count ?? 0,
+		cancellationCount: row.cancellation_count ?? 0,
+		editFilesChanged: row.edit_files_changed ?? 0,
+		editLinesAdded: row.edit_lines_added ?? 0,
+		editLinesRemoved: row.edit_lines_removed ?? 0,
+		compactionCount: row.compaction_count ?? 0,
+		compactionTokensBefore: row.compaction_tokens_before ?? 0,
+		modelSwitchCount: row.model_switch_count ?? 0,
+		subagentSpawnCount: row.subagent_spawn_count ?? 0,
+		largeResultCount: row.large_result_count ?? 0,
+		largeResultBytes: row.large_result_bytes ?? 0,
+		largeResultLines: row.large_result_lines ?? 0,
 	}));
 }

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -4,10 +4,16 @@ import { type AssistantMessage, getPriorityPremiumRequests, type ServiceTier } f
 import { getSessionsDir, isEnoent } from "@oh-my-pi/pi-utils";
 import type {
 	AgentType,
+	HealthEventKind,
 	MessageStats,
+	SessionCompactionEntry,
 	SessionEntry,
+	SessionHealthStats,
+	SessionInitEntry,
 	SessionMessageEntry,
+	SessionModelChangeEntry,
 	SessionServiceTierChangeEntry,
+	ToolResultMessage,
 	UserMessageLink,
 	UserMessageStats,
 } from "./types";
@@ -159,6 +165,399 @@ function extractStats(
 	};
 }
 
+type HealthCounters = Pick<
+	SessionHealthStats,
+	| "retryCount"
+	| "toolLoopCount"
+	| "cancellationCount"
+	| "editFilesChanged"
+	| "editLinesAdded"
+	| "editLinesRemoved"
+	| "compactionCount"
+	| "compactionTokensBefore"
+	| "modelSwitchCount"
+	| "subagentSpawnCount"
+	| "largeResultCount"
+	| "largeResultBytes"
+	| "largeResultLines"
+>;
+
+type HealthDimensions = {
+	toolName?: string | null;
+	model?: string | null;
+	provider?: string | null;
+};
+
+const ABORT_LIKE_RE = /\b(abort(?:ed|ing)?|cancel(?:ed|led|ing)?|interrupt(?:ed|ing)?|stopped by user)\b/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseEntryTimestamp(timestamp: unknown): number {
+	if (typeof timestamp === "number" && Number.isFinite(timestamp)) return timestamp;
+	if (typeof timestamp !== "string") return 0;
+	const parsed = Date.parse(timestamp);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function healthStat(
+	sessionFile: string,
+	folder: string,
+	entryId: string,
+	timestamp: number,
+	agentType: AgentType,
+	kind: HealthEventKind,
+	values: Partial<HealthCounters> & HealthDimensions,
+): SessionHealthStats {
+	return {
+		sessionFile,
+		entryId,
+		folder,
+		timestamp,
+		agentType,
+		kind,
+		toolName: values.toolName ?? null,
+		model: values.model ?? null,
+		provider: values.provider ?? null,
+		retryCount: values.retryCount ?? 0,
+		toolLoopCount: values.toolLoopCount ?? 0,
+		cancellationCount: values.cancellationCount ?? 0,
+		editFilesChanged: values.editFilesChanged ?? 0,
+		editLinesAdded: values.editLinesAdded ?? 0,
+		editLinesRemoved: values.editLinesRemoved ?? 0,
+		compactionCount: values.compactionCount ?? 0,
+		compactionTokensBefore: values.compactionTokensBefore ?? 0,
+		modelSwitchCount: values.modelSwitchCount ?? 0,
+		subagentSpawnCount: values.subagentSpawnCount ?? 0,
+		largeResultCount: values.largeResultCount ?? 0,
+		largeResultBytes: values.largeResultBytes ?? 0,
+		largeResultLines: values.largeResultLines ?? 0,
+	};
+}
+
+function isModelChangeEntry(entry: SessionEntry): entry is SessionModelChangeEntry {
+	const record = entry as Record<string, unknown>;
+	return (
+		entry.type === "model_change" &&
+		typeof record.id === "string" &&
+		typeof record.timestamp === "string" &&
+		typeof record.model === "string"
+	);
+}
+
+function isCompactionEntry(entry: SessionEntry): entry is SessionCompactionEntry {
+	const record = entry as Record<string, unknown>;
+	return entry.type === "compaction" && typeof record.id === "string" && typeof record.timestamp === "string";
+}
+
+function isSessionInitEntry(entry: SessionEntry): entry is SessionInitEntry {
+	const record = entry as Record<string, unknown>;
+	return entry.type === "session_init" && typeof record.id === "string" && typeof record.timestamp === "string";
+}
+
+function isToolResultMessageEntry(entry: SessionEntry): entry is SessionMessageEntry & { message: ToolResultMessage } {
+	if (entry.type !== "message") return false;
+	const msgEntry = entry as SessionMessageEntry;
+	if (typeof msgEntry.id !== "string" || msgEntry.id.length === 0) return false;
+	const message = (msgEntry as unknown as { message?: unknown }).message;
+	if (!isRecord(message)) return false;
+	return message.role === "toolResult" && typeof message.toolName === "string";
+}
+
+function splitProviderModel(value: string): { provider: string | null; model: string } {
+	const slash = value.indexOf("/");
+	if (slash <= 0) return { provider: null, model: value };
+	return { provider: value.slice(0, slash), model: value.slice(slash + 1) };
+}
+
+function assistantModelKey(message: AssistantMessage): string | undefined {
+	if (!message.model) return undefined;
+	return message.provider ? `${message.provider}/${message.model}` : message.model;
+}
+
+function numberField(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isAbortLikeText(value: unknown): boolean {
+	return typeof value === "string" && ABORT_LIKE_RE.test(value);
+}
+
+function extractTextContent(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return "";
+	const parts: string[] = [];
+	for (const block of value) {
+		if (isRecord(block) && block.type === "text" && typeof block.text === "string") {
+			parts.push(block.text);
+		}
+	}
+	return parts.join("\n");
+}
+
+function toolCallNames(content: unknown): string[] {
+	if (!Array.isArray(content)) return [];
+	const names: string[] = [];
+	for (const block of content) {
+		if (isRecord(block) && block.type === "toolCall" && typeof block.name === "string") {
+			names.push(block.name);
+		}
+	}
+	return names;
+}
+
+interface DiffChurn {
+	files: number;
+	added: number;
+	removed: number;
+}
+
+function countLogicalLines(text: string): number {
+	if (text.length === 0) return 0;
+	const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	return normalized.endsWith("\n") ? normalized.slice(0, -1).split("\n").length : normalized.split("\n").length;
+}
+
+function hasMoveMetadata(details: Record<string, unknown>): boolean {
+	const move = typeof details.move === "string" ? details.move.trim() : "";
+	const sourcePath = typeof details.sourcePath === "string" ? details.sourcePath.trim() : "";
+	return move.length > 0 || sourcePath.length > 0;
+}
+
+function churnFromEditMetadata(details: Record<string, unknown>): DiffChurn | null {
+	const op = typeof details.op === "string" ? details.op : undefined;
+	const oldText = typeof details.oldText === "string" ? details.oldText : undefined;
+	const newText = typeof details.newText === "string" ? details.newText : undefined;
+	if (op === "delete" && oldText !== undefined) {
+		return { files: 1, added: 0, removed: countLogicalLines(oldText) };
+	}
+	if (op === "create" && newText !== undefined) {
+		return { files: 1, added: countLogicalLines(newText), removed: 0 };
+	}
+	if (op === "update" && hasMoveMetadata(details)) {
+		return { files: 1, added: 0, removed: 0 };
+	}
+	return null;
+}
+
+function parseUnifiedDiff(diff: string): DiffChurn {
+	let added = 0;
+	let removed = 0;
+	let diffGitFiles = 0;
+	let headerFiles = 0;
+	for (const line of diff.split(/\r?\n/)) {
+		if (line.startsWith("diff --git ")) {
+			diffGitFiles++;
+			continue;
+		}
+		if (line.startsWith("--- ")) {
+			headerFiles++;
+			continue;
+		}
+		if (line.startsWith("+++ ")) continue;
+		if (line.startsWith("+")) added++;
+		else if (line.startsWith("-")) removed++;
+	}
+	const files = diffGitFiles || headerFiles || (added > 0 || removed > 0 ? 1 : 0);
+	return { files, added, removed };
+}
+
+function extractEditChurn(details: unknown): DiffChurn | null {
+	if (!isRecord(details)) return null;
+	const perFile = Array.isArray(details.perFileResults) ? details.perFileResults : [];
+	const paths = new Set<string>();
+	let fallbackFiles = 0;
+	let added = 0;
+	let removed = 0;
+	let sawChurn = false;
+	const addChurn = (pathName: string | null, churn: DiffChurn) => {
+		sawChurn = true;
+		added += churn.added;
+		removed += churn.removed;
+		if (pathName) paths.add(pathName);
+		else fallbackFiles += churn.files;
+	};
+
+	for (const item of perFile) {
+		if (!isRecord(item)) continue;
+		const pathName = typeof item.path === "string" ? item.path : null;
+		if (typeof item.diff === "string" && item.diff.length > 0) {
+			addChurn(pathName, parseUnifiedDiff(item.diff));
+			continue;
+		}
+		const metadataChurn = churnFromEditMetadata(item);
+		if (metadataChurn) addChurn(pathName, metadataChurn);
+	}
+	if (!sawChurn && typeof details.diff === "string" && details.diff.length > 0) {
+		addChurn(null, parseUnifiedDiff(details.diff));
+	}
+	if (!sawChurn) {
+		const metadataChurn = churnFromEditMetadata(details);
+		if (metadataChurn) addChurn(typeof details.path === "string" ? details.path : null, metadataChurn);
+	}
+
+	const files = paths.size + fallbackFiles || (added > 0 || removed > 0 ? 1 : 0);
+	if (files === 0 && added === 0 && removed === 0) return null;
+	return { files, added, removed };
+}
+
+function extractLargeResult(details: unknown): { bytes: number; lines: number } | null {
+	if (!isRecord(details) || !isRecord(details.meta) || !isRecord(details.meta.truncation)) return null;
+	const truncation = details.meta.truncation;
+	return {
+		bytes: numberField(truncation.totalBytes),
+		lines: numberField(truncation.totalLines),
+	};
+}
+
+interface ModelSwitchState {
+	currentModel: string | undefined;
+}
+
+function extractModelChangeHealth(
+	sessionFile: string,
+	folder: string,
+	entry: SessionModelChangeEntry,
+	agentType: AgentType,
+	modelSwitchState: ModelSwitchState,
+): SessionHealthStats | null {
+	const previousModel = modelSwitchState.currentModel;
+	modelSwitchState.currentModel = entry.model;
+	if (!previousModel || previousModel === entry.model) return null;
+
+	const { provider, model } = splitProviderModel(entry.model);
+	return healthStat(sessionFile, folder, entry.id, parseEntryTimestamp(entry.timestamp), agentType, "model_switch", {
+		modelSwitchCount: 1,
+		model,
+		provider,
+	});
+}
+
+function extractCompactionHealth(
+	sessionFile: string,
+	folder: string,
+	entry: SessionCompactionEntry,
+	agentType: AgentType,
+): SessionHealthStats {
+	const record = entry as unknown as Record<string, unknown>;
+	return healthStat(sessionFile, folder, entry.id, parseEntryTimestamp(entry.timestamp), agentType, "compaction", {
+		compactionCount: 1,
+		compactionTokensBefore: numberField(record.tokensBefore),
+	});
+}
+
+function extractSessionInitHealth(
+	sessionFile: string,
+	folder: string,
+	entry: SessionInitEntry,
+	agentType: AgentType,
+): SessionHealthStats | null {
+	if (agentType !== "subagent") return null;
+	return healthStat(sessionFile, folder, entry.id, parseEntryTimestamp(entry.timestamp), agentType, "subagent_spawn", {
+		subagentSpawnCount: 1,
+	});
+}
+
+interface AssistantLoopState {
+	previousToolName: string | undefined;
+}
+
+function extractAssistantHealth(
+	sessionFile: string,
+	folder: string,
+	entry: SessionMessageEntry,
+	agentType: AgentType,
+	loopState: AssistantLoopState,
+): SessionHealthStats[] {
+	const msg = entry.message as AssistantMessage;
+	const timestamp = Number.isFinite(msg.timestamp) ? msg.timestamp : parseEntryTimestamp(entry.timestamp);
+	const rows: SessionHealthStats[] = [];
+	if (msg.stopReason === "error") {
+		rows.push(
+			healthStat(sessionFile, folder, entry.id, timestamp, agentType, "retry", {
+				retryCount: 1,
+				model: msg.model,
+				provider: msg.provider,
+			}),
+		);
+	}
+	if (msg.stopReason === "aborted" || isAbortLikeText(msg.errorMessage)) {
+		rows.push(
+			healthStat(sessionFile, folder, entry.id, timestamp, agentType, "cancellation", {
+				cancellationCount: 1,
+				model: msg.model,
+				provider: msg.provider,
+			}),
+		);
+	}
+	const names = toolCallNames(msg.content);
+	if (names.length > 0) {
+		const loopCounts = new Map<string, number>();
+		let previousTool = loopState.previousToolName;
+		for (const name of names) {
+			if (previousTool === name) loopCounts.set(name, (loopCounts.get(name) ?? 0) + 1);
+			previousTool = name;
+		}
+		loopState.previousToolName = previousTool;
+		for (const [toolName, toolLoopCount] of loopCounts) {
+			rows.push(
+				healthStat(sessionFile, folder, entry.id, timestamp, agentType, "tool_loop", {
+					toolName,
+					toolLoopCount,
+					model: msg.model,
+					provider: msg.provider,
+				}),
+			);
+		}
+	} else {
+		loopState.previousToolName = undefined;
+	}
+	return rows;
+}
+
+function extractToolResultHealth(
+	sessionFile: string,
+	folder: string,
+	entry: SessionMessageEntry & { message: ToolResultMessage },
+	agentType: AgentType,
+): SessionHealthStats[] {
+	const msg = entry.message;
+	const timestamp = parseEntryTimestamp(entry.timestamp);
+	const rows: SessionHealthStats[] = [];
+	if (msg.isError && isAbortLikeText(extractTextContent(msg.content))) {
+		rows.push(
+			healthStat(sessionFile, folder, entry.id, timestamp, agentType, "cancellation", {
+				cancellationCount: 1,
+				toolName: msg.toolName,
+			}),
+		);
+	}
+	const churn = extractEditChurn(msg.details);
+	if (churn) {
+		rows.push(
+			healthStat(sessionFile, folder, entry.id, timestamp, agentType, "edit_churn", {
+				toolName: msg.toolName,
+				editFilesChanged: churn.files,
+				editLinesAdded: churn.added,
+				editLinesRemoved: churn.removed,
+			}),
+		);
+	}
+	const largeResult = extractLargeResult(msg.details);
+	if (largeResult) {
+		rows.push(
+			healthStat(sessionFile, folder, entry.id, timestamp, agentType, "large_result", {
+				toolName: msg.toolName,
+				largeResultCount: 1,
+				largeResultBytes: largeResult.bytes,
+				largeResultLines: largeResult.lines,
+			}),
+		);
+	}
+	return rows;
+}
+
 const LF = 0x0a;
 
 function parseSessionEntriesLenient(bytes: Uint8Array): { entries: SessionEntry[]; read: number } {
@@ -210,6 +609,46 @@ function scanLastServiceTier(bytes: Uint8Array): ServiceTier | undefined {
 
 	return currentServiceTier;
 }
+
+interface PrefixAssistantState {
+	lastToolName: string | undefined;
+	currentModel: string | undefined;
+}
+
+function scanPrefixAssistantState(bytes: Uint8Array): PrefixAssistantState {
+	const state: PrefixAssistantState = { lastToolName: undefined, currentModel: undefined };
+	let cursor = 0;
+
+	while (cursor < bytes.length) {
+		const { values, error, read, done } = Bun.JSONL.parseChunk(bytes, cursor, bytes.length);
+		for (const value of values as SessionEntry[]) {
+			if (isUserMessage(value)) {
+				state.lastToolName = undefined;
+			} else if (isModelChangeEntry(value)) {
+				state.currentModel = value.model;
+			} else if (isAssistantMessage(value)) {
+				const message = value.message as AssistantMessage;
+				const names = toolCallNames(message.content);
+				state.lastToolName = names.at(-1);
+				state.currentModel = assistantModelKey(message) ?? state.currentModel;
+			}
+		}
+
+		if (error) {
+			const nextNewline = bytes.indexOf(LF, Math.max(read, cursor));
+			if (nextNewline === -1) break;
+			cursor = nextNewline + 1;
+			continue;
+		}
+
+		if (read <= cursor) break;
+		cursor = read;
+		if (done) break;
+	}
+
+	return state;
+}
+
 /**
  * Parse a session file and extract all assistant message stats.
  * Uses incremental reading with offset tracking.
@@ -230,6 +669,7 @@ export interface ParseSessionResult {
 	stats: MessageStats[];
 	userStats: UserMessageStats[];
 	userLinks: UserMessageLink[];
+	healthStats: SessionHealthStats[];
 	newOffset: number;
 }
 export async function parseSessionFile(sessionPath: string, fromOffset = 0): Promise<ParseSessionResult> {
@@ -237,7 +677,7 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	try {
 		bytes = await Bun.file(sessionPath).bytes();
 	} catch (err) {
-		if (isEnoent(err)) return { stats: [], userStats: [], userLinks: [], newOffset: fromOffset };
+		if (isEnoent(err)) return { stats: [], userStats: [], userLinks: [], healthStats: [], newOffset: fromOffset };
 		throw err;
 	}
 
@@ -246,17 +686,37 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	const stats: MessageStats[] = [];
 	const userStats: UserMessageStats[] = [];
 	const userLinks: UserMessageLink[] = [];
+	const healthStats: SessionHealthStats[] = [];
 	const userByEntryId = new Map<string, UserMessageStats>();
 	const start = Math.max(0, Math.min(fromOffset, bytes.length));
 	const unprocessed = bytes.subarray(start);
 	const { entries, read } = parseSessionEntriesLenient(unprocessed);
 	let currentServiceTier: ServiceTier | undefined;
+	const assistantLoopState: AssistantLoopState = { previousToolName: undefined };
+	const modelSwitchState: ModelSwitchState = { currentModel: undefined };
 	if (start > 0) {
 		currentServiceTier = scanLastServiceTier(bytes.subarray(0, start));
+		const prefixAssistantState = scanPrefixAssistantState(bytes.subarray(0, start));
+		assistantLoopState.previousToolName = prefixAssistantState.lastToolName;
+		modelSwitchState.currentModel = prefixAssistantState.currentModel;
 	}
 	for (const entry of entries) {
 		if (isServiceTierChange(entry)) {
 			currentServiceTier = entry.serviceTier ?? undefined;
+			continue;
+		}
+		if (isModelChangeEntry(entry)) {
+			const modelChangeHealth = extractModelChangeHealth(sessionPath, folder, entry, agentType, modelSwitchState);
+			if (modelChangeHealth) healthStats.push(modelChangeHealth);
+			continue;
+		}
+		if (isCompactionEntry(entry)) {
+			healthStats.push(extractCompactionHealth(sessionPath, folder, entry, agentType));
+			continue;
+		}
+		if (isSessionInitEntry(entry)) {
+			const sessionInitHealth = extractSessionInitHealth(sessionPath, folder, entry, agentType);
+			if (sessionInitHealth) healthStats.push(sessionInitHealth);
 			continue;
 		}
 		if (isUserMessage(entry)) {
@@ -265,11 +725,19 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 				userStats.push(userMsg);
 				userByEntryId.set(entry.id, userMsg);
 			}
+			assistantLoopState.previousToolName = undefined;
+			continue;
+		}
+		if (isToolResultMessageEntry(entry)) {
+			healthStats.push(...extractToolResultHealth(sessionPath, folder, entry, agentType));
 			continue;
 		}
 		if (isAssistantMessage(entry)) {
 			const msgStats = extractStats(sessionPath, folder, entry, currentServiceTier, agentType);
 			if (msgStats) stats.push(msgStats);
+			healthStats.push(...extractAssistantHealth(sessionPath, folder, entry, agentType, assistantLoopState));
+			modelSwitchState.currentModel =
+				assistantModelKey(entry.message as AssistantMessage) ?? modelSwitchState.currentModel;
 			// Link assistant's responding model back to the user message it answered.
 			const parentId = (entry as SessionMessageEntry).parentId;
 			if (parentId) {
@@ -292,7 +760,7 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 		}
 	}
 
-	return { stats, userStats, userLinks, newOffset: start + read };
+	return { stats, userStats, userLinks, healthStats, newOffset: start + read };
 }
 
 /**
@@ -314,7 +782,10 @@ export async function listSessionFolders(): Promise<string[]> {
 export async function listSessionFiles(folderPath: string): Promise<string[]> {
 	try {
 		const entries = await fs.readdir(folderPath, { recursive: true, withFileTypes: true });
-		return entries.filter(e => e.isFile() && e.name.endsWith(".jsonl")).map(e => path.join(e.parentPath, e.name));
+		return entries
+			.filter(e => e.isFile() && e.name.endsWith(".jsonl"))
+			.map(e => path.join(e.parentPath, e.name))
+			.sort();
 	} catch {
 		return [];
 	}

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -13,6 +13,7 @@ import {
 	getRecentErrors,
 	getRecentRequests,
 	getRequestDetails,
+	getSessionHealthDashboardStats,
 	getTotalMessageCount,
 	syncAllSessions,
 } from "./aggregator";
@@ -212,6 +213,11 @@ async function handleApi(req: Request): Promise<Response> {
 
 	if (path === "/api/stats/behavior") {
 		const stats = await getBehaviorDashboardStats(range);
+		return Response.json(stats);
+	}
+
+	if (path === "/api/stats/health") {
+		const stats = await getSessionHealthDashboardStats(range);
 		return Response.json(stats);
 	}
 

--- a/packages/stats/src/shared-types.ts
+++ b/packages/stats/src/shared-types.ts
@@ -233,6 +233,70 @@ export interface BehaviorDashboardStats {
 	behaviorSeries: BehaviorTimeSeriesPoint[];
 }
 
+export type HealthEventKind =
+	| "retry"
+	| "tool_loop"
+	| "cancellation"
+	| "edit_churn"
+	| "compaction"
+	| "model_switch"
+	| "subagent_spawn"
+	| "large_result";
+
+export interface HealthOverallStats {
+	totalEvents: number;
+	retryCount: number;
+	toolLoopCount: number;
+	cancellationCount: number;
+	editFilesChanged: number;
+	editLinesAdded: number;
+	editLinesRemoved: number;
+	compactionCount: number;
+	compactionTokensBefore: number;
+	modelSwitchCount: number;
+	subagentSpawnCount: number;
+	largeResultCount: number;
+	largeResultBytes: number;
+	largeResultLines: number;
+	firstTimestamp: number;
+	lastTimestamp: number;
+}
+
+export interface HealthKindStats extends HealthOverallStats {
+	kind: HealthEventKind;
+}
+
+export interface HealthDimensionStats extends HealthOverallStats {
+	kind: HealthEventKind;
+	toolName: string | null;
+	model: string | null;
+	provider: string | null;
+}
+
+export interface HealthTimeSeriesPoint {
+	timestamp: number;
+	retryCount: number;
+	toolLoopCount: number;
+	cancellationCount: number;
+	editFilesChanged: number;
+	editLinesAdded: number;
+	editLinesRemoved: number;
+	compactionCount: number;
+	compactionTokensBefore: number;
+	modelSwitchCount: number;
+	subagentSpawnCount: number;
+	largeResultCount: number;
+	largeResultBytes: number;
+	largeResultLines: number;
+}
+
+export interface HealthDashboardStats {
+	overall: HealthOverallStats;
+	byKind: HealthKindStats[];
+	byTool: HealthDimensionStats[];
+	healthSeries: HealthTimeSeriesPoint[];
+}
+
 /** Token savings from a single source type. */
 export interface GainSourceTotals {
 	savedTokens: number;

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage, ServiceTier, StopReason, Usage } from "@oh-my-pi/pi-ai";
-import type { AgentType } from "./shared-types";
+import type { AgentType, HealthEventKind } from "./shared-types";
 
 export * from "./shared-types";
 
@@ -59,12 +59,45 @@ export interface SessionHeader {
 	title?: string;
 }
 
+export interface SessionModelChangeEntry {
+	type: "model_change";
+	id: string;
+	parentId?: string | null;
+	timestamp: string;
+	model: string;
+	role?: string;
+}
+
+export interface SessionCompactionEntry {
+	type: "compaction";
+	id: string;
+	parentId?: string | null;
+	timestamp: string;
+	tokensBefore: number;
+}
+
+export interface SessionInitEntry {
+	type: "session_init";
+	id: string;
+	parentId?: string | null;
+	timestamp: string;
+}
+
+export interface ToolResultMessage {
+	role: "toolResult";
+	toolCallId: string;
+	toolName: string;
+	content: unknown;
+	details?: unknown;
+	isError?: boolean;
+}
+
 export interface SessionMessageEntry {
 	type: "message";
 	id: string;
 	parentId: string | null;
 	timestamp: string;
-	message: AssistantMessage | { role: "user" | "toolResult" };
+	message: AssistantMessage | { role: "user"; content?: unknown; synthetic?: boolean } | ToolResultMessage;
 }
 
 export interface SessionServiceTierChangeEntry {
@@ -75,7 +108,14 @@ export interface SessionServiceTierChangeEntry {
 	serviceTier: ServiceTier | null;
 }
 
-export type SessionEntry = SessionHeader | SessionMessageEntry | SessionServiceTierChangeEntry | { type: string };
+export type SessionEntry =
+	| SessionHeader
+	| SessionModelChangeEntry
+	| SessionCompactionEntry
+	| SessionInitEntry
+	| SessionMessageEntry
+	| SessionServiceTierChangeEntry
+	| { type: string };
 
 /**
  * Behavioral stats extracted from a single user message.
@@ -125,4 +165,40 @@ export interface UserMessageLink {
 	entryId: string;
 	model: string;
 	provider: string;
+}
+
+export interface SessionHealthStats {
+	/** Database ID */
+	id?: number;
+	/** Session file path */
+	sessionFile: string;
+	/** Entry ID within the session */
+	entryId: string;
+	/** Folder/project path */
+	folder: string;
+	/** Unix timestamp in ms */
+	timestamp: number;
+	/** Which agent transcript produced this event */
+	agentType: AgentType;
+	/** Health event category */
+	kind: HealthEventKind;
+	/** Tool dimension for tool-scoped events */
+	toolName: string | null;
+	/** Model dimension for model-scoped events */
+	model: string | null;
+	/** Provider dimension for model-scoped events */
+	provider: string | null;
+	retryCount: number;
+	toolLoopCount: number;
+	cancellationCount: number;
+	editFilesChanged: number;
+	editLinesAdded: number;
+	editLinesRemoved: number;
+	compactionCount: number;
+	compactionTokensBefore: number;
+	modelSwitchCount: number;
+	subagentSpawnCount: number;
+	largeResultCount: number;
+	largeResultBytes: number;
+	largeResultLines: number;
 }

--- a/packages/stats/test/session-health.test.ts
+++ b/packages/stats/test/session-health.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseSessionFile } from "@oh-my-pi/omp-stats/parser";
+import type { SessionHealthStats } from "@oh-my-pi/omp-stats/types";
+import { getAgentDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalAgentDir = getAgentDir();
+let tempDir: TempDir | null = null;
+
+beforeEach(() => {
+	tempDir = TempDir.createSync("@pi-stats-session-health-");
+	const configDir = path.relative(os.homedir(), tempDir.join("config"));
+	process.env.PI_CONFIG_DIR = configDir;
+	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+});
+
+afterEach(() => {
+	if (originalConfigDir === undefined) {
+		delete process.env.PI_CONFIG_DIR;
+	} else {
+		process.env.PI_CONFIG_DIR = originalConfigDir;
+	}
+	setAgentDir(originalAgentDir);
+	tempDir?.removeSync();
+	tempDir = null;
+});
+
+const timestamp = Date.parse("2026-06-27T00:00:00.000Z");
+
+const usage = {
+	input: 10,
+	output: 5,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 15,
+	premiumRequests: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+async function writeHealthSessionFiles(): Promise<{ mainFile: string; subagentFile: string }> {
+	const folder = path.join(getAgentDir(), "sessions", "--tmp--session-health");
+	const mainFile = path.join(folder, "session.jsonl");
+	const subagentFile = path.join(folder, "session", "subagent.jsonl");
+	const mainEntries = [
+		{
+			type: "model_change",
+			id: "model-1",
+			parentId: null,
+			timestamp: new Date(timestamp).toISOString(),
+			model: "openai/gpt-4.1",
+		},
+		{
+			type: "model_change",
+			id: "model-2",
+			parentId: "model-1",
+			timestamp: new Date(timestamp + 30_000).toISOString(),
+			model: "openai/gpt-5",
+		},
+		{
+			type: "compaction",
+			id: "compact-1",
+			parentId: "model-1",
+			timestamp: new Date(timestamp + 60_000).toISOString(),
+			summary: "summary",
+			firstKeptEntryId: "model-1",
+			tokensBefore: 1234,
+		},
+		{
+			type: "message",
+			id: "assistant-1",
+			parentId: null,
+			timestamp: new Date(timestamp + 120_000).toISOString(),
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "read-1", name: "read", arguments: {} },
+					{ type: "text", text: "thinking between duplicate reads should not break loop detection" },
+					{ type: "toolCall", id: "read-2", name: "read", arguments: {} },
+					{ type: "toolCall", id: "grep-1", name: "grep", arguments: {} },
+					{ type: "toolCall", id: "grep-2", name: "grep", arguments: {} },
+					{ type: "toolCall", id: "grep-3", name: "grep", arguments: {} },
+				],
+				api: "openai",
+				provider: "openai",
+				model: "gpt-5",
+				usage,
+				stopReason: "error",
+				errorMessage: "operation aborted by user",
+				timestamp: timestamp + 120_000,
+				duration: 42,
+			},
+		},
+		{
+			type: "message",
+			id: "tool-1",
+			parentId: "assistant-1",
+			timestamp: new Date(timestamp + 180_000).toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId: "edit-1",
+				toolName: "edit",
+				isError: false,
+				content: [{ type: "text", text: "edited" }],
+				details: {
+					perFileResults: [
+						{
+							path: "src/a.ts",
+							diff: "--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line",
+						},
+						{
+							path: "src/deleted.ts",
+							diff: "",
+							op: "delete",
+							oldText: "one\ntwo\n",
+						},
+						{
+							path: "src/renamed.ts",
+							diff: "",
+							op: "update",
+							move: "src/renamed.ts",
+							sourcePath: "src/original.ts",
+						},
+					],
+					meta: {
+						truncation: { totalBytes: 9000, totalLines: 400, outputBytes: 1000, outputLines: 40 },
+					},
+				},
+			},
+		},
+		{
+			type: "message",
+			id: "tool-2",
+			parentId: "assistant-1",
+			timestamp: new Date(timestamp + 240_000).toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId: "bash-1",
+				toolName: "bash",
+				isError: true,
+				content: [{ type: "text", text: "Operation aborted" }],
+				details: {},
+			},
+		},
+		{
+			type: "message",
+			id: "tool-3",
+			parentId: "assistant-1",
+			timestamp: new Date(timestamp + 300_000).toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId: "bash-2",
+				toolName: "bash",
+				isError: true,
+				content: [{ type: "text", text: "script failed" }],
+				details: { reason: "script installed an abort handler" },
+			},
+		},
+		{
+			type: "message",
+			id: "assistant-2",
+			parentId: "tool-3",
+			timestamp: new Date(timestamp + 360_000).toISOString(),
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "grep-4", name: "grep", arguments: {} }],
+				api: "openai",
+				provider: "openai",
+				model: "gpt-5",
+				usage,
+				stopReason: "toolUse",
+				timestamp: timestamp + 360_000,
+				duration: 20,
+			},
+		},
+	];
+	const subagentEntry = {
+		type: "session_init",
+		id: "subagent-1",
+		parentId: null,
+		timestamp: new Date(timestamp).toISOString(),
+		systemPrompt: "system",
+		task: "task",
+		tools: [],
+	};
+	await Bun.write(mainFile, `${mainEntries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
+	await Bun.write(subagentFile, `${JSON.stringify(subagentEntry)}\n`);
+	return { mainFile, subagentFile };
+}
+
+function sumCounters(rows: SessionHealthStats[]) {
+	return rows.reduce(
+		(acc, row) => {
+			acc.retry += row.retryCount;
+			acc.loops += row.toolLoopCount;
+			acc.cancellations += row.cancellationCount;
+			acc.files += row.editFilesChanged;
+			acc.added += row.editLinesAdded;
+			acc.removed += row.editLinesRemoved;
+			acc.compactions += row.compactionCount;
+			acc.tokensBefore += row.compactionTokensBefore;
+			acc.switches += row.modelSwitchCount;
+			acc.subagents += row.subagentSpawnCount;
+			acc.large += row.largeResultCount;
+			acc.largeBytes += row.largeResultBytes;
+			acc.largeLines += row.largeResultLines;
+			return acc;
+		},
+		{
+			retry: 0,
+			loops: 0,
+			cancellations: 0,
+			files: 0,
+			added: 0,
+			removed: 0,
+			compactions: 0,
+			tokensBefore: 0,
+			switches: 0,
+			subagents: 0,
+			large: 0,
+			largeBytes: 0,
+			largeLines: 0,
+		},
+	);
+}
+
+describe("session health parser", () => {
+	it("extracts retry, loop, cancellation, churn, compaction, model, fanout, and large-result signals", async () => {
+		const { mainFile, subagentFile } = await writeHealthSessionFiles();
+
+		const main = await parseSessionFile(mainFile);
+		const subagent = await parseSessionFile(subagentFile);
+		const rows = [...main.healthStats, ...subagent.healthStats];
+
+		expect(rows.map(row => row.kind).sort()).toEqual([
+			"cancellation",
+			"cancellation",
+			"compaction",
+			"edit_churn",
+			"large_result",
+			"model_switch",
+			"retry",
+			"subagent_spawn",
+			"tool_loop",
+			"tool_loop",
+			"tool_loop",
+		]);
+		expect(sumCounters(rows)).toEqual({
+			retry: 1,
+			loops: 4,
+			cancellations: 2,
+			files: 3,
+			added: 2,
+			removed: 3,
+			compactions: 1,
+			tokensBefore: 1234,
+			switches: 1,
+			subagents: 1,
+			large: 1,
+			largeBytes: 9000,
+			largeLines: 400,
+		});
+		expect(rows.find(row => row.kind === "model_switch")).toMatchObject({
+			entryId: "model-2",
+			provider: "openai",
+			model: "gpt-5",
+		});
+		expect(rows.find(row => row.kind === "edit_churn")).toMatchObject({ toolName: "edit", editFilesChanged: 3 });
+	});
+});


### PR DESCRIPTION
## Summary
- add session_health ingestion for retries, cancellations, tool loops, edit churn, compactions, model switches, subagent fanout, and large-result metadata
- expose /api/stats/health aggregates and add the Health dashboard route
- add parser coverage for health signal extraction

## Verification
- bun check (packages/stats)
- bun test test/session-health.test.ts (packages/stats)
- bun test (packages/stats)