### PR TITLE
Apply NODE_EXTRA_CA_CERTS to provider fetches

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -61,6 +61,7 @@ import type {
 } from "./types";
 import { AssistantMessageEventStream } from "./utils/event-stream";
 import { withRequestDebugFetch } from "./utils/request-debug";
+import { withExtraCaFetch } from "./utils/tls-fetch";
 
 function isGoogleVertexAuthenticatedModel(model: Model<Api>): boolean {
 	return (
@@ -225,7 +226,7 @@ export function stream<TApi extends Api>(
 	context: Context,
 	options?: OptionsForApi<TApi>,
 ): AssistantMessageEventStream {
-	const requestOptions = withRequestDebugFetch(options as StreamOptions | undefined) as
+	const requestOptions = withExtraCaFetch(withRequestDebugFetch(options as StreamOptions | undefined)) as
 		| OptionsForApi<TApi>
 		| undefined;
 
@@ -368,7 +369,7 @@ export function streamSimple<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
-	const requestOptions = withRequestDebugFetch(options);
+	const requestOptions = withExtraCaFetch(withRequestDebugFetch(options));
 	const apiKeyResolver = isApiKeyResolver(requestOptions?.apiKey) ? requestOptions.apiKey : undefined;
 	if (apiKeyResolver) {
 		const outer = new AssistantMessageEventStream();

--- a/packages/ai/src/utils/__tests__/tls-fetch.test.ts
+++ b/packages/ai/src/utils/__tests__/tls-fetch.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "../../types";
+import { withExtraCaFetch } from "../tls-fetch";
+
+type BunTlsRequestInit = RequestInit & {
+	tls?: {
+		ca?: string | string[];
+	};
+};
+
+const EXTRA_CA = "-----BEGIN CERTIFICATE-----\nextra-ca\n-----END CERTIFICATE-----\n";
+
+let originalExtraCa: string | undefined;
+let tmpDir: string;
+
+beforeEach(async () => {
+	originalExtraCa = Bun.env.NODE_EXTRA_CA_CERTS;
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-extra-ca-"));
+});
+
+afterEach(async () => {
+	if (originalExtraCa === undefined) delete Bun.env.NODE_EXTRA_CA_CERTS;
+	else Bun.env.NODE_EXTRA_CA_CERTS = originalExtraCa;
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("withExtraCaFetch", () => {
+	it("injects NODE_EXTRA_CA_CERTS into provider fetch TLS options", async () => {
+		const caPath = path.join(tmpDir, "proxy-ca.pem");
+		await fs.writeFile(caPath, EXTRA_CA);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		let captured: BunTlsRequestInit | undefined;
+		const fetchImpl: FetchImpl = async (_input, init) => {
+			captured = init as BunTlsRequestInit | undefined;
+			return new Response("ok");
+		};
+
+		const wrapped = withExtraCaFetch({ fetch: fetchImpl })?.fetch;
+		await wrapped?.("https://relay.example/v1/models");
+
+		expect(Array.isArray(captured?.tls?.ca)).toBe(true);
+		expect(captured?.tls?.ca).toContain(EXTRA_CA);
+	});
+
+	it("preserves existing per-request CA entries", async () => {
+		Bun.env.NODE_EXTRA_CA_CERTS = EXTRA_CA.replace(/\n/g, "\\n");
+
+		let captured: BunTlsRequestInit | undefined;
+		const fetchImpl: FetchImpl = async (_input, init) => {
+			captured = init as BunTlsRequestInit | undefined;
+			return new Response("ok");
+		};
+
+		const wrapped = withExtraCaFetch({ fetch: fetchImpl })?.fetch;
+		await wrapped?.("https://relay.example/v1/models", { tls: { ca: "existing-ca" } } as RequestInit);
+
+		expect(captured?.tls?.ca).toContain("existing-ca");
+		expect(captured?.tls?.ca).toContain(EXTRA_CA);
+	});
+
+	it("leaves fetch options untouched when NODE_EXTRA_CA_CERTS is unset", async () => {
+		delete Bun.env.NODE_EXTRA_CA_CERTS;
+		const fetchImpl: FetchImpl = async () => new Response("ok");
+		const options = { fetch: fetchImpl };
+
+		expect(withExtraCaFetch(options)).toBe(options);
+	});
+});

--- a/packages/ai/src/utils/tls-fetch.ts
+++ b/packages/ai/src/utils/tls-fetch.ts
@@ -1,0 +1,106 @@
+import * as fs from "node:fs";
+import * as tls from "node:tls";
+import { $env, isEnoent } from "@oh-my-pi/pi-utils";
+import type { FetchImpl } from "../types";
+
+type BunTlsOptions = {
+	ca?: string | string[];
+	cert?: string;
+	key?: string;
+};
+
+type BunTlsRequestInit = RequestInit & {
+	tls?: BunTlsOptions;
+};
+
+type TlsFetch = FetchImpl & { [TLS_FETCH_MARKER]?: true };
+
+const TLS_FETCH_MARKER = Symbol("omp.tlsFetch");
+
+let extraCaCacheKey: string | undefined;
+let extraCaCache: string | undefined;
+
+function looksLikeFilePath(value: string): boolean {
+	return value.includes("/") || value.includes("\\") || /\.(pem|crt|cer)$/i.test(value);
+}
+
+function extraCaCacheKeyComponent(value: string): string {
+	if (!value.includes("-----BEGIN") && looksLikeFilePath(value)) {
+		try {
+			return `${value}@${fs.statSync(value).mtimeMs}`;
+		} catch {
+			return value;
+		}
+	}
+	return value;
+}
+
+function resolveExtraCa(): string | undefined {
+	const raw = $env.NODE_EXTRA_CA_CERTS?.trim();
+	if (!raw) return undefined;
+
+	const cacheKey = extraCaCacheKeyComponent(raw);
+	if (cacheKey === extraCaCacheKey) return extraCaCache;
+
+	const inline = raw.replace(/\\n/g, "\n");
+	if (inline.includes("-----BEGIN")) {
+		extraCaCacheKey = cacheKey;
+		extraCaCache = inline;
+		return extraCaCache;
+	}
+
+	if (looksLikeFilePath(raw)) {
+		try {
+			extraCaCache = fs.readFileSync(raw, "utf8");
+			extraCaCacheKey = cacheKey;
+			return extraCaCache;
+		} catch (error) {
+			if (isEnoent(error)) {
+				throw new Error(`NODE_EXTRA_CA_CERTS path does not exist: ${raw}`);
+			}
+			throw error;
+		}
+	}
+
+	extraCaCacheKey = cacheKey;
+	extraCaCache = inline;
+	return extraCaCache;
+}
+
+function mergeTls(init: RequestInit | undefined, ca: string): RequestInit {
+	const existing = (init as BunTlsRequestInit | undefined)?.tls;
+	const existingCa = existing?.ca;
+	const mergedCa = existingCa
+		? [...tls.rootCertificates, ...(Array.isArray(existingCa) ? existingCa : [existingCa]), ca]
+		: [...tls.rootCertificates, ca];
+	return {
+		...init,
+		tls: {
+			...existing,
+			ca: mergedCa,
+		},
+	} as RequestInit;
+}
+
+export function wrapFetchForExtraCa(fetchImpl: FetchImpl): FetchImpl {
+	const maybeWrapped = fetchImpl as TlsFetch;
+	if (maybeWrapped[TLS_FETCH_MARKER]) return fetchImpl;
+
+	const wrapped = Object.assign(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const ca = resolveExtraCa();
+			return ca ? fetchImpl(input, mergeTls(init, ca)) : fetchImpl(input, init);
+		},
+		fetchImpl.preconnect ? { preconnect: fetchImpl.preconnect } : {},
+		{ [TLS_FETCH_MARKER]: true as const },
+	);
+	return wrapped;
+}
+
+export function withExtraCaFetch<T extends { fetch?: FetchImpl } | undefined>(options: T): T {
+	const ca = resolveExtraCa();
+	if (!ca) return options;
+	const fetchImpl = options?.fetch ?? (globalThis.fetch as FetchImpl);
+	const wrapped = wrapFetchForExtraCa(fetchImpl);
+	return { ...(options ?? {}), fetch: wrapped } as T;
+}


### PR DESCRIPTION
## Summary

- add a shared fetch wrapper that applies `NODE_EXTRA_CA_CERTS` through Bun's `RequestInit.tls.ca`
- wire the wrapper into both `stream()` and `streamSimple()` so OpenAI-compatible providers and custom gateways honor extra CA bundles, not only Anthropic Foundry
- preserve existing per-request CA values and keep default behavior unchanged when `NODE_EXTRA_CA_CERTS` is unset

## Why

`NODE_EXTRA_CA_CERTS` was only consumed by the Anthropic Foundry TLS path. OpenAI Responses/Completions and custom OpenAI-compatible gateways use SDK fetch paths that never receive the extra CA bundle, so private/corporate/relay certificates can still fail with certificate verification errors even when users configured `NODE_EXTRA_CA_CERTS`.

## Verification

- `bun test packages/ai/src/utils/__tests__/tls-fetch.test.ts`
- `bun --cwd=packages/ai run check`

Note: `bun --cwd=packages/ai test` is not clean on this Windows workspace due unrelated existing auth-broker temp-directory `EBUSY` failures and a Windows mode-bit assertion; the new TLS test file passes independently.