### PR TITLE
fix(providers): keep runtime headers live

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -303,14 +303,81 @@ function resolveConfigValue(valueConfig: string): string | undefined {
 	return valueConfig;
 }
 
-function resolveConfigHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
-	if (!headers) return undefined;
+type HeaderSource = Record<string, string> | undefined;
+
+interface HeaderResolutionOptions {
+	authHeader?: boolean;
+	apiKeyConfig?: string;
+}
+
+function materializeConfigHeaderSources(
+	sources: readonly HeaderSource[],
+	options?: HeaderResolutionOptions,
+): Record<string, string> | undefined {
 	const resolved: Record<string, string> = {};
-	for (const [key, value] of Object.entries(headers)) {
-		const next = resolveConfigValue(value);
-		if (next) resolved[key] = next;
+	for (const source of sources) {
+		if (!source) continue;
+		for (const [key, value] of Object.entries(source)) {
+			const next = resolveConfigValue(value);
+			if (next) resolved[key] = next;
+		}
+	}
+	if (options?.authHeader && options.apiKeyConfig) {
+		const resolvedKey = resolveConfigValue(options.apiKeyConfig);
+		if (resolvedKey) resolved.Authorization = `Bearer ${resolvedKey}`;
 	}
 	return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+function createLiveConfigHeaders(
+	sources: readonly HeaderSource[],
+	options?: HeaderResolutionOptions,
+): Record<string, string> | undefined {
+	const liveSources = sources.filter((source): source is Record<string, string> => source !== undefined);
+	if (liveSources.length === 0 && (!options?.authHeader || !options.apiKeyConfig)) return undefined;
+
+	const localHeaders: Record<string, string> = {};
+	const allSources = [...liveSources, localHeaders];
+	const current = () => materializeConfigHeaderSources(allSources, options) ?? {};
+	return new Proxy(localHeaders, {
+		get(target, property, receiver) {
+			if (typeof property !== "string") return Reflect.get(target, property, receiver);
+			return current()[property];
+		},
+		set(target, property, value) {
+			if (typeof property !== "string" || typeof value !== "string") return false;
+			target[property] = value;
+			return true;
+		},
+		deleteProperty(target, property) {
+			if (typeof property !== "string") return false;
+			delete target[property];
+			return true;
+		},
+		has(_target, property) {
+			if (typeof property !== "string") return false;
+			return Object.hasOwn(current(), property);
+		},
+		ownKeys() {
+			return Reflect.ownKeys(current());
+		},
+		getOwnPropertyDescriptor(_target, property) {
+			if (typeof property !== "string") return undefined;
+			const headers = current();
+			if (!Object.hasOwn(headers, property)) return undefined;
+			return {
+				configurable: true,
+				enumerable: true,
+				value: headers[property],
+				writable: true,
+			};
+		},
+	});
+}
+
+
+function resolveConfigHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+	return materializeConfigHeaderSources([headers]);
 }
 
 function extractGoogleOAuthToken(value: string | undefined): string | undefined {
@@ -495,21 +562,15 @@ function mergeCustomModelHeaders(
 	authHeader: boolean | undefined,
 	apiKeyConfig: string | undefined,
 ): Record<string, string> | undefined {
-	const resolvedModelHeaders = resolveConfigHeaders(modelHeaders);
-	return mergeAuthHeader({ ...providerHeaders, ...resolvedModelHeaders }, authHeader, apiKeyConfig);
+	return createLiveConfigHeaders([providerHeaders, modelHeaders], { authHeader, apiKeyConfig });
 }
 
-function mergeAuthHeader(
-	headers: Record<string, string> | undefined,
+function mergeAuthHeaderSources(
+	sources: readonly HeaderSource[],
 	authHeader: boolean | undefined,
 	apiKeyConfig: string | undefined,
 ): Record<string, string> | undefined {
-	const nextHeaders = headers && Object.keys(headers).length > 0 ? { ...headers } : undefined;
-	if (!authHeader || !apiKeyConfig) {
-		return nextHeaders;
-	}
-	const resolvedKey = resolveConfigValue(apiKeyConfig);
-	return resolvedKey ? { ...nextHeaders, Authorization: `Bearer ${resolvedKey}` } : nextHeaders;
+	return createLiveConfigHeaders(sources, { authHeader, apiKeyConfig });
 }
 
 /**
@@ -1661,7 +1722,7 @@ export class ModelRegistry {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
 			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
-			headers: override.headers ? { ...(baseOverride?.headers ?? {}), ...override.headers } : baseOverride?.headers,
+			headers: override.headers ? createLiveConfigHeaders([baseOverride?.headers, override.headers]) : baseOverride?.headers,
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
 			remoteCompaction: mergeRemoteCompactionConfig(baseOverride?.remoteCompaction, override.remoteCompaction),
 			transport: override.transport ?? baseOverride?.transport,
@@ -1676,8 +1737,8 @@ export class ModelRegistry {
 			"baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
 		>,
 	): T {
-		const headers = mergeAuthHeader(
-			override.headers ? { ...entry.headers, ...override.headers } : entry.headers,
+		const headers = mergeAuthHeaderSources(
+			override.headers ? [entry.headers, override.headers] : [entry.headers],
 			override.authHeader,
 			override.apiKey,
 		);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -375,7 +375,6 @@ function createLiveConfigHeaders(
 	});
 }
 
-
 function resolveConfigHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
 	return materializeConfigHeaderSources([headers]);
 }
@@ -1722,7 +1721,9 @@ export class ModelRegistry {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
 			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
-			headers: override.headers ? createLiveConfigHeaders([baseOverride?.headers, override.headers]) : baseOverride?.headers,
+			headers: override.headers
+				? createLiveConfigHeaders([baseOverride?.headers, override.headers])
+				: baseOverride?.headers,
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
 			remoteCompaction: mergeRemoteCompactionConfig(baseOverride?.remoteCompaction, override.remoteCompaction),
 			transport: override.transport ?? baseOverride?.transport,

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -142,8 +142,8 @@ describe("ModelRegistry runtime provider registration", () => {
 	});
 
 	test("registerProvider keeps runtime header objects live for request-time reads", () => {
-		const providerHeaders = { "X-Request-ID": "request-1" };
-		const modelHeaders = { "X-Message-ID": "message-1" };
+		const providerHeaders: Record<string, string> = { "X-Request-ID": "request-1" };
+		const modelHeaders: Record<string, string> = { "X-Message-ID": "message-1" };
 
 		registry.registerProvider(
 			"runtime-provider",

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -141,6 +141,36 @@ describe("ModelRegistry runtime provider registration", () => {
 		expectProviderHeader(registry, providerName, runtimeHeader, undefined);
 	});
 
+	test("registerProvider keeps runtime header objects live for request-time reads", () => {
+		const providerHeaders = { "X-Request-ID": "request-1" };
+		const modelHeaders = { "X-Message-ID": "message-1" };
+
+		registry.registerProvider(
+			"runtime-provider",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				headers: providerHeaders,
+				models: [{ ...baseModel, headers: modelHeaders }],
+			},
+			"ext://runtime",
+		);
+
+		providerHeaders["X-Request-ID"] = "request-2";
+		providerHeaders["X-Turn-ID"] = "turn-2";
+		modelHeaders["X-Message-ID"] = "message-2";
+		modelHeaders["X-Model-Turn-ID"] = "model-turn-2";
+
+		const model = registry.find("runtime-provider", "runtime-model");
+		expect({ ...(model?.headers ?? {}) }).toEqual({
+			"X-Request-ID": "request-2",
+			"X-Turn-ID": "turn-2",
+			"X-Message-ID": "message-2",
+			"X-Model-Turn-ID": "model-turn-2",
+		});
+	});
+
 	test("registerProvider applies authHeader overrides to existing provider models across refresh", async () => {
 		const providerName = "anthropic";
 


### PR DESCRIPTION
## Repro
A runtime extension provider registered mutable provider/model `headers`, then mutated those objects after registration; before the fix, `registry.find("runtime-provider", "runtime-model")?.headers` still returned the original `X-Request-ID: first` and `X-Message-ID: message-1` values instead of the updated request headers.

## Cause
`packages/coding-agent/src/config/model-registry.ts` merged provider/model headers with object spreads in `mergeCustomModelHeaders()`, `#mergeProviderOverride()`, and `#applyProviderTransportOverride()`, so extension-owned header objects were copied into registration-time snapshots before provider request builders read `model.headers`.

## Fix
- Added live resolved header wrappers in `model-registry.ts` that enumerate and resolve the current provider/model header sources whenever `model.headers` is read or spread.
- Routed runtime custom model and provider transport header merges through the live wrapper while preserving existing env/command resolution and auth-header behavior.
- Added regression coverage for post-registration provider/model header mutations and request-time object spreading.

## Verification
`bun test packages/coding-agent/test/model-registry-runtime-provider.test.ts packages/coding-agent/test/model-registry-command-values.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts` passed; `bun check` passed; the original JS repro now reads `X-Request-ID: second`, `X-Turn-ID: turn-2`, and `X-Message-ID: message-2`. Fixes #3725