### PR TITLE
fix(ssh): pinned expanded pending preview commit-unstable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed reasoning streaming being locked off for OpenAI-compatible providers that stream reasoning content without advertising reasoning support in model metadata.
 - Fixed `/shake` and other mid-stream chat rebuilds erasing live LLM output by preserving the in-flight streaming components and pending tools.
 - Fixed the `time_spent` status-line segment ticking continuously during idle sessions by ensuring it only accumulates active agent execution windows and resets correctly across session switches.
+- Fixed expanded pending SSH previews committing provisional rows (`⏳ SSH: [host]` header or the framed `╰──╯` footer) to native scrollback before the result render inserted the `Output` section, leaving a stale pending header above the final frame or reusing the pending footer in-place as the new `├── Output ──┤` separator. The SSH renderer now opts out of pending-preview commits in every expansion state. ([#3714](https://github.com/can1357/oh-my-pi/issues/3714))
 
 ## [16.2.2] - 2026-06-27
 

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -369,10 +369,14 @@ export const sshToolRenderer = {
 		});
 	},
 	mergeCallAndResult: true,
-	// Collapsed pending preview caps the command to a viewport-sized tail window
-	// that shifts while args stream. Expanded output is top-anchored enough for
-	// the transcript to commit its settled prefix.
-	provisionalPendingPreview: "collapsed",
+	// Pending call preview can re-anchor wholesale when the final result inserts
+	// the `Output` section, so no pending SSH rows may commit to native
+	// scrollback — even when expanded. The expanded pending shape was previously
+	// allowed to commit, which left two visible shapes in native scrollback once
+	// the result settled: a stale `⏳ SSH: [host]` header above the final frame,
+	// and the pending `╰──╯` footer reused in-place as the new `├── Output ──┤`
+	// separator with a fresh footer pushed below it.
+	provisionalPendingPreview: true,
 	// Partial-result chrome (pending icon and frame state) differs from the
 	// final SSH glyph/state, so the block stays commit-unstable while
 	// `options.isPartial` holds. Without this, a long-running SSH command's

--- a/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
+++ b/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
@@ -46,6 +46,34 @@ describe("ssh tool block commit stability", () => {
 		expect(component.isTranscriptBlockCommitStable()).toBe(false);
 	});
 
+	it("keeps the collapsed pending SSH preview commit-unstable until a result arrives", () => {
+		// Issue #3714: with `provisionalPendingPreview: true` the pending call
+		// preview is commit-unstable regardless of expansion, so neither the
+		// `⏳ SSH: [host]` header nor the framed bottom border can leak into
+		// native scrollback before the result render inserts `Output`.
+		const component = makeSshComponent();
+		component.setArgsComplete();
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(component.isTranscriptBlockCommitStable()).toBe(false);
+	});
+
+	it("keeps the expanded pending SSH preview commit-unstable until a result arrives", () => {
+		// Issue #3714: the previous `"collapsed"` opt-out left expanded pending
+		// rows commit-stable. Once the box outgrew the viewport the stale
+		// `⏳ SSH: [host]` header and the pending `╰──╯` footer reached native
+		// scrollback, then the final result re-anchored the frame and stranded
+		// the pending rows above (header variant) or reused the footer row in
+		// place as `├── Output ──┤` (footer variant). Expanded MUST also be
+		// commit-unstable until the result render replaces the pending shape.
+		const component = makeSshComponent();
+		component.setExpanded(true);
+		component.setArgsComplete();
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(component.isTranscriptBlockCommitStable()).toBe(false);
+	});
+
 	it("flips commit-stable as soon as the SSH result settles", () => {
 		const component = makeSshComponent();
 		component.updateResult(partialResult("connecting…"), true);
@@ -61,6 +89,20 @@ describe("ssh tool block commit stability", () => {
 		// commit-stable behaviour — the SSH opt-in must be renderer-scoped.
 		const component = new ToolExecutionComponent("bash", { command: "ls" }, {}, undefined, uiStub);
 		component.updateResult(partialResult("a\nb\n"), true);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(component.isTranscriptBlockCommitStable()).toBe(true);
+	});
+
+	it("does not opt other foreground tools out of expanded pending-preview commits", () => {
+		// Sanity: bash/eval still use `provisionalPendingPreview: "collapsed"`,
+		// so once expanded their pending preview is commit-stable. The SSH
+		// `true` opt-in MUST remain renderer-scoped — flipping the default
+		// here would block long top-anchored streams (e.g. a task call's
+		// context/assignment markdown) from reaching native scrollback.
+		const component = new ToolExecutionComponent("bash", { command: "ls" }, {}, undefined, uiStub);
+		component.setExpanded(true);
+		component.setArgsComplete();
 
 		expect(component.isTranscriptBlockFinalized()).toBe(false);
 		expect(component.isTranscriptBlockCommitStable()).toBe(true);


### PR DESCRIPTION
## Repro

Run a long-running SSH command, expand the in-flight preview with `ctrl+o`, and scroll the terminal enough for the framed block to outgrow the viewport before the result settles. Once the result lands two distinct stranded shapes appear in native scrollback:

- a stale `⏳ SSH: [host]` header pinned above the final `⇄ SSH: [host]` frame (header variant), and
- the pending bottom border row reused in-place as the new `├── Output ──┤` separator with a fresh `╰──╯` footer pushed below it (footer variant).

## Cause

`sshToolRenderer.provisionalPendingPreview` was set to `"collapsed"`, which opts only the COLLAPSED pending shape out of the transcript's stable-prefix ratchet (`ToolExecutionComponent.isTranscriptBlockCommitStable`, `packages/coding-agent/src/modes/components/tool-execution.ts:683-686`). Expanded pending rows passed through commit-stable, so once the box outgrew the viewport the stable-prefix ratchet promoted them to native scrollback. The settled `renderResult` then inserted an `Output` section and re-anchored the frame, leaving the previously-committed pending rows stranded in history.

The pre-existing `provisionalPartialResult: true` opt-out only covers the partial-result chrome flip (issue #3177); it cannot help here because the pending-call preview commits before any (partial) result exists.

## Fix

- `packages/coding-agent/src/tools/ssh.ts` — `provisionalPendingPreview` flipped from `"collapsed"` to `true` so every pending shape (collapsed or expanded) stays commit-unstable until the result render replaces it. Comment updated to spell out both stranded variants.
- `packages/coding-agent/test/tools/ssh-commit-stability.test.ts` — added three contract tests:
  - collapsed pending SSH preview is commit-unstable before any result;
  - expanded pending SSH preview is also commit-unstable (the regression this PR fixes);
  - bash with expanded pending preview stays commit-stable, proving the opt-in remains renderer-scoped (bash/eval keep `"collapsed"` so their top-anchored expanded pending streams can still reach scrollback).
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] → Fixed` entry.

The bash and `edit` renderers are unchanged; `edit` already uses `provisionalPendingPreview: true` for the same reason. The bash/eval opt-out stays `"collapsed"` because their expanded pending preview is append-shaped and survives the result render without re-anchoring.

## Verification

```
bun test packages/coding-agent/test/tools/ssh-commit-stability.test.ts \
         packages/coding-agent/test/tools/ssh-render.test.ts \
         packages/coding-agent/test/streaming-output-scrollback.test.ts
```
→ 12 pass / 0 fail (3 new ssh-commit-stability cases + 9 pre-existing).

```
bun test packages/coding-agent/test/transcript-streaming-commit-repro.test.ts \
         packages/coding-agent/test/modes/components/transcript-container.test.ts
```
→ 36 pass / 0 fail (adjacent transcript/commit ratchet regressions).

Fixes #3714