### PR TITLE
feat(omp): add TUI restart command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1487,6 +1487,9 @@
 - Fixed the DuckDuckGo web_search provider returning empty results for non-encyclopedic queries by switching from the Instant Answer API to parsing the HTML frontend, and added clear error handling for bot-challenge throttling.
 - Fixed Windows --extension paths with spaces or \\?\ prefixes being truncated or incorrectly passed to Bun import/spawn APIs.
 - Fixed /mcp reauth compatibility with Cloudflare by aligning OAuth prompt behavior with the reference MCP SDK and updating the client label to oh-my-pi.
+### Fixed
+
+- Fixed `/restart` dropping the `--no-extensions` launch state, so restarted TUI sessions continue to suppress configured/project extensions and custom commands.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1499,6 +1499,7 @@
 - Fixed `/restart` allowing process teardown while async background jobs or detached subagents were still running, which could cancel pending work and deliveries.
 - Fixed `/restart` API-key handoffs for resumed/forked sessions by skipping fresh-launch model validation until the restored session model is available.
 - Fixed `/restart` capturing built-in launch flags from the extension-aware parse so extension-registered flags that shadow built-ins do not replay stale built-in values.
+- Fixed `/restart` replaying relative launch path flags such as `--config` against a moved session cwd instead of the original launch cwd.
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1493,6 +1493,9 @@
 ### Changed
 
 - Status line now collapses a linked git worktree path to the project name with a worktree icon, leaving the git segment to show the branch once instead of repeating it in the path.
+### Added
+
+- Added `/restart` to restart OMP from the TUI and resume the current session in the same terminal.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1493,7 +1493,7 @@
 
 ### Fixed
 
