### PR TITLE
fix(coding-agent): expand paste markers in Ctrl+Q follow-ups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+Q / Ctrl+Enter follow-up submissions sending the literal `[Paste #N]` marker instead of the expanded paste body ([#3737](https://github.com/can1357/oh-my-pi/issues/3737)).
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1145,7 +1145,7 @@ export class InputController {
 
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
-		let text = this.ctx.editor.getText().trim();
+		let text = this.ctx.editor.getExpandedText().trim();
 		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
 		const imageLinks =
 			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -13,6 +13,7 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 interface StubEditor {
 	setText: (text: string) => void;
 	getText: () => string;
+	getExpandedText: () => string;
 	addToHistory: (text: string) => void;
 	imageLinks?: unknown;
 	pendingImages: ImageContent[];
@@ -35,6 +36,9 @@ function createContext(opts: {
 			editorText = text;
 		},
 		getText() {
+			return editorText;
+		},
+		getExpandedText() {
 			return editorText;
 		},
 		addToHistory: vi.fn(),

--- a/packages/coding-agent/test/input-controller-followup-paste-expansion.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-paste-expansion.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression: queuing a follow-up message (Ctrl+Q / Ctrl+Enter → `app.message.followUp`)
+ * with a collapsed `[Paste #N, +X lines]` marker must expand the marker to its stored text
+ * before dispatch, identical to the Enter path. Previously `handleFollowUp` read raw
+ * `getText()` so the model received the literal marker string and the paste was silently
+ * dropped (issue #3737).
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+interface PromptOptionsLike {
+	streamingBehavior?: "steer" | "followUp";
+}
+
+describe("InputController.handleFollowUp paste-marker expansion", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("expands [Paste #N] markers to their stored text before dispatch while streaming", async () => {
+		const expanded = "line1\nline2\nline3\nline4\nline5";
+		let editorText = "[Paste #1, +5 lines]";
+		const prompt = vi.fn(async (_text: string, _options?: PromptOptionsLike) => {});
+		const ctx = {
+			editor: {
+				setText(text: string) {
+					editorText = text;
+				},
+				getText: () => editorText,
+				getExpandedText: () =>
+					editorText.replace(/\[Paste #1(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
+				addToHistory: vi.fn(),
+				pendingImages: [],
+				pendingImageLinks: [],
+				clearDraft(text?: string) {
+					if (text !== undefined) this.addToHistory(text);
+					this.setText("");
+				},
+			},
+			ui: { requestRender: vi.fn() },
+			skillCommands: new Map<string, string>(),
+			session: {
+				isStreaming: true,
+				isCompacting: false,
+				isBashRunning: false,
+				isEvalRunning: false,
+				extensionRunner: undefined,
+				prompt,
+			},
+			loopModeEnabled: false,
+			compactionQueuedMessages: [],
+			locallySubmittedUserSignatures: new Set<string>(),
+			updatePendingMessagesDisplay: vi.fn(),
+			showError: vi.fn(),
+			withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		} as unknown as InteractiveModeContext;
+
+		await new InputController(ctx).handleFollowUp();
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		const call = prompt.mock.calls[0];
+		if (!call) throw new Error("expected session.prompt to be called");
+		expect(call[0]).toBe(expanded);
+		expect(call[0]).not.toContain("[Paste #");
+		expect(call[1]?.streamingBehavior).toBe("followUp");
+	});
+
+	it("expands [Paste #N] markers when idle (not streaming)", async () => {
+		const expanded = "queued-paste-body\nspans multiple lines";
+		let editorText = "[Paste #2, +2 lines]";
+		const prompt = vi.fn(async (_text: string, _options?: PromptOptionsLike) => {});
+		const ctx = {
+			editor: {
+				setText(text: string) {
+					editorText = text;
+				},
+				getText: () => editorText,
+				getExpandedText: () =>
+					editorText.replace(/\[Paste #2(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
+				addToHistory: vi.fn(),
+				pendingImages: [],
+				pendingImageLinks: [],
+				clearDraft(text?: string) {
+					if (text !== undefined) this.addToHistory(text);
+					this.setText("");
+				},
+			},
+			ui: { requestRender: vi.fn() },
+			skillCommands: new Map<string, string>(),
+			session: {
+				isStreaming: false,
+				isCompacting: false,
+				isBashRunning: false,
+				isEvalRunning: false,
+				extensionRunner: undefined,
+				prompt,
+			},
+			loopModeEnabled: false,
+			compactionQueuedMessages: [],
+			locallySubmittedUserSignatures: new Set<string>(),
+			updatePendingMessagesDisplay: vi.fn(),
+			showError: vi.fn(),
+			withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		} as unknown as InteractiveModeContext;
+
+		await new InputController(ctx).handleFollowUp();
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		const call = prompt.mock.calls[0];
+		if (!call) throw new Error("expected session.prompt to be called");
+		expect(call[0]).toBe(expanded);
+		expect(call[0]).not.toContain("[Paste #");
+		expect(call[1]?.streamingBehavior).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/input-controller-followup-paste-expansion.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-paste-expansion.test.ts
@@ -28,8 +28,7 @@ describe("InputController.handleFollowUp paste-marker expansion", () => {
 					editorText = text;
 				},
 				getText: () => editorText,
-				getExpandedText: () =>
-					editorText.replace(/\[Paste #1(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
+				getExpandedText: () => editorText.replace(/\[Paste #1(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
 				addToHistory: vi.fn(),
 				pendingImages: [],
 				pendingImageLinks: [],
@@ -76,8 +75,7 @@ describe("InputController.handleFollowUp paste-marker expansion", () => {
 					editorText = text;
 				},
 				getText: () => editorText,
-				getExpandedText: () =>
-					editorText.replace(/\[Paste #2(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
+				getExpandedText: () => editorText.replace(/\[Paste #2(?:, (?:\+\d+ lines|\d+ chars))?\]/g, expanded),
 				addToHistory: vi.fn(),
 				pendingImages: [],
 				pendingImageLinks: [],

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -26,6 +26,7 @@ type FakeEditor = {
 	onSubmit?: (text: string) => Promise<void>;
 	setText(text: string): void;
 	getText(): string;
+	getExpandedText(): string;
 	addToHistory(text: string): void;
 	setActionKeys(action: string, keys: string[]): void;
 	setCustomKeyHandler(key: string, handler: () => void): void;
@@ -103,6 +104,9 @@ async function createContext() {
 			editorText = text;
 		},
 		getText() {
+			return editorText;
+		},
+		getExpandedText() {
 			return editorText;
 		},
 		addToHistory: vi.fn(),

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -624,6 +624,9 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		getText() {
 			return editorText;
 		},
+		getExpandedText() {
+			return editorText;
+		},
 		clearDraft(historyText?: string) {
 			if (historyText !== undefined) this.addToHistory(historyText);
 			this.setText("");

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -27,6 +27,7 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 type StubEditor = {
 	setText: (text: string) => void;
 	getText: () => string;
+	getExpandedText: () => string;
 	clearDraft: (historyText?: string) => void;
 	addToHistory: Mock<(...args: unknown[]) => unknown>;
 	onSubmit?: (text: string) => Promise<void>;
@@ -65,6 +66,9 @@ function createStubInputControllerContext(opts: {
 			editorText = text;
 		},
 		getText() {
+			return editorText;
+		},
+		getExpandedText() {
 			return editorText;
 		},
 		clearDraft(historyText?: string) {


### PR DESCRIPTION
## Repro

In the TUI composer, paste a block large enough to collapse into a `[Paste #N, +X lines]` marker, then submit with **Ctrl+Q** (or **Ctrl+Enter**) instead of Enter. The model receives the literal string `[Paste #1, +47 lines]` rather than the pasted content — the paste is silently dropped, no error surfaced. The same paste submitted with Enter arrives fully expanded.

## Cause

`InputController.handleFollowUp` in `packages/coding-agent/src/modes/controllers/input-controller.ts` read raw editor text via `this.ctx.editor.getText()`, bypassing the paste-store expansion the Enter path applies through `Editor.getExpandedText()`. Every downstream consumer in the method (focused-session submit, compaction queue, skill-command parsing, `session.prompt`) then forwarded the unexpanded marker.

## Fix

- `input-controller.ts`: `handleFollowUp` now reads `this.ctx.editor.getExpandedText().trim()`, matching the Enter path. `getExpandedText` rewrites only `[Paste #N]` markers; `[Image #N]` markers stay intact and `pendingImages` forwarding is unchanged.
- New regression test `test/input-controller-followup-paste-expansion.test.ts` covers the streaming and idle paths: the queued message reaches `session.prompt` as the expanded body, with no `[Paste #` substring remaining.
- Updated existing `InputController` test stubs (`input-controller-skill-queue.test.ts`, `input-controller-followup-image.test.ts`, `input-controller-keybindings.test.ts`) to implement `getExpandedText`, matching the production `CustomEditor` surface.
- Changelog entry under `[Unreleased] / Fixed`.

## Verification

- `bun test test/input-controller*.test.ts` → 127 pass, 0 fail (14 files, including the new regression test).
- `bun check` (run automatically by `gh_push_branch`) passed against the committed tree.

Fixes #3737