### PR TITLE
fix: Terminal title is static (session name + cwd) — reflect agent run state (working / waiting / idle) in it

### DIFF
--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -22,7 +22,7 @@ import { AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "../session/agent-session";
 import type { SessionEntry } from "../session/session-entries";
 import { shouldDisableReasoning, toReasoningEffort } from "../thinking";
-import { setSessionTerminalTitle } from "../utils/title-generator";
+import { refreshSessionTerminalTitle } from "../utils/session-terminal-title";
 import { importRoomKey } from "./crypto";
 import { collabDisplayName } from "./display-name";
 import {
@@ -360,7 +360,7 @@ export class CollabGuestLink {
 		this.#applyAgentSnapshots(pending.agents);
 		this.#ctx.syncRunningSubagentBadge();
 		this.#assistantStreamSynced = false;
-		setSessionTerminalTitle(pending.state.sessionName ?? pending.header.title, pending.state.cwd);
+		refreshSessionTerminalTitle();
 		this.#ctx.chatContainer.clear();
 		this.#ctx.renderInitialMessages({ clearTerminalHistory: true });
 		await this.#ctx.reloadTodos();
@@ -423,7 +423,7 @@ export class CollabGuestLink {
 			case "state": {
 				this.state = frame.state;
 				this.#applyHostState(frame.state);
-				setSessionTerminalTitle(frame.state.sessionName, frame.state.cwd);
+				refreshSessionTerminalTitle();
 				this.#updateStatusSegment();
 				// Reconciler: events normally drive the loader; clear a stale one if
 				// the host reports idle (e.g. events lost across a reconnect).
@@ -586,7 +586,7 @@ export class CollabGuestLink {
 			return;
 		}
 		await this.#ctx.session.newSession();
-		setSessionTerminalTitle(this.#ctx.sessionManager.getSessionName(), this.#ctx.sessionManager.getCwd());
+		refreshSessionTerminalTitle();
 		this.#ctx.statusLine.invalidate();
 		this.#ctx.statusLine.setSessionStartTime(Date.now());
 		this.#ctx.updateEditorTopBorder();

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -802,6 +802,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"terminal.dynamicTitle": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Dynamic Terminal Title",
+			description:
+				"Reflect agent run state (working, waiting, needs attention) in the terminal tab title via OSC 0",
+		},
+	},
+
 	"tui.textSizing": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -51,7 +51,7 @@ import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { refreshSessionTerminalTitle } from "../../utils/session-terminal-title";
 
 function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown: string): void {
 	const block = new TranscriptBlock();
@@ -843,7 +843,7 @@ export class CommandController {
 		}
 		if (!(await this.ctx.session.newSession(options))) return;
 		this.ctx.resetObserverRegistry();
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		refreshSessionTerminalTitle();
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -1038,7 +1038,7 @@ export class CommandController {
 				return;
 			}
 			const name = this.ctx.sessionManager.getSessionName()!;
-			setSessionTerminalTitle(name, this.ctx.sessionManager.getCwd());
+			refreshSessionTerminalTitle();
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
 			this.ctx.showStatus(`Session renamed to "${name}".`);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -302,6 +302,7 @@ export class EventController {
 		}
 		this.#cancelIdleCompaction();
 		this.#setTerminalProgress(true);
+		this.ctx.setTerminalTitleRunState("running");
 		this.ctx.ensureLoadingAnimation();
 		this.ctx.ui.requestRender();
 	}
@@ -1012,6 +1013,7 @@ export class EventController {
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.sendCompletionNotification();
+		this.ctx.setTerminalTitleRunState("waiting_for_input");
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -24,7 +24,15 @@ import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/comp
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
-import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import {
+	resolveTerminalTitleStateGlyph,
+	setTerminalTitle,
+} from "../../utils/title-generator";
+import {
+	buildSessionTerminalTitleFormatOptions,
+	getSessionTerminalTitleContext,
+	refreshSessionTerminalTitle,
+} from "../../utils/session-terminal-title";
 
 const MAX_WIDGET_LINES = 10;
 
@@ -37,6 +45,7 @@ export class ExtensionUiController {
 	// the rest queue. See `#presentDialog`.
 	#dialogActive = false;
 	#dialogQueue: Array<() => void> = [];
+	#terminalTitleStateBeforeDialog: import("../../utils/title-generator").TerminalTitleState | undefined;
 	constructor(private ctx: InteractiveModeContext) {}
 
 	/**
@@ -53,7 +62,19 @@ export class ExtensionUiController {
 			setStatus: (key, text) => this.setHookStatus(key, text),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
-			setTitle: title => setTerminalTitle(title),
+			setTitle: title => {
+				const titleCtx = getSessionTerminalTitleContext();
+				if (!titleCtx || titleCtx.settings.get("terminal.dynamicTitle") !== true) {
+					setTerminalTitle(title);
+					return;
+				}
+				const opts = buildSessionTerminalTitleFormatOptions(titleCtx);
+				const state = opts.state ?? "idle";
+				const preset = opts.symbolPreset ?? "unicode";
+				const glyph = resolveTerminalTitleStateGlyph(state, preset, opts.getSymbol);
+				const composed = glyph ? `${glyph} ${title}` : title;
+				setTerminalTitle(composed);
+			},
 			custom: (factory, options) => this.showHookCustom(factory, options),
 			setEditorText: text => this.ctx.editor.setText(text),
 			pasteToEditor: text => {
@@ -161,7 +182,7 @@ export class ExtensionUiController {
 				if (!success) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				refreshSessionTerminalTitle();
 
 				// Call setup callback if provided
 				if (options?.setup) {
@@ -230,7 +251,7 @@ export class ExtensionUiController {
 				if (!result) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				refreshSessionTerminalTitle();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
@@ -799,7 +820,7 @@ export class ExtensionUiController {
 
 	async #updateSessionName(name: string): Promise<void> {
 		await this.ctx.sessionManager.setSessionName(name, "user");
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		refreshSessionTerminalTitle();
 	}
 
 	#sendExtensionUserMessage: SendUserMessageHandler = (content, options) => {
@@ -854,6 +875,12 @@ export class ExtensionUiController {
 				hide?.();
 				this.#dialogActive = false;
 				this.#advanceDialogQueue();
+				if (!this.#dialogActive && this.#dialogQueue.length === 0) {
+					if (this.#terminalTitleStateBeforeDialog !== undefined) {
+						this.ctx.setTerminalTitleRunState(this.#terminalTitleStateBeforeDialog);
+						this.#terminalTitleStateBeforeDialog = undefined;
+					}
+				}
 			}
 			resolve(value);
 		};
@@ -866,6 +893,10 @@ export class ExtensionUiController {
 			}
 			started = true;
 			this.#dialogActive = true;
+			if (this.#terminalTitleStateBeforeDialog === undefined) {
+				this.#terminalTitleStateBeforeDialog = this.ctx.getTerminalTitleRunState();
+				this.ctx.setTerminalTitleRunState("needs_attention");
+			}
 			try {
 				hide = present(settle);
 			} catch (error) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -32,7 +32,8 @@ import { EnhancedPasteController } from "../../utils/enhanced-paste";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import { generateSessionTitle } from "../../utils/title-generator";
+import { refreshSessionTerminalTitle } from "../../utils/session-terminal-title";
 
 /**
  * Slash commands that may carry secrets in their arguments should never be
@@ -836,10 +837,7 @@ export class InputController {
 						if (title && !this.ctx.sessionManager.getSessionName()) {
 							const applied = await this.ctx.sessionManager.setSessionName(title, "auto");
 							if (applied) {
-								setSessionTerminalTitle(
-									this.ctx.sessionManager.getSessionName()!,
-									this.ctx.sessionManager.getCwd(),
-								);
+								refreshSessionTerminalTitle();
 								this.ctx.updateEditorBorderColor();
 							}
 						}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -49,7 +49,7 @@ import {
 } from "../../tools";
 import { shortenPath } from "../../tools/render-utils";
 import { copyToClipboard } from "../../utils/clipboard";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { refreshSessionTerminalTitle } from "../../utils/session-terminal-title";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -916,7 +916,7 @@ export class SelectorController {
 			getCwd: () => string;
 			titleSource?: "auto" | "user" | undefined;
 		};
-		setSessionTerminalTitle(sessionManager.getSessionName?.(), sessionManager.getCwd());
+		refreshSessionTerminalTitle();
 	}
 
 	async #detachActiveSessionBeforeDeletion(sessionPath: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,7 +112,13 @@ import { renderTreeList } from "../tui/tree-list";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
-import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
+import { popTerminalTitle, pushTerminalTitle } from "../utils/title-generator";
+import {
+	refreshSessionTerminalTitle as refreshSessionTerminalTitleImpl,
+	setSessionTerminalTitleContext,
+	type SessionTerminalTitleContext,
+} from "../utils/session-terminal-title";
+import type { TerminalTitleState } from "../utils/title-generator";
 import {
 	isSearchProviderId,
 	isSearchProviderPreference,
@@ -440,6 +446,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	#workingMessageAccentCacheKey?: WorkingMessageAccentCacheKey;
 	#workingMessageAccentCacheValue?: WorkingMessageAccent;
 	#workingMessageAccentCacheHasValue = false;
+	#terminalTitleState: TerminalTitleState = "idle";
+	get #sessionTerminalTitleContext(): SessionTerminalTitleContext {
+		return {
+			settings: this.settings,
+			sessionManager: this.sessionManager,
+			isStreaming: () => this.viewSession.isStreaming,
+			getTerminalTitleState: () => this.#terminalTitleState,
+		};
+	}
 	get #defaultWorkingMessage(): string {
 		return `Working…${interruptHint()}`;
 	}
@@ -884,7 +899,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		// the initial welcome frame does not append over the previous run's scrollback.
 		this.ui.start({ clearScrollback: options.clearInitialTerminalHistory === true });
 		pushTerminalTitle();
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		setSessionTerminalTitleContext(this.#sessionTerminalTitleContext);
+		this.refreshSessionTerminalTitle("idle");
 		this.updateEditorBorderColor();
 		this.#syncEditorMaxHeight();
 		this.isInitialized = true;
@@ -1062,7 +1078,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		resetCapabilities();
 		await this.refreshSlashCommandState(newCwd);
 		await this.session.refreshSshTool({ activateIfAvailable: true });
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		this.refreshSessionTerminalTitle();
 		this.statusLine.invalidate();
 		this.updateEditorTopBorder();
 	}
@@ -1458,6 +1474,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		this.updateEditorTopBorder();
 		this.ui.requestRender();
+	}
+
+	refreshSessionTerminalTitle(stateOverride?: TerminalTitleState): void {
+		refreshSessionTerminalTitleImpl(stateOverride);
+	}
+
+	setTerminalTitleRunState(state: TerminalTitleState): void {
+		this.#terminalTitleState = state;
+		this.refreshSessionTerminalTitle(state);
+	}
+
+	getTerminalTitleRunState(): TerminalTitleState {
+		return this.#terminalTitleState;
 	}
 
 	/** Refresh the running-subagents status badge from the active local or collab registry. */
@@ -2590,7 +2619,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (seededName && !this.sessionManager.getSessionName()) {
 			const applied = await this.sessionManager.setSessionName(seededName, "auto");
 			if (applied) {
-				setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+				this.refreshSessionTerminalTitle();
 				this.updateEditorBorderColor();
 			}
 		}
@@ -3271,6 +3300,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Drain any in-flight Kitty key release events before stopping.
 		// This prevents escape sequences from leaking to the parent shell over slow SSH.
 		await this.ui.terminal.drainInput(1000);
+		setSessionTerminalTitleContext(undefined);
 		popTerminalTitle();
 		this.stop();
 

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -44,6 +44,10 @@ export type SymbolKey =
 	| "status.shadowed"
 	| "status.aborted"
 	| "status.done"
+	// Terminal title prefixes (idle has no prefix — no key)
+	| "terminal.title.running"
+	| "terminal.title.waiting"
+	| "terminal.title.needsAttention"
 	// Navigation
 	| "nav.cursor"
 	| "nav.selected"
@@ -247,6 +251,10 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"status.shadowed": "◌",
 	"status.aborted": "⏹",
 	"status.done": "•",
+	// Terminal title
+	"terminal.title.running": "⟳",
+	"terminal.title.waiting": "◌",
+	"terminal.title.needsAttention": "●",
 	// Navigation
 	"nav.cursor": "❯",
 	"nav.selected": "➤",
@@ -460,6 +468,10 @@ const NERD_SYMBOLS: SymbolMap = {
 	"status.aborted": "\uf04d",
 	// pick: • | alt: ● ·
 	"status.done": "•",
+	// Terminal title (aligned with status.running / status.shadowed / status.enabled)
+	"terminal.title.running": "\uf110",
+	"terminal.title.waiting": "◐",
+	"terminal.title.needsAttention": "\uf111",
 	// Navigation
 	// pick:  | alt:  
 	"nav.cursor": "\uf054",
@@ -756,6 +768,10 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"status.shadowed": "[/]",
 	"status.aborted": "[-]",
 	"status.done": "*",
+	// Terminal title
+	"terminal.title.running": "[~]",
+	"terminal.title.waiting": "[/]",
+	"terminal.title.needsAttention": "!",
 	// Navigation
 	"nav.cursor": ">",
 	"nav.selected": "->",

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -296,6 +296,11 @@ export interface InteractiveModeContext {
 	updateEditorTopBorder(): void;
 	/** Refresh the running-subagents status badge from the active local or collab registry. */
 	syncRunningSubagentBadge(): void;
+	/** Refresh OSC 0 session title from settings and current run state. */
+	refreshSessionTerminalTitle(stateOverride?: import("../utils/title-generator").TerminalTitleState): void;
+	/** Track run state and refresh the terminal tab title. */
+	setTerminalTitleRunState(state: import("../utils/title-generator").TerminalTitleState): void;
+	getTerminalTitleRunState(): import("../utils/title-generator").TerminalTitleState;
 	updateEditorBorderColor(): void;
 	rebuildChatFromMessages(): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;

--- a/packages/coding-agent/src/utils/session-terminal-title.ts
+++ b/packages/coding-agent/src/utils/session-terminal-title.ts
@@ -1,0 +1,55 @@
+import type { Settings } from "../config/settings";
+import { theme } from "../modes/theme/theme";
+import type { SessionManager } from "../session/session-manager";
+import {
+	setSessionTerminalTitle,
+	type TerminalTitleFormatOptions,
+	type TerminalTitleState,
+} from "./title-generator";
+
+export type SessionTerminalTitleContext = {
+	settings: Settings;
+	sessionManager: SessionManager;
+	isStreaming?: () => boolean;
+	getTerminalTitleState?: () => TerminalTitleState;
+};
+
+let globalSessionTerminalTitleContext: SessionTerminalTitleContext | undefined;
+
+/** Register the active interactive session for title refresh (cleared on shutdown). */
+export function setSessionTerminalTitleContext(ctx: SessionTerminalTitleContext | undefined): void {
+	globalSessionTerminalTitleContext = ctx;
+}
+
+export function getSessionTerminalTitleContext(): SessionTerminalTitleContext | undefined {
+	return globalSessionTerminalTitleContext;
+}
+
+function resolveTerminalTitleState(ctx: SessionTerminalTitleContext): TerminalTitleState {
+	if (ctx.getTerminalTitleState) return ctx.getTerminalTitleState();
+	if (ctx.isStreaming?.()) return "running";
+	return "idle";
+}
+
+export function buildSessionTerminalTitleFormatOptions(
+	ctx: SessionTerminalTitleContext,
+	stateOverride?: TerminalTitleState,
+): TerminalTitleFormatOptions {
+	const dynamicTitle = ctx.settings.get("terminal.dynamicTitle") === true;
+	if (!dynamicTitle) return { dynamicTitle: false };
+	const state = stateOverride ?? resolveTerminalTitleState(ctx);
+	return {
+		dynamicTitle: true,
+		state,
+		symbolPreset: theme.getSymbolPreset(),
+		getSymbol: key => theme.symbol(key),
+	};
+}
+
+/** Refresh OSC 0 session title from settings, theme preset, and run state. */
+export function refreshSessionTerminalTitle(stateOverride?: TerminalTitleState): void {
+	const ctx = globalSessionTerminalTitleContext;
+	if (!ctx) return;
+	const options = buildSessionTerminalTitleFormatOptions(ctx, stateOverride);
+	setSessionTerminalTitle(ctx.sessionManager.getSessionName(), ctx.sessionManager.getCwd(), options);
+}

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -324,6 +324,12 @@ function getFallbackTerminalTitle(cwd: string | undefined): string | undefined {
 	return sanitizeTerminalTitlePart(baseName);
 }
 
+const TERMINAL_TITLE_STATE_THEME_KEYS: Record<Exclude<TerminalTitleState, "idle">, SymbolKey> = {
+	running: "terminal.title.running",
+	waiting_for_input: "terminal.title.waiting",
+	needs_attention: "terminal.title.needsAttention",
+};
+
 const TERMINAL_TITLE_STATE_STATUS_KEYS: Record<Exclude<TerminalTitleState, "idle">, SymbolKey> = {
 	running: "status.running",
 	waiting_for_input: "status.shadowed",
@@ -356,11 +362,12 @@ function resolveStatusGlyphForState(
 	state: Exclude<TerminalTitleState, "idle">,
 	getSymbol?: (key: SymbolKey) => string,
 ): string | undefined {
-	const statusKey = TERMINAL_TITLE_STATE_STATUS_KEYS[state];
-	if (getSymbol) {
-		const fromStatus = getSymbol(statusKey);
-		if (fromStatus) return fromStatus;
-	}
+	if (!getSymbol) return undefined;
+	const themeKey = TERMINAL_TITLE_STATE_THEME_KEYS[state];
+	const fromTheme = getSymbol(themeKey);
+	if (fromTheme) return fromTheme;
+	const fromStatus = getSymbol(TERMINAL_TITLE_STATE_STATUS_KEYS[state]);
+	if (fromStatus) return fromStatus;
 	return undefined;
 }
 

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -12,9 +12,19 @@ import type { Settings } from "../config/settings";
 import titleMarkerInstruction from "../prompts/system/title-marker-instruction.md" with { type: "text" };
 import titleSystemPrompt from "../prompts/system/title-system.md" with { type: "text" };
 import titleMarkerSystemPrompt from "../prompts/system/title-system-marker.md" with { type: "text" };
+import type { SymbolKey, SymbolPreset } from "../modes/theme/theme";
 import { isTinyTitleLocalModelKey, ONLINE_TINY_TITLE_MODEL_KEY } from "../tiny/models";
 import { formatTitleUserMessage, isLowSignalTitleInput, normalizeGeneratedTitle } from "../tiny/text";
 import { tinyTitleClient } from "../tiny/title-client";
+
+export type TerminalTitleState = "running" | "waiting_for_input" | "needs_attention" | "idle";
+
+export type TerminalTitleFormatOptions = {
+	state?: TerminalTitleState;
+	dynamicTitle?: boolean;
+	symbolPreset?: SymbolPreset;
+	getSymbol?: (key: SymbolKey) => string;
+};
 
 const TITLE_SYSTEM_PROMPT = prompt.render(titleSystemPrompt);
 const TITLE_MARKER_SYSTEM_PROMPT = prompt.render(titleMarkerSystemPrompt);
@@ -314,9 +324,69 @@ function getFallbackTerminalTitle(cwd: string | undefined): string | undefined {
 	return sanitizeTerminalTitlePart(baseName);
 }
 
-export function formatSessionTerminalTitle(sessionName: string | undefined, cwd?: string): string {
+const TERMINAL_TITLE_STATE_STATUS_KEYS: Record<Exclude<TerminalTitleState, "idle">, SymbolKey> = {
+	running: "status.running",
+	waiting_for_input: "status.shadowed",
+	needs_attention: "status.enabled",
+};
+
+/** Built-in glyphs per preset when getSymbol is unavailable (mirrors theme UNICODE/NERD/ASCII). */
+const TERMINAL_TITLE_STATE_FALLBACKS: Record<
+	SymbolPreset,
+	Record<Exclude<TerminalTitleState, "idle">, string>
+> = {
+	unicode: {
+		running: "⟳",
+		waiting_for_input: "◌",
+		needs_attention: "●",
+	},
+	nerd: {
+		running: "\uf110",
+		waiting_for_input: "◐",
+		needs_attention: "\uf111",
+	},
+	ascii: {
+		running: "[~]",
+		waiting_for_input: "[/]",
+		needs_attention: "[x]",
+	},
+};
+
+function resolveStatusGlyphForState(
+	state: Exclude<TerminalTitleState, "idle">,
+	getSymbol?: (key: SymbolKey) => string,
+): string | undefined {
+	const statusKey = TERMINAL_TITLE_STATE_STATUS_KEYS[state];
+	if (getSymbol) {
+		const fromStatus = getSymbol(statusKey);
+		if (fromStatus) return fromStatus;
+	}
+	return undefined;
+}
+
+export function resolveTerminalTitleStateGlyph(
+	state: TerminalTitleState,
+	preset: SymbolPreset,
+	getSymbol?: (key: SymbolKey) => string,
+): string {
+	if (state === "idle") return "";
+	const fromSymbol = resolveStatusGlyphForState(state, getSymbol);
+	if (fromSymbol) return fromSymbol;
+	return TERMINAL_TITLE_STATE_FALLBACKS[preset][state];
+}
+
+export function formatSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options?: TerminalTitleFormatOptions,
+): string {
 	const label = sanitizeTerminalTitlePart(sessionName) ?? getFallbackTerminalTitle(cwd);
-	return label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	const labelPart = label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	if (!options?.dynamicTitle) return labelPart;
+	const preset = options.symbolPreset ?? "unicode";
+	const state = options.state ?? "idle";
+	const glyph = resolveTerminalTitleStateGlyph(state, preset, options.getSymbol);
+	return `${glyph}${glyph ? " " : ""}${labelPart}`;
 }
 
 /**
@@ -327,8 +397,12 @@ export function setTerminalTitle(title: string): void {
 	process.stdout.write(`\x1b]0;${sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE}\x07`);
 }
 
-export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
-	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
+export function setSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options?: TerminalTitleFormatOptions,
+): void {
+	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd, options));
 }
 
 /**

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -82,6 +82,12 @@ describe("Settings", () => {
 			expect(getDefault("terminal.showProgress")).toBe(false);
 		});
 
+		it("enables dynamic terminal title by default", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("terminal.dynamicTitle")).toBe(true);
+			expect(getDefault("terminal.dynamicTitle")).toBe(true);
+		});
+
 		it("keeps the normal startup splash disabled by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("startup.showSplash")).toBe(false);

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import type { TerminalTitleState } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import {
+	formatSessionTerminalTitle,
+	generateSessionTitle,
+	resolveTerminalTitleStateGlyph,
+} from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import { logger } from "@oh-my-pi/pi-utils";
 
 function getModelOrThrow(id: string): Model<Api> {
@@ -455,5 +460,60 @@ describe("title generator", () => {
 		await generateSessionTitle("Some message", registry, currentSettings);
 		expect(mockComplete).toHaveBeenCalled();
 		expect(mockComplete.mock.calls[0]?.[0]).toBe(smolModel);
+	});
+});
+
+describe("formatSessionTerminalTitle", () => {
+	const session = "My Session";
+
+	it("keeps legacy shape when dynamic title is off", () => {
+		expect(formatSessionTerminalTitle(session)).toBe("π: My Session");
+		expect(formatSessionTerminalTitle(session, "/tmp", { dynamicTitle: false })).toBe("π: My Session");
+	});
+
+	it("prefixes running state when dynamic title is on", () => {
+		expect(
+			formatSessionTerminalTitle(session, undefined, {
+				dynamicTitle: true,
+				state: "running",
+				symbolPreset: "unicode",
+			}),
+		).toBe("⟳ π: My Session");
+	});
+
+	it("uses waiting and needs_attention glyphs", () => {
+		expect(
+			formatSessionTerminalTitle(session, undefined, {
+				dynamicTitle: true,
+				state: "waiting_for_input",
+				symbolPreset: "unicode",
+			}),
+		).toBe("◌ π: My Session");
+		expect(
+			formatSessionTerminalTitle(session, undefined, {
+				dynamicTitle: true,
+				state: "needs_attention",
+				symbolPreset: "unicode",
+			}),
+		).toBe("● π: My Session");
+	});
+
+	it("omits prefix for idle dynamic title", () => {
+		expect(
+			formatSessionTerminalTitle(session, undefined, {
+				dynamicTitle: true,
+				state: "idle",
+				symbolPreset: "unicode",
+			}),
+		).toBe("π: My Session");
+	});
+
+	it("degrades glyphs for ascii preset", () => {
+		const states: TerminalTitleState[] = ["running", "waiting_for_input", "needs_attention"];
+		for (const state of states) {
+			const glyph = resolveTerminalTitleStateGlyph(state, "ascii");
+			expect(glyph.length).toBeGreaterThan(0);
+		}
+		expect(resolveTerminalTitleStateGlyph("idle", "ascii")).toBe("");
 	});
 });


### PR DESCRIPTION
Implements **dynamic terminal tab titles** for OMP interactive sessions (issue #3587): the OSC 0 title now reflects agent run state so background tabs show whether a session is working, waiting, needs attention, or idle.

## What changed

### Core formatting (`title-generator.ts`)
- Added `TerminalTitleState`: `running`, `waiting_for_input`, `needs_attention`, `idle`.
- Extended `formatSessionTerminalTitle` / `setSessionTerminalTitle` with `TerminalTitleFormatOptions` (state, `terminal.dynamicTitle` gate, `symbolPreset`, theme `getSymbol`).
- Idle keeps the legacy shape (`π: name — cwd`); other states prefix a preset-aware glyph (ASCII → Unicode → Nerd, aligned with theme `terminal.title.*` keys).

### Central refresh (`session-terminal-title.ts`)
- `refreshSessionTerminalTitle(stateOverride?)` reads `terminal.dynamicTitle`, session name/cwd, theme preset, and optional state override.
- `setSessionTerminalTitleContext` registers the active interactive session for controllers and tools.

### Settings & theme (prior commits on branch)
- `terminal.dynamicTitle` (default **on**) next to `terminal.showProgress`.
- Theme symbols `terminal.title.running`, `waiting`, `needs_attention` per preset.

### Lifecycle wiring
- **EventController**: `agent_start` → `running`; `agent_end` / `#finishAgentEnd` → `waiting_for_input` vs `idle`.
- **ExtensionUiController**: `needs_attention` while `#dialogActive`; restores prior state when dialogs settle; extension `ui.setTitle` respects dynamic prefix when enabled.
- **Init / rename**: `interactive-mode`, `input-controller`, `command-controller`, `selector-controller`, `guest` call `refreshSessionTerminalTitle` instead of one-shot static titles.

### Tests
- `title-generator.test.ts`: states, idle unprefixed, setting-off legacy shape, preset degradation.
- `settings-manager.test.ts`: `terminal.dynamicTitle` default.

## Verification

- `bun --cwd=packages/coding-agent run check:types` — **passed**.
- `bun test packages/coding-agent/test/title-generator.test.ts` — module load requires built `pi_natives` in this container (pre-existing); tests are present for CI with natives.

## Commit

- **SHA**: `fe538ed4b`
- **Branch**: `berserk/4e34c99a-8547-4d7e-9307-edb4b0564368` (pushed to `origin`)
- Earlier branch commits: `terminal.dynamicTitle` setting, theme symbols, title-generator state types.

## Commit

fe538ed4b

## Branch

berserk/4e34c99a-8547-4d7e-9307-edb4b0564368

Closes #3587
