### PR TITLE
fix(agent): keep autolearn memory prompts cache-stable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed autolearn and local memory writes mutating Anthropic prompt-cache prefixes mid-session by keeping passive capture guidance and learned-memory prompt injections session-stable.
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -2,9 +2,9 @@
  * Auto-learn session controller (experimental).
  *
  * Subscribes to the session event stream and, after a substantive turn,
- * nudges the agent to capture reusable lessons. Default posture is passive
- * (a hidden reminder rides the next real turn); with `autolearn.autoContinue`
- * it auto-runs exactly one synthetic capture turn at stop.
+ * optionally auto-runs a synthetic capture turn. Passive mode is intentionally
+ * prompt-cache neutral: the standing system guidance remains available, but no
+ * hidden mid-session reminder is inserted into the conversation.
  *
  * Installed once per top-level session (taskDepth 0). The subscription lives
  * for the session's lifetime — `newSession` resets the session in place
@@ -14,11 +14,9 @@ import { logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import autolearnGuidance from "../prompts/system/autolearn-guidance.md" with { type: "text" };
 import autolearnGuidanceLearn from "../prompts/system/autolearn-guidance-learn.md" with { type: "text" };
-import autolearnNudge from "../prompts/system/autolearn-nudge.md" with { type: "text" };
 import autolearnNudgeAutoContinue from "../prompts/system/autolearn-nudge-autocontinue.md" with { type: "text" };
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 
-const AUTOLEARN_NUDGE_PASSIVE = autolearnNudge.trim();
 const AUTOLEARN_NUDGE_AUTOCONTINUE = autolearnNudgeAutoContinue.trim();
 const DEFAULT_MIN_TOOL_CALLS = 5;
 
@@ -110,28 +108,21 @@ export class AutoLearnController {
 		// auto-continue would compete with it.
 		if (startedInGoalMode || this.#session.getGoalModeState()?.enabled) return;
 
-		// Auto-run a capture turn only when explicitly enabled; otherwise the
-		// hidden reminder rides the next real turn passively.
-		//
-		// The two paths get DIFFERENT nudge text:
-		// - Auto-continue spawns a synthetic turn with the nudge as its only
-		//   user-role payload, so the prompt must be terminal — it tells the
-		//   agent to capture and STOP, and must not be read as the user's
-		//   reply to any pending question. Without that contract, the agent
-		//   conflates the synthetic prompt with user approval and resumes
-		//   prior work (e.g. commits/pushes an unanswered "want me to push?"
-		//   question — #3504).
-		// - Passive mode appends the nudge to the user's real next message,
-		//   so the agent must answer the user normally and treat the capture
-		//   as additive — not as the whole turn's job.
+		// Auto-run a capture turn only when explicitly enabled. Passive mode used to
+		// queue a hidden custom message for the next real turn, but that mutates the
+		// persisted conversation prefix after providers have cached it. The standing
+		// auto-learn system guidance is stable; keep passive mode to that guidance
+		// so Anthropic prompt-cache prefixes survive long sessions.
 		const autoContinue = this.#settings.get("autolearn.autoContinue") === true;
-		const content = autoContinue ? AUTOLEARN_NUDGE_AUTOCONTINUE : AUTOLEARN_NUDGE_PASSIVE;
+		if (!autoContinue) return;
+
+		const content = AUTOLEARN_NUDGE_AUTOCONTINUE;
 		// Arm suppression synchronously: the synthetic capture turn's agent_end
 		// fires inside sendCustomMessage (before it resolves), so the flag must be
 		// set before then. Disarm when no turn actually started — a deferred/queued
 		// dispatch or a failed send produces no agent_end, and a latched flag would
 		// otherwise swallow the next real stop.
-		if (autoContinue) this.#suppressNext = true;
+		this.#suppressNext = true;
 
 		this.#session
 			.sendCustomMessage(
@@ -141,7 +132,7 @@ export class AutoLearnController {
 					display: false,
 					attribution: "user",
 				},
-				{ deliverAs: "nextTurn", triggerTurn: autoContinue },
+				{ deliverAs: "nextTurn", triggerTurn: true },
 			)
 			.then(started => {
 				if (!started) this.#suppressNext = false;

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -262,6 +262,10 @@ async function runMemoryStartup(options: {
 }): Promise<void> {
 	await runPhase1(options);
 	await runPhase2(options);
+	// Phase 2 may have rewritten `memory_summary.md`; drop the per-session
+	// snapshot so the refresh below picks up the new summary instead of
+	// returning the cached value from the first prompt build.
+	clearMemoryToolDeveloperInstructionsCache(options.session);
 	await options.session.refreshBaseSystemPrompt?.();
 }
 

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -166,6 +166,11 @@ const memoryToolDeveloperInstructionsBySession = new WeakMap<
 	MemoryInstructionSession,
 	CachedMemoryToolDeveloperInstructions
 >();
+const memoryToolDeveloperInstructionsByRoot = new Map<string, MemoryToolDeveloperInstructionsSnapshot | undefined>();
+
+function getMemoryInstructionRoot(agentDir: string, settings: Settings): string {
+	return getMemoryRoot(agentDir, settings.getCwd());
+}
 
 function getMemoryInstructionSessionFile(session: MemoryInstructionSession): string | undefined {
 	return session.sessionManager.getSessionFile() ?? undefined;
@@ -177,7 +182,7 @@ async function readMemoryToolDeveloperInstructionsSnapshot(
 ): Promise<MemoryToolDeveloperInstructionsSnapshot | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+	const memoryRoot = getMemoryInstructionRoot(agentDir, settings);
 
 	let summary = "";
 	try {
@@ -255,8 +260,10 @@ export async function refreshMemoryToolDeveloperInstructionsCacheAfterStartup(
 	const sessionFile = getMemoryInstructionSessionFile(session);
 	const cached = memoryToolDeveloperInstructionsBySession.get(session);
 	const current = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+	const root = getMemoryInstructionRoot(agentDir, settings);
+	const baseline = memoryToolDeveloperInstructionsByRoot.get(root);
 	const cachedLearned = cached && cached.sessionFile === sessionFile ? cached.snapshot?.learned : undefined;
-	const learned = cachedLearned ?? current?.learned ?? "";
+	const learned = cachedLearned ?? baseline?.learned ?? "";
 	const snapshot = current ? { summary: current.summary, learned } : undefined;
 	cacheMemoryToolDeveloperInstructions(session, sessionFile, snapshot, settings);
 }
@@ -271,6 +278,7 @@ export async function buildMemoryToolDeveloperInstructions(
 ): Promise<string | undefined> {
 	if (!session) {
 		const snapshot = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+		memoryToolDeveloperInstructionsByRoot.set(getMemoryInstructionRoot(agentDir, settings), snapshot);
 		return renderMemoryToolDeveloperInstructionsSnapshot(snapshot, settings);
 	}
 

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -147,10 +147,53 @@ export function startMemoryStartupTask(options: {
 	});
 }
 
+interface MemoryInstructionSession {
+	sessionManager: Pick<AgentSession["sessionManager"], "getSessionFile">;
+}
+
+interface CachedMemoryToolDeveloperInstructions {
+	sessionFile: string | undefined;
+	value: string | undefined;
+}
+
+const memoryToolDeveloperInstructionsBySession = new WeakMap<
+	MemoryInstructionSession,
+	CachedMemoryToolDeveloperInstructions
+>();
+
+function getMemoryInstructionSessionFile(session: MemoryInstructionSession): string | undefined {
+	return session.sessionManager.getSessionFile() ?? undefined;
+}
+
+/**
+ * Drop the per-session memory instruction snapshot after explicit memory state
+ * changes that must affect the active conversation immediately, such as
+ * `/memory clear`.
+ */
+export function clearMemoryToolDeveloperInstructionsCache(session: MemoryInstructionSession | undefined): void {
+	if (session) memoryToolDeveloperInstructionsBySession.delete(session);
+}
+
 /**
  * Build memory usage instructions for prompt injection.
  */
 export async function buildMemoryToolDeveloperInstructions(
+	agentDir: string,
+	settings: Settings,
+	session?: MemoryInstructionSession,
+): Promise<string | undefined> {
+	if (!session) return buildMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+
+	const sessionFile = getMemoryInstructionSessionFile(session);
+	const cached = memoryToolDeveloperInstructionsBySession.get(session);
+	if (cached && cached.sessionFile === sessionFile) return cached.value;
+
+	const value = await buildMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+	memoryToolDeveloperInstructionsBySession.set(session, { sessionFile, value });
+	return value;
+}
+
+async function buildMemoryToolDeveloperInstructionsSnapshot(
 	agentDir: string,
 	settings: Settings,
 ): Promise<string | undefined> {

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -151,8 +151,14 @@ interface MemoryInstructionSession {
 	sessionManager: Pick<AgentSession["sessionManager"], "getSessionFile">;
 }
 
+interface MemoryToolDeveloperInstructionsSnapshot {
+	summary: string;
+	learned: string;
+}
+
 interface CachedMemoryToolDeveloperInstructions {
 	sessionFile: string | undefined;
+	snapshot: MemoryToolDeveloperInstructionsSnapshot | undefined;
 	value: string | undefined;
 }
 
@@ -165,38 +171,10 @@ function getMemoryInstructionSessionFile(session: MemoryInstructionSession): str
 	return session.sessionManager.getSessionFile() ?? undefined;
 }
 
-/**
- * Drop the per-session memory instruction snapshot after explicit memory state
- * changes that must affect the active conversation immediately, such as
- * `/memory clear`.
- */
-export function clearMemoryToolDeveloperInstructionsCache(session: MemoryInstructionSession | undefined): void {
-	if (session) memoryToolDeveloperInstructionsBySession.delete(session);
-}
-
-/**
- * Build memory usage instructions for prompt injection.
- */
-export async function buildMemoryToolDeveloperInstructions(
+async function readMemoryToolDeveloperInstructionsSnapshot(
 	agentDir: string,
 	settings: Settings,
-	session?: MemoryInstructionSession,
-): Promise<string | undefined> {
-	if (!session) return buildMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
-
-	const sessionFile = getMemoryInstructionSessionFile(session);
-	const cached = memoryToolDeveloperInstructionsBySession.get(session);
-	if (cached && cached.sessionFile === sessionFile) return cached.value;
-
-	const value = await buildMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
-	memoryToolDeveloperInstructionsBySession.set(session, { sessionFile, value });
-	return value;
-}
-
-async function buildMemoryToolDeveloperInstructionsSnapshot(
-	agentDir: string,
-	settings: Settings,
-): Promise<string | undefined> {
+): Promise<MemoryToolDeveloperInstructionsSnapshot | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
 	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
@@ -209,9 +187,21 @@ async function buildMemoryToolDeveloperInstructionsSnapshot(
 		// so any captured lessons still surface on their own.
 	}
 	const learned = await readLearnedLessons(memoryRoot);
-	if (!summary && !learned) return undefined;
+	return { summary, learned };
+}
 
-	const summaryOut = summary ? truncateByApproxTokens(summary, cfg.summaryInjectionTokenLimit).trim() : "";
+function renderMemoryToolDeveloperInstructionsSnapshot(
+	snapshot: MemoryToolDeveloperInstructionsSnapshot | undefined,
+	settings: Settings,
+): string | undefined {
+	if (!snapshot) return undefined;
+	const cfg = loadMemoryConfig(settings);
+	if (!cfg.enabled) return undefined;
+	if (!snapshot.summary && !snapshot.learned) return undefined;
+
+	const summaryOut = snapshot.summary
+		? truncateByApproxTokens(snapshot.summary, cfg.summaryInjectionTokenLimit).trim()
+		: "";
 	// Lessons share ONE injection budget with the summary so the combined block
 	// stays within `summaryInjectionTokenLimit` (~4 chars/token, matching
 	// truncateByApproxTokens). With no summary, lessons get the whole budget.
@@ -219,13 +209,77 @@ async function buildMemoryToolDeveloperInstructionsSnapshot(
 	// can exceed `limit * 4` chars and drive the remainder negative — when the
 	// summary already fills the budget, lessons are simply dropped.
 	const learnedBudget = Math.max(0, cfg.summaryInjectionTokenLimit - Math.ceil(summaryOut.length / 4));
-	const learnedOut = learned && learnedBudget > 0 ? truncateByApproxTokens(learned, learnedBudget).trim() : "";
+	const learnedOut =
+		snapshot.learned && learnedBudget > 0 ? truncateByApproxTokens(snapshot.learned, learnedBudget).trim() : "";
 	if (!summaryOut && !learnedOut) return undefined;
 
 	return prompt.render(readPathTemplate, {
 		memory_summary: summaryOut,
 		learned: learnedOut,
 	});
+}
+
+function cacheMemoryToolDeveloperInstructions(
+	session: MemoryInstructionSession,
+	sessionFile: string | undefined,
+	snapshot: MemoryToolDeveloperInstructionsSnapshot | undefined,
+	settings: Settings,
+): string | undefined {
+	const value = renderMemoryToolDeveloperInstructionsSnapshot(snapshot, settings);
+	memoryToolDeveloperInstructionsBySession.set(session, { sessionFile, snapshot, value });
+	return value;
+}
+
+/**
+ * Drop the per-session memory instruction snapshot after explicit memory state
+ * changes that must affect the active conversation immediately, such as
+ * `/memory clear`.
+ */
+export function clearMemoryToolDeveloperInstructionsCache(session: MemoryInstructionSession | undefined): void {
+	if (session) memoryToolDeveloperInstructionsBySession.delete(session);
+}
+
+/**
+ * Refresh the active session's consolidated-memory snapshot after startup maintenance.
+ *
+ * Startup may finish after the first prompt build and write `memory_summary.md`;
+ * the active session should see that summary. It must not reread `learned.md`,
+ * because a `learn` call racing with startup belongs to the next session's
+ * memory prompt, not the active prompt-cache prefix.
+ */
+export async function refreshMemoryToolDeveloperInstructionsCacheAfterStartup(
+	session: MemoryInstructionSession,
+	agentDir: string,
+	settings: Settings,
+): Promise<void> {
+	const sessionFile = getMemoryInstructionSessionFile(session);
+	const cached = memoryToolDeveloperInstructionsBySession.get(session);
+	const current = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+	const cachedLearned = cached && cached.sessionFile === sessionFile ? cached.snapshot?.learned : undefined;
+	const learned = cachedLearned ?? current?.learned ?? "";
+	const snapshot = current ? { summary: current.summary, learned } : undefined;
+	cacheMemoryToolDeveloperInstructions(session, sessionFile, snapshot, settings);
+}
+
+/**
+ * Build memory usage instructions for prompt injection.
+ */
+export async function buildMemoryToolDeveloperInstructions(
+	agentDir: string,
+	settings: Settings,
+	session?: MemoryInstructionSession,
+): Promise<string | undefined> {
+	if (!session) {
+		const snapshot = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+		return renderMemoryToolDeveloperInstructionsSnapshot(snapshot, settings);
+	}
+
+	const sessionFile = getMemoryInstructionSessionFile(session);
+	const cached = memoryToolDeveloperInstructionsBySession.get(session);
+	if (cached && cached.sessionFile === sessionFile) return cached.value;
+
+	const snapshot = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
+	return cacheMemoryToolDeveloperInstructions(session, sessionFile, snapshot, settings);
 }
 
 /**
@@ -262,10 +316,7 @@ async function runMemoryStartup(options: {
 }): Promise<void> {
 	await runPhase1(options);
 	await runPhase2(options);
-	// Phase 2 may have rewritten `memory_summary.md`; drop the per-session
-	// snapshot so the refresh below picks up the new summary instead of
-	// returning the cached value from the first prompt build.
-	clearMemoryToolDeveloperInstructionsCache(options.session);
+	await refreshMemoryToolDeveloperInstructionsCacheAfterStartup(options.session, options.agentDir, options.settings);
 	await options.session.refreshBaseSystemPrompt?.();
 }
 

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -1,6 +1,7 @@
 import {
 	buildMemoryToolDeveloperInstructions,
 	clearMemoryData,
+	clearMemoryToolDeveloperInstructionsCache,
 	enqueueMemoryConsolidation,
 	saveLearnedLesson,
 	startMemoryStartupTask,
@@ -20,10 +21,11 @@ export const localBackend: MemoryBackend = {
 	start(options) {
 		startMemoryStartupTask(options);
 	},
-	async buildDeveloperInstructions(agentDir, settings) {
-		return buildMemoryToolDeveloperInstructions(agentDir, settings);
+	async buildDeveloperInstructions(agentDir, settings, session) {
+		return buildMemoryToolDeveloperInstructions(agentDir, settings, session);
 	},
-	async clear(agentDir, cwd) {
+	async clear(agentDir, cwd, session) {
+		clearMemoryToolDeveloperInstructionsCache(session);
 		await clearMemoryData(agentDir, cwd);
 	},
 	async enqueue(agentDir, cwd) {

--- a/packages/coding-agent/src/prompts/system/autolearn-nudge.md
+++ b/packages/coding-agent/src/prompts/system/autolearn-nudge.md
@@ -1,5 +1,0 @@
-Hidden auto-learn reminder (not a user request). If your previous turn produced anything reusable, capture it now with your learning tools — a repeatable procedure becomes a managed skill (`manage_skill`), and a durable fact, convention, or user preference is worth remembering (`learn`, when memory is enabled).
-
-Only capture what will genuinely help next time. If nothing is worth keeping, do nothing.
-
-This reminder is appended to the user's real message; answer that message normally — the capture is in addition to, not a replacement for, the work the user just asked for.

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -64,32 +64,13 @@ function install(session: FakeSession, overrides: Record<string, unknown> = {}):
 }
 
 describe("AutoLearnController", () => {
-	it("fires one passive nudge once the tool-call threshold is met", () => {
+	it("does not inject a passive nudge into the conversation prefix", () => {
 		const session = new FakeSession();
 		install(session);
 		session.toolCalls(5);
 		session.agentEnd();
 
-		expect(session.sent).toHaveLength(1);
-		expect(session.sent[0]?.message.customType).toBe("autolearn-nudge");
-		expect(session.sent[0]?.message.display).toBe(false);
-		expect(session.sent[0]?.options?.deliverAs).toBe("nextTurn");
-		expect(session.sent[0]?.options?.triggerTurn).toBe(false);
-	});
-
-	it("the passive nudge is framed as additive — answer the user, capture alongside", () => {
-		// Passive mode rides the user's real next message, so the nudge must
-		// NOT tell the agent to stop after capturing — the user's message is
-		// the real work. Locking in the content of #3504's fix so a later
-		// edit cannot silently swap the two prompts.
-		const session = new FakeSession();
-		install(session);
-		session.toolCalls(5);
-		session.agentEnd();
-		const body = String(session.sent[0]?.message.content);
-		expect(body).toMatch(/answer that message normally|in addition to|not a replacement/i);
-		expect(body).not.toMatch(/wait for the user'?s next prompt/i);
-		expect(body).not.toMatch(/then stop\.|do not resume prior work/i);
+		expect(session.sent).toHaveLength(0);
 	});
 
 	it("the auto-continue nudge is terminal — capture then stop, never assume approval (#3504)", () => {
@@ -115,7 +96,7 @@ describe("AutoLearnController", () => {
 
 	it("does not nudge below the threshold", () => {
 		const session = new FakeSession();
-		install(session);
+		install(session, { "autolearn.autoContinue": true });
 		session.toolCalls(4);
 		session.agentEnd();
 		expect(session.sent).toHaveLength(0);
@@ -124,14 +105,14 @@ describe("AutoLearnController", () => {
 	it("does not nudge during plan mode", () => {
 		const session = new FakeSession();
 		session.planEnabled = true;
-		install(session);
+		install(session, { "autolearn.autoContinue": true });
 		session.toolCalls(5);
 		session.agentEnd();
 		expect(session.sent).toHaveLength(0);
 	});
 	it("does not combine tool calls across separate sub-threshold turns", () => {
 		const session = new FakeSession();
-		install(session);
+		install(session, { "autolearn.autoContinue": true });
 		session.toolCalls(3);
 		session.agentEnd();
 		session.toolCalls(3);
@@ -143,7 +124,7 @@ describe("AutoLearnController", () => {
 	it("discards plan-mode tool calls instead of leaking them into the next turn", () => {
 		const session = new FakeSession();
 		session.planEnabled = true;
-		install(session);
+		install(session, { "autolearn.autoContinue": true });
 		session.toolCalls(5);
 		session.agentEnd(); // plan mode: no fire, counter reset
 		session.planEnabled = false;
@@ -152,11 +133,11 @@ describe("AutoLearnController", () => {
 		expect(session.sent).toHaveLength(0);
 	});
 
-	it("stops nudging when autolearn is disabled mid-session", () => {
+	it("stops auto-continuing when autolearn is disabled mid-session", () => {
 		const session = new FakeSession();
 		// Enable via the global layer (not an isolated override) so the live flag
 		// can be flipped and the controller's fire-time re-check is exercised.
-		const settings = Settings.isolated({});
+		const settings = Settings.isolated({ "autolearn.autoContinue": true });
 		settings.set("autolearn.enabled", true);
 		new AutoLearnController({ session: session as unknown as AgentSession, settings });
 		session.toolCalls(5);
@@ -192,7 +173,7 @@ describe("AutoLearnController", () => {
 	it("never nudges a turn that started in goal mode even if the goal ended mid-turn", () => {
 		const session = new FakeSession();
 		session.goalEnabled = true;
-		install(session);
+		install(session, { "autolearn.autoContinue": true });
 		// The turn begins as a goal continuation...
 		session.agentStart();
 		session.toolCalls(5);
@@ -262,7 +243,7 @@ describe("AutoLearnController", () => {
 
 	it("respects a custom minToolCalls threshold", () => {
 		const session = new FakeSession();
-		install(session, { "autolearn.minToolCalls": 2 });
+		install(session, { "autolearn.autoContinue": true, "autolearn.minToolCalls": 2 });
 		session.toolCalls(2);
 		session.agentEnd();
 		expect(session.sent).toHaveLength(1);

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
+	clearMemoryToolDeveloperInstructionsCache,
 	getMemoryRoot,
 	saveLearnedLesson,
 } from "@oh-my-pi/pi-coding-agent/memories";
@@ -195,6 +196,24 @@ describe("learned-lesson read-back", () => {
 		await localBackend.clear(agentDir, settings.getCwd(), session as unknown as AgentSession);
 
 		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+	});
+
+	it("refreshes the frozen memory prompt after background consolidation invalidates it", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const session = sessionWithFile("session-consolidate.jsonl");
+		// First build (before background consolidation finishes) snapshots an empty result.
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+
+		// Background pipeline writes the consolidated summary later.
+		const root = getMemoryRoot(agentDir, settings.getCwd());
+		await Bun.write(path.join(root, "memory_summary.md"), "Consolidated guidance here.\n");
+
+		// Without invalidation the cached undefined would stick.
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+
+		clearMemoryToolDeveloperInstructionsCache(session);
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings, session);
+		expect(out).toContain("Consolidated guidance here.");
 	});
 
 	it("injects both the summary and lessons when both exist", async () => {

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -198,13 +198,15 @@ describe("learned-lesson read-back", () => {
 		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
 	});
 
-	it("refreshes consolidated summaries without rereading learned lessons from the active session", async () => {
+	it("uses the pre-session learned snapshot when startup refresh has no session cache yet", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
-		const session = sessionWithFile("session-consolidate.jsonl");
-		// First build (before background consolidation finishes) snapshots an empty learned.md.
-		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Prior-session lesson" });
+		const initial = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+		expect(initial).toContain("Prior-session lesson");
 
-		// The active session learns while the background pipeline is still running.
+		const session = sessionWithFile("session-consolidate.jsonl");
+		// The active session learns while the background pipeline is still running,
+		// before any session-scoped prompt rebuild has populated the WeakMap.
 		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Active-session lesson" });
 		// Background pipeline writes the consolidated summary later.
 		const root = getMemoryRoot(agentDir, settings.getCwd());
@@ -213,6 +215,7 @@ describe("learned-lesson read-back", () => {
 		await refreshMemoryToolDeveloperInstructionsCacheAfterStartup(session, agentDir, settings);
 		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings, session);
 		expect(out).toContain("Consolidated guidance here.");
+		expect(out).toContain("Prior-session lesson");
 		expect(out).not.toContain("Active-session lesson");
 
 		const nextSession = sessionWithFile("session-after-consolidate.jsonl");

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -9,6 +9,7 @@ import {
 	saveLearnedLesson,
 } from "@oh-my-pi/pi-coding-agent/memories";
 import { localBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/local-backend";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { LearnTool } from "@oh-my-pi/pi-coding-agent/tools/learn";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -157,12 +158,43 @@ describe("learned-lesson read-back", () => {
 		await removeWithRetries(tmp);
 	});
 
+	function sessionWithFile(sessionFile: string) {
+		return {
+			sessionManager: {
+				getSessionFile: () => sessionFile,
+			},
+		};
+	}
+
 	it("injects lessons even when no consolidated summary exists", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "File-backed lesson" });
 		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 		expect(out).toContain("Learned lessons");
 		expect(out).toContain("- File-backed lesson");
+	});
+
+	it("keeps a session's memory prompt stable after a learned lesson is written", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const session = sessionWithFile("session-1.jsonl");
+
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Later session only" });
+
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
+		const nextSession = sessionWithFile("session-2.jsonl");
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings, nextSession);
+		expect(out).toContain("- Later session only");
+	});
+
+	it("refreshes the frozen memory prompt after explicit memory clear", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const session = sessionWithFile("session-clear.jsonl");
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Clearable lesson" });
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toContain("Clearable lesson");
+		await localBackend.clear(agentDir, settings.getCwd(), session as unknown as AgentSession);
+
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
 	});
 
 	it("injects both the summary and lessons when both exist", async () => {

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -5,8 +5,8 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
-	clearMemoryToolDeveloperInstructionsCache,
 	getMemoryRoot,
+	refreshMemoryToolDeveloperInstructionsCacheAfterStartup,
 	saveLearnedLesson,
 } from "@oh-my-pi/pi-coding-agent/memories";
 import { localBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/local-backend";
@@ -198,22 +198,27 @@ describe("learned-lesson read-back", () => {
 		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
 	});
 
-	it("refreshes the frozen memory prompt after background consolidation invalidates it", async () => {
+	it("refreshes consolidated summaries without rereading learned lessons from the active session", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		const session = sessionWithFile("session-consolidate.jsonl");
-		// First build (before background consolidation finishes) snapshots an empty result.
+		// First build (before background consolidation finishes) snapshots an empty learned.md.
 		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
 
+		// The active session learns while the background pipeline is still running.
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Active-session lesson" });
 		// Background pipeline writes the consolidated summary later.
 		const root = getMemoryRoot(agentDir, settings.getCwd());
 		await Bun.write(path.join(root, "memory_summary.md"), "Consolidated guidance here.\n");
 
-		// Without invalidation the cached undefined would stick.
-		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings, session)).toBeUndefined();
-
-		clearMemoryToolDeveloperInstructionsCache(session);
+		await refreshMemoryToolDeveloperInstructionsCacheAfterStartup(session, agentDir, settings);
 		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings, session);
 		expect(out).toContain("Consolidated guidance here.");
+		expect(out).not.toContain("Active-session lesson");
+
+		const nextSession = sessionWithFile("session-after-consolidate.jsonl");
+		const nextOut = await buildMemoryToolDeveloperInstructions(agentDir, settings, nextSession);
+		expect(nextOut).toContain("Consolidated guidance here.");
+		expect(nextOut).toContain("Active-session lesson");
 	});
 
 	it("injects both the summary and lessons when both exist", async () => {


### PR DESCRIPTION
## Repro
The failing scenario is an Anthropic session with `autolearn.enabled: true`, `autolearn.autoContinue: false`, and `memory.backend: local`: after a qualifying turn, passive autolearn queued a hidden `autolearn-nudge` custom message, and after `learn` wrote a lesson, a prompt rebuild read the updated `learned.md` into developer instructions. I reproduced the two paths with `bun test packages/coding-agent/test/autolearn-controller.test.ts -t passive` and `bun test packages/coding-agent/test/autolearn-learn-local.test.ts -t read-back` before the fix.

## Cause
`packages/coding-agent/src/autolearn/controller.ts` sent passive reminders through `AgentSession.sendCustomMessage(..., { deliverAs: "nextTurn" })`, adding a new hidden conversation entry after a provider had cached the existing prefix. Separately, `packages/coding-agent/src/memories/index.ts` rebuilt local memory developer instructions from `learned.md` on every prompt refresh, so `LearnTool` writes changed the active session's `<memories>` block instead of deferring the new lesson to a future session.

## Fix
- Removed passive autolearn custom-message injection; passive mode now relies on stable standing autolearn guidance, while `autolearn.autoContinue` keeps its explicit synthetic capture turn.
- Froze local memory developer instructions per session file, so `learn` writes remain durable but do not mutate the active session prompt prefix.
- Invalidated the frozen local memory prompt only for explicit `/memory clear`-style clears.
- Added regression coverage for passive nudge suppression and per-session learned-memory prompt stability.

## Verification
`bun test packages/coding-agent/test/autolearn-controller.test.ts packages/coding-agent/test/autolearn-learn-local.test.ts` passed with 39 tests. `bun check` passed. Fixes #3743