### PR TITLE
Fix todo HUD and goal context follow-ups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed llama.cpp discovery mapping unlimited `max_tokens = -1` / `n_predict = -1` output limits to the generic 32K discovery cap instead of the discovered runtime context window. ([#3781](https://github.com/can1357/oh-my-pi/issues/3781))
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 - Fixed the `edit` tool persisting unbounded full-file `oldText` / `newText` snapshots in tool-result `details`, inflating per-turn session JSONL lines (hundreds of KB per edit on large files). `details.oldText`/`details.newText` are now pruned when their combined length exceeds 32 KB; the visible diff, path, line, and diagnostic metadata are preserved, and ACP `diff` content still flows for smaller edits. ([#3786](https://github.com/can1357/oh-my-pi/issues/3786))
+- Fixed todo HUD and goal-mode continuations preserving accurate persisted todo context across `/btw` branches, hidden goal prompts, and discovery-only todo tool states.
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4017,6 +4017,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#btwController.dispose();
 			this.#omfgController.dispose();
 			this.chatContainer.clear();
+			this.todoReminderContainer.clear();
 			this.renderInitialMessages({ clearTerminalHistory: true });
 			this.updateEditorBorderColor();
 			this.showStatus(

--- a/packages/coding-agent/src/prompts/goals/goal-mode-context.md
+++ b/packages/coding-agent/src/prompts/goals/goal-mode-context.md
@@ -1,0 +1,4 @@
+{{goalContext}}
+{{#if todoContext}}
+{{todoContext}}
+{{/if}}

--- a/packages/coding-agent/src/prompts/goals/goal-todo-context.md
+++ b/packages/coding-agent/src/prompts/goals/goal-todo-context.md
@@ -4,9 +4,9 @@ Before continuing substantial work, compare your next action with these todos. I
 
 Overall: {{closed}}/{{total}} done, {{open}} open.
 {{#each phases}}
-- {{escapeXml name}}
+- {{name}}
 {{#each tasks}}
-  - [{{status}}] {{escapeXml content}}
+  - [{{status}}] {{content}}
 {{/each}}
 {{/each}}
 </todo_context>

--- a/packages/coding-agent/src/prompts/goals/goal-todo-context.md
+++ b/packages/coding-agent/src/prompts/goals/goal-todo-context.md
@@ -1,6 +1,14 @@
 <todo_context>
 Current persisted todo state for this goal follows. Goal continuations do not get a visible user nudge, so treat this as live progress state, not old transcript decoration.
-{{#if canCallTodoTool}}Before continuing substantial work, compare your next action with these todos. If an item is stale, already finished, or no longer the active pointer, call the `todo` tool first to mark it done or rewrite the list. Do not leave a stale in_progress item while working on later phases.{{else}}Before continuing substantial work, compare your next action with these todos as read-only progress state. The `todo` tool is discoverable but not active in this turn; if the list needs edits, activate `todo` first instead of ignoring the persisted state.{{/if}}
+{{#if canCallTodoTool}}
+Before continuing substantial work, compare your next action with these todos. If an item is stale, already finished, or no longer the active pointer, call the `todo` tool first to mark it done or rewrite the list. Do not leave a stale in_progress item while working on later phases.
+{{else}}
+{{#if canActivateTodoTool}}
+Before continuing substantial work, compare your next action with these todos as read-only progress state. The `todo` tool is discoverable but not active in this turn; if the list needs edits, call `search_tool_bm25` to activate `todo` first instead of ignoring the persisted state.
+{{else}}
+Before continuing substantial work, compare your next action with these todos as read-only progress state. The `todo` tool is not active in this turn, so do not claim todo updates unless a later turn exposes the tool.
+{{/if}}
+{{/if}}
 
 Overall: {{closed}}/{{total}} done, {{open}} open.
 {{#each phases}}

--- a/packages/coding-agent/src/prompts/goals/goal-todo-context.md
+++ b/packages/coding-agent/src/prompts/goals/goal-todo-context.md
@@ -1,6 +1,6 @@
 <todo_context>
 Current persisted todo state for this goal follows. Goal continuations do not get a visible user nudge, so treat this as live progress state, not old transcript decoration.
-Before continuing substantial work, compare your next action with these todos. If an item is stale, already finished, or no longer the active pointer, call the `todo` tool first to mark it done or rewrite the list. Do not leave a stale in_progress item while working on later phases.
+{{#if canCallTodoTool}}Before continuing substantial work, compare your next action with these todos. If an item is stale, already finished, or no longer the active pointer, call the `todo` tool first to mark it done or rewrite the list. Do not leave a stale in_progress item while working on later phases.{{else}}Before continuing substantial work, compare your next action with these todos as read-only progress state. The `todo` tool is discoverable but not active in this turn; if the list needs edits, activate `todo` first instead of ignoring the persisted state.{{/if}}
 
 Overall: {{closed}}/{{total}} done, {{open}} open.
 {{#each phases}}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -116,6 +116,7 @@ import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
+	escapeXmlText,
 	extractRetryHint,
 	formatDuration,
 	getAgentDbPath,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -231,6 +231,7 @@ import { containsWorkflow, WORKFLOW_NOTICE } from "../modes/workflow";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import advisorSystemPrompt from "../prompts/advisor/system.md" with { type: "text" };
+import goalModeContextPrompt from "../prompts/goals/goal-mode-context.md" with { type: "text" };
 import goalTodoContextPrompt from "../prompts/goals/goal-todo-context.md" with { type: "text" };
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
 import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
@@ -6492,15 +6493,25 @@ export class AgentSession {
 		return {
 			role: "custom",
 			customType: "goal-mode-context",
-			content: todoContext ? `${content}\n\n${todoContext}` : content,
+			content: prompt.render(goalModeContextPrompt, { goalContext: content, todoContext }),
 			display: false,
 			attribution: "agent",
 			timestamp: Date.now(),
 		};
 	}
 
+	#sanitizeGoalTodoText(text: string): string {
+		return escapeXmlText(text)
+			.replace(/\r\n/g, "\\n")
+			.replace(/\r/g, "\\r")
+			.replace(/\n/g, "\\n")
+			.replace(/\t/g, "\\t")
+			.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u2028\u2029]/g, " ");
+	}
+
 	#buildGoalTodoContext(): string | undefined {
 		if (!this.settings.get("todo.enabled")) return undefined;
+		if (!this.getActiveToolNames().includes("todo")) return undefined;
 		const phases = this.getTodoPhases().filter(phase => phase.tasks.length > 0);
 		if (phases.length === 0) return undefined;
 
@@ -6508,7 +6519,7 @@ export class AgentSession {
 		let closed = 0;
 		let open = 0;
 		const promptPhases = phases.map(phase => ({
-			name: phase.name,
+			name: this.#sanitizeGoalTodoText(phase.name),
 			tasks: phase.tasks.map(task => {
 				total++;
 				if (task.status === "completed" || task.status === "abandoned") {
@@ -6516,7 +6527,7 @@ export class AgentSession {
 				} else {
 					open++;
 				}
-				return { content: task.content, status: task.status };
+				return { content: this.#sanitizeGoalTodoText(task.content), status: task.status };
 			}),
 		}));
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6516,6 +6516,7 @@ export class AgentSession {
 		const canCallTodoTool = activeToolNames.includes("todo");
 		const canDiscoverTodoTool =
 			!canCallTodoTool && this.getDiscoverableTools({ source: "builtin" }).some(tool => tool.name === "todo");
+		const canActivateTodoTool = canDiscoverTodoTool && activeToolNames.includes("search_tool_bm25");
 		if (!canCallTodoTool && !canDiscoverTodoTool) return undefined;
 		const phases = this.getTodoPhases().filter(phase => phase.tasks.length > 0);
 		if (phases.length === 0) return undefined;
@@ -6538,6 +6539,7 @@ export class AgentSession {
 
 		return prompt.render(goalTodoContextPrompt, {
 			canCallTodoTool,
+			canActivateTodoTool,
 			closed: String(closed),
 			open: String(open),
 			phases: promptPhases,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6512,7 +6512,11 @@ export class AgentSession {
 
 	#buildGoalTodoContext(): string | undefined {
 		if (!this.settings.get("todo.enabled")) return undefined;
-		if (!this.getActiveToolNames().includes("todo")) return undefined;
+		const activeToolNames = this.getActiveToolNames();
+		const canCallTodoTool = activeToolNames.includes("todo");
+		const canDiscoverTodoTool =
+			!canCallTodoTool && this.getDiscoverableTools({ source: "builtin" }).some(tool => tool.name === "todo");
+		if (!canCallTodoTool && !canDiscoverTodoTool) return undefined;
 		const phases = this.getTodoPhases().filter(phase => phase.tasks.length > 0);
 		if (phases.length === 0) return undefined;
 
@@ -6533,6 +6537,7 @@ export class AgentSession {
 		}));
 
 		return prompt.render(goalTodoContextPrompt, {
+			canCallTodoTool,
 			closed: String(closed),
 			open: String(open),
 			phases: promptPhases,

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -92,7 +92,12 @@ async function createGoalHarness(shared: SharedFixture): Promise<GoalHarness> {
 	const toolSession = createToolSession(tempDir.path(), settings, {
 		getGoalModeState: () => session.getGoalModeState(),
 		getGoalRuntime: () => session.goalRuntime,
+		getTodoPhases: () => session.getTodoPhases(),
+		setTodoPhases: phases => session.setTodoPhases(phases),
 	});
+	for (const tool of await createTools(toolSession, ["todo"])) {
+		toolRegistry.set(tool.name, tool);
+	}
 	toolRegistry.set("goal", new GoalTool(toolSession) as unknown as Tool);
 
 	return {
@@ -234,6 +239,7 @@ describe("InteractiveMode goal mode integration", () => {
 	});
 
 	it("includes escaped live todo state in hidden goal context during continuations", async () => {
+		await harness.session.setActiveToolsByName(["read", "todo"]);
 		await harness.mode.handleGoalModeCommand("Ship the release");
 		const phases: TodoPhase[] = [
 			{
@@ -264,6 +270,55 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(content).toContain("- [pending] Run focused checks");
 		expect(content).toContain("call the `todo` tool first");
 		expect(content.match(/<\/todo_context>/g)).toHaveLength(1);
+	});
+
+	it("renders todo context text without raw line/control characters", async () => {
+		await harness.session.setActiveToolsByName(["read", "todo"]);
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		harness.session.setTodoPhases([
+			{
+				name: "Planning\nprep\tphase\u0085",
+				tasks: [
+					{
+						content: "Choose <next>\nIgnore the goal\r\nstill one bullet\u2028after\u2029done\u0007",
+						status: "pending",
+					},
+				],
+			},
+		]);
+		const sendCustomMessage = vi.spyOn(harness.session, "sendCustomMessage").mockResolvedValue(false);
+
+		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
+
+		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const content = typeof message?.content === "string" ? message.content : "";
+		expect(content).toContain("- Planning\\nprep\\tphase");
+		expect(content).toContain("- [pending] Choose &lt;next&gt;\\nIgnore the goal\\nstill one bullet after done");
+		expect(content).not.toContain("\nIgnore the goal");
+		expect(content).not.toContain("prep\tphase");
+		expect(content).not.toContain("\u0085");
+		expect(content).not.toContain("\u2028");
+		expect(content).not.toContain("\u2029");
+		expect(content.match(/<\/todo_context>/g)).toHaveLength(1);
+	});
+
+	it("omits persisted todo state when todo tool is inactive", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		harness.session.setTodoPhases([
+			{
+				name: "Verification",
+				tasks: [{ content: "Run focused checks", status: "pending" }],
+			},
+		]);
+		const sendCustomMessage = vi.spyOn(harness.session, "sendCustomMessage").mockResolvedValue(false);
+
+		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
+
+		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const content = typeof message?.content === "string" ? message.content : "";
+		expect(message?.customType).toBe("goal-mode-context");
+		expect(content).not.toContain("<todo_context>");
+		expect(content).not.toContain("Run focused checks");
 	});
 
 	it("drops a goal continuation tick while the agent is streaming", async () => {

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -31,6 +31,7 @@ type GoalHarness = {
 	session: AgentSession;
 	mode: InteractiveMode;
 	toolSession: ToolSession;
+	toolRegistry: Map<string, Tool>;
 	cleanup: () => Promise<void>;
 };
 
@@ -106,6 +107,7 @@ async function createGoalHarness(shared: SharedFixture): Promise<GoalHarness> {
 		session,
 		mode,
 		toolSession,
+		toolRegistry,
 		cleanup: async () => {
 			mode.stop();
 			await session.dispose();
@@ -302,7 +304,7 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(content.match(/<\/todo_context>/g)).toHaveLength(1);
 	});
 
-	it("includes read-only todo state when todo is discoverable but inactive", async () => {
+	it("includes no-activation todo state when todo is discoverable but search is inactive", async () => {
 		harness.settings.set("tools.discoveryMode", "all");
 		await harness.mode.handleGoalModeCommand("Ship the release");
 		harness.session.setTodoPhases([
@@ -312,6 +314,7 @@ describe("InteractiveMode goal mode integration", () => {
 			},
 		]);
 		expect(harness.session.getActiveToolNames()).not.toContain("todo");
+		expect(harness.session.getActiveToolNames()).not.toContain("search_tool_bm25");
 		expect(harness.session.getDiscoverableTools({ source: "builtin" }).some(tool => tool.name === "todo")).toBe(true);
 		const sendCustomMessage = vi.spyOn(harness.session, "sendCustomMessage").mockResolvedValue(false);
 
@@ -323,8 +326,47 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(content).toContain("<todo_context>");
 		expect(content).toContain("Run focused checks");
 		expect(content).toContain("read-only progress state");
-		expect(content).toContain("discoverable but not active");
+		expect(content).toContain("not active in this turn");
+		expect(content).toContain("do not claim todo updates unless a later turn exposes the tool");
+		expect(content).not.toContain("activate `todo` first");
 		expect(content).not.toContain("call the `todo` tool first");
+	});
+
+	it("advertises todo activation only when search tool is active", async () => {
+		harness.settings.set("tools.discoveryMode", "all");
+		Object.assign(harness.toolSession, {
+			isToolDiscoveryEnabled: () => harness.session.isToolDiscoveryEnabled(),
+			getSelectedDiscoveredToolNames: () => harness.session.getSelectedDiscoveredToolNames(),
+			activateDiscoveredTools: (toolNames: string[]) => harness.session.activateDiscoveredTools(toolNames),
+			getDiscoverableTools: (filter?: Parameters<AgentSession["getDiscoverableTools"]>[0]) =>
+				harness.session.getDiscoverableTools(filter),
+		});
+		for (const tool of await createTools(harness.toolSession, ["search_tool_bm25"])) {
+			harness.toolRegistry.set(tool.name, tool);
+		}
+		await harness.session.setActiveToolsByName(["read", "search_tool_bm25"]);
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		harness.session.setTodoPhases([
+			{
+				name: "Verification",
+				tasks: [{ content: "Run focused checks", status: "pending" }],
+			},
+		]);
+		expect(harness.session.getActiveToolNames()).not.toContain("todo");
+		expect(harness.session.getActiveToolNames()).toContain("search_tool_bm25");
+		const sendCustomMessage = vi.spyOn(harness.session, "sendCustomMessage").mockResolvedValue(false);
+
+		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
+
+		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const content = typeof message?.content === "string" ? message.content : "";
+		expect(message?.customType).toBe("goal-mode-context");
+		expect(content).toContain("<todo_context>");
+		expect(content).toContain("Run focused checks");
+		expect(content).toContain("read-only progress state");
+		expect(content).toContain("discoverable but not active");
+		expect(content).toContain("call `search_tool_bm25` to activate `todo` first");
+		expect(content).not.toContain("do not claim todo updates unless a later turn exposes the tool");
 	});
 
 	it("omits persisted todo state when todo tool is inactive", async () => {

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -10,6 +10,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { DiscoverableTool } from "@oh-my-pi/pi-coding-agent/tool-discovery/tool-index";
 import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import type { TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -338,7 +339,7 @@ describe("InteractiveMode goal mode integration", () => {
 			isToolDiscoveryEnabled: () => harness.session.isToolDiscoveryEnabled(),
 			getSelectedDiscoveredToolNames: () => harness.session.getSelectedDiscoveredToolNames(),
 			activateDiscoveredTools: (toolNames: string[]) => harness.session.activateDiscoveredTools(toolNames),
-			getDiscoverableTools: (filter?: Parameters<AgentSession["getDiscoverableTools"]>[0]) =>
+			getDiscoverableTools: (filter?: { source?: DiscoverableTool["source"] }) =>
 				harness.session.getDiscoverableTools(filter),
 		});
 		for (const tool of await createTools(harness.toolSession, ["search_tool_bm25"])) {

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -302,6 +302,31 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(content.match(/<\/todo_context>/g)).toHaveLength(1);
 	});
 
+	it("includes read-only todo state when todo is discoverable but inactive", async () => {
+		harness.settings.set("tools.discoveryMode", "all");
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		harness.session.setTodoPhases([
+			{
+				name: "Verification",
+				tasks: [{ content: "Run focused checks", status: "pending" }],
+			},
+		]);
+		expect(harness.session.getActiveToolNames()).not.toContain("todo");
+		expect(harness.session.getDiscoverableTools({ source: "builtin" }).some(tool => tool.name === "todo")).toBe(true);
+		const sendCustomMessage = vi.spyOn(harness.session, "sendCustomMessage").mockResolvedValue(false);
+
+		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
+
+		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const content = typeof message?.content === "string" ? message.content : "";
+		expect(message?.customType).toBe("goal-mode-context");
+		expect(content).toContain("<todo_context>");
+		expect(content).toContain("Run focused checks");
+		expect(content).toContain("read-only progress state");
+		expect(content).toContain("discoverable but not active");
+		expect(content).not.toContain("call the `todo` tool first");
+	});
+
 	it("omits persisted todo state when todo tool is inactive", async () => {
 		await harness.mode.handleGoalModeCommand("Ship the release");
 		harness.session.setTodoPhases([

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
@@ -193,7 +194,7 @@ describe("InteractiveMode todo HUD persistence", () => {
 		vi.spyOn(mode, "updateEditorBorderColor").mockImplementation(() => {});
 		vi.spyOn(mode, "showStatus").mockImplementation(() => {});
 
-		await mode.handleBtwBranch("why did this fail?", {} as Parameters<InteractiveMode["handleBtwBranch"]>[1]);
+		await mode.handleBtwBranch("why did this fail?", {} as AssistantMessage);
 
 		expect(mode.todoReminderContainer.children).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -181,6 +181,22 @@ describe("InteractiveMode todo HUD persistence", () => {
 		expect(mode.todoReminderContainer.children).toHaveLength(0);
 		expect(session.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
 	});
+
+	it("clears stale todo reminders when /btw branches", async () => {
+		await createMode(-1);
+		mode.todoReminderContainer.addChild(new Text("stale reminder", 0, 0));
+		vi.spyOn(session, "branchFromBtw").mockResolvedValue({
+			cancelled: false,
+			sessionFile: path.join(tempDir.path(), "branch.jsonl"),
+		});
+		vi.spyOn(mode, "renderInitialMessages").mockImplementation(() => {});
+		vi.spyOn(mode, "updateEditorBorderColor").mockImplementation(() => {});
+		vi.spyOn(mode, "showStatus").mockImplementation(() => {});
+
+		await mode.handleBtwBranch("why did this fail?", {} as Parameters<InteractiveMode["handleBtwBranch"]>[1]);
+
+		expect(mode.todoReminderContainer.children).toHaveLength(0);
+	});
 });
 
 describe("InteractiveMode todo HUD anchor", () => {


### PR DESCRIPTION
## Summary

Follow-up fixes for todo HUD persistence and goal-mode todo context behavior that were previously mixed into PR #3604.

## Changes

- Clear stale todo reminder HUD state after successful `/btw` branching.
- Preserve hidden goal todo context when persisted todos are available and `todo` is callable or discoverable.
- Sanitize/escape todo context text before injecting it into the goal prompt.
- Gate the activation instruction on active `search_tool_bm25`; restricted turns now get read-only no-activation wording.
- Add focused regression coverage for these branches.

## Verification

- `bun --cwd=packages/coding-agent run check` passed.
- `git diff --check origin/main...HEAD` passed.
- Local targeted runtime/UI tests could not run in the fresh clone because the Darwin native addon is not present and local native build fails on this machine; GitHub CI will run with downloaded native artifacts.

## Split note

This PR intentionally excludes the hidden-thinking glyph fix, which is now in a separate PR.
