### PR TITLE
fix(coding-agent): keep Alt+M default role selectable over context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed Alt+M default-role model configuration being disabled by the current session's context size. ([#3708](https://github.com/can1357/oh-my-pi/issues/3708))
 - Fixed interrupted reasoning blocks being incorrectly stripped when they contained a valid signature
 - Fixed interrupted thinking being lost in LLM provider requests after user interrupts by properly stripping trailing reasoning blocks from assistant turns while preserving them in the UI and session history.
 - Fixed the live todo HUD going stale during long tool-use loops by introducing a mid-run reconciliation reminder that prompts the agent to update incomplete items.

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -714,10 +714,6 @@ export class ModelSelectorComponent extends Container {
 		return this.#temporaryOnly && this.#isModelOverCurrentContext(model);
 	}
 
-	#isDefaultRoleActionOverContextLimit(action: MenuRoleAction, model: Model): boolean {
-		return action.role === "default" && this.#isModelOverCurrentContext(model);
-	}
-
 	#formatCurrentContextLimitSuffix(model: Model): string {
 		return ` ${theme.status.disabled} context>${formatNumber(model.contextWindow ?? 0).toLowerCase()}`;
 	}
@@ -1065,47 +1061,16 @@ export class ModelSelectorComponent extends Container {
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
-	#isMenuRoleIndexDisabled(index: number, selectedItem: ModelItem | CanonicalModelItem): boolean {
-		const action = this.#menuRoleActions[index];
-		return action ? this.#isDefaultRoleActionOverContextLimit(action, selectedItem.model) : false;
-	}
-
-	#coerceMenuSelectedIndex(index: number, selectedItem: ModelItem | CanonicalModelItem): number {
+	#coerceMenuSelectedIndex(index: number): number {
 		const maxIndex = this.#menuRoleActions.length - 1;
 		if (maxIndex < 0) {
 			return 0;
 		}
-		const clamped = Math.max(0, Math.min(index, maxIndex));
-		if (!this.#isMenuRoleIndexDisabled(clamped, selectedItem)) {
-			return clamped;
-		}
-		for (let i = clamped + 1; i <= maxIndex; i++) {
-			if (!this.#isMenuRoleIndexDisabled(i, selectedItem)) {
-				return i;
-			}
-		}
-		for (let i = clamped - 1; i >= 0; i--) {
-			if (!this.#isMenuRoleIndexDisabled(i, selectedItem)) {
-				return i;
-			}
-		}
-		return clamped;
+		return Math.max(0, Math.min(index, maxIndex));
 	}
 
-	#moveMenuSelection(delta: number, selectedItem: ModelItem | CanonicalModelItem, optionCount: number): void {
-		let index = this.#menuSelectedIndex;
-		for (let step = 0; step < optionCount; step++) {
-			index = (index + delta + optionCount) % optionCount;
-			if (this.#menuStep !== "role" || !this.#isMenuRoleIndexDisabled(index, selectedItem)) {
-				this.#menuSelectedIndex = index;
-				this.#updateMenu();
-				return;
-			}
-		}
-		this.#menuSelectedIndex =
-			this.#menuStep === "role"
-				? this.#coerceMenuSelectedIndex(this.#menuSelectedIndex, selectedItem)
-				: this.#menuSelectedIndex;
+	#moveMenuSelection(delta: number, _selectedItem: ModelItem | CanonicalModelItem, optionCount: number): void {
+		this.#menuSelectedIndex = (this.#menuSelectedIndex + delta + optionCount) % optionCount;
 		this.#updateMenu();
 	}
 
@@ -1116,7 +1081,7 @@ export class ModelSelectorComponent extends Container {
 		this.#isMenuOpen = true;
 		this.#menuStep = "role";
 		this.#menuSelectedRole = null;
-		this.#menuSelectedIndex = this.#coerceMenuSelectedIndex(0, selectedItem);
+		this.#menuSelectedIndex = this.#coerceMenuSelectedIndex(0);
 		// Collapse the model list while the action/thinking menu is open so the
 		// menu owns the full viewport instead of stacking below a now-irrelevant
 		// (and often off-screen) list.
@@ -1149,9 +1114,7 @@ export class ModelSelectorComponent extends Container {
 				})
 			: this.#menuRoleActions.map((action, index) => {
 					const prefix = index === this.#menuSelectedIndex ? `  ${theme.nav.cursor} ` : "    ";
