### PR TITLE
fix(coding-agent): allow bash interceptor device redirects

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -317,8 +317,12 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 		// `>` must sit outside quoted regions (so `echo "a -> b"` passes) and be
 		// followed by a plausible filename — including `$VAR` targets; `>|`
 		// (clobber) counts as a redirect; `>&2`/`2>&1` style fd duplication is
-		// not matched.
-		pattern: "^\\s*(echo|printf|cat\\s*<<)\\s+(?:[^\"'>]|\"[^\"]*\"|'[^']*')*(?<!\\|)>{1,2}\\|?\\s*[$\\w./~\"'-]",
+		// not matched. A `/dev/` target (`/dev/null`, `/dev/tty`, `/dev/stdout`,
+		// `/dev/stderr`, `/dev/fd/N`), quoted or bare, is a discard/device sink —
+		// not a file the `write` tool can author — so it is excluded via the
+		// `(?![\"']?/dev/)` lookahead.
+		pattern:
+			"^\\s*(echo|printf|cat\\s*<<)\\s+(?:[^\"'>]|\"[^\"]*\"|'[^']*')*(?<!\\|)>{1,2}\\|?\\s*(?![\"']?/dev/)[$\\w./~\"'-]",
 		tool: "write",
 		message: "Use the `write` tool instead of echo/cat redirection. It handles encoding and provides confirmation.",
 	},

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -82,6 +82,30 @@ describe("default echo/printf redirect rule", () => {
 		expect(checkBashInterception("printf 'use 2>&1'", tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(false);
 		expect(checkBashInterception('echo "err" >&2', tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(false);
 	});
+
+	it("does not block redirects to /dev sinks (discard/device targets)", () => {
+		for (const cmd of [
+			'echo "$RESULT" > /dev/null',
+			"echo done > /dev/null 2>&1",
+			'echo "" > /dev/tty',
+			"echo x > /dev/stdout",
+			'echo "marker" > /dev/stderr',
+			"printf y >> /dev/fd/3",
+			"echo x > /dev/zero",
+			"echo x > /dev/random",
+			"echo x > /dev/full",
+			'echo x > "/dev/null"',
+			"echo x > '/dev/null'",
+		]) {
+			expect(checkBashInterception(cmd, tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(false);
+		}
+	});
+
+	it("still blocks real files whose path merely resembles /dev", () => {
+		for (const cmd of ["echo data > ./dev/null", "echo data > /devices/x", "echo conf > ~/.bashrc"]) {
+			expect(checkBashInterception(cmd, tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(true);
+		}
+	});
 });
 
 describe("BashTool argument validation", () => {


### PR DESCRIPTION
## What

Closes #3763.

The bash interceptor's `echo`/`printf` write-redirection rule now excludes every `/dev/...` redirect target (quoted or bare) via a negative lookahead.

This keeps the existing block for real file writes, while allowing device/discard idioms such as:

```sh
echo "$RESULT" > /dev/null
echo done > /dev/null 2>&1
echo "" > /dev/tty
echo x > /dev/stdout
echo "marker" > /dev/stderr
printf y >> /dev/fd/3
echo x > /dev/zero
echo x > "/dev/null"
```

## Why

None of those commands author a file — they target shell device or discard sinks, so the `write` tool is not a usable replacement. Blocking them is an interceptor false positive.

The interceptor is a tool-routing nudge, not a safety gate. Excluding the whole `/dev/` namespace (rather than an allowlist) is deliberate: an allowlist would re-block `/dev/zero`, `/dev/random`, `/dev/full`, `/dev/fd/N`, etc. — the same false-positive class. Destructive raw-device writes (`> /dev/sda`, `dd ... of=/dev/...`, `mkfs`) remain covered by the separate destructive-command blocklist in `bash.ts`.

Paths that merely resemble `/dev` still route to `write`:

```sh
echo data > ./dev/null   # blocked (relative file)
echo data > /devices/x   # blocked (not /dev/)
echo conf > ~/.bashrc    # blocked (real file)
```

## Commit

| Commit | Change |
| --- | --- |
| `e267722c5` | Exclude `/dev/...` redirect targets from the default echo/printf write rule; add regression coverage. |

## Verification

- `bun test test/tools/bash-interceptor.test.ts` — 10 pass, 0 fail (29 assertions)
- `bun check` — passed
