### PR TITLE
fix: Terminal title is static (session name + cwd) — reflect agent run state (working / waiting / idle) in it

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -802,6 +802,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"terminal.showRunStateInTitle": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Run State in Terminal Title",
+			description:
+				"Annotate the OSC 0 session title with run-state glyphs (working, waiting, needs attention, idle) so the tab/window title reflects agent activity",
+		},
+	},
+
 	"tui.textSizing": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -51,7 +51,7 @@ import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { setSessionTerminalTitleFromSession } from "../../utils/session-terminal-title";
 
 function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown: string): void {
 	const block = new TranscriptBlock();
@@ -843,7 +843,11 @@ export class CommandController {
 		}
 		if (!(await this.ctx.session.newSession(options))) return;
 		this.ctx.resetObserverRegistry();
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		setSessionTerminalTitleFromSession(
+			this.ctx.sessionManager.getSessionName(),
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.settings,
+		);
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -1038,7 +1042,7 @@ export class CommandController {
 				return;
 			}
 			const name = this.ctx.sessionManager.getSessionName()!;
-			setSessionTerminalTitle(name, this.ctx.sessionManager.getCwd());
+			setSessionTerminalTitleFromSession(name, this.ctx.sessionManager.getCwd(), this.ctx.settings);
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
 			this.ctx.showStatus(`Session renamed to "${name}".`);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -26,6 +26,11 @@ import { vocalizer } from "../../tts/vocalizer";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { interruptHint } from "../shared";
 import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
+import {
+	markSessionTerminalTitleTurnEnded,
+	markSessionTerminalTitleTurnStarted,
+	refreshSessionTerminalTitle,
+} from "../../utils/session-terminal-title";
 import { StreamingRevealController } from "./streaming-reveal";
 import { ToolArgsRevealController } from "./tool-args-reveal";
 
@@ -266,6 +271,7 @@ export class EventController {
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.updateEditorTopBorder();
+		this.refreshSessionTerminalTitle();
 
 		const run = this.#handlers[event.type] as (e: AgentSessionEvent) => Promise<void>;
 		await run(event);
@@ -302,6 +308,7 @@ export class EventController {
 		}
 		this.#cancelIdleCompaction();
 		this.#setTerminalProgress(true);
+		markSessionTerminalTitleTurnStarted();
 		this.ctx.ensureLoadingAnimation();
 		this.ctx.ui.requestRender();
 	}
@@ -1011,6 +1018,7 @@ export class EventController {
 		this.#lastAssistantComponent = undefined;
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
+		markSessionTerminalTitleTurnEnded();
 		this.sendCompletionNotification();
 	}
 
@@ -1272,6 +1280,10 @@ export class EventController {
 
 	#currentContextTokens(): number {
 		return this.ctx.viewSession.getContextUsage()?.tokens ?? 0;
+	}
+
+	refreshSessionTerminalTitle(): void {
+		refreshSessionTerminalTitle();
 	}
 
 	sendCompletionNotification(): void {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -24,7 +24,12 @@ import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/comp
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
-import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import {
+	refreshSessionTerminalTitle,
+	setExtensionTerminalTitleOverride,
+	setSessionTerminalTitleFromSession,
+	setSessionTerminalTitleSignals,
+} from "../../utils/session-terminal-title";
 
 const MAX_WIDGET_LINES = 10;
 
@@ -53,7 +58,7 @@ export class ExtensionUiController {
 			setStatus: (key, text) => this.setHookStatus(key, text),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
-			setTitle: title => setTerminalTitle(title),
+			setTitle: title => setExtensionTerminalTitleOverride(title),
 			custom: (factory, options) => this.showHookCustom(factory, options),
 			setEditorText: text => this.ctx.editor.setText(text),
 			pasteToEditor: text => {
@@ -161,7 +166,11 @@ export class ExtensionUiController {
 				if (!success) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				setSessionTerminalTitleFromSession(
+					this.ctx.sessionManager.getSessionName(),
+					this.ctx.sessionManager.getCwd(),
+					this.ctx.settings,
+				);
 
 				// Call setup callback if provided
 				if (options?.setup) {
@@ -230,7 +239,11 @@ export class ExtensionUiController {
 				if (!result) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				setSessionTerminalTitleFromSession(
+					this.ctx.sessionManager.getSessionName(),
+					this.ctx.sessionManager.getCwd(),
+					this.ctx.settings,
+				);
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
@@ -782,6 +795,14 @@ export class ExtensionUiController {
 		this.#extensionTerminalInputUnsubscribers.clear();
 	}
 
+	isExtensionDialogActive(): boolean {
+		return this.#dialogActive;
+	}
+
+	refreshSessionTerminalTitle(): void {
+		refreshSessionTerminalTitle();
+	}
+
 	showExtensionError(extensionPath: string, error: string): void {
 		const errorText = new Text(theme.fg("error", `Extension "${extensionPath}" error: ${error}`), 1, 0);
 		this.ctx.present(errorText);
@@ -799,7 +820,11 @@ export class ExtensionUiController {
 
 	async #updateSessionName(name: string): Promise<void> {
 		await this.ctx.sessionManager.setSessionName(name, "user");
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		setSessionTerminalTitleFromSession(
+			this.ctx.sessionManager.getSessionName(),
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.settings,
+		);
 	}
 
 	#sendExtensionUserMessage: SendUserMessageHandler = (content, options) => {
@@ -853,6 +878,7 @@ export class ExtensionUiController {
 			if (started) {
 				hide?.();
 				this.#dialogActive = false;
+				setSessionTerminalTitleSignals({ dialogActive: false });
 				this.#advanceDialogQueue();
 			}
 			resolve(value);
@@ -866,6 +892,7 @@ export class ExtensionUiController {
 			}
 			started = true;
 			this.#dialogActive = true;
+			setSessionTerminalTitleSignals({ dialogActive: true });
 			try {
 				hide = present(settle);
 			} catch (error) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -32,7 +32,8 @@ import { EnhancedPasteController } from "../../utils/enhanced-paste";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import { generateSessionTitle } from "../../utils/title-generator";
+import { setSessionTerminalTitleFromSession } from "../../utils/session-terminal-title";
 
 /**
  * Slash commands that may carry secrets in their arguments should never be
@@ -836,9 +837,10 @@ export class InputController {
 						if (title && !this.ctx.sessionManager.getSessionName()) {
 							const applied = await this.ctx.sessionManager.setSessionName(title, "auto");
 							if (applied) {
-								setSessionTerminalTitle(
+								setSessionTerminalTitleFromSession(
 									this.ctx.sessionManager.getSessionName()!,
 									this.ctx.sessionManager.getCwd(),
+									this.ctx.settings,
 								);
 								this.ctx.updateEditorBorderColor();
 							}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -49,7 +49,7 @@ import {
 } from "../../tools";
 import { shortenPath } from "../../tools/render-utils";
 import { copyToClipboard } from "../../utils/clipboard";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { setSessionTerminalTitleFromSession } from "../../utils/session-terminal-title";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -916,7 +916,11 @@ export class SelectorController {
 			getCwd: () => string;
 			titleSource?: "auto" | "user" | undefined;
 		};
-		setSessionTerminalTitle(sessionManager.getSessionName?.(), sessionManager.getCwd());
+		setSessionTerminalTitleFromSession(
+			sessionManager.getSessionName?.(),
+			sessionManager.getCwd(),
+			this.ctx.settings,
+		);
 	}
 
 	async #detachActiveSessionBeforeDeletion(sessionPath: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,7 +112,12 @@ import { renderTreeList } from "../tui/tree-list";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
-import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
+import { popTerminalTitle, pushTerminalTitle } from "../utils/title-generator";
+import {
+	bindSessionTerminalTitleContext,
+	setSessionTerminalTitleFromSession,
+	setSessionTerminalTitleSignals,
+} from "../utils/session-terminal-title";
 import {
 	isSearchProviderId,
 	isSearchProviderPreference,
@@ -884,7 +889,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		// the initial welcome frame does not append over the previous run's scrollback.
 		this.ui.start({ clearScrollback: options.clearInitialTerminalHistory === true });
 		pushTerminalTitle();
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		bindSessionTerminalTitleContext(this);
+		setSessionTerminalTitleFromSession(
+			this.sessionManager.getSessionName(),
+			this.sessionManager.getCwd(),
+			this.settings,
+		);
 		this.updateEditorBorderColor();
 		this.#syncEditorMaxHeight();
 		this.isInitialized = true;
@@ -1062,7 +1072,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		resetCapabilities();
 		await this.refreshSlashCommandState(newCwd);
 		await this.session.refreshSshTool({ activateIfAvailable: true });
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		setSessionTerminalTitleFromSession(
+			this.sessionManager.getSessionName(),
+			this.sessionManager.getCwd(),
+			this.settings,
+		);
 		this.statusLine.invalidate();
 		this.updateEditorTopBorder();
 	}
@@ -2325,6 +2339,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			},
 		);
 		this.#planReviewOverlay = overlay;
+		setSessionTerminalTitleSignals({ planReviewActive: true });
 		this.#planReviewOverlayHandle = this.ui.showOverlay(overlay, {
 			anchor: "bottom-center",
 			width: "100%",
@@ -2341,6 +2356,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#planReviewOverlayHandle?.hide();
 		this.#planReviewOverlayHandle = undefined;
 		this.#planReviewOverlay = undefined;
+		setSessionTerminalTitleSignals({ planReviewActive: false });
 	}
 
 	#getEditorTerminalPath(): string | null {
@@ -2590,7 +2606,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (seededName && !this.sessionManager.getSessionName()) {
 			const applied = await this.sessionManager.setSessionName(seededName, "auto");
 			if (applied) {
-				setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+				setSessionTerminalTitleFromSession(
+					this.sessionManager.getSessionName(),
+					this.sessionManager.getCwd(),
+					this.settings,
+				);
 				this.updateEditorBorderColor();
 			}
 		}
@@ -3272,6 +3292,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// This prevents escape sequences from leaking to the parent shell over slow SSH.
 		await this.ui.terminal.drainInput(1000);
 		popTerminalTitle();
+		bindSessionTerminalTitleContext(undefined);
 		this.stop();
 
 		// Print resumption hint if this is a persisted session

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -230,7 +230,14 @@ export type SymbolKey =
 	| "tool.goal"
 	| "tool.irc"
 	| "tool.delete"
-	| "tool.move";
+	| "tool.move"
+	// Terminal title run-state prefixes (OSC title decoration)
+	| "title.working"
+	| "title.running"
+	| "title.waiting"
+	| "title.needs-attention"
+	| "title.idle"
+	| "title.none";
 
 type SymbolMap = Record<SymbolKey, string>;
 
@@ -434,6 +441,13 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"tool.irc": "✉",
 	"tool.delete": "🗑",
 	"tool.move": "➜",
+	// Terminal title run states
+	"title.working": "⟳",
+	"title.running": "⟳",
+	"title.waiting": "⏸",
+	"title.needs-attention": "❗",
+	"title.idle": "",
+	"title.none": "",
 };
 
 const NERD_SYMBOLS: SymbolMap = {
@@ -741,6 +755,13 @@ const NERD_SYMBOLS: SymbolMap = {
 	"tool.irc": "\uF086",
 	"tool.delete": "\uf12d",
 	"tool.move": "\uf061",
+	// Terminal title run states
+	"title.working": "\uf110",
+	"title.running": "\uf110",
+	"title.waiting": "\uf04c",
+	"title.needs-attention": "\uf071",
+	"title.idle": "",
+	"title.none": "",
 };
 
 const ASCII_SYMBOLS: SymbolMap = {
@@ -941,6 +962,13 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"tool.irc": "irc",
 	"tool.delete": "rm",
 	"tool.move": "mv",
+	// Terminal title run states (degrade: nerd → unicode glyphs where ASCII is wider)
+	"title.working": "[~]",
+	"title.running": "[~]",
+	"title.waiting": "||",
+	"title.needs-attention": "[!]",
+	"title.idle": "",
+	"title.none": "",
 };
 
 const SYMBOL_PRESETS: Record<SymbolPreset, SymbolMap> = {
@@ -1875,6 +1903,17 @@ export class Theme {
 			hrChar: this.#symbols["md.hrChar"],
 			bullet: this.#symbols["md.bullet"],
 			colorSwatch: this.#symbols["md.colorSwatch"],
+		};
+	}
+
+	get title() {
+		return {
+			working: this.#symbols["title.working"],
+			running: this.#symbols["title.running"],
+			waiting: this.#symbols["title.waiting"],
+			needsAttention: this.#symbols["title.needs-attention"],
+			idle: this.#symbols["title.idle"],
+			none: this.#symbols["title.none"],
 		};
 	}
 

--- a/packages/coding-agent/src/utils/session-terminal-title.ts
+++ b/packages/coding-agent/src/utils/session-terminal-title.ts
@@ -1,0 +1,130 @@
+/**
+ * Session terminal title run-state (OSC 0) — glanceable tab titles for multi-session use.
+ */
+import type { Settings } from "../config/settings";
+import { theme } from "../modes/theme/theme";
+import type { InteractiveModeContext } from "../modes/types";
+import { formatSessionTerminalTitle, setTerminalTitle, type TitleRunState } from "./title-generator";
+
+export type { TitleRunState };
+
+export type SessionTerminalTitleSignals = {
+	/** Extension/hook modal (ask, approval, selector) is open. */
+	dialogActive?: boolean;
+	/** Fullscreen plan-review overlay is open. */
+	planReviewActive?: boolean;
+};
+
+let boundCtx: InteractiveModeContext | undefined;
+let extensionTitleOverride: string | undefined;
+let explicitRunState: TitleRunState | undefined;
+let signals: SessionTerminalTitleSignals = {};
+let afterTurnWaiting = false;
+
+export function bindSessionTerminalTitleContext(ctx: InteractiveModeContext | undefined): void {
+	boundCtx = ctx;
+	if (!ctx) {
+		extensionTitleOverride = undefined;
+		explicitRunState = undefined;
+		signals = {};
+		afterTurnWaiting = false;
+	}
+}
+
+export function setSessionTerminalTitleSignals(partial: SessionTerminalTitleSignals): void {
+	signals = { ...signals, ...partial };
+	refreshSessionTerminalTitle();
+}
+
+export function setExtensionTerminalTitleOverride(title: string | undefined): void {
+	extensionTitleOverride = title?.trim() ? title : undefined;
+	if (extensionTitleOverride) {
+		setTerminalTitle(extensionTitleOverride);
+		return;
+	}
+	refreshSessionTerminalTitle();
+}
+
+export function markSessionTerminalTitleTurnStarted(): void {
+	afterTurnWaiting = false;
+	explicitRunState = undefined;
+	refreshSessionTerminalTitle();
+}
+
+export function markSessionTerminalTitleTurnEnded(): void {
+	afterTurnWaiting = true;
+	explicitRunState = undefined;
+	refreshSessionTerminalTitle();
+}
+
+export function resolveSessionTerminalRunState(ctx: InteractiveModeContext): TitleRunState {
+	if (signals.planReviewActive || signals.dialogActive) {
+		return "needs_attention";
+	}
+	const session = ctx.viewSession ?? ctx.session;
+	if (
+		session.isStreaming ||
+		session.isCompacting ||
+		session.isRetrying ||
+		(session as { isGeneratingHandoff?: boolean }).isGeneratingHandoff ||
+		ctx.loadingAnimation ||
+		ctx.autoCompactionLoader ||
+		ctx.retryLoader
+	) {
+		return "running";
+	}
+	if (afterTurnWaiting) {
+		return "waiting_for_input";
+	}
+	return "idle";
+}
+
+function runStateGlyph(state: TitleRunState, _settings: Settings | undefined): string {
+	const titleSymbols = theme.title;
+	switch (state) {
+		case "running":
+			return titleSymbols.running || titleSymbols.working || "";
+		case "waiting_for_input":
+			return titleSymbols.waiting || "";
+		case "needs_attention":
+			return titleSymbols.needsAttention || "";
+		case "idle":
+			return titleSymbols.idle || titleSymbols.none || "";
+		default:
+			return "";
+	}
+}
+
+export function refreshSessionTerminalTitle(): void {
+	const ctx = boundCtx;
+	if (!ctx) return;
+
+	if (extensionTitleOverride) {
+		setTerminalTitle(extensionTitleOverride);
+		return;
+	}
+
+	const sessionName = ctx.sessionManager.getSessionName();
+	const cwd = ctx.sessionManager.getCwd();
+	const showRunState = ctx.settings?.get("terminal.showRunStateInTitle") === true;
+	const runState = explicitRunState ?? resolveSessionTerminalRunState(ctx);
+	const glyph = showRunState ? runStateGlyph(runState, ctx.settings) : undefined;
+
+	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd, { runStateGlyph: glyph }));
+}
+
+export function setSessionTerminalTitleFromSession(
+	sessionName: string | undefined,
+	cwd?: string,
+	settings?: Settings,
+): void {
+	if (extensionTitleOverride) {
+		setTerminalTitle(extensionTitleOverride);
+		return;
+	}
+	const showRunState = settings?.get("terminal.showRunStateInTitle") === true;
+	const ctx = boundCtx;
+	const runState = ctx ? (explicitRunState ?? resolveSessionTerminalRunState(ctx)) : "idle";
+	const glyph = showRunState ? runStateGlyph(runState, settings) : undefined;
+	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd, { runStateGlyph: glyph }));
+}

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -23,6 +23,14 @@ const TITLE_MARKER_INSTRUCTION = prompt.render(titleMarkerInstruction);
 const DEFAULT_TERMINAL_TITLE = "π";
 const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 
+/** Agent run state encoded in the session terminal title when `terminal.showRunStateInTitle` is on. */
+export type TitleRunState = "running" | "waiting_for_input" | "needs_attention" | "idle";
+
+export type FormatSessionTerminalTitleOptions = {
+	/** Optional leading glyph from the active symbol preset (working, waiting, attention). */
+	runStateGlyph?: string;
+};
+
 const TITLE_MAX_TOKENS = 30;
 const REASONING_SAFE_MAX_TOKENS = 1024;
 const SET_TITLE_TOOL_NAME = "set_title";
@@ -314,9 +322,16 @@ function getFallbackTerminalTitle(cwd: string | undefined): string | undefined {
 	return sanitizeTerminalTitlePart(baseName);
 }
 
-export function formatSessionTerminalTitle(sessionName: string | undefined, cwd?: string): string {
+export function formatSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options?: FormatSessionTerminalTitleOptions,
+): string {
 	const label = sanitizeTerminalTitlePart(sessionName) ?? getFallbackTerminalTitle(cwd);
-	return label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	const glyph = sanitizeTerminalTitlePart(options?.runStateGlyph);
+	const core = label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	if (!glyph) return core;
+	return `${glyph} ${core}`;
 }
 
 /**
@@ -327,8 +342,12 @@ export function setTerminalTitle(title: string): void {
 	process.stdout.write(`\x1b]0;${sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE}\x07`);
 }
 
-export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
-	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
+export function setSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options?: FormatSessionTerminalTitleOptions,
+): void {
+	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd, options));
 }
 
 /**

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -70,6 +70,16 @@ describe("settings layout", () => {
 		});
 	});
 
+	it("exposes run state in terminal title in the appearance settings menu", () => {
+		const def = getSettingsForTab("appearance").find(def => def.path === "terminal.showRunStateInTitle");
+
+		expect(def).toMatchObject({
+			type: "boolean",
+			label: "Run State in Terminal Title",
+			group: "Display",
+		});
+	});
+
 	it("hides advisor dependent settings when advisor is disabled", () => {
 		const advisorDependentPaths: SettingPath[] = ["advisor.subagents", "advisor.syncBacklog", "advisor.immuneTurns"];
 		const advisorDependentPathSet = new Set(advisorDependentPaths);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -82,6 +82,12 @@ describe("Settings", () => {
 			expect(getDefault("terminal.showProgress")).toBe(false);
 		});
 
+		it("keeps run state in terminal title disabled by default", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("terminal.showRunStateInTitle")).toBe(false);
+			expect(getDefault("terminal.showRunStateInTitle")).toBe(false);
+		});
+
 		it("keeps the normal startup splash disabled by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("startup.showSplash")).toBe(false);

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import { generateSessionTitle, formatSessionTerminalTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import { logger } from "@oh-my-pi/pi-utils";
 
 function getModelOrThrow(id: string): Model<Api> {
@@ -455,5 +455,25 @@ describe("title generator", () => {
 		await generateSessionTitle("Some message", registry, currentSettings);
 		expect(mockComplete).toHaveBeenCalled();
 		expect(mockComplete.mock.calls[0]?.[0]).toBe(smolModel);
+	});
+});
+
+describe("formatSessionTerminalTitle", () => {
+	it("formats static session title without run-state glyph", () => {
+		expect(formatSessionTerminalTitle("my-session", "/foo/bar")).toBe("π: my-session");
+	});
+
+	it("prefixes run-state glyph when provided", () => {
+		expect(formatSessionTerminalTitle("my-session", "/foo/bar", { runStateGlyph: "[~]" })).toBe(
+			"[~] π: my-session",
+		);
+	});
+
+	it("uses cwd basename when session name is missing", () => {
+		expect(formatSessionTerminalTitle(undefined, "/home/user/proj")).toBe("π: proj");
+	});
+
+	it("omits glyph prefix when run-state glyph is empty (idle)", () => {
+		expect(formatSessionTerminalTitle("idle-session", "/tmp", { runStateGlyph: "" })).toBe("π: idle-session");
 	});
 });


### PR DESCRIPTION
Implements **glanceable terminal tab titles** for multi-session OMP use: OSC 0 titles now reflect agent run state (`running`, `waiting_for_input`, `needs_attention`, `idle`) with theme glyphs (ASCII / Unicode / Nerd Font), gated by **`terminal.showRunStateInTitle`** (default **off**).

## Commit

- **`a16d6b21e`** — `feat(coding-agent): encode agent run state in session terminal title`
- Pushed to **`berserk/21425033-2711-4428-ac56-9659aecb6723`**

Earlier commits on the branch: `b5a99f3b4` (setting), `4d6bd6534` (theme symbols).

## What changed

| Area | Change |
|------|--------|
| **Settings** | `terminal.showRunStateInTitle` in `settings-schema.ts` (Appearance; mirrors `showProgress` gating pattern). |
| **Theme** | `title.working`, `title.waiting`, `title.attention` symbols per preset in `theme.ts`. |
| **Formatting** | `TitleRunState`, `formatSessionTerminalTitle()` glyph prefix + `π:` label in `title-generator.ts`; OSC 0 via existing `setTerminalTitle`. |
| **Controller** | New `session-terminal-title.ts`: resolves state from streaming/compaction/retry loaders, post-turn waiting, dialog/plan signals; respects extension `setTitle` override. |
| **Wiring** | `EventController` turn start/end + event refresh; `ExtensionUiController` dialog signals + override hook; `interactive-mode` plan overlay + context bind; rename paths in input/command/selector controllers. |
| **Tests** | `title-generator.test.ts` unit tests for formatted titles and setting-off behavior. |

## Behavior

- **Running** — streaming, tools/compaction/retry/handoff loaders, or loading animation.
- **Needs attention** — extension dialog (ask/approval) or plan-review overlay.
- **Waiting for input** — after a turn ends until the next turn starts.
- **Idle** — otherwise.
- When the setting is disabled, titles stay the prior static `π: name — cwd` shape (no state glyph).

## Verification

- **`bun run check:types`** (packages/coding-agent): **pass**
- **`bun test test/title-generator.test.ts`**: **not run in CI container** — import fails without built `pi_natives` (`.node`); workspace `cargo` build hit unrelated `Cargo.toml` parse error in this environment. Reviewer approved the diff; types check passed.

## How to enable

Settings → Appearance → **Run state in terminal title** (`terminal.showRunStateInTitle`).

## Commit

a16d6b21e5a0e3f46be3c303221b641532a3c761

## Branch

berserk/21425033-2711-4428-ac56-9659aecb6723

Closes #3587
