### PR TITLE
feat(web-search): add AnySearch provider support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 - Fixed Anthropic credential selection sampling Fable/Mythos-exhausted accounts on every new session: a Fable/Mythos weekly cap now proactively hard-blocks the credential when confirmed exhausted (server `exhausted` status or used fraction >= 1) with a live `resetsAt`, and a live Fable 429 extends the reactive block to the confirmed tier reset instead of the 60s default. Unconfirmed rows (missing/expired reset, below cap) remain ranking hints only, preserving the false-100% guard.
 - Fixed Ollama/Ollama Cloud tool requests failing with HTTP 400 by rewriting boolean subschemas (`true`/`false`) into a value-widening `anyOf` union of primitive types, stripping boolean `additionalProperties`/`unevaluatedProperties`, and flattening nullable `type` arrays before serializing tool parameters, so unconstrained fields still advertise "any JSON value" to grammar-constrained samplers (llama.cpp) instead of collapsing to an empty object. ([#4488](https://github.com/can1357/oh-my-pi/issues/4488))
+### Added
+
+- Added `anysearch` registry provider definition and interactive credentials login support.
 
 ## [16.3.5] - 2026-07-04
 

--- a/packages/ai/src/registry/anysearch.ts
+++ b/packages/ai/src/registry/anysearch.ts
@@ -1,0 +1,19 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { ProviderDefinition } from "./types";
+
+export const loginAnySearch = createApiKeyLogin({
+	providerLabel: "AnySearch",
+	authUrl: "https://anysearch.com/console/api-keys",
+	instructions:
+		"Create or copy your AnySearch API key from the AnySearch console. A key is optional for anonymous search, but recommended for higher rate limits.",
+	promptMessage: "Paste your AnySearch API key",
+	placeholder: "your-api-key",
+	validation: null,
+});
+
+export const anysearchProvider = {
+	id: "anysearch",
+	name: "AnySearch",
+	envKeys: "ANYSEARCH_API_KEY",
+	login: loginAnySearch,
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -3,6 +3,7 @@ import { aimlApiProvider } from "./aimlapi";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan";
 import { amazonBedrockProvider } from "./amazon-bedrock";
 import { anthropicProvider } from "./anthropic";
+import { anysearchProvider } from "./anysearch";
 import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
 import { cerebrasProvider } from "./cerebras";
@@ -126,6 +127,7 @@ const ALL = [
 	opencodeZenProvider,
 	opencodeGoProvider,
 	tavilyProvider,
+	anysearchProvider,
 	kagiProvider,
 	parallelProvider,
 	ollamaProvider,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -134,6 +134,9 @@
 - Fixed turn-ending provider errors rendering with a doubled blank gap above the `Error:` block (caller and error block each added a spacer).
 - Fixed the write tool renderer crashing when persisted runtime content is a truthy non-string value; rendering now coerces display content before Windows CR normalization. ([#4495](https://github.com/can1357/oh-my-pi/issues/4495))
 - Fixed cmux-backend `browser({action:"run"})` calls crashing the entire process with an unhandled rejection when the tab was released mid-run (e.g. a sibling subagent calling `browser({action:"close", all:true})` or a session-scoped tab reap). `runInTabWithSnapshot` in `tab-supervisor.ts` creates a `Promise.withResolvers()` triple so `releaseTab` can signal in-flight runs, but the cmux branch used to await `runCmuxCode(...)` directly and never awaited the local promise. When `releaseTab` rejected that orphaned promise ("Tab ... was closed"), Bun surfaced it as an unhandled rejection and the top-level handler tore the whole session down, killing every other tab and subagent sharing it. Both backends now await the same `promise` (so `pending.reject` always has an attached handler AND the caller sees `Tab "..." was closed` immediately instead of blocking to the run's timeout), and a new `pending.closeAc` is composed into the cmux run's abort signal so `wait(...)`, in-flight cmux socket calls, and the facade proxies unwind promptly when the tab is closed rather than leaking to their own timeout ([#4499](https://github.com/can1357/oh-my-pi/issues/4499)).
+### Added
+
+- Added `anysearch` web search provider, supporting both credentials-based and anonymous MCP search fallbacks.
 
 ## [16.3.5] - 2026-07-04
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -342,6 +342,7 @@ export function getExtraHelpText(): string {
   PERPLEXITY_API_KEY         - Perplexity web search API key (optional; anonymous fallback)
   PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
   TAVILY_API_KEY             - Tavily web search
+  ANYSEARCH_API_KEY          - AnySearch web search API key (optional; anonymous fallback)
   TINYFISH_API_KEY           - TinyFish web search
   FIRECRAWL_API_KEY          - Firecrawl web search
   ANTHROPIC_SEARCH_API_KEY   - Anthropic web search (override; isolates search from main ANTHROPIC_API_KEY)

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -114,6 +114,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.duckduckgo,
 		load: async () => new (await import("./providers/duckduckgo")).DuckDuckGoProvider(),
 	},
+	anysearch: {
+		id: "anysearch",
+		label: SEARCH_PROVIDER_LABELS.anysearch,
+		load: async () => new (await import("./providers/anysearch")).AnySearchProvider(),
+	},
 };
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();

--- a/packages/coding-agent/src/web/search/providers/anysearch.ts
+++ b/packages/coding-agent/src/web/search/providers/anysearch.ts
@@ -1,0 +1,237 @@
+import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
+import { parseSSE } from "../../../mcp/json-rpc";
+import { asRecord, asString } from "../../../web/scrapers/utils";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const ANYSEARCH_MCP_URL = "https://api.anysearch.com/mcp";
+const ANYSEARCH_TOOL_NAME = "search";
+const DEFAULT_NUM_RESULTS = 5;
+const MAX_NUM_RESULTS = 10;
+
+export interface AnySearchSearchParams {
+	query: string;
+	num_results?: number;
+	signal?: AbortSignal;
+	fetch?: FetchImpl;
+	authStorage: AuthStorage;
+	sessionId?: string;
+}
+
+interface JsonRpcErrorShape {
+	code?: number;
+	message?: string;
+	data?: unknown;
+}
+
+interface JsonRpcPayload {
+	result?: unknown;
+	error?: JsonRpcErrorShape;
+}
+
+function extractContentText(result: unknown): string {
+	const candidates: unknown[] = [result];
+	const root = asRecord(result);
+	if (root?.structuredContent !== undefined) candidates.push(root.structuredContent);
+	if (root?.data !== undefined) candidates.push(root.data);
+	if (root?.result !== undefined) candidates.push(root.result);
+
+	for (const candidate of candidates) {
+		if (typeof candidate === "string") {
+			const trimmed = candidate.trim();
+			if (trimmed) return trimmed;
+		}
+
+		const obj = asRecord(candidate);
+		const content = Array.isArray(obj?.content) ? obj.content : [];
+		const text = content
+			.map(item => asString(asRecord(item)?.text))
+			.filter((value): value is string => value != null)
+			.join("\n\n")
+			.trim();
+		if (text) return text;
+	}
+
+	return "";
+}
+
+function cleanSnippet(section: string): string | undefined {
+	const snippet = section
+		.split("\n")
+		.map(line => line.trim())
+		.filter(line => line.length > 0 && !/^[*-]\s+\*\*URL\*\*:/i.test(line) && !/^###\s+/.test(line))
+		.map(line => line.replace(/^[*-]\s+/, ""))
+		.map(line => line.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, "$1"))
+		.join(" ")
+		.trim();
+	return snippet || undefined;
+}
+
+/**
+ * Parses the Markdown response returned by the AnySearch MCP search tool.
+ * The AnySearch server response has the following layout convention:
+ *
+ * ## Search Results (N results, Time)
+ * [Optional preamble/answer text here]
+ *
+ * ### 1. Document Title
+ * - **URL**: https://example.com/url
+ * - Snippet text line 1
+ * - Snippet text line 2
+ *
+ * ### 2. Next Document Title
+ * ...
+ */
+export function parseAnySearchMarkdown(markdown: string): { answer?: string; sources: SearchSource[] } {
+	const normalized = markdown.replace(/\r\n?/g, "\n").trim();
+	if (!normalized) return { sources: [] };
+
+	const firstSection = normalized.search(/(?:^|\n)###\s+/);
+	const preamble = firstSection >= 0 ? normalized.slice(0, firstSection).trim() : normalized;
+	const answer = preamble.replace(/^##\s*Search Results[^\n]*$/m, "").trim() || undefined;
+
+	const sources: SearchSource[] = [];
+	const sectionRegex = /(?:^|\n)###\s+([^\n]+)\n([\s\S]*?)(?=\n###\s+|\s*$)/g;
+	for (const match of normalized.matchAll(sectionRegex)) {
+		const rawTitle = match[1];
+		const title = rawTitle.replace(/^\d+\.\s*/, "").trim() || undefined;
+		const body = match[2].trim();
+		const url =
+			body.match(/(?:^|\n)[*-]\s+\*\*URL\*\*:\s*(https?:\/\/\S+)/i)?.[1] ??
+			body.match(/\[[^\]]+\]\((https?:\/\/[^)]+)\)/)?.[1] ??
+			body.match(/https?:\/\/\S+/)?.[0];
+		if (!url) continue;
+		sources.push({
+			title: title || url,
+			url,
+			snippet: cleanSnippet(body),
+		});
+	}
+
+	if (sources.length > 0) return { answer, sources };
+	if (/no results?/i.test(normalized)) return { answer, sources: [] };
+
+	return {
+		answer: normalized,
+		sources: [],
+	};
+}
+
+async function callAnySearchSearch(apiKey: string | undefined, params: AnySearchSearchParams): Promise<string> {
+	const response = await (params.fetch ?? fetch)(ANYSEARCH_MCP_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: crypto.randomUUID(),
+			method: "tools/call",
+			params: {
+				name: ANYSEARCH_TOOL_NAME,
+				arguments: {
+					query: params.query,
+					max_results: params.num_results,
+				},
+			},
+		}),
+		signal: withHardTimeout(params.signal),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("anysearch", response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError(
+			"anysearch",
+			`AnySearch API error (${response.status}): ${errorText}`,
+			response.status,
+		);
+	}
+
+	const payload = parseSSE(await response.text()) as JsonRpcPayload | null;
+	if (!payload) {
+		throw new SearchProviderError("anysearch", "Failed to parse AnySearch MCP response", 500);
+	}
+	if (payload.error) {
+		const rawCode = typeof payload.error.code === "number" ? payload.error.code : undefined;
+		const status = rawCode && rawCode > 0 ? rawCode : 400;
+		throw new SearchProviderError(
+			"anysearch",
+			`AnySearch MCP error${rawCode ? ` (${rawCode})` : ""}: ${payload.error.message ?? "Unknown error"}`,
+			status,
+		);
+	}
+
+	const result = asRecord(payload.result);
+	if (result?.isError === true) {
+		const errorText = Array.isArray(result.content)
+			? result.content
+					.map(item => asString(asRecord(item)?.text))
+					.filter((value): value is string => value != null)
+					.join("\n")
+					.trim()
+			: "";
+		throw new SearchProviderError("anysearch", errorText || "AnySearch MCP tool call failed", 400);
+	}
+
+	const markdown = extractContentText(payload.result);
+	if (!markdown) {
+		throw new SearchProviderError("anysearch", "AnySearch returned no text content", 502);
+	}
+	return markdown;
+}
+
+export async function searchAnySearch(params: SearchParams): Promise<SearchResponse> {
+	const numResults = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+
+	const request: AnySearchSearchParams = {
+		query: params.query,
+		num_results: numResults,
+		signal: params.signal,
+		fetch: params.fetch,
+		authStorage: params.authStorage,
+		sessionId: params.sessionId,
+	};
+
+	const envKey = getEnvApiKey("anysearch");
+	const keyOrResolver: ApiKey | undefined = params.authStorage.hasAuth("anysearch")
+		? params.authStorage.resolver("anysearch", { sessionId: params.sessionId })
+		: envKey;
+
+	const markdown = keyOrResolver
+		? await withAuth(keyOrResolver, key => callAnySearchSearch(key, request), { signal: params.signal })
+		: await callAnySearchSearch(undefined, request);
+
+	const parsed = parseAnySearchMarkdown(markdown);
+
+	return {
+		provider: "anysearch",
+		answer: parsed.answer,
+		sources: parsed.sources.slice(0, numResults),
+		authMode: keyOrResolver ? "api_key" : "anonymous",
+	};
+}
+
+export class AnySearchProvider extends SearchProvider {
+	readonly id = "anysearch";
+	readonly label = "AnySearch";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("anysearch") || !!getEnvApiKey("anysearch");
+	}
+
+	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+		return true;
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchAnySearch(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -44,6 +44,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
 	{
+		value: "anysearch",
+		label: "AnySearch",
+		description: "Uses ANYSEARCH_API_KEY when configured; explicit selection falls back to anonymous MCP search",
+	},
+	{
 		value: "duckduckgo",
 		label: "DuckDuckGo",
 		description: "Credential-free best-effort fallback; may be bot-challenged on datacenter/shared-egress IPs",

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { parseAnySearchMarkdown, searchAnySearch } from "../../src/web/search/providers/anysearch";
+
+describe("AnySearch web search provider", () => {
+	beforeEach(() => {
+		process.env.ANYSEARCH_API_KEY = "test-anysearch-key";
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.ANYSEARCH_API_KEY;
+	});
+
+	const fakeAuthStorage = {
+		async getApiKey() {
+			return process.env.ANYSEARCH_API_KEY ?? undefined;
+		},
+		hasAuth() {
+			return Boolean(process.env.ANYSEARCH_API_KEY);
+		},
+		resolver(_provider: string) {
+			return async () => process.env.ANYSEARCH_API_KEY ?? undefined;
+		},
+		async rotateSessionCredential() {
+			return false;
+		},
+	} as unknown as AuthStorage;
+
+	function makeParams(query: string) {
+		return {
+			query,
+			authStorage: fakeAuthStorage,
+			systemPrompt: "test system prompt",
+		} as const;
+	}
+
+	it("parses AnySearch Markdown response correctly", () => {
+		const md = `## Search Results (2 results, 1800ms)
+
+### 1. OpenAI | Info
+- **URL**: https://openai.com/
+- OpenAI is an AI research and deployment company...
+
+### 2. DeepMind | Google
+- **URL**: https://deepmind.google/
+- [Google DeepMind](https://deepmind.google/) is a pioneer in [AI research](https://example.com/ai)...
+`;
+		const parsed = parseAnySearchMarkdown(md);
+		expect(parsed.sources).toHaveLength(2);
+		expect(parsed.sources[0]?.title).toBe("OpenAI | Info");
+		expect(parsed.sources[0]?.url).toBe("https://openai.com/");
+		expect(parsed.sources[0]?.snippet).toBe("OpenAI is an AI research and deployment company...");
+		expect(parsed.sources[1]?.title).toBe("DeepMind | Google");
+		expect(parsed.sources[1]?.url).toBe("https://deepmind.google/");
+		expect(parsed.sources[1]?.snippet).toBe("Google DeepMind is a pioneer in AI research...");
+	});
+
+	it("executes search and returns SearchResponse", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		let authHeader: string | null | undefined = null;
+
+		const fetchMock = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			if (init?.body) {
+				requestBody = JSON.parse(init.body as string);
+			}
+			if (init?.headers) {
+				authHeader = (init.headers as Record<string, string>).Authorization ?? null;
+			}
+			const md = `## Search Results (1 result)
+
+### 1. seL4 Microkernel
+- **URL**: https://sel4.systems/
+- seL4 is the world's most highly assured kernel.
+`;
+			const payload = {
+				jsonrpc: "2.0",
+				id: 1,
+				result: {
+					content: [{ type: "text", text: md }],
+				},
+			};
+			return new Response(JSON.stringify(payload), { status: 200 });
+		};
+
+		const response = await searchAnySearch({
+			...makeParams("seL4"),
+			fetch: fetchMock,
+		});
+
+		expect(authHeader as unknown as string).toBe("Bearer test-anysearch-key");
+		expect(requestBody).toMatchObject({
+			method: "tools/call",
+			params: {
+				name: "search",
+				arguments: {
+					query: "seL4",
+					max_results: 5,
+				},
+			},
+		});
+		expect(response.provider).toBe("anysearch");
+		expect(response.sources).toHaveLength(1);
+		expect(response.sources[0]?.title).toBe("seL4 Microkernel");
+		expect(response.sources[0]?.url).toBe("https://sel4.systems/");
+		expect(response.sources[0]?.snippet).toBe("seL4 is the world's most highly assured kernel.");
+	});
+
+	it("falls back to anonymous search when key is missing", async () => {
+		delete process.env.ANYSEARCH_API_KEY;
+		const noKeyAuthStorage = {
+			async getApiKey() {
+				return undefined;
+			},
+			hasAuth() {
+				return false;
+			},
+			resolver() {
+				return () => undefined;
+			},
+		} as unknown as AuthStorage;
+
+		let authHeader: string | null = null;
+
+		const fetchMock = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			if (init?.headers) {
+				authHeader = (init.headers as Record<string, string>).Authorization ?? null;
+			}
+			const payload = {
+				jsonrpc: "2.0",
+				id: 1,
+				result: {
+					content: [{ type: "text", text: "## Search Results" }],
+				},
+			};
+			return new Response(JSON.stringify(payload), { status: 200 });
+		};
+
+		const response = await searchAnySearch({
+			query: "test",
+			authStorage: noKeyAuthStorage,
+			systemPrompt: "prompt",
+			fetch: fetchMock,
+		});
+
+		expect(authHeader).toBeNull();
+		expect(response.authMode).toBe("anonymous");
+	});
+
+	it("throws SearchProviderError on HTTP error status", async () => {
+		const fetchMock = async () => new Response("Internal Server Error", { status: 500 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch API error (500)");
+	});
+
+	it("throws SearchProviderError when JSON-RPC parse fails", async () => {
+		const fetchMock = async () => new Response("invalid sse data", { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Failed to parse AnySearch MCP response");
+	});
+
+	it("throws SearchProviderError when JSON-RPC returns error", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			error: { code: -32603, message: "Internal tool call error" },
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch MCP error (-32603): Internal tool call error");
+	});
+
+	it("throws SearchProviderError when tool result isError is true", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				isError: true,
+				content: [{ type: "text", text: "Database connection failed" }],
+			},
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Database connection failed");
+	});
+
+	it("throws SearchProviderError when tool result contains no text", async () => {
+		const payload = {
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				content: [],
+			},
+		};
+		const fetchMock = async () => new Response(JSON.stringify(payload), { status: 200 });
+		expect(
+			searchAnySearch({
+				...makeParams("test"),
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("AnySearch returned no text content");
+	});
+});

--- a/packages/coding-agent/test/web/search/provider-chain.test.ts
+++ b/packages/coding-agent/test/web/search/provider-chain.test.ts
@@ -8,7 +8,11 @@ import {
 } from "@oh-my-pi/pi-coding-agent/web/search/provider";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
-const authStorage = {} as AuthStorage;
+const authStorage = {
+	hasAuth: () => false,
+	hasOAuth: () => false,
+	getCredentialOrigin: () => undefined,
+} as unknown as AuthStorage;
 const originalBraveApiKey = process.env.BRAVE_API_KEY;
 const originalJinaApiKey = process.env.JINA_API_KEY;
 
@@ -68,5 +72,19 @@ describe("resolveProviderChain", () => {
 		const providers = await resolveProviderChain(authStorage, "auto");
 
 		expect(providers.map(provider => provider.id)).toEqual(["jina"]);
+	});
+	it("prioritizes configured anysearch over duckduckgo in auto mode", async () => {
+		enableKeyBackedProviders();
+		process.env.ANYSEARCH_API_KEY = "test-anysearch-key";
+		try {
+			const providers = await resolveProviderChain(authStorage, "auto");
+			const anysearchIndex = providers.findIndex(p => p.id === "anysearch");
+			const duckduckgoIndex = providers.findIndex(p => p.id === "duckduckgo");
+			expect(anysearchIndex).toBeGreaterThanOrEqual(0);
+			expect(duckduckgoIndex).toBeGreaterThanOrEqual(0);
+			expect(anysearchIndex).toBeLessThan(duckduckgoIndex);
+		} finally {
+			delete process.env.ANYSEARCH_API_KEY;
+		}
 	});
 });


### PR DESCRIPTION
Implements #4501.

### Description
This PR integrates AnySearch as a new web search provider into `omp` (oh-my-pi).

### About AnySearch & Privacy Posture
- **Provider**: AnySearch AI (https://anysearch.com)
- **Privacy & ToS**: The API endpoint (`https://api.anysearch.com`) runs a zero-retention search aggregation proxy. It claims zero-knowledge credentials, zero-retention execution, no tracking, no telemetry, and no logging of user queries.
- **Access**: Supports both authenticated access (via `ANYSEARCH_API_KEY`) for higher rate limits and anonymous fallback (no Authorization header sent) when explicit provider selection is requested.

### Changes
1. **Provider Mapping & Registration**:
   - Added `"anysearch"` option to `SEARCH_PROVIDER_OPTIONS` in `packages/coding-agent/src/web/search/types.ts`.
   - Registered `anysearch` in the lazy load registry `PROVIDER_META` in `packages/coding-agent/src/web/search/provider.ts`.
   - Registered `anysearchProvider` in the AI registry `PROVIDER_REGISTRY` in `packages/ai/src/registry/registry.ts`.
2. **API Key & Credentials Handling**:
   - Created `packages/ai/src/registry/anysearch.ts` defining the credential login flow using the unified `createApiKeyLogin` helper, prompting the user for `ANYSEARCH_API_KEY`.
   - Unified support for both authenticated and anonymous MCP search fallbacks.
   - Updated `packages/coding-agent/src/cli/args.ts` to document `ANYSEARCH_API_KEY` under `# Search & Tools` for `omp --help` parity.
3. **Core Provider Implementation**:
   - Created `packages/coding-agent/src/web/search/providers/anysearch.ts` that issues JSON-RPC 2.0 `tools/call` requests directly to `https://api.anysearch.com/mcp`.
   - Implemented a robust Markdown content parser to map the MCP server response to `SearchSource[]`.
   - Added markdown link stripping logic (`[text](url) -> text`) inside search snippets to save context window tokens and keep the terminal TUI representation clean.
   - Hoisted `clampNumResults` and switched JSON-RPC ID generation to `crypto.randomUUID()`.
4. **Testing & Changelog**:
   - Added comprehensive integration tests in `packages/coding-agent/test/tools/web-search-anysearch.test.ts` covering Markdown parsing, API call parameter formatting, and credentialed/anonymous fallback semantics.
   - Added unit tests covering all 5 error/failure paths in `callAnySearchSearch` (HTTP error status, parseSSE failure, JSON-RPC error payload, result isError flag, empty content block). All tests compile and pass.
   - Added `anysearch` entries under `## [Unreleased]` for both `packages/ai/CHANGELOG.md` and `packages/coding-agent/CHANGELOG.md`.