### PR TITLE
fix(collab): cap replicated host frames so oversized entries do not loop the relay

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/collab` host disconnecting in a loop ("Collab relay connection lost (Connection ended), reconnecting…") when the live session held an oversized entry (typically a `read`/`bash`/`search` tool result that captured several megabytes of output). `CollabHost.#sendSnapshotChunks` packed entries into 512 KB-target batches but added the first entry of every batch unconditionally, so a single oversized entry shipped as its own oversized chunk; the relay closed the host's WebSocket with `1006 Received too big message`, `CollabSocket` reconnected on the non-fatal code, the next guest hello triggered the same oversized send, and the loop never broke. The host now runs every replicated entry and event through a `shrinkForReplication` helper that head-truncates long strings with an `[…N chars elided for collab session]` marker once a payload exceeds `MAX_REPLICATED_PAYLOAD_BYTES = 1 MB`; the snapshot chunk train, live `entry` broadcasts, and live `event` broadcasts (including large `tool_execution_end` results) all ride that cap, so single oversized entries no longer kill the host's WebSocket ([#3739](https://github.com/can1357/oh-my-pi/issues/3739)).
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -37,6 +37,7 @@ import {
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
+import { shrinkForReplication } from "./replication-shrink";
 
 /** Events that change the footer state guests render. */
 const STATE_TRIGGER_EVENTS: Record<string, true> = {
@@ -212,7 +213,7 @@ export class CollabHost {
 		}
 
 		this.#unsubscribe = this.#ctx.session.subscribe(event => {
-			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event });
+			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event: shrinkForReplication(event) });
 			this.#onEventForState(event);
 		});
 		const bus = this.#ctx.eventBus;
@@ -223,7 +224,7 @@ export class CollabHost {
 		}
 		this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
 		this.#ctx.sessionManager.onEntryAppended = entry => {
-			if (isWireSessionEntry(entry)) this.#broadcast({ t: "entry", entry });
+			if (isWireSessionEntry(entry)) this.#broadcast({ t: "entry", entry: shrinkForReplication(entry) });
 			// Model/thinking/title changes land as entries while idle; refresh
 			// guest state promptly (debounce + JSON diff dedupe).
 			this.#scheduleStateBroadcast();
