### PR TITLE
fix(coding-agent): nudge todo reconciliation mid-run instead of only at stop

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the live todo HUD going stale during long tool-use loops by adding a mid-run reconciliation reminder: after several consecutive tool-use turns without invoking the `todo` tool, the agent now receives a `<system-reminder>` listing the still-incomplete items so it flips them as work completes rather than batch-marking everything `done` at the very end of a run. ([#3651](https://github.com/can1357/oh-my-pi/issues/3651))
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/mid-run-todo-nudge.md
+++ b/packages/coding-agent/src/prompts/system/mid-run-todo-nudge.md
@@ -1,0 +1,12 @@
+<system-reminder>
+You have completed several tool calls since the last `{{toolRefs.todo}}` update, and {{incompleteCount}} todo item{{#if plural}}s{{/if}} still {{#if plural}}remain{{else}}remains{{/if}} pending or in_progress:
+{{#each phases}}
+- {{name}}
+{{#each tasks}}
+  - {{content}} ({{status}})
+{{/each}}
+{{/each}}
+
+If any are now done, call `{{toolRefs.todo}}` with `op: "done"` so the live HUD matches reality. Keep todos in sync as you work — do not batch every transition at the end of the run.
+(Mid-run reminder {{attempt}}/{{maxAttempts}})
+</system-reminder>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2840,6 +2840,27 @@ export class AgentSession {
 	}
 
 	#processAgentEvent = async (event: AgentEvent): Promise<void> => {
+		// Step the mid-run todo counter synchronously, BEFORE any await in this
+		// handler. The agent loop's next-turn `getAsideMessages` poll can run
+		// before queued microtasks drain, so `#takeMidRunTodoNudge` MUST see the
+		// freshest counter — otherwise a turn that just invoked `todo` could
+		// trip a spurious nudge against stale state, and a turn that just hit
+		// the threshold could fail to nudge until a later turn (issue #3651).
+		// Pure in-memory math — no ordering requirement vs persistence or
+		// session-event fan-out.
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			const tooledTurn = event.message.content.some(content => content.type === "toolCall");
+			if (tooledTurn) {
+				const touchedTodo = event.message.content.some(
+					content => content.type === "toolCall" && content.name === "todo",
+				);
+				if (touchedTodo) {
+					this.#toolTurnsSinceLastTodoTouch = 0;
+				} else {
+					this.#toolTurnsSinceLastTodoTouch++;
+				}
+			}
+		}
 		// Plan-mode internal transition: stamp `SILENT_ABORT_MARKER` on the
 		// persisted message BEFORE the obfuscator's display-side copy below.
 		// Invariant (must hold across refactors): this branch precedes the
@@ -3014,17 +3035,6 @@ export class AgentSession {
 			if (event.message.role === "assistant") {
 				this.#lastAssistantMessage = event.message;
 				const assistantMsg = event.message as AssistantMessage;
-				const tooledTurn = assistantMsg.content.some(content => content.type === "toolCall");
-				if (tooledTurn) {
-					const touchedTodo = assistantMsg.content.some(
-						content => content.type === "toolCall" && content.name === "todo",
-					);
-					if (touchedTodo) {
-						this.#toolTurnsSinceLastTodoTouch = 0;
-					} else {
-						this.#toolTurnsSinceLastTodoTouch++;
-					}
-				}
 				const currentGrantsAnthropicPriority =
 					this.serviceTier === "priority" || this.serviceTier === "claude-only";
 				if (assistantMsg.disabledFeatures?.includes("priority") && currentGrantsAnthropicPriority) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -234,6 +234,7 @@ import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with 
 import geminiToolReminderTemplate from "../prompts/system/gemini-tool-call-reminder.md" with { type: "text" };
 import ircAutoReplyTemplate from "../prompts/system/irc-autoreply.md" with { type: "text" };
 import ircIncomingTemplate from "../prompts/system/irc-incoming.md" with { type: "text" };
+import midRunTodoNudgePrompt from "../prompts/system/mid-run-todo-nudge.md" with { type: "text" };
 import planModeActivePrompt from "../prompts/system/plan-mode-active.md" with { type: "text" };
 import planModeReferencePrompt from "../prompts/system/plan-mode-reference.md" with { type: "text" };
 import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool-decision-reminder.md" with {
@@ -324,6 +325,16 @@ import { classifyUnexpectedStop, isUnexpectedStopCandidate } from "./unexpected-
 import { YieldQueue } from "./yield-queue";
 
 const SESSION_STOP_CONTINUATION_CAP = 8;
+
+/**
+ * Consecutive tool-use turns without the agent touching the `todo` tool that
+ * trip the mid-run reconciliation nudge. Picked so a single batch of edits +
+ * verification (~3-5 turns each) does not trigger it, but a sustained loop of
+ * work without flipping any todos does. Without this nudge, long runs drive
+ * the live todo HUD to `0/N` until the final stop, then batch-flip to `N/N`
+ * (issue #3651).
+ */
+const MID_RUN_TODO_NUDGE_TURN_THRESHOLD = 8;
 
 /** Abort reason for the Gemini reasoning-header runaway interrupt. Surfaced on the
  *  discarded assistant turn only; never reaches the model. */
@@ -1289,6 +1300,15 @@ export class AgentSession {
 	 * instruction") does not drive 1/3 → 2/3 → 3/3 without user input.
 	 */
 	#todoReminderAwaitingProgress = false;
+	/**
+	 * Consecutive tool-use turns the agent has completed without invoking the
+	 * `todo` tool. Drives {@link #takeMidRunTodoNudge} so the live HUD stays in
+	 * sync with actual progress instead of flipping `0/N -> N/N` only at the
+	 * very end of a long run (issue #3651). Reset to 0 on any assistant turn
+	 * that calls `todo`, on a successful nudge fire (cooldown), and at every
+	 * new-prompt / clear / handoff lifecycle boundary.
+	 */
+	#toolTurnsSinceLastTodoTouch = 0;
 	#todoPhases: TodoPhase[] = [];
 	#toolChoiceQueue = new ToolChoiceQueue();
 
@@ -1750,6 +1770,9 @@ export class AgentSession {
 			this.#pendingIrcAsides = [];
 			const thunks: AsideMessage[] = pendingIrc.map(record => () => record);
 			thunks.push(...this.yieldQueue.drainLazy());
+			// Mid-run todo reconciliation — evaluated at injection time so a turn
+			// that flips a todo just before this poll suppresses the nudge.
+			thunks.push(() => this.#takeMidRunTodoNudge());
 			return thunks;
 		});
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
@@ -2991,6 +3014,17 @@ export class AgentSession {
 			if (event.message.role === "assistant") {
 				this.#lastAssistantMessage = event.message;
 				const assistantMsg = event.message as AssistantMessage;
+				const tooledTurn = assistantMsg.content.some(content => content.type === "toolCall");
+				if (tooledTurn) {
+					const touchedTodo = assistantMsg.content.some(
+						content => content.type === "toolCall" && content.name === "todo",
+					);
+					if (touchedTodo) {
+						this.#toolTurnsSinceLastTodoTouch = 0;
+					} else {
+						this.#toolTurnsSinceLastTodoTouch++;
+					}
+				}
 				const currentGrantsAnthropicPriority =
 					this.serviceTier === "priority" || this.serviceTier === "claude-only";
 				if (assistantMsg.disabledFeatures?.includes("priority") && currentGrantsAnthropicPriority) {
@@ -3285,7 +3319,11 @@ export class AgentSession {
 				this.#trackPostPromptTask(compactionTask);
 				compactionResult = await compactionTask;
 			}
-			// Check for incomplete todos only after a final assistant stop, not intermediate tool-use turns.
+			// Stop-time todo reconciliation only fires at a text-only final stop. A run
+			// that ends still mid-tool-use (deadline hit, context full, etc.) skips the
+			// reminder so we don't pile a follow-up onto an already in-flight turn.
+			// Mid-run sync is handled separately via #takeMidRunTodoNudge so a long
+			// tool-use loop still gets prodded to keep the live HUD honest (issue #3651).
 			const hasToolCalls = msg.content.some(content => content.type === "toolCall");
 			if (hasToolCalls) {
 				await emitAgentEndNotification();
@@ -6595,6 +6633,7 @@ export class AgentSession {
 			// Reset todo reminder count on new user prompt
 			this.#todoReminderCount = 0;
 			this.#todoReminderAwaitingProgress = false;
+			this.#toolTurnsSinceLastTodoTouch = 0;
 			this.#emptyStopRetryCount = 0;
 			this.#unexpectedStopRetryCount = 0;
 			// A new prompt cycle starts: drop any sticky yield-termination from the
@@ -7531,6 +7570,7 @@ export class AgentSession {
 
 		this.#todoReminderCount = 0;
 		this.#todoReminderAwaitingProgress = false;
+		this.#toolTurnsSinceLastTodoTouch = 0;
 		this.#planReferenceSent = false;
 		this.#planReferencePath = "local://PLAN.md";
 		this.#resetAdvisorSessionState();
@@ -8854,6 +8894,7 @@ export class AgentSession {
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#todoReminderCount = 0;
 			this.#todoReminderAwaitingProgress = false;
+			this.#toolTurnsSinceLastTodoTouch = 0;
 
 			// Inject the handoff document as a custom message
 			const handoffContent = createHandoffContext(handoffText);
@@ -9799,6 +9840,82 @@ export class AgentSession {
 		this.sessionManager.appendMessage(reminderMessage);
 		this.#scheduleAgentContinue({ generation: this.#promptGeneration });
 		return true;
+	}
+
+	/**
+	 * Build the next mid-run todo reconciliation nudge when the agent has gone
+	 * {@link MID_RUN_TODO_NUDGE_TURN_THRESHOLD} tool-use turns without invoking
+	 * the `todo` tool and incomplete items remain. Returns the developer-role
+	 * reminder when it should fire, or `null` to skip. Called once per turn via
+	 * the aside provider; mutates internal counters when it fires so the caller
+	 * does not need to track delivery state.
+	 *
+	 * Companion to {@link #checkTodoCompletion}, which only fires when the agent
+	 * stops with text. Without this, a long tool-use loop drives the live HUD
+	 * to `0/N` until the final stop, then batch-flips to `N/N` (issue #3651).
+	 * Shares `#todoReminderCount` / `#todoReminderAwaitingProgress` with the
+	 * stop-time path so the per-cycle reminder budget is unified.
+	 */
+	#takeMidRunTodoNudge(): AgentMessage | null {
+		if (this.#toolTurnsSinceLastTodoTouch < MID_RUN_TODO_NUDGE_TURN_THRESHOLD) return null;
+		if (this.#todoReminderAwaitingProgress) return null;
+		if (!this.settings.get("todo.enabled")) return null;
+		if (!this.settings.get("todo.reminders")) return null;
+		// Plan-mode runs are authoring a plan file, not implementing it; todos
+		// don't apply, mirroring {@link #createEagerTodoPrelude}.
+		if (this.#planModeState?.enabled) return null;
+
+		const remindersMax = this.settings.get("todo.reminders.max");
+		if (this.#todoReminderCount >= remindersMax) return null;
+
+		const phases = this.getTodoPhases();
+		if (phases.length === 0) return null;
+		const incompleteByPhase = phases
+			.map(phase => ({
+				name: phase.name,
+				tasks: phase.tasks
+					.filter(
+						(task): task is TodoItem & { status: "pending" | "in_progress" } =>
+							task.status === "pending" || task.status === "in_progress",
+					)
+					.map(task => ({ content: task.content, status: task.status })),
+			}))
+			.filter(phase => phase.tasks.length > 0);
+		const incomplete = incompleteByPhase.flatMap(phase => phase.tasks);
+		if (incomplete.length === 0) return null;
+
+		// Reset the turn counter so the nudge has another full runway before the
+		// next mid-run fire; the shared #todoReminderCount cap keeps total reminders
+		// (mid-run + stop-time) bounded per cycle.
+		this.#toolTurnsSinceLastTodoTouch = 0;
+		this.#todoReminderCount++;
+		this.#todoReminderAwaitingProgress = true;
+		const attempt = this.#todoReminderCount;
+
+		const { toolRefs } = this.#buildEagerPreludeContext();
+		const reminder = prompt.render(midRunTodoNudgePrompt, {
+			toolRefs,
+			incompleteCount: incomplete.length,
+			plural: incomplete.length !== 1,
+			phases: incompleteByPhase,
+			attempt,
+			maxAttempts: remindersMax,
+		});
+
+		logger.debug("Mid-run todo nudge fired", { incomplete: incomplete.length, attempt });
+		void this.#emitSessionEvent({
+			type: "todo_reminder",
+			todos: incomplete,
+			attempt,
+			maxAttempts: remindersMax,
+		});
+
+		return {
+			role: "developer",
+			content: [{ type: "text", text: reminder }],
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9874,6 +9874,12 @@ export class AgentSession {
 		// Plan-mode runs are authoring a plan file, not implementing it; todos
 		// don't apply, mirroring {@link #createEagerTodoPrelude}.
 		if (this.#planModeState?.enabled) return null;
+		// Tool discovery / explicit active-tool lists can hide `todo` from this
+		// run while `todo.enabled` remains true (e.g. `setActiveToolsByName`
+		// restricting the slate). Mirror {@link #createEagerTodoPrelude}'s
+		// guard so we never ask the model to call a tool that is not in its
+		// schema — the request would fabricate an unknown tool call.
+		if (!this.getActiveToolNames().includes("todo")) return null;
 
 		const remindersMax = this.settings.get("todo.reminders.max");
 		if (this.#todoReminderCount >= remindersMax) return null;

--- a/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
@@ -205,4 +205,28 @@ describe("AgentSession mid-run todo reconciliation nudge", () => {
 		expect(messages).toEqual([]);
 		expect(reminderEvents).toEqual([]);
 	});
+
+	it("counter update lands synchronously with the message_end emit (no microtask drain required)", () => {
+		// Regression for the review on PR #3652: pre-fix the counter update sat
+		// after `await messageEndPersistence.persist(...)`, so the live counter
+		// only caught up once microtasks drained. A poll between the emit burst
+		// and the persistence chain settling would observe stale state — a turn
+		// that JUST flipped a todo could still trip the nudge against the
+		// pre-reset counter. With the hoisted (synchronous) update, the
+		// production-shaped contract holds even when the aside poll runs in the
+		// same JS task as the emit, before any microtask gets a chance to fire.
+		for (let i = 0; i < THRESHOLD; i++) emitToolUseTurn("edit");
+
+		if (!asideProvider) throw new Error("aside provider was never captured");
+		const result = asideProvider();
+		if (result instanceof Promise) throw new Error("aside provider unexpectedly returned a Promise");
+		const messagesAfterThreshold = result
+			.map(entry => (typeof entry === "function" ? entry() : entry))
+			.filter((m): m is NonNullable<typeof m> => Boolean(m))
+			.filter(m => m.role === "developer");
+		// The threshold-hit fire is the proof point: pre-hoist, the eight
+		// increments are all queued microtasks, so this sync poll would see
+		// counter=0 and skip the nudge entirely.
+		expect(messagesAfterThreshold.length).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AsideMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, ToolCall } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression coverage for issue #3651: the only structured "reconcile your
+ * todos" reminder used to fire at a text-only `agent_end`. A model running a
+ * long tool-use loop therefore got no nudge until the very last turn, then
+ * batch-flipped every task `done`. The contract this defends:
+ *
+ *   1. After {@link MID_RUN_TODO_NUDGE_TURN_THRESHOLD} consecutive tool-use
+ *      turns without invoking the `todo` tool, the aside provider injects a
+ *      `<system-reminder>` for the next turn AND emits a `todo_reminder` event.
+ *   2. Sub-threshold counts do NOT inject anything.
+ *   3. Any `todo` tool call inside the run resets the counter, so an interleaved
+ *      todo turn keeps the nudge silent.
+ *
+ * Drives the aside provider directly: the production agent loop polls it
+ * between tool-use turns (mid-work boundary in `agent-loop.ts`), so calling it
+ * after a batch of synthesized `message_end` events mirrors that injection
+ * point without spinning a real model.
+ */
+describe("AgentSession mid-run todo reconciliation nudge", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let reminderEvents: Array<Extract<AgentSessionEvent, { type: "todo_reminder" }>>;
+	let asideProvider: (() => AsideMessage[] | Promise<AsideMessage[]>) | undefined;
+
+	const THRESHOLD = 8; // mirrors MID_RUN_TODO_NUDGE_TURN_THRESHOLD
+
+	function toolUseAssistant(toolName: string): AssistantMessage {
+		const id = `call_${toolName}_${Date.now()}_${Math.random()}`;
+		const toolCall: ToolCall = { type: "toolCall", id, name: toolName, arguments: {} };
+		return {
+			role: "assistant",
+			content: [toolCall],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "toolUse",
+			usage: {
+				input: 50,
+				output: 10,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 60,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+	}
+
+	function emitToolUseTurn(toolName: string): void {
+		session.agent.emitExternalEvent({ type: "message_end", message: toolUseAssistant(toolName) });
+	}
+
+	/**
+	 * #processAgentEvent fires off message_end handlers as async microtasks that
+	 * chain on `#messageEndPersistenceTail`. After a batch of synchronous emits
+	 * the counter only catches up once every queued persist task drains, so
+	 * tests yield a full event-loop tick before draining asides.
+	 */
+	async function settle(): Promise<void> {
+		await Bun.sleep(0);
+	}
+
+	async function drainAsides(): Promise<Array<{ role: string; text: string }>> {
+		if (!asideProvider) throw new Error("aside provider was never captured");
+		const thunks = await asideProvider();
+		const out: Array<{ role: string; text: string }> = [];
+		for (const entry of thunks) {
+			const message = typeof entry === "function" ? entry() : entry;
+			if (!message) continue;
+			if (message.role !== "developer") continue;
+			const content = message.content;
+			if (!Array.isArray(content)) continue;
+			for (const part of content) {
+				if (part.type === "text") out.push({ role: message.role, text: part.text });
+			}
+		}
+		return out;
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-todo-mid-run-nudge-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		// Capture the aside provider AgentSession installs in its constructor.
+		// Wrap the instance method (not the prototype) so concurrent test files
+		// constructing their own Agents are never observed through this seam.
+		asideProvider = undefined;
+		const originalSet = agent.setAsideMessageProvider.bind(agent);
+		agent.setAsideMessageProvider = (fn): void => {
+			if (fn !== undefined && asideProvider === undefined) asideProvider = fn;
+			originalSet(fn);
+		};
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"todo.enabled": true,
+				"todo.reminders": true,
+				"todo.reminders.max": 3,
+			}),
+			modelRegistry,
+		});
+
+		reminderEvents = [];
+		session.subscribe((event: AgentSessionEvent) => {
+			if (event.type === "todo_reminder") reminderEvents.push(event);
+		});
+
+		session.setTodoPhases([
+			{
+				name: "Refactor pass",
+				tasks: [
+					{ content: "Sweep call sites", status: "in_progress" },
+					{ content: "Update tests", status: "pending" },
+					{ content: "Polish docs", status: "pending" },
+				],
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	it("stays silent until the threshold of non-todo tool-use turns is reached", async () => {
+		for (let i = 0; i < THRESHOLD - 1; i++) emitToolUseTurn("edit");
+
+		await settle();
+		const messages = await drainAsides();
+		expect(messages).toEqual([]);
+		expect(reminderEvents).toEqual([]);
+	});
+
+	it("injects a developer-role reminder once the threshold is reached", async () => {
+		for (let i = 0; i < THRESHOLD; i++) emitToolUseTurn("edit");
+
+		await settle();
+		const messages = await drainAsides();
+		expect(messages.length).toBe(1);
+		const text = messages[0]?.text ?? "";
+		expect(text).toContain("<system-reminder>");
+		// Surfaces every incomplete task by content, not just a count.
+		expect(text).toContain("Sweep call sites");
+		expect(text).toContain("Update tests");
+		expect(text).toContain("Polish docs");
+		// Carries the mid-run framing so the agent does not treat it as a stop-time prompt.
+		expect(text).toContain("Mid-run reminder 1/3");
+
+		expect(reminderEvents.length).toBe(1);
+		expect(reminderEvents[0]?.attempt).toBe(1);
+		expect(reminderEvents[0]?.maxAttempts).toBe(3);
+		expect(reminderEvents[0]?.todos.length).toBe(3);
+
+		// Counter reset: another full runway is required before the next nudge,
+		// so an immediate poll right after firing must NOT re-inject.
+		const followUp = await drainAsides();
+		expect(followUp).toEqual([]);
+	});
+
+	it("does not nudge when a `todo` call has reset the counter mid-window", async () => {
+		// Seven non-todo turns get us within one of the threshold...
+		for (let i = 0; i < THRESHOLD - 1; i++) emitToolUseTurn("edit");
+		// ...then a todo call resets the counter; the remaining runway is fresh.
+		emitToolUseTurn("todo");
+		for (let i = 0; i < THRESHOLD - 1; i++) emitToolUseTurn("edit");
+
+		await settle();
+		const messages = await drainAsides();
+		expect(messages).toEqual([]);
+		expect(reminderEvents).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { Agent, type AsideMessage } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentTool, type AsideMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ToolCall } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -8,6 +8,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TodoTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 /**
@@ -102,11 +103,26 @@ describe("AgentSession mid-run todo reconciliation nudge", () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected built-in anthropic model to exist");
 
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": true,
+			"todo.reminders": true,
+			"todo.reminders.max": 3,
+		});
+		const toolSession: ToolSession = {
+			cwd: tempDir.path(),
+			hasUI: false,
+			getSessionFile: () => sessionManager.getSessionFile() ?? null,
+			getSessionSpawns: () => "*",
+			settings,
+		};
+		const todoTool = new TodoTool(toolSession);
+
 		const agent = new Agent({
 			initialState: {
 				model,
 				systemPrompt: ["Test"],
-				tools: [],
+				tools: [todoTool as unknown as AgentTool],
 				messages: [],
 			},
 		});
@@ -124,12 +140,7 @@ describe("AgentSession mid-run todo reconciliation nudge", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager,
-			settings: Settings.isolated({
-				"compaction.enabled": false,
-				"todo.enabled": true,
-				"todo.reminders": true,
-				"todo.reminders.max": 3,
-			}),
+			settings,
 			modelRegistry,
 		});
 
@@ -228,5 +239,22 @@ describe("AgentSession mid-run todo reconciliation nudge", () => {
 		// increments are all queued microtasks, so this sync poll would see
 		// counter=0 and skip the nudge entirely.
 		expect(messagesAfterThreshold.length).toBe(1);
+	});
+
+	it("stays silent when `todo` is not in the active-tool list, even if `todo.enabled` is still on", async () => {
+		// Regression for the review on PR #3652: an explicit active-tool list
+		// (or discovery-mode filtering) can drop `todo` from the slate while the
+		// setting flag stays true and an incomplete persisted/user-edited todo
+		// list survives. Asking the model to call a tool that is not in its
+		// schema would produce fabricated/unknown tool calls or loop on
+		// impossible reminders. Mirror {@link #createEagerTodoPrelude}'s guard.
+		await session.setActiveToolsByName([]);
+		expect(session.getActiveToolNames()).not.toContain("todo");
+
+		for (let i = 0; i < THRESHOLD; i++) emitToolUseTurn("edit");
+		await settle();
+		const messages = await drainAsides();
+		expect(messages).toEqual([]);
+		expect(reminderEvents).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Repro

A run that warrants a multi-task todo list and then works through every task across many consecutive **tool-use** turns never received a structured "reconcile your todos" prompt. The only call site for `#checkTodoCompletion` was inside the `agent_end` handler, guarded so it never ran when the just-finished assistant message had tool calls. The model therefore worked the entire run with the live HUD at `0/N` and only batch-flipped to `N/N` once it produced its final text-only stop.

Reproduced with `bun test packages/coding-agent/test/agent-session-todo-mid-run-nudge.test.ts` against `main`: eight synthetic tool-use `message_end` events leave the aside provider returning only IRC + `yieldQueue` thunks, so the next-turn injection point sees nothing.

## Cause

`packages/coding-agent/src/session/agent-session.ts`:

- The `agent_end` early-return `if (hasToolCalls) { … return; }` (now ~L3327) suppresses `#checkTodoCompletion` on any run whose final assistant message has tool calls — fine in itself, but the only other reminder path was static prose in `prompts/tools/todo.md`, so there was no mechanism to keep the HUD synced during the working portion of a normal interactive run.
- Per-turn boundaries (the agent loop's `getAsideMessages` poll at `agent-loop.ts:1054`) were already in place and used by IRC asides and the yield queue, but nothing was checking todo state there.

## Fix

- New module-level constant `MID_RUN_TODO_NUDGE_TURN_THRESHOLD = 8` plus private `#toolTurnsSinceLastTodoTouch` on `AgentSession`.
- Assistant `message_end` handler increments the counter on a tool-use turn and resets it to `0` whenever the turn invoked the `todo` tool (`content.type === "toolCall" && content.name === "todo"`).
- New `#takeMidRunTodoNudge` builds a developer-role `<system-reminder>` (rendered from `prompts/system/mid-run-todo-nudge.md`, the same Handlebars + `prompt.render` flow used by the eager preludes) listing every pending / in_progress item. Wired into the existing aside provider as a thunk so the production agent loop folds it into the next-turn `pendingMessages` at the mid-work boundary without spawning extra model calls.
- Shares `todo.reminders`, `todo.reminders.max`, `#todoReminderCount`, and `#todoReminderAwaitingProgress` with the stop-time path so mid-run + stop-time fires stay bounded by a single per-cycle budget (default 3). Skips plan mode and unprimed runs the same way `#createEagerTodoPrelude` / `#checkTodoCompletion` already do.
- Reset `#toolTurnsSinceLastTodoTouch` at every existing reminder lifecycle boundary: new prompt, session swap, handoff.
- Expanded the `agent_end` early-return comment so the stop-time vs mid-run split reads in isolation (linking the new path explicitly to issue #3651).
- Bumped `CHANGELOG.md` under `[Unreleased] / Fixed`.

## Verification

- `cd packages/coding-agent && bun test test/agent-session-todo-mid-run-nudge.test.ts` — 3 pass (sub-threshold silence, threshold-hit fire with counter reset cooldown, todo touch resets the window).
- `cd packages/coding-agent && bun test test/agent-session*` — 389 pass / 17 skip / 0 fail across 49 files, including the existing `agent-session-todo-reminder-loop.test.ts` (#2590 stop-time suppression contract).
- `bunx biome check` on every touched file: clean.
- `bun check:types` (`tsgo`): clean.

The pre-publish gate (`bun run fix` → `bun check`) runs again on PR open below.

Fixes #3651