### PR TITLE
fix(export): use browser-safe single-key toggles in HTML export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the HTML session export's "toggle thinking" and "toggle tools" keyboard shortcuts being unreachable in a web browser: `Ctrl+T` and `Ctrl+O` are reserved by every major browser (new tab / open file), so the page never saw the keystroke. The shortcuts are now bare `T` / `O` (suppressed while focus is in the search input) and the in-page help bar reads `T toggle thinking · O toggle tools` ([#3670](https://github.com/can1357/oh-my-pi/issues/3670)).
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -1236,7 +1236,7 @@
         let html = `
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
-            <div class="help-bar">Ctrl+T toggle thinking · Ctrl+O toggle tools</div>
+            <div class="help-bar">T toggle thinking · O toggle tools</div>
             <div class="header-info">
               <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : 'unknown'}</span></div>
               <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${globalStats.models.join(', ') || 'unknown'}</span></div>
@@ -1580,13 +1580,19 @@
           searchQuery = '';
           navigateTo(leafId, 'bottom');
         }
-        if (e.ctrlKey && e.key === 't') {
+        if (e.key === 't' || e.key === 'T' || e.key === 'o' || e.key === 'O') {
+          // Skip when typing in the sidebar search (or any other editable target)
+          // so the chord can't fire on a user's letter input. Avoid Ctrl/Cmd-based
+          // chords entirely — every major browser reserves Ctrl+T (new tab) and
+          // Ctrl+O (open file), so the shortcut would never reach the page.
+          const t = e.target;
+          const editable =
+            t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+          if (editable) return;
+          if (e.ctrlKey || e.metaKey || e.altKey) return;
           e.preventDefault();
-          toggleThinking();
-        }
-        if (e.ctrlKey && e.key === 'o') {
-          e.preventDefault();
-          toggleToolOutputs();
+          if (e.key === 't' || e.key === 'T') toggleThinking();
+          else toggleToolOutputs();
         }
       });
 


### PR DESCRIPTION
## Repro

Open any `omp` HTML session export in a web browser and press `Ctrl+T` (advertised by the in-page help bar as "toggle thinking"). Chrome/Edge/Firefox/Safari all open a new tab — the page never sees the keystroke. `Ctrl+O` opens the browser's file picker for the same reason. Both advertised toggles were therefore unreachable, including in the sidebar:

```bash
omp export session.jsonl --out session.html
open session.html   # press Ctrl+T → new tab; press Ctrl+O → file picker
```

## Cause

`packages/coding-agent/src/export/html/template.js` bound `toggleThinking` / `toggleToolOutputs` to `Ctrl+T` / `Ctrl+O`, mirroring the TUI keybindings — but `Ctrl+T` (new tab) and `Ctrl+O` (open file) are reserved by every major browser and cannot be intercepted by a page. The help bar text `Ctrl+T toggle thinking · Ctrl+O toggle tools` documented the same dead chord.

## Fix

- `template.js` keyboard handler: trigger on bare `t`/`T`/`o`/`O`; skip when focus is in an `<input>`, `<textarea>`, or `[contenteditable]` (so the sidebar search and any future editable field still accept those letters); let any chord with `ctrlKey`/`metaKey`/`altKey` fall through to the browser.
- `template.js` help bar: `T toggle thinking · O toggle tools`.
- `CHANGELOG.md`: entry under `[Unreleased]` describing the fix.

TUI bindings in `packages/coding-agent/src/config/keybindings.ts` (`app.thinking.toggle` / `app.tools.expand`) are unchanged — terminal users continue to press `Ctrl+T` / `Ctrl+O`.

## Verification

Rendered the test-fixture session through `exportFromFile` and grepped the produced HTML — the help bar now reads `T toggle thinking · O toggle tools`.

Ran a standalone harness (`/tmp/smoke-3670.mjs`, not committed) that re-uses the inline handler verbatim and dispatches synthetic `KeyboardEvent`s through a fake document:

|Event|Expected|Result|
|---|---|---|
|`keydown { key: 't' }`|`toggleThinking()`, `preventDefault()`|ok|
|`keydown { key: 'o' }`|`toggleToolOutputs()`, `preventDefault()`|ok|
|`keydown { key: 'T' }`|`toggleThinking()`|ok|
|`keydown { key: 't', ctrlKey: true }`|no-op, **not** prevented (passes to browser)|ok|
|`keydown { key: 'o', metaKey: true }`|no-op, **not** prevented|ok|
|`keydown { key: 't', altKey: true }`|no-op|ok|
|`keydown { key: 't', target: <input> }`|no-op (search input accepts the letter)|ok|
|`keydown { key: 'o', target: <textarea> }`|no-op|ok|
|`keydown { key: 'T', target: contenteditable }`|no-op|ok|

Pre-publish `bun run fix` + `bun check` ran via `gh_push_branch`.

Fixes #3670