### PR TITLE
fix(advisor): notify when advisor model is unavailable

### DIFF
--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1124,6 +1124,83 @@ describe("advisor", () => {
 			expect(failures).toHaveLength(2);
 		});
 
+		it("rolls advisor state back after each failed prompt so retries don't replay duplicate turns", async () => {
+			// The real `Agent` appends the user batch + a synthetic `stopReason: "error"`
+			// assistant turn before `state.error` is read. Without rollback, the runtime's
+			// retry/drop path would replay the failed batch on top of those orphans,
+			// duplicating session-update user turns and leaking dropped failures into the
+			// next successful run's context.
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			const rollbackCalls: number[] = [];
+			const lengthsBeforePrompt: number[] = [];
+			let shouldFail = true;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					lengthsBeforePrompt.push(state.messages.length);
+					state.messages.push({ role: "user", content: input, timestamp: Date.now() } as AgentMessage);
+					if (shouldFail) {
+						state.messages.push({
+							role: "assistant",
+							content: [{ type: "text", text: "" }],
+							stopReason: "error",
+							errorMessage: "404 No endpoints available",
+							timestamp: Date.now(),
+						} as unknown as AgentMessage);
+						state.error = "404 No endpoints available";
+					} else {
+						state.messages.push({
+							role: "assistant",
+							content: [{ type: "text", text: "ok" }],
+							timestamp: Date.now(),
+						} as unknown as AgentMessage);
+						state.error = undefined;
+					}
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				rollbackTo: count => {
+					rollbackCalls.push(count);
+					if (count < state.messages.length) state.messages.length = count;
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			// Three failed prompts each rolled back to the empty baseline, so every retry
+			// saw a clean state.messages instead of stacked failed turns.
+			expect(lengthsBeforePrompt).toEqual([0, 0, 0]);
+			expect(rollbackCalls).toEqual([0, 0, 0]);
+			// The drop-after-3 path also left state.messages empty — no orphan failed
+			// turns leak into the next successful run's context.
+			expect(state.messages).toHaveLength(0);
+			expect(state.error).toBeUndefined();
+
+			// A subsequent successful run starts from the clean baseline and is NOT
+			// rolled back.
+			shouldFail = false;
+			messages.push({ role: "user", content: "bbb", timestamp: 2 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+
+			expect(lengthsBeforePrompt[lengthsBeforePrompt.length - 1]).toBe(0);
+			expect(rollbackCalls).toHaveLength(3);
+			expect(state.messages).toHaveLength(2);
+		});
+
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {
 			const promptInputs: string[] = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1005,6 +1005,68 @@ describe("advisor", () => {
 			expect(runtime.backlog).toBe(0);
 		});
 
+		it("notifies the host once when consecutive prompt failures make the advisor unavailable", async () => {
+			const promptInputs: string[] = [];
+			const failures: unknown[] = [];
+			let shouldFail = true;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					if (shouldFail) {
+						throw new Error(
+							"404 No endpoints available matching your guardrail restrictions and data policy.",
+						);
+					}
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: error => failures.push(error),
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(3);
+			expect(failures).toHaveLength(1);
+			const failure = failures[0];
+			expect(failure).toBeInstanceOf(Error);
+			if (!(failure instanceof Error)) throw new Error("expected advisor failure error");
+			expect(failure.message).toContain("No endpoints available");
+
+			messages.push({ role: "user", content: "bbb", timestamp: 2 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(6);
+			expect(failures).toHaveLength(1);
+
+			shouldFail = false;
+			messages.push({ role: "user", content: "ccc", timestamp: 3 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			expect(failures).toHaveLength(1);
+
+			shouldFail = true;
+			messages.push({ role: "user", content: "ddd", timestamp: 4 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(failures).toHaveLength(2);
+		});
+
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {
 			const promptInputs: string[] = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1065,6 +1065,65 @@ describe("advisor", () => {
 			expect(failures).toHaveLength(2);
 		});
 
+		it("treats a clean prompt resolution with state.error as a failed turn (real Agent contract)", async () => {
+			// `Agent.#runLoop` catches provider/stream failures internally — it resolves
+			// `prompt()` cleanly and stores the message on `state.error` (e.g. the
+			// OpenRouter ZDR `404 No endpoints available` case from #3635). The runtime
+			// must surface that as a failed turn even though the awaited promise did
+			// not reject.
+			const promptInputs: string[] = [];
+			const failures: unknown[] = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let shouldFail = true;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					state.error = shouldFail
+						? "404 No endpoints available matching your guardrail restrictions and data policy."
+						: undefined;
+				},
+				abort: () => {},
+				reset: () => {
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: error => failures.push(error),
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(3);
+			expect(failures).toHaveLength(1);
+			const failure = failures[0];
+			if (!(failure instanceof Error)) throw new Error("expected advisor failure error");
+			expect(failure.message).toContain("No endpoints available");
+			expect(runtime.backlog).toBe(0);
+
+			shouldFail = false;
+			messages.push({ role: "user", content: "bbb", timestamp: 2 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			expect(failures).toHaveLength(1);
+
+			shouldFail = true;
+			messages.push({ role: "user", content: "ccc", timestamp: 3 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(failures).toHaveLength(2);
+		});
+
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {
 			const promptInputs: string[] = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1013,9 +1013,7 @@ describe("advisor", () => {
 				prompt: async input => {
 					promptInputs.push(input);
 					if (shouldFail) {
-						throw new Error(
-							"404 No endpoints available matching your guardrail restrictions and data policy.",
-						);
+						throw new Error("404 No endpoints available matching your guardrail restrictions and data policy.");
 					}
 				},
 				abort: () => {},

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -37,6 +37,8 @@ export interface AdvisorRuntimeHost {
 	 * one that routes `advise()` results back to the primary.
 	 */
 	beginAdvisorUpdate?(): void;
+	/** Surface a non-recovering advisor failure to the host UI without adding model-visible context. */
+	notifyFailure?(error: unknown): void;
 }
 
 interface PendingDelta {
@@ -63,6 +65,7 @@ export class AdvisorRuntime {
 	#busy = false;
 	#backlog = 0;
 	#consecutiveFailures = 0;
+	#failureNotified = false;
 	#latestMessages?: AgentMessage[];
 	#waiters: CatchupWaiter[] = [];
 	/** Bumped by every external {@link reset}/{@link dispose}. A drain iteration
@@ -121,6 +124,7 @@ export class AdvisorRuntime {
 		this.#pending = [];
 		this.#backlog = 0;
 		this.#consecutiveFailures = 0;
+		this.#failureNotified = false;
 		this.#wakeAllWaiters();
 		try {
 			this.agent.abort("advisor disposed");
@@ -131,6 +135,7 @@ export class AdvisorRuntime {
 		this.#lastCount = 0;
 		this.#pending = [];
 		this.#consecutiveFailures = 0;
+		this.#failureNotified = false;
 		this.#seenContext.clear();
 		if (clearBacklog) {
 			this.#backlog = 0;
@@ -168,6 +173,7 @@ export class AdvisorRuntime {
 		this.#pending = [];
 		this.#backlog = 0;
 		this.#consecutiveFailures = 0;
+		this.#failureNotified = false;
 		this.#seenContext.clear();
 		this.#wakeAllWaiters();
 	}
@@ -289,6 +295,7 @@ export class AdvisorRuntime {
 					await this.agent.prompt(batch);
 					success = true;
 					this.#consecutiveFailures = 0;
+					this.#failureNotified = false;
 				} catch (err) {
 					// reset()/dispose() aborts the in-flight prompt; the rejection is the
 					// reset itself, not a transient advisor failure. Drop the stale batch
@@ -299,6 +306,14 @@ export class AdvisorRuntime {
 					this.#consecutiveFailures++;
 					if (this.#consecutiveFailures >= 3) {
 						logger.warn("advisor failed consecutively 3 times; dropping backlog to prevent stall");
+						if (!this.#failureNotified) {
+							this.#failureNotified = true;
+							try {
+								this.host.notifyFailure?.(err);
+							} catch (notifyErr) {
+								logger.warn("advisor failure notification failed", { err: String(notifyErr) });
+							}
+						}
 						this.#consecutiveFailures = 0;
 						// The dropped batch may carry primary-context we never delivered; drop
 						// the seen-state too so the next turn re-expands it instead of marking

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -15,6 +15,12 @@ export interface AdvisorAgent {
 	prompt(input: string): Promise<void>;
 	abort(reason?: unknown): void;
 	reset(): void;
+	/**
+	 * Drop messages appended past `count`. Called after a failed `prompt()` so a
+	 * retry doesn't replay the failed user batch + synthetic assistant-error
+	 * turn `Agent.#runLoop` records on its internal state.
+	 */
+	rollbackTo?(count: number): void;
 	readonly state: { messages: AgentMessage[]; error?: string };
 }
 
@@ -244,6 +250,28 @@ export class AdvisorRuntime {
 		}
 	}
 
+	/**
+	 * Drop the user batch + synthetic assistant-error turn `Agent.#runLoop`
+	 * appended for a failed prompt so a retry replays a clean baseline and the
+	 * dropped-after-3 path never leaks orphan failures into the next successful
+	 * run. Prefers the agent's own `rollbackTo` (which also re-syncs its
+	 * append-only context); falls back to truncating `state.messages` for tests
+	 * that hand-roll a minimal facade.
+	 */
+	#rollbackFailedTurn(snapshot: number): void {
+		const messages = this.agent.state.messages;
+		if (messages.length <= snapshot) return;
+		try {
+			if (this.agent.rollbackTo) {
+				this.agent.rollbackTo(snapshot);
+				return;
+			}
+			messages.length = snapshot;
+		} catch (err) {
+			logger.debug("advisor rollback failed", { err: String(err) });
+		}
+	}
+
 	async #drain(): Promise<void> {
 		if (this.#busy) return;
 		this.#busy = true;
@@ -292,6 +320,12 @@ export class AdvisorRuntime {
 				}
 
 				let success = false;
+				// Capture the advisor's message count BEFORE the prompt so a failure can
+				// roll back the user batch + synthetic assistant-error turn `Agent.#runLoop`
+				// appends to internal state. Without this, a retry would replay the
+				// failed batch on top of the stale turns and the dropped-after-3 path
+				// would leak orphan failures into the next successful run's context.
+				const messageSnapshot = this.agent.state.messages.length;
 				try {
 					// Reset the host's per-update advisor state (one-advise-per-update
 					// gate) before each model cycle, so the new batch starts with a
@@ -315,6 +349,7 @@ export class AdvisorRuntime {
 					// (reset already cleared #pending and rewound the cursor) instead of
 					// requeuing it into the post-reset conversation.
 					if (this.#epoch !== epoch) continue;
+					this.#rollbackFailedTurn(messageSnapshot);
 					logger.debug("advisor turn failed", { err: String(err) });
 					this.#consecutiveFailures++;
 					if (this.#consecutiveFailures >= 3) {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -5,12 +5,17 @@ import { logger } from "@oh-my-pi/pi-utils";
 import { obfuscateToolArguments, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
 
-/** Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core `Agent`. */
+/**
+ * Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core
+ * `Agent`. `state.error` mirrors `Agent.state.error`: provider/stream failures
+ * the loop catches internally never reject `prompt()`, so the runtime reads
+ * this field after every prompt to detect a failed turn.
+ */
 export interface AdvisorAgent {
 	prompt(input: string): Promise<void>;
 	abort(reason?: unknown): void;
 	reset(): void;
-	readonly state: { messages: AgentMessage[] };
+	readonly state: { messages: AgentMessage[]; error?: string };
 }
 
 export interface AdvisorRuntimeHost {
@@ -293,6 +298,14 @@ export class AdvisorRuntime {
 					// fresh budget. Dedupe history persists across cycles.
 					this.host.beginAdvisorUpdate?.();
 					await this.agent.prompt(batch);
+					// `Agent.#runLoop` catches provider/stream failures internally and
+					// resolves `prompt()` cleanly with the assistant turn ending in
+					// `stopReason: "error"` and the message recorded on `state.error`.
+					// Treat that as a failed turn so OpenRouter ZDR-style endpoint
+					// rejections trip the retry/notify path instead of looking like a
+					// successful empty cycle.
+					const promptError = this.agent.state.error;
+					if (promptError) throw new Error(promptError);
 					success = true;
 					this.#consecutiveFailures = 0;
 					this.#failureNotified = false;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2049,6 +2049,10 @@ export class AgentSession {
 			maintainContext: incomingTokens => this.#maintainAdvisorContext(incomingTokens),
 			obfuscator: this.#obfuscator,
 			beginAdvisorUpdate: () => this.#advisorEmissionGuard.beginUpdate(),
+			notifyFailure: error => {
+				const message = error instanceof Error ? error.message : String(error);
+				this.emitNotice("warning", `Advisor unavailable for ${formatModelString(advisorSel.model)}: ${message}`, "advisor");
+			},
 		});
 		if (seedToCurrent) {
 			this.#advisorRuntime.seedTo(this.agent.state.messages.length);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2027,6 +2027,19 @@ export class AgentSession {
 				advisorAgent.reset();
 				appendOnlyContext.log.clear();
 			},
+			rollbackTo: count => {
+				// Drop the failed user batch + synthetic assistant-error turn
+				// `Agent.#runLoop` appended for a turn ending in `stopReason: "error"`.
+				// The append-only context auto-resyncs on the next prompt's
+				// `syncMessages` shrink path, but reset the sync cursor so the log
+				// can't carry the dropped tail forward if no further turn ever runs.
+				const messages = advisorAgent.state.messages;
+				if (count < messages.length) {
+					messages.length = count;
+				}
+				appendOnlyContext.resetSyncCursor();
+				advisorAgent.state.error = undefined;
+			},
 			state: advisorAgent.state,
 		};
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2051,7 +2051,11 @@ export class AgentSession {
 			beginAdvisorUpdate: () => this.#advisorEmissionGuard.beginUpdate(),
 			notifyFailure: error => {
 				const message = error instanceof Error ? error.message : String(error);
-				this.emitNotice("warning", `Advisor unavailable for ${formatModelString(advisorSel.model)}: ${message}`, "advisor");
+				this.emitNotice(
+					"warning",
+					`Advisor unavailable for ${formatModelString(advisorSel.model)}: ${message}`,
+					"advisor",
+				);
 			},
 		});
 		if (seedToCurrent) {


### PR DESCRIPTION
## Repro
A failing advisor provider call currently retries and drops its backlog without any user-visible session notice. I reproduced with an `AdvisorRuntime` whose advisor `prompt()` throws `404 No endpoints available matching your guardrail restrictions and data policy`, which produced `{"promptAttempts":3,"backlog":0,"notices":0}` before the fix.

## Cause
`packages/coding-agent/src/advisor/runtime.ts` handled `agent.prompt(batch)` failures only with debug/warn logs and backlog retry/drop state. `packages/coding-agent/src/session/agent-session.ts` only recorded advisor events to `__advisor.jsonl`, so advisor provider failures never reached `AgentSession.emitNotice` or the interactive notice renderer.

## Fix
- Added an `AdvisorRuntimeHost.notifyFailure` callback fired when the advisor reaches its consecutive-failure drop threshold.
- Wired advisor failures in `AgentSession` to a warning notice that includes the selected advisor model and provider error text.
- Added advisor runtime coverage for one visible notification per outage, with notification re-armed after a successful advisor prompt.

## Verification
Ran `bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` — 52 pass, 0 fail. Re-ran the minimal runtime scenario after the fix and observed `{"promptAttempts":3,"backlog":0,"notices":1,"notice":"404 No endpoints available matching your guardrail restrictions and data policy. Configure: https://openrouter.ai/settings/privacy"}`. `gh_push_branch` completed the pre-publish gate and pushed `farm/1386763e/notify-unavailable-advisor-model`. Fixes #3635