### PR TITLE
fix(tui): preserve in-flight assistant turn across /shake rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/shake` (and other mid-stream chat rebuilds) erasing the live LLM output by preserving the in-flight `streamingComponent` and `pendingTools` across `rebuildChatFromMessages` so subsequent `message_update`/`message_end` events keep updating on-screen components. ([#3656](https://github.com/can1357/oh-my-pi/issues/3656))
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1478,11 +1478,47 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	rebuildChatFromMessages(): void {
+		// Mid-stream rebuilds (e.g. `/shake`, theme/setting changes that touch the
+		// transcript) replay only committed `state.messages`. The agent's in-flight
+		// `streamMessage` and its still-pending tool calls live OUTSIDE
+		// `state.messages` until `message_end`, so a plain clear+replay detaches
+		// their UI components while keeping the `streamingComponent` / `pendingTools`
+		// references — subsequent `message_update`/`message_end` events would then
+		// update orphaned components that never re-render and the live LLM output
+		// vanishes from the chat (#3656). Snapshot the in-flight components,
+		// clear+replay, then re-append them in their original chat-container order
+		// and restore the `pendingTools` map so streaming routes back into them.
+		const liveComponents: Component[] = [];
+		const livePendingTools = new Map<string, ToolExecutionHandle>();
+		if (this.session?.isStreaming) {
+			const liveSet = new Set<Component>();
+			if (this.streamingComponent) liveSet.add(this.streamingComponent);
+			for (const [id, component] of this.pendingTools) {
+				livePendingTools.set(id, component);
+				liveSet.add(component as unknown as Component);
+			}
+			if (liveSet.size > 0) {
+				for (const child of this.chatContainer.children) {
+					if (liveSet.has(child)) liveComponents.push(child);
+				}
+			}
+		}
 		this.chatContainer.clear();
 		// Live display uses the compacted transcript tail; export/resume callers
 		// can still request the full inline compaction history.
 		const context = this.viewSession.buildTranscriptSessionContext({ collapseCompactedHistory: true });
 		this.renderSessionContext(context);
+		for (const child of liveComponents) {
+			this.chatContainer.addChild(child);
+		}
+		// `renderSessionContext` clears `pendingTools` at start AND end so the
+		// reconstructed historical tool components don't leak into live tracking.
+		// Restore the in-flight entries afterwards so the next streamed tool-call
+		// delta is routed into the preserved component instead of stacking a
+		// duplicate ToolExecutionComponent below it.
+		for (const [id, component] of livePendingTools) {
+			this.pendingTools.set(id, component);
+		}
 		// During the pre-streaming window — after `startPendingSubmission` has
 		// optimistically rendered the user's message but before the user
 		// `message_start` event lands it in `session` entries — any rebuild

--- a/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
+++ b/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression for issue #3656 — running `/shake` (or any mid-stream rebuild)
+ * while the LLM is still streaming used to wipe the in-flight assistant turn
+ * from the chat. `rebuildChatFromMessages` clears `chatContainer` and replays
+ * only committed `state.messages`; the agent's in-flight `streamMessage` and
+ * its still-pending tool calls live OUTSIDE `state.messages` until
+ * `message_end`, so the live `streamingComponent` and `pendingTools` entries
+ * were detached and every subsequent `message_update`/`message_end` event
+ * routed deltas into orphaned components that never re-rendered.
+ *
+ * The fix snapshots the live components before clear, re-appends them after
+ * the historical replay, and restores the `pendingTools` map so streaming
+ * continues into the same on-screen components.
+ */
+describe("issue #3656 /shake mid-stream preserves the in-flight assistant turn", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-3656-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	function makeStreamingFixture(): {
+		streamingComponent: AssistantMessageComponent;
+		pendingTool: ToolExecutionComponent;
+	} {
+		const streamingComponent = new AssistantMessageComponent();
+		const pendingTool = new ToolExecutionComponent(
+			"bash",
+			{ command: "echo hi" },
+			{},
+			undefined,
+			mode.ui,
+			tempDir.path(),
+			"call-1",
+		);
+		mode.chatContainer.addChild(streamingComponent);
+		mode.chatContainer.addChild(pendingTool);
+		mode.streamingComponent = streamingComponent;
+		mode.pendingTools.set("call-1", pendingTool);
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		return { streamingComponent, pendingTool };
+	}
+
+	it("keeps the streaming assistant component attached after a mid-stream rebuild", () => {
+		const { streamingComponent } = makeStreamingFixture();
+
+		mode.rebuildChatFromMessages();
+
+		expect(mode.chatContainer.children).toContain(streamingComponent);
+		expect(mode.streamingComponent).toBe(streamingComponent);
+	});
+
+	it("keeps in-flight tool components attached and tracked in pendingTools", () => {
+		const { pendingTool } = makeStreamingFixture();
+
+		mode.rebuildChatFromMessages();
+
+		expect(mode.chatContainer.children).toContain(pendingTool);
+		expect(mode.pendingTools.get("call-1")).toBe(pendingTool);
+	});
+
+	it("re-appends in-flight components after the historical replay (live tail order)", () => {
+		const { streamingComponent, pendingTool } = makeStreamingFixture();
+
+		mode.rebuildChatFromMessages();
+
+		const children = mode.chatContainer.children;
+		const streamingIdx = children.indexOf(streamingComponent);
+		const pendingIdx = children.indexOf(pendingTool);
+		expect(streamingIdx).toBeGreaterThanOrEqual(0);
+		expect(pendingIdx).toBeGreaterThan(streamingIdx);
+	});
+
+	it("does not preserve in-flight tracking when the session is idle (post-stream rebuilds reset cleanly)", () => {
+		const streamingComponent = new AssistantMessageComponent();
+		mode.chatContainer.addChild(streamingComponent);
+		mode.streamingComponent = streamingComponent;
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => false });
+
+		mode.rebuildChatFromMessages();
+
+		// Idle rebuilds (resume, /compact post-flush, theme overlay close) treat
+		// `streamingComponent` as stale UI to discard — the chat must be redrawn
+		// purely from committed messages.
+		expect(mode.chatContainer.children).not.toContain(streamingComponent);
+	});
+});


### PR DESCRIPTION
## Repro

While the LLM is streaming a response in interactive TUI mode, run
`/shake` (or any subcommand such as `/shake elide`). The whole in-flight
assistant message — text, thinking, streamed tool calls — disappears
from the chat and never reappears, even though the agent keeps emitting
tokens behind the scenes and the request runs to completion. Other
mid-stream rebuild triggers (`/shake images`, the
`display.cacheMissMarker` and `tui.renderMermaid` setting toggles in the
settings overlay) hit the same UI corruption.

Reproduce: prompt any model, then immediately type `/shake` while the
response is still streaming.

## Cause

`CommandController.handleShakeCommand` (`packages/coding-agent/src/modes/controllers/command-controller.ts:1152`)
calls `rebuildChatFromMessages()` once `session.shake(mode)` returns.
`rebuildChatFromMessages` clears `chatContainer` and replays only
committed `state.messages` (`packages/coding-agent/src/modes/interactive-mode.ts:1480`).
The agent's in-flight `streamMessage` and its still-pending tool calls
live OUTSIDE `state.messages` until `message_end` fires, so the live
`AssistantMessageComponent` (`this.streamingComponent`) and the pending
`ToolExecutionComponent`s tracked in `this.pendingTools` get detached
from the chat container while their references stay live. Every
subsequent `message_update`/`message_end` event then updates orphaned
components that never re-render — the LLM output is "hidden or removed"
from the user's perspective.

## Fix

- Snapshot the live `streamingComponent` and `pendingTools` (in their
  original chat-container order) before `chatContainer.clear()` when
  `session.isStreaming` is true.
- After `renderSessionContext` replays committed history, re-append the
  snapshotted components.
- `renderSessionContext` `.clear()`s `pendingTools` at start AND end to
  prevent historical tool components leaking into live tracking;
  restore the in-flight entries afterwards so the next streamed
  tool-call delta is routed into the preserved component instead of
  stacking a duplicate `ToolExecutionComponent` below it.
- Idle rebuilds (resume, `/compact` post-flush, settings overlay close
  with no active stream) are unchanged: the snapshot only runs when
  `session.isStreaming` is true.
- Added `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

- `bun test test/issue-3656-shake-during-stream.test.ts` — 4/4 pass. The
  new test seeds a `streamingComponent` + pending `ToolExecutionComponent`,
  flips `session.isStreaming` to true, invokes
  `rebuildChatFromMessages()`, and asserts the live components stay
  attached in tail order and `pendingTools` still tracks them. The same
  test fails (3/4) on `main` (verified by stashing the fix and re-running
  before restoring), so it actually defends the contract.
- `bun test test/issue-2372-repro.test.ts` (related rebuild path) — 5/5 pass.
- `bun test test/modes/utils/render-initial-messages.test.ts
  test/modes/controllers/handoff-command.test.ts
  test/slash-commands/shake.test.ts test/shake.test.ts
  test/compaction-lifecycle.test.ts
  test/modes/controllers/tan-command-controller.test.ts
  test/modes/controllers/event-controller-message-start.test.ts` —
  all pass.

Fixes #3656