### PR TITLE
feat(coding-agent): show run state in terminal title

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
+### Added
+
+- Added run-state prefixes to interactive terminal titles so background tabs show when the agent is running, waiting for input, or blocked on a question/approval. ([#3587](https://github.com/can1357/oh-my-pi/issues/3587))
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -18,6 +18,7 @@
 import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { Component } from "@oh-my-pi/pi-tui";
 import { getConfigRootDir, logger } from "@oh-my-pi/pi-utils";
 import type { AgentHubRemote, AgentHubRemoteTranscript } from "../modes/components/agent-hub";
 import type { InteractiveModeContext } from "../modes/types";
@@ -25,7 +26,6 @@ import { AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "../session/agent-session";
 import type { SessionEntry } from "../session/session-entries";
 import { shouldDisableReasoning, toReasoningEffort } from "../thinking";
-import { setSessionTerminalTitle } from "../utils/title-generator";
 import { importRoomKey } from "./crypto";
 import { collabDisplayName } from "./display-name";
 import {
@@ -85,7 +85,8 @@ interface PendingSnapshot {
 /** Minimal context surface the idle-state reconciler mutates. */
 export interface GuestIdleReconcilerCtx {
 	statusLine: { markActivityEnd: () => void };
-	loadingAnimation: { stop: () => void } | undefined;
+	statusContainer: { removeChild: (child: Component) => void };
+	loadingAnimation: (Component & { stop: () => void }) | undefined;
 }
 
 /**
@@ -103,8 +104,10 @@ export interface GuestIdleReconcilerCtx {
 export function reconcileGuestIdleHostState(ctx: GuestIdleReconcilerCtx, isStreaming: boolean): void {
 	if (isStreaming) return;
 	ctx.statusLine.markActivityEnd();
-	if (ctx.loadingAnimation) {
-		ctx.loadingAnimation.stop();
+	const loader = ctx.loadingAnimation;
+	if (loader) {
+		loader.stop();
+		ctx.statusContainer.removeChild(loader);
 		ctx.loadingAnimation = undefined;
 	}
 }
@@ -155,6 +158,7 @@ export class CollabGuestLink {
 	/** False until the first assistant message_start (real or synthesized) since (re)sync. */
 	#assistantStreamSynced = false;
 	state: CollabSessionState | null = null;
+	#terminalTitleOptions: { sessionName?: string | undefined; cwd?: string | undefined } | undefined;
 	/** Local mirror of the host's agent ecosystem (refs carry `session: null`). */
 	readonly agentRegistry = new AgentRegistry();
 	/** Per-agent `hasSessionFile` from the last snapshot; gates remote transcript fetches. */
@@ -204,6 +208,10 @@ export class CollabGuestLink {
 	/** True when this guest joined through a read-only (view) link. */
 	get readOnly(): boolean {
 		return this.#readOnly;
+	}
+
+	get terminalTitleOptions(): { sessionName?: string | undefined; cwd?: string | undefined } | undefined {
+		return this.#terminalTitleOptions;
 	}
 
 	/** Shows the read-only status hint when applicable; true when the action must be dropped. */
@@ -333,6 +341,7 @@ export class CollabGuestLink {
 
 		this.#ctx.collabGuest = this;
 		this.#ctx.syncRunningSubagentBadge();
+		this.#ctx.refreshTerminalTitle(this.#terminalTitleOptions);
 	}
 
 	/** User-initiated leave (or post-disconnect cleanup): restore the previous session. */
@@ -417,7 +426,11 @@ export class CollabGuestLink {
 		this.#applyAgentSnapshots(pending.agents);
 		this.#ctx.syncRunningSubagentBadge();
 		this.#assistantStreamSynced = false;
-		setSessionTerminalTitle(pending.state.sessionName ?? pending.header.title, pending.state.cwd);
+		this.#terminalTitleOptions = {
+			sessionName: pending.state.sessionName ?? pending.header.title,
+			cwd: pending.state.cwd,
+		};
+		this.#ctx.refreshTerminalTitle(this.#terminalTitleOptions);
 		this.#ctx.chatContainer.clear();
 		this.#ctx.renderInitialMessages({ clearTerminalHistory: true });
 		await this.#ctx.reloadTodos();
@@ -480,9 +493,11 @@ export class CollabGuestLink {
 			case "state": {
 				this.state = frame.state;
 				this.#applyHostState(frame.state);
-				setSessionTerminalTitle(frame.state.sessionName, frame.state.cwd);
 				this.#updateStatusSegment();
 				reconcileGuestIdleHostState(this.#ctx, frame.state.isStreaming);
+				// Idle reconciliation clears loader-owned title state before the refresh.
+				this.#terminalTitleOptions = { sessionName: frame.state.sessionName, cwd: frame.state.cwd };
+				this.#ctx.refreshTerminalTitle(this.#terminalTitleOptions);
 				this.#ctx.statusLine.invalidate();
 				this.#ctx.ui.requestRender();
 				break;
@@ -691,6 +706,18 @@ export class CollabGuestLink {
 			this.#ctx.loadingAnimation.stop();
 			this.#ctx.loadingAnimation = undefined;
 		}
+		if (this.#ctx.autoCompactionLoader) {
+			this.#ctx.autoCompactionLoader.stop();
+			this.#ctx.autoCompactionLoader = undefined;
+		}
+		if (this.#ctx.compactionLoader) {
+			this.#ctx.compactionLoader.stop();
+			this.#ctx.compactionLoader = undefined;
+		}
+		if (this.#ctx.retryLoader) {
+			this.#ctx.retryLoader.stop();
+			this.#ctx.retryLoader = undefined;
+		}
 	}
 
 	async #restoreLocalSession(): Promise<void> {
@@ -711,7 +738,7 @@ export class CollabGuestLink {
 			return;
 		}
 		await this.#ctx.session.newSession();
-		setSessionTerminalTitle(this.#ctx.sessionManager.getSessionName(), this.#ctx.sessionManager.getCwd());
+		this.#ctx.refreshTerminalTitle();
 		this.#ctx.statusLine.invalidate();
 		this.#ctx.statusLine.resetActiveTime();
 		this.#ctx.ui.requestRender();

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -878,6 +878,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"terminal.showTitleState": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Terminal Title State",
+			description: "Prefix the terminal title with the agent run state",
+		},
+	},
+
 	"tui.textSizing": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/__tests__/terminal-title-state.test.ts
+++ b/packages/coding-agent/src/modes/__tests__/terminal-title-state.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { setTerminalHeadless, TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../../config/model-registry";
+import { resetSettingsForTest, Settings } from "../../config/settings";
+import { AgentRegistry } from "../../registry/agent-registry";
+import { AgentSession } from "../../session/agent-session";
+import { AuthStorage } from "../../session/auth-storage";
+import { HistoryStorage } from "../../session/history-storage";
+import { SessionManager } from "../../session/session-manager";
+import { formatSessionTerminalTitle } from "../../utils/title-generator";
+import { buildSessionTerminalTitleOptions, InteractiveMode } from "../interactive-mode";
+import { countRunningSubagentBadgeAgents, resolveTerminalTitleBaseState } from "../running-subagent-badge";
+import { initTheme, theme } from "../theme/theme";
+
+function registryWithRunningSubagents(count: number): AgentRegistry {
+	const registry = new AgentRegistry();
+	for (let index = 0; index < count; index += 1) {
+		registry.register({
+			id: `Sub${index}`,
+			displayName: `Sub ${index}`,
+			kind: "sub",
+			session: null,
+			status: "running",
+		});
+	}
+	return registry;
+}
+
+describe("terminal title state", () => {
+	it("treats detached running subagents as a running title state", () => {
+		const registry = registryWithRunningSubagents(1);
+
+		expect(countRunningSubagentBadgeAgents(registry)).toBe(1);
+		expect(
+			resolveTerminalTitleBaseState({
+				sessionStreaming: false,
+				sessionCompacting: false,
+				viewSessionStreaming: false,
+				viewSessionCompacting: false,
+				sessionPostPromptWork: false,
+				viewSessionPostPromptWork: false,
+				collabHostStreaming: false,
+				hasLoadingAnimation: false,
+				hasCompactionLoader: false,
+				hasAutoCompactionLoader: false,
+				hasRetryLoader: false,
+				runningTitleDepth: 0,
+				hasInputCallback: false,
+				runningSubagentCount: countRunningSubagentBadgeAgents(registry),
+			}),
+		).toBe("running");
+	});
+
+	it("preserves waiting title state when no session work or detached subagents are running", () => {
+		expect(
+			resolveTerminalTitleBaseState({
+				sessionStreaming: false,
+				sessionCompacting: false,
+				viewSessionStreaming: false,
+				viewSessionCompacting: false,
+				sessionPostPromptWork: false,
+				viewSessionPostPromptWork: false,
+				collabHostStreaming: false,
+				hasLoadingAnimation: false,
+				hasCompactionLoader: false,
+				hasAutoCompactionLoader: false,
+				hasRetryLoader: false,
+				runningTitleDepth: 0,
+				hasInputCallback: true,
+				runningSubagentCount: 0,
+			}),
+		).toBe("waiting");
+	});
+
+	it("treats a streaming collab host as a running title state", () => {
+		expect(
+			resolveTerminalTitleBaseState({
+				sessionStreaming: false,
+				sessionCompacting: false,
+				viewSessionStreaming: false,
+				viewSessionCompacting: false,
+				sessionPostPromptWork: false,
+				viewSessionPostPromptWork: false,
+				collabHostStreaming: true,
+				hasLoadingAnimation: false,
+				hasCompactionLoader: false,
+				hasAutoCompactionLoader: false,
+				hasRetryLoader: false,
+				runningTitleDepth: 0,
+				hasInputCallback: false,
+				runningSubagentCount: 0,
+			}),
+		).toBe("running");
+	});
+
+	it("treats queued post-prompt work as a running title state", () => {
+		expect(
+			resolveTerminalTitleBaseState({
+				sessionStreaming: false,
+				sessionCompacting: false,
+				viewSessionStreaming: false,
+				viewSessionCompacting: false,
+				sessionPostPromptWork: true,
+				viewSessionPostPromptWork: false,
+				collabHostStreaming: false,
+				hasLoadingAnimation: false,
+				hasCompactionLoader: false,
+				hasAutoCompactionLoader: false,
+				hasRetryLoader: false,
+				runningTitleDepth: 0,
+				hasInputCallback: false,
+				runningSubagentCount: 0,
+			}),
+		).toBe("running");
+	});
+
+	it("builds stateful collab session title options from the active run state", () => {
+		const options = buildSessionTerminalTitleOptions({
+			showTitleState: true,
+			state: "running",
+			stateSymbol: "▶",
+		});
+
+		expect(options).toEqual({ state: "running", stateSymbol: "▶" });
+	});
+
+	it("omits collab session title options when title-state prefixes are disabled", () => {
+		expect(
+			buildSessionTerminalTitleOptions({
+				showTitleState: false,
+				state: "running",
+				stateSymbol: "▶",
+			}),
+		).toEqual({ state: "idle", stateSymbol: undefined });
+	});
+});
+
+describe("terminal title registry subscription", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		AgentRegistry.resetGlobalForTests();
+		tempDir = TempDir.createSync("@pi-title-state-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.addMessageToChat = vi.fn();
+		mode.ui.requestRender = vi.fn();
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		HistoryStorage.resetInstance();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("flips the OSC title to running when a detached subagent registers and back when it finishes", () => {
+		const previousHeadless = setTerminalHeadless(false);
+		const originalTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		try {
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			const write = process.stdout.write as typeof process.stdout.write & {
+				mock: { calls: unknown[][] };
+				mockClear(): void;
+			};
+			mode.settings.set("terminal.showTitleState", true);
+			// Establish the badge subscription against the global registry — the
+			// same wiring the live TUI uses for detached subagents.
+			mode.syncRunningSubagentBadge({ requestRender: false });
+			write.mockClear();
+
+			const cwd = mode.sessionManager.getCwd();
+			const idleTitle = `\x1b]0;${formatSessionTerminalTitle(undefined, cwd)}\x07`;
+			const runningTitle = `\x1b]0;${formatSessionTerminalTitle(undefined, cwd, {
+				state: "running",
+				stateSymbol: theme.symbol("status.running"),
+			})}\x07`;
+			expect(runningTitle).not.toBe(idleTitle);
+
+			// A detached subagent starting must push the running-state OSC title
+			// through the registry change listener, with no other trigger.
+			AgentRegistry.global().register({
+				id: "DetachedSub",
+				displayName: "Detached Sub",
+				kind: "sub",
+				session: null,
+				status: "running",
+			});
+			const titleWrites = () =>
+				write.mock.calls.map(call => String(call[0])).filter(chunk => chunk.startsWith("\x1b]0;"));
+			expect(titleWrites().at(-1)).toBe(runningTitle);
+			write.mockClear();
+
+			// The subagent finishing must drop the running prefix again.
+			AgentRegistry.global().setStatus("DetachedSub", "idle");
+			expect(titleWrites().at(-1)).toBe(idleTitle);
+		} finally {
+			setTerminalHeadless(previousHeadless);
+			if (originalTTY) {
+				Object.defineProperty(process.stdout, "isTTY", originalTTY);
+			} else {
+				Reflect.deleteProperty(process.stdout, "isTTY");
+			}
+		}
+	});
+});

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -56,7 +56,6 @@ import {
 } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
 
 function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown: string): void {
 	const block = new TranscriptBlock();
@@ -925,9 +924,12 @@ export class CommandController {
 				await Bun.sleep(10);
 			}
 		}
-		if (!(await this.ctx.session.newSession(options))) return;
+		if (!(await this.ctx.session.newSession(options))) {
+			this.ctx.refreshTerminalTitle();
+			return;
+		}
 		this.ctx.resetObserverRegistry();
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		this.ctx.refreshTerminalTitle();
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.resetActiveTime();
@@ -1276,9 +1278,21 @@ export class CommandController {
 		beforeFlush?: (outcome: CompactionOutcome) => void | Promise<void>,
 		mode?: CompactMode,
 	): Promise<CompactionOutcome> {
+		// An in-flight compaction already owns the loader and the title state;
+		// starting another would clobber both, so reject instead of stealing.
+		if (this.ctx.compactionLoader && (this.ctx.session.isCompacting || this.ctx.viewSession.isCompacting)) {
+			this.ctx.showWarning("Compaction already in progress.");
+			return "failed";
+		}
 		if (this.ctx.loadingAnimation) {
 			this.ctx.loadingAnimation.stop();
 			this.ctx.loadingAnimation = undefined;
+		}
+		// A stale loader (left behind by an aborted flow) must be stopped and
+		// released before a new one takes ownership, or its ticker leaks.
+		if (this.ctx.compactionLoader) {
+			this.ctx.compactionLoader.stop();
+			this.ctx.compactionLoader = undefined;
 		}
 		this.ctx.statusContainer.disposeChildren();
 
@@ -1290,7 +1304,9 @@ export class CommandController {
 			label,
 			getSymbolTheme().spinnerFrames,
 		);
+		this.ctx.compactionLoader = compactingLoader;
 		this.ctx.statusContainer.addChild(compactingLoader);
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 
 		let outcome: CompactionOutcome = "ok";
@@ -1310,7 +1326,11 @@ export class CommandController {
 			await this.ctx.session.compact(instructions, options);
 
 			compactingLoader.stop();
+			if (this.ctx.compactionLoader === compactingLoader) {
+				this.ctx.compactionLoader = undefined;
+			}
 			this.ctx.statusContainer.disposeChildren();
+			this.ctx.refreshTerminalTitle();
 			this.ctx.rebuildChatFromMessages();
 
 			this.ctx.statusLine.invalidate();
@@ -1334,6 +1354,10 @@ export class CommandController {
 			}
 		} finally {
 			compactingLoader.stop();
+			if (this.ctx.compactionLoader === compactingLoader) {
+				this.ctx.compactionLoader = undefined;
+				this.ctx.refreshTerminalTitle();
+			}
 			this.ctx.statusContainer.disposeChildren();
 		}
 		// Run the caller's pre-flush hook (e.g. the plan-approval model transition)
@@ -1373,6 +1397,7 @@ export class CommandController {
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.statusContainer.addChild(handoffLoader);
+		const releaseTitleRunning = this.ctx.pushTerminalTitleRunning();
 		this.ctx.ui.requestRender();
 
 		try {
@@ -1407,6 +1432,7 @@ export class CommandController {
 			}
 		} finally {
 			handoffLoader.stop();
+			releaseTitleRunning();
 			this.ctx.statusContainer.disposeChildren();
 		}
 		this.ctx.ui.requestRender(true, { clearScrollback: true });

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -168,6 +168,10 @@ export class EventController {
 			todo_auto_clear: e => this.#handleTodoAutoClear(e),
 			irc_message: e => this.#handleIrcMessage(e),
 			notice: e => this.#handleNotice(e),
+			post_prompt_work_drained: async () => {
+				this.ctx.refreshTerminalTitle();
+				this.ctx.ui.requestRender();
+			},
 			thinking_level_changed: async () => {
 				this.ctx.statusLine.invalidate();
 				this.ctx.updateEditorBorderColor();
@@ -428,6 +432,7 @@ export class EventController {
 		this.ctx.statusLine.markActivityStart();
 		this.#setTerminalProgress(true);
 		this.ctx.ensureLoadingAnimation();
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 	}
 
@@ -1194,6 +1199,7 @@ export class EventController {
 		this.#resolveDisplaceableTodo();
 		this.ctx.flushPendingCommandOutput();
 		this.#lastAssistantComponent = undefined;
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.#scheduleIdleRecap();
@@ -1225,6 +1231,14 @@ export class EventController {
 		if (!this.ctx.viewSession.isStreaming) return;
 		if (this.ctx.autoCompactionLoader || this.ctx.retryLoader) return;
 		this.ctx.ensureLoadingAnimation();
+	}
+
+	#refreshTerminalTitleAfterCompactionEnd(): void {
+		if (!this.ctx.session.isCompacting && !this.ctx.viewSession.isCompacting) {
+			this.ctx.refreshTerminalTitle();
+			return;
+		}
+		setTimeout(() => this.ctx.refreshTerminalTitle(), 0);
 	}
 
 	/**
@@ -1270,6 +1284,7 @@ export class EventController {
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.statusContainer.addChild(this.ctx.autoCompactionLoader);
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 	}
 
@@ -1351,6 +1366,7 @@ export class EventController {
 		}
 		await this.ctx.flushCompactionQueue({ willRetry: event.willRetry });
 		this.#ensureWorkingLoaderWhileStreaming();
+		this.#refreshTerminalTitleAfterCompactionEnd();
 		this.ctx.ui.requestRender();
 	}
 
@@ -1374,6 +1390,7 @@ export class EventController {
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.statusContainer.addChild(this.ctx.retryLoader);
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 	}
 
@@ -1401,6 +1418,7 @@ export class EventController {
 			this.ctx.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 		}
 		this.#ensureWorkingLoaderWhileStreaming();
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,5 +1,6 @@
 import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
 import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
 import { KeybindingsManager } from "../../config/keybindings";
 import type {
@@ -28,7 +29,6 @@ import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/comp
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { normalizeCustomMessagePayload, USER_INTERRUPT_LABEL } from "../../session/messages";
-import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
 const ASK_OTHER_OPTION = "Other (type your own)";
@@ -88,7 +88,7 @@ export class ExtensionUiController {
 			setStatus: (key, text) => this.setHookStatus(key, text),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
-			setTitle: title => setTerminalTitle(title),
+			setTitle: title => this.ctx.setExtensionTerminalTitle(title),
 			custom: (factory, options) => this.showHookCustom(factory, options),
 			setEditorText: text => {
 				this.ctx.editor.setText(text);
@@ -193,10 +193,10 @@ export class ExtensionUiController {
 				this.clearExtensionTerminalInputListeners();
 				this.clearHookWidgets();
 				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
+				this.ctx.refreshTerminalTitle();
 				if (!success) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 
 				// Call setup callback if provided
 				if (options?.setup) {
@@ -255,7 +255,7 @@ export class ExtensionUiController {
 				if (!result) {
 					return { cancelled: true };
 				}
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				this.ctx.refreshTerminalTitle();
 				this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
@@ -413,6 +413,7 @@ export class ExtensionUiController {
 				this.clearExtensionTerminalInputListeners();
 				this.clearHookWidgets();
 				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
+				this.ctx.refreshTerminalTitle();
 				if (!success) {
 					return { cancelled: true };
 				}
@@ -472,6 +473,7 @@ export class ExtensionUiController {
 				if (!result) {
 					return { cancelled: true };
 				}
+				this.ctx.refreshTerminalTitle();
 				this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
@@ -998,47 +1000,84 @@ export class ExtensionUiController {
 		const savedText = this.ctx.editor.getText();
 		const keybindings = KeybindingsManager.inMemory();
 
-		const { promise, resolve } = Promise.withResolvers<T>();
+		const { promise, resolve, reject } = Promise.withResolvers<T>();
 		let component: (Component & { dispose?(): void }) | undefined;
 		let overlayHandle: OverlayHandle | undefined;
 		let closed = false;
+		// One attention token for the entire custom-UI lifecycle: acquired here
+		// (never per path, so nested dialogs the component opens stack their own
+		// depth) and released exactly once by whichever settle path runs first —
+		// done(), factory rejection, or a dispose racing the factory.
+		const releaseTitleAttention = this.ctx.pushTerminalTitleAttention();
+
+		// Teardown must never break settlement: a throwing extension dispose (or
+		// overlay/editor teardown) is contained and logged — consistent with how
+		// session/widget disposal failures are handled — so the token release and
+		// promise resolution below are unconditional.
+		const disposeSafely = (target: { dispose?(): void } | undefined) => {
+			try {
+				target?.dispose?.();
+			} catch (error) {
+				logger.warn("Extension custom UI dispose failed", { error });
+			}
+		};
 
 		const close = (result: T) => {
 			if (closed) return;
 			closed = true;
-			component?.dispose?.();
-			overlayHandle?.hide();
-			overlayHandle = undefined;
-			if (!options?.overlay) {
-				this.ctx.editorContainer.clear();
-				this.ctx.editorContainer.addChild(this.ctx.editor);
-				this.ctx.editor.setText(savedText);
+			try {
+				disposeSafely(component);
+				overlayHandle?.hide();
+				overlayHandle = undefined;
+				if (!options?.overlay) {
+					this.ctx.editorContainer.clear();
+					this.ctx.editorContainer.addChild(this.ctx.editor);
+					this.ctx.editor.setText(savedText);
+				}
+				this.ctx.ui.setFocus(this.ctx.editor);
+				this.ctx.ui.requestRender();
+			} catch (error) {
+				logger.warn("Extension custom UI teardown failed", { error });
+			} finally {
+				releaseTitleAttention();
+				resolve(result);
 			}
-			this.ctx.ui.setFocus(this.ctx.editor);
-			this.ctx.ui.requestRender();
-			resolve(result);
 		};
 
-		Promise.try(() => factory(this.ctx.ui, theme, keybindings, close)).then(c => {
-			if (closed) {
-				c.dispose?.();
-				return;
-			}
-			component = c;
-			if (options?.overlay) {
-				overlayHandle = this.ctx.ui.showOverlay(component, {
-					anchor: "bottom-center",
-					width: "100%",
-					maxHeight: "100%",
-					margin: 0,
-				});
-				return;
-			}
-			this.ctx.editorContainer.clear();
-			this.ctx.editorContainer.addChild(component);
-			this.ctx.ui.setFocus(component);
-			this.ctx.ui.requestRender();
-		});
+		// Any failure before the component is interactive — factory rejection or a
+		// throwing mount — releases the attention token and rejects the outer
+		// promise instead of stranding a needs_attention title on a hung promise.
+		const fail = (error: unknown): void => {
+			if (closed) return;
+			closed = true;
+			releaseTitleAttention();
+			reject(error instanceof Error ? error : new Error(String(error)));
+		};
+
+		Promise.try(() => factory(this.ctx.ui, theme, keybindings, close))
+			.then(c => {
+				if (closed) {
+					// done() won the race: the late component was never mounted, so it
+					// is only disposed — the token was already released by close().
+					disposeSafely(c);
+					return;
+				}
+				component = c;
+				if (options?.overlay) {
+					overlayHandle = this.ctx.ui.showOverlay(component, {
+						anchor: "bottom-center",
+						width: "100%",
+						maxHeight: "100%",
+						margin: 0,
+					});
+					return;
+				}
+				this.ctx.editorContainer.clear();
+				this.ctx.editorContainer.addChild(component);
+				this.ctx.ui.setFocus(component);
+				this.ctx.ui.requestRender();
+			})
+			.catch(fail);
 		return promise;
 	}
 
@@ -1085,7 +1124,16 @@ export class ExtensionUiController {
 		const instructions = typeof instructionsOrOptions === "string" ? instructionsOrOptions : undefined;
 		const options =
 			instructionsOrOptions && typeof instructionsOrOptions === "object" ? instructionsOrOptions : undefined;
-		await this.ctx.session.compact(instructions, options);
+		// Capture the promise before awaiting so the title flips to compacting
+		// immediately, and always refresh on settle (success or rejection) so a
+		// failed extension compaction cannot strand a running title.
+		const compaction = this.ctx.session.compact(instructions, options);
+		this.ctx.refreshTerminalTitle();
+		try {
+			await compaction;
+		} finally {
+			this.ctx.refreshTerminalTitle();
+		}
 	}
 
 	async #updateSessionName(name: string): Promise<void> {
@@ -1131,6 +1179,7 @@ export class ExtensionUiController {
 		let settled = false;
 		let started = false;
 		let hide: (() => void) | undefined;
+		let releaseTitleAttention: (() => void) | undefined;
 
 		function onAbort(): void {
 			settle(undefined);
@@ -1142,6 +1191,8 @@ export class ExtensionUiController {
 			signal?.removeEventListener("abort", onAbort);
 			if (started) {
 				hide?.();
+				releaseTitleAttention?.();
+				releaseTitleAttention = undefined;
 				this.#dialogActive = false;
 				this.#advanceDialogQueue();
 			}
@@ -1158,10 +1209,13 @@ export class ExtensionUiController {
 			this.#dialogActive = true;
 			try {
 				hide = present(settle);
+				releaseTitleAttention = this.ctx.pushTerminalTitleAttention();
 			} catch (error) {
 				settled = true;
 				signal?.removeEventListener("abort", onAbort);
 				this.#dialogActive = false;
+				releaseTitleAttention?.();
+				releaseTitleAttention = undefined;
 				reject(error);
 				this.#advanceDialogQueue();
 			}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -67,7 +67,6 @@ import {
 import { shortenPath } from "../../tools/render-utils";
 import { copyToClipboard } from "../../utils/clipboard";
 import { repo } from "../../utils/git";
-import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
@@ -442,6 +441,10 @@ export class SelectorController {
 				break;
 
 			// Settings with UI side effects
+			case "terminal.showTitleState":
+				this.ctx.refreshTerminalTitle();
+				break;
+
 			case "terminal.showImages":
 			case "showImages": {
 				const visible = value as boolean;
@@ -1185,6 +1188,7 @@ export class SelectorController {
 
 					// Set up escape handler and loader if summarizing
 					let summaryLoader: Loader | undefined;
+					let releaseTitleRunning: (() => void) | undefined;
 					const originalOnEscape = this.ctx.editor.onEscape;
 
 					if (wantsSummary) {
@@ -1200,6 +1204,7 @@ export class SelectorController {
 							getSymbolTheme().spinnerFrames,
 						);
 						this.ctx.statusContainer.addChild(summaryLoader);
+						releaseTitleRunning = this.ctx.pushTerminalTitleRunning();
 						this.ctx.ui.requestRender();
 					}
 
@@ -1233,6 +1238,7 @@ export class SelectorController {
 					} finally {
 						if (summaryLoader) {
 							summaryLoader.stop();
+							releaseTitleRunning?.();
 							this.ctx.statusContainer.disposeChildren();
 						}
 						this.ctx.editor.onEscape = originalOnEscape;
@@ -1332,12 +1338,7 @@ export class SelectorController {
 	}
 
 	#refreshSessionTerminalTitle(): void {
-		const sessionManager = this.ctx.sessionManager as {
-			getSessionName?: () => string | undefined;
-			getCwd: () => string;
-			titleSource?: "auto" | "user" | undefined;
-		};
-		setSessionTerminalTitle(sessionManager.getSessionName?.(), sessionManager.getCwd());
+		this.ctx.refreshTerminalTitle();
 	}
 
 	async #detachActiveSessionBeforeDeletion(sessionPath: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -107,6 +107,7 @@ export class SessionFocusController {
 		// Mid-turn attach: no agent_start will arrive; arm the loader/turn state manually.
 		if (target.isStreaming) await this.ctx.eventController.handleEvent({ type: "agent_start" });
 		this.ctx.updateEditorBorderColor();
+		this.ctx.refreshTerminalTitle();
 		this.ctx.ui.requestRender();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -130,7 +130,14 @@ import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
-import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
+import {
+	popTerminalTitle,
+	pushTerminalTitle,
+	type SessionTerminalTitleOptions,
+	setSessionTerminalTitle,
+	setTerminalTitle,
+	type TerminalTitleRunState,
+} from "../utils/title-generator";
 import { aggregateVibeWorkerTokensPerSecond, VibeSessionRegistry } from "../vibe/runtime";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
@@ -169,7 +176,12 @@ import {
 	parseLoopLimitArgs,
 } from "./loop-limit";
 import { OAuthManualInputManager } from "./oauth-manual-input";
-import { countRunningSubagentBadgeAgents, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
+import {
+	countRunningSubagentBadgeAgents,
+	getRunningSubagentBadgeRegistry,
+	handleRunningSubagentRegistryChange,
+	resolveTerminalTitleBaseState,
+} from "./running-subagent-badge";
 import {
 	type ObservableSession,
 	type SessionObserverChangeKind,
@@ -239,6 +251,21 @@ function workingMessagePalettes(accent: WorkingMessageAccent): { main: ShimmerPa
 		workingMessagePaletteCache.set(accent, entry);
 	}
 	return entry;
+}
+
+export interface BuildSessionTerminalTitleOptionsInput {
+	showTitleState: boolean;
+	state: TerminalTitleRunState;
+	stateSymbol: string | undefined;
+}
+
+export function buildSessionTerminalTitleOptions(
+	input: BuildSessionTerminalTitleOptionsInput,
+): SessionTerminalTitleOptions {
+	return {
+		state: input.showTitleState ? input.state : "idle",
+		stateSymbol: input.showTitleState ? input.stateSymbol : undefined,
+	};
 }
 
 function renderWorkingMessage(message: string, accent?: WorkingMessageAccent): string {
@@ -356,6 +383,11 @@ class AnchoredLiveContainer extends Container implements NativeScrollbackLiveReg
 /** How long the ctrl+p model-role cycle chip track lingers above the editor
  *  before it auto-clears, mirroring the todo HUD's auto-clear timer. */
 const MODEL_CYCLE_TRACK_CLEAR_MS = 4000;
+const TERMINAL_TITLE_STATE_SYMBOL_KEYS = {
+	running: "status.running",
+	waiting: "status.pending",
+	needs_attention: "status.warning",
+} as const;
 
 const SUBAGENT_HUD_VISIBLE_LIMIT = 8;
 const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
@@ -491,7 +523,12 @@ export class InteractiveMode implements InteractiveModeContext {
 	lastAssistantUsage: Usage | undefined = undefined;
 	loadingAnimation: Loader | undefined = undefined;
 	autoCompactionLoader: Loader | undefined = undefined;
+	compactionLoader: Loader | undefined = undefined;
 	retryLoader: Loader | undefined = undefined;
+	#terminalTitleAttentionDepth = 0;
+	#terminalTitleRunningDepth = 0;
+	#terminalTitleOwner: "session" | "extension" = "session";
+	#planReviewTitleAttentionRelease: (() => void) | undefined;
 	#pendingWorkingMessage: string | undefined;
 	#workingMessageAccentCacheKey?: WorkingMessageAccentCacheKey;
 	#workingMessageAccentCacheValue?: WorkingMessageAccent;
@@ -599,6 +636,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.autoCompactionLoader) {
 			this.autoCompactionLoader.stop();
 			this.autoCompactionLoader = undefined;
+		}
+		if (this.compactionLoader) {
+			this.compactionLoader.stop();
+			this.compactionLoader = undefined;
 		}
 		if (this.retryLoader) {
 			this.retryLoader.stop();
@@ -971,7 +1012,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// the initial welcome frame does not append over the previous run's scrollback.
 		this.ui.start({ clearScrollback: options.clearInitialTerminalHistory === true });
 		pushTerminalTitle();
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		this.refreshTerminalTitle();
 		this.updateEditorBorderColor();
 		// Single side-effect point for title changes: every setSessionName caller
 		// (first-input titling, /rename, extension renames, plan seeding, replan
@@ -980,7 +1021,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// all of which can reach setSessionName during init.
 		this.#eventBusUnsubscribers.push(
 			this.sessionManager.onSessionNameChanged(() => {
-				setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+				this.refreshTerminalTitle();
 				this.#handleSessionAccentInputsChanged();
 			}),
 		);
@@ -1226,9 +1267,90 @@ export class InteractiveMode implements InteractiveModeContext {
 		resetCapabilities();
 		await this.refreshSkillState();
 		await this.refreshSlashCommandState(newCwd);
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		this.refreshTerminalTitle();
 		this.statusLine.invalidate();
 		this.ui.requestRender();
+	}
+
+	#terminalTitleBaseState(): Exclude<TerminalTitleRunState, "needs_attention"> {
+		const registry = getRunningSubagentBadgeRegistry(this.collabGuest);
+		return resolveTerminalTitleBaseState({
+			sessionStreaming: this.session.isStreaming,
+			sessionCompacting: this.session.isCompacting,
+			viewSessionStreaming: this.viewSession.isStreaming,
+			viewSessionCompacting: this.viewSession.isCompacting,
+			sessionPostPromptWork: this.session.hasPostPromptWork,
+			viewSessionPostPromptWork: this.viewSession.hasPostPromptWork,
+			collabHostStreaming: this.collabGuest?.state?.isStreaming === true,
+			hasLoadingAnimation: Boolean(this.loadingAnimation),
+			hasCompactionLoader: Boolean(this.compactionLoader),
+			hasAutoCompactionLoader: Boolean(this.autoCompactionLoader),
+			hasRetryLoader: Boolean(this.retryLoader),
+			runningTitleDepth: this.#terminalTitleRunningDepth,
+			hasInputCallback: Boolean(this.onInputCallback),
+			runningSubagentCount: countRunningSubagentBadgeAgents(registry),
+		});
+	}
+
+	#terminalTitleState(): TerminalTitleRunState {
+		if (this.#terminalTitleAttentionDepth > 0) {
+			return "needs_attention";
+		}
+		return this.#terminalTitleBaseState();
+	}
+
+	#terminalTitleStateSymbol(state: TerminalTitleRunState): string | undefined {
+		if (state === "idle") {
+			return undefined;
+		}
+		return theme.symbol(TERMINAL_TITLE_STATE_SYMBOL_KEYS[state]);
+	}
+
+	refreshTerminalTitle(options?: { sessionName?: string | undefined; cwd?: string | undefined }): void {
+		if (!this.settings.get("terminal.showTitleState") && this.#terminalTitleOwner === "extension") return;
+		const showTitleState = this.settings.get("terminal.showTitleState");
+		const state = showTitleState ? this.#terminalTitleState() : "idle";
+		// Collab lifecycle callbacks often refresh without args; keep the host title fields.
+		const titleOptions = options ?? this.collabGuest?.terminalTitleOptions;
+		this.#terminalTitleOwner = "session";
+		setSessionTerminalTitle(
+			titleOptions?.sessionName ?? this.sessionManager.getSessionName(),
+			titleOptions?.cwd ?? this.sessionManager.getCwd(),
+			buildSessionTerminalTitleOptions({
+				showTitleState,
+				state,
+				stateSymbol: this.#terminalTitleStateSymbol(state),
+			}),
+		);
+	}
+
+	setExtensionTerminalTitle(title: string): void {
+		this.#terminalTitleOwner = "extension";
+		setTerminalTitle(title);
+	}
+
+	pushTerminalTitleAttention(): () => void {
+		let released = false;
+		this.#terminalTitleAttentionDepth += 1;
+		this.refreshTerminalTitle();
+		return () => {
+			if (released) return;
+			released = true;
+			this.#terminalTitleAttentionDepth = Math.max(0, this.#terminalTitleAttentionDepth - 1);
+			this.refreshTerminalTitle();
+		};
+	}
+
+	pushTerminalTitleRunning(): () => void {
+		let released = false;
+		this.#terminalTitleRunningDepth += 1;
+		this.refreshTerminalTitle();
+		return () => {
+			if (released) return;
+			released = true;
+			this.#terminalTitleRunningDepth = Math.max(0, this.#terminalTitleRunningDepth - 1);
+			this.refreshTerminalTitle();
+		};
 	}
 
 	async getUserInput(): Promise<SubmittedUserInput> {
@@ -1238,8 +1360,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		const { promise, resolve } = Promise.withResolvers<SubmittedUserInput>();
 		this.onInputCallback = input => {
 			this.onInputCallback = undefined;
+			this.refreshTerminalTitle();
 			resolve(input);
 		};
+		this.refreshTerminalTitle();
 		this.#scheduleLoopAutoSubmit();
 		this.#scheduleGoalContinuation();
 
@@ -1649,7 +1773,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#agentRegistryUnsubscribe?.();
 			this.#agentRegistrySubscriptionTarget = registry;
 			this.#agentRegistryUnsubscribe = registry.onChange(() => {
-				this.syncRunningSubagentBadge();
+				handleRunningSubagentRegistryChange({
+					syncRunningSubagentBadge: () => this.syncRunningSubagentBadge(),
+					refreshTerminalTitle: options => this.refreshTerminalTitle(options),
+					requestRender: () => this.ui.requestRender(),
+				});
 			});
 		}
 		const count = countRunningSubagentBadgeAgents(registry);
@@ -2673,11 +2801,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			mouseTracking: false,
 		});
 		this.ui.setFocus(overlay);
+		this.#planReviewTitleAttentionRelease = this.pushTerminalTitleAttention();
 		this.ui.requestRender();
 		return promise;
 	}
 
 	#hidePlanReview(): void {
+		this.#planReviewTitleAttentionRelease?.();
+		this.#planReviewTitleAttentionRelease = undefined;
 		this.#planReviewOverlayHandle?.hide();
 		this.#planReviewOverlayHandle = undefined;
 		this.#planReviewOverlay = undefined;
@@ -4062,6 +4193,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				getSymbolTheme().spinnerFrames,
 			);
 			this.statusContainer.addChild(this.loadingAnimation);
+			this.refreshTerminalTitle();
 		} else if (!this.statusContainer.children.includes(this.loadingAnimation)) {
 			this.statusContainer.disposeChildren();
 			this.statusContainer.addChild(this.loadingAnimation);
@@ -4078,6 +4210,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (clearStatusContainer) {
 			this.statusContainer.disposeChildren();
 		}
+		this.refreshTerminalTitle();
 	}
 
 	setWorkingMessage(message?: string): void {

--- a/packages/coding-agent/src/modes/running-subagent-badge.ts
+++ b/packages/coding-agent/src/modes/running-subagent-badge.ts
@@ -1,4 +1,46 @@
 import { AgentRegistry } from "../registry/agent-registry";
+import type { TerminalTitleRunState } from "../utils/title-generator";
+
+export interface TerminalTitleBaseStateInput {
+	sessionStreaming: boolean;
+	sessionCompacting: boolean;
+	viewSessionStreaming: boolean;
+	viewSessionCompacting: boolean;
+	sessionPostPromptWork: boolean;
+	viewSessionPostPromptWork: boolean;
+	collabHostStreaming: boolean;
+	hasLoadingAnimation: boolean;
+	hasCompactionLoader: boolean;
+	hasAutoCompactionLoader: boolean;
+	hasRetryLoader: boolean;
+	runningTitleDepth: number;
+	hasInputCallback: boolean;
+	runningSubagentCount: number;
+}
+
+export function resolveTerminalTitleBaseState(
+	input: TerminalTitleBaseStateInput,
+): Exclude<TerminalTitleRunState, "needs_attention"> {
+	if (
+		input.sessionStreaming ||
+		input.sessionCompacting ||
+		input.viewSessionStreaming ||
+		input.viewSessionCompacting ||
+		input.sessionPostPromptWork ||
+		input.viewSessionPostPromptWork ||
+		input.collabHostStreaming ||
+		input.hasLoadingAnimation ||
+		input.hasCompactionLoader ||
+		input.hasAutoCompactionLoader ||
+		input.hasRetryLoader ||
+		input.runningTitleDepth > 0 ||
+		input.runningSubagentCount > 0
+	) {
+		return "running";
+	}
+	if (input.hasInputCallback) return "waiting";
+	return "idle";
+}
 
 export interface RunningSubagentRegistrySource {
 	agentRegistry: AgentRegistry;
@@ -10,4 +52,16 @@ export function getRunningSubagentBadgeRegistry(collabGuest: RunningSubagentRegi
 
 export function countRunningSubagentBadgeAgents(registry: AgentRegistry): number {
 	return registry.list().filter(ref => ref.kind === "sub" && ref.status === "running").length;
+}
+
+export interface RunningSubagentRegistryChangeHandlers {
+	syncRunningSubagentBadge(): void;
+	refreshTerminalTitle(options?: { sessionName?: string | undefined; cwd?: string | undefined }): void;
+	requestRender(): void;
+}
+
+export function handleRunningSubagentRegistryChange(handlers: RunningSubagentRegistryChangeHandlers): void {
+	handlers.syncRunningSubagentBadge();
+	handlers.refreshTerminalTitle();
+	handlers.requestRender();
 }

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -192,6 +192,7 @@ export interface InteractiveModeContext {
 	lastAssistantUsage: Usage | undefined;
 	loadingAnimation: Loader | undefined;
 	autoCompactionLoader: Loader | undefined;
+	compactionLoader: Loader | undefined;
 	retryLoader: Loader | undefined;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: SubmittedUserInput) => void;
@@ -218,6 +219,10 @@ export interface InteractiveModeContext {
 	init(options?: InteractiveModeInitOptions): Promise<void>;
 	playWelcomeIntro(): void;
 	shutdown(): Promise<void>;
+	refreshTerminalTitle(options?: { sessionName?: string | undefined; cwd?: string | undefined }): void;
+	setExtensionTerminalTitle(title: string): void;
+	pushTerminalTitleAttention(): () => void;
+	pushTerminalTitleRunning(): () => void;
 	checkShutdownRequested(): Promise<void>;
 
 	// Extension UI integration

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -692,6 +692,7 @@ export type AgentSessionEvent =
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }
 	| { type: "irc_message"; message: CustomMessage }
+	| { type: "post_prompt_work_drained" }
 	| { type: "notice"; level: "info" | "warning" | "error"; message: string; source?: string }
 	| {
 			type: "thinking_level_changed";
@@ -5179,6 +5180,7 @@ export class AgentSession {
 		this.#postPromptTasksResolve();
 		this.#postPromptTasksResolve = undefined;
 		this.#postPromptTasksPromise = undefined;
+		this.#emit({ type: "post_prompt_work_drained" });
 	}
 
 	#trackPostPromptTask(task: Promise<unknown>): void {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -373,9 +373,29 @@ function getFallbackTerminalTitle(cwd: string | undefined): string | undefined {
 	return sanitizeTerminalTitlePart(baseName);
 }
 
-export function formatSessionTerminalTitle(sessionName: string | undefined, cwd?: string): string {
+export type TerminalTitleRunState = "idle" | "running" | "waiting" | "needs_attention";
+
+export interface SessionTerminalTitleOptions {
+	state?: TerminalTitleRunState;
+	stateSymbol?: string;
+}
+
+const DEFAULT_TERMINAL_TITLE_STATE_SYMBOLS = {
+	running: "●",
+	waiting: "○",
+	needs_attention: "!",
+} satisfies Record<Exclude<TerminalTitleRunState, "idle">, string>;
+
+export function formatSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options: SessionTerminalTitleOptions = {},
+): string {
 	const label = sanitizeTerminalTitlePart(sessionName) ?? getFallbackTerminalTitle(cwd);
-	return label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	const baseTitle = label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
+	if (!options.state || options.state === "idle") return baseTitle;
+	const symbol = sanitizeTerminalTitlePart(options.stateSymbol ?? DEFAULT_TERMINAL_TITLE_STATE_SYMBOLS[options.state]);
+	return symbol ? `${symbol} ${baseTitle}` : baseTitle;
 }
 
 /**
@@ -386,8 +406,12 @@ export function setTerminalTitle(title: string): void {
 	process.stdout.write(`\x1b]0;${sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE}\x07`);
 }
 
-export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
-	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
+export function setSessionTerminalTitle(
+	sessionName: string | undefined,
+	cwd?: string,
+	options?: SessionTerminalTitleOptions,
+): void {
+	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd, options));
 }
 
 /**

--- a/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
+++ b/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/collab/guest";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { type Component, Container } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -38,16 +39,28 @@ interface Fixture {
 	ctx: GuestIdleReconcilerCtx;
 	markActivityEnd: Mock<() => void>;
 	loaderStop: Mock<() => void>;
+	statusContainer: Container;
+	loader: Component | undefined;
 }
 
 function makeCtx(hasLoader: boolean): Fixture {
 	const markActivityEnd: Mock<() => void> = mock(() => {});
 	const loaderStop: Mock<() => void> = mock(() => {});
+	const statusContainer = new Container();
+	const loader = hasLoader
+		? ({
+				stop: loaderStop,
+				render: () => ["Working…"],
+				invalidate: () => {},
+			} as Component & { stop: () => void })
+		: undefined;
+	if (loader) statusContainer.addChild(loader);
 	const ctx: GuestIdleReconcilerCtx = {
 		statusLine: { markActivityEnd },
-		loadingAnimation: hasLoader ? { stop: loaderStop } : undefined,
+		statusContainer,
+		loadingAnimation: loader,
 	};
-	return { ctx, markActivityEnd, loaderStop };
+	return { ctx, markActivityEnd, loaderStop, statusContainer, loader };
 }
 
 function makeSession(): ConstructorParameters<typeof StatusLineComponent>[0] {
@@ -86,12 +99,13 @@ function makeSession(): ConstructorParameters<typeof StatusLineComponent>[0] {
 
 describe("reconcileGuestIdleHostState", () => {
 	it("closes the active-time window and stops the loader when the host reports idle", () => {
-		const { ctx, markActivityEnd, loaderStop } = makeCtx(true);
+		const { ctx, markActivityEnd, loaderStop, statusContainer, loader } = makeCtx(true);
 		reconcileGuestIdleHostState(ctx, false);
 		expect(markActivityEnd).toHaveBeenCalledTimes(1);
 		expect(loaderStop).toHaveBeenCalledTimes(1);
 		// Loader is cleared so a second reconciliation does not re-stop it.
 		expect(ctx.loadingAnimation).toBeUndefined();
+		expect(statusContainer.children).not.toContain(loader);
 	});
 
 	it("is a no-op while the host is still streaming so live turns keep the meter open", () => {
@@ -133,6 +147,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 
 		const ctx: GuestSnapshotActivityReconcilerCtx = {
 			statusLine,
+			statusContainer: new Container(),
 			loadingAnimation: undefined,
 		};
 		reconcileGuestSnapshotHostState(ctx, false);

--- a/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
+++ b/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
@@ -42,7 +42,13 @@ function makeAgents(ids: string[]): AgentSnapshot[] {
 	}));
 }
 
-function makeGuestContext(counts: number[]): InteractiveModeContext {
+type TitleRefreshRecord = {
+	options: { sessionName?: string | undefined; cwd?: string | undefined } | undefined;
+	hadLoader: boolean;
+	hasGuest: boolean;
+};
+
+function makeGuestContext(counts: number[], titleRefreshes: TitleRefreshRecord[]): InteractiveModeContext {
 	let statusLineCount = 0;
 	const ctx = {
 		collabGuest: undefined as CollabGuestLink | undefined,
@@ -63,13 +69,16 @@ function makeGuestContext(counts: number[]): InteractiveModeContext {
 				setDisableReasoning: () => {},
 			},
 		},
-		statusContainer: { clear: () => {} },
+		statusContainer: { clear: () => {}, removeChild: () => {} },
 		pendingMessagesContainer: { clear: () => {} },
 		compactionQueuedMessages: [],
 		streamingComponent: undefined,
 		streamingMessage: undefined,
 		pendingTools: new Map(),
 		loadingAnimation: undefined,
+		autoCompactionLoader: undefined,
+		compactionLoader: undefined,
+		retryLoader: undefined,
 		statusLine: {
 			setSubagentCount: (count: number) => {
 				statusLineCount = count;
@@ -93,6 +102,13 @@ function makeGuestContext(counts: number[]): InteractiveModeContext {
 		updateEditorTopBorder: () => {},
 		updateEditorBorderColor: () => {},
 		eventController: { handleEvent: () => Promise.resolve() },
+		refreshTerminalTitle: (options?: { sessionName?: string | undefined; cwd?: string | undefined }) => {
+			titleRefreshes.push({
+				options,
+				hadLoader: ctx.loadingAnimation !== undefined,
+				hasGuest: ctx.collabGuest !== undefined,
+			});
+		},
 		syncRunningSubagentBadge: () => {
 			const registry = getRunningSubagentBadgeRegistry(ctx.collabGuest);
 			const count = countRunningSubagentBadgeAgents(registry);
@@ -141,7 +157,8 @@ describe("collab guest running-subagents badge", () => {
 		await hostOpen.promise;
 
 		const counts: number[] = [];
-		const ctx = makeGuestContext(counts);
+		const titleRefreshes: TitleRefreshRecord[] = [];
+		const ctx = makeGuestContext(counts, titleRefreshes);
 		const guest = new CollabGuestLink(ctx);
 
 		try {
@@ -149,6 +166,59 @@ describe("collab guest running-subagents badge", () => {
 			expect(ctx.collabGuest).toBe(guest);
 			expect(counts).toEqual([0, 1]);
 			expect(ctx.statusLine.subagentCount).toBe(1);
+			expect(titleRefreshes).toEqual([
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: false },
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: true },
+			]);
+
+			let stoppedLoader = false;
+			const stateRefresh = Promise.withResolvers<void>();
+			const recordRefresh = ctx.refreshTerminalTitle.bind(ctx);
+			ctx.refreshTerminalTitle = options => {
+				recordRefresh(options);
+				stateRefresh.resolve();
+			};
+			ctx.loadingAnimation = {
+				stop: () => {
+					stoppedLoader = true;
+				},
+			} as unknown as typeof ctx.loadingAnimation;
+			hostSocket.send({ t: "state", state: { ...makeState(), sessionName: "renamed host", cwd: "/renamed" } });
+			await stateRefresh.promise;
+			expect(stoppedLoader).toBe(true);
+			expect(guest.terminalTitleOptions).toEqual({ sessionName: "renamed host", cwd: "/renamed" });
+			expect(titleRefreshes.at(-1)).toEqual({
+				options: { sessionName: "renamed host", cwd: "/renamed" },
+				hadLoader: false,
+				hasGuest: true,
+			});
+
+			let autoCompactionStopped = false;
+			let compactionStopped = false;
+			let retryStopped = false;
+			let hadMaintenanceLoaderAtRefresh = true;
+			ctx.autoCompactionLoader = {
+				stop: () => {
+					autoCompactionStopped = true;
+				},
+			} as unknown as typeof ctx.autoCompactionLoader;
+			ctx.compactionLoader = {
+				stop: () => {
+					compactionStopped = true;
+				},
+			} as unknown as typeof ctx.compactionLoader;
+			ctx.retryLoader = {
+				stop: () => {
+					retryStopped = true;
+				},
+			} as unknown as typeof ctx.retryLoader;
+			const recordSnapshotRefresh = ctx.refreshTerminalTitle.bind(ctx);
+			ctx.refreshTerminalTitle = options => {
+				hadMaintenanceLoaderAtRefresh = Boolean(
+					ctx.autoCompactionLoader || ctx.compactionLoader || ctx.retryLoader,
+				);
+				recordSnapshotRefresh(options);
+			};
 
 			nextWelcomeAgents = makeAgents(["remote-one", "remote-two"]);
 			const secondSnapshot = Promise.withResolvers<void>();
@@ -160,11 +230,31 @@ describe("collab guest running-subagents badge", () => {
 			sendWelcome(nextWelcomeAgents);
 			await secondSnapshot.promise;
 			expect(ctx.statusLine.subagentCount).toBe(2);
+			expect(autoCompactionStopped).toBe(true);
+			expect(compactionStopped).toBe(true);
+			expect(retryStopped).toBe(true);
+			expect(ctx.autoCompactionLoader).toBeUndefined();
+			expect(ctx.compactionLoader).toBeUndefined();
+			expect(ctx.retryLoader).toBeUndefined();
+			expect(hadMaintenanceLoaderAtRefresh).toBe(false);
+			expect(titleRefreshes).toEqual([
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: false },
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: true },
+				{ options: { sessionName: "renamed host", cwd: "/renamed" }, hadLoader: false, hasGuest: true },
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: true },
+			]);
 
 			await guest.leave("test cleanup");
 			expect(ctx.collabGuest).toBeUndefined();
 			expect(ctx.statusLine.subagentCount).toBe(0);
 			expect(counts.at(-1)).toBe(0);
+			expect(titleRefreshes).toEqual([
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: false },
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: true },
+				{ options: { sessionName: "renamed host", cwd: "/renamed" }, hadLoader: false, hasGuest: true },
+				{ options: { sessionName: "host session", cwd: "/tmp" }, hadLoader: false, hasGuest: true },
+				{ options: undefined, hadLoader: false, hasGuest: false },
+			]);
 		} finally {
 			hostSocket.close();
 			writeSpy.mockRestore();

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -240,6 +240,7 @@ async function makeHarness(opts?: { readOnly?: boolean }): Promise<GuestUiHarnes
 		updateEditorTopBorder: () => {},
 		updateEditorBorderColor: () => {},
 		eventController: { handleEvent: () => Promise.resolve() },
+		refreshTerminalTitle: () => {},
 		syncRunningSubagentBadge: () => {},
 		showHookSelector: (
 			title: string,
@@ -472,6 +473,7 @@ function makeHostContext(): InteractiveModeContext {
 		},
 		ui: { requestRender: () => {} },
 		showStatus: () => {},
+		pushTerminalTitleAttention: () => () => {},
 		collabHost: undefined,
 	} as unknown as InteractiveModeContext;
 }

--- a/packages/coding-agent/test/compaction-lifecycle.test.ts
+++ b/packages/coding-agent/test/compaction-lifecycle.test.ts
@@ -20,7 +20,7 @@ import { Container, Spacer } from "@oh-my-pi/pi-tui";
  * in-memory Container instances and a session stub whose `compact()` outcome we
  * drive.
  */
-function buildCtx(compact: InteractiveModeContext["session"]["compact"]) {
+function buildCtx(compact: InteractiveModeContext["session"]["compact"], opts?: { sessionCompacting?: boolean }) {
 	const chatContainer = new Container();
 	const statusContainer = new Container();
 	// Pre-existing transcript content. The regression we defend leaked an extra
@@ -37,16 +37,22 @@ function buildCtx(compact: InteractiveModeContext["session"]["compact"]) {
 		statusChildrenAtRebuild = statusContainer.children.length;
 	});
 	const showError = vi.fn();
+	const showWarning = vi.fn();
+	const refreshTerminalTitle = vi.fn();
 	const ctx = {
 		loadingAnimation: undefined,
+		compactionLoader: undefined,
 		chatContainer,
 		statusContainer,
 		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
-		session: { compact },
+		session: { compact, isCompacting: opts?.sessionCompacting ?? false },
+		viewSession: { isCompacting: false },
 		rebuildChatFromMessages,
+		refreshTerminalTitle,
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
 		showError,
+		showWarning,
 		flushCompactionQueue: vi.fn(async () => undefined),
 		// executeCompaction consults display.collapseCompacted on the ok path to
 		// decide whether the rebuild replaces the terminal transcript.
@@ -58,7 +64,9 @@ function buildCtx(compact: InteractiveModeContext["session"]["compact"]) {
 		chatContainer,
 		statusContainer,
 		rebuildChatFromMessages,
+		refreshTerminalTitle,
 		showError,
+		showWarning,
 		statusAtRebuild: () => statusChildrenAtRebuild,
 	};
 }
@@ -82,6 +90,31 @@ describe("executeCompaction UI lifecycle", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("refreshes the terminal title while the manual compaction loader is active", async () => {
+		let ctx: InteractiveModeContext | undefined;
+		let refreshTerminalTitle: { mock: { calls: unknown[][] } } | undefined;
+		let loaderDuringCompact: unknown;
+		let refreshCountDuringCompact = 0;
+		const compact = vi.fn(async (): Promise<CompactionResult<unknown>> => {
+			if (!ctx || !refreshTerminalTitle) throw new Error("Expected context");
+			loaderDuringCompact = ctx.compactionLoader;
+			refreshCountDuringCompact = refreshTerminalTitle.mock.calls.length;
+			return { summary: "", firstKeptEntryId: "", tokensBefore: 0 };
+		});
+		const built = buildCtx(compact);
+		ctx = built.ctx;
+		refreshTerminalTitle = built.refreshTerminalTitle;
+
+		const controller = new CommandController(ctx);
+		const outcome = await controller.executeCompaction();
+
+		expect(outcome).toBe("ok");
+		expect(loaderDuringCompact).toBeDefined();
+		expect(refreshCountDuringCompact).toBe(1);
+		expect(ctx.compactionLoader).toBeUndefined();
+		expect(built.refreshTerminalTitle).toHaveBeenCalledTimes(2);
 	});
 
 	it("leaves the transcript untouched and drains the loader when compaction is cancelled", async () => {
@@ -122,5 +155,45 @@ describe("executeCompaction UI lifecycle", () => {
 		// finally that runs afterward: the status container was already empty at
 		// the instant rebuildChatFromMessages ran (1 leaked loader without the fix).
 		expect(statusAtRebuild()).toBe(0);
+	});
+
+	it("stops and releases a stale compaction loader before installing a new one", async () => {
+		const compact = vi.fn(
+			async (): Promise<CompactionResult<unknown>> => ({ summary: "", firstKeptEntryId: "", tokensBefore: 0 }),
+		);
+		const { ctx } = buildCtx(compact);
+		const staleStop = vi.fn();
+		// A loader left behind by an aborted flow: no compaction is running, so
+		// executeCompaction must reclaim ownership instead of leaking its ticker.
+		const staleLoader = { stop: staleStop } as unknown as InteractiveModeContext["compactionLoader"];
+		ctx.compactionLoader = staleLoader;
+
+		const controller = new CommandController(ctx);
+		const outcome = await controller.executeCompaction();
+
+		expect(outcome).toBe("ok");
+		expect(staleStop).toHaveBeenCalledTimes(1);
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(ctx.compactionLoader).toBeUndefined();
+	});
+
+	it("rejects a second compaction while an active one owns the loader", async () => {
+		const compact = vi.fn(
+			async (): Promise<CompactionResult<unknown>> => ({ summary: "", firstKeptEntryId: "", tokensBefore: 0 }),
+		);
+		const { ctx, showWarning } = buildCtx(compact, { sessionCompacting: true });
+		const activeStop = vi.fn();
+		const activeLoader = { stop: activeStop } as unknown as InteractiveModeContext["compactionLoader"];
+		ctx.compactionLoader = activeLoader;
+
+		const controller = new CommandController(ctx);
+		const outcome = await controller.executeCompaction();
+
+		expect(outcome).toBe("failed");
+		expect(showWarning).toHaveBeenCalledWith("Compaction already in progress.");
+		// The in-flight compaction keeps its loader: not stopped, not replaced.
+		expect(activeStop).not.toHaveBeenCalled();
+		expect(ctx.compactionLoader).toBe(activeLoader);
+		expect(compact).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -101,6 +101,7 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		updateEditorTopBorder: vi.fn(),
 		updatePendingMessagesDisplay: vi.fn(),
 		ensureLoadingAnimation: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
 		statusContainer,
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,

--- a/packages/coding-agent/test/event-controller-todo-reminder.test.ts
+++ b/packages/coding-agent/test/event-controller-todo-reminder.test.ts
@@ -24,6 +24,7 @@ function createContext() {
 		// handlers). Leaving it false matches the implicit assumption in this
 		// fixture: the todo HUD lifecycle is independent of the working loader.
 		viewSession: { isStreaming: false },
+		refreshTerminalTitle: vi.fn(),
 		setTodos: vi.fn(),
 		present,
 	} as unknown as InteractiveModeContext;

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -75,6 +75,7 @@ function createControllerContext() {
 		editorContainer,
 		ui,
 		hookEditor: undefined,
+		pushTerminalTitleAttention: vi.fn(() => vi.fn()),
 	} as unknown as TestContext;
 
 	return { ctx, editor, editorContainer, ui };

--- a/packages/coding-agent/test/issue-927-repro.test.ts
+++ b/packages/coding-agent/test/issue-927-repro.test.ts
@@ -10,7 +10,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { setTerminalHeadless, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("issue #927 optimistic pending spinner", () => {
 	let authStorage: AuthStorage;
@@ -72,5 +72,53 @@ describe("issue #927 optimistic pending spinner", () => {
 		expect(mode.optimisticUserMessageSignature).toBeUndefined();
 		expect(mode.locallySubmittedUserSignatures.has("/extension-no-turn\u00000")).toBe(false);
 		expect(mode.statusContainer.children.length).toBe(0);
+	});
+
+	it("refreshes the terminal title around pending-submission loaders", () => {
+		const refreshTerminalTitle = vi.spyOn(mode, "refreshTerminalTitle");
+
+		mode.startPendingSubmission({ text: "cancel me" });
+		expect(mode.loadingAnimation).toBeDefined();
+
+		mode.cancelPendingSubmission();
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(refreshTerminalTitle).toHaveBeenCalledTimes(2);
+	});
+
+	it("preserves hook-owned titles until terminal state titles are enabled", () => {
+		const previousHeadless = setTerminalHeadless(false);
+		const originalTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		try {
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			const write = process.stdout.write as typeof process.stdout.write & {
+				mock: { calls: unknown[][] };
+				mockClear(): void;
+			};
+
+			mode.refreshTerminalTitle();
+			expect(write.mock.calls.at(-1)?.[0]).toEqual(expect.stringMatching(/^\x1b]0;π:/));
+			write.mockClear();
+
+			mode.setExtensionTerminalTitle("hook title");
+			expect(write.mock.calls.at(-1)?.[0]).toBe("\x1b]0;hook title\x07");
+			write.mockClear();
+
+			mode.refreshTerminalTitle();
+			expect(write.mock.calls).toEqual([]);
+
+			mode.settings.set("terminal.showTitleState", true);
+			mode.startPendingSubmission({ text: "running title" });
+
+			const titleWrites = write.mock.calls.map(call => String(call[0]));
+			expect(titleWrites.some(title => title.startsWith("\x1b]0;") && title !== "\x1b]0;hook title\x07")).toBe(true);
+		} finally {
+			setTerminalHeadless(previousHeadless);
+			if (originalTTY) {
+				Object.defineProperty(process.stdout, "isTTY", originalTTY);
+			} else {
+				Reflect.deleteProperty(process.stdout, "isTTY");
+			}
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
@@ -78,6 +78,7 @@ function createContext(
 		statusContainer: { clear: vi.fn() },
 		statusLine: { invalidate: vi.fn(), markActivityStart: vi.fn(), markActivityEnd: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
 		editor: { getText: () => options.editorText ?? "" },
 		sessionManager: { getSessionName: () => options.sessionName },
 		todoPhases: options.todoPhases ?? [],

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -23,6 +23,7 @@ function createContext() {
 		setWorkingMessage,
 		clearPinnedError: vi.fn(),
 		ensureLoadingAnimation,
+		refreshTerminalTitle: vi.fn(),
 		ui: { requestRender: vi.fn() },
 		session,
 		viewSession: session,

--- a/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
@@ -71,6 +71,7 @@ function createContext(options: { terminalProgress?: boolean } = {}) {
 		showStatus: vi.fn(),
 		showWarning: vi.fn(),
 		showError: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
 		editor: { getText: () => "" },
 		sessionManager: { getSessionName: () => "test-session" },
 		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn(), terminal: { setProgress } },

--- a/packages/coding-agent/test/modes/controllers/event-controller-superseded-agent-end.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-superseded-agent-end.test.ts
@@ -34,6 +34,7 @@ function createContext() {
 		editor: { getText: () => "" },
 		sessionManager: { getSessionName: () => "test-session" },
 		ensureLoadingAnimation: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
 		ui: { requestRender: vi.fn() },
 		viewSession: { isCompacting: false, getLastAssistantMessage: () => undefined },
 		session: {

--- a/packages/coding-agent/test/modes/controllers/event-controller-title-state.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-title-state.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+function createContext() {
+	const streamState = { isStreaming: false };
+	const compactionState = { isCompacting: false };
+	const children: unknown[] = [];
+	const statusContainer = {
+		children,
+		clear() {
+			children.length = 0;
+		},
+		disposeChildren() {
+			children.length = 0;
+		},
+		addChild(child: unknown) {
+			children.push(child);
+		},
+		removeChild(child: unknown) {
+			const index = children.indexOf(child);
+			if (index !== -1) children.splice(index, 1);
+		},
+	};
+	const ctx = {
+		isInitialized: true,
+		settings: { get: (path: string) => path === "terminal.showProgress" && false },
+		statusLine: { invalidate: vi.fn(), markActivityStart: vi.fn(), markActivityEnd: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		pendingTools: new Map<string, unknown>(),
+		hideThinkingBlock: false,
+		setWorkingMessage: vi.fn(),
+		clearPinnedError: vi.fn(),
+		loadingAnimation: undefined,
+		autoCompactionLoader: undefined,
+		retryLoader: undefined,
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		statusContainer,
+		chatContainer: { removeChild: vi.fn(), clear: vi.fn() },
+		flushPendingModelSwitch: vi.fn(async () => {}),
+		flushCompactionQueue: vi.fn(async () => {}),
+		rebuildChatFromMessages: vi.fn(),
+		reloadTodos: vi.fn(async () => {}),
+		showStatus: vi.fn(),
+		showWarning: vi.fn(),
+		showError: vi.fn(),
+		editor: { getText: () => "" },
+		sessionManager: { getSessionName: () => "test-session" },
+		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		viewSession: {
+			get isCompacting() {
+				return compactionState.isCompacting;
+			},
+			getLastAssistantMessage: () => undefined,
+		},
+		session: {
+			get isStreaming() {
+				return streamState.isStreaming;
+			},
+			get isCompacting() {
+				return compactionState.isCompacting;
+			},
+			getToolByName: () => undefined,
+		},
+		flushPendingCommandOutput: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
+	} as unknown as InteractiveModeContext & { refreshTerminalTitle: ReturnlessMock };
+	ctx.ensureLoadingAnimation = vi.fn(() => {
+		if (ctx.loadingAnimation) return;
+		statusContainer.clear();
+		ctx.loadingAnimation = { stop: vi.fn() } as unknown as typeof ctx.loadingAnimation;
+		statusContainer.addChild(ctx.loadingAnimation);
+	});
+	return { ctx, streamState, compactionState };
+}
+
+type ReturnlessMock = ReturnlessFn & { mock: { calls: unknown[][] } };
+type ReturnlessFn = () => void;
+
+const AGENT_START = { type: "agent_start" } as unknown as AgentSessionEvent;
+const AGENT_END = { type: "agent_end" } as unknown as AgentSessionEvent;
+const COMPACTION_START = {
+	type: "auto_compaction_start",
+	reason: "overflow",
+	action: "context-full",
+} as unknown as AgentSessionEvent;
+const COMPACTION_END = {
+	type: "auto_compaction_end",
+	action: "context-full",
+	result: { summary: "s", shortSummary: "s", tokensBefore: 10, details: {}, firstKeptEntryId: undefined },
+	willRetry: false,
+} as unknown as AgentSessionEvent;
+const POST_PROMPT_WORK_DRAINED = { type: "post_prompt_work_drained" } as unknown as AgentSessionEvent;
+
+describe("EventController terminal title state", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("refreshes the terminal title around running lifecycle events", async () => {
+		const { ctx, streamState } = createContext();
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent(AGENT_START);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(1);
+
+		streamState.isStreaming = true;
+		await controller.handleEvent(COMPACTION_START);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(2);
+
+		await controller.handleEvent(COMPACTION_END);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(3);
+
+		streamState.isStreaming = false;
+		await controller.handleEvent(AGENT_END);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(4);
+	});
+
+	it("refreshes the terminal title when post-prompt work drains", async () => {
+		const { ctx } = createContext();
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent(POST_PROMPT_WORK_DRAINED);
+
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(1);
+		expect(ctx.ui.requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers the idle title refresh until auto-compaction clears its session flag", async () => {
+		const { ctx, compactionState } = createContext();
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent(COMPACTION_START);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(1);
+
+		compactionState.isCompacting = true;
+		await controller.handleEvent(COMPACTION_END);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(1);
+
+		compactionState.isCompacting = false;
+		vi.advanceTimersByTime(0);
+		expect(ctx.refreshTerminalTitle).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller-title-state.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller-title-state.test.ts
@@ -1,0 +1,271 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type {
+	ExtensionCommandContextActions,
+	ExtensionContextActions,
+	ExtensionUIContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { ExtensionUiController } from "@oh-my-pi/pi-coding-agent/modes/controllers/extension-ui-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { type Component, Container } from "@oh-my-pi/pi-tui";
+
+function createContext() {
+	const editor = { id: "core-editor", getText: vi.fn(() => "draft"), setText: vi.fn() };
+	const editorContainer = {
+		children: [] as unknown[],
+		clear() {
+			this.children = [];
+		},
+		addChild(child: unknown) {
+			this.children.push(child);
+		},
+	};
+	const release = vi.fn();
+	const pushTerminalTitleAttention = vi.fn(() => release);
+	const ctx = {
+		editor,
+		editorContainer,
+		ui: {
+			requestRender: vi.fn(),
+			setFocus: vi.fn(),
+			terminal: { rows: 40, columns: 120 },
+		},
+		hookSelector: undefined,
+		pushTerminalTitleAttention,
+	} as unknown as InteractiveModeContext & {
+		pushTerminalTitleAttention: () => () => void;
+	};
+	return { ctx, release, pushTerminalTitleAttention };
+}
+
+describe("ExtensionUiController terminal title attention", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	it("marks hook selectors as needing attention until they close", async () => {
+		const { ctx, release, pushTerminalTitleAttention } = createContext();
+		const controller = new ExtensionUiController(ctx);
+		const abortController = new AbortController();
+
+		const promise = controller.showHookSelector("Approval required", ["Approve", "Deny"], {
+			signal: abortController.signal,
+		});
+
+		expect(pushTerminalTitleAttention).toHaveBeenCalledTimes(1);
+
+		abortController.abort();
+		await promise;
+
+		expect(release).toHaveBeenCalledTimes(1);
+	});
+
+	it("holds the attention token across a deferred custom UI until done() fires", async () => {
+		const { ctx, release, pushTerminalTitleAttention } = createContext();
+		const controller = new ExtensionUiController(ctx);
+		const mounted = Promise.withResolvers<void>();
+		const dispose = vi.fn();
+		// Minimal stand-in for a mounted extension component; only dispose is
+		// exercised by the close path under test.
+		const component = { dispose } as unknown as Component & { dispose?(): void };
+		let done: ((result: string) => void) | undefined;
+
+		const promise = controller.showHookCustom<string>(async (_tui, _theme, _keybindings, doneFn) => {
+			done = doneFn;
+			await mounted.promise;
+			return component;
+		});
+
+		// needs_attention is claimed synchronously, before the component mounts.
+		expect(pushTerminalTitleAttention).toHaveBeenCalledTimes(1);
+		expect(release).not.toHaveBeenCalled();
+
+		mounted.resolve();
+		await Promise.resolve();
+		if (!done) throw new Error("Expected done callback");
+		done("picked");
+
+		expect(await promise).toBe("picked");
+		expect(release).toHaveBeenCalledTimes(1);
+		expect(dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("releases the attention token when the custom UI factory rejects", async () => {
+		const { ctx, release, pushTerminalTitleAttention } = createContext();
+		const controller = new ExtensionUiController(ctx);
+		const failure = new Error("factory exploded");
+
+		const promise = controller.showHookCustom<string>(async () => {
+			throw failure;
+		});
+
+		expect(pushTerminalTitleAttention).toHaveBeenCalledTimes(1);
+		await expect(promise).rejects.toBe(failure);
+		expect(release).toHaveBeenCalledTimes(1);
+	});
+
+	it("settles done() and releases the token exactly once when component dispose throws", async () => {
+		const { ctx, release, pushTerminalTitleAttention } = createContext();
+		const controller = new ExtensionUiController(ctx);
+		const dispose = vi.fn(() => {
+			throw new Error("dispose exploded");
+		});
+		const component = { dispose } as unknown as Component & { dispose?(): void };
+		let done: ((result: string) => void) | undefined;
+
+		const promise = controller.showHookCustom<string>((_tui, _theme, _keybindings, doneFn) => {
+			done = doneFn;
+			return component;
+		});
+		await Promise.resolve();
+		expect(pushTerminalTitleAttention).toHaveBeenCalledTimes(1);
+		if (!done) throw new Error("Expected done callback");
+
+		// A throwing extension dispose is contained: the promise still resolves
+		// with the done() result and the attention token is released exactly once.
+		done("survived");
+
+		expect(await promise).toBe("survived");
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(release).toHaveBeenCalledTimes(1);
+	});
+
+	it("contains a throwing dispose from a late component after done() won the race", async () => {
+		const { ctx, release } = createContext();
+		const controller = new ExtensionUiController(ctx);
+		const mounted = Promise.withResolvers<void>();
+		const disposed = Promise.withResolvers<void>();
+		const lateDispose = vi.fn(() => {
+			disposed.resolve();
+			throw new Error("late dispose exploded");
+		});
+		const lateComponent = { dispose: lateDispose } as unknown as Component & { dispose?(): void };
+
+		const promise = controller.showHookCustom<string>(async (_tui, _theme, _keybindings, doneFn) => {
+			// Settle before the component ever materializes.
+			doneFn("early");
+			await mounted.promise;
+			return lateComponent;
+		});
+
+		expect(await promise).toBe("early");
+		expect(release).toHaveBeenCalledTimes(1);
+
+		// The component arrives after settlement; its throwing dispose is
+		// contained and must not double-release or produce an unhandled rejection.
+		mounted.resolve();
+		await disposed.promise;
+
+		expect(lateDispose).toHaveBeenCalledTimes(1);
+		expect(release).toHaveBeenCalledTimes(1);
+	});
+	for (const initializer of ["hooks", "custom-tools"] as const) {
+		it(`refreshes the terminal title when ${initializer} new-session setup is cancelled`, async () => {
+			let commandActions: ExtensionCommandContextActions | undefined;
+			const refreshTerminalTitle = vi.fn();
+			const extensionRunner = {
+				initialize(
+					_actions: unknown,
+					_contextActions: unknown,
+					capturedCommandActions: ExtensionCommandContextActions,
+				): void {
+					commandActions = capturedCommandActions;
+				},
+				onError: vi.fn(),
+				emit: vi.fn(async () => {}),
+			};
+			const ctx = {
+				session: {
+					extensionRunner,
+					newSession: vi.fn(async () => false),
+				},
+				setToolUIContext: vi.fn(),
+				clearTransientSessionUi: vi.fn(),
+				refreshTerminalTitle,
+				hookWidgetContainerAbove: new Container(),
+				hookWidgetContainerBelow: new Container(),
+				ui: { requestRender: vi.fn() },
+				editor: {
+					setText: vi.fn(),
+					handleInput: vi.fn(),
+					getText: vi.fn(() => ""),
+				},
+				setWorkingMessage: vi.fn(),
+				setEditorComponent: vi.fn(),
+				toolOutputExpanded: false,
+				setToolsExpanded: vi.fn(),
+			} as unknown as InteractiveModeContext;
+			const controller = new ExtensionUiController(ctx);
+
+			if (initializer === "hooks") {
+				controller.initializeHookRunner({} as ExtensionUIContext, false);
+			} else {
+				await controller.initHooksAndCustomTools();
+			}
+			if (!commandActions) throw new Error("Expected extension command actions");
+
+			await commandActions.newSession();
+
+			expect(refreshTerminalTitle).toHaveBeenCalledTimes(1);
+		});
+	}
+
+	for (const settle of ["resolves", "rejects"] as const) {
+		it(`refreshes the terminal title immediately and after extension compact ${settle}`, async () => {
+			let contextActions: ExtensionContextActions | undefined;
+			const refreshTerminalTitle = vi.fn();
+			const compaction = Promise.withResolvers<void>();
+			const extensionRunner = {
+				initialize(
+					_actions: unknown,
+					capturedContextActions: ExtensionContextActions,
+					_commandActions: unknown,
+				): void {
+					contextActions = capturedContextActions;
+				},
+				onError: vi.fn(),
+				emit: vi.fn(async () => {}),
+			};
+			const ctx = {
+				session: {
+					extensionRunner,
+					compact: vi.fn(() => compaction.promise),
+				},
+				setToolUIContext: vi.fn(),
+				refreshTerminalTitle,
+				hookWidgetContainerAbove: new Container(),
+				hookWidgetContainerBelow: new Container(),
+				ui: { requestRender: vi.fn() },
+				editor: {
+					setText: vi.fn(),
+					handleInput: vi.fn(),
+					getText: vi.fn(() => ""),
+				},
+				setWorkingMessage: vi.fn(),
+				setEditorComponent: vi.fn(),
+				toolOutputExpanded: false,
+				setToolsExpanded: vi.fn(),
+			} as unknown as InteractiveModeContext;
+			const controller = new ExtensionUiController(ctx);
+			await controller.initHooksAndCustomTools();
+			if (!contextActions) throw new Error("Expected extension context actions");
+
+			const run = contextActions.compact("shrink it");
+			// The title flips before the compaction settles: the promise is captured
+			// and the refresh fires synchronously.
+			expect(refreshTerminalTitle).toHaveBeenCalledTimes(1);
+
+			if (settle === "resolves") {
+				compaction.resolve();
+				await run;
+			} else {
+				const failure = new Error("compaction exploded");
+				compaction.reject(failure);
+				await expect(run).rejects.toBe(failure);
+			}
+
+			// Settled either way: the finally-refresh clears the compacting title.
+			expect(refreshTerminalTitle).toHaveBeenCalledTimes(2);
+		});
+	}
+});

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -42,6 +42,7 @@ describe("/handoff command", () => {
 			if (isGeneratingHandoff) abortHandoff();
 		});
 		const requestRender = vi.fn();
+		const releaseTerminalTitleRunning = vi.fn();
 		const ctx = {
 			sessionManager: {
 				getEntries: () => [{ type: "message" }, { type: "message" }],
@@ -64,6 +65,7 @@ describe("/handoff command", () => {
 			ui: { requestRender, requestComponentRender: vi.fn() },
 			editor: { onEscape: originalOnEscape },
 			rebuildChatFromMessages: vi.fn(),
+			pushTerminalTitleRunning: vi.fn(() => releaseTerminalTitleRunning),
 			statusLine: { invalidate: vi.fn() },
 			updateEditorTopBorder: vi.fn(),
 			updateEditorBorderColor: vi.fn(),
@@ -88,6 +90,8 @@ describe("/handoff command", () => {
 		expect(statusContainer.children).toHaveLength(0);
 		expect(ctx.editor.onEscape).toBe(originalOnEscape);
 		expect(ctx.session.handoff).toHaveBeenCalledWith("focus on tests");
+		expect(ctx.pushTerminalTitleRunning).toHaveBeenCalledTimes(1);
+		expect(releaseTerminalTitleRunning).toHaveBeenCalledTimes(1);
 	});
 
 	it("refuses to hand off while a response is streaming", async () => {

--- a/packages/coding-agent/test/modes/controllers/local-loader-title-state.test.ts
+++ b/packages/coding-agent/test/modes/controllers/local-loader-title-state.test.ts
@@ -1,0 +1,148 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { type Component, Container } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+function deferred<T>() {
+	const { promise, resolve } = Promise.withResolvers<T>();
+	return { promise, resolve };
+}
+
+describe("local maintenance loaders terminal title state", () => {
+	it("marks the terminal title running while handoff generation owns a local loader", async () => {
+		const releaseTitleRunning = vi.fn();
+		const handoff = deferred<{ savedPath?: string } | undefined>();
+		const ctx = {
+			session: { isStreaming: false, handoff: vi.fn(() => handoff.promise) },
+			sessionManager: { getEntries: () => [{ type: "message" }, { type: "message" }] },
+			loadingAnimation: undefined,
+			statusContainer: new Container(),
+			ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+			rebuildChatFromMessages: vi.fn(),
+			statusLine: { invalidate: vi.fn() },
+			updateEditorTopBorder: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			reloadTodos: vi.fn(async () => {}),
+			present: vi.fn(),
+			showStatus: vi.fn(),
+			pushTerminalTitleRunning: vi.fn(() => releaseTitleRunning),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		const run = controller.handleHandoffCommand();
+		await Promise.resolve();
+		expect(ctx.pushTerminalTitleRunning).toHaveBeenCalledTimes(1);
+		expect(releaseTitleRunning).not.toHaveBeenCalled();
+
+		handoff.resolve({});
+		await run;
+		expect(releaseTitleRunning).toHaveBeenCalledTimes(1);
+	});
+
+	it("refreshes the terminal title when new session hooks cancel after a local loader stops", async () => {
+		const loader = { stop: vi.fn(), setMessage: vi.fn() };
+		const bag = {
+			session: {
+				isStreaming: false,
+				isCompacting: false,
+				newSession: vi.fn(async () => false),
+			},
+			loadingAnimation: loader as { stop(): void } | undefined,
+			autoCompactionLoader: undefined,
+			statusContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+			clearOptimisticUserMessage: vi.fn(),
+			applyPendingWorkingMessage: vi.fn(),
+			refreshTerminalTitle: vi.fn(),
+			clearTransientSessionUi: vi.fn(() => {
+				bag.loadingAnimation?.stop();
+				bag.loadingAnimation = undefined;
+			}),
+		};
+		const ctx = bag as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		await controller.handleClearCommand();
+
+		expect(loader.stop).toHaveBeenCalledTimes(1);
+		expect(bag.refreshTerminalTitle).toHaveBeenCalledTimes(1);
+		expect(bag.ui.requestRender).not.toHaveBeenCalled();
+	});
+
+	it("marks the terminal title running while branch summarization owns a local loader", async () => {
+		const releaseTitleRunning = vi.fn();
+		const navigation = deferred<{ aborted?: boolean; cancelled?: boolean; editorText?: string }>();
+		settings.set("branchSummary.enabled", true);
+		let focusedComponent: Component | undefined;
+		const editorContainer = new Container();
+		const editor = { getText: () => "", setText: vi.fn(), onEscape: undefined as (() => void) | undefined };
+		const ctx = {
+			session: {
+				navigateTree: vi.fn(() => navigation.promise),
+				abortBranchSummary: vi.fn(),
+			},
+			sessionManager: {
+				getTree: () => [
+					{
+						entry: {
+							type: "message",
+							id: "entry-1",
+							parentId: null,
+							timestamp: "2026-01-01T00:00:00.000Z",
+							message: { role: "user", content: "hello" },
+						},
+						children: [],
+					},
+				],
+				getLeafId: () => null,
+				appendLabelChange: vi.fn(),
+			},
+			ui: {
+				terminal: { rows: 30 },
+				setFocus: vi.fn((component: Component) => {
+					focusedComponent = component;
+				}),
+				requestRender: vi.fn(),
+				requestComponentRender: vi.fn(),
+			},
+			editor,
+			editorContainer,
+			chatContainer: new Container(),
+			statusContainer: new Container(),
+			showHookSelector: vi.fn(async () => "Summarize"),
+			showHookEditor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			renderInitialMessages: vi.fn(),
+			reloadTodos: vi.fn(async () => {}),
+			pushTerminalTitleRunning: vi.fn(() => releaseTitleRunning),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showTreeSelector();
+		focusedComponent?.handleInput?.("\n");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(ctx.pushTerminalTitleRunning).toHaveBeenCalledTimes(1);
+		expect(releaseTitleRunning).not.toHaveBeenCalled();
+
+		navigation.resolve({});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(releaseTitleRunning).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
+++ b/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
@@ -36,6 +36,7 @@ function createResumeContext(opts: { flushFails?: boolean; sourceCwd?: string } 
 		clearTransientSessionUi: vi.fn(),
 		applyCwdChange,
 		updateEditorBorderColor: vi.fn(),
+		refreshTerminalTitle: vi.fn(),
 		renderInitialMessages: vi.fn(),
 		reloadTodos: vi.fn(async () => {}),
 		showStatus: vi.fn(),

--- a/packages/coding-agent/test/selector-controller-tree-summary.test.ts
+++ b/packages/coding-agent/test/selector-controller-tree-summary.test.ts
@@ -97,6 +97,7 @@ function createHarness(summaryChoice = "No summary"): TreeSummaryHarness {
 		},
 		renderInitialMessages: vi.fn(),
 		reloadTodos: vi.fn(async () => {}),
+		pushTerminalTitleRunning: () => () => {},
 		session: {
 			navigateTree,
 			abortBranchSummary: vi.fn(),

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -54,6 +54,17 @@ describe("selector setting side effects", () => {
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 
+	it("refreshes the terminal title when title state display changes", () => {
+		const refreshTerminalTitle = vi.fn();
+		const controller = new SelectorController({
+			refreshTerminalTitle,
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("terminal.showTitleState", false);
+
+		expect(refreshTerminalTitle).toHaveBeenCalledTimes(1);
+	});
+
 	it("invalidates the UI and requests a repaint when tui.tight changes", () => {
 		const invalidate = vi.fn();
 		const requestRender = vi.fn();

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -50,6 +50,7 @@ interface Harness {
 		resetTranscriptAnchors: () => number;
 		renderInitialMessages: () => number;
 		mainUnsubscribe: () => number;
+		refreshTerminalTitle: () => number;
 	};
 }
 
@@ -61,6 +62,7 @@ function makeHarness(): Harness {
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
 	let mainUnsubscribe = 0;
+	let refreshTerminalTitle = 0;
 
 	const ctx = {
 		session: main.session,
@@ -88,6 +90,9 @@ function makeHarness(): Harness {
 			renderInitialMessages++;
 		},
 		updateEditorBorderColor() {},
+		refreshTerminalTitle: () => {
+			refreshTerminalTitle++;
+		},
 		ui: { requestRender() {} },
 		showStatus() {},
 		collabGuest: undefined,
@@ -109,6 +114,7 @@ function makeHarness(): Harness {
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
 			renderInitialMessages: () => renderInitialMessages,
 			mainUnsubscribe: () => mainUnsubscribe,
+			refreshTerminalTitle: () => refreshTerminalTitle,
 		},
 	};
 }
@@ -187,6 +193,18 @@ describe("SessionFocusController", () => {
 			[parent.session, "Parent"],
 			[h.main.session, undefined],
 		]);
+	});
+
+	it("refreshes terminal title state after the viewed session changes", async () => {
+		const h = makeHarness();
+		const worker = makeSessionStub();
+		registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
+
+		await h.controller.focusAgent("Worker");
+		expect(h.counts.refreshTerminalTitle()).toBe(1);
+
+		await h.controller.unfocus();
+		expect(h.counts.refreshTerminalTitle()).toBe(2);
 	});
 
 	it("parking the focused agent auto-unfocuses back to the main session", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -127,6 +127,12 @@ describe("Settings", () => {
 			expect(getDefault("terminal.showProgress")).toBe(false);
 		});
 
+		it("keeps terminal title state disabled by default", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("terminal.showTitleState")).toBe(false);
+			expect(getDefault("terminal.showTitleState")).toBe(false);
+		});
+
 		it("keeps the normal startup splash disabled by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("startup.showSplash")).toBe(false);

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import { formatSessionTerminalTitle, generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import { logger } from "@oh-my-pi/pi-utils";
 
 function getModelOrThrow(id: string): Model<Api> {
@@ -568,5 +568,38 @@ describe("title generator", () => {
 		await generateSessionTitle("Some message", registry, currentSettings);
 		expect(mockComplete).toHaveBeenCalled();
 		expect(mockComplete.mock.calls[0]?.[0]).toBe(smolModel);
+	});
+});
+describe("terminal title formatting", () => {
+	it("uses the session name when present", () => {
+		expect(formatSessionTerminalTitle("Build title state", "/tmp/repo")).toBe("π: Build title state");
+	});
+
+	it("uses the cwd basename when the session name is missing", () => {
+		expect(formatSessionTerminalTitle(undefined, "/tmp/repo")).toBe("π: repo");
+	});
+
+	it("prefixes running state", () => {
+		expect(formatSessionTerminalTitle("Build title state", "/tmp/repo", { state: "running", stateSymbol: "R" })).toBe(
+			"R π: Build title state",
+		);
+	});
+
+	it("prefixes waiting state", () => {
+		expect(formatSessionTerminalTitle("Build title state", "/tmp/repo", { state: "waiting", stateSymbol: "W" })).toBe(
+			"W π: Build title state",
+		);
+	});
+
+	it("prefixes needs-attention state", () => {
+		expect(
+			formatSessionTerminalTitle("Build title state", "/tmp/repo", { state: "needs_attention", stateSymbol: "!" }),
+		).toBe("! π: Build title state");
+	});
+
+	it("leaves idle state unprefixed", () => {
+		expect(formatSessionTerminalTitle("Build title state", "/tmp/repo", { state: "idle", stateSymbol: "X" })).toBe(
+			"π: Build title state",
+		);
 	});
 });


### PR DESCRIPTION
## What

- Prefix interactive terminal titles with the current run state when `terminal.showTitleState` is enabled.
- Track running, waiting-for-input, and needs-attention states from local interactive lifecycle events, dialogs, and plan review.
- Add formatter, settings, lifecycle, and dialog regression coverage.

## Why

Fixes #3587.

Related closed attempts #3643/#3644 were unmerged; this keeps collab guest title replication unchanged and refreshes maintenance title state after loader cleanup. #2718 also touches the terminal title formatter for cwd reporting, so this may need a rebase if that lands first.

## Testing

- `bun test packages/coding-agent/test/title-generator.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/modes/controllers/event-controller-title-state.test.ts packages/coding-agent/test/modes/controllers/extension-ui-controller-title-state.test.ts packages/coding-agent/test/event-controller-error-banner.test.ts packages/coding-agent/test/hook-editor.test.ts`
- `bun --cwd=packages/coding-agent run check`

- `bun --cwd=packages/coding-agent test test/modes/controllers/extension-ui-controller-title-state.test.ts test/selector-settings-side-effects.test.ts test/modes/controllers/event-controller-title-state.test.ts test/modes/controllers/local-loader-title-state.test.ts` (`33 pass, 0 fail`)
- `bun --cwd=packages/coding-agent run check:types`

Manual OSC title smoke was not run because this harness is not attached to a TTY.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
