### PR TITLE
fix(session): compaction summary at chronological position in collapsed transcript

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed subagents spawned with an output schema (`agent(..., schema=...)`, `task` with structured output) failing with `schema_violation: missing required fields` since the typed-yield rework: a `type: "result"` finalize carrying the full object was assembled as a section named `result`, nesting the payload one level deep. String-typed yields are now treated as terminal finalizers (their data is the complete result), only array-typed yields form accumulating sections, and a data-less finalize keeps accumulated sections instead of collapsing to the last assistant turn.
 - Fixed the per-provider concurrency cap (e.g. `providers.ollama-cloud.maxConcurrency`) bracketing the whole subagent lifecycle, which deadlocked any spawn tree wider than the cap because parents held every slot while waiting for children queued on the same cap. The semaphore now wraps each provider HTTP request, so a parent's slot frees between turns and child subagents can acquire while their parent's tool calls are running. ([#3749](https://github.com/can1357/oh-my-pi/issues/3749))
 - Fixed Ctrl+Q / Ctrl+Enter follow-up submissions sending the literal `[Paste #N]` marker instead of the expanded paste body ([#3737](https://github.com/can1357/oh-my-pi/issues/3737)).
+- Fixed `/compact` summary divider landing at the top of the transcript and scrolling into frozen native scrollback where Ctrl+O could not expand it. The collapsed display transcript now emits the summary at the chronological compaction point (after kept messages), keeping it in the live region.
 
 ## [16.2.4] - 2026-06-28
 

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -295,21 +295,23 @@ export function buildSessionContext(
 		})();
 		const remoteReplacementHistory = providerPayload?.items;
 
-		if (options?.transcript) handleEntryResetTracking(compaction);
-		// Emit summary first; re-attach any archived snapcompact frames so the
-		// model can keep reading the archived history after every context rebuild.
+		// Re-attach any archived snapcompact frames so the model can keep
+		// reading the archived history after every context rebuild.
 		const snapcompactArchive = snapcompact.getPreservedArchive(compaction.preserveData);
-		pushMessage(
-			createCompactionSummaryMessage(
-				compaction.summary,
-				compaction.tokensBefore,
-				compaction.timestamp,
-				compaction.shortSummary,
-				providerPayload,
-				undefined,
-				snapcompactArchive ? snapcompact.historyBlocks(snapcompactArchive) : undefined,
-			),
+		const compactionSummaryMsg = createCompactionSummaryMessage(
+			compaction.summary,
+			compaction.tokensBefore,
+			compaction.timestamp,
+			compaction.shortSummary,
+			providerPayload,
+			undefined,
+			snapcompactArchive ? snapcompact.historyBlocks(snapcompactArchive) : undefined,
 		);
+		// Agent context (non-transcript): summary first so the LLM sees the
+		// compacted context before recent messages.
+		if (!options?.transcript) {
+			pushMessage(compactionSummaryMsg);
+		}
 
 		// Find compaction index in path
 		const compactionIdx = path.findIndex(e => e.type === "compaction" && e.id === compaction.id);
@@ -331,6 +333,16 @@ export function buildSessionContext(
 					appendMessage(entry);
 				}
 			}
+		}
+
+		// Display transcript: emit the summary at the chronological compaction
+		// point (after kept messages, before post-compaction) so it stays in
+		// the live region where Ctrl+O can expand it. Reset tracking fires
+		// here so the first post-compaction assistant turn — not a kept
+		// pre-compaction one — is marked as a cache miss.
+		if (options?.transcript) handleEntryResetTracking(compaction);
+		if (options?.transcript) {
+			pushMessage(compactionSummaryMsg);
 		}
 
 		// Emit messages after compaction

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -1173,8 +1173,10 @@ describe("buildSessionContext", () => {
 			collapseCompactedHistory: true,
 		});
 
-		expect(transcript.messages.map(m => m.role)).toEqual(["compactionSummary", "user", "user"]);
-		expect((transcript.messages[0] as { summary: string }).summary).toContain("Second summary");
+		expect(transcript.messages.map(m => m.role)).toEqual(["user", "compactionSummary", "user"]);
+		const summaryMsg = transcript.messages[1];
+		if (summaryMsg?.role !== "compactionSummary") throw new Error("Expected compaction summary at index 1");
+		expect(summaryMsg.summary).toContain("Second summary");
 		expect(transcript.cacheMissExplainedAt).toEqual([false, false, false]);
 	});
 
@@ -1204,7 +1206,7 @@ describe("buildSessionContext", () => {
 		// The provider payload is attached to the summary for LLM replay only; the
 		// collapsed display must still emit the kept SessionEntry rows so a
 		// remotely-compacted session keeps its recent turns visible.
-		expect(transcript.messages.map(m => m.role)).toEqual(["compactionSummary", "user", "assistant", "user"]);
+		expect(transcript.messages.map(m => m.role)).toEqual(["user", "assistant", "compactionSummary", "user"]);
 		const dump = JSON.stringify(transcript.messages);
 		expect(dump).toContain("kept-user");
 		expect(dump).toContain("kept-assistant");

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -248,6 +248,105 @@ describe("buildSessionContext", () => {
 		});
 	});
 
