### PR TITLE
fix: tolerate GLM 5.2 stray dot in hunk headers

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tolerated a stray `.` before the trailing `:` in hunk headers (e.g. `SWAP 2.=3.:`, `INS.POST 2.:`, `DEL 2.=3.`), recovering from GLM 5.2's tendency to insert an extra dot between the line number/range and the colon. The parser now skips the spurious dot so these headers parse correctly instead of failing with "payload line has no preceding hunk header."
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/hashline/src/tokenizer.ts
+++ b/packages/hashline/src/tokenizer.ts
@@ -234,8 +234,22 @@ function scanKeyword(line: string, index: number, end: number, keyword: string):
 	return next;
 }
 
+/**
+ * GLM 5.2 inserts a stray `.` between the line number/range and the trailing
+ * `:` (e.g. `SWAP 2.=3.:`, `INS.POST 2.:`). A `.` is never valid syntax at
+ * this position, so skip it when it precedes an optional `:` or end-of-line.
+ */
+function skipStrayDot(line: string, index: number, end: number): number {
+	if (index < end && line.charCodeAt(index) === CHAR_DOT) {
+		const after = skipWhitespace(line, index + 1, end);
+		if (after === end || line.charCodeAt(after) === CHAR_COLON) return after;
+	}
+	return index;
+}
+
 function consumeOptionalColon(line: string, index: number, end: number): number {
-	const cursor = skipWhitespace(line, index, end);
+	let cursor = skipWhitespace(line, index, end);
+	cursor = skipStrayDot(line, cursor, end);
 	return cursor < end && line.charCodeAt(cursor) === CHAR_COLON ? skipWhitespace(line, cursor + 1, end) : cursor;
 }
 
@@ -337,7 +351,8 @@ function scanHunkAnchor(line: string, start: number, end: number): TargetScan | 
 	if (deleteBlockEnd !== null) {
 		const anchor = scanLineNumber(line, skipWhitespace(line, deleteBlockEnd, end), end);
 		if (anchor === null) return null;
-		const next = skipWhitespace(line, anchor.nextIndex, end);
+		let next = skipWhitespace(line, anchor.nextIndex, end);
+		next = skipStrayDot(line, next, end);
 		if (next < end && line.charCodeAt(next) === CHAR_COLON) return null;
 		return { target: { kind: "delete_block", anchor: { line: anchor.line } }, nextIndex: next };
 	}
@@ -345,7 +360,8 @@ function scanHunkAnchor(line: string, start: number, end: number): TargetScan | 
 	if (deleteEnd !== null) {
 		const range = scanHeaderRange(line, deleteEnd, end, true);
 		if (range === null) return null;
-		const next = skipWhitespace(line, range.nextIndex, end);
+		let next = skipWhitespace(line, range.nextIndex, end);
+		next = skipStrayDot(line, next, end);
 		if (next < end && line.charCodeAt(next) === CHAR_COLON) return null;
 		return { target: { kind: "delete", range: range.range }, nextIndex: next };
 	}

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -94,6 +94,21 @@ describe("hashline core — verb header forms", () => {
 		expect(applyPatch(FILE, "INS.PRE 2\n+X")).toBe("a\nX\nb\nc\nd\ne");
 		expect(applyPatch(FILE, "INS.HEAD\n+X")).toBe("X\na\nb\nc\nd\ne");
 	});
+
+	it("tolerates GLM 5.2 stray dot before the trailing colon", () => {
+		// GLM 5.2 inserts a `.` between the line number/range and `:`,
+		// e.g. `SWAP 2.=3.:` instead of `SWAP 2.=3:`.
+		expect(applyPatch(FILE, "SWAP 2.=3.:\n+X")).toBe("a\nX\nd\ne");
+		expect(applyPatch(FILE, "SWAP 2.=2.:\n+X")).toBe("a\nX\nc\nd\ne");
+		// `INS.POST 2.:` instead of `INS.POST 2:`
+		expect(applyPatch(FILE, "INS.POST 2.:\n+X")).toBe("a\nb\nX\nc\nd\ne");
+		expect(applyPatch(FILE, "INS.PRE 2.:\n+X")).toBe("a\nX\nb\nc\nd\ne");
+		// `DEL 2.=3.` instead of `DEL 2.=3` (stray dot, no colon)
+		expect(applyPatch(FILE, "DEL 2.=3.")).toBe("a\nd\ne");
+		// `INS.HEAD.:` and `INS.TAIL.:` with stray dot
+		expect(applyPatch(FILE, "INS.HEAD.:\n+X")).toBe("X\na\nb\nc\nd\ne");
+		expect(applyPatch(FILE, "INS.TAIL.:\n+X")).toBe("a\nb\nc\nd\ne\nX");
+	});
 });
 
 describe("hashline body contracts", () => {


### PR DESCRIPTION
GLM 5.2 inserts an extra `.` between the line number/range and the trailing `:` (e.g. `SWAP 2.=3.:`, `INS.POST 2.:`, `DEL 2.=3.`). The parser failed with "payload line has no preceding hunk header" and could not recover. Add a `skipStrayDot` helper that skips a spurious `.` before the optional colon or end-of-line, wired into `consumeOptionalColon` (covers SWAP, INS.*, SWAP.BLK, INS.BLK.POST) and the DEL / DEL.BLK branches.