### PR TITLE
fix(tui): keep ask Other context visible

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the ask tool's `Other (type your own)` editor dropping the original question and option list while the user types a custom answer. ([#3660](https://github.com/can1357/oh-my-pi/issues/3660))
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -136,6 +136,45 @@ function stripRecommendedSuffix(label: string): string {
 	return label.endsWith(RECOMMENDED_SUFFIX) ? label.slice(0, -RECOMMENDED_SUFFIX.length) : label;
 }
 
+interface CustomInputContext {
+	selectionMarker: "radio" | "checkbox";
+	checkedIndices?: readonly number[];
+	markableCount: number;
+}
+
+function getSelectOptionDescription(option: ExtensionUISelectItem): string | undefined {
+	return typeof option === "string" ? undefined : option.description;
+}
+
+function formatCustomInputTitle(
+	question: string,
+	options: ExtensionUISelectItem[],
+	context: CustomInputContext,
+): string {
+	const selectedIndex = options.findIndex(option => getSelectOptionLabel(option) === OTHER_OPTION);
+	const lines = [question, ""];
+	const checked = new Set(context.checkedIndices ?? []);
+	for (let index = 0; index < options.length; index++) {
+		const option = options[index]!;
+		const label = getSelectOptionLabel(option);
+		const isSelected = index === selectedIndex;
+		const isMarkable = index < context.markableCount;
+		const prefix =
+			context.selectionMarker === "radio" && (isMarkable || isSelected)
+				? `${isSelected ? theme.radio.selected : theme.radio.unselected} `
+				: context.selectionMarker === "checkbox" && isMarkable
+					? `${checked.has(index) ? theme.checkbox.checked : theme.checkbox.unchecked} `
+					: isSelected
+						? `${theme.nav.cursor} `
+						: "  ";
+		lines.push(prefix + label);
+		const description = getSelectOptionDescription(option);
+		if (description) lines.push(`    ${description}`);
+	}
+	lines.push("", "Enter your response:");
+	return lines.join("\n");
+}
+
 // =============================================================================
 // Question Selection Logic
 // =============================================================================
@@ -250,9 +289,14 @@ async function askSingleQuestion(
 		return { choice, timedOut: timeoutTriggered, navigation: navigationAction };
 	};
 
