### PR TITLE
fix(tui): keep Shift+Enter enhanced in iTerm fallback overlays

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed modified Enter/keyboard shortcuts in fullscreen overlays on terminals using the xterm `modifyOtherKeys` fallback (including iTerm2 when Kitty keyboard negotiation does not complete) by reasserting the active fallback sequence after alternate-screen entry ([#3705](https://github.com/can1357/oh-my-pi/issues/3705)).
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -336,10 +336,15 @@ export interface Terminal {
 	// so the TUI re-pushes this after entering the alternate screen.
 	get kittyEnableSequence(): string | null;
 
-	// The active modified-key reporting sequence to reassert after terminal buffer
-	// switches, or null when no enhanced keyboard mode is active. Optional so
-	// custom Terminals built against older pi-tui versions keep working.
-	readonly keyboardEnhancementSequence?: string | null;
+	// The active modified-key reporting sequence to reassert on alternate-screen
+	// entry, or null when no enhanced keyboard mode is active. Optional so custom
+	// Terminals built against older pi-tui versions keep working.
+	readonly keyboardEnhancementEnterSequence?: string | null;
+
+	// The sequence that cleanly disables the active enhanced keyboard mode on
+	// alternate-screen exit, or null when no exit handshake is required. Optional
+	// so custom Terminals built against older pi-tui versions keep working.
+	readonly keyboardEnhancementExitSequence?: string | null;
 
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines
@@ -477,9 +482,18 @@ export class ProcessTerminal implements Terminal {
 		return this.#kittyProtocolActive ? this.#kittyEnableSeq : null;
 	}
 
-	get keyboardEnhancementSequence(): string | null {
+	get keyboardEnhancementEnterSequence(): string | null {
 		if (this.#kittyProtocolActive) return this.#kittyEnableSeq;
 		return this.#modifyOtherKeysActive ? "\x1b[>4;2m" : null;
+	}
+
+	get keyboardEnhancementExitSequence(): string | null {
+		// kitty is a stack push (per-screen), so the matching pop balances alt-screen
+		// entry. xterm modifyOtherKeys is a single global flag with no per-screen
+		// stack — emitting `>4;0m` here would clear it on the normal screen too,
+		// breaking the composer between overlays. terminal.stop() still disables it
+		// globally on graceful exit; the emergency-restore path mirrors that.
+		return this.#kittyProtocolActive ? "\x1b[<u" : null;
 	}
 
 	get appearance(): TerminalAppearance | undefined {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -336,6 +336,10 @@ export interface Terminal {
 	// so the TUI re-pushes this after entering the alternate screen.
 	get kittyEnableSequence(): string | null;
 
+	// The active modified-key reporting sequence to reassert after terminal buffer
+	// switches, or null when no enhanced keyboard mode is active.
+	get keyboardEnhancementSequence(): string | null;
+
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines
 
@@ -470,6 +474,11 @@ export class ProcessTerminal implements Terminal {
 
 	get kittyEnableSequence(): string | null {
 		return this.#kittyProtocolActive ? this.#kittyEnableSeq : null;
+	}
+
+	get keyboardEnhancementSequence(): string | null {
+		if (this.#kittyProtocolActive) return this.#kittyEnableSeq;
+		return this.#modifyOtherKeysActive ? "\x1b[>4;2m" : null;
 	}
 
 	get appearance(): TerminalAppearance | undefined {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -337,8 +337,9 @@ export interface Terminal {
 	get kittyEnableSequence(): string | null;
 
 	// The active modified-key reporting sequence to reassert after terminal buffer
-	// switches, or null when no enhanced keyboard mode is active.
-	get keyboardEnhancementSequence(): string | null;
+	// switches, or null when no enhanced keyboard mode is active. Optional so
+	// custom Terminals built against older pi-tui versions keep working.
+	readonly keyboardEnhancementSequence?: string | null;
 
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2488,11 +2488,11 @@ export class TUI extends Container {
 		// modal there; the normal screen and all accounting stay untouched.
 		const wantAlt = this.#wantsAltScreen();
 		if (wantAlt && !this.#altActive) {
-			// Kitty keyboard flags are per-screen: re-push our level on the freshly
-			// entered alternate screen, or Esc/modified keys revert to legacy
-			// encoding inside fullscreen overlays (Ghostty/kitty). See kitty
-			// keyboard-protocol docs: the mode stack is separate per screen.
-			this.terminal.write(`\x1b[?1049h${this.terminal.kittyEnableSequence ?? ""}${MOUSE_TRACKING_ON}`);
+			// Enhanced keyboard modes can be buffer-local: re-push the active
+			// modified-key reporting sequence on the freshly entered alternate
+			// screen, or Esc/modified keys revert to legacy encoding inside
+			// fullscreen overlays (Ghostty/kitty/iTerm2).
+			this.terminal.write(`\x1b[?1049h${this.terminal.keyboardEnhancementSequence ?? ""}${MOUSE_TRACKING_ON}`);
 			setAltScreenActive(true);
 			this.terminal.hideCursor();
 			this.#forgetHardwareCursorState();
@@ -3346,7 +3346,7 @@ export class TUI extends Container {
 		setAltScreenActive(true);
 		this.#forgetHardwareCursorState();
 		this.#recordHardwareCursorHidden();
-		return `${ALT_SCREEN_ENTER}${this.terminal.kittyEnableSequence ?? ""}`;
+		return `${ALT_SCREEN_ENTER}${this.terminal.keyboardEnhancementSequence ?? ""}`;
 	}
 
 	#leaveResizeAltSequence(): string {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1745,8 +1745,8 @@ export class TUI extends Container {
 			this.terminal.write(this.#leaveResizeAltSequence());
 		}
 		if (this.#altActive) {
-			const kittyPop = this.terminal.kittyEnableSequence ? "\x1b[<u" : "";
-			this.terminal.write(`${MOUSE_TRACKING_OFF}${kittyPop}\x1b[?1049l`);
+			const enhancementExit = this.#keyboardEnhancementExit();
+			this.terminal.write(`${MOUSE_TRACKING_OFF}${enhancementExit}\x1b[?1049l`);
 			setAltScreenActive(false);
 			this.#altActive = false;
 			this.#altPreviousLines = [];
@@ -2492,7 +2492,7 @@ export class TUI extends Container {
 			// modified-key reporting sequence on the freshly entered alternate
 			// screen, or Esc/modified keys revert to legacy encoding inside
 			// fullscreen overlays (Ghostty/kitty/iTerm2).
-			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementSequence()}${MOUSE_TRACKING_ON}`);
+			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementEnter()}${MOUSE_TRACKING_ON}`);
 			setAltScreenActive(true);
 			this.terminal.hideCursor();
 			this.#forgetHardwareCursorState();
@@ -2502,8 +2502,8 @@ export class TUI extends Container {
 			this.#altEnterWidth = width;
 			this.#altEnterHeight = height;
 		} else if (!wantAlt && this.#altActive) {
-			const kittyPop = this.terminal.kittyEnableSequence ? "\x1b[<u" : "";
-			this.terminal.write(`${MOUSE_TRACKING_OFF}${kittyPop}\x1b[?1049l`);
+			const enhancementExit = this.#keyboardEnhancementExit();
+			this.terminal.write(`${MOUSE_TRACKING_OFF}${enhancementExit}\x1b[?1049l`);
 			setAltScreenActive(false);
 			this.#forgetHardwareCursorState();
 			this.#altActive = false;
@@ -3339,9 +3339,24 @@ export class TUI extends Container {
 		return { window: this.#prepareLinesArray(window, width), contentRows: count };
 	}
 
-	/** Enter or leave the alternate screen borrowed for transient resize frames. */
-	#keyboardEnhancementSequence(): string {
-		return this.terminal.keyboardEnhancementSequence ?? this.terminal.kittyEnableSequence ?? "";
+	/**
+	 * Resolve the active keyboard-enhancement enter sequence. Falls back to the
+	 * legacy `kittyEnableSequence` when a custom Terminal predates the
+	 * `keyboardEnhancementEnterSequence` property.
+	 */
+	#keyboardEnhancementEnter(): string {
+		return this.terminal.keyboardEnhancementEnterSequence ?? this.terminal.kittyEnableSequence ?? "";
+	}
+
+	/**
+	 * Resolve the active keyboard-enhancement exit sequence. Falls back to popping
+	 * kitty whenever a custom Terminal exposes its push sequence but predates the
+	 * `keyboardEnhancementExitSequence` property.
+	 */
+	#keyboardEnhancementExit(): string {
+		const exit = this.terminal.keyboardEnhancementExitSequence;
+		if (exit !== undefined) return exit ?? "";
+		return this.terminal.kittyEnableSequence ? "\x1b[<u" : "";
 	}
 
 	#enterResizeAltSequence(): string {
@@ -3350,16 +3365,16 @@ export class TUI extends Container {
 		setAltScreenActive(true);
 		this.#forgetHardwareCursorState();
 		this.#recordHardwareCursorHidden();
-		return `${ALT_SCREEN_ENTER}${this.#keyboardEnhancementSequence()}`;
+		return `${ALT_SCREEN_ENTER}${this.#keyboardEnhancementEnter()}`;
 	}
 
 	#leaveResizeAltSequence(): string {
 		if (!this.#resizeAltActive) return "";
-		const kittyPop = this.terminal.kittyEnableSequence ? "\x1b[<u" : "";
+		const enhancementExit = this.#keyboardEnhancementExit();
 		this.#resizeAltActive = false;
 		setAltScreenActive(false);
 		this.#forgetHardwareCursorState();
-		return `${kittyPop}${ALT_SCREEN_EXIT}`;
+		return `${enhancementExit}${ALT_SCREEN_EXIT}`;
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2492,7 +2492,7 @@ export class TUI extends Container {
 			// modified-key reporting sequence on the freshly entered alternate
 			// screen, or Esc/modified keys revert to legacy encoding inside
 			// fullscreen overlays (Ghostty/kitty/iTerm2).
-			this.terminal.write(`\x1b[?1049h${this.terminal.keyboardEnhancementSequence ?? ""}${MOUSE_TRACKING_ON}`);
+			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementSequence()}${MOUSE_TRACKING_ON}`);
 			setAltScreenActive(true);
 			this.terminal.hideCursor();
 			this.#forgetHardwareCursorState();
@@ -3340,13 +3340,17 @@ export class TUI extends Container {
 	}
 
 	/** Enter or leave the alternate screen borrowed for transient resize frames. */
+	#keyboardEnhancementSequence(): string {
+		return this.terminal.keyboardEnhancementSequence ?? this.terminal.kittyEnableSequence ?? "";
+	}
+
 	#enterResizeAltSequence(): string {
 		if (this.#resizeAltActive || this.#altActive) return "";
 		this.#resizeAltActive = true;
 		setAltScreenActive(true);
 		this.#forgetHardwareCursorState();
 		this.#recordHardwareCursorHidden();
-		return `${ALT_SCREEN_ENTER}${this.terminal.keyboardEnhancementSequence ?? ""}`;
+		return `${ALT_SCREEN_ENTER}${this.#keyboardEnhancementSequence()}`;
 	}
 
 	#leaveResizeAltSequence(): string {

--- a/packages/tui/test/issue-2045-repro.test.ts
+++ b/packages/tui/test/issue-2045-repro.test.ts
@@ -28,6 +28,10 @@ class CaptureTerminal implements Terminal {
 		return null;
 	}
 
+	get keyboardEnhancementSequence(): string | null {
+		return null;
+	}
+
 	get appearance(): TerminalAppearance | undefined {
 		return undefined;
 	}

--- a/packages/tui/test/issue-2045-repro.test.ts
+++ b/packages/tui/test/issue-2045-repro.test.ts
@@ -28,7 +28,11 @@ class CaptureTerminal implements Terminal {
 		return null;
 	}
 
-	get keyboardEnhancementSequence(): string | null {
+	get keyboardEnhancementEnterSequence(): string | null {
+		return null;
+	}
+
+	get keyboardEnhancementExitSequence(): string | null {
 		return null;
 	}
 

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import type { Component } from "@oh-my-pi/pi-tui";
 import {
 	createProcessTerminalRenderHarness,
 	type ProcessTerminalRenderHarness,
@@ -10,6 +11,13 @@ import {
 // is only a sentinel that guarantees a reply even from terminals that ignore
 // `CSI ? u`. Some terminals (Superset / xterm-on-Electron) answer DA1 first;
 // the kitty reply must still be honored regardless of ordering.
+
+class ModalProbe implements Component {
+	invalidate(): void {}
+	render(): string[] {
+		return ["modal"];
+	}
+}
 describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () => {
 	let harness: ProcessTerminalRenderHarness | undefined;
 
@@ -65,5 +73,27 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		expect(harness.terminal.kittyProtocolActive).toBe(false);
 		expect(out).toContain("\x1b[>4;2m");
 		expect(out).not.toContain("\x1b[>1u");
+	});
+
+	it("reasserts modifyOtherKeys fallback when fullscreen overlays enter the alternate screen", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		await harness.feed("\x1b[?1;2c");
+		expect(harness.writes.join("")).toContain("\x1b[>4;2m");
+		harness.writes.length = 0;
+
+		const overlay = harness.tui.showOverlay(new ModalProbe(), {
+			fullscreen: true,
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		await harness.settle();
+
+		const out = harness.writes.join("");
+		expect(out).toContain("\x1b[?1049h\x1b[>4;2m");
+		overlay.hide();
 	});
 });

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -92,8 +92,45 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		});
 		await harness.settle();
 
-		const out = harness.writes.join("");
-		expect(out).toContain("\x1b[?1049h\x1b[>4;2m");
+		const enterOut = harness.writes.join("");
+		expect(enterOut).toContain("\x1b[?1049h\x1b[>4;2m");
+		harness.writes.length = 0;
+
 		overlay.hide();
+		await harness.settle();
+
+		const exitOut = harness.writes.join("");
+		// xterm modifyOtherKeys is a single global flag (no per-screen stack),
+		// so the overlay exit must NOT emit `>4;0m` — that would clear it on the
+		// normal screen and break the composer between overlays. Only the kitty
+		// pop is per-screen and safe to emit on exit.
+		expect(exitOut).toContain("\x1b[?1049l");
+		expect(exitOut).not.toContain("\x1b[>4;0m");
+	});
+
+	it("pops the kitty keyboard frame on fullscreen overlay exit", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		await harness.feed("\x1b[?0u", "\x1b[?1;2c");
+		expect(harness.terminal.kittyProtocolActive).toBe(true);
+		harness.writes.length = 0;
+
+		const overlay = harness.tui.showOverlay(new ModalProbe(), {
+			fullscreen: true,
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		await harness.settle();
+		expect(harness.writes.join("")).toContain("\x1b[?1049h\x1b[>1u");
+		harness.writes.length = 0;
+
+		overlay.hide();
+		await harness.settle();
+
+		const exitOut = harness.writes.join("");
+		// Kitty keyboard flags are per-screen, so the matching pop must precede
+		// the alt-screen exit to balance the push from overlay entry.
+		expect(exitOut).toContain("\x1b[<u\x1b[?1049l");
 	});
 });

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -7,7 +7,8 @@ class MinimalTerminal implements Terminal {
 	rows = 24;
 	kittyProtocolActive = false;
 	kittyEnableSequence: string | null = null;
-	keyboardEnhancementSequence: string | null = null;
+	keyboardEnhancementEnterSequence: string | null = null;
+	keyboardEnhancementExitSequence: string | null = null;
 	appearance: TerminalAppearance | undefined;
 	#onInput: ((data: string) => void) | undefined;
 	#onResize: (() => void) | undefined;

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -7,6 +7,7 @@ class MinimalTerminal implements Terminal {
 	rows = 24;
 	kittyProtocolActive = false;
 	kittyEnableSequence: string | null = null;
+	keyboardEnhancementSequence: string | null = null;
 	appearance: TerminalAppearance | undefined;
 	#onInput: ((data: string) => void) | undefined;
 	#onResize: (() => void) | undefined;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -117,6 +117,12 @@ class CountingViewportTerminal extends VirtualTerminal {
 	}
 }
 
+class LegacyKeyboardVirtualTerminal extends VirtualTerminal {
+	get keyboardEnhancementSequence(): string | null {
+		return undefined as unknown as string | null;
+	}
+}
+
 function rows(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
 }
@@ -3276,6 +3282,32 @@ describe("TUI terminal-state regressions", () => {
 				// Transcript is back on the normal screen after leaving the alt buffer.
 				expect(visible(term).some(line => line.includes("base-"))).toBeTrue();
 				expect(visible(term).some(line => line.includes("MODAL-0"))).toBeFalse();
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("falls back to kittyEnableSequence for legacy custom terminals", async () => {
+			const term = new LegacyKeyboardVirtualTerminal(40, 8, 200);
+			const writes = captureWrites(term);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(rows("base-", 8)));
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const showFrom = writes.length;
+				tui.showOverlay(new MutableLinesComponent(["MODAL-0"]), {
+					width: "100%",
+					maxHeight: "100%",
+					margin: 0,
+					fullscreen: true,
+				});
+				await settle(term);
+
+				const modalWrites = writes.slice(showFrom).join("");
+				expect(modalWrites).toContain("\x1b[?1049h\x1b[>1u");
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -118,7 +118,11 @@ class CountingViewportTerminal extends VirtualTerminal {
 }
 
 class LegacyKeyboardVirtualTerminal extends VirtualTerminal {
-	get keyboardEnhancementSequence(): string | null {
+	get keyboardEnhancementEnterSequence(): string | null {
+		return undefined as unknown as string | null;
+	}
+
+	get keyboardEnhancementExitSequence(): string | null {
 		return undefined as unknown as string | null;
 	}
 }

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -208,8 +208,12 @@ export class VirtualTerminal implements Terminal {
 		return "\x1b[>1u";
 	}
 
-	get keyboardEnhancementSequence(): string | null {
+	get keyboardEnhancementEnterSequence(): string | null {
 		return "\x1b[>1u";
+	}
+
+	get keyboardEnhancementExitSequence(): string | null {
+		return "\x1b[<u";
 	}
 
 	get appearance(): TerminalAppearance | undefined {

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -208,6 +208,10 @@ export class VirtualTerminal implements Terminal {
 		return "\x1b[>1u";
 	}
 
+	get keyboardEnhancementSequence(): string | null {
+		return "\x1b[>1u";
+	}
+
 	get appearance(): TerminalAppearance | undefined {
 		return undefined;
 	}


### PR DESCRIPTION
## Repro
When the keyboard capability probe falls back to xterm `modifyOtherKeys`, entering a fullscreen alternate-screen overlay did not reassert that active fallback; `bun run build:native && bun test packages/tui/test/kitty-keyboard-da1-ordering.test.ts` failed because the overlay entry bytes contained `CSI ?1049 h` followed directly by mouse tracking, not `CSI >4;2m`.

## Cause
`packages/tui/src/tui.ts` re-pushed only `Terminal.kittyEnableSequence` after alternate-screen entry. `packages/tui/src/terminal.ts` tracked `#modifyOtherKeysActive`, but exposed no sequence for the TUI to reassert when the active enhanced-keyboard mode was the xterm fallback rather than Kitty.

## Fix
- Added `Terminal.keyboardEnhancementSequence` so `ProcessTerminal` can expose the active Kitty or `modifyOtherKeys` enable sequence.
- Reasserted that active enhanced-keyboard sequence for fullscreen and resize alternate-screen entry.
- Added a `ProcessTerminal` regression test covering the `modifyOtherKeys` fallback path used when no Kitty keyboard reply arrives.
- Updated the TUI changelog entry for #3705.

## Verification
`bun test packages/tui/test/kitty-keyboard-da1-ordering.test.ts packages/tui/test/render-regressions.test.ts` passed with 103 tests. `bun --cwd=packages/tui run check:types` passed. `bun --cwd=packages/tui run check` passed. `gh_push_branch` ran its pre-publish gate and pushed `farm/4678e70c/fix-iterm-shift-enter` at `2edd55e494e1`. Fixes #3705