### PR TITLE
fix(cli): honor web search provider settings in omp search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed `omp search` applying `providers.webSearch` and `providers.webSearchExclude` before resolving its implicit provider chain. ([#3793](https://github.com/can1357/oh-my-pi/issues/3793))
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 
 ## [16.2.5] - 2026-06-28

--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -4,8 +4,10 @@
  * Handles `omp q`/`omp web-search` subcommands for testing web search providers.
  */
 
-import { APP_NAME } from "@oh-my-pi/pi-utils";
+import { APP_NAME, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
+import { Settings } from "../config/settings";
 import { initTheme, theme } from "../modes/theme/theme";
 import { runSearchQuery, type SearchQueryParams } from "../web/search/index";
 import { SEARCH_PROVIDER_ORDER } from "../web/search/provider";
@@ -84,6 +86,9 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 		process.stderr.write(`${chalk.red("Error: --limit must be a number")}\n`);
 		process.exit(1);
 	}
+
+	const settings = await Settings.init({ cwd: getProjectDir() });
+	applyProviderGlobalsFromSettings(settings);
 
 	await initTheme();
 

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -138,14 +138,20 @@ async function executeSearch(
 	options: ExecuteSearchOptions,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
 	const { authStorage, sessionId, signal } = options;
-	const providers =
-		params.provider && params.provider !== "auto"
-			? await getSearchProvider(params.provider).then(async provider =>
-					(await provider.isExplicitlyAvailable(authStorage))
-						? [provider]
-						: resolveProviderChain(authStorage, "auto"),
-				)
-			: await resolveProviderChain(authStorage);
+	const explicitProvider = params.provider;
+	let providers: SearchProvider[];
+	if (explicitProvider && explicitProvider !== "auto") {
+		const provider = await getSearchProvider(explicitProvider);
+		providers = (await provider.isExplicitlyAvailable(authStorage))
+			? [provider]
+			: await resolveProviderChain(authStorage, "auto");
+	} else if (explicitProvider === "auto") {
+		// Explicit `--provider auto` bypasses the configured preferred provider
+		// for this invocation; exclusions still apply.
+		providers = await resolveProviderChain(authStorage, "auto");
+	} else {
+		providers = await resolveProviderChain(authStorage);
+	}
 	if (providers.length === 0) {
 		const message = "No web search provider configured.";
 		return {

--- a/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
+++ b/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { setExcludedSearchProviders, setPreferredSearchProvider } from "@oh-my-pi/pi-coding-agent/web/search/provider";
-import { getConfigRootDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { __resetDirsFromEnvForTests, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { runSearchCommand } from "../../../src/cli/web-search-cli";
 
 const WEB_SEARCH_ENV_KEYS = [
@@ -25,7 +24,8 @@ const WEB_SEARCH_ENV_KEYS = [
 ] as const;
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
-const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+const originalOmpProfile = process.env.OMP_PROFILE;
+const originalPiProfile = process.env.PI_PROFILE;
 
 let tempAgentDir: TempDir | undefined;
 let originalEnv: Partial<Record<(typeof WEB_SEARCH_ENV_KEYS)[number], string | undefined>> = {};
@@ -35,6 +35,11 @@ function responseUrl(input: string | Request | URL): string {
 	if (typeof input === "string") return input;
 	if (input instanceof URL) return input.toString();
 	return input.url;
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
 }
 
 function makeFetchMock(): typeof fetch {
@@ -93,16 +98,12 @@ afterEach(async () => {
 	setExcludedSearchProviders([]);
 	process.exitCode = originalExitCode;
 	for (const key of WEB_SEARCH_ENV_KEYS) {
-		const value = originalEnv[key];
-		if (value === undefined) delete process.env[key];
-		else process.env[key] = value;
+		restoreEnv(key, originalEnv[key]);
 	}
-	if (originalAgentDir) {
-		setAgentDir(originalAgentDir);
-	} else {
-		setAgentDir(fallbackAgentDir);
-		delete process.env.PI_CODING_AGENT_DIR;
-	}
+	restoreEnv("PI_CODING_AGENT_DIR", originalAgentDir);
+	restoreEnv("OMP_PROFILE", originalOmpProfile);
+	restoreEnv("PI_PROFILE", originalPiProfile);
+	__resetDirsFromEnvForTests();
 	if (tempAgentDir) {
 		await tempAgentDir.remove();
 		tempAgentDir = undefined;

--- a/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
+++ b/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { setExcludedSearchProviders, setPreferredSearchProvider } from "@oh-my-pi/pi-coding-agent/web/search/provider";
+import { getConfigRootDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { runSearchCommand } from "../../../src/cli/web-search-cli";
+
+const WEB_SEARCH_ENV_KEYS = [
+	"ANTHROPIC_API_KEY",
+	"BRAVE_API_KEY",
+	"EXA_API_KEY",
+	"FIRECRAWL_API_KEY",
+	"JINA_API_KEY",
+	"KAGI_API_KEY",
+	"MOONSHOT_API_KEY",
+	"MOONSHOT_SEARCH_API_KEY",
+	"PARALLEL_API_KEY",
+	"PERPLEXITY_API_KEY",
+	"SEARXNG_ENDPOINT",
+	"SYNTHETIC_API_KEY",
+	"TAVILY_API_KEY",
+	"TINYFISH_API_KEY",
+	"XAI_API_KEY",
+] as const;
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+let tempAgentDir: TempDir | undefined;
+let originalEnv: Partial<Record<(typeof WEB_SEARCH_ENV_KEYS)[number], string | undefined>> = {};
+let originalExitCode: typeof process.exitCode;
+
+function responseUrl(input: string | Request | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
+}
+
+function makeFetchMock(): typeof fetch {
+	return Object.assign(
+		async (input: string | Request | URL, _init?: RequestInit): Promise<Response> => {
+			const url = responseUrl(input);
+			if (url.startsWith("https://s.jina.ai/")) {
+				return new Response(
+					JSON.stringify({ data: [{ title: "Jina result", url: "https://jina.example", content: "jina" }] }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "https://api.tavily.com/search") {
+				return new Response(
+					JSON.stringify({
+						answer: "Tavily answer",
+						results: [{ title: "Tavily result", url: "https://tavily.example", content: "tavily" }],
+						request_id: "req-test",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(`unexpected URL: ${url}`, { status: 500 });
+		},
+		{ preconnect: fetch.preconnect },
+	);
+}
+
+beforeEach(async () => {
+	originalEnv = Object.fromEntries(WEB_SEARCH_ENV_KEYS.map(key => [key, process.env[key]]));
+	for (const key of WEB_SEARCH_ENV_KEYS) delete process.env[key];
+	process.env.JINA_API_KEY = "test-jina-key";
+	process.env.TAVILY_API_KEY = "test-tavily-key";
+	originalExitCode = process.exitCode;
+	process.exitCode = undefined;
+
+	resetSettingsForTest();
+	setPreferredSearchProvider("auto");
+	setExcludedSearchProviders([]);
+	tempAgentDir = TempDir.createSync("@omp-search-cli-");
+	setAgentDir(tempAgentDir.path());
+	await Settings.init({
+		inMemory: true,
+		cwd: tempAgentDir.path(),
+		overrides: {
+			"providers.webSearch": "tavily",
+			"providers.webSearchExclude": ["jina"],
+		},
+	});
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	resetSettingsForTest();
+	setPreferredSearchProvider("auto");
+	setExcludedSearchProviders([]);
+	process.exitCode = originalExitCode;
+	for (const key of WEB_SEARCH_ENV_KEYS) {
+		const value = originalEnv[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	if (tempAgentDir) {
+		await tempAgentDir.remove();
+		tempAgentDir = undefined;
+	}
+});
+
+describe("runSearchCommand provider settings", () => {
+	it("applies configured web-search preference and exclusions before resolving the implicit chain", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(makeFetchMock());
+
+		let stdout = "";
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+			return true;
+		});
+
+		await runSearchCommand({ query: "provider selection smoke test", limit: 1, expanded: false });
+
+		const plain = stripVTControlCharacters(stdout);
+		expect(plain).toContain("Provider: Tavily (API)");
+		expect(plain).not.toContain("Provider: Jina");
+	});
+});

--- a/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
+++ b/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
@@ -125,4 +125,33 @@ describe("runSearchCommand provider settings", () => {
 		expect(plain).toContain("Provider: Tavily (API)");
 		expect(plain).not.toContain("Provider: Jina");
 	});
+
+	it("treats explicit --provider auto as a one-shot override of the configured preferred provider", async () => {
+		// Same Tavily preference is configured by `beforeEach`, but no exclusions
+		// hide Jina here, so the auto chain order (Jina before Tavily) decides.
+		const currentTempDir = tempAgentDir;
+		if (!currentTempDir) throw new Error("tempAgentDir missing");
+		resetSettingsForTest();
+		setPreferredSearchProvider("auto");
+		setExcludedSearchProviders([]);
+		await Settings.init({
+			inMemory: true,
+			cwd: currentTempDir.path(),
+			overrides: { "providers.webSearch": "tavily" },
+		});
+
+		vi.spyOn(globalThis, "fetch").mockImplementation(makeFetchMock());
+
+		let stdout = "";
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+			return true;
+		});
+
+		await runSearchCommand({ query: "explicit auto chain", provider: "auto", limit: 1, expanded: false });
+
+		const plain = stripVTControlCharacters(stdout);
+		expect(plain).toContain("Provider: Jina");
+		expect(plain).not.toContain("Provider: Tavily (API)");
+	});
 });


### PR DESCRIPTION
## Repro
Configured `providers.webSearch = "tavily"` and `providers.webSearchExclude = ["jina"]`, then reproduced the implicit search provider chain ignoring those settings with `bun test packages/coding-agent/test/repro-3793.test.ts`: the chain resolved to `["jina", "tavily", "duckduckgo"]` instead of Tavily-only/excluding Jina.

## Cause
`packages/coding-agent/src/cli/web-search-cli.ts` built `SearchQueryParams` and called `runSearchQuery()` without initializing `Settings` or calling `applyProviderGlobalsFromSettings()`, so `resolveProviderChain()` kept the module defaults (`preferredProvId = "auto"`, no exclusions) in the standalone `omp search` path.

## Fix
- Initialize settings with the current project cwd in `runSearchCommand()` and apply provider globals before rendering/running the search.
- Added CLI-level regression coverage proving `omp search` prefers configured Tavily and excludes an otherwise-available Jina provider when no `--provider` is passed.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification
`bun test test/web/search/cli-provider-settings.test.ts test/web/search/provider-chain.test.ts` passed with 4 tests / 5 assertions; `bun check` passed in `packages/coding-agent`. Fixes #3793