### PR TITLE
fix(agent): shorten isolated task worktree paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed isolated subagent worktrees embedding long task ids and `merged` in the working path; isolation now uses compact hashed segments with an `m` mount dir. ([#3756](https://github.com/can1357/oh-my-pi/issues/3756))
 - Fixed recoverable context-overflow compaction keeping the failed assistant error turn in visible session history after scheduling the retry. ([#3747](https://github.com/can1357/oh-my-pi/issues/3747))
 - Fixed editing a file read from outside the workspace (e.g. `~/.claude/settings.json`) failing with "File not found": the read snapshot header now carries the full out-of-workspace path so the edit resolves it directly instead of against the working directory.
 - Fixed subagents spawned with an output schema (`agent(..., schema=...)`, `task` with structured output) failing with `schema_violation: missing required fields` since the typed-yield rework: a `type: "result"` finalize carrying the full object was assembled as a section named `result`, nesting the payload one level deep. String-typed yields are now treated as terminal finalizers (their data is the complete result), only array-typed yields form accumulating sections, and a data-less finalize keeps accumulated sections instead of collapsing to the last assistant turn.

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -7,9 +7,9 @@
  *     containing a `.git` *file* that points back at
  *     `<parent-repo>/.git/worktrees/<name>/`.
  *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
- *     `merged` subdir mounted/cloned by `natives.isoStart`. These are ephemeral
- *     — `ensureIsolation` always `rm -rf`s the base before re-creating it, so
- *     any leftover on disk is a leak from a crashed run.
+ *     compact `m` subdir mounted/cloned by `natives.isoStart`. Legacy `merged`
+ *     subdirs are still recognized. These are ephemeral; `ensureIsolation`
+ *     removes the base before re-creating it, so leftovers are crashed runs.
  *
  * Legacy entries from before the encoding change keep working because git still
  * tracks them by branch name. This command exists to GC them on demand.
@@ -21,6 +21,8 @@ import chalk from "chalk";
 import * as git from "../utils/git";
 
 type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
+
+const TASK_ISOLATION_MOUNT_DIRS = ["m", "merged"] as const;
 
 export interface WorktreeEntry {
 	/** Absolute path to the worktree dir (or stray container) under `~/.omp/wt/`. */
@@ -209,8 +211,9 @@ async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
 	if (gitStat?.isFile()) {
 		return classifyPrCheckout(dir, gitEntry);
 	}
-	const mergedStat = await fs.stat(path.join(dir, "merged")).catch(() => null);
-	if (mergedStat?.isDirectory()) {
+	for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
+		const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
+		if (!mountStat?.isDirectory()) continue;
 		return {
 			path: dir,
 			kind: "task-isolation",

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -3,12 +3,16 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@oh-my-pi/pi-natives";
-import { getWorktreeDir, hashPath, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import * as jj from "../utils/jj";
 import { mapWithConcurrencyLimit } from "./parallel";
 
 const { IsoBackendKind } = natives;
+
+const TASK_ISOLATION_DIR_PREFIX = "t";
+const TASK_ISOLATION_DIR_DIGEST_CHARS = 9;
+const TASK_ISOLATION_MOUNT_DIR = "m";
 type IsoBackendKind = natives.IsoBackendKind;
 
 /** Baseline state for a single git repository. */
@@ -389,15 +393,20 @@ function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
+function getTaskIsolationSegment(repoRoot: string, id: string): string {
+	const key = `${path.resolve(repoRoot)}\0${id}`;
+	const digest = Bun.hash(key).toString(16).padStart(16, "0").slice(-TASK_ISOLATION_DIR_DIGEST_CHARS);
+	return `${TASK_ISOLATION_DIR_PREFIX}${digest}`;
+}
+
 export async function ensureIsolation(
 	baseCwd: string,
 	id: string,
 	preferred?: IsoBackendKind,
 ): Promise<IsolationHandle> {
 	const repoRoot = await getRepoRoot(baseCwd);
-	const baseDir = getWorktreeDir(`${id}-${hashPath(repoRoot)}`);
-	const mergedDir = path.join(baseDir, "merged");
-
+	const baseDir = getWorktreeDir(getTaskIsolationSegment(repoRoot, id));
+	const mergedDir = path.join(baseDir, TASK_ISOLATION_MOUNT_DIR);
 	const resolution = natives.isoResolve(preferred ?? null);
 	const candidates = resolution.candidates.length > 0 ? resolution.candidates : [resolution.kind];
 	let fallbackReason = resolution.reason ?? null;

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/task/worktree";
 import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
 import * as natives from "@oh-my-pi/pi-natives";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries, setWorktreesDir } from "@oh-my-pi/pi-utils";
 
 const tempDirs: string[] = [];
 
@@ -147,6 +147,39 @@ describe("worktree isolation helpers", () => {
 			expect(handle.backend).toBe(natives.IsoBackendKind.Rcopy);
 			expect(handle.fellBack).toBe(true);
 			expect(handle.fallbackReason).toBe(unavailable.message);
+		});
+
+		it("uses compact isolation paths that do not embed long task ids", async () => {
+			const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+			const worktreeBase = await fs.mkdtemp(path.join(os.tmpdir(), "omp-worktree-base-"));
+			tempDirs.push(worktreeBase);
+			delete process.env.OMP_WORKTREE_DIR;
+			setWorktreesDir(worktreeBase);
+			vi.spyOn(natives, "isoResolve").mockReturnValue({
+				kind: natives.IsoBackendKind.Rcopy,
+				candidates: [natives.IsoBackendKind.Rcopy],
+				fellBack: false,
+				reason: undefined,
+			});
+			vi.spyOn(natives, "isoStart").mockResolvedValue(undefined);
+
+			try {
+				const longTaskId = "orchestrate-goal-execution.Test1-0982d2a";
+				const handle = await ensureIsolation(repo, longTaskId);
+				const mergedLeaf = path.basename(handle.mergedDir);
+				const isolationSegment = path.basename(path.dirname(handle.mergedDir));
+
+				expect(mergedLeaf).toBe("m");
+				expect(isolationSegment).not.toContain(longTaskId);
+				expect(isolationSegment.length).toBeLessThanOrEqual(12);
+			} finally {
+				if (originalWorktreeDir === undefined) {
+					delete process.env.OMP_WORKTREE_DIR;
+				} else {
+					process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+				}
+				setWorktreesDir(undefined);
+			}
 		});
 
 		// First mutator: runs on the pristine fixture, so no reset is needed. Leaves


### PR DESCRIPTION
## Repro
Launching an isolated task with a long id such as `orchestrate-goal-execution.Test1-0982d2a` made `ensureIsolation()` build a cwd containing the full task id and `merged`. I reproduced it with `bun test packages/coding-agent/test/task/worktree.test.ts`, where the new regression case failed because the mount leaf was `merged` instead of compact `m`.

## Cause
`packages/coding-agent/src/task/worktree.ts` built task isolation paths as `getWorktreeDir(`${id}-${hashPath(repoRoot)}`)/merged`, so descriptive subagent ids were copied directly into the filesystem path passed to `runSubprocess()`. `packages/coding-agent/src/cli/worktree-cli.ts` also only recognized the legacy `merged` layout for cleanup.

## Fix
- Replace full task-id isolation directory names with compact repo/id hash segments prefixed by `t`.
- Rename the task isolation mount leaf from `merged` to `m`.
- Keep `omp worktree` cleanup recognizing both new `m` and legacy `merged` task-isolation directories.
- Add a regression test that asserts long task ids are not embedded in the isolated cwd.

## Verification
`bun test packages/coding-agent/test/task/worktree.test.ts` passed with 16 tests. `bun run check` passed in `packages/coding-agent`. Fixes #3756