### PR TITLE
fix(task): scoped provider concurrency cap to each LLM turn

### DIFF
--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -5,7 +5,7 @@
  * a summary of the branch being left so context isn't lost.
  */
 
-import type { ApiKey, Model } from "@oh-my-pi/pi-ai";
+import type { Api, ApiKey, AssistantMessage, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
@@ -88,6 +88,17 @@ export interface GenerateBranchSummaryOptions {
 	 * wrapped in an OTEL chat span tagged with `pi.gen_ai.oneshot.kind = "branch_summary"`.
 	 */
 	telemetry?: AgentTelemetry;
+	/**
+	 * Optional completion transport override (same contract as
+	 * {@link SummaryOptions.completeImpl}). Lets the host route the branch
+	 * summary HTTP request through its provider-concurrency limiter instead
+	 * of the default `completeSimple` transport.
+	 */
+	completeImpl?: <TApi extends Api>(
+		model: Model<TApi>,
+		ctx: Context,
+		options: SimpleStreamOptions,
+	) => Promise<AssistantMessage>;
 }
 
 // ============================================================================
@@ -310,7 +321,7 @@ export async function generateBranchSummary(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
 		{ apiKey, signal, maxTokens: 2048, metadata },
-		{ telemetry: options.telemetry, oneshotKind: "branch_summary" },
+		{ telemetry: options.telemetry, oneshotKind: "branch_summary", completeImpl: options.completeImpl },
 	);
 
 	// Check if aborted or errored

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+	type Api,
 	type ApiKey,
 	type AssistantMessage,
 	type Context,
@@ -828,6 +829,12 @@ export interface HandoffFromContextOptions {
 	 * anything provided here.
 	 */
 	streamOptions: SimpleStreamOptions;
+	/** Optional completion transport override for host-level request wrappers. */
+	completeImpl?: <TApi extends Api>(
+		model: Model<TApi>,
+		ctx: Context,
+		options: SimpleStreamOptions,
+	) => Promise<AssistantMessage>;
 	/** See {@link HandoffOptions.telemetry}. */
 	telemetry?: AgentTelemetry;
 	/** See {@link HandoffOptions.thinkingLevel}. */
@@ -859,7 +866,7 @@ export async function generateHandoffFromContext(
 			reasoning: resolveCompactionEffort(model, options.thinkingLevel),
 			toolChoice: "none",
 		},
-		{ telemetry: options.telemetry, oneshotKind: "handoff" },
+		{ telemetry: options.telemetry, oneshotKind: "handoff", completeImpl: options.completeImpl },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -680,6 +680,19 @@ export interface SummaryOptions {
 	tools?: Tool[];
 	/** Optional fetch implementation threaded into remote compaction calls. */
 	fetch?: FetchImpl;
+	/**
+	 * Optional completion transport override for host-level request wrappers
+	 * (e.g. the coding-agent provider-concurrency limiter). When provided,
+	 * every local summarization oneshot (`generateSummary`,
+	 * `generateTurnPrefixSummary`, `generateShortSummary`) routes through it
+	 * instead of the default `completeSimple`, so cap policies enforced on
+	 * the live agent turn also bracket compaction HTTP requests.
+	 */
+	completeImpl?: <TApi extends Api>(
+		model: Model<TApi>,
+		ctx: Context,
+		options: SimpleStreamOptions,
+	) => Promise<AssistantMessage>;
 }
 
 function formatPreviousSnapcompactArchive(archiveText: string): string {
@@ -769,7 +782,7 @@ export async function generateSummary(
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_summary" },
+		{ telemetry: options?.telemetry, oneshotKind: "compaction_summary", completeImpl: options?.completeImpl },
 	);
 
 	if (response.stopReason === "error") {
@@ -960,7 +973,7 @@ async function generateShortSummary(
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_short_summary" },
+		{ telemetry: options?.telemetry, oneshotKind: "compaction_short_summary", completeImpl: options?.completeImpl },
 	);
 
 	if (response.stopReason === "error") {
@@ -1229,6 +1242,7 @@ export async function compact(
 		promptCacheKey: options?.promptCacheKey,
 		tools: options?.tools,
 		fetch: options?.fetch,
+		completeImpl: options?.completeImpl,
 	};
 
 	const previousSnapcompactArchive = snapcompact.getPreservedArchive(previousPreserveData);
@@ -1413,6 +1427,7 @@ export async function compact(
 				// resolves its own reasoning via resolveCompactionEffort.
 				thinkingLevel: options?.thinkingLevel,
 				fetch: summaryOptions.fetch,
+				completeImpl: summaryOptions.completeImpl,
 			});
 
 	// Compute file lists and append to summary
@@ -1476,7 +1491,7 @@ async function generateTurnPrefixSummary(
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_turn_prefix" },
+		{ telemetry: options?.telemetry, oneshotKind: "compaction_turn_prefix", completeImpl: options?.completeImpl },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed recoverable context-overflow compaction keeping the failed assistant error turn in visible session history after scheduling the retry. ([#3747](https://github.com/can1357/oh-my-pi/issues/3747))
+- Fixed the per-provider concurrency cap (e.g. `providers.ollama-cloud.maxConcurrency`) bracketing the whole subagent lifecycle, which deadlocked any spawn tree wider than the cap because parents held every slot while waiting for children queued on the same cap. The semaphore now wraps each provider HTTP request, so a parent's slot frees between turns and child subagents can acquire while their parent's tool calls are running. ([#3749](https://github.com/can1357/oh-my-pi/issues/3749))
 
 ## [16.2.4] - 2026-06-28
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2536,13 +2536,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// One-shot launch-latency marker: fired the first time the loop dispatches
 		// a chat request to the provider transport. See onFirstChatDispatch.
 		let notifyFirstChatDispatch = options.onFirstChatDispatch;
-		// Shared, settings-aware stream wrapper used by both the main agent and
-		// the advisor (via AgentSessionConfig.streamFn). Keeps OpenRouter
-		// sticky-routing variants, antigravity endpoint routing, in-flight caps,
-		// and the loop guard consistent across every agent the session drives.
-		// Wrapped in a per-provider concurrency limiter so each LLM HTTP request
-		// — not the whole subagent lifecycle — holds the slot, preventing the
-		// nested-spawn deadlock from issue #3749.
+		// Shared, settings-aware stream wrapper used by the main agent, advisor,
+		// and side-channel requests (`/btw`, `/omfg`, IRC auto-replies, handoff).
+		// Keeps OpenRouter sticky-routing variants, antigravity endpoint routing,
+		// in-flight caps, and the loop guard consistent across every provider call
+		// the session drives. Wrapped in a per-provider concurrency limiter so
+		// each LLM HTTP request — not the whole subagent lifecycle — holds the
+		// slot, preventing the nested-spawn deadlock from issue #3749.
 		const settingsAwareStreamFn = wrapStreamFnWithProviderConcurrency(
 			settings,
 			createSettingsAwareStreamFn(settings),
@@ -2716,6 +2716,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			transformProviderContext,
 			onPayload,
 			onResponse,
+			sideStreamFn: settingsAwareStreamFn,
 			advisorStreamFn: settingsAwareStreamFn,
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -130,6 +130,7 @@ import {
 	loadProjectContextFiles as loadContextFilesInternal,
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
+import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -2539,7 +2540,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// the advisor (via AgentSessionConfig.streamFn). Keeps OpenRouter
 		// sticky-routing variants, antigravity endpoint routing, in-flight caps,
 		// and the loop guard consistent across every agent the session drives.
-		const settingsAwareStreamFn = createSettingsAwareStreamFn(settings);
+		// Wrapped in a per-provider concurrency limiter so each LLM HTTP request
+		// — not the whole subagent lifecycle — holds the slot, preventing the
+		// nested-spawn deadlock from issue #3749.
+		const settingsAwareStreamFn = wrapStreamFnWithProviderConcurrency(
+			settings,
+			createSettingsAwareStreamFn(settings),
+		);
 		agent = new Agent({
 			initialState: {
 				systemPrompt,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10726,6 +10726,18 @@ export class AgentSession {
 						tools: this.agent.state.tools,
 						sessionId: this.sessionId,
 						promptCacheKey: this.sessionId,
+						// Route every summarization HTTP request through the
+						// session's side-stream transport so the provider
+						// concurrency cap (e.g. providers.ollama-cloud.maxConcurrency)
+						// brackets compaction the same way it brackets the live
+						// agent turn — without this, multiple ollama-cloud
+						// subagents auto/manually compacting issued uncapped
+						// summary requests in parallel (chatgpt-codex review on
+						// #3751).
+						completeImpl: async (requestModel, requestContext, requestOptions) => {
+							const stream = await this.#sideStreamFn(requestModel, requestContext, requestOptions);
+							return stream.result();
+						},
 					},
 				);
 			} catch (error) {
@@ -13554,6 +13566,12 @@ export class AgentSession {
 				metadata: this.agent.metadataForProvider(model.provider),
 				convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 				telemetry: resolveTelemetry(this.agent.telemetry, this.sessionId),
+				// Same per-provider concurrency cap rationale as the compaction
+				// path above (chatgpt-codex review on #3751).
+				completeImpl: async (requestModel, requestContext, requestOptions) => {
+					const stream = await this.#sideStreamFn(requestModel, requestContext, requestOptions);
+					return stream.result();
+				},
 			});
 			this.#branchSummaryAbortController = undefined;
 			if (result.aborted) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -535,6 +535,13 @@ export interface AgentSessionConfig {
 	 */
 	transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
 	/**
+	 * Stream wrapper passed to side-channel requests (`/btw`, `/omfg`, IRC
+	 * auto-replies, and handoff generation) so they apply the same provider
+	 * shaping and host-level request wrappers as normal agent turns. Defaults
+	 * to plain `streamSimple` when omitted.
+	 */
+	sideStreamFn?: StreamFn;
+	/**
 	 * Stream wrapper passed to the advisor agent so its requests apply the
 	 * session's `providers.openrouterVariant`, `providers.antigravityEndpoint`,
 	 * `providers.maxInFlightRequests`, and `model.loopGuard.*` settings —
@@ -1459,6 +1466,7 @@ export class AgentSession {
 	#onResponse: SimpleStreamOptions["onResponse"] | undefined;
 	#onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	#transformProviderContext: ((context: Context, model: Model) => Context | Promise<Context>) | undefined;
+	#sideStreamFn: StreamFn;
 	#advisorStreamFn: StreamFn | undefined;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	#rebuildSystemPrompt:
@@ -1788,6 +1796,7 @@ export class AgentSession {
 		this.#requestedToolNames = config.requestedToolNames;
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#transformProviderContext = config.transformProviderContext;
+		this.#sideStreamFn = config.sideStreamFn ?? streamSimple;
 		this.#advisorStreamFn = config.advisorStreamFn;
 		this.#onPayload = config.onPayload;
 		this.rawSseDebugBuffer = config.rawSseDebugBuffer ?? new RawSseDebugBuffer();
@@ -9195,6 +9204,10 @@ export class AgentSession {
 				model,
 				{
 					streamOptions: handoffStreamOptions,
+					completeImpl: async (requestModel, requestContext, requestOptions) => {
+						const stream = await this.#sideStreamFn(requestModel, requestContext, requestOptions);
+						return stream.result();
+					},
 					telemetry: resolveTelemetry(this.agent.telemetry, this.sessionId),
 					// Honor the user's /model thinking selection on the handoff path.
 					// Clamped per-model inside generateHandoffFromContext via
@@ -12923,7 +12936,7 @@ export class AgentSession {
 		let providerReplyText = "";
 		let emittedReplyText = "";
 		let assistantMessage: AssistantMessage | undefined;
-		const stream = streamSimple(model, obfuscateProviderContext(this.#obfuscator, context), options);
+		const stream = await this.#sideStreamFn(model, obfuscateProviderContext(this.#obfuscator, context), options);
 		for await (const event of stream) {
 			if (event.type === "text_delta") {
 				providerReplyText += event.delta;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -56,7 +56,6 @@ import { ToolAbortError } from "../tools/tool-errors";
 import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
-import { Semaphore } from "./parallel";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import {
 	type AgentDefinition,
@@ -197,51 +196,6 @@ function installSubagentRetryFallbackChain(args: {
 	}
 	settings.override("retry.fallbackChains", fallbackChains);
 	return role;
-}
-
-const PROVIDER_MAX_CONCURRENCY_SETTINGS: Record<string, SettingPath> = {
-	"ollama-cloud": "providers.ollama-cloud.maxConcurrency",
-};
-
-interface ProviderSemaphoreEntry {
-	limit: number;
-	semaphore: Semaphore;
-}
-
-const providerSemaphores = new Map<string, ProviderSemaphoreEntry>();
-
-/**
- * Resolve the configured concurrency ceiling for a provider, or `undefined`
- * when the provider has no cap concept at all. A configured value `<= 0` means
- * "unlimited" and maps to `Infinity` — still a tracked ceiling, so every run
- * holds a slot and a later finite resize counts work started while unlimited.
- */
-function getProviderConcurrencyLimit(settings: Settings, provider: string): number | undefined {
-	const settingPath = PROVIDER_MAX_CONCURRENCY_SETTINGS[provider];
-	if (!settingPath) return undefined;
-	const raw = settings.get(settingPath);
-	const limit = Number.isFinite(raw) ? Math.trunc(raw) : 0;
-	return limit > 0 ? limit : Number.POSITIVE_INFINITY;
-}
-
-function getProviderSemaphore(settings: Settings, provider: string): Semaphore | undefined {
-	const limit = getProviderConcurrencyLimit(settings, provider);
-	if (limit === undefined) return undefined;
-	// Always hand out (and acquire on) the single shared limiter, even when
-	// unlimited (Infinity). Resizing it in place — rather than replacing it —
-	// keeps every in-flight slot counted, so a runtime or mixed limit change can
-	// never push concurrency past the cap (issue #3464 review feedback).
-	const existing = providerSemaphores.get(provider);
-	if (existing) {
-		if (existing.limit !== limit) {
-			existing.limit = limit;
-			existing.semaphore.resize(limit);
-		}
-		return existing.semaphore;
-	}
-	const semaphore = new Semaphore(limit);
-	providerSemaphores.set(provider, { limit, semaphore });
-	return semaphore;
 }
 
 function renderIrcPeerRoster(selfId: string): string {
@@ -2028,8 +1982,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		let sessionOpenedAt: number | undefined;
 		let sessionCreatedAt: number | undefined;
 		let readyAt: number | undefined;
-		let providerSemaphore: Semaphore | undefined;
-		let providerSemaphoreAcquired = false;
 
 		try {
 			checkAbort();
@@ -2098,13 +2050,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? resolvedThinkingLevel
 				: (thinkingLevel ?? resolvedThinkingLevel);
 			resolvedAt = performance.now();
-			if (model) {
-				providerSemaphore = getProviderSemaphore(settings, model.provider);
-				if (providerSemaphore) {
-					await providerSemaphore.acquire(abortSignal);
-					providerSemaphoreAcquired = true;
-				}
-			}
 
 			const effectiveCwd = worktree ?? cwd;
 			const sessionManager = sessionFile
@@ -2395,10 +2340,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				}
 				if (exitCode === 0) exitCode = 1;
 			}
-			if (providerSemaphoreAcquired) {
-				providerSemaphore?.release();
-				providerSemaphoreAcquired = false;
-			}
 			sessionAbortController.abort();
 			try {
 				await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
@@ -2429,9 +2370,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		}
 
 		// Launch-latency breakdown (subagent invocation → first chat dispatch).
-		// Phase deltas are performance.now() spans; the semaphore brackets use the
-		// Date.now epochs captured by the spawn site (invokedAt before acquire,
-		// acquiredAt after) so queue wait and pre-run setup are reported apart.
+		// Phase deltas are performance.now() spans; the task-tool concurrency
+		// brackets use the Date.now epochs captured by the spawn site
+		// (invokedAt before acquire, acquiredAt after) so queue wait and
+		// pre-run setup are reported apart.
 		const span = (from: number | undefined, to: number | undefined): number | undefined =>
 			from !== undefined && to !== undefined ? Math.round(to - from) : undefined;
 		const queueMs =

--- a/packages/coding-agent/src/task/provider-concurrency.ts
+++ b/packages/coding-agent/src/task/provider-concurrency.ts
@@ -1,0 +1,100 @@
+/**
+ * Per-provider LLM concurrency cap, applied around each provider HTTP request.
+ *
+ * The semaphore brackets only the streaming request itself, not the whole
+ * agent lifetime: a parent subagent releases its slot the moment its LLM
+ * stream finishes producing, so children spawned during tool execution can
+ * acquire slots for their own turns. Holding the slot across the parent's
+ * full conversation deadlocks any spawn tree whose width exceeds
+ * `maxConcurrency` because the parents wait for children that wait for
+ * slots the parents are holding (issue
+ * [#3749](https://github.com/can1357/oh-my-pi/issues/3749)).
+ */
+
+import type { StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { Settings } from "../config/settings";
+import type { SettingPath } from "../config/settings-schema";
+import { Semaphore } from "./parallel";
+
+const PROVIDER_MAX_CONCURRENCY_SETTINGS: Record<string, SettingPath> = {
+	"ollama-cloud": "providers.ollama-cloud.maxConcurrency",
+};
+
+interface ProviderSemaphoreEntry {
+	limit: number;
+	semaphore: Semaphore;
+}
+
+const providerSemaphores = new Map<string, ProviderSemaphoreEntry>();
+
+/**
+ * Resolve the configured concurrency ceiling for a provider, or `undefined`
+ * when the provider has no cap concept at all. A configured value `<= 0` means
+ * "unlimited" and maps to `Infinity` — still a tracked ceiling, so every run
+ * holds a slot and a later finite resize counts work started while unlimited.
+ */
+export function getProviderConcurrencyLimit(settings: Settings, provider: string): number | undefined {
+	const settingPath = PROVIDER_MAX_CONCURRENCY_SETTINGS[provider];
+	if (!settingPath) return undefined;
+	const raw = settings.get(settingPath);
+	const limit = Number.isFinite(raw) ? Math.trunc(raw) : 0;
+	return limit > 0 ? limit : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Hand out the single shared limiter for `provider` (creating one lazily) and
+ * resize it in place when the configured limit changes. Replacing the
+ * semaphore would orphan in-flight slots on the old instance and let a
+ * runtime or mixed limit value exceed the cap (issue #3464 review feedback).
+ */
+export function getProviderSemaphore(settings: Settings, provider: string): Semaphore | undefined {
+	const limit = getProviderConcurrencyLimit(settings, provider);
+	if (limit === undefined) return undefined;
+	const existing = providerSemaphores.get(provider);
+	if (existing) {
+		if (existing.limit !== limit) {
+			existing.limit = limit;
+			existing.semaphore.resize(limit);
+		}
+		return existing.semaphore;
+	}
+	const semaphore = new Semaphore(limit);
+	providerSemaphores.set(provider, { limit, semaphore });
+	return semaphore;
+}
+
+/**
+ * Wrap a {@link StreamFn} so every LLM HTTP request acquires the provider's
+ * concurrency slot before the request goes out and releases it when the
+ * stream finishes producing (success, error, or abort). Providers without a
+ * configured cap pass straight through.
+ *
+ * The acquire bracket is intentionally narrow (one slot per LLM call), so
+ * spawn trees deeper than `maxConcurrency` no longer deadlock on themselves —
+ * see the module-level comment for the failure mode this fixes.
+ */
+export function wrapStreamFnWithProviderConcurrency(settings: Settings, base: StreamFn): StreamFn {
+	return async (model, context, options) => {
+		const semaphore = getProviderSemaphore(settings, model.provider);
+		if (!semaphore) return base(model, context, options);
+		await semaphore.acquire(options?.signal);
+		let released = false;
+		const release = () => {
+			if (released) return;
+			released = true;
+			semaphore.release();
+		};
+		try {
+			const stream = await base(model, context, options);
+			// EventStream.result() settles when the producer pushes 'done'/'error'
+			// or calls fail() — i.e. once the provider has finished producing.
+			// Releasing here keeps the slot held for the network request and
+			// nothing else.
+			stream.result().then(release, release);
+			return stream;
+		} catch (err) {
+			release();
+			throw err;
+		}
+	};
+}

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, type StreamFn } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, Model, ToolCall } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -154,6 +155,76 @@ describe("AgentSession handoff", () => {
 		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(0);
 		expect(events.filter(event => event.type === "auto_compaction_end")).toHaveLength(0);
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
+	});
+
+	it("runs handoff generation through the configured side stream function", async () => {
+		const handoffText = "## Goal\nContinue via side stream";
+		let sideStreamCalls = 0;
+		let capturedSideSessionId: string | undefined;
+		const sideStreamFn: StreamFn = (requestModel, _context, options) => {
+			sideStreamCalls++;
+			capturedSideSessionId = options?.sessionId;
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: handoffText }],
+					api: requestModel.api,
+					provider: requestModel.provider,
+					model: requestModel.id,
+					stopReason: "stop",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: Date.now(),
+				};
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		};
+		await session.dispose();
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": true,
+				"compaction.autoContinue": false,
+			}),
+			modelRegistry,
+			obfuscator,
+			sideStreamFn,
+		});
+		const preHandoffSessionId = session.sessionId;
+
+		const generateHandoffSpy = vi
+			.spyOn(compactionModule, "generateHandoffFromContext")
+			.mockImplementation(async (context, requestModel, options) => {
+				expect(options.completeImpl).toBeDefined();
+				const message = await options.completeImpl!(requestModel, context, options.streamOptions);
+				return message.content
+					.filter(block => block.type === "text")
+					.map(block => block.text)
+					.join("\n");
+			});
+
+		const result = await session.handoff();
+
+		expect(generateHandoffSpy).toHaveBeenCalledTimes(1);
+		expect(result?.document).toBe(handoffText);
+		expect(sideStreamCalls).toBe(1);
+		expect(capturedSideSessionId).toStartWith(`${preHandoffSessionId}:side:`);
 	});
 
 	it("preserves queued steering and follow-up messages across the handoff reset", async () => {

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { Agent, type AgentMessage, type AgentTool, AppendOnlyContextManager } from "@oh-my-pi/pi-agent-core";
+import {
+	Agent,
+	type AgentMessage,
+	type AgentTool,
+	AppendOnlyContextManager,
+	type StreamFn,
+} from "@oh-my-pi/pi-agent-core";
 import {
 	type Api,
 	type Context,
@@ -276,6 +282,55 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.sessionId).toStartWith(`${cacheSessionId}:side:`);
 		expect(capturedOptions?.sessionId).not.toBe(cacheSessionId);
 		expect(capturedOptions?.preferWebsockets).toBe(false);
+	});
+
+	it("runs ephemeral side-channel requests through the configured side stream function", async () => {
+		const model = buildModel({
+			id: "side-stream-model",
+			name: "Side Stream Model",
+			api: "anthropic",
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		let capturedOptions: SimpleStreamOptions | undefined;
+		let capturedContext: Context | undefined;
+		const sideStreamFn: StreamFn = (_model, context, options) => {
+			capturedContext = context;
+			capturedOptions = options;
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("Side answer");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "Side answer", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		};
+		const session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["system prompt"],
+					messages: [],
+					tools: [],
+				},
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: createModelRegistryStub() as never,
+			sideStreamFn,
+		});
+		sessions.push(session);
+
+		const result = await session.runEphemeralTurn({ promptText: "Question?" });
+
+		expect(result.replyText).toBe("Side answer");
+		expect(capturedContext?.messages.at(-1)?.content).toEqual([{ type: "text", text: "Question?" }]);
+		expect(capturedOptions?.sessionId).toStartWith(`${session.sessionId}:side:`);
 	});
 
 	it("rotates ephemeral side-channel credentials on Google Resource exhausted", async () => {

--- a/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
+++ b/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
@@ -1,30 +1,18 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import { Agent, type StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
-import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
-import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
-import {
-	AgentSession,
-	type AgentSessionEvent,
-	type PromptOptions,
-} from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import { Semaphore } from "@oh-my-pi/pi-coding-agent/task/parallel";
-import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
-import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { wrapStreamFnWithProviderConcurrency } from "@oh-my-pi/pi-coding-agent/task/provider-concurrency";
 import { TempDir } from "@oh-my-pi/pi-utils";
-
-type MockPromptSession = AgentSession & {
-	emit(event: AgentSessionEvent): void;
-};
 
 interface Deferred {
 	promise: Promise<void>;
@@ -36,63 +24,11 @@ function deferred(): Deferred {
 	return { promise, resolve };
 }
 
-function createSessionResult(session: AgentSession): CreateAgentSessionResult {
-	return {
-		session,
-		extensionsResult: { extensions: [], errors: [], runtime: {} as unknown } as LoadExtensionsResult,
-		setToolUIContext: () => {},
-		eventBus: new EventBus(),
-	};
-}
-
-function createGateSession(onPrompt: () => Promise<void>): MockPromptSession {
-	const listeners: Array<(event: AgentSessionEvent) => void> = [];
-	const session = {
-		agent: { state: { systemPrompt: ["test"] } },
-		state: { messages: [] },
-		extensionRunner: undefined,
-		sessionManager: { appendSessionInit: () => {} },
-		getActiveToolNames: () => ["yield"],
-		setActiveToolsByName: async () => {},
-		subscribe: (listener: (event: AgentSessionEvent) => void) => {
-			listeners.push(listener);
-			return () => {};
-		},
-		prompt: async (_text: string, _options?: PromptOptions) => {
-			await onPrompt();
-			for (const listener of listeners) {
-				listener({
-					type: "tool_execution_end",
-					toolCallId: "tool-yield",
-					toolName: "yield",
-					result: { content: [{ type: "text", text: "Result submitted." }], details: { status: "success" } },
-					isError: false,
-				});
-			}
-		},
-		waitForIdle: async () => {},
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
-		emit: (event: AgentSessionEvent) => {
-			for (const listener of listeners) listener(event);
-		},
-	};
-	return session as unknown as MockPromptSession;
-}
-
 function requireModel(provider: GeneratedProvider, id: string): Model {
 	const model = getBundledModel(provider, id);
 	if (!model) throw new Error(`Expected bundled model ${provider}/${id}`);
 	return model;
 }
-
-const taskAgent: AgentDefinition = {
-	name: "task",
-	description: "General task agent",
-	systemPrompt: "test",
-	source: "bundled",
-};
 
 describe("issue #3464: ollama-cloud task backoff", () => {
 	let tempDir: TempDir;
@@ -161,62 +97,76 @@ describe("issue #3464: ollama-cloud task backoff", () => {
 		expect(session.model?.id).toBe(fallback.id);
 	});
 
-	it("bounds concurrent subagent runs by the resolved ollama-cloud provider limit", async () => {
+	it("bounds concurrent ollama-cloud LLM streams by the configured maxConcurrency", async () => {
 		const cloudModel = requireModel("ollama-cloud", "gpt-oss:120b");
-		const started: string[] = [];
-		const gates = new Map<string, Deferred>();
-		const firstStarted = deferred();
-		const secondStarted = deferred();
-		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
-			const id = options?.agentId ?? "unknown";
-			const gate = deferred();
-			gates.set(id, gate);
-			return createSessionResult(
-				createGateSession(async () => {
-					started.push(id);
-					if (id === "CloudOne") firstStarted.resolve();
-					if (id === "CloudTwo") secondStarted.resolve();
-					await gate.promise;
-				}),
-			);
-		});
 		const settings = Settings.isolated({
-			"providers.ollama-cloud.maxConcurrency": 1,
+			"providers.ollama-cloud.maxConcurrency": 2,
 		});
 
-		const first = runSubprocess({
-			cwd: "/tmp",
-			agent: taskAgent,
-			task: "first",
-			index: 0,
-			id: "CloudOne",
-			modelOverride: `${cloudModel.provider}/${cloudModel.id}`,
-			settings,
-			modelRegistry,
-			enableLsp: false,
-		});
-		const second = runSubprocess({
-			cwd: "/tmp",
-			agent: taskAgent,
-			task: "second",
-			index: 1,
-			id: "CloudTwo",
-			modelOverride: `${cloudModel.provider}/${cloudModel.id}`,
-			settings,
-			modelRegistry,
-			enableLsp: false,
-		});
+		let inFlight = 0;
+		let peakInFlight = 0;
+		let invocations = 0;
+		const gates: Deferred[] = [];
+		const base: StreamFn = model => {
+			const gate = deferred();
+			gates.push(gate);
+			invocations++;
+			inFlight++;
+			peakInFlight = Math.max(peakInFlight, inFlight);
+			const stream = new AssistantMessageEventStream();
+			void gate.promise.then(() => {
+				inFlight--;
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				stream.push({ type: "done", reason: "stop", message });
+				stream.end();
+			});
+			return stream;
+		};
+		const wrapped = wrapStreamFnWithProviderConcurrency(settings, base);
 
-		await firstStarted.promise;
-		expect(started).toEqual(["CloudOne"]);
-		expect(gates.has("CloudTwo")).toBe(false);
+		const waitForInvocations = async (target: number): Promise<void> => {
+			for (let i = 0; i < 1000 && invocations < target; i++) {
+				await Promise.resolve();
+			}
+			expect(invocations).toBe(target);
+		};
 
-		gates.get("CloudOne")?.resolve();
-		await first;
-		await secondStarted.promise;
-		expect(started).toEqual(["CloudOne", "CloudTwo"]);
-		gates.get("CloudTwo")?.resolve();
-		await second;
+		const calls = Array.from({ length: 4 }, async () => wrapped(cloudModel, { messages: [] }, {}));
+		// Two slots admit two calls; the next two queue behind them.
+		await waitForInvocations(2);
+		expect(inFlight).toBe(2);
+
+		// Release the first slot; exactly one queued waiter is admitted.
+		gates[0]!.resolve();
+		await waitForInvocations(3);
+		expect(inFlight).toBe(2);
+		expect(peakInFlight).toBe(2);
+
+		gates[1]!.resolve();
+		await waitForInvocations(4);
+		expect(inFlight).toBe(2);
+
+		gates[2]!.resolve();
+		gates[3]!.resolve();
+		await Promise.all(calls);
+		expect(inFlight).toBe(0);
+		expect(peakInFlight).toBe(2);
 	});
 
 	it("frees a queued slot when its acquire waiter is aborted", async () => {

--- a/packages/coding-agent/test/issue-3749-provider-semaphore-deadlock.test.ts
+++ b/packages/coding-agent/test/issue-3749-provider-semaphore-deadlock.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression for [#3749](https://github.com/can1357/oh-my-pi/issues/3749):
+ * the per-provider concurrency cap used to bracket the whole subagent
+ * lifecycle (acquired before session creation, released only after the
+ * subagent yielded), so any spawn tree wider than `maxConcurrency`
+ * deadlocked — parents held every slot while they waited for children
+ * that were queued on the same cap. The fix moves the bracket to each
+ * LLM HTTP request; this file exercises the new contract.
+ */
+import { describe, expect, it } from "bun:test";
+import type { StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { wrapStreamFnWithProviderConcurrency } from "@oh-my-pi/pi-coding-agent/task/provider-concurrency";
+
+interface Deferred {
+	promise: Promise<void>;
+	resolve: () => void;
+}
+
+function deferred(): Deferred {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	return { promise, resolve };
+}
+
+function requireModel(provider: string, id: string): Model {
+	const model = getBundledModel(provider as Parameters<typeof getBundledModel>[0], id);
+	if (!model) throw new Error(`Expected bundled model ${provider}/${id}`);
+	return model;
+}
+
+/**
+ * Build a base StreamFn that gates each invocation through an externally
+ * resolved Deferred, so the test can interleave parent and child turns
+ * deterministically without leaning on wall-clock timers.
+ */
+function makeGatedStream(): {
+	stream: StreamFn;
+	gates: Deferred[];
+	invocations: () => number;
+	inFlight: () => number;
+	peakInFlight: () => number;
+} {
+	let inFlight = 0;
+	let peakInFlight = 0;
+	let invocations = 0;
+	const gates: Deferred[] = [];
+	const stream: StreamFn = model => {
+		const gate = deferred();
+		gates.push(gate);
+		invocations++;
+		inFlight++;
+		peakInFlight = Math.max(peakInFlight, inFlight);
+		const events = new AssistantMessageEventStream();
+		void gate.promise.then(() => {
+			inFlight--;
+			const message: AssistantMessage = {
+				role: "assistant",
+				content: [],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			};
+			events.push({ type: "done", reason: "stop", message });
+			events.end();
+		});
+		return events;
+	};
+	return {
+		stream,
+		gates,
+		invocations: () => invocations,
+		inFlight: () => inFlight,
+		peakInFlight: () => peakInFlight,
+	};
+}
+
+/**
+ * Drain microtasks until `check()` is true. Uses `Promise.resolve()` (a
+ * microtask hop, not a real-time delay), so the wait is bounded by the
+ * number of pending continuations and never burns wall-clock seconds.
+ */
+async function waitFor(check: () => boolean, label: string): Promise<void> {
+	for (let i = 0; i < 1000 && !check(); i++) {
+		await Promise.resolve();
+	}
+	if (!check()) {
+		throw new Error(`Timed out waiting for: ${label}`);
+	}
+}
+
+describe("issue #3749: provider semaphore deadlock", () => {
+	it("releases the slot between LLM turns so a child can acquire while the parent is mid-conversation", async () => {
+		const model = requireModel("ollama-cloud", "gpt-oss:120b");
+		const settings = Settings.isolated({ "providers.ollama-cloud.maxConcurrency": 1 });
+		const { stream, gates, invocations, inFlight, peakInFlight } = makeGatedStream();
+		const wrapped = wrapStreamFnWithProviderConcurrency(settings, stream);
+
+		// Parent's first turn acquires the only slot.
+		const parentTurn1 = wrapped(model, { messages: [] }, {});
+		await waitFor(() => invocations() === 1, "parent turn 1 invoked");
+		expect(inFlight()).toBe(1);
+
+		// Child tries to acquire while parent's first turn is in flight.
+		// Under the old lifetime-scoped bracket the child would queue and
+		// the parent (waiting for the child) would deadlock. The wrapper
+		// bounds only the HTTP request, so the child waits one parent turn,
+		// not the parent's whole lifetime.
+		const childTurn = wrapped(model, { messages: [] }, {});
+		await waitFor(() => gates.length === 1, "child queued");
+		expect(invocations()).toBe(1);
+
+		// Parent's first LLM stream completes → slot frees → child acquires.
+		gates[0]!.resolve();
+		await parentTurn1;
+		await waitFor(() => invocations() === 2, "child admitted after parent turn");
+		expect(inFlight()).toBe(1);
+
+		// Child completes. Parent's second turn can now start.
+		gates[1]!.resolve();
+		await childTurn;
+
+		const parentTurn2 = wrapped(model, { messages: [] }, {});
+		await waitFor(() => invocations() === 3, "parent turn 2 invoked");
+		gates[2]!.resolve();
+		await parentTurn2;
+
+		expect(peakInFlight()).toBe(1);
+	});
+
+	it("admits a deeper spawn tree than maxConcurrency without deadlocking", async () => {
+		const model = requireModel("ollama-cloud", "gpt-oss:120b");
+		const settings = Settings.isolated({ "providers.ollama-cloud.maxConcurrency": 2 });
+		const { stream, gates, invocations, peakInFlight } = makeGatedStream();
+		const wrapped = wrapStreamFnWithProviderConcurrency(settings, stream);
+
+		// 3 "parents" + 6 "children" all sharing a cap of 2. The old bracket
+		// would freeze after the first two parents acquired both slots.
+		const parents = [0, 1, 2].map(async () => wrapped(model, { messages: [] }, {}));
+		const children: Promise<unknown>[] = [];
+		for (let i = 0; i < 3; i++) {
+			children.push(Promise.resolve(wrapped(model, { messages: [] }, {})));
+			children.push(Promise.resolve(wrapped(model, { messages: [] }, {})));
+		}
+
+		// Drain by resolving gates in submission order as they appear.
+		for (let i = 0; i < 9; i++) {
+			await waitFor(() => gates.length > i, `gate ${i} created`);
+			gates[i]!.resolve();
+		}
+
+		await Promise.all([...parents, ...children]);
+		expect(invocations()).toBe(9);
+		expect(peakInFlight()).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/issue-3751-compaction-provider-cap.test.ts
+++ b/packages/coding-agent/test/issue-3751-compaction-provider-cap.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression for the [#3751](https://github.com/can1357/oh-my-pi/pull/3751)
+ * chatgpt-codex follow-up: the per-LLM-turn provider concurrency wrapper
+ * (`wrapStreamFnWithProviderConcurrency`) was only attached to
+ * `Agent.streamFn` / `Agent.sideStreamFn`, so direct compaction oneshots
+ * (`#compactWithFallbackModel` → `compact()` → `instrumentedCompleteSimple`)
+ * still went through the default `completeSimple` transport and bypassed
+ * `providers.ollama-cloud.maxConcurrency`.
+ *
+ * The fix threads a `completeImpl` through `SummaryOptions` /
+ * `GenerateBranchSummaryOptions`, and agent-session wires it to the same
+ * `#sideStreamFn` the handoff path already uses. This test asserts both
+ * halves of the contract:
+ *  1. `SummaryOptions.completeImpl` is honored by every fan-out
+ *     summarizer (history + turn-prefix + short), so the default
+ *     `completeSimple` is never reached.
+ *  2. When that override is built from the limiter-wrapped sideStreamFn —
+ *     the exact shape agent-session installs — peak in-flight HTTP
+ *     requests respect the configured cap even with a concurrent
+ *     unrelated provider call.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { StreamFn } from "@oh-my-pi/pi-agent-core";
+import { compact, type CompactionPreparation, createFileOps, DEFAULT_COMPACTION_SETTINGS } from "@oh-my-pi/pi-agent-core/compaction";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
+import * as ai from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { wrapStreamFnWithProviderConcurrency } from "@oh-my-pi/pi-coding-agent/task/provider-concurrency";
+
+interface Deferred {
+	promise: Promise<void>;
+	resolve: () => void;
+}
+
+function deferred(): Deferred {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	return { promise, resolve };
+}
+
+function requireModel(provider: string, id: string): Model {
+	const model = getBundledModel(provider as Parameters<typeof getBundledModel>[0], id);
+	if (!model) throw new Error(`Expected bundled model ${provider}/${id}`);
+	return model;
+}
+
+function makeAssistantMessage(text: string, model: Model): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function makePreparation(): CompactionPreparation {
+	return {
+		firstKeptEntryId: "kept-1",
+		messagesToSummarize: [
+			{ role: "user", content: "history msg", timestamp: 1 } satisfies AgentMessage,
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "history reply" }],
+				timestamp: 2,
+			} satisfies AgentMessage,
+		],
+		turnPrefixMessages: [{ role: "user", content: "turn prefix msg", timestamp: 3 } satisfies AgentMessage],
+		recentMessages: [{ role: "user", content: "recent msg", timestamp: 4 } satisfies AgentMessage],
+		isSplitTurn: true,
+		tokensBefore: 12_345,
+		fileOps: createFileOps(),
+		settings: { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+	};
+}
+
+async function waitFor(check: () => boolean, label: string): Promise<void> {
+	for (let i = 0; i < 1000 && !check(); i++) {
+		await Promise.resolve();
+	}
+	if (!check()) throw new Error(`Timed out waiting for: ${label}`);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("issue #3751: compaction summaries respect provider concurrency cap", () => {
+	it("compact() routes every fan-out summarizer through SummaryOptions.completeImpl", async () => {
+		const model = requireModel("ollama-cloud", "gpt-oss:120b");
+		const defaultSpy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(makeAssistantMessage("default transport must not run", model));
+
+		const overrideCalls: { model: Model; system: string | undefined }[] = [];
+		const override = async (requestModel: Model, ctx: ai.Context): Promise<AssistantMessage> => {
+			overrideCalls.push({ model: requestModel, system: ctx.systemPrompt?.[0] });
+			return makeAssistantMessage("summary text", requestModel);
+		};
+
+		await compact(makePreparation(), model, "test-key", undefined, undefined, {
+			completeImpl: override,
+		});
+
+		// Split-turn preparation fans out into history + turn-prefix + short.
+		expect(overrideCalls).toHaveLength(3);
+		expect(defaultSpy).not.toHaveBeenCalled();
+		// Each summarizer ships the system prompt that documents the compaction
+		// contract; we just sanity-check the override actually saw the request
+		// instead of being short-circuited by remote compaction or hook paths.
+		for (const call of overrideCalls) {
+			expect(call.model.provider).toBe(model.provider);
+			expect(typeof call.system).toBe("string");
+		}
+	});
+
+	it("limiter-wrapped sideStreamFn caps compaction HTTP requests at maxConcurrency=1", async () => {
+		const model = requireModel("ollama-cloud", "gpt-oss:120b");
+		const settings = Settings.isolated({ "providers.ollama-cloud.maxConcurrency": 1 });
+
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const gates: Deferred[] = [];
+		const base: StreamFn = streamModel => {
+			const gate = deferred();
+			gates.push(gate);
+			inFlight++;
+			peakInFlight = Math.max(peakInFlight, inFlight);
+			const events = new AssistantMessageEventStream();
+			void gate.promise.then(() => {
+				inFlight--;
+				events.push({ type: "done", reason: "stop", message: makeAssistantMessage("ok", streamModel) });
+				events.end();
+			});
+			return events;
+		};
+		const sideStreamFn = wrapStreamFnWithProviderConcurrency(settings, base);
+
+		// Exactly the shape agent-session.ts:#compactWithFallbackModel installs.
+		const completeImpl = async (
+			requestModel: Model,
+			requestContext: ai.Context,
+			requestOptions: ai.SimpleStreamOptions,
+		): Promise<AssistantMessage> => {
+			const stream = await sideStreamFn(requestModel, requestContext, requestOptions);
+			return stream.result();
+		};
+
+		const defaultSpy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(makeAssistantMessage("default transport must not run", model));
+
+		// Kick off compaction; it must immediately try to acquire the slot.
+		const compaction = compact(makePreparation(), model, "test-key", undefined, undefined, {
+			completeImpl,
+		});
+		await waitFor(() => gates.length === 1, "first compaction summarizer in flight");
+		expect(inFlight).toBe(1);
+
+		// A direct sideStreamFn call (e.g. /btw, IRC reply) issued while
+		// compaction is mid-flight must queue behind the held slot — proving
+		// the cap is shared. Under the pre-fix wiring this would bypass the
+		// limiter and run immediately, pushing peakInFlight to 2.
+		const concurrent = sideStreamFn(model, { messages: [] }, {});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(gates).toHaveLength(1);
+
+		// Drain in submission order: 4 HTTP requests total = 3 compaction
+		// summarizers + 1 concurrent side request. We intentionally do NOT
+		// distinguish which gate is which — that's the whole point of the
+		// shared cap. Whatever order the limiter admits them in, peak
+		// in-flight must never exceed 1.
+		for (let i = 0; i < 4; i++) {
+			await waitFor(() => gates.length > i, `request ${i + 1} admitted`);
+			expect(inFlight).toBe(1);
+			gates[i]!.resolve();
+		}
+		await Promise.all([compaction, concurrent]);
+
+		expect(peakInFlight).toBe(1);
+		expect(defaultSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/issue-3751-compaction-provider-cap.test.ts
+++ b/packages/coding-agent/test/issue-3751-compaction-provider-cap.test.ts
@@ -21,10 +21,15 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
-import { compact, type CompactionPreparation, createFileOps, DEFAULT_COMPACTION_SETTINGS } from "@oh-my-pi/pi-agent-core/compaction";
+import {
+	type CompactionPreparation,
+	compact,
+	createFileOps,
+	DEFAULT_COMPACTION_SETTINGS,
+} from "@oh-my-pi/pi-agent-core/compaction";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
-import * as ai from "@oh-my-pi/pi-ai";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import * as ai from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -66,16 +71,12 @@ function makeAssistantMessage(text: string, model: Model): AssistantMessage {
 	};
 }
 
-function makePreparation(): CompactionPreparation {
+function makePreparation(model: Model): CompactionPreparation {
 	return {
 		firstKeptEntryId: "kept-1",
 		messagesToSummarize: [
 			{ role: "user", content: "history msg", timestamp: 1 } satisfies AgentMessage,
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "history reply" }],
-				timestamp: 2,
-			} satisfies AgentMessage,
+			makeAssistantMessage("history reply", model),
 		],
 		turnPrefixMessages: [{ role: "user", content: "turn prefix msg", timestamp: 3 } satisfies AgentMessage],
 		recentMessages: [{ role: "user", content: "recent msg", timestamp: 4 } satisfies AgentMessage],
@@ -110,7 +111,7 @@ describe("issue #3751: compaction summaries respect provider concurrency cap", (
 			return makeAssistantMessage("summary text", requestModel);
 		};
 
-		await compact(makePreparation(), model, "test-key", undefined, undefined, {
+		await compact(makePreparation(model), model, "test-key", undefined, undefined, {
 			completeImpl: override,
 		});
 
@@ -163,7 +164,7 @@ describe("issue #3751: compaction summaries respect provider concurrency cap", (
 			.mockResolvedValue(makeAssistantMessage("default transport must not run", model));
 
 		// Kick off compaction; it must immediately try to acquire the slot.
-		const compaction = compact(makePreparation(), model, "test-key", undefined, undefined, {
+		const compaction = compact(makePreparation(model), model, "test-key", undefined, undefined, {
 			completeImpl,
 		});
 		await waitFor(() => gates.length === 1, "first compaction summarizer in flight");


### PR DESCRIPTION
## Repro

With `providers.ollama-cloud.maxConcurrency = N`, spawning more than `N` subagents that each spawn children deadlocks the harness: parents acquire every slot in `runSubagent` and then wait for their children, but the children block on `acquire()` before reaching `session.prompt()`. Symptoms match the report — 40% CPU, zero LLM requests, daemon log silence, agents cancelled with `tokens=0, requests=0`. `bun test test/issue-3749-provider-semaphore-deadlock.test.ts` reproduces both the parent-blocks-child shape and the wider 3+6 spawn tree under a cap of 2.

## Cause

`runSubagent` in `packages/coding-agent/src/task/executor.ts` acquired the per-provider semaphore at the very start (before `SessionManager.open`) and released it only in the outer `finally`, so the slot was held across `driveSessionToYield`. That bracket covers the whole conversation: model resolution, session setup, every LLM turn, every tool call (including `task` spawns), and every retry. A spawn tree wider than `maxConcurrency` therefore created a circular wait — children waited on the parents' slots while parents waited on the children to yield.

## Fix

- New `packages/coding-agent/src/task/provider-concurrency.ts` owns the per-provider semaphore state and exports `wrapStreamFnWithProviderConcurrency(settings, base)`. The wrapper acquires the slot immediately before invoking the inner `StreamFn`, and releases it when the returned `EventStream.result()` settles (`done`/`error`/`fail`) — exactly the lifetime of the provider HTTP request.
- `packages/coding-agent/src/sdk.ts` now layers the wrapper over `createSettingsAwareStreamFn` once, so both the main agent and the advisor honor the cap.
- `packages/coding-agent/src/task/executor.ts` drops the lifetime-scoped `acquire/release` and its associated state. The helpers (`getProviderConcurrencyLimit`, `getProviderSemaphore`, `PROVIDER_MAX_CONCURRENCY_SETTINGS`) moved into the new module unchanged.
- Tests: `test/issue-3749-provider-semaphore-deadlock.test.ts` covers (a) a parent freeing the slot between turns so a child can acquire mid-conversation and (b) a 3-parent/6-child tree completing under a cap of 2. `test/issue-3464-ollama-cloud-task-backoff.test.ts` had a now-stale assertion ("second subagent never starts while first holds the cap") that encoded the buggy contract; replaced it with a wrapper-level test that asserts peak in-flight LLM streams stay at the configured cap. `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

`bun run check` and `bun test test/task/ test/session/ test/settings-stream-fn.test.ts test/advisor-provider-options-parity.test.ts test/issue-3464-ollama-cloud-task-backoff.test.ts test/issue-3749-provider-semaphore-deadlock.test.ts` — 296 pass, 0 fail. The new regression test deadlocks without the fix (the 3+6 tree never reaches `invocations() === 9`) and passes with it. Fixes #3749.