### PR TITLE
fix(tui): open mid-prompt skill autocomplete

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash skill autocomplete staying closed after existing prompt text; mid-prompt `/...` lookup now shows only `/skill:<name>` commands and accepting one replaces the draft with that skill command ([#3654](https://github.com/can1357/oh-my-pi/issues/3654)).
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -68,6 +68,13 @@ export function findLeadingSlashCommandStart(text: string): number | null {
 	return text.length - trimmed.length;
 }
 
+export function findTrailingSlashCommandStart(text: string): number | null {
+	const match = /(?:^|\s)\/([^\s/]*)$/.exec(text);
+	if (!match || match.index === undefined) return null;
+	const slashOffset = match[0].indexOf("/");
+	return match.index + slashOffset;
+}
+
 function extractQuotedPrefix(text: string): string | null {
 	const quoteStart = findUnclosedQuoteStart(text);
 	if (quoteStart === null) {
@@ -324,6 +331,25 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 		.map(({ score: _, ...rest }) => rest);
 }
 
+function hasPromptTextBeforeSlash(
+	lines: string[],
+	cursorLine: number,
+	textBeforeCursor: string,
+	slashStart: number,
+): boolean {
+	for (let i = 0; i < cursorLine; i += 1) {
+		if ((lines[i] || "").trim() !== "") return true;
+	}
+	return textBeforeCursor.slice(0, slashStart).trim() !== "";
+}
+
+function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: string): AutocompleteItem[] {
+	return buildSlashCommandCompletions(
+		commands.filter(cmd => getCommandName(cmd)?.startsWith("skill:")),
+		lowerPrefix,
+	);
+}
+
 // Combined provider that handles both slash commands and file paths.
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#commands: CommandEntry[];
@@ -379,29 +405,37 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const trailingSlashStart = findTrailingSlashCommandStart(textBeforeCursor);
+		const hasPromptTextBeforeTrailingSlash =
+			trailingSlashStart !== null &&
+			hasPromptTextBeforeSlash(lines, cursorLine, textBeforeCursor, trailingSlashStart);
+		const slashStart = hasPromptTextBeforeTrailingSlash ? trailingSlashStart : leadingSlashStart;
 		if (slashStart !== null) {
 			const commandText = textBeforeCursor.slice(slashStart);
 			const spaceIndex = commandText.indexOf(" ");
+			const isMidPromptSkillLookup = hasPromptTextBeforeTrailingSlash;
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
 				const prefix = commandText.slice(1); // Remove the "/"
 				const lowerPrefix = prefix.toLowerCase();
 
-				const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
+				const matches = isMidPromptSkillLookup
+					? buildMidPromptSkillCompletions(this.#commands, lowerPrefix)
+					: buildSlashCommandCompletions(this.#commands, lowerPrefix);
 
 				if (matches.length === 0) return null;
 
 				return {
 					items: matches,
-					// Preserve the full text-before-cursor (incl. leading
-					// whitespace) so the editor's Enter-staleness check
-					// (`autocompletePrefix !== currentTextBeforeCursor`)
-					// still applies the completion for `  /sk`.
-					prefix: textBeforeCursor,
+					// Preserve the full text-before-cursor for submitted slash
+					// commands so the editor's Enter-staleness check still applies
+					// completion for `  /sk`. Mid-prompt skill lookup keeps only
+					// the slash token because accepting it replaces the whole draft.
+					prefix: isMidPromptSkillLookup ? commandText : textBeforeCursor,
 				};
-			} else {
+			} else if (!isMidPromptSkillLookup) {
 				// Space found - complete command arguments
 				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
@@ -421,6 +455,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					prefix: argumentText,
 				};
 			}
+			return null;
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
@@ -462,15 +497,30 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 		const afterCursor = currentLine.slice(cursorCol);
 
-		const slashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const trailingSlashStart = findTrailingSlashCommandStart(textBeforeCursor);
+		const isMidPromptSkillLookup =
+			item.value.startsWith("skill:") &&
+			trailingSlashStart !== null &&
+			hasPromptTextBeforeSlash(lines, cursorLine, textBeforeCursor, trailingSlashStart) &&
+			findTrailingSlashCommandStart(prefix) !== null;
+
+		if (isMidPromptSkillLookup) {
+			const newLine = `/${item.value}`;
+			return {
+				lines: [newLine],
+				cursorLine: 0,
+				cursorCol: newLine.length,
+			};
+		}
 
 		// Slash command suggestions can be accepted before the debounced refresh
 		// catches up to newly typed characters. Replace the live command token,
 		// not only the prefix captured when the suggestion list was rendered.
-		if (findLeadingSlashCommandStart(prefix) !== null && slashStart !== null) {
-			const slashPrefix = textBeforeCursor.slice(slashStart);
+		if (findLeadingSlashCommandStart(prefix) !== null && leadingSlashStart !== null) {
+			const slashPrefix = textBeforeCursor.slice(leadingSlashStart);
 			if (!slashPrefix.includes(" ") && !slashPrefix.slice(1).includes("/")) {
-				const beforeSlash = currentLine.slice(0, slashStart);
+				const beforeSlash = currentLine.slice(0, leadingSlashStart);
 				const newLine = `${beforeSlash}/${item.value} ${afterCursor}`;
 				const newLines = [...lines];
 				newLines[cursorLine] = newLine;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteProvider,
 	type CombinedAutocompleteProvider,
 	findLeadingSlashCommandStart,
+	findTrailingSlashCommandStart,
 } from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -1131,7 +1132,7 @@ export class Editor implements Component, Focusable {
 					// Check for stale autocomplete state due to debounce
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (currentTextBeforeCursor !== this.#autocompletePrefix) {
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
 						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
 					} else {
@@ -1755,8 +1756,8 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
-			// Auto-trigger for "/" at the start of a line (slash commands)
-			if (char === "/" && this.#isAtStartOfSubmittedMessage()) {
+			// Auto-trigger for "/" at the start of a submitted command or a mid-prompt skill lookup.
+			if (char === "/" && (this.#isAtStartOfSubmittedMessage() || this.#isInMidPromptSkillSlashContext())) {
 				this.#tryTriggerAutocomplete();
 			}
 			// Auto-trigger for "@" file reference (fuzzy search)
@@ -1777,8 +1778,8 @@ export class Editor implements Component, Focusable {
 			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-				// Check if we're in a slash command (with or without space for arguments)
-				if (this.#isInSubmittedSlashCommandContext()) {
+				// Check if we're in a slash command or mid-prompt skill lookup.
+				if (this.#isInSlashAutocompleteContext()) {
 					this.#tryTriggerAutocomplete();
 				}
 				// Check if we're in an @ file reference context
@@ -1901,7 +1902,7 @@ export class Editor implements Component, Focusable {
 		}
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-		if (this.#isInSubmittedSlashCommandContext()) {
+		if (this.#isInSlashAutocompleteContext()) {
 			this.#tryTriggerAutocomplete();
 		} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
 			this.#tryTriggerAutocomplete();
@@ -2067,8 +2068,8 @@ export class Editor implements Component, Focusable {
 			// If autocomplete was cancelled (no matches), re-trigger if we're in a completable context
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			// Slash command context
-			if (this.#isInSubmittedSlashCommandContext()) {
+			// Slash command or mid-prompt skill lookup context
+			if (this.#isInSlashAutocompleteContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -2236,7 +2237,7 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			if (this.#isInSubmittedSlashCommandContext()) {
+			if (this.#isInSlashAutocompleteContext()) {
 				this.#tryTriggerAutocomplete();
 			} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
 				this.#tryTriggerAutocomplete();
@@ -2568,8 +2569,8 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			// Slash command context
-			if (this.#isInSubmittedSlashCommandContext()) {
+			// Slash command or mid-prompt skill lookup context
+			if (this.#isInSlashAutocompleteContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -2799,6 +2800,27 @@ export class Editor implements Component, Focusable {
 		return this.#hasOnlyWhitespaceBeforeCursorLine() && beforeCursor.trimStart().startsWith("/");
 	}
 
+	#isInMidPromptSkillSlashContext(): boolean {
+		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
+		const slashStart = findTrailingSlashCommandStart(beforeCursor);
+		if (slashStart === null) return false;
+		if (this.#hasOnlyWhitespaceBeforeCursorLine() && findLeadingSlashCommandStart(beforeCursor) !== null)
+			return false;
+		return !this.#hasOnlyWhitespaceBeforeCursorLine() || beforeCursor.slice(0, slashStart).trim() !== "";
+	}
+
+	#isInSlashAutocompleteContext(): boolean {
+		return this.#isInSubmittedSlashCommandContext() || this.#isInMidPromptSkillSlashContext();
+	}
+
+	#autocompletePrefixMatchesCursorText(currentTextBeforeCursor: string): boolean {
+		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
+		if (findTrailingSlashCommandStart(this.#autocompletePrefix) !== 0) return false;
+		const slashStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
+		return slashStart !== null && currentTextBeforeCursor.slice(slashStart) === this.#autocompletePrefix;
+	}
+
 	#isSlashCommandNameAutocompleteSelection(): boolean {
 		if (this.#autocompleteState !== "regular") {
 			return false;
@@ -2879,16 +2901,18 @@ export class Editor implements Component, Focusable {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 
-		// Check if we're in a slash command context
-		if (this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) {
+		// Check if we're in a slash command or mid-prompt skill lookup context
+		if (
+			(this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) ||
+			this.#isInMidPromptSkillSlashContext()
+		) {
 			this.#handleSlashCommandCompletion();
 		} else {
 			this.#forceFileAutocomplete(true);
 		}
 	}
-
 	#handleSlashCommandCompletion(): void {
-		this.#tryTriggerAutocomplete(true);
+		this.#tryTriggerAutocomplete();
 	}
 
 	/*

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -62,13 +62,35 @@ describe("CombinedAutocompleteProvider", () => {
 	});
 
 	describe("slash commands", () => {
-		it("does not suggest slash commands after prose", async () => {
-			const provider = new CombinedAutocompleteProvider([{ name: "skill", description: "Manage skills" }], "/tmp");
-			const line = "run /sk";
+		it("suggests only skill commands after prose", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "skill:security-scan", description: "Security scan" },
+					{ name: "model", description: "Switch model" },
+				],
+				"/tmp",
+			);
+			const line = "run /security";
 
 			const result = await provider.getSuggestions([line], 0, line.length);
 
-			expect(result).toBeNull();
+			expect(result?.prefix).toBe("/security");
+			expect(result?.items.map(item => item.value)).toEqual(["skill:security-scan"]);
+		});
+
+		it("suggests only skill commands after prior prompt lines", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "skill:security-scan", description: "Security scan" },
+					{ name: "model", description: "Switch model" },
+				],
+				"/tmp",
+			);
+
+			const result = await provider.getSuggestions(["there is an issue", "/skill:"], 1, "/skill:".length);
+
+			expect(result?.prefix).toBe("/skill:");
+			expect(result?.items.map(item => item.value)).toEqual(["skill:security-scan"]);
 		});
 	});
 	describe("applyCompletion", () => {
@@ -106,6 +128,21 @@ describe("CombinedAutocompleteProvider", () => {
 
 			expect(result.lines[0]).toBe("  /skill ");
 			expect(result.cursorCol).toBe("  /skill ".length);
+		});
+
+		it("replaces the whole draft when applying a mid-prompt skill completion", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(
+				["explain this", "then use /security"],
+				1,
+				"then use /security".length,
+				{ value: "skill:security-scan", label: "/skill:security-scan" },
+				"/security",
+			);
+
+			expect(result.lines).toEqual(["/skill:security-scan"]);
+			expect(result.cursorLine).toBe(0);
+			expect(result.cursorCol).toBe("/skill:security-scan".length);
 		});
 
 		it("preserves earlier slash command arguments when completing a path inside the last argument", () => {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -134,26 +134,28 @@ class SyncSlashProvider implements AutocompleteProvider {
 }
 
 describe("Editor Enter handler sync slash completion", () => {
-	it("does not trigger slash autocomplete after prior prompt text", async () => {
-		let suggestionCalls = 0;
+	it("opens mid-prompt skill autocomplete and replaces the draft on Tab", async () => {
 		const editor = new Editor(defaultEditorTheme);
-		editor.setAutocompleteProvider({
-			async getSuggestions(lines, cursorLine, cursorCol) {
-				suggestionCalls += 1;
-				const currentLine = lines[cursorLine] ?? "";
-				return { prefix: currentLine.slice(0, cursorCol), items: [{ value: "model", label: "/model" }] };
-			},
-			applyCompletion(lines, cursorLine, cursorCol) {
-				return { lines, cursorLine, cursorCol };
-			},
-		});
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{ name: "skill:security-scan", description: "Security scan" },
+					{ name: "model", description: "Switch model" },
+				],
+				"/tmp",
+			),
+		);
 
 		editor.setText("explain this\n");
 		editor.handleInput("/");
 		await Bun.sleep(0);
 
-		expect(suggestionCalls).toBe(0);
-		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("security");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("/skill:security-scan");
 	});
 
 	it("completes slash command synchronously before async resolves and submits", () => {


### PR DESCRIPTION
## Repro
Reproduced the TUI path by importing `CombinedAutocompleteProvider` and `Editor`: `getSuggestions(["kasjjhkjashd /security"], 0, 22)` returned `null`, and `Editor` stayed closed after `setText("there is an issue\n")` then `handleInput("/")`.

## Cause
`packages/tui/src/components/editor.ts` only triggered slash autocomplete when `#hasOnlyWhitespaceBeforeCursorLine()` and the current line formed a submitted slash-command context, while `packages/tui/src/autocomplete.ts` only completed leading slash commands. Mid-prompt slash skill tokens never reached the provider, and prior-line slash tokens would have used the full slash-command palette instead of skills only.

## Fix
- Added trailing slash-token detection for mid-prompt skill lookup in `CombinedAutocompleteProvider`.
- Filtered mid-prompt slash suggestions to `skill:` commands and made acceptance replace the whole draft with `/skill:<name>`.
- Updated `Editor` trigger guards so slash, continued typing, backspace/undo/delete retriggers, Tab, and Enter recognize the mid-prompt skill autocomplete context.
- Added regression coverage for same-line prose, prior prompt lines, draft replacement, and editor Tab acceptance.

## Verification
`bun test packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts` passed: 49 pass, 0 fail. `bun --cwd=packages/tui run check` passed. Manual JS repro after the fix returned `sameLineItems: ["skill:security-scan"]`, opened the editor popup after existing text plus `/`, and accepted to `/skill:security-scan`. Fixes #3654