### PR TITLE
fix(session): guard oversized session JSONL loads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed reasoning streaming being locked off for OpenAI-compatible providers that stream reasoning content without advertising reasoning support in model metadata.
 - Fixed `/shake` and other mid-stream chat rebuilds erasing live LLM output by preserving the in-flight streaming components and pending tools.
 - Fixed the `time_spent` status-line segment ticking continuously during idle sessions by ensuring it only accumulates active agent execution windows and resets correctly across session switches.
+- Fixed oversized session JSONL files crashing Bun during resume or `/tan` by rejecting unsafe full-session loads before materializing the file. ([#3718](https://github.com/can1357/oh-my-pi/issues/3718))
 
 ## [16.2.2] - 2026-06-27
 

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -20,6 +20,24 @@ import {
 	titleUpdateFromSlot,
 } from "./session-title-slot";
 
+// Stay below Bun/JSC's maximum JS string size before calling Bun.file().text().
+const MAX_SESSION_JSONL_FULL_READ_BYTES = 1024 * 1024 * 1024;
+
+function formatBytes(bytes: number): string {
+	const mib = bytes / (1024 * 1024);
+	return `${mib.toFixed(mib >= 10 ? 0 : 1)} MiB`;
+}
+
+function assertSessionFileSafeToRead(filePath: string, storage: SessionStorage): void {
+	const { size } = storage.statSync(filePath);
+	if (size <= MAX_SESSION_JSONL_FULL_READ_BYTES) return;
+	throw new Error(
+		`Session file is too large to load safely (${formatBytes(size)} > ${formatBytes(
+			MAX_SESSION_JSONL_FULL_READ_BYTES,
+		)}): ${filePath}. Move the oversized session out of the sessions directory or trim persisted compaction payloads.`,
+	);
+}
+
 function splitTitleSlot(content: string): { body: string; slot: SessionTitleUpdate | undefined } {
 	const slot = titleUpdateFromSlot(parseTitleSlotFromContent(content));
 	if (!slot) return { body: content, slot: undefined };
@@ -82,6 +100,7 @@ export async function loadEntriesFromFile(
 ): Promise<FileEntry[]> {
 	let content: string;
 	try {
+		assertSessionFileSafeToRead(filePath, storage);
 		content = await storage.readText(filePath);
 	} catch (err) {
 		if (isEnoent(err)) return [];

--- a/packages/coding-agent/test/session/session-loader.test.ts
+++ b/packages/coding-agent/test/session/session-loader.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
+import { MemorySessionStorage, type SessionStorageStat } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+class OversizedMemorySessionStorage extends MemorySessionStorage {
+	readTextCalls = 0;
+
+	statSync(path: string): SessionStorageStat {
+		return { ...super.statSync(path), size: 1024 * 1024 * 1024 + 1 };
+	}
+
+	readText(path: string): Promise<string> {
+		this.readTextCalls++;
+		return super.readText(path);
+	}
+}
+
+describe("loadEntriesFromFile", () => {
+	it("rejects oversized session files before materializing their full text", async () => {
+		const storage = new OversizedMemorySessionStorage();
+		const filePath = "/sessions/oversized.jsonl";
+		await storage.writeText(
+			filePath,
+			`${JSON.stringify({ type: "session", version: 1, id: "session-1", timestamp: "2026-01-01T00:00:00.000Z" })}\n`,
+		);
+
+		await expect(loadEntriesFromFile(filePath, storage)).rejects.toThrow("Session file is too large to load safely");
+		expect(storage.readTextCalls).toBe(0);
+	});
+});


### PR DESCRIPTION
## Repro
A session storage entry reporting a 3.5 GB JSONL file reaches `loadEntriesFromFile()` and, before this fix, the loader calls `readText()`; for `FileSessionStorage` that is `Bun.file(path).text()`, matching the reporter's oversized-session crash path. Repro recorded with a fake `SessionStorage` that reports `size=3_500_000_000` and throws from `readText()`, producing `readTextCalls=1`.

## Cause
`packages/coding-agent/src/session/session-loader.ts` loaded the whole session JSONL as one string in `loadEntriesFromFile()` without checking `SessionStorage.statSync()`. `SessionManager.open()`, `SessionManager.forkFrom()`, `setSessionFile()`, and `peekSessionInit()` all route through that loader, so `/tan`, resume, and parked-subagent revival could all ask Bun/JSC to materialize an oversized session as a single JS string.

## Fix
- Added a shared safe full-read byte guard in `session-loader.ts` before `storage.readText()`.
- Preserved missing-file behavior by keeping ENOENT mapped to an empty entry list.
- Added `packages/coding-agent/test/session/session-loader.test.ts` coverage proving oversized sessions fail before `readText()` materializes the file.
- Added a coding-agent changelog entry for #3718.

## Verification
`bun test packages/coding-agent/test/session/session-loader.test.ts packages/coding-agent/test/session/session-manager-fork.test.ts packages/coding-agent/test/session/peek-session-init.test.ts` passed with 5 tests. `bun run fix` applied no TS fixes. `bun check` passed. Fixes #3718