-	const promptForCustomInput = async (): Promise<{ input: string | undefined }> => {
+	const promptForCustomInput = async (
+		title: string,
+		optionsToShow: ExtensionUISelectItem[],
+		context: CustomInputContext,
+	): Promise<{ input: string | undefined }> => {
 		const dialogOptions = signal ? { signal } : undefined;
-		const showCustomInput = () => ui.editor("Enter your response:", undefined, dialogOptions, { promptStyle: true });
+		const editorTitle = formatCustomInputTitle(title, optionsToShow, context);
+		const showCustomInput = () => ui.editor(editorTitle, undefined, dialogOptions, { promptStyle: true });
 		const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
 		return { input };
 	};
@@ -306,7 +350,11 @@ async function askSingleQuestion(
 					timedOut = true;
 					break;
 				}
-				const customResult = await promptForCustomInput();
+				const customResult = await promptForCustomInput(`${prefix}${promptWithProgress}`, opts, {
+					selectionMarker: "checkbox",
+					checkedIndices,
+					markableCount: questionOptions.length,
+				});
 				if (customResult.input === undefined) {
 					continue;
 				}
@@ -372,7 +420,10 @@ async function askSingleQuestion(
 				if (selectTimedOut) {
 					break;
 				}
-				const customResult = await promptForCustomInput();
+				const customResult = await promptForCustomInput(promptWithProgress, optionsWithNavigation, {
+					selectionMarker: "radio",
+					markableCount: displayOptions.length,
+				});
 				if (customResult.input === undefined) {
 					continue;
 				}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -159,16 +159,26 @@ function truncateCustomInputDescription(text: string): string {
 	return `${flattened.slice(0, MAX_CUSTOM_INPUT_DESCRIPTION_CHARS - 1).trimEnd()}…`;
 }
 
-/** Window the option list around must-keep rows so the title stays bounded.
- *  Must-keep = the selected `Other` row, the first option (anchor), and every
- *  user-checked row. Remaining budget fills from the start. Gaps between kept
- *  indices are reported so the renderer can drop a `… N more options …`
- *  marker, preserving the "more available" signal. */
+interface CustomInputOptionGap {
+	total: number;
+	checked: number;
+}
+
+interface CustomInputOptionWindow {
+	indices: number[];
+	gapBefore: Map<number, CustomInputOptionGap>;
+}
+
+/** Window the option list so the title stays bounded. Required rows are the
+ *  selected `Other` row and the first option as an anchor; checked rows fill
+ *  the remaining budget before unselected leading rows. Hidden checked options
+ *  are summarized in gap markers so the rendered option-row count still never
+ *  exceeds {@link MAX_CUSTOM_INPUT_OPTION_ROWS}. */
 function pickCustomInputOptionWindow(
 	total: number,
 	selectedIndex: number,
 	checked: ReadonlySet<number>,
-): { indices: number[]; gapBefore: Map<number, number> } {
+): CustomInputOptionWindow {
 	if (total === 0) return { indices: [], gapBefore: new Map() };
 	if (total <= MAX_CUSTOM_INPUT_OPTION_ROWS) {
 		return {
@@ -177,22 +187,44 @@ function pickCustomInputOptionWindow(
 		};
 	}
 	const keep = new Set<number>();
-	if (selectedIndex >= 0 && selectedIndex < total) keep.add(selectedIndex);
-	keep.add(0);
-	for (const i of checked) {
-		if (i >= 0 && i < total) keep.add(i);
+	const addIfRoom = (index: number) => {
+		if (index >= 0 && index < total && keep.size < MAX_CUSTOM_INPUT_OPTION_ROWS) {
+			keep.add(index);
+		}
+	};
+	addIfRoom(selectedIndex);
+	addIfRoom(0);
+	for (const i of [...checked].sort((a, b) => a - b)) {
+		addIfRoom(i);
 	}
 	for (let i = 0; i < total && keep.size < MAX_CUSTOM_INPUT_OPTION_ROWS; i++) {
-		keep.add(i);
+		addIfRoom(i);
 	}
 	const indices = [...keep].sort((a, b) => a - b);
-	const gapBefore = new Map<number, number>();
+	const gapBefore = new Map<number, CustomInputOptionGap>();
+	const countCheckedBetween = (startInclusive: number, endExclusive: number): number => {
+		let count = 0;
+		for (const i of checked) {
+			if (i >= startInclusive && i < endExclusive) count++;
+		}
+		return count;
+	};
 	let prev = -1;
 	for (const idx of indices) {
-		if (idx > prev + 1) gapBefore.set(idx, idx - prev - 1);
+		if (idx > prev + 1) {
+			gapBefore.set(idx, {
+				total: idx - prev - 1,
+				checked: countCheckedBetween(prev + 1, idx),
+			});
+		}
 		prev = idx;
 	}
-	if (prev < total - 1) gapBefore.set(total, total - 1 - prev);
+	if (prev < total - 1) {
+		gapBefore.set(total, {
+			total: total - 1 - prev,
+			checked: countCheckedBetween(prev + 1, total),
+		});
+	}
 	return { indices, gapBefore };
 }
 
@@ -205,8 +237,9 @@ function formatCustomInputTitle(
 	const checked = new Set(context.checkedIndices ?? []);
 	const window = pickCustomInputOptionWindow(options.length, selectedIndex, checked);
 	const lines: string[] = [question, ""];
-	const emitGap = (count: number) => {
-		lines.push(`    … ${count} more option${count === 1 ? "" : "s"} …`);
+	const emitGap = (gap: CustomInputOptionGap) => {
+		const checkedSuffix = gap.checked > 0 ? `, ${gap.checked} checked` : "";
+		lines.push(`    … ${gap.total} more option${gap.total === 1 ? "" : "s"}${checkedSuffix} …`);
 	};
 	for (const index of window.indices) {
 		const gap = window.gapBefore.get(index);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -142,8 +142,58 @@ interface CustomInputContext {
 	markableCount: number;
 }
 
+/** Hard caps for the editor title rendered while the user types an `Other`
+ *  custom answer. Without these the title is one `Text` child stacked above the
+ *  prompt editor (no `maxVisible` windowing), so a question with many options
+ *  or paragraph-long descriptions hides the input row and hint. */
+const MAX_CUSTOM_INPUT_OPTION_ROWS = 8;
+const MAX_CUSTOM_INPUT_DESCRIPTION_CHARS = 120;
+
 function getSelectOptionDescription(option: ExtensionUISelectItem): string | undefined {
 	return typeof option === "string" ? undefined : option.description;
+}
+
+function truncateCustomInputDescription(text: string): string {
+	const flattened = text.replace(/\s+/g, " ").trim();
+	if (flattened.length <= MAX_CUSTOM_INPUT_DESCRIPTION_CHARS) return flattened;
+	return `${flattened.slice(0, MAX_CUSTOM_INPUT_DESCRIPTION_CHARS - 1).trimEnd()}…`;
+}
+
+/** Window the option list around must-keep rows so the title stays bounded.
+ *  Must-keep = the selected `Other` row, the first option (anchor), and every
+ *  user-checked row. Remaining budget fills from the start. Gaps between kept
+ *  indices are reported so the renderer can drop a `… N more options …`
+ *  marker, preserving the "more available" signal. */
+function pickCustomInputOptionWindow(
+	total: number,
+	selectedIndex: number,
+	checked: ReadonlySet<number>,
+): { indices: number[]; gapBefore: Map<number, number> } {
+	if (total === 0) return { indices: [], gapBefore: new Map() };
+	if (total <= MAX_CUSTOM_INPUT_OPTION_ROWS) {
+		return {
+			indices: Array.from({ length: total }, (_, i) => i),
+			gapBefore: new Map(),
+		};
+	}
+	const keep = new Set<number>();
+	if (selectedIndex >= 0 && selectedIndex < total) keep.add(selectedIndex);
+	keep.add(0);
+	for (const i of checked) {
+		if (i >= 0 && i < total) keep.add(i);
+	}
+	for (let i = 0; i < total && keep.size < MAX_CUSTOM_INPUT_OPTION_ROWS; i++) {
+		keep.add(i);
+	}
+	const indices = [...keep].sort((a, b) => a - b);
+	const gapBefore = new Map<number, number>();
+	let prev = -1;
+	for (const idx of indices) {
+		if (idx > prev + 1) gapBefore.set(idx, idx - prev - 1);
+		prev = idx;
+	}
+	if (prev < total - 1) gapBefore.set(total, total - 1 - prev);
+	return { indices, gapBefore };
 }
 
 function formatCustomInputTitle(
@@ -152,9 +202,15 @@ function formatCustomInputTitle(
 	context: CustomInputContext,
 ): string {
 	const selectedIndex = options.findIndex(option => getSelectOptionLabel(option) === OTHER_OPTION);
-	const lines = [question, ""];
 	const checked = new Set(context.checkedIndices ?? []);
-	for (let index = 0; index < options.length; index++) {
+	const window = pickCustomInputOptionWindow(options.length, selectedIndex, checked);
+	const lines: string[] = [question, ""];
+	const emitGap = (count: number) => {
+		lines.push(`    … ${count} more option${count === 1 ? "" : "s"} …`);
+	};
+	for (const index of window.indices) {
+		const gap = window.gapBefore.get(index);
+		if (gap !== undefined) emitGap(gap);
 		const option = options[index]!;
 		const label = getSelectOptionLabel(option);
 		const isSelected = index === selectedIndex;
@@ -169,8 +225,10 @@ function formatCustomInputTitle(
 						: "  ";
 		lines.push(prefix + label);
 		const description = getSelectOptionDescription(option);
-		if (description) lines.push(`    ${description}`);
+		if (description) lines.push(`    ${truncateCustomInputDescription(description)}`);
 	}
+	const trailingGap = window.gapBefore.get(options.length);
+	if (trailingGap !== undefined) emitGap(trailingGap);
 	lines.push("", "Enter your response:");
 	return lines.join("\n");
 }

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -17,7 +17,17 @@
 
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
-import { type Component, Markdown, type MarkdownTheme, renderInlineMarkdown, TERMINAL, Text } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	Ellipsis,
+	Markdown,
+	type MarkdownTheme,
+	renderInlineMarkdown,
+	TERMINAL,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
 import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type as arkType } from "arktype";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
@@ -143,20 +153,39 @@ interface CustomInputContext {
 }
 
 /** Hard caps for the editor title rendered while the user types an `Other`
- *  custom answer. Without these the title is one `Text` child stacked above the
- *  prompt editor (no `maxVisible` windowing), so a question with many options
- *  or paragraph-long descriptions hides the input row and hint. */
+ *  custom answer. {@link HookEditorComponent} renders the title via a single
+ *  `Text` child stacked above the prompt editor with no `maxVisible` windowing,
+ *  so the title MUST fit a normal terminal:
+ *  - {@link MAX_CUSTOM_INPUT_OPTION_ROWS}: at most this many option-row entries
+ *    survive {@link pickCustomInputOptionWindow}, regardless of total options.
+ *  - {@link MAX_CUSTOM_INPUT_TITLE_ROWS}: hard cap on rendered title rows after
+ *    every line is pre-truncated to one row at the live terminal width. Sized
+ *    so a 24-row terminal still has space for the input row, hint, and chrome.
+ */
 const MAX_CUSTOM_INPUT_OPTION_ROWS = 8;
-const MAX_CUSTOM_INPUT_DESCRIPTION_CHARS = 120;
+const MAX_CUSTOM_INPUT_TITLE_ROWS = 16;
+const MIN_CUSTOM_INPUT_CONTENT_WIDTH = 20;
+/** Subtracted from the terminal width to leave room for the surrounding
+ *  `Text(... padX=1)` padding + DynamicBorder vertical chrome. */
+const CUSTOM_INPUT_CHROME_COLUMNS = 4;
+const CUSTOM_INPUT_DESCRIPTION_INDENT = "    ";
+
+function customInputContentWidth(): number {
+	const cols = process.stdout.columns ?? 80;
+	return Math.max(MIN_CUSTOM_INPUT_CONTENT_WIDTH, cols - CUSTOM_INPUT_CHROME_COLUMNS);
+}
+
+function clampLineToWidth(line: string, width: number): string {
+	if (visibleWidth(line) <= width) return line;
+	return truncateToWidth(line, width, Ellipsis.Unicode);
+}
+
+function flattenDescription(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
 
 function getSelectOptionDescription(option: ExtensionUISelectItem): string | undefined {
 	return typeof option === "string" ? undefined : option.description;
-}
-
-function truncateCustomInputDescription(text: string): string {
-	const flattened = text.replace(/\s+/g, " ").trim();
-	if (flattened.length <= MAX_CUSTOM_INPUT_DESCRIPTION_CHARS) return flattened;
-	return `${flattened.slice(0, MAX_CUSTOM_INPUT_DESCRIPTION_CHARS - 1).trimEnd()}…`;
 }
 
 interface CustomInputOptionGap {
@@ -228,19 +257,37 @@ function pickCustomInputOptionWindow(
 	return { indices, gapBefore };
 }
 
-function formatCustomInputTitle(
+interface CustomInputRow {
+	text: string;
+	/** Lower priority drops first when over budget; negative values are pinned
+	 *  and never dropped (question, blank, option labels, gap markers, prompt). */
+	priority: number;
+}
+
+function buildCustomInputRows(
 	question: string,
 	options: ExtensionUISelectItem[],
 	context: CustomInputContext,
-): string {
+	contentWidth: number,
+): CustomInputRow[] {
 	const selectedIndex = options.findIndex(option => getSelectOptionLabel(option) === OTHER_OPTION);
 	const checked = new Set(context.checkedIndices ?? []);
 	const window = pickCustomInputOptionWindow(options.length, selectedIndex, checked);
-	const lines: string[] = [question, ""];
+	const rows: CustomInputRow[] = [];
+	rows.push({ text: clampLineToWidth(question, contentWidth), priority: -1 });
+	rows.push({ text: "", priority: -1 });
+
 	const emitGap = (gap: CustomInputOptionGap) => {
 		const checkedSuffix = gap.checked > 0 ? `, ${gap.checked} checked` : "";
-		lines.push(`    … ${gap.total} more option${gap.total === 1 ? "" : "s"}${checkedSuffix} …`);
+		rows.push({
+			text: clampLineToWidth(
+				`    … ${gap.total} more option${gap.total === 1 ? "" : "s"}${checkedSuffix} …`,
+				contentWidth,
+			),
+			priority: -1,
+		});
 	};
+
 	for (const index of window.indices) {
 		const gap = window.gapBefore.get(index);
 		if (gap !== undefined) emitGap(gap);
@@ -256,14 +303,54 @@ function formatCustomInputTitle(
 					: isSelected
 						? `${theme.nav.cursor} `
 						: "  ";
-		lines.push(prefix + label);
+		rows.push({ text: clampLineToWidth(prefix + label, contentWidth), priority: -1 });
 		const description = getSelectOptionDescription(option);
-		if (description) lines.push(`    ${truncateCustomInputDescription(description)}`);
+		if (description) {
+			const flat = flattenDescription(description);
+			if (flat) {
+				rows.push({
+					text: clampLineToWidth(`${CUSTOM_INPUT_DESCRIPTION_INDENT}${flat}`, contentWidth),
+					// Selected (Other) carries no description; favor checked rows
+					// when budget pressure forces description rows to be dropped.
+					priority: isSelected ? 2 : checked.has(index) ? 1 : 0,
+				});
+			}
+		}
 	}
+
 	const trailingGap = window.gapBefore.get(options.length);
 	if (trailingGap !== undefined) emitGap(trailingGap);
-	lines.push("", "Enter your response:");
-	return lines.join("\n");
+	rows.push({ text: "", priority: -1 });
+	rows.push({ text: "Enter your response:", priority: -1 });
+	return rows;
+}
+
+function applyCustomInputRowBudget(rows: CustomInputRow[], budget: number): CustomInputRow[] {
+	if (rows.length <= budget) return rows;
+	// Drop droppable rows lowest priority first; on ties, drop later rows first
+	// so the user still sees the earliest options' descriptions.
+	const droppable = rows
+		.map((row, index) => ({ row, index }))
+		.filter(entry => entry.row.priority >= 0)
+		.sort((a, b) => a.row.priority - b.row.priority || b.index - a.index);
+	const removed = new Set<number>();
+	for (const { index } of droppable) {
+		if (rows.length - removed.size <= budget) break;
+		removed.add(index);
+	}
+	return rows.filter((_, i) => !removed.has(i));
+}
+
+function formatCustomInputTitle(
+	question: string,
+	options: ExtensionUISelectItem[],
+	context: CustomInputContext,
+): string {
+	const contentWidth = customInputContentWidth();
+	const rows = buildCustomInputRows(question, options, context, contentWidth);
+	return applyCustomInputRowBudget(rows, MAX_CUSTOM_INPUT_TITLE_ROWS)
+		.map(row => row.text)
+		.join("\n");
 }
 
 // =============================================================================

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -565,7 +565,7 @@ describe("AskTool custom input", () => {
 	});
 	it("keeps question context visible while entering Other custom input", async () => {
 		const tool = new AskTool(createSession());
-		const editor = vi.fn(async () => "custom");
+		const editor = vi.fn(async (_title: string) => "custom");
 		const questions = [
 			{
 				id: "details",
@@ -580,7 +580,7 @@ describe("AskTool custom input", () => {
 
 		await tool.execute("call-editor-context", { questions }, undefined, undefined, context);
 
-		const title = editor.mock.calls[0]?.[0];
+		const title = editor.mock.calls[0]?.[0] ?? "";
 		expect(title).toContain("Share details");
 		expect(title).toContain("yes");
 		expect(title).toContain("no");
@@ -588,7 +588,6 @@ describe("AskTool custom input", () => {
 		expect(title).toContain("Other (type your own)");
 		expect(title).toContain("Enter your response:");
 	});
-
 
 	it("returns to the option selector when custom input is dismissed in single-question flow", async () => {
 		const tool = new AskTool(createSession());

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -651,6 +651,37 @@ describe("AskTool custom input", () => {
 		expect(title).toContain("more option");
 	});
 
+	it("summarizes excess checked options instead of exceeding the context cap", async () => {
+		const tool = new AskTool(createSession());
+		const editor = vi.fn(async (_title: string) => "custom");
+		const options = Array.from({ length: 20 }, (_, i) => ({ label: `checked-${i}` }));
+		const questions = [{ id: "pick", question: "Pick many", options, multi: true }];
+		let call = 0;
+		const context = createContext({
+			select: async (_prompt, opts) => {
+				if (call < 12) {
+					const label = `checked-${call}`;
+					call += 1;
+					return selectItemLabel(opts.find(o => selectItemLabel(o) === label));
+				}
+				return "Other (type your own)";
+			},
+			editor,
+		});
+
+		await tool.execute("call-editor-cap-many-checked", { questions }, undefined, undefined, context);
+
+		const title = editor.mock.calls[0]?.[0] ?? "";
+		const optionRows = title
+			.split("\n")
+			.filter(line => line.includes("checked-") || line.includes("Other (type your own)"));
+		expect(optionRows.length).toBeLessThanOrEqual(8);
+		expect(title).toContain("Other (type your own)");
+		expect(title).toContain("checked");
+		expect(title).toContain("more option");
+		expect(title).toContain("Enter your response:");
+	});
+
 	it("returns to the option selector when custom input is dismissed in single-question flow", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -563,6 +563,32 @@ describe("AskTool custom input", () => {
 		expect(editor).toHaveBeenCalledTimes(1);
 		expect(abort).not.toHaveBeenCalled();
 	});
+	it("keeps question context visible while entering Other custom input", async () => {
+		const tool = new AskTool(createSession());
+		const editor = vi.fn(async () => "custom");
+		const questions = [
+			{
+				id: "details",
+				question: "Share details",
+				options: [{ label: "yes" }, { label: "no", description: "Skip the optional detail." }],
+			},
+		];
+		const context = createContext({
+			select: async () => "Other (type your own)",
+			editor,
+		});
+
+		await tool.execute("call-editor-context", { questions }, undefined, undefined, context);
+
+		const title = editor.mock.calls[0]?.[0];
+		expect(title).toContain("Share details");
+		expect(title).toContain("yes");
+		expect(title).toContain("no");
+		expect(title).toContain("Skip the optional detail.");
+		expect(title).toContain("Other (type your own)");
+		expect(title).toContain("Enter your response:");
+	});
+
 
 	it("returns to the option selector when custom input is dismissed in single-question flow", async () => {
 		const tool = new AskTool(createSession());

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -682,6 +682,48 @@ describe("AskTool custom input", () => {
 		expect(title).toContain("Enter your response:");
 	});
 
+	it("enforces total title row budget under narrow terminals", async () => {
+		const originalColumns = process.stdout.columns;
+		// Force an 80-wide terminal so long descriptions would wrap to multiple
+		// rendered rows without per-line width truncation + total row budget.
+		Object.defineProperty(process.stdout, "columns", { value: 80, configurable: true });
+		try {
+			const tool = new AskTool(createSession());
+			const editor = vi.fn(async (_title: string) => "custom");
+			const longDescription = "x".repeat(400);
+			const options = Array.from({ length: 8 }, (_, i) => ({
+				label: `option-${i}`,
+				description: longDescription,
+			}));
+			const questions = [{ id: "pick", question: "Pick one", options }];
+			const context = createContext({
+				select: async () => "Other (type your own)",
+				editor,
+			});
+
+			await tool.execute("call-editor-row-budget", { questions }, undefined, undefined, context);
+
+			const title = editor.mock.calls[0]?.[0] ?? "";
+			const lines = title.split("\n");
+			// 16-row hard budget keeps the input row + hint reachable on 80x24.
+			expect(lines.length).toBeLessThanOrEqual(16);
+			// Every emitted line must fit on a single 80-cell row after truncation.
+			for (const line of lines) {
+				expect(stripAnsi(line).length).toBeLessThanOrEqual(80);
+			}
+			expect(title).toContain("Pick one");
+			expect(title).toContain("Other (type your own)");
+			expect(title).toContain("Enter your response:");
+			expect(title).not.toContain("x".repeat(400));
+		} finally {
+			if (originalColumns === undefined) {
+				Object.defineProperty(process.stdout, "columns", { value: undefined, configurable: true });
+			} else {
+				Object.defineProperty(process.stdout, "columns", { value: originalColumns, configurable: true });
+			}
+		}
+	});
+
 	it("returns to the option selector when custom input is dismissed in single-question flow", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -589,6 +589,68 @@ describe("AskTool custom input", () => {
 		expect(title).toContain("Enter your response:");
 	});
 
+	it("caps Other editor context for long option lists with long descriptions", async () => {
+		const tool = new AskTool(createSession());
+		const editor = vi.fn(async (_title: string) => "custom");
+		const longDescription = "x".repeat(400);
+		const optionCount = 20;
+		const options = Array.from({ length: optionCount }, (_, i) => ({
+			label: `option-${i}`,
+			description: longDescription,
+		}));
+		const questions = [{ id: "pick", question: "Pick one", options }];
+		const context = createContext({
+			select: async () => "Other (type your own)",
+			editor,
+		});
+
+		await tool.execute("call-editor-cap", { questions }, undefined, undefined, context);
+
+		const title = editor.mock.calls[0]?.[0] ?? "";
+		const lineCount = title.split("\n").length;
+		// Cap is 8 option rows + their (single-line) descriptions + chrome; far below
+		// 20 options × (label + multi-line description) the unbounded path would emit.
+		expect(lineCount).toBeLessThanOrEqual(22);
+		expect(title).toContain("Pick one");
+		expect(title).toContain("option-0");
+		expect(title).toContain("Other (type your own)");
+		expect(title).toContain("more option");
+		expect(title).toContain("Enter your response:");
+		// Descriptions are flattened to a single line and truncated.
+		expect(title).not.toContain("x".repeat(400));
+		// Every option-row description must fit on one line.
+		for (const line of title.split("\n")) {
+			expect(line.length).toBeLessThanOrEqual(160);
+		}
+	});
+
+	it("keeps user-checked options visible in capped multi-select context", async () => {
+		const tool = new AskTool(createSession());
+		const editor = vi.fn(async (_title: string) => "custom");
+		const options = Array.from({ length: 20 }, (_, i) => ({ label: `opt-${i}` }));
+		const questions = [{ id: "pick", question: "Multi pick", options, multi: true }];
+		let call = 0;
+		const context = createContext({
+			select: async (_prompt, opts) => {
+				call += 1;
+				if (call === 1) return selectItemLabel(opts.find(o => selectItemLabel(o) === "opt-12"));
+				if (call === 2) return selectItemLabel(opts.find(o => selectItemLabel(o) === "opt-17"));
+				return "Other (type your own)";
+			},
+			editor,
+		});
+
+		await tool.execute("call-editor-cap-multi", { questions }, undefined, undefined, context);
+
+		const title = editor.mock.calls[0]?.[0] ?? "";
+		// Checked options must survive the window so the user sees what they had
+		// already toggled before switching to Other.
+		expect(title).toContain("opt-12");
+		expect(title).toContain("opt-17");
+		expect(title).toContain("Other (type your own)");
+		expect(title).toContain("more option");
+	});
+
 	it("returns to the option selector when custom input is dismissed in single-question flow", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();


### PR DESCRIPTION
## Repro
Selecting `Other (type your own)` in the ask tool opened the custom editor with only `Enter your response:`. Reproduced with `bun test packages/coding-agent/test/tools/ask.test.ts -t "keeps question context visible"`, which failed because the editor title did not contain the original question.

## Cause
`packages/coding-agent/src/tools/ask.ts` routed the Other branch through `promptForCustomInput()`, which always called `ui.editor("Enter your response:", ...)` and discarded the selector prompt, option labels, and option descriptions before the prompt-style editor mounted.

## Fix
- Added ask editor title formatting that includes the current question, option list, descriptions, and selected Other row before `Enter your response:`.
- Reused the same path for single-select and multi-select ask flows, preserving checked options in multi-select.
- Added a regression test covering the custom editor context.
- Added a coding-agent changelog entry for #3660.

## Verification
`bun test packages/coding-agent/test/tools/ask.test.ts` passed with 36 tests. `bun check` passed. `gh_push_branch` reran the pre-publish gate and pushed successfully. Fixes #3660