### PR TITLE
fix(catalog): strip LiteLLM reseller usage suffixes

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Updated pricing and context window limits for several catalog models.
 - Disabled reasoning capability for multiple providers in the catalog.
 
+### Fixed
+
+- Fixed LiteLLM MiniMax M3 discovery to drop reseller-only `(3x usage)` display suffixes. ([#3715](https://github.com/can1357/oh-my-pi/issues/3715))
+
 ## [16.2.2] - 2026-06-27
 
 ### Removed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2856,6 +2856,33 @@ function normalizeLiteLLMRuntimeBaseUrl(baseUrl: string): string {
 	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
 }
 
+const LITELLM_RESELLER_USAGE_SUFFIX = /\s+\(\d+(?:\.\d+)?[x×] usage\)$/i;
+
+function stripLiteLLMResellerUsageSuffix(name: string): string {
+	const cleaned = name.replace(LITELLM_RESELLER_USAGE_SUFFIX, "").trim();
+	return cleaned.length > 0 ? cleaned : name;
+}
+
+function toLiteLLMDisplayName(modelName: string | undefined, referenceName: string | undefined, id: string): string {
+	const cleanedModelName = modelName ? stripLiteLLMResellerUsageSuffix(modelName) : undefined;
+	if (cleanedModelName && cleanedModelName !== id) {
+		return cleanedModelName;
+	}
+	return referenceName ? stripLiteLLMResellerUsageSuffix(referenceName) : id;
+}
+
+function mapLiteLLMOpenAICompatibleModel<TApi extends Api>(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<TApi>,
+	reference: ModelSpec<TApi> | undefined,
+): ModelSpec<TApi> {
+	const model = mapWithBundledReference(entry, defaults, reference);
+	return {
+		...model,
+		name: stripLiteLLMResellerUsageSuffix(model.name),
+	};
+}
+
 function toNonEmptyString(value: unknown): string | undefined {
 	if (typeof value !== "string") {
 		return undefined;
@@ -2955,7 +2982,7 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 	};
 	return {
 		id,
-		name: modelName && modelName !== id ? modelName : (reference?.name ?? id),
+		name: toLiteLLMDisplayName(modelName, reference?.name, id),
 		api: options.api,
 		provider: options.provider,
 		baseUrl: runtimeBaseUrl,
@@ -3074,7 +3101,8 @@ export function litellmModelManagerOptions(
 				provider: "litellm",
 				baseUrl,
 				apiKey,
-				mapModel: (entry, defaults) => mapWithBundledReference(entry, defaults, resolveReference(defaults.id)),
+				mapModel: (entry, defaults) =>
+					mapLiteLLMOpenAICompatibleModel(entry, defaults, resolveReference(defaults.id)),
 				fetch: config?.fetch,
 			});
 		},

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -317,6 +317,39 @@ describe("LiteLLM provider discovery", () => {
 		expect(models?.[0]).toMatchObject({ id: "legacy-gpt", contextWindow: 96_000 });
 	});
 
+	test("drops reseller usage suffix from LiteLLM rich model names", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{
+							model_group: "minimax-m3",
+							model_name: "MiniMax M3 (3x usage)",
+						},
+					],
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.[0]).toMatchObject({
+			id: "minimax-m3",
+			name: "MiniMax M3",
+			provider: "litellm",
+			baseUrl: "http://primary:4000/v1",
+		});
+	});
+
 	test("falls back to OpenAI models list when rich endpoints are unavailable", async () => {
 		const authByUrl = new Map<string, string | undefined>();
 		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {


### PR DESCRIPTION
## Repro
A focused LiteLLM discovery test reproduces the issue by returning `model_group: "minimax-m3"` and `model_name: "MiniMax M3 (3x usage)"` from `/model_group/info`; before the fix, `bun test packages/catalog/test/litellm-provider.test.ts --filter 'drops reseller usage suffix'` failed because the discovered model name stayed `MiniMax M3 (3x usage)`.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` trusted LiteLLM rich metadata and OpenAI-compatible fallback names verbatim in `mapLiteLLMRichEntry` / `mapWithBundledReference`, so reseller-only `(3x usage)` decorations sourced from LiteLLM metadata or references could become the LiteLLM display name.

## Fix
- Added LiteLLM-only display-name sanitization for trailing reseller usage multipliers.
- Applied the sanitizer to rich LiteLLM metadata and `/v1/models` fallback enrichment.
- Added a regression test covering `litellm/minimax-m3` rich metadata with `MiniMax M3 (3x usage)`.
- Added a catalog changelog entry for #3715.

## Verification
Ran `bun test packages/catalog/test/litellm-provider.test.ts`: 9 pass, 0 fail. `gh_push_branch` completed the pre-publish gate and pushed `6701debd698b`. Fixes #3715