### PR TITLE
feat(coding-agent): integrate comment-checker as built-in feature

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "@types/bun": "catalog:",
       },
       "optionalDependencies": {
+        "@code-yeongyu/comment-checker": "catalog:",
         "@huggingface/transformers": "catalog:",
         "sherpa-onnx-node": "1.13.2",
       },
@@ -334,6 +335,7 @@
     "@biomejs/biome": "^2.4.16",
     "@bufbuild/protobuf": "^2.12.0",
     "@bufbuild/protoc-gen-es": "^2.12.0",
+    "@code-yeongyu/comment-checker": "^0.8.0",
     "@huggingface/transformers": "^4.2.0",
     "@mozilla/readability": "^0.6.0",
     "@napi-rs/cli": "3.7.0",
@@ -477,6 +479,8 @@
     "@bufbuild/protoc-gen-es": ["@bufbuild/protoc-gen-es@2.12.1", "", { "dependencies": { "@bufbuild/protobuf": "2.12.1", "@bufbuild/protoplugin": "2.12.1" }, "bin": { "protoc-gen-es": "bin/protoc-gen-es" } }, "sha512-SWa7XvRYRouMo+vBQmpNFZ+ZEqQ8AC0LpL4QWAo1gvstLhFh/Y7Nf/a+MK7ZxDq5LZSThwfk974L1sFxO3OaGw=="],
 
     "@bufbuild/protoplugin": ["@bufbuild/protoplugin@2.12.1", "", { "dependencies": { "@bufbuild/protobuf": "2.12.1", "@typescript/vfs": "^1.6.2", "typescript": "5.4.5" } }, "sha512-PY58KxQVAD1BnnKtStOctsMoegEVGfBnY5AOqVQOIu711nA13oYtTqJM8df5lUQg2J1DR3XxUXptE+fWX5oLdA=="],
+
+    "@code-yeongyu/comment-checker": ["@code-yeongyu/comment-checker@0.8.0", "", { "bin": { "comment-checker": "cli.js" } }, "sha512-Ret0qHtgDhEemQYNduqSyaihFWJSOKae4YW3sUHS680G8K57CsRUkK6Gs4kbzDuWqiNUYs254+qu5hZZZSEKUA=="],
 
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "@biomejs/biome": "^2.4.16",
       "@bufbuild/protobuf": "^2.12.0",
       "@bufbuild/protoc-gen-es": "^2.12.0",
+      "@code-yeongyu/comment-checker": "^0.8.0",
       "@huggingface/transformers": "^4.2.0",
       "@mozilla/readability": "^0.6.0",
       "@napi-rs/cli": "3.7.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -90,6 +90,7 @@
     "zod": "catalog:"
   },
   "optionalDependencies": {
+    "@code-yeongyu/comment-checker": "catalog:",
     "@huggingface/transformers": "catalog:",
     "sherpa-onnx-node": "1.13.2"
   },

