### PR TITLE
fix(utils): normalize ptree.bytes() to Uint8Array

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalized `ptree.ChildProcess.bytes()` to always return a `Uint8Array`. Bun's `Response(stream).bytes()` returns the raw `ArrayBuffer` once the body arrives in more than one chunk (subprocess stdout past ~128 KB), which broke callers relying on `Uint8Array` methods like `.indexOf` and `.subarray` — including the `ssh://` read path's `decodeUtf8Text`, which crashed with `indexOf is not a function` on larger remote text files. ([#3712](https://github.com/can1357/oh-my-pi/issues/3712))
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/utils/src/ptree.ts
+++ b/packages/utils/src/ptree.ts
@@ -247,7 +247,12 @@ export class ChildProcess<In extends InMask = InMask> {
 	}
 
 	async bytes(): Promise<Uint8Array> {
-		return new Response(this.stdout).bytes();
+		// Bun's `Response(stream).bytes()` returns the raw `ArrayBuffer` once the
+		// stream emits more than one chunk (subprocess stdout chunks past ~128 KB).
+		// Normalize at the contract boundary so every caller — SSH read,
+		// `decodeUtf8Text`, callers slicing with `.subarray` — sees a `Uint8Array`.
+		const body = (await new Response(this.stdout).bytes()) as Uint8Array | ArrayBuffer;
+		return body instanceof Uint8Array ? body : new Uint8Array(body);
 	}
 
 	// ── Wait ─────────────────────────────────────────────────────────────

--- a/packages/utils/test/ptree-bytes.test.ts
+++ b/packages/utils/test/ptree-bytes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { spawn } from "@oh-my-pi/pi-utils/ptree";
+
+describe("ptree.ChildProcess.bytes()", () => {
+	// Regression for https://github.com/can1357/oh-my-pi/issues/3712:
+	// `Response(stream).bytes()` returns the raw `ArrayBuffer` once the body
+	// arrives in more than one chunk (which happens for subprocess stdout past
+	// ~128 KB). Downstream code — e.g. the SSH read path's `decodeUtf8Text` —
+	// relied on `Uint8Array` methods (`.indexOf`, `.subarray`) and crashed.
+	it("returns a Uint8Array regardless of stdout size", async () => {
+		// 256 KB is comfortably past the multi-chunk boundary observed on Bun
+		// 1.3.x; the test then asserts only on the contract, not on the exact
+		// chunk threshold, so it stays robust to future Bun runtime changes.
+		const size = 256 * 1024;
+		const child = spawn(["bun", "-e", `process.stdout.write("a".repeat(${size}))`]);
+		const bytes = await child.bytes();
+		await child.exitedCleanly;
+
+		expect(bytes).toBeInstanceOf(Uint8Array);
+		expect(bytes.length).toBe(size);
+		// The two methods the SSH read path depends on.
+		expect(typeof bytes.indexOf).toBe("function");
+		expect(typeof bytes.subarray).toBe("function");
+		expect(bytes.indexOf(0)).toBe(-1);
+		expect(bytes.subarray(0, 4)).toEqual(new Uint8Array([0x61, 0x61, 0x61, 0x61]));
+	});
+});


### PR DESCRIPTION
## Repro

`ssh://` reads of larger remote text files crash with `TypeError: bytes.indexOf is not a function` before the read tool can render the requested line range. Smaller files work, so the failure looks file-specific. The root path is `SshProtocolHandler.resolve()` → `readRemoteFile()` → `decodeUtf8Text(fileResult.bytes)`, where `decodeUtf8Text` calls `bytes.indexOf(0)`. The reporter narrowed it to `ptree.ChildProcess.bytes()` returning an `ArrayBuffer` for larger stdout streams.

Local probe (Bun 1.3.14) — `ptree.spawn(["bash","-c","head -c N /dev/urandom | base64"]).bytes()`:

| `head -c` size | Effective stdout | `bytes()` constructor |
|---|---|---|
| 1 KB | 1.4 KB | `Uint8Array` |
| 64 KB | 88 KB | `Uint8Array` |
| 256 KB | 354 KB | `ArrayBuffer` |
| 1 MB | 1.42 MB | `ArrayBuffer` |

Direct probe of `new Response(stream).bytes()` confirms the same boundary: single-chunk streams yield `Uint8Array`, ≥2 chunks yield `ArrayBuffer`. Threading the result through the SSH decode path reproduces the reported error verbatim.

## Cause

`packages/utils/src/ptree.ts` `ChildProcess.bytes()`:

```ts
async bytes(): Promise<Uint8Array> {
	return new Response(this.stdout).bytes();
}
```

Bun's `Response(stream).bytes()` returns the raw `ArrayBuffer` once the body arrives in more than one chunk (subprocess stdout past ~128 KB) instead of the WHATWG-spec'd `Uint8Array`. The declared contract is `Promise<Uint8Array>`, so every caller — most visibly `decodeUtf8Text` in `packages/coding-agent/src/internal-urls/ssh-protocol.ts` and `readRemoteFile`'s `raw.subarray(0, maxBytes)` slice in `packages/coding-agent/src/ssh/file-transfer.ts` — assumes typed-array methods are available. On a multi-chunk read those methods are missing, surfacing as the reported `indexOf is not a function`.

## Fix

- `packages/utils/src/ptree.ts`: normalize at the boundary — when `Response.bytes()` returns an `ArrayBuffer`, wrap in a zero-copy `Uint8Array` view before returning. Keeps the public contract honored for every caller, including the SSH read path and `decodeUtf8Text`.
- `packages/utils/test/ptree-bytes.test.ts`: regression test that spawns a Bun subprocess emitting a 256 KB stdout payload (comfortably past the multi-chunk boundary) and asserts the return value is a `Uint8Array` with working `.indexOf` and `.subarray`.
- `packages/utils/CHANGELOG.md`: `[Unreleased]` → `Fixed` entry.

## Verification

- `bun test packages/utils/test/ptree-bytes.test.ts` → 1 pass, 6 expect() calls.
- `bun test packages/utils/test/` → 415 pass, 0 fail (full utils suite).
- `bun test packages/coding-agent/src/internal-urls/__tests__/ssh-protocol.test.ts packages/coding-agent/src/ssh/__tests__/file-transfer-posix-guard.test.ts` → 33 pass, 0 fail.
- Manual repro: re-ran the original `ptree.spawn(...).bytes()` probe across 1 KB / 64 KB / 256 KB / 1 MB / 4 MB stdouts — every size returns `Uint8Array` post-fix; the standalone `decodeUtf8Text(bytes)` call against a 270 KB payload now decodes cleanly instead of throwing.

Fixes #3712