-- Fixed `/restart` dropping launch-only auth, context, config, and extension state (`--api-key`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve runtime API keys, disabled context sources, custom config overlays, and extension/plugin roots.
+- Fixed `/restart` dropping launch-only auth, prompt, skill, context, config, and extension state (`--api-key`, `--system-prompt`, `--append-system-prompt`, `--skills`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve runtime API keys, custom system prompts, skill filters, disabled context sources, custom config overlays, and extension/plugin roots.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1487,18 +1487,19 @@
 - Fixed the DuckDuckGo web_search provider returning empty results for non-encyclopedic queries by switching from the Instant Answer API to parsing the HTML frontend, and added clear error handling for bot-challenge throttling.
 - Fixed Windows --extension paths with spaces or \\?\ prefixes being truncated or incorrectly passed to Bun import/spawn APIs.
 - Fixed /mcp reauth compatibility with Cloudflare by aligning OAuth prompt behavior with the reference MCP SDK and updating the client label to oh-my-pi.
+### Added
+
+- Added `/restart` to restart OMP from the TUI and resume the current session in the same terminal.
+
 ### Fixed
 
-- Fixed `/restart` dropping the `--no-extensions` launch state, so restarted TUI sessions continue to suppress configured/project extensions and custom commands.
+- Fixed `/restart` dropping launch-only config and extension state (`--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve custom config overlays and extension/plugin roots.
 
 ## [16.2.5] - 2026-06-28
 
 ### Changed
 
 - Status line now collapses a linked git worktree path to the project name with a worktree icon, leaving the git segment to show the branch once instead of repeating it in the path.
-### Added
-
-- Added `/restart` to restart OMP from the TUI and resume the current session in the same terminal.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1496,6 +1496,10 @@
 - Fixed `/restart` dropping launch-only auth, prompt, skill, context, config, and extension state (`--api-key`, `--system-prompt`, `--append-system-prompt`, `--skills`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, `--plugin-dir`, and extension-registered CLI flags), so restarted TUI sessions preserve runtime API keys, custom system prompts, skill filters, disabled context sources, custom config overlays, extension/plugin roots, and extension flag values.
 - Fixed `/restart` dropping launch-only model, thinking, and advisor overrides (`--models`, `--smol`, `--slow`, `--plan`, `--thinking`, `--hide-thinking`, and `--advisor`).
 - Fixed `/restart` allowing process teardown while async background jobs were still running, which could cancel pending job work and deliveries.
+- Fixed `/restart` allowing process teardown while async background jobs or detached subagents were still running, which could cancel pending work and deliveries.
+- Fixed `/restart` API-key handoffs for resumed/forked sessions by skipping fresh-launch model validation until the restored session model is available.
+- Fixed `/restart` capturing built-in launch flags from the extension-aware parse so extension-registered flags that shadow built-ins do not replay stale built-in values.
+- Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1493,7 +1493,7 @@
 
 ### Fixed
 
-- Fixed `/restart` dropping launch-only auth, prompt, skill, context, config, and extension state (`--api-key`, `--system-prompt`, `--append-system-prompt`, `--skills`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve runtime API keys, custom system prompts, skill filters, disabled context sources, custom config overlays, and extension/plugin roots.
+- Fixed `/restart` dropping launch-only auth, prompt, skill, context, config, and extension state (`--api-key`, `--system-prompt`, `--append-system-prompt`, `--skills`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, `--plugin-dir`, and extension-registered CLI flags), so restarted TUI sessions preserve runtime API keys, custom system prompts, skill filters, disabled context sources, custom config overlays, extension/plugin roots, and extension flag values.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1493,7 +1493,7 @@
 
 ### Fixed
 
-- Fixed `/restart` dropping launch-only config and extension state (`--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve custom config overlays and extension/plugin roots.
+- Fixed `/restart` dropping launch-only auth, context, config, and extension state (`--api-key`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, and `--plugin-dir`), so restarted TUI sessions preserve runtime API keys, disabled context sources, custom config overlays, and extension/plugin roots.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Fixed spilled tool-output artifact descriptors leaking on error/abort paths. `OutputSink.dump()` was the only path that closed the spill `Bun.FileSink`, but the bash and Python executors re-throw on failure and their `finally` blocks never closed the sink, so a large-output command that errored leaked the artifact descriptor until an unrelated read (e.g. a `SKILL.md` load) hit `EMFILE`. `OutputSink` now exposes an idempotent `dispose()` that closes the sink exactly once, wired into every executor's `finally` ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
 - Fixed the first submitted prompt stalling while the local tiny-title worker started: the interactive submit handler now paints the pending user row before starting title generation, and startup prewarms an idle, unref'd worker so the first submit reuses a live subprocess instead of paying spawn latency ahead of the first frame ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).
 - Fixed legacy Pi extensions failing validation when importing the upstream `keyText` keybinding helper ([#6470](https://github.com/can1357/oh-my-pi/issues/6470)).
+### Fixed
+
+- Fixed `/restart` dropping undelivered async results, reinterpreting literal prompts, rereading literal prompt paths, and racing marketplace updates.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1500,6 +1500,7 @@
 - Fixed `/restart` API-key handoffs for resumed/forked sessions by skipping fresh-launch model validation until the restored session model is available.
 - Fixed `/restart` capturing built-in launch flags from the extension-aware parse so extension-registered flags that shadow built-ins do not replay stale built-in values.
 - Fixed `/restart` replaying relative launch path flags such as `--config` against a moved session cwd instead of the original launch cwd.
+- Fixed `/restart` dropping `--max-time`; restarted sessions now replay only the remaining wall-clock budget instead of resetting the original duration.
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1494,6 +1494,8 @@
 ### Fixed
 
 - Fixed `/restart` dropping launch-only auth, prompt, skill, context, config, and extension state (`--api-key`, `--system-prompt`, `--append-system-prompt`, `--skills`, `--no-lsp`, `--no-skills`, `--no-rules`, `--no-extensions`, `--config`, `--extension`, `--hook`, `--plugin-dir`, and extension-registered CLI flags), so restarted TUI sessions preserve runtime API keys, custom system prompts, skill filters, disabled context sources, custom config overlays, extension/plugin roots, and extension flag values.
+- Fixed `/restart` dropping launch-only model, thinking, and advisor overrides (`--models`, `--smol`, `--slow`, `--plan`, `--thinking`, `--hide-thinking`, and `--advisor`).
+- Fixed `/restart` allowing process teardown while async background jobs were still running, which could cancel pending job work and deliveries.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -12,6 +12,8 @@ export const RESTART_ADVISOR_ENABLED_ENV = "OMP_RESTART_ADVISOR_ENABLED";
 
 /** Environment variable used for one-hop restart handoff of extension CLI flag values. */
 export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
+/** Environment variable used to preserve CLI extension package roots across picker resumes and restarts. */
+export const RESTART_EXTENSION_PACKAGE_ROOTS_ENV = "OMP_RESTART_EXTENSION_PACKAGE_ROOTS";
 
 /** Tool approval modes that can be restored across a process restart. */
 export type RestartApprovalMode = "always-ask" | "write" | "yolo";
@@ -34,6 +36,7 @@ export interface RestartLaunchFlags {
 	noTitle?: boolean;
 	configFiles?: string[];
 	extensionPaths?: string[];
+	extensionPackageRoots?: string[];
 	hookPaths?: string[];
 	pluginDirs?: string[];
 	extensionFlagValues?: readonly RestartExtensionFlagValue[];
@@ -157,6 +160,32 @@ export function consumeRestartExtensionFlagValues(
 	return values;
 }
 
+/** Consume CLI extension package roots from the one-hop restart environment payload. */
+export function consumeRestartExtensionPackageRoots(
+	env: Record<string, string | undefined> = process.env,
+): string[] | undefined {
+	const encoded = env[RESTART_EXTENSION_PACKAGE_ROOTS_ENV];
+	if (encoded === undefined) return undefined;
+	delete env[RESTART_EXTENSION_PACKAGE_ROOTS_ENV];
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(encoded);
+	} catch {
+		return undefined;
+	}
+	if (!Array.isArray(decoded)) return undefined;
+	return decoded.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+/** Prefer restart-carried package roots over CLI paths re-resolved in the restarted cwd. */
+export function selectRestartExtensionPackageRoots(
+	carriedRoots: readonly string[] | undefined,
+	extensionPaths: readonly string[] | undefined,
+	hookPaths: readonly string[] | undefined,
+): string[] {
+	return carriedRoots !== undefined ? [...carriedRoots] : [...(extensionPaths ?? []), ...(hookPaths ?? [])];
+}
+
 /** Restore restart-carried extension flag values for names still registered after discovery. */
 export function restoreRestartExtensionFlagValues(
 	sink: RestartExtensionFlagSink,
@@ -201,6 +230,10 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 	}
 	if (options.extensionFlagValues !== undefined) {
 		childEnv[RESTART_EXTENSION_FLAG_VALUES_ENV] = JSON.stringify(options.extensionFlagValues);
+		hasChildEnv = true;
+	}
+	if (options.extensionPackageRoots !== undefined) {
+		childEnv[RESTART_EXTENSION_PACKAGE_ROOTS_ENV] = JSON.stringify(options.extensionPackageRoots);
 		hasChildEnv = true;
 	}
 	if (options.advisor !== undefined) {

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -9,6 +9,8 @@ export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
 export const RESTART_API_KEY_PROVIDER_ENV = "OMP_RESTART_API_KEY_PROVIDER";
 /** Environment variable used for one-hop restart handoff of the live advisor toggle. */
 export const RESTART_ADVISOR_ENABLED_ENV = "OMP_RESTART_ADVISOR_ENABLED";
+/** Environment variable used for one-hop restart handoff of the live computer-use toggle. */
+export const RESTART_COMPUTER_ENABLED_ENV = "OMP_RESTART_COMPUTER_ENABLED";
 
 /** Environment variable used for one-hop restart handoff of extension CLI flag values. */
 export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
@@ -57,6 +59,7 @@ export interface RestartLaunchFlags {
 	thinking?: ConfiguredThinkingLevel;
 	hideThinking?: boolean;
 	advisor?: boolean;
+	computer?: boolean;
 	providerSessionId?: string;
 	providerPromptCacheKey?: string;
 	skillPatterns?: string[];
@@ -166,6 +169,18 @@ export function consumeRestartAdvisorEnabled(
 	const encoded = env[RESTART_ADVISOR_ENABLED_ENV];
 	if (encoded === undefined) return undefined;
 	delete env[RESTART_ADVISOR_ENABLED_ENV];
+	if (encoded === "1") return true;
+	if (encoded === "0") return false;
+	return undefined;
+}
+
+/** Consume the restart-only computer-use toggle override from the one-hop restart environment. */
+export function consumeRestartComputerEnabled(
+	env: Record<string, string | undefined> = process.env,
+): boolean | undefined {
+	const encoded = env[RESTART_COMPUTER_ENABLED_ENV];
+	if (encoded === undefined) return undefined;
+	delete env[RESTART_COMPUTER_ENABLED_ENV];
 	if (encoded === "1") return true;
 	if (encoded === "0") return false;
 	return undefined;
@@ -290,6 +305,10 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 	}
 	if (options.advisor !== undefined) {
 		childEnv[RESTART_ADVISOR_ENABLED_ENV] = options.advisor ? "1" : "0";
+		hasChildEnv = true;
+	}
+	if (options.computer !== undefined) {
+		childEnv[RESTART_COMPUTER_ENABLED_ENV] = options.computer ? "1" : "0";
 		hasChildEnv = true;
 	}
 	return hasChildEnv ? childEnv : undefined;

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -34,6 +34,7 @@ export interface BuildRestartCommandOptions {
 	cwd: string;
 	sessionDir: string;
 	activeProfile?: string;
+	disableExtensions?: boolean;
 	toolRestriction?: RestartToolRestriction;
 	approvalMode: RestartApprovalMode;
 }
@@ -90,6 +91,10 @@ export function buildRestartCommand(
 
 	if (options.activeProfile !== undefined) {
 		cmd.push("--profile", options.activeProfile);
+	}
+
+	if (options.disableExtensions) {
+		cmd.push("--no-extensions");
 	}
 
 	cmd.push("--cwd", options.cwd, "--approval-mode", options.approvalMode);

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -35,6 +35,7 @@ export interface RestartLaunchFlags {
 	noPty?: boolean;
 	noTitle?: boolean;
 	configFiles?: string[];
+	configEnvFiles?: string[];
 	extensionPaths?: string[];
 	extensionPackageRoots?: string[];
 	hookPaths?: string[];
@@ -226,6 +227,10 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 		if (options.apiKeyProvider) {
 			childEnv[RESTART_API_KEY_PROVIDER_ENV] = options.apiKeyProvider;
 		}
+		hasChildEnv = true;
+	}
+	if (options.configEnvFiles !== undefined) {
+		childEnv.PI_CONFIG_FILES = options.configEnvFiles.join(path.delimiter);
 		hasChildEnv = true;
 	}
 	if (options.extensionFlagValues !== undefined) {

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -11,7 +11,7 @@ export type RestartApprovalMode = "always-ask" | "write" | "yolo";
 /** Tool filter that must be restored in the restarted process. */
 export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; toolNames: string[] };
 
-/** CLI launch flags for config, context, auth, and extension discovery that must survive restart. */
+/** CLI launch flags for config, prompt, context, auth, and extension discovery that must survive restart. */
 export interface RestartLaunchFlags {
 	apiKey?: string;
 	disableExtensions?: boolean;
@@ -22,6 +22,9 @@ export interface RestartLaunchFlags {
 	extensionPaths?: string[];
 	hookPaths?: string[];
 	pluginDirs?: string[];
+	skillPatterns?: string[];
+	systemPrompt?: string;
+	appendSystemPrompt?: string;
 }
 
 /** Self-entrypoint command before restart-specific CLI arguments are appended. */
@@ -137,6 +140,12 @@ export function buildRestartCommand(
 	appendRepeatedFlag(cmd, "--extension", options.extensionPaths);
 	appendRepeatedFlag(cmd, "--hook", options.hookPaths);
 	appendRepeatedFlag(cmd, "--plugin-dir", options.pluginDirs);
+	if (options.systemPrompt !== undefined) {
+		cmd.push("--system-prompt", options.systemPrompt);
+	}
+	if (options.appendSystemPrompt !== undefined) {
+		cmd.push("--append-system-prompt", options.appendSystemPrompt);
+	}
 
 	if (options.disableLsp) {
 		cmd.push("--no-lsp");
@@ -146,6 +155,9 @@ export function buildRestartCommand(
 	}
 	if (options.disableRules) {
 		cmd.push("--no-rules");
+	}
+	if (options.skillPatterns && options.skillPatterns.length > 0) {
+		cmd.push("--skills", options.skillPatterns.join(","));
 	}
 
 	cmd.push("--cwd", options.cwd, "--approval-mode", options.approvalMode);

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 
 import { isCompiledBinary, workerHostEntry } from "@oh-my-pi/pi-utils";
+import type { ConfiguredThinkingLevel } from "../thinking";
 
 /** Environment variable used for one-hop restart handoff of runtime CLI API keys. */
 export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
@@ -29,6 +30,13 @@ export interface RestartLaunchFlags {
 	hookPaths?: string[];
 	pluginDirs?: string[];
 	extensionFlagValues?: readonly RestartExtensionFlagValue[];
+	modelPatterns?: string[];
+	smolModel?: string;
+	slowModel?: string;
+	planModel?: string;
+	thinking?: ConfiguredThinkingLevel;
+	hideThinking?: boolean;
+	advisor?: boolean;
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -209,6 +217,27 @@ export function buildRestartCommand(
 	}
 	if (options.appendSystemPrompt !== undefined) {
 		cmd.push("--append-system-prompt", options.appendSystemPrompt);
+	}
+	if (options.modelPatterns && options.modelPatterns.length > 0) {
+		cmd.push("--models", options.modelPatterns.join(","));
+	}
+	if (options.smolModel !== undefined) {
+		cmd.push("--smol", options.smolModel);
+	}
+	if (options.slowModel !== undefined) {
+		cmd.push("--slow", options.slowModel);
+	}
+	if (options.planModel !== undefined) {
+		cmd.push("--plan", options.planModel);
+	}
+	if (options.thinking !== undefined) {
+		cmd.push("--thinking", options.thinking);
+	}
+	if (options.hideThinking) {
+		cmd.push("--hide-thinking");
+	}
+	if (options.advisor) {
+		cmd.push("--advisor");
 	}
 
 	if (options.disableLsp) {

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -5,6 +5,8 @@ import type { ConfiguredThinkingLevel } from "../thinking";
 
 /** Environment variable used for one-hop restart handoff of runtime CLI API keys. */
 export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
+/** Environment variable used for one-hop restart handoff of the runtime CLI API key's original provider. */
+export const RESTART_API_KEY_PROVIDER_ENV = "OMP_RESTART_API_KEY_PROVIDER";
 
 /** Environment variable used for one-hop restart handoff of extension CLI flag values. */
 export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
@@ -21,6 +23,7 @@ export type RestartExtensionFlagValue = readonly [name: string, value: boolean |
 /** CLI launch state for time budget, auth, prompts, skills, context, config, and extensions that must survive restart. */
 export interface RestartLaunchFlags {
 	apiKey?: string;
+	apiKeyProvider?: string;
 	disableExtensions?: boolean;
 	disableLsp?: boolean;
 	disableRules?: boolean;
@@ -37,6 +40,7 @@ export interface RestartLaunchFlags {
 	thinking?: ConfiguredThinkingLevel;
 	hideThinking?: boolean;
 	advisor?: boolean;
+	providerSessionId?: string;
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -166,6 +170,9 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 	let hasChildEnv = false;
 	if (options.apiKey) {
 		childEnv[RESTART_API_KEY_ENV] = options.apiKey;
+		if (options.apiKeyProvider) {
+			childEnv[RESTART_API_KEY_PROVIDER_ENV] = options.apiKeyProvider;
+		}
 		hasChildEnv = true;
 	}
 	if (options.extensionFlagValues && options.extensionFlagValues.length > 0) {
@@ -224,6 +231,9 @@ export function buildRestartCommand(
 	}
 	if (options.appendSystemPrompt !== undefined) {
 		cmd.push("--append-system-prompt", options.appendSystemPrompt);
+	}
+	if (options.providerSessionId !== undefined) {
+		cmd.push("--provider-session-id", options.providerSessionId);
 	}
 	if (options.modelPatterns && options.modelPatterns.length > 0) {
 		cmd.push("--models", options.modelPatterns.join(","));

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -62,6 +62,7 @@ export interface RestartLaunchFlags {
 	appendSystemPrompt?: string;
 	/** Absolute wall-clock deadline in epoch milliseconds for replaying remaining --max-time. */
 	maxTimeDeadline?: number;
+	autoApprove?: boolean;
 }
 
 /** Self-entrypoint command before restart-specific CLI arguments are appended. */
@@ -345,6 +346,9 @@ export function buildRestartCommand(
 	}
 	if (options.advisor) {
 		cmd.push("--advisor");
+	}
+	if (options.autoApprove) {
+		cmd.push("--auto-approve");
 	}
 
 	const maxTimeSeconds = getRestartMaxTimeSeconds(options.maxTimeDeadline);

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -43,10 +43,16 @@ export interface RestartLaunchFlags {
 	smolModel?: string;
 	slowModel?: string;
 	planModel?: string;
+	prewalk?: boolean;
+	noPrewalk?: boolean;
+	prewalkInto?: string;
+	planYolo?: boolean;
+	planYoloInto?: string;
 	thinking?: ConfiguredThinkingLevel;
 	hideThinking?: boolean;
 	advisor?: boolean;
 	providerSessionId?: string;
+	providerPromptCacheKey?: string;
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -263,6 +269,9 @@ export function buildRestartCommand(
 	if (options.providerSessionId !== undefined) {
 		cmd.push("--provider-session-id", options.providerSessionId);
 	}
+	if (options.providerPromptCacheKey !== undefined) {
+		cmd.push("--prompt-cache-key", options.providerPromptCacheKey);
+	}
 	if (options.modelPatterns && options.modelPatterns.length > 0) {
 		cmd.push("--models", options.modelPatterns.join(","));
 	}
@@ -274,6 +283,21 @@ export function buildRestartCommand(
 	}
 	if (options.planModel !== undefined) {
 		cmd.push("--plan", options.planModel);
+	}
+	if (options.prewalk) {
+		cmd.push("--prewalk");
+	}
+	if (options.noPrewalk) {
+		cmd.push("--no-prewalk");
+	}
+	if (options.prewalkInto !== undefined) {
+		cmd.push("--prewalk-into", options.prewalkInto);
+	}
+	if (options.planYolo) {
+		cmd.push("--plan-yolo");
+	}
+	if (options.planYoloInto !== undefined) {
+		cmd.push("--plan-yolo-into", options.planYoloInto);
 	}
 	if (options.thinking !== undefined) {
 		cmd.push("--thinking", options.thinking);

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -1,0 +1,127 @@
+import * as path from "node:path";
+
+import { isCompiledBinary, workerHostEntry } from "@oh-my-pi/pi-utils";
+
+/** Tool approval modes that can be restored across a process restart. */
+export type RestartApprovalMode = "always-ask" | "write" | "yolo";
+
+/** Tool filter that must be restored in the restarted process. */
+export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; toolNames: string[] };
+
+/** Self-entrypoint command before restart-specific CLI arguments are appended. */
+export interface RestartCommandBase {
+	cmd: string[];
+	cwd?: string;
+}
+
+/** Complete restart command with the cwd used to spawn it. */
+export interface RestartCommand {
+	cmd: string[];
+	cwd: string;
+}
+
+/** Runtime dependencies used to resolve the current OMP entrypoint. */
+export interface RestartCommandEnvironment {
+	isCompiledBinary: () => boolean;
+	workerHostEntry: () => string | null;
+	execPath: string;
+	packageRoot: string;
+}
+
+/** Inputs copied from live interactive state into the restarted process argv. */
+export interface BuildRestartCommandOptions {
+	sessionId: string;
+	cwd: string;
+	sessionDir: string;
+	activeProfile?: string;
+	toolRestriction?: RestartToolRestriction;
+	approvalMode: RestartApprovalMode;
+}
+
+/** Minimal child process contract needed to await restart completion. */
+export interface RestartSubprocess {
+	exited: Promise<number>;
+}
+
+/** Injectable restart child spawner used by tests. */
+export type RestartSpawn = (options: {
+	cmd: string[];
+	cwd: string;
+	stdin: "inherit";
+	stdout: "inherit";
+	stderr: "inherit";
+}) => RestartSubprocess;
+
+/** Optional dependencies for spawning the restart process. */
+export interface SpawnRestartProcessOptions {
+	spawn?: RestartSpawn;
+}
+
+function defaultRestartCommandEnvironment(): RestartCommandEnvironment {
+	return {
+		isCompiledBinary,
+		workerHostEntry,
+		execPath: process.execPath,
+		packageRoot: path.resolve(import.meta.dir, "..", ".."),
+	};
+}
+
+/** Resolve the base command that re-enters the same OMP build. */
+export function resolveRestartBaseCommand(
+	env: RestartCommandEnvironment = defaultRestartCommandEnvironment(),
+): RestartCommandBase {
+	if (env.isCompiledBinary()) return { cmd: [env.execPath] };
+
+	const hostEntry = env.workerHostEntry();
+	if (hostEntry) {
+		return { cmd: [env.execPath, path.basename(hostEntry)], cwd: path.dirname(hostEntry) };
+	}
+
+	return { cmd: [env.execPath, "src/cli.ts"], cwd: env.packageRoot };
+}
+
+/** Build a restart-safe argv that resumes the current persisted session only. */
+export function buildRestartCommand(
+	options: BuildRestartCommandOptions,
+	env?: RestartCommandEnvironment,
+): RestartCommand {
+	const base = resolveRestartBaseCommand(env);
+	const cmd = [...base.cmd];
+
+	if (options.activeProfile !== undefined) {
+		cmd.push("--profile", options.activeProfile);
+	}
+
+	cmd.push("--cwd", options.cwd, "--approval-mode", options.approvalMode);
+
+	if (options.toolRestriction?.kind === "none") {
+		cmd.push("--no-tools");
+	} else if (options.toolRestriction?.kind === "allowlist") {
+		if (options.toolRestriction.toolNames.length === 0) {
+			cmd.push("--no-tools");
+		} else {
+			cmd.push("--tools", options.toolRestriction.toolNames.join(","));
+		}
+	}
+
+	cmd.push("--session-dir", options.sessionDir, "--resume", options.sessionId);
+
+	return { cmd, cwd: base.cwd ?? options.cwd };
+}
+
+/** Spawn the replacement OMP process with inherited stdio and return its exit code. */
+export async function spawnRestartProcess(
+	command: RestartCommand,
+	options: SpawnRestartProcessOptions = {},
+): Promise<number> {
+	const spawn = options.spawn ?? Bun.spawn;
+	const proc = spawn({
+		cmd: command.cmd,
+		cwd: command.cwd,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+
+	return await proc.exited;
+}

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -8,6 +8,15 @@ export type RestartApprovalMode = "always-ask" | "write" | "yolo";
 /** Tool filter that must be restored in the restarted process. */
 export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; toolNames: string[] };
 
+/** CLI launch flags for config and extension discovery that must survive restart. */
+export interface RestartLaunchFlags {
+	disableExtensions?: boolean;
+	configFiles?: string[];
+	extensionPaths?: string[];
+	hookPaths?: string[];
+	pluginDirs?: string[];
+}
+
 /** Self-entrypoint command before restart-specific CLI arguments are appended. */
 export interface RestartCommandBase {
 	cmd: string[];
@@ -29,12 +38,11 @@ export interface RestartCommandEnvironment {
 }
 
 /** Inputs copied from live interactive state into the restarted process argv. */
-export interface BuildRestartCommandOptions {
+export interface BuildRestartCommandOptions extends RestartLaunchFlags {
 	sessionId: string;
 	cwd: string;
 	sessionDir: string;
 	activeProfile?: string;
-	disableExtensions?: boolean;
 	toolRestriction?: RestartToolRestriction;
 	approvalMode: RestartApprovalMode;
 }
@@ -67,6 +75,12 @@ function defaultRestartCommandEnvironment(): RestartCommandEnvironment {
 	};
 }
 
+function appendRepeatedFlag(cmd: string[], flag: string, values: readonly string[] | undefined): void {
+	for (const value of values ?? []) {
+		cmd.push(flag, value);
+	}
+}
+
 /** Resolve the base command that re-enters the same OMP build. */
 export function resolveRestartBaseCommand(
 	env: RestartCommandEnvironment = defaultRestartCommandEnvironment(),
@@ -93,9 +107,15 @@ export function buildRestartCommand(
 		cmd.push("--profile", options.activeProfile);
 	}
 
+	appendRepeatedFlag(cmd, "--config", options.configFiles);
+
 	if (options.disableExtensions) {
 		cmd.push("--no-extensions");
 	}
+
+	appendRepeatedFlag(cmd, "--extension", options.extensionPaths);
+	appendRepeatedFlag(cmd, "--hook", options.hookPaths);
+	appendRepeatedFlag(cmd, "--plugin-dir", options.pluginDirs);
 
 	cmd.push("--cwd", options.cwd, "--approval-mode", options.approvalMode);
 

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -14,6 +14,8 @@ export const RESTART_ADVISOR_ENABLED_ENV = "OMP_RESTART_ADVISOR_ENABLED";
 export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
 /** Environment variable used to preserve CLI extension package roots across picker resumes and restarts. */
 export const RESTART_EXTENSION_PACKAGE_ROOTS_ENV = "OMP_RESTART_EXTENSION_PACKAGE_ROOTS";
+/** Environment variable used for one-hop restart handoff of literal system prompt values. */
+export const RESTART_LITERAL_PROMPTS_ENV = "OMP_RESTART_LITERAL_PROMPTS";
 
 /** Tool approval modes that can be restored across a process restart. */
 export type RestartApprovalMode = "always-ask" | "write" | "yolo";
@@ -60,6 +62,10 @@ export interface RestartLaunchFlags {
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
+	/** Literal system prompt classified at initial launch; restored through a restart-only env handoff. */
+	restartLiteralSystemPrompt?: string;
+	/** Literal append system prompt classified at initial launch; restored through a restart-only env handoff. */
+	restartLiteralAppendSystemPrompt?: string;
 	/** Absolute wall-clock deadline in epoch milliseconds for replaying remaining --max-time. */
 	maxTimeDeadline?: number;
 	autoApprove?: boolean;
@@ -123,6 +129,33 @@ export interface SpawnRestartProcessOptions {
 export interface RestartExtensionFlagSink {
 	getFlags(): { has(name: string): boolean };
 	setFlagValue(name: string, value: boolean | string): void;
+}
+
+/** Literal prompt values carried only by a restart child environment. */
+export interface RestartLiteralPrompts {
+	systemPrompt?: string;
+	appendSystemPrompt?: string;
+}
+
+/** Consume literal prompt values from the one-hop restart environment payload. */
+export function consumeRestartLiteralPrompts(
+	env: Record<string, string | undefined> = process.env,
+): RestartLiteralPrompts | undefined {
+	const encoded = env[RESTART_LITERAL_PROMPTS_ENV];
+	if (encoded === undefined) return undefined;
+	delete env[RESTART_LITERAL_PROMPTS_ENV];
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(encoded);
+	} catch {
+		return undefined;
+	}
+	if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) return undefined;
+	const values: RestartLiteralPrompts = {};
+	const source = decoded as Record<string, unknown>;
+	if (typeof source.systemPrompt === "string") values.systemPrompt = source.systemPrompt;
+	if (typeof source.appendSystemPrompt === "string") values.appendSystemPrompt = source.appendSystemPrompt;
+	return values.systemPrompt !== undefined || values.appendSystemPrompt !== undefined ? values : undefined;
 }
 
 /** Consume the restart-only advisor toggle override from the one-hop restart environment. */
@@ -240,6 +273,17 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 	}
 	if (options.extensionPackageRoots !== undefined) {
 		childEnv[RESTART_EXTENSION_PACKAGE_ROOTS_ENV] = JSON.stringify(options.extensionPackageRoots);
+		hasChildEnv = true;
+	}
+	if (options.restartLiteralSystemPrompt !== undefined || options.restartLiteralAppendSystemPrompt !== undefined) {
+		childEnv[RESTART_LITERAL_PROMPTS_ENV] = JSON.stringify({
+			...(options.restartLiteralSystemPrompt !== undefined
+				? { systemPrompt: options.restartLiteralSystemPrompt }
+				: {}),
+			...(options.restartLiteralAppendSystemPrompt !== undefined
+				? { appendSystemPrompt: options.restartLiteralAppendSystemPrompt }
+				: {}),
+		} satisfies RestartLiteralPrompts);
 		hasChildEnv = true;
 	}
 	if (options.advisor !== undefined) {

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -131,7 +131,7 @@ export function consumeRestartExtensionFlagValues(
 	env: Record<string, string | undefined> = process.env,
 ): RestartExtensionFlagValue[] | undefined {
 	const encoded = env[RESTART_EXTENSION_FLAG_VALUES_ENV];
-	if (!encoded) return undefined;
+	if (encoded === undefined) return undefined;
 	delete env[RESTART_EXTENSION_FLAG_VALUES_ENV];
 	let decoded: unknown;
 	try {
@@ -148,7 +148,7 @@ export function consumeRestartExtensionFlagValues(
 		if (typeof value !== "boolean" && typeof value !== "string") continue;
 		values.push([name, value]);
 	}
-	return values.length > 0 ? values : undefined;
+	return values;
 }
 
 /** Restore restart-carried extension flag values for names still registered after discovery. */
@@ -193,7 +193,7 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 		}
 		hasChildEnv = true;
 	}
-	if (options.extensionFlagValues && options.extensionFlagValues.length > 0) {
+	if (options.extensionFlagValues !== undefined) {
 		childEnv[RESTART_EXTENSION_FLAG_VALUES_ENV] = JSON.stringify(options.extensionFlagValues);
 		hasChildEnv = true;
 	}

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -5,13 +5,19 @@ import { isCompiledBinary, workerHostEntry } from "@oh-my-pi/pi-utils";
 /** Environment variable used for one-hop restart handoff of runtime CLI API keys. */
 export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
 
+/** Environment variable used for one-hop restart handoff of extension CLI flag values. */
+export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
+
 /** Tool approval modes that can be restored across a process restart. */
 export type RestartApprovalMode = "always-ask" | "write" | "yolo";
 
 /** Tool filter that must be restored in the restarted process. */
 export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; toolNames: string[] };
 
-/** CLI launch flags for config, prompt, context, auth, and extension discovery that must survive restart. */
+/** Extension CLI flag value restored directly after extension discovery on restart. */
+export type RestartExtensionFlagValue = readonly [name: string, value: boolean | string];
+
+/** CLI launch state for auth, prompts, skills, context, config, and extensions that must survive restart. */
 export interface RestartLaunchFlags {
 	apiKey?: string;
 	disableExtensions?: boolean;
@@ -22,6 +28,7 @@ export interface RestartLaunchFlags {
 	extensionPaths?: string[];
 	hookPaths?: string[];
 	pluginDirs?: string[];
+	extensionFlagValues?: readonly RestartExtensionFlagValue[];
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -48,7 +55,7 @@ export interface RestartCommandEnvironment {
 	packageRoot: string;
 }
 
-/** Inputs copied from live interactive state into the restarted process argv. */
+/** Inputs copied from live interactive state into the restarted process argv/env. */
 export interface BuildRestartCommandOptions extends RestartLaunchFlags {
 	sessionId: string;
 	cwd: string;
@@ -81,6 +88,49 @@ export interface SpawnRestartProcessOptions {
 	spawn?: RestartSpawn;
 }
 
+/** Minimal extension flag sink needed to restore restart-carried flag values. */
+export interface RestartExtensionFlagSink {
+	getFlags(): { has(name: string): boolean };
+	setFlagValue(name: string, value: boolean | string): void;
+}
+
+/** Consume extension CLI flag values from the one-hop restart environment payload. */
+export function consumeRestartExtensionFlagValues(
+	env: Record<string, string | undefined> = process.env,
+): RestartExtensionFlagValue[] | undefined {
+	const encoded = env[RESTART_EXTENSION_FLAG_VALUES_ENV];
+	if (!encoded) return undefined;
+	delete env[RESTART_EXTENSION_FLAG_VALUES_ENV];
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(encoded);
+	} catch {
+		return undefined;
+	}
+	if (!Array.isArray(decoded)) return undefined;
+	const values: RestartExtensionFlagValue[] = [];
+	for (const entry of decoded) {
+		if (!Array.isArray(entry) || entry.length !== 2) continue;
+		const [name, value] = entry;
+		if (typeof name !== "string") continue;
+		if (typeof value !== "boolean" && typeof value !== "string") continue;
+		values.push([name, value]);
+	}
+	return values.length > 0 ? values : undefined;
+}
+
+/** Restore restart-carried extension flag values for names still registered after discovery. */
+export function restoreRestartExtensionFlagValues(
+	sink: RestartExtensionFlagSink,
+	values: readonly RestartExtensionFlagValue[] | undefined,
+): void {
+	if (!values) return;
+	const registeredFlags = sink.getFlags();
+	for (const [name, value] of values) {
+		if (registeredFlags.has(name)) sink.setFlagValue(name, value);
+	}
+}
+
 function defaultRestartCommandEnvironment(): RestartCommandEnvironment {
 	return {
 		isCompiledBinary,
@@ -94,6 +144,20 @@ function appendRepeatedFlag(cmd: string[], flag: string, values: readonly string
 	for (const value of values ?? []) {
 		cmd.push(flag, value);
 	}
+}
+
+function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | undefined {
+	const childEnv: Record<string, string> = {};
+	let hasChildEnv = false;
+	if (options.apiKey) {
+		childEnv[RESTART_API_KEY_ENV] = options.apiKey;
+		hasChildEnv = true;
+	}
+	if (options.extensionFlagValues && options.extensionFlagValues.length > 0) {
+		childEnv[RESTART_EXTENSION_FLAG_VALUES_ENV] = JSON.stringify(options.extensionFlagValues);
+		hasChildEnv = true;
+	}
+	return hasChildEnv ? childEnv : undefined;
 }
 
 function buildChildEnv(overrides: Record<string, string> | undefined): Record<string, string> | undefined {
@@ -126,7 +190,7 @@ export function buildRestartCommand(
 ): RestartCommand {
 	const base = resolveRestartBaseCommand(env);
 	const cmd = [...base.cmd];
-	const childEnv = options.apiKey ? { [RESTART_API_KEY_ENV]: options.apiKey } : undefined;
+	const childEnv = buildRestartEnv(options);
 	if (options.activeProfile !== undefined) {
 		cmd.push("--profile", options.activeProfile);
 	}

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -35,6 +35,8 @@ export interface RestartLaunchFlags {
 	hookPaths?: string[];
 	pluginDirs?: string[];
 	extensionFlagValues?: readonly RestartExtensionFlagValue[];
+	provider?: string;
+	model?: string;
 	modelPatterns?: string[];
 	smolModel?: string;
 	slowModel?: string;
@@ -244,6 +246,12 @@ export function buildRestartCommand(
 	appendRepeatedFlag(cmd, "--extension", options.extensionPaths);
 	appendRepeatedFlag(cmd, "--hook", options.hookPaths);
 	appendRepeatedFlag(cmd, "--plugin-dir", options.pluginDirs);
+	if (options.provider !== undefined) {
+		cmd.push("--provider", options.provider);
+	}
+	if (options.model !== undefined) {
+		cmd.push("--model", options.model);
+	}
 	if (options.systemPrompt !== undefined) {
 		cmd.push("--system-prompt", options.systemPrompt);
 	}

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -199,10 +199,10 @@ export function resolveRestartBaseCommand(
 
 	const hostEntry = env.workerHostEntry();
 	if (hostEntry) {
-		return { cmd: [env.execPath, path.basename(hostEntry)], cwd: path.dirname(hostEntry) };
+		return { cmd: [env.execPath, hostEntry] };
 	}
 
-	return { cmd: [env.execPath, "src/cli.ts"], cwd: env.packageRoot };
+	return { cmd: [env.execPath, path.join(env.packageRoot, "src/cli.ts")] };
 }
 
 /** Build a restart-safe argv that resumes the current persisted session only. */

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 
-import { isCompiledBinary, workerHostEntry } from "@oh-my-pi/pi-utils";
+import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix, workerHostEntry } from "@oh-my-pi/pi-utils";
 import type { ConfiguredThinkingLevel } from "../thinking";
 
 /** Environment variable used for one-hop restart handoff of runtime CLI API keys. */
@@ -89,6 +89,7 @@ export interface RestartCommandEnvironment {
 	isCompiledBinary: () => boolean;
 	workerHostEntry: () => string | null;
 	execPath: string;
+	platform?: NodeJS.Platform;
 	packageRoot: string;
 }
 
@@ -238,6 +239,7 @@ function defaultRestartCommandEnvironment(): RestartCommandEnvironment {
 		isCompiledBinary,
 		workerHostEntry,
 		execPath: process.execPath,
+		platform: process.platform,
 		packageRoot: path.resolve(import.meta.dir, "..", ".."),
 	};
 }
@@ -306,14 +308,14 @@ function buildChildEnv(overrides: Record<string, string> | undefined): Record<st
 export function resolveRestartBaseCommand(
 	env: RestartCommandEnvironment = defaultRestartCommandEnvironment(),
 ): RestartCommandBase {
-	if (env.isCompiledBinary()) return { cmd: [env.execPath] };
-
+	const executable = stripWindowsExtendedLengthPathPrefix(env.execPath, env.platform);
+	if (env.isCompiledBinary()) return { cmd: [executable] };
 	const hostEntry = env.workerHostEntry();
 	if (hostEntry) {
-		return { cmd: [env.execPath, hostEntry] };
+		return { cmd: [executable, hostEntry] };
 	}
 
-	return { cmd: [env.execPath, path.join(env.packageRoot, "src/cli.ts")] };
+	return { cmd: [executable, path.join(env.packageRoot, "src/cli.ts")] };
 }
 
 /** Build a restart-safe argv that resumes the current persisted session only. */

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -2,15 +2,22 @@ import * as path from "node:path";
 
 import { isCompiledBinary, workerHostEntry } from "@oh-my-pi/pi-utils";
 
+/** Environment variable used for one-hop restart handoff of runtime CLI API keys. */
+export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
+
 /** Tool approval modes that can be restored across a process restart. */
 export type RestartApprovalMode = "always-ask" | "write" | "yolo";
 
 /** Tool filter that must be restored in the restarted process. */
 export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; toolNames: string[] };
 
-/** CLI launch flags for config and extension discovery that must survive restart. */
+/** CLI launch flags for config, context, auth, and extension discovery that must survive restart. */
 export interface RestartLaunchFlags {
+	apiKey?: string;
 	disableExtensions?: boolean;
+	disableLsp?: boolean;
+	disableRules?: boolean;
+	disableSkills?: boolean;
 	configFiles?: string[];
 	extensionPaths?: string[];
 	hookPaths?: string[];
@@ -23,10 +30,11 @@ export interface RestartCommandBase {
 	cwd?: string;
 }
 
-/** Complete restart command with the cwd used to spawn it. */
+/** Complete restart command with the cwd/env used to spawn it. */
 export interface RestartCommand {
 	cmd: string[];
 	cwd: string;
+	env?: Record<string, string>;
 }
 
 /** Runtime dependencies used to resolve the current OMP entrypoint. */
@@ -52,14 +60,18 @@ export interface RestartSubprocess {
 	exited: Promise<number>;
 }
 
-/** Injectable restart child spawner used by tests. */
-export type RestartSpawn = (options: {
+/** Bun.spawn-compatible options used to launch the restart child. */
+export interface RestartSpawnInput {
 	cmd: string[];
 	cwd: string;
+	env?: Record<string, string>;
 	stdin: "inherit";
 	stdout: "inherit";
 	stderr: "inherit";
-}) => RestartSubprocess;
+}
+
+/** Injectable restart child spawner used by tests. */
+export type RestartSpawn = (options: RestartSpawnInput) => RestartSubprocess;
 
 /** Optional dependencies for spawning the restart process. */
 export interface SpawnRestartProcessOptions {
@@ -79,6 +91,15 @@ function appendRepeatedFlag(cmd: string[], flag: string, values: readonly string
 	for (const value of values ?? []) {
 		cmd.push(flag, value);
 	}
+}
+
+function buildChildEnv(overrides: Record<string, string> | undefined): Record<string, string> | undefined {
+	if (!overrides) return undefined;
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+	return { ...env, ...overrides };
 }
 
 /** Resolve the base command that re-enters the same OMP build. */
@@ -102,7 +123,7 @@ export function buildRestartCommand(
 ): RestartCommand {
 	const base = resolveRestartBaseCommand(env);
 	const cmd = [...base.cmd];
-
+	const childEnv = options.apiKey ? { [RESTART_API_KEY_ENV]: options.apiKey } : undefined;
 	if (options.activeProfile !== undefined) {
 		cmd.push("--profile", options.activeProfile);
 	}
@@ -116,6 +137,16 @@ export function buildRestartCommand(
 	appendRepeatedFlag(cmd, "--extension", options.extensionPaths);
 	appendRepeatedFlag(cmd, "--hook", options.hookPaths);
 	appendRepeatedFlag(cmd, "--plugin-dir", options.pluginDirs);
+
+	if (options.disableLsp) {
+		cmd.push("--no-lsp");
+	}
+	if (options.disableSkills) {
+		cmd.push("--no-skills");
+	}
+	if (options.disableRules) {
+		cmd.push("--no-rules");
+	}
 
 	cmd.push("--cwd", options.cwd, "--approval-mode", options.approvalMode);
 
@@ -131,7 +162,7 @@ export function buildRestartCommand(
 
 	cmd.push("--session-dir", options.sessionDir, "--resume", options.sessionId);
 
-	return { cmd, cwd: base.cwd ?? options.cwd };
+	return { cmd, cwd: base.cwd ?? options.cwd, ...(childEnv ? { env: childEnv } : {}) };
 }
 
 /** Spawn the replacement OMP process with inherited stdio and return its exit code. */
@@ -140,13 +171,16 @@ export async function spawnRestartProcess(
 	options: SpawnRestartProcessOptions = {},
 ): Promise<number> {
 	const spawn = options.spawn ?? Bun.spawn;
-	const proc = spawn({
+	const spawnOptions: RestartSpawnInput = {
 		cmd: command.cmd,
 		cwd: command.cwd,
 		stdin: "inherit",
 		stdout: "inherit",
 		stderr: "inherit",
-	});
+	};
+	const env = buildChildEnv(command.env);
+	if (env) spawnOptions.env = env;
+	const proc = spawn(spawnOptions);
 
 	return await proc.exited;
 }

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -18,7 +18,7 @@ export type RestartToolRestriction = { kind: "none" } | { kind: "allowlist"; too
 /** Extension CLI flag value restored directly after extension discovery on restart. */
 export type RestartExtensionFlagValue = readonly [name: string, value: boolean | string];
 
-/** CLI launch state for auth, prompts, skills, context, config, and extensions that must survive restart. */
+/** CLI launch state for time budget, auth, prompts, skills, context, config, and extensions that must survive restart. */
 export interface RestartLaunchFlags {
 	apiKey?: string;
 	disableExtensions?: boolean;
@@ -40,6 +40,8 @@ export interface RestartLaunchFlags {
 	skillPatterns?: string[];
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
+	/** Absolute wall-clock deadline in epoch milliseconds for replaying remaining --max-time. */
+	maxTimeDeadline?: number;
 }
 
 /** Self-entrypoint command before restart-specific CLI arguments are appended. */
@@ -154,6 +156,11 @@ function appendRepeatedFlag(cmd: string[], flag: string, values: readonly string
 	}
 }
 
+function getRestartMaxTimeSeconds(deadline: number | undefined): number | undefined {
+	if (deadline === undefined || !Number.isFinite(deadline)) return undefined;
+	return Math.max(1, Math.ceil((deadline - Date.now()) / 1000));
+}
+
 function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | undefined {
 	const childEnv: Record<string, string> = {};
 	let hasChildEnv = false;
@@ -238,6 +245,11 @@ export function buildRestartCommand(
 	}
 	if (options.advisor) {
 		cmd.push("--advisor");
+	}
+
+	const maxTimeSeconds = getRestartMaxTimeSeconds(options.maxTimeDeadline);
+	if (maxTimeSeconds !== undefined) {
+		cmd.push("--max-time", String(maxTimeSeconds));
 	}
 
 	if (options.disableLsp) {

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -7,6 +7,8 @@ import type { ConfiguredThinkingLevel } from "../thinking";
 export const RESTART_API_KEY_ENV = "OMP_RESTART_API_KEY";
 /** Environment variable used for one-hop restart handoff of the runtime CLI API key's original provider. */
 export const RESTART_API_KEY_PROVIDER_ENV = "OMP_RESTART_API_KEY_PROVIDER";
+/** Environment variable used for one-hop restart handoff of the live advisor toggle. */
+export const RESTART_ADVISOR_ENABLED_ENV = "OMP_RESTART_ADVISOR_ENABLED";
 
 /** Environment variable used for one-hop restart handoff of extension CLI flag values. */
 export const RESTART_EXTENSION_FLAG_VALUES_ENV = "OMP_RESTART_EXTENSION_FLAG_VALUES";
@@ -108,6 +110,18 @@ export interface RestartExtensionFlagSink {
 	setFlagValue(name: string, value: boolean | string): void;
 }
 
+/** Consume the restart-only advisor toggle override from the one-hop restart environment. */
+export function consumeRestartAdvisorEnabled(
+	env: Record<string, string | undefined> = process.env,
+): boolean | undefined {
+	const encoded = env[RESTART_ADVISOR_ENABLED_ENV];
+	if (encoded === undefined) return undefined;
+	delete env[RESTART_ADVISOR_ENABLED_ENV];
+	if (encoded === "1") return true;
+	if (encoded === "0") return false;
+	return undefined;
+}
+
 /** Consume extension CLI flag values from the one-hop restart environment payload. */
 export function consumeRestartExtensionFlagValues(
 	env: Record<string, string | undefined> = process.env,
@@ -177,6 +191,10 @@ function buildRestartEnv(options: RestartLaunchFlags): Record<string, string> | 
 	}
 	if (options.extensionFlagValues && options.extensionFlagValues.length > 0) {
 		childEnv[RESTART_EXTENSION_FLAG_VALUES_ENV] = JSON.stringify(options.extensionFlagValues);
+		hasChildEnv = true;
+	}
+	if (options.advisor !== undefined) {
+		childEnv[RESTART_ADVISOR_ENABLED_ENV] = options.advisor ? "1" : "0";
 		hasChildEnv = true;
 	}
 	return hasChildEnv ? childEnv : undefined;

--- a/packages/coding-agent/src/cli/restart.ts
+++ b/packages/coding-agent/src/cli/restart.ts
@@ -30,6 +30,8 @@ export interface RestartLaunchFlags {
 	disableLsp?: boolean;
 	disableRules?: boolean;
 	disableSkills?: boolean;
+	noPty?: boolean;
+	noTitle?: boolean;
 	configFiles?: string[];
 	extensionPaths?: string[];
 	hookPaths?: string[];
@@ -296,6 +298,12 @@ export function buildRestartCommand(
 	}
 	if (options.disableRules) {
 		cmd.push("--no-rules");
+	}
+	if (options.noPty) {
+		cmd.push("--no-pty");
+	}
+	if (options.noTitle) {
+		cmd.push("--no-title");
 	}
 	if (options.skillPatterns && options.skillPatterns.length > 0) {
 		cmd.push("--skills", options.skillPatterns.join(","));

--- a/packages/coding-agent/src/extensibility/plugins/marketplace-auto-update.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace-auto-update.ts
@@ -8,12 +8,16 @@ interface MarketplaceAutoUpdateOptions {
 	clearPluginRootsCache: () => void;
 }
 
-export function scheduleMarketplaceAutoUpdate(options: MarketplaceAutoUpdateOptions): void {
+/**
+ * Start the startup update without blocking launch and return the settled work so a restart can
+ * keep its replacement from concurrently touching the marketplace registries.
+ */
+export function scheduleMarketplaceAutoUpdate(options: MarketplaceAutoUpdateOptions): Promise<void> {
 	if (options.autoUpdate === "off") {
-		return;
+		return Promise.resolve();
 	}
 
-	void runMarketplaceAutoUpdate(options);
+	return runMarketplaceAutoUpdate(options);
 }
 
 async function runMarketplaceAutoUpdate(options: MarketplaceAutoUpdateOptions): Promise<void> {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -438,6 +438,11 @@ function resolveRestartLaunchPaths(values: readonly string[] | undefined, cwd: s
 	return values?.map(value => resolveRestartLaunchPath(value, cwd));
 }
 
+function resolveRestartConfigEnvFiles(value: string | undefined, cwd: string): string[] | undefined {
+	const configFiles = value?.split(path.delimiter).filter(Boolean);
+	return configFiles && configFiles.length > 0 ? resolveRestartLaunchPaths(configFiles, cwd) : undefined;
+}
+
 /** Resolve a restart prompt flag to its original file path only when the launch input was file-backed. */
 export async function resolveRestartPromptLaunchValue(
 	value: string | undefined,
@@ -506,6 +511,7 @@ export function buildRestartLaunchFlags(
 	sessionStartCwd: string = launchCwd,
 	restartApiKey?: string,
 	restartExtensionPackageRoots?: readonly string[],
+	restartConfigFilesEnv?: string,
 ): RestartLaunchFlags {
 	const extensionPackageRootInputs = selectRestartExtensionPackageRoots(
 		restartExtensionPackageRoots,
@@ -530,6 +536,7 @@ export function buildRestartLaunchFlags(
 		disableSkills: Boolean(parsed.noSkills),
 		noTitle: Boolean(parsed.noTitle),
 		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
+		configEnvFiles: resolveRestartConfigEnvFiles(restartConfigFilesEnv, launchCwd),
 		extensionPackageRoots,
 		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, sessionStartCwd),
 		hookPaths: resolveRestartLaunchPaths(parsed.hooks, sessionStartCwd),
@@ -1432,6 +1439,7 @@ export async function runRootCommand(
 
 	let cwd = getProjectDir();
 	const launchConfigCwd = cwd;
+	const restartConfigFilesEnv = process.env.PI_CONFIG_FILES;
 	const settingsInstance =
 		deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
 	if (parsedArgs.approvalMode) {
@@ -1911,6 +1919,7 @@ export async function runRootCommand(
 					cwd,
 					restartApiKeyHandoff?.apiKey,
 					restartExtensionPackageRoots,
+					restartConfigFilesEnv,
 				),
 			);
 		} else {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1707,10 +1707,9 @@ export async function runRootCommand(
 			? null
 			: applyExtensionFlags(extensionFlagSink, rawArgs);
 		const initialArgs = parsedWithExtensionFlags ?? parsedArgs;
-		const extensionFlagValues = parsedWithExtensionFlags?.unknownFlags;
 		const currentExtensionFlagValues =
 			restartExtensionFlagValues ??
-			(extensionFlagValues && extensionFlagValues.size > 0 ? [...extensionFlagValues.entries()] : undefined);
+			(parsedWithExtensionFlags ? [...parsedWithExtensionFlags.unknownFlags.entries()] : undefined);
 		restoreRestartExtensionFlagValues(extensionFlagSink, restartExtensionFlagValues);
 		normalizeContinueSessionArgs(initialArgs, rawArgs);
 		for (const message of formatExtensionLoadNotifications(extensionsResult.errors)) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -90,7 +90,12 @@ import { resolveResumableSession, type SessionInfo } from "./session/session-lis
 import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
-import { discoverTitleSystemPromptFile, encodeLiteralPromptInput, resolvePromptInput } from "./system-prompt";
+import {
+	discoverTitleSystemPromptFile,
+	encodeLiteralPromptInput,
+	isEncodedLiteralPromptInput,
+	resolvePromptInput,
+} from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { AUTO_THINKING, concreteThinkingLevel, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
@@ -438,7 +443,7 @@ export async function resolveRestartPromptLaunchValue(
 	fallbackValue?: string,
 ): Promise<string | undefined> {
 	const source = value ?? fallbackValue;
-	if (!source || source.includes("\n")) return source;
+	if (!source || source.includes("\n") || isEncodedLiteralPromptInput(source)) return source;
 	const resolved = resolveRestartLaunchPath(source, launchCwd);
 	try {
 		await Bun.file(resolved).text();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -6,6 +6,7 @@
  */
 import * as fsSync from "node:fs";
 import * as os from "node:os";
+import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
@@ -417,7 +418,36 @@ function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): R
 	return undefined;
 }
 
-function buildRestartLaunchFlags(
+function resolveRestartLaunchPath(value: string, cwd: string): string {
+	if (value === "~") return os.homedir();
+	if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+	return path.isAbsolute(value) ? value : path.resolve(cwd, value);
+}
+
+function resolveRestartLaunchPaths(values: readonly string[] | undefined, cwd: string): string[] | undefined {
+	return values?.map(value => resolveRestartLaunchPath(value, cwd));
+}
+
+function isExplicitPathLikeLaunchValue(value: string): boolean {
+	return (
+		value === "~" ||
+		value.startsWith("~/") ||
+		path.isAbsolute(value) ||
+		value === "." ||
+		value === ".." ||
+		value.startsWith("./") ||
+		value.startsWith("../") ||
+		value.startsWith(".\\") ||
+		value.startsWith("..\\")
+	);
+}
+
+function resolvePathLikeRestartLaunchValues(values: readonly string[] | undefined, cwd: string): string[] | undefined {
+	return values?.map(value => (isExplicitPathLikeLaunchValue(value) ? resolveRestartLaunchPath(value, cwd) : value));
+}
+
+/** Build restart launch state from parsed args, resolving path flags against the original launch cwd. */
+export function buildRestartLaunchFlags(
 	parsed: Pick<
 		Args,
 		| "apiKey"
@@ -440,6 +470,7 @@ function buildRestartLaunchFlags(
 		| "thinking"
 		| "systemPrompt"
 	>,
+	launchCwd: string,
 	extensionFlagValues?: readonly RestartExtensionFlagValue[],
 ): RestartLaunchFlags {
 	return {
@@ -450,10 +481,10 @@ function buildRestartLaunchFlags(
 		disableLsp: Boolean(parsed.noLsp),
 		disableRules: Boolean(parsed.noRules),
 		disableSkills: Boolean(parsed.noSkills),
-		configFiles: parsed.config,
-		extensionPaths: parsed.extensions,
-		hookPaths: parsed.hooks,
-		pluginDirs: parsed.pluginDirs,
+		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
+		extensionPaths: resolvePathLikeRestartLaunchValues(parsed.extensions, launchCwd),
+		hookPaths: resolvePathLikeRestartLaunchValues(parsed.hooks, launchCwd),
+		pluginDirs: resolveRestartLaunchPaths(parsed.pluginDirs, launchCwd),
 		modelPatterns: parsed.models,
 		planModel: parsed.plan,
 		thinking: parsed.thinking,
@@ -1254,6 +1285,7 @@ export async function runRootCommand(
 	}
 
 	let cwd = getProjectDir();
+	const launchConfigCwd = cwd;
 	const settingsInstance =
 		deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
 	if (parsedArgs.approvalMode) {
@@ -1692,7 +1724,7 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(initialArgs),
-				buildRestartLaunchFlags(initialArgs, currentExtensionFlagValues),
+				buildRestartLaunchFlags(initialArgs, launchConfigCwd, currentExtensionFlagValues),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -430,6 +430,7 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	joinLink?: string,
 	restartToolRestriction?: RestartToolRestriction,
+	restartDisableExtensions = false,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -440,6 +441,7 @@ async function runInteractiveMode(
 		mcpManager,
 		eventBus,
 		restartToolRestriction,
+		restartDisableExtensions,
 	);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
@@ -1600,6 +1602,7 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(parsedArgs),
+				Boolean(parsedArgs.noExtensions),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -477,8 +477,10 @@ export function buildRestartLaunchFlags(
 		| "models"
 		| "noExtensions"
 		| "noLsp"
+		| "noPty"
 		| "noRules"
 		| "noSkills"
+		| "noTitle"
 		| "pluginDirs"
 		| "plan"
 		| "provider"
@@ -503,8 +505,10 @@ export function buildRestartLaunchFlags(
 		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
 		disableLsp: Boolean(parsed.noLsp),
+		noPty: Boolean(parsed.noPty),
 		disableRules: Boolean(parsed.noRules),
 		disableSkills: Boolean(parsed.noSkills),
+		noTitle: Boolean(parsed.noTitle),
 		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
 		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, sessionStartCwd),
 		hookPaths: resolveRestartLaunchPaths(parsed.hooks, sessionStartCwd),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -476,6 +476,7 @@ export function buildRestartLaunchFlags(
 		| "apiKey"
 		| "advisor"
 		| "appendSystemPrompt"
+		| "autoApprove"
 		| "config"
 		| "extensions"
 		| "hideThinking"
@@ -528,6 +529,7 @@ export function buildRestartLaunchFlags(
 		apiKey: parsed.apiKey ?? restartApiKey,
 		apiKeyProvider,
 		advisor: Boolean(parsed.advisor),
+		autoApprove: Boolean(parsed.autoApprove),
 		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
 		disableLsp: Boolean(parsed.noLsp),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -445,7 +445,7 @@ export async function resolveRestartPromptLaunchValue(
 	}
 }
 
-/** Build restart launch state from parsed args and deadline, resolving path flags against the original launch cwd. */
+/** Build restart launch state, resolving config/plugin paths from launch cwd and extension roots from session cwd. */
 export function buildRestartLaunchFlags(
 	parsed: Pick<
 		Args,
@@ -474,6 +474,7 @@ export function buildRestartLaunchFlags(
 	extensionFlagValues?: readonly RestartExtensionFlagValue[],
 	maxTimeDeadline?: number,
 	apiKeyProvider?: string,
+	sessionStartCwd: string = launchCwd,
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
@@ -485,8 +486,8 @@ export function buildRestartLaunchFlags(
 		disableRules: Boolean(parsed.noRules),
 		disableSkills: Boolean(parsed.noSkills),
 		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
-		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, launchCwd),
-		hookPaths: resolveRestartLaunchPaths(parsed.hooks, launchCwd),
+		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, sessionStartCwd),
+		hookPaths: resolveRestartLaunchPaths(parsed.hooks, sessionStartCwd),
 		pluginDirs: resolveRestartLaunchPaths(parsed.pluginDirs, launchCwd),
 		modelPatterns: parsed.models,
 		planModel: parsed.plan,
@@ -1807,16 +1808,14 @@ export async function runRootCommand(
 				buildRestartLaunchFlags(
 					{
 						...initialArgs,
-						systemPrompt: await resolveRestartPromptLaunchValue(initialArgs.systemPrompt, launchConfigCwd),
-						appendSystemPrompt: await resolveRestartPromptLaunchValue(
-							initialArgs.appendSystemPrompt,
-							launchConfigCwd,
-						),
+						systemPrompt: await resolveRestartPromptLaunchValue(initialArgs.systemPrompt, cwd),
+						appendSystemPrompt: await resolveRestartPromptLaunchValue(initialArgs.appendSystemPrompt, cwd),
 					},
 					launchConfigCwd,
 					currentExtensionFlagValues,
 					sessionOptions.deadline,
 					runtimeApiKeyProvider,
+					cwd,
 				),
 			);
 		} else {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -44,6 +44,7 @@ import {
 	DEFAULT_PREWALK_TARGET,
 	expandRoleAlias,
 	getModelMatchPreferences,
+	parseModelString,
 	resolveCliModel,
 	resolveModelRoleValue,
 	resolveModelScope,
@@ -446,7 +447,7 @@ function resolvePathLikeRestartLaunchValues(values: readonly string[] | undefine
 	return values?.map(value => (isExplicitPathLikeLaunchValue(value) ? resolveRestartLaunchPath(value, cwd) : value));
 }
 
-/** Build restart launch state from parsed args, resolving path flags against the original launch cwd. */
+/** Build restart launch state from parsed args and deadline, resolving path flags against the original launch cwd. */
 export function buildRestartLaunchFlags(
 	parsed: Pick<
 		Args,
@@ -472,6 +473,7 @@ export function buildRestartLaunchFlags(
 	>,
 	launchCwd: string,
 	extensionFlagValues?: readonly RestartExtensionFlagValue[],
+	maxTimeDeadline?: number,
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
@@ -489,6 +491,7 @@ export function buildRestartLaunchFlags(
 		planModel: parsed.plan,
 		thinking: parsed.thinking,
 		extensionFlagValues,
+		maxTimeDeadline,
 		skillPatterns: parsed.skills,
 		slowModel: parsed.slow,
 		smolModel: parsed.smol,
@@ -496,6 +499,9 @@ export function buildRestartLaunchFlags(
 		systemPrompt: parsed.systemPrompt,
 	};
 }
+
+type RuntimeApiKeySessionOptions = { model?: { provider: string }; modelPattern?: string };
+type RestorableModelSource = Pick<SessionManager, "getRestorableModelStrings">;
 
 /** Return whether a runtime API key needs an explicit launch model before session restore. */
 export function requiresLaunchModelForRuntimeApiKey(
@@ -507,10 +513,41 @@ export function requiresLaunchModelForRuntimeApiKey(
 	return !sessionOptions.model && !sessionOptions.modelPattern;
 }
 
-/** Apply a CLI runtime API key after createSession restores a session model provider. */
+/** Return the provider for the first persisted model that session restore will try. */
+export function getPersistedSessionModelProvider(
+	sessionManager: RestorableModelSource | undefined,
+): string | undefined {
+	if (!sessionManager) return undefined;
+	for (const modelString of sessionManager.getRestorableModelStrings()) {
+		const parsedModel = parseModelString(modelString, { allowMaxAlias: true });
+		if (parsedModel) return parsedModel.provider;
+	}
+	return undefined;
+}
+
+/** Install a runtime API key before createSession can restore a persisted model. */
+export function applyRuntimeApiKeyBeforeSessionRestore(
+	parsed: Pick<Args, "apiKey" | "continue" | "resume" | "fork">,
+	sessionOptions: RuntimeApiKeySessionOptions,
+	sessionManager: RestorableModelSource | undefined,
+	authStorage: Pick<AuthStorage, "setRuntimeApiKey">,
+): boolean {
+	if (!parsed.apiKey) return false;
+	if (sessionOptions.model) {
+		authStorage.setRuntimeApiKey(sessionOptions.model.provider, parsed.apiKey);
+		return true;
+	}
+	if (sessionOptions.modelPattern || !(parsed.continue || parsed.resume || parsed.fork)) return false;
+	const provider = getPersistedSessionModelProvider(sessionManager);
+	if (!provider) return false;
+	authStorage.setRuntimeApiKey(provider, parsed.apiKey);
+	return true;
+}
+
+/** Apply a runtime API key when the provider was only known after createSession. */
 export function applyRuntimeApiKeyForRestoredSession(
 	parsed: Pick<Args, "apiKey">,
-	sessionOptions: { model?: { provider: string } },
+	sessionOptions: RuntimeApiKeySessionOptions,
 	session: { model?: { provider: string } },
 	authStorage: Pick<AuthStorage, "setRuntimeApiKey">,
 ): void {
@@ -1520,6 +1557,7 @@ export async function runRootCommand(
 	}
 
 	// Handle CLI --api-key as runtime override (not persisted)
+	let runtimeApiKeyInstalledBeforeSessionRestore = false;
 	if (parsedArgs.apiKey) {
 		if (requiresLaunchModelForRuntimeApiKey(parsedArgs, sessionOptions)) {
 			process.stderr.write(
@@ -1527,9 +1565,12 @@ export async function runRootCommand(
 			);
 			process.exit(1);
 		}
-		if (sessionOptions.model) {
-			authStorage.setRuntimeApiKey(sessionOptions.model.provider, parsedArgs.apiKey);
-		}
+		runtimeApiKeyInstalledBeforeSessionRestore = applyRuntimeApiKeyBeforeSessionRestore(
+			parsedArgs,
+			sessionOptions,
+			sessionManager,
+			authStorage,
+		);
 	}
 
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
@@ -1651,7 +1692,9 @@ export async function runRootCommand(
 			}),
 			Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
 		);
-		applyRuntimeApiKeyForRestoredSession(parsedArgs, sessionOptions, session, authStorage);
+		if (!runtimeApiKeyInstalledBeforeSessionRestore) {
+			applyRuntimeApiKeyForRestoredSession(parsedArgs, sessionOptions, session, authStorage);
+		}
 
 		if (modelFallbackMessage) {
 			notifs.push({ kind: "warn", message: modelFallbackMessage });
@@ -1724,7 +1767,7 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(initialArgs),
-				buildRestartLaunchFlags(initialArgs, launchConfigCwd, currentExtensionFlagValues),
+				buildRestartLaunchFlags(initialArgs, launchConfigCwd, currentExtensionFlagValues, sessionOptions.deadline),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -415,11 +415,23 @@ function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): R
 function buildRestartLaunchFlags(
 	parsed: Pick<
 		Args,
-		"apiKey" | "config" | "extensions" | "hooks" | "noExtensions" | "noLsp" | "noRules" | "noSkills" | "pluginDirs"
+		| "apiKey"
+		| "appendSystemPrompt"
+		| "config"
+		| "extensions"
+		| "hooks"
+		| "noExtensions"
+		| "noLsp"
+		| "noRules"
+		| "noSkills"
+		| "pluginDirs"
+		| "skills"
+		| "systemPrompt"
 	>,
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
+		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
 		disableLsp: Boolean(parsed.noLsp),
 		disableRules: Boolean(parsed.noRules),
@@ -428,8 +440,11 @@ function buildRestartLaunchFlags(
 		extensionPaths: parsed.extensions,
 		hookPaths: parsed.hooks,
 		pluginDirs: parsed.pluginDirs,
+		skillPatterns: parsed.skills,
+		systemPrompt: parsed.systemPrompt,
 	};
 }
+
 function applyRestartApiKeyHandoff(parsed: Args, env: Record<string, string | undefined> = process.env): void {
 	const apiKey = env[RESTART_API_KEY_ENV];
 	if (!apiKey) return;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -68,6 +68,7 @@ import { formatExtensionLoadNotifications } from "./extensibility/extensions/loa
 import { ExtensionRunner } from "./extensibility/extensions/runner";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import { scheduleMarketplaceAutoUpdate } from "./extensibility/plugins/marketplace-auto-update";
+import { resolvePath } from "./extensibility/utils";
 import { registerDaemonProjectPresence } from "./launch/presence";
 import type { MCPManager } from "./mcp";
 import { InteractiveMode } from "./modes/interactive-mode";
@@ -429,9 +430,7 @@ function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): R
 }
 
 function resolveRestartLaunchPath(value: string, cwd: string): string {
-	if (value === "~") return os.homedir();
-	if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
-	return path.isAbsolute(value) ? value : path.resolve(cwd, value);
+	return resolvePath(value, cwd);
 }
 
 function resolveRestartLaunchPaths(values: readonly string[] | undefined, cwd: string): string[] | undefined {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -423,22 +423,30 @@ function buildRestartLaunchFlags(
 	parsed: Pick<
 		Args,
 		| "apiKey"
+		| "advisor"
 		| "appendSystemPrompt"
 		| "config"
 		| "extensions"
+		| "hideThinking"
 		| "hooks"
+		| "models"
 		| "noExtensions"
 		| "noLsp"
 		| "noRules"
 		| "noSkills"
 		| "pluginDirs"
+		| "plan"
 		| "skills"
+		| "slow"
+		| "smol"
+		| "thinking"
 		| "systemPrompt"
 	>,
 	extensionFlagValues?: readonly RestartExtensionFlagValue[],
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
+		advisor: Boolean(parsed.advisor),
 		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
 		disableLsp: Boolean(parsed.noLsp),
@@ -448,8 +456,14 @@ function buildRestartLaunchFlags(
 		extensionPaths: parsed.extensions,
 		hookPaths: parsed.hooks,
 		pluginDirs: parsed.pluginDirs,
+		modelPatterns: parsed.models,
+		planModel: parsed.plan,
+		thinking: parsed.thinking,
 		extensionFlagValues,
 		skillPatterns: parsed.skills,
+		slowModel: parsed.slow,
+		smolModel: parsed.smol,
+		hideThinking: Boolean(parsed.hideThinking),
 		systemPrompt: parsed.systemPrompt,
 	};
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -31,12 +31,14 @@ import { buildInitialMessage } from "./cli/initial-message";
 import {
 	consumeRestartAdvisorEnabled,
 	consumeRestartExtensionFlagValues,
+	consumeRestartExtensionPackageRoots,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
 	type RestartExtensionFlagValue,
 	type RestartLaunchFlags,
 	type RestartToolRestriction,
 	restoreRestartExtensionFlagValues,
+	selectRestartExtensionPackageRoots,
 } from "./cli/restart";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
@@ -503,7 +505,19 @@ export function buildRestartLaunchFlags(
 	apiKeyProvider?: string,
 	sessionStartCwd: string = launchCwd,
 	restartApiKey?: string,
+	restartExtensionPackageRoots?: readonly string[],
 ): RestartLaunchFlags {
+	const extensionPackageRootInputs = selectRestartExtensionPackageRoots(
+		restartExtensionPackageRoots,
+		parsed.extensions,
+		parsed.hooks,
+	);
+	const extensionPackageRoots =
+		restartExtensionPackageRoots !== undefined
+			? extensionPackageRootInputs
+			: extensionPackageRootInputs.length > 0
+				? resolveRestartLaunchPaths(extensionPackageRootInputs, launchCwd)
+				: undefined;
 	return {
 		apiKey: parsed.apiKey ?? restartApiKey,
 		apiKeyProvider,
@@ -516,6 +530,7 @@ export function buildRestartLaunchFlags(
 		disableSkills: Boolean(parsed.noSkills),
 		noTitle: Boolean(parsed.noTitle),
 		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
+		extensionPackageRoots,
 		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, sessionStartCwd),
 		hookPaths: resolveRestartLaunchPaths(parsed.hooks, sessionStartCwd),
 		pluginDirs: resolveRestartLaunchPaths(parsed.pluginDirs, launchCwd),
@@ -1351,6 +1366,7 @@ export async function runRootCommand(
 	const restartApiKeyHandoff = applyRestartApiKeyHandoff(parsedArgs);
 	const restartApiKeyProvider = restartApiKeyHandoff?.provider;
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
+	const restartExtensionPackageRoots = consumeRestartExtensionPackageRoots();
 	const restartAdvisorEnabled = consumeRestartAdvisorEnabled();
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
@@ -1404,7 +1420,11 @@ export async function runRootCommand(
 	// `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` sub-trees.
 	// `--no-extensions` short-circuits both the factory load and the sub-discovery.
 	if (!parsedArgs.noExtensions) {
-		const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
+		const cliExtensions = selectRestartExtensionPackageRoots(
+			restartExtensionPackageRoots,
+			parsedArgs.extensions,
+			parsedArgs.hooks,
+		);
 		if (cliExtensions.length > 0) {
 			injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir());
 		}
@@ -1890,6 +1910,7 @@ export async function runRootCommand(
 					runtimeApiKeyProvider,
 					cwd,
 					restartApiKeyHandoff?.apiKey,
+					restartExtensionPackageRoots,
 				),
 			);
 		} else {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -475,9 +475,10 @@ export function buildRestartLaunchFlags(
 	maxTimeDeadline?: number,
 	apiKeyProvider?: string,
 	sessionStartCwd: string = launchCwd,
+	restartApiKey?: string,
 ): RestartLaunchFlags {
 	return {
-		apiKey: parsed.apiKey,
+		apiKey: parsed.apiKey ?? restartApiKey,
 		apiKeyProvider,
 		advisor: Boolean(parsed.advisor),
 		appendSystemPrompt: parsed.appendSystemPrompt,
@@ -576,17 +577,23 @@ export function applyRuntimeApiKeyForRestoredSession(
 	return provider;
 }
 
+interface RestartApiKeyHandoff {
+	apiKey?: string;
+	provider?: string;
+}
+
 function applyRestartApiKeyHandoff(
 	parsed: Args,
 	env: Record<string, string | undefined> = process.env,
-): string | undefined {
+): RestartApiKeyHandoff | undefined {
 	const apiKey = env[RESTART_API_KEY_ENV];
 	const apiKeyProvider = env[RESTART_API_KEY_PROVIDER_ENV];
 	delete env[RESTART_API_KEY_ENV];
 	delete env[RESTART_API_KEY_PROVIDER_ENV];
 	if (!apiKey) return undefined;
-	if (!parsed.apiKey) parsed.apiKey = apiKey;
-	return apiKeyProvider;
+	const injectedApiKey = parsed.apiKey ? undefined : apiKey;
+	if (injectedApiKey) parsed.apiKey = injectedApiKey;
+	return { apiKey: injectedApiKey, provider: apiKeyProvider };
 }
 
 async function runInteractiveMode(
@@ -1288,7 +1295,8 @@ export async function runRootCommand(
 	await logger.time("initTheme:initial", initTheme);
 
 	const parsedArgs = parsed;
-	const restartApiKeyProvider = applyRestartApiKeyHandoff(parsedArgs);
+	const restartApiKeyHandoff = applyRestartApiKeyHandoff(parsedArgs);
+	const restartApiKeyProvider = restartApiKeyHandoff?.provider;
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
@@ -1816,6 +1824,7 @@ export async function runRootCommand(
 					sessionOptions.deadline,
 					runtimeApiKeyProvider,
 					cwd,
+					restartApiKeyHandoff?.apiKey,
 				),
 			);
 		} else {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -30,6 +30,7 @@ import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import {
 	consumeRestartAdvisorEnabled,
+	consumeRestartComputerEnabled,
 	consumeRestartExtensionFlagValues,
 	consumeRestartExtensionPackageRoots,
 	consumeRestartLiteralPrompts,
@@ -1434,6 +1435,7 @@ export async function runRootCommand(
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
 	const restartExtensionPackageRoots = consumeRestartExtensionPackageRoots();
 	const restartAdvisorEnabled = consumeRestartAdvisorEnabled();
+	const restartComputerEnabled = consumeRestartComputerEnabled();
 	const restartLiteralPrompts = consumeRestartLiteralPrompts();
 	if (restartLiteralPrompts) restartLiteralPromptInputs.set(parsedArgs, restartLiteralPrompts);
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
@@ -1565,6 +1567,9 @@ export async function runRootCommand(
 	}
 	if (restartAdvisorEnabled !== undefined) {
 		settingsInstance.override("advisor.enabled", restartAdvisorEnabled);
+	}
+	if (restartComputerEnabled !== undefined) {
+		settingsInstance.override("computer.enabled", restartComputerEnabled);
 	}
 
 	await logger.time(

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -434,14 +434,16 @@ function resolveRestartLaunchPaths(values: readonly string[] | undefined, cwd: s
 export async function resolveRestartPromptLaunchValue(
 	value: string | undefined,
 	launchCwd: string,
+	fallbackValue?: string,
 ): Promise<string | undefined> {
-	if (!value || value.includes("\n")) return value;
-	const resolved = resolveRestartLaunchPath(value, launchCwd);
+	const source = value ?? fallbackValue;
+	if (!source || source.includes("\n")) return source;
+	const resolved = resolveRestartLaunchPath(source, launchCwd);
 	try {
 		await Bun.file(resolved).text();
 		return resolved;
 	} catch {
-		return value;
+		return source;
 	}
 }
 
@@ -1028,6 +1030,13 @@ export function applyResolvedSystemPromptInputs(
 	}
 }
 
+interface RestartPromptSources {
+	discoveredSystemPromptSource?: string;
+	discoveredAppendPromptSource?: string;
+}
+
+const restartPromptSources = new WeakMap<CreateAgentSessionOptions, RestartPromptSources>();
+
 /** Builds startup session options from parsed CLI flags, scoped models, and resolved session lineage. */
 export async function buildSessionOptions(
 	parsed: Args,
@@ -1050,8 +1059,11 @@ export async function buildSessionOptions(
 	}
 
 	// Auto-discover SYSTEM.md if no CLI system prompt provided
-	const systemPromptSource = parsed.systemPrompt ?? discoverSystemPromptFile();
-	const appendPromptSource = parsed.appendSystemPrompt ?? discoverAppendSystemPromptFile();
+	const discoveredSystemPromptSource = parsed.systemPrompt === undefined ? discoverSystemPromptFile() : undefined;
+	const systemPromptSource = parsed.systemPrompt ?? discoveredSystemPromptSource;
+	const discoveredAppendPromptSource =
+		parsed.appendSystemPrompt === undefined ? discoverAppendSystemPromptFile() : undefined;
+	const appendPromptSource = parsed.appendSystemPrompt ?? discoveredAppendPromptSource;
 	const titleSystemPromptSource = discoverTitleSystemPromptFile();
 	const [resolvedSystemPrompt, resolvedAppendPrompt, titleSystemPrompt] = await Promise.all([
 		resolvePromptInput(systemPromptSource, "system prompt"),
@@ -1278,6 +1290,7 @@ export async function buildSessionOptions(
 		options.additionalExtensionPaths = [];
 	}
 
+	restartPromptSources.set(options, { discoveredSystemPromptSource, discoveredAppendPromptSource });
 	return options;
 }
 
@@ -1586,6 +1599,7 @@ export async function runRootCommand(
 		modelRegistry,
 		settingsInstance,
 	);
+	const { discoveredSystemPromptSource, discoveredAppendPromptSource } = restartPromptSources.get(sessionOptions) ?? {};
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
@@ -1825,8 +1839,16 @@ export async function runRootCommand(
 				buildRestartLaunchFlags(
 					{
 						...applyLiveThinkingToRestartLaunchArgs(initialArgs, session.configuredThinkingLevel()),
-						systemPrompt: await resolveRestartPromptLaunchValue(initialArgs.systemPrompt, cwd),
-						appendSystemPrompt: await resolveRestartPromptLaunchValue(initialArgs.appendSystemPrompt, cwd),
+						systemPrompt: await resolveRestartPromptLaunchValue(
+							initialArgs.systemPrompt,
+							cwd,
+							discoveredSystemPromptSource,
+						),
+						appendSystemPrompt: await resolveRestartPromptLaunchValue(
+							initialArgs.appendSystemPrompt,
+							cwd,
+							discoveredAppendPromptSource,
+						),
 					},
 					launchConfigCwd,
 					currentExtensionFlagValues,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -32,10 +32,12 @@ import {
 	consumeRestartAdvisorEnabled,
 	consumeRestartExtensionFlagValues,
 	consumeRestartExtensionPackageRoots,
+	consumeRestartLiteralPrompts,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
 	type RestartExtensionFlagValue,
 	type RestartLaunchFlags,
+	type RestartLiteralPrompts,
 	type RestartToolRestriction,
 	restoreRestartExtensionFlagValues,
 	selectRestartExtensionPackageRoots,
@@ -95,9 +97,9 @@ import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
 import {
 	discoverTitleSystemPromptFile,
-	encodeLiteralPromptInput,
-	isEncodedLiteralPromptInput,
+	type PromptInputResolution,
 	resolvePromptInput,
+	resolvePromptInputWithSource,
 } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
@@ -442,21 +444,38 @@ function resolveRestartConfigEnvFiles(value: string | undefined, cwd: string): s
 	return configFiles && configFiles.length > 0 ? resolveRestartLaunchPaths(configFiles, cwd) : undefined;
 }
 
-/** Resolve a restart prompt flag to its original file path only when the launch input was file-backed. */
-export async function resolveRestartPromptLaunchValue(
-	value: string | undefined,
+/** Initial prompt-source classifications retained for a restart. */
+export interface RestartPromptSources {
+	systemPrompt?: PromptInputResolution;
+	appendSystemPrompt?: PromptInputResolution;
+}
+
+function buildRestartPromptLaunchFlags(
+	sources: RestartPromptSources | undefined,
 	launchCwd: string,
-	fallbackValue?: string,
-): Promise<string | undefined> {
-	const source = value ?? fallbackValue;
-	if (!source || source.includes("\n") || isEncodedLiteralPromptInput(source)) return source;
-	const resolved = resolveRestartLaunchPath(source, launchCwd);
-	try {
-		await Bun.file(resolved).text();
-		return resolved;
-	} catch {
-		return encodeLiteralPromptInput(source);
+	parsed: Pick<Args, "systemPrompt" | "appendSystemPrompt">,
+): Pick<
+	RestartLaunchFlags,
+	"systemPrompt" | "appendSystemPrompt" | "restartLiteralSystemPrompt" | "restartLiteralAppendSystemPrompt"
+> {
+	if (!sources) {
+		return {
+			systemPrompt: parsed.systemPrompt,
+			appendSystemPrompt: parsed.appendSystemPrompt,
+		};
 	}
+	const systemPrompt = sources.systemPrompt;
+	const appendSystemPrompt = sources.appendSystemPrompt;
+	return {
+		systemPrompt:
+			systemPrompt?.source === "file" ? resolveRestartLaunchPath(systemPrompt.input, launchCwd) : undefined,
+		appendSystemPrompt:
+			appendSystemPrompt?.source === "file"
+				? resolveRestartLaunchPath(appendSystemPrompt.input, launchCwd)
+				: undefined,
+		restartLiteralSystemPrompt: systemPrompt?.source === "literal" ? systemPrompt.input : undefined,
+		restartLiteralAppendSystemPrompt: appendSystemPrompt?.source === "literal" ? appendSystemPrompt.input : undefined,
+	};
 }
 
 /** Return parsed restart launch args with the current session thinking selector overriding stale launch input. */
@@ -512,6 +531,7 @@ export function buildRestartLaunchFlags(
 	restartApiKey?: string,
 	restartExtensionPackageRoots?: readonly string[],
 	restartConfigFilesEnv?: string,
+	restartPromptSources?: RestartPromptSources,
 ): RestartLaunchFlags {
 	const extensionPackageRootInputs = selectRestartExtensionPackageRoots(
 		restartExtensionPackageRoots,
@@ -524,12 +544,12 @@ export function buildRestartLaunchFlags(
 			: extensionPackageRootInputs.length > 0
 				? resolveRestartLaunchPaths(extensionPackageRootInputs, launchCwd)
 				: undefined;
+	const restartPromptLaunchFlags = buildRestartPromptLaunchFlags(restartPromptSources, sessionStartCwd, parsed);
 	return {
 		apiKey: parsed.apiKey ?? restartApiKey,
 		apiKeyProvider,
 		advisor: Boolean(parsed.advisor),
 		autoApprove: Boolean(parsed.autoApprove),
-		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
 		disableLsp: Boolean(parsed.noLsp),
 		noPty: Boolean(parsed.noPty),
@@ -560,11 +580,11 @@ export function buildRestartLaunchFlags(
 		slowModel: parsed.slow,
 		smolModel: parsed.smol,
 		hideThinking: Boolean(parsed.hideThinking),
-		systemPrompt: parsed.systemPrompt,
+		...restartPromptLaunchFlags,
 	};
 }
 
-type RuntimeApiKeySessionOptions = { model?: { provider: string }; modelPattern?: string };
+type RuntimeApiKeySessionOptions = { model?: { provider: string }; modelPattern?: string | string[] };
 type RestorableModelSource = Pick<SessionManager, "getRestorableModelStrings">;
 
 /** Return whether a runtime API key lacks both a launch model and a restorable provider. */
@@ -680,6 +700,7 @@ async function runInteractiveMode(
 	joinLink?: string,
 	restartToolRestriction?: RestartToolRestriction,
 	restartLaunchFlags?: RestartLaunchFlags,
+	startupMarketplaceUpdate?: Promise<void>,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -691,6 +712,7 @@ async function runInteractiveMode(
 		eventBus,
 		restartToolRestriction,
 		restartLaunchFlags,
+		startupMarketplaceUpdate,
 	);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
@@ -1084,12 +1106,36 @@ export function applyResolvedSystemPromptInputs(
 	}
 }
 
-interface RestartPromptSources {
-	discoveredSystemPromptSource?: string;
-	discoveredAppendPromptSource?: string;
+/** Resolve initial custom prompts while preserving whether each was literal or file-backed. */
+export async function resolveStartupPromptInputs({
+	systemPromptSource,
+	appendSystemPromptSource,
+	restartLiteralPrompts,
+}: {
+	systemPromptSource?: string;
+	appendSystemPromptSource?: string;
+	restartLiteralPrompts?: RestartLiteralPrompts;
+}): Promise<RestartPromptSources> {
+	const [systemPrompt, appendSystemPrompt] = await Promise.all([
+		restartLiteralPrompts?.systemPrompt === undefined
+			? resolvePromptInputWithSource(systemPromptSource, "system prompt")
+			: Promise.resolve({
+					source: "literal" as const,
+					input: restartLiteralPrompts.systemPrompt,
+					value: restartLiteralPrompts.systemPrompt,
+				}),
+		restartLiteralPrompts?.appendSystemPrompt === undefined
+			? resolvePromptInputWithSource(appendSystemPromptSource, "append system prompt")
+			: Promise.resolve({
+					source: "literal" as const,
+					input: restartLiteralPrompts.appendSystemPrompt,
+					value: restartLiteralPrompts.appendSystemPrompt,
+				}),
+	]);
+	return { systemPrompt, appendSystemPrompt };
 }
-
 const restartPromptSources = new WeakMap<CreateAgentSessionOptions, RestartPromptSources>();
+const restartLiteralPromptInputs = new WeakMap<Args, RestartLiteralPrompts>();
 
 /** Builds startup session options from parsed CLI flags, scoped models, and resolved session lineage. */
 export async function buildSessionOptions(
@@ -1112,18 +1158,30 @@ export async function buildSessionOptions(
 		options.deadline = Date.now() + parsed.maxTime * 1000;
 	}
 
-	// Auto-discover SYSTEM.md if no CLI system prompt provided
-	const discoveredSystemPromptSource = parsed.systemPrompt === undefined ? discoverSystemPromptFile() : undefined;
+	const restartLiteralPrompts = restartLiteralPromptInputs.get(parsed);
+	const restartSystemPrompt = restartLiteralPrompts?.systemPrompt;
+	const restartAppendSystemPrompt = restartLiteralPrompts?.appendSystemPrompt;
+	// Auto-discover prompt files only when no CLI or restart-literal prompt was provided.
+	const discoveredSystemPromptSource =
+		parsed.systemPrompt === undefined && restartSystemPrompt === undefined ? discoverSystemPromptFile() : undefined;
 	const systemPromptSource = parsed.systemPrompt ?? discoveredSystemPromptSource;
 	const discoveredAppendPromptSource =
-		parsed.appendSystemPrompt === undefined ? discoverAppendSystemPromptFile() : undefined;
+		parsed.appendSystemPrompt === undefined && restartAppendSystemPrompt === undefined
+			? discoverAppendSystemPromptFile()
+			: undefined;
 	const appendPromptSource = parsed.appendSystemPrompt ?? discoveredAppendPromptSource;
 	const titleSystemPromptSource = discoverTitleSystemPromptFile();
-	const [resolvedSystemPrompt, resolvedAppendPrompt, titleSystemPrompt] = await Promise.all([
-		resolvePromptInput(systemPromptSource, "system prompt"),
-		resolvePromptInput(appendPromptSource, "append system prompt"),
+	const [resolvedPromptInputs, titleSystemPrompt] = await Promise.all([
+		resolveStartupPromptInputs({
+			systemPromptSource,
+			appendSystemPromptSource: appendPromptSource,
+			restartLiteralPrompts,
+		}),
 		resolvePromptInput(titleSystemPromptSource, "title system prompt"),
 	]);
+	const { systemPrompt: systemPromptInput, appendSystemPrompt: appendPromptInput } = resolvedPromptInputs;
+	const resolvedSystemPrompt = systemPromptInput?.value;
+	const resolvedAppendPrompt = appendPromptInput?.value;
 
 	if (sessionManager) {
 		options.sessionManager = sessionManager;
@@ -1344,7 +1402,7 @@ export async function buildSessionOptions(
 		options.additionalExtensionPaths = [];
 	}
 
-	restartPromptSources.set(options, { discoveredSystemPromptSource, discoveredAppendPromptSource });
+	restartPromptSources.set(options, { systemPrompt: systemPromptInput, appendSystemPrompt: appendPromptInput });
 	return options;
 }
 
@@ -1376,6 +1434,8 @@ export async function runRootCommand(
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
 	const restartExtensionPackageRoots = consumeRestartExtensionPackageRoots();
 	const restartAdvisorEnabled = consumeRestartAdvisorEnabled();
+	const restartLiteralPrompts = consumeRestartLiteralPrompts();
+	if (restartLiteralPrompts) restartLiteralPromptInputs.set(parsedArgs, restartLiteralPrompts);
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
@@ -1648,7 +1708,7 @@ export async function runRootCommand(
 		await logger.time("registerDaemonProjectPresence", registerDaemonProjectPresence, cwd);
 	}
 
-	scheduleMarketplaceAutoUpdate({
+	const marketplaceAutoUpdate = scheduleMarketplaceAutoUpdate({
 		autoUpdate: settingsInstance.get("marketplace.autoUpdate"),
 		resolveActiveProjectRegistryPath,
 		clearPluginRootsCache: clearPluginRootsAndCaches,
@@ -1663,7 +1723,7 @@ export async function runRootCommand(
 		modelRegistry,
 		settingsInstance,
 	);
-	const { discoveredSystemPromptSource, discoveredAppendPromptSource } = restartPromptSources.get(sessionOptions) ?? {};
+	const restartPromptSourceSnapshot = restartPromptSources.get(sessionOptions);
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
@@ -1900,19 +1960,7 @@ export async function runRootCommand(
 				parsedArgs.join,
 				buildRestartToolRestriction(initialArgs),
 				buildRestartLaunchFlags(
-					{
-						...applyLiveThinkingToRestartLaunchArgs(initialArgs, session.configuredThinkingLevel()),
-						systemPrompt: await resolveRestartPromptLaunchValue(
-							initialArgs.systemPrompt,
-							cwd,
-							discoveredSystemPromptSource,
-						),
-						appendSystemPrompt: await resolveRestartPromptLaunchValue(
-							initialArgs.appendSystemPrompt,
-							cwd,
-							discoveredAppendPromptSource,
-						),
-					},
+					applyLiveThinkingToRestartLaunchArgs(initialArgs, session.configuredThinkingLevel()),
 					launchConfigCwd,
 					currentExtensionFlagValues,
 					sessionOptions.deadline,
@@ -1921,7 +1969,9 @@ export async function runRootCommand(
 					restartApiKeyHandoff?.apiKey,
 					restartExtensionPackageRoots,
 					restartConfigFilesEnv,
+					restartPromptSourceSnapshot,
 				),
+				marketplaceAutoUpdate,
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -31,6 +31,7 @@ import { buildInitialMessage } from "./cli/initial-message";
 import {
 	consumeRestartExtensionFlagValues,
 	RESTART_API_KEY_ENV,
+	RESTART_API_KEY_PROVIDER_ENV,
 	type RestartExtensionFlagValue,
 	type RestartLaunchFlags,
 	type RestartToolRestriction,
@@ -429,22 +430,19 @@ function resolveRestartLaunchPaths(values: readonly string[] | undefined, cwd: s
 	return values?.map(value => resolveRestartLaunchPath(value, cwd));
 }
 
-function isExplicitPathLikeLaunchValue(value: string): boolean {
-	return (
-		value === "~" ||
-		value.startsWith("~/") ||
-		path.isAbsolute(value) ||
-		value === "." ||
-		value === ".." ||
-		value.startsWith("./") ||
-		value.startsWith("../") ||
-		value.startsWith(".\\") ||
-		value.startsWith("..\\")
-	);
-}
-
-function resolvePathLikeRestartLaunchValues(values: readonly string[] | undefined, cwd: string): string[] | undefined {
-	return values?.map(value => (isExplicitPathLikeLaunchValue(value) ? resolveRestartLaunchPath(value, cwd) : value));
+/** Resolve a restart prompt flag to its original file path only when the launch input was file-backed. */
+export async function resolveRestartPromptLaunchValue(
+	value: string | undefined,
+	launchCwd: string,
+): Promise<string | undefined> {
+	if (!value || value.includes("\n")) return value;
+	const resolved = resolveRestartLaunchPath(value, launchCwd);
+	try {
+		await Bun.file(resolved).text();
+		return resolved;
+	} catch {
+		return value;
+	}
 }
 
 /** Build restart launch state from parsed args and deadline, resolving path flags against the original launch cwd. */
@@ -465,6 +463,7 @@ export function buildRestartLaunchFlags(
 		| "noSkills"
 		| "pluginDirs"
 		| "plan"
+		| "providerSessionId"
 		| "skills"
 		| "slow"
 		| "smol"
@@ -474,9 +473,11 @@ export function buildRestartLaunchFlags(
 	launchCwd: string,
 	extensionFlagValues?: readonly RestartExtensionFlagValue[],
 	maxTimeDeadline?: number,
+	apiKeyProvider?: string,
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
+		apiKeyProvider,
 		advisor: Boolean(parsed.advisor),
 		appendSystemPrompt: parsed.appendSystemPrompt,
 		disableExtensions: Boolean(parsed.noExtensions),
@@ -484,11 +485,12 @@ export function buildRestartLaunchFlags(
 		disableRules: Boolean(parsed.noRules),
 		disableSkills: Boolean(parsed.noSkills),
 		configFiles: resolveRestartLaunchPaths(parsed.config, launchCwd),
-		extensionPaths: resolvePathLikeRestartLaunchValues(parsed.extensions, launchCwd),
-		hookPaths: resolvePathLikeRestartLaunchValues(parsed.hooks, launchCwd),
+		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, launchCwd),
+		hookPaths: resolveRestartLaunchPaths(parsed.hooks, launchCwd),
 		pluginDirs: resolveRestartLaunchPaths(parsed.pluginDirs, launchCwd),
 		modelPatterns: parsed.models,
 		planModel: parsed.plan,
+		providerSessionId: parsed.providerSessionId,
 		thinking: parsed.thinking,
 		extensionFlagValues,
 		maxTimeDeadline,
@@ -525,23 +527,37 @@ export function getPersistedSessionModelProvider(
 	return undefined;
 }
 
+/** Return the provider a runtime API key should be installed for before session restore. */
+export function getRuntimeApiKeyProviderBeforeSessionRestore(
+	parsed: Pick<Args, "apiKey" | "continue" | "resume" | "fork">,
+	sessionOptions: RuntimeApiKeySessionOptions,
+	sessionManager: RestorableModelSource | undefined,
+	restartApiKeyProvider?: string,
+): string | undefined {
+	if (!parsed.apiKey) return undefined;
+	if (restartApiKeyProvider) return restartApiKeyProvider;
+	if (sessionOptions.model) return sessionOptions.model.provider;
+	if (sessionOptions.modelPattern || !(parsed.continue || parsed.resume || parsed.fork)) return undefined;
+	return getPersistedSessionModelProvider(sessionManager);
+}
+
 /** Install a runtime API key before createSession can restore a persisted model. */
 export function applyRuntimeApiKeyBeforeSessionRestore(
 	parsed: Pick<Args, "apiKey" | "continue" | "resume" | "fork">,
 	sessionOptions: RuntimeApiKeySessionOptions,
 	sessionManager: RestorableModelSource | undefined,
 	authStorage: Pick<AuthStorage, "setRuntimeApiKey">,
-): boolean {
-	if (!parsed.apiKey) return false;
-	if (sessionOptions.model) {
-		authStorage.setRuntimeApiKey(sessionOptions.model.provider, parsed.apiKey);
-		return true;
-	}
-	if (sessionOptions.modelPattern || !(parsed.continue || parsed.resume || parsed.fork)) return false;
-	const provider = getPersistedSessionModelProvider(sessionManager);
-	if (!provider) return false;
+	restartApiKeyProvider?: string,
+): string | undefined {
+	const provider = getRuntimeApiKeyProviderBeforeSessionRestore(
+		parsed,
+		sessionOptions,
+		sessionManager,
+		restartApiKeyProvider,
+	);
+	if (!parsed.apiKey || !provider) return undefined;
 	authStorage.setRuntimeApiKey(provider, parsed.apiKey);
-	return true;
+	return provider;
 }
 
 /** Apply a runtime API key when the provider was only known after createSession. */
@@ -550,16 +566,26 @@ export function applyRuntimeApiKeyForRestoredSession(
 	sessionOptions: RuntimeApiKeySessionOptions,
 	session: { model?: { provider: string } },
 	authStorage: Pick<AuthStorage, "setRuntimeApiKey">,
-): void {
-	if (!parsed.apiKey || sessionOptions.model || !session.model) return;
-	authStorage.setRuntimeApiKey(session.model.provider, parsed.apiKey);
+	restartApiKeyProvider?: string,
+): string | undefined {
+	if (!parsed.apiKey || sessionOptions.model) return undefined;
+	const provider = restartApiKeyProvider ?? session.model?.provider;
+	if (!provider) return undefined;
+	authStorage.setRuntimeApiKey(provider, parsed.apiKey);
+	return provider;
 }
 
-function applyRestartApiKeyHandoff(parsed: Args, env: Record<string, string | undefined> = process.env): void {
+function applyRestartApiKeyHandoff(
+	parsed: Args,
+	env: Record<string, string | undefined> = process.env,
+): string | undefined {
 	const apiKey = env[RESTART_API_KEY_ENV];
-	if (!apiKey) return;
-	if (!parsed.apiKey) parsed.apiKey = apiKey;
+	const apiKeyProvider = env[RESTART_API_KEY_PROVIDER_ENV];
 	delete env[RESTART_API_KEY_ENV];
+	delete env[RESTART_API_KEY_PROVIDER_ENV];
+	if (!apiKey) return undefined;
+	if (!parsed.apiKey) parsed.apiKey = apiKey;
+	return apiKeyProvider;
 }
 
 async function runInteractiveMode(
@@ -1261,7 +1287,7 @@ export async function runRootCommand(
 	await logger.time("initTheme:initial", initTheme);
 
 	const parsedArgs = parsed;
-	applyRestartApiKeyHandoff(parsedArgs);
+	const restartApiKeyProvider = applyRestartApiKeyHandoff(parsedArgs);
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
@@ -1557,6 +1583,7 @@ export async function runRootCommand(
 	}
 
 	// Handle CLI --api-key as runtime override (not persisted)
+	let runtimeApiKeyProvider = restartApiKeyProvider;
 	let runtimeApiKeyInstalledBeforeSessionRestore = false;
 	if (parsedArgs.apiKey) {
 		if (requiresLaunchModelForRuntimeApiKey(parsedArgs, sessionOptions)) {
@@ -1565,12 +1592,15 @@ export async function runRootCommand(
 			);
 			process.exit(1);
 		}
-		runtimeApiKeyInstalledBeforeSessionRestore = applyRuntimeApiKeyBeforeSessionRestore(
+		const installedProvider = applyRuntimeApiKeyBeforeSessionRestore(
 			parsedArgs,
 			sessionOptions,
 			sessionManager,
 			authStorage,
+			restartApiKeyProvider,
 		);
+		runtimeApiKeyInstalledBeforeSessionRestore = installedProvider !== undefined;
+		runtimeApiKeyProvider = installedProvider ?? runtimeApiKeyProvider;
 	}
 
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
@@ -1693,7 +1723,14 @@ export async function runRootCommand(
 			Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
 		);
 		if (!runtimeApiKeyInstalledBeforeSessionRestore) {
-			applyRuntimeApiKeyForRestoredSession(parsedArgs, sessionOptions, session, authStorage);
+			const restoredProvider = applyRuntimeApiKeyForRestoredSession(
+				parsedArgs,
+				sessionOptions,
+				session,
+				authStorage,
+				restartApiKeyProvider,
+			);
+			runtimeApiKeyProvider = restoredProvider ?? runtimeApiKeyProvider;
 		}
 
 		if (modelFallbackMessage) {
@@ -1767,7 +1804,20 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(initialArgs),
-				buildRestartLaunchFlags(initialArgs, launchConfigCwd, currentExtensionFlagValues, sessionOptions.deadline),
+				buildRestartLaunchFlags(
+					{
+						...initialArgs,
+						systemPrompt: await resolveRestartPromptLaunchValue(initialArgs.systemPrompt, launchConfigCwd),
+						appendSystemPrompt: await resolveRestartPromptLaunchValue(
+							initialArgs.appendSystemPrompt,
+							launchConfigCwd,
+						),
+					},
+					launchConfigCwd,
+					currentExtensionFlagValues,
+					sessionOptions.deadline,
+					runtimeApiKeyProvider,
+				),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -468,6 +468,16 @@ function buildRestartLaunchFlags(
 	};
 }
 
+/** Return whether a runtime API key needs an explicit launch model before session restore. */
+export function requiresLaunchModelForRuntimeApiKey(
+	parsed: Pick<Args, "apiKey" | "continue" | "resume" | "fork">,
+	sessionOptions: Pick<CreateAgentSessionOptions, "model" | "modelPattern">,
+): boolean {
+	if (!parsed.apiKey) return false;
+	if (parsed.continue || parsed.resume || parsed.fork) return false;
+	return !sessionOptions.model && !sessionOptions.modelPattern;
+}
+
 function applyRestartApiKeyHandoff(parsed: Args, env: Record<string, string | undefined> = process.env): void {
 	const apiKey = env[RESTART_API_KEY_ENV];
 	if (!apiKey) return;
@@ -1470,7 +1480,7 @@ export async function runRootCommand(
 
 	// Handle CLI --api-key as runtime override (not persisted)
 	if (parsedArgs.apiKey) {
-		if (!sessionOptions.model && !sessionOptions.modelPattern) {
+		if (requiresLaunchModelForRuntimeApiKey(parsedArgs, sessionOptions)) {
 			process.stderr.write(
 				`${chalk.red("--api-key requires a model to be specified via --model, --provider/--model, or --models")}\n`,
 			);
@@ -1674,8 +1684,8 @@ export async function runRootCommand(
 				initialMessage,
 				initialImages,
 				parsedArgs.join,
-				buildRestartToolRestriction(parsedArgs),
-				buildRestartLaunchFlags(parsedArgs, currentExtensionFlagValues),
+				buildRestartToolRestriction(initialArgs),
+				buildRestartLaunchFlags(initialArgs, currentExtensionFlagValues),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -518,14 +518,19 @@ export function buildRestartLaunchFlags(
 type RuntimeApiKeySessionOptions = { model?: { provider: string }; modelPattern?: string };
 type RestorableModelSource = Pick<SessionManager, "getRestorableModelStrings">;
 
-/** Return whether a runtime API key needs an explicit launch model before session restore. */
+/** Return whether a runtime API key lacks both a launch model and a restorable provider. */
 export function requiresLaunchModelForRuntimeApiKey(
 	parsed: Pick<Args, "apiKey" | "continue" | "resume" | "fork">,
 	sessionOptions: Pick<CreateAgentSessionOptions, "model" | "modelPattern">,
+	sessionManager?: RestorableModelSource,
+	restartApiKeyProvider?: string,
 ): boolean {
 	if (!parsed.apiKey) return false;
-	if (parsed.continue || parsed.resume || parsed.fork) return false;
-	return !sessionOptions.model && !sessionOptions.modelPattern;
+	if (sessionOptions.model || sessionOptions.modelPattern || restartApiKeyProvider) return false;
+	if (parsed.continue || parsed.resume || parsed.fork) {
+		return getPersistedSessionModelProvider(sessionManager) === undefined;
+	}
+	return true;
 }
 
 /** Return the provider for the first persisted model that session restore will try. */
@@ -1618,7 +1623,7 @@ export async function runRootCommand(
 	let runtimeApiKeyProvider = restartApiKeyProvider;
 	let runtimeApiKeyInstalledBeforeSessionRestore = false;
 	if (parsedArgs.apiKey) {
-		if (requiresLaunchModelForRuntimeApiKey(parsedArgs, sessionOptions)) {
+		if (requiresLaunchModelForRuntimeApiKey(parsedArgs, sessionOptions, sessionManager, restartApiKeyProvider)) {
 			process.stderr.write(
 				`${chalk.red("--api-key requires a model to be specified via --model, --provider/--model, or --models")}\n`,
 			);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -478,13 +478,19 @@ export function buildRestartLaunchFlags(
 		| "noExtensions"
 		| "noLsp"
 		| "noPty"
+		| "noPrewalk"
 		| "noRules"
 		| "noSkills"
 		| "noTitle"
 		| "pluginDirs"
 		| "plan"
+		| "planYolo"
+		| "planYoloInto"
+		| "prewalk"
+		| "prewalkInto"
 		| "provider"
 		| "providerSessionId"
+		| "providerPromptCacheKey"
 		| "skills"
 		| "slow"
 		| "smol"
@@ -516,7 +522,13 @@ export function buildRestartLaunchFlags(
 		model: parsed.model,
 		modelPatterns: parsed.models,
 		planModel: parsed.plan,
+		noPrewalk: Boolean(parsed.noPrewalk),
+		planYolo: Boolean(parsed.planYolo),
+		planYoloInto: parsed.planYoloInto,
+		prewalk: Boolean(parsed.prewalk),
+		prewalkInto: parsed.prewalkInto,
 		providerSessionId: parsed.providerSessionId,
+		providerPromptCacheKey: parsed.providerPromptCacheKey,
 		provider: parsed.provider,
 		thinking: parsed.thinking,
 		extensionFlagValues,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -90,7 +90,7 @@ import { resolveResumableSession, type SessionInfo } from "./session/session-lis
 import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
-import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
+import { discoverTitleSystemPromptFile, encodeLiteralPromptInput, resolvePromptInput } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { AUTO_THINKING, concreteThinkingLevel, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
@@ -444,7 +444,7 @@ export async function resolveRestartPromptLaunchValue(
 		await Bun.file(resolved).text();
 		return resolved;
 	} catch {
-		return source;
+		return encodeLiteralPromptInput(source);
 	}
 }
 
@@ -467,6 +467,7 @@ export function buildRestartLaunchFlags(
 		| "config"
 		| "extensions"
 		| "hideThinking"
+		| "model"
 		| "hooks"
 		| "models"
 		| "noExtensions"
@@ -475,6 +476,7 @@ export function buildRestartLaunchFlags(
 		| "noSkills"
 		| "pluginDirs"
 		| "plan"
+		| "provider"
 		| "providerSessionId"
 		| "skills"
 		| "slow"
@@ -502,9 +504,11 @@ export function buildRestartLaunchFlags(
 		extensionPaths: resolveRestartLaunchPaths(parsed.extensions, sessionStartCwd),
 		hookPaths: resolveRestartLaunchPaths(parsed.hooks, sessionStartCwd),
 		pluginDirs: resolveRestartLaunchPaths(parsed.pluginDirs, launchCwd),
+		model: parsed.model,
 		modelPatterns: parsed.models,
 		planModel: parsed.plan,
 		providerSessionId: parsed.providerSessionId,
+		provider: parsed.provider,
 		thinking: parsed.thinking,
 		extensionFlagValues,
 		maxTimeDeadline,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -98,7 +98,7 @@ import {
 } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
-import { AUTO_THINKING, concreteThinkingLevel, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
+import { type ConfiguredThinkingLevel, concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import {
 	getChangelogPath,
@@ -553,7 +553,7 @@ export function getPersistedSessionModelProvider(
 ): string | undefined {
 	if (!sessionManager) return undefined;
 	for (const modelString of sessionManager.getRestorableModelStrings()) {
-		const parsedModel = parseModelString(modelString, { allowMaxAlias: true });
+		const parsedModel = parseModelString(modelString);
 		if (parsedModel) return parsedModel.provider;
 	}
 	return undefined;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -29,6 +29,7 @@ import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-fla
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import {
+	consumeRestartAdvisorEnabled,
 	consumeRestartExtensionFlagValues,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
@@ -1325,6 +1326,7 @@ export async function runRootCommand(
 	const restartApiKeyHandoff = applyRestartApiKeyHandoff(parsedArgs);
 	const restartApiKeyProvider = restartApiKeyHandoff?.provider;
 	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
+	const restartAdvisorEnabled = consumeRestartAdvisorEnabled();
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
@@ -1446,6 +1448,9 @@ export async function runRootCommand(
 	// Apply --advisor CLI flag (ephemeral, not persisted)
 	if (parsedArgs.advisor) {
 		settingsInstance.override("advisor.enabled", true);
+	}
+	if (restartAdvisorEnabled !== undefined) {
+		settingsInstance.override("advisor.enabled", restartAdvisorEnabled);
 	}
 
 	await logger.time(

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -27,6 +27,7 @@ import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
+import type { RestartToolRestriction } from "./cli/restart";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
@@ -405,6 +406,12 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 	};
 }
 
+function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): RestartToolRestriction | undefined {
+	if (parsed.tools && parsed.tools.length > 0) return { kind: "allowlist", toolNames: parsed.tools };
+	if (parsed.noTools || parsed.tools) return { kind: "none" };
+	return undefined;
+}
+
 async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
@@ -422,6 +429,7 @@ async function runInteractiveMode(
 	initialMessage?: string,
 	initialImages?: ImageContent[],
 	joinLink?: string,
+	restartToolRestriction?: RestartToolRestriction,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -431,6 +439,7 @@ async function runInteractiveMode(
 		lspServers,
 		mcpManager,
 		eventBus,
+		restartToolRestriction,
 	);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
@@ -1590,6 +1599,7 @@ export async function runRootCommand(
 				initialMessage,
 				initialImages,
 				parsedArgs.join,
+				buildRestartToolRestriction(parsedArgs),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -27,7 +27,14 @@ import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
-import { RESTART_API_KEY_ENV, type RestartLaunchFlags, type RestartToolRestriction } from "./cli/restart";
+import {
+	consumeRestartExtensionFlagValues,
+	RESTART_API_KEY_ENV,
+	type RestartExtensionFlagValue,
+	type RestartLaunchFlags,
+	type RestartToolRestriction,
+	restoreRestartExtensionFlagValues,
+} from "./cli/restart";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
@@ -428,6 +435,7 @@ function buildRestartLaunchFlags(
 		| "skills"
 		| "systemPrompt"
 	>,
+	extensionFlagValues?: readonly RestartExtensionFlagValue[],
 ): RestartLaunchFlags {
 	return {
 		apiKey: parsed.apiKey,
@@ -440,6 +448,7 @@ function buildRestartLaunchFlags(
 		extensionPaths: parsed.extensions,
 		hookPaths: parsed.hooks,
 		pluginDirs: parsed.pluginDirs,
+		extensionFlagValues,
 		skillPatterns: parsed.skills,
 		systemPrompt: parsed.systemPrompt,
 	};
@@ -1152,6 +1161,7 @@ export async function runRootCommand(
 
 	const parsedArgs = parsed;
 	applyRestartApiKeyHandoff(parsedArgs);
+	const restartExtensionFlagValues = consumeRestartExtensionFlagValues();
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
@@ -1502,7 +1512,15 @@ export async function runRootCommand(
 				extensionsResult.runtime.flagValues.set(name, value);
 			},
 		};
-		const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
+		const parsedWithExtensionFlags = restartExtensionFlagValues
+			? null
+			: applyExtensionFlags(extensionFlagSink, rawArgs);
+		const initialArgs = parsedWithExtensionFlags ?? parsedArgs;
+		const extensionFlagValues = parsedWithExtensionFlags?.unknownFlags;
+		const currentExtensionFlagValues =
+			restartExtensionFlagValues ??
+			(extensionFlagValues && extensionFlagValues.size > 0 ? [...extensionFlagValues.entries()] : undefined);
+		restoreRestartExtensionFlagValues(extensionFlagSink, restartExtensionFlagValues);
 		normalizeContinueSessionArgs(initialArgs, rawArgs);
 		for (const message of formatExtensionLoadNotifications(extensionsResult.errors)) {
 			if (isInteractive) {
@@ -1643,7 +1661,7 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(parsedArgs),
-				buildRestartLaunchFlags(parsedArgs),
+				buildRestartLaunchFlags(parsedArgs, currentExtensionFlagValues),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -27,7 +27,7 @@ import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
-import type { RestartLaunchFlags, RestartToolRestriction } from "./cli/restart";
+import { RESTART_API_KEY_ENV, type RestartLaunchFlags, type RestartToolRestriction } from "./cli/restart";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
@@ -413,15 +413,28 @@ function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): R
 }
 
 function buildRestartLaunchFlags(
-	parsed: Pick<Args, "config" | "extensions" | "hooks" | "noExtensions" | "pluginDirs">,
+	parsed: Pick<
+		Args,
+		"apiKey" | "config" | "extensions" | "hooks" | "noExtensions" | "noLsp" | "noRules" | "noSkills" | "pluginDirs"
+	>,
 ): RestartLaunchFlags {
 	return {
+		apiKey: parsed.apiKey,
 		disableExtensions: Boolean(parsed.noExtensions),
+		disableLsp: Boolean(parsed.noLsp),
+		disableRules: Boolean(parsed.noRules),
+		disableSkills: Boolean(parsed.noSkills),
 		configFiles: parsed.config,
 		extensionPaths: parsed.extensions,
 		hookPaths: parsed.hooks,
 		pluginDirs: parsed.pluginDirs,
 	};
+}
+function applyRestartApiKeyHandoff(parsed: Args, env: Record<string, string | undefined> = process.env): void {
+	const apiKey = env[RESTART_API_KEY_ENV];
+	if (!apiKey) return;
+	if (!parsed.apiKey) parsed.apiKey = apiKey;
+	delete env[RESTART_API_KEY_ENV];
 }
 
 async function runInteractiveMode(
@@ -1123,6 +1136,7 @@ export async function runRootCommand(
 	await logger.time("initTheme:initial", initTheme);
 
 	const parsedArgs = parsed;
+	applyRestartApiKeyHandoff(parsedArgs);
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -27,7 +27,7 @@ import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
-import type { RestartToolRestriction } from "./cli/restart";
+import type { RestartLaunchFlags, RestartToolRestriction } from "./cli/restart";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
@@ -412,6 +412,18 @@ function buildRestartToolRestriction(parsed: Pick<Args, "noTools" | "tools">): R
 	return undefined;
 }
 
+function buildRestartLaunchFlags(
+	parsed: Pick<Args, "config" | "extensions" | "hooks" | "noExtensions" | "pluginDirs">,
+): RestartLaunchFlags {
+	return {
+		disableExtensions: Boolean(parsed.noExtensions),
+		configFiles: parsed.config,
+		extensionPaths: parsed.extensions,
+		hookPaths: parsed.hooks,
+		pluginDirs: parsed.pluginDirs,
+	};
+}
+
 async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
@@ -430,7 +442,7 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	joinLink?: string,
 	restartToolRestriction?: RestartToolRestriction,
-	restartDisableExtensions = false,
+	restartLaunchFlags?: RestartLaunchFlags,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -441,7 +453,7 @@ async function runInteractiveMode(
 		mcpManager,
 		eventBus,
 		restartToolRestriction,
-		restartDisableExtensions,
+		restartLaunchFlags,
 	);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
@@ -1602,7 +1614,7 @@ export async function runRootCommand(
 				initialImages,
 				parsedArgs.join,
 				buildRestartToolRestriction(parsedArgs),
-				Boolean(parsedArgs.noExtensions),
+				buildRestartLaunchFlags(parsedArgs),
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -92,7 +92,7 @@ import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
-import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
+import { AUTO_THINKING, concreteThinkingLevel, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import {
 	getChangelogPath,
@@ -443,6 +443,15 @@ export async function resolveRestartPromptLaunchValue(
 	} catch {
 		return value;
 	}
+}
+
+/** Return parsed restart launch args with the current session thinking selector overriding stale launch input. */
+export function applyLiveThinkingToRestartLaunchArgs<T extends Pick<Args, "thinking">>(
+	initialArgs: T,
+	liveThinking: ConfiguredThinkingLevel | undefined,
+): T {
+	if (liveThinking === undefined) return initialArgs;
+	return { ...initialArgs, thinking: liveThinking };
 }
 
 /** Build restart launch state, resolving config/plugin paths from launch cwd and extension roots from session cwd. */
@@ -1815,7 +1824,7 @@ export async function runRootCommand(
 				buildRestartToolRestriction(initialArgs),
 				buildRestartLaunchFlags(
 					{
-						...initialArgs,
+						...applyLiveThinkingToRestartLaunchArgs(initialArgs, session.configuredThinkingLevel()),
 						systemPrompt: await resolveRestartPromptLaunchValue(initialArgs.systemPrompt, cwd),
 						appendSystemPrompt: await resolveRestartPromptLaunchValue(initialArgs.appendSystemPrompt, cwd),
 					},

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -405,9 +405,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			enableMCP: false,
 			titleSystemPrompt,
 		});
-		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
-			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
-		}
+		applyRuntimeApiKeyForRestoredSession(args.parsedArgs, args.baseOptions, nextSession, args.authStorage);
 		applyExtensionFlags(nextSession.extensionRunner, args.rawArgs);
 		return nextSession;
 	};
@@ -476,6 +474,17 @@ export function requiresLaunchModelForRuntimeApiKey(
 	if (!parsed.apiKey) return false;
 	if (parsed.continue || parsed.resume || parsed.fork) return false;
 	return !sessionOptions.model && !sessionOptions.modelPattern;
+}
+
+/** Apply a CLI runtime API key after createSession restores a session model provider. */
+export function applyRuntimeApiKeyForRestoredSession(
+	parsed: Pick<Args, "apiKey">,
+	sessionOptions: { model?: { provider: string } },
+	session: { model?: { provider: string } },
+	authStorage: Pick<AuthStorage, "setRuntimeApiKey">,
+): void {
+	if (!parsed.apiKey || sessionOptions.model || !session.model) return;
+	authStorage.setRuntimeApiKey(session.model.provider, parsed.apiKey);
 }
 
 function applyRestartApiKeyHandoff(parsed: Args, env: Record<string, string | undefined> = process.env): void {
@@ -1610,9 +1619,7 @@ export async function runRootCommand(
 			}),
 			Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
 		);
-		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
-			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
-		}
+		applyRuntimeApiKeyForRestoredSession(parsedArgs, sessionOptions, session, authStorage);
 
 		if (modelFallbackMessage) {
 			notifs.push({ kind: "warn", message: modelFallbackMessage });

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -226,10 +226,12 @@ export function hasRestartBlockingWork(
 		AgentSession,
 		"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
 	>,
+	subagentRegistry?: AgentRegistry,
 ): boolean {
 	const asyncJobSnapshot = session.getAsyncJobSnapshot();
 	const hasPendingAsyncDelivery =
 		(asyncJobSnapshot?.delivery.queued ?? 0) > 0 || asyncJobSnapshot?.delivery.delivering === true;
+	const hasRunningSubagents = subagentRegistry ? countRunningSubagentBadgeAgents(subagentRegistry) > 0 : false;
 	return (
 		session.isStreaming ||
 		session.isCompacting ||
@@ -237,7 +239,8 @@ export function hasRestartBlockingWork(
 		session.isBashRunning ||
 		session.isEvalRunning ||
 		(asyncJobSnapshot?.running.length ?? 0) > 0 ||
-		hasPendingAsyncDelivery
+		hasPendingAsyncDelivery ||
+		hasRunningSubagents
 	);
 }
 
@@ -4010,7 +4013,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Leave collab first (/leave)");
 			return;
 		}
-		if (hasRestartBlockingWork(this.session)) {
+		if (hasRestartBlockingWork(this.session, getRunningSubagentBadgeRegistry(this.collabGuest))) {
 			this.showWarning("Wait for the current response or tool execution to finish or abort it before restarting.");
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -271,10 +271,9 @@ export interface InteractiveRestartCommandInput {
 export function buildInteractiveRestartCommandOptions(
 	options: InteractiveRestartCommandInput,
 ): restartProcess.BuildRestartCommandOptions {
+	const isEphemeralFallback = options.liveModelChangeRole === EPHEMERAL_MODEL_CHANGE_ROLE;
 	const liveModelSelector =
-		options.liveModel && options.liveModelChangeRole !== EPHEMERAL_MODEL_CHANGE_ROLE
-			? formatModelStringWithRouting(options.liveModel)
-			: undefined;
+		options.liveModel && !isEphemeralFallback ? formatModelStringWithRouting(options.liveModel) : undefined;
 	return {
 		sessionId: options.sessionId,
 		cwd: options.cwd,
@@ -283,8 +282,8 @@ export function buildInteractiveRestartCommandOptions(
 		toolRestriction: options.toolRestriction,
 		approvalMode: options.approvalMode,
 		...options.launchFlags,
-		provider: liveModelSelector ? undefined : options.launchFlags?.provider,
-		model: liveModelSelector ?? options.launchFlags?.model,
+		provider: isEphemeralFallback ? undefined : liveModelSelector ? undefined : options.launchFlags?.provider,
+		model: isEphemeralFallback ? undefined : (liveModelSelector ?? options.launchFlags?.model),
 		providerSessionId: options.liveProviderSessionId,
 		advisor: options.liveAdvisorEnabled,
 		hideThinking: options.liveHideThinkingBlock,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -253,6 +253,7 @@ export interface InteractiveRestartCommandInput {
 	approvalMode: restartProcess.RestartApprovalMode;
 	launchFlags?: restartProcess.RestartLaunchFlags;
 	liveProviderSessionId: string;
+	liveAdvisorEnabled: boolean;
 }
 
 /** Build `/restart` options with live session state overriding stale launch-time flags. */
@@ -268,6 +269,7 @@ export function buildInteractiveRestartCommandOptions(
 		approvalMode: options.approvalMode,
 		...options.launchFlags,
 		providerSessionId: options.liveProviderSessionId,
+		advisor: options.liveAdvisorEnabled,
 	};
 }
 
@@ -4066,6 +4068,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				toolRestriction: this.#restartToolRestriction,
 				approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
 				launchFlags: this.#restartLaunchFlags,
+				liveAdvisorEnabled: this.session.isAdvisorEnabled(),
 				liveProviderSessionId: this.session.sessionId,
 			}),
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -244,6 +244,33 @@ export function hasRestartBlockingWork(
 	);
 }
 
+export interface InteractiveRestartCommandInput {
+	sessionId: string;
+	cwd: string;
+	sessionDir: string;
+	activeProfile?: string;
+	toolRestriction?: restartProcess.RestartToolRestriction;
+	approvalMode: restartProcess.RestartApprovalMode;
+	launchFlags?: restartProcess.RestartLaunchFlags;
+	liveProviderSessionId: string;
+}
+
+/** Build `/restart` options with live session state overriding stale launch-time flags. */
+export function buildInteractiveRestartCommandOptions(
+	options: InteractiveRestartCommandInput,
+): restartProcess.BuildRestartCommandOptions {
+	return {
+		sessionId: options.sessionId,
+		cwd: options.cwd,
+		sessionDir: options.sessionDir,
+		activeProfile: options.activeProfile,
+		toolRestriction: options.toolRestriction,
+		approvalMode: options.approvalMode,
+		...options.launchFlags,
+		providerSessionId: options.liveProviderSessionId,
+	};
+}
+
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
 	mid: "muted",
@@ -4030,15 +4057,18 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		const command = restartProcess.buildRestartCommand({
-			sessionId: this.sessionManager.getSessionId(),
-			cwd: this.sessionManager.getCwd(),
-			sessionDir: this.sessionManager.getSessionDir(),
-			activeProfile: getActiveProfile(),
-			toolRestriction: this.#restartToolRestriction,
-			approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
-			...this.#restartLaunchFlags,
-		});
+		const command = restartProcess.buildRestartCommand(
+			buildInteractiveRestartCommandOptions({
+				sessionId: this.sessionManager.getSessionId(),
+				cwd: this.sessionManager.getCwd(),
+				sessionDir: this.sessionManager.getSessionDir(),
+				activeProfile: getActiveProfile(),
+				toolRestriction: this.#restartToolRestriction,
+				approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
+				launchFlags: this.#restartLaunchFlags,
+				liveProviderSessionId: this.session.sessionId,
+			}),
+		);
 
 		this.#isShuttingDown = true;
 		try {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -51,8 +51,10 @@ import {
 	prompt,
 	setProjectDir,
 } from "@oh-my-pi/pi-utils";
+import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import chalk from "chalk";
 import { reset as resetCapabilities } from "../capability";
+import * as restartProcess from "../cli/restart";
 import type { CollabGuestLink } from "../collab/guest";
 import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
@@ -110,6 +112,7 @@ import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
 import { formatDuration } from "../slash-commands/helpers/format";
+import { errorMessage } from "../slash-commands/helpers/parse";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { formatTaskId } from "../task/render";
@@ -646,6 +649,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#resizeHandler?: () => void;
 	#observerRegistry: SessionObserverRegistry;
 	#eventBus?: EventBus;
+	readonly #restartToolRestriction: restartProcess.RestartToolRestriction | undefined;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
@@ -666,6 +670,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		lspServers: LspStartupServerInfo[] | undefined = undefined,
 		mcpManager?: MCPManager,
 		eventBus?: EventBus,
+		restartToolRestriction?: restartProcess.RestartToolRestriction,
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -681,6 +686,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			new MCPCommandController(this).handleMCPAuthChallenge(serverName, challenge),
 		);
 		this.#eventBus = eventBus;
+		this.#restartToolRestriction = restartToolRestriction;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -3899,11 +3905,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async shutdown(): Promise<void> {
-		if (this.#isShuttingDown) return;
-		this.#isShuttingDown = true;
-
 		await this.#liveCommandController.stop();
+
+	async #teardownForProcessExit(options: {
+		printResumeHint: boolean;
+	}): Promise<{ sessionId: string; sessionFile: string | undefined }> {
+		// Snapshot the editor before any teardown empties it. Persisting the draft
+		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
+		// already cleared so saveDraft("") just removes any stale sidecar.
+		const draftText = this.editor.getText();
 
 		this.#btwController.dispose();
 		this.#omfgController.dispose();
@@ -3952,11 +3962,72 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Print resumption hint if this is a persisted session
 		const sessionId = this.sessionManager.getSessionId();
 		const sessionFile = this.sessionManager.getSessionFile();
-		if (sessionId && sessionFile) {
+		if (options.printResumeHint && sessionId && sessionFile) {
 			process.stderr.write(`\n${chalk.dim(`Resume this session with ${APP_NAME} --resume ${sessionId}`)}\n`);
 		}
 
+		return { sessionId, sessionFile };
+	}
+
+	async shutdown(): Promise<void> {
+		if (this.#isShuttingDown) return;
+		this.#isShuttingDown = true;
+		await this.#teardownForProcessExit({ printResumeHint: true });
 		await postmortem.quit(0);
+	}
+
+	async restart(): Promise<void> {
+		if (this.#isShuttingDown) return;
+		if (this.collabHost) {
+			this.showWarning("Stop hosting first (/collab stop)");
+			return;
+		}
+		if (this.collabGuest) {
+			this.showWarning("Leave collab first (/leave)");
+			return;
+		}
+		if (
+			this.session.isStreaming ||
+			this.session.isCompacting ||
+			this.session.hasPostPromptWork ||
+			this.session.isBashRunning ||
+			this.session.isEvalRunning
+		) {
+			this.showWarning("Wait for the current response or tool execution to finish or abort it before restarting.");
+			return;
+		}
+		if (!this.sessionManager.getSessionFile()) {
+			this.showWarning("Cannot restart because this session is not persisted.");
+			return;
+		}
+
+		try {
+			await this.sessionManager.flush();
+			await this.sessionManager.ensureOnDisk();
+		} catch (error) {
+			this.showWarning(`Restart failed: ${errorMessage(error)}`);
+			return;
+		}
+
+		const command = restartProcess.buildRestartCommand({
+			sessionId: this.sessionManager.getSessionId(),
+			cwd: this.sessionManager.getCwd(),
+			sessionDir: this.sessionManager.getSessionDir(),
+			activeProfile: getActiveProfile(),
+			toolRestriction: this.#restartToolRestriction,
+			approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
+		});
+
+		this.#isShuttingDown = true;
+		try {
+			await this.#teardownForProcessExit({ printResumeHint: false });
+			await postmortem.cleanup();
+			const exitCode = await restartProcess.spawnRestartProcess(command);
+			await postmortem.quit(exitCode);
+		} catch (error) {
+			process.stderr.write(`Restart failed: ${errorMessage(error)}\n`);
+			await postmortem.quit(1);
+		}
 	}
 
 	async checkShutdownRequested(): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -232,6 +232,7 @@ export function hasRestartBlockingWork(
 		| "isEvalRunning"
 		| "queuedMessageCount"
 		| "getAsyncJobSnapshot"
+		| "hasPendingAsyncWork"
 	>,
 	subagentRegistry?: AgentRegistry,
 ): boolean {
@@ -246,6 +247,7 @@ export function hasRestartBlockingWork(
 		session.isBashRunning ||
 		session.isEvalRunning ||
 		session.queuedMessageCount > 0 ||
+		session.hasPendingAsyncWork() ||
 		(asyncJobSnapshot?.running.length ?? 0) > 0 ||
 		hasPendingAsyncDelivery ||
 		hasRunningSubagents
@@ -288,6 +290,16 @@ export function buildInteractiveRestartCommandOptions(
 		advisor: options.liveAdvisorEnabled,
 		hideThinking: options.liveHideThinkingBlock,
 	};
+}
+
+/** Keep a restart child from concurrently updating marketplace state with its parent. */
+export async function spawnRestartAfterStartupMarketplaceUpdate(
+	startupMarketplaceUpdate: Promise<void> | undefined,
+	command: restartProcess.RestartCommand,
+	spawnRestart: (command: restartProcess.RestartCommand) => Promise<number> = restartProcess.spawnRestartProcess,
+): Promise<number> {
+	await startupMarketplaceUpdate;
+	return await spawnRestart(command);
 }
 
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
@@ -721,6 +733,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#eventBus?: EventBus;
 	readonly #restartToolRestriction: restartProcess.RestartToolRestriction | undefined;
 	readonly #restartLaunchFlags: restartProcess.RestartLaunchFlags;
+	readonly #startupMarketplaceUpdate: Promise<void> | undefined;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
@@ -743,6 +756,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		eventBus?: EventBus,
 		restartToolRestriction?: restartProcess.RestartToolRestriction,
 		restartLaunchFlags: restartProcess.RestartLaunchFlags = {},
+		startupMarketplaceUpdate?: Promise<void>,
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -760,6 +774,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#eventBus = eventBus;
 		this.#restartToolRestriction = restartToolRestriction;
 		this.#restartLaunchFlags = restartLaunchFlags;
+		this.#startupMarketplaceUpdate = startupMarketplaceUpdate;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -4130,7 +4145,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		try {
 			await this.#teardownForProcessExit({ printResumeHint: false });
 			await postmortem.cleanup();
-			const exitCode = await restartProcess.spawnRestartProcess(command);
+			const exitCode = await spawnRestartAfterStartupMarketplaceUpdate(this.#startupMarketplaceUpdate, command);
 			await postmortem.quit(exitCode);
 		} catch (error) {
 			process.stderr.write(`Restart failed: ${errorMessage(error)}\n`);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -220,6 +220,27 @@ import { UiHelpers } from "./utils/ui-helpers";
 
 const STILL_CLOSING_DELAY_MS = 3_000;
 
+/** Return whether `/restart` must wait for active session work before teardown. */
+export function hasRestartBlockingWork(
+	session: Pick<
+		AgentSession,
+		"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
+	>,
+): boolean {
+	const asyncJobSnapshot = session.getAsyncJobSnapshot();
+	const hasPendingAsyncDelivery =
+		(asyncJobSnapshot?.delivery.queued ?? 0) > 0 || asyncJobSnapshot?.delivery.delivering === true;
+	return (
+		session.isStreaming ||
+		session.isCompacting ||
+		session.hasPostPromptWork ||
+		session.isBashRunning ||
+		session.isEvalRunning ||
+		(asyncJobSnapshot?.running.length ?? 0) > 0 ||
+		hasPendingAsyncDelivery
+	);
+}
+
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
 	mid: "muted",
@@ -3989,13 +4010,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Leave collab first (/leave)");
 			return;
 		}
-		if (
-			this.session.isStreaming ||
-			this.session.isCompacting ||
-			this.session.hasPostPromptWork ||
-			this.session.isBashRunning ||
-			this.session.isEvalRunning
-		) {
+		if (hasRestartBlockingWork(this.session)) {
 			this.showWarning("Wait for the current response or tool execution to finish or abort it before restarting.");
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -953,6 +953,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#signalTeardown = createSessionTeardown({
 			getDraftText: () => this.editor.getText(),
 			beginDispose: () => this.session.beginDispose(),
+			flush: () => this.sessionManager.flush(),
 			saveDraft: text => this.sessionManager.saveDraft(text),
 			disposeSession: reason =>
 				this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS, reason }),
@@ -4012,6 +4013,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (this.#signalTeardown) {
 				await this.#signalTeardown();
 			} else {
+				this.session.beginDispose();
+				try {
+					await this.sessionManager.flush();
+				} catch (err) {
+					logger.warn("Failed to flush session during fallback teardown", { error: String(err) });
+				}
+				try {
+					await this.sessionManager.saveDraft(draftText);
+				} catch (err) {
+					logger.warn("Failed to save session draft during fallback teardown", { error: String(err) });
+				}
 				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 			}
 		} finally {
@@ -4051,49 +4063,71 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async restart(): Promise<void> {
 		if (this.#isShuttingDown) return;
+		this.#isShuttingDown = true;
+
 		if (this.collabHost) {
 			this.showWarning("Stop hosting first (/collab stop)");
+			this.#isShuttingDown = false;
 			return;
 		}
 		if (this.collabGuest) {
 			this.showWarning("Leave collab first (/leave)");
+			this.#isShuttingDown = false;
 			return;
 		}
 		if (hasRestartBlockingWork(this.session, getRunningSubagentBadgeRegistry(this.collabGuest))) {
 			this.showWarning("Wait for active work to finish and drain or dequeue queued messages before restarting.");
+			this.#isShuttingDown = false;
 			return;
 		}
 		if (!this.sessionManager.getSessionFile()) {
 			this.showWarning("Cannot restart because this session is not persisted.");
+			this.#isShuttingDown = false;
 			return;
 		}
 
+		let command: restartProcess.RestartCommand;
 		try {
-			await this.sessionManager.flush();
-			await this.sessionManager.ensureOnDisk();
+			command = restartProcess.buildRestartCommand(
+				buildInteractiveRestartCommandOptions({
+					sessionId: this.sessionManager.getSessionId(),
+					cwd: this.sessionManager.getCwd(),
+					sessionDir: this.sessionManager.getSessionDir(),
+					activeProfile: getActiveProfile(),
+					toolRestriction: this.#restartToolRestriction,
+					approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
+					launchFlags: this.#restartLaunchFlags,
+					liveAdvisorEnabled: this.session.isAdvisorEnabled(),
+					liveHideThinkingBlock: this.hideThinkingBlock,
+					liveModel: this.session.model,
+					liveModelChangeRole: this.sessionManager.getLastModelChangeRole(),
+					liveProviderSessionId: this.session.sessionId,
+				}),
+			);
 		} catch (error) {
 			this.showWarning(`Restart failed: ${errorMessage(error)}`);
+			this.#isShuttingDown = false;
 			return;
 		}
 
-		const command = restartProcess.buildRestartCommand(
-			buildInteractiveRestartCommandOptions({
-				sessionId: this.sessionManager.getSessionId(),
-				cwd: this.sessionManager.getCwd(),
-				sessionDir: this.sessionManager.getSessionDir(),
-				activeProfile: getActiveProfile(),
-				toolRestriction: this.#restartToolRestriction,
-				approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
-				launchFlags: this.#restartLaunchFlags,
-				liveAdvisorEnabled: this.session.isAdvisorEnabled(),
-				liveHideThinkingBlock: this.hideThinkingBlock,
-				liveModel: this.session.model,
-				liveModelChangeRole: this.sessionManager.getLastModelChangeRole(),
-				liveProviderSessionId: this.session.sessionId,
-			}),
-		);
+		// Teardown ownership transfers here. Mark the session synchronously so
+		// deferred work cannot attach while persistence or process handoff awaits.
+		this.session.beginDispose();
+		try {
+			await this.sessionManager.ensureOnDisk();
+		} catch (error) {
+			process.stderr.write(`Restart failed: ${errorMessage(error)}\n`);
+			try {
+				await this.#teardownForProcessExit({ printResumeHint: false });
+			} catch (teardownError) {
+				logger.warn("Failed to finish teardown after restart persistence failure", {
+					error: errorMessage(teardownError),
+				});
+			}
+			await postmortem.quit(1);
+			return;
+		}
 
-		this.#isShuttingDown = true;
 		try {
 			await this.#teardownForProcessExit({ printResumeHint: false });
 			await postmortem.cleanup();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -650,7 +650,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#observerRegistry: SessionObserverRegistry;
 	#eventBus?: EventBus;
 	readonly #restartToolRestriction: restartProcess.RestartToolRestriction | undefined;
-	readonly #restartDisableExtensions: boolean;
+	readonly #restartLaunchFlags: restartProcess.RestartLaunchFlags;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
@@ -672,7 +672,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		mcpManager?: MCPManager,
 		eventBus?: EventBus,
 		restartToolRestriction?: restartProcess.RestartToolRestriction,
-		restartDisableExtensions = false,
+		restartLaunchFlags: restartProcess.RestartLaunchFlags = {},
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -689,7 +689,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 		this.#eventBus = eventBus;
 		this.#restartToolRestriction = restartToolRestriction;
-		this.#restartDisableExtensions = restartDisableExtensions;
+		this.#restartLaunchFlags = restartLaunchFlags;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -4019,7 +4019,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			activeProfile: getActiveProfile(),
 			toolRestriction: this.#restartToolRestriction,
 			approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
-			disableExtensions: this.#restartDisableExtensions,
+			...this.#restartLaunchFlags,
 		});
 
 		this.#isShuttingDown = true;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -255,12 +255,14 @@ export interface InteractiveRestartCommandInput {
 	liveProviderSessionId: string;
 	liveAdvisorEnabled: boolean;
 	liveHideThinkingBlock: boolean;
+	liveModel?: Pick<Model, "provider" | "id">;
 }
 
 /** Build `/restart` options with live session state overriding stale launch-time flags. */
 export function buildInteractiveRestartCommandOptions(
 	options: InteractiveRestartCommandInput,
 ): restartProcess.BuildRestartCommandOptions {
+	const liveModelSelector = options.liveModel ? `${options.liveModel.provider}/${options.liveModel.id}` : undefined;
 	return {
 		sessionId: options.sessionId,
 		cwd: options.cwd,
@@ -269,6 +271,8 @@ export function buildInteractiveRestartCommandOptions(
 		toolRestriction: options.toolRestriction,
 		approvalMode: options.approvalMode,
 		...options.launchFlags,
+		provider: liveModelSelector ? undefined : options.launchFlags?.provider,
+		model: liveModelSelector ?? options.launchFlags?.model,
 		providerSessionId: options.liveProviderSessionId,
 		advisor: options.liveAdvisorEnabled,
 		hideThinking: options.liveHideThinkingBlock,
@@ -4072,6 +4076,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				launchFlags: this.#restartLaunchFlags,
 				liveAdvisorEnabled: this.session.isAdvisorEnabled(),
 				liveHideThinkingBlock: this.hideThinkingBlock,
+				liveModel: this.session.model,
 				liveProviderSessionId: this.session.sessionId,
 			}),
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -650,6 +650,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#observerRegistry: SessionObserverRegistry;
 	#eventBus?: EventBus;
 	readonly #restartToolRestriction: restartProcess.RestartToolRestriction | undefined;
+	readonly #restartDisableExtensions: boolean;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
@@ -671,6 +672,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		mcpManager?: MCPManager,
 		eventBus?: EventBus,
 		restartToolRestriction?: restartProcess.RestartToolRestriction,
+		restartDisableExtensions = false,
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -687,6 +689,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 		this.#eventBus = eventBus;
 		this.#restartToolRestriction = restartToolRestriction;
+		this.#restartDisableExtensions = restartDisableExtensions;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -4016,6 +4019,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			activeProfile: getActiveProfile(),
 			toolRestriction: this.#restartToolRestriction,
 			approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
+			disableExtensions: this.#restartDisableExtensions,
 		});
 
 		this.#isShuttingDown = true;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -264,6 +264,7 @@ export interface InteractiveRestartCommandInput {
 	launchFlags?: restartProcess.RestartLaunchFlags;
 	liveProviderSessionId: string;
 	liveAdvisorEnabled: boolean;
+	liveComputerEnabled: boolean;
 	liveHideThinkingBlock: boolean;
 	liveModel?: Model;
 	liveModelChangeRole?: string;
@@ -288,6 +289,7 @@ export function buildInteractiveRestartCommandOptions(
 		model: isEphemeralFallback ? undefined : (liveModelSelector ?? options.launchFlags?.model),
 		providerSessionId: options.liveProviderSessionId,
 		advisor: options.liveAdvisorEnabled,
+		computer: options.liveComputerEnabled,
 		hideThinking: options.liveHideThinkingBlock,
 	};
 }
@@ -4112,6 +4114,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
 					launchFlags: this.#restartLaunchFlags,
 					liveAdvisorEnabled: this.session.isAdvisorEnabled(),
+					liveComputerEnabled: this.settings.get("computer.enabled"),
 					liveHideThinkingBlock: this.hideThinkingBlock,
 					liveModel: this.session.model,
 					liveModelChangeRole: this.sessionManager.getLastModelChangeRole(),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -225,7 +225,13 @@ const STILL_CLOSING_DELAY_MS = 3_000;
 export function hasRestartBlockingWork(
 	session: Pick<
 		AgentSession,
-		"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
+		| "isStreaming"
+		| "isCompacting"
+		| "hasPostPromptWork"
+		| "isBashRunning"
+		| "isEvalRunning"
+		| "queuedMessageCount"
+		| "getAsyncJobSnapshot"
 	>,
 	subagentRegistry?: AgentRegistry,
 ): boolean {
@@ -239,6 +245,7 @@ export function hasRestartBlockingWork(
 		session.hasPostPromptWork ||
 		session.isBashRunning ||
 		session.isEvalRunning ||
+		session.queuedMessageCount > 0 ||
 		(asyncJobSnapshot?.running.length ?? 0) > 0 ||
 		hasPendingAsyncDelivery ||
 		hasRunningSubagents
@@ -4054,7 +4061,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		if (hasRestartBlockingWork(this.session, getRunningSubagentBadgeRegistry(this.collabGuest))) {
-			this.showWarning("Wait for the current response or tool execution to finish or abort it before restarting.");
+			this.showWarning("Wait for active work to finish and drain or dequeue queued messages before restarting.");
 			return;
 		}
 		if (!this.sessionManager.getSessionFile()) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -58,7 +58,7 @@ import * as restartProcess from "../cli/restart";
 import type { CollabGuestLink } from "../collab/guest";
 import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
-import { formatModelString, type ResolvedModelRoleValue } from "../config/model-resolver";
+import { formatModelString, formatModelStringWithRouting, type ResolvedModelRoleValue } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import {
 	isSettingsInitialized,
@@ -107,6 +107,7 @@ import {
 import type { CompactMode } from "../session/compact-modes";
 import { HistoryStorage } from "../session/history-storage";
 import type { SessionContext } from "../session/session-context";
+import { EPHEMERAL_MODEL_CHANGE_ROLE } from "../session/session-entries";
 import { getRecentSessions } from "../session/session-listing";
 import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
@@ -255,14 +256,18 @@ export interface InteractiveRestartCommandInput {
 	liveProviderSessionId: string;
 	liveAdvisorEnabled: boolean;
 	liveHideThinkingBlock: boolean;
-	liveModel?: Pick<Model, "provider" | "id">;
+	liveModel?: Model;
+	liveModelChangeRole?: string;
 }
 
 /** Build `/restart` options with live session state overriding stale launch-time flags. */
 export function buildInteractiveRestartCommandOptions(
 	options: InteractiveRestartCommandInput,
 ): restartProcess.BuildRestartCommandOptions {
-	const liveModelSelector = options.liveModel ? `${options.liveModel.provider}/${options.liveModel.id}` : undefined;
+	const liveModelSelector =
+		options.liveModel && options.liveModelChangeRole !== EPHEMERAL_MODEL_CHANGE_ROLE
+			? formatModelStringWithRouting(options.liveModel)
+			: undefined;
 	return {
 		sessionId: options.sessionId,
 		cwd: options.cwd,
@@ -4077,6 +4082,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				liveAdvisorEnabled: this.session.isAdvisorEnabled(),
 				liveHideThinkingBlock: this.hideThinkingBlock,
 				liveModel: this.session.model,
+				liveModelChangeRole: this.sessionManager.getLastModelChangeRole(),
 				liveProviderSessionId: this.session.sessionId,
 			}),
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3979,11 +3979,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-		await this.#liveCommandController.stop();
-
 	async #teardownForProcessExit(options: {
 		printResumeHint: boolean;
 	}): Promise<{ sessionId: string; sessionFile: string | undefined }> {
+		await this.#liveCommandController.stop();
 		// Snapshot the editor before any teardown empties it. Persisting the draft
 		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
 		// already cleared so saveDraft("") just removes any stale sidecar.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -254,6 +254,7 @@ export interface InteractiveRestartCommandInput {
 	launchFlags?: restartProcess.RestartLaunchFlags;
 	liveProviderSessionId: string;
 	liveAdvisorEnabled: boolean;
+	liveHideThinkingBlock: boolean;
 }
 
 /** Build `/restart` options with live session state overriding stale launch-time flags. */
@@ -270,6 +271,7 @@ export function buildInteractiveRestartCommandOptions(
 		...options.launchFlags,
 		providerSessionId: options.liveProviderSessionId,
 		advisor: options.liveAdvisorEnabled,
+		hideThinking: options.liveHideThinkingBlock,
 	};
 }
 
@@ -4069,6 +4071,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				approvalMode: this.settings.get("tools.approvalMode") as restartProcess.RestartApprovalMode,
 				launchFlags: this.#restartLaunchFlags,
 				liveAdvisorEnabled: this.session.isAdvisorEnabled(),
+				liveHideThinkingBlock: this.hideThinkingBlock,
 				liveProviderSessionId: this.session.sessionId,
 			}),
 		);

--- a/packages/coding-agent/src/modes/session-teardown.test.ts
+++ b/packages/coding-agent/src/modes/session-teardown.test.ts
@@ -21,6 +21,9 @@ describe("createSessionTeardown", () => {
 			beginDispose: () => {
 				order.push("beginDispose");
 			},
+			flush: async () => {
+				order.push("flush");
+			},
 			saveDraft: async text => {
 				order.push("saveDraft");
 				saved.push(text);
@@ -32,13 +35,13 @@ describe("createSessionTeardown", () => {
 
 		await teardown();
 
-		expect(order).toEqual(["beginDispose", "saveDraft", "disposeSession"]);
+		expect(order).toEqual(["beginDispose", "flush", "saveDraft", "disposeSession"]);
 		expect(saved).toEqual(["unsent draft"]);
 	});
 
-	it("marks the session disposing before awaiting draft persistence", async () => {
+	it("marks the session disposing before awaiting flush or draft persistence", async () => {
 		const order: string[] = [];
-		const release = Promise.withResolvers<void>();
+		const releaseFlush = Promise.withResolvers<void>();
 
 		const teardown = createSessionTeardown({
 			getDraftText: () => {
@@ -48,10 +51,13 @@ describe("createSessionTeardown", () => {
 			beginDispose: () => {
 				order.push("beginDispose");
 			},
+			flush: async () => {
+				order.push("flush:start");
+				await releaseFlush.promise;
+				order.push("flush:done");
+			},
 			saveDraft: async () => {
-				order.push("saveDraft:start");
-				await release.promise;
-				order.push("saveDraft:done");
+				order.push("saveDraft");
 			},
 			disposeSession: async () => {
 				order.push("disposeSession");
@@ -59,11 +65,11 @@ describe("createSessionTeardown", () => {
 		});
 
 		const running = teardown();
-		expect(order).toEqual(["snapshot", "beginDispose", "saveDraft:start"]);
-		release.resolve();
+		expect(order).toEqual(["snapshot", "beginDispose", "flush:start"]);
+		releaseFlush.resolve();
 		await running;
 
-		expect(order).toEqual(["snapshot", "beginDispose", "saveDraft:start", "saveDraft:done", "disposeSession"]);
+		expect(order).toEqual(["snapshot", "beginDispose", "flush:start", "flush:done", "saveDraft", "disposeSession"]);
 	});
 
 	it("still disposes when saveDraft rejects — never leaves session_shutdown unemitted", async () => {
@@ -72,6 +78,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "draft",
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async () => {
 				throw new Error("disk full");
 			},
@@ -90,6 +97,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "",
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async text => {
 				seen.push(text);
 			},
@@ -113,6 +121,7 @@ describe("createSessionTeardown", () => {
 				return `draft-${getDraftCalls}`;
 			},
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async () => {
 				saveDraftCalls++;
 			},
@@ -145,6 +154,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => editorText,
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async text => {
 				captured = text;
 			},
@@ -164,6 +174,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "",
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async () => {},
 			disposeSession: async reason => {
 				received.push(reason);
@@ -181,6 +192,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "",
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async () => {},
 			disposeSession: async reason => {
 				received.push(reason);
@@ -199,6 +211,7 @@ describe("createSessionTeardown", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "",
 			beginDispose: () => {},
+			flush: async () => {},
 			saveDraft: async () => {},
 			disposeSession: async reason => {
 				received.push(reason);

--- a/packages/coding-agent/src/modes/session-teardown.ts
+++ b/packages/coding-agent/src/modes/session-teardown.ts
@@ -22,6 +22,10 @@ export interface SessionTeardownDeps {
 	 */
 	beginDispose: () => void;
 	/**
+	 * Flush pending session writes before shutdown.
+	 */
+	flush: () => Promise<void>;
+	/**
 	 * Persist the snapshotted draft. Called even for an empty string so a
 	 * previously-persisted draft sidecar is cleared on a clean exit.
 	 */
@@ -68,6 +72,11 @@ export function createSessionTeardown(deps: SessionTeardownDeps): SessionTeardow
 	const run = async (reason?: postmortem.Reason): Promise<void> => {
 		const draftText = deps.getDraftText();
 		deps.beginDispose();
+		try {
+			await deps.flush();
+		} catch (err) {
+			logger.warn("Failed to flush session during teardown", { error: String(err) });
+		}
 		try {
 			await deps.saveDraft(draftText);
 		} catch (err) {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -220,6 +220,7 @@ export interface InteractiveModeContext {
 	init(options?: InteractiveModeInitOptions): Promise<void>;
 	playWelcomeIntro(): void;
 	shutdown(): Promise<void>;
+	restart(): Promise<void>;
 	checkShutdownRequested(): Promise<void>;
 
 	// Extension UI integration

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -31,7 +31,12 @@ import {
 	sanitizeRehydratedOpenAIResponsesAssistantMessage,
 	stripInternalDetailsFields,
 } from "./messages";
-import { type BuildSessionContextOptions, buildSessionContext, type SessionContext } from "./session-context";
+import {
+	type BuildSessionContextOptions,
+	buildSessionContext,
+	getRestorableSessionModels,
+	type SessionContext,
+} from "./session-context";
 import {
 	type BranchSummaryEntry,
 	type CompactionEntry,
@@ -2057,6 +2062,12 @@ export class SessionManager {
 			if (entry.type === "model_change") return entry.role ?? "default";
 		}
 		return undefined;
+	}
+
+	/** Model selectors createSession will try when restoring this branch, in fallback order. */
+	getRestorableModelStrings(): string[] {
+		const context = this.buildSessionContext();
+		return getRestorableSessionModels(context.models, this.getLastModelChangeRole());
 	}
 
 	getEntry(id: string): SessionEntry | undefined {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -167,6 +167,20 @@ const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashComma
 	return commandConsumed();
 };
 
+const restartHandler = async (
+	_command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> => {
+	await runtime.output("Restart is only available in the TUI.");
+	return commandConsumed();
+};
+
+const restartHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime): SlashCommandResult => {
+	runtime.ctx.editor.setText("");
+	void runtime.ctx.restart();
+	return commandConsumed();
+};
+
 async function handleUsageResetCommand(
 	arg: string,
 	session: AgentSession,
@@ -1873,6 +1887,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		name: "exit",
 		description: "Exit the application",
 		handleTui: shutdownHandlerTui,
+	},
+	{
+		name: "restart",
+		description: "Restart OMP and resume this session",
+		handle: restartHandler,
+		handleTui: restartHandlerTui,
 	},
 	{
 		name: "marketplace",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -176,7 +176,6 @@ const restartHandler = async (
 };
 
 const restartHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime): SlashCommandResult => {
-	runtime.ctx.editor.setText("");
 	void runtime.ctx.restart();
 	return commandConsumed();
 };

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -328,6 +328,10 @@ function decodeLiteralPromptInput(input: string): string | undefined {
 	}
 }
 
+export function isEncodedLiteralPromptInput(input: string): boolean {
+	return decodeLiteralPromptInput(input) !== undefined;
+}
+
 /** Resolve input as file path or literal string */
 export async function resolvePromptInput(input: string | undefined, description: string): Promise<string | undefined> {
 	if (!input) {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -311,10 +311,31 @@ export function discoverTitleSystemPromptFile(cwd?: string): string | undefined 
 	return undefined;
 }
 
+const LITERAL_PROMPT_INPUT_PREFIX = "omp-restart-literal-prompt:";
+
+/** Encode a prompt string so later prompt resolution cannot reinterpret it as a file path. */
+export function encodeLiteralPromptInput(input: string): string {
+	return `${LITERAL_PROMPT_INPUT_PREFIX}${Buffer.from(input, "utf8").toString("base64url")}`;
+}
+
+function decodeLiteralPromptInput(input: string): string | undefined {
+	if (!input.startsWith(LITERAL_PROMPT_INPUT_PREFIX)) return undefined;
+	const encoded = input.slice(LITERAL_PROMPT_INPUT_PREFIX.length);
+	try {
+		return Buffer.from(encoded, "base64url").toString("utf8");
+	} catch {
+		return undefined;
+	}
+}
+
 /** Resolve input as file path or literal string */
 export async function resolvePromptInput(input: string | undefined, description: string): Promise<string | undefined> {
 	if (!input) {
 		return undefined;
+	}
+	const decodedLiteral = decodeLiteralPromptInput(input);
+	if (decodedLiteral !== undefined) {
+		return decodedLiteral;
 	} else if (input.includes("\n")) {
 		return input;
 	}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -311,47 +311,36 @@ export function discoverTitleSystemPromptFile(cwd?: string): string | undefined 
 	return undefined;
 }
 
-const LITERAL_PROMPT_INPUT_PREFIX = "omp-restart-literal-prompt:";
+/** How a custom prompt was classified during startup resolution. */
+export type PromptInputResolution =
+	| { source: "file"; input: string; value: string }
+	| { source: "literal"; input: string; value: string };
 
-/** Encode a prompt string so later prompt resolution cannot reinterpret it as a file path. */
-export function encodeLiteralPromptInput(input: string): string {
-	return `${LITERAL_PROMPT_INPUT_PREFIX}${Buffer.from(input, "utf8").toString("base64url")}`;
-}
-
-function decodeLiteralPromptInput(input: string): string | undefined {
-	if (!input.startsWith(LITERAL_PROMPT_INPUT_PREFIX)) return undefined;
-	const encoded = input.slice(LITERAL_PROMPT_INPUT_PREFIX.length);
-	try {
-		return Buffer.from(encoded, "base64url").toString("utf8");
-	} catch {
-		return undefined;
-	}
-}
-
-export function isEncodedLiteralPromptInput(input: string): boolean {
-	return decodeLiteralPromptInput(input) !== undefined;
-}
-
-/** Resolve input as file path or literal string */
-export async function resolvePromptInput(input: string | undefined, description: string): Promise<string | undefined> {
+/** Resolve input as file path or literal string, retaining the initial source classification. */
+export async function resolvePromptInputWithSource(
+	input: string | undefined,
+	description: string,
+): Promise<PromptInputResolution | undefined> {
 	if (!input) {
 		return undefined;
 	}
-	const decodedLiteral = decodeLiteralPromptInput(input);
-	if (decodedLiteral !== undefined) {
-		return decodedLiteral;
-	} else if (input.includes("\n")) {
-		return input;
+	if (input.includes("\n")) {
+		return { source: "literal", input, value: input };
 	}
 
 	try {
-		return await Bun.file(input).text();
+		return { source: "file", input, value: await Bun.file(input).text() };
 	} catch (error) {
 		if (!hasFsCode(error, "ENAMETOOLONG") && !isEnoent(error)) {
 			logger.warn(`Could not read ${description} file`, { path: input, error: String(error) });
 		}
-		return input;
+		return { source: "literal", input, value: input };
 	}
+}
+
+/** Resolve input as file path or literal string. */
+export async function resolvePromptInput(input: string | undefined, description: string): Promise<string | undefined> {
+	return (await resolvePromptInputWithSource(input, description))?.value;
 }
 
 export interface LoadContextFilesOptions {

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -15,6 +15,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { hasRestartBlockingWork } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -94,7 +95,7 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(sawResult).toBe(true);
 	});
 
-	it("still reports pending async work while a delivered result awaits injection", async () => {
+	it("still blocks restart while a delivered result awaits idle injection", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
 		const agent = new Agent({
@@ -131,6 +132,7 @@ describe("AgentSession owner-routed async delivery", () => {
 		// count as pending async work, or the run driver terminates and the
 		// delivered result is silently dropped from the final report.
 		expect(session.hasPendingAsyncWork()).toBe(true);
+		expect(hasRestartBlockingWork(session)).toBe(true);
 
 		// Settling drains the queued follow-up into a real turn and only then
 		// reaches quiescence.

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -47,6 +47,7 @@ describe("buildAvailableSlashCommands", () => {
 		expect(byName["reset-usage"]).toBeUndefined();
 
 		expect(byName.fast.description).toBe("Toggle fast mode");
+		expect(byName.restart.description).toBe("Restart OMP and resume this session");
 		expect(byName["ext:hello"].description).toBe("Extension hello");
 		expect(byName["custom:hello"].description).toBe("Custom hello");
 		expect(byName["server:prompt"].description).toBe("MCP prompt");
@@ -54,6 +55,7 @@ describe("buildAvailableSlashCommands", () => {
 		expect(byName["skill:reviewer"].description).toBe("Review code");
 
 		expect(byName.model.source).toBe("builtin");
+		expect(byName.restart.source).toBe("builtin");
 		expect(byName["skill:reviewer"].source).toBe("skill");
 		expect(byName["ext:hello"].source).toBe("extension");
 		expect(byName["server:prompt"].source).toBe("mcp_prompt");

--- a/packages/coding-agent/test/cli-max-time-flag.test.ts
+++ b/packages/coding-agent/test/cli-max-time-flag.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import { buildRestartLaunchFlags, runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import type { CreateAgentSessionOptions } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -75,6 +75,14 @@ describe("parseArgs — --max-time flag", () => {
 		expect(stderr).toContain("Run `omp --help` for available flags.");
 		expect(stderr).not.toContain("parseMaxTimeSeconds");
 		expect(stderr).not.toContain("CliUsageError");
+
+	it("captures the absolute restart deadline for maxTime", () => {
+		const parsed = parseArgs(["--max-time", "30", "--print", "hello"]);
+		const deadline = 1_700_000_030_000;
+
+		const flags = buildRestartLaunchFlags(parsed, "/repo/project", undefined, deadline);
+
+		expect(flags.maxTimeDeadline).toBe(deadline);
 	});
 
 	it("converts maxTime to an absolute session deadline", async () => {

--- a/packages/coding-agent/test/cli-max-time-flag.test.ts
+++ b/packages/coding-agent/test/cli-max-time-flag.test.ts
@@ -75,7 +75,7 @@ describe("parseArgs — --max-time flag", () => {
 		expect(stderr).toContain("Run `omp --help` for available flags.");
 		expect(stderr).not.toContain("parseMaxTimeSeconds");
 		expect(stderr).not.toContain("CliUsageError");
-
+	});
 	it("captures the absolute restart deadline for maxTime", () => {
 		const parsed = parseArgs(["--max-time", "30", "--print", "hello"]);
 		const deadline = 1_700_000_030_000;

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { hasRestartBlockingWork } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import {
+	buildInteractiveRestartCommandOptions,
+	hasRestartBlockingWork,
+} from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
@@ -46,6 +49,20 @@ const deliveringDeliverySnapshot: AsyncJobSnapshot = {
 	delivery: { queued: 0, delivering: true, pendingJobIds: ["job-3"] },
 };
 
+describe("restart command options", () => {
+	test("uses the live provider session id after stale launch flags", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { providerSessionId: "launch-provider-session" },
+			liveProviderSessionId: "fresh-provider-session",
+		});
+
+		expect(options.providerSessionId).toBe("fresh-provider-session");
+	});
+});
 describe("restart active-work guard", () => {
 	test("allows restart when the session is idle", () => {
 		expect(hasRestartBlockingWork(sessionState())).toBe(false);

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -3,6 +3,7 @@ import type { Model } from "@oh-my-pi/pi-ai";
 import {
 	buildInteractiveRestartCommandOptions,
 	hasRestartBlockingWork,
+	spawnRestartAfterStartupMarketplaceUpdate,
 } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -16,6 +17,7 @@ type RestartBlockingSessionState = Pick<
 	| "isEvalRunning"
 	| "queuedMessageCount"
 	| "getAsyncJobSnapshot"
+	| "hasPendingAsyncWork"
 >;
 
 function restartModel(overrides: Pick<Model, "provider" | "id"> & Partial<Model>): Model {
@@ -42,6 +44,7 @@ function sessionState(overrides: Partial<RestartBlockingSessionState> = {}): Res
 		isEvalRunning: false,
 		queuedMessageCount: 0,
 		getAsyncJobSnapshot: () => null,
+		hasPendingAsyncWork: () => false,
 		...overrides,
 	};
 }
@@ -290,5 +293,27 @@ describe("restart active-work guard", () => {
 		registry.setStatus("Worker", "idle");
 
 		expect(hasRestartBlockingWork(sessionState(), registry)).toBe(false);
+	});
+});
+
+describe("restart startup lifecycle", () => {
+	test("waits for the parent marketplace auto-update before spawning the child", async () => {
+		const update = Promise.withResolvers<void>();
+		let spawned = false;
+		const restarted = spawnRestartAfterStartupMarketplaceUpdate(
+			update.promise,
+			{ cmd: ["omp"], cwd: "/repo/project" },
+			async () => {
+				spawned = true;
+				return 0;
+			},
+		);
+
+		await Promise.resolve();
+		expect(spawned).toBe(false);
+
+		update.resolve();
+		expect(await restarted).toBe(0);
+		expect(spawned).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -9,7 +9,13 @@ import type { AgentSession, AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/s
 
 type RestartBlockingSessionState = Pick<
 	AgentSession,
-	"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
+	| "isStreaming"
+	| "isCompacting"
+	| "hasPostPromptWork"
+	| "isBashRunning"
+	| "isEvalRunning"
+	| "queuedMessageCount"
+	| "getAsyncJobSnapshot"
 >;
 
 function restartModel(overrides: Pick<Model, "provider" | "id"> & Partial<Model>): Model {
@@ -34,6 +40,7 @@ function sessionState(overrides: Partial<RestartBlockingSessionState> = {}): Res
 		hasPostPromptWork: false,
 		isBashRunning: false,
 		isEvalRunning: false,
+		queuedMessageCount: 0,
 		getAsyncJobSnapshot: () => null,
 		...overrides,
 	};
@@ -200,6 +207,10 @@ describe("restart active-work guard", () => {
 		expect(hasRestartBlockingWork(sessionState({ hasPostPromptWork: true }))).toBe(true);
 		expect(hasRestartBlockingWork(sessionState({ isBashRunning: true }))).toBe(true);
 		expect(hasRestartBlockingWork(sessionState({ isEvalRunning: true }))).toBe(true);
+	});
+
+	test("blocks restart while user messages are queued", () => {
+		expect(hasRestartBlockingWork(sessionState({ queuedMessageCount: 1 }))).toBe(true);
 	});
 
 	test("blocks restart while async work or async delivery is active", () => {

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -85,6 +85,7 @@ describe("restart command options", () => {
 			launchFlags: { providerSessionId: "launch-provider-session" },
 			liveProviderSessionId: "fresh-provider-session",
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 		});
 
@@ -99,6 +100,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { provider: "anthropic", model: "claude-launch" },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveModel: restartModel({ provider: "openai", id: "gpt-5-live" }),
 			liveProviderSessionId: "provider-session",
@@ -116,6 +118,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { provider: "openrouter", model: "z-ai/glm-4.7" },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveModel: restartModel({
 				provider: "openrouter",
@@ -137,6 +140,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { provider: "anthropic", model: "claude-launch" },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveModel: restartModel({ provider: "openrouter", id: "fallback-live" }),
 			liveModelChangeRole: "fallback",
@@ -155,6 +159,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { provider: "openai", model: "gpt-A" },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveModel: restartModel({ provider: "anthropic", id: "claude-C" }),
 			liveModelChangeRole: "fallback",
@@ -173,6 +178,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { autoApprove: true },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveModel: restartModel({ provider: "openai", id: "gpt-5-live" }),
 			liveProviderSessionId: "provider-session",
@@ -189,6 +195,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { advisor: false },
 			liveAdvisorEnabled: true,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveProviderSessionId: "provider-session",
 		});
@@ -199,12 +206,41 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { advisor: true },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveProviderSessionId: "provider-session",
 		});
 
 		expect(enabledOptions.advisor).toBe(true);
 		expect(disabledOptions.advisor).toBe(false);
+	});
+
+	test("uses the live computer-use state after a session-scoped toggle", () => {
+		const enabledOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { computer: false },
+			liveAdvisorEnabled: false,
+			liveComputerEnabled: true,
+			liveHideThinkingBlock: false,
+			liveProviderSessionId: "provider-session",
+		});
+		const disabledOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { computer: true },
+			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
+			liveHideThinkingBlock: false,
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(enabledOptions.computer).toBe(true);
+		expect(disabledOptions.computer).toBe(false);
 	});
 
 	test("uses the live thinking visibility state after stale launch flags", () => {
@@ -215,6 +251,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { hideThinking: false },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: true,
 			liveProviderSessionId: "provider-session",
 		});
@@ -225,6 +262,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { hideThinking: true },
 			liveAdvisorEnabled: false,
+			liveComputerEnabled: false,
 			liveHideThinkingBlock: false,
 			liveProviderSessionId: "provider-session",
 		});

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
 import {
 	buildInteractiveRestartCommandOptions,
 	hasRestartBlockingWork,
@@ -10,6 +11,21 @@ type RestartBlockingSessionState = Pick<
 	AgentSession,
 	"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
 >;
+
+function restartModel(overrides: Pick<Model, "provider" | "id"> & Partial<Model>): Model {
+	return {
+		name: overrides.id,
+		api: "openai-completions",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: null,
+		maxTokens: null,
+		compat: {},
+		...overrides,
+	} as Model;
+}
 
 function sessionState(overrides: Partial<RestartBlockingSessionState> = {}): RestartBlockingSessionState {
 	return {
@@ -74,12 +90,51 @@ describe("restart command options", () => {
 			launchFlags: { provider: "anthropic", model: "claude-launch" },
 			liveAdvisorEnabled: false,
 			liveHideThinkingBlock: false,
-			liveModel: { provider: "openai", id: "gpt-5-live" },
+			liveModel: restartModel({ provider: "openai", id: "gpt-5-live" }),
 			liveProviderSessionId: "provider-session",
 		});
 
 		expect(options.provider).toBeUndefined();
 		expect(options.model).toBe("openai/gpt-5-live");
+	});
+
+	test("preserves routed live model selectors", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { provider: "openrouter", model: "z-ai/glm-4.7" },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveModel: restartModel({
+				provider: "openrouter",
+				id: "z-ai/glm-4.7",
+				compat: { openRouterRouting: { only: ["cerebras"] } } as Model["compat"],
+			}),
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(options.provider).toBeUndefined();
+		expect(options.model).toBe("openrouter/z-ai/glm-4.7@cerebras");
+	});
+
+	test("keeps launch model when the live model is an ephemeral fallback", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { provider: "anthropic", model: "claude-launch" },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveModel: restartModel({ provider: "openrouter", id: "fallback-live" }),
+			liveModelChangeRole: "fallback",
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(options.provider).toBe("anthropic");
+		expect(options.model).toBe("claude-launch");
 	});
 
 	test("uses the live advisor state after stale launch flags", () => {

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -40,13 +40,26 @@ const queuedDeliverySnapshot: AsyncJobSnapshot = {
 	delivery: { queued: 1, delivering: false, pendingJobIds: ["job-2"] },
 };
 
+const deliveringDeliverySnapshot: AsyncJobSnapshot = {
+	running: [],
+	recent: [],
+	delivery: { queued: 0, delivering: true, pendingJobIds: ["job-3"] },
+};
+
 describe("restart active-work guard", () => {
 	test("allows restart when the session is idle", () => {
 		expect(hasRestartBlockingWork(sessionState())).toBe(false);
 	});
 
-	test("blocks restart while direct work, async work, or async delivery is active", () => {
+	test("blocks restart while main session work is active", () => {
+		expect(hasRestartBlockingWork(sessionState({ isStreaming: true }))).toBe(true);
+		expect(hasRestartBlockingWork(sessionState({ isCompacting: true }))).toBe(true);
+		expect(hasRestartBlockingWork(sessionState({ hasPostPromptWork: true }))).toBe(true);
 		expect(hasRestartBlockingWork(sessionState({ isBashRunning: true }))).toBe(true);
+		expect(hasRestartBlockingWork(sessionState({ isEvalRunning: true }))).toBe(true);
+	});
+
+	test("blocks restart while async work or async delivery is active", () => {
 		expect(
 			hasRestartBlockingWork(
 				sessionState({
@@ -58,6 +71,13 @@ describe("restart active-work guard", () => {
 			hasRestartBlockingWork(
 				sessionState({
 					getAsyncJobSnapshot: () => queuedDeliverySnapshot,
+				}),
+			),
+		).toBe(true);
+		expect(
+			hasRestartBlockingWork(
+				sessionState({
+					getAsyncJobSnapshot: () => deliveringDeliverySnapshot,
 				}),
 			),
 		).toBe(true);

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -65,6 +65,23 @@ describe("restart command options", () => {
 		expect(options.providerSessionId).toBe("fresh-provider-session");
 	});
 
+	test("uses the live model after stale launch flags", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { provider: "anthropic", model: "claude-launch" },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveModel: { provider: "openai", id: "gpt-5-live" },
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(options.provider).toBeUndefined();
+		expect(options.model).toBe("openai/gpt-5-live");
+	});
+
 	test("uses the live advisor state after stale launch flags", () => {
 		const enabledOptions = buildInteractiveRestartCommandOptions({
 			sessionId: "local-session",

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { hasRestartBlockingWork } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 type RestartBlockingSessionState = Pick<
@@ -60,5 +61,26 @@ describe("restart active-work guard", () => {
 				}),
 			),
 		).toBe(true);
+	});
+
+	test("blocks restart while detached subagents are running", () => {
+		const registry = new AgentRegistry();
+
+		expect(hasRestartBlockingWork(sessionState(), registry)).toBe(false);
+
+		registry.register({
+			id: "Worker",
+			displayName: "Worker",
+			kind: "sub",
+			status: "running",
+			session: null,
+			sessionFile: "/tmp/Worker.jsonl",
+		});
+
+		expect(hasRestartBlockingWork(sessionState(), registry)).toBe(true);
+
+		registry.setStatus("Worker", "idle");
+
+		expect(hasRestartBlockingWork(sessionState(), registry)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { hasRestartBlockingWork } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import type { AgentSession, AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+type RestartBlockingSessionState = Pick<
+	AgentSession,
+	"isStreaming" | "isCompacting" | "hasPostPromptWork" | "isBashRunning" | "isEvalRunning" | "getAsyncJobSnapshot"
+>;
+
+function sessionState(overrides: Partial<RestartBlockingSessionState> = {}): RestartBlockingSessionState {
+	return {
+		isStreaming: false,
+		isCompacting: false,
+		hasPostPromptWork: false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		getAsyncJobSnapshot: () => null,
+		...overrides,
+	};
+}
+
+const runningAsyncSnapshot: AsyncJobSnapshot = {
+	running: [
+		{
+			id: "job-1",
+			type: "bash",
+			status: "running",
+			label: "bash: sleep 60",
+			startTime: 1,
+		},
+	],
+	recent: [],
+	delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+};
+
+const queuedDeliverySnapshot: AsyncJobSnapshot = {
+	running: [],
+	recent: [],
+	delivery: { queued: 1, delivering: false, pendingJobIds: ["job-2"] },
+};
+
+describe("restart active-work guard", () => {
+	test("allows restart when the session is idle", () => {
+		expect(hasRestartBlockingWork(sessionState())).toBe(false);
+	});
+
+	test("blocks restart while direct work, async work, or async delivery is active", () => {
+		expect(hasRestartBlockingWork(sessionState({ isBashRunning: true }))).toBe(true);
+		expect(
+			hasRestartBlockingWork(
+				sessionState({
+					getAsyncJobSnapshot: () => runningAsyncSnapshot,
+				}),
+			),
+		).toBe(true);
+		expect(
+			hasRestartBlockingWork(
+				sessionState({
+					getAsyncJobSnapshot: () => queuedDeliverySnapshot,
+				}),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -58,9 +58,34 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { providerSessionId: "launch-provider-session" },
 			liveProviderSessionId: "fresh-provider-session",
+			liveAdvisorEnabled: false,
 		});
 
 		expect(options.providerSessionId).toBe("fresh-provider-session");
+	});
+
+	test("uses the live advisor state after stale launch flags", () => {
+		const enabledOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { advisor: false },
+			liveAdvisorEnabled: true,
+			liveProviderSessionId: "provider-session",
+		});
+		const disabledOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { advisor: true },
+			liveAdvisorEnabled: false,
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(enabledOptions.advisor).toBe(true);
+		expect(disabledOptions.advisor).toBe(false);
 	});
 });
 describe("restart active-work guard", () => {

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -126,7 +126,7 @@ describe("restart command options", () => {
 		expect(options.model).toBe("openrouter/z-ai/glm-4.7@cerebras");
 	});
 
-	test("keeps launch model when the live model is an ephemeral fallback", () => {
+	test("omits model/provider overrides and relies on session restore when the live model is an ephemeral fallback", () => {
 		const options = buildInteractiveRestartCommandOptions({
 			sessionId: "local-session",
 			cwd: "/repo/project",
@@ -140,8 +140,42 @@ describe("restart command options", () => {
 			liveProviderSessionId: "provider-session",
 		});
 
-		expect(options.provider).toBe("anthropic");
-		expect(options.model).toBe("claude-launch");
+		expect(options.provider).toBeUndefined();
+		expect(options.model).toBeUndefined();
+	});
+
+	test("launch A -> switch B -> fallback C restart selection", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { provider: "openai", model: "gpt-A" },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveModel: restartModel({ provider: "anthropic", id: "claude-C" }),
+			liveModelChangeRole: "fallback",
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(options.provider).toBeUndefined();
+		expect(options.model).toBeUndefined();
+	});
+
+	test("preserves autoApprove flag from launch flags", () => {
+		const options = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { autoApprove: true },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveModel: restartModel({ provider: "openai", id: "gpt-5-live" }),
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(options.autoApprove).toBe(true);
 	});
 
 	test("uses the live advisor state after stale launch flags", () => {

--- a/packages/coding-agent/test/interactive-mode-restart.test.ts
+++ b/packages/coding-agent/test/interactive-mode-restart.test.ts
@@ -59,6 +59,7 @@ describe("restart command options", () => {
 			launchFlags: { providerSessionId: "launch-provider-session" },
 			liveProviderSessionId: "fresh-provider-session",
 			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
 		});
 
 		expect(options.providerSessionId).toBe("fresh-provider-session");
@@ -72,6 +73,7 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { advisor: false },
 			liveAdvisorEnabled: true,
+			liveHideThinkingBlock: false,
 			liveProviderSessionId: "provider-session",
 		});
 		const disabledOptions = buildInteractiveRestartCommandOptions({
@@ -81,11 +83,38 @@ describe("restart command options", () => {
 			approvalMode: "write",
 			launchFlags: { advisor: true },
 			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
 			liveProviderSessionId: "provider-session",
 		});
 
 		expect(enabledOptions.advisor).toBe(true);
 		expect(disabledOptions.advisor).toBe(false);
+	});
+
+	test("uses the live thinking visibility state after stale launch flags", () => {
+		const hiddenOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { hideThinking: false },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: true,
+			liveProviderSessionId: "provider-session",
+		});
+		const visibleOptions = buildInteractiveRestartCommandOptions({
+			sessionId: "local-session",
+			cwd: "/repo/project",
+			sessionDir: "/repo/project/.sessions",
+			approvalMode: "write",
+			launchFlags: { hideThinking: true },
+			liveAdvisorEnabled: false,
+			liveHideThinkingBlock: false,
+			liveProviderSessionId: "provider-session",
+		});
+
+		expect(hiddenOptions.hideThinking).toBe(true);
+		expect(visibleOptions.hideThinking).toBe(false);
 	});
 });
 describe("restart active-work guard", () => {

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
+import * as restartProcess from "@oh-my-pi/pi-coding-agent/cli/restart";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
@@ -20,6 +21,7 @@ describe("InteractiveMode long shutdown status", () => {
 	let authStorage: AuthStorage;
 	let mode: InteractiveMode;
 	let session: AgentSession;
+	let sessionManager: SessionManager;
 	let tempDir: TempDir;
 
 	beforeAll(() => {
@@ -34,9 +36,10 @@ describe("InteractiveMode long shutdown status", () => {
 		const modelRegistry = new ModelRegistry(authStorage);
 		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("expected bundled model");
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.join("sessions"));
 		session = new AgentSession({
 			agent: new Agent({ initialState: { model, systemPrompt: ["test"], tools: [], messages: [] } }),
-			sessionManager: SessionManager.inMemory(tempDir.path()),
+			sessionManager,
 			settings: Settings.isolated(),
 			modelRegistry,
 		});
@@ -81,5 +84,54 @@ describe("InteractiveMode long shutdown status", () => {
 		vi.advanceTimersByTime(10_000);
 		await flushMicrotasks();
 		expect(statuses).toHaveLength(2);
+	});
+
+	it("marks the session disposing and admits only one restart while persistence waits", async () => {
+		const ensureStarted = Promise.withResolvers<void>();
+		const releaseEnsure = Promise.withResolvers<void>();
+		vi.spyOn(sessionManager, "getSessionFile").mockReturnValue(tempDir.join("session.jsonl"));
+		const ensureOnDisk = vi.spyOn(sessionManager, "ensureOnDisk").mockImplementation(async () => {
+			ensureStarted.resolve();
+			await releaseEnsure.promise;
+		});
+		vi.spyOn(postmortem, "cleanup").mockResolvedValue(undefined);
+		const spawnRestart = vi.spyOn(restartProcess, "spawnRestartProcess").mockResolvedValue(0);
+
+		const firstRestart = mode.restart();
+		await ensureStarted.promise;
+
+		expect(session.isDisposed).toBe(true);
+		await mode.restart();
+		expect(ensureOnDisk).toHaveBeenCalledTimes(1);
+		expect(spawnRestart).not.toHaveBeenCalled();
+
+		releaseEnsure.resolve();
+		await firstRestart;
+
+		expect(spawnRestart).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears the restart guard when command construction fails before teardown", async () => {
+		vi.spyOn(sessionManager, "getSessionFile").mockReturnValue(tempDir.join("session.jsonl"));
+		vi.spyOn(sessionManager, "ensureOnDisk").mockResolvedValue(undefined);
+		vi.spyOn(postmortem, "cleanup").mockResolvedValue(undefined);
+		const warning = vi.spyOn(mode, "showWarning");
+		const buildCommand = vi
+			.spyOn(restartProcess, "buildRestartCommand")
+			.mockImplementationOnce(() => {
+				throw new Error("invalid restart command");
+			})
+			.mockReturnValue({ cmd: ["omp"], cwd: tempDir.path() });
+		const spawnRestart = vi.spyOn(restartProcess, "spawnRestartProcess").mockResolvedValue(0);
+
+		await mode.restart();
+
+		expect(warning).toHaveBeenCalledWith("Restart failed: invalid restart command");
+		expect(session.isDisposed).toBe(false);
+
+		await mode.restart();
+
+		expect(buildCommand).toHaveBeenCalledTimes(2);
+		expect(spawnRestart).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/restart-api-key-validation.test.ts
+++ b/packages/coding-agent/test/restart-api-key-validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { requiresLaunchModelForRuntimeApiKey } from "@oh-my-pi/pi-coding-agent/main";
+import {
+	applyRuntimeApiKeyForRestoredSession,
+	requiresLaunchModelForRuntimeApiKey,
+} from "@oh-my-pi/pi-coding-agent/main";
 
 describe("restart runtime API key validation", () => {
 	test("requires a launch model only for fresh CLI API-key runs", () => {
@@ -11,5 +14,32 @@ describe("restart runtime API key validation", () => {
 			false,
 		);
 		expect(requiresLaunchModelForRuntimeApiKey({}, {})).toBe(false);
+	});
+
+	test("applies runtime API key after restored session model supplies the provider", () => {
+		const applied: { provider: string; apiKey: string }[] = [];
+		const authStorage = {
+			setRuntimeApiKey(provider: string, apiKey: string): void {
+				applied.push({ provider, apiKey });
+			},
+		};
+
+		applyRuntimeApiKeyForRestoredSession(
+			{ apiKey: "sk-runtime" },
+			{},
+			{ model: { provider: "restored-provider" } },
+			authStorage,
+		);
+		expect(applied).toEqual([{ provider: "restored-provider", apiKey: "sk-runtime" }]);
+
+		applyRuntimeApiKeyForRestoredSession(
+			{ apiKey: "sk-runtime" },
+			{ model: { provider: "launch-provider" } },
+			{ model: { provider: "restored-provider" } },
+			authStorage,
+		);
+		applyRuntimeApiKeyForRestoredSession({ apiKey: "sk-runtime" }, {}, {}, authStorage);
+		applyRuntimeApiKeyForRestoredSession({}, {}, { model: { provider: "restored-provider" } }, authStorage);
+		expect(applied).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/restart-api-key-validation.test.ts
+++ b/packages/coding-agent/test/restart-api-key-validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	applyRuntimeApiKeyBeforeSessionRestore,
 	applyRuntimeApiKeyForRestoredSession,
@@ -7,11 +8,38 @@ import {
 } from "@oh-my-pi/pi-coding-agent/main";
 
 describe("restart runtime API key validation", () => {
-	test("requires a launch model only for fresh CLI API-key runs", () => {
+	test("requires a launch model unless resume can restore a provider", () => {
+		const restorableSource = {
+			getRestorableModelStrings: () => ["openai/gpt-5"],
+		};
+		const emptySource = {
+			getRestorableModelStrings: () => [],
+		};
+		const launchModel = buildModel({
+			id: "gpt-5",
+			name: "gpt-5",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+		});
+
 		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime" }, {})).toBe(true);
-		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", resume: "sess-1" }, {})).toBe(false);
-		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", continue: true }, {})).toBe(false);
-		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", fork: "sess-1" }, {})).toBe(false);
+		expect(
+			requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", resume: "sess-1" }, {}, restorableSource),
+		).toBe(false);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", resume: "sess-1" }, {}, emptySource)).toBe(
+			true,
+		);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", continue: true }, {})).toBe(true);
+		expect(
+			requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", fork: "sess-1" }, {}, undefined, "openai"),
+		).toBe(false);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime" }, { model: launchModel })).toBe(false);
 		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime" }, { modelPattern: "openai/gpt-5" })).toBe(
 			false,
 		);

--- a/packages/coding-agent/test/restart-api-key-validation.test.ts
+++ b/packages/coding-agent/test/restart-api-key-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-	applyRuntimeApiKeyForRestoredSession,
+	applyRuntimeApiKeyBeforeSessionRestore,
+	getPersistedSessionModelProvider,
 	requiresLaunchModelForRuntimeApiKey,
 } from "@oh-my-pi/pi-coding-agent/main";
 
@@ -16,30 +17,64 @@ describe("restart runtime API key validation", () => {
 		expect(requiresLaunchModelForRuntimeApiKey({}, {})).toBe(false);
 	});
 
-	test("applies runtime API key after restored session model supplies the provider", () => {
+	test("derives restart runtime provider from persisted session models", () => {
+		expect(
+			getPersistedSessionModelProvider({
+				getRestorableModelStrings: () => ["anthropic/claude-sonnet-4-5:high"],
+			}),
+		).toBe("anthropic");
+		expect(
+			getPersistedSessionModelProvider({
+				getRestorableModelStrings: () => ["not-a-model", "openai/gpt-5"],
+			}),
+		).toBe("openai");
+		expect(getPersistedSessionModelProvider(undefined)).toBeUndefined();
+	});
+
+	test("applies runtime API key before restored session model lookup", () => {
 		const applied: { provider: string; apiKey: string }[] = [];
 		const authStorage = {
 			setRuntimeApiKey(provider: string, apiKey: string): void {
 				applied.push({ provider, apiKey });
 			},
 		};
+		const restoredSource = {
+			getRestorableModelStrings: () => ["restored-provider/restored-model"],
+		};
 
-		applyRuntimeApiKeyForRestoredSession(
-			{ apiKey: "sk-runtime" },
-			{},
-			{ model: { provider: "restored-provider" } },
-			authStorage,
-		);
-		expect(applied).toEqual([{ provider: "restored-provider", apiKey: "sk-runtime" }]);
+		expect(
+			applyRuntimeApiKeyBeforeSessionRestore(
+				{ apiKey: "sk-runtime" },
+				{ model: { provider: "launch-provider" } },
+				undefined,
+				authStorage,
+			),
+		).toBe(true);
+		expect(
+			applyRuntimeApiKeyBeforeSessionRestore(
+				{ apiKey: "sk-runtime", resume: "sess-1" },
+				{},
+				restoredSource,
+				authStorage,
+			),
+		).toBe(true);
+		expect(applied).toEqual([
+			{ provider: "launch-provider", apiKey: "sk-runtime" },
+			{ provider: "restored-provider", apiKey: "sk-runtime" },
+		]);
 
-		applyRuntimeApiKeyForRestoredSession(
-			{ apiKey: "sk-runtime" },
-			{ model: { provider: "launch-provider" } },
-			{ model: { provider: "restored-provider" } },
-			authStorage,
+		expect(applyRuntimeApiKeyBeforeSessionRestore({ apiKey: "sk-runtime" }, {}, restoredSource, authStorage)).toBe(
+			false,
 		);
-		applyRuntimeApiKeyForRestoredSession({ apiKey: "sk-runtime" }, {}, {}, authStorage);
-		applyRuntimeApiKeyForRestoredSession({}, {}, { model: { provider: "restored-provider" } }, authStorage);
-		expect(applied).toHaveLength(1);
+		expect(
+			applyRuntimeApiKeyBeforeSessionRestore(
+				{ apiKey: "sk-runtime", resume: "sess-1" },
+				{ modelPattern: "extension/model" },
+				restoredSource,
+				authStorage,
+			),
+		).toBe(false);
+		expect(applyRuntimeApiKeyBeforeSessionRestore({}, {}, restoredSource, authStorage)).toBe(false);
+		expect(applied).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/restart-api-key-validation.test.ts
+++ b/packages/coding-agent/test/restart-api-key-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	applyRuntimeApiKeyBeforeSessionRestore,
+	applyRuntimeApiKeyForRestoredSession,
 	getPersistedSessionModelProvider,
 	requiresLaunchModelForRuntimeApiKey,
 } from "@oh-my-pi/pi-coding-agent/main";
@@ -49,7 +50,7 @@ describe("restart runtime API key validation", () => {
 				undefined,
 				authStorage,
 			),
-		).toBe(true);
+		).toBe("launch-provider");
 		expect(
 			applyRuntimeApiKeyBeforeSessionRestore(
 				{ apiKey: "sk-runtime", resume: "sess-1" },
@@ -57,14 +58,14 @@ describe("restart runtime API key validation", () => {
 				restoredSource,
 				authStorage,
 			),
-		).toBe(true);
+		).toBe("restored-provider");
 		expect(applied).toEqual([
 			{ provider: "launch-provider", apiKey: "sk-runtime" },
 			{ provider: "restored-provider", apiKey: "sk-runtime" },
 		]);
 
 		expect(applyRuntimeApiKeyBeforeSessionRestore({ apiKey: "sk-runtime" }, {}, restoredSource, authStorage)).toBe(
-			false,
+			undefined,
 		);
 		expect(
 			applyRuntimeApiKeyBeforeSessionRestore(
@@ -73,8 +74,51 @@ describe("restart runtime API key validation", () => {
 				restoredSource,
 				authStorage,
 			),
-		).toBe(false);
-		expect(applyRuntimeApiKeyBeforeSessionRestore({}, {}, restoredSource, authStorage)).toBe(false);
+		).toBeUndefined();
+		expect(applyRuntimeApiKeyBeforeSessionRestore({}, {}, restoredSource, authStorage)).toBeUndefined();
 		expect(applied).toHaveLength(2);
+	});
+
+	test("uses the original provider when installing restart API keys before restore", () => {
+		const applied: { provider: string; apiKey: string }[] = [];
+		const authStorage = {
+			setRuntimeApiKey(provider: string, apiKey: string): void {
+				applied.push({ provider, apiKey });
+			},
+		};
+		const restoredSource = {
+			getRestorableModelStrings: () => ["anthropic/claude-sonnet-4-5"],
+		};
+
+		expect(
+			applyRuntimeApiKeyBeforeSessionRestore(
+				{ apiKey: "sk-runtime", resume: "sess-1" },
+				{},
+				restoredSource,
+				authStorage,
+				"openai",
+			),
+		).toBe("openai");
+		expect(applied).toEqual([{ provider: "openai", apiKey: "sk-runtime" }]);
+	});
+
+	test("keeps post-restore API key handoff scoped to the original provider", () => {
+		const applied: { provider: string; apiKey: string }[] = [];
+		const authStorage = {
+			setRuntimeApiKey(provider: string, apiKey: string): void {
+				applied.push({ provider, apiKey });
+			},
+		};
+
+		expect(
+			applyRuntimeApiKeyForRestoredSession(
+				{ apiKey: "sk-runtime" },
+				{},
+				{ model: { provider: "anthropic" } },
+				authStorage,
+				"openai",
+			),
+		).toBe("openai");
+		expect(applied).toEqual([{ provider: "openai", apiKey: "sk-runtime" }]);
 	});
 });

--- a/packages/coding-agent/test/restart-api-key-validation.test.ts
+++ b/packages/coding-agent/test/restart-api-key-validation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { requiresLaunchModelForRuntimeApiKey } from "@oh-my-pi/pi-coding-agent/main";
+
+describe("restart runtime API key validation", () => {
+	test("requires a launch model only for fresh CLI API-key runs", () => {
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime" }, {})).toBe(true);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", resume: "sess-1" }, {})).toBe(false);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", continue: true }, {})).toBe(false);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime", fork: "sess-1" }, {})).toBe(false);
+		expect(requiresLaunchModelForRuntimeApiKey({ apiKey: "sk-runtime" }, { modelPattern: "openai/gpt-5" })).toBe(
+			false,
+		);
+		expect(requiresLaunchModelForRuntimeApiKey({}, {})).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -14,6 +14,7 @@ import {
 	type RestartExtensionFlagValue,
 	type RestartSpawn,
 	type RestartSpawnInput,
+	resolveRestartBaseCommand,
 	restoreRestartExtensionFlagValues,
 	selectRestartExtensionPackageRoots,
 	spawnRestartProcess,
@@ -64,6 +65,42 @@ describe("restart command construction", () => {
 			],
 			cwd: "/repo/project",
 		});
+	});
+
+	test("keeps normal POSIX executable paths unchanged", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			platform: "linux",
+			packageRoot,
+		};
+
+		expect(resolveRestartBaseCommand(env)).toEqual({ cmd: ["/opt/omp/omp"] });
+	});
+
+	test("strips extended-length drive executable paths before spawning", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "\\\\?\\C:\\Program Files\\Bun\\bun.exe",
+			platform: "win32",
+			packageRoot,
+		};
+
+		expect(resolveRestartBaseCommand(env)).toEqual({ cmd: ["C:\\Program Files\\Bun\\bun.exe"] });
+	});
+
+	test("strips extended-length UNC executable paths before spawning", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "\\\\?\\UNC\\server\\share\\bun.exe",
+			platform: "win32",
+			packageRoot,
+		};
+
+		expect(resolveRestartBaseCommand(env)).toEqual({ cmd: ["\\\\server\\share\\bun.exe"] });
 	});
 
 	test("builds a host-entry restart command without changing session cwd", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import {
 	buildRestartCommand,
+	consumeRestartAdvisorEnabled,
 	consumeRestartExtensionFlagValues,
+	RESTART_ADVISOR_ENABLED_ENV,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
 	RESTART_EXTENSION_FLAG_VALUES_ENV,
@@ -232,11 +234,45 @@ describe("restart command construction", () => {
 		});
 	});
 
+	test("hands off live advisor state via child env", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const enabledCommand = buildRestartCommand({ ...baseOptions(), advisor: true }, env);
+		const disabledCommand = buildRestartCommand({ ...baseOptions(), advisor: false }, env);
+
+		expect(enabledCommand.cmd).toContain("--advisor");
+		expect(enabledCommand.env).toEqual({
+			[RESTART_ADVISOR_ENABLED_ENV]: "1",
+		});
+		expect(disabledCommand.cmd).not.toContain("--advisor");
+		expect(disabledCommand.env).toEqual({
+			[RESTART_ADVISOR_ENABLED_ENV]: "0",
+		});
+	});
+
 	test("ignores malformed restart extension flag env payloads", () => {
 		const env = { [RESTART_EXTENSION_FLAG_VALUES_ENV]: "not-json" };
 
 		expect(consumeRestartExtensionFlagValues(env)).toBeUndefined();
 		expect(env[RESTART_EXTENSION_FLAG_VALUES_ENV]).toBeUndefined();
+	});
+
+	test("consumes restart advisor env toggles", () => {
+		const enabledEnv = { [RESTART_ADVISOR_ENABLED_ENV]: "1" };
+		const disabledEnv = { [RESTART_ADVISOR_ENABLED_ENV]: "0" };
+		const invalidEnv = { [RESTART_ADVISOR_ENABLED_ENV]: "yes" };
+
+		expect(consumeRestartAdvisorEnabled(enabledEnv)).toBe(true);
+		expect(consumeRestartAdvisorEnabled(disabledEnv)).toBe(false);
+		expect(consumeRestartAdvisorEnabled(invalidEnv)).toBeUndefined();
+		expect(enabledEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
+		expect(disabledEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
+		expect(invalidEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
 	});
 
 	test("restores only registered extension flag values", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import * as path from "node:path";
 import {
 	buildRestartCommand,
 	consumeRestartAdvisorEnabled,
@@ -186,6 +187,20 @@ describe("restart command construction", () => {
 		expect(valuesForFlag(command.cmd, "--config")).toEqual(["./dev.yml", "/tmp/override.yml"]);
 		expect(command.cmd.indexOf("--config")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--config")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("overrides inherited PI_CONFIG_FILES with resolved launch paths", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+		const configEnvFiles = ["/project-a/omp.yml", "/shared/override.yml"];
+
+		const command = buildRestartCommand({ ...baseOptions(), configEnvFiles }, env);
+
+		expect(command.env?.PI_CONFIG_FILES).toBe(configEnvFiles.join(path.delimiter));
 	});
 
 	test("preserves explicit extension and plugin roots across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -307,6 +307,40 @@ describe("restart command construction", () => {
 		expect(valuesForFlag(disabledCommand.cmd, "--skills")).toEqual(["git-*"]);
 	});
 
+	test("preserves CLI-only model and UI overrides across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{
+				...baseOptions(),
+				modelPatterns: ["sonnet", "gpt-5"],
+				smolModel: "haiku",
+				slowModel: "opus",
+				planModel: "planner",
+				thinking: "auto",
+				hideThinking: true,
+				advisor: true,
+			},
+			env,
+		);
+
+		expect(valuesForFlag(command.cmd, "--models")).toEqual(["sonnet,gpt-5"]);
+		expect(valuesForFlag(command.cmd, "--smol")).toEqual(["haiku"]);
+		expect(valuesForFlag(command.cmd, "--slow")).toEqual(["opus"]);
+		expect(valuesForFlag(command.cmd, "--plan")).toEqual(["planner"]);
+		expect(valuesForFlag(command.cmd, "--thinking")).toEqual(["auto"]);
+		expect(command.cmd).toContain("--hide-thinking");
+		expect(command.cmd).toContain("--advisor");
+		expect(command.cmd.indexOf("--models")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--hide-thinking")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(command.cmd.indexOf("--advisor")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
 	test("preserves disabled tools across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -3,11 +3,13 @@ import * as path from "node:path";
 import {
 	buildRestartCommand,
 	consumeRestartAdvisorEnabled,
+	consumeRestartComputerEnabled,
 	consumeRestartExtensionFlagValues,
 	consumeRestartExtensionPackageRoots,
 	RESTART_ADVISOR_ENABLED_ENV,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
+	RESTART_COMPUTER_ENABLED_ENV,
 	RESTART_EXTENSION_FLAG_VALUES_ENV,
 	RESTART_EXTENSION_PACKAGE_ROOTS_ENV,
 	type RestartCommandEnvironment,
@@ -345,6 +347,25 @@ describe("restart command construction", () => {
 		});
 	});
 
+	test("hands off live computer-use state via child env", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const enabledCommand = buildRestartCommand({ ...baseOptions(), computer: true }, env);
+		const disabledCommand = buildRestartCommand({ ...baseOptions(), computer: false }, env);
+
+		expect(enabledCommand.env).toEqual({
+			[RESTART_COMPUTER_ENABLED_ENV]: "1",
+		});
+		expect(disabledCommand.env).toEqual({
+			[RESTART_COMPUTER_ENABLED_ENV]: "0",
+		});
+	});
+
 	test("carries autoApprove flag in command", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,
@@ -401,6 +422,19 @@ describe("restart command construction", () => {
 		expect(enabledEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
 		expect(disabledEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
 		expect(invalidEnv[RESTART_ADVISOR_ENABLED_ENV]).toBeUndefined();
+	});
+
+	test("consumes restart computer-use env toggles", () => {
+		const enabledEnv = { [RESTART_COMPUTER_ENABLED_ENV]: "1" };
+		const disabledEnv = { [RESTART_COMPUTER_ENABLED_ENV]: "0" };
+		const invalidEnv = { [RESTART_COMPUTER_ENABLED_ENV]: "yes" };
+
+		expect(consumeRestartComputerEnabled(enabledEnv)).toBe(true);
+		expect(consumeRestartComputerEnabled(disabledEnv)).toBe(false);
+		expect(consumeRestartComputerEnabled(invalidEnv)).toBeUndefined();
+		expect(enabledEnv[RESTART_COMPUTER_ENABLED_ENV]).toBeUndefined();
+		expect(disabledEnv[RESTART_COMPUTER_ENABLED_ENV]).toBeUndefined();
+		expect(invalidEnv[RESTART_COMPUTER_ENABLED_ENV]).toBeUndefined();
 	});
 
 	test("restores only registered extension flag values", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -60,7 +60,7 @@ describe("restart command construction", () => {
 		});
 	});
 
-	test("builds a host-entry restart command from the host directory", () => {
+	test("builds a host-entry restart command without changing session cwd", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => false,
 			workerHostEntry: () => "/repo/packages/coding-agent/src/cli.ts",
@@ -70,11 +70,11 @@ describe("restart command construction", () => {
 
 		const command = buildRestartCommand(baseOptions(), env);
 
-		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "cli.ts"]);
-		expect(command.cwd).toBe("/repo/packages/coding-agent/src");
+		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "/repo/packages/coding-agent/src/cli.ts"]);
+		expect(command.cwd).toBe("/repo/project");
 	});
 
-	test("builds a source fallback restart command from the package root", () => {
+	test("builds a source fallback restart command without changing session cwd", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => false,
 			workerHostEntry: () => null,
@@ -84,8 +84,8 @@ describe("restart command construction", () => {
 
 		const command = buildRestartCommand(baseOptions(), env);
 
-		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "src/cli.ts"]);
-		expect(command.cwd).toBe(packageRoot);
+		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "/repo/packages/coding-agent/src/cli.ts"]);
+		expect(command.cwd).toBe("/repo/project");
 	});
 
 	test("omits profile arguments when no active profile exists", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -250,6 +250,21 @@ describe("restart command construction", () => {
 		});
 	});
 
+	test("hands off empty extension CLI flag snapshots as restart markers", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), extensionFlagValues: [] }, env);
+
+		expect(command.env).toEqual({
+			[RESTART_EXTENSION_FLAG_VALUES_ENV]: "[]",
+		});
+	});
+
 	test("hands off live advisor state via child env", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,
@@ -275,6 +290,13 @@ describe("restart command construction", () => {
 		const env = { [RESTART_EXTENSION_FLAG_VALUES_ENV]: "not-json" };
 
 		expect(consumeRestartExtensionFlagValues(env)).toBeUndefined();
+		expect(env[RESTART_EXTENSION_FLAG_VALUES_ENV]).toBeUndefined();
+	});
+
+	test("consumes empty restart extension flag snapshots as restart markers", () => {
+		const env = { [RESTART_EXTENSION_FLAG_VALUES_ENV]: "[]" };
+
+		expect(consumeRestartExtensionFlagValues(env)).toEqual([]);
 		expect(env[RESTART_EXTENSION_FLAG_VALUES_ENV]).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
 	buildRestartCommand,
 	consumeRestartExtensionFlagValues,
@@ -354,6 +354,43 @@ describe("restart command construction", () => {
 		expect(command.cmd.indexOf("--models")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--hide-thinking")).toBeLessThan(command.cmd.indexOf("--resume"));
 		expect(command.cmd.indexOf("--advisor")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves a positive remaining max-time budget across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+		const now = 1_700_000_000_000;
+		const nowSpy = spyOn(Date, "now").mockReturnValue(now);
+		try {
+			const command = buildRestartCommand({ ...baseOptions(), maxTimeDeadline: now + 125_001 }, env);
+
+			expect(valuesForFlag(command.cmd, "--max-time")).toEqual(["126"]);
+			expect(command.cmd.indexOf("--max-time")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		} finally {
+			nowSpy.mockRestore();
+		}
+	});
+
+	test("clamps elapsed max-time deadlines to one second across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+		const now = 1_700_000_000_000;
+		const nowSpy = spyOn(Date, "now").mockReturnValue(now);
+		try {
+			const command = buildRestartCommand({ ...baseOptions(), maxTimeDeadline: now }, env);
+
+			expect(valuesForFlag(command.cmd, "--max-time")).toEqual(["1"]);
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	test("preserves disabled tools across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -308,6 +308,21 @@ describe("restart command construction", () => {
 		});
 	});
 
+	test("carries autoApprove flag in command", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const enabledCommand = buildRestartCommand({ ...baseOptions(), autoApprove: true }, env);
+		const disabledCommand = buildRestartCommand({ ...baseOptions(), autoApprove: false }, env);
+
+		expect(enabledCommand.cmd).toContain("--auto-approve");
+		expect(disabledCommand.cmd).not.toContain("--auto-approve");
+	});
+
 	test("ignores malformed restart extension flag env payloads", () => {
 		const env = { [RESTART_EXTENSION_FLAG_VALUES_ENV]: "not-json" };
 

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildRestartCommand,
+	type RestartCommandEnvironment,
+	type RestartSpawn,
+	spawnRestartProcess,
+} from "@oh-my-pi/pi-coding-agent/cli/restart";
+
+const packageRoot = "/repo/packages/coding-agent";
+
+function baseOptions() {
+	return {
+		sessionId: "sess-1",
+		cwd: "/repo/project",
+		sessionDir: "/repo/project/.sessions",
+		activeProfile: "work",
+		approvalMode: "write" as const,
+	};
+}
+
+describe("restart command construction", () => {
+	test("builds a compiled binary restart command", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => "/ignored/cli.ts",
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		expect(buildRestartCommand(baseOptions(), env)).toEqual({
+			cmd: [
+				"/opt/omp/omp",
+				"--profile",
+				"work",
+				"--cwd",
+				"/repo/project",
+				"--approval-mode",
+				"write",
+				"--session-dir",
+				"/repo/project/.sessions",
+				"--resume",
+				"sess-1",
+			],
+			cwd: "/repo/project",
+		});
+	});
+
+	test("builds a host-entry restart command from the host directory", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => false,
+			workerHostEntry: () => "/repo/packages/coding-agent/src/cli.ts",
+			execPath: "/usr/bin/bun",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(baseOptions(), env);
+
+		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "cli.ts"]);
+		expect(command.cwd).toBe("/repo/packages/coding-agent/src");
+	});
+
+	test("builds a source fallback restart command from the package root", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => false,
+			workerHostEntry: () => null,
+			execPath: "/usr/bin/bun",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(baseOptions(), env);
+
+		expect(command.cmd.slice(0, 2)).toEqual(["/usr/bin/bun", "src/cli.ts"]);
+		expect(command.cwd).toBe(packageRoot);
+	});
+
+	test("omits profile arguments when no active profile exists", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{
+				sessionId: "sess-1",
+				cwd: "/repo/project",
+				approvalMode: "write",
+				sessionDir: "/repo/project/.sessions",
+			},
+			env,
+		);
+
+		expect(command.cmd).toEqual([
+			"/opt/omp/omp",
+			"--cwd",
+			"/repo/project",
+			"--approval-mode",
+			"write",
+			"--session-dir",
+			"/repo/project/.sessions",
+			"--resume",
+			"sess-1",
+		]);
+		expect(command.cmd).not.toContain("--profile");
+		expect(command.cmd).not.toContain("work");
+		expect(command.cwd).toBe("/repo/project");
+	});
+
+	test("preserves disabled tools across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), toolRestriction: { kind: "none" } }, env);
+
+		expect(command.cmd).toContain("--no-tools");
+		expect(command.cmd.indexOf("--no-tools")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd).not.toContain("--tools");
+	});
+
+	test("preserves a tool allowlist across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{ ...baseOptions(), toolRestriction: { kind: "allowlist", toolNames: ["read", "grep"] } },
+			env,
+		);
+
+		expect(command.cmd).toContain("--tools");
+		expect(command.cmd[command.cmd.indexOf("--tools") + 1]).toBe("read,grep");
+		expect(command.cmd.indexOf("--tools")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd).not.toContain("--no-tools");
+	});
+});
+
+type RecordedSpawnOptions = {
+	cmd: string[];
+	cwd: string;
+	stdin: "inherit";
+	stdout: "inherit";
+	stderr: "inherit";
+};
+
+describe("restart process spawning", () => {
+	test("spawns with inherited stdio and returns the child exit code", async () => {
+		let recorded: RecordedSpawnOptions | undefined;
+		const spawn: RestartSpawn = options => {
+			recorded = options;
+			return { exited: Promise.resolve(7) };
+		};
+
+		const exitCode = await spawnRestartProcess(
+			{ cmd: ["/opt/omp/omp", "--resume", "sess-1"], cwd: "/repo/project" },
+			{ spawn },
+		);
+
+		expect(exitCode).toBe(7);
+		expect(recorded).toEqual({
+			cmd: ["/opt/omp/omp", "--resume", "sess-1"],
+			cwd: "/repo/project",
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+	});
+});

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
 	buildRestartCommand,
+	consumeRestartExtensionFlagValues,
 	RESTART_API_KEY_ENV,
+	RESTART_EXTENSION_FLAG_VALUES_ENV,
 	type RestartCommandEnvironment,
+	type RestartExtensionFlagValue,
 	type RestartSpawn,
 	type RestartSpawnInput,
+	restoreRestartExtensionFlagValues,
 	spawnRestartProcess,
 } from "@oh-my-pi/pi-coding-agent/cli/restart";
 
@@ -186,6 +190,56 @@ describe("restart command construction", () => {
 		expect(command.cmd).not.toContain("--api-key");
 		expect(command.cmd).not.toContain("sk-runtime");
 		expect(command.env).toEqual({ [RESTART_API_KEY_ENV]: "sk-runtime" });
+	});
+
+	test("hands off extension CLI flag values via child env instead of argv", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+		const extensionFlagValues: RestartExtensionFlagValue[] = [
+			["spawn-peer", "reviewer"],
+			["headless", true],
+		];
+
+		const command = buildRestartCommand({ ...baseOptions(), extensionFlagValues }, env);
+
+		expect(command.cmd).not.toContain("--spawn-peer");
+		expect(command.cmd).not.toContain("--headless");
+		expect(command.env).toEqual({
+			[RESTART_EXTENSION_FLAG_VALUES_ENV]: JSON.stringify(extensionFlagValues),
+		});
+	});
+
+	test("ignores malformed restart extension flag env payloads", () => {
+		const env = { [RESTART_EXTENSION_FLAG_VALUES_ENV]: "not-json" };
+
+		expect(consumeRestartExtensionFlagValues(env)).toBeUndefined();
+		expect(env[RESTART_EXTENSION_FLAG_VALUES_ENV]).toBeUndefined();
+	});
+
+	test("restores only registered extension flag values", () => {
+		const recorded = new Map<string, boolean | string>();
+		const registeredFlags: Record<string, true> = { "spawn-peer": true, headless: true };
+		const sink = {
+			getFlags: () => ({ has: (name: string) => registeredFlags[name] === true }),
+			setFlagValue: (name: string, value: boolean | string) => {
+				recorded.set(name, value);
+			},
+		};
+
+		restoreRestartExtensionFlagValues(sink, [
+			["spawn-peer", "reviewer"],
+			["missing", "dropped"],
+			["headless", true],
+		]);
+
+		expect([...recorded.entries()]).toEqual([
+			["spawn-peer", "reviewer"],
+			["headless", true],
+		]);
 	});
 
 	test("preserves disabled context flags across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
 	buildRestartCommand,
+	RESTART_API_KEY_ENV,
 	type RestartCommandEnvironment,
 	type RestartSpawn,
+	type RestartSpawnInput,
 	spawnRestartProcess,
 } from "@oh-my-pi/pi-coding-agent/cli/restart";
 
@@ -171,6 +173,42 @@ describe("restart command construction", () => {
 		expect(command.cmd.indexOf("--plugin-dir")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
 
+	test("hands off CLI API keys via child env instead of argv", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), apiKey: "sk-runtime" }, env);
+
+		expect(command.cmd).not.toContain("--api-key");
+		expect(command.cmd).not.toContain("sk-runtime");
+		expect(command.env).toEqual({ [RESTART_API_KEY_ENV]: "sk-runtime" });
+	});
+
+	test("preserves disabled context flags across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{ ...baseOptions(), disableLsp: true, disableRules: true, disableSkills: true },
+			env,
+		);
+
+		expect(command.cmd).toContain("--no-lsp");
+		expect(command.cmd).toContain("--no-skills");
+		expect(command.cmd).toContain("--no-rules");
+		expect(command.cmd.indexOf("--no-lsp")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--no-skills")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(command.cmd.indexOf("--no-rules")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
 	test("preserves disabled tools across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,
@@ -206,17 +244,9 @@ describe("restart command construction", () => {
 	});
 });
 
-type RecordedSpawnOptions = {
-	cmd: string[];
-	cwd: string;
-	stdin: "inherit";
-	stdout: "inherit";
-	stderr: "inherit";
-};
-
 describe("restart process spawning", () => {
 	test("spawns with inherited stdio and returns the child exit code", async () => {
-		let recorded: RecordedSpawnOptions | undefined;
+		let recorded: RestartSpawnInput | undefined;
 		const spawn: RestartSpawn = options => {
 			recorded = options;
 			return { exited: Promise.resolve(7) };
@@ -235,5 +265,21 @@ describe("restart process spawning", () => {
 			stdout: "inherit",
 			stderr: "inherit",
 		});
+	});
+
+	test("passes restart env overrides to the child process", async () => {
+		let recorded: RestartSpawnInput | undefined;
+		const spawn: RestartSpawn = options => {
+			recorded = options;
+			return { exited: Promise.resolve(0) };
+		};
+
+		await spawnRestartProcess(
+			{ cmd: ["/opt/omp/omp", "--resume", "sess-1"], cwd: "/repo/project", env: { [RESTART_API_KEY_ENV]: "sk" } },
+			{ spawn },
+		);
+
+		expect(recorded?.cmd).toEqual(["/opt/omp/omp", "--resume", "sess-1"]);
+		expect(recorded?.env?.[RESTART_API_KEY_ENV]).toBe("sk");
 	});
 });

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -3,6 +3,7 @@ import {
 	buildRestartCommand,
 	consumeRestartExtensionFlagValues,
 	RESTART_API_KEY_ENV,
+	RESTART_API_KEY_PROVIDER_ENV,
 	RESTART_EXTENSION_FLAG_VALUES_ENV,
 	type RestartCommandEnvironment,
 	type RestartExtensionFlagValue,
@@ -200,11 +201,14 @@ describe("restart command construction", () => {
 			packageRoot,
 		};
 
-		const command = buildRestartCommand({ ...baseOptions(), apiKey: "sk-runtime" }, env);
+		const command = buildRestartCommand({ ...baseOptions(), apiKey: "sk-runtime", apiKeyProvider: "openai" }, env);
 
 		expect(command.cmd).not.toContain("--api-key");
 		expect(command.cmd).not.toContain("sk-runtime");
-		expect(command.env).toEqual({ [RESTART_API_KEY_ENV]: "sk-runtime" });
+		expect(command.env).toEqual({
+			[RESTART_API_KEY_ENV]: "sk-runtime",
+			[RESTART_API_KEY_PROVIDER_ENV]: "openai",
+		});
 	});
 
 	test("hands off extension CLI flag values via child env instead of argv", () => {
@@ -299,6 +303,21 @@ describe("restart command construction", () => {
 		expect(valuesForFlag(command.cmd, "--append-system-prompt")).toEqual(["Append this guidance"]);
 		expect(command.cmd.indexOf("--system-prompt")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--append-system-prompt")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves provider session ids across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), providerSessionId: "provider-session-1" }, env);
+
+		expect(valuesForFlag(command.cmd, "--provider-session-id")).toEqual(["provider-session-1"]);
+		expect(command.cmd.indexOf("--provider-session-id")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--provider-session-id")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
 
 	test("preserves skill filters across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -387,9 +387,17 @@ describe("restart command construction", () => {
 			packageRoot,
 		};
 
-		const command = buildRestartCommand({ ...baseOptions(), providerSessionId: "provider-session-1" }, env);
+		const command = buildRestartCommand(
+			{
+				...baseOptions(),
+				providerSessionId: "provider-session-1",
+				providerPromptCacheKey: "cache-shard-1",
+			},
+			env,
+		);
 
 		expect(valuesForFlag(command.cmd, "--provider-session-id")).toEqual(["provider-session-1"]);
+		expect(valuesForFlag(command.cmd, "--prompt-cache-key")).toEqual(["cache-shard-1"]);
 		expect(command.cmd.indexOf("--provider-session-id")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--provider-session-id")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
@@ -453,6 +461,34 @@ describe("restart command construction", () => {
 		expect(command.cmd.indexOf("--models")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--hide-thinking")).toBeLessThan(command.cmd.indexOf("--resume"));
 		expect(command.cmd.indexOf("--advisor")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves prewalk and plan-yolo overrides across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+		const command = buildRestartCommand(
+			{
+				...baseOptions(),
+				prewalk: true,
+				prewalkInto: "@smol",
+				planYolo: true,
+				planYoloInto: "@slow",
+			},
+			env,
+		);
+		const disabledCommand = buildRestartCommand({ ...baseOptions(), noPrewalk: true }, env);
+
+		expect(command.cmd).toContain("--prewalk");
+		expect(valuesForFlag(command.cmd, "--prewalk-into")).toEqual(["@smol"]);
+		expect(command.cmd).toContain("--plan-yolo");
+		expect(valuesForFlag(command.cmd, "--plan-yolo-into")).toEqual(["@slow"]);
+		expect(command.cmd.indexOf("--prewalk")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(command.cmd.indexOf("--plan-yolo")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(disabledCommand.cmd).toContain("--no-prewalk");
 	});
 
 	test("preserves a positive remaining max-time budget across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -121,6 +121,21 @@ describe("restart command construction", () => {
 		expect(command.cwd).toBe("/repo/project");
 	});
 
+	test("preserves custom session dirs across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), sessionDir: "/tmp/omp-sessions" }, env);
+
+		expect(valuesForFlag(command.cmd, "--session-dir")).toEqual(["/tmp/omp-sessions"]);
+		expect(command.cmd.indexOf("--session-dir")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(command.cwd).toBe("/repo/project");
+	});
+
 	test("preserves disabled extension discovery across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -209,6 +209,50 @@ describe("restart command construction", () => {
 		expect(command.cmd.indexOf("--no-rules")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
 
+	test("preserves CLI system prompts across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{
+				...baseOptions(),
+				systemPrompt: "Use this exact prompt",
+				appendSystemPrompt: "Append this guidance",
+			},
+			env,
+		);
+
+		expect(valuesForFlag(command.cmd, "--system-prompt")).toEqual(["Use this exact prompt"]);
+		expect(valuesForFlag(command.cmd, "--append-system-prompt")).toEqual(["Append this guidance"]);
+		expect(command.cmd.indexOf("--system-prompt")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--append-system-prompt")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves skill filters across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), skillPatterns: ["git-*", "review"] }, env);
+		const disabledCommand = buildRestartCommand(
+			{ ...baseOptions(), disableSkills: true, skillPatterns: ["git-*"] },
+			env,
+		);
+
+		expect(valuesForFlag(command.cmd, "--skills")).toEqual(["git-*,review"]);
+		expect(command.cmd.indexOf("--skills")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--skills")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(disabledCommand.cmd).toContain("--no-skills");
+		expect(valuesForFlag(disabledCommand.cmd, "--skills")).toEqual(["git-*"]);
+	});
+
 	test("preserves disabled tools across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -388,6 +388,8 @@ describe("restart command construction", () => {
 		const command = buildRestartCommand(
 			{
 				...baseOptions(),
+				provider: "openai",
+				model: "gpt-5",
 				modelPatterns: ["sonnet", "gpt-5"],
 				smolModel: "haiku",
 				slowModel: "opus",
@@ -399,6 +401,8 @@ describe("restart command construction", () => {
 			env,
 		);
 
+		expect(valuesForFlag(command.cmd, "--provider")).toEqual(["openai"]);
+		expect(valuesForFlag(command.cmd, "--model")).toEqual(["gpt-5"]);
 		expect(valuesForFlag(command.cmd, "--models")).toEqual(["sonnet,gpt-5"]);
 		expect(valuesForFlag(command.cmd, "--smol")).toEqual(["haiku"]);
 		expect(valuesForFlag(command.cmd, "--slow")).toEqual(["opus"]);
@@ -406,6 +410,8 @@ describe("restart command construction", () => {
 		expect(valuesForFlag(command.cmd, "--thinking")).toEqual(["auto"]);
 		expect(command.cmd).toContain("--hide-thinking");
 		expect(command.cmd).toContain("--advisor");
+		expect(command.cmd.indexOf("--provider")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--model")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--models")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--hide-thinking")).toBeLessThan(command.cmd.indexOf("--resume"));
 		expect(command.cmd.indexOf("--advisor")).toBeLessThan(command.cmd.indexOf("--resume"));

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -3,15 +3,18 @@ import {
 	buildRestartCommand,
 	consumeRestartAdvisorEnabled,
 	consumeRestartExtensionFlagValues,
+	consumeRestartExtensionPackageRoots,
 	RESTART_ADVISOR_ENABLED_ENV,
 	RESTART_API_KEY_ENV,
 	RESTART_API_KEY_PROVIDER_ENV,
 	RESTART_EXTENSION_FLAG_VALUES_ENV,
+	RESTART_EXTENSION_PACKAGE_ROOTS_ENV,
 	type RestartCommandEnvironment,
 	type RestartExtensionFlagValue,
 	type RestartSpawn,
 	type RestartSpawnInput,
 	restoreRestartExtensionFlagValues,
+	selectRestartExtensionPackageRoots,
 	spawnRestartProcess,
 } from "@oh-my-pi/pi-coding-agent/cli/restart";
 
@@ -198,6 +201,7 @@ describe("restart command construction", () => {
 				...baseOptions(),
 				extensionPaths: ["./ext-one", "pkg-two"],
 				hookPaths: ["./hook-one"],
+				extensionPackageRoots: ["/project-a/ext-one", "/project-a/hook-one"],
 				pluginDirs: ["./plugin-one", "./plugin-two"],
 			},
 			env,
@@ -206,6 +210,9 @@ describe("restart command construction", () => {
 		expect(valuesForFlag(command.cmd, "--extension")).toEqual(["./ext-one", "pkg-two"]);
 		expect(valuesForFlag(command.cmd, "--hook")).toEqual(["./hook-one"]);
 		expect(valuesForFlag(command.cmd, "--plugin-dir")).toEqual(["./plugin-one", "./plugin-two"]);
+		expect(command.env).toEqual({
+			[RESTART_EXTENSION_PACKAGE_ROOTS_ENV]: JSON.stringify(["/project-a/ext-one", "/project-a/hook-one"]),
+		});
 		expect(command.cmd.indexOf("--extension")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--hook")).toBeLessThan(command.cmd.indexOf("--resume"));
 		expect(command.cmd.indexOf("--plugin-dir")).toBeLessThan(command.cmd.indexOf("--resume"));
@@ -298,6 +305,22 @@ describe("restart command construction", () => {
 
 		expect(consumeRestartExtensionFlagValues(env)).toEqual([]);
 		expect(env[RESTART_EXTENSION_FLAG_VALUES_ENV]).toBeUndefined();
+	});
+
+	test("preserves carried extension package roots across picker-cwd restarts", () => {
+		const env = {
+			[RESTART_EXTENSION_PACKAGE_ROOTS_ENV]: JSON.stringify(["/project-a/ext", "/project-a/hook"]),
+		};
+
+		const carriedRoots = consumeRestartExtensionPackageRoots(env);
+
+		expect(carriedRoots).toEqual(["/project-a/ext", "/project-a/hook"]);
+		expect(selectRestartExtensionPackageRoots(carriedRoots, ["/project-b/ext"], ["/project-b/hook"])).toEqual([
+			"/project-a/ext",
+			"/project-a/hook",
+		]);
+		expect(env[RESTART_EXTENSION_PACKAGE_ROOTS_ENV]).toBeUndefined();
+		expect(selectRestartExtensionPackageRoots(undefined, ["./ext"], ["./hook"])).toEqual(["./ext", "./hook"]);
 	});
 
 	test("consumes restart advisor env toggles", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -18,6 +18,14 @@ function baseOptions() {
 	};
 }
 
+function valuesForFlag(cmd: string[], flag: string): string[] {
+	const values: string[] = [];
+	for (let index = 0; index < cmd.length - 1; index++) {
+		if (cmd[index] === flag) values.push(cmd[index + 1] as string);
+	}
+	return values;
+}
+
 describe("restart command construction", () => {
 	test("builds a compiled binary restart command", () => {
 		const env: RestartCommandEnvironment = {
@@ -120,6 +128,47 @@ describe("restart command construction", () => {
 		expect(command.cmd).toContain("--no-extensions");
 		expect(command.cmd.indexOf("--no-extensions")).toBeLessThan(command.cmd.indexOf("--session-dir"));
 		expect(command.cmd.indexOf("--no-extensions")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves custom config files across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), configFiles: ["./dev.yml", "/tmp/override.yml"] }, env);
+
+		expect(valuesForFlag(command.cmd, "--config")).toEqual(["./dev.yml", "/tmp/override.yml"]);
+		expect(command.cmd.indexOf("--config")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--config")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
+	test("preserves explicit extension and plugin roots across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand(
+			{
+				...baseOptions(),
+				extensionPaths: ["./ext-one", "pkg-two"],
+				hookPaths: ["./hook-one"],
+				pluginDirs: ["./plugin-one", "./plugin-two"],
+			},
+			env,
+		);
+
+		expect(valuesForFlag(command.cmd, "--extension")).toEqual(["./ext-one", "pkg-two"]);
+		expect(valuesForFlag(command.cmd, "--hook")).toEqual(["./hook-one"]);
+		expect(valuesForFlag(command.cmd, "--plugin-dir")).toEqual(["./plugin-one", "./plugin-two"]);
+		expect(command.cmd.indexOf("--extension")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--hook")).toBeLessThan(command.cmd.indexOf("--resume"));
+		expect(command.cmd.indexOf("--plugin-dir")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
 
 	test("preserves disabled tools across restart", () => {

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -107,6 +107,21 @@ describe("restart command construction", () => {
 		expect(command.cwd).toBe("/repo/project");
 	});
 
+	test("preserves disabled extension discovery across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), disableExtensions: true }, env);
+
+		expect(command.cmd).toContain("--no-extensions");
+		expect(command.cmd.indexOf("--no-extensions")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--no-extensions")).toBeLessThan(command.cmd.indexOf("--resume"));
+	});
+
 	test("preserves disabled tools across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,

--- a/packages/coding-agent/test/restart-command.test.ts
+++ b/packages/coding-agent/test/restart-command.test.ts
@@ -154,6 +154,22 @@ describe("restart command construction", () => {
 		expect(command.cmd.indexOf("--no-extensions")).toBeLessThan(command.cmd.indexOf("--resume"));
 	});
 
+	test("preserves env-only CLI toggles across restart", () => {
+		const env: RestartCommandEnvironment = {
+			isCompiledBinary: () => true,
+			workerHostEntry: () => null,
+			execPath: "/opt/omp/omp",
+			packageRoot,
+		};
+
+		const command = buildRestartCommand({ ...baseOptions(), noPty: true, noTitle: true }, env);
+
+		expect(command.cmd).toContain("--no-pty");
+		expect(command.cmd).toContain("--no-title");
+		expect(command.cmd.indexOf("--no-pty")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+		expect(command.cmd.indexOf("--no-title")).toBeLessThan(command.cmd.indexOf("--session-dir"));
+	});
+
 	test("preserves custom config files across restart", () => {
 		const env: RestartCommandEnvironment = {
 			isCompiledBinary: () => true,

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { buildRestartLaunchFlags } from "@oh-my-pi/pi-coding-agent/main";
+
+describe("restart launch flags", () => {
+	test("resolves path launch flags against the original launch cwd", () => {
+		const flags = buildRestartLaunchFlags(
+			{
+				config: ["./omp.yml", "/tmp/global.yml"],
+				extensions: ["./ext", "pkg-extension", "../shared/ext"],
+				hooks: ["./hooks/restart.ts", "@scope/pkg"],
+				pluginDirs: ["plugins", "/opt/plugins"],
+			},
+			"/repo/original",
+		);
+
+		expect(flags.configFiles).toEqual(["/repo/original/omp.yml", "/tmp/global.yml"]);
+		expect(flags.extensionPaths).toEqual(["/repo/original/ext", "pkg-extension", "/repo/shared/ext"]);
+		expect(flags.hookPaths).toEqual(["/repo/original/hooks/restart.ts", "@scope/pkg"]);
+		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
+	});
+});

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
-import { buildRestartLaunchFlags, resolveRestartPromptLaunchValue } from "@oh-my-pi/pi-coding-agent/main";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import {
+	applyLiveThinkingToRestartLaunchArgs,
+	buildRestartLaunchFlags,
+	resolveRestartPromptLaunchValue,
+} from "@oh-my-pi/pi-coding-agent/main";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("restart launch flags", () => {
@@ -52,6 +57,23 @@ describe("restart launch flags", () => {
 		);
 
 		expect(cliFlags.apiKey).toBe("sk-cli");
+	});
+
+	test("uses the live thinking selector instead of the stale launch selector", () => {
+		const restartArgs = applyLiveThinkingToRestartLaunchArgs({ thinking: ThinkingLevel.High }, ThinkingLevel.Low);
+		const flags = buildRestartLaunchFlags(
+			restartArgs,
+			"/repo/original",
+			undefined,
+			undefined,
+			undefined,
+			"/repo/resumed",
+		);
+
+		expect(flags.thinking).toBe(ThinkingLevel.Low);
+		expect(applyLiveThinkingToRestartLaunchArgs({ thinking: ThinkingLevel.High }, undefined).thinking).toBe(
+			ThinkingLevel.High,
+		);
 	});
 
 	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -68,6 +68,12 @@ describe("restart launch flags", () => {
 		expect(cliFlags.apiKey).toBe("sk-cli");
 	});
 
+	test("preserves empty extension flag snapshots as restart markers", () => {
+		const flags = buildRestartLaunchFlags({}, "/repo/original", []);
+
+		expect(flags.extensionFlagValues).toEqual([]);
+	});
+
 	test("uses the live thinking selector instead of the stale launch selector", () => {
 		const restartArgs = applyLiveThinkingToRestartLaunchArgs({ thinking: ThinkingLevel.High }, ThinkingLevel.Low);
 		const flags = buildRestartLaunchFlags(

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -6,6 +6,7 @@ import {
 	buildRestartLaunchFlags,
 	resolveRestartPromptLaunchValue,
 } from "@oh-my-pi/pi-coding-agent/main";
+import { resolvePromptInput } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("restart launch flags", () => {
@@ -17,6 +18,8 @@ describe("restart launch flags", () => {
 				hooks: ["./hooks/restart.ts", "@scope/pkg"],
 				pluginDirs: ["plugins", "/opt/plugins"],
 				providerSessionId: "provider-session-1",
+				provider: "openai",
+				model: "gpt-5",
 			},
 			"/repo/original",
 			undefined,
@@ -30,6 +33,8 @@ describe("restart launch flags", () => {
 		expect(flags.hookPaths).toEqual(["/repo/resumed/hooks/restart.ts", "/repo/resumed/@scope/pkg"]);
 		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
 		expect(flags.providerSessionId).toBe("provider-session-1");
+		expect(flags.provider).toBe("openai");
+		expect(flags.model).toBe("gpt-5");
 	});
 
 	test("carries env-injected API keys through extension-aware restart snapshots", () => {
@@ -87,7 +92,10 @@ describe("restart launch flags", () => {
 		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).toBe(sessionPromptPath);
 		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).not.toBe(launchPromptPath);
 		expect(await resolveRestartPromptLaunchValue(undefined, sessionCwd, launchPromptPath)).toBe(launchPromptPath);
-		expect(await resolveRestartPromptLaunchValue("literal prompt", sessionCwd)).toBe("literal prompt");
+		const literalRestartValue = await resolveRestartPromptLaunchValue("literal prompt", sessionCwd);
+		expect(literalRestartValue).not.toBe("literal prompt");
+		await Bun.write(path.join(sessionCwd, "literal prompt"), "session literal file");
+		expect(await resolvePromptInput(literalRestartValue, "system prompt")).toBe("literal prompt");
 		expect(await resolveRestartPromptLaunchValue("literal\nprompt", sessionCwd)).toBe("literal\nprompt");
 	});
 });

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -27,6 +27,33 @@ describe("restart launch flags", () => {
 		expect(flags.providerSessionId).toBe("provider-session-1");
 	});
 
+	test("carries env-injected API keys through extension-aware restart snapshots", () => {
+		const flags = buildRestartLaunchFlags(
+			{},
+			"/repo/original",
+			undefined,
+			undefined,
+			"openai",
+			"/repo/resumed",
+			"sk-runtime",
+		);
+
+		expect(flags.apiKey).toBe("sk-runtime");
+		expect(flags.apiKeyProvider).toBe("openai");
+
+		const cliFlags = buildRestartLaunchFlags(
+			{ apiKey: "sk-cli" },
+			"/repo/original",
+			undefined,
+			undefined,
+			"openai",
+			"/repo/resumed",
+			"sk-runtime",
+		);
+
+		expect(cliFlags.apiKey).toBe("sk-cli");
+	});
+
 	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {
 		using tempDir = TempDir.createSync("@omp-restart-prompts-");
 		const launchPromptPath = path.join(tempDir.path(), "launch", "prompts", "system.md");

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -37,6 +37,13 @@ describe("restart launch flags", () => {
 
 		expect(flags.configFiles).toEqual(["/repo/original/omp.yml", "/tmp/global.yml"]);
 		expect(flags.extensionPaths).toEqual(["/repo/resumed/ext", "/repo/resumed/pkg-extension", "/repo/shared/ext"]);
+		expect(flags.extensionPackageRoots).toEqual([
+			"/repo/original/ext",
+			"/repo/original/pkg-extension",
+			"/repo/shared/ext",
+			"/repo/original/hooks/restart.ts",
+			"/repo/original/@scope/pkg",
+		]);
 		expect(flags.hookPaths).toEqual(["/repo/resumed/hooks/restart.ts", "/repo/resumed/@scope/pkg"]);
 		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
 		expect(flags.providerSessionId).toBe("provider-session-1");

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -20,6 +20,8 @@ describe("restart launch flags", () => {
 				providerSessionId: "provider-session-1",
 				provider: "openai",
 				model: "gpt-5",
+				noPty: true,
+				noTitle: true,
 			},
 			"/repo/original",
 			undefined,
@@ -35,6 +37,8 @@ describe("restart launch flags", () => {
 		expect(flags.providerSessionId).toBe("provider-session-1");
 		expect(flags.provider).toBe("openai");
 		expect(flags.model).toBe("gpt-5");
+		expect(flags.noPty).toBe(true);
+		expect(flags.noTitle).toBe(true);
 	});
 
 	test("carries env-injected API keys through extension-aware restart snapshots", () => {

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -96,6 +96,9 @@ describe("restart launch flags", () => {
 		expect(literalRestartValue).not.toBe("literal prompt");
 		await Bun.write(path.join(sessionCwd, "literal prompt"), "session literal file");
 		expect(await resolvePromptInput(literalRestartValue, "system prompt")).toBe("literal prompt");
+		const secondRestartValue = await resolveRestartPromptLaunchValue(literalRestartValue, sessionCwd);
+		expect(secondRestartValue).toBe(literalRestartValue);
+		expect(await resolvePromptInput(secondRestartValue, "system prompt")).toBe("literal prompt");
 		expect(await resolveRestartPromptLaunchValue("literal\nprompt", sessionCwd)).toBe("literal\nprompt");
 	});
 });

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -112,6 +112,16 @@ describe("restart launch flags", () => {
 		);
 	});
 
+	test("preserves autoApprove flag in launch flags snapshot", () => {
+		const flags = buildRestartLaunchFlags({ autoApprove: true }, "/repo/original");
+
+		expect(flags.autoApprove).toBe(true);
+
+		const defaultFlags = buildRestartLaunchFlags({}, "/repo/original");
+
+		expect(defaultFlags.autoApprove).toBe(false);
+	});
+
 	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {
 		using tempDir = TempDir.createSync("@omp-restart-prompts-");
 		const launchPromptPath = path.join(tempDir.path(), "launch", "prompts", "system.md");

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { buildRestartLaunchFlags } from "@oh-my-pi/pi-coding-agent/main";
+import * as path from "node:path";
+import { buildRestartLaunchFlags, resolveRestartPromptLaunchValue } from "@oh-my-pi/pi-coding-agent/main";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("restart launch flags", () => {
 	test("resolves path launch flags against the original launch cwd", () => {
@@ -9,13 +11,25 @@ describe("restart launch flags", () => {
 				extensions: ["./ext", "pkg-extension", "../shared/ext"],
 				hooks: ["./hooks/restart.ts", "@scope/pkg"],
 				pluginDirs: ["plugins", "/opt/plugins"],
+				providerSessionId: "provider-session-1",
 			},
 			"/repo/original",
 		);
 
 		expect(flags.configFiles).toEqual(["/repo/original/omp.yml", "/tmp/global.yml"]);
-		expect(flags.extensionPaths).toEqual(["/repo/original/ext", "pkg-extension", "/repo/shared/ext"]);
-		expect(flags.hookPaths).toEqual(["/repo/original/hooks/restart.ts", "@scope/pkg"]);
+		expect(flags.extensionPaths).toEqual(["/repo/original/ext", "/repo/original/pkg-extension", "/repo/shared/ext"]);
+		expect(flags.hookPaths).toEqual(["/repo/original/hooks/restart.ts", "/repo/original/@scope/pkg"]);
 		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
+		expect(flags.providerSessionId).toBe("provider-session-1");
+	});
+
+	test("absolutizes only file-backed prompt launch flags", async () => {
+		using tempDir = TempDir.createSync("@omp-restart-prompts-");
+		const promptPath = path.join(tempDir.path(), "prompts", "system.md");
+		await Bun.write(promptPath, "single-line prompt");
+
+		expect(await resolveRestartPromptLaunchValue("prompts/system.md", tempDir.path())).toBe(promptPath);
+		expect(await resolveRestartPromptLaunchValue("literal prompt", tempDir.path())).toBe("literal prompt");
+		expect(await resolveRestartPromptLaunchValue("literal\nprompt", tempDir.path())).toBe("literal\nprompt");
 	});
 });

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -4,7 +4,7 @@ import { buildRestartLaunchFlags, resolveRestartPromptLaunchValue } from "@oh-my
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("restart launch flags", () => {
-	test("resolves path launch flags against the original launch cwd", () => {
+	test("resolves launch and session path flags against their live startup cwd", () => {
 		const flags = buildRestartLaunchFlags(
 			{
 				config: ["./omp.yml", "/tmp/global.yml"],
@@ -14,22 +14,30 @@ describe("restart launch flags", () => {
 				providerSessionId: "provider-session-1",
 			},
 			"/repo/original",
+			undefined,
+			undefined,
+			undefined,
+			"/repo/resumed",
 		);
 
 		expect(flags.configFiles).toEqual(["/repo/original/omp.yml", "/tmp/global.yml"]);
-		expect(flags.extensionPaths).toEqual(["/repo/original/ext", "/repo/original/pkg-extension", "/repo/shared/ext"]);
-		expect(flags.hookPaths).toEqual(["/repo/original/hooks/restart.ts", "/repo/original/@scope/pkg"]);
+		expect(flags.extensionPaths).toEqual(["/repo/resumed/ext", "/repo/resumed/pkg-extension", "/repo/shared/ext"]);
+		expect(flags.hookPaths).toEqual(["/repo/resumed/hooks/restart.ts", "/repo/resumed/@scope/pkg"]);
 		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
 		expect(flags.providerSessionId).toBe("provider-session-1");
 	});
 
-	test("absolutizes only file-backed prompt launch flags", async () => {
+	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {
 		using tempDir = TempDir.createSync("@omp-restart-prompts-");
-		const promptPath = path.join(tempDir.path(), "prompts", "system.md");
-		await Bun.write(promptPath, "single-line prompt");
+		const launchPromptPath = path.join(tempDir.path(), "launch", "prompts", "system.md");
+		const sessionCwd = path.join(tempDir.path(), "session");
+		const sessionPromptPath = path.join(sessionCwd, "prompts", "system.md");
+		await Bun.write(launchPromptPath, "launch prompt");
+		await Bun.write(sessionPromptPath, "session prompt");
 
-		expect(await resolveRestartPromptLaunchValue("prompts/system.md", tempDir.path())).toBe(promptPath);
-		expect(await resolveRestartPromptLaunchValue("literal prompt", tempDir.path())).toBe("literal prompt");
-		expect(await resolveRestartPromptLaunchValue("literal\nprompt", tempDir.path())).toBe("literal\nprompt");
+		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).toBe(sessionPromptPath);
+		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).not.toBe(launchPromptPath);
+		expect(await resolveRestartPromptLaunchValue("literal prompt", sessionCwd)).toBe("literal prompt");
+		expect(await resolveRestartPromptLaunchValue("literal\nprompt", sessionCwd)).toBe("literal\nprompt");
 	});
 });

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -18,10 +18,15 @@ describe("restart launch flags", () => {
 				hooks: ["./hooks/restart.ts", "@scope/pkg"],
 				pluginDirs: ["plugins", "/opt/plugins"],
 				providerSessionId: "provider-session-1",
+				providerPromptCacheKey: "cache-shard-1",
 				provider: "openai",
 				model: "gpt-5",
 				noPty: true,
 				noTitle: true,
+				prewalk: true,
+				prewalkInto: "@smol",
+				planYolo: true,
+				planYoloInto: "@slow",
 			},
 			"/repo/original",
 			undefined,
@@ -35,10 +40,15 @@ describe("restart launch flags", () => {
 		expect(flags.hookPaths).toEqual(["/repo/resumed/hooks/restart.ts", "/repo/resumed/@scope/pkg"]);
 		expect(flags.pluginDirs).toEqual(["/repo/original/plugins", "/opt/plugins"]);
 		expect(flags.providerSessionId).toBe("provider-session-1");
+		expect(flags.providerPromptCacheKey).toBe("cache-shard-1");
 		expect(flags.provider).toBe("openai");
 		expect(flags.model).toBe("gpt-5");
 		expect(flags.noPty).toBe(true);
 		expect(flags.noTitle).toBe(true);
+		expect(flags.prewalk).toBe(true);
+		expect(flags.prewalkInto).toBe("@smol");
+		expect(flags.planYolo).toBe(true);
+		expect(flags.planYoloInto).toBe("@slow");
 	});
 
 	test("carries env-injected API keys through extension-aware restart snapshots", () => {

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -86,6 +86,7 @@ describe("restart launch flags", () => {
 
 		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).toBe(sessionPromptPath);
 		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).not.toBe(launchPromptPath);
+		expect(await resolveRestartPromptLaunchValue(undefined, sessionCwd, launchPromptPath)).toBe(launchPromptPath);
 		expect(await resolveRestartPromptLaunchValue("literal prompt", sessionCwd)).toBe("literal prompt");
 		expect(await resolveRestartPromptLaunchValue("literal\nprompt", sessionCwd)).toBe("literal\nprompt");
 	});

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import {
@@ -120,6 +121,34 @@ describe("restart launch flags", () => {
 		const defaultFlags = buildRestartLaunchFlags({}, "/repo/original");
 
 		expect(defaultFlags.autoApprove).toBe(false);
+	});
+	test("resolves extension and hook path flags with tilde forms and relative paths", () => {
+		const home = os.homedir();
+		const flags = buildRestartLaunchFlags(
+			{
+				extensions: ["~/my-ext", "~\\windows-ext", "~name/named-ext", "./relative-ext"],
+				hooks: ["~/my-hook.ts", "~\\windows-hook.ts", "~name/named-hook.ts", "./relative-hook.ts"],
+			},
+			"/repo/original",
+			undefined,
+			undefined,
+			undefined,
+			"/repo/resumed",
+		);
+
+		expect(flags.extensionPaths).toEqual([
+			path.join(home, "my-ext"),
+			`${home}\\windows-ext`,
+			path.join(home, "name/named-ext"),
+			"/repo/resumed/relative-ext",
+		]);
+
+		expect(flags.hookPaths).toEqual([
+			path.join(home, "my-hook.ts"),
+			`${home}\\windows-hook.ts`,
+			path.join(home, "name/named-hook.ts"),
+			"/repo/resumed/relative-hook.ts",
+		]);
 	});
 
 	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { buildRestartCommand, consumeRestartLiteralPrompts } from "@oh-my-pi/pi-coding-agent/cli/restart";
 import {
 	applyLiveThinkingToRestartLaunchArgs,
 	buildRestartLaunchFlags,
-	resolveRestartPromptLaunchValue,
+	resolveStartupPromptInputs,
 } from "@oh-my-pi/pi-coding-agent/main";
-import { resolvePromptInput } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { resolvePromptInput, resolvePromptInputWithSource } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("restart launch flags", () => {
@@ -151,24 +152,69 @@ describe("restart launch flags", () => {
 		]);
 	});
 
-	test("absolutizes file-backed prompt flags from the session-start cwd only", async () => {
-		using tempDir = TempDir.createSync("@omp-restart-prompts-");
-		const launchPromptPath = path.join(tempDir.path(), "launch", "prompts", "system.md");
-		const sessionCwd = path.join(tempDir.path(), "session");
-		const sessionPromptPath = path.join(sessionCwd, "prompts", "system.md");
-		await Bun.write(launchPromptPath, "launch prompt");
-		await Bun.write(sessionPromptPath, "session prompt");
+	test("preserves initial prompt source classification across restart", async () => {
+		const tempDir = TempDir.createSync("restart-prompt-flags");
+		const sessionCwd = path.resolve(tempDir.path());
+		const fileBackedPrompt = path.join(sessionCwd, "prompts", "system.md");
+		const literalSystemPrompt = path.join(sessionCwd, "literal-system-prompt");
+		const literalAppendPrompt = path.join(sessionCwd, "literal-append-prompt");
+		const prefixCollision = "omp-restart-literal-prompt:bm90LWludGVybmFs";
+		try {
+			await Bun.write(fileBackedPrompt, "file-backed prompt");
+			const fileBackedSource = await resolvePromptInputWithSource(fileBackedPrompt, "system prompt");
+			const literalSystemSource = await resolvePromptInputWithSource(literalSystemPrompt, "system prompt");
+			const literalAppendSource = await resolvePromptInputWithSource(literalAppendPrompt, "append system prompt");
 
-		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).toBe(sessionPromptPath);
-		expect(await resolveRestartPromptLaunchValue("prompts/system.md", sessionCwd)).not.toBe(launchPromptPath);
-		expect(await resolveRestartPromptLaunchValue(undefined, sessionCwd, launchPromptPath)).toBe(launchPromptPath);
-		const literalRestartValue = await resolveRestartPromptLaunchValue("literal prompt", sessionCwd);
-		expect(literalRestartValue).not.toBe("literal prompt");
-		await Bun.write(path.join(sessionCwd, "literal prompt"), "session literal file");
-		expect(await resolvePromptInput(literalRestartValue, "system prompt")).toBe("literal prompt");
-		const secondRestartValue = await resolveRestartPromptLaunchValue(literalRestartValue, sessionCwd);
-		expect(secondRestartValue).toBe(literalRestartValue);
-		expect(await resolvePromptInput(secondRestartValue, "system prompt")).toBe("literal prompt");
-		expect(await resolveRestartPromptLaunchValue("literal\nprompt", sessionCwd)).toBe("literal\nprompt");
+			expect(fileBackedSource?.source).toBe("file");
+			expect(literalSystemSource?.source).toBe("literal");
+			expect(literalAppendSource?.source).toBe("literal");
+			expect(await resolvePromptInput(prefixCollision, "system prompt")).toBe(prefixCollision);
+
+			await Bun.write(literalSystemPrompt, "new system file");
+			await Bun.write(literalAppendPrompt, "new append file");
+			const flags = buildRestartLaunchFlags(
+				{ systemPrompt: literalSystemPrompt, appendSystemPrompt: literalAppendPrompt },
+				sessionCwd,
+				undefined,
+				undefined,
+				undefined,
+				sessionCwd,
+				undefined,
+				undefined,
+				undefined,
+				{ systemPrompt: literalSystemSource, appendSystemPrompt: literalAppendSource },
+			);
+			const fileFlags = buildRestartLaunchFlags(
+				{ systemPrompt: fileBackedPrompt },
+				sessionCwd,
+				undefined,
+				undefined,
+				undefined,
+				sessionCwd,
+				undefined,
+				undefined,
+				undefined,
+				{ systemPrompt: fileBackedSource },
+			);
+			const command = buildRestartCommand({
+				sessionId: "session-1",
+				cwd: sessionCwd,
+				sessionDir: tempDir.join("sessions"),
+				approvalMode: "write",
+				...flags,
+			});
+			const restartLiterals = consumeRestartLiteralPrompts(command.env);
+			const childInputs = await resolveStartupPromptInputs({
+				restartLiteralPrompts: restartLiterals,
+			});
+
+			expect(fileFlags.systemPrompt).toBe(fileBackedPrompt);
+			expect(command.cmd).not.toContain("--system-prompt");
+			expect(command.cmd).not.toContain("--append-system-prompt");
+			expect(childInputs.systemPrompt?.value).toBe(literalSystemPrompt);
+			expect(childInputs.appendSystemPrompt?.value).toBe(literalAppendPrompt);
+		} finally {
+			await tempDir.remove();
+		}
 	});
 });

--- a/packages/coding-agent/test/restart-launch-flags.test.ts
+++ b/packages/coding-agent/test/restart-launch-flags.test.ts
@@ -33,9 +33,13 @@ describe("restart launch flags", () => {
 			undefined,
 			undefined,
 			"/repo/resumed",
+			undefined,
+			undefined,
+			["env-overlay.yml", "/tmp/env-overlay.yml"].join(path.delimiter),
 		);
 
 		expect(flags.configFiles).toEqual(["/repo/original/omp.yml", "/tmp/global.yml"]);
+		expect(flags.configEnvFiles).toEqual(["/repo/original/env-overlay.yml", "/tmp/env-overlay.yml"]);
 		expect(flags.extensionPaths).toEqual(["/repo/resumed/ext", "/repo/resumed/pkg-extension", "/repo/shared/ext"]);
 		expect(flags.extensionPackageRoots).toEqual([
 			"/repo/original/ext",

--- a/packages/coding-agent/test/restart-slash-command.test.ts
+++ b/packages/coding-agent/test/restart-slash-command.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test, vi } from "bun:test";
+import type { BuiltinSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+describe("/restart slash command", () => {
+	test("clears the editor and restarts the TUI", async () => {
+		const setText = vi.fn();
+		const restart = vi.fn(async () => undefined);
+		const runtime = { ctx: { editor: { setText }, restart } } as unknown as BuiltinSlashCommandRuntime;
+
+		const result = await executeBuiltinSlashCommand("/restart", runtime);
+
+		expect(result).toBe(true);
+		expect(setText).toHaveBeenCalledWith("");
+		expect(restart).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/restart-slash-command.test.ts
+++ b/packages/coding-agent/test/restart-slash-command.test.ts
@@ -3,7 +3,7 @@ import type { BuiltinSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 
 describe("/restart slash command", () => {
-	test("clears the editor and restarts the TUI", async () => {
+	test("keeps the draft for restart teardown to persist", async () => {
 		const setText = vi.fn();
 		const restart = vi.fn(async () => undefined);
 		const runtime = { ctx: { editor: { setText }, restart } } as unknown as BuiltinSlashCommandRuntime;
@@ -11,7 +11,7 @@ describe("/restart slash command", () => {
 		const result = await executeBuiltinSlashCommand("/restart", runtime);
 
 		expect(result).toBe(true);
-		expect(setText).toHaveBeenCalledWith("");
+		expect(setText).not.toHaveBeenCalled();
 		expect(restart).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -257,7 +257,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
 		});
 		try {
-			const { options: cliOptions } = await buildCliSessionOptions(
+			const cliOptions = await buildCliSessionOptions(
 				parsed,
 				[],
 				SessionManager.inMemory(),
@@ -312,7 +312,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
 		});
 		try {
-			const { options: cliOptions } = await buildCliSessionOptions(
+			const cliOptions = await buildCliSessionOptions(
 				parsed,
 				[],
 				SessionManager.inMemory(),

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -257,7 +257,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
 		});
 		try {
-			const cliOptions = await buildCliSessionOptions(
+			const { options: cliOptions } = await buildCliSessionOptions(
 				parsed,
 				[],
 				SessionManager.inMemory(),
@@ -312,7 +312,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
 		});
 		try {
-			const cliOptions = await buildCliSessionOptions(
+			const { options: cliOptions } = await buildCliSessionOptions(
 				parsed,
 				[],
 				SessionManager.inMemory(),

--- a/packages/coding-agent/test/session-exit-diagnostics.test.ts
+++ b/packages/coding-agent/test/session-exit-diagnostics.test.ts
@@ -180,6 +180,7 @@ describe("session exit diagnostics", () => {
 		const teardown = createSessionTeardown({
 			getDraftText: () => "",
 			beginDispose: () => activeSession.beginDispose(),
+			flush: () => sessionManager.flush(),
 			saveDraft: async () => {},
 			disposeSession: reason => activeSession.dispose({ reason }),
 		});

--- a/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
+++ b/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
@@ -216,7 +216,7 @@ describe("provider prompt-cache key session affinity", () => {
 				},
 			];
 
-			const options = await buildSessionOptions(
+			const { options } = await buildSessionOptions(
 				parsed,
 				scopedModels,
 				forkedManager,

--- a/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
+++ b/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
@@ -216,7 +216,7 @@ describe("provider prompt-cache key session affinity", () => {
 				},
 			];
 
-			const { options } = await buildSessionOptions(
+			const options = await buildSessionOptions(
 				parsed,
 				scopedModels,
 				forkedManager,


### PR DESCRIPTION
## Summary
- Added `/restart` to restart OMP from the TUI and resume the current session.
- Added restart-safe command construction that preserves the same build entrypoint, cwd, active profile, approval mode, and session id without reclassifying literal startup prompts.
- Split interactive teardown so restart can flush, save, stop live commands, clean up the TUI, spawn the replacement process, and exit with the child code.
- Block restart while queued async delivery remains, serialize startup marketplace updates, and normalize Windows extended drive/UNC executable paths.
- Preserve the session-effective `/computer on|off` tool state through a consumed one-hop restart override.
- Added focused tests for restart command construction, slash dispatch, and available-command metadata.

## Screenshots
No visual change.

## Testing

Latest-head verification after rebasing onto `main@22a2ea169`:

- `bun test` over 15 restart, async-delivery, launch-flag, model-selection, and system-prompt suites — 150 passed, 0 failed, 470 assertions.
- `bun run check:ts`
- Regression coverage includes successful/blocked draft preservation, live-command teardown, pending async result guards, one-hop literal prompt transport, file-vs-literal classification, parent/child startup serialization, Windows extended drive/UNC paths, and enabled/disabled session-scoped computer-use state.

## Risk
- Restart is intentionally TUI-only; ACP/text invocation returns an explicit message instead of restarting.
- Active runs are blocked before teardown to avoid killing in-flight model/tool work.
- The command resumes by session id only and does not replay original argv, prompts, or file arguments.

## Notes
- Root `bun check` is blocked in this workstation by stable rustfmt ignoring the repo's nightly Rust formatting config and emitting unrelated Rust formatting diffs; the coding-agent package check passed.

## AI Review Report

Independent review passes covered process handoff, teardown ordering, async delivery, launch argument integrity, initial-prompt classification, marketplace startup concurrency, Windows executable paths, and current-main compatibility. Remediation fixed queued-result loss, literal-prompt token hijacking/reclassification, overlapping parent/child updates, extended-path launch failures, and loss of session-scoped `/computer` state. The latest review surface has no unresolved thread.

## Security Audit
- No secrets or environment values are copied into the restart argv.
- Restart argv is rebuilt from explicit runtime state only: profile, cwd, approval mode, and session id.
- Collab host/guest and active execution guards prevent restarting during shared or in-flight work.