### PR TITLE
fix(ai): preserve Z.AI usage quota windows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.AI usage reporting to preserve distinct 5-hour, weekly, and monthly quota windows instead of rendering duplicate token windows as separate accounts ([#3721](https://github.com/can1357/oh-my-pi/pull/3721) by [@wolfiesch](https://github.com/wolfiesch)).
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -19,12 +19,8 @@ const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const WEEK_MS = 7 * DAY_MS;
+// Z.AI reports calendar-month quotas as unit 5; durationMs is only a drain-rate estimate.
 const MONTH_MS = 30 * DAY_MS;
-
-interface ZaiUsageDetail {
-	modelCode?: string;
-	usage?: number;
-}
 
 function normalizeZaiBaseUrl(baseUrl?: string): string {
 	if (!baseUrl?.trim()) return DEFAULT_ENDPOINT;
@@ -35,6 +31,13 @@ function normalizeZaiBaseUrl(baseUrl?: string): string {
 	}
 }
 
+type ZaiWindowUnit = number | string;
+
+interface ZaiUsageDetail {
+	modelCode?: string;
+	usage?: number;
+}
+
 interface ZaiUsageLimitItem {
 	type?: string;
 	usage?: number;
@@ -42,7 +45,7 @@ interface ZaiUsageLimitItem {
 	percentage?: number;
 	remaining?: number;
 	nextResetTime?: number;
-	unit?: number;
+	unit?: ZaiWindowUnit;
 	number?: number;
 	usageDetails?: ZaiUsageDetail[];
 }
@@ -77,6 +80,14 @@ function parseUsageDetails(value: unknown): ZaiUsageDetail[] | undefined {
 	return details.length > 0 ? details : undefined;
 }
 
+function parseWindowUnit(value: unknown): ZaiWindowUnit | undefined {
+	const numeric = toNumber(value);
+	if (numeric !== undefined) return numeric;
+	if (typeof value !== "string") return undefined;
+	const unit = value.trim().toLowerCase();
+	return unit ? unit : undefined;
+}
+
 function parseLimitItem(value: unknown): ZaiUsageLimitItem | null {
 	if (!isRecord(value)) return null;
 	const type = typeof value.type === "string" ? value.type : undefined;
@@ -88,7 +99,7 @@ function parseLimitItem(value: unknown): ZaiUsageLimitItem | null {
 		percentage: toNumber(value.percentage),
 		remaining: toNumber(value.remaining),
 		nextResetTime: parseMillis(value.nextResetTime),
-		unit: toNumber(value.unit),
+		unit: parseWindowUnit(value.unit),
 		number: toNumber(value.number),
 		usageDetails: parseUsageDetails(value.usageDetails),
 	};
@@ -132,41 +143,107 @@ function formatDate(value: Date): string {
 	)}:${pad(value.getSeconds())}`;
 }
 
-function formatCountedUnit(count: number, singular: string): string {
-	const suffix = count === 1 ? "" : "s";
-	return `${count} ${singular}${suffix}`;
+function formatWindowLabel(count: number, singular: string, recurring: string): string {
+	return count === 1 ? recurring : `${count}-${singular.toLowerCase()}`;
 }
 
-function buildZaiWindow(parsed: ZaiUsageLimitItem): UsageWindow {
-	const count = parsed.number !== undefined && parsed.number > 0 ? parsed.number : 1;
+function normalizeWindowUnit(unit: ZaiWindowUnit | undefined): "hour" | "day" | "month" | "week" | undefined {
+	switch (unit) {
+		case 3:
+			return "hour";
+		case 4:
+			return "day";
+		case 5:
+			return "month";
+		case 6:
+			return "week";
+	}
+	if (typeof unit !== "string") return undefined;
+	switch (unit) {
+		case "h":
+		case "hr":
+		case "hour":
+		case "hours":
+			return "hour";
+		case "d":
+		case "day":
+		case "days":
+			return "day";
+		case "mo":
+		case "mon":
+		case "month":
+		case "months":
+			return "month";
+		case "w":
+		case "wk":
+		case "week":
+		case "weeks":
+			return "week";
+		default:
+			return undefined;
+	}
+}
+
+function formatUnknownUnitKey(unit: ZaiWindowUnit): string {
+	const key = String(unit)
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+	return key || "unknown";
+}
+
+function formatFallbackWindowId(parsed: ZaiUsageLimitItem, fallbackOrdinal: number): string {
+	const typeKey =
+		parsed.type
+			?.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-|-$/g, "") || "quota";
+	const resetKey = parsed.nextResetTime !== undefined ? `reset-${parsed.nextResetTime}` : `row-${fallbackOrdinal + 1}`;
+	return `${typeKey}-${resetKey}`;
+}
+
+function buildZaiWindow(parsed: ZaiUsageLimitItem, fallbackOrdinal: number, usedFallbackIds: Set<string>): UsageWindow {
+	const count = parsed.unit === 6 ? 1 : parsed.number !== undefined && parsed.number > 0 ? parsed.number : 1;
 	let id: string;
 	let label: string;
 	let durationMs: number | undefined;
-	switch (parsed.unit) {
-		case 3:
+	switch (normalizeWindowUnit(parsed.unit)) {
+		case "hour":
 			id = `${count}h`;
-			label = formatCountedUnit(count, "Hour");
+			label = formatWindowLabel(count, "Hour", "Hourly");
 			durationMs = count * HOUR_MS;
 			break;
-		case 4:
+		case "day":
 			id = `${count}d`;
-			label = formatCountedUnit(count, "Day");
+			label = formatWindowLabel(count, "Day", "Daily");
 			durationMs = count * DAY_MS;
 			break;
-		case 5:
+		case "month":
 			id = `${count}mo`;
-			label = count === 1 ? "Monthly" : formatCountedUnit(count, "Month");
+			label = formatWindowLabel(count, "Month", "Monthly");
 			durationMs = count * MONTH_MS;
 			break;
-		case 6:
-			id = "1w";
-			label = "Weekly";
-			durationMs = WEEK_MS;
+		case "week":
+			id = `${count}w`;
+			label = formatWindowLabel(count, "Week", "Weekly");
+			durationMs = count * WEEK_MS;
 			break;
-		default:
-			id = parsed.unit !== undefined ? `${count}u${parsed.unit}` : "quota";
+		default: {
+			const fallbackId = formatFallbackWindowId(parsed, fallbackOrdinal);
+			const baseId =
+				parsed.unit !== undefined ? `${count}u${formatUnknownUnitKey(parsed.unit)}-${fallbackId}` : fallbackId;
+			let candidateId = baseId;
+			let counter = 1;
+			while (usedFallbackIds.has(candidateId)) {
+				candidateId = `${baseId}-row-${fallbackOrdinal + 1}-${counter}`;
+				counter++;
+			}
+			usedFallbackIds.add(candidateId);
+			id = candidateId;
 			label = "Quota";
 			break;
+		}
 	}
 	return {
 		id,
@@ -254,9 +331,10 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 
 	const limitsPayload = Array.isArray(payload.data?.limits) ? payload.data?.limits : [];
 	const limits: UsageLimit[] = [];
+	const usedFallbackIds = new Set<string>();
 
-	for (const rawLimit of limitsPayload) {
-		const parsed = parseLimitItem(rawLimit);
+	for (let index = 0; index < limitsPayload.length; index += 1) {
+		const parsed = parseLimitItem(limitsPayload[index]);
 		if (!parsed) continue;
 		if (parsed.type === "TOKENS_LIMIT") {
 			const amount = buildUsageAmount({
@@ -266,7 +344,7 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 				percentage: parsed.percentage,
 				unit: "tokens",
 			});
-			const window = buildZaiWindow(parsed);
+			const window = buildZaiWindow(parsed, index, usedFallbackIds);
 			limits.push({
 				id: `zai:tokens:${window.id}`,
 				label: `ZAI ${window.label} Token Quota`,
@@ -281,7 +359,7 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 			});
 		}
 		if (parsed.type === "TIME_LIMIT") {
-			const window = buildZaiWindow(parsed);
+			const window = buildZaiWindow(parsed, index, usedFallbackIds);
 			const amount = buildUsageAmount({
 				used: parsed.currentValue,
 				limit: parsed.usage,

--- a/packages/ai/test/zai-usage.test.ts
+++ b/packages/ai/test/zai-usage.test.ts
@@ -51,7 +51,7 @@ describe("zai usage provider", () => {
 							],
 						},
 						{ type: "TOKENS_LIMIT", percentage: 82, nextResetTime: 1782656863894, unit: 3, number: 5 },
-						{ type: "TOKENS_LIMIT", percentage: 38, nextResetTime: 1783165208993, unit: 6, number: 7 },
+						{ type: "TOKENS_LIMIT", percentage: 38, nextResetTime: 1783165208993, unit: 6, number: 1 },
 					],
 				},
 			}),
@@ -65,7 +65,7 @@ describe("zai usage provider", () => {
 		]);
 		expect(report!.limits.map(limit => limit.label)).toEqual([
 			"ZAI Web Search / Reader / Zread Quota",
-			"ZAI 5 Hours Token Quota",
+			"ZAI 5-hour Token Quota",
 			"ZAI Weekly Token Quota",
 		]);
 		expect(report!.limits.map(limit => limit.scope.windowId)).toEqual(["1mo", "5h", "1w"]);
@@ -75,6 +75,82 @@ describe("zai usage provider", () => {
 			30 * 24 * 60 * 60 * 1000,
 			5 * 60 * 60 * 1000,
 			7 * 24 * 60 * 60 * 1000,
+		]);
+	});
+
+	it("treats numeric weekly token quota counts as the Z.AI rolling day window", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [
+						{ type: "TOKENS_LIMIT", percentage: 38, nextResetTime: 1783165208993, unit: 6, number: 7 },
+						{ type: "TOKENS_LIMIT", percentage: 12, nextResetTime: 1783765208993, unit: "w", number: 7 },
+					],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(limit => limit.id)).toEqual(["zai:tokens:1w", "zai:tokens:7w"]);
+		expect(report!.limits.map(limit => limit.label)).toEqual(["ZAI Weekly Token Quota", "ZAI 7-week Token Quota"]);
+		expect(report!.limits.map(limit => limit.scope.windowId)).toEqual(["1w", "7w"]);
+		expect(report!.limits.map(limit => limit.window?.durationMs)).toEqual([
+			7 * 24 * 60 * 60 * 1000,
+			7 * 7 * 24 * 60 * 60 * 1000,
+		]);
+	});
+
+	it("keeps Z.AI quota window ids distinct when units are string-coded or omitted", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [
+						{ type: "TOKENS_LIMIT", percentage: 82, nextResetTime: 1782656863894, unit: "h", number: 5 },
+						{ type: "TOKENS_LIMIT", percentage: 38, nextResetTime: 1783165208993, unit: "w", number: 1 },
+						{ type: "TOKENS_LIMIT", percentage: 12, nextResetTime: 1783251608993 },
+						{ type: "TOKENS_LIMIT", percentage: 18, nextResetTime: 1783338008993, unit: "rolling" },
+					],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(limit => limit.id)).toEqual([
+			"zai:tokens:5h",
+			"zai:tokens:1w",
+			"zai:tokens:tokens-limit-reset-1783251608993",
+			"zai:tokens:1urolling-tokens-limit-reset-1783338008993",
+		]);
+		expect(report!.limits.map(limit => limit.scope.windowId)).toEqual([
+			"5h",
+			"1w",
+			"tokens-limit-reset-1783251608993",
+			"1urolling-tokens-limit-reset-1783338008993",
+		]);
+	});
+
+	it("disambiguates duplicate fallback window IDs sharing a reset time on collision", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [
+						{ type: "TOKENS_LIMIT", percentage: 12, nextResetTime: 1783251608993 },
+						{ type: "TOKENS_LIMIT", percentage: 18, nextResetTime: 1783251608993 },
+					],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(limit => limit.id)).toEqual([
+			"zai:tokens:tokens-limit-reset-1783251608993",
+			"zai:tokens:tokens-limit-reset-1783251608993-row-2-1",
 		]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
+### Changed
+
+- Restructured the TUI usage footer to show one provider-wide account header with stable columns, so each limit row no longer repeats truncated account emails or swaps column order when usage fractions differ; every meter now shows its exact percentage and reset time ([#3721](https://github.com/can1357/oh-my-pi/pull/3721) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -44,7 +44,11 @@ import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-stora
 import type { CompactMode } from "../../session/compact-modes";
 import type { NewSessionOptions } from "../../session/session-entries";
 import { formatShakeSummary, type ShakeMode, type ShakeResult } from "../../session/shake-types";
-import { formatActiveAccountLabel, limitMatchesActiveAccount } from "../../slash-commands/helpers/active-oauth-account";
+import {
+	formatActiveAccountLabel,
+	limitMatchesActiveAccount,
+	reportMatchesActiveAccount,
+} from "../../slash-commands/helpers/active-oauth-account";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
@@ -1450,10 +1454,6 @@ function formatProviderName(provider: string): string {
 		.join(" ");
 }
 
-function formatNumber(value: number, maxFractionDigits = 1): string {
-	return new Intl.NumberFormat("en-US", { maximumFractionDigits: maxFractionDigits }).format(value);
-}
-
 function resolveProviderAuthMode(authStorage: AuthStorage, provider: string): string {
 	if (authStorage.hasOAuth(provider)) {
 		return "oauth";
@@ -1510,22 +1510,6 @@ function orgSuffix(report: UsageReport): string {
 	return org ? ` (${org})` : "";
 }
 
-function formatAccountLabel(limit: UsageLimit, report: UsageReport, index: number): string {
-	const email = report.metadata?.email;
-	if (typeof email === "string" && email) return `${email}${orgSuffix(report)}`;
-	const accountId =
-		typeof report.metadata?.accountId === "string" && report.metadata.accountId
-			? report.metadata.accountId
-			: limit.scope.accountId || undefined;
-	if (accountId) return `${accountId}${orgSuffix(report)}`;
-	const projectId =
-		typeof report.metadata?.projectId === "string" && report.metadata.projectId
-			? report.metadata.projectId
-			: limit.scope.projectId || undefined;
-	if (projectId) return projectId;
-	return `account ${index + 1}`;
-}
-
 function formatUnlimitedReportLabel(report: UsageReport, index: number): string {
 	const email = report.metadata?.email;
 	if (typeof email === "string" && email) return `${email}${orgSuffix(report)}`;
@@ -1536,6 +1520,246 @@ function formatUnlimitedReportLabel(report: UsageReport, index: number): string 
 	return `account ${index + 1}`;
 }
 
+function resolveReportProjectId(report: UsageReport): string | undefined {
+	const projectId = report.metadata?.projectId;
+	if (typeof projectId === "string" && projectId) return projectId;
+	for (const limit of report.limits) {
+		const scopedProjectId = limit.scope.projectId;
+		if (typeof scopedProjectId === "string" && scopedProjectId) return scopedProjectId;
+	}
+	return undefined;
+}
+
+function resolveReportOrganizationId(report: UsageReport): string | undefined {
+	const metadataOrgId = report.metadata?.orgId;
+	if (typeof metadataOrgId === "string" && metadataOrgId) return metadataOrgId;
+	const metadataOrgName = report.metadata?.orgName;
+	if (typeof metadataOrgName === "string" && metadataOrgName) return metadataOrgName;
+	for (const limit of report.limits) {
+		const scopedOrgId = limit.scope.orgId;
+		if (typeof scopedOrgId === "string" && scopedOrgId) return scopedOrgId;
+	}
+	return undefined;
+}
+
+function resolveReportAccountId(report: UsageReport): string | undefined {
+	const metadataAccountId = report.metadata?.accountId;
+	if (typeof metadataAccountId === "string" && metadataAccountId) return metadataAccountId;
+	const metadataAccountIdAlias = report.metadata?.account_id;
+	if (typeof metadataAccountIdAlias === "string" && metadataAccountIdAlias) return metadataAccountIdAlias;
+	for (const limit of report.limits) {
+		const scopedAccountId = limit.scope.accountId;
+		if (typeof scopedAccountId === "string" && scopedAccountId) return scopedAccountId;
+	}
+	return undefined;
+}
+
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function toGraphemes(text: string): string[] {
+	const clusters: string[] = [];
+	for (const { segment } of GRAPHEME_SEGMENTER.segment(text)) clusters.push(segment);
+	return clusters;
+}
+
+/**
+ * Shortest stable fragments (min 4 grapheme clusters, prefix or tail —
+ * whichever distinguishes sooner) that tell every account id in a collision
+ * group apart. Ids are first grouped into NFC equivalence classes so
+ * composed-vs-decomposed sequences that render identically share one
+ * canonical identity (never "distinguished" from each other, and never
+ * blocking distinctness for a genuinely different sibling). Slicing works on
+ * grapheme clusters, so astral pairs are never split into lone surrogates.
+ */
+function shortestUniqueIdFragments(ids: readonly string[]): Map<string, string> {
+	const rawsByCanonical = new Map<string, string[]>();
+	for (const id of new Set(ids)) {
+		const canonical = id.normalize("NFC");
+		const raws = rawsByCanonical.get(canonical);
+		if (raws) raws.push(id);
+		else rawsByCanonical.set(canonical, [id]);
+	}
+	const canonicals = [...rawsByCanonical.keys()];
+	const fragments = new Map<string, string>();
+	if (canonicals.length === 1) {
+		// Every id renders identically — nothing can visually distinguish
+		// them, so keep the full canonical identity.
+		for (const raw of rawsByCanonical.get(canonicals[0])!) {
+			fragments.set(raw, canonicals[0]);
+		}
+		return fragments;
+	}
+	const clustersByCanonical = new Map(canonicals.map(canonical => [canonical, toGraphemes(canonical)]));
+	const maxLength = Math.max(...canonicals.map(canonical => clustersByCanonical.get(canonical)!.length));
+	const distinctLength = (slice: (clusters: string[], length: number) => string): number => {
+		for (let length = Math.min(4, maxLength); length <= maxLength; length++) {
+			const seen = new Set(canonicals.map(canonical => slice(clustersByCanonical.get(canonical)!, length)));
+			if (seen.size === canonicals.length) return length;
+		}
+		return maxLength;
+	};
+	const prefixLength = distinctLength((clusters, length) => clusters.slice(0, length).join(""));
+	const tailLength = distinctLength((clusters, length) => clusters.slice(-length).join(""));
+	// Ties prefer the tail: unequal-length ids (one a prefix of another) pass
+	// the prefix distinctness check on length alone, which a tight cell's
+	// front-anchored trim then destroys; tail trims keep the distinguishing
+	// edge instead.
+	const keepEnd = tailLength <= prefixLength;
+	const length = keepEnd ? tailLength : prefixLength;
+	for (const [canonical, raws] of rawsByCanonical) {
+		const clusters = clustersByCanonical.get(canonical)!;
+		const text =
+			clusters.length <= length
+				? canonical
+				: keepEnd
+					? `…${clusters.slice(-length).join("")}`
+					: `${clusters.slice(0, length).join("")}…`;
+		for (const raw of raws) fragments.set(raw, text);
+	}
+	return fragments;
+}
+
+/** Keep as many whole clusters as fit `maxWidth`, anchored at the kept edge. */
+function fitClustersToWidth(clusters: readonly string[], maxWidth: number, keepEnd: boolean): string {
+	let out = "";
+	if (keepEnd) {
+		for (let i = clusters.length - 1; i >= 0; i--) {
+			const next = `${clusters[i]}${out}`;
+			if (visibleWidth(next) > maxWidth) break;
+			out = next;
+		}
+	} else {
+		for (const cluster of clusters) {
+			const next = `${out}${cluster}`;
+			if (visibleWidth(next) > maxWidth) break;
+			out = next;
+		}
+	}
+	return out || clusters[keepEnd ? clusters.length - 1 : 0] || "";
+}
+
+/**
+ * Bare-tier texts for a collision group: every id's rendered cell fitted to
+ * the group's shared budget. Instead of one prefix/tail edge for the whole
+ * group, each NFC identity class gets its own edge: classes (≤2 candidate
+ * texts each, tail preferred) are matched injectively onto texts via
+ * deterministic augmenting paths (Kuhn's bipartite matching, O(classes ×
+ * candidates) per augmentation), so a collision-free combination is found
+ * whenever one exists. Unmatched classes fall back to their tail fit.
+ * NFC-equivalent raw ids always share one class and therefore one text.
+ */
+function planBareFragmentTexts(ids: readonly string[], maxWidth: number): Map<string, string> {
+	const rawsByCanonical = new Map<string, string[]>();
+	for (const id of new Set(ids)) {
+		const canonical = id.normalize("NFC");
+		const raws = rawsByCanonical.get(canonical);
+		if (raws) raws.push(id);
+		else rawsByCanonical.set(canonical, [id]);
+	}
+	const canonicals = [...rawsByCanonical.keys()].sort();
+	const candidates = canonicals.map(canonical => {
+		const clusters = toGraphemes(canonical);
+		// Tail first: account ids usually differ at the end.
+		return [
+			...new Set([fitClustersToWidth(clusters, maxWidth, true), fitClustersToWidth(clusters, maxWidth, false)]),
+		];
+	});
+	const chosen: (string | undefined)[] = new Array(canonicals.length);
+	const textOwner = new Map<string, number>();
+	const augment = (index: number, visited: Set<string>): boolean => {
+		for (const text of candidates[index]) {
+			if (visited.has(text)) continue;
+			visited.add(text);
+			const owner = textOwner.get(text);
+			if (owner === undefined || augment(owner, visited)) {
+				textOwner.set(text, index);
+				chosen[index] = text;
+				return true;
+			}
+		}
+		return false;
+	};
+	for (let index = 0; index < canonicals.length; index++) augment(index, new Set());
+	// No perfect matching exists for these classes: best-effort tails.
+	for (let index = 0; index < canonicals.length; index++) chosen[index] ??= candidates[index][0];
+	const texts = new Map<string, string>();
+	for (const [index, canonical] of canonicals.entries()) {
+		for (const raw of rawsByCanonical.get(canonical)!) texts.set(raw, chosen[index]!);
+	}
+	return texts;
+}
+
+/** Header label for a report column, derived from report metadata or limit scope. */
+function formatReportAccountLabel(report: UsageReport, index: number): string {
+	const projectId = resolveReportProjectId(report);
+	const email = report.metadata?.email;
+	if (typeof email === "string" && email) {
+		const label = projectId && email !== projectId ? `${email} (${projectId})` : email;
+		return `${label}${orgSuffix(report)}`;
+	}
+	const accountId = report.metadata?.accountId;
+	if (typeof accountId === "string" && accountId) {
+		const label = projectId && accountId !== projectId ? `${accountId} (${projectId})` : accountId;
+		return `${label}${orgSuffix(report)}`;
+	}
+	if (projectId) return `${projectId}${orgSuffix(report)}`;
+	for (const limit of report.limits) {
+		const scopedAccountId = limit.scope.accountId;
+		if (typeof scopedAccountId === "string" && scopedAccountId) {
+			const label =
+				projectId && scopedAccountId !== projectId ? `${scopedAccountId} (${projectId})` : scopedAccountId;
+			return `${label}${orgSuffix(report)}`;
+		}
+	}
+	return `account ${index + 1}`;
+}
+
+function formatReportAccountKey(report: UsageReport, index: number): string {
+	const projectId = resolveReportProjectId(report);
+	const organizationId = resolveReportOrganizationId(report);
+	const email = report.metadata?.email;
+	const accountId = report.metadata?.accountId;
+	const emailKey = typeof email === "string" && email ? `email:${email}` : undefined;
+	const metadataAccountKey = typeof accountId === "string" && accountId ? `account:${accountId}` : undefined;
+	let scopedAccountKey: string | undefined;
+	for (const limit of report.limits) {
+		const scopedAccountId = limit.scope.accountId;
+		if (typeof scopedAccountId === "string" && scopedAccountId) {
+			scopedAccountKey = `account:${scopedAccountId}`;
+			break;
+		}
+	}
+	const accountKey = metadataAccountKey ?? scopedAccountKey;
+	const keys = [
+		organizationId ? `org:${organizationId}` : undefined,
+		projectId ? `project:${projectId}` : undefined,
+		emailKey,
+		accountKey,
+	].filter((key): key is string => key !== undefined);
+	return keys.length > 0 ? keys.join("|") : `index:${index}`;
+}
+
+/** Sort reports so the active account is first and the rest are deterministic. */
+function stableAccountOrder(
+	reports: UsageReport[],
+	activeAccount: OAuthAccountIdentity | undefined,
+	fallbackIndices: ReadonlyMap<UsageReport, number>,
+): UsageReport[] {
+	return [...reports].sort((a, b) => {
+		const aActive = reportMatchesActiveAccount(a, activeAccount);
+		const bActive = reportMatchesActiveAccount(b, activeAccount);
+		if (aActive && !bActive) return -1;
+		if (!aActive && bActive) return 1;
+		const aIndex = fallbackIndices.get(a) ?? 0;
+		const bIndex = fallbackIndices.get(b) ?? 0;
+		const labelOrder = formatReportAccountLabel(a, aIndex).localeCompare(formatReportAccountLabel(b, bIndex));
+		if (labelOrder !== 0) return labelOrder;
+		const keyOrder = formatReportAccountKey(a, aIndex).localeCompare(formatReportAccountKey(b, bIndex));
+		if (keyOrder !== 0) return keyOrder;
+		return aIndex - bIndex;
+	});
+}
+
 function formatResetShort(limit: UsageLimit, nowMs: number): string | undefined {
 	const resetsAt = limit.window?.resetsAt;
 	if (resetsAt === undefined) return undefined;
@@ -1543,48 +1767,6 @@ function formatResetShort(limit: UsageLimit, nowMs: number): string | undefined 
 	// rendering a negative delta is meaningless, so drop the suffix in that case.
 	if (resetsAt <= nowMs) return undefined;
 	return formatDuration(resetsAt - nowMs);
-}
-
-function formatAccountHeaderRow(
-	limits: UsageLimit[],
-	reports: UsageReport[],
-	nowMs: number,
-	columnWidth: number,
-	uiTheme: typeof theme,
-	activeAccount?: OAuthAccountIdentity,
-): string[] {
-	const parts = limits.map((limit, index) => {
-		const reset = formatResetShort(limit, nowMs);
-		const report = reports[index];
-		const active = report !== undefined && limitMatchesActiveAccount(report, limit, activeAccount);
-		const label = formatAccountLabel(limit, report, index);
-		return {
-			label: active ? `● ${label}` : label,
-			suffix: reset ? `(${reset})` : "",
-			active,
-		};
-	});
-	const maxSuffixWidth = parts.reduce((max, p) => Math.max(max, visibleWidth(p.suffix)), 0);
-	const gap = maxSuffixWidth > 0 ? 1 : 0;
-	const prefixBudget = columnWidth - maxSuffixWidth - gap;
-
-	// If suffix can't share the cell with at least `x…`, fall back to whole-label truncation.
-	if (prefixBudget < 2) {
-		return parts.map(p => {
-			const full = p.suffix ? `${p.label} ${p.suffix}` : p.label;
-			const cell = padColumn(truncateJobLabel(full, columnWidth), columnWidth);
-			return p.active ? uiTheme.fg("accent", cell) : cell;
-		});
-	}
-
-	return parts.map(p => {
-		const prefix = truncateJobLabel(p.label, prefixBudget);
-		const prefixCell = prefix + " ".repeat(prefixBudget - visibleWidth(prefix));
-		const styledPrefix = p.active ? uiTheme.fg("accent", prefixCell) : prefixCell;
-		if (!p.suffix) return styledPrefix + " ".repeat(maxSuffixWidth + gap);
-		const suffixPad = " ".repeat(maxSuffixWidth - visibleWidth(p.suffix));
-		return `${styledPrefix} ${suffixPad}${uiTheme.fg("dim", p.suffix)}`;
-	});
 }
 
 function padColumn(text: string, width: number): string {
@@ -1603,36 +1785,6 @@ function resolveAggregateStatus(limits: UsageLimit[]): UsageLimit["status"] {
 	}
 	if (hasWarning) return "warning";
 	return "exhausted";
-}
-
-function formatAggregateAmount(limits: UsageLimit[]): string {
-	const fractions = limits
-		.map(limit => resolveUsedFraction(limit))
-		.filter((value): value is number => value !== undefined);
-	if (fractions.length === limits.length && fractions.length > 0) {
-		const sum = fractions.reduce((total, value) => total + value, 0);
-		const avgRemaining = Math.max(0, ((limits.length - sum) / limits.length) * 100);
-		return `${formatNumber(avgRemaining)}% free`;
-	}
-
-	const amounts = limits
-		.map(limit => limit.amount)
-		.filter(amount => amount.used !== undefined && amount.limit !== undefined && amount.limit > 0);
-	if (amounts.length === limits.length && amounts.length > 0) {
-		const totalUsed = amounts.reduce((sum, amount) => sum + (amount.used ?? 0), 0);
-		const totalLimit = amounts.reduce((sum, amount) => sum + (amount.limit ?? 0), 0);
-		const remainingPct = totalLimit > 0 ? Math.max(0, 100 - (totalUsed / totalLimit) * 100) : 0;
-		return `${formatNumber(remainingPct)}% free`;
-	}
-
-	// Count unique accounts from limit scopes — not limits.length.
-	const uniqueAccountIds = new Set(
-		limits.map(limit => limit.scope.accountId).filter((id): id is string => typeof id === "string" && id.length > 0),
-	);
-	if (uniqueAccountIds.size > 0) return `${uniqueAccountIds.size} ${uniqueAccountIds.size === 1 ? "acct" : "accts"}`;
-	// No account IDs available — keep the pre-existing fallback so providers
-	// that don't populate scope.accountId still show a summary.
-	return `${limits.length} accts`;
 }
 
 function resolveResetRange(limits: UsageLimit[], nowMs: number): string | null {
@@ -1699,7 +1851,6 @@ export function formatCompactQuota(
 	}
 	return `Quota: ${lines.join(" │ ")}`;
 }
-
 function resolveStatusIcon(status: UsageLimit["status"], uiTheme: typeof theme): string {
 	if (status === "exhausted") return uiTheme.fg("error", uiTheme.status.error);
 	if (status === "warning") return uiTheme.fg("warning", uiTheme.status.warning);
@@ -1714,7 +1865,10 @@ function resolveStatusColor(status: UsageLimit["status"]): "success" | "warning"
 	return "dim";
 }
 
-function renderUsageBar(limit: UsageLimit, uiTheme: typeof theme, barWidth: number): string {
+function renderUsageBar(limit: UsageLimit | undefined, uiTheme: typeof theme, barWidth: number): string {
+	if (limit === undefined) {
+		return uiTheme.fg("dim", "·".repeat(barWidth));
+	}
 	const fraction = resolveUsedFraction(limit);
 	if (fraction === undefined) {
 		return uiTheme.fg("dim", "·".repeat(barWidth));
@@ -1730,6 +1884,35 @@ function renderUsageBar(limit: UsageLimit, uiTheme: typeof theme, barWidth: numb
 	const empty = "░".repeat(Math.max(0, barWidth - fullCells - (partial ? 1 : 0)));
 	const color = resolveStatusColor(limit.status);
 	return `${uiTheme.fg(color, leading)}${uiTheme.fg("dim", empty)}`;
+}
+
+/** Exact percentage and reset time for a single meter cell. */
+function formatMeterDetails(limit: UsageLimit | undefined, nowMs: number): string {
+	if (limit === undefined) return "—";
+	const fraction = resolveUsedFraction(limit);
+	const parts: string[] = [];
+	if (fraction !== undefined) {
+		parts.push(`${(fraction * 100).toFixed(1)}% used`);
+	} else if (limit.amount.remainingFraction !== undefined) {
+		parts.push(`${(limit.amount.remainingFraction * 100).toFixed(1)}% left`);
+	} else {
+		parts.push("no data");
+	}
+	const reset = formatResetShort(limit, nowMs);
+	if (reset) parts.push(reset);
+	return parts.join(" · ");
+}
+
+function renderAccountHeaderCell(
+	report: UsageReport,
+	label: string,
+	columnWidth: number,
+	uiTheme: typeof theme,
+	activeAccount?: OAuthAccountIdentity,
+): string {
+	const active = reportMatchesActiveAccount(report, activeAccount);
+	const cell = truncateJobLabel(active ? `● ${label}` : label, columnWidth);
+	return padColumn(active ? uiTheme.fg("accent", cell) : cell, columnWidth);
 }
 
 /**
@@ -1779,11 +1962,32 @@ export function renderUsageReports(
 		const providerName = formatProviderName(provider);
 		const activeAccount = resolveActiveAccount?.(provider);
 
+		const reportFallbackIndices = new Map<UsageReport, number>();
+		for (const [index, report] of providerReports.entries()) {
+			reportFallbackIndices.set(report, index);
+		}
+		const reportAccountKeys = new Map<UsageReport, string>();
+		const usedReportKeys = new Set<string>();
+		for (const report of providerReports) {
+			const fallbackIndex = reportFallbackIndices.get(report) ?? 0;
+			const baseKey = formatReportAccountKey(report, fallbackIndex);
+			let key = baseKey;
+			let collision = 0;
+			while (usedReportKeys.has(key)) {
+				collision += 1;
+				key = `${baseKey}|index:${fallbackIndex}-${collision}`;
+			}
+			usedReportKeys.add(key);
+			reportAccountKeys.set(report, key);
+		}
+
 		const limitGroups = new Map<
 			string,
-			{ label: string; windowLabel: string; limits: UsageLimit[]; reports: UsageReport[] }
+			{ label: string; windowLabel: string; limitsByAccountKey: Map<string, UsageLimit> }
 		>();
 		for (const report of providerReports) {
+			const accountKey =
+				reportAccountKeys.get(report) ?? formatReportAccountKey(report, reportFallbackIndices.get(report) ?? 0);
 			for (const limit of report.limits) {
 				const windowId = limit.window?.id ?? limit.scope.windowId ?? "default";
 				const key = `${formatLimitTitle(limit)}|${windowId}`;
@@ -1791,11 +1995,9 @@ export function renderUsageReports(
 				const entry = limitGroups.get(key) ?? {
 					label: formatLimitTitle(limit),
 					windowLabel,
-					limits: [],
-					reports: [],
+					limitsByAccountKey: new Map<string, UsageLimit>(),
 				};
-				entry.limits.push(limit);
-				entry.reports.push(report);
+				entry.limitsByAccountKey.set(accountKey, limit);
 				limitGroups.set(key, entry);
 			}
 		}
@@ -1825,10 +2027,13 @@ export function renderUsageReports(
 					: typeof report.metadata?.accountId === "string" && report.metadata.accountId
 						? report.metadata.accountId
 						: "account";
+			// Same matching rules as the account columns (alias/scope ids,
+			// normalization, decisive account-id, org gate). Reset-only rows have
+			// no limits, so they match on report metadata alone.
 			const isActive =
-				!!activeAccount &&
-				((!!activeAccount.accountId && activeAccount.accountId === report.metadata?.accountId) ||
-					(!!activeAccount.email && activeAccount.email === report.metadata?.email));
+				report.limits.length > 0
+					? reportMatchesActiveAccount(report, activeAccount)
+					: limitMatchesActiveAccount(report, undefined, activeAccount);
 			resetAccountLines.push(
 				`    • ${label}: ${count} saved reset${count === 1 ? "" : "s"}${isActive ? " (active)" : ""}`,
 			);
@@ -1857,53 +2062,120 @@ export function renderUsageReports(
 			for (const line of resetAccountLines) lines.push(uiTheme.fg("dim", line));
 		}
 
+		const providerAccounts = stableAccountOrder(
+			providerReports.filter(report => report.limits.length > 0),
+			activeAccount,
+			reportFallbackIndices,
+		);
+
 		const renderableGroups = Array.from(limitGroups.values()).map(group => {
-			const entries = group.limits.map((limit, index) => ({
-				limit,
-				report: group.reports[index],
-				fraction: resolveUsedFraction(limit),
-				index,
-			}));
-			entries.sort((a, b) => {
-				const aFraction = a.fraction ?? -1;
-				const bFraction = b.fraction ?? -1;
-				if (aFraction !== bFraction) return bFraction - aFraction;
-				return a.index - b.index;
+			const columns = providerAccounts.map(account => {
+				const accountKey =
+					reportAccountKeys.get(account) ??
+					formatReportAccountKey(account, reportFallbackIndices.get(account) ?? 0);
+				return group.limitsByAccountKey.get(accountKey);
 			});
-			const sortedLimits = entries.map(entry => entry.limit);
-			const sortedReports = entries.map(entry => entry.report);
-			return { group, sortedLimits, sortedReports, amountText: formatAggregateAmount(sortedLimits) };
+			return { group, columns };
+		});
+		renderableGroups.sort((left, right) => {
+			const labelOrder = left.group.label.localeCompare(right.group.label);
+			if (labelOrder !== 0) return labelOrder;
+			return left.group.windowLabel.localeCompare(right.group.windowLabel);
 		});
 
-		const sectionCount = renderableGroups.reduce((max, g) => Math.max(max, g.sortedLimits.length), 0);
-		const sectionTrailing = renderableGroups.reduce((max, g) => Math.max(max, visibleWidth(g.amountText)), 0);
-		const sectionColumnWidth = resolveColumnWidth(sectionCount, availableWidth, sectionTrailing);
-		const sectionBarWidth = Math.min(sectionColumnWidth, BAR_WIDTH_MAX);
+		const accountCount = providerAccounts.length;
+		const sectionColumnWidth = resolveColumnWidth(accountCount, availableWidth, 0);
+		const meterWidth = Math.min(BAR_WIDTH_MAX, sectionColumnWidth);
 
-		for (const { group, sortedLimits, sortedReports, amountText } of renderableGroups) {
-			const status = resolveAggregateStatus(sortedLimits);
+		// One provider-wide account header so columns stay aligned across limit groups.
+		if (accountCount > 0) {
+			const baseLabels = providerAccounts.map((report, index) =>
+				formatReportAccountLabel(report, reportFallbackIndices.get(report) ?? index),
+			);
+			const labelCounts = new Map<string, number>();
+			for (const label of baseLabels) labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+			const activeFlags = providerAccounts.map(report => reportMatchesActiveAccount(report, activeAccount));
+			// Per colliding label group: shortest-unique id fragments plus a
+			// group-wide suffix tier chosen against the tightest marker-adjusted
+			// cell, so sibling columns always disambiguate the same way.
+			const collisionPlans = new Map<
+				string,
+				{
+					fragments: Map<string, string>;
+					tier: "full" | "fragment" | "bare";
+					bareTexts: Map<string, string> | undefined;
+				}
+			>();
+			for (const [label, count] of labelCounts) {
+				if (count <= 1) continue;
+				const memberIds: string[] = [];
+				let minBudget = Number.POSITIVE_INFINITY;
+				for (const [index, report] of providerAccounts.entries()) {
+					if (baseLabels[index] !== label) continue;
+					const id = resolveReportAccountId(report);
+					if (id) memberIds.push(id);
+					minBudget = Math.min(minBudget, sectionColumnWidth - (activeFlags[index] ? 2 : 0));
+				}
+				if (memberIds.length === 0) continue;
+				const fragments = shortestUniqueIdFragments(memberIds);
+				const maxFullSuffix = Math.max(...memberIds.map(id => visibleWidth(` (${id})`)));
+				const maxFragmentSuffix = Math.max(...[...fragments.values()].map(f => visibleWidth(` (${f})`)));
+				const tier =
+					minBudget - maxFullSuffix >= 2 ? "full" : minBudget - maxFragmentSuffix >= 2 ? "fragment" : "bare";
+				collisionPlans.set(label, {
+					fragments,
+					tier,
+					// Bare texts fit to the GROUP's tightest budget so
+					// NFC-equivalent siblings render the same text whether or
+					// not they carry the active marker, and each identity class
+					// gets its own collision-free prefix/tail edge.
+					bareTexts: tier === "bare" ? planBareFragmentTexts(memberIds, minBudget) : undefined,
+				});
+			}
+			const headerCells = providerAccounts.map((report, index) => {
+				let label = baseLabels[index];
+				// Same rendered label on two columns (e.g. one email across
+				// workspaces): disambiguate with the stable account id. The id
+				// (or its shortest-unique fragment) is the only part telling
+				// colliding columns apart, so end-truncation must never eat it:
+				// the base is truncated separately, and in the tightest tier the
+				// base and decorations are dropped so the complete fragment
+				// renders directly. Unique labels render unchanged.
+				const plan = collisionPlans.get(label);
+				const accountId = plan ? resolveReportAccountId(report) : undefined;
+				if (plan && accountId) {
+					const budget = sectionColumnWidth - (activeFlags[index] ? 2 : 0);
+					if (plan.tier === "full") {
+						const suffix = ` (${accountId})`;
+						label = `${truncateJobLabel(label, budget - visibleWidth(suffix))}${suffix}`;
+					} else if (plan.tier === "fragment") {
+						const fragment = plan.fragments.get(accountId) ?? accountId;
+						const suffix = ` (${fragment})`;
+						label = `${truncateJobLabel(label, budget - visibleWidth(suffix))}${suffix}`;
+					} else {
+						label = plan.bareTexts?.get(accountId) ?? accountId;
+					}
+				}
+				return renderAccountHeaderCell(report, label, sectionColumnWidth, uiTheme, activeAccount);
+			});
+
+			lines.push(`  ${headerCells.join(" ")}`.trimEnd());
+		}
+
+		for (const { group, columns } of renderableGroups) {
+			const status = resolveAggregateStatus(columns.filter((limit): limit is UsageLimit => limit !== undefined));
 			const statusIcon = resolveStatusIcon(status, uiTheme);
 
 			const windowSuffix = formatWindowSuffix(group.label, group.windowLabel, uiTheme);
 			lines.push(`${statusIcon} ${uiTheme.bold(group.label)} ${windowSuffix}`.trim());
-			const accountLabels = formatAccountHeaderRow(
-				sortedLimits,
-				sortedReports,
-				nowMs,
-				sectionColumnWidth,
-				uiTheme,
-				activeAccount,
-			);
-			lines.push(`  ${accountLabels.join(" ")}`.trimEnd());
-			const bars = sortedLimits.map(limit =>
-				padColumn(renderUsageBar(limit, uiTheme, sectionBarWidth), sectionColumnWidth),
-			);
-			lines.push(`  ${bars.join(" ")} ${amountText}`.trimEnd());
-			const resetText = sortedLimits.length <= 1 ? resolveResetRange(sortedLimits, nowMs) : null;
-			if (resetText) {
-				lines.push(`  ${uiTheme.fg("dim", resetText)}`.trimEnd());
-			}
-			const notes = [...new Set(sortedLimits.flatMap(limit => limit.notes ?? []))];
+			const bars = columns.map(limit => padColumn(renderUsageBar(limit, uiTheme, meterWidth), sectionColumnWidth));
+			lines.push(`  ${bars.join(" ")}`.trimEnd());
+			const details = columns.map(limit => {
+				const text = replaceTabs(sanitizeText(formatMeterDetails(limit, nowMs)));
+				return padColumn(uiTheme.fg("dim", truncateJobLabel(text, sectionColumnWidth)), sectionColumnWidth);
+			});
+			lines.push(`  ${details.join(" ")}`.trimEnd());
+			const notes = [...new Set(columns.flatMap(limit => limit?.notes ?? []))];
 			if (notes.length > 0) {
 				lines.push(
 					`  ${uiTheme.fg("dim", replaceTabs(truncateToWidth(sanitizeText(notes.map(n => n.replace(/[\r\n]+/g, " ")).join(" • ")), 110)))}`.trimEnd(),
@@ -1914,7 +2186,7 @@ export function renderUsageReports(
 		// Render accounts with no rate limits (e.g. business/enterprise plans).
 		const unlimitedReports = providerReports.filter(report => report.limits.length === 0);
 		for (const report of unlimitedReports) {
-			const label = formatUnlimitedReportLabel(report, 0);
+			const label = formatUnlimitedReportLabel(report, reportFallbackIndices.get(report) ?? 0);
 			const tier = report.metadata?.planType;
 			const tierSuffix = typeof tier === "string" && tier ? ` ${uiTheme.fg("dim", `(${tier})`)}` : "";
 			lines.push(

--- a/packages/coding-agent/src/slash-commands/helpers/active-oauth-account.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/active-oauth-account.ts
@@ -36,14 +36,24 @@ export function formatActiveAccountLabel(identity: OAuthAccountIdentity | undefi
  *   recovered at all) matches on the org alone. When neither side carries
  *   an org, the base fallback applies unchanged (providers without orgs
  *   keep their former behavior).
- * - `accountId` ↔ report metadata `accountId`/`account_id` or `limit.scope.accountId`
- * - `email`     ↔ report metadata `email`
  * - `projectId` ↔ report metadata `projectId` or `limit.scope.projectId`
- *   (Google-style providers key usage on the GCP project, not an account id)
+ *   (Google-style providers key usage on the GCP project, not an account id).
+ *   DECISIVE when both sides expose one, and checked BEFORE account/email:
+ *   one account spans many projects with per-project pools, so a report
+ *   attributed to a different project never matches via the shared
+ *   account id or email.
+ * - `accountId` ↔ report metadata `accountId`/`account_id` or `limit.scope.accountId`.
+ *   DECISIVE when both sides expose one: a report that carries a different
+ *   account id is a sibling workspace's pool, so it never falls through to
+ *   the shared-email check (same email ≠ same quota pool).
+ * - `email`     ↔ report metadata `email`
+ *
+ * `limit` is absent for report-level checks (e.g. reset-credit-only rows),
+ * in which case only report metadata participates.
  */
 export function limitMatchesActiveAccount(
 	report: UsageReport,
-	limit: UsageLimit,
+	limit: UsageLimit | undefined,
 	identity: OAuthAccountIdentity | undefined,
 ): boolean {
 	if (!identity) return false;
@@ -60,16 +70,22 @@ export function limitMatchesActiveAccount(
 		if (activeOrgId !== reportOrgId) return false;
 		if (!activeAccountId && !activeEmail && !activeProjectId) return true;
 	}
+	if (activeProjectId) {
+		const reportProjectIds = [
+			normalizeIdentityValue(metadata.projectId),
+			normalizeIdentityValue(limit?.scope.projectId),
+		].filter((value): value is string => value !== undefined);
+		if (reportProjectIds.length > 0) return reportProjectIds.includes(activeProjectId);
+	}
 	if (activeAccountId) {
-		const reportAccountId = normalizeIdentityValue(metadata.accountId) ?? normalizeIdentityValue(metadata.account_id);
-		if (reportAccountId === activeAccountId) return true;
-		if (normalizeIdentityValue(limit.scope.accountId) === activeAccountId) return true;
+		const reportAccountIds = [
+			normalizeIdentityValue(metadata.accountId),
+			normalizeIdentityValue(metadata.account_id),
+			normalizeIdentityValue(limit?.scope.accountId),
+		].filter((value): value is string => value !== undefined);
+		if (reportAccountIds.length > 0) return reportAccountIds.includes(activeAccountId);
 	}
 	if (activeEmail && normalizeIdentityValue(metadata.email) === activeEmail) return true;
-	if (activeProjectId) {
-		if (normalizeIdentityValue(metadata.projectId) === activeProjectId) return true;
-		if (normalizeIdentityValue(limit.scope.projectId) === activeProjectId) return true;
-	}
 	return false;
 }
 

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -27,7 +27,7 @@ describe("CommandController /usage", () => {
 		setThemeInstance(theme);
 	});
 
-	it("renders bars and free percentage for limits that only report remainingFraction", async () => {
+	it("renders usage bars for limits that only report remainingFraction", async () => {
 		const present = vi.fn();
 		const ctx = {
 			session: {},
@@ -61,7 +61,7 @@ describe("CommandController /usage", () => {
 		const firstCall = present.mock.calls[0];
 		expect(firstCall).toBeDefined();
 		const output = renderPresentedBlocks(firstCall?.[0]);
-		expect(output).toContain("25% free");
+		expect(output).toContain("75.0% used");
 		expect(output).toContain("█");
 		expect(output).not.toContain("··········");
 	});
@@ -110,8 +110,7 @@ describe("CommandController /usage", () => {
 		const output = renderPresentedBlocks(firstCall?.[0]);
 		expect(output).toContain("Cursor");
 		expect(output).toContain("gpt-4 requests");
-		expect(output).toContain("70% free");
-		expect(output).toContain("resets in 1d");
+		expect(output).toContain("30.0% used · 1d");
 	});
 
 	it("renders saved reset expiry lines for future and expired credits", async () => {

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -18,6 +18,7 @@ import { stripVTControlCharacters } from "node:util";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
 import { renderUsageReports } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { OAuthAccountIdentity } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 
 const HOUR = 3_600_000;
 
@@ -25,7 +26,23 @@ beforeAll(async () => {
 	await initTheme();
 });
 
-function limit(label: string, windowId: string, durationMs: number, frac: number, notes?: string[]) {
+function makeReport(provider: string, email: string, limits: UsageReport["limits"], notes?: string[]): UsageReport {
+	return {
+		provider,
+		fetchedAt: Date.now(),
+		limits,
+		...(notes ? { notes } : {}),
+		metadata: { email },
+	};
+}
+
+function makeLimit(
+	label: string,
+	windowId: string,
+	durationMs: number,
+	frac: number,
+	notes?: string[],
+): UsageReport["limits"][number] {
 	return {
 		id: windowId,
 		label,
@@ -34,33 +51,23 @@ function limit(label: string, windowId: string, durationMs: number, frac: number
 		amount: { unit: "percent", usedFraction: frac },
 		status: frac >= 0.8 ? "warning" : "ok",
 		...(notes ? { notes } : {}),
-	} satisfies UsageReport["limits"][number];
-}
-
-function report(provider: string, email: string, limits: UsageReport["limits"], notes?: string[]) {
-	return {
-		provider,
-		fetchedAt: Date.now(),
-		limits,
-		...(notes ? { notes } : {}),
-		metadata: { email },
-	} satisfies UsageReport;
+	};
 }
 
 describe("renderUsageReports (#3268 TUI aggregate)", () => {
 	it("renders provider-wide UsageReport.notes exactly once for multiple accounts", () => {
 		const disclaimer = "OMP-observed spend only; OpenCode usage outside OMP is not included.";
 		const reports: UsageReport[] = [
-			report(
+			makeReport(
 				"opencode-go",
 				"acct-a@example.test",
-				[limit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.3)],
+				[makeLimit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.3)],
 				[disclaimer],
 			),
-			report(
+			makeReport(
 				"opencode-go",
 				"acct-b@example.test",
-				[limit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.6)],
+				[makeLimit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.6)],
 				[disclaimer],
 			),
 		];
@@ -74,8 +81,12 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		// one aggregate group; both carry an identical per-limit note.
 		const note = "Overage requests: 5";
 		const reports: UsageReport[] = [
-			report("github-copilot", "acct-a@example.test", [limit("Copilot", "monthly", 30 * 24 * HOUR, 0.8, [note])]),
-			report("github-copilot", "acct-b@example.test", [limit("Copilot", "monthly", 30 * 24 * HOUR, 0.9, [note])]),
+			makeReport("github-copilot", "acct-a@example.test", [
+				makeLimit("Copilot", "monthly", 30 * 24 * HOUR, 0.8, [note]),
+			]),
+			makeReport("github-copilot", "acct-b@example.test", [
+				makeLimit("Copilot", "monthly", 30 * 24 * HOUR, 0.9, [note]),
+			]),
 		];
 		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
 		const occurrences = text.split(note).length - 1;
@@ -87,7 +98,7 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 	it("preserves organization suffixes when wide account columns can fit them", () => {
 		const now = Date.now();
 		const accountLimit = () => ({
-			...limit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.3),
+			...makeLimit("5 Hour limit", "rolling-5h", 5 * HOUR, 0.3),
 			window: {
 				id: "rolling-5h",
 				label: "5 Hour limit",
@@ -97,10 +108,10 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		});
 		const reports: UsageReport[] = [
 			{
-				...report("anthropic", "rae@example.com", [accountLimit()]),
+				...makeReport("anthropic", "rae@example.com", [accountLimit()]),
 				metadata: { email: "rae@example.com", orgId: "team-org", orgName: "Team Org" },
 			},
-			report("anthropic", "rae@example.com", [accountLimit()]),
+			makeReport("anthropic", "rae@example.com", [accountLimit()]),
 		];
 
 		const text = stripVTControlCharacters(renderUsageReports(reports, theme, now, 160));
@@ -113,7 +124,7 @@ describe("renderUsageReports session marker (#5691 org-qualified identity)", () 
 	it("suffixes the active org so same-email multi-org accounts are tellable apart", () => {
 		const email = "dev@example.test";
 		const reports: UsageReport[] = [
-			report("anthropic", email, [limit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
+			makeReport("anthropic", email, [makeLimit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
 		];
 		const text = stripVTControlCharacters(
 			renderUsageReports(reports, theme, Date.now(), 120, provider =>
@@ -127,7 +138,7 @@ describe("renderUsageReports session marker (#5691 org-qualified identity)", () 
 	it("falls back to the bare base when the active identity carries no org", () => {
 		const email = "solo@example.test";
 		const reports: UsageReport[] = [
-			report("anthropic", email, [limit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
+			makeReport("anthropic", email, [makeLimit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
 		];
 		const text = stripVTControlCharacters(
 			renderUsageReports(reports, theme, Date.now(), 120, provider =>
@@ -137,5 +148,644 @@ describe("renderUsageReports session marker (#5691 org-qualified identity)", () 
 		const marker = text.split("\n").find(line => line.includes("in use by this session"));
 		expect(marker).toContain(email);
 		expect(marker).not.toContain("(");
+	});
+});
+
+describe("renderUsageReports account columns", () => {
+	function active(email: string): OAuthAccountIdentity {
+		return { email };
+	}
+
+	it("keeps account columns stable across limit groups", () => {
+		// acct-a is alphabetically before acct-b and has the higher fraction in
+		// the first group. A fraction-based sort would swap columns between
+		// groups; stable ordering must keep acct-a first everywhere.
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "acct-a@example.test", [
+				makeLimit("5 hours", "5h", 5 * HOUR, 0.9),
+				makeLimit("7 days", "7d", 7 * 24 * HOUR, 0.2),
+			]),
+			makeReport("openai-codex", "acct-b@example.test", [
+				makeLimit("5 hours", "5h", 5 * HOUR, 0.3),
+				makeLimit("7 days", "7d", 7 * 24 * HOUR, 0.8),
+			]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		const headerIndex = text.indexOf("acct-a@example.test");
+		expect(headerIndex).toBeGreaterThan(-1);
+		expect(text.indexOf("acct-b@example.test")).toBeGreaterThan(headerIndex);
+		// Both percentages for each group must appear.
+		expect(text).toContain("90.0% used");
+		expect(text).toContain("30.0% used");
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("80.0% used");
+	});
+
+	it("keeps project-scoped reports with the same email in separate columns", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("google-antigravity", "o@example.test", [
+					{
+						...makeLimit("Tokens", "daily", 24 * HOUR, 0.2),
+						scope: { provider: "google-antigravity", projectId: "alpha", windowId: "daily" },
+					},
+				]),
+				metadata: { email: "o@example.test", projectId: "alpha" },
+			},
+			{
+				...makeReport("google-antigravity", "o@example.test", [
+					{
+						...makeLimit("Tokens", "daily", 24 * HOUR, 0.7),
+						scope: { provider: "google-antigravity", projectId: "beta", windowId: "daily" },
+					},
+				]),
+				metadata: { email: "o@example.test", projectId: "beta" },
+			},
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		expect(text).toContain("o@example.test (alpha)");
+		expect(text).toContain("o@example.test (beta)");
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("70.0% used");
+	});
+
+	it("keeps same-email account-id reports in separate columns", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email: "shared@example.test", accountId: "acct-a" },
+			},
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email: "shared@example.test", accountId: "acct-b" },
+			},
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("70.0% used");
+	});
+
+	it("suffixes colliding same-email headers with the account id, leaving unique labels bare", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email: "shared@example.test", accountId: "acct-a" },
+			},
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email: "shared@example.test", accountId: "acct-b" },
+			},
+			makeReport("openai-codex", "unique@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.4)]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 200));
+		const header = text.split("\n").find(line => line.includes("shared@example.test"));
+		// Colliding email labels gain their stable account-id suffix…
+		expect(header).toContain("shared@example.test (acct-a)");
+		expect(header).toContain("shared@example.test (acct-b)");
+		// …while the non-colliding label stays bare.
+		expect(header).toContain("unique@example.test");
+		expect(header).not.toContain("unique@example.test (");
+	});
+
+	it("still disambiguates when the shared email contains one account id as a substring", () => {
+		// "abc" is a substring of the shared email; a containment guard would
+		// skip its suffix and leave two identical headers.
+		const email = "abc@example.test";
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair(email, "abc", "def"), theme, Date.now(), 200),
+		);
+		const header = text.split("\n").find(line => line.includes("abc@example.test"));
+		expect(header).toContain("abc@example.test (abc)");
+		expect(header).toContain("abc@example.test (def)");
+	});
+
+	it("keeps colliding headers distinct under narrow columns by truncating the base, not the id suffix", () => {
+		const email = "verylongsharedmailbox@example.test";
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email, accountId: "acct-a" },
+			},
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email, accountId: "acct-b" },
+			},
+		];
+		// availableWidth 54 with two accounts → 25-wide columns: the raw email
+		// alone (34 cols) would end-truncate past the suffix.
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 54, provider =>
+				provider === "openai-codex" ? { email, accountId: "acct-b" } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("(acct-"));
+		expect(header).toBeDefined();
+		// The distinguishing id tails survive truncation on both columns, and
+		// the active marker still fits in front of the truncated base.
+		expect(header).toContain("(acct-b)");
+		expect(header).toContain("(acct-a)");
+		expect(header).toContain("●");
+		const first = header!.slice(2, 27);
+		const second = header!.slice(28, 53);
+		expect(first).not.toBe(second);
+		expect(first.trimEnd().length).toBeLessThanOrEqual(25);
+		// Bar rows stay aligned to the same 25-column grid.
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		expect(barLine).toBeDefined();
+		expect(/[█▒▓░·]/u.test(barLine![2])).toBe(true);
+		expect(/[█▒▓░·]/u.test(barLine![28])).toBe(true);
+		expect(barLine![27]).toBe(" ");
+	});
+
+	it("falls back to shortest-unique id fragments when UUID suffixes exceed the column", () => {
+		const email = "verylongsharedmailbox@example.test";
+		const idA = "11111111-2222-3333-4444-555555555555";
+		const idB = "11111111-2222-3333-4444-555555555556";
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email, accountId: idA },
+			},
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email, accountId: idB },
+			},
+		];
+		// 25-wide columns cannot hold a 36-char UUID suffix; the ids differ
+		// only in their tails, so the group falls back to tail fragments.
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 54, provider =>
+				provider === "openai-codex" ? { email, accountId: idB } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("(…"));
+		expect(header).toBeDefined();
+		expect(header).toContain("●");
+		const first = header!.slice(2, 27);
+		const second = header!.slice(28, 53);
+		// Both cells keep a distinguishing fragment, stay distinct, and fit.
+		expect(first).not.toBe(second);
+		expect(first).toContain("(…");
+		expect(second).toContain("(…");
+		expect(first.trimEnd().length).toBeLessThanOrEqual(25);
+		expect(second.trimEnd().length).toBeLessThanOrEqual(25);
+		// Bar offsets are unchanged by the fragment fallback.
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		expect(barLine).toBeDefined();
+		expect(/[█▒▓░·]/u.test(barLine![2])).toBe(true);
+		expect(/[█▒▓░·]/u.test(barLine![28])).toBe(true);
+		expect(barLine![27]).toBe(" ");
+	});
+
+	function makeCollidingPair(email: string, idA: string, idB: string): UsageReport[] {
+		return [
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email, accountId: idA },
+			},
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email, accountId: idB },
+			},
+		];
+	}
+
+	it("renders complete unique fragments directly in 6-column cells", () => {
+		const idA = "11111111-2222-3333-4444-555555555555";
+		const idB = "11111111-2222-3333-4444-555555555556";
+		// availableWidth 15 with two accounts → 6-wide columns; active marker
+		// leaves a 4-column budget, so decorations and base are dropped but
+		// the distinguishing fragment must survive whole.
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair("shared@example.test", idA, idB), theme, Date.now(), 15, provider =>
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: idB } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("5555") || line.includes("5556"));
+		expect(header).toBeDefined();
+		const first = header!.slice(2, 8);
+		const second = header!.slice(9, 15);
+		expect(first).not.toBe(second);
+		// The unique final character survives in both cells.
+		expect(first).toContain("5556");
+		expect(second).toContain("5555");
+		expect(header).toContain("●");
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		expect(barLine).toBeDefined();
+		expect(/[█▒▓░·]/u.test(barLine![2])).toBe(true);
+		expect(/[█▒▓░·]/u.test(barLine![9])).toBe(true);
+		expect(barLine![8]).toBe(" ");
+	});
+
+	it("keeps astral-tail fragments whole instead of splitting surrogate pairs", () => {
+		// The distinguishing emoji sits before a shared "1111" tail, so any
+		// code-unit slicer reaches distinctness only by splitting the pair
+		// into identical-looking lone surrogates.
+		const idA = "11111111-2222-3333-4444-5555😀1111";
+		const idB = "11111111-2222-3333-4444-5555😁1111";
+		const text = stripVTControlCharacters(
+			renderUsageReports(
+				makeCollidingPair("verylongsharedmailbox@example.test", idA, idB),
+				theme,
+				Date.now(),
+				54,
+				provider =>
+					provider === "openai-codex"
+						? { email: "verylongsharedmailbox@example.test", accountId: idB }
+						: undefined,
+			),
+		);
+		const header = text.split("\n").find(line => line.includes("(…"));
+		expect(header).toBeDefined();
+		// Emoji clusters render intact — no lone surrogates / replacement chars.
+		expect(header).toContain("😀");
+		expect(header).toContain("😁");
+		expect(header).not.toContain("\uFFFD");
+		const surrogates = /[\uD800-\uDFFF]/;
+		expect(surrogates.test(header!.replaceAll("😀", "").replaceAll("😁", ""))).toBe(false);
+		const first = header!.slice(2, 27);
+		const second = header!.slice(28, 53);
+		expect(first).not.toBe(second);
+	});
+
+	it("fits double-width fragments by visible columns without cutting the unique tail", () => {
+		const idA = "acct-stable-一二三四五";
+		const idB = "acct-stable-一二三四六";
+		// availableWidth 25 → 11-wide columns: the "…二三四五" tail fragment is
+		// 9 visible columns, exactly filling the active cell beside its marker.
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair("shared@example.test", idA, idB), theme, Date.now(), 25, provider =>
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: idB } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("二三四"));
+		expect(header).toBeDefined();
+		// Both distinguishing CJK tails survive whole.
+		expect(header).toContain("二三四五");
+		expect(header).toContain("二三四六");
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		expect(barLine).toBeDefined();
+		expect(/[█▒▓░·]/u.test(barLine![2])).toBe(true);
+		expect(/[█▒▓░·]/u.test(barLine![14])).toBe(true);
+		expect(barLine![13]).toBe(" ");
+	});
+
+	it("does not falsely distinguish ids whose difference renders identically", () => {
+		// Same rendered id: composed é vs e + combining acute. NFC-normalized
+		// comparison must treat them as one identity rather than emitting two
+		// identical-looking "distinct" fragments.
+		const idA = "acct-caf\u00e9-11111111-2222-3333-4444-555555555555";
+		const idB = "acct-cafe\u0301-11111111-2222-3333-4444-555555555555";
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair("verylongsharedmailbox@example.test", idA, idB), theme, Date.now(), 54),
+		);
+		// Single-class groups render a tail-anchored slice of the shared id.
+		const header = text.split("\n").find(line => line.includes("555555"));
+		expect(header).toBeDefined();
+		// Cells contain no spaces in the bare-fragment tier, so token-split is
+		// column-safe even though combining marks skew code-unit offsets.
+		const [first, second] = header!.trim().split(/\s+/u);
+		expect(second).toBeDefined();
+		// No pseudo-distinct fragments: the cells render the same.
+		expect(first.normalize("NFC")).toBe(second.normalize("NFC"));
+	});
+
+	it("trims unellipsized tail fragments from the front in tiny active cells", () => {
+		// Tail-distinct ids of unequal length: "abcd" is short enough to carry
+		// no ellipsis, yet its distinguishing edge is still the END. A 4-col
+		// active cell (2-col budget beside the marker) must trim it to "cd",
+		// not end-truncate it into the sibling's "ab".
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair("shared@example.test", "ab", "abcd"), theme, Date.now(), 11, provider =>
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: "abcd" } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("●"));
+		expect(header).toBeDefined();
+		const first = header!.slice(2, 6).trimEnd();
+		const second = header!.slice(7, 11).trimEnd();
+		// Active "abcd" column keeps its tail; sibling keeps its whole id.
+		expect(first).toBe("● cd");
+		expect(second).toBe("ab");
+	});
+
+	it("keeps a tail-distinct third id distinguishable beside an NFC-equivalent pair", () => {
+		const email = "verylongsharedmailbox@example.test";
+		const composed = "acct-caf\u00e9-11111111-2222-3333-4444-555555555555";
+		const decomposed = "acct-cafe\u0301-11111111-2222-3333-4444-555555555555";
+		const distinct = "acct-caf\u00e9-11111111-2222-3333-4444-555555555556";
+		const reports: UsageReport[] = [
+			...makeCollidingPair(email, composed, decomposed),
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.4)]),
+				metadata: { email, accountId: distinct },
+			},
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 80));
+		const header = text.split("\n").find(line => line.includes("(…"));
+		expect(header).toBeDefined();
+		// The render-identical pair shares one fragment; the tail-distinct id
+		// still gets its own — the pair must not push the group to maxLength.
+		expect(header).toContain("(…5555)");
+		expect(header).toContain("(…5556)");
+		expect(header!.match(/\(…5555\)/gu)?.length).toBe(2);
+	});
+
+	it("renders NFC-equivalent ids identically in bare tier regardless of the active marker", () => {
+		// Same rendered identity (composed vs decomposed é); 4-col cells where
+		// only one column carries the ● marker. Both cells must fit to the
+		// group's shared (tightest) budget so the identity text matches —
+		// different trims would falsely imply two different accounts.
+		const idA = "acct-caf\u00e9-11111111";
+		const idB = "acct-cafe\u0301-11111111";
+		const text = stripVTControlCharacters(
+			renderUsageReports(makeCollidingPair("shared@example.test", idA, idB), theme, Date.now(), 11, provider =>
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: idB } : undefined,
+			),
+		);
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("●"));
+		expect(header).toBeDefined();
+		const first = header!.slice(2, 6).trimEnd();
+		const second = header!.slice(7, 11).trimEnd();
+		// Strip the marker: the identity texts must be equal.
+		expect(first.startsWith("● ")).toBe(true);
+		expect(first.slice(2)).toBe(second);
+		// Bars keep equal widths on the same 4-column grid.
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		expect(barLine).toBeDefined();
+		expect(/^[█▒▓░·]+$/u.test(barLine!.slice(2, 6))).toBe(true);
+		expect(/^[█▒▓░·]+$/u.test(barLine!.slice(7, 11))).toBe(true);
+		expect(barLine![6]).toBe(" ");
+	});
+
+	it("assigns per-identity prefix/tail edges so mixed ids stay distinct under the bare budget", () => {
+		// One group-wide edge collapses these: prefixes give aaaa/aaaa/Zaaa,
+		// tails give aaaX/aaaY/aaaX. Augmenting paths settle on the
+		// collision-free aaaX/aaaY/Zaaa deterministically.
+		const email = "shared@example.test";
+		const reports: UsageReport[] = [
+			...makeCollidingPair(email, "aaaaX", "aaaaY"),
+			{
+				...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, 0.4)]),
+				metadata: { email, accountId: "ZaaaaX" },
+			},
+		];
+		// availableWidth 16 with three accounts → 4-col cells.
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 16));
+		const lines = text.split("\n");
+		const header = lines.find(line => line.includes("aaa"));
+		expect(header).toBeDefined();
+		const cells = [header!.slice(2, 6).trimEnd(), header!.slice(7, 11).trimEnd(), header!.slice(12, 16).trimEnd()];
+		// Deterministic collision-free combination.
+		expect(new Set(cells).size).toBe(3);
+		expect(cells.sort()).toEqual(["Zaaa", "aaaX", "aaaY"]);
+	});
+
+	it("finds mixed edges in large collision groups instead of capping out to uniform tails", () => {
+		// 14 identity classes: the aaaaX/aaaaY/ZaaaaX trio still requires a
+		// mixed prefix/tail assignment, and the sheer class count must not
+		// trigger any fallback that reintroduces the tail collision.
+		const email = "shared@example.test";
+		const ids = [
+			"aaaaX",
+			"aaaaY",
+			"ZaaaaX",
+			...Array.from({ length: 11 }, (_, i) => `filler${String(i).padStart(2, "0")}`),
+		];
+		const reports: UsageReport[] = ids.map((id, i) => ({
+			...makeReport("openai-codex", email, [makeLimit("5 hours", "5h", 5 * HOUR, (i + 1) / 20)]),
+			metadata: { email, accountId: id },
+		}));
+		// availableWidth 71 with 14 accounts → 4-col cells.
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 71));
+		const header = text.split("\n").find(line => line.includes("aaa"));
+		expect(header).toBeDefined();
+		const cells = Array.from({ length: 14 }, (_, i) => header!.slice(2 + i * 5, 6 + i * 5).trimEnd());
+		expect(new Set(cells).size).toBe(14);
+		// The trio's collision-free mixed assignment survives at scale.
+		expect(cells).toContain("aaaX");
+		expect(cells).toContain("aaaY");
+		expect(cells).toContain("Zaaa");
+	});
+
+	it("places the active account first and marks it in the header", () => {
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "acct-a@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.5)]),
+			makeReport("openai-codex", "acct-b@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.6)]),
+		];
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 120, provider =>
+				provider === "openai-codex" ? active("acct-a@example.test") : undefined,
+			),
+		);
+		const activeHeader = text.indexOf("● acct-a@example.test");
+		expect(activeHeader).toBeGreaterThan(-1);
+		expect(text.indexOf("acct-b@example.test")).toBeGreaterThan(activeHeader);
+	});
+
+	it("marks only the exact account active when same-email reports differ by account id", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email: "shared@example.test", accountId: "acct-a" },
+			},
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email: "shared@example.test", accountId: "acct-b" },
+			},
+		];
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 120, provider =>
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: "acct-b" } : undefined,
+			),
+		);
+		// Exactly one active marker: acct-a shares the email but has a different
+		// account id, so it must not be claimed by the active identity.
+		expect(text.match(/●/g)?.length).toBe(1);
+		// The exact account (acct-b, 70%) sorts first; the sibling follows.
+		expect(text.indexOf("70.0% used")).toBeLessThan(text.indexOf("20.0% used"));
+	});
+
+	it("matches saved-reset active markers via snake-case alias ids and reset-only reports", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email: "shared@example.test", account_id: "ACC-A" },
+				resetCredits: { availableCount: 1 },
+			},
+			{
+				// Reset-only row: no limits, so matching must fall back to report metadata.
+				...makeReport("openai-codex", "shared@example.test", []),
+				metadata: { email: "shared@example.test", account_id: "ACC-B" },
+				resetCredits: { availableCount: 2 },
+			},
+		];
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 120, provider =>
+				// Lowercase active id: alias (`account_id`) and case normalization must apply.
+				provider === "openai-codex" ? { email: "shared@example.test", accountId: "acc-b" } : undefined,
+			),
+		);
+		const resetLines = text.split("\n").filter(line => line.includes("saved reset"));
+		expect(resetLines).toHaveLength(2);
+		expect(resetLines.find(line => line.includes("2 saved resets"))).toContain("(active)");
+		expect(resetLines.find(line => line.includes("1 saved reset"))).not.toContain("(active)");
+	});
+
+	it("treats the active project id as decisive for same-account multi-project reports", () => {
+		const email = "dev@example.test";
+		const reports: UsageReport[] = [
+			{
+				...makeReport("google-antigravity", email, [
+					{
+						...makeLimit("Tokens", "daily", 24 * HOUR, 0.2),
+						scope: { provider: "google-antigravity", projectId: "proj-alpha", windowId: "daily" },
+					},
+				]),
+				metadata: { email, accountId: "acct-1", projectId: "proj-alpha" },
+				resetCredits: { availableCount: 1 },
+			},
+			{
+				...makeReport("google-antigravity", email, [
+					{
+						...makeLimit("Tokens", "daily", 24 * HOUR, 0.7),
+						scope: { provider: "google-antigravity", projectId: "proj-beta", windowId: "daily" },
+					},
+				]),
+				metadata: { email, accountId: "acct-1", projectId: "proj-beta" },
+				resetCredits: { availableCount: 2 },
+			},
+		];
+		const text = stripVTControlCharacters(
+			renderUsageReports(reports, theme, Date.now(), 120, provider =>
+				// Same email and account id on both reports: only the project id
+				// tells the pools apart, so it must be decisive (uppercase to
+				// exercise normalization).
+				provider === "google-antigravity" ? { email, accountId: "acct-1", projectId: "PROJ-BETA" } : undefined,
+			),
+		);
+		// Unique marker on the exact project's column, which sorts first.
+		expect(text.match(/●/g)?.length).toBe(1);
+		expect(text.indexOf("70.0% used")).toBeLessThan(text.indexOf("20.0% used"));
+		// Saved-reset marker follows the same project-decisive rules.
+		const resetLines = text.split("\n").filter(line => line.includes("saved reset"));
+		expect(resetLines).toHaveLength(2);
+		expect(resetLines.find(line => line.includes("2 saved resets"))).toContain("(active)");
+		expect(resetLines.find(line => line.includes("1 saved reset"))).not.toContain("(active)");
+	});
+
+	it("leaves a placeholder when an account has no limit in a group", () => {
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "acct-a@example.test", [
+				makeLimit("5 hours", "5h", 5 * HOUR, 0.5),
+				makeLimit("7 days", "7d", 7 * 24 * HOUR, 0.5),
+			]),
+			makeReport("openai-codex", "acct-b@example.test", [
+				makeLimit("5 hours", "5h", 5 * HOUR, 0.6),
+				// No 7-day limit for acct-b.
+			]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		// Both account headers are present.
+		expect(text).toContain("acct-a@example.test");
+		expect(text).toContain("acct-b@example.test");
+		// The 7 days group still has two columns; the missing one renders a placeholder.
+		const sevenDaysIndex = text.indexOf("7 days");
+		expect(sevenDaysIndex).toBeGreaterThan(-1);
+		const segment = text.slice(sevenDaysIndex, sevenDaysIndex + 200);
+		expect(segment).toContain("50.0% used");
+		expect(segment).toContain("—");
+	});
+
+	it("shows exact per-meter percentages and reset times instead of one aggregate", () => {
+		const nowMs = Date.now();
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "acct-a@example.test", [
+				{
+					...makeLimit("5 hours", "5h", 5 * HOUR, 0.25),
+					window: { id: "5h", label: "5 hours", durationMs: 5 * HOUR, resetsAt: nowMs + HOUR },
+				},
+			]),
+			makeReport("openai-codex", "acct-b@example.test", [
+				{
+					...makeLimit("5 hours", "5h", 5 * HOUR, 0.75),
+					window: { id: "5h", label: "5 hours", durationMs: 5 * HOUR, resetsAt: nowMs + 2 * HOUR },
+				},
+			]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, nowMs, 120));
+		// Each meter reports its own exact percentage; no averaged "free" text.
+		expect(text).toContain("25.0% used");
+		expect(text).toContain("75.0% used");
+		expect(text).not.toMatch(/\d+% free/);
+		// Reset times are shown per meter.
+		expect(text).toContain("1h");
+		expect(text).toContain("2h");
+	});
+
+	it("keeps same-email organization reports in separate columns", () => {
+		const reports: UsageReport[] = [
+			{
+				...makeReport("anthropic", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+				metadata: { email: "shared@example.test", accountId: "shared-id", orgId: "org-a", orgName: "Org A" },
+			},
+			{
+				...makeReport("anthropic", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+				metadata: { email: "shared@example.test", accountId: "shared-id", orgId: "org-b", orgName: "Org B" },
+			},
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		expect(text).toContain("shared@example.test (Org A)");
+		expect(text).toContain("shared@example.test (Org B)");
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("70.0% used");
+	});
+
+	it("uses a stable per-report fallback when account metadata collides", () => {
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+			makeReport("openai-codex", "shared@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		expect(text.match(/shared@example\.test/g)?.length).toBe(2);
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("70.0% used");
+	});
+
+	it("uses real report indexes for deterministic fallback labels", () => {
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "", [makeLimit("5 hours", "5h", 5 * HOUR, 0.2)]),
+			makeReport("openai-codex", "", [makeLimit("5 hours", "5h", 5 * HOUR, 0.7)]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		const header = text.split("\n").find(line => line.includes("account 1"));
+		expect(header).toContain("account 1");
+		expect(header).toContain("account 2");
+		expect(text).toContain("20.0% used");
+		expect(text).toContain("70.0% used");
+	});
+
+	it("caps wide meter bars while keeping them aligned with account columns", () => {
+		const reports: UsageReport[] = [
+			makeReport("openai-codex", "alpha@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.5)]),
+			makeReport("openai-codex", "beta@example.test", [makeLimit("5 hours", "5h", 5 * HOUR, 0.6)]),
+		];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 200));
+		const lines = text.split("\n");
+		const headerLine = lines.find(line => line.includes("alpha@example.test"));
+		const barLine = lines.find(line => /[█▒▓░·]/u.test(line));
+		if (!headerLine || !barLine) throw new Error("expected usage header and bar lines");
+		const barRuns = [...barLine.matchAll(/[█▒▓░·]+/gu)];
+		expect(barRuns.map(match => match[0].length)).toEqual([24, 24]);
+		expect(barRuns.map(match => match.index)).toEqual([
+			headerLine.indexOf("alpha@example.test"),
+			headerLine.indexOf("beta@example.test"),
+		]);
 	});
 });


### PR DESCRIPTION
## What

- Parse Z.AI quota `unit` values into distinct monthly, 5-hour, and weekly windows.
- Label monthly web/search/reader/zread quota separately from token quota.
- Keep one provider-wide account header with deterministic account columns across every limit row.
- Include organization identity in report keys so same-email subscriptions cannot overwrite one another.
- Keep meter bars capped at 24 cells while preserving alignment beneath wide account-label columns.
- Show each meter's exact percentage and reset time instead of an averaged free-capacity value.

## Why

The previous normalization grouped distinct Z.AI quota windows together and the TUI reordered account columns by usage fraction. Multi-account reports could collide when email identities matched across organizations. The normalized report and renderer now preserve provider-native windows, account identity, stable ordering, and per-meter detail.

## Testing

```bash
bun test packages/ai/test/zai-usage.test.ts packages/coding-agent/test/modes/controllers/usage-command.test.ts packages/coding-agent/test/usage-report-tui-notes.test.ts
bun --cwd=packages/coding-agent run check
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
