### PR TITLE
fix(agent): load WSL host .agents skills

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed WSL sessions missing Agent Skills stored in the Windows host profile's `.agents/skills` directory. ([#3779](https://github.com/can1357/oh-my-pi/issues/3779))
+
 ## [16.2.5] - 2026-06-28
 
 ### Changed

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -28,9 +28,62 @@ const DISPLAY_NAME = "Agents (standard)";
 const PRIORITY = 70;
 const AGENT_DIR_CANDIDATES = [".agent", ".agents"] as const;
 
-/** User-level paths: ~/.agent/<segments> and ~/.agents/<segments>. */
-function getUserPathCandidates(ctx: LoadContext, ...segments: string[]): string[] {
-	return AGENT_DIR_CANDIDATES.map(baseDir => path.join(ctx.home, baseDir, ...segments));
+interface UserPathCandidateOptions {
+	platform?: NodeJS.Platform;
+	env?: NodeJS.ProcessEnv;
+	wslPath?: (windowsPath: string) => string | undefined;
+}
+
+const WINDOWS_DRIVE_PROFILE_PATTERN = /^([A-Za-z]):[\\/](.*)$/;
+
+function isWsl(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
+	return platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP);
+}
+
+function convertWindowsPathToDefaultWslMount(windowsPath: string): string | undefined {
+	const trimmed = windowsPath.trim();
+	if (trimmed.length === 0) return undefined;
+	if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
+	const match = WINDOWS_DRIVE_PROFILE_PATTERN.exec(trimmed);
+	if (!match) return undefined;
+	const [, drive, rest] = match;
+	const segments = rest.replace(/\\/g, "/").split("/").filter(Boolean);
+	return path.join("/mnt", drive.toLowerCase(), ...segments);
+}
+
+function resolveWithWslPath(windowsPath: string): string | undefined {
+	try {
+		const result = Bun.spawnSync(["wslpath", "-u", windowsPath], { stdout: "pipe", stderr: "ignore" });
+		if (result.exitCode !== 0) return undefined;
+		const resolved = result.stdout.toString().trim();
+		return resolved.length > 0 ? resolved : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Resolve the Windows host profile home exposed to WSL, if available. */
+export function getWslWindowsHomeCandidate(options: UserPathCandidateOptions = {}): string | undefined {
+	const platform = options.platform ?? process.platform;
+	const env = options.env ?? process.env;
+	if (!isWsl(platform, env)) return undefined;
+	const userProfile = env.USERPROFILE;
+	if (!userProfile) return undefined;
+	return (options.wslPath ?? resolveWithWslPath)(userProfile) ?? convertWindowsPathToDefaultWslMount(userProfile);
+}
+
+function getUserHomeCandidates(ctx: LoadContext): string[] {
+	const homes = [ctx.home];
+	const wslHome = getWslWindowsHomeCandidate();
+	if (wslHome && !homes.includes(wslHome)) homes.push(wslHome);
+	return homes;
+}
+
+/** User-level paths: ~/.agent[s]/<segments>, plus the Windows host profile under WSL. */
+export function getUserPathCandidates(ctx: LoadContext, ...segments: string[]): string[] {
+	return getUserHomeCandidates(ctx).flatMap(home =>
+		AGENT_DIR_CANDIDATES.map(baseDir => path.join(home, baseDir, ...segments)),
+	);
 }
 
 /**

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type Skill as CapabilitySkill, skillCapability } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import { getCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { getWslWindowsHomeCandidate } from "@oh-my-pi/pi-coding-agent/discovery/agents";
 import { loadSkills, loadSkillsFromDir, type Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -227,6 +228,55 @@ describe("skills", () => {
 				await removeWithRetries(tempHome);
 				await removeWithRetries(tempCwd);
 			}
+		});
+
+		it("should load Windows host ~/.agents/skills when running under WSL (#3779)", async () => {
+			const tempHostHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-wsl-host-"));
+			const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-wsl-cwd-"));
+			const skillDir = path.join(tempHostHome, ".agents", "skills", "wsl-host-skill");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", "description: Loaded from WSL host USERPROFILE", "---", "", "# wsl-host-skill"].join("\n"),
+			);
+			const previousWslDistroName = process.env.WSL_DISTRO_NAME;
+			const previousWslInterop = process.env.WSL_INTEROP;
+			const previousUserProfile = process.env.USERPROFILE;
+			process.env.WSL_DISTRO_NAME = "Ubuntu";
+			delete process.env.WSL_INTEROP;
+			process.env.USERPROFILE = tempHostHome;
+			try {
+				const { skills } = await loadSkills({
+					enableCodexUser: false,
+					enableClaudeUser: false,
+					enableClaudeProject: false,
+					enablePiUser: false,
+					enablePiProject: false,
+					cwd: tempCwd,
+				});
+				const skill = skills.find(s => s.name === "wsl-host-skill");
+				expect(skill?.source).toBe("agents:user");
+				expect(skill?.filePath).toBe(path.join(skillDir, "SKILL.md"));
+			} finally {
+				if (previousWslDistroName === undefined) delete process.env.WSL_DISTRO_NAME;
+				else process.env.WSL_DISTRO_NAME = previousWslDistroName;
+				if (previousWslInterop === undefined) delete process.env.WSL_INTEROP;
+				else process.env.WSL_INTEROP = previousWslInterop;
+				if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+				else process.env.USERPROFILE = previousUserProfile;
+				await removeWithRetries(tempHostHome);
+				await removeWithRetries(tempCwd);
+			}
+		});
+
+		it("converts Windows USERPROFILE paths to the default WSL mount (#3779)", () => {
+			const resolved = getWslWindowsHomeCandidate({
+				platform: "linux",
+				env: { WSL_DISTRO_NAME: "Ubuntu", USERPROFILE: "C:\\Users\\alice" },
+				wslPath: () => undefined,
+			});
+
+			expect(resolved).toBe(path.join("/mnt", "c", "Users", "alice"));
 		});
 
 		it("respects an explicit enableAgentsUser: false (#2401)", async () => {


### PR DESCRIPTION
## Repro
Create `$USERPROFILE/.agents/skills/git-commit/SKILL.md`, set `WSL_DISTRO_NAME=Ubuntu` and `USERPROFILE` to that host-profile directory, then call `loadSkills({ enableCodexUser:false, enableClaudeUser:false, enableClaudeProject:false, enablePiUser:false, enablePiProject:false })`; before the fix the result was `{"found":false,"names":[]}`.

## Cause
`packages/coding-agent/src/discovery/agents.ts` built user-level `.agent` / `.agents` candidates only from `ctx.home`, which comes from `os.homedir()`. Under WSL that is the Linux home, so Agent Skills stored in the Windows host profile exposed through `%USERPROFILE%` were never scanned.

## Fix
- Add WSL host-profile home resolution for the agents provider, using `wslpath` when available and a `/mnt/<drive>/...` fallback for Windows drive paths.
- Include the resolved host home in user-level `.agent[s]` candidate paths without replacing the Linux home.
- Add regression coverage for WSL host `.agents/skills` loading and Windows `USERPROFILE` path conversion.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/skills.test.ts` passed (32 tests). The JS repro now returns `{"found":true,"names":["git-commit:agents:user"]}`. `bun run --cwd packages/coding-agent check` passed. `gh_push_branch` completed and pushed `55e917ca6dcf`. Fixes #3779