### PR TITLE
fix(coding-agent): bound edit-tool oldText/newText snapshots in tool-result details

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
+- Fixed the `edit` tool persisting unbounded full-file `oldText` / `newText` snapshots in tool-result `details`, inflating per-turn session JSONL lines (hundreds of KB per edit on large files). `details.oldText`/`details.newText` are now pruned when their combined length exceeds 32 KB; the visible diff, path, line, and diagnostic metadata are preserved, and ACP `diff` content still flows for smaller edits. ([#3786](https://github.com/can1357/oh-my-pi/issues/3786))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -269,10 +269,10 @@ export async function executeHashlineSingle(
 					.join("\n\n"),
 			},
 		],
-		details: {
+		details: pruneOversizedEditSnapshots({
 			diff: rendered.map(r => r.toolResult.details?.diff ?? "").join("\n"),
 			perFileResults: rendered.map(r => r.perFileResult),
-		},
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -27,6 +27,7 @@ import { ToolError } from "../../tools/tool-errors";
 import { generateDiffString } from "../diff";
 import { getFileSnapshotStore } from "../file-snapshot-store";
 import type { EditToolDetails, EditToolPerFileResult, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditSnapshots } from "../snapshot-details";
 import { nativeBlockResolver } from "./block-resolver";
 import { HashlineFilesystem } from "./filesystem";
 import { hashPatchInput, NOOP_HARD_LIMIT, recordNoopEdit, resetNoopEdit } from "./noop-loop-guard";
@@ -114,17 +115,22 @@ function renderSection(
 	if (result.op === "delete") {
 		const toolResult: AgentToolResult<EditToolDetails, typeof hashlineEditParamsSchema> = {
 			content: [{ type: "text", text: `Deleted ${result.path}` }],
-			details: {
+			details: pruneOversizedEditSnapshots({
 				diff: "",
 				op: "delete",
 				path: result.path,
 				oldText: result.before,
 				meta: outputMeta().get(),
-			},
+			}),
 		};
 		return {
 			toolResult,
-			perFileResult: { path: result.path, diff: "", op: "delete", oldText: result.before },
+			perFileResult: pruneOversizedEditSnapshots({
+				path: result.path,
+				diff: "",
+				op: "delete",
+				oldText: result.before,
+			}),
 		};
 	}
 
@@ -161,7 +167,7 @@ function renderSection(
 					text: `${result.header}${blockBlock}${moveBlock}${previewBlock}${warningsBlock}`,
 				},
 			],
-			details: {
+			details: pruneOversizedEditSnapshots({
 				diff: diff.diff,
 				firstChangedLine,
 				diagnostics,
@@ -172,9 +178,9 @@ function renderSection(
 				oldText: result.before,
 				newText: result.after,
 				meta,
-			},
+			}),
 		},
-		perFileResult: {
+		perFileResult: pruneOversizedEditSnapshots({
 			path: result.moveDest ?? result.path,
 			diff: diff.diff,
 			firstChangedLine,
@@ -184,7 +190,7 @@ function renderSection(
 			sourcePath: result.moveDest ? sourcePath : undefined,
 			oldText: result.before,
 			newText: result.after,
-		},
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -160,6 +160,7 @@ async function executeApplyPatchPerFile(
 				meta: details?.meta,
 				oldText: details?.oldText,
 				newText: details?.newText,
+				snapshotsPruned: details?.snapshotsPruned,
 			});
 			const text = result.content?.find(c => c.type === "text")?.text ?? "";
 			if (text) contentTexts.push(text);
@@ -218,6 +219,11 @@ async function executeSinglePathEntries(
 	let firstOldText: string | undefined;
 	let hasLastNewText = false;
 	let lastNewText: string | undefined;
+	// Any pruned child invalidates the aggregate snapshot: combining a kept
+	// first-entry oldText with a pruned next entry's newText (or vice-versa)
+	// would describe a transition the file never made. Suppress aggregate
+	// snapshots and stamp the marker so ACP/downstream can degrade cleanly.
+	let snapshotsPruned = false;
 
 	for (let i = 0; i < runs.length; i++) {
 		const isLast = i === runs.length - 1;
@@ -241,6 +247,7 @@ async function executeSinglePathEntries(
 				lastNewText = details.newText;
 				hasLastNewText = true;
 			}
+			if (details?.snapshotsPruned) snapshotsPruned = true;
 			const text = result.content?.find(c => c.type === "text")?.text ?? "";
 			if (text) contentTexts.push(text);
 		} catch (err) {
@@ -282,8 +289,12 @@ async function executeSinglePathEntries(
 			diff: diffTexts.join("\n"),
 			firstChangedLine,
 			path: metadataPath ?? path,
-			...(hasFirstOldText ? { oldText: firstOldText } : {}),
-			...(hasLastNewText ? { newText: lastNewText } : {}),
+			...(snapshotsPruned
+				? { snapshotsPruned: true as const }
+				: {
+						...(hasFirstOldText ? { oldText: firstOldText } : {}),
+						...(hasLastNewText ? { newText: lastNewText } : {}),
+					}),
 		}),
 		// Any per-entry failure marks the aggregate result as an error so the
 		// renderer takes the error branch instead of falling through to the

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -25,6 +25,7 @@ import applyPatchGrammar from "./modes/apply-patch.lark" with { type: "text" };
 import { executePatchSingle, type PatchEditEntry, type PatchParams, patchEditSchema } from "./modes/patch";
 import { executeReplaceSingle, type ReplaceEditEntry, type ReplaceParams, replaceEditSchema } from "./modes/replace";
 import { type EditToolDetails, type EditToolPerFileResult, getLspBatchRequest, type LspBatchRequest } from "./renderer";
+import { pruneOversizedEditSnapshots } from "./snapshot-details";
 import { EDIT_MODE_STRATEGIES } from "./streaming";
 
 export * from "@oh-my-pi/hashline";
@@ -38,6 +39,7 @@ export * from "./modes/patch";
 export * from "./modes/replace";
 export * from "./normalize";
 export * from "./renderer";
+export * from "./snapshot-details";
 export * from "./streaming";
 
 type TInput =
@@ -186,14 +188,14 @@ async function executeApplyPatchPerFile(
 
 	return {
 		content: [{ type: "text", text: contentTexts.join("\n") }],
-		details: {
+		details: pruneOversizedEditSnapshots({
 			diff: perFileResults
 				.map(r => r.diff)
 				.filter(Boolean)
 				.join("\n"),
 			firstChangedLine: perFileResults.find(r => r.firstChangedLine)?.firstChangedLine,
 			perFileResults,
-		},
+		}),
 	};
 }
 
@@ -276,13 +278,13 @@ async function executeSinglePathEntries(
 
 	return {
 		content: [{ type: "text", text: contentTexts.join("\n") }],
-		details: {
+		details: pruneOversizedEditSnapshots({
 			diff: diffTexts.join("\n"),
 			firstChangedLine,
 			path: metadataPath ?? path,
 			...(hasFirstOldText ? { oldText: firstOldText } : {}),
 			...(hasLastNewText ? { newText: lastNewText } : {}),
-		},
+		}),
 		// Any per-entry failure marks the aggregate result as an error so the
 		// renderer takes the error branch instead of falling through to the
 		// streaming-edit preview (which displays the *proposed* diff and looks

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -48,6 +48,7 @@ import {
 } from "../normalize";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditSnapshots } from "../snapshot-details";
 import {
 	type ContextLineResult,
 	DEFAULT_FUZZY_THRESHOLD,
@@ -1894,7 +1895,7 @@ export async function executePatchSingle(
 
 	return {
 		content: [{ type: "text", text: resultText }],
-		details: {
+		details: pruneOversizedEditSnapshots({
 			diff: diffResult.diff,
 			// When the patch moves the file, anchor the diff to the destination
 			// path. ACP `ToolCallContent.diff.path` comes from this field, and
@@ -1909,6 +1910,6 @@ export async function executePatchSingle(
 			meta,
 			oldText,
 			newText,
-		},
+		}),
 	};
 }

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -24,6 +24,7 @@ import {
 } from "../normalize";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
+import { pruneOversizedEditSnapshots } from "../snapshot-details";
 
 export interface FuzzyMatch {
 	actualText: string;
@@ -1123,7 +1124,7 @@ export async function executeReplaceSingle(
 
 	return {
 		content: [{ type: "text", text: resultText }],
-		details: {
+		details: pruneOversizedEditSnapshots({
 			diff: diffResult.diff,
 			path: absolutePath,
 			firstChangedLine: diffResult.firstChangedLine,
@@ -1131,6 +1132,6 @@ export async function executeReplaceSingle(
 			meta,
 			oldText: rawContent,
 			newText: finalContent,
-		},
+		}),
 	};
 }

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -70,6 +70,8 @@ export interface EditToolPerFileResult {
 	oldText?: string;
 	/** Source-of-truth content after the edit; `undefined` for delete operations. */
 	newText?: string;
+	/** True when {@link pruneOversizedEditSnapshots} dropped `oldText`/`newText` from this entry. Aggregators check this to suppress misleading combined snapshots when at least one entry of a multi-entry single-path edit was pruned. */
+	snapshotsPruned?: boolean;
 	/** Pre-move source path; set only when the edit moved/renamed the file. The header renders `sourcePath → path`. */
 	sourcePath?: string;
 }
@@ -95,6 +97,8 @@ export interface EditToolDetails {
 	oldText?: string;
 	/** Source-of-truth content after the edit; `undefined` for delete operations. */
 	newText?: string;
+	/** True when {@link pruneOversizedEditSnapshots} dropped `oldText`/`newText` from this entry. Aggregators check this to suppress misleading combined snapshots when at least one entry of a multi-entry single-path edit was pruned. */
+	snapshotsPruned?: boolean;
 	/** Pre-move source path; set only when the edit moved/renamed the file. The header renders `sourcePath → path`. */
 	sourcePath?: string;
 }

--- a/packages/coding-agent/src/edit/snapshot-details.ts
+++ b/packages/coding-agent/src/edit/snapshot-details.ts
@@ -14,11 +14,15 @@
 import type { EditToolDetails, EditToolPerFileResult } from "./renderer";
 
 /**
- * Combined `oldText` + `newText` character budget per edit-tool result.
+ * Combined `oldText` + `newText` character budget for a single edit-tool
+ * result. Applies both per-entry (one file at a time) and as an aggregate
+ * across `perFileResults` (so a many-small-files batch can't accumulate
+ * unbounded snapshot bytes — see #3787 review).
  *
  * Picked so typical code-file edits keep ACP diff visualization while
- * pathological cases (large generated files, full-file rewrites) drop the raw
- * snapshots before they hit the session JSONL.
+ * pathological cases (large generated files, full-file rewrites, or
+ * many-file batches) drop the raw snapshots before they hit the
+ * session JSONL.
  */
 export const MAX_EDIT_SNAPSHOT_TEXT_CHARS = 32_768;
 
@@ -30,6 +34,28 @@ function pruneSnapshot<T extends WithSnapshot>(details: T): T {
 	}
 	const { oldText: _old, newText: _new, ...rest } = details;
 	return { ...rest, snapshotsPruned: true } as T;
+}
+
+/**
+ * Walk `perFileResults` in order with a shared budget. Each per-entry payload
+ * is first capped individually by {@link pruneSnapshot}; if its kept bytes
+ * would push the running aggregate past the cap, strip and mark this entry
+ * too. Early entries get to keep their diff visualization; later entries in
+ * a large batch degrade to text-only.
+ */
+function capPerFileSnapshots<T extends WithSnapshot>(entries: T[]): T[] {
+	let remaining = MAX_EDIT_SNAPSHOT_TEXT_CHARS;
+	return entries.map(entry => {
+		const perEntry = pruneSnapshot(entry);
+		const kept = (perEntry.oldText?.length ?? 0) + (perEntry.newText?.length ?? 0);
+		if (kept === 0) return perEntry;
+		if (kept <= remaining) {
+			remaining -= kept;
+			return perEntry;
+		}
+		const { oldText: _old, newText: _new, ...rest } = perEntry;
+		return { ...rest, snapshotsPruned: true } as T;
+	});
 }
 
 /**
@@ -45,7 +71,7 @@ export function pruneOversizedEditSnapshots(
 ): EditToolDetails | EditToolPerFileResult {
 	const pruned = pruneSnapshot(details);
 	if ("perFileResults" in pruned && pruned.perFileResults) {
-		return { ...pruned, perFileResults: pruned.perFileResults.map(pruneSnapshot) };
+		return { ...pruned, perFileResults: capPerFileSnapshots(pruned.perFileResults) };
 	}
 	return pruned;
 }

--- a/packages/coding-agent/src/edit/snapshot-details.ts
+++ b/packages/coding-agent/src/edit/snapshot-details.ts
@@ -22,14 +22,14 @@ import type { EditToolDetails, EditToolPerFileResult } from "./renderer";
  */
 export const MAX_EDIT_SNAPSHOT_TEXT_CHARS = 32_768;
 
-type WithSnapshot = { oldText?: string; newText?: string };
+type WithSnapshot = { oldText?: string; newText?: string; snapshotsPruned?: boolean };
 
 function pruneSnapshot<T extends WithSnapshot>(details: T): T {
 	if ((details.oldText?.length ?? 0) + (details.newText?.length ?? 0) <= MAX_EDIT_SNAPSHOT_TEXT_CHARS) {
 		return details;
 	}
 	const { oldText: _old, newText: _new, ...rest } = details;
-	return rest as T;
+	return { ...rest, snapshotsPruned: true } as T;
 }
 
 /**

--- a/packages/coding-agent/src/edit/snapshot-details.ts
+++ b/packages/coding-agent/src/edit/snapshot-details.ts
@@ -1,0 +1,51 @@
+/**
+ * Bound the size of the `oldText` / `newText` snapshots that edit-tool results
+ * carry in `details`. These fields hold the full pre/post file content; for
+ * large files they balloon the per-turn JSONL line and the session file
+ * (300 KB+ each on the cases reported in #3786) without paying for any LLM
+ * context (provider serializers send only `content`, never `details`).
+ *
+ * Only consumer of the raw snapshots is the ACP event mapper, which builds a
+ * `diff` ToolCallContent for ACP clients (Zed). When the snapshots are pruned
+ * the mapper returns `undefined` for that file and the text content still
+ * flows — diff visualization degrades gracefully for over-threshold edits.
+ */
+
+import type { EditToolDetails, EditToolPerFileResult } from "./renderer";
+
+/**
+ * Combined `oldText` + `newText` character budget per edit-tool result.
+ *
+ * Picked so typical code-file edits keep ACP diff visualization while
+ * pathological cases (large generated files, full-file rewrites) drop the raw
+ * snapshots before they hit the session JSONL.
+ */
+export const MAX_EDIT_SNAPSHOT_TEXT_CHARS = 32_768;
+
+type WithSnapshot = { oldText?: string; newText?: string };
+
+function pruneSnapshot<T extends WithSnapshot>(details: T): T {
+	if ((details.oldText?.length ?? 0) + (details.newText?.length ?? 0) <= MAX_EDIT_SNAPSHOT_TEXT_CHARS) {
+		return details;
+	}
+	const { oldText: _old, newText: _new, ...rest } = details;
+	return rest as T;
+}
+
+/**
+ * Prune oversized `oldText` / `newText` from an edit-tool details payload,
+ * recursing into `perFileResults` when present. Per-file overload comes first
+ * so the more specific shape (required `path`) wins overload resolution at
+ * the per-file call sites.
+ */
+export function pruneOversizedEditSnapshots(details: EditToolPerFileResult): EditToolPerFileResult;
+export function pruneOversizedEditSnapshots(details: EditToolDetails): EditToolDetails;
+export function pruneOversizedEditSnapshots(
+	details: EditToolDetails | EditToolPerFileResult,
+): EditToolDetails | EditToolPerFileResult {
+	const pruned = pruneSnapshot(details);
+	if ("perFileResults" in pruned && pruned.perFileResults) {
+		return { ...pruned, perFileResults: pruned.perFileResults.map(pruneSnapshot) };
+	}
+	return pruned;
+}

--- a/packages/coding-agent/test/edit-snapshot-details.test.ts
+++ b/packages/coding-agent/test/edit-snapshot-details.test.ts
@@ -94,6 +94,35 @@ describe("pruneOversizedEditSnapshots", () => {
 			newText: small,
 		});
 	});
+
+	test("caps cumulative perFileResults snapshots at the shared aggregate budget", () => {
+		// Each entry is individually under the per-entry budget but their sum
+		// busts it: walking left-to-right, the first two fit, the rest must be
+		// stripped so a many-small-files batch can't accumulate unbounded bytes.
+		const entrySize = Math.floor(MAX_EDIT_SNAPSHOT_TEXT_CHARS / 4);
+		const chunk = "y".repeat(entrySize);
+		const entries = Array.from({ length: 5 }, (_, i) => ({
+			path: `/f${i}`,
+			diff: `d${i}`,
+			oldText: chunk,
+			newText: chunk,
+		}));
+		const result = pruneOversizedEditSnapshots({ diff: "agg", perFileResults: entries });
+
+		const kept = result.perFileResults!.filter(e => e.oldText !== undefined);
+		const pruned = result.perFileResults!.filter(e => e.snapshotsPruned === true);
+		expect(kept.length).toBe(2);
+		expect(pruned.length).toBe(3);
+
+		// Total kept snapshot bytes never exceed the shared cap.
+		const totalKept = result.perFileResults!.reduce(
+			(acc, e) => acc + (e.oldText?.length ?? 0) + (e.newText?.length ?? 0),
+			0,
+		);
+		expect(totalKept).toBeLessThanOrEqual(MAX_EDIT_SNAPSHOT_TEXT_CHARS);
+		// Pruned entries keep their diff/path so the renderer still works.
+		expect(pruned[0]).toMatchObject({ path: "/f2", diff: "d2", snapshotsPruned: true });
+	});
 });
 
 describe("executePatchSingle on oversized files", () => {

--- a/packages/coding-agent/test/edit-snapshot-details.test.ts
+++ b/packages/coding-agent/test/edit-snapshot-details.test.ts
@@ -2,13 +2,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { formatHashlineHeader } from "@oh-my-pi/hashline";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
+	canonicalSnapshotKey,
 	DEFAULT_FUZZY_THRESHOLD,
 	EditTool,
 	type EditToolDetails,
+	executeHashlineSingle,
 	executePatchSingle,
 	executeReplaceSingle,
+	getFileSnapshotStore,
 	MAX_EDIT_SNAPSHOT_TEXT_CHARS,
 	pruneOversizedEditSnapshots,
 } from "@oh-my-pi/pi-coding-agent/edit";
@@ -215,5 +219,61 @@ describe("EditTool single-path aggregation across mixed-size entries", () => {
 		expect(details.newText).toBeUndefined();
 		// Aggregate diff still reflects both transitions.
 		expect(details.diff.length).toBeGreaterThan(0);
+	});
+});
+
+describe("executeHashlineSingle multi-section aggregate cap", () => {
+	test("strips per-file snapshots once the shared budget is spent", async () => {
+		// Five files, each ~10 KB combined oldText+newText after a one-line
+		// swap. Each entry fits the per-entry 32 KB budget individually but the
+		// 50 KB cumulative bytes bust the shared aggregate budget — without
+		// the wrapping fix from #3787 review every per-file snapshot would
+		// survive to the session JSONL.
+		const fileCount = 5;
+		const session = {
+			cwd: tempDir,
+			settings: Settings.isolated(),
+		} as unknown as ToolSession;
+
+		const tags: string[] = [];
+		const filler = "filler line of content xxxx yyyy zzzz\n".repeat(120); // ~5 KB
+		for (let i = 0; i < fileCount; i++) {
+			const filePath = path.join(tempDir, `f${i}.ts`);
+			const source = `header${i}\n${filler}`;
+			await Bun.write(filePath, source);
+			const tag = getFileSnapshotStore(session).record(canonicalSnapshotKey(filePath), source);
+			tags.push(tag);
+		}
+
+		const sections = tags.map((tag, i) =>
+			[formatHashlineHeader(`f${i}.ts`, tag), "SWAP 1.=1:", `+HEADER${i}`].join("\n"),
+		);
+		const input = sections.join("\n");
+
+		const result = await executeHashlineSingle({
+			session,
+			input,
+			writethrough: async (targetPath, content) => {
+				await Bun.write(targetPath, content);
+				return undefined;
+			},
+			beginDeferredDiagnosticsForPath: noopBeginDeferred,
+		});
+
+		const details = result.details as EditToolDetails;
+		expect(details.perFileResults).toBeDefined();
+		expect(details.perFileResults!.length).toBe(fileCount);
+
+		const kept = details.perFileResults!.filter(e => e.oldText !== undefined);
+		const pruned = details.perFileResults!.filter(e => e.snapshotsPruned === true);
+		expect(kept.length).toBeGreaterThan(0);
+		expect(pruned.length).toBeGreaterThan(0);
+		expect(kept.length + pruned.length).toBe(fileCount);
+
+		const totalKept = details.perFileResults!.reduce(
+			(acc, e) => acc + (e.oldText?.length ?? 0) + (e.newText?.length ?? 0),
+			0,
+		);
+		expect(totalKept).toBeLessThanOrEqual(MAX_EDIT_SNAPSHOT_TEXT_CHARS);
 	});
 });

--- a/packages/coding-agent/test/edit-snapshot-details.test.ts
+++ b/packages/coding-agent/test/edit-snapshot-details.test.ts
@@ -5,6 +5,8 @@ import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	DEFAULT_FUZZY_THRESHOLD,
+	EditTool,
+	type EditToolDetails,
 	executePatchSingle,
 	executeReplaceSingle,
 	MAX_EDIT_SNAPSHOT_TEXT_CHARS,
@@ -69,7 +71,7 @@ describe("pruneOversizedEditSnapshots", () => {
 			oldText: oversized,
 			newText: oversized,
 		});
-		expect(result).toEqual({ diff: "@@", path: "/p", firstChangedLine: 5 });
+		expect(result).toEqual({ diff: "@@", path: "/p", firstChangedLine: 5, snapshotsPruned: true });
 		expect("oldText" in result).toBe(false);
 		expect("newText" in result).toBe(false);
 	});
@@ -84,7 +86,7 @@ describe("pruneOversizedEditSnapshots", () => {
 				{ path: "/small", diff: "d2", oldText: small, newText: small },
 			],
 		});
-		expect(result.perFileResults?.[0]).toEqual({ path: "/big", diff: "d1" });
+		expect(result.perFileResults?.[0]).toEqual({ path: "/big", diff: "d1", snapshotsPruned: true });
 		expect(result.perFileResults?.[1]).toEqual({
 			path: "/small",
 			diff: "d2",
@@ -139,5 +141,50 @@ describe("executeReplaceSingle on oversized files", () => {
 		expect(details.path).toBe(path.join(tempDir, "big.txt"));
 		expect(details.oldText).toBeUndefined();
 		expect(details.newText).toBeUndefined();
+	});
+});
+
+describe("EditTool single-path aggregation across mixed-size entries", () => {
+	test("pruned first-entry snapshots suppress aggregate snapshots from a later kept entry", async () => {
+		// Reviewer scenario from #3787: a multi-entry single-path edit where the
+		// first entry shrinks a large file (oldText pruned, file becomes tiny)
+		// and a later entry trivially edits the now-tiny file (snapshots kept).
+		// Without the marker, the aggregator would record the second entry's
+		// small oldText as the whole-file pre-image and ACP clients would
+		// render a misleading partial diff.
+		await Bun.write(path.join(tempDir, "shrink.txt"), `${FILLER}TAIL\n`);
+
+		// Replace mode lets us shrink the file in one edit, then tweak the result.
+		const replaceSession = {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			enableLsp: false,
+			settings: Settings.isolated({ "edit.mode": "replace" }),
+			getArtifactsDir: () => null,
+			getSessionId: () => null,
+			getPlanModeState: () => undefined,
+		} as unknown as ToolSession;
+		const tool = new EditTool(replaceSession);
+
+		const result = await tool.execute("call-shrink", {
+			path: "shrink.txt",
+			edits: [
+				// Entry 1: collapse the entire large prefix into one tiny token —
+				// oldText is ~1.28 MB, newText is tiny → combined > 32 KB → pruned.
+				{ old_text: FILLER, new_text: "tiny\n" },
+				// Entry 2: trivial rename on the now-tiny file —
+				// oldText/newText combined well under 32 KB → kept by the inner.
+				{ old_text: "TAIL", new_text: "DONE" },
+			],
+		});
+
+		const details = result.details as EditToolDetails;
+		expect(details.snapshotsPruned).toBe(true);
+		expect(details.oldText).toBeUndefined();
+		expect(details.newText).toBeUndefined();
+		// Aggregate diff still reflects both transitions.
+		expect(details.diff.length).toBeGreaterThan(0);
 	});
 });

--- a/packages/coding-agent/test/edit-snapshot-details.test.ts
+++ b/packages/coding-agent/test/edit-snapshot-details.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	DEFAULT_FUZZY_THRESHOLD,
+	executePatchSingle,
+	executeReplaceSingle,
+	MAX_EDIT_SNAPSHOT_TEXT_CHARS,
+	pruneOversizedEditSnapshots,
+} from "@oh-my-pi/pi-coding-agent/edit";
+import { writethroughNoop } from "@oh-my-pi/pi-coding-agent/lsp";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function makeSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		enableLsp: false,
+		settings: Settings.isolated({ "edit.mode": "patch" }),
+		getArtifactsDir: () => null,
+		getSessionId: () => null,
+		getPlanModeState: () => undefined,
+	} as unknown as ToolSession;
+}
+
+const noopBeginDeferred = (_p: string) => ({
+	onDeferredDiagnostics: () => {},
+	signal: new AbortController().signal,
+	finalize: () => {},
+});
+
+// 100 KB of line-broken content. Real code has line breaks, so the generated
+// unified diff stays bounded — the bug under test is the unbounded
+// `oldText`/`newText` snapshots that survived in `details`, not the diff.
+const FILLER = `${"a line of content xxxx yyyy zzzz".repeat(20)}\n`.repeat(2_000);
+
+let tempDir: string;
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-edit-snapshot-"));
+	await Settings.init({ inMemory: true, cwd: tempDir });
+});
+
+afterEach(async () => {
+	resetSettingsForTest();
+	await removeWithRetries(tempDir);
+});
+
+describe("pruneOversizedEditSnapshots", () => {
+	test("returns input unchanged when combined snapshot is under the budget", () => {
+		const oldText = "x".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS / 2);
+		const newText = "y".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS / 2);
+		const details = { diff: "d", path: "/p", oldText, newText };
+		expect(pruneOversizedEditSnapshots(details)).toBe(details);
+	});
+
+	test("drops oldText and newText when combined size exceeds the budget", () => {
+		const oversized = "x".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS);
+		const result = pruneOversizedEditSnapshots({
+			diff: "@@",
+			path: "/p",
+			firstChangedLine: 5,
+			oldText: oversized,
+			newText: oversized,
+		});
+		expect(result).toEqual({ diff: "@@", path: "/p", firstChangedLine: 5 });
+		expect("oldText" in result).toBe(false);
+		expect("newText" in result).toBe(false);
+	});
+
+	test("prunes snapshots inside perFileResults independently of the aggregate", () => {
+		const oversized = "x".repeat(MAX_EDIT_SNAPSHOT_TEXT_CHARS);
+		const small = "tiny";
+		const result = pruneOversizedEditSnapshots({
+			diff: "d",
+			perFileResults: [
+				{ path: "/big", diff: "d1", oldText: oversized, newText: oversized },
+				{ path: "/small", diff: "d2", oldText: small, newText: small },
+			],
+		});
+		expect(result.perFileResults?.[0]).toEqual({ path: "/big", diff: "d1" });
+		expect(result.perFileResults?.[1]).toEqual({
+			path: "/small",
+			diff: "d2",
+			oldText: small,
+			newText: small,
+		});
+	});
+});
+
+describe("executePatchSingle on oversized files", () => {
+	test("prunes oldText / newText while keeping diff and path", async () => {
+		await Bun.write(path.join(tempDir, "big.txt"), `${FILLER}anchor\n${FILLER}`);
+
+		const result = await executePatchSingle({
+			session: makeSession(tempDir),
+			path: "big.txt",
+			params: { op: "update", diff: "@@\n-anchor\n+ANCHOR" },
+			allowFuzzy: true,
+			fuzzyThreshold: DEFAULT_FUZZY_THRESHOLD,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: noopBeginDeferred,
+		});
+
+		const details = result.details!;
+		expect(details.path).toBe(path.join(tempDir, "big.txt"));
+		expect(details.diff).toMatch(/-\d+\|anchor/);
+		expect(details.diff).toMatch(/\+\d+\|ANCHOR/);
+		expect(details.oldText).toBeUndefined();
+		expect(details.newText).toBeUndefined();
+
+		// The serialized result stays well under the source file. Before the fix
+		// it was ~2x the file size (full oldText + full newText in details).
+		expect(JSON.stringify(result).length).toBeLessThan(FILLER.length / 10);
+	});
+});
+
+describe("executeReplaceSingle on oversized files", () => {
+	test("prunes oldText / newText while keeping diff", async () => {
+		await Bun.write(path.join(tempDir, "big.txt"), `${FILLER}LINE A\n${FILLER}`);
+
+		const result = await executeReplaceSingle({
+			session: makeSession(tempDir),
+			path: "big.txt",
+			params: { old_text: "LINE A", new_text: "LINE B" },
+			allowFuzzy: false,
+			fuzzyThreshold: DEFAULT_FUZZY_THRESHOLD,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: noopBeginDeferred,
+		});
+
+		const details = result.details!;
+		expect(details.path).toBe(path.join(tempDir, "big.txt"));
+		expect(details.oldText).toBeUndefined();
+		expect(details.newText).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro

A single `replace` edit on a synthetic 320 KB file produced a tool-result message whose JSON serialization was ~960 KB:

```
content bytes: 65
details bytes: 960193
  oldText bytes: 320008
  newText bytes: 320008
  diff bytes:    320027
total serialized: 960281
```

That entire blob is written to the per-turn session JSONL line. Real-world examples from the reporter's sessions hit 643 KB / 663 KB / 348 KB per edit, dominated by `details.oldText` + `details.newText`.

## Cause

Edit-tool result builders attach the full pre/post file content to `details.oldText` / `details.newText`:

- `packages/coding-agent/src/edit/modes/patch.ts` `executePatchSingle`
- `packages/coding-agent/src/edit/modes/replace.ts` `executeReplaceSingle`
- `packages/coding-agent/src/edit/hashline/execute.ts` `renderSection` (delete + update branches; also stamped onto the per-file result)
- `packages/coding-agent/src/edit/index.ts` `executeApplyPatchPerFile` / `executeSinglePathEntries` propagate them onto the aggregate details and per-file entries

Those snapshots are never sent to the LLM — `estimateTokens` only counts `message.content` (verified: 622 KB of `details` reports 10 tokens), and every provider serializer (OpenAI Responses, OpenAI Chat, Anthropic) emits only `content` for tool results. The only production consumer is the ACP event mapper at `packages/coding-agent/src/modes/acp/acp-event-mapper.ts` `extractDiffToolCallContent`, which builds a `diff` ToolCallContent for ACP clients (Zed). So the snapshots ride along to disk for every edit even when nothing reads them.

## Fix

- Add `packages/coding-agent/src/edit/snapshot-details.ts` with `pruneOversizedEditSnapshots` and `MAX_EDIT_SNAPSHOT_TEXT_CHARS = 32_768`. Two overloads (per-file first for tighter overload resolution at per-file call sites): returns the input unchanged when the combined snapshot is under the budget; otherwise returns a shallow copy without `oldText`/`newText`, and (for the aggregate overload) recurses through `perFileResults`.
- Apply the helper at every construction site that stamps these fields: both edit modes, both hashline result/per-file branches, both aggregators.
- Re-export the helper and threshold from the `edit/index.ts` barrel so callers and tests can reach them via `@oh-my-pi/pi-coding-agent/edit`.
- Add `packages/coding-agent/CHANGELOG.md` entry.

The visible diff, path, line number, op, move, and diagnostic metadata are all preserved. ACP returns `undefined` for over-budget files and the text content still flows — diff visualization degrades gracefully for pathologically large edits; small/medium edits keep working exactly as before.

## Verification

- `bun test packages/coding-agent/test/edit-snapshot-details.test.ts` — 5/5 pass. New file covers: helper passes small payloads through unchanged, drops oversized `oldText`/`newText`, recurses into `perFileResults`, and end-to-end `executePatchSingle` / `executeReplaceSingle` on >100 KB files prune snapshots while keeping diff/path.
- `bun test packages/coding-agent/test/edit-snapshot-details.test.ts packages/coding-agent/test/edit-per-file-diff-content.test.ts packages/coding-agent/test/edit-diff.test.ts packages/coding-agent/test/edit-mode.test.ts packages/coding-agent/test/edit-patch-unchanged-error.test.ts packages/coding-agent/test/edit-streaming-preview.test.ts packages/coding-agent/test/edit-acp-bridge.test.ts` — 79/79 pass; no regression in existing edit-tool coverage.
- `bun --cwd=packages/coding-agent run check` — passed.
- `packages/coding-agent/test/acp-event-mapper.test.ts` and `packages/coding-agent/test/edit-auto-generated-regressions.test.ts` fail on `main` with `Cannot find module './tool-views.generated.js'` (pre-existing missing generated artifact, unrelated to this diff).

Fixes #3786