### PR TITLE
fix(ai): infer Antigravity reset windows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Antigravity usage reporting to infer daily vs weekly windows from unlabeled reset-only quota rows, so fresh Cloud Code Assist payloads no longer collapse those counters into `Default` ([#3797](https://github.com/can1357/oh-my-pi/issues/3797)).
+
 ## [16.2.5] - 2026-06-28
 
 ### Fixed

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -68,6 +68,13 @@ function classifyWindow(id: string | undefined, label: string | undefined): Anti
 	return undefined;
 }
 
+function inferWindowFromReset(resetAt: number | undefined, nowMs: number): AntigravityWindowDescriptor {
+	if (resetAt !== undefined && Number.isFinite(resetAt) && resetAt - nowMs > ONE_DAY_MS) {
+		return { id: "weekly", label: "Weekly", durationMs: ONE_WEEK_MS };
+	}
+	return { id: "daily", label: "Daily", durationMs: ONE_DAY_MS };
+}
+
 function withWindowDescriptor(
 	info: AntigravityQuotaInfo,
 	descriptor: AntigravityWindowDescriptor | undefined,
@@ -94,11 +101,10 @@ function getUsageStatus(remainingFraction: number | undefined): UsageStatus | un
 	return "ok";
 }
 
-function parseWindow(info: AntigravityQuotaInfo): UsageWindow | undefined {
-	const descriptor = classifyWindow(info.windowId, info.windowLabel);
+function parseWindow(info: AntigravityQuotaInfo, nowMs: number): UsageWindow | undefined {
 	const resetAt = info.resetTime ? Date.parse(info.resetTime) : undefined;
 	const hasResetAt = resetAt !== undefined && Number.isFinite(resetAt);
-	if (!descriptor && !hasResetAt) return undefined;
+	const descriptor = classifyWindow(info.windowId, info.windowLabel) ?? inferWindowFromReset(resetAt, nowMs);
 	return {
 		id: descriptor?.id ?? info.windowId ?? "default",
 		label: info.windowLabel ?? descriptor?.label ?? "Default",
@@ -278,7 +284,7 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 		const quotaInfos = normalizeQuotaInfos(modelInfo);
 		for (const quotaInfo of quotaInfos) {
 			const amount = buildAmount(quotaInfo);
-			const window = parseWindow(quotaInfo);
+			const window = parseWindow(quotaInfo, nowMs);
 			if (window?.resetsAt) {
 				earliestReset = earliestReset ? Math.min(earliestReset, window.resetsAt) : window.resetsAt;
 			}

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -68,11 +68,55 @@ function classifyWindow(id: string | undefined, label: string | undefined): Anti
 	return undefined;
 }
 
+function parseResetTime(info: AntigravityQuotaInfo): number | undefined {
+	const resetAt = info.resetTime ? Date.parse(info.resetTime) : undefined;
+	return resetAt !== undefined && Number.isFinite(resetAt) ? resetAt : undefined;
+}
+
 function inferWindowFromReset(resetAt: number | undefined, nowMs: number): AntigravityWindowDescriptor {
-	if (resetAt !== undefined && Number.isFinite(resetAt) && resetAt - nowMs > ONE_DAY_MS) {
+	if (resetAt !== undefined && resetAt - nowMs > ONE_DAY_MS) {
 		return { id: "weekly", label: "Weekly", durationMs: ONE_WEEK_MS };
 	}
 	return { id: "daily", label: "Daily", durationMs: ONE_DAY_MS };
+}
+
+function quotaInferenceKey(info: AntigravityQuotaInfo): string {
+	return [info.modelProvider ?? "", info.apiProvider ?? "", info.tier ?? ""].join("|");
+}
+
+function inferWindowDescriptors(
+	quotaInfos: AntigravityQuotaInfo[],
+	nowMs: number,
+): WeakMap<AntigravityQuotaInfo, AntigravityWindowDescriptor> {
+	const descriptors = new WeakMap<AntigravityQuotaInfo, AntigravityWindowDescriptor>();
+	const groups = new Map<string, { info: AntigravityQuotaInfo; resetAt: number | undefined }[]>();
+
+	for (const info of quotaInfos) {
+		const explicitDescriptor = classifyWindow(info.windowId, info.windowLabel);
+		if (explicitDescriptor) {
+			descriptors.set(info, explicitDescriptor);
+			continue;
+		}
+		const group = groups.get(quotaInferenceKey(info)) ?? [];
+		group.push({ info, resetAt: parseResetTime(info) });
+		groups.set(quotaInferenceKey(info), group);
+	}
+
+	for (const group of groups.values()) {
+		const resetTimes = [...new Set(group.map(entry => entry.resetAt).filter(resetAt => resetAt !== undefined))].sort(
+			(a, b) => a - b,
+		);
+		const latestReset = resetTimes.length > 1 ? resetTimes.at(-1) : undefined;
+		for (const entry of group) {
+			const descriptor =
+				latestReset !== undefined && entry.resetAt === latestReset
+					? { id: "weekly", label: "Weekly", durationMs: ONE_WEEK_MS }
+					: inferWindowFromReset(entry.resetAt, nowMs);
+			descriptors.set(entry.info, descriptor);
+		}
+	}
+
+	return descriptors;
 }
 
 function withWindowDescriptor(
@@ -101,10 +145,13 @@ function getUsageStatus(remainingFraction: number | undefined): UsageStatus | un
 	return "ok";
 }
 
-function parseWindow(info: AntigravityQuotaInfo, nowMs: number): UsageWindow | undefined {
-	const resetAt = info.resetTime ? Date.parse(info.resetTime) : undefined;
-	const hasResetAt = resetAt !== undefined && Number.isFinite(resetAt);
-	const descriptor = classifyWindow(info.windowId, info.windowLabel) ?? inferWindowFromReset(resetAt, nowMs);
+function parseWindow(
+	info: AntigravityQuotaInfo,
+	descriptor: AntigravityWindowDescriptor | undefined,
+): UsageWindow | undefined {
+	const resetAt = parseResetTime(info);
+	const hasResetAt = resetAt !== undefined;
+	if (!descriptor && !hasResetAt) return undefined;
 	return {
 		id: descriptor?.id ?? info.windowId ?? "default",
 		label: info.windowLabel ?? descriptor?.label ?? "Default",
@@ -282,9 +329,10 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 
 	for (const [_modelId, modelInfo] of Object.entries(data.models ?? {})) {
 		const quotaInfos = normalizeQuotaInfos(modelInfo);
+		const inferredDescriptors = inferWindowDescriptors(quotaInfos, nowMs);
 		for (const quotaInfo of quotaInfos) {
 			const amount = buildAmount(quotaInfo);
-			const window = parseWindow(quotaInfo, nowMs);
+			const window = parseWindow(quotaInfo, inferredDescriptors.get(quotaInfo));
 			if (window?.resetsAt) {
 				earliestReset = earliestReset ? Math.min(earliestReset, window.resetsAt) : window.resetsAt;
 			}

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -219,10 +219,10 @@ describe("antigravity usage provider", () => {
 		expect(weekly?.window?.durationMs).toBe(7 * 24 * 60 * 60 * 1000);
 		expect(weekly?.amount.remainingFraction).toBe(0.4);
 	});
-	it("infers daily and weekly windows from unlabeled Antigravity reset horizons", async () => {
+	it("keeps near-reset unlabeled weekly windows separate from daily windows", async () => {
 		const now = Date.now();
 		const dailyReset = new Date(now + 5 * 3600_000).toISOString();
-		const weeklyReset = new Date(now + 27 * 3600_000).toISOString();
+		const weeklyReset = new Date(now + 23 * 3600_000).toISOString();
 		const payload = {
 			models: {
 				gemini: {

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -219,6 +219,35 @@ describe("antigravity usage provider", () => {
 		expect(weekly?.window?.durationMs).toBe(7 * 24 * 60 * 60 * 1000);
 		expect(weekly?.amount.remainingFraction).toBe(0.4);
 	});
+	it("infers daily and weekly windows from unlabeled Antigravity reset horizons", async () => {
+		const now = Date.now();
+		const dailyReset = new Date(now + 5 * 3600_000).toISOString();
+		const weeklyReset = new Date(now + 27 * 3600_000).toISOString();
+		const payload = {
+			models: {
+				gemini: {
+					displayName: "Gemini",
+					modelProvider: "MODEL_PROVIDER_GOOGLE",
+					quotaInfos: [
+						{ remainingFraction: 0.9, resetTime: dailyReset },
+						{ remainingFraction: 0.3, resetTime: weeklyReset },
+					],
+				},
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+
+		const daily = report!.limits.find(limit => limit.scope.windowId === "daily");
+		const weekly = report!.limits.find(limit => limit.scope.windowId === "weekly");
+		expect(report!.limits).toHaveLength(2);
+		expect(daily?.window?.label).toBe("Daily");
+		expect(daily?.amount.remainingFraction).toBe(0.9);
+		expect(weekly?.window?.label).toBe("Weekly");
+		expect(weekly?.amount.remainingFraction).toBe(0.3);
+	});
 
 	it("normalizes 7 Day window ids to the weekly usage window", async () => {
 		const payload = {


### PR DESCRIPTION
## Repro
An Antigravity `quotaInfos` payload with multiple reset horizons but no `windowId`/`windowLabel` reproduced the reporter's collapse: `bun test packages/ai/test/google-antigravity-usage.test.ts -t "infers daily and weekly windows"` failed with one normalized limit instead of two.

## Cause
`packages/ai/src/usage/google-antigravity.ts` only classified windows from explicit Antigravity window metadata (`windowId`, `windowLabel`, `weeklyQuotaInfo`, `quotaInfoByWindow`). When the upstream response returned unlabeled reset-only rows, `parseWindow` labeled them `Default` and the dedupe key in `fetchAntigravityUsage` merged distinct reset horizons under `default`.

## Fix
- Infer `Daily` for unlabeled Antigravity rows by default and `Weekly` when the reset horizon is greater than 24 hours.
- Thread the fetch timestamp into `parseWindow` so the inference is deterministic within a report.
- Add regression coverage for unlabeled daily-ish and weekly-ish reset rows.
- Add the fix to `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/google-antigravity-usage.test.ts` passed: 17 pass, 0 fail. `bun test packages/coding-agent/test/usage-cli.test.ts` passed: 16 pass, 0 fail. `bun check` passed. Fixes #3797