### PR TITLE
fix(mcp): preserve npx cmd shim launching

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
+- Fixed Windows MCP stdio launches for PATH-resolved `npx.cmd` shims by preserving the `cmd.exe` wrapper path that keeps npm-owned subprocess stdio attached. ([#3794](https://github.com/can1357/oh-my-pi/issues/3794))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -139,7 +139,6 @@ async function resolveWindowsCommandPath(
 	return hasExt ? command : null;
 }
 
-
 function quoteCmdArg(value: string): string {
 	if (value.length === 0) return '""';
 	let result = '"';

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -139,72 +139,6 @@ async function resolveWindowsCommandPath(
 	return hasExt ? command : null;
 }
 
-function resolveWindowsShimPath(value: string, shimDir: string): string | null {
-	const match = /^%dp0%[\\/]*(.*)$/i.exec(value);
-	if (!match) return null;
-	const suffix = match[1];
-	if (!suffix) return shimDir;
-	return path.join(shimDir, ...suffix.split(/[\\/]+/).filter(Boolean));
-}
-
-function extractWindowsNpmShimTarget(content: string): string | null {
-	const match = /"%_prog%"\s+"([^"]+)"\s+%\*/i.exec(content);
-	return match?.[1] ?? null;
-}
-
-/**
- * Extract the shim's PATH-fallback interpreter (`SET "_prog=node"`). The
- * `IF EXIST` branch assigns a `%dp0%`-prefixed value, so requiring a
- * non-`%`-leading value picks the bare program name.
- */
-function extractWindowsNpmShimProg(content: string): string | null {
-	const match = /SET\s+"_prog=([^%"][^"]*)"/i.exec(content);
-	return match?.[1] ?? null;
-}
-
-async function resolveWindowsNpmShimCommand(
-	command: string,
-	args: readonly string[],
-	cwd: string,
-	windowsHide: boolean,
-): Promise<StdioSpawnCommand | null> {
-	if (!isWindowsBatchCommand(command)) return null;
-	if (!hasPathSegment(command)) return null;
-	const commandPath = path.resolve(cwd, command);
-
-	let content: string;
-	try {
-		content = await Bun.file(commandPath).text();
-	} catch {
-		return null;
-	}
-
-	// cmd-shim emits the same invocation line for every interpreter; only
-	// bypass cmd.exe when the shim's fallback interpreter is actually node.
-	const prog = extractWindowsNpmShimProg(content);
-	if (
-		!prog ||
-		path
-			.basename(prog)
-			.replace(/\.exe$/i, "")
-			.toLowerCase() !== "node"
-	)
-		return null;
-
-	const rawTarget = extractWindowsNpmShimTarget(content);
-	if (!rawTarget) return null;
-
-	const target = resolveWindowsShimPath(rawTarget, path.dirname(commandPath));
-	if (!target) return null;
-
-	const siblingNode = path.join(path.dirname(commandPath), "node.exe");
-	const nodeCommand = (await fileExists(siblingNode)) ? siblingNode : "node";
-	return {
-		cmd: [nodeCommand, target, ...args],
-		windowsHide,
-		detached: false,
-	};
-}
 
 function quoteCmdArg(value: string): string {
 	if (value.length === 0) return '""';
@@ -260,8 +194,6 @@ export async function resolveStdioSpawnCommand(
 	const windowsHide = options.hostHasInheritableConsole === undefined ? true : !options.hostHasInheritableConsole;
 	const resolved = await resolveWindowsCommandPath(config.command, options.cwd, options.env);
 	const resolvedCommand = resolved ?? config.command;
-	const npmShimCommand = await resolveWindowsNpmShimCommand(resolvedCommand, args, options.cwd, windowsHide);
-	if (npmShimCommand) return npmShimCommand;
 
 	// Direct-spawn only when we resolved to a concrete file AND its extension
 	// is not a batch script. Everything else (resolved .cmd/.bat, or an

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -70,11 +70,10 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("launches npm .cmd shims through node so CodeGraph owns the stdio pipes", async () => {
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-codegraph-"));
+	it("keeps PATH-resolved npx.cmd on the cmd.exe path so npm preserves stdio semantics", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-npx-"));
 		try {
-			const shim = path.join(tempDir, "codegraph.cmd");
-			const entry = path.join(tempDir, "node_modules", "@colbymchenry", "codegraph", "npm-shim.js");
+			const shim = path.join(tempDir, "npx.cmd");
 			await Bun.write(
 				shim,
 				[
@@ -94,13 +93,13 @@ describe("resolveStdioSpawnCommand", () => {
 					"  SET PATHEXT=%PATHEXT:;.JS;=;%",
 					")",
 					"",
-					'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "%dp0%\\node_modules\\@colbymchenry\\codegraph\\npm-shim.js" %*',
+					'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "%dp0%\\node_modules\\npm\\bin\\npx-cli.js" %*',
 					"",
 				].join("\r\n"),
 			);
 
 			const result = await resolveStdioSpawnCommand(
-				{ type: "stdio", command: "codegraph.cmd", args: ["serve", "--mcp"] },
+				{ type: "stdio", command: "npx", args: ["-y", "mcp-gdb"] },
 				{
 					cwd: tempDir,
 					env: {
@@ -113,7 +112,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["node", entry, "serve", "--mcp"]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${shim}" "-y" "mcp-gdb""`]);
 			expect(result.windowsHide).toBe(false);
 			expect(result.detached).toBe(false);
 		} finally {


### PR DESCRIPTION
## Repro
A Windows stdio resolver fixture with `command: "npx"`, `args: ["-y", "mcp-gdb"]`, and an npm-style `npx.cmd` on `PATH` reproduced the mismatch: OMP resolved it to `node .../npx-cli.js -y mcp-gdb` instead of the reporter's working `cmd.exe /c npx -y mcp-gdb` launch shape.

## Cause
`resolveStdioSpawnCommand` in `packages/coding-agent/src/mcp/transports/stdio.ts` special-cased npm `.cmd` shims and bypassed `cmd.exe`, so a PATH-resolved `npx.cmd` did not use the same Windows command-wrapper semantics as the working manual `cmd /c npx ...` configuration.

## Fix
- Removed the npm-shim-to-`node` rewrite so resolved `.cmd`/`.bat` commands consistently use the existing `cmd.exe /d /s /c` path.
- Added a regression test in `packages/coding-agent/test/mcp-stdio-transport.test.ts` for `npx -y mcp-gdb` with a PATH-resolved npm `npx.cmd` shim.
- Added an Unreleased changelog entry for the Windows MCP stdio fix.

## Verification
Ran `bun test packages/coding-agent/test/mcp-stdio-transport.test.ts packages/coding-agent/src/mcp/transports/stdio.test.ts`: 25 pass, 0 fail. `gh_push_branch` completed the pre-publish gate and pushed `farm/6a57f6ae/fix-windows-npx-mcp-stdio`. Fixes #3794