### PR TITLE
fix(hashline): recover stale edit anchors after line shifts

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recovered stale edit anchors after earlier in-session insertions or deletions shifted unchanged target lines. ([#3775](https://github.com/can1357/oh-my-pi/issues/3775))
+
 ## [16.2.0] - 2026-06-27
 
 ### Added

--- a/packages/hashline/src/messages.ts
+++ b/packages/hashline/src/messages.ts
@@ -168,6 +168,10 @@ export const RECOVERY_SESSION_CHAIN_WARNING =
 export const RECOVERY_SESSION_REPLAY_WARNING =
 	"Recovered by replaying your edits onto the current file content (a prior in-session edit changed the lines you re-targeted with a stale hash). Verify the diff matches your intent.";
 
+/** `Recovery`: stale anchors were relocated to unchanged live lines after drift. */
+export const RECOVERY_LINE_REMAP_WARNING =
+	"Recovered by remapping stale line anchors to unchanged current lines (file changed since the tagged read). Verify the diff matches your intent.";
+
 /**
  * `insert head:`/`insert tail:` applied despite a stale snapshot tag.
  * Head/tail position is content-independent, so drift is non-fatal: apply

--- a/packages/hashline/src/recovery.ts
+++ b/packages/hashline/src/recovery.ts
@@ -10,7 +10,12 @@
  */
 import * as Diff from "diff";
 import { applyEdits } from "./apply";
-import { RECOVERY_EXTERNAL_WARNING, RECOVERY_SESSION_CHAIN_WARNING, RECOVERY_SESSION_REPLAY_WARNING } from "./messages";
+import {
+	RECOVERY_EXTERNAL_WARNING,
+	RECOVERY_LINE_REMAP_WARNING,
+	RECOVERY_SESSION_CHAIN_WARNING,
+	RECOVERY_SESSION_REPLAY_WARNING,
+} from "./messages";
 import type { Snapshot, SnapshotStore } from "./snapshots";
 import type { Anchor, ApplyResult, Edit } from "./types";
 
@@ -97,6 +102,111 @@ function verifyAnchorContent(previousText: string, currentText: string, edits: r
 	return true;
 }
 
+function buildLineMap(previousText: string, currentText: string): Map<number, number> {
+	const previousLines = previousText.split("\n");
+	const currentLines = currentText.split("\n");
+	const changes = Diff.diffArrays(previousLines, currentLines);
+	const map = new Map<number, number>();
+	let previousLine = 1;
+	let currentLine = 1;
+
+	for (const change of changes) {
+		const count = change.value.length;
+		if (change.added) {
+			currentLine += count;
+			continue;
+		}
+		if (change.removed) {
+			previousLine += count;
+			continue;
+		}
+		for (let offset = 0; offset < count; offset++) {
+			map.set(previousLine + offset, currentLine + offset);
+		}
+		previousLine += count;
+		currentLine += count;
+	}
+
+	return map;
+}
+
+function remapEditsToCurrent(previousText: string, currentText: string, edits: readonly Edit[]): Edit[] | null {
+	const lineMap = buildLineMap(previousText, currentText);
+	const offsets: number[] = [];
+
+	const mapLine = (line: number): number | null => {
+		const mapped = lineMap.get(line);
+		if (mapped === undefined) return null;
+		offsets.push(mapped - line);
+		return mapped;
+	};
+
+	const mapAnchor = (anchor: Anchor): Anchor | null => {
+		const line = mapLine(anchor.line);
+		return line === null ? null : { line };
+	};
+
+	const remapped: Edit[] = [];
+	for (const edit of edits) {
+		if (edit.kind === "delete") {
+			const anchor = mapAnchor(edit.anchor);
+			if (anchor === null) return null;
+			remapped.push({ ...edit, anchor });
+			continue;
+		}
+		if (edit.kind === "block") {
+			const anchor = mapAnchor(edit.anchor);
+			if (anchor === null) return null;
+			remapped.push({ ...edit, anchor });
+			continue;
+		}
+
+		let blockStart = edit.blockStart;
+		if (blockStart !== undefined) {
+			const mappedBlockStart = mapLine(blockStart);
+			if (mappedBlockStart === null) return null;
+			blockStart = mappedBlockStart;
+		}
+
+		const cursor = edit.cursor;
+		if (cursor.kind !== "before_anchor" && cursor.kind !== "after_anchor") {
+			remapped.push(blockStart === edit.blockStart ? edit : { ...edit, blockStart });
+			continue;
+		}
+
+		const anchor = mapAnchor(cursor.anchor);
+		if (anchor === null) return null;
+		remapped.push({ ...edit, cursor: { kind: cursor.kind, anchor }, blockStart });
+	}
+
+	if (offsets.length === 0) return null;
+	const firstOffset = offsets[0];
+	if (firstOffset === 0) return null;
+	if (!offsets.every(offset => offset === firstOffset)) return null;
+	return remapped;
+}
+
+function replayRemappedAnchorsOnCurrent(
+	previousText: string,
+	currentText: string,
+	edits: readonly Edit[],
+): RecoveryResult | null {
+	const remapped = remapEditsToCurrent(previousText, currentText, edits);
+	if (remapped === null) return null;
+	let applied: ApplyResult;
+	try {
+		applied = applyEdits(currentText, remapped);
+	} catch {
+		return null;
+	}
+	if (applied.text === currentText) return null;
+	return {
+		text: applied.text,
+		firstChangedLine: applied.firstChangedLine,
+		warnings: [RECOVERY_LINE_REMAP_WARNING, ...(applied.warnings ?? [])],
+	};
+}
+
 function replaySessionChainOnCurrent(
 	previousText: string,
 	currentText: string,
@@ -150,11 +260,15 @@ function isHeadSnapshot(head: Snapshot | null, snapshot: Snapshot): boolean {
 /**
  * Stateless recovery driver over a {@link SnapshotStore}. Construct once and
  * call {@link Recovery.tryRecover} per stale-tag incident. The default
- * implementation tries two strategies in order:
+ * implementation tries three strategies in order:
  *
  * 1. Apply the edits on the full-file version the tag names, then 3-way-merge
  *    the resulting patch onto the live content (handles external writes).
- * 2. (Session chain) If that version wasn't the head, replay the edits onto
+ * 2. Remap every stale anchor through the unchanged-line diff from the tagged
+ *    snapshot to the live text, then replay on live content. This handles a
+ *    prior insertion/deletion before the target while refusing changed anchors
+ *    and mixed offsets across the same edit range.
+ * 3. (Session chain) If that version wasn't the head, replay the edits onto
  *    the live content directly when line counts match AND every edit's anchor
  *    line content is unchanged between version and current — a prior in-session
  *    edit advanced the tag and the model's anchors still name the same logical
@@ -176,10 +290,16 @@ export class Recovery {
 		const recoveryWarning = isHead ? RECOVERY_EXTERNAL_WARNING : RECOVERY_SESSION_CHAIN_WARNING;
 		const merged = applyEditsToSnapshot(snapshot.text, currentText, edits, recoveryWarning);
 		if (merged !== null) return merged;
-		// Session-chain fallback: the 3-way merge on the version refused.
-		// Replay onto current is gated by line-count equality AND
-		// anchor-content alignment — see `replaySessionChainOnCurrent`
-		// for why both guards together still don't fully prove correctness.
+		// Line-shift fallback: the 3-way merge refused, but unchanged anchor
+		// lines may have moved because a prior edit inserted or deleted rows
+		// before them. Remap only when every anchor resolves through the diff
+		// with one consistent offset; otherwise the edit range was touched.
+		const remapped = replayRemappedAnchorsOnCurrent(snapshot.text, currentText, edits);
+		if (remapped !== null) return remapped;
+		// Session-chain fallback: replay onto current is gated by line-count
+		// equality AND anchor-content alignment — see
+		// `replaySessionChainOnCurrent` for why both guards together still
+		// don't fully prove correctness.
 		if (!isHead) return replaySessionChainOnCurrent(snapshot.text, currentText, edits);
 		return null;
 	}

--- a/packages/hashline/src/recovery.ts
+++ b/packages/hashline/src/recovery.ts
@@ -130,8 +130,69 @@ function buildLineMap(previousText: string, currentText: string): Map<number, nu
 	return map;
 }
 
+function lineIsDuplicated(lines: readonly string[], line: number): boolean {
+	const value = lines[line - 1];
+	return lines.indexOf(value) !== lines.lastIndexOf(value);
+}
+
+function nearestContextLine(
+	line: number,
+	direction: -1 | 1,
+	anchorLines: ReadonlySet<number>,
+	lineCount: number,
+): number | undefined {
+	for (let candidate = line + direction; candidate >= 1 && candidate <= lineCount; candidate += direction) {
+		if (!anchorLines.has(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+function validateDuplicateAnchorContext(
+	line: number,
+	mapped: number,
+	previousLines: readonly string[],
+	lineMap: ReadonlyMap<number, number>,
+	anchorLines: ReadonlySet<number>,
+): boolean {
+	let checked = false;
+	const before = nearestContextLine(line, -1, anchorLines, previousLines.length);
+	if (before !== undefined) {
+		checked = true;
+		if (lineMap.get(before) !== mapped - (line - before)) return false;
+	}
+	const after = nearestContextLine(line, 1, anchorLines, previousLines.length);
+	if (after !== undefined) {
+		checked = true;
+		if (lineMap.get(after) !== mapped + (after - line)) return false;
+	}
+	return checked;
+}
+
+function validateRemappedAnchorContext(
+	previousText: string,
+	currentText: string,
+	lineMap: ReadonlyMap<number, number>,
+	edits: readonly Edit[],
+): boolean {
+	const previousLines = previousText.split("\n");
+	const currentLines = currentText.split("\n");
+	const anchorLines = new Set(collectAnchorLines(edits));
+
+	for (const line of anchorLines) {
+		const mapped = lineMap.get(line);
+		if (mapped === undefined) return false;
+		if (!lineIsDuplicated(previousLines, line) && !lineIsDuplicated(currentLines, mapped)) continue;
+		if (!validateDuplicateAnchorContext(line, mapped, previousLines, lineMap, anchorLines)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 function remapEditsToCurrent(previousText: string, currentText: string, edits: readonly Edit[]): Edit[] | null {
 	const lineMap = buildLineMap(previousText, currentText);
+	if (!validateRemappedAnchorContext(previousText, currentText, lineMap, edits)) return null;
 	const offsets: number[] = [];
 
 	const mapLine = (line: number): number | null => {

--- a/packages/hashline/test/recovery-session-chain.test.ts
+++ b/packages/hashline/test/recovery-session-chain.test.ts
@@ -5,14 +5,24 @@
  * (the model is anchored against content that no longer exists), not
  * silently overwrite the new content with the stale-authored payload.
  *
- * Companion positive case: when the prior edit changed lines elsewhere
- * but left the re-targeted line alone, replay must still succeed and
- * surface the standard session-chain banner.
+ * Companion positive cases: unchanged equal-line anchors still replay with the
+ * standard session-chain banner, and anchors shifted by prior insertions remap
+ * to the same logical line before replay.
  */
 import { describe, expect, it } from "bun:test";
-import { InMemorySnapshotStore, parsePatch, RECOVERY_SESSION_REPLAY_WARNING, Recovery } from "@oh-my-pi/hashline";
+import {
+	InMemorySnapshotStore,
+	parsePatch,
+	RECOVERY_LINE_REMAP_WARNING,
+	RECOVERY_SESSION_REPLAY_WARNING,
+	Recovery,
+} from "@oh-my-pi/hashline";
 
 const PATH = "/tmp/__hashline-recovery-session-chain__.ts";
+
+function lines(...rows: string[]): string {
+	return `${rows.join("\n")}\n`;
+}
 
 function seedTwoSnapshots(): { store: InMemorySnapshotStore; v0Text: string; v1Text: string; h0: string; h1: string } {
 	const store = new InMemorySnapshotStore();
@@ -70,5 +80,45 @@ describe("Recovery — session-chain replay anchor-content gate", () => {
 		// pointing at duplicated rows even with both guards satisfied), so
 		// the dedicated REPLAY warning surfaces a "verify the diff" hedge.
 		expect(recovered?.warnings).toContain(RECOVERY_SESSION_REPLAY_WARNING);
+	});
+
+	it("recovers stale anchors shifted by a prior in-session insertion", () => {
+		const store = new InMemorySnapshotStore();
+		const v0Text = lines("L1", "L2", "L3", "L4", "L5", "L6");
+		const h0 = store.record(PATH, v0Text);
+		const v1Text = lines("L1", "L2", "INSERTED", "L3", "L4", "L5", "L6");
+		store.record(PATH, v1Text);
+		const { edits } = parsePatch("SWAP 5.=5:\n+L5-MODEL");
+
+		const recovered = new Recovery(store).tryRecover({
+			path: PATH,
+			currentText: v1Text,
+			fileHash: h0,
+			edits,
+		});
+
+		expect(recovered).not.toBeNull();
+		expect(recovered?.text).toBe(lines("L1", "L2", "INSERTED", "L3", "L4", "L5-MODEL", "L6"));
+		expect(recovered?.warnings).toContain(RECOVERY_LINE_REMAP_WARNING);
+	});
+
+	it("recovers stale anchors shifted by a prior in-session deletion", () => {
+		const store = new InMemorySnapshotStore();
+		const v0Text = lines("L1", "L2", "L3", "L4", "L5", "L6");
+		const h0 = store.record(PATH, v0Text);
+		const v1Text = lines("L1", "L3", "L4", "L5", "L6");
+		store.record(PATH, v1Text);
+		const { edits } = parsePatch("SWAP 5.=5:\n+L5-MODEL");
+
+		const recovered = new Recovery(store).tryRecover({
+			path: PATH,
+			currentText: v1Text,
+			fileHash: h0,
+			edits,
+		});
+
+		expect(recovered).not.toBeNull();
+		expect(recovered?.text).toBe(lines("L1", "L3", "L4", "L5-MODEL", "L6"));
+		expect(recovered?.warnings).toContain(RECOVERY_LINE_REMAP_WARNING);
 	});
 });

--- a/packages/hashline/test/recovery-session-chain.test.ts
+++ b/packages/hashline/test/recovery-session-chain.test.ts
@@ -121,4 +121,22 @@ describe("Recovery — session-chain replay anchor-content gate", () => {
 		expect(recovered?.text).toBe(lines("L1", "L3", "L4", "L5-MODEL", "L6"));
 		expect(recovered?.warnings).toContain(RECOVERY_LINE_REMAP_WARNING);
 	});
+
+	it("refuses duplicate-line remaps when surrounding context no longer matches", () => {
+		const store = new InMemorySnapshotStore();
+		const v0Text = lines("start", "DUP", "mid", "DUP", "tail");
+		const h0 = store.record(PATH, v0Text);
+		const v1Text = lines("start", "mid", "DUP", "CHANGED", "tail");
+		store.record(PATH, v1Text);
+		const { edits } = parsePatch("SWAP 4.=4:\n+MODEL");
+
+		const recovered = new Recovery(store).tryRecover({
+			path: PATH,
+			currentText: v1Text,
+			fileHash: h0,
+			edits,
+		});
+
+		expect(recovered).toBeNull();
+	});
 });


### PR DESCRIPTION
## Repro
A stale edit anchored at old line 5 after an earlier in-session insertion shifts that same logical line to line 6. `bun test packages/hashline/test/recovery-session-chain.test.ts` failed with `expect(recovered).not.toBeNull()` because `Recovery.tryRecover` returned `null`.

## Cause
`packages/hashline/src/recovery.ts` only retried stale snapshots via strict 3-way patch application, then a session-chain replay path gated on equal line counts and same-index anchor content. Prior insertions or deletions before an unchanged target changed the line count, so the replay path refused even though the target line still existed unchanged at a shifted line number.

## Fix
- Added unchanged-line diff remapping for stale edit anchors before the session-chain replay fallback.
- Kept recovery conservative by requiring every anchor to map through unchanged diff hunks with one consistent offset, so changed anchors and touched edit ranges still reject.
- Added recovery warning text for remapped stale anchors.
- Added regression tests for prior in-session insertion and deletion drift.

## Verification
`bun run --cwd packages/hashline check` passed. `bun run --cwd packages/hashline test` passed with 209 tests, 432 expectations. Fixes #3775