### PR TITLE
fix(tool): require browser run code in schema

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed intent tracing injection for closed union tool schemas so provider validation accepts `i` inside each variant. ([#3645](https://github.com/can1357/oh-my-pi/issues/3645))
+
 ### Removed
 
 - Removed support for Pi dialect integration

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -535,7 +535,7 @@ export function normalizeMessagesForProvider(
 }
 
 const INTENT_FIELD_DESCRIPTION = "concise intent";
-const INTENT_SCHEMA_COMBINATORS = ["anyOf", "oneOf", "allOf"] as const;
+const INTENT_SCHEMA_UNION_KEYS = ["anyOf", "oneOf"] as const;
 
 function injectIntentIntoSchema(
 	schema: unknown,
@@ -543,20 +543,32 @@ function injectIntentIntoSchema(
 	describeIntent = true,
 ): unknown {
 	if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
-	let schemaRecord = schema as Record<string, unknown>;
-	for (const key of INTENT_SCHEMA_COMBINATORS) {
-		const variants = schemaRecord[key];
-		if (!Array.isArray(variants)) continue;
-		schemaRecord = {
-			...schemaRecord,
-			[key]: variants.map(variant => injectIntentIntoSchema(variant, mode, describeIntent)),
-		};
-	}
+	const schemaRecord = schema as Record<string, unknown>;
 	const propertiesValue = schemaRecord.properties;
-	const properties =
-		propertiesValue && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)
-			? (propertiesValue as Record<string, unknown>)
-			: {};
+	const hasOwnProperties =
+		propertiesValue !== null && typeof propertiesValue === "object" && !Array.isArray(propertiesValue);
+
+	// Pure union root (anyOf/oneOf with no own properties): push `i` into each
+	// alternative branch so each closed shape keeps `additionalProperties: false`
+	// honest with intent tracing. Adding a sibling root `properties: { i }` /
+	// `required: [i]` would force every input to satisfy both root *and* a
+	// branch, leaving no satisfiable shape because each branch's
+	// `additionalProperties: false` rejects every other field — and OpenAI
+	// strict sanitization later promotes that sibling to a closed root
+	// `type: "object"` that rejects every non-`i` key outright. allOf is not
+	// alternation (its members are sub-constraints), so we don't recurse into it.
+	if (!hasOwnProperties) {
+		for (const key of INTENT_SCHEMA_UNION_KEYS) {
+			const variants = schemaRecord[key];
+			if (!Array.isArray(variants)) continue;
+			return {
+				...schemaRecord,
+				[key]: variants.map(variant => injectIntentIntoSchema(variant, mode, describeIntent)),
+			};
+		}
+	}
+
+	const properties = hasOwnProperties ? (propertiesValue as Record<string, unknown>) : {};
 	const requiredValue = schemaRecord.required;
 	const required = Array.isArray(requiredValue)
 		? requiredValue.filter((item): item is string => typeof item === "string")

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -535,6 +535,7 @@ export function normalizeMessagesForProvider(
 }
 
 const INTENT_FIELD_DESCRIPTION = "concise intent";
+const INTENT_SCHEMA_COMBINATORS = ["anyOf", "oneOf", "allOf"] as const;
 
 function injectIntentIntoSchema(
 	schema: unknown,
@@ -542,7 +543,15 @@ function injectIntentIntoSchema(
 	describeIntent = true,
 ): unknown {
 	if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
-	const schemaRecord = schema as Record<string, unknown>;
+	let schemaRecord = schema as Record<string, unknown>;
+	for (const key of INTENT_SCHEMA_COMBINATORS) {
+		const variants = schemaRecord[key];
+		if (!Array.isArray(variants)) continue;
+		schemaRecord = {
+			...schemaRecord,
+			[key]: variants.map(variant => injectIntentIntoSchema(variant, mode, describeIntent)),
+		};
+	}
 	const propertiesValue = schemaRecord.properties;
 	const properties =
 		propertiesValue && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)

--- a/packages/agent/test/normalize-tools-prune.test.ts
+++ b/packages/agent/test/normalize-tools-prune.test.ts
@@ -123,3 +123,50 @@ describe("normalizeTools — omit-intent tools", () => {
 		expect(hasField(out?.parameters, "nested")).toBe(true);
 	});
 });
+
+describe("normalizeTools — union-shaped schemas", () => {
+	const variantOne = type({
+		action: type("'open'").describe("operation"),
+		"name?": "string",
+	});
+	const variantTwo = type({
+		action: type("'run'").describe("operation"),
+		code: "string",
+	});
+	const unionSchema = variantOne.or(variantTwo);
+
+	function unionTool(): AgentTool<typeof unionSchema, { ok: true }> {
+		return {
+			name: "discriminated",
+			label: "Discriminated",
+			description: "tool whose parameters union over an action discriminator",
+			parameters: unionSchema,
+			async execute() {
+				return { content: [{ type: "text", text: "ok" }] };
+			},
+		};
+	}
+
+	it("injects the intent field into each anyOf branch", () => {
+		const out = normalizeTools([unionTool()], true)?.[0];
+		const params = out?.parameters as {
+			anyOf?: Array<{ properties?: Record<string, unknown>; required?: string[] }>;
+		};
+		const branches = params.anyOf ?? [];
+		expect(branches.length).toBeGreaterThan(0);
+		for (const branch of branches) {
+			expect(branch.properties?.[INTENT_FIELD]).toBeDefined();
+			expect(branch.required ?? []).toContain(INTENT_FIELD);
+		}
+	});
+
+	it("does not add root-sibling properties next to a pure anyOf", () => {
+		// Root must stay a pure union; adding sibling `properties: { i }` /
+		// `required: [i]` collides with each closed branch's
+		// `additionalProperties: false` and leaves no satisfiable input.
+		const out = normalizeTools([unionTool()], true)?.[0];
+		const params = out?.parameters as Record<string, unknown>;
+		expect(params.properties).toBeUndefined();
+		expect(params.required).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Fixed the browser tool schema so `run` calls require `code` during JSON-schema validation. ([#3645](https://github.com/can1357/oh-my-pi/issues/3645))
 - Improved robustness of MCP authentication error detection and header-based server discovery
 - Fixed reliable detection of 401/403 authorization failures during Smithery commands and HTTP RPCs
 

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -35,8 +35,8 @@ const appSchema = type({
 	"target?": type("string").describe("substring to pick a window"),
 });
 
-const browserSchema = type({
-	action: type("'open' | 'close' | 'run'").describe("operation"),
+const browserOpenSchema = type({
+	action: type("'open'").describe("operation"),
 	"name?": type("string").describe("tab id (default 'main')"),
 	"url?": type("string").describe("url to open"),
 	"app?": appSchema,
@@ -54,6 +54,48 @@ const browserSchema = type({
 	"all?": type("boolean").describe("close every tab"),
 	"kill?": type("boolean").describe("also kill spawned-app browsers"),
 });
+
+const browserCloseSchema = type({
+	action: type("'close'").describe("operation"),
+	"name?": type("string").describe("tab id (default 'main')"),
+	"url?": type("string").describe("url to open"),
+	"app?": appSchema,
+	"viewport?": {
+		width: "number",
+		height: "number",
+		"scale?": "number",
+	},
+	"wait_until?": type("'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'").describe(
+		"navigation wait condition",
+	),
+	"dialogs?": type("'accept' | 'dismiss'").describe("auto-handle dialogs"),
+	"code?": type("string").describe("js body to run in tab"),
+	"timeout?": type("number").describe("timeout in seconds"),
+	"all?": type("boolean").describe("close every tab"),
+	"kill?": type("boolean").describe("also kill spawned-app browsers"),
+});
+
+const browserRunSchema = type({
+	action: type("'run'").describe("operation"),
+	"name?": type("string").describe("tab id (default 'main')"),
+	"url?": type("string").describe("url to open"),
+	"app?": appSchema,
+	"viewport?": {
+		width: "number",
+		height: "number",
+		"scale?": "number",
+	},
+	"wait_until?": type("'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'").describe(
+		"navigation wait condition",
+	),
+	"dialogs?": type("'accept' | 'dismiss'").describe("auto-handle dialogs"),
+	code: type("string").describe("js body to run in tab"),
+	"timeout?": type("number").describe("timeout in seconds"),
+	"all?": type("boolean").describe("close every tab"),
+	"kill?": type("boolean").describe("also kill spawned-app browsers"),
+});
+
+const browserSchema = browserOpenSchema.or(browserCloseSchema).or(browserRunSchema);
 
 /** Input schema for the browser tool. */
 export type BrowserParams = typeof browserSchema.infer;

--- a/packages/coding-agent/test/tools/browser-schema.test.ts
+++ b/packages/coding-agent/test/tools/browser-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolCall } from "@oh-my-pi/pi-ai";
+import { toolWireSchema, validateJsonSchemaValue } from "@oh-my-pi/pi-ai/utils/schema";
+import { validateToolCall } from "@oh-my-pi/pi-ai/utils/validation";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
+
+describe("browser tool schema", () => {
+	it("rejects run calls without code at schema validation", () => {
+		const session: ToolSession = {
+			cwd: "/tmp/test",
+			hasUI: true,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const tool = new BrowserTool(session);
+		const call: ToolCall = {
+			type: "toolCall",
+			id: "browser-run-without-code",
+			name: "browser",
+			arguments: { action: "run", name: "x" },
+		};
+
+		expect(validateJsonSchemaValue(toolWireSchema(tool), call.arguments).success).toBe(false);
+		expect(() => validateToolCall([tool], call)).toThrow(/Validation failed for tool "browser"[\s\S]*code/);
+	});
+
+	it("accepts run calls with code at schema validation", () => {
+		const session: ToolSession = {
+			cwd: "/tmp/test",
+			hasUI: true,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const tool = new BrowserTool(session);
+		const call: ToolCall = {
+			type: "toolCall",
+			id: "browser-run-with-code",
+			name: "browser",
+			arguments: { action: "run", name: "x", code: "return document.title;" },
+		};
+
+		expect(validateJsonSchemaValue(toolWireSchema(tool), call.arguments).success).toBe(true);
+		expect(validateToolCall([tool], call)).toEqual(call.arguments);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-schema.test.ts
+++ b/packages/coding-agent/test/tools/browser-schema.test.ts
@@ -1,23 +1,30 @@
 import { describe, expect, it } from "bun:test";
 import { normalizeTools } from "@oh-my-pi/pi-agent-core/agent-loop";
-import type { ToolCall } from "@oh-my-pi/pi-ai";
-import { toolWireSchema, validateJsonSchemaValue } from "@oh-my-pi/pi-ai/utils/schema";
+import type { ToolCall, TSchema } from "@oh-my-pi/pi-ai";
+import {
+	adaptSchemaForStrict,
+	toolWireSchema,
+	validateJsonSchemaValue,
+	validateStrictSchemaEnforcement,
+} from "@oh-my-pi/pi-ai/utils/schema";
 import { validateToolCall } from "@oh-my-pi/pi-ai/utils/validation";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
+function makeSession(): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+}
 describe("browser tool schema", () => {
 	it("rejects run calls without code at schema validation", () => {
-		const session: ToolSession = {
-			cwd: "/tmp/test",
-			hasUI: true,
-			getSessionFile: () => null,
-			getSessionSpawns: () => "*",
-			settings: Settings.isolated(),
-		};
-		const tool = new BrowserTool(session);
+		const tool = new BrowserTool(makeSession());
 		const call: ToolCall = {
 			type: "toolCall",
 			id: "browser-run-without-code",
@@ -30,14 +37,7 @@ describe("browser tool schema", () => {
 	});
 
 	it("accepts run calls with code at schema validation", () => {
-		const session: ToolSession = {
-			cwd: "/tmp/test",
-			hasUI: true,
-			getSessionFile: () => null,
-			getSessionSpawns: () => "*",
-			settings: Settings.isolated(),
-		};
-		const tool = new BrowserTool(session);
+		const tool = new BrowserTool(makeSession());
 		const call: ToolCall = {
 			type: "toolCall",
 			id: "browser-run-with-code",
@@ -49,16 +49,16 @@ describe("browser tool schema", () => {
 		expect(validateToolCall([tool], call)).toEqual(call.arguments);
 	});
 
+	// Reproduces the regression the Codex review flagged on #3647: with default
+	// `tools.intentTracing`, normalizeTools must keep the closed action variants
+	// satisfiable for inputs that carry the injected `i` field. The earlier
+	// version of injectIntentIntoSchema appended a root sibling
+	// `properties: { i }, required: [i]` next to the closed `anyOf` branches,
+	// which collided with each branch's `additionalProperties: false` and made
+	// every input fail validation.
 	it("keeps intent tracing satisfiable across action variants", () => {
-		const session: ToolSession = {
-			cwd: "/tmp/test",
-			hasUI: true,
-			getSessionFile: () => null,
-			getSessionSpawns: () => "*",
-			settings: Settings.isolated(),
-		};
-		const normalized = normalizeTools([new BrowserTool(session)], true)?.[0];
-		const schema = normalized?.parameters;
+		const normalized = normalizeTools([new BrowserTool(makeSession())], true)?.[0];
+		const schema = normalized?.parameters as TSchema;
 
 		expect(validateJsonSchemaValue(schema, { action: "run", name: "x" }).success).toBe(false);
 		expect(
@@ -75,6 +75,41 @@ describe("browser tool schema", () => {
 				action: "open",
 				name: "docs",
 				url: "https://example.com",
+			}).success,
+		).toBe(true);
+	});
+
+	// Each branch is closed (`additionalProperties: false`) and intent
+	// injection now lands inside every branch's `properties`/`required`, so
+	// `enforceStrictSchema` keeps strict mode on and the result remains free of
+	// strict-mode violations. Without the union-aware injection fix, the
+	// post-injection schema would either lose strict (no satisfiable input) or
+	// trip the additionalProperties / properties-coverage strict rules.
+	it("survives OpenAI strict-mode enforcement after intent injection", () => {
+		const normalized = normalizeTools([new BrowserTool(makeSession())], true)?.[0];
+		const schema = normalized?.parameters as Record<string, unknown>;
+		const strict = adaptSchemaForStrict(schema, true);
+
+		expect(strict.strict).toBe(true);
+		const enforcement = validateStrictSchemaEnforcement(schema, strict);
+		expect(enforcement.compatible).toBe(true);
+		expect(enforcement.violations).toEqual([]);
+
+		// And the post-strict schema is still satisfiable for a real run call.
+		expect(
+			validateJsonSchemaValue(strict.schema, {
+				[INTENT_FIELD]: "Reading page DOM",
+				action: "run",
+				name: "docs",
+				url: null,
+				app: null,
+				viewport: null,
+				wait_until: null,
+				dialogs: null,
+				code: "return 1;",
+				timeout: null,
+				all: null,
+				kill: null,
 			}).success,
 		).toBe(true);
 	});

--- a/packages/coding-agent/test/tools/browser-schema.test.ts
+++ b/packages/coding-agent/test/tools/browser-schema.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import { normalizeTools } from "@oh-my-pi/pi-agent-core/agent-loop";
 import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { toolWireSchema, validateJsonSchemaValue } from "@oh-my-pi/pi-ai/utils/schema";
 import { validateToolCall } from "@oh-my-pi/pi-ai/utils/validation";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 describe("browser tool schema", () => {
 	it("rejects run calls without code at schema validation", () => {
@@ -45,5 +47,35 @@ describe("browser tool schema", () => {
 
 		expect(validateJsonSchemaValue(toolWireSchema(tool), call.arguments).success).toBe(true);
 		expect(validateToolCall([tool], call)).toEqual(call.arguments);
+	});
+
+	it("keeps intent tracing satisfiable across action variants", () => {
+		const session: ToolSession = {
+			cwd: "/tmp/test",
+			hasUI: true,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const normalized = normalizeTools([new BrowserTool(session)], true)?.[0];
+		const schema = normalized?.parameters;
+
+		expect(validateJsonSchemaValue(schema, { action: "run", name: "x" }).success).toBe(false);
+		expect(
+			validateJsonSchemaValue(schema, {
+				[INTENT_FIELD]: "Inspecting page state",
+				action: "run",
+				name: "x",
+				code: "return document.title;",
+			}).success,
+		).toBe(true);
+		expect(
+			validateJsonSchemaValue(schema, {
+				[INTENT_FIELD]: "Opening docs tab",
+				action: "open",
+				name: "docs",
+				url: "https://example.com",
+			}).success,
+		).toBe(true);
 	});
 });


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/tools/browser-schema.test.ts` reproduced the failure before the fix: `browser { action: "run", name: "x" }` passed `toolWireSchema` JSON-schema validation (`Received: true`) even though execution later rejects it.

## Cause
`packages/coding-agent/src/tools/browser.ts` defined one flat ArkType object for all browser actions with `code?`, so both the provider-facing schema and `validateToolCall` treated `code` as optional for `run`; only `BrowserTool.#run()` enforced the requirement at execution time.

## Fix
- Split the browser parameters into action-specific ArkType variants keyed by `action`.
- Kept `code` optional for `open` and `close`, but required it in the `run` variant so JSON-schema validation rejects code-less run calls.
- Added `packages/coding-agent/test/tools/browser-schema.test.ts` to cover schema validation and `validateToolCall` behavior for `run` with and without `code`.
- Added the coding-agent changelog entry for #3645.

## Verification
Passed: `bun test packages/coding-agent/test/tools/browser-schema.test.ts`; `bun test packages/coding-agent/test/tools/provider-schema-compatibility.test.ts`; `bun run check` in `packages/coding-agent`. Pre-publish gate also passed during `gh_push_branch`. Fixes #3645