### PR TITLE
fix(tools): materialize URL paths for search scopes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Improved robustness of MCP authentication error detection and header-based server discovery
+- Fixed `search` and AST tools accepting external read URLs by materializing fetched URL text through the read cache before path resolution. ([#3649](https://github.com/can1357/oh-my-pi/issues/3649))
 - Fixed reliable detection of 401/403 authorization failures during Smithery commands and HTTP RPCs
 - Prevented auto-generated session titles from accidentally re-shouting user all-caps text
 - Fixed auto-generated session titles re-shouting emphatic ALL-CAPS from the user's message. `reconcileTitleCasing` (`packages/coding-agent/src/tiny/text.ts`) restored any source token with interior/repeated uppercase, so shouting like "unify ALL ERROR HANDLING" turned the model's clean sentence case ("Unify error handling…") back into "Unify ERROR HANDLING…". Casing is now restored only from mixed-case identifiers the user typed deliberately (`TinyVMM`, `iOS`, `IDs`); pure all-caps is left to the model's own output.

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -16,6 +16,7 @@ import { Ellipsis, fileHyperlink, framedBlock, renderStatusLine, truncateToWidth
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
 import { truncateForPrompt } from "./approval";
+import { materializeReadUrlToFile, parseReadUrlTarget } from "./fetch";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
 import { classifyGroupedLines, formatGroupedFiles, groupLineIndicesByBlank } from "./grouped-file-output";
 import type { OutputMeta } from "./output-meta";
@@ -284,6 +285,16 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				signal,
 				localProtocolOptions: this.session.localProtocolOptions,
 				skills: this.session.skills,
+				resolveExternalUrl: async rawPath => {
+					const target = parseReadUrlTarget(rawPath);
+					if (!target) return undefined;
+					const materialized = await materializeReadUrlToFile(
+						this.session,
+						{ path: target.path, raw: target.raw },
+						signal,
+					);
+					return { sourcePath: materialized.path, immutable: true };
+				},
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -14,6 +14,7 @@ import astGrepDescription from "../prompts/tools/ast-grep.md" with { type: "text
 import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
+import { materializeReadUrlToFile, parseReadUrlTarget } from "./fetch";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
 import { classifyGroupedLines, formatGroupedFiles, groupLineIndicesByBlank } from "./grouped-file-output";
 import { formatMatchLine } from "./match-line-format";
@@ -186,6 +187,16 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				signal,
 				localProtocolOptions: this.session.localProtocolOptions,
 				skills: this.session.skills,
+				resolveExternalUrl: async rawPath => {
+					const target = parseReadUrlTarget(rawPath);
+					if (!target) return undefined;
+					const materialized = await materializeReadUrlToFile(
+						this.session,
+						{ path: target.path, raw: target.raw },
+						signal,
+					);
+					return { sourcePath: materialized.path, immutable: true };
+				},
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1559,9 +1559,12 @@ export interface ReadUrlToolDetails {
 
 interface ReadUrlCacheEntry {
 	artifactId?: string;
+	artifactPath?: string;
+	contentPath?: string;
 	details: ReadUrlToolDetails;
 	image?: FetchImagePayload;
 	output: string;
+	content: string;
 }
 
 const READ_URL_CACHE_MAX_ENTRIES = 100;
@@ -1572,18 +1575,22 @@ function getReadUrlCacheKey(session: ToolSession, requestedUrl: string, raw: boo
 	return `${scope}::${raw ? "raw" : "rendered"}::${normalizeUrl(requestedUrl)}`;
 }
 
-async function readArtifactOutput(session: ToolSession, artifactId: string): Promise<string | null> {
+async function findArtifactPath(session: ToolSession, artifactId: string): Promise<string | null> {
 	const artifactsDir = session.getArtifactsDir?.();
 	if (!artifactsDir) return null;
 
 	try {
 		const files = await fs.readdir(artifactsDir);
 		const match = files.find(file => file.startsWith(`${artifactId}.`));
-		if (!match) return null;
-		return await Bun.file(path.join(artifactsDir, match)).text();
+		return match ? path.join(artifactsDir, match) : null;
 	} catch {
 		return null;
 	}
+}
+
+async function readArtifactOutput(session: ToolSession, artifactId: string): Promise<string | null> {
+	const artifactPath = await findArtifactPath(session, artifactId);
+	return artifactPath ? await Bun.file(artifactPath).text() : null;
 }
 
 async function materializeReadUrlCacheEntry(
@@ -1600,17 +1607,58 @@ async function materializeReadUrlCacheEntry(
 	return entry.output.length > 0 ? entry : null;
 }
 
-async function persistReadUrlArtifact(session: ToolSession, output: string): Promise<string | undefined> {
-	const { path: artifactPath, id } = (await session.allocateOutputArtifact?.("read")) ?? {};
-	if (!artifactPath) return undefined;
-	await Bun.write(artifactPath, output);
-	return id;
+async function persistReadUrlArtifact(
+	session: ToolSession,
+	output: string,
+): Promise<{ id?: string; path?: string } | undefined> {
+	const artifact = await session.allocateOutputArtifact?.("read");
+	if (!artifact?.path) return undefined;
+	await Bun.write(artifact.path, output);
+	return artifact;
 }
 
 async function ensureReadUrlCacheArtifact(session: ToolSession, entry: ReadUrlCacheEntry): Promise<ReadUrlCacheEntry> {
-	if (entry.artifactId) return entry;
-	const artifactId = await persistReadUrlArtifact(session, entry.output);
-	return artifactId ? { ...entry, artifactId } : entry;
+	if (entry.artifactId && entry.artifactPath) return entry;
+	if (entry.artifactId) {
+		const artifactPath = await findArtifactPath(session, entry.artifactId);
+		if (artifactPath) return { ...entry, artifactPath };
+	}
+	const artifact = await persistReadUrlArtifact(session, entry.output);
+	return artifact?.id ? { ...entry, artifactId: artifact.id, artifactPath: artifact.path } : entry;
+}
+
+function readUrlContentExtension(finalUrl: string): string {
+	try {
+		const ext = getFilenameExtensionHint(new URL(finalUrl).pathname);
+		return ext && /^\.[a-z0-9][a-z0-9+.-]{0,15}$/i.test(ext) ? ext : ".txt";
+	} catch {
+		return ".txt";
+	}
+}
+
+async function ensureReadUrlContentFile(
+	session: ToolSession,
+	entry: ReadUrlCacheEntry,
+	raw: boolean,
+): Promise<ReadUrlCacheEntry> {
+	if (entry.contentPath) {
+		try {
+			await Bun.file(entry.contentPath).stat();
+			return entry;
+		} catch {
+			// Recreate below when the cached scratch file was removed.
+		}
+	}
+	const root = session.getArtifactsDir?.();
+	if (!root) {
+		throw new ToolError("Cannot search URL output because this session cannot materialize read artifacts.");
+	}
+	const dir = path.join(root, "url-search");
+	await fs.mkdir(dir, { recursive: true });
+	const hash = Bun.hash(`${raw ? "raw" : "rendered"}:${entry.details.finalUrl}`).toString(36);
+	const contentPath = path.join(dir, `${hash}${readUrlContentExtension(entry.details.finalUrl)}`);
+	await Bun.write(contentPath, entry.content);
+	return { ...entry, contentPath };
 }
 
 function cacheReadUrlEntry(session: ToolSession, requestedUrl: string, raw: boolean, entry: ReadUrlCacheEntry): void {
@@ -1644,10 +1692,11 @@ async function buildReadUrlCacheEntry(
 		webpExclusionForModel(session.getActiveModel?.()),
 	);
 	const output = buildUrlReadOutput(result, result.content);
-	const artifactId = options?.ensureArtifact ? await persistReadUrlArtifact(session, output) : undefined;
+	const artifact = options?.ensureArtifact ? await persistReadUrlArtifact(session, output) : undefined;
 
 	return {
-		artifactId,
+		artifactId: artifact?.id,
+		artifactPath: artifact?.path,
 		details: {
 			kind: "url",
 			url: result.url,
@@ -1659,6 +1708,7 @@ async function buildReadUrlCacheEntry(
 		},
 		image: result.image,
 		output,
+		content: result.content,
 	};
 }
 
@@ -1684,6 +1734,24 @@ export async function loadReadUrlCacheEntry(
 	});
 	cacheReadUrlEntry(session, params.path, raw, fresh);
 	return fresh;
+}
+
+/** Materialize rendered URL body text to a local file for tools that require filesystem paths. */
+export async function materializeReadUrlToFile(
+	session: ToolSession,
+	params: { path: string; raw?: boolean },
+	signal?: AbortSignal,
+): Promise<{ path: string; details: ReadUrlToolDetails }> {
+	if (!session.settings.get("fetch.enabled")) {
+		throw new ToolError("URL reads are disabled by settings.");
+	}
+	const cacheEntry = await loadReadUrlCacheEntry(session, params, signal, { preferCached: true });
+	const materialized = await ensureReadUrlContentFile(session, cacheEntry, params.raw ?? false);
+	cacheReadUrlEntry(session, params.path, params.raw ?? false, materialized);
+	if (!materialized.contentPath) {
+		throw new ToolError("Cannot search URL output because this session cannot materialize read artifacts.");
+	}
+	return { path: materialized.contentPath, details: materialized.details };
 }
 
 function buildUrlReadOutput(result: FetchRenderResult, content: string): string {

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -36,6 +36,7 @@ import {
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { type ArchiveReader, type ExtractedArchiveFile, openArchive, parseArchivePathCandidates } from "../utils/zip";
 import type { ToolSession } from ".";
+import { materializeReadUrlToFile, parseReadUrlTarget } from "./fetch";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
 import { classifyGroupedLines, formatGroupedFiles, groupLineIndicesByBlank } from "./grouped-file-output";
 import { formatMatchLine } from "./match-line-format";
@@ -971,6 +972,16 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 						signal,
 						localProtocolOptions: this.session.localProtocolOptions,
 						skills: this.session.skills,
+						resolveExternalUrl: async rawPath => {
+							const target = parseReadUrlTarget(rawPath);
+							if (!target) return undefined;
+							const materialized = await materializeReadUrlToFile(
+								this.session,
+								{ path: target.path, raw: target.raw },
+								signal,
+							);
+							return { sourcePath: materialized.path, immutable: true };
+						},
 					});
 					searchPath = scope.searchPath;
 					isDirectory = scope.isDirectory;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1024,6 +1024,14 @@ export function resolveReadPath(filePath: string, cwd: string): string {
 // Tool-scope resolution (search/ast tools)
 // =============================================================================
 
+/** Local file materialized from a readable external URL for shared tool-scope resolution. */
+export interface ResolvedExternalSearchUrl {
+	/** Absolute or cwd-relative file path to search. */
+	sourcePath: string;
+	/** True when the materialized file must not mint editable anchors. */
+	immutable?: boolean;
+}
+
 export interface ToolScopeOptions {
 	rawPaths: string[];
 	cwd: string;
@@ -1047,6 +1055,8 @@ export interface ToolScopeOptions {
 	localProtocolOptions?: LocalProtocolOptions;
 	/** Calling session's loaded skills — lets skill:// resolve without process-global state. */
 	skills?: readonly Skill[];
+	/** Materialize readable external URLs to local text files before scope derivation. */
+	resolveExternalUrl?: (rawPath: string) => Promise<ResolvedExternalSearchUrl | undefined>;
 }
 
 export interface ToolScopeResolution {
@@ -1078,19 +1088,22 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 	if (rawPaths.some(rawPath => rawPath.length === 0)) {
 		throw new ToolError("`paths` must contain non-empty paths or globs");
 	}
-	// External (http/https/ftp/file) URLs are not searchable; route the caller
-	// to `read` instead of letting the path-resolver surface a confusing
-	// "Path not found" for a slash-stripped URL.
-	const externalUrl = rawPaths.find(rawPath => /^(?:https?|ftp|file|ws|wss):\/\//i.test(rawPath));
-	if (externalUrl) {
-		throw new ToolError(
-			`Cannot ${internalUrlAction} external URL: ${externalUrl}. Use \`read\` to fetch web content, then search the returned text.`,
-		);
-	}
+	const externalUrlRe = /^(?:https?|ftp|file|ws|wss):\/\//i;
 	const internalRouter = InternalUrlRouter.instance();
 	const resolvedPathInputs: string[] = [];
 	const immutableSourcePaths = new Set<string>();
 	for (const rawPath of rawPaths) {
+		const externalUrl = externalUrlRe.test(rawPath);
+		if (externalUrl && opts.resolveExternalUrl) {
+			const resolved = await opts.resolveExternalUrl(rawPath);
+			if (resolved) {
+				resolvedPathInputs.push(resolved.sourcePath);
+				if (opts.trackImmutableSources && resolved.immutable) {
+					immutableSourcePaths.add(path.resolve(resolved.sourcePath));
+				}
+				continue;
+			}
+		}
 		if (!internalRouter.canHandle(rawPath)) {
 			resolvedPathInputs.push(rawPath);
 			continue;

--- a/packages/coding-agent/test/tools/search-url-paths.test.ts
+++ b/packages/coding-agent/test/tools/search-url-paths.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import * as scrapers from "@oh-my-pi/pi-coding-agent/web/scrapers/types";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function createSession(testDir: string): ToolSession {
+	const sessionFile = path.join(testDir, "session.jsonl");
+	const artifactsDir = sessionFile.slice(0, -6);
+	let nextArtifactId = 0;
+	return {
+		cwd: testDir,
+		hasUI: false,
+		getSessionFile: () => sessionFile,
+		getArtifactsDir: () => artifactsDir,
+		getSessionSpawns: () => "*",
+		allocateOutputArtifact: async toolType => {
+			const id = String(nextArtifactId++);
+			return { id, path: path.join(artifactsDir, `${id}.${toolType}.log`) };
+		},
+		settings: Settings.isolated({ "fetch.enabled": true, "grep.contextBefore": 0, "grep.contextAfter": 0 }),
+	};
+}
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(entry => entry.type === "text")
+		.map(entry => entry.text ?? "")
+		.join("\n");
+}
+
+function stubLoadPage(body: string, contentType: string): void {
+	vi.spyOn(scrapers, "loadPage").mockImplementation(async requestedUrl => ({
+		ok: true,
+		status: 200,
+		finalUrl: requestedUrl,
+		contentType,
+		content: body,
+	}));
+}
+
+describe("search tools with external URL paths", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = await fs.mkdtemp(path.join(os.tmpdir(), "search-url-paths-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await removeWithRetries(testDir);
+	});
+
+	it("search fetches a URL through the read cache and greps the rendered text", async () => {
+		stubLoadPage("alpha\nremote needle\nomega\n", "text/plain");
+		const tools = await createTools(createSession(testDir));
+		const tool = tools.find(entry => entry.name === "grep");
+		expect(tool).toBeDefined();
+
+		const result = await tool!.execute("search-url", {
+			pattern: "remote needle",
+			paths: ["https://example.com/notes.txt"],
+		});
+
+		const text = resultText(result);
+		expect(text).toContain("remote needle");
+		expect(text).not.toContain("Cannot search external URL");
+	});
+
+	it("ast_grep materializes URL content with the source extension", async () => {
+		stubLoadPage("export function remoteNeedle() {\n\treturn 1;\n}\n", "text/plain");
+		const tools = await createTools(createSession(testDir));
+		const tool = tools.find(entry => entry.name === "ast_grep");
+		expect(tool).toBeDefined();
+
+		const result = await tool!.execute("ast-grep-url", {
+			pat: "remoteNeedle",
+			paths: ["https://example.com/snippet.ts"],
+		});
+
+		const text = resultText(result);
+		expect(text).toContain("remoteNeedle");
+		expect(text).not.toContain("Parse issues");
+	});
+});


### PR DESCRIPTION
## Repro
Calling the shared search scope resolver with `rawPaths: ["https://example.com/page"]` reproduced the issue: it threw `Cannot search external URL: https://example.com/page...` before `search`, `ast_grep`, or `ast_edit` could use the read URL pipeline.

## Cause
`packages/coding-agent/src/tools/path-utils.ts` rejected `http(s)`, `ftp`, `file`, and websocket-style URLs inside `resolveToolSearchScope` before callers reached any URL-aware read/cache logic. The read URL cache lived separately in `packages/coding-agent/src/tools/fetch.ts`, so the shared scope resolver had no way to turn readable URLs into filesystem paths.

## Fix
- Added a `resolveExternalUrl` hook to `resolveToolSearchScope` so callers can materialize readable external URLs before normal path/glob derivation.
- Added `materializeReadUrlToFile` in `packages/coding-agent/src/tools/fetch.ts`, reusing the read URL cache and writing rendered URL body text to a session artifact scratch file with the URL source extension preserved.
- Wired `search`, `ast_grep`, and `ast_edit` to materialize readable URL paths through that hook.
- Added regression coverage for `search` and `ast_grep` URL paths.

## Verification
`bun run check` in `packages/coding-agent` passed. `bun test test/tools/search-url-paths.test.ts test/tools/fetch-url-selectors.test.ts test/tools/ast-grep.test.ts` in `packages/coding-agent` passed: 18 tests, 49 assertions. Fixes #3649