### PR TITLE
fix(session): avoid ctrl-c rewrites for compacted sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed large resumed sessions dominated by repeated compaction summaries exhausting memory on Ctrl+C flush, and improved fork session previews that start with developer or assistant turns. ([#3789](https://github.com/can1357/oh-my-pi/issues/3789))
+
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -245,20 +245,21 @@ function countMessageMarkers(content: string): number {
 	return count;
 }
 
-function extractFirstUserMessageFromPrefix(content: string): string | undefined {
-	const roleIndex = content.indexOf('"role"');
-	if (roleIndex === -1) return undefined;
+function extractFirstDisplayMessageFromPrefix(content: string): string | undefined {
+	let fallback: string | undefined;
+	let index = content.indexOf('"role"');
 
-	let index = roleIndex;
 	while (index !== -1) {
 		const role = extractStringProperty(content, "role", index);
-		if (role === "user") {
-			return extractStringProperty(content, "content", index) ?? extractStringProperty(content, "text", index);
+		const text = extractStringProperty(content, "content", index) ?? extractStringProperty(content, "text", index);
+		if (text) {
+			if (role === "user") return text;
+			if (!fallback && (role === "developer" || role === "assistant")) fallback = text;
 		}
 		index = content.indexOf('"role"', index + 6);
 	}
 
-	return undefined;
+	return fallback;
 }
 
 interface SessionListHeader {
@@ -394,7 +395,7 @@ async function scanSessionFile(
 			}
 		}
 
-		firstMessage ||= extractFirstUserMessageFromPrefix(content) ?? "";
+		firstMessage ||= extractFirstDisplayMessageFromPrefix(content) ?? "";
 		const messageCount = Math.max(parsedMessageCount, countMessageMarkers(content));
 		return {
 			path: file,

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -76,10 +76,28 @@ function elideCompactionSummary(entry: CompactionEntry | undefined): boolean {
 	return true;
 }
 
+function collectActiveBranchIds(entries: FileEntry[]): Set<string> {
+	const byId = new Map<string, SessionEntry>();
+	for (const entry of entries) {
+		const id = (entry as SessionEntry).id;
+		if (typeof id === "string") byId.set(id, entry as SessionEntry);
+	}
+	const branchIds = new Set<string>();
+	let cursor = entries[entries.length - 1] as SessionEntry | undefined;
+	while (cursor && typeof cursor.id === "string" && !branchIds.has(cursor.id)) {
+		branchIds.add(cursor.id);
+		const parentId = cursor.parentId;
+		cursor = parentId ? byId.get(parentId) : undefined;
+	}
+	return branchIds;
+}
+
 function elideSupersededCompactionEntries(entries: FileEntry[]): void {
+	const branchIds = collectActiveBranchIds(entries);
 	let previousCompaction: CompactionEntry | undefined;
 	for (const entry of entries) {
 		if (entry.type !== "compaction") continue;
+		if (!branchIds.has(entry.id)) continue;
 		elideCompactionSummary(previousCompaction);
 		previousCompaction = entry;
 	}
@@ -90,7 +108,6 @@ async function loadEntriesFromFileStream(filePath: string): Promise<{
 	titleSlot: SessionTitleUpdate | undefined;
 }> {
 	const entries: FileEntry[] = [];
-	let previousCompaction: CompactionEntry | undefined;
 	let titleSlot: SessionTitleUpdate | undefined;
 	let sawBodyLine = false;
 	const input = fs.createReadStream(filePath, { encoding: "utf8" });
@@ -115,10 +132,6 @@ async function loadEntriesFromFileStream(filePath: string): Promise<{
 				entry = JSON.parse(line) as FileEntry;
 			} catch {
 				continue;
-			}
-			if (entry.type === "compaction") {
-				elideCompactionSummary(previousCompaction);
-				previousCompaction = entry;
 			}
 			entries.push(entry);
 		}

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,8 +1,11 @@
+import * as fs from "node:fs";
+import * as readline from "node:readline";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
 import { buildSessionContext } from "./session-context";
 import {
+	type CompactionEntry,
 	type FileEntry,
 	type RawFileEntry,
 	SESSION_TITLE_SLOT_BYTES,
@@ -19,6 +22,10 @@ import {
 	type SessionTitleUpdate,
 	titleUpdateFromSlot,
 } from "./session-title-slot";
+
+const STREAM_LOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+const ELIDED_COMPACTION_SUMMARY = "[Superseded compaction summary elided during session load]";
+const ELIDED_COMPACTION_SHORT_SUMMARY = "Superseded compaction elided";
 
 function splitTitleSlot(content: string): { body: string; slot: SessionTitleUpdate | undefined } {
 	const slot = titleUpdateFromSlot(parseTitleSlotFromContent(content));
@@ -54,6 +61,76 @@ export function parseSessionContent(content: string): {
 	return { entries: foldTitleSlot(entries, slot), titleSlot: slot };
 }
 
+function elideCompactionSummary(entry: CompactionEntry | undefined): boolean {
+	if (!entry) return false;
+	if (
+		entry.summary === ELIDED_COMPACTION_SUMMARY &&
+		entry.shortSummary === ELIDED_COMPACTION_SHORT_SUMMARY &&
+		entry.preserveData === undefined
+	) {
+		return false;
+	}
+	entry.summary = ELIDED_COMPACTION_SUMMARY;
+	entry.shortSummary = ELIDED_COMPACTION_SHORT_SUMMARY;
+	entry.preserveData = undefined;
+	return true;
+}
+
+function elideSupersededCompactionEntries(entries: FileEntry[]): void {
+	let previousCompaction: CompactionEntry | undefined;
+	for (const entry of entries) {
+		if (entry.type !== "compaction") continue;
+		elideCompactionSummary(previousCompaction);
+		previousCompaction = entry;
+	}
+}
+
+async function loadEntriesFromFileStream(filePath: string): Promise<{
+	entries: FileEntry[];
+	titleSlot: SessionTitleUpdate | undefined;
+}> {
+	const entries: FileEntry[] = [];
+	let previousCompaction: CompactionEntry | undefined;
+	let titleSlot: SessionTitleUpdate | undefined;
+	let sawBodyLine = false;
+	const input = fs.createReadStream(filePath, { encoding: "utf8" });
+	const lines = readline.createInterface({ input, crlfDelay: Infinity });
+
+	try {
+		for await (const rawLine of lines) {
+			const line = rawLine.trim();
+			if (!line) continue;
+			if (!sawBodyLine) {
+				const slot = parseTitleSlotLine(line);
+				if (slot) {
+					titleSlot = titleUpdateFromSlot(slot);
+					sawBodyLine = true;
+					continue;
+				}
+				sawBodyLine = true;
+			}
+
+			let entry: FileEntry;
+			try {
+				entry = JSON.parse(line) as FileEntry;
+			} catch {
+				continue;
+			}
+			if (entry.type === "compaction") {
+				elideCompactionSummary(previousCompaction);
+				previousCompaction = entry;
+			}
+			entries.push(entry);
+		}
+	} catch (err) {
+		input.destroy();
+		if (isEnoent(err)) return { entries: [], titleSlot: undefined };
+		throw err;
+	}
+
+	return { entries: foldTitleSlot(entries, titleSlot), titleSlot };
+}
+
 /** Read only the fixed-size head window to detect a physical title slot. */
 export async function readTitleSlotFromFile(
 	filePath: string,
@@ -80,14 +157,19 @@ export async function loadEntriesFromFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<FileEntry[]> {
-	let content: string;
+	let loaded: { entries: FileEntry[]; titleSlot: SessionTitleUpdate | undefined };
 	try {
-		content = await storage.readText(filePath);
+		const stat = storage.statSync(filePath);
+		loaded =
+			storage instanceof FileSessionStorage && stat.size >= STREAM_LOAD_THRESHOLD_BYTES
+				? await loadEntriesFromFileStream(filePath)
+				: parseSessionContent(await storage.readText(filePath));
 	} catch (err) {
 		if (isEnoent(err)) return [];
 		throw err;
 	}
-	const { entries } = parseSessionContent(content);
+	const { entries } = loaded;
+	elideSupersededCompactionEntries(entries);
 
 	// Validate session header
 	if (entries.length === 0) return entries;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -504,9 +504,10 @@ export class SessionManager {
 		return this.#forceFileCreation || this.#fileIsCurrent || this.#historyContainsAssistantMessage();
 	}
 
-	#elideSupersededCompactions(): boolean {
+	#elideSupersededCompactionsOnBranch(leafId: string | null): boolean {
+		if (!leafId) return false;
 		let changed = false;
-		for (const entry of this.#entries) {
+		for (const entry of this.#index.pathTo(leafId)) {
 			if (entry.type !== "compaction") continue;
 			if (
 				entry.summary === SUPERSEDED_COMPACTION_SUMMARY &&
@@ -1330,7 +1331,7 @@ export class SessionManager {
 		fromExtension?: boolean,
 		preserveData?: Record<string, unknown>,
 	): string {
-		const elidedSupersededCompactions = this.#elideSupersededCompactions();
+		const elidedSupersededCompactions = this.#elideSupersededCompactionsOnBranch(this.#index.leafId());
 		const entry: CompactionEntry<T> = {
 			type: "compaction",
 			...this.#freshEntryFields(),

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -66,6 +66,8 @@ import {
 import { type SessionTitleUpdate, serializeTitleSlot } from "./session-title-slot";
 
 const JSONL_SUFFIX_LENGTH = ".jsonl".length;
+const SUPERSEDED_COMPACTION_SUMMARY = "[Superseded compaction summary elided after a newer compaction]";
+const SUPERSEDED_COMPACTION_SHORT_SUMMARY = "Superseded compaction elided";
 
 function mintSessionId(): string {
 	return Bun.randomUUIDv7();
@@ -500,6 +502,25 @@ export class SessionManager {
 
 	#shouldHaveSessionFile(): boolean {
 		return this.#forceFileCreation || this.#fileIsCurrent || this.#historyContainsAssistantMessage();
+	}
+
+	#elideSupersededCompactions(): boolean {
+		let changed = false;
+		for (const entry of this.#entries) {
+			if (entry.type !== "compaction") continue;
+			if (
+				entry.summary === SUPERSEDED_COMPACTION_SUMMARY &&
+				entry.shortSummary === SUPERSEDED_COMPACTION_SHORT_SUMMARY &&
+				entry.preserveData === undefined
+			) {
+				continue;
+			}
+			entry.summary = SUPERSEDED_COMPACTION_SUMMARY;
+			entry.shortSummary = SUPERSEDED_COMPACTION_SHORT_SUMMARY;
+			entry.preserveData = undefined;
+			changed = true;
+		}
+		return changed;
 	}
 
 	/**
@@ -1024,14 +1045,18 @@ export class SessionManager {
 	}
 
 	/**
-	 * Synchronously flush all in-memory entries to disk. Use when the process may
-	 * exit before an async flush settles (Ctrl+C in the TUI). Software-crash
-	 * durable; not atomic and not power-loss safe — a same-process crash never
-	 * lands mid-`writeFileSync`.
+	 * Synchronously makes the current append-only session durable. Avoid rewriting
+	 * an already-current file: large restored sessions can contain GiB of compacted
+	 * history, and Ctrl+C must not rebuild the whole JSONL string just to flush.
 	 */
 	flushSync(): void {
 		if (!this.#persist || !this.#sessionFile) return;
 		if (this.#diskFailure) throw this.#diskFailure;
+		if (this.#fileIsCurrent && !this.#rewriteRequired) {
+			const writerError = this.#writer?.getError();
+			if (writerError) throw writerError;
+			return;
+		}
 		this.#rewriteSynchronously();
 		if (this.#diskFailure) throw this.#diskFailure;
 	}
@@ -1305,6 +1330,7 @@ export class SessionManager {
 		fromExtension?: boolean,
 		preserveData?: Record<string, unknown>,
 	): string {
+		const elidedSupersededCompactions = this.#elideSupersededCompactions();
 		const entry: CompactionEntry<T> = {
 			type: "compaction",
 			...this.#freshEntryFields(),
@@ -1317,6 +1343,9 @@ export class SessionManager {
 			preserveData,
 		};
 		this.#recordEntry(entry);
+		if (elidedSupersededCompactions) {
+			void this.#rewriteAtomically().catch(err => this.#noteDiskFailure(err));
+		}
 		return entry.id;
 	}
 

--- a/packages/coding-agent/test/session-manager/large-session-memory.test.ts
+++ b/packages/coding-agent/test/session-manager/large-session-memory.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { listSessions } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+class CountingMemorySessionStorage extends MemorySessionStorage {
+	writeTextSyncCalls = 0;
+
+	writeTextSync(filePath: string, content: string): void {
+		this.writeTextSyncCalls++;
+		super.writeTextSync(filePath, content);
+	}
+}
+
+function makeAssistantMessage(text: string) {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected built-in anthropic model to exist");
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: 2,
+	};
+}
+
+describe("large session memory guards", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })));
+		tempDirs.length = 0;
+	});
+
+	it("does not rewrite an already-current session during sync flush", () => {
+		const storage = new CountingMemorySessionStorage();
+		const session = SessionManager.create("/work", "/sessions", storage);
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+
+		storage.writeTextSyncCalls = 0;
+		session.flushSync();
+
+		expect(storage.writeTextSyncCalls).toBe(0);
+	});
+
+	it("elides superseded compactions and rewrites the compacted file", async () => {
+		const storage = new CountingMemorySessionStorage();
+		const session = SessionManager.create("/work", "/sessions", storage);
+		const firstKeptEntryId = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+
+		const firstSummary = `first-${"x".repeat(4096)}`;
+		const secondSummary = `second-${"y".repeat(4096)}`;
+		session.appendCompaction(firstSummary, undefined, firstKeptEntryId, 1000, undefined, undefined, {
+			openaiRemoteCompaction: { provider: "anthropic", replacementHistory: [] },
+		});
+		session.appendCompaction(secondSummary, undefined, firstKeptEntryId, 1000);
+		await session.flush();
+
+		const compactions = session.getEntries().filter(entry => entry.type === "compaction");
+		expect(compactions).toHaveLength(2);
+		expect(compactions[0]?.summary).not.toBe(firstSummary);
+		expect(compactions[0]?.summary).toContain("Superseded compaction");
+		expect(compactions[0]?.preserveData).toBeUndefined();
+		expect(compactions[1]?.summary).toBe(secondSummary);
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+		const persisted = await storage.readText(sessionFile);
+		expect(persisted).not.toContain(firstSummary);
+		expect(persisted).toContain(secondSummary);
+	});
+
+	it("streams large session files and keeps only the latest compaction summary", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-large-session-"));
+		tempDirs.push(tempDir);
+		const sessionFile = path.join(tempDir, "large.jsonl");
+		const oldSummary = `old-${"x".repeat(5 * 1024 * 1024)}`;
+		const latestSummary = `latest-${"y".repeat(5 * 1024 * 1024)}`;
+		const lines = [
+			{ type: "session", version: 3, id: "sess", timestamp: "2026-01-01T00:00:00.000Z", cwd: tempDir },
+			{
+				type: "message",
+				id: "u1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: { role: "user", content: "hi", timestamp: 1 },
+			},
+			{
+				type: "compaction",
+				id: "c1",
+				parentId: "u1",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				summary: oldSummary,
+				firstKeptEntryId: "u1",
+				tokensBefore: 1000,
+				preserveData: { stale: true },
+			},
+			{
+				type: "message",
+				id: "a1",
+				parentId: "c1",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				message: makeAssistantMessage("hello"),
+			},
+			{
+				type: "compaction",
+				id: "c2",
+				parentId: "a1",
+				timestamp: "2026-01-01T00:00:04.000Z",
+				summary: latestSummary,
+				firstKeptEntryId: "a1",
+				tokensBefore: 1000,
+			},
+		].map(entry => `${JSON.stringify(entry)}\n`);
+		await fsp.writeFile(sessionFile, lines.join(""));
+
+		const entries = await loadEntriesFromFile(sessionFile);
+		const compactions = entries.filter(entry => entry.type === "compaction");
+
+		expect(compactions).toHaveLength(2);
+		expect(compactions[0]?.summary).not.toBe(oldSummary);
+		expect(compactions[0]?.summary).toContain("Superseded compaction");
+		expect(compactions[0]?.preserveData).toBeUndefined();
+		expect(compactions[1]?.summary).toBe(latestSummary);
+	});
+
+	it("uses developer prefix text when a fork has no early user message", async () => {
+		const storage = new MemorySessionStorage();
+		const sessionDir = "/sessions/project";
+		const sessionFile = `${sessionDir}/fork.jsonl`;
+		const lines = [
+			{ type: "session", version: 3, id: "fork", timestamp: "2026-01-01T00:00:00.000Z", cwd: "/work" },
+			{
+				type: "message",
+				id: "d1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: { role: "developer", content: "Plan fork context", timestamp: 1 },
+			},
+		].map(entry => `${JSON.stringify(entry)}\n`);
+		storage.writeTextSync(sessionFile, lines.join(""));
+
+		const sessions = await listSessions(sessionDir, storage);
+
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.firstMessage).toBe("Plan fork context");
+	});
+});

--- a/packages/coding-agent/test/session-manager/large-session-memory.test.ts
+++ b/packages/coding-agent/test/session-manager/large-session-memory.test.ts
@@ -141,6 +141,113 @@ describe("large session memory guards", () => {
 		expect(compactions[1]?.summary).toBe(latestSummary);
 	});
 
+	it("preserves sibling-branch compactions when a newer compaction lands on another branch", async () => {
+		const storage = new CountingMemorySessionStorage();
+		const session = SessionManager.create("/work", "/sessions", storage);
+		const rootId = session.appendMessage({ role: "user", content: "shared root", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("root reply"));
+
+		const branchACompactionSummary = `branch-a-${"x".repeat(1024)}`;
+		const branchAPreserve = { openaiRemoteCompaction: { provider: "anthropic", replacementHistory: [] } };
+		session.appendCompaction(
+			branchACompactionSummary,
+			undefined,
+			rootId,
+			1000,
+			undefined,
+			undefined,
+			branchAPreserve,
+		);
+		const branchACompactionId = session.getLeafId();
+		if (!branchACompactionId) throw new Error("Expected branch A compaction id");
+
+		session.branch(rootId);
+		session.appendMessage(makeAssistantMessage("branch B reply"));
+		const branchBCompactionSummary = `branch-b-${"y".repeat(1024)}`;
+		session.appendCompaction(branchBCompactionSummary, undefined, rootId, 1000);
+
+		const branchACompaction = session.getEntry(branchACompactionId);
+		if (branchACompaction?.type !== "compaction") throw new Error("Expected sibling compaction entry");
+		expect(branchACompaction.summary).toBe(branchACompactionSummary);
+		expect(branchACompaction.preserveData).toEqual(branchAPreserve);
+
+		const branchBCompactions = session
+			.getEntries()
+			.filter(entry => entry.type === "compaction" && entry.summary === branchBCompactionSummary);
+		expect(branchBCompactions).toHaveLength(1);
+	});
+
+	it("only elides loaded compactions on the active branch", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-branch-load-"));
+		tempDirs.push(tempDir);
+		const sessionFile = path.join(tempDir, "branched.jsonl");
+		const branchASummary = `branch-a-${"x".repeat(1024)}`;
+		const branchBOldSummary = `branch-b-old-${"y".repeat(1024)}`;
+		const branchBNewSummary = `branch-b-new-${"z".repeat(1024)}`;
+		const lines = [
+			{ type: "session", version: 3, id: "sess", timestamp: "2026-01-01T00:00:00.000Z", cwd: tempDir },
+			{
+				type: "message",
+				id: "u1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: { role: "user", content: "shared", timestamp: 1 },
+			},
+			{
+				type: "compaction",
+				id: "ca",
+				parentId: "u1",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				summary: branchASummary,
+				firstKeptEntryId: "u1",
+				tokensBefore: 1000,
+				preserveData: { openaiRemoteCompaction: { provider: "anthropic", replacementHistory: [] } },
+			},
+			{
+				type: "compaction",
+				id: "cb1",
+				parentId: "u1",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				summary: branchBOldSummary,
+				firstKeptEntryId: "u1",
+				tokensBefore: 1000,
+				preserveData: { stale: true },
+			},
+			{
+				type: "message",
+				id: "a1",
+				parentId: "cb1",
+				timestamp: "2026-01-01T00:00:04.000Z",
+				message: makeAssistantMessage("branch b reply"),
+			},
+			{
+				type: "compaction",
+				id: "cb2",
+				parentId: "a1",
+				timestamp: "2026-01-01T00:00:05.000Z",
+				summary: branchBNewSummary,
+				firstKeptEntryId: "a1",
+				tokensBefore: 1000,
+			},
+		].map(entry => `${JSON.stringify(entry)}\n`);
+		await fsp.writeFile(sessionFile, lines.join(""));
+
+		const entries = await loadEntriesFromFile(sessionFile);
+		const byId = new Map(entries.map(entry => [(entry as { id?: string }).id, entry] as const));
+		const branchA = byId.get("ca");
+		const branchBOld = byId.get("cb1");
+		const branchBNew = byId.get("cb2");
+		if (branchA?.type !== "compaction" || branchBOld?.type !== "compaction" || branchBNew?.type !== "compaction") {
+			throw new Error("Expected compaction entries");
+		}
+
+		expect(branchA.summary).toBe(branchASummary);
+		expect(branchA.preserveData).toBeDefined();
+		expect(branchBOld.summary).toContain("Superseded compaction");
+		expect(branchBOld.preserveData).toBeUndefined();
+		expect(branchBNew.summary).toBe(branchBNewSummary);
+	});
+
 	it("uses developer prefix text when a fork has no early user message", async () => {
 		const storage = new MemorySessionStorage();
 		const sessionDir = "/sessions/project";


### PR DESCRIPTION
## Repro
A focused regression test reproduces the issue with `bun test packages/coding-agent/test/session-manager/large-session-memory.test.ts`: before the fix, `SessionManager.flushSync()` rewrites an already-current append-only file, older compaction payloads remain in memory/on disk, large session load keeps superseded 5 MiB compaction summaries, and developer-started fork previews show `(no messages)`.

## Cause
`packages/coding-agent/src/session/session-manager.ts` always routed `flushSync()` through `#rewriteSynchronously()`, which serializes every loaded entry into one JSONL string even when the append writer already made the file current. `packages/coding-agent/src/session/session-loader.ts` also loaded session JSONL through `readText()`, materializing multi-GiB files and retaining superseded compaction payloads, while `packages/coding-agent/src/session/session-listing.ts` only looked for an early user message in the prefix preview.

## Fix
- Stream large physical session JSONL files and elide superseded compaction summaries while loading.
- Elide older compaction payloads when appending a newer compaction, then compact the file asynchronously.
- Make `flushSync()` return after checking append-writer errors when the append-only session file is already current.
- Fall back to developer or assistant prefix text when session-list previews have no early user turn.
- Add regression coverage for sync flush, compaction elision, streamed loading, and fork previews.

## Verification
`bun test packages/coding-agent/test/session-manager/large-session-memory.test.ts` passed with 4 tests. `bun run check` in `packages/coding-agent` passed. Fixes #3789