+	describe("collapsed transcript ordering", () => {
+		it("display transcript: summary after kept messages, not at top", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "old question"),
+				msg("2", "1", "assistant", "old response"),
+				msg("3", "2", "user", "kept question"),
+				msg("4", "3", "assistant", "kept response"),
+				compaction("5", "4", "Summary of compacted turns", "3"),
+				msg("6", "5", "user", "after compact"),
+			];
+
+			// Display transcript: kept messages → summary → post-compaction
+			const transcript = buildSessionContext(entries, undefined, undefined, {
+				transcript: true,
+				collapseCompactedHistory: true,
+			});
+
+			expect(transcript.messages).toHaveLength(4);
+			expect(transcript.messages[0]?.role).toBe("user");
+			expect(transcript.messages[1]?.role).toBe("assistant");
+			expect(transcript.messages[2]?.role).toBe("compactionSummary");
+			expect(transcript.messages[3]?.role).toBe("user");
+		});
+
+		it("agent context: summary stays at top", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "old question"),
+				msg("2", "1", "assistant", "old response"),
+				msg("3", "2", "user", "kept question"),
+				msg("4", "3", "assistant", "kept response"),
+				compaction("5", "4", "Summary of compacted turns", "3"),
+				msg("6", "5", "user", "after compact"),
+			];
+
+			// Agent context (no transcript): summary first
+			const agentCtx = buildSessionContext(entries);
+
+			expect(agentCtx.messages).toHaveLength(4);
+			expect(agentCtx.messages[0]?.role).toBe("compactionSummary");
+			expect(agentCtx.messages[1]?.role).toBe("user");
+			expect(agentCtx.messages[2]?.role).toBe("assistant");
+			expect(agentCtx.messages[3]?.role).toBe("user");
+		});
+
+		it("display transcript with no post-compaction messages: summary at bottom", () => {
+			// Simulates the moment right after /compact runs — compaction is the
+			// last entry, so the summary should be the last (bottom) message.
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "old question"),
+				msg("2", "1", "assistant", "old response"),
+				msg("3", "2", "user", "kept question"),
+				msg("4", "3", "assistant", "kept response"),
+				compaction("5", "4", "Freshly compacted", "3"),
+			];
+
+			const transcript = buildSessionContext(entries, undefined, undefined, {
+				transcript: true,
+				collapseCompactedHistory: true,
+			});
+
+			expect(transcript.messages).toHaveLength(3);
+			expect(transcript.messages[0]?.role).toBe("user");
+			expect(transcript.messages[1]?.role).toBe("assistant");
+			expect(transcript.messages[2]?.role).toBe("compactionSummary");
+		});
+
+		it("collapsed transcript marks first post-compaction assistant as cache miss", () => {
+			// With kept assistant BEFORE compaction and assistant AFTER compaction,
+			// the cache-miss flag must land on the post-compaction assistant (the
+			// turn that actually follows /compact), not on the kept pre-compaction one.
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "old question"),
+				msg("2", "1", "assistant", "old response"),
+				msg("3", "2", "user", "kept question"),
+				msg("4", "3", "assistant", "kept response"),
+				compaction("5", "4", "Compacted", "3"),
+				msg("6", "5", "user", "after compact"),
+				msg("7", "6", "assistant", "after response"),
+			];
+
+			const transcript = buildSessionContext(entries, undefined, undefined, {
+				transcript: true,
+				collapseCompactedHistory: true,
+			});
+
+			// Roles: user(3), assistant(4), compactionSummary, user(6), assistant(7)
+			expect(transcript.messages.map(m => m.role)).toEqual([
+				"user",
+				"assistant",
+				"compactionSummary",
+				"user",
+				"assistant",
+			]);
+			// cacheMissExplainedAt: the kept assistant (index 1) should NOT be a miss;
+			// the post-compaction assistant (index 4) SHOULD be a miss.
+			expect(transcript.cacheMissExplainedAt).toEqual([false, false, false, false, true]);
+		});
+	});
+
 	describe("with branches", () => {
 		it("follows path to specified leaf", () => {
 			// Tree:


### PR DESCRIPTION
## Problem

Since `3bcbf1515` (fix #3258), manual `/compact` produces no visible feedback: the `📸 compacted` divider lands at transcript index 0 (top), scrolls into native scrollback, and **Ctrl+O can no longer expand it**. The user sees the spinner stop and nothing else — no summary, no divider, no way to inspect what was compacted.

## Root cause

`3bcbf1515` added `collapseCompactedHistory` for performance (avoids replaying compacted history on every rebuild). The collapsed branch in `buildSessionContext` emits the `compactionSummary` message **before** kept messages — at position 0. After `rebuildChatFromMessages()` the viewport stays at the bottom, so the divider at the top immediately enters native scrollback as a frozen snapshot. `resetDisplay()` doesn't help — the divider re-enters scrollback on the next render.

## Fix

In the collapsed transcript branch (`options.transcript && options.collapseCompactedHistory`), emit **kept messages first**, then the `compactionSummary`, then post-compaction messages — restoring the chronological position the divider had before `3bcbf1515`.

Agent context (non-transcript path) keeps summary-first ordering unchanged — the LLM still sees the compacted context before recent messages.

## Behavior

- **Before:** `/compact` → divider at top → frozen in scrollback → invisible, Ctrl+O dead
- **After:** `/compact` → divider at bottom (most recent position) → live, Ctrl+O expands summary

## Regression

Introduced by `3bcbf1515` — `fix(tui): reduced large transcript stalls` (#3258). The performance fix correctly collapsed compacted history but inadvertently moved the divider from its chronological position (where it fired) to index 0.