--- a/packages/coding-agent/src/comment-checker/cli.ts
+++ b/packages/coding-agent/src/comment-checker/cli.ts
@@ -1,0 +1,229 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import type { CommentCheckerHookInput } from "./core";
+
+export type ProcessResult = {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+};
+
+export const MAX_PROCESS_OUTPUT_BYTES = 64 * 1024;
+export const PROCESS_TIMEOUT_MS = 30_000;
+
+export type ProcessExecutor = (command: string, args: string[], stdin: string) => Promise<ProcessResult>;
+
+export type RunCommentCheckerOptions = {
+	binaryPath?: string;
+	customPrompt?: string;
+	resolveBinary?: () => string | undefined;
+	executor?: ProcessExecutor;
+};
+
+export type CommentCheckerRunResult = {
+	status: "pass" | "warning" | "error" | "missing";
+	message: string;
+	binaryPath?: string;
+	exitCode?: number | null;
+	stdout?: string;
+	stderr?: string;
+};
+
+export async function runCommentChecker(
+	input: CommentCheckerHookInput,
+	options: RunCommentCheckerOptions = {},
+): Promise<CommentCheckerRunResult> {
+	const binaryPath =
+		options.binaryPath ?? (options.resolveBinary ? options.resolveBinary() : resolveCommentCheckerBinary());
+	if (!binaryPath) {
+		return {
+			status: "missing",
+			message: "comment-checker binary not found. Install @code-yeongyu/comment-checker or reload the package.",
+		};
+	}
+
+	const args = ["check"];
+	if (options.customPrompt) {
+		args.push("--prompt", options.customPrompt);
+	}
+
+	const executor = options.executor ?? spawnProcess;
+	const result = await executor(binaryPath, args, JSON.stringify(input));
+	const message = result.stderr || result.stdout;
+	if (result.exitCode === 0) {
+		return {
+			status: "pass",
+			message: "",
+			binaryPath,
+			exitCode: result.exitCode,
+			stdout: result.stdout,
+			stderr: result.stderr,
+		};
+	}
+	if (result.exitCode === 2) {
+		return {
+			status: "warning",
+			message,
+			binaryPath,
+			exitCode: result.exitCode,
+			stdout: result.stdout,
+			stderr: result.stderr,
+		};
+	}
+	return {
+		status: "error",
+		message,
+		binaryPath,
+		exitCode: result.exitCode,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}
+
+export function resolveCommentCheckerBinary(): string | undefined {
+	const binaryName = process.platform === "win32" ? "comment-checker.exe" : "comment-checker";
+	const fromPackageApi = resolvePackageApiBinary();
+	if (fromPackageApi) return fromPackageApi;
+	const fromPackage = resolvePackageBinary(binaryName);
+	if (fromPackage) return fromPackage;
+	return undefined;
+}
+
+function resolvePackageApiBinary(): string | undefined {
+	try {
+		const require = createRequire(import.meta.url);
+		const packageExports: unknown = require("@code-yeongyu/comment-checker");
+		if (!isCommentCheckerPackage(packageExports)) return undefined;
+		const binaryPath = packageExports.getBinaryPath();
+		return existsSync(binaryPath) ? binaryPath : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolvePackageBinary(binaryName: string): string | undefined {
+	try {
+		const require = createRequire(import.meta.url);
+		const packagePath = require.resolve("@code-yeongyu/comment-checker/package.json");
+		const binaryPath = join(dirname(packagePath), "bin", binaryName);
+		return existsSync(binaryPath) ? binaryPath : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isCommentCheckerPackage(value: unknown): value is { getBinaryPath: () => string } {
+	if (typeof value !== "object" || value === null) return false;
+	return typeof Object.getOwnPropertyDescriptor(value, "getBinaryPath")?.value === "function";
+}
+
+interface OutputAccumulator {
+	text: string;
+	bytes: number;
+	truncated: boolean;
+}
+
+function appendOutput(output: OutputAccumulator, chunk: string, maxOutputBytes: number): void {
+	if (output.truncated) return;
+
+	const remainingBytes = maxOutputBytes - output.bytes;
+	const chunkBytes = Buffer.byteLength(chunk, "utf8");
+	if (chunkBytes <= remainingBytes) {
+		output.text += chunk;
+		output.bytes += chunkBytes;
+		return;
+	}
+
+	if (remainingBytes > 0) {
+		const prefix = truncateUtf8Prefix(chunk, remainingBytes);
+		output.text += prefix;
+		output.bytes += Buffer.byteLength(prefix, "utf8");
+	}
+	output.truncated = true;
+}
+
+function replaceOutput(output: OutputAccumulator, text: string, maxOutputBytes: number): void {
+	output.text = "";
+	output.bytes = 0;
+	output.truncated = false;
+	appendOutput(output, text, maxOutputBytes);
+}
+
+function truncateUtf8Prefix(text: string, maxBytes: number): string {
+	let bytes = 0;
+	let endIndex = 0;
+	for (const character of text) {
+		const characterBytes = Buffer.byteLength(character, "utf8");
+		if (bytes + characterBytes > maxBytes) break;
+		bytes += characterBytes;
+		endIndex += character.length;
+	}
+	return text.slice(0, endIndex);
+}
+
+function formatOutput(output: OutputAccumulator, streamName: "stdout" | "stderr", maxOutputBytes: number): string {
+	if (!output.truncated) return output.text;
+	return `${output.text}\n[${streamName} truncated after ${maxOutputBytes} bytes]`;
+}
+
+export function spawnProcess(
+	command: string,
+	args: string[],
+	stdin: string,
+	maxOutputBytes: number = MAX_PROCESS_OUTPUT_BYTES,
+	processTimeoutMs: number = PROCESS_TIMEOUT_MS,
+): Promise<ProcessResult> {
+	const outputByteLimit = Number.isFinite(maxOutputBytes) && maxOutputBytes > 0 ? Math.floor(maxOutputBytes) : 0;
+	const timeoutLimit = Number.isFinite(processTimeoutMs) && processTimeoutMs > 0 ? Math.floor(processTimeoutMs) : 0;
+	const proc = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+	const stdout: OutputAccumulator = { text: "", bytes: 0, truncated: false };
+	const stderr: OutputAccumulator = { text: "", bytes: 0, truncated: false };
+	let timedOut = false;
+	let killTimer: ReturnType<typeof setTimeout> | undefined;
+	const { promise, resolve } = Promise.withResolvers<ProcessResult>();
+
+	const timeoutTimer =
+		timeoutLimit > 0
+			? setTimeout(() => {
+					timedOut = true;
+					replaceOutput(stderr, `comment-checker process timed out after ${timeoutLimit} ms`, outputByteLimit);
+					proc.kill("SIGTERM");
+					killTimer = setTimeout(() => {
+						proc.kill("SIGKILL");
+					}, 1_000);
+					killTimer.unref();
+				}, timeoutLimit)
+			: undefined;
+	timeoutTimer?.unref();
+
+	const finish = (exitCode: number | null): void => {
+		clearTimeout(timeoutTimer);
+		clearTimeout(killTimer);
+		resolve({
+			exitCode: timedOut ? null : exitCode,
+			stdout: formatOutput(stdout, "stdout", outputByteLimit),
+			stderr: formatOutput(stderr, "stderr", outputByteLimit),
+		});
+	};
+
+	proc.stdout.setEncoding("utf-8");
+	proc.stderr.setEncoding("utf-8");
+	proc.stdout.on("data", (chunk: string) => {
+		appendOutput(stdout, chunk, outputByteLimit);
+	});
+	proc.stderr.on("data", (chunk: string) => {
+		appendOutput(stderr, chunk, outputByteLimit);
+	});
+	proc.once("error", error => {
+		appendOutput(stderr, error.message, outputByteLimit);
+		finish(null);
+	});
+	proc.once("close", exitCode => {
+		finish(exitCode);
+	});
+	proc.stdin.end(stdin);
+
+	return promise;
+}

--- a/packages/coding-agent/src/comment-checker/core.ts
+++ b/packages/coding-agent/src/comment-checker/core.ts
@@ -1,0 +1,416 @@
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+
+export type CheckerToolName = "Write" | "Edit" | "MultiEdit";
+
+export type CheckerEdit = {
+	old_string: string;
+	new_string: string;
+};
+
+export type CheckerToolInput = {
+	file_path: string;
+	content?: string;
+	old_string?: string;
+	new_string?: string;
+	edits?: CheckerEdit[];
+};
+
+export type CommentCheckRequest = {
+	sourceToolName: string;
+	toolName: CheckerToolName;
+	filePath: string;
+	toolInput: CheckerToolInput;
+};
+
+export type OmpPerFileEditResult = {
+	filePath: string;
+	movePath?: string | undefined;
+	oldText: string;
+	newText: string;
+	success: boolean;
+};
+
+export type CommentCheckerHookInput = {
+	session_id: string;
+	tool_name: CheckerToolName;
+	transcript_path: string;
+	cwd: string;
+	hook_event_name: "PostToolUse";
+	tool_input: CheckerToolInput;
+};
+
+export type ToolResultContent = TextContent | ImageContent;
+
+export type ToolResultLike = {
+	toolName: string;
+	input: Record<string, unknown>;
+	content?: ToolResultContent[];
+	isError?: boolean;
+	details?: unknown;
+};
+
+type ApplyPatchAccumulator = {
+	operation: "add" | "delete" | "update";
+	filePath: string;
+	movePath?: string;
+	oldLines: string[];
+	newLines: string[];
+};
+
+type ApplyPatchFileMetadata = {
+	filePath: string;
+	movePath?: string;
+	before: string;
+	after: string;
+	type?: string;
+};
+
+export function extractFromOmpEditDetails(details: unknown): Array<OmpPerFileEditResult & { op: "write" | "edit" }> {
+	if (!isRecord(details)) return [];
+	const source = details.perFileResults ?? details.files;
+	if (!Array.isArray(source)) return [];
+	const results: Array<OmpPerFileEditResult & { op: "write" | "edit" }> = [];
+	for (const item of source) {
+		if (!isRecord(item)) continue;
+		const filePath = getString(item, ["filePath", "file_path"]) ?? "";
+		const movePath = getString(item, ["movePath", "move_path"]);
+		const oldText = getString(item, ["oldText", "old_text", "oldString", "old_string"]) ?? "";
+		const newText = getString(item, ["newText", "new_text", "newString", "new_string"]) ?? "";
+		if (typeof filePath !== "string" || filePath.length === 0) continue;
+		const success = item.success;
+		if (success === false) continue;
+		results.push({
+			filePath,
+			movePath: typeof movePath === "string" && movePath.length > 0 ? movePath : undefined,
+			oldText,
+			newText,
+			op: oldText.length === 0 ? "write" : "edit",
+			success: success === true,
+		});
+	}
+	return results;
+}
+
+function ompEditResultsToCommentCheckRequests(
+	sourceToolName: string,
+	results: Array<OmpPerFileEditResult & { op: "write" | "edit" }>,
+): CommentCheckRequest[] {
+	const requests: CommentCheckRequest[] = [];
+	for (const result of results) {
+		if (result.op === "write") {
+			requests.push({
+				sourceToolName,
+				toolName: "Write",
+				filePath: result.filePath,
+				toolInput: {
+					file_path: result.filePath,
+					content: result.newText,
+				},
+			});
+			continue;
+		}
+		requests.push({
+			sourceToolName,
+			toolName: "Edit",
+			filePath: result.filePath,
+			toolInput: {
+				file_path: result.filePath,
+				old_string: result.oldText,
+				new_string: result.newText,
+			},
+		});
+	}
+	return requests;
+}
+
+export function extractCommentCheckRequests(event: ToolResultLike): CommentCheckRequest[] {
+	if (event.isError) return [];
+	if (isToolFailureOutput(getContentText(event.content))) return [];
+
+	const toolName = event.toolName.toLowerCase();
+	if (toolName === "write") return extractWriteRequest(event);
+	if (toolName === "edit") {
+		const ompResults = extractFromOmpEditDetails(event.details);
+		const ompRequests = ompEditResultsToCommentCheckRequests(event.toolName, ompResults);
+		if (ompRequests.length > 0) return ompRequests;
+		return extractEditRequest(event);
+	}
+	if (toolName === "multiedit" || toolName === "multi_edit") return extractMultiEditRequest(event);
+	if (toolName === "apply_patch") return extractApplyPatchRequests(event);
+	return [];
+}
+
+export function toHookInput(
+	request: CommentCheckRequest,
+	context: {
+		sessionId: string;
+		cwd: string;
+	},
+): CommentCheckerHookInput {
+	return {
+		session_id: context.sessionId,
+		tool_name: request.toolName,
+		transcript_path: "",
+		cwd: context.cwd,
+		hook_event_name: "PostToolUse",
+		tool_input: request.toolInput,
+	};
+}
+
+export function isToolFailureOutput(text: string): boolean {
+	const lower = text.trim().toLowerCase();
+	return (
+		lower.startsWith("error") ||
+		lower.includes("error:") ||
+		lower.includes("failed to") ||
+		lower.includes("could not")
+	);
+}
+
+function extractWriteRequest(event: ToolResultLike): CommentCheckRequest[] {
+	const filePath = getString(event.input, ["filePath", "file_path", "path"]);
+	const content = getString(event.input, ["content"]);
+	if (!filePath || content === undefined) return [];
+	return [
+		{
+			sourceToolName: event.toolName,
+			toolName: "Write",
+			filePath,
+			toolInput: {
+				file_path: filePath,
+				content,
+			},
+		},
+	];
+}
+
+function extractEditRequest(event: ToolResultLike): CommentCheckRequest[] {
+	const filePath = getString(event.input, ["filePath", "file_path", "path"]);
+	const oldString = getString(event.input, ["oldString", "old_string"]);
+	const newString = getString(event.input, ["newString", "new_string"]);
+	if (!filePath || (oldString === undefined && newString === undefined)) return [];
+	const toolInput: CheckerToolInput = { file_path: filePath };
+	if (oldString !== undefined) toolInput.old_string = oldString;
+	if (newString !== undefined) toolInput.new_string = newString;
+	return [
+		{
+			sourceToolName: event.toolName,
+			toolName: "Edit",
+			filePath,
+			toolInput,
+		},
+	];
+}
+
+function extractMultiEditRequest(event: ToolResultLike): CommentCheckRequest[] {
+	const filePath = getString(event.input, ["filePath", "file_path", "path"]);
+	const edits = getEdits(event.input.edits);
+	if (!filePath || edits.length === 0) return [];
+	return [
+		{
+			sourceToolName: event.toolName,
+			toolName: "MultiEdit",
+			filePath,
+			toolInput: {
+				file_path: filePath,
+				edits,
+			},
+		},
+	];
+}
+
+function extractApplyPatchRequests(event: ToolResultLike): CommentCheckRequest[] {
+	const metadataRequests = extractApplyPatchMetadataRequests(event.details, event.toolName);
+	if (metadataRequests.length > 0) return metadataRequests;
+
+	const patch = getString(event.input, ["input", "patch"]);
+	if (!patch) return [];
+	return parseApplyPatchRequests(patch, event.toolName);
+}
+
+function extractApplyPatchMetadataRequests(details: unknown, sourceToolName: string): CommentCheckRequest[] {
+	const metadataFiles = getApplyPatchMetadataFiles(details);
+	if (metadataFiles.length === 0) return [];
+
+	const requests: CommentCheckRequest[] = [];
+	for (const file of metadataFiles) {
+		if (file.type === "delete") continue;
+		const filePath = file.movePath ?? file.filePath;
+		if (file.before.length === 0) {
+			requests.push({
+				sourceToolName,
+				toolName: "Write",
+				filePath,
+				toolInput: {
+					file_path: filePath,
+					content: file.after,
+				},
+			});
+			continue;
+		}
+		requests.push({
+			sourceToolName,
+			toolName: "Edit",
+			filePath,
+			toolInput: {
+				file_path: filePath,
+				old_string: file.before,
+				new_string: file.after,
+			},
+		});
+	}
+	return requests;
+}
+
+function getApplyPatchMetadataFiles(details: unknown): ApplyPatchFileMetadata[] {
+	if (!isRecord(details)) return [];
+	const direct = readApplyPatchMetadataFiles(details.files);
+	if (direct.length > 0) return direct;
+	const resultValue = details.result;
+	const result = isRecord(resultValue) ? readApplyPatchMetadataFiles(resultValue.files) : [];
+	if (result.length > 0) return result;
+	const metadataValue = details.metadata;
+	const metadata = isRecord(metadataValue) ? readApplyPatchMetadataFiles(metadataValue.files) : [];
+	return metadata;
+}
+
+function readApplyPatchMetadataFiles(value: unknown): ApplyPatchFileMetadata[] {
+	if (!Array.isArray(value)) return [];
+	const files: ApplyPatchFileMetadata[] = [];
+	for (const item of value) {
+		if (!isRecord(item)) continue;
+		const filePath = getString(item, ["filePath", "file_path", "path"]);
+		const movePath = getString(item, ["movePath", "move_path"]);
+		const before = getString(item, ["before", "old", "oldString", "old_string"]);
+		const after = getString(item, ["after", "new", "newString", "new_string"]);
+		const type = getString(item, ["type", "operation"]);
+		if (!filePath || before === undefined || after === undefined) continue;
+		const file: ApplyPatchFileMetadata = { filePath, before, after };
+		if (movePath !== undefined) file.movePath = movePath;
+		if (type !== undefined) file.type = type;
+		files.push(file);
+	}
+	return files;
+}
+
+export function parseApplyPatchRequests(patch: string, sourceToolName = "apply_patch"): CommentCheckRequest[] {
+	const requests: CommentCheckRequest[] = [];
+	let current: ApplyPatchAccumulator | undefined;
+
+	const flush = (): void => {
+		if (!current) return;
+		if (current.operation === "add") {
+			const content = joinPatchLines(current.newLines);
+			if (content.length > 0) {
+				requests.push({
+					sourceToolName,
+					toolName: "Write",
+					filePath: current.filePath,
+					toolInput: {
+						file_path: current.filePath,
+						content,
+					},
+				});
+			}
+		}
+		if (current.operation === "update") {
+			const newString = joinPatchLines(current.newLines);
+			if (newString.length > 0) {
+				const filePath = current.movePath ?? current.filePath;
+				requests.push({
+					sourceToolName,
+					toolName: "Edit",
+					filePath,
+					toolInput: {
+						file_path: filePath,
+						old_string: joinPatchLines(current.oldLines),
+						new_string: newString,
+					},
+				});
+			}
+		}
+		current = undefined;
+	};
+
+	for (const line of patch.split(/\r?\n/)) {
+		if (line === "*** Begin Patch" || line === "*** End Patch") continue;
+		if (line.startsWith("*** Add File: ")) {
+			flush();
+			current = makeAccumulator("add", line.slice("*** Add File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Update File: ")) {
+			flush();
+			current = makeAccumulator("update", line.slice("*** Update File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Delete File: ")) {
+			flush();
+			current = makeAccumulator("delete", line.slice("*** Delete File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Move to: ")) {
+			if (current?.operation === "update") current.movePath = line.slice("*** Move to: ".length).trim();
+			continue;
+		}
+		if (!current) continue;
+		if (line.startsWith("@@")) continue;
+		if (current.operation === "add") {
+			if (line.startsWith("+")) current.newLines.push(line.slice(1));
+			continue;
+		}
+		if (current.operation === "update") {
+			if (line.startsWith("+")) current.newLines.push(line.slice(1));
+			if (line.startsWith("-")) current.oldLines.push(line.slice(1));
+		}
+	}
+
+	flush();
+	return requests;
+}
+
+function makeAccumulator(operation: ApplyPatchAccumulator["operation"], filePath: string): ApplyPatchAccumulator {
+	return {
+		operation,
+		filePath,
+		oldLines: [],
+		newLines: [],
+	};
+}
+
+function getContentText(content: ToolResultContent[] | undefined): string {
+	if (!content) return "";
+	return content
+		.filter((block): block is TextContent => block.type === "text")
+		.map(block => block.text)
+		.join("\n");
+}
+
+function getString(input: Record<string, unknown>, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = input[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+function getEdits(value: unknown): CheckerEdit[] {
+	if (!Array.isArray(value)) return [];
+	const edits: CheckerEdit[] = [];
+	for (const item of value) {
+		if (!isRecord(item)) continue;
+		const oldString = getString(item, ["oldString", "old_string"]);
+		const newString = getString(item, ["newString", "new_string"]);
+		if (oldString === undefined || newString === undefined) continue;
+		edits.push({ old_string: oldString, new_string: newString });
+	}
+	return edits;
+}
+
+function joinPatchLines(lines: string[]): string {
+	return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/coding-agent/src/comment-checker/index.ts
+++ b/packages/coding-agent/src/comment-checker/index.ts
@@ -1,0 +1,208 @@
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { Settings } from "../config/settings";
+import type {
+	ExtensionContext,
+	ExtensionFactory,
+	ToolResultEvent,
+	ToolResultEventResult,
+} from "../extensibility/extensions";
+import { type CommentCheckerRunResult, resolveCommentCheckerBinary, runCommentChecker } from "./cli";
+import {
+	type CommentCheckerHookInput,
+	extractCommentCheckRequests,
+	type ToolResultContent,
+	type ToolResultLike,
+	toHookInput,
+} from "./core";
+import {
+	COMMENT_CHECKER_WIDGET_KEY,
+	type CommentCheckerUiState,
+	formatFooterStatus,
+	syncCommentCheckerWidget,
+} from "./ui";
+
+export const OMP_WARNING_ENTRY_TYPE = "omp-comment-checker:warning";
+
+type WarningRecord = {
+	id: string;
+	filePath: string;
+	message: string;
+	sourceToolName: string;
+	ts: number;
+	fired: boolean;
+};
+
+class SelfHealStore {
+	#records = new Map<string, WarningRecord>();
+
+	clear(): void {
+		this.#records.clear();
+	}
+
+	record(warning: { filePath: string; message: string; sourceToolName: string }): WarningRecord {
+		const id = `${warning.filePath}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+		const record: WarningRecord = {
+			id,
+			filePath: warning.filePath,
+			message: warning.message,
+			sourceToolName: warning.sourceToolName,
+			ts: Date.now(),
+			fired: false,
+		};
+		this.#records.set(id, record);
+		return record;
+	}
+
+	unfired(): WarningRecord[] {
+		return [...this.#records.values()].filter(record => !record.fired);
+	}
+
+	markFired(ids: string[]): void {
+		for (const id of ids) {
+			const record = this.#records.get(id);
+			if (record) record.fired = true;
+		}
+	}
+}
+
+function toToolResultLike(event: ToolResultEvent): ToolResultLike {
+	return {
+		toolName: event.toolName,
+		input: event.input,
+		content: event.content as ToolResultContent[] | undefined,
+		isError: event.isError,
+		details: event.details,
+	};
+}
+
+function getSessionId(ctx: ExtensionContext): string {
+	return ctx.sessionManager.getSessionId() ?? ctx.sessionManager.getHeader()?.id ?? "unknown";
+}
+
+export type CommentCheckerHandlerDeps = {
+	run?: (input: CommentCheckerHookInput) => Promise<CommentCheckerRunResult>;
+	onWarning?: (warning: { filePath: string; message: string; sourceToolName: string }) => void;
+};
+
+export function createCommentCheckerToolResultHandler(deps: CommentCheckerHandlerDeps) {
+	return async (event: ToolResultEvent, ctx: ExtensionContext): Promise<ToolResultEventResult | undefined> => {
+		const requests = extractCommentCheckRequests(toToolResultLike(event));
+		if (requests.length === 0) return undefined;
+
+		const checkedFiles: string[] = [];
+		const warnings: Array<{ filePath: string; message: string; sourceToolName: string }> = [];
+		const runner = deps.run ?? ((input: CommentCheckerHookInput) => runCommentChecker(input));
+
+		for (const request of requests) {
+			const input = toHookInput(request, { sessionId: getSessionId(ctx), cwd: ctx.cwd });
+			const result = await runner(input);
+			if (result.status === "missing") {
+				syncCommentCheckerWidget(ctx.ui.setWidget, { status: "missing", checkedFiles, warnings });
+				return undefined;
+			}
+			if (result.status === "error") {
+				syncCommentCheckerWidget(ctx.ui.setWidget, {
+					status: "error",
+					checkedFiles,
+					warnings,
+					errorMessage: result.message,
+				});
+				return undefined;
+			}
+			checkedFiles.push(request.filePath);
+			if (result.status === "warning" && result.message.trim().length > 0) {
+				warnings.push({
+					filePath: request.filePath,
+					message: result.message.trim(),
+					sourceToolName: request.sourceToolName,
+				});
+			}
+		}
+
+		for (const warning of warnings) {
+			deps.onWarning?.(warning);
+		}
+
+		if (warnings.length === 0) {
+			syncCommentCheckerWidget(ctx.ui.setWidget, { status: "clean", checkedFiles, warnings });
+			return undefined;
+		}
+
+		syncCommentCheckerWidget(ctx.ui.setWidget, { status: "warning", checkedFiles, warnings });
+		const appended: (TextContent | ImageContent)[] = [
+			...(event.content ?? []),
+			...warnings.map(warning => ({ type: "text" as const, text: `\n\n${warning.message}` })),
+		];
+		return { content: appended };
+	};
+}
+
+export const createCommentCheckerExtension: ExtensionFactory = api => {
+	const store = new SelfHealStore();
+	let state: CommentCheckerUiState = { status: "idle", checkedFiles: [], warnings: [] };
+
+	const setState = (ctx: ExtensionContext, nextState: CommentCheckerUiState): void => {
+		state = nextState;
+		syncCommentCheckerWidget(ctx.ui.setWidget, state);
+		ctx.ui.setStatus(COMMENT_CHECKER_WIDGET_KEY, formatFooterStatus(state));
+	};
+
+	api.on("session_start", async (_event, ctx) => {
+		store.clear();
+		if (!resolveCommentCheckerBinary()) {
+			setState(ctx, { status: "missing", checkedFiles: [], warnings: [] });
+			return;
+		}
+		setState(ctx, { status: "idle", checkedFiles: [], warnings: [] });
+	});
+
+	api.on("tool_result", async (event, ctx) => {
+		const handler = createCommentCheckerToolResultHandler({
+			run: input => runCommentChecker(input, { customPrompt: Settings.instance.get("commentChecker.prompt") }),
+			onWarning: warning => {
+				const record = store.record(warning);
+				api.appendEntry(OMP_WARNING_ENTRY_TYPE, {
+					filePath: record.filePath,
+					message: record.message,
+					sourceToolName: record.sourceToolName,
+					ts: record.ts,
+					id: record.id,
+				});
+			},
+		});
+		return handler(event, ctx);
+	});
+
+	api.on("session_compact", async () => {
+		const unfired = store.unfired();
+		if (unfired.length === 0) return;
+		const summary = unfired.map(w => `• ${w.filePath}: ${w.message}`).join("\n");
+		api.sendMessage(
+			{
+				customType: OMP_WARNING_ENTRY_TYPE,
+				content: `omp-comment-checker self-heal: ${unfired.length} warning(s) still need addressing:\n${summary}`,
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
+		store.markFired(unfired.map(w => w.id));
+	});
+
+	api.registerCommand("comment-checker", {
+		description: "Show omp-comment-checker status and pending warnings.",
+		handler: async (_args, ctx) => {
+			if (!resolveCommentCheckerBinary()) {
+				setState(ctx, { status: "missing", checkedFiles: [], warnings: [] });
+				ctx.ui.notify("omp-comment-checker binary missing; reinstall @code-yeongyu/comment-checker.", "warning");
+				return;
+			}
+			const unfired = store.unfired();
+			if (unfired.length === 0) {
+				ctx.ui.notify("omp-comment-checker: no pending warnings.", "info");
+				return;
+			}
+			const summary = unfired.map(w => `${w.filePath}: ${w.message}`).join("\n");
+			ctx.ui.notify(`${unfired.length} pending warning(s):\n${summary}`, "warning");
+		},
+	});
+};

--- a/packages/coding-agent/src/comment-checker/ui.ts
+++ b/packages/coding-agent/src/comment-checker/ui.ts
@@ -1,0 +1,58 @@
+export const COMMENT_CHECKER_WIDGET_KEY = "omp-comment-checker";
+
+export type CommentCheckerUiStatus = "idle" | "loading" | "missing" | "clean" | "warning" | "error";
+
+export type CommentCheckerWarning = {
+	filePath: string;
+	message: string;
+};
+
+export type CommentCheckerUiState = {
+	status: CommentCheckerUiStatus;
+	checkedFiles: string[];
+	warnings: CommentCheckerWarning[];
+	errorMessage?: string;
+};
+
+export type WidgetSetter = (
+	key: string,
+	lines: string[] | undefined,
+	options?: { placement?: "aboveEditor" | "belowEditor" },
+) => void;
+
+function formatPreview(message: string): string {
+	const trimmed = message.trim();
+	if (trimmed.length <= 80) return trimmed;
+	return `${trimmed.slice(0, 77).trimEnd()}…`;
+}
+
+export function getCommentCheckerWidgetLines(state: CommentCheckerUiState): string[] | undefined {
+	if (state.status !== "warning") return undefined;
+	if (state.warnings.length === 0) return undefined;
+	const header = "⚠ omp-comment-checker";
+	const summary = `  ${state.warnings.length} warning(s) in:`;
+	const maxLines = 10;
+	const lines: string[] = [header, summary];
+	for (const warning of state.warnings.slice(0, maxLines)) {
+		const preview = formatPreview(warning.message);
+		lines.push(`  • ${warning.filePath} — ${preview}`);
+	}
+	if (state.warnings.length > maxLines) {
+		lines.push(`  … (${state.warnings.length - maxLines} more)`);
+	}
+	return lines;
+}
+
+export function formatFooterStatus(state: CommentCheckerUiState): string | undefined {
+	if (state.status === "clean") return "comment-checker: clean";
+	if (state.status !== "warning") return undefined;
+	if (state.warnings.length === 0) return undefined;
+	const maxFiles = 3;
+	const fileList = state.warnings.slice(0, maxFiles).map(warning => warning.filePath);
+	const suffix = state.warnings.length > maxFiles ? " …" : "";
+	return `⚠ comment-checker: ${state.warnings.length} warning(s) in ${fileList.join(", ")}${suffix}`;
+}
+
+export function syncCommentCheckerWidget(setWidget: WidgetSetter, state: CommentCheckerUiState): void {
+	setWidget(COMMENT_CHECKER_WIDGET_KEY, getCommentCheckerWidgetLines(state), { placement: "aboveEditor" });
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -137,6 +137,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Output Limits",
 		"Execution",
 		"Discovery & MCP",
+		"Comment Checker",
 		"Developer",
 	],
 	tasks: ["Modes", "Subagents", "Isolation", "Commands & Skills"],
@@ -4817,6 +4818,29 @@ export const SETTINGS_SCHEMA = {
 	"thinkingBudgets.high": { type: "number", default: 16384 },
 
 	"thinkingBudgets.xhigh": { type: "number", default: 32768 },
+	"commentChecker.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Comment Checker",
+			label: "Comment Checker",
+			description:
+				"Run @code-yeongyu/comment-checker after write/edit/multiedit/apply_patch and surface warnings back to the agent. Requires the @code-yeongyu/comment-checker binary (npm optional dependency).",
+		},
+	},
+	"commentChecker.prompt": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "tools",
+			group: "Comment Checker",
+			label: "Comment Checker Prompt",
+			description:
+				"Optional custom prompt passed to the comment-checker binary (--prompt). Leave empty for the default.",
+			condition: "commentCheckerActive",
+		},
+	},
 } as const;
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -127,6 +127,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	commentCheckerActive: () => {
+		try {
+			return Settings.instance.get("commentChecker.enabled") === true;
+		} catch {
+			return false;
+		}
+	},
 };
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1815,6 +1815,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		const inlineExtensions: ExtensionFactory[] = options.extensions ? [...options.extensions] : [];
 		inlineExtensions.push((await import("./autoresearch")).createAutoresearchExtension);
+		if (settings.get("commentChecker.enabled")) {
+			inlineExtensions.push((await import("./comment-checker")).createCommentCheckerExtension);
+		}
 		if (customTools.length > 0) {
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}

--- a/packages/coding-agent/test/comment-checker/core.test.ts
+++ b/packages/coding-agent/test/comment-checker/core.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "bun:test";
+import {
+	extractCommentCheckRequests,
+	extractFromOmpEditDetails,
+	isToolFailureOutput,
+	type ToolResultLike,
+	toHookInput,
+} from "../../src/comment-checker/core";
+
+describe("extractCommentCheckRequests", () => {
+	it("maps a write tool result to a Write hook input", () => {
+		const event: ToolResultLike = {
+			toolName: "write",
+			input: {
+				filePath: "src/example.ts",
+				content: "const value = 1;\n",
+			},
+			content: [{ type: "text", text: "wrote src/example.ts" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "write",
+				toolName: "Write",
+				filePath: "src/example.ts",
+				toolInput: {
+					file_path: "src/example.ts",
+					content: "const value = 1;\n",
+				},
+			},
+		]);
+	});
+
+	it("maps an edit tool result to an Edit hook input", () => {
+		const event: ToolResultLike = {
+			toolName: "edit",
+			input: {
+				path: "src/example.ts",
+				old_string: "const value = 1;",
+				new_string: "const value = 2;",
+			},
+			content: [{ type: "text", text: "edited src/example.ts" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "edit",
+				toolName: "Edit",
+				filePath: "src/example.ts",
+				toolInput: {
+					file_path: "src/example.ts",
+					old_string: "const value = 1;",
+					new_string: "const value = 2;",
+				},
+			},
+		]);
+	});
+
+	it("maps a multiedit tool result to a MultiEdit hook input", () => {
+		const event: ToolResultLike = {
+			toolName: "multiedit",
+			input: {
+				file_path: "src/example.ts",
+				edits: [
+					{ old_string: "const a = 1;", new_string: "const a = 2;" },
+					{ oldString: "const b = 1;", newString: "const b = 2;" },
+				],
+			},
+			content: [{ type: "text", text: "edited src/example.ts" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "multiedit",
+				toolName: "MultiEdit",
+				filePath: "src/example.ts",
+				toolInput: {
+					file_path: "src/example.ts",
+					edits: [
+						{ old_string: "const a = 1;", new_string: "const a = 2;" },
+						{ old_string: "const b = 1;", new_string: "const b = 2;" },
+					],
+				},
+			},
+		]);
+	});
+
+	it("maps apply_patch add and update hunks to checker inputs", () => {
+		const patch = `*** Begin Patch
+*** Add File: src/added.ts
++// explain value
++const value = 1;
+*** Update File: src/old.ts
+*** Move to: src/new.ts
+@@
+-const before = 1;
++// explain next value
++const after = 2;
+*** Delete File: src/deleted.ts
+*** End Patch`;
+		const event: ToolResultLike = {
+			toolName: "apply_patch",
+			input: { input: patch },
+			content: [{ type: "text", text: "add: src/added.ts\nupdate: src/old.ts -> src/new.ts" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Write",
+				filePath: "src/added.ts",
+				toolInput: {
+					file_path: "src/added.ts",
+					content: "// explain value\nconst value = 1;\n",
+				},
+			},
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Edit",
+				filePath: "src/new.ts",
+				toolInput: {
+					file_path: "src/new.ts",
+					old_string: "const before = 1;\n",
+					new_string: "// explain next value\nconst after = 2;\n",
+				},
+			},
+		]);
+	});
+
+	it("uses full before and after content from apply_patch OMO metadata", () => {
+		const event: ToolResultLike = {
+			toolName: "apply_patch",
+			input: { input: "*** Begin Patch\n*** End Patch" },
+			details: {
+				files: [
+					{
+						filePath: "src/added.ts",
+						before: "",
+						after: "// explain value\nconst value = 1;\n",
+						type: "add",
+					},
+					{
+						filePath: "src/old.ts",
+						movePath: "src/new.ts",
+						before: "const before = 1;\n",
+						after: "// explain next value\nconst after = 2;\n",
+						type: "update",
+					},
+					{
+						filePath: "src/deleted.ts",
+						before: "// old comment\n",
+						after: "",
+						type: "delete",
+					},
+				],
+			},
+			content: [{ type: "text", text: "apply_patch ok" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Write",
+				filePath: "src/added.ts",
+				toolInput: {
+					file_path: "src/added.ts",
+					content: "// explain value\nconst value = 1;\n",
+				},
+			},
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Edit",
+				filePath: "src/new.ts",
+				toolInput: {
+					file_path: "src/new.ts",
+					old_string: "const before = 1;\n",
+					new_string: "// explain next value\nconst after = 2;\n",
+				},
+			},
+		]);
+	});
+
+	it("returns no work for a failed tool result", () => {
+		const event: ToolResultLike = {
+			toolName: "write",
+			input: {
+				filePath: "src/example.ts",
+				content: "const value = 1;\n",
+			},
+			content: [{ type: "text", text: "Error: failed to write" }],
+			isError: false,
+		};
+
+		const requests = extractCommentCheckRequests(event);
+
+		expect(requests).toEqual([]);
+	});
+
+	it("extracts per-file results from omp edit details", () => {
+		const details = {
+			perFileResults: [
+				{
+					filePath: "src/a.ts",
+					newText: "const a = 1;\n",
+					success: true,
+				},
+				{
+					filePath: "src/b.ts",
+					oldText: "const b = 1;\n",
+					newText: "const b = 2;\n",
+					success: true,
+				},
+				{
+					filePath: "src/c.ts",
+					oldText: "const c = 1;\n",
+					newText: "const c = 2;\n",
+					success: false,
+				},
+			],
+		};
+
+		const results = extractFromOmpEditDetails(details);
+
+		expect(results).toEqual([
+			{ filePath: "src/a.ts", oldText: "", newText: "const a = 1;\n", success: true, op: "write" },
+			{ filePath: "src/b.ts", oldText: "const b = 1;\n", newText: "const b = 2;\n", success: true, op: "edit" },
+		]);
+	});
+});
+
+describe("toHookInput", () => {
+	it("includes session id and cwd in the hook input", () => {
+		const [request] = extractCommentCheckRequests({
+			toolName: "write",
+			input: {
+				filePath: "src/example.ts",
+				content: "const value = 1;\n",
+			},
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+		});
+		if (!request) throw new Error("expected a comment check request");
+
+		const input = toHookInput(request, {
+			sessionId: "session-1",
+			cwd: "/workspace",
+		});
+
+		expect(input).toEqual({
+			session_id: "session-1",
+			tool_name: "Write",
+			transcript_path: "",
+			cwd: "/workspace",
+			hook_event_name: "PostToolUse",
+			tool_input: {
+				file_path: "src/example.ts",
+				content: "const value = 1;\n",
+			},
+		});
+	});
+});
+
+describe("isToolFailureOutput", () => {
+	it("identifies failed tool execution text", () => {
+		expect(isToolFailureOutput("Could not apply patch")).toBe(true);
+	});
+
+	it("does not flag clean tool output", () => {
+		expect(isToolFailureOutput("wrote src/example.ts")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Integrates [`@code-yeongyu/comment-checker`](https://github.com/code-yeongyu/go-claude-code-comment-checker) (the native tree-sitter-powered comment checker behind [pi-comment-checker](https://github.com/code-yeongyu/pi-comment-checker)) directly into the `@oh-my-pi/pi-coding-agent` package as a first-party built-in extension — not a plugin, not an external extension. Configurable via the TUI settings panel.

## What it does

After `write` / `edit` / `multiedit` / `apply_patch` tool results, the comment-checker runs the native binary on the changed content and, when it detects comments/docstrings (exit code `2`), appends the warning back into the tool result so the agent **must** react. Behavior matrix (matches the upstream extension):

| Case | Result |
| --- | --- |
| Binary missing | Silent no-op (TUI hidden, tool output unchanged) |
| Exit `0` | Clean — no modification |
| Exit `2` | Warning message appended to tool result; above-editor widget + footer status |
| Other exit | Error state, tool output unchanged |

It also includes omp-specific per-file edit-details extraction (reads `perFileResults` / `files` from edit tool details), and a **self-heal** path: unfired warnings are re-surfaced as a custom LLM-visible message on `session_compact`.

## Wiring

- **New `src/comment-checker/` module** — `core.ts` (request extraction), `cli.ts` (binary runner with timeout/truncation, `Promise.withResolvers`), `ui.ts` (widget + footer formatting), `index.ts` (extension factory).
- **Registration**: loaded as an inline extension via `loadExtensionFromFactory` in `sdk.ts`, gated on the `commentChecker.enabled` setting. Lazy-loaded with `await import("./comment-checker")` (same pattern as the existing autoresearch built-in).
- **Settings** (`settings-schema.ts`):
  - `commentChecker.enabled` — boolean, **default `false`** (opt-in). Tools tab, "Comment Checker" group.
  - `commentChecker.prompt` — optional string, custom `--prompt` passed to the binary. Gated on the `commentCheckerActive` condition.
- **TUI**: `commentCheckerActive` condition in `settings-defs.ts`; "Comment Checker" group added to `TAB_GROUPS.tools`.
- **Slash command**: `/comment-checker` shows binary status and pending warnings.
- **Dependency**: `@code-yeongyu/comment-checker` added as an `optionalDependency` (catalog version `^0.8.0`). The binary resolver tries the package's `getBinaryPath()` first, then `bin/`, then returns `undefined` (silent no-op) — so users who don't install it see zero footprint.

## Why default OFF

Auto-flagging comments on every write/edit is disruptive to existing users who don't want it. Default-OFF matches how the plugin works today (you had to install it to get it) and keeps the upgrade footprint zero. The `commentCheckerActive` condition means the sub-settings (custom prompt) only appear once the master flag is on.

## Binary strategy

`@code-yeongyu/comment-checker` ships prebuilt per-platform binaries (linux/darwin × arm64/x64, win32-x64) via npm `optionalDependencies` + a `postinstall` that extracts them. By declaring it as an omp `optionalDependency`, `bun install` pulls the platform binary automatically; if it's absent the resolver returns `undefined` and the extension is a silent no-op. No PATH fallback is needed for the common case.

## Tests

10 unit tests (`test/comment-checker/core.test.ts`) covering: write/edit/multiedit extraction, apply_patch raw-patch parsing + OMO metadata, omp per-file edit-details extraction (with failed-result filtering), failure-output detection, and hook-input conversion. All pass:

```
10 pass | 0 fail | 10 expect() calls
```

`bun run check:types` (tsgo) passes clean. `bunx biome check` passes on all changed files.

## Origin

Ported from [`code-yeongyu/pi-comment-checker`](https://github.com/code-yeongyu/pi-comment-checker) and the omp-specific adaptation in [`niklasschaeffer/omp-comment-checker`](https://github.com/niklasschaeffer/omp-comment-checker), adapted to omp's modern `ExtensionAPI` (`on("tool_result")`, `setWidget`, `sendMessage`, `appendEntry`, `registerCommand`).

## Checklist

- [x] Built-in module (not a plugin/extension file)
- [x] TUI-configurable (settings panel, tools tab)
- [x] Default OFF (opt-in)
- [x] Typechecks
- [x] Lint-clean (biome)
- [x] Unit tests pass
- [x] Binary smoke-tested (exit 2 on `// bad comment`)