### PR TITLE
fix(mcp): support legacy SSE transport

### DIFF
--- a/docs/mcp-protocol-transports.md
+++ b/docs/mcp-protocol-transports.md
@@ -11,7 +11,7 @@ Covers:
 - Request correlation and lifecycle for stdio and HTTP/SSE transports
 - Timeout, cancellation, and auth-refresh behavior
 - Error propagation and malformed payload handling
-- Transport selection boundaries (`stdio` vs `http`/`sse`)
+- Transport selection boundaries (`stdio` vs `http` vs `sse`)
 - Which reconnect/retry responsibilities are transport-level vs manager/tool-bridge-level
 
 Does not cover extension authoring UX or command UI.
@@ -21,6 +21,7 @@ Does not cover extension authoring UX or command UI.
 - [`src/mcp/types.ts`](../packages/coding-agent/src/mcp/types.ts)
 - [`src/mcp/transports/stdio.ts`](../packages/coding-agent/src/mcp/transports/stdio.ts)
 - [`src/mcp/transports/http.ts`](../packages/coding-agent/src/mcp/transports/http.ts)
+- [`src/mcp/transports/sse.ts`](../packages/coding-agent/src/mcp/transports/sse.ts)
 - [`src/mcp/transports/index.ts`](../packages/coding-agent/src/mcp/transports/index.ts)
 - [`src/mcp/json-rpc.ts`](../packages/coding-agent/src/mcp/json-rpc.ts)
 - [`src/mcp/client.ts`](../packages/coding-agent/src/mcp/client.ts)
@@ -33,7 +34,7 @@ Does not cover extension authoring UX or command UI.
 - Message shapes are defined in `types.ts` (`JsonRpcRequest`, `JsonRpcNotification`, `JsonRpcResponse`, `JsonRpcMessage`).
 - MCP client logic (`client.ts`) decides method order and session handshake:
   1. `initialize` request
-  2. for HTTP/SSE transports, start the optional background SSE listener after the initialize response has established any session id
+  2. for Streamable HTTP transports, start the optional background SSE listener after the initialize response has established any session id
   3. `notifications/initialized` notification
   4. method calls like `tools/list`, `tools/call`
 
@@ -50,20 +51,22 @@ Does not cover extension authoring UX or command UI.
 Transport implementations own framing and I/O details:
 
 - `StdioTransport`: newline-delimited JSON over subprocess stdio
-- `HttpTransport`: JSON-RPC over HTTP POST, with optional SSE responses/listening
+- `HttpTransport`: Streamable HTTP JSON-RPC over POST, with optional SSE responses/listening
+- `LegacySseTransport`: protocol revision 2024-11-05 HTTP+SSE, with a persistent GET stream and POST endpoint discovered from the `endpoint` event
 
 ### Manager/client wiring
 
-`connectToServer()` always installs an `onRequest` handler for standard server-to-client requests. `MCPManager` installs notification handlers, OAuth refresh hooks for HTTP OAuth servers, and `onClose` reconnect handling for managed connections.
+`connectToServer()` always installs an `onRequest` handler for standard server-to-client requests. `MCPManager` installs notification handlers, OAuth refresh hooks for HTTP-like OAuth servers, and `onClose` reconnect handling for managed connections.
 
 ## Transport selection
 
 `client.ts:createTransport()` chooses transport from config:
 
 - `type` omitted or `"stdio"` -> `createStdioTransport`
-- `"http"` or `"sse"` -> `createHttpTransport`
+- `"http"` -> `createHttpTransport`
+- `"sse"` -> `createSseTransport`
 
-`"sse"` is treated as an HTTP transport variant (same class), not a separate transport implementation.
+`"sse"` uses the legacy HTTP+SSE transport: it opens the configured URL with GET, reads the `endpoint` event's plain-text URL/path, POSTs JSON-RPC requests to that endpoint, and receives JSON-RPC responses on the stream.
 
 ## JSON-RPC message flow and correlation
 
@@ -152,7 +155,7 @@ When process exits or stream closes:
 - There is no explicit queue or high-watermark management in transport.
 - Inbound processing is stream-driven (`for await` over `readJsonl`), one parsed message at a time.
 
