### PR TITLE
fix(coding-agent): preserve queued skill invocations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/skill:` prompts submitted during compaction so they are re-invoked as user-attributed skill prompts instead of being dropped or treated as plain text.
+
 ## [16.2.2] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -13,9 +13,10 @@ import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { materializeImageReferenceLinks, shiftImageMarkers } from "../../modes/image-references";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
+import { invokeSkillCommandFromText, isKnownSkillCommand } from "../../modes/skill-command";
 import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
-import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails, USER_INTERRUPT_LABEL } from "../../session/messages";
+import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { isLowSignalTitleInput } from "../../tiny/text";
@@ -715,11 +716,18 @@ export class InputController {
 			}
 
 			// Handle skill commands (/skill:name [args]). Enter ⇒ steer (matches the
-			// free-text Enter semantics applied a few lines below at the streaming
-			// branch). Ctrl+Enter routes through `handleFollowUp` and dispatches the
-			// same helper with `"followUp"`.
-			if (text && (await this.#invokeSkillCommand(text, "steer"))) {
-				return;
+			// free-text Enter semantics below); Ctrl+Enter routes through `handleFollowUp`.
+			// During compaction, queue immediately so bash/python/loop-mode branches do
+			// not consume the skill before the compaction-resume path re-parses it.
+			if (text && isKnownSkillCommand(this.ctx, text)) {
+				if (this.ctx.session.isCompacting) {
+					const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
+					this.ctx.queueCompactionMessage(text, "steer", images);
+					return;
+				}
+				if (await this.#invokeSkillCommand(text, "steer")) {
+					return;
+				}
 			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
@@ -1086,47 +1094,15 @@ export class InputController {
 	 * ignores it.
 	 */
 	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		if (!text.startsWith("/skill:")) return false;
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skillPath = this.ctx.skillCommands?.get(commandName);
-		if (!skillPath) return false;
+		if (!isKnownSkillCommand(this.ctx, text)) return false;
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
-		try {
-			const content = await Bun.file(skillPath).text();
-			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-			const metaLines = [`Skill: ${skillPath}`];
-			if (args) {
-				metaLines.push(`User: ${args}`);
-			}
-			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-			const skillName = commandName.slice("skill:".length);
-			const details: SkillPromptDetails = {
-				name: skillName || commandName,
-				path: skillPath,
-				args: args || undefined,
-				lineCount: body ? body.split("\n").length : 0,
-			};
-			await this.ctx.session.promptCustomMessage(
-				{
-					customType: SKILL_PROMPT_MESSAGE_TYPE,
-					content: message,
-					display: true,
-					details,
-					attribution: "user",
-				},
-				{ streamingBehavior, queueChipText: text },
-			);
-			if (this.ctx.session.isStreaming) {
-				this.ctx.updatePendingMessagesDisplay();
-				this.ctx.ui.requestRender();
-			}
-		} catch (err) {
-			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+		const handled = await invokeSkillCommandFromText(this.ctx, text, streamingBehavior);
+		if (this.ctx.session.isStreaming) {
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
 		}
-		return true;
+		return handled;
 	}
 
 	async handleRetry(): Promise<void> {
@@ -1159,9 +1135,8 @@ export class InputController {
 		// Compaction first: while compacting, free text gets queued via
 		// `queueCompactionMessage`, and `/skill:*` rides the same queue so a
 		// skill typed during compaction is not lost or short-circuited through
-		// `promptCustomMessage`. The skill text is queued verbatim; whether
-		// the queued entry is later re-parsed into a skill invocation is a
-		// separate concern owned by the compaction-resume path.
+		// `promptCustomMessage`. The compaction-resume path re-parses the
+		// queued text into a user-attributed skill invocation before delivery.
 		if (this.ctx.session.isCompacting) {
 			const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 			this.ctx.queueCompactionMessage(text, "followUp", images);

--- a/packages/coding-agent/src/modes/skill-command.ts
+++ b/packages/coding-agent/src/modes/skill-command.ts
@@ -1,3 +1,4 @@
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../session/messages";
 import type { InteractiveModeContext } from "./types";
 
@@ -8,7 +9,7 @@ type SkillPromptMessage = Pick<
 	"customType" | "content" | "display" | "details" | "attribution"
 > & {
 	customType: typeof SKILL_PROMPT_MESSAGE_TYPE;
-	content: string;
+	content: string | (TextContent | ImageContent)[];
 	display: true;
 	details: SkillPromptDetails;
 	attribution: "user";
@@ -27,6 +28,7 @@ interface ParsedSkillCommand {
 interface InvokeSkillCommandOptions {
 	propagateErrors?: boolean;
 	queueOnly?: boolean;
+	images?: ImageContent[];
 }
 
 /** Built custom-message payload and delivery options for a `/skill:` command. */
@@ -55,6 +57,7 @@ export async function buildSkillCommandPrompt(
 	ctx: SkillCommandHost,
 	text: string,
 	streamingBehavior: "steer" | "followUp",
+	images?: ImageContent[],
 ): Promise<BuiltSkillCommandPrompt | undefined> {
 	const parsed = parseSkillCommand(text);
 	if (!parsed) return undefined;
@@ -68,6 +71,8 @@ export async function buildSkillCommandPrompt(
 		metaLines.push(`User: ${parsed.args}`);
 	}
 	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+	const textBlock: TextContent = { type: "text", text: message };
+	const promptContent = images && images.length > 0 ? [textBlock, ...images] : message;
 	const skillName = parsed.commandName.slice("skill:".length);
 	const details: SkillPromptDetails = {
 		name: skillName || parsed.commandName,
@@ -79,7 +84,7 @@ export async function buildSkillCommandPrompt(
 	return {
 		message: {
 			customType: SKILL_PROMPT_MESSAGE_TYPE,
-			content: message,
+			content: promptContent,
 			display: true,
 			details,
 			attribution: "user",
@@ -96,7 +101,7 @@ export async function invokeSkillCommandFromText(
 	options?: InvokeSkillCommandOptions,
 ): Promise<boolean> {
 	try {
-		const built = await buildSkillCommandPrompt(ctx, text, streamingBehavior);
+		const built = await buildSkillCommandPrompt(ctx, text, streamingBehavior, options?.images);
 		if (!built) return false;
 		const promptOptions = options?.queueOnly ? { ...built.options, queueOnly: true } : built.options;
 		await ctx.session.promptCustomMessage(built.message, promptOptions);

--- a/packages/coding-agent/src/modes/skill-command.ts
+++ b/packages/coding-agent/src/modes/skill-command.ts
@@ -26,6 +26,7 @@ interface ParsedSkillCommand {
 
 interface InvokeSkillCommandOptions {
 	propagateErrors?: boolean;
+	queueOnly?: boolean;
 }
 
 /** Built custom-message payload and delivery options for a `/skill:` command. */
@@ -97,7 +98,8 @@ export async function invokeSkillCommandFromText(
 	try {
 		const built = await buildSkillCommandPrompt(ctx, text, streamingBehavior);
 		if (!built) return false;
-		await ctx.session.promptCustomMessage(built.message, built.options);
+		const promptOptions = options?.queueOnly ? { ...built.options, queueOnly: true } : built.options;
+		await ctx.session.promptCustomMessage(built.message, promptOptions);
 		return true;
 	} catch (err) {
 		if (options?.propagateErrors) {

--- a/packages/coding-agent/src/modes/skill-command.ts
+++ b/packages/coding-agent/src/modes/skill-command.ts
@@ -1,0 +1,109 @@
+import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../session/messages";
+import type { InteractiveModeContext } from "./types";
+
+type SkillCommandHost = Pick<InteractiveModeContext, "skillCommands" | "session" | "showError">;
+
+type SkillPromptMessage = Pick<
+	CustomMessage<SkillPromptDetails>,
+	"customType" | "content" | "display" | "details" | "attribution"
+> & {
+	customType: typeof SKILL_PROMPT_MESSAGE_TYPE;
+	content: string;
+	display: true;
+	details: SkillPromptDetails;
+	attribution: "user";
+};
+
+type SkillPromptOptions = {
+	streamingBehavior: "steer" | "followUp";
+	queueChipText: string;
+};
+
+interface ParsedSkillCommand {
+	commandName: string;
+	args: string;
+}
+
+interface InvokeSkillCommandOptions {
+	propagateErrors?: boolean;
+}
+
+/** Built custom-message payload and delivery options for a `/skill:` command. */
+export interface BuiltSkillCommandPrompt {
+	message: SkillPromptMessage;
+	options: SkillPromptOptions;
+}
+
+function parseSkillCommand(text: string): ParsedSkillCommand | undefined {
+	if (!text.startsWith("/skill:")) return undefined;
+	const spaceIndex = text.indexOf(" ");
+	const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+	return { commandName, args };
+}
+
+/** Return true when `text` names a registered `/skill:<name>` command. */
+export function isKnownSkillCommand(ctx: SkillCommandHost, text: string): boolean {
+	const parsed = parseSkillCommand(text);
+	if (!parsed) return false;
+	return ctx.skillCommands.has(parsed.commandName);
+}
+
+/** Build the user-attributed custom message for a registered `/skill:<name>` command. */
+export async function buildSkillCommandPrompt(
+	ctx: SkillCommandHost,
+	text: string,
+	streamingBehavior: "steer" | "followUp",
+): Promise<BuiltSkillCommandPrompt | undefined> {
+	const parsed = parseSkillCommand(text);
+	if (!parsed) return undefined;
+	const skillPath = ctx.skillCommands.get(parsed.commandName);
+	if (!skillPath) return undefined;
+
+	const content = await Bun.file(skillPath).text();
+	const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+	const metaLines = [`Skill: ${skillPath}`];
+	if (parsed.args) {
+		metaLines.push(`User: ${parsed.args}`);
+	}
+	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+	const skillName = parsed.commandName.slice("skill:".length);
+	const details: SkillPromptDetails = {
+		name: skillName || parsed.commandName,
+		path: skillPath,
+		args: parsed.args || undefined,
+		lineCount: body ? body.split("\n").length : 0,
+	};
+
+	return {
+		message: {
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: message,
+			display: true,
+			details,
+			attribution: "user",
+		},
+		options: { streamingBehavior, queueChipText: text },
+	};
+}
+
+/** Invoke a registered `/skill:<name>` command as a user-attributed custom message. */
+export async function invokeSkillCommandFromText(
+	ctx: SkillCommandHost,
+	text: string,
+	streamingBehavior: "steer" | "followUp",
+	options?: InvokeSkillCommandOptions,
+): Promise<boolean> {
+	try {
+		const built = await buildSkillCommandPrompt(ctx, text, streamingBehavior);
+		if (!built) return false;
+		await ctx.session.promptCustomMessage(built.message, built.options);
+		return true;
+	} catch (err) {
+		if (options?.propagateErrors) {
+			throw err;
+		}
+		ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+		return true;
+	}
+}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -672,6 +672,7 @@ export class UiHelpers {
 			await invokeSkillCommandFromText(this.ctx, message.text, message.mode, {
 				propagateErrors: true,
 				queueOnly: true,
+				images: message.images,
 			})
 		) {
 			return;
@@ -770,7 +771,12 @@ export class UiHelpers {
 			// is not sent as a literal prompt after compaction.
 			let promptPromise: Promise<unknown>;
 			if (isKnownSkillCommand(this.ctx, firstPrompt.text)) {
-				const built = await buildSkillCommandPrompt(this.ctx, firstPrompt.text, firstPrompt.mode);
+				const built = await buildSkillCommandPrompt(
+					this.ctx,
+					firstPrompt.text,
+					firstPrompt.mode,
+					firstPrompt.images,
+				);
 				promptPromise = built
 					? this.ctx.session.promptCustomMessage(built.message, built.options).catch(restoreQueue)
 					: Promise.resolve();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -45,6 +45,7 @@ import {
 	type SkillPromptDetails,
 } from "../../session/messages";
 import type { SessionContext } from "../../session/session-context";
+import { buildSkillCommandPrompt, invokeSkillCommandFromText, isKnownSkillCommand } from "../skill-command";
 import { createAssistantMessageComponent } from "./interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
@@ -667,6 +668,9 @@ export class UiHelpers {
 	}
 
 	async #deliverQueuedMessage(message: CompactionQueuedMessage): Promise<void> {
+		if (await invokeSkillCommandFromText(this.ctx, message.text, message.mode, { propagateErrors: true })) {
+			return;
+		}
 		if (this.ctx.isKnownSlashCommand(message.text)) {
 			await this.ctx.session.prompt(message.text);
 			return;
@@ -754,29 +758,32 @@ export class UiHelpers {
 				await this.#deliverQueuedMessage(message);
 			}
 
-			// Pass streamingBehavior so that if the session is still streaming when
-			// compaction-end fires (race window between isStreaming flipping false and
-			// the event landing here), prompt() routes the message into the steer/
-			// follow-up queue instead of throwing AgentBusyError. When the session is
-			// genuinely idle, streamingBehavior is ignored and a fresh prompt runs as
-			// before. This keeps the steer preview honest: if delivery has to be
-			// deferred, the message lands in the same queue every other consumer
-			// (Alt+Up dequeue, post-stream drain) already drains, instead of being
-			// stranded in compactionQueuedMessages with no drainer.
-			//
-			// firstPrompt is fire-and-forget — its rejection is funneled through
-			// `restoreQueue` rather than rethrown, so we use the primitive
-			// recordLocalSubmission and dispose manually in the catch.
-			const disposeFirstPrompt = this.ctx.recordLocalSubmission(firstPrompt.text, firstPrompt.images?.length ?? 0);
-			const promptPromise = this.ctx.session
-				.prompt(firstPrompt.text, {
-					streamingBehavior: firstPrompt.mode === "followUp" ? "followUp" : "steer",
-					images: firstPrompt.images,
-				})
-				.catch((error: unknown) => {
-					disposeFirstPrompt();
-					restoreQueue(error);
-				});
+			// First prompt is fire-and-forget — its rejection is funneled through
+			// `restoreQueue` rather than rethrown. Plain prompts use primitive
+			// recordLocalSubmission and dispose manually in the catch. Skill prompts
+			// are rebuilt as user-attributed custom messages so queued `/skill:` text
+			// is not sent as a literal prompt after compaction.
+			let promptPromise: Promise<unknown>;
+			if (isKnownSkillCommand(this.ctx, firstPrompt.text)) {
+				const built = await buildSkillCommandPrompt(this.ctx, firstPrompt.text, firstPrompt.mode);
+				promptPromise = built
+					? this.ctx.session.promptCustomMessage(built.message, built.options).catch(restoreQueue)
+					: Promise.resolve();
+			} else {
+				const disposeFirstPrompt = this.ctx.recordLocalSubmission(
+					firstPrompt.text,
+					firstPrompt.images?.length ?? 0,
+				);
+				promptPromise = this.ctx.session
+					.prompt(firstPrompt.text, {
+						streamingBehavior: firstPrompt.mode === "followUp" ? "followUp" : "steer",
+						images: firstPrompt.images,
+					})
+					.catch((error: unknown) => {
+						disposeFirstPrompt();
+						restoreQueue(error);
+					});
+			}
 
 			for (const message of rest) {
 				await this.#deliverQueuedMessage(message);

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -668,7 +668,12 @@ export class UiHelpers {
 	}
 
 	async #deliverQueuedMessage(message: CompactionQueuedMessage): Promise<void> {
-		if (await invokeSkillCommandFromText(this.ctx, message.text, message.mode, { propagateErrors: true })) {
+		if (
+			await invokeSkillCommandFromText(this.ctx, message.text, message.mode, {
+				propagateErrors: true,
+				queueOnly: true,
+			})
+		) {
 			return;
 		}
 		if (this.ctx.isKnownSlashCommand(message.text)) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6526,7 +6526,10 @@ export class AgentSession {
 
 	async promptCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
-		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice"> & { queueChipText?: string },
+		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice"> & {
+			queueChipText?: string;
+			queueOnly?: boolean;
+		},
 	): Promise<void> {
 		const textContent =
 			typeof message.content === "string"
@@ -6546,6 +6549,16 @@ export class AgentSession {
 			keywordNotices = this.#createMagicKeywordNotices(skillArgs);
 		}
 
+		if (options?.queueOnly) {
+			if (!options.streamingBehavior) {
+				throw new AgentBusyError();
+			}
+			for (const notice of keywordNotices) {
+				await this.#queueCustomMessage(notice, options.streamingBehavior);
+			}
+			await this.#queueCustomMessage(message, options.streamingBehavior, options.queueChipText);
+			return;
+		}
 		if (this.isStreaming) {
 			if (!options?.streamingBehavior) {
 				throw new AgentBusyError();
@@ -7109,6 +7122,40 @@ export class AgentSession {
 		} finally {
 			this.#endInFlight();
 		}
+	}
+
+	/** Queue a custom message without starting a turn, matching steer/follow-up delivery. */
+	async #queueCustomMessage<T = unknown>(
+		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
+		deliverAs: "steer" | "followUp",
+		queueChipText?: string,
+	): Promise<void> {
+		const details =
+			queueChipText !== undefined
+				? ({
+						...((message.details && typeof message.details === "object" ? message.details : {}) as Record<
+							string,
+							unknown
+						>),
+						__queueChipText: queueChipText,
+					} as T)
+				: message.details;
+		const appMessage: CustomMessage<T> = {
+			role: "custom",
+			customType: message.customType,
+			content: message.content,
+			display: message.display,
+			details,
+			attribution: message.attribution ?? "agent",
+			timestamp: Date.now(),
+		};
+		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (deliverAs === "followUp") {
+			this.agent.followUp(normalizedAppMessage);
+		} else {
+			this.agent.steer(normalizedAppMessage);
+		}
+		this.#scheduleIdleQueueDrain();
 	}
 
 	/**

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -481,6 +481,30 @@ export function sanitizeRehydratedOpenAIResponsesAssistantMessage(message: Assis
 	};
 }
 
+function convertImageBearingCustomMessage(message: CustomMessage | HookMessage): Message[] | undefined {
+	if (typeof message.content === "string") return undefined;
+	const textBlocks = message.content.filter((content): content is TextContent => content.type === "text");
+	const imageBlocks = message.content.filter((content): content is ImageContent => content.type === "image");
+	if (imageBlocks.length === 0) return undefined;
+
+	const converted: Message[] = [];
+	if (textBlocks.length > 0) {
+		converted.push({
+			role: "developer",
+			content: textBlocks,
+			attribution: message.attribution,
+			timestamp: message.timestamp,
+		});
+	}
+	converted.push({
+		role: "user",
+		content: [{ type: "text", text: `Images attached to ${message.customType}.` }, ...imageBlocks],
+		attribution: message.attribution,
+		timestamp: message.timestamp,
+	});
+	return converted;
+}
+
 /**
  * Transform AgentMessages (including custom types) to LLM-compatible Messages.
  *
@@ -556,7 +580,12 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				return out;
 			}
 			case "custom":
-			case "hookMessage":
+			case "hookMessage": {
+				const split = convertImageBearingCustomMessage(m);
+				if (split) return split;
+				const converted = convertMessageToLlm(m);
+				return converted ? [converted] : [];
+			}
 			case "branchSummary":
 			case "compactionSummary":
 			case "user":

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -268,8 +268,9 @@ describe("compaction skill re-invocation", () => {
 	});
 
 	it("re-invokes a queued skill as a user-attributed skill prompt", async () => {
+		const image: ImageContent = { type: "image", data: "aGVsbG8=", mimeType: "image/png" };
 		const { ctx, promptCustomMessage, promptCustomMessageCalled, prompt, steer, followUp } =
-			createCompactionDrainContext([{ text: "/skill:test-skill arg1 arg2", mode: "followUp" }]);
+			createCompactionDrainContext([{ text: "/skill:test-skill arg1 arg2", mode: "followUp", images: [image] }]);
 		const uiHelpers = new UiHelpers(ctx);
 
 		await uiHelpers.flushCompactionQueue({ willRetry: false });
@@ -278,7 +279,11 @@ describe("compaction skill re-invocation", () => {
 		const [message, options] = firstPromptCustomCall(promptCustomMessage);
 		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
 		expect(message.attribution).toBe("user");
-		expect(message.content).toContain("Do the thing.");
+		if (!Array.isArray(message.content)) {
+			throw new Error("expected queued skill prompt to preserve image content blocks");
+		}
+		expect(message.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Do the thing.") });
+		expect(message.content[1]).toEqual(image);
 		expect(message.details).toMatchObject({ name: "test-skill", args: "arg1 arg2", lineCount: 1 });
 		expect(options).toEqual({
 			streamingBehavior: "followUp",
@@ -292,13 +297,22 @@ describe("compaction skill re-invocation", () => {
 	it("queues retry-drained skills without appending them to session history", async () => {
 		const fixture = await createRealSession();
 		try {
-			const { ctx } = createCompactionDrainContext([{ text: "/skill:test-skill retry args", mode: "followUp" }]);
+			const image: ImageContent = { type: "image", data: "cmV0cnk=", mimeType: "image/png" };
+			const { ctx } = createCompactionDrainContext([
+				{ text: "/skill:test-skill retry args", mode: "followUp", images: [image] },
+			]);
 			ctx.session = fixture.session;
 			const uiHelpers = new UiHelpers(ctx);
 
 			await uiHelpers.flushCompactionQueue({ willRetry: true });
 
 			expect(fixture.session.getQueuedMessages().followUp).toEqual(["/skill:test-skill retry args"]);
+			const queued = fixture.session.agent.peekFollowUpQueue()[0];
+			if (queued?.role !== "custom" || !Array.isArray(queued.content)) {
+				throw new Error("expected retry-drained skill to be queued as image-bearing custom content");
+			}
+			expect(queued.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+			expect(queued.content[1]).toEqual(image);
 			expect(fixture.session.messages).toEqual([]);
 		} finally {
 			await fixture.session.dispose();

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -15,7 +15,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -35,7 +35,13 @@ type StubEditor = {
 
 type PromptCustomMessage = Mock<
 	(
-		message: { details: SkillPromptDetails },
+		message: {
+			customType?: string;
+			content?: string | unknown[];
+			display?: boolean;
+			attribution?: string;
+			details: SkillPromptDetails;
+		},
 		options?: { streamingBehavior?: "steer" | "followUp"; queueChipText?: string },
 	) => Promise<void>
 >;
@@ -46,7 +52,11 @@ async function writeSkillFile(dir: string, skillName: string, body: string): Pro
 	return skillPath;
 }
 
-function createStubInputControllerContext(opts: { skillCommands: Map<string, string>; isStreaming: boolean }) {
+function createStubInputControllerContext(opts: {
+	skillCommands: Map<string, string>;
+	isStreaming: boolean;
+	isCompacting?: boolean;
+}) {
 	let editorText = "";
 	const editor: StubEditor = {
 		setText(text) {
@@ -65,14 +75,14 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
-
+	const queueCompactionMessage = vi.fn((_text: string, _mode: "steer" | "followUp", _images?: ImageContent[]) => {});
 	const ctx = {
 		editor,
 		ui: { requestRender },
 		skillCommands: opts.skillCommands,
 		session: {
 			isStreaming: opts.isStreaming,
-			isCompacting: false,
+			isCompacting: opts.isCompacting ?? false,
 			isBashRunning: false,
 			isEvalRunning: false,
 			extensionRunner: undefined,
@@ -92,6 +102,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		queueCompactionMessage,
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -102,6 +113,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 		handleGoalModeCommand,
 		updatePendingMessagesDisplay,
 		requestRender,
+		queueCompactionMessage,
 	};
 }
 
@@ -137,6 +149,22 @@ describe("InputController skill queue chip metadata", () => {
 		expect(promptCustomMessage.mock.calls[0]?.[0].details.__queueChipText).toBeUndefined();
 		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues known skill steers during compaction instead of dispatching immediately", async () => {
+		const { ctx, editor, promptCustomMessage, queueCompactionMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+			isCompacting: true,
+		});
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill arg1 arg2");
+		await editor.onSubmit?.("/skill:test-skill arg1 arg2");
+
+		expect(queueCompactionMessage).toHaveBeenCalledWith("/skill:test-skill arg1 arg2", "steer", undefined);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
 	});
 
 	it("passes slash-form queueChipText for streaming skill follow-ups", async () => {
@@ -186,6 +214,79 @@ describe("InputController skill queue chip metadata", () => {
 			queueChipText: "/skill:test-skill arg1 arg2",
 		});
 		expect(promptCustomMessage.mock.calls[0]?.[0].details.__queueChipText).toBeUndefined();
+	});
+});
+
+describe("compaction skill re-invocation", () => {
+	let tempDir: TempDir;
+	let skillCommands: Map<string, string>;
+
+	function firstPromptCustomCall(promptCustomMessage: PromptCustomMessage) {
+		const call = promptCustomMessage.mock.calls[0];
+		if (!call) {
+			throw new Error("expected promptCustomMessage to be called");
+		}
+		return call;
+	}
+
+	function createCompactionDrainContext(queuedMessages: CompactionQueuedMessage[]) {
+		const promptCustomMessageCalled = Promise.withResolvers<void>();
+		const promptCustomMessage: PromptCustomMessage = vi.fn(async () => {
+			promptCustomMessageCalled.resolve();
+		});
+		const prompt = vi.fn(async (_text: string, _options?: { streamingBehavior?: "steer" | "followUp" }) => {});
+		const steer = vi.fn(async (_text: string, _images?: ImageContent[]) => {});
+		const followUp = vi.fn(async (_text: string, _images?: ImageContent[]) => {});
+		const ctx = {
+			skillCommands,
+			compactionQueuedMessages: queuedMessages,
+			updatePendingMessagesDisplay: vi.fn(),
+			showError: vi.fn(),
+			isKnownSlashCommand: vi.fn(() => false),
+			recordLocalSubmission: vi.fn((_text: string, _imageCount: number) => vi.fn()),
+			withLocalSubmission: vi.fn(async (_text: string, fn: () => unknown) => Promise.resolve(fn())),
+			session: {
+				promptCustomMessage,
+				prompt,
+				steer,
+				followUp,
+				clearQueue: vi.fn(),
+			},
+		} as unknown as InteractiveModeContext;
+		return { ctx, promptCustomMessage, promptCustomMessageCalled, prompt, steer, followUp };
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-skill-compaction-stub-");
+		const skillPath = await writeSkillFile(tempDir.path(), "test-skill", "Do the thing.");
+		skillCommands = new Map<string, string>([["skill:test-skill", skillPath]]);
+	});
+
+	afterEach(() => {
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	it("re-invokes a queued skill as a user-attributed skill prompt", async () => {
+		const { ctx, promptCustomMessage, promptCustomMessageCalled, prompt, steer, followUp } =
+			createCompactionDrainContext([{ text: "/skill:test-skill arg1 arg2", mode: "followUp" }]);
+		const uiHelpers = new UiHelpers(ctx);
+
+		await uiHelpers.flushCompactionQueue({ willRetry: false });
+		await promptCustomMessageCalled;
+
+		const [message, options] = firstPromptCustomCall(promptCustomMessage);
+		expect(message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message.attribution).toBe("user");
+		expect(message.content).toContain("Do the thing.");
+		expect(message.details).toMatchObject({ name: "test-skill", args: "arg1 arg2", lineCount: 1 });
+		expect(options).toEqual({
+			streamingBehavior: "followUp",
+			queueChipText: "/skill:test-skill arg1 arg2",
+		});
+		expect(prompt).not.toHaveBeenCalled();
+		expect(steer).not.toHaveBeenCalled();
+		expect(followUp).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -42,7 +42,7 @@ type PromptCustomMessage = Mock<
 			attribution?: string;
 			details: SkillPromptDetails;
 		},
-		options?: { streamingBehavior?: "steer" | "followUp"; queueChipText?: string },
+		options?: { streamingBehavior?: "steer" | "followUp"; queueChipText?: string; queueOnly?: boolean },
 	) => Promise<void>
 >;
 
@@ -287,6 +287,24 @@ describe("compaction skill re-invocation", () => {
 		expect(prompt).not.toHaveBeenCalled();
 		expect(steer).not.toHaveBeenCalled();
 		expect(followUp).not.toHaveBeenCalled();
+	});
+
+	it("queues retry-drained skills without appending them to session history", async () => {
+		const fixture = await createRealSession();
+		try {
+			const { ctx } = createCompactionDrainContext([{ text: "/skill:test-skill retry args", mode: "followUp" }]);
+			ctx.session = fixture.session;
+			const uiHelpers = new UiHelpers(ctx);
+
+			await uiHelpers.flushCompactionQueue({ willRetry: true });
+
+			expect(fixture.session.getQueuedMessages().followUp).toEqual(["/skill:test-skill retry args"]);
+			expect(fixture.session.messages).toEqual([]);
+		} finally {
+			await fixture.session.dispose();
+			fixture.authStorage.close();
+			fixture.tempDir.removeSync();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -259,6 +259,34 @@ describe("convertToLlm custom message mapping", () => {
 		expectAttribution(converted[0], "user");
 		expect(inferCopilotInitiator(converted)).toBe("user");
 	});
+
+	it("routes custom-message images through a user message", () => {
+		const image: ImageContent = { type: "image", data: "c2tpbGw=", mimeType: "image/png" };
+		const messages: AgentMessage[] = [
+			{
+				role: "custom",
+				customType: "skill-prompt",
+				content: [{ type: "text", text: "Skill body" }, image],
+				display: true,
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		];
+
+		const converted = convertToLlm(messages);
+
+		expect(converted.map(message => message.role)).toEqual(["developer", "user"]);
+		expectAttribution(converted[0], "user");
+		expectAttribution(converted[1], "user");
+		if (converted[0]?.role !== "developer" || !Array.isArray(converted[0].content)) {
+			throw new Error("Expected developer skill text");
+		}
+		expect(converted[0].content).toEqual([{ type: "text", text: "Skill body" }]);
+		if (converted[1]?.role !== "user" || !Array.isArray(converted[1].content)) {
+			throw new Error("Expected user skill images");
+		}
+		expect(converted[1].content.filter(content => content.type === "image")).toEqual([image]);
+	});
 });
 
 function getUserText(message: AgentMessage | undefined): string {


### PR DESCRIPTION
## Repro
Queued `/skill:` commands submitted while compaction is active fail the regression in `packages/coding-agent/test/input-controller-skill-queue.test.ts`: `cd packages/coding-agent && bun run gen:tool-views && bun test test/input-controller-skill-queue.test.ts` showed Enter-submitted `/skill:` bypassing `queueCompactionMessage` and a queued `/skill:` draining without `promptCustomMessage`/`attribution: "user"`.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` dispatched known `/skill:` commands before the compaction queue branch, and `packages/coding-agent/src/modes/utils/ui-helpers.ts` drained `CompactionQueuedMessage` entries through `prompt`/`steer`/`followUp` without rebuilding the `skill-prompt` custom message.

## Fix
- Added `packages/coding-agent/src/modes/skill-command.ts` to parse known `/skill:` commands and build/invoke user-attributed skill prompt custom messages.
- Queued known `/skill:` steers immediately during compaction before bash/python/loop-mode handling can consume them.
- Re-invoked compaction-queued `/skill:` entries through `promptCustomMessage` when the queue drains.
- Added regression coverage for compaction-time skill queueing and user-attributed skill re-invocation.

## Verification
`cd packages/coding-agent && bun test test/input-controller-skill-queue.test.ts test/input-controller-compaction-image.test.ts` passed with 29 tests. `cd packages/coding-agent && bun check` passed. Fixes #3697