### PR TITLE
feat(advisor): add advisor.minSeverity config to filter advisories by severity

### DIFF
--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -9,6 +9,7 @@ import { formatSessionHistoryMarkdown } from "../../session/session-history-form
 import { YieldQueue } from "../../session/yield-queue";
 import {
 	ADVISOR_READONLY_TOOL_NAMES,
+	ADVISOR_SEVERITY_RANK,
 	AdviseTool,
 	type AdvisorAgent,
 	type AdvisorNote,
@@ -1425,6 +1426,37 @@ describe("advisor", () => {
 					}),
 				).toBe("steer");
 			}
+		});
+	});
+
+	describe("ADVISOR_SEVERITY_RANK", () => {
+		it("ranks nit < concern < blocker", () => {
+			expect(ADVISOR_SEVERITY_RANK.nit).toBeLessThan(ADVISOR_SEVERITY_RANK.concern);
+			expect(ADVISOR_SEVERITY_RANK.concern).toBeLessThan(ADVISOR_SEVERITY_RANK.blocker);
+		});
+
+		it("filters correctly for minSeverity = concern", () => {
+			const minSeverity = "concern";
+			// nit should be filtered (rank below threshold)
+			expect(ADVISOR_SEVERITY_RANK.nit < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(true);
+			// concern should pass (rank at threshold)
+			expect(ADVISOR_SEVERITY_RANK.concern < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
+			// blocker should pass (rank above threshold)
+			expect(ADVISOR_SEVERITY_RANK.blocker < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
+		});
+
+		it("filters correctly for minSeverity = blocker", () => {
+			const minSeverity = "blocker";
+			expect(ADVISOR_SEVERITY_RANK.nit < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(true);
+			expect(ADVISOR_SEVERITY_RANK.concern < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(true);
+			expect(ADVISOR_SEVERITY_RANK.blocker < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
+		});
+
+		it("passes all severities when minSeverity = nit (default)", () => {
+			const minSeverity = "nit";
+			expect(ADVISOR_SEVERITY_RANK.nit < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
+			expect(ADVISOR_SEVERITY_RANK.concern < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
+			expect(ADVISOR_SEVERITY_RANK.blocker < ADVISOR_SEVERITY_RANK[minSeverity]).toBe(false);
 		});
 	});
 });

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -146,7 +146,7 @@ function advisorNoteDedupeKey(note: string): string {
 /** Rank advisor severities so the dedupe state can detect a real escalation
  *  (nit → concern → blocker) versus a verbatim repeat. `undefined` defers to
  *  `nit` because the schema treats an omitted severity as a plain nit. */
-const ADVISOR_SEVERITY_RANK: Record<AdvisorSeverity, number> = { nit: 1, concern: 2, blocker: 3 };
+export const ADVISOR_SEVERITY_RANK: Record<AdvisorSeverity, number> = { nit: 1, concern: 2, blocker: 3 };
 function advisorSeverityRank(severity: AdvisorSeverity | undefined): number {
 	return ADVISOR_SEVERITY_RANK[severity ?? "nit"];
 }

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -438,6 +438,19 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.minSeverity": {
+		type: "enum",
+		values: ["nit", "concern", "blocker"],
+		default: "nit",
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Minimum Severity",
+			description:
+				"Only deliver advisor notes at or above this severity level. Notes below the threshold are dropped before delivery to the main agent.",
+			condition: "advisorEnabled",
+		},
+	},
 	shellPath: { type: "string", default: undefined },
 	"git.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -130,6 +130,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import {
+	ADVISOR_SEVERITY_RANK,
 	AdviseTool,
 	type AdvisorAgent,
 	AdvisorEmissionGuard,
@@ -1943,6 +1944,11 @@ export class AgentSession {
 		const enqueueAdvice = (note: string, severity?: AdvisorSeverity) => {
 			if (!this.#advisorEmissionGuard.accept(note)) {
 				logger.debug("advisor advice suppressed by emission guard", { severity });
+				return;
+			}
+			const minSeverity = (this.settings.get("advisor.minSeverity") as AdvisorSeverity) ?? "nit";
+			if (ADVISOR_SEVERITY_RANK[severity ?? "nit"] < ADVISOR_SEVERITY_RANK[minSeverity]) {
+				logger.debug("advisor advice suppressed by minSeverity filter", { severity, minSeverity });
 				return;
 			}
 			const interrupting = isInterruptingSeverity(severity);


### PR DESCRIPTION
## Summary

Adds a new `advisor.minSeverity` configuration option that deterministically filters advisor notes below the configured severity threshold before delivery to the main agent.

## Changes

- **`settings-schema.ts`**: New `advisor.minSeverity` enum setting (`nit` | `concern` | `blocker`, default: `nit`) with UI metadata in the Advisor group
- **`advise-tool.ts`**: Export `ADVISOR_SEVERITY_RANK` for use in the delivery filter
- **`agent-session.ts`**: Filter in `enqueueAdvice` that compares advisory severity rank against the configured threshold, dropping notes below it with a debug log
- **`advisor.test.ts`**: Tests verifying rank ordering and filter comparison logic for all threshold levels

## Behavior

| `minSeverity` | nit | concern | blocker |
|---|---|---|---|
| `nit` (default) | ✅ pass | ✅ pass | ✅ pass |
| `concern` | ❌ drop | ✅ pass | ✅ pass |
| `blocker` | ❌ drop | ❌ drop | ✅ pass |

The advisor model still generates all severities internally (reasoning preserved in advisor transcript). Only delivery to the main agent is gated.

## Testing

- 74 related tests pass (advisor unit tests + settings layout + advisor toggle + advisor watchdog)
- Existing behavior preserved: default `nit` passes everything through

Closes #3378