-## HTTP/SSE transport internals
+## Streamable HTTP transport internals
 
 ## Lifecycle and connection semantics
 
@@ -183,7 +186,7 @@ For `notify()`:
 - timeout uses an internal `AbortController` with the same resolved timeout
 - there is no external abort option on the transport interface
 
-For HTTP OAuth configs managed by `MCPManager`, outbound requests and best-effort server-request responses retry once on `HTTP 401`/`403` if token refresh returns replacement headers.
+For HTTP-like OAuth configs managed by `MCPManager`, outbound requests and best-effort server-request responses retry once on `HTTP 401`/`403` if token refresh returns replacement headers.
 
 ## HTTP error propagation
 
@@ -209,7 +212,7 @@ Two SSE paths exist:
 
 2. **Background SSE listener** (`startSSEListener()`)
    - optional GET listener for server-initiated notifications and server-to-client requests
-   - `connectToServer()` starts it for HTTP/SSE transports after `initialize` and before `notifications/initialized`
+   - `connectToServer()` starts it for Streamable HTTP transports after `initialize` and before `notifications/initialized`
    - listener startup waits up to one second, or less for very small request timeouts; `timeout: 0` / `OMP_MCP_TIMEOUT_MS=0` disables that startup deadline
    - if GET returns `405`, another non-OK status, no body, or times out, listener silently disables itself
 
@@ -220,6 +223,16 @@ SSE JSON parsing errors bubble out of `readSseJson` and reject request/listener.
 - Request SSE parse errors reject the active request.
 - Background listener errors trigger `onError` (except AbortError), and an established listener ending while still connected triggers `onClose` so the manager can reconnect.
 - Transport does not restart the listener itself; managed connections may reconnect through manager `onClose` handling.
+
+## Legacy HTTP+SSE transport internals
+
+`LegacySseTransport` implements MCP protocol revision 2024-11-05:
+
+- `connect()` opens the configured URL with `GET Accept: text/event-stream`.
+- The first `endpoint` event is control data, not JSON; its `data` value is resolved against the configured URL and stored as the JSON-RPC POST endpoint.
+- `request()` and `notify()` POST JSON-RPC frames to the discovered endpoint.
+- JSON-RPC responses, notifications, and server-to-client requests are read from `event: message` stream events and correlated by request id.
+- If the stream ends, pending requests fail with `Legacy SSE stream closed`; managed connections may reconnect through `onClose`.
 
 ## `json-rpc.ts` utility vs transport abstraction
 
@@ -239,7 +252,7 @@ This path is lightweight but less robust than full transport implementation.
 
 Current transport implementations do **not**:
 
-- retry ordinary failed requests, except the HTTP transport's single OAuth-refresh retry when `onAuthError` is wired
+- retry ordinary failed requests, except HTTP-like transports' single OAuth-refresh retry when `onAuthError` is wired
 - reconnect after stdio process exit
 - reconnect SSE listeners by themselves
 - resend in-flight requests after disconnect
@@ -258,6 +271,7 @@ They fail fast and propagate errors.
 - **Stdio stream/process ends**: transport closes; pending requests rejected as `Transport closed`; manager-managed connections trigger reconnect.
 - **HTTP non-2xx**: request/notify throws HTTP error; managed OAuth requests can refresh auth and retry once on 401/403.
 - **Invalid JSON response**: parse exception propagated.
