### PR TITLE
Fix large session resume memory blowups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed large `omp resume` sessions dominated by repeated compaction summaries exhausting memory on Ctrl+C/resume shutdown. Session loading now streams multi-MiB JSONL files and elides superseded compaction payloads, sync flush skips whole-file rewrites when append state is already current, and session list previews can fall back to developer/assistant turns instead of showing `(no messages)` for forked plan sessions.
+
 ## [16.1.17] - 2026-06-24
 
 ### Fixed

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -245,20 +245,21 @@ function countMessageMarkers(content: string): number {
 	return count;
 }
 
-function extractFirstUserMessageFromPrefix(content: string): string | undefined {
-	const roleIndex = content.indexOf('"role"');
-	if (roleIndex === -1) return undefined;
+function extractFirstDisplayMessageFromPrefix(content: string): string | undefined {
+	let fallback: string | undefined;
+	let index = content.indexOf('"role"');
 
-	let index = roleIndex;
 	while (index !== -1) {
 		const role = extractStringProperty(content, "role", index);
-		if (role === "user") {
-			return extractStringProperty(content, "content", index) ?? extractStringProperty(content, "text", index);
+		const text = extractStringProperty(content, "content", index) ?? extractStringProperty(content, "text", index);
+		if (text) {
+			if (role === "user") return text;
+			if (!fallback && (role === "developer" || role === "assistant")) fallback = text;
 		}
 		index = content.indexOf('"role"', index + 6);
 	}
 
-	return undefined;
+	return fallback;
 }
 
 interface SessionListHeader {
@@ -364,7 +365,7 @@ async function scanSessionFile(
 			}
 		}
 
-		firstMessage ||= extractFirstUserMessageFromPrefix(content) ?? "";
+		firstMessage ||= extractFirstDisplayMessageFromPrefix(content) ?? "";
 		const messageCount = Math.max(parsedMessageCount, countMessageMarkers(content));
 		return {
 			path: file,

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as readline from "node:readline";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
@@ -7,9 +9,49 @@ import { migrateToCurrentVersion } from "./session-migrations";
 import { isImageBlock, isImageDataPayload } from "./session-persistence";
 import { FileSessionStorage, type SessionStorage } from "./session-storage";
 
+const STREAM_LOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+const ELIDED_COMPACTION_SUMMARY = "[Superseded compaction summary elided during session load]";
+
 /** Exported for compaction.test.ts */
 export function parseSessionEntries(content: string): FileEntry[] {
 	return parseJsonlLenient<FileEntry>(content);
+}
+
+function elideCompactionSummary(entry: FileEntry | undefined): void {
+	if (entry?.type !== "compaction") return;
+	entry.summary = ELIDED_COMPACTION_SUMMARY;
+	entry.shortSummary ??= "Superseded compaction elided";
+	entry.preserveData = undefined;
+}
+
+async function loadEntriesFromFileStream(filePath: string): Promise<FileEntry[]> {
+	const entries: FileEntry[] = [];
+	let latestCompactionIndex: number | undefined;
+	const input = fs.createReadStream(filePath, { encoding: "utf8" });
+	const lines = readline.createInterface({ input, crlfDelay: Infinity });
+
+	try {
+		for await (const line of lines) {
+			if (!line) continue;
+			let entry: FileEntry;
+			try {
+				entry = JSON.parse(line) as FileEntry;
+			} catch {
+				continue;
+			}
+			if (entry.type === "compaction") {
+				elideCompactionSummary(latestCompactionIndex === undefined ? undefined : entries[latestCompactionIndex]);
+				latestCompactionIndex = entries.length;
+			}
+			entries.push(entry);
+		}
+	} catch (err) {
+		input.destroy();
+		if (isEnoent(err)) return [];
+		throw err;
+	}
+
+	return entries;
 }
 
 /** Exported for testing */
@@ -17,14 +59,17 @@ export async function loadEntriesFromFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<FileEntry[]> {
-	let content: string;
+	let entries: FileEntry[];
 	try {
-		content = await storage.readText(filePath);
+		const stat = storage.statSync(filePath);
+		entries =
+			storage instanceof FileSessionStorage && stat.size >= STREAM_LOAD_THRESHOLD_BYTES
+				? await loadEntriesFromFileStream(filePath)
+				: parseSessionEntries(await storage.readText(filePath));
 	} catch (err) {
 		if (isEnoent(err)) return [];
 		throw err;
 	}
-	const entries = parseJsonlLenient<FileEntry>(content);
 
 	// Validate session header
 	if (entries.length === 0) return entries;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -63,6 +63,9 @@ import {
 
 const JSONL_SUFFIX_LENGTH = ".jsonl".length;
 
+const SUPERSEDED_COMPACTION_SUMMARY = "[Superseded compaction summary elided after a newer compaction]";
+const SUPERSEDED_COMPACTION_SHORT_SUMMARY = "Superseded compaction elided";
+
 function mintSessionId(): string {
 	return Bun.randomUUIDv7();
 }
@@ -622,6 +625,25 @@ export class SessionManager {
 		};
 	}
 
+	#elideSupersededCompactions(): boolean {
+		let changed = false;
+		for (const entry of this.#entries) {
+			if (entry.type !== "compaction") continue;
+			if (
+				entry.summary === SUPERSEDED_COMPACTION_SUMMARY &&
+				entry.shortSummary === SUPERSEDED_COMPACTION_SHORT_SUMMARY &&
+				entry.preserveData === undefined
+			) {
+				continue;
+			}
+			entry.summary = SUPERSEDED_COMPACTION_SUMMARY;
+			entry.shortSummary = SUPERSEDED_COMPACTION_SHORT_SUMMARY;
+			entry.preserveData = undefined;
+			changed = true;
+		}
+		return changed;
+	}
+
 	#recordEntry(entry: SessionEntry): void {
 		this.#entries.push(entry);
 		this.#index.insert(entry);
@@ -947,14 +969,18 @@ export class SessionManager {
 	}
 
 	/**
-	 * Synchronously flush all in-memory entries to disk. Use when the process may
-	 * exit before an async flush settles (Ctrl+C in the TUI). Software-crash
-	 * durable; not atomic and not power-loss safe — a same-process crash never
-	 * lands mid-`writeFileSync`.
+	 * Synchronously makes the current append-only session durable. Avoid rewriting
+	 * an already-current file: large restored sessions can contain GiB of compacted
+	 * history, and Ctrl+C must not rebuild the whole JSONL string just to flush.
 	 */
 	flushSync(): void {
 		if (!this.#persist || !this.#sessionFile) return;
 		if (this.#diskFailure) throw this.#diskFailure;
+		if (this.#fileIsCurrent && !this.#rewriteRequired) {
+			const writerError = this.#writer?.getError();
+			if (writerError) throw writerError;
+			return;
+		}
 		this.#rewriteSynchronously();
 		if (this.#diskFailure) throw this.#diskFailure;
 	}
@@ -1215,6 +1241,7 @@ export class SessionManager {
 		fromExtension?: boolean,
 		preserveData?: Record<string, unknown>,
 	): string {
+		const elidedSupersededCompactions = this.#elideSupersededCompactions();
 		const entry: CompactionEntry<T> = {
 			type: "compaction",
 			...this.#freshEntryFields(),
@@ -1227,6 +1254,9 @@ export class SessionManager {
 			preserveData,
 		};
 		this.#recordEntry(entry);
+		if (elidedSupersededCompactions) {
+			void this.#rewriteAtomically().catch(err => this.#noteDiskFailure(err));
+		}
 		return entry.id;
 	}
 

--- a/packages/coding-agent/test/session-manager/large-session-memory.test.ts
+++ b/packages/coding-agent/test/session-manager/large-session-memory.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+class CountingMemorySessionStorage extends MemorySessionStorage {
+	writeTextSyncCalls = 0;
+
+	writeTextSync(filePath: string, content: string): void {
+		this.writeTextSyncCalls++;
+		super.writeTextSync(filePath, content);
+	}
+}
+
+function appendAssistant(session: SessionManager, text: string): string {
+	return session.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "test",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 2,
+	});
+}
+
+describe("large session memory guards", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })));
+		tempDirs.length = 0;
+	});
+
+	it("does not rewrite an already-current session during sync flush", () => {
+		const storage = new CountingMemorySessionStorage();
+		const session = SessionManager.create("/work", "/sessions", storage);
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		appendAssistant(session, "hi");
+
+		storage.writeTextSyncCalls = 0;
+		session.flushSync();
+
+		expect(storage.writeTextSyncCalls).toBe(0);
+	});
+
+	it("elides superseded compactions and rewrites the compacted file", async () => {
+		const storage = new CountingMemorySessionStorage();
+		const session = SessionManager.create("/work", "/sessions", storage);
+		const firstKeptEntryId = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		appendAssistant(session, "hi");
+
+		const firstSummary = `first-${"x".repeat(4096)}`;
+		const secondSummary = `second-${"y".repeat(4096)}`;
+		session.appendCompaction(firstSummary, undefined, firstKeptEntryId, 1000, undefined, undefined, {
+			openaiRemoteCompaction: { provider: "test", replacementHistory: [] },
+		});
+		session.appendCompaction(secondSummary, undefined, firstKeptEntryId, 1000);
+		await session.flush();
+
+		const compactions = session.getEntries().filter(entry => entry.type === "compaction");
+		expect(compactions).toHaveLength(2);
+		expect(compactions[0]?.summary).not.toBe(firstSummary);
+		expect(compactions[0]?.summary).toContain("Superseded compaction");
+		expect(compactions[0]?.preserveData).toBeUndefined();
+		expect(compactions[1]?.summary).toBe(secondSummary);
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+		const persisted = await storage.readText(sessionFile);
+		expect(persisted).not.toContain(firstSummary);
+		expect(persisted).toContain(secondSummary);
+	});
+
+	it("streams large session files and keeps only the latest compaction summary", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-large-session-"));
+		tempDirs.push(tempDir);
+		const sessionFile = path.join(tempDir, "large.jsonl");
+		const oldSummary = `old-${"x".repeat(5 * 1024 * 1024)}`;
+		const latestSummary = `latest-${"y".repeat(5 * 1024 * 1024)}`;
+		const lines = [
+			{ type: "session", version: 3, id: "sess", timestamp: "2026-01-01T00:00:00.000Z", cwd: tempDir },
+			{
+				type: "message",
+				id: "u1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: { role: "user", content: "hi", timestamp: 1 },
+			},
+			{
+				type: "compaction",
+				id: "c1",
+				parentId: "u1",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				summary: oldSummary,
+				firstKeptEntryId: "u1",
+				tokensBefore: 1000,
+				preserveData: { stale: true },
+			},
+			{
+				type: "message",
+				id: "a1",
+				parentId: "c1",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "hello" }],
+					api: "test",
+					provider: "test",
+					model: "test",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 2,
+				},
+			},
+			{
+				type: "compaction",
+				id: "c2",
+				parentId: "a1",
+				timestamp: "2026-01-01T00:00:04.000Z",
+				summary: latestSummary,
+				firstKeptEntryId: "a1",
+				tokensBefore: 1000,
+			},
+		].map(entry => `${JSON.stringify(entry)}\n`);
+		await fsp.writeFile(sessionFile, lines.join(""));
+
+		const entries = await loadEntriesFromFile(sessionFile);
+		const compactions = entries.filter(entry => entry.type === "compaction");
+
+		expect(compactions).toHaveLength(2);
+		expect(compactions[0]?.summary).not.toBe(oldSummary);
+		expect(compactions[0]?.summary).toContain("Superseded compaction");
+		expect(compactions[0]?.preserveData).toBeUndefined();
+		expect(compactions[1]?.summary).toBe(latestSummary);
+	});
+});


### PR DESCRIPTION
## Summary
- Stream-load multi-MiB session JSONL files instead of reading them into one giant string.
- Elide superseded compaction summaries during load and after newer compactions so resumed sessions keep only the latest full compaction payload.
- Make sync Ctrl+C flush skip whole-file rewrites when the append-only file is already current.
- Let session list previews fall back to developer/assistant text instead of showing `(no messages)` for forked plan sessions.

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/session-manager/large-session-memory.test.ts` currently cannot run in this checkout because the native addon is missing and `bun --cwd=packages/natives run build` cannot build it without `cargo` installed.
