### PR TITLE
fix(setup): harden global omp symlink against bun pm -g bin failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "overrides": {},
   "scripts": {
-    "setup": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && ln -sfn \"$(pwd)/packages/coding-agent/scripts/omp\" \"$(bun pm -g bin)/omp\"",
+    "setup": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && sh scripts/link-omp.sh",
     "dev": "bun --cwd=packages/coding-agent src/cli.ts",
     "dev:timing": "PI_TIMING=x bun --cwd=packages/coding-agent --preload ../utils/src/module-timer.ts src/cli.ts",
     "stats": "bun --cwd=packages/coding-agent src/cli.ts stats",

--- a/scripts/link-omp.sh
+++ b/scripts/link-omp.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Install the dev `omp` wrapper into Bun's global bin directory.
+#
+# Replaces the bun-shebang symlink that `bun --cwd=packages/coding-agent link`
+# creates (pointing at `src/cli.ts`) with the safer wrapper at
+# `packages/coding-agent/scripts/omp`. See that wrapper's header comment for the
+# bunfig.toml-preload bug it works around.
+#
+# We resolve Bun's global bin path defensively because `bun pm -g bin` aborts
+# (`No package.json was found for directory "$HOME/.bun/install/global"`) on
+# fresh hosts where the global install has not been initialized. Falling
+# through that error would expand `$(bun pm -g bin)/omp` to `/omp` and try to
+# write under `/` — see https://github.com/can1357/oh-my-pi/issues/3701.
+set -e
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+target=$repo_root/packages/coding-agent/scripts/omp
+
+if [ ! -x "$target" ]; then
+	echo "link-omp: target wrapper not found or not executable: $target" >&2
+	exit 1
+fi
+
+global_bin=$(bun pm -g bin 2>/dev/null || true)
+if [ -z "$global_bin" ]; then
+	global_bin=${BUN_INSTALL:-$HOME/.bun}/bin
+fi
+
+mkdir -p "$global_bin"
+ln -sfn "$target" "$global_bin/omp"
+echo "link-omp: linked $global_bin/omp -> $target"


### PR DESCRIPTION
## Repro

On a fresh host without `$HOME/.bun/install/global/package.json`, `bun pm -g bin` aborts with `No package.json was found for directory ".../.bun/install/global"`. The root `setup` script ran:

```sh
ln -sfn "$(pwd)/packages/coding-agent/scripts/omp" "$(bun pm -g bin)/omp"
```

The failed command substitution expands to empty, so `ln` tries to write `/omp` and dies with `Permission denied` (or, on a writable root filesystem, would link directly under `/`). Reproduced locally by shimming `bun` on `PATH` to emit the reporter's exact stderr — `ln` then fails with `failed to create symbolic link '/omp': Permission denied`. Same failure observed by the reporter on Debian x64, Bun 1.3.14.

## Cause

`package.json#scripts.setup` interpolated `$(bun pm -g bin)` directly into the destination path without checking the exit status. Bun's `bun pm -g bin` is not robust to the global install directory being uninitialized, so any user who ran `bun setup` before invoking any `bun add -g` (or who cleaned their `~/.bun`) hits the failure.

## Fix

- Add `scripts/link-omp.sh`: captures `bun pm -g bin`, falls back to `${BUN_INSTALL:-$HOME/.bun}/bin` (Bun's documented install layout), `mkdir -p`s the target, and links the dev wrapper onto it. Header comment documents why the wrapper exists (replaces bun-shebang link to dodge cwd `bunfig.toml` preload) and why the fallback is needed (cites #3701).
- Update `package.json#scripts.setup` to invoke `sh scripts/link-omp.sh` instead of the inline one-liner.

## Verification

Reproduced with a PATH shim that makes `bun pm -g bin` emit the reporter's error, then re-ran both the old inline form and the new script:

```
$ PATH=/tmp/bunsim_demo/shim:$PATH bash -c 'ln -sfn "$(pwd)/packages/coding-agent/scripts/omp" "$(bun pm -g bin)/omp"'
error: No package.json was found for directory "/home/hermes/.bun/install/global"
note: Run "bun init" to initialize a project
ln: failed to create symbolic link '/omp': Permission denied
exit=1

$ HOME=/tmp/bunsim_demo BUN_INSTALL= PATH=/tmp/bunsim_demo/shim:$PATH sh scripts/link-omp.sh
link-omp: linked /tmp/bunsim_demo/.bun/bin/omp -> .../packages/coding-agent/scripts/omp
exit=0
```

Also smoke-tested three layouts directly: missing `BUN_INSTALL`, present-but-empty `$BUN_INSTALL/install/global`, and the happy path with a populated global package.json. All three produce the correct symlink at `$BUN_INSTALL/bin/omp` (or `~/.bun/bin/omp`). `gh_open_pr` runs `bun run fix` + `bun check` as the gate. Fixes #3701.