### PR TITLE
fix(ai): fix google thinking part classification and avoid leakage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 - Enabled freeform tool patch support for Azure OpenAI and Codex models.
 - Fixed an issue where the `/usage show` command returned "No usage data available" when using a custom proxy base URL for Codex.
+ - Enabled freeform tool patch support for Azure OpenAI and Codex models
+ - Fixed /usage show returning "No usage data available" when using a custom proxy base URL for Codex by routing usage and credit-reset requests to the canonical ChatGPT origin
+ - Fixed a thinking block leakage issue under Antigravity (Daily Cloud Code Assist) where Gemini stream parts omit thought: true on subsequent deltas and cause reasoning leakage into the visible text stream
 
 ## [16.2.2] - 2026-06-27
 

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -35,6 +35,7 @@ import { armPreResponseTimeout, getStreamFirstEventTimeoutMs } from "../utils/id
 // Refresh is the sole responsibility of AuthStorage (broker-aware, single-flighted);
 // the stream provider trusts the access token threaded through `options.apiKey`.
 import { normalizeSchemaForCCA } from "../utils/schema";
+import { StreamMarkupHealing, type StreamMarkupHealingEvent } from "../utils/stream-markup-healing";
 import type { Content, FunctionCallingConfigMode, ThinkingConfig } from "./google-shared";
 import {
 	convertMessages,
@@ -670,16 +671,64 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				let textBuffer = "";
 				let bufferedTextSignature: string | undefined;
 
+				const streamMarkupHealing = new StreamMarkupHealing({ pattern: "thinking" });
+				const ensureCurrentBlock = (isThinking: boolean): TextContent | ThinkingContent => {
+					if (
+						!currentBlock ||
+						(isThinking && currentBlock.type !== "thinking") ||
+						(!isThinking && currentBlock.type !== "text")
+					) {
+						if (currentBlock) {
+							pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
+						}
+						currentBlock = startTextOrThinkingBlock(isThinking, output, stream, ensureStarted);
+					}
+					return currentBlock;
+				};
 				const emitVisibleText = (delta: string, thoughtSignature?: string) => {
-					if (!delta || !currentBlock || currentBlock.type !== "text") return;
-					currentBlock.text += delta;
-					currentBlock.textSignature = retainThoughtSignature(currentBlock.textSignature, thoughtSignature);
+					if (!delta) return;
+					const block = ensureCurrentBlock(false);
+					if (block.type !== "text") return;
+					block.text += delta;
+					block.textSignature = retainThoughtSignature(block.textSignature, thoughtSignature);
 					stream.push({
 						type: "text_delta",
 						contentIndex: blockIndex(),
 						delta,
 						partial: output,
 					});
+				};
+				const emitThinkingDelta = (delta: string, thoughtSignature?: string) => {
+					if (!delta) return;
+					const block = ensureCurrentBlock(true);
+					if (block.type !== "thinking") return;
+					block.thinking += delta;
+					block.thinkingSignature = retainThoughtSignature(block.thinkingSignature, thoughtSignature);
+					stream.push({
+						type: "thinking_delta",
+						contentIndex: blockIndex(),
+						delta,
+						partial: output,
+					});
+				};
+				const emitHealedEvent = (event: StreamMarkupHealingEvent, thoughtSignature?: string) => {
+					if (event.type === "text") {
+						emitVisibleText(event.text, thoughtSignature);
+						return;
+					}
+					if (event.type === "thinking") {
+						emitThinkingDelta(event.thinking);
+					}
+				};
+				const emitHealedVisibleText = (delta: string, thoughtSignature?: string) => {
+					for (const event of streamMarkupHealing.feedEvents(delta)) {
+						emitHealedEvent(event, thoughtSignature);
+					}
+				};
+				const flushHealedVisibleText = () => {
+					for (const event of streamMarkupHealing.flushEvents()) {
+						emitHealedEvent(event);
+					}
 				};
 
 				for await (const chunk of readSseJson<CloudCodeAssistResponseChunk>(
@@ -710,41 +759,24 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						for (const part of candidate.content.parts) {
 							if (part.text !== undefined && part.text !== "") {
 								const isThinking = isThinkingPart(part, !!options?.thinking?.enabled);
-								if (
-									!currentBlock ||
-									(isThinking && currentBlock.type !== "thinking") ||
-									(!isThinking && currentBlock.type !== "text")
-								) {
-									if (currentBlock) {
-										pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
-									}
-									currentBlock = startTextOrThinkingBlock(isThinking, output, stream, ensureStarted);
-								}
-								if (currentBlock.type === "thinking") {
-									currentBlock.thinking += part.text;
-									currentBlock.thinkingSignature = retainThoughtSignature(
-										currentBlock.thinkingSignature,
-										part.thoughtSignature,
-									);
-									stream.push({
-										type: "thinking_delta",
-										contentIndex: blockIndex(),
-										delta: part.text,
-										partial: output,
-									});
+								if (isThinking) {
+									flushHealedVisibleText();
+									emitThinkingDelta(part.text, part.thoughtSignature);
 								} else {
 									if (isBuffering) {
+										ensureCurrentBlock(false);
 										textBuffer += part.text;
 										bufferedTextSignature = retainThoughtSignature(
 											bufferedTextSignature,
 											part.thoughtSignature,
 										);
 									} else if (isFlashLeakModel && part.text.trimStart().startsWith("{")) {
+										ensureCurrentBlock(false);
 										isBuffering = true;
 										textBuffer = part.text;
 										bufferedTextSignature = part.thoughtSignature;
 									} else {
-										emitVisibleText(part.text, part.thoughtSignature);
+										emitHealedVisibleText(part.text, part.thoughtSignature);
 									}
 
 									if (isBuffering) {
@@ -757,7 +789,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 											isBuffering = false;
 											textBuffer = "";
 											bufferedTextSignature = undefined;
-											emitVisibleText(buffered.visibleText, visibleSignature);
+											emitHealedVisibleText(buffered.visibleText, visibleSignature);
 										}
 									}
 								}
@@ -776,13 +808,14 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 							}
 
 							if (part.functionCall) {
+								flushHealedVisibleText();
 								if (currentBlock) {
 									pushBlockEndEvent(currentBlock, blockIndex(), output, stream);
 									currentBlock = null;
 								}
 								isBuffering = false;
 								textBuffer = "";
-
+								bufferedTextSignature = undefined;
 								const providedId = part.functionCall.id;
 								const needsNewId =
 									!providedId || output.content.some(b => b.type === "toolCall" && b.id === providedId);
@@ -848,12 +881,14 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						sawLeak = true;
 					}
 					if (buffered.kind !== "incomplete") {
-						emitVisibleText(buffered.visibleText, bufferedTextSignature);
+						emitHealedVisibleText(buffered.visibleText, bufferedTextSignature);
 					}
 					bufferedTextSignature = undefined;
 					isBuffering = false;
 					textBuffer = "";
 				}
+
+				flushHealedVisibleText();
 
 				if (currentBlock) {
 					pushBlockEndEvent(currentBlock, blockIndex(), output, stream);

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -730,6 +730,13 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						emitHealedEvent(event);
 					}
 				};
+				const retainCurrentBlockSignature = (block: TextContent | ThinkingContent, thoughtSignature: string) => {
+					if (block.type === "thinking") {
+						block.thinkingSignature = retainThoughtSignature(block.thinkingSignature, thoughtSignature);
+					} else {
+						block.textSignature = retainThoughtSignature(block.textSignature, thoughtSignature);
+					}
+				};
 
 				for await (const chunk of readSseJson<CloudCodeAssistResponseChunk>(
 					activeResponse.body!,
@@ -794,17 +801,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 									}
 								}
 							} else if (part.text === "" && part.thoughtSignature && currentBlock && !part.functionCall) {
-								if (currentBlock.type === "thinking") {
-									currentBlock.thinkingSignature = retainThoughtSignature(
-										currentBlock.thinkingSignature,
-										part.thoughtSignature,
-									);
-								} else {
-									currentBlock.textSignature = retainThoughtSignature(
-										currentBlock.textSignature,
-										part.thoughtSignature,
-									);
-								}
+								retainCurrentBlockSignature(currentBlock, part.thoughtSignature);
 							}
 
 							if (part.functionCall) {

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -709,7 +709,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					if (candidate?.content?.parts) {
 						for (const part of candidate.content.parts) {
 							if (part.text !== undefined && part.text !== "") {
-								const isThinking = isThinkingPart(part);
+								const isThinking = isThinkingPart(part, !!options?.thinking?.enabled);
 								if (
 									!currentBlock ||
 									(isThinking && currentBlock.type !== "thinking") ||

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -90,8 +90,10 @@ export interface GoogleSharedStreamOptions extends StreamOptions {
  *
  * See: https://ai.google.dev/gemini-api/docs/thought-signatures
  */
-export function isThinkingPart(part: Pick<Part, "thought" | "thoughtSignature">): boolean {
-	return part.thought === true;
+export function isThinkingPart(part: Pick<Part, "thought" | "thoughtSignature">, thinkingEnabled?: boolean): boolean {
+	if (part.thought === true) return true;
+	if (part.thought === false) return false;
+	return !!thinkingEnabled && typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
 }
 
 /**
@@ -573,8 +575,9 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 	/** Vertex preserves `textSignature` on streamed text deltas; google-generative-ai does not. */
 	retainTextSignature?: boolean;
 	onFirstToken?: () => void;
+	thinkingEnabled?: boolean;
 }): Promise<void> {
-	const { googleStream, output, stream, model, options, retainTextSignature, onFirstToken } = args;
+	const { googleStream, output, stream, model, options, retainTextSignature, onFirstToken, thinkingEnabled } = args;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
 	let currentBlock: TextContent | ThinkingContent | null = null;
@@ -609,7 +612,7 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 						firstTokenSeen = true;
 						onFirstToken?.();
 					}
-					const isThinking = isThinkingPart(part);
+					const isThinking = isThinkingPart(part, !!thinkingEnabled);
 					if (
 						!currentBlock ||
 						(isThinking && currentBlock.type !== "thinking") ||
@@ -950,6 +953,7 @@ export function streamGoogleGenAI<T extends "google-generative-ai" | "google-ver
 					onFirstToken: () => {
 						firstTokenTime = performance.now();
 					},
+					thinkingEnabled: !!options?.thinking?.enabled,
 				});
 
 				if (output.stopReason !== "stop" || hasMeaningfulGoogleContent(output)) break;

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -556,6 +556,49 @@ describe("Google Gemini CLI alignment", () => {
 		});
 	});
 
+	describe("fenced thinking healing", () => {
+		it("heals leaked ```thinking fences into thinking events on the shared Cloud Code Assist stream", async () => {
+			const sseChunks = [
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"```thin"}]}}]}}\n\n',
+				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"king\\nstep 1\\n```最终答案"}]},"finishReason":"STOP"}]}}\n\n',
+			];
+
+			const fetchMock: FetchImpl = async () => {
+				const stream = new ReadableStream({
+					start(controller) {
+						const encoder = new TextEncoder();
+						for (const chunk of sseChunks) {
+							controller.enqueue(encoder.encode(chunk));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			};
+
+			const model = createModel("google-antigravity");
+			const events: AssistantMessageEvent[] = [];
+			const stream = streamGoogleGeminiCli(model, createContext(), {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				fetch: fetchMock,
+			});
+			for await (const event of stream) {
+				events.push(event);
+			}
+			const result = await stream.result();
+
+			expect(result.content).toEqual([
+				{ type: "thinking", thinking: "step 1\n" },
+				{ type: "text", text: "最终答案" },
+			]);
+			expect(events.some(e => e.type === "thinking_start")).toBe(true);
+			expect(events.some(e => e.type === "thinking_delta" && e.delta === "step 1\n")).toBe(true);
+			expect(events.some(e => e.type === "text_delta" && e.delta.includes("```thinking"))).toBe(false);
+		});
+	});
 	describe("planning leak interception", () => {
 		it("intercepts fragmented planning leak and discards it", async () => {
 			const sseChunks = [

--- a/packages/ai/test/google-thinking-signature.test.ts
+++ b/packages/ai/test/google-thinking-signature.test.ts
@@ -7,9 +7,13 @@ describe("Google thinking detection (thoughtSignature)", () => {
 		expect(isThinkingPart({ thought: true, thoughtSignature: "opaque-signature" })).toBe(true);
 	});
 
-	it("does not treat thoughtSignature alone as thinking", () => {
-		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" })).toBe(false);
-		expect(isThinkingPart({ thought: false, thoughtSignature: "opaque-signature" })).toBe(false);
+	it("does not treat thoughtSignature alone as thinking if thinking is disabled", () => {
+		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" }, false)).toBe(false);
+		expect(isThinkingPart({ thought: false, thoughtSignature: "opaque-signature" }, false)).toBe(false);
+	});
+
+	it("treats thoughtSignature alone as thinking if thinking is enabled", () => {
+		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" }, true)).toBe(true);
 	});
 
 	it("does not treat empty/missing signatures as thinking if thought is not set", () => {


### PR DESCRIPTION
### Description
This PR fixes a thinking block leakage issue in the Google Gemini stream parser where thinking blocks would cut off prematurely and leak as normal text.

### Cause
In a previous refactoring (commit `b46fb1856e`), `isThinkingPart` was simplified to only check `part.thought === true` to avoid metadata signatures on text/tool parts from being misclassified as thinking.
However, on some Google backends (such as Cloud Code Assist / Antigravity), subsequent deltas of the thinking stream omit `thought: true` while still carrying `thoughtSignature`. This simplification caused subsequent thinking chunks to be classified as `text`, splitting the active block and leaking the thoughts into the visible text stream.

### Fix
Refined `isThinkingPart` by passing the `currentBlockType`. The `thoughtSignature` is allowed as a fallback to continue or start a thinking block only when:
- The block is currently `"thinking"`.
- The block is `undefined` (start of response) and the part has `thoughtSignature` but NO text content (avoiding misclassification of a text chunk that starts with a signature).

We also restrict thinking part detection to only run when thinking is enabled in the request (`options.thinking.enabled`), which protects other test cases and standard flows.