### PR TITLE
fix(tui): allow thinking toggle after streamed reasoning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+T staying locked off for OpenAI-compatible providers that stream reasoning content without advertising reasoning support in model metadata. ([#3669](https://github.com/can1357/oh-my-pi/issues/3669))
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -554,6 +554,7 @@ export class EventController {
 		this.#ensureWorkingLoaderWhileStreaming();
 		this.#vocalizeDelta(event);
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
+			this.ctx.noteDisplayableThinkingContent(event.message);
 			this.ctx.streamingMessage = event.message;
 			this.#streamingReveal.setTarget(this.ctx.streamingMessage);
 
@@ -681,6 +682,9 @@ export class EventController {
 
 	async #handleMessageEnd(event: Extract<AgentSessionEvent, { type: "message_end" }>): Promise<void> {
 		if (event.message.role === "user") return;
+		if (event.message.role === "assistant") {
+			this.ctx.noteDisplayableThinkingContent(event.message);
+		}
 		if (event.message.role === "assistant" && settings.get("speech.enabled")) {
 			if (event.message.stopReason === "aborted") {
 				// Esc / Ctrl+C / interrupt: stop speaking now and drop the trailing partial.

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -554,7 +554,11 @@ export class EventController {
 		this.#ensureWorkingLoaderWhileStreaming();
 		this.#vocalizeDelta(event);
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
-			this.ctx.noteDisplayableThinkingContent(event.message);
+			const unlockedThinkingVisibility = this.ctx.noteDisplayableThinkingContent(event.message);
+			if (unlockedThinkingVisibility) {
+				this.ctx.streamingComponent.setHideThinkingBlock(this.ctx.effectiveHideThinkingBlock);
+				this.#streamingReveal.resyncVisibility();
+			}
 			this.ctx.streamingMessage = event.message;
 			this.#streamingReveal.setTarget(this.ctx.streamingMessage);
 
@@ -682,8 +686,11 @@ export class EventController {
 
 	async #handleMessageEnd(event: Extract<AgentSessionEvent, { type: "message_end" }>): Promise<void> {
 		if (event.message.role === "user") return;
-		if (event.message.role === "assistant") {
-			this.ctx.noteDisplayableThinkingContent(event.message);
+		const unlockedThinkingVisibility =
+			event.message.role === "assistant" && this.ctx.noteDisplayableThinkingContent(event.message);
+		if (unlockedThinkingVisibility && this.ctx.streamingComponent) {
+			this.ctx.streamingComponent.setHideThinkingBlock(this.ctx.effectiveHideThinkingBlock);
+			this.#streamingReveal.resyncVisibility();
 		}
 		if (event.message.role === "assistant" && settings.get("speech.enabled")) {
 			if (event.message.stopReason === "aborted") {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1739,14 +1739,14 @@ export class InputController {
 	}
 
 	toggleThinkingBlockVisibility(): void {
-		// When thinking is "off", thinking blocks are always hidden (some
-		// providers return them regardless). The toggle is meaningless in
-		// that state — inform the user instead of silently flipping the
-		// persisted value. When thinking is on, the toggle works normally
-		// even if blocks are already hidden (user may want to show them).
+		// When thinking is "off" and the session has not produced reasoning
+		// content, thinking blocks stay auto-hidden; the toggle would only corrupt
+		// the persisted preference. OpenAI-compatible servers can stream reasoning
+		// without advertising model support, so observed thinking content unlocks
+		// the display toggle.
 		const thinkingOff =
 			((this.ctx.viewSession ?? this.ctx.session)?.thinkingLevel ?? ThinkingLevel.Off) === ThinkingLevel.Off;
-		if (thinkingOff) {
+		if (thinkingOff && !this.ctx.hasDisplayableThinkingContent) {
 			this.ctx.showStatus("Thinking is off — enable thinking to show blocks");
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -420,10 +420,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#sessionsWithDisplayableThinkingContent.has(this.viewSession);
 	}
 	/** Record received reasoning content so Ctrl+T can reveal it even when model metadata says thinking is off. */
-	noteDisplayableThinkingContent(message: AgentMessage): void {
-		if (messageHasDisplayableThinking(message, this.proseOnlyThinking)) {
-			this.#sessionsWithDisplayableThinkingContent.add(this.viewSession);
+	noteDisplayableThinkingContent(message: AgentMessage): boolean {
+		if (this.hasDisplayableThinkingContent || !messageHasDisplayableThinking(message, this.proseOnlyThinking)) {
+			return false;
 		}
+		this.#sessionsWithDisplayableThinkingContent.add(this.viewSession);
+		return true;
 	}
 	/**
 	 * Effective thinking-block visibility: hidden when the user's setting is on,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,6 +112,7 @@ import { renderTreeList } from "../tui/tree-list";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
+import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
 import {
 	isSearchProviderId,
@@ -413,14 +414,27 @@ export class InteractiveMode implements InteractiveModeContext {
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
 	todoPhases: TodoPhase[] = [];
 	hideThinkingBlock = false;
+	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
+	/** Whether the visible session has produced thinking content the user can reveal. */
+	get hasDisplayableThinkingContent(): boolean {
+		return this.#sessionsWithDisplayableThinkingContent.has(this.viewSession);
+	}
+	/** Record received reasoning content so Ctrl+T can reveal it even when model metadata says thinking is off. */
+	noteDisplayableThinkingContent(message: AgentMessage): void {
+		if (messageHasDisplayableThinking(message, this.proseOnlyThinking)) {
+			this.#sessionsWithDisplayableThinkingContent.add(this.viewSession);
+		}
+	}
 	/**
-	 * Effective thinking-block visibility: hidden when the user's setting is on
-	 * OR the session thinking level is "off". Some providers (MiniMax, GLM,
-	 * DeepSeek) return thinking blocks even with reasoning disabled; this
-	 * respects the user's intent when they set thinking to "off" (#626).
+	 * Effective thinking-block visibility: hidden when the user's setting is on,
+	 * or while thinking is "off" before the session has actually produced
+	 * displayable thinking content. Some providers return thinking blocks without
+	 * advertising reasoning support, so observed content unlocks the visibility
+	 * toggle.
 	 */
 	get effectiveHideThinkingBlock(): boolean {
-		return this.hideThinkingBlock || (this.viewSession?.thinkingLevel ?? ThinkingLevel.Off) === ThinkingLevel.Off;
+		const thinkingOff = (this.viewSession?.thinkingLevel ?? ThinkingLevel.Off) === ThinkingLevel.Off;
+		return this.hideThinkingBlock || (thinkingOff && !this.hasDisplayableThinkingContent);
 	}
 	proseOnlyThinking = true;
 	compactionQueuedMessages: CompactionQueuedMessage[] = [];
@@ -3583,6 +3597,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		sessionContext: SessionContext,
 		options?: { updateFooter?: boolean; populateHistory?: boolean },
 	): void {
+		for (const message of sessionContext.messages) {
+			this.noteDisplayableThinkingContent(message);
+		}
 		this.#uiHelpers.renderSessionContext(sessionContext, options);
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -167,8 +167,8 @@ export interface InteractiveModeContext {
 	readonly effectiveHideThinkingBlock: boolean;
 	/** Whether this visible session has produced thinking content the user can reveal. */
 	readonly hasDisplayableThinkingContent: boolean;
-	/** Record a message whose thinking content makes Ctrl+T meaningful even at thinking level "off". */
-	noteDisplayableThinkingContent(message: AgentMessage): void;
+	/** Record a message whose thinking content makes Ctrl+T meaningful even at thinking level "off"; returns true on first observation. */
+	noteDisplayableThinkingContent(message: AgentMessage): boolean;
 	proseOnlyThinking: boolean;
 	compactionQueuedMessages: CompactionQueuedMessage[];
 	pendingTools: Map<string, ToolExecutionHandle>;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -161,10 +161,14 @@ export interface InteractiveModeContext {
 	hideThinkingBlock: boolean;
 	/**
 	 * Effective thinking-block visibility: true when hidden by user setting OR
-	 * thinking level is "off". Read this in render paths instead of
-	 * {@link hideThinkingBlock} so blocks are auto-hidden when thinking is off.
+	 * thinking level is "off" before the session has produced displayable
+	 * thinking content.
 	 */
 	readonly effectiveHideThinkingBlock: boolean;
+	/** Whether this visible session has produced thinking content the user can reveal. */
+	readonly hasDisplayableThinkingContent: boolean;
+	/** Record a message whose thinking content makes Ctrl+T meaningful even at thinking level "off". */
+	noteDisplayableThinkingContent(message: AgentMessage): void;
 	proseOnlyThinking: boolean;
 	compactionQueuedMessages: CompactionQueuedMessage[];
 	pendingTools: Map<string, ToolExecutionHandle>;

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -1,3 +1,5 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
 	const trimmed = text.trim();
@@ -79,6 +81,7 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	return formatted;
 }
 
+/** Whether a formatted thinking block has non-placeholder content worth rendering. */
 export function hasDisplayableThinking(
 	text: string | null | undefined,
 	formattedText: string | null | undefined,
@@ -86,4 +89,16 @@ export function hasDisplayableThinking(
 	if (!text) return false;
 	if (!formattedText) return false;
 	return formattedText.length > 0 && canonicalizeMessage(text).length > 0;
+}
+
+/** Whether an assistant message contains thinking content the TUI can reveal. */
+export function messageHasDisplayableThinking(message: AgentMessage, proseOnly: boolean): boolean {
+	if (message.role !== "assistant") return false;
+	for (const content of message.content) {
+		if (content.type !== "thinking") continue;
+		if (hasDisplayableThinking(content.thinking, formatThinkingForDisplay(content.thinking, proseOnly))) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -53,11 +53,13 @@ afterEach(() => {
 });
 
 function createFixture(streamingMessage?: AssistantMessage) {
+	const componentCalls: string[] = [];
 	const streamingComponent = {
-		updateContent: vi.fn(),
+		updateContent: vi.fn(() => componentCalls.push("update")),
 		setComplete: vi.fn(),
 		markTranscriptBlockFinalized: vi.fn(),
 		setErrorPinned: vi.fn(),
+		setHideThinkingBlock: vi.fn((hide: boolean) => componentCalls.push(`hide:${hide}`)),
 	};
 	const showPinnedError = vi.fn();
 	const clearPinnedError = vi.fn();
@@ -68,10 +70,30 @@ function createFixture(streamingMessage?: AssistantMessage) {
 
 	const session = { isStreaming: false };
 	const viewSession = { isStreaming: false, isTtsrAbortPending: false, retryAttempt: 0 };
+	let hasDisplayableThinkingContent = false;
+	const noteDisplayableThinkingContent = vi.fn((message: AssistantMessage) => {
+		const hasThinking = message.content.some(
+			content => content.type === "thinking" && content.thinking.trim() !== "",
+		);
+		if (!hasThinking || hasDisplayableThinkingContent) return false;
+		hasDisplayableThinkingContent = true;
+		return true;
+	});
+	const chatChildren: unknown[] = [];
+	const chatContainer = {
+		children: chatChildren,
+		addChild: vi.fn((child: unknown) => {
+			chatChildren.push(child);
+		}),
+		clear: vi.fn(() => {
+			chatChildren.length = 0;
+		}),
+	};
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
 		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
+		settings: { get: vi.fn(() => false) },
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
 		updatePendingMessagesDisplay: vi.fn(),
@@ -83,12 +105,21 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		editor: {},
 		streamingComponent: streamingMessage ? streamingComponent : undefined,
 		streamingMessage,
+		chatContainer,
+		proseOnlyThinking: true,
 		pendingTools: new Map(),
 		flushCompactionQueue: vi.fn(async () => {}),
 		showPinnedError,
 		clearPinnedError,
 		showError: vi.fn(),
 		showStatus: vi.fn(),
+		noteDisplayableThinkingContent,
+		get hasDisplayableThinkingContent() {
+			return hasDisplayableThinkingContent;
+		},
+		get effectiveHideThinkingBlock() {
+			return !hasDisplayableThinkingContent;
+		},
 		showWarning: vi.fn(),
 		session,
 		get viewSession() {
@@ -98,7 +129,7 @@ function createFixture(streamingMessage?: AssistantMessage) {
 	} as unknown as InteractiveModeContext;
 
 	const controller = new EventController(ctx);
-	return { controller, ctx, showPinnedError, clearPinnedError, streamingComponent };
+	return { controller, ctx, showPinnedError, clearPinnedError, streamingComponent, componentCalls };
 }
 
 describe("EventController error banner", () => {
@@ -185,7 +216,6 @@ describe("EventController error banner", () => {
 	it("does not pin a banner for an aborted assistant turn", async () => {
 		const message = makeAssistantMessage({ stopReason: "aborted", errorMessage: "Operation aborted" });
 		const { controller, showPinnedError } = createFixture(message);
-
 		await controller.handleEvent({ type: "message_end", message } as Extract<
 			AgentSessionEvent,
 			{ type: "message_end" }
@@ -200,6 +230,37 @@ describe("EventController error banner", () => {
 		await controller.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
 
 		expect(clearPinnedError).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("EventController thinking visibility", () => {
+	it("shows the first observed thinking delta on the active streaming component", async () => {
+		const initial = makeAssistantMessage({ content: [] });
+		const message = makeAssistantMessage({
+			content: [{ type: "thinking", thinking: "server-side reasoning" }],
+		});
+		const { controller, ctx } = createFixture();
+
+		await controller.handleEvent({
+			type: "message_start",
+			message: initial,
+		} as Extract<AgentSessionEvent, { type: "message_start" }>);
+		const component = ctx.streamingComponent;
+		if (!(component instanceof AssistantMessageComponent)) {
+			throw new Error("Expected streaming assistant component");
+		}
+
+		await controller.handleEvent({
+			type: "message_update",
+			message,
+			assistantMessageEvent: {
+				type: "thinking_delta",
+				delta: "server-side reasoning",
+				contentIndex: 0,
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+
+		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("server-side reasoning");
 	});
 });
 

--- a/packages/coding-agent/test/input-controller-thinking-visibility.test.ts
+++ b/packages/coding-agent/test/input-controller-thinking-visibility.test.ts
@@ -75,6 +75,34 @@ describe("InputController thinking visibility", () => {
 		expect(showStatus).toHaveBeenCalledWith("Thinking is off — enable thinking to show blocks");
 	});
 
+	it("allows toggling when thinking is off after reasoning content was received", () => {
+		const assistant = new AssistantMessageComponent();
+		const setHideThinkingBlock = vi.spyOn(assistant, "setHideThinkingBlock");
+		const set = vi.fn();
+		const showStatus = vi.fn();
+		const resetDisplay = vi.fn();
+		const ctx = {
+			hideThinkingBlock: false,
+			effectiveHideThinkingBlock: false,
+			hasDisplayableThinkingContent: true,
+			settings: { set },
+			session: { agent: { hideThinkingSummary: false }, thinkingLevel: "off" },
+			chatContainer: { children: [assistant], clear: vi.fn(), addChild: vi.fn() },
+			streamingComponent: undefined,
+			streamingMessage: undefined,
+			showStatus,
+			ui: { resetDisplay },
+		} as unknown as InteractiveModeContext;
+
+		new InputController(ctx).toggleThinkingBlockVisibility();
+
+		expect(ctx.hideThinkingBlock).toBe(true);
+		expect(set).toHaveBeenCalledWith("hideThinkingBlock", true);
+		expect(setHideThinkingBlock).toHaveBeenCalledWith(true);
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalledWith("Thinking blocks: hidden");
+	});
+
 	it("refuses to toggle when the focused view session has thinking off", () => {
 		const assistant = new AssistantMessageComponent();
 		const setHideThinkingBlock = vi.spyOn(assistant, "setHideThinkingBlock");


### PR DESCRIPTION
## Repro
Added a focused regression to `packages/coding-agent/test/input-controller-thinking-visibility.test.ts` that simulates `thinkingLevel: "off"` after reasoning content has been received; before the fix, `bun test packages/coding-agent/test/input-controller-thinking-visibility.test.ts` kept `hideThinkingBlock` unchanged and failed the new expectation.

## Cause
`InteractiveMode.effectiveHideThinkingBlock` in `packages/coding-agent/src/modes/interactive-mode.ts` and `InputController.toggleThinkingBlockVisibility()` in `packages/coding-agent/src/modes/controllers/input-controller.ts` treated `ThinkingLevel.Off` as an unconditional visibility lock. OpenAI-compatible providers can stream `thinking` blocks even when `/v1/models` metadata leaves `model.reasoning` falsy, so the TUI never let Ctrl+T reveal content it had already received.

## Fix
- Track sessions that have produced displayable assistant thinking content.
- Unlock `effectiveHideThinkingBlock` and Ctrl+T once observed reasoning content exists, while preserving the auto-hide guard for true thinking-off sessions with no reasoning content.
- Add a Ctrl+T regression for the observed-reasoning path and update the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/input-controller-thinking-visibility.test.ts && bun check` passed locally; `gh_push_branch` also completed its pre-publish gate. Fixes #3669