-					const disabled = this.#isDefaultRoleActionOverContextLimit(action, selectedItem.model);
-					const suffix = disabled ? this.#formatCurrentContextLimitSuffix(selectedItem.model) : "";
-					return `${prefix}${action.label}${suffix}`;
+					return `${prefix}${action.label}`;
 				});
 
 		const selectedRoleName = this.#menuSelectedRole ? getRoleInfo(this.#menuSelectedRole, this.#settings).name : "";
@@ -1301,7 +1264,7 @@ export class ModelSelectorComponent extends Container {
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			if (this.#menuStep === "role") {
 				const action = this.#menuRoleActions[this.#menuSelectedIndex];
-				if (!action || this.#isDefaultRoleActionOverContextLimit(action, selectedItem.model)) return;
+				if (!action) return;
 				this.#menuSelectedRole = action.role;
 				this.#menuStep = "thinking";
 				this.#menuSelectedIndex = this.#getThinkingPreselectIndex(action.role, selectedItem.model);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -540,19 +540,28 @@ export class SelectorController {
 							done();
 							this.ctx.ui.requestRender();
 						} else if (role === "default") {
-							// Default: update agent state and persist
+							const contextWindow = model.contextWindow ?? 0;
+							const switchActiveModel =
+								currentContextTokens <= 0 || contextWindow <= 0 || currentContextTokens <= contextWindow;
 							await this.ctx.session.setModel(model, role, {
 								selector,
 								thinkingLevel: concreteThinking,
 								persist: true,
+								switchActiveModel,
 							});
 							if (isAuto) {
-								this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
-							} else if (concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
+								if (switchActiveModel) {
+									this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
+								} else {
+									this.ctx.settings.set("defaultThinkingLevel", AUTO_THINKING);
+								}
+							} else if (switchActiveModel && concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(concreteThinking);
 							}
-							this.ctx.statusLine.invalidate();
-							this.ctx.updateEditorBorderColor();
+							if (switchActiveModel) {
+								this.ctx.statusLine.invalidate();
+								this.ctx.updateEditorBorderColor();
+							}
 							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
 							// Don't call done() - selector stays open for role assignment
 						} else {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -540,25 +540,22 @@ export class SelectorController {
 							done();
 							this.ctx.ui.requestRender();
 						} else if (role === "default") {
-							const contextWindow = model.contextWindow ?? 0;
-							const switchActiveModel =
-								currentContextTokens <= 0 || contextWindow <= 0 || currentContextTokens <= contextWindow;
-							await this.ctx.session.setModel(model, role, {
+							const { switched } = await this.ctx.session.setModel(model, role, {
 								selector,
 								thinkingLevel: concreteThinking,
 								persist: true,
-								switchActiveModel,
+								currentContextTokens,
 							});
 							if (isAuto) {
-								if (switchActiveModel) {
+								if (switched) {
 									this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
 								} else {
 									this.ctx.settings.set("defaultThinkingLevel", AUTO_THINKING);
 								}
-							} else if (switchActiveModel && concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
+							} else if (switched && concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(concreteThinking);
 							}
-							if (switchActiveModel) {
+							if (switched) {
 								this.ctx.statusLine.invalidate();
 								this.ctx.updateEditorBorderColor();
 							}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7863,17 +7863,24 @@ export class AgentSession {
 	/**
 	 * Set model directly.
 	 * Validates that a credential source is configured (synchronously, without
-	 * refreshing OAuth or running command-backed key programs). By default, the
-	 * active session switches immediately; callers may persist role settings
-	 * without touching the live session via `switchActiveModel: false`.
+	 * refreshing OAuth or running command-backed key programs). The active
+	 * session switches by default; when `currentContextTokens` is provided and
+	 * exceeds the refreshed candidate's context window, the live switch is
+	 * skipped while role persistence still runs. Returns whether the active
+	 * model actually switched, computed against the refreshed metadata so
+	 * dynamic providers (e.g. llama.cpp) honor their post-load contextWindow.
 	 * @throws Error if no API key available for the model
 	 */
 	async setModel(
 		model: Model,
 		role: string = "default",
-		options?: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean; switchActiveModel?: boolean },
-	): Promise<void> {
-		const switchActiveModel = options?.switchActiveModel ?? true;
+		options?: {
+			selector?: string;
+			thinkingLevel?: ThinkingLevel;
+			persist?: boolean;
+			currentContextTokens?: number;
+		},
+	): Promise<{ switched: boolean }> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		if (!this.#modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
@@ -7881,7 +7888,15 @@ export class AgentSession {
 
 		const targetModel = await this.#modelRegistry.refreshSelectedModelMetadata(model);
 
-		if (switchActiveModel) {
+		const currentContextTokens = options?.currentContextTokens ?? 0;
+		const targetContextWindow = targetModel.contextWindow ?? 0;
+		const switched = !(
+			currentContextTokens > 0 &&
+			targetContextWindow > 0 &&
+			currentContextTokens > targetContextWindow
+		);
+
+		if (switched) {
 			this.#clearActiveRetryFallback();
 			this.#setModelWithProviderSessionReset(targetModel);
 			this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
@@ -7892,8 +7907,8 @@ export class AgentSession {
 				this.#formatRoleModelValue(role, targetModel, options.selector, options.thinkingLevel),
 			);
 		}
-		if (!switchActiveModel) {
-			return;
+		if (!switched) {
+			return { switched: false };
 		}
 		this.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 
@@ -7901,6 +7916,7 @@ export class AgentSession {
 		// configured defaultLevel; otherwise preserve the current level (or auto).
 		this.#reapplyThinkingLevel(targetModel.thinking?.defaultLevel);
 		await this.#syncAfterModelChange(previousEditMode);
+		return { switched: true };
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7863,16 +7863,17 @@ export class AgentSession {
 	/**
 	 * Set model directly.
 	 * Validates that a credential source is configured (synchronously, without
-	 * refreshing OAuth or running command-backed key programs) and saves to the
-	 * active session. Persists settings only when requested. The concrete key is
-	 * resolved lazily per request, so switching never blocks the event loop.
+	 * refreshing OAuth or running command-backed key programs). By default, the
+	 * active session switches immediately; callers may persist role settings
+	 * without touching the live session via `switchActiveModel: false`.
 	 * @throws Error if no API key available for the model
 	 */
 	async setModel(
 		model: Model,
 		role: string = "default",
-		options?: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean },
+		options?: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean; switchActiveModel?: boolean },
 	): Promise<void> {
+		const switchActiveModel = options?.switchActiveModel ?? true;
 		const previousEditMode = this.#resolveActiveEditMode();
 		if (!this.#modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
@@ -7880,14 +7881,19 @@ export class AgentSession {
 
 		const targetModel = await this.#modelRegistry.refreshSelectedModelMetadata(model);
 
-		this.#clearActiveRetryFallback();
-		this.#setModelWithProviderSessionReset(targetModel);
-		this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
+		if (switchActiveModel) {
+			this.#clearActiveRetryFallback();
+			this.#setModelWithProviderSessionReset(targetModel);
+			this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
+		}
 		if (options?.persist) {
 			this.settings.setModelRole(
 				role,
 				this.#formatRoleModelValue(role, targetModel, options.selector, options.thinkingLevel),
 			);
+		}
+		if (!switchActiveModel) {
+			return;
 		}
 		this.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -189,6 +189,21 @@ describe("AgentSession model persistence", () => {
 		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
 	});
 
+	it("persists the default role without switching the active model when requested", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const nextModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		const created = await createSession({
+			initialModel: defaultModel,
+			modelRoles: { default: modelValue(defaultModel) },
+		});
+
+		await created.session.setModel(nextModel, "default", { persist: true, switchActiveModel: false });
+
+		expect(created.session.model?.id).toBe(defaultModel.id);
+		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
+	});
+
 	it("cycles role models without rewriting configured roles", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -189,7 +189,7 @@ describe("AgentSession model persistence", () => {
 		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
 	});
 
-	it("persists the default role without switching the active model when requested", async () => {
+	it("persists the default role without switching the active model when over context", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const nextModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
 
@@ -198,8 +198,16 @@ describe("AgentSession model persistence", () => {
 			modelRoles: { default: modelValue(defaultModel) },
 		});
 
-		await created.session.setModel(nextModel, "default", { persist: true, switchActiveModel: false });
+		const targetWindow = nextModel.contextWindow ?? 0;
+		expect(targetWindow).toBeGreaterThan(0);
+		const overflowTokens = targetWindow + 1;
 
+		const result = await created.session.setModel(nextModel, "default", {
+			persist: true,
+			currentContextTokens: overflowTokens,
+		});
+
+		expect(result).toEqual({ switched: false });
 		expect(created.session.model?.id).toBe(defaultModel.id);
 		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
 	});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -7,6 +7,7 @@ import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-regis
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ModelSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { ConfiguredThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
 function normalizeRenderedText(text: string): string {
@@ -66,7 +67,7 @@ function createContextTestModel(id: string, contextWindow: number): Model {
 function createScopedSelector(
 	models: Model[],
 	settings: Settings,
-	onSelect: (model: Model) => void,
+	onSelect: (model: Model, role: string | null, thinkingLevel?: ConfiguredThinkingLevel, selector?: string) => void,
 	options?: { temporaryOnly?: boolean; currentContextTokens?: number },
 ): ModelSelectorComponent {
 	const modelRegistry = {
@@ -83,7 +84,7 @@ function createScopedSelector(
 		settings,
 		modelRegistry,
 		models.map(model => ({ model })),
-		model => onSelect(model),
+		(model, role, thinkingLevel, selector) => onSelect(model, role, thinkingLevel, selector),
 		() => {},
 		options,
 	);
@@ -207,7 +208,7 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(rendered).toContain("default/smol/plan/task/slow/custom roles");
 	});
 
-	test("opens the role assignment menu but guards over-context default switches", async () => {
+	test("opens over-context default role actions for global configuration", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});
 		const small = createContextTestModel("only-small", 4096);
@@ -225,12 +226,18 @@ describe("ModelSelector role badge thinking display", () => {
 		selector.handleInput("\n");
 		const afterOpen = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(afterOpen).toContain("Action for: only-small");
-		expect(afterOpen).toContain("Set as DEFAULT (Default) ⦸ context>4.1k");
+		expect(afterOpen).toContain("Set as DEFAULT (Default)");
+		expect(afterOpen).not.toContain("context>4.1k");
 
 		selector.handleInput("\n");
 		const afterRoleEnter = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(afterRoleEnter).toContain("Thinking for: Fast (only-small)");
+		expect(afterRoleEnter).toContain("Thinking for: Default (only-small)");
 		expect(onSelect).not.toHaveBeenCalled();
+
+		selector.handleInput("\n");
+		expect(onSelect.mock.calls[0]?.[0]).toBe(small);
+		expect(onSelect.mock.calls[0]?.[1]).toBe("default");
+		expect(onSelect.mock.calls[0]?.[3]).toBe("test/only-small");
 	});
 
 	test("uses cached models for Enter while offline refresh is still pending", () => {


### PR DESCRIPTION
## Repro
The focused regression path is `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts -t "opens the role assignment menu but guards over-context default switches"`; before the fix, the test passed because it asserted the broken `Set as DEFAULT … context>4.1k` disabled state and skipped Default action.

## Cause
`packages/coding-agent/src/modes/components/model-selector.ts` had a separate `#isDefaultRoleActionOverContextLimit` guard that was not gated by `temporaryOnly`, so Alt+M role configuration disabled the Default action based on transient session tokens. `packages/coding-agent/src/modes/controllers/selector-controller.ts` then coupled Default-role persistence to `AgentSession.setModel`, whose live `#setModelWithProviderSessionReset` side effect was the only part that needed context-window protection.

## Fix
- Removed the Default-action context guard from role-menu rendering, navigation, and Enter handling.
- Added `switchActiveModel: false` support to `AgentSession.setModel` so callers can persist role settings without switching the live session model.
- Made Alt+M Default-role assignment persist the global default model while skipping only the active-session switch when the candidate model is below the current session context size.
- Updated selector and session persistence regression tests and the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` passed: 10 tests, 44 assertions. `bun test packages/coding-agent/test/agent-session-model-persistence.test.ts` passed: 17 tests, 34 assertions. `bun run --cwd packages/coding-agent check:types` passed. Fixes #3708