### PR TITLE
fix(providers): honor llama.cpp unlimited output cap

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed llama.cpp discovery mapping unlimited `max_tokens = -1` / `n_predict = -1` output limits to the generic 32K discovery cap instead of the discovered runtime context window. ([#3781](https://github.com/can1357/oh-my-pi/issues/3781))
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -496,8 +496,11 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 		}
 		const entries = parseLlamaCppModelList(await response.json());
 		const entry = entries.find(entry => entry.id === model.id);
+		if (!entry) {
+			return undefined;
+		}
 		const contextWindow =
-			entry?.runtimeContextWindow ?? serverMetadata?.contextWindow ?? entry?.trainingContextWindow;
+			entry.runtimeContextWindow ?? serverMetadata?.contextWindow ?? entry.trainingContextWindow;
 		if (contextWindow === undefined) {
 			return undefined;
 		}

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -122,7 +122,7 @@ type OllamaDiscoveredModelMetadata = {
 type LlamaCppDiscoveredServerMetadata = {
 	contextWindow?: number;
 	input?: ("text" | "image")[];
-	maxTokens?: number | "contextWindow";
+	maxTokens?: "contextWindow";
 };
 
 type LlamaCppDiscoveredModelRuntimeMetadata = {
@@ -149,20 +149,25 @@ function toPositiveNumberOrUndefined(value: unknown): number | undefined {
 	return undefined;
 }
 
-function toFiniteNumberOrUndefined(value: unknown): number | undefined {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return value;
+function isLlamaCppUnlimitedSentinel(value: unknown): boolean {
+	if (typeof value === "number") {
+		return value === -1;
 	}
 	if (typeof value === "string" && value.trim()) {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed)) {
-			return parsed;
-		}
+		return Number(value) === -1;
 	}
-	return undefined;
+	return false;
 }
 
-function extractLlamaCppMaxTokens(payload: Record<string, unknown>): number | "contextWindow" | undefined {
+/**
+ * llama.cpp `/props.default_generation_settings.params.{max_tokens,n_predict}`
+ * are per-request defaults the server applies when a client omits the field —
+ * clients can still raise them per call. Positive values therefore are NOT
+ * hard model caps; only the `-1` unlimited sentinel reliably tells us the
+ * server bounds generation by the runtime context window. Anything else
+ * leaves the discovery default in place.
+ */
+function extractLlamaCppMaxTokens(payload: Record<string, unknown>): "contextWindow" | undefined {
 	const generationSettings = payload.default_generation_settings;
 	const params = isRecord(generationSettings) ? generationSettings.params : undefined;
 	const candidates = [
@@ -173,23 +178,10 @@ function extractLlamaCppMaxTokens(payload: Record<string, unknown>): number | "c
 		payload.max_tokens,
 		payload.n_predict,
 	];
-	let hasContextBoundedLimit = false;
-	for (const candidate of candidates) {
-		const value = toFiniteNumberOrUndefined(candidate);
-		if (value === undefined) {
-			continue;
-		}
-		if (value > 0) {
-			return value;
-		}
-		if (value === -1) {
-			hasContextBoundedLimit = true;
-		}
-	}
-	return hasContextBoundedLimit ? "contextWindow" : undefined;
+	return candidates.some(isLlamaCppUnlimitedSentinel) ? "contextWindow" : undefined;
 }
 
-function resolveLlamaCppMaxTokens(contextWindow: number, maxTokens: number | "contextWindow" | undefined): number {
+function resolveLlamaCppMaxTokens(contextWindow: number, maxTokens: "contextWindow" | undefined): number {
 	return maxTokens === "contextWindow"
 		? contextWindow
 		: Math.min(contextWindow, maxTokens ?? DISCOVERY_DEFAULT_MAX_TOKENS);

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -122,6 +122,12 @@ type OllamaDiscoveredModelMetadata = {
 type LlamaCppDiscoveredServerMetadata = {
 	contextWindow?: number;
 	input?: ("text" | "image")[];
+	maxTokens?: number | "contextWindow";
+};
+
+type LlamaCppDiscoveredModelRuntimeMetadata = {
+	contextWindow: number;
+	maxTokens: number;
 };
 
 type LlamaCppModelListEntry = {
@@ -141,6 +147,52 @@ function toPositiveNumberOrUndefined(value: unknown): number | undefined {
 		}
 	}
 	return undefined;
+}
+
+function toFiniteNumberOrUndefined(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+	return undefined;
+}
+
+function extractLlamaCppMaxTokens(payload: Record<string, unknown>): number | "contextWindow" | undefined {
+	const generationSettings = payload.default_generation_settings;
+	const params = isRecord(generationSettings) ? generationSettings.params : undefined;
+	const candidates = [
+		isRecord(params) ? params.max_tokens : undefined,
+		isRecord(params) ? params.n_predict : undefined,
+		isRecord(generationSettings) ? generationSettings.max_tokens : undefined,
+		isRecord(generationSettings) ? generationSettings.n_predict : undefined,
+		payload.max_tokens,
+		payload.n_predict,
+	];
+	let hasContextBoundedLimit = false;
+	for (const candidate of candidates) {
+		const value = toFiniteNumberOrUndefined(candidate);
+		if (value === undefined) {
+			continue;
+		}
+		if (value > 0) {
+			return value;
+		}
+		if (value === -1) {
+			hasContextBoundedLimit = true;
+		}
+	}
+	return hasContextBoundedLimit ? "contextWindow" : undefined;
+}
+
+function resolveLlamaCppMaxTokens(contextWindow: number, maxTokens: number | "contextWindow" | undefined): number {
+	return maxTokens === "contextWindow"
+		? contextWindow
+		: Math.min(contextWindow, maxTokens ?? DISCOVERY_DEFAULT_MAX_TOKENS);
 }
 
 function extractOllamaRuntimeContextWindow(payload: Record<string, unknown>): number | undefined {
@@ -353,6 +405,7 @@ async function discoverLlamaCppServerMetadata(
 		}
 		return {
 			contextWindow: extractLlamaCppContextWindow(payload),
+			maxTokens: extractLlamaCppMaxTokens(payload),
 			input: extractLlamaCppInputCapabilities(payload),
 		};
 	} catch {
@@ -410,7 +463,7 @@ export async function discoverLlamaCppModels(
 				imageInputDecoder: "stb",
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow,
-				maxTokens: Math.min(contextWindow, DISCOVERY_DEFAULT_MAX_TOKENS),
+				maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
 				headers,
 				compat: {
 					supportsStore: false,
@@ -423,24 +476,35 @@ export async function discoverLlamaCppModels(
 	return discovered;
 }
 
-export async function discoverLlamaCppModelContextWindow(
+export async function discoverLlamaCppModelRuntimeMetadata(
 	model: Pick<Model<Api>, "provider" | "id" | "baseUrl" | "headers">,
 	ctx: DiscoveryContext,
-): Promise<number | undefined> {
+): Promise<LlamaCppDiscoveredModelRuntimeMetadata | undefined> {
 	const baseUrl = normalizeLlamaCppBaseUrl(model.baseUrl);
 	const modelsUrl = `${baseUrl}/models`;
 	const baseHeaders: Record<string, string> = { ...(model.headers ?? {}) };
 	const attempt = async (headers: Record<string, string>) => {
-		const response = await ctx.fetch(modelsUrl, {
-			headers,
-			signal: AbortSignal.timeout(250),
-		});
+		const [response, serverMetadata] = await Promise.all([
+			ctx.fetch(modelsUrl, {
+				headers,
+				signal: AbortSignal.timeout(250),
+			}),
+			discoverLlamaCppServerMetadata(ctx, baseUrl, headers),
+		]);
 		if (!response.ok) {
 			return undefined;
 		}
 		const entries = parseLlamaCppModelList(await response.json());
 		const entry = entries.find(entry => entry.id === model.id);
-		return entry?.runtimeContextWindow ?? entry?.trainingContextWindow;
+		const contextWindow =
+			entry?.runtimeContextWindow ?? serverMetadata?.contextWindow ?? entry?.trainingContextWindow;
+		if (contextWindow === undefined) {
+			return undefined;
+		}
+		return {
+			contextWindow,
+			maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
+		};
 	};
 	try {
 		const apiKey = await ctx.getBearerApiKeyResolver(model.provider);

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -499,8 +499,7 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 		if (!entry) {
 			return undefined;
 		}
-		const contextWindow =
-			entry.runtimeContextWindow ?? serverMetadata?.contextWindow ?? entry.trainingContextWindow;
+		const contextWindow = entry.runtimeContextWindow ?? serverMetadata?.contextWindow ?? entry.trainingContextWindow;
 		if (contextWindow === undefined) {
 			return undefined;
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -75,7 +75,7 @@ import {
 	DISCOVERY_DEFAULT_MAX_TOKENS,
 	type DiscoveryContext,
 	type DiscoveryProviderConfig,
-	discoverLlamaCppModelContextWindow,
+	discoverLlamaCppModelRuntimeMetadata,
 	discoverModelsByProviderType,
 	getImplicitOllamaBaseUrl,
 	getOllamaContextLengthOverride,
@@ -873,10 +873,11 @@ export class ModelRegistry {
 		if (!isLlamaCppDiscovery) {
 			return model;
 		}
-		const contextWindow = await discoverLlamaCppModelContextWindow(model, this.#nonResolvingDiscoveryContext());
-		if (contextWindow === undefined) {
+		const runtimeMetadata = await discoverLlamaCppModelRuntimeMetadata(model, this.#nonResolvingDiscoveryContext());
+		if (runtimeMetadata === undefined) {
 			return this.find(model.provider, model.id) ?? model;
 		}
+		const { contextWindow, maxTokens } = runtimeMetadata;
 		const current = this.find(model.provider, model.id) ?? model;
 		const override = this.#resolveLiveModelOverride(current);
 		const customModel = this.#resolveLiveCustomModelOverlay(current);
@@ -888,7 +889,6 @@ export class ModelRegistry {
 		) {
 			patch.contextWindow = contextWindow;
 		}
-		const maxTokens = Math.min(contextWindow, DISCOVERY_DEFAULT_MAX_TOKENS);
 		if (
 			override?.maxTokens === undefined &&
 			customModel?.maxTokens === undefined &&

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -889,12 +889,19 @@ export class ModelRegistry {
 		) {
 			patch.contextWindow = contextWindow;
 		}
+		const effectiveContextWindow =
+			override?.contextWindow ??
+			customModel?.contextWindow ??
+			patch.contextWindow ??
+			current.contextWindow ??
+			contextWindow;
+		const effectiveMaxTokens = Math.min(maxTokens, effectiveContextWindow);
 		if (
 			override?.maxTokens === undefined &&
 			customModel?.maxTokens === undefined &&
-			current.maxTokens !== maxTokens
+			current.maxTokens !== effectiveMaxTokens
 		) {
-			patch.maxTokens = maxTokens;
+			patch.maxTokens = effectiveMaxTokens;
 		}
 		if (patch.contextWindow === undefined && patch.maxTokens === undefined) {
 			return current;

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -830,6 +830,60 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("llama.cpp", "sleeping-model")?.contextWindow).toBe(239104);
 	});
 
+	test("llama.cpp selected model refresh leaves the cached model untouched when /models no longer lists it", async () => {
+		writeModelCache(
+			"llama.cpp",
+			Date.now(),
+			[
+				buildModel({
+					id: "swapped-out-model",
+					name: "swapped-out-model",
+					provider: "llama.cpp",
+					api: "openai-responses",
+					baseUrl: "http://127.0.0.1:8080",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 32768,
+				}),
+			],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(JSON.stringify({ data: [{ id: "another-model", meta: { n_ctx: 524288 } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 524288,
+							params: { max_tokens: -1, n_predict: -1 },
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		const stale = registry.find("llama.cpp", "swapped-out-model");
+		if (!stale) throw new Error("cached llama.cpp model missing");
+		const refreshed = await registry.refreshSelectedModelMetadata(stale);
+		expect(refreshed.contextWindow).toBe(128000);
+		expect(refreshed.maxTokens).toBe(32768);
+	});
+
 	test("llama.cpp selected model refresh does not resolve command api keys", async () => {
 		const commandLogPath = path.join(tempDir, "llama-cpp-key-command.log");
 		writeRawModelsJson({

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -648,7 +648,7 @@ describe("ModelRegistry runtime discovery", () => {
 		const apiKey = await registry.getApiKey(llamaModels[0]);
 		expect(apiKey).toBe(kNoAuth);
 	});
-	test("llama.cpp discovery reads context window from props n_ctx", async () => {
+	test("llama.cpp discovery maps unlimited output limits to the context window", async () => {
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
 			if (url === "http://127.0.0.1:8080/models") {
@@ -662,6 +662,7 @@ describe("ModelRegistry runtime discovery", () => {
 					JSON.stringify({
 						default_generation_settings: {
 							n_ctx: 262144,
+							params: { max_tokens: -1, n_predict: -1 },
 						},
 						modalities: {
 							vision: true,
@@ -680,8 +681,40 @@ describe("ModelRegistry runtime discovery", () => {
 		await registry.refresh();
 		const llama = registry.find("llama.cpp", "qwen35-35b-a3b");
 		expect(llama?.contextWindow).toBe(262144);
-		expect(llama?.maxTokens).toBe(32_768);
+		expect(llama?.maxTokens).toBe(262144);
 		expect(llama?.input).toEqual(["text", "image"]);
+	});
+
+	test("llama.cpp discovery honors positive output limits from props", async () => {
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(JSON.stringify({ data: [{ id: "bounded-output" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 262144,
+							params: { max_tokens: 65536, n_predict: 65536 },
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const llama = registry.find("llama.cpp", "bounded-output");
+		expect(llama?.contextWindow).toBe(262144);
+		expect(llama?.maxTokens).toBe(65536);
 	});
 	test("llama.cpp discovery prefers runtime n_ctx over training context metadata", async () => {
 		const fetchMock: FetchImpl = async input => {
@@ -741,7 +774,7 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("llama.cpp", "unloaded")?.contextWindow).toBe(128000);
 	});
 
-	test("llama.cpp selected model refresh patches newly loaded meta n_ctx", async () => {
+	test("llama.cpp selected model refresh patches newly loaded meta n_ctx and unlimited output limit", async () => {
 		writeModelCache(
 			"llama.cpp",
 			Date.now(),
@@ -771,6 +804,20 @@ describe("ModelRegistry runtime discovery", () => {
 					headers: { "Content-Type": "application/json" },
 				});
 			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 239104,
+							params: { max_tokens: -1, n_predict: -1 },
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
 			throw new Error(`Unexpected URL: ${url}`);
 		};
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
@@ -779,7 +826,7 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(stale.contextWindow).toBe(128000);
 		const refreshed = await registry.refreshSelectedModelMetadata(stale);
 		expect(refreshed.contextWindow).toBe(239104);
-		expect(refreshed.maxTokens).toBe(32768);
+		expect(refreshed.maxTokens).toBe(239104);
 		expect(registry.find("llama.cpp", "sleeping-model")?.contextWindow).toBe(239104);
 	});
 

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -685,7 +685,7 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(llama?.input).toEqual(["text", "image"]);
 	});
 
-	test("llama.cpp discovery honors positive output limits from props", async () => {
+	test("llama.cpp discovery ignores positive props defaults as per-request limits, not hard caps", async () => {
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
 			if (url === "http://127.0.0.1:8080/models") {
@@ -714,7 +714,7 @@ describe("ModelRegistry runtime discovery", () => {
 		await registry.refresh();
 		const llama = registry.find("llama.cpp", "bounded-output");
 		expect(llama?.contextWindow).toBe(262144);
-		expect(llama?.maxTokens).toBe(65536);
+		expect(llama?.maxTokens).toBe(32_768);
 	});
 	test("llama.cpp discovery prefers runtime n_ctx over training context metadata", async () => {
 		const fetchMock: FetchImpl = async input => {

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -884,6 +884,72 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(refreshed.maxTokens).toBe(32768);
 	});
 
+	test("llama.cpp selected model refresh clamps unlimited output to overridden context", async () => {
+		writeRawModelsJson({
+			"llama.cpp": {
+				baseUrl: "http://127.0.0.1:8080",
+				api: "openai-responses",
+				auth: "none",
+				discovery: { type: "llama.cpp" },
+				modelOverrides: {
+					"bounded-context-model": { contextWindow: 128000 },
+				},
+			},
+		});
+		writeModelCache(
+			"llama.cpp",
+			Date.now(),
+			[
+				buildModel({
+					id: "bounded-context-model",
+					name: "bounded-context-model",
+					provider: "llama.cpp",
+					api: "openai-responses",
+					baseUrl: "http://127.0.0.1:8080",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 262144,
+					maxTokens: 32768,
+				}),
+			],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(JSON.stringify({ data: [{ id: "bounded-context-model", meta: { n_ctx: 262144 } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 262144,
+							params: { max_tokens: -1, n_predict: -1 },
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		const bounded = registry.find("llama.cpp", "bounded-context-model");
+		if (!bounded) throw new Error("cached llama.cpp model missing");
+		expect(bounded.contextWindow).toBe(128000);
+		const refreshed = await registry.refreshSelectedModelMetadata(bounded);
+		expect(refreshed.contextWindow).toBe(128000);
+		expect(refreshed.maxTokens).toBe(128000);
+	});
+
 	test("llama.cpp selected model refresh does not resolve command api keys", async () => {
 		const commandLogPath = path.join(tempDir, "llama-cpp-key-command.log");
 		writeRawModelsJson({


### PR DESCRIPTION
## Repro
A mocked llama.cpp `/models` + `/props` discovery run with `n_ctx=262144` and `default_generation_settings.params.max_tokens=-1` / `n_predict=-1` reproduced the issue: `bun .wt/llama-cpp-output-limit-repro.ts` returned `contextWindow: 262144` and `maxTokens: 32768` before the fix.

## Cause
`packages/coding-agent/src/config/model-discovery.ts` read llama.cpp runtime context metadata but ignored `/props` output-limit fields, so `discoverLlamaCppModels` always computed `maxTokens` with `Math.min(contextWindow, DISCOVERY_DEFAULT_MAX_TOKENS)`. `packages/coding-agent/src/config/model-registry.ts` used the same default in selected-model metadata refresh.

## Fix
- Parse llama.cpp `/props` `max_tokens` / `n_predict` values, including nested `default_generation_settings.params`.
- Map llama.cpp `-1` generation limits to the resolved runtime context window and honor positive advertised limits.
- Reuse the same runtime metadata resolution when refreshing selected llama.cpp model metadata.
- Add regression coverage for unlimited limits, positive limits, and selected-model refresh.

## Verification
`bun .wt/llama-cpp-output-limit-repro.ts` now returns `contextWindow: 262144` and `maxTokens: 262144`; `bun test packages/coding-agent/test/model-discovery.test.ts -t llama.cpp` passed; `bun test packages/coding-agent/test/model-discovery.test.ts` passed; `bun check` passed. Fixes #3781