### PR TITLE
fix(providers): honor local runtime context limits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed Ollama and llama.cpp discovery overestimating local context windows by using model training metadata instead of the runtime `num_ctx` / `n_ctx`, which could let compaction retry prompts that llama.cpp rejects as over context. ([#3752](https://github.com/can1357/oh-my-pi/issues/3752))
 - Fixed recoverable context-overflow compaction keeping the failed assistant error turn in visible session history after scheduling the retry. ([#3747](https://github.com/can1357/oh-my-pi/issues/3747))
 - Fixed editing a file read from outside the workspace (e.g. `~/.claude/settings.json`) failing with "File not found": the read snapshot header now carries the full out-of-workspace path so the edit resolves it directly instead of against the working directory.
 - Fixed subagents spawned with an output schema (`agent(..., schema=...)`, `task` with structured output) failing with `schema_violation: missing required fields` since the typed-yield rework: a `type: "result"` finalize carrying the full object was assembled as a section named `result`, nesting the payload one level deep. String-typed yields are now treated as terminal finalizers (their data is the complete result), only array-typed yields form accumulating sections, and a data-less finalize keeps accumulated sections instead of collapsing to the last assistant turn.

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -142,7 +142,21 @@ function toPositiveNumberOrUndefined(value: unknown): number | undefined {
 	return undefined;
 }
 
+function extractOllamaRuntimeContextWindow(payload: Record<string, unknown>): number | undefined {
+	const parameters = payload.parameters;
+	if (typeof parameters !== "string") {
+		return undefined;
+	}
+	const match = parameters.match(/(?:^|\n)\s*num_ctx\s+(\d+)\s*(?:$|\n)/m);
+	return match ? toPositiveNumberOrUndefined(match[1]) : undefined;
+}
+
 function extractOllamaContextWindow(payload: Record<string, unknown>): number | undefined {
+	const runtimeContextWindow = extractOllamaRuntimeContextWindow(payload);
+	if (runtimeContextWindow !== undefined) {
+		return runtimeContextWindow;
+	}
+
 	const modelInfo = payload.model_info;
 	if (isRecord(modelInfo)) {
 		for (const [key, value] of Object.entries(modelInfo)) {
@@ -155,12 +169,7 @@ function extractOllamaContextWindow(payload: Record<string, unknown>): number | 
 		}
 	}
 
-	const parameters = payload.parameters;
-	if (typeof parameters !== "string") {
-		return undefined;
-	}
-	const match = parameters.match(/(?:^|\n)\s*num_ctx\s+(\d+)\s*(?:$|\n)/m);
-	return match ? toPositiveNumberOrUndefined(match[1]) : undefined;
+	return undefined;
 }
 
 function extractLlamaCppContextWindow(payload: Record<string, unknown>): number | undefined {
@@ -179,7 +188,7 @@ function extractLlamaCppModelContextWindow(item: Record<string, unknown>): numbe
 	if (!isRecord(meta)) {
 		return undefined;
 	}
-	return toPositiveNumberOrUndefined(meta.n_ctx) ?? toPositiveNumberOrUndefined(meta.n_ctx_train);
+	return toPositiveNumberOrUndefined(meta.n_ctx);
 }
 
 function parseLlamaCppModelList(payload: unknown): LlamaCppModelListEntry[] {

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -126,7 +126,8 @@ type LlamaCppDiscoveredServerMetadata = {
 
 type LlamaCppModelListEntry = {
 	id: string;
-	contextWindow?: number;
+	runtimeContextWindow?: number;
+	trainingContextWindow?: number;
 };
 
 function toPositiveNumberOrUndefined(value: unknown): number | undefined {
@@ -183,12 +184,17 @@ function extractLlamaCppContextWindow(payload: Record<string, unknown>): number 
 	return toPositiveNumberOrUndefined(payload.n_ctx);
 }
 
-function extractLlamaCppModelContextWindow(item: Record<string, unknown>): number | undefined {
+function extractLlamaCppModelContextWindows(
+	item: Record<string, unknown>,
+): Pick<LlamaCppModelListEntry, "runtimeContextWindow" | "trainingContextWindow"> {
 	const meta = item.meta;
 	if (!isRecord(meta)) {
-		return undefined;
+		return {};
 	}
-	return toPositiveNumberOrUndefined(meta.n_ctx);
+	return {
+		runtimeContextWindow: toPositiveNumberOrUndefined(meta.n_ctx),
+		trainingContextWindow: toPositiveNumberOrUndefined(meta.n_ctx_train),
+	};
 }
 
 function parseLlamaCppModelList(payload: unknown): LlamaCppModelListEntry[] {
@@ -199,7 +205,7 @@ function parseLlamaCppModelList(payload: unknown): LlamaCppModelListEntry[] {
 		if (!isRecord(item) || typeof item.id !== "string" || !item.id) {
 			return [];
 		}
-		return [{ id: item.id, contextWindow: extractLlamaCppModelContextWindow(item) }];
+		return [{ id: item.id, ...extractLlamaCppModelContextWindows(item) }];
 	});
 }
 
@@ -387,7 +393,11 @@ export async function discoverLlamaCppModels(
 	for (const item of models) {
 		const { id } = item;
 		if (!id) continue;
-		const contextWindow = item.contextWindow ?? serverMetadata?.contextWindow ?? DISCOVERY_DEFAULT_CONTEXT_WINDOW;
+		const contextWindow =
+			item.runtimeContextWindow ??
+			serverMetadata?.contextWindow ??
+			item.trainingContextWindow ??
+			DISCOVERY_DEFAULT_CONTEXT_WINDOW;
 		discovered.push(
 			buildModel({
 				id,
@@ -429,7 +439,8 @@ export async function discoverLlamaCppModelContextWindow(
 			return undefined;
 		}
 		const entries = parseLlamaCppModelList(await response.json());
-		return entries.find(entry => entry.id === model.id)?.contextWindow;
+		const entry = entries.find(entry => entry.id === model.id);
+		return entry?.runtimeContextWindow ?? entry?.trainingContextWindow;
 	};
 	try {
 		const apiKey = await ctx.getBearerApiKeyResolver(model.provider);

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -174,6 +174,22 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(model?.maxTokens).toBe(32768);
 	});
 
+	test("prefers Ollama runtime num_ctx over training context metadata", async () => {
+		const fetchMock = mockOllamaDiscovery(["qwen3:27b"], "http://127.0.0.1:11434", {
+			parameters: "temperature 0.6\nnum_ctx 123904\n",
+			model_info: {
+				"qwen3.context_length": 262144,
+			},
+			capabilities: ["completion", "thinking"],
+		});
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+
+		const model = registry.find("ollama", "qwen3:27b");
+		expect(model?.contextWindow).toBe(123904);
+		expect(model?.maxTokens).toBe(32_768);
+	});
+
 	test("discovers ollama-cloud through built-in descriptor flow without regressing local implicit ollama", async () => {
 		authStorage.setRuntimeApiKey("ollama-cloud", "cloud-test-key");
 
@@ -667,7 +683,7 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(llama?.maxTokens).toBe(32_768);
 		expect(llama?.input).toEqual(["text", "image"]);
 	});
-	test("llama.cpp discovery prefers per-model meta n_ctx over props", async () => {
+	test("llama.cpp discovery prefers runtime n_ctx over training context metadata", async () => {
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
 			if (url === "http://127.0.0.1:8080/models") {
@@ -696,7 +712,7 @@ describe("ModelRegistry runtime discovery", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 		await registry.refresh();
 		expect(registry.find("llama.cpp", "ctx-88k")?.contextWindow).toBe(88832);
-		expect(registry.find("llama.cpp", "ctx-train")?.contextWindow).toBe(65536);
+		expect(registry.find("llama.cpp", "ctx-train")?.contextWindow).toBe(128000);
 		expect(registry.find("llama.cpp", "unloaded")?.contextWindow).toBe(128000);
 	});
 

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -716,6 +716,31 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("llama.cpp", "unloaded")?.contextWindow).toBe(128000);
 	});
 
+	test("llama.cpp discovery falls back to n_ctx_train before the global default", async () => {
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(
+					JSON.stringify({
+						data: [{ id: "ctx-train", meta: { n_ctx_train: 65536 } }, { id: "unloaded" }],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(JSON.stringify({ default_generation_settings: {} }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		expect(registry.find("llama.cpp", "ctx-train")?.contextWindow).toBe(65536);
+		expect(registry.find("llama.cpp", "unloaded")?.contextWindow).toBe(128000);
+	});
+
 	test("llama.cpp selected model refresh patches newly loaded meta n_ctx", async () => {
 		writeModelCache(
 			"llama.cpp",


### PR DESCRIPTION
## Repro
A focused discovery regression reproduced the issue with `bun test packages/coding-agent/test/model-discovery.test.ts -t "runtime n_ctx|runtime num_ctx"`: before the fix, Ollama returned `contextWindow=262144` despite `parameters: num_ctx 123904`, and llama.cpp returned `65536` from `meta.n_ctx_train` despite `/props` advertising runtime `n_ctx=128000`.

## Cause
`packages/coding-agent/src/config/model-discovery.ts` treated local model training metadata as the active context window: Ollama `extractOllamaContextWindow()` returned `model_info.*.context_length` before `parameters num_ctx`, and llama.cpp `extractLlamaCppModelContextWindow()` treated `meta.n_ctx_train` as a runtime limit before `discoverLlamaCppModels()` could fall back to `/props` `default_generation_settings.n_ctx`.

## Fix
- Prefer Ollama runtime `num_ctx` from `/api/show` parameters before model training `context_length`.
- Stop treating llama.cpp `n_ctx_train` as a runtime window; keep `meta.n_ctx` authoritative and otherwise use server `/props` `n_ctx` or the existing default.
- Add regression coverage for both local-provider discovery paths and document the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/model-discovery.test.ts -t "runtime n_ctx|runtime num_ctx"` passed after the fix; `bun test packages/coding-agent/test/model-discovery.test.ts` passed with 31 tests and 107 assertions. Fixes #3752