### PR TITLE
fix(coding-agent): preserve queued skill invocations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/skill:` prompts submitted during compaction so they are re-invoked as user-attributed skill prompts instead of being dropped or treated as auto-invoked text.
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -13,9 +13,10 @@ import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { materializeImageReferenceLinks, shiftImageMarkers } from "../../modes/image-references";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
+import { invokeSkillCommandFromText, isKnownSkillCommand } from "../../modes/skill-command";
 import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
-import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails, USER_INTERRUPT_LABEL } from "../../session/messages";
+import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { isLowSignalTitleInput } from "../../tiny/text";
@@ -715,11 +716,18 @@ export class InputController {
 			}
 
 			// Handle skill commands (/skill:name [args]). Enter ⇒ steer (matches the
-			// free-text Enter semantics applied a few lines below at the streaming
-			// branch). Ctrl+Enter routes through `handleFollowUp` and dispatches the
-			// same helper with `"followUp"`.
-			if (text && (await this.#invokeSkillCommand(text, "steer"))) {
-				return;
+			// free-text Enter semantics below); Ctrl+Enter routes through `handleFollowUp`.
+			// During compaction, queue immediately so slash/python/loop-mode branches do
+			// not consume the skill before the compaction-resume path re-parses it.
+			if (text && isKnownSkillCommand(this.ctx, text)) {
+				if (this.ctx.session.isCompacting) {
+					const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
+					this.ctx.queueCompactionMessage(text, "steer", images);
+					return;
+				}
+				if (await this.#invokeSkillCommand(text, "steer")) {
+					return;
+				}
 			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
@@ -1086,47 +1094,15 @@ export class InputController {
 	 * ignores it.
 	 */
 	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		if (!text.startsWith("/skill:")) return false;
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skillPath = this.ctx.skillCommands?.get(commandName);
-		if (!skillPath) return false;
+		if (!isKnownSkillCommand(this.ctx, text)) return false;
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
-		try {
-			const content = await Bun.file(skillPath).text();
-			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-			const metaLines = [`Skill: ${skillPath}`];
-			if (args) {
-				metaLines.push(`User: ${args}`);
-			}
-			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-			const skillName = commandName.slice("skill:".length);
-			const details: SkillPromptDetails = {
-				name: skillName || commandName,
-				path: skillPath,
-				args: args || undefined,
-				lineCount: body ? body.split("\n").length : 0,
-			};
-			await this.ctx.session.promptCustomMessage(
-				{
-					customType: SKILL_PROMPT_MESSAGE_TYPE,
-					content: message,
-					display: true,
-					details,
-					attribution: "user",
-				},
-				{ streamingBehavior, queueChipText: text },
-			);
-			if (this.ctx.session.isStreaming) {
-				this.ctx.updatePendingMessagesDisplay();
-				this.ctx.ui.requestRender();
-			}
-		} catch (err) {
-			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+		const handled = await invokeSkillCommandFromText(this.ctx, text, streamingBehavior);
+		if (this.ctx.session.isStreaming) {
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
 		}
-		return true;
+		return handled;
 	}
 
 	async handleRetry(): Promise<void> {
@@ -1159,9 +1135,8 @@ export class InputController {
 		// Compaction first: while compacting, free text gets queued via
 		// `queueCompactionMessage`, and `/skill:*` rides the same queue so a
 		// skill typed during compaction is not lost or short-circuited through
-		// `promptCustomMessage`. The skill text is queued verbatim; whether
-		// the queued entry is later re-parsed into a skill invocation is a
-		// separate concern owned by the compaction-resume path.
+		// `promptCustomMessage`. The compaction-resume path re-parses the
+		// queued text into a user-attributed skill invocation before delivery.
 		if (this.ctx.session.isCompacting) {
 			const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 			this.ctx.queueCompactionMessage(text, "followUp", images);

--- a/packages/coding-agent/src/modes/skill-command.ts
+++ b/packages/coding-agent/src/modes/skill-command.ts
@@ -1,0 +1,101 @@
+import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../session/messages";
+import type { InteractiveModeContext } from "./types";
+
+type SkillCommandHost = Pick<InteractiveModeContext, "skillCommands" | "session" | "showError">;
+
+interface InvokeSkillCommandOptions {
+	propagateErrors?: boolean;
+}
+
+type SkillPromptMessage = {
+	customType: typeof SKILL_PROMPT_MESSAGE_TYPE;
+	content: string;
+	display: true;
+	details: SkillPromptDetails;
+	attribution: "user";
+};
+
+type SkillPromptOptions = {
+	streamingBehavior: "steer" | "followUp";
+	queueChipText: string;
+};
+
+export interface BuiltSkillCommandPrompt {
+	message: SkillPromptMessage;
+	options: SkillPromptOptions;
+}
+
+/** True iff `text` is `/skill:<name>` and `<name>` resolves in `ctx.skillCommands`. */
+export function isKnownSkillCommand(ctx: SkillCommandHost, text: string): boolean {
+	if (!text.startsWith("/skill:")) return false;
+	const spaceIndex = text.indexOf(" ");
+	const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	return ctx.skillCommands?.has(commandName) ?? false;
+}
+
+/**
+ * Parse `/skill:<name> [args]` and build the user-attributed skill-prompt
+ * custom message. Returns null when `text` is not a registered `/skill:`
+ * command, so callers can fall through to plain-text handling.
+ */
+export async function buildSkillCommandPrompt(
+	ctx: SkillCommandHost,
+	text: string,
+	streamingBehavior: "steer" | "followUp",
+): Promise<BuiltSkillCommandPrompt | null> {
+	if (!text.startsWith("/skill:")) return null;
+	const spaceIndex = text.indexOf(" ");
+	const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+	const skillPath = ctx.skillCommands?.get(commandName);
+	if (!skillPath) return null;
+	const content = await Bun.file(skillPath).text();
+	const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+	const metaLines = [`Skill: ${skillPath}`];
+	if (args) {
+		metaLines.push(`User: ${args}`);
+	}
+	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+	const skillName = commandName.slice("skill:".length);
+	const details: SkillPromptDetails = {
+		name: skillName || commandName,
+		path: skillPath,
+		args: args || undefined,
+		lineCount: body ? body.split("\n").length : 0,
+	};
+	return {
+		message: {
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: message,
+			display: true,
+			details,
+			attribution: "user",
+		},
+		options: { streamingBehavior, queueChipText: text },
+	};
+}
+
+/**
+ * Parse `/skill:<name> [args]` and invoke it as a user-attributed skill-prompt
+ * custom message. Returns false when `text` is not a known `/skill:` command,
+ * so callers can fall through to plain-text handling.
+ */
+export async function invokeSkillCommandFromText(
+	ctx: SkillCommandHost,
+	text: string,
+	streamingBehavior: "steer" | "followUp",
+	options?: InvokeSkillCommandOptions,
+): Promise<boolean> {
+	if (!isKnownSkillCommand(ctx, text)) return false;
+	try {
+		const built = await buildSkillCommandPrompt(ctx, text, streamingBehavior);
+		if (!built) return false;
+		await ctx.session.promptCustomMessage(built.message, built.options);
+	} catch (err) {
+		if (options?.propagateErrors) {
+			throw err;
+		}
+		ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	return true;
+}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -45,6 +45,7 @@ import {
 	type SkillPromptDetails,
 } from "../../session/messages";
 import type { SessionContext } from "../../session/session-context";
+import { buildSkillCommandPrompt, invokeSkillCommandFromText, isKnownSkillCommand } from "../skill-command";
 import { createAssistantMessageComponent } from "./interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
@@ -667,6 +668,9 @@ export class UiHelpers {
 	}
 
 	async #deliverQueuedMessage(message: CompactionQueuedMessage): Promise<void> {
+		if (await invokeSkillCommandFromText(this.ctx, message.text, message.mode, { propagateErrors: true })) {
+			return;
+		}
 		if (this.ctx.isKnownSlashCommand(message.text)) {
 			await this.ctx.session.prompt(message.text);
 			return;
@@ -765,18 +769,29 @@ export class UiHelpers {
 			// stranded in compactionQueuedMessages with no drainer.
 			//
 			// firstPrompt is fire-and-forget — its rejection is funneled through
-			// `restoreQueue` rather than rethrown, so we use the primitive
+			// `restoreQueue` rather than rethrown. Non-skill prompts use primitive
 			// recordLocalSubmission and dispose manually in the catch.
-			const disposeFirstPrompt = this.ctx.recordLocalSubmission(firstPrompt.text, firstPrompt.images?.length ?? 0);
-			const promptPromise = this.ctx.session
-				.prompt(firstPrompt.text, {
-					streamingBehavior: firstPrompt.mode === "followUp" ? "followUp" : "steer",
-					images: firstPrompt.images,
-				})
-				.catch((error: unknown) => {
-					disposeFirstPrompt();
-					restoreQueue(error);
-				});
+			let promptPromise: Promise<unknown>;
+			if (isKnownSkillCommand(this.ctx, firstPrompt.text)) {
+				const built = await buildSkillCommandPrompt(this.ctx, firstPrompt.text, firstPrompt.mode);
+				promptPromise = built
+					? this.ctx.session.promptCustomMessage(built.message, built.options).catch(restoreQueue)
+					: Promise.resolve();
+			} else {
+				const disposeFirstPrompt = this.ctx.recordLocalSubmission(
+					firstPrompt.text,
+					firstPrompt.images?.length ?? 0,
+				);
+				promptPromise = this.ctx.session
+					.prompt(firstPrompt.text, {
+						streamingBehavior: firstPrompt.mode === "followUp" ? "followUp" : "steer",
+						images: firstPrompt.images,
+					})
+					.catch((error: unknown) => {
+						disposeFirstPrompt();
+						restoreQueue(error);
+					});
+			}
 
 			for (const message of rest) {
 				await this.#deliverQueuedMessage(message);

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -14,8 +14,9 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { invokeSkillCommandFromText } from "@oh-my-pi/pi-coding-agent/modes/skill-command";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -28,6 +29,7 @@ type StubEditor = {
 	setText: (text: string) => void;
 	getText: () => string;
 	addToHistory: Mock<(...args: unknown[]) => unknown>;
+	clearDraft: (submittedText?: string) => void;
 	onSubmit?: (text: string) => Promise<void>;
 	pendingImages: ImageContent[];
 	pendingImageLinks: (string | undefined)[];
@@ -35,7 +37,13 @@ type StubEditor = {
 
 type PromptCustomMessage = Mock<
 	(
-		message: { details: SkillPromptDetails },
+		message: {
+			customType?: string;
+			content?: string;
+			display?: boolean;
+			attribution?: string;
+			details: SkillPromptDetails;
+		},
 		options?: { streamingBehavior?: "steer" | "followUp"; queueChipText?: string },
 	) => Promise<void>
 >;
@@ -46,7 +54,12 @@ async function writeSkillFile(dir: string, skillName: string, body: string): Pro
 	return skillPath;
 }
 
-function createStubInputControllerContext(opts: { skillCommands: Map<string, string>; isStreaming: boolean }) {
+function createStubInputControllerContext(opts: {
+	skillCommands: Map<string, string>;
+	isStreaming: boolean;
+	isCompacting?: boolean;
+	loopModeEnabled?: boolean;
+}) {
 	let editorText = "";
 	const editor: StubEditor = {
 		setText(text) {
@@ -54,6 +67,14 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 		},
 		getText() {
 			return editorText;
+		},
+		clearDraft(submittedText) {
+			if (submittedText !== undefined) {
+				editor.addToHistory(submittedText);
+			}
+			editorText = "";
+			editor.pendingImages = [];
+			editor.pendingImageLinks = [];
 		},
 		addToHistory: vi.fn(),
 		pendingImages: [] as ImageContent[],
@@ -65,31 +86,33 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
+	const queueCompactionMessage = vi.fn((_text: string, _mode: "steer" | "followUp", _images?: ImageContent[]) => {});
+	const session = {
+		isStreaming: opts.isStreaming,
+		isCompacting: opts.isCompacting ?? false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		extensionRunner: undefined,
+		prompt,
+		promptCustomMessage,
+	};
 
 	const ctx = {
 		editor,
 		ui: { requestRender },
 		skillCommands: opts.skillCommands,
-		session: {
-			isStreaming: opts.isStreaming,
-			isCompacting: false,
-			isBashRunning: false,
-			isEvalRunning: false,
-			extensionRunner: undefined,
-			prompt,
-			promptCustomMessage,
-		},
-		get viewSession() {
-			return (this as typeof ctx).session;
-		},
+		session,
+		viewSession: session,
 		showError,
 		handleGoalModeCommand,
 		goalModeEnabled: false,
 		updatePendingMessagesDisplay,
 		isBashMode: false,
 		isPythonMode: false,
-		loopModeEnabled: false,
+		loopModeEnabled: opts.loopModeEnabled ?? false,
+		loopPrompt: undefined as string | undefined,
 		compactionQueuedMessages: [],
+		queueCompactionMessage,
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
@@ -102,6 +125,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 		handleGoalModeCommand,
 		updatePendingMessagesDisplay,
 		requestRender,
+		queueCompactionMessage,
 	};
 }
 
@@ -186,6 +210,297 @@ describe("InputController skill queue chip metadata", () => {
 			queueChipText: "/skill:test-skill arg1 arg2",
 		});
 		expect(promptCustomMessage.mock.calls[0]?.[0].details.__queueChipText).toBeUndefined();
+	});
+});
+
+describe("compaction skill re-invocation", () => {
+	let tempDir: TempDir;
+	let skillCommands: Map<string, string>;
+
+	function firstPromptCustomCall(promptCustomMessage: PromptCustomMessage) {
+		const call = promptCustomMessage.mock.calls[0];
+		if (!call) {
+			throw new Error("expected promptCustomMessage to be called");
+		}
+		return call;
+	}
+
+	function createCompactionDrainContext(
+		queuedMessages: CompactionQueuedMessage[],
+		options?: { promptCustomMessageError?: Error; knownSlashCommands?: readonly string[] },
+	) {
+		const promptCustomMessageCalled = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const promptCustomMessage: PromptCustomMessage = vi.fn(async (_message, callOptions) => {
+			order.push(`skill:${callOptions?.queueChipText ?? ""}`);
+			promptCustomMessageCalled.resolve();
+			if (options?.promptCustomMessageError) {
+				throw options.promptCustomMessageError;
+			}
+		});
+		const prompt = vi.fn(
+			async (text: string, _options?: { streamingBehavior?: "steer" | "followUp"; images?: ImageContent[] }) => {
+				order.push(`prompt:${text}`);
+			},
+		);
+		const steer = vi.fn(async (text: string, _images?: ImageContent[]) => {
+			order.push(`steer:${text}`);
+		});
+		const followUp = vi.fn(async (text: string, _images?: ImageContent[]) => {
+			order.push(`followUp:${text}`);
+		});
+		const clearQueue = vi.fn();
+		const showError = vi.fn();
+		const updatePendingMessagesDisplay = vi.fn();
+		const isKnownSlashCommand = vi.fn((text: string) => options?.knownSlashCommands?.includes(text) ?? false);
+		const recordLocalSubmission = vi.fn((_text: string, _imageCount: number) => vi.fn());
+		const withLocalSubmission = vi.fn(async (_text: string, fn: () => unknown) => Promise.resolve(fn()));
+		const session = {
+			promptCustomMessage,
+			prompt,
+			steer,
+			followUp,
+			clearQueue,
+		};
+		const ctx = {
+			skillCommands,
+			compactionQueuedMessages: queuedMessages,
+			updatePendingMessagesDisplay,
+			showError,
+			isKnownSlashCommand,
+			recordLocalSubmission,
+			withLocalSubmission,
+			session,
+		} as unknown as InteractiveModeContext;
+		return {
+			ctx,
+			promptCustomMessage,
+			promptCustomMessageCalled: promptCustomMessageCalled.promise,
+			prompt,
+			steer,
+			followUp,
+			showError,
+			clearQueue,
+			order,
+			updatePendingMessagesDisplay,
+			recordLocalSubmission,
+			withLocalSubmission,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-skill-compaction-stub-");
+		const skillPath = await writeSkillFile(tempDir.path(), "test-skill", "Do the thing.");
+		skillCommands = new Map<string, string>([["skill:test-skill", skillPath]]);
+	});
+
+	afterEach(() => {
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	it("invokes known skill commands as user-attributed skill prompts", async () => {
+		const { ctx, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+		const skillPath = skillCommands.get("skill:test-skill");
+		if (!skillPath) {
+			throw new Error("test skill command was not registered");
+		}
+
+		const handled = await invokeSkillCommandFromText(ctx, "/skill:test-skill arg1 arg2", "steer");
+
+		expect(handled).toBe(true);
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		const [message, options] = firstPromptCustomCall(promptCustomMessage);
+		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message.display).toBe(true);
+		expect(message.attribution).toBe("user");
+		expect(message.content).toContain("Do the thing.");
+		expect(message.details).toMatchObject({
+			name: "test-skill",
+			path: skillPath,
+			args: "arg1 arg2",
+			lineCount: 1,
+		});
+		expect(options).toEqual({
+			streamingBehavior: "steer",
+			queueChipText: "/skill:test-skill arg1 arg2",
+		});
+	});
+
+	it("leaves unknown skill and non-skill text for plain prompt handling", async () => {
+		const { ctx, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+
+		expect(await invokeSkillCommandFromText(ctx, "/skill:nope", "steer")).toBe(false);
+		expect(await invokeSkillCommandFromText(ctx, "hello", "steer")).toBe(false);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+	});
+
+	it("re-invokes a lone compaction-queued skill instead of prompting literal text", async () => {
+		const { ctx, promptCustomMessage, promptCustomMessageCalled, prompt } = createCompactionDrainContext([
+			{ text: "/skill:test-skill", mode: "steer" },
+		]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		const [message] = firstPromptCustomCall(promptCustomMessage);
+		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message.attribution).toBe("user");
+		expect(prompt.mock.calls.map(call => call[0])).not.toContain("/skill:test-skill");
+	});
+
+	it("submits a skill first prompt before draining later queued text", async () => {
+		const { ctx, promptCustomMessageCalled, order } = createCompactionDrainContext([
+			{ text: "/skill:test-skill", mode: "steer" },
+			{ text: "after skill", mode: "steer" },
+		]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		expect(order).toEqual(["skill:/skill:test-skill", "steer:after skill"]);
+	});
+
+	it("preserves follow-up mode for a non-retry skill first prompt", async () => {
+		const { ctx, promptCustomMessage, promptCustomMessageCalled } = createCompactionDrainContext([
+			{ text: "/skill:test-skill", mode: "followUp" },
+		]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		const [, options] = firstPromptCustomCall(promptCustomMessage);
+		expect(options).toEqual({
+			streamingBehavior: "followUp",
+			queueChipText: "/skill:test-skill",
+		});
+	});
+
+	it("restores a compaction-queued skill when custom-message dispatch fails", async () => {
+		const queuedMessages: CompactionQueuedMessage[] = [{ text: "/skill:test-skill", mode: "steer" }];
+		const promptError = new Error("model is unavailable");
+		const { ctx, promptCustomMessageCalled, clearQueue, showError } = createCompactionDrainContext(queuedMessages, {
+			promptCustomMessageError: promptError,
+		});
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(clearQueue).toHaveBeenCalledTimes(1);
+		expect(ctx.compactionQueuedMessages).toEqual(queuedMessages);
+		expect(showError.mock.calls[0]?.[0]).toContain("model is unavailable");
+	});
+
+	it("restores willRetry queued skills when custom-message dispatch fails", async () => {
+		const queuedMessages: CompactionQueuedMessage[] = [{ text: "/skill:test-skill", mode: "followUp" }];
+		const { ctx, clearQueue, showError } = createCompactionDrainContext(queuedMessages, {
+			promptCustomMessageError: new Error("follow-up unavailable"),
+		});
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: true });
+
+		expect(clearQueue).toHaveBeenCalledTimes(1);
+		expect(ctx.compactionQueuedMessages).toEqual(queuedMessages);
+		expect(showError.mock.calls[0]?.[0]).toContain("follow-up unavailable");
+	});
+
+	it("restores later queued skills when custom-message dispatch fails", async () => {
+		const queuedMessages: CompactionQueuedMessage[] = [
+			{ text: "hello", mode: "steer" },
+			{ text: "/skill:test-skill", mode: "steer" },
+		];
+		const { ctx, promptCustomMessageCalled, clearQueue, showError } = createCompactionDrainContext(queuedMessages, {
+			promptCustomMessageError: new Error("later skill unavailable"),
+		});
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		expect(clearQueue).toHaveBeenCalledTimes(1);
+		expect(ctx.compactionQueuedMessages).toEqual(queuedMessages);
+		expect(showError.mock.calls[0]?.[0]).toContain("later skill unavailable");
+	});
+
+	it("re-invokes willRetry follow-up skills with follow-up streaming behavior", async () => {
+		const { ctx, promptCustomMessage } = createCompactionDrainContext([
+			{ text: "/skill:test-skill", mode: "followUp" },
+		]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: true });
+
+		const [message, options] = firstPromptCustomCall(promptCustomMessage);
+		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message.attribution).toBe("user");
+		expect(options).toEqual({
+			streamingBehavior: "followUp",
+			queueChipText: "/skill:test-skill",
+		});
+	});
+
+	it("keeps regular first prompts and re-invokes later queued skills", async () => {
+		const { ctx, promptCustomMessage, prompt } = createCompactionDrainContext([
+			{ text: "hello", mode: "steer" },
+			{ text: "/skill:test-skill", mode: "steer" },
+		]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+
+		expect(prompt.mock.calls[0]?.[0]).toBe("hello");
+		const [message] = firstPromptCustomCall(promptCustomMessage);
+		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message.attribution).toBe("user");
+		expect(prompt.mock.calls.map(call => call[0])).not.toContain("/skill:test-skill");
+	});
+
+	it("runs known slash precommands before a skill first prompt", async () => {
+		const { ctx, promptCustomMessageCalled, prompt, order } = createCompactionDrainContext(
+			[
+				{ text: "/known", mode: "steer" },
+				{ text: "/skill:test-skill", mode: "steer" },
+			],
+			{ knownSlashCommands: ["/known"] },
+		);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		expect(prompt).toHaveBeenCalledWith("/known");
+		expect(order).toEqual(["prompt:/known", "skill:/skill:test-skill"]);
+	});
+
+	it("queues Enter-submitted skills during compaction before loop mode can consume them", async () => {
+		const { ctx, editor, promptCustomMessage, queueCompactionMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: true,
+			isCompacting: true,
+			loopModeEnabled: true,
+		});
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill");
+		await editor.onSubmit?.("/skill:test-skill");
+
+		expect(queueCompactionMessage).toHaveBeenCalledWith("/skill:test-skill", "steer", undefined);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+		expect(ctx.loopPrompt).toBeUndefined();
 	});
 });
 
@@ -450,6 +765,14 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		getText() {
 			return editorText;
 		},
+		clearDraft(submittedText) {
+			if (submittedText !== undefined) {
+				editor.addToHistory(submittedText);
+			}
+			editorText = "";
+			editor.pendingImages = [];
+			editor.pendingImageLinks = [];
+		},
 		addToHistory: vi.fn(),
 		pendingImages: [] as ImageContent[],
 		pendingImageLinks: [] as (string | undefined)[],
@@ -480,8 +803,10 @@ describe("UiHelpers / InputController against derived queued custom display", ()
 
 	beforeEach(async () => {
 		const themeInstance = await getThemeByName("dark");
-		expect(themeInstance).toBeDefined();
-		setThemeInstance(themeInstance!);
+		if (!themeInstance) {
+			throw new Error("dark theme is not registered");
+		}
+		setThemeInstance(themeInstance);
 	});
 
 	afterEach(async () => {
@@ -526,6 +851,7 @@ function createEventControllerFixture() {
 	const updatePendingMessagesDisplay = vi.fn();
 	const addMessageToChat = vi.fn();
 	const requestRender = vi.fn();
+	const session = {};
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
@@ -535,10 +861,8 @@ function createEventControllerFixture() {
 		addMessageToChat,
 		updatePendingMessagesDisplay,
 		pendingTools: new Map(),
-		session: {},
-		get viewSession() {
-			return (this as typeof ctx).session;
-		},
+		session,
+		viewSession: session,
 	} as unknown as InteractiveModeContext;
 
 	const controller = new EventController(ctx);


### PR DESCRIPTION
## What

- Re-parse compaction-queued `/skill:` prompts through the skill custom-message path instead of sending them as literal text.
- Queue Enter-submitted known skills immediately during compaction so bash/python/loop-mode handling cannot consume them first.
- Split skill command handling into a build step plus dispatch so skill first-prompts are submitted before later queued messages drain.
- Add regression tests for user attribution, first-prompt ordering, follow-up mode, dispatch failure restoration, known slash precommands, and loop-mode compaction handling.

## Why

A `/skill:` entered during auto-compaction could be dropped or later treated like model auto-invoked plain text. The compaction queue stored only `{ text, mode, images }`, and resume drained it through `prompt`/`steer`/`followUp` instead of rebuilding the `skill-prompt` custom message with `attribution: "user"`.

Closes #3697

## Verification

- `cd packages/coding-agent && bun check`
- `cd packages/coding-agent && bun test test/input-controller-skill-queue.test.ts test/issue-825-repro.test.ts test/input-controller-compaction-image.test.ts test/compaction-lifecycle.test.ts`

## Commit

| Commit | Summary |
| --- | --- |
| `01ef3ee` | `fix(coding-agent): preserve queued skill invocations` |
