### PR TITLE
fix(grep-builtin): accept --color/--colour/--version

### DIFF
--- a/crates/pi-uu-grep/src/lib.rs
+++ b/crates/pi-uu-grep/src/lib.rs
@@ -30,6 +30,7 @@ pub use rg::run as run_rg;
 #[derive(Parser, Debug)]
 #[command(
 	name = "grep",
+	version = concat!("grep (pi-uu-grep) ", env!("CARGO_PKG_VERSION")),
 	about = "Search for PATTERN in each FILE or standard input.",
 	disable_help_flag = true,
 	disable_version_flag = true
@@ -125,6 +126,31 @@ struct Cli {
 	#[allow(dead_code)]
 	#[arg(long = "help", action = clap::ArgAction::Help)]
 	help: Option<bool>,
+
+	/// Print version information.
+	///
+	/// GNU grep ships a `--version`, and shell startup scripts probe it.
+	/// Routed through clap so output lands on the in-process stdout via the
+	/// same path as `--help`.
+	#[allow(dead_code)]
+	#[arg(short = 'V', long = "version", action = clap::ArgAction::Version)]
+	version: Option<bool>,
+
+	/// Surface color in matches: accepted for GNU-grep compatibility and
+	/// silently ignored. The builtin writes to in-process file descriptors
+	/// (often a pipe consumed by another tool), so injecting ANSI escapes
+	/// would corrupt downstream output. The common `alias grep='grep
+	/// --color=auto'` from distro bashrc files passes through unchanged.
+	#[allow(dead_code)]
+	#[arg(
+		long = "color",
+		alias = "colour",
+		value_name = "WHEN",
+		num_args = 0..=1,
+		require_equals = true,
+		default_missing_value = "auto",
+	)]
+	color: Option<String>,
 
 	/// PATTERN followed by FILEs (PATTERN is omitted when -e is given).
 	#[arg(value_name = "ARGS")]
@@ -741,5 +767,30 @@ mod tests {
 		assert!(stdout.contains("foooo"), "regex alternative should match: {stdout}");
 		assert!(stdout.contains("bar)"), "literal alternative should match: {stdout}");
 		assert!(!stdout.contains("baz"), "non-matching line leaked: {stdout}");
+	}
+
+	#[test]
+	fn color_flag_is_accepted_and_ignored() {
+		// Regression for #3755: the universal `alias grep='grep --color=auto'`
+		// must not break bare `grep` in shell pipelines.
+		for color in ["--color=auto", "--color=always", "--color=never", "--color", "--colour=auto"] {
+			let (code, stdout, stderr) = run_grep(&[color, "foo"], "foo\nbar\n");
+			assert_eq!(code, 0, "{color}: stderr: {stderr}");
+			assert!(stderr.is_empty(), "{color}: unexpected stderr: {stderr}");
+			assert_eq!(stdout, "foo\n", "{color}: matched lines: {stdout:?}");
+		}
+	}
+
+	#[test]
+	fn version_flag_prints_and_exits_zero() {
+		// `grep --version` is the universal probe shells run; the builtin must
+		// not reject it with exit 2.
+		let (code, stdout, stderr) = run_grep(&["--version"], "");
+		assert_eq!(code, 0, "stderr: {stderr}");
+		assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+		assert!(
+			stdout.contains("grep") && stdout.contains("pi-uu-grep"),
+			"version output should identify the builtin, got: {stdout:?}"
+		);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the in-process `grep` builtin rejecting GNU-grep's `--color`/`--colour` (with or without `=WHEN`) and `--version` flags. The shadowing rejection broke bash's near-universal `alias grep='grep --color=auto'`, causing bare `grep` in any pipeline to fail with exit 2. The builtin now accepts and ignores `--color[=WHEN]` (its output goes through in-process file descriptors, never a TTY, so ANSI injection would corrupt downstream consumers) and reports its version through the context streams ([#3755](https://github.com/can1357/oh-my-pi/issues/3755)).
+
 ## [16.2.4] - 2026-06-28
 
 ### Fixed


### PR DESCRIPTION
## Repro

Inside the harness shell on Linux, bare `grep` fails 100% of the time because the distro alias `grep --color=auto` (almost universal on Linux) is appended before the in-process `pi-shell` builtin sees the command, and the builtin's clap parser rejects `--color`. The probe `grep --version` (used by various shell startup scripts) fails the same way.

```
$ cd crates/pi-uu-grep && cargo test --lib color_flag_is_accepted_and_ignored version_flag_prints_and_exits_zero
thread 'tests::color_flag_is_accepted_and_ignored' panicked:
  --color=auto: stderr: error: unexpected argument '--color' found
thread 'tests::version_flag_prints_and_exits_zero' panicked:
  stderr: error: unexpected argument '--version' found
```

## Cause

`crates/pi-uu-grep/src/lib.rs` defines a clap `Cli` whose flag set is a subset of GNU grep. `--color`/`--colour` and `--version` are missing, and `disable_version_flag = true` keeps clap from auto-adding the latter. The builtin is registered ahead of `/usr/bin/grep` in `crates/pi-shell/src/shell.rs:535`, so the shadowed binary is unreachable through the alias path.

## Fix

- `Cli`: add `color: Option<String>` with `--color`/`--colour` (alias), `num_args = 0..=1`, `require_equals = true`, `default_missing_value = "auto"` — accepted and silently dropped. The builtin writes to in-process file descriptors (commonly a pipe consumed by another tool), so injecting ANSI escapes for `--color=always` would corrupt downstream output; matching GNU's `auto` mode against a non-TTY also means "no color", so dropping the flag preserves observable behavior.
- `Cli`: add `version: Option<bool>` with `ArgAction::Version`, plus `version = concat!("grep (pi-uu-grep) ", env!("CARGO_PKG_VERSION"))`. Clap returns a non-stderr `Err` that the existing handler routes through `pi_uutils_ctx::stdout()` with exit 0 — the same wiring `--help` already uses.
- Two regression tests in `crates/pi-uu-grep/src/lib.rs`:
  - `color_flag_is_accepted_and_ignored` covers `--color=auto`, `--color=always`, `--color=never`, bare `--color`, and `--colour=auto`.
  - `version_flag_prints_and_exits_zero` asserts exit 0, empty stderr, and a stdout that identifies the builtin.
- Changelog entry under `packages/natives/CHANGELOG.md` `[Unreleased] / Fixed`.

The reporter also noted `command grep` failing with `pi-natives:command: syntax error`. That's a separate brush-core builtin issue and out of scope here — the standard POSIX `command` semantics would still resolve to the builtin anyway, so the real fix had to be at the builtin's flag surface, which this PR addresses.

## Verification

`cd crates/pi-uu-grep && cargo test --lib --quiet` → 6 passed (2 new + 4 existing).
`cd crates/pi-shell && cargo test --lib --quiet` → 822 passed (no regression in the dispatch path or in the grep/rg builtin tests).
`cd crates/pi-uu-grep && cargo clippy --lib --tests --quiet` → clean.

Fixes #3755