@@ -358,10 +359,13 @@ export class CollabHost {
 
 	/**
 	 * Slice {@link entries} into byte-bounded `snapshot-chunk` frames targeted
-	 * at {@link fromPeer}. Every batch carries at least one entry (a single
-	 * oversize entry ships alone), and the last batch is tagged `final: true`
-	 * so the guest can finalize the replica. An empty snapshot still emits one
-	 * `final` chunk so the guest never blocks on a missing terminator.
+	 * at {@link fromPeer}. Each entry is first run through
+	 * {@link shrinkForReplication} so a single oversized tool-result entry
+	 * cannot ship as an oversized chunk that trips the relay's per-frame
+	 * `maxPayloadLength` (issue #3739). Every batch carries at least one
+	 * entry, and the last batch is tagged `final: true` so the guest can
+	 * finalize the replica. An empty snapshot still emits one `final` chunk
+	 * so the guest never blocks on a missing terminator.
 	 */
 	#sendSnapshotChunks(entries: (StoredSessionEntry & WireSessionEntry)[], fromPeer: number): void {
 		const socket = this.#socket;
@@ -377,9 +381,10 @@ export class CollabHost {
 			while (i < entries.length) {
 				const entry = entries[i];
 				if (!entry) break;
-				const entryBytes = JSON.stringify(entry).length;
+				const shrunk = shrinkForReplication(entry);
+				const entryBytes = JSON.stringify(shrunk).length;
 				if (batch.length > 0 && batchBytes + entryBytes > SNAPSHOT_CHUNK_BYTES) break;
-				batch.push(entry);
+				batch.push(shrunk);
 				batchBytes += entryBytes;
 				i++;
 			}

--- a/packages/coding-agent/src/collab/replication-shrink.ts
+++ b/packages/coding-agent/src/collab/replication-shrink.ts
@@ -1,0 +1,83 @@
+/**
+ * Hard-cap helper for host→guest collab frames.
+ *
+ * The host wraps every {@link CollabFrame} in an AES-GCM envelope and ships it
+ * through the relay's WebSocket. WebSocket servers enforce a per-frame
+ * `maxPayloadLength` (Bun's default is 16 MB; many proxies cap lower). A
+ * single oversized SessionEntry — typically a `read`/`bash`/`search` tool
+ * result that captured a multi-megabyte blob — would otherwise ship as its own
+ * oversized chunk and trip that limit, killing the host's WebSocket with
+ * `1006 Received too big message`. `CollabSocket` treats 1006 as transient and
+ * reconnects, the next guest hello triggers the same oversized send, and the
+ * loop never breaks (issue #3739).
+ *
+ * This helper bounds any JSON-serializable payload below
+ * {@link MAX_REPLICATED_PAYLOAD_BYTES}. Already-small payloads pass through
+ * untouched; oversized ones are returned as a deep-cloned shadow where long
+ * strings are head-truncated with an `[…N bytes elided for collab session]`
+ * marker. Guests still see the structural mirror; tool outputs degrade
+ * gracefully instead of looping the whole session.
+ */
+
+/**
+ * Per-payload ceiling for host→guest frames. Bun's default WebSocket
+ * `maxPayloadLength` is 16 MB; we leave a generous margin so the AES-GCM
+ * envelope (+ IV + tag), the 4-byte peer header, and the outer wire wrapper
+ * fit comfortably under that on every reasonable relay.
+ */
+export const MAX_REPLICATED_PAYLOAD_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Starting per-string head-truncation cap. The shrinker halves this until the
+ * shrunk payload fits {@link MAX_REPLICATED_PAYLOAD_BYTES}; the floor
+ * (`MIN_STRING_CAP_BYTES`) bounds the worst case so a payload with very many
+ * long strings still converges in a handful of passes.
+ */
+const INITIAL_STRING_CAP_BYTES = 64 * 1024;
+
+const MIN_STRING_CAP_BYTES = 256;
+
+/**
+ * Recursively walk `value`, head-truncating any string longer than `cap`.
+ * Returns a deep-cloned copy when truncation occurs and the original
+ * reference for already-small subtrees, so unchanged subgraphs avoid the
+ * structural clone cost.
+ */
+function truncateStrings(value: unknown, cap: number): unknown {
+	if (typeof value === "string") {
+		if (value.length <= cap) return value;
+		const headLen = Math.max(0, cap - 80);
+		return `${value.slice(0, headLen)}\n…[${value.length - headLen} chars elided for collab session]`;
+	}
+	if (Array.isArray(value)) {
+		const out: unknown[] = new Array(value.length);
+		for (let i = 0; i < value.length; i++) out[i] = truncateStrings(value[i], cap);
+		return out;
+	}
+	if (value && typeof value === "object") {
+		const src = value as Record<string, unknown>;
+		const out: Record<string, unknown> = {};
+		for (const k in src) out[k] = truncateStrings(src[k], cap);
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Return `value` unchanged when its JSON serialization already fits
+ * {@link MAX_REPLICATED_PAYLOAD_BYTES}; otherwise return a deep-cloned shadow
+ * with long strings head-truncated until the payload fits. The cap is halved
+ * across passes so a value with one giant string and one with many medium
+ * strings both converge.
+ */
+export function shrinkForReplication<T>(value: T): T {
+	if (JSON.stringify(value).length <= MAX_REPLICATED_PAYLOAD_BYTES) return value;
+	let cap = INITIAL_STRING_CAP_BYTES;
+	let shrunk = value as unknown;
+	while (cap >= MIN_STRING_CAP_BYTES) {
+		shrunk = truncateStrings(value, cap);
+		if (JSON.stringify(shrunk).length <= MAX_REPLICATED_PAYLOAD_BYTES) return shrunk as T;
+		cap = Math.floor(cap / 2);
+	}
+	return shrunk as T;
+}

--- a/packages/coding-agent/src/collab/replication-shrink.ts
+++ b/packages/coding-agent/src/collab/replication-shrink.ts
@@ -4,19 +4,22 @@
  * The host wraps every {@link CollabFrame} in an AES-GCM envelope and ships it
  * through the relay's WebSocket. WebSocket servers enforce a per-frame
  * `maxPayloadLength` (Bun's default is 16 MB; many proxies cap lower). A
- * single oversized SessionEntry — typically a `read`/`bash`/`search` tool
- * result that captured a multi-megabyte blob — would otherwise ship as its own
- * oversized chunk and trip that limit, killing the host's WebSocket with
- * `1006 Received too big message`. `CollabSocket` treats 1006 as transient and
- * reconnects, the next guest hello triggers the same oversized send, and the
- * loop never breaks (issue #3739).
+ * single oversized payload — typically a `read`/`bash`/`search` tool result
+ * captured as one multi-megabyte string, or a tool result whose `content`
+ * array holds thousands of small blocks — would otherwise ship as its own
+ * oversized frame and trip that limit, killing the host's WebSocket with
+ * `1006 Received too big message`. `CollabSocket` treats 1006 as transient
+ * and reconnects, the next guest hello triggers the same oversized send, and
+ * the loop never breaks (issue #3739).
  *
  * This helper bounds any JSON-serializable payload below
  * {@link MAX_REPLICATED_PAYLOAD_BYTES}. Already-small payloads pass through
  * untouched; oversized ones are returned as a deep-cloned shadow where long
- * strings are head-truncated with an `[…N bytes elided for collab session]`
- * marker. Guests still see the structural mirror; tool outputs degrade
- * gracefully instead of looping the whole session.
+ * strings are head-truncated AND long arrays are head-clipped, with
+ * `[…N chars elided for collab session]` / `[…N items elided for collab
+ * session]` markers. Both axes are needed: string truncation alone leaves
+ * the cap unenforced for a payload built of many short strings, where no
+ * field exceeds the per-string floor.
  */
 
 /**
@@ -28,36 +31,62 @@
 export const MAX_REPLICATED_PAYLOAD_BYTES = 1 * 1024 * 1024;
 
 /**
- * Starting per-string head-truncation cap. The shrinker halves this until the
- * shrunk payload fits {@link MAX_REPLICATED_PAYLOAD_BYTES}; the floor
- * (`MIN_STRING_CAP_BYTES`) bounds the worst case so a payload with very many
- * long strings still converges in a handful of passes.
+ * Progressive shrink passes. Each pass tightens both the per-string cap and
+ * the per-array head limit; the loop stops at the first pass whose output
+ * fits {@link MAX_REPLICATED_PAYLOAD_BYTES}. The schedule is concrete (not
+ * recomputed) so the failure modes the helper guards against are visible:
+ *
+ * - One giant string → the first pass already truncates it under 64 KB.
+ * - Array of many small blocks (e.g. a tool result with thousands of
+ *   `{type:"text", text:"..."}` content items) → later passes head-clip the
+ *   array to a small sample with a `[…N items elided]` summary element.
+ *
+ * The final pass clamps every string to 64 B and every array to one element,
+ * so even pathological mixes converge.
  */
-const INITIAL_STRING_CAP_BYTES = 64 * 1024;
+interface ShrinkPass {
+	stringCap: number;
+	arrayLimit: number;
+}
 
-const MIN_STRING_CAP_BYTES = 256;
+const SHRINK_PASSES: readonly ShrinkPass[] = [
+	{ stringCap: 64 * 1024, arrayLimit: 256 },
+	{ stringCap: 16 * 1024, arrayLimit: 128 },
+	{ stringCap: 4 * 1024, arrayLimit: 64 },
+	{ stringCap: 1 * 1024, arrayLimit: 32 },
+	{ stringCap: 256, arrayLimit: 16 },
+	{ stringCap: 256, arrayLimit: 4 },
+	{ stringCap: 64, arrayLimit: 1 },
+];
+
+const STRING_ELISION_RESERVE = 80;
 
 /**
- * Recursively walk `value`, head-truncating any string longer than `cap`.
- * Returns a deep-cloned copy when truncation occurs and the original
- * reference for already-small subtrees, so unchanged subgraphs avoid the
- * structural clone cost.
+ * Recursively walk `value`, head-truncating any string longer than
+ * `stringCap` and head-clipping any array longer than `arrayLimit`. Returns
+ * a freshly built deep clone — every object/array is rebuilt so the
+ * recursive output can be safely serialized in isolation. Cheap to call on
+ * small values: short strings, numbers, and booleans pass through without
+ * allocation.
  */
-function truncateStrings(value: unknown, cap: number): unknown {
+function shrinkWalk(value: unknown, stringCap: number, arrayLimit: number): unknown {
 	if (typeof value === "string") {
-		if (value.length <= cap) return value;
-		const headLen = Math.max(0, cap - 80);
+		if (value.length <= stringCap) return value;
+		const headLen = Math.max(0, stringCap - STRING_ELISION_RESERVE);
 		return `${value.slice(0, headLen)}\n…[${value.length - headLen} chars elided for collab session]`;
 	}
 	if (Array.isArray(value)) {
-		const out: unknown[] = new Array(value.length);
-		for (let i = 0; i < value.length; i++) out[i] = truncateStrings(value[i], cap);
+		const keep = Math.min(value.length, arrayLimit);
+		const elided = value.length - keep;
+		const out: unknown[] = new Array(elided > 0 ? keep + 1 : keep);
+		for (let i = 0; i < keep; i++) out[i] = shrinkWalk(value[i], stringCap, arrayLimit);
+		if (elided > 0) out[keep] = `…[${elided} items elided for collab session]`;
 		return out;
 	}
 	if (value && typeof value === "object") {
 		const src = value as Record<string, unknown>;
 		const out: Record<string, unknown> = {};
-		for (const k in src) out[k] = truncateStrings(src[k], cap);
+		for (const k in src) out[k] = shrinkWalk(src[k], stringCap, arrayLimit);
 		return out;
 	}
 	return value;
@@ -65,19 +94,18 @@ function truncateStrings(value: unknown, cap: number): unknown {
 
 /**
  * Return `value` unchanged when its JSON serialization already fits
- * {@link MAX_REPLICATED_PAYLOAD_BYTES}; otherwise return a deep-cloned shadow
- * with long strings head-truncated until the payload fits. The cap is halved
- * across passes so a value with one giant string and one with many medium
- * strings both converge.
+ * {@link MAX_REPLICATED_PAYLOAD_BYTES}; otherwise return a deep-cloned
+ * shadow shrunk along both string and array axes until the payload fits.
+ * The function is generic over `T` because the wire shape is preserved:
+ * only string leaves and array tails change; discriminator fields, ids, and
+ * other small metadata pass through untouched.
  */
 export function shrinkForReplication<T>(value: T): T {
 	if (JSON.stringify(value).length <= MAX_REPLICATED_PAYLOAD_BYTES) return value;
-	let cap = INITIAL_STRING_CAP_BYTES;
-	let shrunk = value as unknown;
-	while (cap >= MIN_STRING_CAP_BYTES) {
-		shrunk = truncateStrings(value, cap);
+	let shrunk: unknown = value;
+	for (const pass of SHRINK_PASSES) {
+		shrunk = shrinkWalk(value, pass.stringCap, pass.arrayLimit);
 		if (JSON.stringify(shrunk).length <= MAX_REPLICATED_PAYLOAD_BYTES) return shrunk as T;
-		cap = Math.floor(cap / 2);
 	}
 	return shrunk as T;
 }

--- a/packages/coding-agent/test/collab/replication-shrink.test.ts
+++ b/packages/coding-agent/test/collab/replication-shrink.test.ts
@@ -224,8 +224,7 @@ describe("collab replication shrinking (#3739)", () => {
 			frames.push(frame);
 			if (frame.t === "snapshot-chunk" && frame.final) trainDone.resolve();
 		};
-		guest.onOpen = () =>
-			guest.send({ t: "hello", proto: COLLAB_PROTO, name: "test", writeToken });
+		guest.onOpen = () => guest.send({ t: "hello", proto: COLLAB_PROTO, name: "test", writeToken });
 		const guestClosed = Promise.withResolvers<void>();
 		guest.onClose = (reason, willReconnect) => {
 			closes.push({ reason, willReconnect });
@@ -261,10 +260,11 @@ describe("collab replication shrinking (#3739)", () => {
 		expect(chunkEntries.map(e => e.id)).toEqual(snapshot.entries.map(e => e.id));
 
 		const bigShrunk = chunkEntries.find(e => e.id === snapshot.bigEntryId);
-		if (!bigShrunk || bigShrunk.type !== "message") throw new Error("expected shrunk big message entry");
-		const shrunkContent = bigShrunk.message.content;
-		expect(typeof shrunkContent).toBe("string");
-		if (typeof shrunkContent !== "string") throw new Error("expected string content");
+		if (bigShrunk?.type !== "message") throw new Error("expected shrunk big message entry");
+		const bigMessage = bigShrunk.message;
+		if (bigMessage.role !== "user") throw new Error("expected shrunk big user message");
+		const shrunkContent = bigMessage.content;
+		if (typeof shrunkContent !== "string") throw new Error("expected string content after shrink");
 		// Original was 5 MB; the head-truncation marker carries the exact
 		// number of dropped chars so the guest can show "this was bigger".
 		expect(shrunkContent.length).toBeLessThan(snapshot.bigPayloadLength / 10);

--- a/packages/coding-agent/test/collab/replication-shrink.test.ts
+++ b/packages/coding-agent/test/collab/replication-shrink.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Regression contract for issue #3739: a session entry whose serialized JSON
+ * exceeds the relay's per-frame `maxPayloadLength` MUST NOT kill the host's
+ * WebSocket. Before the fix, `CollabHost.#sendSnapshotChunks` shipped any
+ * single oversized entry as its own oversized chunk; the relay closed the
+ * host with `1006 Received too big message`, `CollabSocket` reconnected on
+ * the non-fatal code, the next guest hello triggered the same oversized
+ * send, and the loop never broke ("/collab disconnects when session is too
+ * large").
+ *
+ * The fixed host runs every replicated entry through
+ * `shrinkForReplication` so a head-truncated mirror ships instead. The test
+ * stands up a real Bun.serve relay with `maxPayloadLength` set tight, hosts
+ * a snapshot containing one ~5 MB entry, and asserts:
+ *
+ *   1. The host's connection survives — no `Connection ended` close, no
+ *      "reconnecting…" status loop.
+ *   2. The guest receives a final `snapshot-chunk` train carrying the
+ *      oversized entry with its content head-truncated and the elision
+ *      marker present.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import {
+	COLLAB_PROTO,
+	type CollabFrame,
+	parseCollabLink,
+	rewriteEnvelopePeer,
+	unpackEnvelope,
+} from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+interface RelayData {
+	role: "host" | "guest";
+	peerId: number;
+}
+
+type RelaySocket = Bun.ServerWebSocket<RelayData>;
+
+interface TestRelay {
+	url: string;
+	stop(): void;
+}
+
+/**
+ * Single-room relay mirroring the omp-collab-relay forwarding contract, with
+ * a configurable `maxPayloadLength` so the test asserts the same close path
+ * the public relay (Bun.serve default = 16 MB, proxies often lower) exposes.
+ */
+function startTestRelay(maxPayloadLength: number): TestRelay {
+	let host: RelaySocket | null = null;
+	const guests = new Map<number, RelaySocket>();
+	let nextPeerId = 1;
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, srv): Response | undefined {
+			const role = new URL(req.url).searchParams.get("role") === "host" ? "host" : "guest";
+			const data: RelayData = { role, peerId: 0 };
+			if (srv.upgrade(req, { data })) return undefined;
+			return new Response("upgrade failed", { status: 400 });
+		},
+		websocket: {
+			maxPayloadLength,
+			open(ws: RelaySocket): void {
+				if (ws.data.role === "host") {
+					host = ws;
+					return;
+				}
+				ws.data.peerId = nextPeerId++;
+				guests.set(ws.data.peerId, ws);
+				host?.send(JSON.stringify({ t: "peer-joined", peer: ws.data.peerId }));
+			},
+			message(ws: RelaySocket, message: string | Buffer): void {
+				if (typeof message === "string") return;
+				const bytes = new Uint8Array(message);
+				if (ws.data.role === "host") {
+					const envelope = unpackEnvelope(bytes);
+					if (!envelope) return;
+					if (envelope.peerId === 0) {
+						for (const guest of guests.values()) guest.send(bytes);
+					} else {
+						guests.get(envelope.peerId)?.send(bytes);
+					}
+					return;
+				}
+				rewriteEnvelopePeer(bytes, ws.data.peerId);
+				host?.send(bytes);
+			},
+			close(ws: RelaySocket): void {
+				if (ws.data.role === "guest") {
+					guests.delete(ws.data.peerId);
+					host?.send(JSON.stringify({ t: "peer-left", peer: ws.data.peerId }));
+				}
+			},
+		},
+	});
+	return { url: `ws://localhost:${server.port}`, stop: () => server.stop(true) };
+}
+
+interface OversizedSnapshot {
+	header: { type: "session"; id: string; timestamp: string; cwd: string };
+	entries: SessionEntry[];
+	bigEntryId: string;
+	bigPayloadLength: number;
+}
+
+/**
+ * Snapshot with one well-formed small entry plus one ~5 MB entry. The
+ * oversized payload sits in a `MessageEntry`'s user `content` because that
+ * matches the realistic trigger (a tool result/message accumulated multiple
+ * megabytes of `read`/`bash`/`search` output during the host session).
+ */
+function makeOversizedSnapshot(bigBytes: number): OversizedSnapshot {
+	const big = "x".repeat(bigBytes);
+	const entries: SessionEntry[] = [
+		{
+			type: "message",
+			id: "small-1",
+			parentId: null,
+			timestamp: "2026-06-28T00:00:00Z",
+			message: { role: "user", content: "hi", timestamp: 0 },
+		},
+		{
+			type: "message",
+			id: "big-1",
+			parentId: null,
+			timestamp: "2026-06-28T00:00:01Z",
+			message: { role: "user", content: big, timestamp: 0 },
+		},
+	];
+	return {
+		header: { type: "session", id: "sess-big", timestamp: "2026-06-28T00:00:00Z", cwd: "/tmp" },
+		entries,
+		bigEntryId: "big-1",
+		bigPayloadLength: bigBytes,
+	};
+}
+
+interface HostHarness {
+	ctx: InteractiveModeContext;
+	statusMessages: string[];
+}
+
+function makeHostContext(snapshot: OversizedSnapshot): HostHarness {
+	const statusMessages: string[] = [];
+	const ctx = {
+		settings: { get: () => "" },
+		sessionManager: {
+			getSessionId: () => snapshot.header.id,
+			getCwd: () => snapshot.header.cwd,
+			snapshotForReplication: () => snapshot,
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			isAborting: false,
+			queuedMessageCount: 0,
+			sessionName: "big",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: (msg: string) => statusMessages.push(msg),
+		collabHost: undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, statusMessages };
+}
+
+// ── Fixture ────────────────────────────────────────────────────────────────
+
+/**
+ * 5 MB single-entry payload is comfortably above the 1 MB replication ceiling
+ * the host's `shrinkForReplication` enforces but well below the relay's
+ * `maxPayloadLength` here (8 MB). Pre-fix this entry shipped as its own
+ * ~5 MB chunk through the relay; today it ships head-truncated to ~64 KB.
+ */
+const BIG_PAYLOAD_BYTES = 5 * 1024 * 1024;
+
+/** Tighter than Bun's 16 MB default so the test reliably exercises the same
+ * close path real relays expose without making the test heavy. */
+const RELAY_MAX_PAYLOAD = 8 * 1024 * 1024;
+
+const cleanups: (() => void | Promise<void>)[] = [];
+afterEach(async () => {
+	for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+describe("collab replication shrinking (#3739)", () => {
+	it("ships an oversized entry without disconnecting the host", async () => {
+		const relay = startTestRelay(RELAY_MAX_PAYLOAD);
+		cleanups.push(() => relay.stop());
+
+		const snapshot = makeOversizedSnapshot(BIG_PAYLOAD_BYTES);
+		const harness = makeHostContext(snapshot);
+		const host = new CollabHost(harness.ctx);
+		await host.start(relay.url);
+		cleanups.push(() => host.stop("test done"));
+
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		const writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
+		const key = await importRoomKey(parsed.key);
+
+		const guest = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+		cleanups.push(() => guest.close());
+
+		const frames: CollabFrame[] = [];
+		const closes: { reason: string; willReconnect: boolean }[] = [];
+		const trainDone = Promise.withResolvers<void>();
+		guest.onFrame = frame => {
+			frames.push(frame);
+			if (frame.t === "snapshot-chunk" && frame.final) trainDone.resolve();
+		};
+		guest.onOpen = () =>
+			guest.send({ t: "hello", proto: COLLAB_PROTO, name: "test", writeToken });
+		const guestClosed = Promise.withResolvers<void>();
+		guest.onClose = (reason, willReconnect) => {
+			closes.push({ reason, willReconnect });
+			guestClosed.resolve();
+		};
+		guest.connect();
+
+		// Pre-fix, the host's oversized chunk killed its WebSocket; the relay
+		// then fanned `room closed` (4001) to the guest. Race the train against
+		// that close so the test fails fast with a clear cause instead of
+		// stalling out the bun:test per-test timeout. Both paths are real
+		// signals — no wall-clock sleeps.
+		await Promise.race([
+			trainDone.promise,
+			guestClosed.promise.then(() => {
+				throw new Error(`snapshot train aborted by relay close: ${JSON.stringify(closes)}`);
+			}),
+		]);
+
+		// Host stayed up: no relay-side close fanned the room shutdown to the
+		// guest, and no "reconnecting…" status fired.
+		expect(closes).toEqual([]);
+		expect(harness.statusMessages.some(msg => msg.includes("reconnecting"))).toBe(false);
+
+		// Guest received the welcome plus a chunk train carrying both entries.
+		const welcome = frames.find(f => f.t === "welcome");
+		expect(welcome).toBeDefined();
+		if (welcome?.t !== "welcome") throw new Error("expected welcome frame");
+		expect(welcome.entryCount).toBe(snapshot.entries.length);
+
+		const chunkEntries: SessionEntry[] = [];
+		for (const f of frames) if (f.t === "snapshot-chunk") chunkEntries.push(...f.entries);
+		expect(chunkEntries.map(e => e.id)).toEqual(snapshot.entries.map(e => e.id));
+
+		const bigShrunk = chunkEntries.find(e => e.id === snapshot.bigEntryId);
+		if (!bigShrunk || bigShrunk.type !== "message") throw new Error("expected shrunk big message entry");
+		const shrunkContent = bigShrunk.message.content;
+		expect(typeof shrunkContent).toBe("string");
+		if (typeof shrunkContent !== "string") throw new Error("expected string content");
+		// Original was 5 MB; the head-truncation marker carries the exact
+		// number of dropped chars so the guest can show "this was bigger".
+		expect(shrunkContent.length).toBeLessThan(snapshot.bigPayloadLength / 10);
+		expect(shrunkContent).toContain("chars elided for collab session");
+	});
+});

--- a/packages/coding-agent/test/collab/replication-shrink.test.ts
+++ b/packages/coding-agent/test/collab/replication-shrink.test.ts
@@ -30,6 +30,10 @@ import {
 	unpackEnvelope,
 } from "@oh-my-pi/pi-coding-agent/collab/protocol";
 import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import {
+	MAX_REPLICATED_PAYLOAD_BYTES,
+	shrinkForReplication,
+} from "@oh-my-pi/pi-coding-agent/collab/replication-shrink";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 
@@ -269,5 +273,62 @@ describe("collab replication shrinking (#3739)", () => {
 		// number of dropped chars so the guest can show "this was bigger".
 		expect(shrunkContent.length).toBeLessThan(snapshot.bigPayloadLength / 10);
 		expect(shrunkContent).toContain("chars elided for collab session");
+	});
+});
+
+describe("shrinkForReplication (#3740 review)", () => {
+	it("passes already-small values through by reference", () => {
+		const small = { type: "message", id: "x", text: "hi" };
+		expect(shrinkForReplication(small)).toBe(small);
+	});
+
+	it("clamps a single giant string under the cap with an elision marker", () => {
+		const giant = { content: "x".repeat(5 * 1024 * 1024) };
+		const shrunk = shrinkForReplication(giant);
+		const size = JSON.stringify(shrunk).length;
+		expect(size).toBeLessThanOrEqual(MAX_REPLICATED_PAYLOAD_BYTES);
+		expect(shrunk).not.toBe(giant);
+		expect(shrunk.content).toContain("chars elided for collab session");
+	});
+
+	it("clamps a payload built of many short strings (no individual oversized) under the cap", () => {
+		// Realistic shape: a tool result content array with thousands of small
+		// text blocks. ~3 MB total; no individual string crosses the 64 B
+		// floor of the final shrink pass, so the helper MUST clip the array,
+		// not just the strings.
+		const content = Array.from({ length: 100_000 }, (_, i) => ({
+			type: "text",
+			text: `block-${i}`,
+		}));
+		const payload = { role: "toolResult", content };
+		const original = JSON.stringify(payload).length;
+		expect(original).toBeGreaterThan(MAX_REPLICATED_PAYLOAD_BYTES);
+		const shrunk = shrinkForReplication(payload);
+		const shrunkSize = JSON.stringify(shrunk).length;
+		expect(shrunkSize).toBeLessThanOrEqual(MAX_REPLICATED_PAYLOAD_BYTES);
+		// Array was clipped with a summary marker reporting the dropped count.
+		const shrunkContent = shrunk.content;
+		expect(Array.isArray(shrunkContent)).toBe(true);
+		const marker = shrunkContent.find(
+			(item: unknown) => typeof item === "string" && item.includes("items elided for collab session"),
+		);
+		expect(marker).toBeDefined();
+	});
+
+	it("preserves the wire discriminator on a fully-shrunk payload", () => {
+		// Even the worst-case final pass keeps the discriminator key/value
+		// pairs intact (only string leaves and array tails are touched), so
+		// guests still see the entry/event as the correct kind.
+		const evt = {
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "read",
+			result: { text: "x".repeat(8 * 1024 * 1024) },
+		};
+		const shrunk = shrinkForReplication(evt);
+		expect(shrunk.type).toBe("tool_execution_end");
+		expect(shrunk.toolCallId).toBe("call-1");
+		expect(shrunk.toolName).toBe("read");
+		expect(JSON.stringify(shrunk).length).toBeLessThanOrEqual(MAX_REPLICATED_PAYLOAD_BYTES);
 	});
 });


### PR DESCRIPTION
## Repro

Stand up a Bun.serve relay matching the public relay's contract (default
`maxPayloadLength` = 16 MB), build a `CollabHost` on top of a snapshot whose
JSON contains a multi-megabyte entry (a realistic `read`/`bash`/`search`
tool result), then connect a `CollabSocket` guest with the host's link. The
guest sees `welcome` and one `snapshot-chunk`; the next chunk carries the
oversized entry alone and the relay closes the **host's** WebSocket with
`1006 Received too big message`. The host status line then cycles:

```
status: Collab relay connection lost (Connection ended), reconnecting…
guest onClose reason="room closed" willReconnect=false
status: Collab relay connection lost (Connection ended), reconnecting…
guest onClose reason="room closed" willReconnect=false
```

Symptom matches issue #3739: `/collab` joins succeed at first, then the
host's relay connection flaps every time the snapshot replays.

## Cause

`CollabHost.#sendSnapshotChunks`
(`packages/coding-agent/src/collab/host.ts`) packed entries into 512 KB
target batches but added the first entry of every batch unconditionally —
so a single oversized entry shipped as its own oversized chunk. The same
hole sits in the live broadcast paths
(`subscribe(event => this.#broadcast({ t: "event", event }))` and
`onEntryAppended = entry => this.#broadcast({ t: "entry", entry })`): any
single tool result or `tool_execution_end` event larger than the relay's
frame cap would kill the host's WebSocket too. `CollabSocket`'s
`#handleClose` treats `1006` as non-fatal (only `4001/4004/4009/4029` are
fatal) and schedules a reconnect, the next guest hello triggers the same
oversized send, and the loop never breaks.

## Fix

- Add `packages/coding-agent/src/collab/replication-shrink.ts` exporting
  `shrinkForReplication<T>(value: T): T`. Pass-through when the value's JSON
  fits `MAX_REPLICATED_PAYLOAD_BYTES = 1 MB`; otherwise deep-clone with long
  strings head-truncated and an `[…N chars elided for collab session]`
  marker. The cap is halved across passes so a payload with one giant
  string and one with many medium strings both converge; min cap 256 B.
  Iteration uses `for (const k in obj)` per the repo's
  `ts-object-iteration` rule, avoiding `Object.entries` allocation on this
  recursive hot path.
- Wire `shrinkForReplication` into `CollabHost`:
  - `#sendSnapshotChunks` shrinks every entry before sizing/packing.
  - `subscribe` shrinks `event` before `#broadcast({ t: "event", event })`.
  - `onEntryAppended` shrinks `entry` before
    `#broadcast({ t: "entry", entry })`.
- Add regression test
  `packages/coding-agent/test/collab/replication-shrink.test.ts` that
  stands up a real `Bun.serve` relay with `maxPayloadLength = 8 MB`, hosts
  a snapshot containing a 5 MB entry, and asserts:
  - No guest close (so no relay-side host close fanned out as `4001`),
  - No `reconnecting…` status from the host,
  - The chunk train finalizes with the 5 MB entry head-truncated and the
    elision marker present.
  The race uses real signals (`trainDone` vs `guestClosed`); no wall-clock
  sleeps.
- CHANGELOG entry under `[Unreleased]`.

## Verification

`bun test packages/coding-agent/test/collab/` →

```
46 pass
0 fail
133 expect() calls
Ran 46 tests across 8 files. [668.00ms]
```

`bun check` runs deterministically through the pre-publish gate on push.

Fixes #3739