### PR TITLE
[codex] Prune oversized edit snapshots from tool details

### DIFF
--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -27,6 +27,7 @@ import { ToolError } from "../../tools/tool-errors";
 import { generateDiffString } from "../diff";
 import { getFileSnapshotStore } from "../file-snapshot-store";
 import type { EditToolDetails, EditToolPerFileResult, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditDetails, pruneOversizedEditPerFileResult } from "../snapshot-details";
 import { nativeBlockResolver } from "./block-resolver";
 import { HashlineFilesystem } from "./filesystem";
 import { hashPatchInput, NOOP_HARD_LIMIT, recordNoopEdit, resetNoopEdit } from "./noop-loop-guard";
@@ -114,17 +115,22 @@ function renderSection(
 	if (result.op === "delete") {
 		const toolResult: AgentToolResult<EditToolDetails, typeof hashlineEditParamsSchema> = {
 			content: [{ type: "text", text: `Deleted ${result.path}` }],
-			details: {
+			details: pruneOversizedEditDetails({
 				diff: "",
 				op: "delete",
 				path: result.path,
 				oldText: result.before,
 				meta: outputMeta().get(),
-			},
+			}),
 		};
 		return {
 			toolResult,
-			perFileResult: { path: result.path, diff: "", op: "delete", oldText: result.before },
+			perFileResult: pruneOversizedEditPerFileResult({
+				path: result.path,
+				diff: "",
+				op: "delete",
+				oldText: result.before,
+			}),
 		};
 	}
 
@@ -161,7 +167,7 @@ function renderSection(
 					text: `${result.header}${blockBlock}${moveBlock}${previewBlock}${warningsBlock}`,
 				},
 			],
-			details: {
+			details: pruneOversizedEditDetails({
 				diff: diff.diff,
 				firstChangedLine,
 				diagnostics,
@@ -172,9 +178,9 @@ function renderSection(
 				oldText: result.before,
 				newText: result.after,
 				meta,
-			},
+			}),
 		},
