### PR TITLE
fix(ai): honor NODE_EXTRA_CA_CERTS on every provider fetch

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -128,6 +128,12 @@ When `CLAUDE_CODE_USE_FOUNDRY` is enabled, Anthropic requests switch to Foundry 
   - a filesystem path to PEM content, or
   - inline PEM (including escaped `\n` sequences).
 
+  `NODE_EXTRA_CA_CERTS` is honoured for every provider fetch (OpenAI-compatible,
+  Codex, Ollama, Azure Responses, Google, Anthropic), not just Foundry — Bun's
+  `fetch` does not consume the env var natively, so the bundle is merged into
+  `RequestInit.tls.ca` alongside the system root store. The `CLAUDE_CODE_*` mTLS
+  material remains Anthropic-Foundry-specific.
+
 | Variable                    | Value type                                     | Behavior                                                                      |
 | --------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------- |
 | `CLAUDE_CODE_USE_FOUNDRY`   | Boolean-like string (`1`, `true`, `yes`, `on`) | Enables Foundry mode for Anthropic provider                                   |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Applied `NODE_EXTRA_CA_CERTS` to every provider fetch — OpenAI-compatible, Codex, Ollama, Azure Responses, and Google — not just the Anthropic Foundry path, so custom gateways behind a private CA bundle no longer fail with certificate verification errors ([#3731](https://github.com/can1357/oh-my-pi/issues/3731)).
+
 ## [16.2.3] - 2026-06-28
 
 ### Changed

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -965,7 +965,14 @@ For Cloudflare AI Gateway models, use provider base URL format
 
 For Anthropic Foundry routing, set `CLAUDE_CODE_USE_FOUNDRY=true` plus:
 `FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_API_KEY`, optional `ANTHROPIC_CUSTOM_HEADERS`,
-and optional mTLS material (`CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`, `NODE_EXTRA_CA_CERTS`).
+and optional mTLS material (`CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`).
+
+`NODE_EXTRA_CA_CERTS` (PEM file path or inline PEM, mirroring Node's contract)
+is honoured on every provider fetch — OpenAI-compatible, Codex, Ollama, Azure
+Responses, Google, and Anthropic alike — for corporate relays or private CA
+bundles. Bun's `fetch` does not consume the env var natively, so omp injects
+the bundle into `RequestInit.tls.ca` and seeds the system root store
+alongside it.
 
 Provider endpoint defaults for the current OpenAI-compatible integrations:
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -74,6 +74,7 @@ import { AssistantMessageEventStream } from "./utils/event-stream";
 import { wrapFetchForProxy } from "./utils/proxy";
 import { withRequestDebugFetch } from "./utils/request-debug";
 import { withGeminiThinkingLoopGuard } from "./utils/thinking-loop";
+import { withExtraCaFetch } from "./utils/tls-fetch";
 
 function isGoogleVertexAuthenticatedModel(model: Model<Api>): boolean {
 	return (
@@ -698,7 +699,7 @@ function streamDispatch<TApi extends Api>(
 	options?: OptionsForApi<TApi>,
 ): AssistantMessageEventStream {
 	const baseOptions = (options || {}) as StreamOptions;
-	const debugOptions = withRequestDebugFetch(baseOptions);
+	const debugOptions = withExtraCaFetch(withRequestDebugFetch(baseOptions));
 	const requestOptions = {
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
@@ -932,7 +933,7 @@ export function streamSimple<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
 	const baseOptions = (options || {}) as SimpleStreamOptions;
-	const debugOptions = withRequestDebugFetch(baseOptions);
+	const debugOptions = withExtraCaFetch(withRequestDebugFetch(baseOptions));
 	const requestOptions = {
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),

--- a/packages/ai/src/utils/__tests__/tls-fetch.test.ts
+++ b/packages/ai/src/utils/__tests__/tls-fetch.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as tls from "node:tls";
+import * as AIError from "../../error";
+import type { FetchImpl } from "../../types";
+import { __resetExtraCaCache, withExtraCaFetch, wrapFetchForExtraCa } from "../tls-fetch";
+
+const SAMPLE_PEM =
+	"-----BEGIN CERTIFICATE-----\nMIIBkTCCATegAwIBAgIUF/sample/extra/ca/for/tests/1234567=\n-----END CERTIFICATE-----\n";
+const SECONDARY_PEM =
+	"-----BEGIN CERTIFICATE-----\nMIIBkTCCATegAwIBAgIUF/sample/extra/ca/for/tests/SECOND=\n-----END CERTIFICATE-----\n";
+
+type CapturedInit = RequestInit & { tls?: { ca?: string | string[] } };
+
+function makeRecordingFetch(): { fetchImpl: FetchImpl; calls: CapturedInit[] } {
+	const calls: CapturedInit[] = [];
+	const fetchImpl: FetchImpl = async (_input, init) => {
+		calls.push((init ?? {}) as CapturedInit);
+		return new Response("ok");
+	};
+	return { fetchImpl, calls };
+}
+
+describe("wrapFetchForExtraCa", () => {
+	let tmpDir: string;
+	let originalEnv: string | undefined;
+
+	beforeEach(async () => {
+		__resetExtraCaCache();
+		originalEnv = Bun.env.NODE_EXTRA_CA_CERTS;
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-extra-ca-"));
+	});
+
+	afterEach(async () => {
+		__resetExtraCaCache();
+		if (originalEnv === undefined) delete Bun.env.NODE_EXTRA_CA_CERTS;
+		else Bun.env.NODE_EXTRA_CA_CERTS = originalEnv;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns the original fetch when NODE_EXTRA_CA_CERTS is unset", async () => {
+		delete Bun.env.NODE_EXTRA_CA_CERTS;
+		const { fetchImpl, calls } = makeRecordingFetch();
+
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		expect(wrapped).toBe(fetchImpl);
+
+		await wrapped("https://example.test/v1");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].tls).toBeUndefined();
+	});
+
+	it("loads the CA bundle from a path and seeds the system root store", async () => {
+		const caPath = path.join(tmpDir, "corp.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		await wrapped("https://corp.example/v1");
+
+		expect(calls).toHaveLength(1);
+		const ca = calls[0].tls?.ca;
+		expect(ca).toContain(SAMPLE_PEM);
+		// Default trust must remain — Bun's tls.ca REPLACES the system store
+		// when set, so the wrapper has to prepend tls.rootCertificates.
+		expect((ca as string[]).slice(0, tls.rootCertificates.length)).toEqual([...tls.rootCertificates]);
+	});
+
+	it("accepts an extensionless path per Node's NODE_EXTRA_CA_CERTS contract", async () => {
+		const caPath = path.join(tmpDir, "corp-ca");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		await wrapped("https://corp.example/v1");
+
+		expect(calls[0].tls?.ca).toContain(SAMPLE_PEM);
+	});
+
+	it("accepts an inline PEM and expands escaped \\n", async () => {
+		Bun.env.NODE_EXTRA_CA_CERTS = SAMPLE_PEM.replace(/\n/g, "\\n");
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		await wrapped("https://corp.example/v1");
+
+		expect(calls[0].tls?.ca).toContain(SAMPLE_PEM);
+	});
+
+	it("appends to existing tls.ca without re-seeding system roots", async () => {
+		const caPath = path.join(tmpDir, "corp.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		// Simulate the Anthropic Foundry path: caller already curated the CA
+		// list with their own roots. Wrapper must append, not re-seed.
+		await wrapped("https://corp.example/v1", { tls: { ca: [SECONDARY_PEM] } } as RequestInit);
+
+		const ca = calls[0].tls?.ca as string[];
+		expect(ca).toEqual([SECONDARY_PEM, SAMPLE_PEM]);
+	});
+
+	it("invalidates the cache when the bundle file is rewritten", async () => {
+		const caPath = path.join(tmpDir, "rotating.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		await wrapped("https://corp.example/v1");
+		expect(calls[0].tls?.ca).toContain(SAMPLE_PEM);
+
+		// Bump mtime so the path@mtime cache key changes.
+		const future = new Date(Date.now() + 5_000);
+		await fs.utimes(caPath, future, future);
+		await Bun.write(caPath, SECONDARY_PEM);
+		await fs.utimes(caPath, future, future);
+
+		await wrapped("https://corp.example/v1");
+		const ca = calls[1].tls?.ca as string[];
+		expect(ca).toContain(SECONDARY_PEM);
+		expect(ca).not.toContain(SAMPLE_PEM);
+	});
+
+	it("throws ValidationError when the configured path does not exist", async () => {
+		Bun.env.NODE_EXTRA_CA_CERTS = path.join(tmpDir, "missing.pem");
+
+		const { fetchImpl } = makeRecordingFetch();
+		const wrapped = wrapFetchForExtraCa(fetchImpl);
+		await expect(wrapped("https://corp.example/v1")).rejects.toBeInstanceOf(AIError.ValidationError);
+	});
+
+	it("is idempotent — wrapping a wrapped fetch returns the same reference", async () => {
+		const caPath = path.join(tmpDir, "corp.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl } = makeRecordingFetch();
+		const once = wrapFetchForExtraCa(fetchImpl);
+		const twice = wrapFetchForExtraCa(once);
+		expect(twice).toBe(once);
+	});
+});
+
+describe("withExtraCaFetch", () => {
+	let tmpDir: string;
+	let originalEnv: string | undefined;
+
+	beforeEach(async () => {
+		__resetExtraCaCache();
+		originalEnv = Bun.env.NODE_EXTRA_CA_CERTS;
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-extra-ca-opts-"));
+	});
+
+	afterEach(async () => {
+		__resetExtraCaCache();
+		if (originalEnv === undefined) delete Bun.env.NODE_EXTRA_CA_CERTS;
+		else Bun.env.NODE_EXTRA_CA_CERTS = originalEnv;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns the original options when NODE_EXTRA_CA_CERTS is unset", () => {
+		delete Bun.env.NODE_EXTRA_CA_CERTS;
+		const original = { fetch: undefined };
+		expect(withExtraCaFetch(original)).toBe(original);
+	});
+
+	it("wraps the supplied fetch when the env var is set", async () => {
+		const caPath = path.join(tmpDir, "corp.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const { fetchImpl, calls } = makeRecordingFetch();
+		const wrapped = withExtraCaFetch({ fetch: fetchImpl });
+		expect(wrapped.fetch).not.toBe(fetchImpl);
+		await wrapped.fetch?.("https://corp.example/v1");
+		expect(calls[0].tls?.ca).toContain(SAMPLE_PEM);
+	});
+
+	it("wraps globalThis.fetch when no fetch is supplied", async () => {
+		const caPath = path.join(tmpDir, "corp.pem");
+		await Bun.write(caPath, SAMPLE_PEM);
+		Bun.env.NODE_EXTRA_CA_CERTS = caPath;
+
+		const wrapped = withExtraCaFetch({} as { fetch?: FetchImpl });
+		expect(typeof wrapped.fetch).toBe("function");
+		expect(wrapped.fetch).not.toBe(globalThis.fetch);
+	});
+});

--- a/packages/ai/src/utils/tls-fetch.ts
+++ b/packages/ai/src/utils/tls-fetch.ts
@@ -1,0 +1,159 @@
+/**
+ * `NODE_EXTRA_CA_CERTS` shim for the Bun fetch path used by every provider
+ * stream.
+ *
+ * Node's TLS layer honours `NODE_EXTRA_CA_CERTS` natively, but Bun's
+ * `fetch` does not, and the OpenAI-compatible providers (`openai-responses`,
+ * `openai-completions`, `openai-codex-responses`, `ollama-chat`, ...) route
+ * every request through Bun's runtime. Without this wrapper, corporate
+ * relays and private gateways behind a custom CA bundle fail with
+ * `unknown certificate verification error` even when the env var is set.
+ * (Foundry mTLS in {@link resolveFoundryTlsOptions} consumed the env var for
+ * the Anthropic path only — issue #3731.)
+ *
+ * The wrapper merges the resolved CA bundle into Bun's `RequestInit.tls.ca`.
+ * Bun's `tls.ca` REPLACES the default trust store when set, so the wrapper
+ * always seeds {@link tls.rootCertificates} when the caller has not already
+ * curated their own CA list.
+ */
+import * as fs from "node:fs";
+import * as tls from "node:tls";
+import { $env, isEnoent } from "@oh-my-pi/pi-utils";
+import * as AIError from "../error";
+import type { FetchImpl } from "../types";
+
+/** Bun extension to `RequestInit` for the TLS options we touch. */
+type BunTlsOptions = {
+	ca?: string | string[];
+	cert?: string;
+	key?: string;
+	rejectUnauthorized?: boolean;
+	serverName?: string;
+	ciphers?: string;
+};
+
+type BunTlsRequestInit = RequestInit & { tls?: BunTlsOptions };
+
+const EXTRA_CA_FETCH_MARKER = Symbol("omp.extraCaFetch");
+type ExtraCaFetch = FetchImpl & { [EXTRA_CA_FETCH_MARKER]?: true };
+
+/**
+ * Cached resolution of `NODE_EXTRA_CA_CERTS`. Keyed on the env value plus
+ * the file mtime for path values so on-disk cert rotation (short-lived
+ * corporate bundles) invalidates the cache instead of pinning the first
+ * read forever. Mirrors {@link foundryTlsOptionsCacheKey}.
+ */
+let cacheKey: string | undefined;
+let cacheValue: string | undefined;
+
+/**
+ * Returns the PEM bytes referenced by `NODE_EXTRA_CA_CERTS`, or `undefined`
+ * when the env var is unset/empty.
+ *
+ * Accepts the same shapes Node accepts plus an inline-PEM escape hatch:
+ * - Inline PEM (`-----BEGIN CERTIFICATE-----...`). Literal `\n` escapes in
+ *   the env value are expanded so callers can ship single-line PEMs through
+ *   shell exports.
+ * - File path. Anything that does not contain a PEM header is treated as a
+ *   path, matching Node's "extensionless filename is still a path" contract.
+ *   `ENOENT` becomes {@link AIError.ValidationError}; other I/O errors bubble.
+ */
+function resolveExtraCa(): string | undefined {
+	const raw = $env.NODE_EXTRA_CA_CERTS?.trim();
+	if (!raw) return undefined;
+
+	let key: string;
+	if (raw.includes("-----BEGIN")) {
+		key = raw;
+	} else {
+		try {
+			key = `${raw}@${fs.statSync(raw).mtimeMs}`;
+		} catch {
+			key = raw;
+		}
+	}
+	if (key === cacheKey) return cacheValue;
+
+	if (raw.includes("-----BEGIN")) {
+		cacheValue = raw.replace(/\\n/g, "\n");
+	} else {
+		try {
+			cacheValue = fs.readFileSync(raw, "utf8");
+		} catch (error) {
+			if (isEnoent(error)) {
+				throw new AIError.ValidationError(`NODE_EXTRA_CA_CERTS path does not exist: ${raw}`);
+			}
+			throw error;
+		}
+	}
+	cacheKey = key;
+	return cacheValue;
+}
+
+/** Test seam: drop the cached PEM so a follow-up call re-reads the env. */
+export function __resetExtraCaCache(): void {
+	cacheKey = undefined;
+	cacheValue = undefined;
+}
+
+/**
+ * Merge `extraCa` into `init.tls.ca`. When the caller has not supplied a CA
+ * list, the system root store is included alongside the extra bundle —
+ * Bun's `tls.ca` replaces the default trust store, so omitting roots would
+ * break every public host. When the caller already curated a list (e.g.
+ * Anthropic Foundry's {@link resolveFoundryTlsOptions}, which already seeds
+ * `tls.rootCertificates`), only the extra CA is appended.
+ */
+function withExtraCaInit(init: RequestInit | undefined, extraCa: string): RequestInit {
+	const existingTls = (init as BunTlsRequestInit | undefined)?.tls;
+	const existingCa = existingTls?.ca;
+	let mergedCa: string[];
+	if (existingCa === undefined) {
+		mergedCa = [...tls.rootCertificates, extraCa];
+	} else if (Array.isArray(existingCa)) {
+		mergedCa = [...existingCa, extraCa];
+	} else {
+		mergedCa = [existingCa, extraCa];
+	}
+	return { ...init, tls: { ...existingTls, ca: mergedCa } } as RequestInit;
+}
+
+/**
+ * Wrap `fetchImpl` so every call honours `NODE_EXTRA_CA_CERTS`. Idempotent:
+ * a fetch already wrapped is returned unchanged so repeated composition
+ * (Anthropic auth-retry replays, request-debug fan-out) never stacks
+ * wrappers. When the env var is unset the original fetch is returned, so
+ * default deployments pay nothing.
+ */
+export function wrapFetchForExtraCa(fetchImpl: FetchImpl): FetchImpl {
+	const maybeWrapped = fetchImpl as ExtraCaFetch;
+	if (maybeWrapped[EXTRA_CA_FETCH_MARKER]) return fetchImpl;
+	// Peek once at construction — if the env var is unset, skip the wrapper
+	// entirely so the hot fetch path stays a single function call. The env
+	// is evaluated again per request below to catch in-process updates from
+	// tests (`__resetExtraCaCache` + env mutation).
+	if (!$env.NODE_EXTRA_CA_CERTS?.trim()) return fetchImpl;
+
+	const wrapped = Object.assign(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const extraCa = resolveExtraCa();
+			return extraCa ? fetchImpl(input, withExtraCaInit(init, extraCa)) : fetchImpl(input, init);
+		},
+		fetchImpl.preconnect ? { preconnect: fetchImpl.preconnect } : {},
+		{ [EXTRA_CA_FETCH_MARKER]: true as const },
+	);
+	return wrapped;
+}
+
+/**
+ * Convenience for the stream-entry composition in `stream.ts`. Mirrors
+ * {@link withRequestDebugFetch} so the proxy/debug/extra-CA wrappers compose
+ * uniformly. No-op when the env var is unset.
+ */
+export function withExtraCaFetch<T extends { fetch?: FetchImpl } | undefined>(options: T): T {
+	if (!$env.NODE_EXTRA_CA_CERTS?.trim()) return options;
+	const fetchImpl = options?.fetch ?? (globalThis.fetch as FetchImpl);
+	const wrapped = wrapFetchForExtraCa(fetchImpl);
+	if (wrapped === fetchImpl && options?.fetch !== undefined) return options;
+	return { ...(options ?? {}), fetch: wrapped } as T;
+}


### PR DESCRIPTION
## Repro

A user-supplied `NODE_EXTRA_CA_CERTS` bundle was only consumed by `resolveFoundryTlsOptions()` on the Anthropic Foundry path. OpenAI-compatible providers (`openai-responses`, `openai-completions`, `openai-codex-responses`, `azure-openai-responses`, `ollama-chat`, Google) route every request through Bun's `fetch`, which does NOT honor the env var natively — so a custom gateway with a private CA chain still failed with `unknown certificate verification error` even with `NODE_EXTRA_CA_CERTS` set, contradicting the docs.

```sh
grep -rn 'NODE_EXTRA_CA_CERTS' packages/ai/src
# packages/ai/src/providers/anthropic.ts:1121: foundryTlsCacheKeyComponent($env.NODE_EXTRA_CA_CERTS),
# packages/ai/src/providers/anthropic.ts:1218: const ca = resolvePemValue($env.NODE_EXTRA_CA_CERTS, "NODE_EXTRA_CA_CERTS");
```

## Cause

`streamDispatch`/`streamSimple` in `packages/ai/src/stream.ts` compose `withRequestDebugFetch` + `wrapFetchForProxy` on `options.fetch` — neither touches TLS. Every downstream provider (`postOpenAIStream`, `fetchWithRetry` in ollama/codex/etc.) inherits that fetch, so the env var never reaches Bun's `RequestInit.tls.ca`. The Foundry path read it directly into its own per-request `fetchOptions`, which is why Anthropic worked.

## Fix

- New `packages/ai/src/utils/tls-fetch.ts` exports `wrapFetchForExtraCa(fetchImpl)` + `withExtraCaFetch(options)`. The wrapper merges the resolved bundle into `RequestInit.tls.ca` and seeds `tls.rootCertificates` alongside it (Bun's `tls.ca` REPLACES the system trust store when set). When the caller already curated a CA list (Foundry's case), the wrapper appends instead of re-seeding.
- Resolution mirrors `resolveFoundryTlsOptions`: inline PEM (with literal `\n` expansion), extensionless paths treated as filesystem paths per Node's contract, `ENOENT` surfaced as `AIError.ValidationError`. Cached by `path@mtime` so rotated short-lived bundles are picked up live.
- `streamDispatch` and `streamSimple` now compose `withExtraCaFetch(withRequestDebugFetch(...))` before `wrapFetchForProxy`, so the wrapper sits inside proxy/debug. No behavior change when the env var is unset — the wrapper short-circuits to the original fetch.
- `packages/ai/README.md`, `docs/environment-variables.md`, and the pi-ai changelog updated to reflect the broader scope. The Foundry-specific `CLAUDE_CODE_CLIENT_CERT`/`CLAUDE_CODE_CLIENT_KEY` material stays Anthropic-only.

## Verification

- `bun test src/utils/__tests__/tls-fetch.test.ts` — 11 pass (path bundle, extensionless path, inline PEM with `\n` escapes, append-not-reseed against existing `tls.ca`, mtime-keyed cache rotation, `ValidationError` on missing path, idempotent wrap, env-unset fast path).
- `bun test test/proxy.test.ts test/request-debug.test.ts src/utils/__tests__/tls-fetch.test.ts` — 50 pass (proxy/debug composition unchanged).
- `bun --cwd=packages/ai run check` — passed.

Fixes #3731