### PR TITLE
feat(agent): add Codex V2 remote compaction mode 

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an isolated Codex V2-style Responses compaction path that appends a `compaction_trigger`, requires exactly one provider `compaction` output item, and stores retained native replacement history for replay without running local text summaries.
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -656,6 +656,9 @@ export interface SummaryOptions {
 	convertToLlm?: ConvertToLlm;
 	tools?: Tool[];
 	serviceTier?: ServiceTier;
+	sessionId?: SimpleStreamOptions["sessionId"];
+	promptCacheKey?: SimpleStreamOptions["promptCacheKey"];
+	preferWebsockets?: SimpleStreamOptions["preferWebsockets"];
 	/**
 	 * Optional telemetry handle. When provided, every LLM call emitted during
 	 * compaction is wrapped in an OTEL chat span tagged with
@@ -719,6 +722,9 @@ async function requestCodexV2RemoteCompactionViaProvider(
 			reasoning: resolveCompactionEffort(model, options.thinkingLevel),
 			initiatorOverride: options.initiatorOverride,
 			serviceTier: options.serviceTier,
+			sessionId: options.sessionId,
+			promptCacheKey: options.promptCacheKey,
+			preferWebsockets: options.preferWebsockets,
 			streamIdleTimeoutMs: CODEX_V2_COMPACTION_STREAM_IDLE_TIMEOUT_MS,
 			streamFirstEventTimeoutMs: CODEX_V2_COMPACTION_STREAM_IDLE_TIMEOUT_MS,
 			metadata: options.metadata,
@@ -1209,6 +1215,9 @@ export async function compact(
 		convertToLlm: options?.convertToLlm,
 		tools: options?.tools,
 		serviceTier: options?.serviceTier,
+		sessionId: options?.sessionId,
+		promptCacheKey: options?.promptCacheKey,
+		preferWebsockets: options?.preferWebsockets,
 		telemetry: options?.telemetry,
 		// Honor /model thinking selection on every fan-out summarizer.
 		// Without this propagation, generateSummary / generateTurnPrefixSummary

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -14,12 +14,14 @@ import {
 	type Message,
 	type MessageAttribution,
 	type Model,
+	type ServiceTier,
 	type SimpleStreamOptions,
 	type Tool,
 	type Usage,
 	withAuth,
 } from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { createOpenAIResponsesHistoryPayload, getOpenAIResponsesHistoryItems } from "@oh-my-pi/pi-ai/utils";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
@@ -29,13 +31,24 @@ import { ThinkingLevel } from "../thinking";
 import { countTokens } from "../tokenizer";
 import type { AgentMessage } from "../types";
 import type { CompactionEntry, SessionEntry } from "./entries";
-import { type ConvertToLlm, createBranchSummaryMessage, createCustomMessage, defaultConvertToLlm } from "./messages";
 import {
-	buildOpenAiNativeHistory,
+	type ConvertToLlm,
+	createBranchSummaryMessage,
+	createCustomMessage,
+	defaultConvertToLlm,
+	markCodexV2RetainedMessage,
+} from "./messages";
+import {
+	buildCodexV2ReplacementHistory,
+	buildOpenAiNativeHistoryWithCodexV2Retention,
 	getPreservedOpenAiRemoteCompactionData,
+	isCodexV2CompactionItem,
+	type OpenAiRemoteCompactionPreserveData,
 	requestOpenAiRemoteCompaction,
 	requestRemoteCompaction,
+	shouldUseCodexV2RemoteCompaction,
 	shouldUseOpenAiRemoteCompaction,
+	trimCodexV2CompactionInputToFitContextWindow,
 	withOpenAiRemoteCompactionPreserveData,
 } from "./openai";
 import autoHandoffThresholdFocusPrompt from "./prompts/auto-handoff-threshold-focus.md" with { type: "text" };
@@ -146,7 +159,7 @@ export interface CompactionResult<T = unknown> {
 
 export interface CompactionSettings {
 	enabled: boolean;
-	strategy?: "context-full" | "handoff" | "shake" | "snapcompact" | "off";
+	strategy?: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2" | "off";
 	thresholdPercent?: number;
 	thresholdTokens?: number;
 	midTurnEnabled?: boolean;
@@ -641,6 +654,8 @@ export interface SummaryOptions {
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
 	convertToLlm?: ConvertToLlm;
+	tools?: Tool[];
+	serviceTier?: ServiceTier;
 	/**
 	 * Optional telemetry handle. When provided, every LLM call emitted during
 	 * compaction is wrapped in an OTEL chat span tagged with
@@ -661,6 +676,80 @@ export interface SummaryOptions {
 	fetch?: FetchImpl;
 }
 
+const CODEX_V2_COMPACTION_SUMMARY =
+	"Context compacted by Codex V2 remote compaction. Provider-native replacement history carries the retained context.";
+const CODEX_V2_COMPACTION_SHORT_SUMMARY = "Codex V2 remote compaction";
+const CODEX_V2_COMPACTION_STREAM_IDLE_TIMEOUT_MS = 300_000;
+
+async function requestCodexV2RemoteCompactionViaProvider(
+	model: Model,
+	apiKey: ApiKey,
+	remoteHistory: Array<Record<string, unknown>>,
+	codexV2RetainedItems: Array<Record<string, unknown>>,
+	instructions: string,
+	signal: AbortSignal | undefined,
+	options: SummaryOptions,
+): Promise<OpenAiRemoteCompactionPreserveData> {
+	if (!shouldUseCodexV2RemoteCompaction(model)) {
+		throw new Error(`Codex V2 compaction requires an OpenAI Responses-capable model (${model.provider}/${model.id})`);
+	}
+	const compactInput = trimCodexV2CompactionInputToFitContextWindow(
+		remoteHistory,
+		model.contextWindow ?? Number.POSITIVE_INFINITY,
+		instructions,
+	);
+	const requestHistory = [...compactInput, { type: "compaction_trigger" }];
+	const response = await instrumentedCompleteSimple(
+		model,
+		{
+			systemPrompt: [instructions],
+			messages: [
+				{
+					role: "user" as const,
+					content: "",
+					providerPayload: createOpenAIResponsesHistoryPayload(model.provider, requestHistory, false),
+					timestamp: Date.now(),
+				},
+			],
+			tools: options.tools,
+		},
+		{
+			signal,
+			apiKey,
+			reasoning: resolveCompactionEffort(model, options.thinkingLevel),
+			initiatorOverride: options.initiatorOverride,
+			serviceTier: options.serviceTier,
+			streamIdleTimeoutMs: CODEX_V2_COMPACTION_STREAM_IDLE_TIMEOUT_MS,
+			streamFirstEventTimeoutMs: CODEX_V2_COMPACTION_STREAM_IDLE_TIMEOUT_MS,
+			metadata: options.metadata,
+			fetch: options.fetch,
+		},
+		{ telemetry: options.telemetry, oneshotKind: "codex_v2_compaction" },
+	);
+	if (response.stopReason === "error") {
+		throw createSummarizationError("Codex V2 remote compaction failed", response);
+	}
+
+	const outputItems =
+		getOpenAIResponsesHistoryItems(response.providerPayload, model.provider, response.provider) ?? [];
+	const compactionItems = outputItems.filter(isCodexV2CompactionItem);
+	if (compactionItems.length !== 1) {
+		throw new Error(
+			`Codex V2 remote compaction expected exactly one compaction output item, got ${compactionItems.length} from ${outputItems.length} output items`,
+		);
+	}
+	const compactionItem = compactionItems[0];
+	if (!compactionItem) {
+		throw new Error("Codex V2 remote compaction missing compaction output item");
+	}
+	return {
+		provider: model.provider,
+		method: "codex-v2",
+		replacementHistory: buildCodexV2ReplacementHistory(codexV2RetainedItems, compactionItem),
+		compactionItem,
+	};
+}
+
 function formatPreviousSnapcompactArchive(archiveText: string): string {
 	return prompt.render(snapcompactArchiveContextPrompt, { archiveText });
 }
@@ -675,11 +764,14 @@ function mergePreviousSummaryWithSnapcompactArchive(
 }
 
 function createSnapcompactArchiveMigrationMessage(archiveText: string): Message {
-	return {
-		role: "user",
-		content: [{ type: "text", text: formatPreviousSnapcompactArchive(archiveText) }],
-		timestamp: Date.now(),
-	};
+	return markCodexV2RetainedMessage(
+		{
+			role: "user",
+			content: [{ type: "text", text: formatPreviousSnapcompactArchive(archiveText) }],
+			timestamp: Date.now(),
+		},
+		false,
+	);
 }
 
 export async function generateSummary(
@@ -1115,6 +1207,8 @@ export async function compact(
 		initiatorOverride: options?.initiatorOverride,
 		metadata: options?.metadata,
 		convertToLlm: options?.convertToLlm,
+		tools: options?.tools,
+		serviceTier: options?.serviceTier,
 		telemetry: options?.telemetry,
 		// Honor /model thinking selection on every fan-out summarizer.
 		// Without this propagation, generateSummary / generateTurnPrefixSummary
@@ -1137,51 +1231,86 @@ export async function compact(
 		? createSnapcompactArchiveMigrationMessage(previousSnapcompactArchiveText)
 		: undefined;
 
+	const previousRemoteCompaction = getPreservedOpenAiRemoteCompactionData(previousPreserveData);
+	const previousReplacementHistory =
+		previousRemoteCompaction?.provider === model.provider &&
+		(settings.strategy !== "codex-v2" || previousRemoteCompaction.method === "codex-v2")
+			? previousRemoteCompaction.replacementHistory
+			: undefined;
+	const remoteMessages: AgentMessage[] = [
+		...(snapcompactArchiveMigrationMessage ? [snapcompactArchiveMigrationMessage] : []),
+		...messagesToSummarize,
+		...turnPrefixMessages,
+		...recentMessages,
+	];
+	const { history: remoteHistory, codexV2RetainedItems } = buildOpenAiNativeHistoryWithCodexV2Retention(
+		(summaryOptions.convertToLlm ?? defaultConvertToLlm)(remoteMessages),
+		model,
+		previousReplacementHistory,
+	);
+
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
-	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model)) {
-		const previousRemoteCompaction = getPreservedOpenAiRemoteCompactionData(previousPreserveData);
-		const remoteMessages: AgentMessage[] = [
-			...(snapcompactArchiveMigrationMessage ? [snapcompactArchiveMigrationMessage] : []),
-			...messagesToSummarize,
-			...turnPrefixMessages,
-			...recentMessages,
-		];
-		const previousReplacementHistory =
-			previousRemoteCompaction?.provider === model.provider
-				? previousRemoteCompaction.replacementHistory
-				: undefined;
-		const remoteHistory = buildOpenAiNativeHistory(
-			(summaryOptions.convertToLlm ?? defaultConvertToLlm)(remoteMessages),
+	if (settings.strategy === "codex-v2") {
+		if (remoteHistory.length === 0) {
+			throw new Error("Codex V2 compaction requires non-empty OpenAI Responses history");
+		}
+		if (!summaryOptions.remoteInstructions) {
+			throw new Error("Codex V2 compaction requires base session instructions");
+		}
+		if (!summaryOptions.tools) {
+			throw new Error("Codex V2 compaction requires current tool definitions");
+		}
+		const remote = await requestCodexV2RemoteCompactionViaProvider(
 			model,
-			previousReplacementHistory,
+			apiKey,
+			remoteHistory,
+			codexV2RetainedItems,
+			summaryOptions.remoteInstructions,
+			signal,
+			summaryOptions,
 		);
-		if (remoteHistory.length > 0) {
-			try {
-				const remote = await withAuth(
-					apiKey,
-					key =>
-						requestOpenAiRemoteCompaction(
-							model,
-							key,
-							remoteHistory,
-							summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
-							signal,
-							{ fetch: summaryOptions.fetch },
-						),
-					{ signal },
-				);
-				preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, remote);
-			} catch (err) {
-				// A user/session abort is a cancellation, not a remote failure —
-				// swallowing it here would downgrade Esc into "fall back to local
-				// summarization" and keep compaction running on an aborted signal.
-				if (signal?.aborted) throw err;
-				logger.warn("OpenAI remote compaction failed, falling back to local summarization", {
-					error: err instanceof Error ? err.message : String(err),
-					model: model.id,
-					provider: model.provider,
-				});
-			}
+		preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, remote);
+		const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+		const summary = upsertFileOperations(CODEX_V2_COMPACTION_SUMMARY, readFiles, modifiedFiles, fileOps.read);
+		if (!firstKeptEntryId) {
+			throw new Error("First kept entry has no ID - session may need migration");
+		}
+		return {
+			summary,
+			shortSummary: CODEX_V2_COMPACTION_SHORT_SUMMARY,
+			firstKeptEntryId,
+			tokensBefore,
+			details: { readFiles, modifiedFiles } as CompactionDetails,
+			preserveData: previousSnapcompactArchive ? snapcompact.stripPreservedArchive(preserveData) : preserveData,
+		};
+	}
+
+	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model) && remoteHistory.length > 0) {
+		try {
+			const remote = await withAuth(
+				apiKey,
+				key =>
+					requestOpenAiRemoteCompaction(
+						model,
+						key,
+						remoteHistory,
+						summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
+						signal,
+						{ fetch: summaryOptions.fetch },
+					),
+				{ signal },
+			);
+			preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, remote);
+		} catch (err) {
+			// A user/session abort is a cancellation, not a remote failure —
+			// swallowing it here would downgrade Esc into "fall back to local
+			// summarization" and keep compaction running on an aborted signal.
+			if (signal?.aborted) throw err;
+			logger.warn("OpenAI remote compaction failed, falling back to local summarization", {
+				error: err instanceof Error ? err.message : String(err),
+				model: model.id,
+				provider: model.provider,
+			});
 		}
 	}
 

--- a/packages/agent/src/compaction/messages.ts
+++ b/packages/agent/src/compaction/messages.ts
@@ -14,6 +14,17 @@ import compactionSummaryContextPrompt from "./prompts/compaction-summary-context
 const COMPACTION_SUMMARY_TEMPLATE = compactionSummaryContextPrompt;
 const BRANCH_SUMMARY_TEMPLATE = branchSummaryContextPrompt;
 
+const codexV2RetainMessages = new WeakMap<Message, boolean>();
+
+export function markCodexV2RetainedMessage<T extends Message>(message: T, retained: boolean): T {
+	codexV2RetainMessages.set(message, retained);
+	return message;
+}
+
+export function shouldRetainMessageForCodexV2(message: Message): boolean {
+	return codexV2RetainMessages.get(message) === true;
+}
+
 export interface CustomMessage<T = unknown> {
 	role: "custom";
 	customType: string;
@@ -176,40 +187,46 @@ export function convertMessageToLlm(message: AgentMessage): Message | undefined 
 				};
 			}
 			case "branchSummary":
-				return {
-					role: "user",
-					content: [
-						{
-							type: "text" as const,
-							text: renderBranchSummaryContext(message.summary),
-						},
-					],
-					attribution: "agent",
-					timestamp: message.timestamp,
-				};
+				return markCodexV2RetainedMessage(
+					{
+						role: "user",
+						content: [
+							{
+								type: "text" as const,
+								text: renderBranchSummaryContext(message.summary),
+							},
+						],
+						attribution: "agent",
+						timestamp: message.timestamp,
+					},
+					false,
+				);
 			case "compactionSummary":
-				return {
-					role: "user",
-					content:
-						message.blocks !== undefined
-							? [{ type: "text" as const, text: message.summary }, ...message.blocks]
-							: [
-									{
-										type: "text" as const,
-										text: renderCompactionSummaryContext(message.summary),
-									},
-									...(message.images ?? []),
-								],
-					attribution: "agent",
-					providerPayload: message.providerPayload,
-					timestamp: message.timestamp,
-				};
+				return markCodexV2RetainedMessage(
+					{
+						role: "user",
+						content:
+							message.blocks !== undefined
+								? [{ type: "text" as const, text: message.summary }, ...message.blocks]
+								: [
+										{
+											type: "text" as const,
+											text: renderCompactionSummaryContext(message.summary),
+										},
+										...(message.images ?? []),
+									],
+						attribution: "agent",
+						providerPayload: message.providerPayload,
+						timestamp: message.timestamp,
+					},
+					false,
+				);
 		}
 	}
 
 	switch (message.role) {
 		case "user":
-			return { ...message, attribution: message.attribution ?? "user" };
+			return markCodexV2RetainedMessage({ ...message, attribution: message.attribution ?? "user" }, true);
 		case "developer":
 			return { ...message, attribution: message.attribution ?? "agent" };
 		case "assistant":

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -376,6 +376,7 @@ function truncateTextToTokenBudget(text: string, maxTokens: number): string {
 	if (textTokens <= maxTokens) return text;
 	const marker = `…${Math.max(1, textTokens - maxTokens)} tokens truncated…`;
 	const markerTokens = countTokens(marker);
+	if (markerTokens >= maxTokens) return "";
 	const contentTokens = Math.max(1, maxTokens - markerTokens);
 	const maxChars = Math.max(1, contentTokens * 4);
 	const headChars = Math.ceil(maxChars / 2);

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -326,8 +326,11 @@ export function trimCodexV2CompactionInputToFitContextWindow(
 		const item = trimmed[index];
 		if (!item) break;
 		const rewritten = codexV2RewrittenOutputItem(item);
-		if (!rewritten) break;
+		if (!rewritten) continue;
 		rewriteAt(index, rewritten);
+	}
+	if (Math.ceil(chars / 4) > contextWindow) {
+		throw new Error("Codex V2 compaction input exceeds the model context window after trimming");
 	}
 	return trimmed;
 }
@@ -346,23 +349,25 @@ function shouldRetainCodexV2InputItem(item: Record<string, unknown>): boolean {
 	return item.role === "user";
 }
 
-function textFragmentsFromResponseItem(item: Record<string, unknown>): string[] {
-	const content = item.content;
-	if (typeof content === "string") return content.length > 0 ? [content] : [];
-	if (!Array.isArray(content)) return [];
-	const fragments: string[] = [];
-	for (const block of content) {
-		if (!isRecord(block)) continue;
-		if (typeof block.text === "string" && block.text.length > 0) {
-			fragments.push(block.text);
-		}
+function serializedTokenEstimate(value: unknown): number {
+	const serialized = JSON.stringify(value);
+	return Math.max(1, Math.ceil((serialized?.length ?? 0) / 4));
+}
+
+function responseContentBlockTokenCount(block: unknown): number {
+	if (isRecord(block) && typeof block.text === "string") {
+		return Math.max(1, countTokens(block.text));
 	}
-	return fragments;
+	return serializedTokenEstimate(block);
 }
 
 function responseMessageTokenCount(item: Record<string, unknown>): number {
-	const fragments = textFragmentsFromResponseItem(item);
-	return fragments.length === 0 ? 1 : countTokens(fragments);
+	const content = item.content;
+	if (typeof content === "string") return Math.max(1, countTokens(content));
+	if (!Array.isArray(content)) return serializedTokenEstimate(item);
+	let total = 0;
+	for (const block of content) total += responseContentBlockTokenCount(block);
+	return Math.max(1, total);
 }
 
 function truncateTextToTokenBudget(text: string, maxTokens: number): string {
@@ -396,7 +401,11 @@ function truncateResponseMessageToTokenBudget(
 	const nextContent: unknown[] = [];
 	for (const block of content) {
 		if (!isRecord(block) || typeof block.text !== "string") {
-			nextContent.push(block);
+			const tokenCount = responseContentBlockTokenCount(block);
+			if (tokenCount <= remaining) {
+				nextContent.push(block);
+				remaining -= tokenCount;
+			}
 			continue;
 		}
 		if (remaining <= 0) continue;

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -28,6 +28,8 @@ import {
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, logger } from "@oh-my-pi/pi-utils";
+import { countTokens } from "../tokenizer";
+import { shouldRetainMessageForCodexV2 } from "./messages";
 
 // ============================================================================
 // Public types
@@ -47,6 +49,10 @@ export const REMOTE_COMPACTION_TIMEOUT_MS = 180_000;
 
 const DEFAULT_AZURE_API_VERSION = "v1";
 
+const CODEX_V2_CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE =
+	"Output exceeded the available model context and was truncated";
+const CODEX_V2_RETAINED_MESSAGE_TOKEN_BUDGET = 64_000;
+
 /** Race the caller's signal against the request timeout; `timeoutMs <= 0` disables the watchdog. */
 function withRequestTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal | undefined {
 	if (timeoutMs <= 0) return signal;
@@ -62,6 +68,7 @@ export type OpenAiRemoteCompactionItem = {
 
 export interface OpenAiRemoteCompactionPreserveData {
 	provider?: string;
+	method?: "legacy" | "codex-v2";
 	replacementHistory: Array<Record<string, unknown>>;
 	compactionItem: OpenAiRemoteCompactionItem;
 }
@@ -97,6 +104,18 @@ export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
 	if (model.provider === "openai" || model.provider === "openai-codex") return true;
 	if (model.remoteCompaction?.enabled !== true) return false;
 	return isOpenAiRemoteCompactionApi(model.remoteCompaction.api ?? model.api);
+}
+
+export function shouldUseCodexV2RemoteCompaction(model: Model): boolean {
+	if (model.remoteCompaction?.enabled === false) return false;
+	const compactionApi = model.remoteCompaction?.api ?? model.api;
+	if (model.provider === "openai" || model.provider === "openai-codex") {
+		return compactionApi === "openai-responses" || compactionApi === "openai-codex-responses";
+	}
+	return (
+		model.remoteCompaction?.enabled === true &&
+		(compactionApi === "openai-responses" || compactionApi === "openai-codex-responses")
+	);
 }
 
 function resolveOpenAiCompactEndpoint(model: Model): string {
@@ -173,7 +192,12 @@ export function getPreservedOpenAiRemoteCompactionData(
 ): OpenAiRemoteCompactionPreserveData | undefined {
 	const candidate = preserveData?.[OPENAI_REMOTE_COMPACTION_PRESERVE_KEY];
 	if (!candidate || typeof candidate !== "object") return undefined;
-	const maybeData = candidate as { provider?: unknown; replacementHistory?: unknown; compactionItem?: unknown };
+	const maybeData = candidate as {
+		provider?: unknown;
+		method?: unknown;
+		replacementHistory?: unknown;
+		compactionItem?: unknown;
+	};
 	if (!Array.isArray(maybeData.replacementHistory)) return undefined;
 	const maybeItem = maybeData.compactionItem;
 	if (!maybeItem || typeof maybeItem !== "object") return undefined;
@@ -186,6 +210,7 @@ export function getPreservedOpenAiRemoteCompactionData(
 	}
 	return {
 		provider: typeof maybeData.provider === "string" ? maybeData.provider : undefined,
+		method: maybeData.method === "codex-v2" || maybeData.method === "legacy" ? maybeData.method : undefined,
 		replacementHistory: maybeData.replacementHistory as Array<Record<string, unknown>>,
 		compactionItem: compactionItem as unknown as OpenAiRemoteCompactionItem,
 	};
@@ -265,6 +290,166 @@ function trimOpenAiCompactInput(
 	return trimmed;
 }
 
+function codexV2RewrittenOutputItem(item: Record<string, unknown>): Record<string, unknown> | undefined {
+	if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
+		return {
+			...item,
+			output: CODEX_V2_CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
+		};
+	}
+	if (item.type === "tool_search_output") {
+		return {
+			...item,
+			tools: [],
+		};
+	}
+	return undefined;
+}
+
+export function trimCodexV2CompactionInputToFitContextWindow(
+	input: Array<Record<string, unknown>>,
+	contextWindow: number,
+	instructions: string,
+): Array<Record<string, unknown>> {
+	const trimmed = [...input];
+	const sizes = trimmed.map(item => JSON.stringify(item).length);
+	let chars = instructions.length;
+	for (const size of sizes) chars += size;
+	const rewriteAt = (index: number, item: Record<string, unknown>): void => {
+		const previousSize = sizes[index] ?? 0;
+		const nextSize = JSON.stringify(item).length;
+		trimmed[index] = item;
+		sizes[index] = nextSize;
+		chars += nextSize - previousSize;
+	};
+	for (let index = trimmed.length - 1; index >= 0 && Math.ceil(chars / 4) > contextWindow; index--) {
+		const item = trimmed[index];
+		if (!item) break;
+		const rewritten = codexV2RewrittenOutputItem(item);
+		if (!rewritten) break;
+		rewriteAt(index, rewritten);
+	}
+	return trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function isCodexV2CompactionItem(item: unknown): item is OpenAiRemoteCompactionItem {
+	if (!isRecord(item)) return false;
+	return item.type === "compaction" && typeof item.encrypted_content === "string";
+}
+
+function shouldRetainCodexV2InputItem(item: Record<string, unknown>): boolean {
+	if (item.type !== "message") return false;
+	return item.role === "user";
+}
+
+function textFragmentsFromResponseItem(item: Record<string, unknown>): string[] {
+	const content = item.content;
+	if (typeof content === "string") return content.length > 0 ? [content] : [];
+	if (!Array.isArray(content)) return [];
+	const fragments: string[] = [];
+	for (const block of content) {
+		if (!isRecord(block)) continue;
+		if (typeof block.text === "string" && block.text.length > 0) {
+			fragments.push(block.text);
+		}
+	}
+	return fragments;
+}
+
+function responseMessageTokenCount(item: Record<string, unknown>): number {
+	const fragments = textFragmentsFromResponseItem(item);
+	return fragments.length === 0 ? 1 : countTokens(fragments);
+}
+
+function truncateTextToTokenBudget(text: string, maxTokens: number): string {
+	if (maxTokens <= 0) return "";
+	const textTokens = countTokens(text);
+	if (textTokens <= maxTokens) return text;
+	const marker = `…${Math.max(1, textTokens - maxTokens)} tokens truncated…`;
+	const markerTokens = countTokens(marker);
+	const contentTokens = Math.max(1, maxTokens - markerTokens);
+	const maxChars = Math.max(1, contentTokens * 4);
+	const headChars = Math.ceil(maxChars / 2);
+	const tailChars = Math.floor(maxChars / 2);
+	return `${text.slice(0, headChars)}${marker}${text.slice(Math.max(0, text.length - tailChars))}`;
+}
+function truncateResponseMessageToTokenBudget(
+	item: Record<string, unknown>,
+	maxTokens: number,
+): Record<string, unknown> | undefined {
+	if (maxTokens <= 0) return undefined;
+	const content = item.content;
+	const clone = structuredClone(item) as Record<string, unknown>;
+	if (typeof content === "string") {
+		const text = truncateTextToTokenBudget(content, maxTokens);
+		if (text.length === 0) return undefined;
+		clone.content = text;
+		return clone;
+	}
+	if (!Array.isArray(content)) return clone;
+
+	let remaining = maxTokens;
+	const nextContent: unknown[] = [];
+	for (const block of content) {
+		if (!isRecord(block) || typeof block.text !== "string") {
+			nextContent.push(block);
+			continue;
+		}
+		if (remaining <= 0) continue;
+		const tokenCount = countTokens(block.text);
+		if (tokenCount <= remaining) {
+			nextContent.push(block);
+			remaining -= tokenCount;
+			continue;
+		}
+		const text = truncateTextToTokenBudget(block.text, remaining);
+		if (text.length > 0) {
+			nextContent.push({ ...block, text });
+			remaining = 0;
+		}
+	}
+	if (nextContent.length === 0) return undefined;
+	clone.content = nextContent;
+	return clone;
+}
+
+function truncateCodexV2RetainedMessages(items: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+	let remaining = CODEX_V2_RETAINED_MESSAGE_TOKEN_BUDGET;
+	const retainedReversed: Array<Record<string, unknown>> = [];
+	for (let i = items.length - 1; i >= 0; i--) {
+		if (remaining <= 0) continue;
+		const item = items[i];
+		if (!item) continue;
+		const tokenCount = Math.max(1, responseMessageTokenCount(item));
+		if (tokenCount <= remaining) {
+			retainedReversed.push(item);
+			remaining -= tokenCount;
+			continue;
+		}
+		const truncated = truncateResponseMessageToTokenBudget(item, remaining);
+		if (truncated) {
+			retainedReversed.push(truncated);
+			remaining = 0;
+		}
+	}
+	retainedReversed.reverse();
+	return retainedReversed;
+}
+
+export function buildCodexV2ReplacementHistory(
+	input: Array<Record<string, unknown>>,
+	compactionItem: OpenAiRemoteCompactionItem,
+): Array<Record<string, unknown>> {
+	const retained = input
+		.filter(shouldRetainCodexV2InputItem)
+		.map(item => structuredClone(item) as Record<string, unknown>);
+	return [...truncateCodexV2RetainedMessages(retained), structuredClone(compactionItem) as Record<string, unknown>];
+}
+
 // Register every tool-call id in `items` (and the subset using the custom-tool
 // wire shape) into the running sets. The history builder maintains both sets
 // incrementally as native history is appended, so this only scans the
@@ -304,12 +489,24 @@ function addOpenAiCallIds(
  * @param previousReplacementHistory - History from a prior compaction whose
  *   encrypted reasoning we want to preserve.
  */
-export function buildOpenAiNativeHistory(
+export interface OpenAiNativeHistoryWithCodexV2Retention {
+	history: Array<Record<string, unknown>>;
+	codexV2RetainedItems: Array<Record<string, unknown>>;
+}
+
+function codexV2RetainedNativeItems(items: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+	return items.filter(shouldRetainCodexV2InputItem);
+}
+
+export function buildOpenAiNativeHistoryWithCodexV2Retention(
 	messages: Message[],
 	model: Model,
 	previousReplacementHistory?: Array<Record<string, unknown>>,
-): Array<Record<string, unknown>> {
+): OpenAiNativeHistoryWithCodexV2Retention {
 	const input: Array<Record<string, unknown>> = previousReplacementHistory ? [...previousReplacementHistory] : [];
+	const codexV2RetainedItems = previousReplacementHistory
+		? codexV2RetainedNativeItems(previousReplacementHistory)
+		: [];
 	const transformedMessages = transformMessages(messages, model, id => normalizeOpenAiCompactionToolCallId(id));
 
 	let msgIndex = 0;
@@ -318,10 +515,10 @@ export function buildOpenAiNativeHistory(
 	addOpenAiCallIds(input, knownCallIds, customCallIds);
 	for (const message of transformedMessages) {
 		if (message.role === "user" || message.role === "developer") {
-			const providerPayload = (message as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider);
+			const historyItems = getOpenAIResponsesHistoryItems(message.providerPayload, model.provider);
 			if (historyItems) {
 				input.push(...historyItems);
+				codexV2RetainedItems.push(...codexV2RetainedNativeItems(historyItems));
 				addOpenAiCallIds(historyItems, knownCallIds, customCallIds);
 				msgIndex++;
 				continue;
@@ -349,7 +546,11 @@ export function buildOpenAiNativeHistory(
 				}
 			}
 			if (contentBlocks.length > 0) {
-				input.push({ type: "message", role: message.role, content: contentBlocks });
+				const item = { type: "message", role: message.role, content: contentBlocks };
+				input.push(item);
+				if (message.role === "user" && shouldRetainMessageForCodexV2(message)) {
+					codexV2RetainedItems.push(item);
+				}
 			}
 			msgIndex++;
 			continue;
@@ -363,11 +564,14 @@ export function buildOpenAiNativeHistory(
 				assistant.provider,
 			);
 			if (providerPayload) {
+				const retainedItems = codexV2RetainedNativeItems(providerPayload.items);
 				if (providerPayload.dt) {
 					input.push(...providerPayload.items);
+					codexV2RetainedItems.push(...retainedItems);
 					addOpenAiCallIds(providerPayload.items, knownCallIds, customCallIds);
 				} else {
 					input.splice(0, input.length, ...providerPayload.items);
+					codexV2RetainedItems.splice(0, codexV2RetainedItems.length, ...retainedItems);
 					knownCallIds.clear();
 					customCallIds.clear();
 					addOpenAiCallIds(input, knownCallIds, customCallIds);
@@ -488,7 +692,15 @@ export function buildOpenAiNativeHistory(
 		msgIndex++;
 	}
 
-	return input;
+	return { history: input, codexV2RetainedItems };
+}
+
+export function buildOpenAiNativeHistory(
+	messages: Message[],
+	model: Model,
+	previousReplacementHistory?: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+	return buildOpenAiNativeHistoryWithCodexV2Retention(messages, model, previousReplacementHistory).history;
 }
 
 // ============================================================================

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -257,13 +257,14 @@ describe("remote compaction input trimming", () => {
 		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(false);
 	});
 
-	test("rewrites trailing tool outputs for Codex V2 compaction input overflow", () => {
+	test("continues scanning older tool outputs when newer items cannot be rewritten", () => {
 		const trimmed = trimCodexV2CompactionInputToFitContextWindow(
 			[
 				{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
 				{ type: "function_call_output", call_id: "call_1", output: "x".repeat(10_000) },
+				{ type: "message", role: "assistant", content: [{ type: "output_text", text: "tail" }] },
 			],
-			1,
+			200,
 			"compact",
 		);
 
@@ -274,7 +275,18 @@ describe("remote compaction input trimming", () => {
 				call_id: "call_1",
 				output: "Output exceeded the available model context and was truncated",
 			},
+			{ type: "message", role: "assistant", content: [{ type: "output_text", text: "tail" }] },
 		]);
+	});
+
+	test("fails locally when Codex V2 input still exceeds context after trimming", () => {
+		expect(() =>
+			trimCodexV2CompactionInputToFitContextWindow(
+				[{ type: "message", role: "user", content: [{ type: "input_text", text: "x".repeat(10_000) }] }],
+				1,
+				"compact",
+			),
+		).toThrow("exceeds the model context window");
 	});
 });
 
@@ -319,6 +331,28 @@ describe("Codex V2 replacement history", () => {
 		expect(block.text).toContain("tokens truncated");
 		expect(block.text.endsWith("END")).toBe(true);
 		expect(history.at(-1)).toEqual(compactionItem);
+	});
+
+	test("drops oversized retained image messages from the retained-message budget", () => {
+		const compactionItem = { type: "compaction" as const, encrypted_content: "sealed" };
+		const history = buildCodexV2ReplacementHistory(
+			[
+				{
+					type: "message",
+					role: "user",
+					content: [
+						{
+							type: "input_image",
+							image_url: `data:image/png;base64,${"x".repeat(300_000)}`,
+							detail: "auto",
+						},
+					],
+				},
+			],
+			compactionItem,
+		);
+
+		expect(history).toEqual([compactionItem]);
 	});
 
 	test("carries explicit Codex V2 retention decisions through native history conversion", () => {

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -333,6 +333,35 @@ describe("Codex V2 replacement history", () => {
 		expect(history.at(-1)).toEqual(compactionItem);
 	});
 
+	test("drops an oversized text message when the remaining budget cannot fit the truncation marker", () => {
+		const compactionItem = { type: "compaction" as const, encrypted_content: "sealed" };
+		const newestNearlyFullBudget = "n".repeat(255_996);
+		const history = buildCodexV2ReplacementHistory(
+			[
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: `old ${"x".repeat(1_000)}` }],
+				},
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: newestNearlyFullBudget }],
+				},
+			],
+			compactionItem,
+		);
+
+		expect(history).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: newestNearlyFullBudget }],
+			},
+			compactionItem,
+		]);
+	});
+
 	test("drops oversized retained image messages from the retained-message budget", () => {
 		const compactionItem = { type: "compaction" as const, encrypted_content: "sealed" };
 		const history = buildCodexV2ReplacementHistory(

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -5,13 +5,20 @@ import {
 	createFileOps,
 	DEFAULT_COMPACTION_SETTINGS,
 } from "@oh-my-pi/pi-agent-core/compaction";
+import { markCodexV2RetainedMessage } from "@oh-my-pi/pi-agent-core/compaction/messages";
 import {
+	buildCodexV2ReplacementHistory,
 	buildOpenAiNativeHistory,
+	buildOpenAiNativeHistoryWithCodexV2Retention,
 	requestOpenAiRemoteCompaction,
+	shouldUseCodexV2RemoteCompaction,
 	shouldUseOpenAiRemoteCompaction,
+	trimCodexV2CompactionInputToFitContextWindow,
 } from "@oh-my-pi/pi-agent-core/compaction/openai";
 import * as ai from "@oh-my-pi/pi-ai";
-import type { AssistantMessage, FetchImpl, Model, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
+import { buildParams as buildOpenAIResponsesParams } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { AssistantMessage, FetchImpl, Model, Tool, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
+import { createOpenAIResponsesHistoryPayload } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
@@ -249,6 +256,111 @@ describe("remote compaction input trimming", () => {
 		expect(requestInput?.some(item => item.type === "custom_tool_call")).toBe(false);
 		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(false);
 	});
+
+	test("rewrites trailing tool outputs for Codex V2 compaction input overflow", () => {
+		const trimmed = trimCodexV2CompactionInputToFitContextWindow(
+			[
+				{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
+				{ type: "function_call_output", call_id: "call_1", output: "x".repeat(10_000) },
+			],
+			1,
+			"compact",
+		);
+
+		expect(trimmed).toEqual([
+			{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
+			{
+				type: "function_call_output",
+				call_id: "call_1",
+				output: "Output exceeded the available model context and was truncated",
+			},
+		]);
+	});
+});
+
+describe("Codex V2 replacement history", () => {
+	test("drops instruction wrappers and retains user messages before appending the compaction item", () => {
+		const compactionItem = { type: "compaction" as const, encrypted_content: "sealed" };
+		const history = buildCodexV2ReplacementHistory(
+			[
+				{ type: "message", role: "system", content: [{ type: "input_text", text: "system" }] },
+				{ type: "message", role: "developer", content: [{ type: "input_text", text: "developer" }] },
+				{ type: "message", role: "assistant", content: [{ type: "output_text", text: "assistant" }] },
+				{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
+				{ type: "function_call_output", call_id: "call_1", output: "result" },
+				{ type: "message", role: "user", content: [{ type: "input_text", text: "user" }] },
+			],
+			compactionItem,
+		);
+
+		expect(history.map(item => item.type)).toEqual(["message", "compaction"]);
+		expect(history.slice(0, -1).map(item => item.role)).toEqual(["user"]);
+		expect(history.at(-1)).toEqual(compactionItem);
+	});
+
+	test("middle-truncates an oversized retained user message", () => {
+		const compactionItem = { type: "compaction" as const, encrypted_content: "sealed" };
+		const history = buildCodexV2ReplacementHistory(
+			[
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: `START ${"x".repeat(300_000)} END` }],
+				},
+			],
+			compactionItem,
+		);
+		const retained = history[0];
+		const block = Array.isArray(retained?.content) ? retained.content[0] : undefined;
+		if (!block || typeof block !== "object" || !("text" in block) || typeof block.text !== "string") {
+			throw new Error("expected retained text block");
+		}
+		expect(block.text.startsWith("START")).toBe(true);
+		expect(block.text).toContain("tokens truncated");
+		expect(block.text.endsWith("END")).toBe(true);
+		expect(history.at(-1)).toEqual(compactionItem);
+	});
+
+	test("carries explicit Codex V2 retention decisions through native history conversion", () => {
+		const staleResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "missing_call",
+			toolName: "read",
+			content: [{ type: "text", text: "stale result" }],
+			isError: false,
+			timestamp: 3,
+		};
+		const { history, codexV2RetainedItems } = buildOpenAiNativeHistoryWithCodexV2Retention(
+			[
+				markCodexV2RetainedMessage({ role: "user", content: "operator", timestamp: 1 }, true),
+				markCodexV2RetainedMessage({ role: "user", content: "generated wrapper", timestamp: 2 }, false),
+				staleResult,
+			],
+			makeOpenAiModel(),
+		);
+
+		expect(
+			history.filter(item => item.type === "message" && item.role === "user").flatMap(item => item.content),
+		).toContainEqual({
+			type: "input_text",
+			text: '<stale-tool-result tool="read" id="missing_call">\nstale result\n</stale-tool-result>',
+		});
+		expect(codexV2RetainedItems.flatMap(item => item.content)).toEqual([{ type: "input_text", text: "operator" }]);
+	});
+
+	test("gates Codex V2 to OpenAI Responses-capable models", () => {
+		expect(shouldUseCodexV2RemoteCompaction(makeOpenAiModel())).toBe(true);
+		expect(shouldUseCodexV2RemoteCompaction(makeAzureModel())).toBe(false);
+		expect(
+			shouldUseCodexV2RemoteCompaction(
+				makeOpenAiModel({
+					provider: "cliproxy-codex",
+					baseUrl: "http://127.0.0.1:8317/v1",
+					remoteCompaction: { enabled: true, api: "openai-responses" },
+				}),
+			),
+		).toBe(true);
+	});
 });
 
 test("uses configured OpenAI-compatible compaction for custom providers", async () => {
@@ -417,6 +529,20 @@ describe("compact() remote compaction failure handling", () => {
 		};
 	}
 
+	function codexV2CompactionMessage(items: Array<Record<string, unknown>>): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [],
+			timestamp: Date.now(),
+			provider: "openai",
+			model: "gpt-5",
+			api: "openai-responses",
+			usage: ZERO_USAGE,
+			stopReason: "stop",
+			providerPayload: { type: "openaiResponsesHistory", provider: "openai", items },
+		};
+	}
+
 	function makePreparation(): CompactionPreparation {
 		return {
 			firstKeptEntryId: "kept-1",
@@ -467,5 +593,111 @@ describe("compact() remote compaction failure handling", () => {
 
 		expect(result.summary).toContain("local summary");
 		expect(completeSpy).toHaveBeenCalled();
+	});
+
+	test("codex-v2 strategy installs provider replacement history without local summary calls", async () => {
+		const compactionItem = { type: "compaction", encrypted_content: "sealed" };
+		const completeSpy = vi.spyOn(ai, "completeSimple").mockResolvedValue(codexV2CompactionMessage([compactionItem]));
+		const tool = {
+			name: "read",
+			description: "Read a file",
+			parameters: { type: "object", properties: {}, additionalProperties: false },
+		} as Tool;
+		const preparation = makePreparation();
+		preparation.settings = { ...preparation.settings, strategy: "codex-v2" };
+
+		const result = await compact(preparation, makeOpenAiModel(), "test-key", undefined, undefined, {
+			remoteInstructions: "base instructions",
+			serviceTier: "priority",
+			tools: [tool],
+		});
+
+		expect(result.summary).toContain("Codex V2 remote compaction");
+		expect(result.shortSummary).toBe("Codex V2 remote compaction");
+		const remote = result.preserveData?.openaiRemoteCompaction as
+			| { method?: string; replacementHistory?: Array<Record<string, unknown>> }
+			| undefined;
+		expect(remote?.method).toBe("codex-v2");
+		expect(remote?.replacementHistory?.map(item => item.type)).toEqual(["message", "message", "compaction"]);
+		const context = completeSpy.mock.calls[0]?.[1] as
+			| { messages?: Array<{ providerPayload?: { items?: Array<Record<string, unknown>> } }>; tools?: Tool[] }
+			| undefined;
+		expect(context?.tools).toEqual([tool]);
+		expect(context?.messages?.[0]?.providerPayload?.items?.at(-1)).toEqual({ type: "compaction_trigger" });
+		const options = completeSpy.mock.calls[0]?.[2] as
+			| {
+					maxTokens?: number;
+					serviceTier?: string;
+					streamFirstEventTimeoutMs?: number;
+					streamIdleTimeoutMs?: number;
+			  }
+			| undefined;
+		expect(options?.serviceTier).toBe("priority");
+		expect(options?.streamIdleTimeoutMs).toBe(300_000);
+		expect(options?.streamFirstEventTimeoutMs).toBe(300_000);
+		expect(options).not.toHaveProperty("maxTokens");
+		expect(completeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("codex-v2 Responses payload is stateless and ZDR-friendly", () => {
+		const model = makeOpenAiModel();
+		const inputItems = [
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "operator" }] },
+			{ type: "compaction_trigger" },
+		];
+		const { params } = buildOpenAIResponsesParams(
+			model,
+			{
+				systemPrompt: ["base instructions"],
+				messages: [
+					{
+						role: "user",
+						content: "",
+						providerPayload: createOpenAIResponsesHistoryPayload(model.provider, inputItems, false),
+						timestamp: 1,
+					},
+				],
+			},
+			{ serviceTier: "priority" },
+			undefined,
+		);
+
+		expect(params.store).toBe(false);
+		expect("previous_response_id" in params).toBe(false);
+		expect(params.service_tier).toBe("priority");
+		if (!Array.isArray(params.input)) {
+			throw new Error("expected Responses input array");
+		}
+		expect(params.input).toContainEqual({ type: "compaction_trigger" });
+	});
+
+	test("codex-v2 does not seed requests from legacy remote replacement history", async () => {
+		const compactionItem = { type: "compaction", encrypted_content: "sealed" };
+		const completeSpy = vi.spyOn(ai, "completeSimple").mockResolvedValue(codexV2CompactionMessage([compactionItem]));
+		const preparation = makePreparation();
+		preparation.settings = { ...preparation.settings, strategy: "codex-v2" };
+		preparation.previousPreserveData = {
+			openaiRemoteCompaction: {
+				provider: "openai",
+				method: "legacy",
+				replacementHistory: [
+					{ type: "message", role: "user", content: [{ type: "input_text", text: "legacy retained" }] },
+				],
+				compactionItem: { type: "compaction_summary", summary: "legacy" },
+			},
+		};
+
+		await compact(preparation, makeOpenAiModel(), "test-key", undefined, undefined, {
+			remoteInstructions: "base instructions",
+			tools: [],
+		});
+
+		type CodexV2RequestContext = {
+			messages?: Array<{ providerPayload?: { items?: Array<Record<string, unknown>> } }>;
+		};
+		const context = completeSpy.mock.calls[0]?.[1] as CodexV2RequestContext | undefined;
+		const payloadItems = context?.messages?.[0]?.providerPayload?.items ?? [];
+		expect(JSON.stringify(payloadItems)).not.toContain("legacy retained");
+		expect(payloadItems.at(-1)).toEqual({ type: "compaction_trigger" });
 	});
 });

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -610,6 +610,9 @@ describe("compact() remote compaction failure handling", () => {
 			remoteInstructions: "base instructions",
 			serviceTier: "priority",
 			tools: [tool],
+			sessionId: "session-1:compact:side",
+			promptCacheKey: "session-1",
+			preferWebsockets: false,
 		});
 
 		expect(result.summary).toContain("Codex V2 remote compaction");
@@ -627,12 +630,18 @@ describe("compact() remote compaction failure handling", () => {
 		const options = completeSpy.mock.calls[0]?.[2] as
 			| {
 					maxTokens?: number;
+					preferWebsockets?: boolean;
+					promptCacheKey?: string;
 					serviceTier?: string;
+					sessionId?: string;
 					streamFirstEventTimeoutMs?: number;
 					streamIdleTimeoutMs?: number;
 			  }
 			| undefined;
 		expect(options?.serviceTier).toBe("priority");
+		expect(options?.sessionId).toBe("session-1:compact:side");
+		expect(options?.promptCacheKey).toBe("session-1");
+		expect(options?.preferWebsockets).toBe(false);
 		expect(options?.streamIdleTimeoutMs).toBe(300_000);
 		expect(options?.streamFirstEventTimeoutMs).toBe(300_000);
 		expect(options).not.toHaveProperty("maxTokens");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a selectable Codex V2 compaction strategy and `/compact codex-v2` mode that use provider-native Responses replacement history while keeping legacy remote compaction unchanged.
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1787,14 +1787,14 @@ export const SETTINGS_SCHEMA = {
 
 	"compaction.strategy": {
 		type: "enum",
-		values: ["context-full", "handoff", "shake", "snapcompact", "off"] as const,
+		values: ["context-full", "handoff", "shake", "snapcompact", "codex-v2", "off"] as const,
 		default: "snapcompact",
 		ui: {
 			tab: "context",
 			group: "Compaction",
 			label: "Compaction Strategy",
 			description:
-				"Choose in-place context-full maintenance, auto-handoff, surgical shake (drop heavy content), snapcompact (archive history as dense images), or disable auto maintenance (off)",
+				"Choose in-place context-full maintenance, auto-handoff, surgical shake (drop heavy content), snapcompact (archive history as dense images), Codex V2 remote compaction, or disable auto maintenance (off)",
 			options: [
 				{
 					value: "context-full",
@@ -1811,6 +1811,12 @@ export const SETTINGS_SCHEMA = {
 					value: "snapcompact",
 					label: "Snapcompact",
 					description: "Archive history onto dense bitmap images the model reads back; no LLM call",
+				},
+				{
+					value: "codex-v2",
+					label: "Codex V2",
+					description:
+						"Use the OpenAI Responses compaction trigger and replay provider-native replacement history",
 				},
 				{
 					value: "off",
@@ -4840,7 +4846,7 @@ export type Personality = SettingValue<"personality">;
 
 export interface CompactionSettings {
 	enabled: boolean;
-	strategy: "context-full" | "handoff" | "shake" | "snapcompact" | "off";
+	strategy: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2" | "off";
 	thresholdPercent: number;
 	thresholdTokens: number;
 	reserveTokens: number;

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -110,11 +110,11 @@ export type CustomToolSessionEvent =
 	| {
 			reason: "auto_compaction_start";
 			trigger: "threshold" | "overflow" | "idle" | "incomplete";
-			action: "context-full" | "handoff" | "shake" | "snapcompact";
+			action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 	  }
 	| {
 			reason: "auto_compaction_end";
-			action: "context-full" | "handoff" | "shake" | "snapcompact";
+			action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 			result: CompactionResult | undefined;
 			aborted: boolean;
 			willRetry: boolean;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -291,7 +291,7 @@ export interface CompactOptions {
 	/**
 	 * Force a one-off compaction mode for this invocation, overriding the
 	 * configured `compaction.strategy` / `remoteEnabled` (the `/compact`
-	 * subcommands: `soft` | `remote` | `snapcompact`). Omitted = configured behavior.
+	 * subcommands: `soft` | `remote` | `snapcompact` | `codex-v2`). Omitted = configured behavior.
 	 */
 	mode?: CompactMode;
 }

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -216,13 +216,13 @@ export interface TurnEndEvent {
 export interface AutoCompactionStartEvent {
 	type: "auto_compaction_start";
 	reason: "threshold" | "overflow" | "idle" | "incomplete";
-	action: "context-full" | "handoff" | "shake" | "snapcompact";
+	action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 }
 
 /** Fired when auto-compaction ends */
 export interface AutoCompactionEndEvent {
 	type: "auto_compaction_end";
-	action: "context-full" | "handoff" | "shake" | "snapcompact";
+	action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 	result: CompactionResult | undefined;
 	aborted: boolean;
 	willRetry: boolean;

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -43,18 +43,27 @@ class SummaryDividerComponent implements Component {
 		const label = this.options.label();
 		// sep.dot ships pre-padded (" · "); trim so the hint joins with single spaces.
 		const hint = `${theme.sep.dot.trim()} ctrl+o`;
-		const plainWidth = Bun.stringWidth(`${label} ${hint}`, { countAnsiEscapeCodes: false });
-		// ` label hint ` framed by rules on both sides.
+		const labelWidth = Bun.stringWidth(label, { countAnsiEscapeCodes: false });
+		const labelWithHintWidth = Bun.stringWidth(`${label} ${hint}`, { countAnsiEscapeCodes: false });
+		// ` label hint ` framed by rules on both sides. If the label is too wide
+		// for the hint, keep the rule and drop only the hint; a compaction marker
+		// should still look like a divider in narrow panes.
+		const withHint = this.#framedRule(width, rule, label, labelWithHintWidth, ` ${hint}`);
+		if (withHint) return withHint;
+		const withoutHint = this.#framedRule(width, rule, label, labelWidth, "");
+		if (withoutHint) return withoutHint;
+		return theme.fg("muted", label);
+	}
+
+	#framedRule(width: number, rule: string, label: string, plainWidth: number, suffix: string): string | undefined {
+		// ` label suffix ` framed by rules on both sides.
 		const remaining = width - plainWidth - 2;
-		if (remaining < 4) {
-			// Too narrow for a framed rule — emit the bare label.
-			return theme.fg("muted", label);
-		}
+		if (remaining < 4) return undefined;
 		const left = Math.floor(remaining / 2);
 		const right = remaining - left;
 		return (
 			theme.fg("dim", rule.repeat(left)) +
-			` ${theme.fg("muted", label)} ${theme.fg("dim", hint)} ` +
+			` ${theme.fg("muted", label)}${theme.fg("dim", suffix)} ` +
 			theme.fg("dim", rule.repeat(right))
 		);
 	}
@@ -87,7 +96,7 @@ export class CompactionSummaryMessageComponent implements Component {
 
 	constructor(private readonly message: CompactionSummaryMessage) {
 		this.#divider = new SummaryDividerComponent({
-			label: () => `${theme.icon.camera} compacted`,
+			label: () => this.#label(),
 			detailMarkdown: () => this.#detailMarkdown(),
 		});
 	}
@@ -104,12 +113,23 @@ export class CompactionSummaryMessageComponent implements Component {
 		return this.#divider.render(width);
 	}
 
+	#label(): string {
+		return this.#isCodexV2() ? `${theme.icon.context} Codex V2 compacted` : `${theme.icon.camera} compacted`;
+	}
 	#detailMarkdown(): string {
 		const tokenStr = this.message.tokensBefore.toLocaleString();
 		const frameCount = this.message.images?.length ?? 0;
 		const frameNote =
 			frameCount > 0 ? `\n\n_${frameCount} snapcompact frame${frameCount === 1 ? "" : "s"} attached_` : "";
-		return `**Compacted from ${tokenStr} tokens**\n\n${this.message.summary}${frameNote}`;
+		const codexV2Note = this.#isCodexV2() ? "\n\n_Codex V2 provider-native compaction item attached_" : "";
+		return `**Compacted from ${tokenStr} tokens**\n\n${this.message.summary}${frameNote}${codexV2Note}`;
+	}
+
+	#isCodexV2(): boolean {
+		return (
+			this.message.shortSummary === "Codex V2 remote compaction" ||
+			this.message.summary.startsWith("Context compacted by Codex V2 remote compaction.")
+		);
 	}
 }
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -324,6 +324,10 @@ import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey }
 import { classifyUnexpectedStop, isUnexpectedStopCandidate } from "./unexpected-stop-classifier";
 import { YieldQueue } from "./yield-queue";
 
+export function resolveAdvisorCompactionSettings(settings: CompactionSettings): CompactionSettings {
+	return settings.strategy === "codex-v2" ? { ...settings, strategy: "context-full" } : settings;
+}
+
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
 /** Abort reason for the Gemini reasoning-header runaway interrupt. Surfaced on the
@@ -2223,6 +2227,7 @@ export class AgentSession {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.strategy === "off") return false;
 		if (!compactionSettings.enabled) return false;
+		const advisorCompactionSettings = resolveAdvisorCompactionSettings(compactionSettings);
 
 		const advisorModel = advisor.state.model;
 		const contextWindow = advisorModel.contextWindow ?? 0;
@@ -2234,7 +2239,7 @@ export class AgentSession {
 			contextTokens += estimateTokens(message);
 		}
 
-		if (!shouldCompact(contextTokens, contextWindow, compactionSettings)) {
+		if (!shouldCompact(contextTokens, contextWindow, advisorCompactionSettings)) {
 			return false;
 		}
 
@@ -2244,7 +2249,7 @@ export class AgentSession {
 			const newModel = advisor.state.model;
 			const newWindow = newModel.contextWindow ?? 0;
 			if (newWindow > 0) {
-				const stillNeedsCompaction = shouldCompact(contextTokens, newWindow, compactionSettings);
+				const stillNeedsCompaction = shouldCompact(contextTokens, newWindow, advisorCompactionSettings);
 				if (!stillNeedsCompaction) return false;
 			}
 		}
@@ -2277,7 +2282,7 @@ export class AgentSession {
 			} satisfies SessionMessageEntry;
 		});
 
-		const preparation = prepareCompaction(pathEntries, compactionSettings);
+		const preparation = prepareCompaction(pathEntries, advisorCompactionSettings);
 		if (!preparation) {
 			// Cannot prepare compaction, fallback to re-prime
 			return true;
@@ -2287,10 +2292,10 @@ export class AgentSession {
 			? ThinkingLevel.Off
 			: advisor.state.thinkingLevel;
 
-		// Advisor state is in-memory-only, so snapcompact's frame archive has no
-		// stable SessionEntry preserveData slot to carry across future advisor
-		// maintenance runs. Use an LLM summary even when the primary session is
-		// configured for snapcompact.
+		// Advisor state is in-memory-only, so it has no stable preserveData slot
+		// for snapcompact frames or Codex V2 replacement history. Use the
+		// context-full LLM summary path for advisor maintenance even when the
+		// primary session is configured for snapcompact or Codex V2.
 		const availableModels = this.#modelRegistry.getAvailable();
 		const candidates = this.#resolveCompactionModelCandidates(advisorModel, availableModels);
 		if (candidates.length === 0) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -332,6 +332,18 @@ export function resolveCodexV2ActiveCompactionCandidates(model: Model | null | u
 	return model && shouldUseCodexV2RemoteCompaction(model) ? [model] : [];
 }
 
+export function resolveCodexV2CompactionCacheOptions(
+	providerSessionId: string,
+	promptCacheKey: string | undefined,
+	requestId: string,
+): Pick<SummaryOptions, "sessionId" | "promptCacheKey" | "preferWebsockets"> {
+	return {
+		sessionId: `${providerSessionId}:compact:${requestId}`,
+		promptCacheKey: promptCacheKey ?? providerSessionId,
+		preferWebsockets: false,
+	};
+}
+
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
 /** Abort reason for the Gemini reasoning-header runaway interrupt. Surfaced on the
@@ -4714,6 +4726,14 @@ export class AgentSession {
 
 	#activeProviderSessionId(sessionId?: string): string {
 		return this.#freshProviderSessionId ?? this.#providerSessionId ?? sessionId ?? this.sessionManager.getSessionId();
+	}
+
+	#codexV2CompactionCacheOptions(): Pick<SummaryOptions, "sessionId" | "promptCacheKey" | "preferWebsockets"> {
+		return resolveCodexV2CompactionCacheOptions(
+			this.#activeProviderSessionId(),
+			this.agent.promptCacheKey ?? this.agent.sessionId,
+			Snowflake.next(),
+		);
 	}
 
 	/**
@@ -10313,6 +10333,7 @@ export class AgentSession {
 						// via resolveCompactionEffort so unsupported-effort models
 						// (xai-oauth/grok-build) don't trip requireSupportedEffort.
 						thinkingLevel: this.thinkingLevel,
+						...(preparation.settings.strategy === "codex-v2" ? this.#codexV2CompactionCacheOptions() : {}),
 					},
 				);
 			} catch (error) {
@@ -10913,6 +10934,9 @@ export class AgentSession {
 									convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 									tools: this.agent.state.tools,
 									serviceTier: this.#effectiveServiceTier(candidate),
+									...(preparation.settings.strategy === "codex-v2"
+										? this.#codexV2CompactionCacheOptions()
+										: {}),
 									telemetry,
 									// Honor the user's /model thinking selection on the
 									// auto-compaction path — the most-fired compaction

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -69,6 +69,7 @@ import {
 	type ShakeRegion,
 	type SummaryOptions,
 	shouldCompact,
+	shouldUseCodexV2RemoteCompaction,
 	shouldUseOpenAiRemoteCompaction,
 } from "@oh-my-pi/pi-agent-core/compaction";
 import {
@@ -353,11 +354,11 @@ export type AgentSessionEvent =
 	| {
 			type: "auto_compaction_start";
 			reason: "threshold" | "overflow" | "idle" | "incomplete";
-			action: "context-full" | "handoff" | "shake" | "snapcompact";
+			action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 	  }
 	| {
 			type: "auto_compaction_end";
-			action: "context-full" | "handoff" | "shake" | "snapcompact";
+			action: "context-full" | "handoff" | "shake" | "snapcompact" | "codex-v2";
 			result: CompactionResult | undefined;
 			aborted: boolean;
 			willRetry: boolean;
@@ -8406,19 +8407,24 @@ export class AgentSession {
 			const effectiveSettings = compactMode
 				? { ...compactionSettings, ...compactMode.overrides }
 				: compactionSettings;
-			// /compact remote demands provider-native compaction. When no remote
-			// endpoint is configured (one would override per-model gating in
-			// compact()), drop fallback candidates that aren't remote-capable so the
-			// engine never silently runs a local summary on a configured-but-non-
-			// remote compactionModel. If filtering empties the chain, warn and fall
-			// back to the full chain so the operation still completes.
+			// /compact remote demands provider-native compaction. /compact codex-v2
+			// is stricter: it must use the Responses compaction-trigger path and
+			// must not silently fall back to a local summary.
 			const availableModels = this.#modelRegistry.getAvailable();
+			const requireCodexV2 = effectiveSettings.strategy === "codex-v2";
 			const requireProviderRemote = Boolean(compactMode?.requiresRemote && !effectiveSettings.remoteEndpoint);
-			let compactionCandidates = this.#getCompactionModelCandidates(
-				availableModels,
-				requireProviderRemote ? shouldUseOpenAiRemoteCompaction : undefined,
-			);
-			if (requireProviderRemote && compactionCandidates.length === 0) {
+			const remotePredicate = requireCodexV2
+				? shouldUseCodexV2RemoteCompaction
+				: requireProviderRemote
+					? shouldUseOpenAiRemoteCompaction
+					: undefined;
+			let compactionCandidates = this.#getCompactionModelCandidates(availableModels, remotePredicate);
+			if (requireCodexV2 && compactionCandidates.length === 0) {
+				throw new Error(
+					`Codex V2 compaction requires an OpenAI Responses-capable model (${this.model.id} is not eligible and no eligible fallback is configured).`,
+				);
+			}
+			if (requireProviderRemote && !requireCodexV2 && compactionCandidates.length === 0) {
 				this.emitNotice(
 					"warning",
 					`remote compaction is unavailable for ${this.model.id} (no remote endpoint configured and no provider-native remote-capable model in the fallback chain) — using a local summary instead`,
@@ -8576,6 +8582,7 @@ export class AgentSession {
 							promptOverride: this.#obfuscateTextForProvider(compactionPrep.hookPrompt),
 							extraContext: compactionPrep.hookContext,
 							remoteInstructions: this.#baseSystemPrompt.join("\n\n"),
+							tools: this.agent.state.tools,
 							convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 						},
 						compactionCandidates,
@@ -10291,6 +10298,8 @@ export class AgentSession {
 						...options,
 						metadata: this.agent.metadataForProvider(candidate.provider),
 						convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
+						tools: options?.tools ?? this.agent.state.tools,
+						serviceTier: this.#effectiveServiceTier(candidate),
 						telemetry,
 						// Honor the user's /model thinking selection (incl. `off`) on
 						// the manual `/compact` path. Clamped per-model inside compact()
@@ -10619,12 +10628,14 @@ export class AgentSession {
 		// so a handoff request on the existing context is still viable. Snapcompact is
 		// a local-only strategy: if it cannot run, report the local blocker instead of
 		// silently swapping in a provider-backed summary.
-		let action: "context-full" | "handoff" | "snapcompact" =
+		let action: "context-full" | "handoff" | "snapcompact" | "codex-v2" =
 			compactionSettings.strategy === "snapcompact"
 				? "snapcompact"
-				: compactionSettings.strategy === "handoff" && reason !== "overflow" && !suppressHandoff
-					? "handoff"
-					: "context-full";
+				: compactionSettings.strategy === "codex-v2"
+					? "codex-v2"
+					: compactionSettings.strategy === "handoff" && reason !== "overflow" && !suppressHandoff
+						? "handoff"
+						: "context-full";
 		// Abort any older auto-compaction before installing this run's controller.
 		this.#autoCompactionAbortController?.abort();
 		const autoCompactionAbortController = new AbortController();
@@ -10857,7 +10868,15 @@ export class AgentSession {
 				details = snapcompactResult.details;
 				preserveData = { ...(compactionPrep.preserveData ?? {}), ...(snapcompactResult.preserveData ?? {}) };
 			} else {
-				const candidates = this.#getCompactionModelCandidates(availableModels);
+				const candidates = this.#getCompactionModelCandidates(
+					availableModels,
+					compactionSettings.strategy === "codex-v2" ? shouldUseCodexV2RemoteCompaction : undefined,
+				);
+				if (compactionSettings.strategy === "codex-v2" && candidates.length === 0) {
+					throw new Error(
+						`Codex V2 compaction requires an OpenAI Responses-capable model (${this.model.id} is not eligible and no eligible fallback is configured).`,
+					);
+				}
 				const retrySettings = this.settings.getGroup("retry");
 				const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
 				let compactResult: CompactionResult | undefined;
@@ -10885,6 +10904,8 @@ export class AgentSession {
 									metadata: this.agent.metadataForProvider(candidate.provider),
 									initiatorOverride: "agent",
 									convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
+									tools: this.agent.state.tools,
+									serviceTier: this.#effectiveServiceTier(candidate),
 									telemetry,
 									// Honor the user's /model thinking selection on the
 									// auto-compaction path — the most-fired compaction

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -328,6 +328,10 @@ export function resolveAdvisorCompactionSettings(settings: CompactionSettings): 
 	return settings.strategy === "codex-v2" ? { ...settings, strategy: "context-full" } : settings;
 }
 
+export function resolveCodexV2ActiveCompactionCandidates(model: Model | null | undefined): Model[] {
+	return model && shouldUseCodexV2RemoteCompaction(model) ? [model] : [];
+}
+
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
 /** Abort reason for the Gemini reasoning-header runaway interrupt. Surfaced on the
@@ -8418,15 +8422,13 @@ export class AgentSession {
 			const availableModels = this.#modelRegistry.getAvailable();
 			const requireCodexV2 = effectiveSettings.strategy === "codex-v2";
 			const requireProviderRemote = Boolean(compactMode?.requiresRemote && !effectiveSettings.remoteEndpoint);
-			const remotePredicate = requireCodexV2
-				? shouldUseCodexV2RemoteCompaction
-				: requireProviderRemote
-					? shouldUseOpenAiRemoteCompaction
-					: undefined;
-			let compactionCandidates = this.#getCompactionModelCandidates(availableModels, remotePredicate);
+			const remotePredicate = requireProviderRemote ? shouldUseOpenAiRemoteCompaction : undefined;
+			let compactionCandidates = requireCodexV2
+				? resolveCodexV2ActiveCompactionCandidates(this.model)
+				: this.#getCompactionModelCandidates(availableModels, remotePredicate);
 			if (requireCodexV2 && compactionCandidates.length === 0) {
 				throw new Error(
-					`Codex V2 compaction requires an OpenAI Responses-capable model (${this.model.id} is not eligible and no eligible fallback is configured).`,
+					`Codex V2 compaction requires the active model to be OpenAI Responses-capable (${this.model.id} is not eligible).`,
 				);
 			}
 			if (requireProviderRemote && !requireCodexV2 && compactionCandidates.length === 0) {
@@ -10873,13 +10875,13 @@ export class AgentSession {
 				details = snapcompactResult.details;
 				preserveData = { ...(compactionPrep.preserveData ?? {}), ...(snapcompactResult.preserveData ?? {}) };
 			} else {
-				const candidates = this.#getCompactionModelCandidates(
-					availableModels,
-					compactionSettings.strategy === "codex-v2" ? shouldUseCodexV2RemoteCompaction : undefined,
-				);
-				if (compactionSettings.strategy === "codex-v2" && candidates.length === 0) {
+				const requiresCodexV2 = compactionSettings.strategy === "codex-v2";
+				const candidates = requiresCodexV2
+					? resolveCodexV2ActiveCompactionCandidates(this.model)
+					: this.#getCompactionModelCandidates(availableModels);
+				if (requiresCodexV2 && candidates.length === 0) {
 					throw new Error(
-						`Codex V2 compaction requires an OpenAI Responses-capable model (${this.model.id} is not eligible and no eligible fallback is configured).`,
+						`Codex V2 compaction requires the active model to be OpenAI Responses-capable (${this.model.id} is not eligible).`,
 					);
 				}
 				const retrySettings = this.settings.getGroup("retry");

--- a/packages/coding-agent/src/session/compact-modes.ts
+++ b/packages/coding-agent/src/session/compact-modes.ts
@@ -12,7 +12,7 @@
  */
 
 /** Subcommand selecting a one-off compaction mode for manual `/compact`. */
-export type CompactMode = "soft" | "remote" | "snapcompact";
+export type CompactMode = "soft" | "remote" | "snapcompact" | "codex-v2";
 
 /**
  * Per-invocation overrides merged over the configured `compaction.*` settings.
@@ -20,7 +20,7 @@ export type CompactMode = "soft" | "remote" | "snapcompact";
  * assignable to the full `CompactionSettings`.
  */
 export interface CompactionOverride {
-	strategy?: "context-full" | "snapcompact";
+	strategy?: "context-full" | "snapcompact" | "codex-v2";
 	remoteEnabled?: boolean;
 }
 
@@ -55,6 +55,13 @@ export const COMPACT_MODES: readonly CompactModeDef[] = [
 		description: "Summarize via the remote endpoint / provider-native compaction",
 		overrides: { strategy: "context-full", remoteEnabled: true },
 		requiresRemote: true,
+	},
+	{
+		name: "codex-v2",
+		description: "Compact via OpenAI Responses compaction trigger and preserve provider-native history",
+		overrides: { strategy: "codex-v2", remoteEnabled: true },
+		requiresRemote: true,
+		rejectsFocus: true,
 	},
 	{
 		name: "snapcompact",

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -9,6 +9,7 @@ import {
 	type BranchSummaryMessage,
 	type CompactionSummaryMessage,
 	convertMessageToLlm,
+	markCodexV2RetainedMessage,
 } from "@oh-my-pi/pi-agent-core/compaction/messages";
 import type {
 	AssistantMessage,
@@ -497,24 +498,30 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 					return [];
 				}
 				return [
-					{
-						role: "user",
-						content: [{ type: "text", text: bashExecutionToText(m) }],
-						attribution: "user",
-						timestamp: m.timestamp,
-					},
+					markCodexV2RetainedMessage(
+						{
+							role: "user",
+							content: [{ type: "text", text: bashExecutionToText(m) }],
+							attribution: "user",
+							timestamp: m.timestamp,
+						},
+						false,
+					),
 				];
 			case "pythonExecution":
 				if (m.excludeFromContext) {
 					return [];
 				}
 				return [
-					{
-						role: "user",
-						content: [{ type: "text", text: pythonExecutionToText(m) }],
-						attribution: "user",
-						timestamp: m.timestamp,
-					},
+					markCodexV2RetainedMessage(
+						{
+							role: "user",
+							content: [{ type: "text", text: pythonExecutionToText(m) }],
+							attribution: "user",
+							timestamp: m.timestamp,
+						},
+						false,
+					),
 				];
 			case "fileMention": {
 				// One `fileMention` can mix `@notes.md` (text) and `@screenshot.png` (image)
@@ -546,12 +553,17 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 					for (const file of imageFiles) {
 						if (file.image) content.push(file.image);
 					}
-					out.push({
-						role: "user",
-						content,
-						attribution: "user",
-						timestamp: m.timestamp,
-					});
+					out.push(
+						markCodexV2RetainedMessage(
+							{
+								role: "user",
+								content,
+								attribution: "user",
+								timestamp: m.timestamp,
+							},
+							true,
+						),
+					);
 				}
 				return out;
 			}

--- a/packages/coding-agent/test/advisor-compaction-settings.test.ts
+++ b/packages/coding-agent/test/advisor-compaction-settings.test.ts
@@ -1,10 +1,58 @@
 import { describe, expect, it } from "bun:test";
 import { type CompactionSettings, DEFAULT_COMPACTION_SETTINGS } from "@oh-my-pi/pi-agent-core/compaction";
-import { resolveAdvisorCompactionSettings } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import {
+	resolveAdvisorCompactionSettings,
+	resolveCodexV2ActiveCompactionCandidates,
+} from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 function settings(strategy: CompactionSettings["strategy"]): CompactionSettings {
 	return { ...DEFAULT_COMPACTION_SETTINGS, strategy };
 }
+
+function openAiModel(overrides: Partial<ModelSpec<"openai-responses">> = {}) {
+	return buildModel({
+		id: "gpt-5",
+		name: "GPT-5",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+		...overrides,
+	});
+}
+
+function anthropicModel(overrides: Partial<ModelSpec<"anthropic">> = {}) {
+	return buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+		...overrides,
+	});
+}
+
+describe("resolveCodexV2ActiveCompactionCandidates", () => {
+	it("uses only the active model when it can replay Codex V2 history", () => {
+		const model = openAiModel();
+		expect(resolveCodexV2ActiveCompactionCandidates(model)).toEqual([model]);
+	});
+
+	it("rejects non-OpenAI active models instead of relying on fallback candidates", () => {
+		expect(resolveCodexV2ActiveCompactionCandidates(anthropicModel())).toEqual([]);
+	});
+});
 
 describe("resolveAdvisorCompactionSettings", () => {
 	it("falls back from codex-v2 to context-full without changing thresholds", () => {

--- a/packages/coding-agent/test/advisor-compaction-settings.test.ts
+++ b/packages/coding-agent/test/advisor-compaction-settings.test.ts
@@ -5,6 +5,7 @@ import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
 	resolveAdvisorCompactionSettings,
 	resolveCodexV2ActiveCompactionCandidates,
+	resolveCodexV2CompactionCacheOptions,
 } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 function settings(strategy: CompactionSettings["strategy"]): CompactionSettings {
@@ -51,6 +52,24 @@ describe("resolveCodexV2ActiveCompactionCandidates", () => {
 
 	it("rejects non-OpenAI active models instead of relying on fallback candidates", () => {
 		expect(resolveCodexV2ActiveCompactionCandidates(anthropicModel())).toEqual([]);
+	});
+});
+
+describe("resolveCodexV2CompactionCacheOptions", () => {
+	it("uses the live prompt cache key while isolating the side request session id", () => {
+		expect(resolveCodexV2CompactionCacheOptions("provider-session", "live-cache-key", "side-1")).toEqual({
+			sessionId: "provider-session:compact:side-1",
+			promptCacheKey: "live-cache-key",
+			preferWebsockets: false,
+		});
+	});
+
+	it("falls back to the provider session id when no live prompt cache key is set", () => {
+		expect(resolveCodexV2CompactionCacheOptions("provider-session", undefined, "side-1")).toEqual({
+			sessionId: "provider-session:compact:side-1",
+			promptCacheKey: "provider-session",
+			preferWebsockets: false,
+		});
 	});
 });
 

--- a/packages/coding-agent/test/advisor-compaction-settings.test.ts
+++ b/packages/coding-agent/test/advisor-compaction-settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { type CompactionSettings, DEFAULT_COMPACTION_SETTINGS } from "@oh-my-pi/pi-agent-core/compaction";
+import { resolveAdvisorCompactionSettings } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+function settings(strategy: CompactionSettings["strategy"]): CompactionSettings {
+	return { ...DEFAULT_COMPACTION_SETTINGS, strategy };
+}
+
+describe("resolveAdvisorCompactionSettings", () => {
+	it("falls back from codex-v2 to context-full without changing thresholds", () => {
+		const input = {
+			...settings("codex-v2"),
+			thresholdPercent: 86,
+			thresholdTokens: 12345,
+			keepRecentTokens: 6789,
+			reserveTokens: 4321,
+		};
+
+		expect(resolveAdvisorCompactionSettings(input)).toEqual({ ...input, strategy: "context-full" });
+		expect(input.strategy).toBe("codex-v2");
+	});
+
+	it("leaves non-codex-v2 strategies unchanged", () => {
+		for (const strategy of ["context-full", "snapcompact", "handoff", "shake", "off"] as const) {
+			const input = settings(strategy);
+			expect(resolveAdvisorCompactionSettings(input)).toBe(input);
+		}
+	});
+});

--- a/packages/coding-agent/test/compact-modes.test.ts
+++ b/packages/coding-agent/test/compact-modes.test.ts
@@ -9,10 +9,13 @@ describe("compact mode registry", () => {
 		expect(findCompactMode("soft")?.overrides).toEqual({ strategy: "context-full", remoteEnabled: false });
 		expect(findCompactMode("remote")?.overrides).toEqual({ strategy: "context-full", remoteEnabled: true });
 		expect(findCompactMode("snapcompact")?.overrides).toEqual({ strategy: "snapcompact" });
+		expect(findCompactMode("codex-v2")?.overrides).toEqual({ strategy: "codex-v2", remoteEnabled: true });
 	});
 
-	it("flags remote as remote-requiring and snapcompact as focus-rejecting", () => {
+	it("flags remote and codex-v2 as remote-requiring and snapcompact as focus-rejecting", () => {
 		expect(findCompactMode("remote")?.requiresRemote).toBe(true);
+		expect(findCompactMode("codex-v2")?.requiresRemote).toBe(true);
+		expect(findCompactMode("codex-v2")?.rejectsFocus).toBe(true);
 		expect(findCompactMode("snapcompact")?.rejectsFocus).toBe(true);
 		// soft is a plain local summary: neither flag.
 		expect(findCompactMode("soft")?.requiresRemote).toBeUndefined();
@@ -36,6 +39,7 @@ describe("parseCompactArgs", () => {
 	it("detects a leading mode token", () => {
 		expect(parseCompactArgs("soft")).toEqual({ mode: "soft" });
 		expect(parseCompactArgs("remote")).toEqual({ mode: "remote" });
+		expect(parseCompactArgs("codex-v2")).toEqual({ mode: "codex-v2" });
 		expect(parseCompactArgs("snapcompact")).toEqual({ mode: "snapcompact" });
 	});
 
@@ -57,10 +61,14 @@ describe("parseCompactArgs", () => {
 	});
 
 	it("rejects focus instructions for modes that produce no summary", () => {
-		const result = parseCompactArgs("snapcompact keep the diffs");
-		expect(result).toHaveProperty("error");
-		expect("error" in result && result.error).toContain("snapcompact");
-		// Bare snapcompact is fine.
+		const snapcompactResult = parseCompactArgs("snapcompact keep the diffs");
+		expect(snapcompactResult).toHaveProperty("error");
+		expect("error" in snapcompactResult && snapcompactResult.error).toContain("snapcompact");
+		const codexV2Result = parseCompactArgs("codex-v2 preserve encrypted state");
+		expect(codexV2Result).toHaveProperty("error");
+		expect("error" in codexV2Result && codexV2Result.error).toContain("codex-v2");
+		// Bare no-summary modes are fine.
 		expect(parseCompactArgs("snapcompact")).toEqual({ mode: "snapcompact" });
+		expect(parseCompactArgs("codex-v2")).toEqual({ mode: "codex-v2" });
 	});
 });

--- a/packages/coding-agent/test/modes/components/compaction-divider.test.ts
+++ b/packages/coding-agent/test/modes/components/compaction-divider.test.ts
@@ -11,6 +11,8 @@ import { createCompactionSummaryMessage } from "@oh-my-pi/pi-agent-core/compacti
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { CompactionSummaryMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/compaction-summary-message";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { CompactionEntry, SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 
 beforeAll(() => {
 	initTheme();
@@ -44,6 +46,84 @@ describe("CompactionSummaryMessageComponent", () => {
 		expect(text).toContain(SUMMARY);
 		expect(text).toContain("tokens");
 		expect(text).toContain("1 snapcompact frame attached");
+	});
+
+	it("collapsed: names Codex V2 native compactions in the transcript", () => {
+		const component = new CompactionSummaryMessageComponent(
+			createCompactionSummaryMessage(
+				"Context compacted by Codex V2 remote compaction. Provider-native replacement history carries the retained context.",
+				128000,
+				new Date().toISOString(),
+				"Codex V2 remote compaction",
+			),
+		);
+		const collapsed = Bun.stripANSI(component.render(80).join("\n"));
+		expect(collapsed).toContain("Codex V2 compacted");
+		expect(collapsed).toContain("ctrl+o");
+		expect(collapsed).not.toContain("Provider-native replacement history");
+
+		const narrow = Bun.stripANSI(component.render(32).join("\n"));
+		expect(narrow).toContain("Codex V2 compacted");
+		expect(narrow).toContain("─");
+		expect(narrow).not.toContain("Provider-native replacement history");
+
+		component.setExpanded(true);
+		const expanded = Bun.stripANSI(component.render(80).join("\n"));
+		expect(expanded).toContain("Codex V2 provider-native compaction item attached");
+	});
+
+	it("renders the collapsed transcript marker for a codex-v2 compact entry", () => {
+		const timestamp = new Date().toISOString();
+		const oldUser: SessionEntry = {
+			type: "message",
+			id: "old-user",
+			parentId: null,
+			timestamp,
+			message: { role: "user", content: "old context", timestamp: Date.now() },
+		};
+		const keptUser: SessionEntry = {
+			type: "message",
+			id: "kept-user",
+			parentId: oldUser.id,
+			timestamp,
+			message: { role: "user", content: "kept context", timestamp: Date.now() },
+		};
+		const compaction: CompactionEntry = {
+			type: "compaction",
+			id: "codex-v2-compact",
+			parentId: keptUser.id,
+			timestamp,
+			summary:
+				"Context compacted by Codex V2 remote compaction. Provider-native replacement history carries the retained context.",
+			shortSummary: "Codex V2 remote compaction",
+			firstKeptEntryId: keptUser.id,
+			tokensBefore: 128000,
+			preserveData: {
+				openaiRemoteCompaction: {
+					provider: "openai-codex",
+					method: "codex-v2",
+					replacementHistory: [
+						{ type: "message", role: "user", content: [{ type: "input_text", text: "kept context" }] },
+						{ type: "compaction", encrypted_content: "encrypted" },
+					],
+					compactionItem: { type: "compaction", encrypted_content: "encrypted" },
+				},
+			},
+		};
+
+		const transcript = buildSessionContext([oldUser, keptUser, compaction], undefined, undefined, {
+			transcript: true,
+			collapseCompactedHistory: true,
+		});
+
+		expect(transcript.messages.map(message => message.role)).toEqual(["compactionSummary", "user"]);
+		const summaryMessage = transcript.messages[0];
+		if (summaryMessage?.role !== "compactionSummary") {
+			throw new Error("collapsed transcript did not expose the compaction marker");
+		}
+		const rendered = Bun.stripANSI(new CompactionSummaryMessageComponent(summaryMessage).render(32).join("\n"));
+		expect(rendered).toContain("Codex V2 compacted");
+		expect(rendered).toContain("─");
 	});
 
 	it("degrades to a bare label when the viewport is too narrow for a framed rule", () => {

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -97,4 +97,15 @@ describe("settings layout", () => {
 			group: "Services",
 		});
 	});
+
+	it("exposes Codex V2 compaction in the context settings menu", () => {
+		const def = getSettingsForTab("context").find(def => def.path === "compaction.strategy");
+
+		expect(def).toMatchObject({
+			type: "submenu",
+			label: "Compaction Strategy",
+			group: "Compaction",
+		});
+		expect(def && "options" in def ? def.options.map(option => option.value) : []).toContain("codex-v2");
+	});
 });

--- a/packages/coding-agent/test/slash-commands/compact.test.ts
+++ b/packages/coding-agent/test/slash-commands/compact.test.ts
@@ -39,7 +39,7 @@ describe("/compact dispatch (ACP)", () => {
 	});
 
 	it("threads each mode subcommand into compact()", async () => {
-		for (const mode of ["soft", "remote", "snapcompact"] as const satisfies readonly CompactMode[]) {
+		for (const mode of ["soft", "remote", "codex-v2", "snapcompact"] as const satisfies readonly CompactMode[]) {
 			const h = acpRuntime();
 			await executeAcpBuiltinSlashCommand(`/compact ${mode}`, h.runtime);
 			expect(h.compact).toHaveBeenCalledWith(undefined, { mode });
@@ -58,18 +58,20 @@ describe("/compact dispatch (ACP)", () => {
 		expect(h.compact).toHaveBeenCalledWith("summarize the auth flow", undefined);
 	});
 
-	it("rejects focus text on snapcompact without compacting", async () => {
-		const h = acpRuntime();
-		const result = await executeAcpBuiltinSlashCommand("/compact snapcompact keep the diffs", h.runtime);
-		expect(h.compact).not.toHaveBeenCalled();
-		expect(result).toEqual({ consumed: true });
-		expect((h.output.mock.calls[0]?.[0] as string) ?? "").toContain("snapcompact");
+	it("rejects focus text on no-summary modes without compacting", async () => {
+		for (const mode of ["codex-v2", "snapcompact"] as const satisfies readonly CompactMode[]) {
+			const h = acpRuntime();
+			const result = await executeAcpBuiltinSlashCommand(`/compact ${mode} keep the diffs`, h.runtime);
+			expect(h.compact).not.toHaveBeenCalled();
+			expect(result).toEqual({ consumed: true });
+			expect((h.output.mock.calls[0]?.[0] as string) ?? "").toContain(mode);
+		}
 	});
 
 	it("advertises the mode subcommands and input hint to ACP clients", () => {
 		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "compact");
 		expect(advertised).toBeDefined();
-		expect(advertised?.input?.hint).toBe("[soft|remote|snapcompact] [focus]");
+		expect(advertised?.input?.hint).toBe("[soft|remote|codex-v2|snapcompact] [focus]");
 	});
 });
 
@@ -88,10 +90,18 @@ describe("/compact dispatch (TUI)", () => {
 		expect(h.handleCompactCommand).toHaveBeenCalledWith(undefined, undefined);
 	});
 
-	it("warns on snapcompact + focus text and does not compact", async () => {
+	it("routes codex-v2 mode to the TUI compaction handler", async () => {
 		const h = tuiRuntime();
-		await executeBuiltinSlashCommand("/compact snapcompact keep diffs", h.runtime);
-		expect(h.handleCompactCommand).not.toHaveBeenCalled();
-		expect(h.showWarning).toHaveBeenCalled();
+		await executeBuiltinSlashCommand("/compact codex-v2", h.runtime);
+		expect(h.handleCompactCommand).toHaveBeenCalledWith(undefined, "codex-v2");
+	});
+
+	it("warns on no-summary mode + focus text and does not compact", async () => {
+		for (const mode of ["codex-v2", "snapcompact"] as const satisfies readonly CompactMode[]) {
+			const h = tuiRuntime();
+			await executeBuiltinSlashCommand(`/compact ${mode} keep diffs`, h.runtime);
+			expect(h.handleCompactCommand).not.toHaveBeenCalled();
+			expect(h.showWarning).toHaveBeenCalled();
+		}
 	});
 });


### PR DESCRIPTION
   ## Summary                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Adds a `codex-v2` compaction mode that uses OpenAI/Codex Responses-native remote compaction instead of local plaintext summarization.                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   This mode sends the current OpenAI Responses history plus a `compaction_trigger` item, receives the provider-native encrypted `compaction` item, and stores a replayable replacement history in the compaction entry. Future OpenAI/Codex Responses turns replay that provider-native history instead of relying on a generated long summary.                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## What changed                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - Added `/compact codex-v2`.                                                                                                                                                                                                                                                                                                                                                                                                           
   - Added `codex-v2` to compaction settings.                                                                                                                                                                                                                                                                                                                                                                                             
   - Added Codex V2 remote compaction plumbing:                                                                                                                                                                                                                                                                                                                                                                                           
     - builds OpenAI Responses-native history                                                                                                                                                                                                                                                                                                                                                                                             
     - appends `{ type: "compaction_trigger" }`                                                                                                                                                                                                                                                                                                                                                                                           
     - requires exactly one encrypted `{ type: "compaction", encrypted_content: ... }` output item                                                                                                                                                                                                                                                                                                                                        
     - stores provider-native replacement history in `preserveData.openaiRemoteCompaction`                                                                                                                                                                                                                                                                                                                                                
   - Keeps Codex V2 compaction stateless/ZDR-friendly:                                                                                                                                                                                                                                                                                                                                                                                    
     - no `previous_response_id`                                                                                                                                                                                                                                                                                                                                                                                                          
     - no `providerSessionState`                                                                                                                                                                                                                                                                                                                                                                                                          
     - `store: false`                                                                                                                                                                                                                                                                                                                                                                                                                     
   - Reuses prompt caching correctly:                                                                                                                                                                                                                                                                                                                                                                                                     
     - compaction request uses the live `agent.promptCacheKey ?? agent.sessionId`                                                                                                                                                                                                                                                                                                                                                         
     - compaction request uses a unique side `sessionId`                                                                                                                                                                                                                                                                                                                                                                                  
     - compaction request forces `preferWebsockets: false`                                                                                                                                                                                                                                                                                                                                                                                
     - avoids stateful WebSocket chaining while still hitting the live prompt cache                                                                                                                                                                                                                                                                                                                                                       
   - Threads current session state into the Codex V2 compaction request:                                                                                                                                                                                                                                                                                                                                                                  
     - base system prompt / context files / `AGENTS.md` via `remoteInstructions`                                                                                                                                                                                                                                                                                                                                                          
     - current tool definitions via `tools`                                                                                                                                                                                                                                                                                                                                                                                               
     - selected reasoning effort                                                                                                                                                                                                                                                                                                                                                                                                          
     - service tier                                                                                                                                                                                                                                                                                                                                                                                                                       
     - telemetry metadata                                                                                                                                                                                                                                                                                                                                                                                                                 
   - Adds a visible transcript divider for Codex V2 compaction so users can see where compaction occurred.                                                                                                                                                                                                                                                                                                                                
   - Extends Codex V2 compaction stream timeouts to 5 minutes for both first-event and idle waits.                                                                                                                                                                                                                                                                                                                                        
   - Requires the active model itself to be OpenAI Responses / Codex Responses-capable for Codex V2:                                                                                                                                                                                                                                                                                                                                      
     - no GLM/Anthropic/Gemini/etc. main model + OpenAI fallback                                                                                                                                                                                                                                                                                                                                                                          
     - avoids creating OpenAI-only replacement history that the active model cannot replay                                                                                                                                                                                                                                                                                                                                                
   - Keeps advisor compaction on its private summary fallback under `codex-v2`:                                                                                                                                                                                                                                                                                                                                                           
     - advisor `codex-v2` normalizes to `context-full`                                                                                                                                                                                                                                                                                                                                                                                    
     - avoids advisor re-prime churn                                                                                                                                                                                                                                                                                                                                                                                                      
     - does not pretend advisor has provider-native replacement-history persistence                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Behavioral notes                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Codex V2 replacement history intentionally stores:                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - retained user messages                                                                                                                                                                                                                                                                                                                                                                                                               
   - encrypted OpenAI/Codex `compaction` item                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   It does not persist raw system prompts, tool schemas, developer messages, assistant messages, or tool results in the replacement history.                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Current system prompts, context files such as `AGENTS.md`, and tool definitions are still sent from live session state on future turns. They are also sent to the Codex V2 compaction request so the provider-native compactor sees the same active instructions/tools.                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Safety / compatibility                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - `codex-v2` fails fast unless the active model is Codex V2-compatible.                                                                                                                                                                                                                                                                                                                                                                
   - Manual `/compact codex-v2` and auto-compaction both use the active-model-only guard.                                                                                                                                                                                                                                                                                                                                                 
   - `remote` and `context-full` behavior remain separate.                                                                                                                                                                                                                                                                                                                                                                                
   - `snapcompact` behavior is unchanged.                                                                                                                                                                                                                                                                                                                                                                                                 
   - Advisor compaction remains private summary maintenance; it does not create main-session compaction entries.                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ## Tests                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Added/updated tests for:                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   - Codex V2 capability gating                                                                                                                                                                                                                                                                                                                                                                                                           
   - active-model-only Codex V2 guard                                                                                                                                                                                                                                                                                                                                                                                                     
   - provider-native replacement history storage                                                                                                                                                                                                                                                                                                                                                                                          
   - stateless/ZDR-friendly Responses payload                                                                                                                                                                                                                                                                                                                                                                                             
   - prompt cache reuse and side-request session isolation                                                                                                                                                                                                                                                                                                                                                                                
   - service tier propagation                                                                                                                                                                                                                                                                                                                                                                                                             
   - Codex V2 timeout options                                                                                                                                                                                                                                                                                                                                                                                                             
   - rejecting legacy replacement-history seeding                                                                                                                                                                                                                                                                                                                                                                                         
   - `codex-v2` compact mode parsing/settings                                                                                                                                                                                                                                                                                                                                                                                             
   - slash command routing                                                                                                                                                                                                                                                                                                                                                                                                                
   - visible Codex V2 compaction divider                                                                                                                                                                                                                                                                                                                                                                                                  
   - advisor fallback from `codex-v2` to summary compaction                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   Verified locally:                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   ```text                                                                                                                                                                                                                                                                                                                                                                                                                                
   bun test packages/agent/test/remote-compaction.test.ts packages/coding-agent/test/advisor-compaction-settings.test.ts packages/coding-agent/test/compact-modes.test.ts packages/coding-agent/test/slash-commands/compact.test.ts                                                                                                                                                                                                       
   # 44 pass, 0 fail                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   bun --cwd=packages/agent run check                                                                                                                                                                                                                                                                                                                                                                                                     
   # passed                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   bun --cwd=packages/coding-agent run check                                                                                                                                                                                                                                                                                                                                                                                              
   # passed                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
   bun run check:ts                                                                                                                                                                                                                                                                                                                                                                                                                       
   # passed      