-		perFileResult: {
+		perFileResult: pruneOversizedEditPerFileResult({
 			path: result.moveDest ?? result.path,
 			diff: diff.diff,
 			firstChangedLine,
@@ -184,7 +190,7 @@ function renderSection(
 			sourcePath: result.moveDest ? sourcePath : undefined,
 			oldText: result.before,
 			newText: result.after,
-		},
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -25,6 +25,7 @@ import applyPatchGrammar from "./modes/apply-patch.lark" with { type: "text" };
 import { executePatchSingle, type PatchEditEntry, type PatchParams, patchEditSchema } from "./modes/patch";
 import { executeReplaceSingle, type ReplaceEditEntry, type ReplaceParams, replaceEditSchema } from "./modes/replace";
 import { type EditToolDetails, type EditToolPerFileResult, getLspBatchRequest, type LspBatchRequest } from "./renderer";
+import { pruneOversizedEditDetails, pruneOversizedEditPerFileResult } from "./snapshot-details";
 import { EDIT_MODE_STRATEGIES } from "./streaming";
 
 export * from "@oh-my-pi/hashline";
@@ -147,18 +148,20 @@ async function executeApplyPatchPerFile(
 		try {
 			const result = await run(batchRequest);
 			const details = result.details;
-			perFileResults.push({
-				path: details?.path ?? path,
-				diff: details?.diff ?? "",
-				firstChangedLine: details?.firstChangedLine,
-				diagnostics: details?.diagnostics,
-				op: details?.op,
-				move: details?.move,
-				sourcePath: details?.sourcePath,
-				meta: details?.meta,
-				oldText: details?.oldText,
-				newText: details?.newText,
-			});
+			perFileResults.push(
+				pruneOversizedEditPerFileResult({
+					path: details?.path ?? path,
+					diff: details?.diff ?? "",
+					firstChangedLine: details?.firstChangedLine,
+					diagnostics: details?.diagnostics,
+					op: details?.op,
+					move: details?.move,
+					sourcePath: details?.sourcePath,
+					meta: details?.meta,
+					oldText: details?.oldText,
+					newText: details?.newText,
+				}),
+			);
 			const text = result.content?.find(c => c.type === "text")?.text ?? "";
 			if (text) contentTexts.push(text);
 		} catch (err) {
@@ -186,14 +189,14 @@ async function executeApplyPatchPerFile(
 
 	return {
 		content: [{ type: "text", text: contentTexts.join("\n") }],
-		details: {
+		details: pruneOversizedEditDetails({
 			diff: perFileResults
 				.map(r => r.diff)
 				.filter(Boolean)
 				.join("\n"),
 			firstChangedLine: perFileResults.find(r => r.firstChangedLine)?.firstChangedLine,
 			perFileResults,
-		},
+		}),
 	};
 }
 
@@ -276,13 +279,13 @@ async function executeSinglePathEntries(
 
 	return {
 		content: [{ type: "text", text: contentTexts.join("\n") }],
-		details: {
+		details: pruneOversizedEditDetails({
 			diff: diffTexts.join("\n"),
 			firstChangedLine,
 			path: metadataPath ?? path,
 			...(hasFirstOldText ? { oldText: firstOldText } : {}),
 			...(hasLastNewText ? { newText: lastNewText } : {}),
-		},
+		}),
 		// Any per-entry failure marks the aggregate result as an error so the
 		// renderer takes the error branch instead of falling through to the
 		// streaming-edit preview (which displays the *proposed* diff and looks

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -48,6 +48,7 @@ import {
 } from "../normalize";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditDetails } from "../snapshot-details";
 import {
 	type ContextLineResult,
 	DEFAULT_FUZZY_THRESHOLD,
@@ -1894,7 +1895,7 @@ export async function executePatchSingle(
 
 	return {
 		content: [{ type: "text", text: resultText }],
-		details: {
+		details: pruneOversizedEditDetails({
 			diff: diffResult.diff,
 			// When the patch moves the file, anchor the diff to the destination
 			// path. ACP `ToolCallContent.diff.path` comes from this field, and
@@ -1909,6 +1910,6 @@ export async function executePatchSingle(
 			meta,
 			oldText,
 			newText,
-		},
+		}),
 	};
 }

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -24,6 +24,7 @@ import {
 } from "../normalize";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditDetails } from "../snapshot-details";
 
 export interface FuzzyMatch {
 	actualText: string;
@@ -1123,7 +1124,7 @@ export async function executeReplaceSingle(
 
 	return {
 		content: [{ type: "text", text: resultText }],
-		details: {
+		details: pruneOversizedEditDetails({
 			diff: diffResult.diff,
 			path: absolutePath,
 			firstChangedLine: diffResult.firstChangedLine,
@@ -1131,6 +1132,6 @@ export async function executeReplaceSingle(
 			meta,
 			oldText: rawContent,
 			newText: finalContent,
-		},
+		}),
 	};
 }

--- a/packages/coding-agent/src/edit/snapshot-details.ts
+++ b/packages/coding-agent/src/edit/snapshot-details.ts
@@ -1,0 +1,43 @@
+import type { EditToolDetails, EditToolPerFileResult } from "./renderer";
+
+export const MAX_EDIT_SNAPSHOT_TEXT_CHARS = 32_768;
+
+type EditSnapshotDetails = {
+	oldText?: string;
+	newText?: string;
+};
+
+function hasSnapshotText(details: EditSnapshotDetails): boolean {
+	return Object.hasOwn(details, "oldText") || Object.hasOwn(details, "newText");
+}
+
+function snapshotTextChars(details: EditSnapshotDetails): number {
+	return (details.oldText?.length ?? 0) + (details.newText?.length ?? 0);
+}
+
+export function pruneOversizedEditSnapshots<T extends EditSnapshotDetails>(details: T): T {
+	if (!hasSnapshotText(details) || snapshotTextChars(details) <= MAX_EDIT_SNAPSHOT_TEXT_CHARS) {
+		return details;
+	}
+
+	const pruned: T = { ...details };
+	delete pruned.oldText;
+	delete pruned.newText;
+	return pruned;
+}
+
+export function pruneOversizedEditPerFileResult(details: EditToolPerFileResult): EditToolPerFileResult {
+	return pruneOversizedEditSnapshots(details);
+}
+
+export function pruneOversizedEditDetails(details: EditToolDetails): EditToolDetails {
+	const pruned = pruneOversizedEditSnapshots(details);
+	if (!pruned.perFileResults) {
+		return pruned;
+	}
+
+	return {
+		...pruned,
+		perFileResults: pruned.perFileResults.map(pruneOversizedEditPerFileResult),
+	};
+}

--- a/packages/coding-agent/test/edit-per-file-diff-content.test.ts
+++ b/packages/coding-agent/test/edit-per-file-diff-content.test.ts
@@ -72,6 +72,27 @@ describe("executePatchSingle — oldText/newText propagation", () => {
 		expect(result.details?.newText).toBe("b\n");
 	});
 
+	test("update: oversized oldText and newText are omitted from persisted details", async () => {
+		const largePrefix = "x".repeat(80_000);
+		await Bun.write(path.join(tempDir, "large.txt"), `${largePrefix}\na\n`);
+
+		const result = await executePatchSingle({
+			session: makeSession(tempDir),
+			path: "large.txt",
+			params: { op: "update", diff: "@@\n-a\n+b" },
+			allowFuzzy: true,
+			fuzzyThreshold: DEFAULT_FUZZY_THRESHOLD,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: noopBeginDeferred,
+		});
+
+		expect(result.details?.path).toBe(path.join(tempDir, "large.txt"));
+		expect(result.details?.diff).toContain("-a");
+		expect(result.details?.diff).toContain("+b");
+		expect("oldText" in (result.details ?? {})).toBe(false);
+		expect("newText" in (result.details ?? {})).toBe(false);
+	});
+
 	test("create: oldText is undefined, newText is the created content", async () => {
 		const result = await executePatchSingle({
 			session: makeSession(tempDir),

--- a/packages/coding-agent/test/edit-snapshot-details.test.ts
+++ b/packages/coding-agent/test/edit-snapshot-details.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+	MAX_EDIT_SNAPSHOT_TEXT_CHARS,
+	pruneOversizedEditDetails,
+} from "@oh-my-pi/pi-coding-agent/edit/snapshot-details";
+
+describe("edit snapshot details", () => {
+	test("preserves small oldText and newText snapshots", () => {
+		const details = pruneOversizedEditDetails({
+			diff: "@@\n-before\n+after",
+			path: "small.ts",
+			oldText: "before\n",
+			newText: "after\n",
+		});
+
+		expect(details.oldText).toBe("before\n");
+		expect(details.newText).toBe("after\n");
+	});
+
+	test("omits oversized oldText and newText snapshots without dropping diff metadata", () => {
+		const oversizedText = "x".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS + 1);
+		const details = pruneOversizedEditDetails({
+			diff: "@@\n-before\n+after",
+			path: "large.ts",
+			firstChangedLine: 12,
+			oldText: oversizedText,
+			newText: "after\n",
+		});
+
+		expect(details.diff).toBe("@@\n-before\n+after");
+		expect(details.path).toBe("large.ts");
+		expect(details.firstChangedLine).toBe(12);
+		expect("oldText" in details).toBe(false);
+		expect("newText" in details).toBe(false);
+	});
+
+	test("omits oversized snapshots from per-file edit results", () => {
+		const oversizedText = "x".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS + 1);
+		const details = pruneOversizedEditDetails({
+			diff: "@@\n-a\n+b",
+			perFileResults: [
+				{
+					path: "large.ts",
+					diff: "@@\n-a\n+b",
+					oldText: oversizedText,
+					newText: "b\n",
+				},
+				{
+					path: "small.ts",
+					diff: "@@\n-before\n+after",
+					oldText: "before\n",
+					newText: "after\n",
+				},
+			],
+		});
+
+		expect(details.perFileResults?.[0]?.diff).toBe("@@\n-a\n+b");
+		expect("oldText" in (details.perFileResults?.[0] ?? {})).toBe(false);
+		expect("newText" in (details.perFileResults?.[0] ?? {})).toBe(false);
+		expect(details.perFileResults?.[1]?.oldText).toBe("before\n");
+		expect(details.perFileResults?.[1]?.newText).toBe("after\n");
+	});
+});


### PR DESCRIPTION
## Summary
- prune oversized edit `oldText` / `newText` snapshots from edit tool result details
- keep diff/path/line/diagnostic metadata intact so edit rendering still works
- cover the sanitizer directly and add an integration regression for large patch edits

## Root cause
The edit tool stored full before/after file contents in `details.oldText` and `details.newText`. Large-file edits could add hundreds of KB to a single tool result, which then made the newest turn too large for compaction to cut at a turn boundary.

## Validation
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/edit-snapshot-details.test.ts`

## Local limitation
- `bun test packages/coding-agent/test/edit-per-file-diff-content.test.ts` and `bun test packages/coding-agent/test/acp-event-mapper.test.ts` were attempted but this fresh macOS clone lacks the local `pi_natives.darwin-arm64.node` addon. Building it locally also could not proceed because `cargo` / `rustc` are not installed on this machine. CI should run these with the native build available.