### PR TITLE
fix(ai): ignore non-canonical codex baseUrl for wham/usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Default reasoning context to `all_turns` for all Codex requests
 
+### Fixed
+
+- Fixed `/usage show` returning "No usage data available" when `providers.openai-codex.baseUrl` points at a `/responses`-only proxy (e.g. Headroom). `normalizeCodexBaseUrl` now falls back to the canonical ChatGPT origin for the `wham/usage` and `wham/rate-limit-reset-credits` account endpoints whenever the configured base URL is not on `chatgpt.com` / `chat.openai.com`, so streaming traffic keeps flowing through the proxy while usage requests go straight to OpenAI ([#3679](https://github.com/can1357/oh-my-pi/issues/3679)).
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/ai/src/usage/openai-codex-base-url.ts
+++ b/packages/ai/src/usage/openai-codex-base-url.ts
@@ -1,15 +1,32 @@
 import { CODEX_BASE_URL } from "@oh-my-pi/pi-catalog/wire/codex";
 
+/**
+ * Resolve the base URL for ChatGPT account-API requests (`wham/usage`,
+ * `wham/rate-limit-reset-credits`).
+ *
+ * These endpoints live on the canonical ChatGPT origin and authenticate with
+ * the Codex OAuth bearer minted for that origin. They are NOT part of the
+ * `/responses` API surface that streaming proxies (Headroom, 9router, etc.)
+ * forward, so a `providers.openai-codex.baseUrl` override pointed at such a
+ * proxy MUST NOT be used here — doing so 404s and silently breaks
+ * `/usage show` (issue #3679).
+ *
+ * Accepted overrides are the canonical `chatgpt.com` / `chat.openai.com`
+ * origins (optionally without `/backend-api`, which is appended). Any other
+ * host falls back to {@link CODEX_BASE_URL}.
+ */
 export function normalizeCodexBaseUrl(baseUrl?: string): string {
-	const fallback = CODEX_BASE_URL;
-	const trimmed = baseUrl?.trim() ? baseUrl.trim() : fallback;
-	const base = trimmed.replace(/\/+$/, "");
-	const lower = base.toLowerCase();
-	if (
-		(lower.startsWith("https://chatgpt.com") || lower.startsWith("https://chat.openai.com")) &&
-		!lower.includes("/backend-api")
-	) {
-		return `${base}/backend-api`;
+	const trimmed = baseUrl?.trim().replace(/\/+$/, "");
+	if (!trimmed) return CODEX_BASE_URL;
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return CODEX_BASE_URL;
 	}
-	return base;
+	const host = parsed.host.toLowerCase();
+	if (host !== "chatgpt.com" && host !== "chat.openai.com") return CODEX_BASE_URL;
+	const lower = trimmed.toLowerCase();
+	if (!lower.includes("/backend-api")) return `${parsed.origin}/backend-api`;
+	return trimmed;
 }

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -226,4 +226,46 @@ describe("openai-codex usage parser", () => {
 		);
 		expect(extraFetchCalls).toBe(0);
 	});
+
+	it("ignores non-canonical provider baseUrl overrides for wham/usage (#3679)", async () => {
+		// Headroom + similar /responses proxies don't serve ChatGPT account
+		// endpoints; without this fall-back `/usage show` 404s on the proxy.
+		const requested: string[] = [];
+		const fetchImpl: FetchImpl = (async (url: string | URL | Request) => {
+			requested.push(typeof url === "string" ? url : url.toString());
+			return new Response(JSON.stringify(makePayload()), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+				baseUrl: "http://127.0.0.1:8787/v1",
+			},
+			{ fetch: fetchImpl },
+		);
+		expect(requested).toEqual(["https://chatgpt.com/backend-api/wham/usage"]);
+	});
+
+	it("keeps a canonical chatgpt.com baseUrl override (and adds /backend-api when missing)", async () => {
+		const requested: string[] = [];
+		const fetchImpl: FetchImpl = (async (url: string | URL | Request) => {
+			requested.push(typeof url === "string" ? url : url.toString());
+			return new Response(JSON.stringify(makePayload()), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+				baseUrl: "https://chatgpt.com",
+			},
+			{ fetch: fetchImpl },
+		);
+		expect(requested).toEqual(["https://chatgpt.com/backend-api/wham/usage"]);
+	});
 });


### PR DESCRIPTION
## Repro

`~/.omp/agent/models.yml` sets:

```yaml
providers:
  openai-codex:
    baseUrl: http://127.0.0.1:8787/v1
```

(Headroom or any `/responses`-only Codex proxy.) Streaming works, but `/usage show` reports `Warning: No usage data available.`. Direct repro:

```js
await openaiCodexUsageProvider.fetchUsage(
  { provider: "openai-codex", credential: { type: "oauth", accessToken, accountId, email }, baseUrl: "http://127.0.0.1:8787/v1" },
  { fetch },
);
// → fetches http://127.0.0.1:8787/v1/wham/usage  (proxy doesn't serve it → 404)
```

## Cause

`normalizeCodexBaseUrl` in `packages/ai/src/usage/openai-codex-base-url.ts` returned any non-`chatgpt.com` `baseUrl` verbatim. The two callers — `openaiCodexUsageProvider.fetchUsage` (`packages/ai/src/usage/openai-codex.ts`) and `listCodexResetCredits` / `consumeCodexResetCredit` (`packages/ai/src/usage/openai-codex-reset.ts`) — concatenate `wham/usage` and `wham/rate-limit-reset-credits` respectively. Those are ChatGPT account-API endpoints scoped to the canonical OAuth origin, not part of the `/responses` API surface a streaming proxy forwards, so the request 404s and the usage report comes back empty.

## Fix

- `packages/ai/src/usage/openai-codex-base-url.ts` — rewrite `normalizeCodexBaseUrl` to:
  - return `CODEX_BASE_URL` for empty / unparseable / non-`chatgpt.com|chat.openai.com` hosts (the fix), and
  - append `/backend-api` only for canonical origins missing it (preserved behavior).
- `packages/ai/test/openai-codex-usage.test.ts` — two regressions: non-canonical override falls back to canonical, canonical override without `/backend-api` is upgraded.
- `packages/ai/CHANGELOG.md` — `[Unreleased] / Fixed` entry citing #3679.

## Verification

- `bun test test/openai-codex-usage.test.ts` → 10 pass, 0 fail (8 existing + 2 new).
- `bun test test/openai-codex-reset.test.ts test/auth-storage-codex-selection.test.ts` → 27 pass, 0 fail (sibling consumers of `normalizeCodexBaseUrl`).
- Repro script with the fix applied resolves all three cases (`undefined`, `http://127.0.0.1:8787/v1`, `https://chatgpt.com`) to `https://chatgpt.com/backend-api/wham/usage`.

Fixes #3679