### PR TITLE
fix(coding-agent): present user-invoked skills as user turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed user-invoked `/skill:` prompts sent via steer, follow-up, or direct invocation to reach the model as user-initiated messages instead of sharing the developer/system role used by auto-applied skills.
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -563,6 +563,12 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			case "developer":
 			case "assistant":
 			case "toolResult": {
+				// User-invoked `/skill:` must reach the model as a user turn; auto-applied/read skills stay developer.
+				if (m.role === "custom" && m.customType === SKILL_PROMPT_MESSAGE_TYPE && m.attribution === "user") {
+					const content = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
+					return [{ role: "user", content, attribution: "user", timestamp: m.timestamp }];
+				}
+
 				// Core roles share one transformer with agent-core —
 				// duplicating them here is how snapcompact frames once
 				// silently fell off the provider request.

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -240,7 +240,27 @@ describe("convertToLlm custom message mapping", () => {
 		expect(converted[0].content.filter(content => content.type === "image")).toEqual([image]);
 	});
 
-	it("allows custom messages to opt into user attribution", () => {
+	it("keeps non-skill user-attributed custom messages on the developer role", () => {
+		const messages: AgentMessage[] = [
+			{
+				role: "custom",
+				customType: "ultrathink-notice",
+				content: "User requested deeper reasoning",
+				display: true,
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		];
+
+		const converted = convertToLlm(messages);
+
+		expect(converted).toHaveLength(1);
+		expect(converted[0]?.role).toBe("developer");
+		expectAttribution(converted[0], "user");
+		expect(inferCopilotInitiator(converted)).toBe("user");
+	});
+
+	it("maps user-invoked skill prompts to the user role", () => {
 		const messages: AgentMessage[] = [
 			{
 				role: "custom",
@@ -255,9 +275,14 @@ describe("convertToLlm custom message mapping", () => {
 		const converted = convertToLlm(messages);
 
 		expect(converted).toHaveLength(1);
-		expect(converted[0]?.role).toBe("developer");
+		expect(converted[0]?.role).toBe("user");
 		expectAttribution(converted[0], "user");
 		expect(inferCopilotInitiator(converted)).toBe("user");
+		if (converted[0]?.role !== "user" || !Array.isArray(converted[0].content)) {
+			throw new Error("Expected user array content");
+		}
+		const text = converted[0].content.find(content => content.type === "text")?.text ?? "";
+		expect(text).toContain("Run this skill with my arguments");
 	});
 });
 


### PR DESCRIPTION
## What

- Map user-attributed `/skill:` prompt messages to LLM-facing `role: "user"` in the coding-agent conversion seam.
- Keep auto/legacy skill prompts and other user-attributed custom messages on the existing developer-message path.
- Add regression coverage for both sides of that split.

## Why

User-invoked skills already carried `attribution: "user"` internally, but most providers do not surface that attribution to the model. Because the generic custom-message conversion emitted `role: "developer"`, the model could not distinguish a user-requested skill from an auto-applied skill. Presenting only user-invoked skill prompts as user turns makes the initiating actor visible to every provider.

This is separate from #3692, which preserves queued `/skill:` attribution during compaction. This PR changes the model-facing role after attribution has already been preserved.

Closes #3698

## Commits

| Commit | Change |
| --- | --- |
| `6283cc9bf` | `fix(coding-agent): present user-invoked skills as user turns` |

## Verification

- `cd packages/coding-agent && bun test test/session-messages.test.ts test/agent-session-skill-keywords.test.ts test/agent-session-before-agent-start-attribution.test.ts`
- `cd packages/coding-agent && bun check`
