### PR TITLE
fix(coding-agent): present user skill prompts as user turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed user-invoked `/skill:` prompts reaching model providers as developer turns instead of user turns. ([#3698](https://github.com/can1357/oh-my-pi/issues/3698))
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { convertToLlm, SKILL_PROMPT_MESSAGE_TYPE, type CustomMessage, type SkillPromptDetails } from "./messages";
+
+function customMessage(
+	customType: string,
+	attribution: "agent" | "user",
+): CustomMessage<SkillPromptDetails> {
+	return {
+		role: "custom",
+		customType,
+		content: "Use this skill.",
+		display: true,
+		details: { name: "atomic-commit", path: "/tmp/SKILL.md", lineCount: 1 },
+		attribution,
+		timestamp: 1,
+	};
+}
+
+describe("convertToLlm", () => {
+	it("presents user-invoked skill prompts as user turns", () => {
+		const [message] = convertToLlm([customMessage(SKILL_PROMPT_MESSAGE_TYPE, "user")]);
+
+		expect(message?.role).toBe("user");
+		if (message?.role !== "user") {
+			throw new Error(`Expected user role, received ${message?.role ?? "none"}`);
+		}
+		expect(message.attribution).toBe("user");
+	});
+
+	it("keeps auto-applied skill prompts and other custom messages as developer turns", () => {
+		const [autoSkill, otherCustom] = convertToLlm([
+			customMessage(SKILL_PROMPT_MESSAGE_TYPE, "agent"),
+			customMessage("extension-note", "user"),
+		]);
+
+		expect(autoSkill?.role).toBe("developer");
+		expect(otherCustom?.role).toBe("developer");
+	});
+});

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { convertToLlm, SKILL_PROMPT_MESSAGE_TYPE, type CustomMessage, type SkillPromptDetails } from "./messages";
+import { type CustomMessage, convertToLlm, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "./messages";
 
-function customMessage(
-	customType: string,
-	attribution: "agent" | "user",
-): CustomMessage<SkillPromptDetails> {
+function customMessage(customType: string, attribution: "agent" | "user"): CustomMessage<SkillPromptDetails> {
 	return {
 		role: "custom",
 		customType,

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -481,6 +481,16 @@ export function sanitizeRehydratedOpenAIResponsesAssistantMessage(message: Assis
 	};
 }
 
+function customMessageContentToLlmContent(
+	content: CustomMessage["content"],
+): (TextContent | ImageContent)[] {
+	return typeof content === "string" ? [{ type: "text", text: content }] : content;
+}
+
+function isUserInvokedSkillPrompt(message: CustomMessage): boolean {
+	return message.customType === SKILL_PROMPT_MESSAGE_TYPE && message.attribution === "user";
+}
+
 /**
  * Transform AgentMessages (including custom types) to LLM-compatible Messages.
  *
@@ -555,7 +565,20 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				}
 				return out;
 			}
-			case "custom":
+			case "custom": {
+				if (isUserInvokedSkillPrompt(m)) {
+					return [
+						{
+							role: "user",
+							content: customMessageContentToLlmContent(m.content),
+							attribution: "user",
+							timestamp: m.timestamp,
+						},
+					];
+				}
+				const converted = convertMessageToLlm(m);
+				return converted ? [converted] : [];
+			}
 			case "hookMessage":
 			case "branchSummary":
 			case "compactionSummary":

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -481,9 +481,7 @@ export function sanitizeRehydratedOpenAIResponsesAssistantMessage(message: Assis
 	};
 }
 
-function customMessageContentToLlmContent(
-	content: CustomMessage["content"],
-): (TextContent | ImageContent)[] {
+function customMessageContentToLlmContent(content: CustomMessage["content"]): (TextContent | ImageContent)[] {
 	return typeof content === "string" ? [{ type: "text", text: content }] : content;
 }
 


### PR DESCRIPTION
## Repro
A focused regression test constructs a `customType: "skill-prompt"` message with `attribution: "user"` and runs `bun test packages/coding-agent/src/session/messages.test.ts`; before the fix it failed because `convertToLlm` returned role `developer` instead of `user`.

## Cause
`packages/coding-agent/src/session/messages.ts` delegated every `custom` message to `@oh-my-pi/pi-agent-core/compaction/messages` `convertMessageToLlm`, whose generic custom-message conversion always emits a developer-role model message while only preserving the attribution metadata.

## Fix
- Added a coding-agent conversion seam for user-attributed `skill-prompt` custom messages that emits a user-role LLM message.
- Kept auto-applied skill prompts and non-skill custom messages on the existing developer-role path.
- Added regression coverage for both the remapped user skill prompt and unchanged developer-framed custom prompt cases.
- Added the coding-agent changelog entry for #3698.

## Verification
`bun test packages/coding-agent/src/session/messages.test.ts` passed with 2 tests; `bun run check:types` passed in `packages/coding-agent`. Fixes #3698