+- **Legacy SSE stream ends**: pending requests fail with `Legacy SSE stream closed`; manager-managed connections trigger reconnect.
 - **SSE ends without matching id**: request fails with `No response received for request ID ...`.
 - **Timeout**: transport-specific timeout error.
 - **Caller abort**: AbortError/reason propagated from caller signal where the method accepts one.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed MCP `type: "sse"` servers by adding the legacy HTTP+SSE endpoint handshake and streaming JSON-RPC response path. ([#3710](https://github.com/can1357/oh-my-pi/issues/3710))
 - Fixed interrupted reasoning blocks being incorrectly stripped when they contained a valid signature
 - Fixed interrupted thinking being lost in LLM provider requests after user interrupts by properly stripping trailing reasoning blocks from assistant turns while preserving them in the UI and session history.
 - Fixed the live todo HUD going stale during long tool-use loops by introducing a mid-run reconciliation reminder that prompts the agent to update incomplete items.

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -8,6 +8,7 @@ import * as url from "node:url";
 import { getProjectDir, logger, withTimeout } from "@oh-my-pi/pi-utils";
 import { describeMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "./timeout";
 import { createHttpTransport } from "./transports/http";
+import { createSseTransport } from "./transports/sse";
 import { createStdioTransport } from "./transports/stdio";
 import type {
 	MCPGetPromptParams,
@@ -77,8 +78,9 @@ async function createTransport(config: MCPServerConfig): Promise<MCPTransport> {
 		case "stdio":
 			return createStdioTransport(config as MCPStdioServerConfig);
 		case "http":
+			return createHttpTransport(config as MCPHttpServerConfig);
 		case "sse":
-			return createHttpTransport(config as MCPHttpServerConfig | MCPSseServerConfig);
+			return createSseTransport(config as MCPSseServerConfig);
 		default:
 			throw new Error(`Unknown server type: ${serverType}`);
 	}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -37,7 +37,6 @@ import type { McpConnectionStatusEvent } from "./startup-events";
 import type { MCPToolDetails } from "./tool-bridge";
 import { DeferredMCPTool, MCPTool } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
-import { HttpTransport } from "./transports/http";
 import type {
 	MCPGetPromptResult,
 	MCPPrompt,
@@ -48,6 +47,7 @@ import type {
 	MCPServerConfig,
 	MCPServerConnection,
 	MCPToolDefinition,
+	MCPTransport,
 } from "./types";
 import { MCPNotificationMethods } from "./types";
 
@@ -56,6 +56,13 @@ type ToolLoadResult = {
 	serverTools: MCPToolDefinition[];
 };
 
+interface AuthRefreshableMCPTransport extends MCPTransport {
+	onAuthError?: () => Promise<Record<string, string> | null>;
+}
+
+function isAuthRefreshableMCPTransport(transport: MCPTransport): transport is AuthRefreshableMCPTransport {
+	return "onAuthError" in transport;
+}
 type TrackedPromise<T> = {
 	promise: Promise<T>;
 	status: "pending" | "fulfilled" | "rejected";
@@ -419,12 +426,12 @@ export class MCPManager {
 						this.#connections.set(name, connection);
 					}
 
-					// Wire auth refresh for HTTP transports so 401s trigger token refresh.
+					// Wire auth refresh for HTTP-like transports so 401s trigger token refresh.
 					// Gate on a resolvable managed credential, not on the auth block:
 					// definition-only configs (url-keyed fallback) get Bearer injection
 					// too and need the same mid-session refresh hook.
 					if (
-						connection.transport instanceof HttpTransport &&
+						isAuthRefreshableMCPTransport(connection.transport) &&
 						lookupMcpOAuthCredential(this.#authStorage, config)
 					) {
 						connection.transport.onAuthError = async () => {
@@ -957,9 +964,9 @@ export class MCPManager {
 
 		this.#connections.set(name, connection);
 
-		// Wire auth refresh for HTTP transports, and reconnect for any transport.
+		// Wire auth refresh for HTTP-like transports, and reconnect for any transport.
 		// Same gate as connectServers: any resolvable managed credential.
-		if (connection.transport instanceof HttpTransport && lookupMcpOAuthCredential(this.#authStorage, config)) {
+		if (isAuthRefreshableMCPTransport(connection.transport) && lookupMcpOAuthCredential(this.#authStorage, config)) {
 			connection.transport.onAuthError = async () => {
 				const refreshed = await this.#resolveAuthConfig(config, { forceRefresh: true });
 				if (refreshed.type === "http" || refreshed.type === "sse") {

--- a/packages/coding-agent/src/mcp/transports/index.ts
+++ b/packages/coding-agent/src/mcp/transports/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from "./http";
+export * from "./sse";
 export * from "./stdio";

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -155,7 +155,7 @@ export class LegacySseTransport implements MCPTransport {
 		} finally {
 			operation.clear();
 			if (endpointReceived) {
-				this.#rejectPending(new Error("Legacy SSE stream closed"));
+				this.#rejectPending(new Error("Transport closed: legacy SSE stream closed"));
 			}
 		}
 	}

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -1,0 +1,365 @@
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { logger, readSseEvents, Snowflake } from "@oh-my-pi/pi-utils";
+import type {
+	JsonRpcError,
+	JsonRpcMessage,
+	JsonRpcRequest,
+	JsonRpcResponse,
+	MCPRequestOptions,
+	MCPSseServerConfig,
+	MCPTransport,
+} from "../../mcp/types";
+import { toJsonRpcError } from "../../mcp/types";
+import { createMCPTimeout, getNeverAbortSignal, resolveMCPTimeoutMs } from "../timeout";
+
+interface MCPTimeoutOperation {
+	signal?: AbortSignal;
+	clear: () => void;
+	isTimeoutAbort: (error: unknown) => boolean;
+}
+
+interface PendingLegacySseRequest {
+	resolve: (value: unknown) => void;
+	reject: (reason?: unknown) => void;
+	operation: MCPTimeoutOperation;
+	abortHandler?: () => void;
+}
+
+/** Legacy MCP HTTP+SSE transport from protocol revision 2024-11-05. */
+export class LegacySseTransport implements MCPTransport {
+	#connected = false;
+	#endpointUrl: string | null = null;
+	#sseConnection: AbortController | null = null;
+	#pending = new Map<string | number, PendingLegacySseRequest>();
+	#config: MCPSseServerConfig;
+
+	onClose?: () => void;
+	onError?: (error: Error) => void;
+	onNotification?: (method: string, params: unknown) => void;
+	onRequest?: (method: string, params: unknown) => Promise<unknown>;
+	/** Called on 401/403 to attempt token refresh. Returns updated headers or null. */
+	onAuthError?: () => Promise<Record<string, string> | null>;
+
+	constructor(config: MCPSseServerConfig) {
+		this.#config = config;
+	}
+
+	get connected(): boolean {
+		return this.#connected;
+	}
+
+	get url(): string {
+		return this.#config.url;
+	}
+
+	async connect(): Promise<void> {
+		if (this.#connected) return;
+		if (this.#sseConnection) return;
+
+		const connection = new AbortController();
+		const timeout = resolveMCPTimeoutMs(this.#config.timeout);
+		const operation = createMCPTimeout(timeout, connection.signal);
+		const endpointReady = Promise.withResolvers<void>();
+		this.#sseConnection = connection;
+
+		try {
+			const response = await fetch(this.#config.url, {
+				method: "GET",
+				headers: {
+					Accept: "text/event-stream",
+					...this.#config.headers,
+				},
+				signal: operation.signal,
+			});
+
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`HTTP ${response.status}: ${text}`);
+			}
+			if (!response.body) {
+				throw new Error("Legacy SSE response did not include a body");
+			}
+
+			void this.#readSSEStream(response.body, operation, endpointReady).finally(() => {
+				const wasConnected = this.#connected;
+				if (this.#sseConnection === connection) this.#sseConnection = null;
+				if (wasConnected) this.onClose?.();
+			});
+			await endpointReady.promise;
+		} catch (error) {
+			operation.clear();
+			if (this.#sseConnection === connection) this.#sseConnection = null;
+			connection.abort();
+			if (operation.isTimeoutAbort(error)) {
+				throw new Error(`Legacy SSE endpoint timeout after ${timeout}ms`);
+			}
+			throw error;
+		}
+	}
+
+	async #readSSEStream(
+		body: ReadableStream<Uint8Array>,
+		operation: MCPTimeoutOperation,
+		endpointReady: PromiseWithResolvers<void>,
+	): Promise<void> {
+		const signal = operation.signal ?? getNeverAbortSignal();
+		let endpointReceived = false;
+		try {
+			for await (const event of readSseEvents(body, signal)) {
+				if (event.event === "endpoint") {
+					if (!this.#endpointUrl) {
+						this.#endpointUrl = new URL(event.data, this.#config.url).href;
+						this.#connected = true;
+						endpointReceived = true;
+						operation.clear();
+						endpointReady.resolve();
+					}
+					continue;
+				}
+				if (event.data === "" || event.data === "[DONE]") continue;
+
+				let payload: unknown;
+				try {
+					payload = JSON.parse(event.data) as unknown;
+				} catch (error) {
+					if (error instanceof SyntaxError) {
+						throw new Error(`Legacy SSE message event contained non-JSON data: ${event.data}`);
+					}
+					throw error;
+				}
+
+				const messages = Array.isArray(payload) ? payload : [payload];
+				for (const message of messages) {
+					if (typeof message !== "object" || message === null) continue;
+					this.#dispatchMessage(message as JsonRpcMessage);
+				}
+			}
+			if (!endpointReceived) {
+				endpointReady.reject(new Error("Legacy SSE endpoint event not received"));
+			}
+		} catch (error) {
+			if (!endpointReceived) {
+				endpointReady.reject(error);
+			} else if (error instanceof Error && error.name !== "AbortError") {
+				logger.debug("Legacy SSE stream error", { url: this.#config.url, error: error.message });
+				this.onError?.(error);
+				this.#rejectPending(error);
+			}
+		} finally {
+			operation.clear();
+			if (endpointReceived) {
+				this.#rejectPending(new Error("Legacy SSE stream closed"));
+			}
+		}
+	}
+
+	#dispatchMessage(message: JsonRpcMessage): void {
+		if ("id" in message && ("result" in message || "error" in message)) {
+			const pending = this.#pending.get(message.id);
+			if (pending) {
+				this.#pending.delete(message.id);
+				pending.operation.clear();
+				if (pending.abortHandler) pending.operation.signal?.removeEventListener("abort", pending.abortHandler);
+				const response = message as JsonRpcResponse;
+				if (response.error) {
+					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+				} else {
+					pending.resolve(response.result);
+				}
+				return;
+			}
+		}
+		if ("method" in message && "id" in message && message.id != null) {
+			void this.#handleServerRequest(message as JsonRpcRequest);
+			return;
+		}
+		if ("method" in message && !("id" in message)) {
+			this.onNotification?.(message.method, message.params);
+		}
+	}
+
+	async request<T = unknown>(
+		method: string,
+		params?: Record<string, unknown>,
+		options?: MCPRequestOptions,
+	): Promise<T> {
+		if (!this.#connected || !this.#endpointUrl) {
+			throw new Error("Transport not connected");
+		}
+
+		const id = Snowflake.next();
+		const body = {
+			jsonrpc: "2.0" as const,
+			id,
+			method,
+			params: params ?? {},
+		};
+		const timeout = resolveMCPTimeoutMs(this.#config.timeout);
+		const operation = createMCPTimeout(timeout, options?.signal);
+		const deferred = Promise.withResolvers<unknown>();
+		const pending: PendingLegacySseRequest = {
+			resolve: deferred.resolve,
+			reject: deferred.reject,
+			operation,
+		};
+		if (operation.signal) {
+			pending.abortHandler = () => {
+				this.#pending.delete(id);
+				operation.clear();
+				deferred.reject(
+					options?.signal?.aborted && options.signal.reason instanceof Error
+						? options.signal.reason
+						: new Error(`Legacy SSE response timeout after ${timeout}ms`),
+				);
+			};
+			operation.signal.addEventListener("abort", pending.abortHandler, { once: true });
+		}
+		this.#pending.set(id, pending);
+
+		try {
+			const response = await this.#postJson(body, operation.signal);
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`HTTP ${response.status}: ${text}`);
+			}
+			await response.body?.cancel();
+			return (await deferred.promise) as T;
+		} catch (error) {
+			this.#pending.delete(id);
+			operation.clear();
+			if (pending.abortHandler) operation.signal?.removeEventListener("abort", pending.abortHandler);
+			if (operation.isTimeoutAbort(error)) {
+				throw new Error(`Request timeout after ${timeout}ms`);
+			}
+			throw error;
+		}
+	}
+
+	async notify(method: string, params?: Record<string, unknown>): Promise<void> {
+		if (!this.#connected || !this.#endpointUrl) {
+			throw new Error("Transport not connected");
+		}
+
+		const timeout = resolveMCPTimeoutMs(this.#config.timeout);
+		const operation = createMCPTimeout(timeout);
+		try {
+			const response = await this.#postJson(
+				{
+					jsonrpc: "2.0" as const,
+					method,
+					params: params ?? {},
+				},
+				operation.signal,
+			);
+			operation.clear();
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`HTTP ${response.status}: ${text}`);
+			}
+			await response.body?.cancel();
+		} catch (error) {
+			operation.clear();
+			if (operation.isTimeoutAbort(error)) {
+				throw new Error(`Notify timeout after ${timeout}ms`);
+			}
+			throw error;
+		}
+	}
+
+	async #postJson(
+		body: JsonRpcRequest | JsonRpcResponse | { jsonrpc: "2.0"; method: string; params: Record<string, unknown> },
+		signal?: AbortSignal,
+	): Promise<Response> {
+		const endpointUrl = this.#endpointUrl;
+		if (!endpointUrl) throw new Error("Transport not connected");
+		let headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			...this.#config.headers,
+		};
+		let response = await fetch(endpointUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal,
+		});
+		const status = AIError.status(response);
+		if (!this.onAuthError || (status !== 401 && status !== 403)) return response;
+
+		const refreshedHeaders = await this.onAuthError();
+		if (!refreshedHeaders) return response;
+		await response.body?.cancel();
+		this.#config.headers = refreshedHeaders;
+		headers = {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			...this.#config.headers,
+		};
+		response = await fetch(endpointUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal,
+		});
+		return response;
+	}
+
+	async #handleServerRequest(request: JsonRpcRequest): Promise<void> {
+		if (!this.onRequest) {
+			await this.#sendServerResponse(request.id, undefined, { code: -32601, message: "Method not found" });
+			return;
+		}
+		try {
+			const result = await this.onRequest(request.method, request.params);
+			await this.#sendServerResponse(request.id, result);
+		} catch (error) {
+			await this.#sendServerResponse(request.id, undefined, toJsonRpcError(error));
+		}
+	}
+
+	async #sendServerResponse(id: string | number, result?: unknown, error?: JsonRpcError): Promise<void> {
+		if (!this.#connected) return;
+		const timeout = resolveMCPTimeoutMs(this.#config.timeout);
+		const operation = createMCPTimeout(timeout);
+		try {
+			const response = await this.#postJson(
+				error ? { jsonrpc: "2.0" as const, id, error } : { jsonrpc: "2.0" as const, id, result: result ?? {} },
+				operation.signal,
+			);
+			operation.clear();
+			await response.body?.cancel();
+		} catch {
+			operation.clear();
+		}
+	}
+
+	#rejectPending(error: Error): void {
+		for (const [id, pending] of this.#pending) {
+			this.#pending.delete(id);
+			pending.operation.clear();
+			if (pending.abortHandler) pending.operation.signal?.removeEventListener("abort", pending.abortHandler);
+			pending.reject(error);
+		}
+	}
+
+	async close(): Promise<void> {
+		if (!this.#connected && !this.#sseConnection) return;
+		const wasConnected = this.#connected;
+		this.#connected = false;
+		this.#endpointUrl = null;
+		if (this.#sseConnection) {
+			this.#sseConnection.abort();
+			this.#sseConnection = null;
+		}
+		this.#rejectPending(new Error("Transport closed"));
+		if (wasConnected) this.onClose?.();
+		this.onClose = undefined;
+	}
+}
+
+/** Create and connect a legacy HTTP+SSE transport. */
+export async function createSseTransport(config: MCPSseServerConfig): Promise<LegacySseTransport> {
+	const transport = new LegacySseTransport(config);
+	await transport.connect();
+	return transport;
+}

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -108,7 +108,14 @@ export class LegacySseTransport implements MCPTransport {
 			for await (const event of readSseEvents(body, signal)) {
 				if (event.event === "endpoint") {
 					if (!this.#endpointUrl) {
-						this.#endpointUrl = new URL(event.data, this.#config.url).href;
+						const endpointUrl = new URL(event.data, this.#config.url);
+						const configuredUrl = new URL(this.#config.url);
+						if (endpointUrl.origin !== configuredUrl.origin) {
+							throw new Error(
+								`Legacy SSE endpoint origin mismatch: expected ${configuredUrl.origin}, received ${endpointUrl.origin}`,
+							);
+						}
+						this.#endpointUrl = endpointUrl.href;
 						this.#connected = true;
 						endpointReceived = true;
 						operation.clear();

--- a/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
+++ b/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { connectToServer, listTools } from "@oh-my-pi/pi-coding-agent/mcp/client";
+import type { JsonRpcMessage } from "@oh-my-pi/pi-coding-agent/mcp/types";
+
+const encoder = new TextEncoder();
+let server: Bun.Server<undefined> | null = null;
+
+afterEach(() => {
+	server?.stop(true);
+	server = null;
+});
+
+describe("legacy MCP HTTP+SSE transport", () => {
+	it("reads the endpoint event as a POST URL and receives JSON-RPC responses from the stream", async () => {
+		let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+		const postTargets: string[] = [];
+
+		server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const url = new URL(req.url);
+				if (req.method === "GET" && url.pathname === "/mcp/sse") {
+					const stream = new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamController = controller;
+							controller.enqueue(
+								encoder.encode("event: endpoint\ndata: /mcp/messages/?session_id=legacy-session\n\n"),
+							);
+						},
+					});
+					return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+				}
+
+				if (req.method === "POST" && url.pathname === "/mcp/messages/") {
+					postTargets.push(`${url.pathname}${url.search}`);
+					const body = (await req.json()) as JsonRpcMessage;
+					if (!streamController) return new Response("SSE stream not open", { status: 500 });
+
+					if ("id" in body && "method" in body && body.method === "initialize") {
+						streamController.enqueue(
+							encoder.encode(
+								`event: message\ndata: ${JSON.stringify({
+									jsonrpc: "2.0",
+									id: body.id,
+									result: {
+										protocolVersion: "2024-11-05",
+										capabilities: { tools: {} },
+										serverInfo: { name: "legacy-sse", version: "1.0.0" },
+									},
+								})}\n\n`,
+							),
+						);
+					} else if ("id" in body && "method" in body && body.method === "tools/list") {
+						streamController.enqueue(
+							encoder.encode(
+								`event: message\ndata: ${JSON.stringify({
+									jsonrpc: "2.0",
+									id: body.id,
+									result: { tools: [{ name: "crawl", inputSchema: { type: "object" } }] },
+								})}\n\n`,
+							),
+						);
+					}
+					return new Response(null, { status: 202 });
+				}
+
+				return new Response("not found", { status: 404 });
+			},
+		});
+
+		const connection = await connectToServer("legacy-sse", {
+			type: "sse",
+			url: `http://127.0.0.1:${server.port}/mcp/sse`,
+			timeout: 1000,
+		});
+		try {
+			const tools = await listTools(connection);
+
+			expect(postTargets).toContain("/mcp/messages/?session_id=legacy-session");
+			expect(tools).toEqual([{ name: "crawl", inputSchema: { type: "object" } }]);
+		} finally {
+			await connection.transport.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
+++ b/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { connectToServer, listTools } from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { isRetriableConnectionError } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import type { JsonRpcMessage } from "@oh-my-pi/pi-coding-agent/mcp/types";
 
 const encoder = new TextEncoder();
@@ -106,5 +107,70 @@ describe("legacy MCP HTTP+SSE transport", () => {
 				timeout: 1000,
 			}),
 		).rejects.toThrow("Legacy SSE endpoint origin mismatch");
+	});
+
+	it("surfaces stream drops during requests as retriable transport failures", async () => {
+		let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+		server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const url = new URL(req.url);
+				if (req.method === "GET" && url.pathname === "/mcp/sse") {
+					const stream = new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamController = controller;
+							controller.enqueue(
+								encoder.encode("event: endpoint\ndata: /mcp/messages/?session_id=legacy-session\n\n"),
+							);
+						},
+					});
+					return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+				}
+
+				if (req.method === "POST" && url.pathname === "/mcp/messages/") {
+					const body = (await req.json()) as JsonRpcMessage;
+					if (!streamController) return new Response("SSE stream not open", { status: 500 });
+					if ("id" in body && "method" in body && body.method === "initialize") {
+						streamController.enqueue(
+							encoder.encode(
+								`event: message\ndata: ${JSON.stringify({
+									jsonrpc: "2.0",
+									id: body.id,
+									result: {
+										protocolVersion: "2024-11-05",
+										capabilities: { tools: {} },
+										serverInfo: { name: "legacy-sse", version: "1.0.0" },
+									},
+								})}\n\n`,
+							),
+						);
+					} else if ("id" in body && "method" in body && body.method === "tools/list") {
+						streamController.close();
+					}
+					return new Response(null, { status: 202 });
+				}
+
+				return new Response("not found", { status: 404 });
+			},
+		});
+
+		const connection = await connectToServer("legacy-sse", {
+			type: "sse",
+			url: `http://127.0.0.1:${server.port}/mcp/sse`,
+			timeout: 1000,
+		});
+		try {
+			await listTools(connection);
+			throw new Error("Expected listTools to fail after legacy SSE stream close");
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			if (error instanceof Error) {
+				expect(error.message).toBe("Transport closed: legacy SSE stream closed");
+				expect(isRetriableConnectionError(error)).toBe(true);
+			}
+		} finally {
+			await connection.transport.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
+++ b/packages/coding-agent/test/mcp-legacy-sse-transport.test.ts
@@ -82,4 +82,29 @@ describe("legacy MCP HTTP+SSE transport", () => {
 			await connection.transport.close();
 		}
 	});
+
+	it("rejects endpoint events that point at another origin", async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				const url = new URL(req.url);
+				if (req.method === "GET" && url.pathname === "/mcp/sse") {
+					return new Response(
+						"event: endpoint\ndata: https://attacker.example/mcp/messages/?session_id=stolen\n\n",
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+
+		await expect(
+			connectToServer("legacy-sse", {
+				type: "sse",
+				url: `http://127.0.0.1:${server.port}/mcp/sse`,
+				headers: { Authorization: "Bearer secret" },
+				timeout: 1000,
+			}),
+		).rejects.toThrow("Legacy SSE endpoint origin mismatch");
+	});
 });


### PR DESCRIPTION
## Repro
A minimal legacy HTTP+SSE MCP server that returns `event: endpoint` with `data: /mcp/messages/?session_id=test` on `GET /mcp/sse` reproduced the failure when connecting with `{ type: "sse" }`: `connectToServer` attempted Streamable HTTP parsing and failed with `JSON Parse error: Unrecognized token '/'`.

## Cause
`packages/coding-agent/src/mcp/client.ts` routed both `type: "http"` and `type: "sse"` to `createHttpTransport`, so `packages/coding-agent/src/mcp/transports/http.ts` treated the legacy endpoint event as a Streamable HTTP SSE JSON message via `readSseJson`.

## Fix
- Added `LegacySseTransport` in `packages/coding-agent/src/mcp/transports/sse.ts` to open the GET SSE stream, resolve the endpoint event path, POST JSON-RPC requests/notifications to that endpoint, and correlate streamed responses by id.
- Routed `type: "sse"` to `createSseTransport` while leaving `type: "http"` on Streamable HTTP.
- Preserved OAuth refresh wiring for HTTP-like transports and documented the separate Streamable HTTP vs legacy HTTP+SSE paths.
- Added a Bun integration test covering endpoint handoff, initialize, initialized notification, and `tools/list` over the legacy SSE stream.

## Verification
`bun test packages/coding-agent/test/mcp-legacy-sse-transport.test.ts` passed. `bun run check` passed in `packages/coding-agent`. Fixes #3710