### PR TITLE
fix(web-search): scrape DuckDuckGo HTML frontend instead of Instant Answer API

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -14,7 +14,7 @@
   - `packages/coding-agent/src/web/search/providers/anthropic.ts` — Claude web-search provider.
   - `packages/coding-agent/src/web/search/providers/brave.ts` — Brave Search API adapter.
   - `packages/coding-agent/src/web/search/providers/codex.ts` — OpenAI Codex SSE adapter.
-  - `packages/coding-agent/src/web/search/providers/duckduckgo.ts` — DuckDuckGo Instant Answer API adapter.
+  - `packages/coding-agent/src/web/search/providers/duckduckgo.ts` — DuckDuckGo HTML frontend scraper.
   - `packages/coding-agent/src/web/search/providers/exa.ts` — Exa API or MCP adapter.
   - `packages/coding-agent/src/web/search/providers/firecrawl.ts` — Firecrawl search adapter.
   - `packages/coding-agent/src/web/search/providers/gemini.ts` — Gemini grounding SSE adapter.
@@ -197,8 +197,10 @@ Streaming: none. `WebSearchTool.execute()` forwards its `AbortSignal` into `exec
     - Output: `sources`, `relatedQuestions` from `suggestions`.
   - **DuckDuckGo** — `packages/coding-agent/src/web/search/providers/duckduckgo.ts`
     - Availability: always available; no API key.
-    - Querying: GET official Instant Answer API `https://api.duckduckgo.com/` with JSON/no-HTML flags; no scraped HTML.
-    - `limit` / `num_search_results`: collapsed and clamped to `1..20`, default `10`; output may include `answer` and `sources` from abstracts/results/topics.
+    - Querying: POST the no-JS HTML frontend `https://html.duckduckgo.com/html/` with `q`, `kl=us-en`, and an optional `df` recency filter (`d`/`w`/`m`/`y`); parses the result list and unwraps `//duckduckgo.com/l/?uddg=…` redirect URLs.
+    - `recency` maps to `df`; values outside `day|week|month|year` are ignored.
+    - `limit` / `num_search_results`: collapsed and clamped to `1..30`, default `10`; output exposes `sources` only (DuckDuckGo's HTML page does not return a standalone abstract).
+    - DuckDuckGo serves a bot-detection challenge (HTTP 200/202 with an `anomaly-modal` body) when it throttles datacenter or shared-egress IPs. The adapter detects this and raises a `SearchProviderError` so the orchestrator can fall through to the next configured provider with a clear cause.
 
 ## Side Effects
 - Network

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
+- Fixed `web_search` with the `duckduckgo` provider returning empty results for any non-encyclopedic query. The provider hit DuckDuckGo's Instant Answer API (`api.duckduckgo.com`), which only serves Wikipedia/Wolfram-Alpha-style topics, so the orchestrator surfaced "DuckDuckGo returned no renderable search content" for typical agent queries. It now POSTs the no-JS HTML frontend (`html.duckduckgo.com/html/`) and parses the result list, with a clear bot-challenge error when DuckDuckGo throttles the request from datacenter/shared-egress IPs. ([#3799](https://github.com/can1357/oh-my-pi/issues/3799))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -6,122 +6,179 @@ import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
-const DUCKDUCKGO_SEARCH_URL = "https://api.duckduckgo.com/";
+/**
+ * DuckDuckGo's no-JS HTML search frontend. POST `q=…` to receive a static
+ * results page we can parse without a real browser. The Instant Answer API
+ * (`api.duckduckgo.com`) was tried first but it only returns content for
+ * Wikipedia/Wolfram-Alpha-style topics — empty for the vast majority of
+ * agent queries (see #3799).
+ */
+const DUCKDUCKGO_HTML_URL = "https://html.duckduckgo.com/html/";
 const DEFAULT_NUM_RESULTS = 10;
-const MAX_NUM_RESULTS = 20;
+const MAX_NUM_RESULTS = 30;
 
-interface DuckDuckGoTopic {
-	FirstURL?: string | null;
-	Text?: string | null;
-	Topics?: DuckDuckGoTopic[] | null;
+/**
+ * Recency → DDG `df` form param. DDG accepts single letters for the time
+ * filter; queries without a `df` value return the unfiltered default.
+ */
+const RECENCY_TO_DDG_DF: Record<NonNullable<SearchParams["recency"]>, string> = {
+	day: "d",
+	week: "w",
+	month: "m",
+	year: "y",
+};
+
+/**
+ * Browser-like UA so DDG serves the standard results page instead of the
+ * mobile-only or noscript variants. DDG returns HTTP 202 plus an anomaly
+ * modal when it suspects automation; we surface that as a clear error so
+ * the orchestrator can fall through to the next provider with context.
+ */
+const BROWSER_USER_AGENT =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+interface ParsedResult {
+	title: string;
+	url: string;
+	snippet?: string;
 }
 
-interface DuckDuckGoResponse {
-	AbstractText?: string | null;
-	AbstractURL?: string | null;
-	AbstractSource?: string | null;
-	Answer?: string | null;
-	Definition?: string | null;
-	Heading?: string | null;
-	Results?: DuckDuckGoTopic[] | null;
-	RelatedTopics?: DuckDuckGoTopic[] | null;
-}
-
-function cleanText(value: string | null | undefined): string | undefined {
-	const cleaned = value
-		?.replace(/<[^>]*>/g, " ")
+/**
+ * Decode an HTML-encoded fragment lifted from DDG markup. Strips inline tags
+ * (the results page wraps query terms in `<b>`), unescapes the small set of
+ * named entities DDG emits, and normalises whitespace.
+ */
+function decodeHtmlText(value: string): string {
+	return value
+		.replace(/<[^>]*>/g, " ")
+		.replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+		.replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(Number.parseInt(code, 16)))
 		.replace(/&nbsp;/gi, " ")
 		.replace(/&amp;/gi, "&")
 		.replace(/&lt;/gi, "<")
 		.replace(/&gt;/gi, ">")
 		.replace(/&quot;/gi, '"')
-		.replace(/&#39;/gi, "'")
+		.replace(/&#39;|&apos;/gi, "'")
 		.replace(/\s+/g, " ")
 		.trim();
-	return cleaned ? cleaned : undefined;
 }
 
-function addSource(sources: SearchSource[], source: SearchSource): void {
-	if (!source.url || sources.some(existing => existing.url === source.url)) return;
-	sources.push(source);
-}
-
-function addTopicSource(sources: SearchSource[], topic: DuckDuckGoTopic): void {
-	const url = topic.FirstURL?.trim();
-	if (!url) return;
-	const text = cleanText(topic.Text);
-	addSource(sources, {
-		title: text ?? url,
-		url,
-		snippet: text,
-	});
-}
-
-function collectTopicSources(sources: SearchSource[], topics: readonly DuckDuckGoTopic[] | null | undefined): void {
-	if (!topics) return;
-	for (const topic of topics) {
-		addTopicSource(sources, topic);
-		collectTopicSources(sources, topic.Topics);
+/**
+ * Resolve a DDG result href back to the underlying target URL.
+ *
+ * DDG routes outbound clicks through `//duckduckgo.com/l/?uddg=<encoded>` so
+ * it can record analytics; we want the unwrapped URL. Handles three shapes
+ * the page mixes in practice: redirect wrappers, protocol-relative links,
+ * and (rarely) absolute URLs on sponsored or instant answer rows.
+ */
+function unwrapResultUrl(href: string): string | undefined {
+	if (!href) return undefined;
+	const decoded = href.replace(/&amp;/gi, "&");
+	const wrapMatch = decoded.match(/[?&]uddg=([^&]+)/);
+	if (wrapMatch) {
+		try {
+			return decodeURIComponent(wrapMatch[1]);
+		} catch {
+			return undefined;
+		}
 	}
+	if (decoded.startsWith("//")) return `https:${decoded}`;
+	if (decoded.startsWith("http://") || decoded.startsWith("https://")) return decoded;
+	return undefined;
 }
 
-async function callDuckDuckGoSearch(params: SearchParams): Promise<DuckDuckGoResponse> {
-	const queryString = [
-		["q", params.query],
-		["format", "json"],
-		["no_redirect", "1"],
-		["no_html", "1"],
-		["skip_disambig", "1"],
-		["t", "oh-my-pi"],
-	]
-		.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-		.join("&");
-	const response = await (params.fetch ?? fetch)(`${DUCKDUCKGO_SEARCH_URL}?${queryString}`, {
-		method: "GET",
+/**
+ * Walk the HTML page and pull out result blocks in document order.
+ *
+ * DDG renders each result inside a `<div class="result …">` container with
+ * `<a class="result__a" …>` for the title link and an optional sibling
+ * `<a class="result__snippet">` (or `<div class="result__snippet">` in some
+ * variants) for the preview text. Sponsored placements, missing snippets,
+ * and the trailing pagination row are tolerated.
+ */
+function parseHtmlResults(html: string): ParsedResult[] {
+	const results: ParsedResult[] = [];
+	const blockRe = /<div\b[^>]*\bclass="[^"]*\bresult\b[^"]*"[^>]*>([\s\S]*?)(?=<div\b[^>]*\bclass="[^"]*\bresult\b|<div\b[^>]*\bclass="[^"]*\bnav-link\b|$)/g;
+	const titleRe = /<a\b[^>]*\bclass="[^"]*\bresult__a\b[^"]*"[^>]*\bhref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/;
+	const snippetRe = /<(?:a|div|span)\b[^>]*\bclass="[^"]*\bresult__snippet\b[^"]*"[^>]*>([\s\S]*?)<\/(?:a|div|span)>/;
+	for (const match of html.matchAll(blockRe)) {
+		const block = match[1];
+		const title = titleRe.exec(block);
+		if (!title) continue;
+		const url = unwrapResultUrl(title[1]);
+		if (!url) continue;
+		const titleText = decodeHtmlText(title[2]);
+		if (!titleText) continue;
+		const snippet = snippetRe.exec(block);
+		const snippetText = snippet ? decodeHtmlText(snippet[1]) : undefined;
+		results.push({ title: titleText, url, snippet: snippetText || undefined });
+	}
+	return results;
+}
+
+/**
+ * `true` when the page DDG returned is the bot-challenge modal instead of
+ * real results. DDG mixes status codes (200 vs 202) on these so the body
+ * check is the reliable signal.
+ */
+function isAnomalyResponse(html: string): boolean {
+	return html.includes("anomaly-modal") || html.includes("anomaly.js");
+}
+
+async function callDuckDuckGoHtml(params: SearchParams): Promise<string> {
+	const form = new URLSearchParams({ q: params.query, kl: "us-en" });
+	const df = params.recency ? RECENCY_TO_DDG_DF[params.recency] : undefined;
+	if (df) form.set("df", df);
+
+	const response = await (params.fetch ?? fetch)(DUCKDUCKGO_HTML_URL, {
+		method: "POST",
+		body: form.toString(),
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			"User-Agent": BROWSER_USER_AGENT,
+			Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+			"Accept-Language": "en-US,en;q=0.5",
+		},
 		signal: withHardTimeout(params.signal),
 	});
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		const classified = classifyProviderHttpError("duckduckgo", response.status, errorText);
+	const body = await response.text();
+	if (!response.ok && response.status !== 202) {
+		const classified = classifyProviderHttpError("duckduckgo", response.status, body);
 		if (classified) throw classified;
+		throw new SearchProviderError("duckduckgo", `DuckDuckGo HTML error (${response.status})`, response.status);
+	}
+
+	if (isAnomalyResponse(body)) {
 		throw new SearchProviderError(
 			"duckduckgo",
-			`DuckDuckGo API error (${response.status}): ${errorText}`,
-			response.status,
+			"DuckDuckGo blocked the request with a bot-detection challenge. DuckDuckGo throttles repeat searches from datacenter and shared-egress IPs; configure another provider (e.g. Brave, Tavily, SearXNG) or retry from a residential network.",
+			429,
 		);
 	}
 
-	return (await response.json()) as DuckDuckGoResponse;
+	return body;
 }
 
-/** Execute DuckDuckGo Instant Answer API search. */
+/** Execute a DuckDuckGo web search via the no-JS HTML frontend. */
 export async function searchDuckDuckGo(params: SearchParams): Promise<SearchResponse> {
 	const numResults = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
-	const data = await callDuckDuckGoSearch(params);
-	const answer = cleanText(data.AbstractText) ?? cleanText(data.Answer) ?? cleanText(data.Definition);
-	const sources: SearchSource[] = [];
+	const html = await callDuckDuckGoHtml(params);
+	const parsed = parseHtmlResults(html);
 
-	const abstractUrl = data.AbstractURL?.trim();
-	if (abstractUrl) {
-		addSource(sources, {
-			title: cleanText(data.AbstractSource) ?? cleanText(data.Heading) ?? abstractUrl,
-			url: abstractUrl,
-			snippet: cleanText(data.AbstractText),
-		});
+	const sources: SearchSource[] = [];
+	const seen = new Set<string>();
+	for (const result of parsed) {
+		if (seen.has(result.url)) continue;
+		seen.add(result.url);
+		sources.push({ title: result.title, url: result.url, snippet: result.snippet });
+		if (sources.length >= numResults) break;
 	}
 
-	collectTopicSources(sources, data.Results);
-	collectTopicSources(sources, data.RelatedTopics);
-
-	return {
-		provider: "duckduckgo",
-		answer,
-		sources: sources.slice(0, numResults),
-	};
+	return { provider: "duckduckgo", sources };
 }
 
-/** Search provider for DuckDuckGo Instant Answer API. */
+/** Search provider for DuckDuckGo (no API key required). */
 export class DuckDuckGoProvider extends SearchProvider {
 	readonly id = "duckduckgo";
 	readonly label = "DuckDuckGo";

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -98,7 +98,8 @@ function unwrapResultUrl(href: string): string | undefined {
  */
 function parseHtmlResults(html: string): ParsedResult[] {
 	const results: ParsedResult[] = [];
-	const blockRe = /<div\b[^>]*\bclass="[^"]*\bresult\b[^"]*"[^>]*>([\s\S]*?)(?=<div\b[^>]*\bclass="[^"]*\bresult\b|<div\b[^>]*\bclass="[^"]*\bnav-link\b|$)/g;
+	const blockRe =
+		/<div\b[^>]*\bclass="[^"]*\bresult\b[^"]*"[^>]*>([\s\S]*?)(?=<div\b[^>]*\bclass="[^"]*\bresult\b|<div\b[^>]*\bclass="[^"]*\bnav-link\b|$)/g;
 	const titleRe = /<a\b[^>]*\bclass="[^"]*\bresult__a\b[^"]*"[^>]*\bhref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/;
 	const snippetRe = /<(?:a|div|span)\b[^>]*\bclass="[^"]*\bresult__snippet\b[^"]*"[^>]*>([\s\S]*?)<\/(?:a|div|span)>/;
 	for (const match of html.matchAll(blockRe)) {

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -43,7 +43,7 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
-	{ value: "duckduckgo", label: "DuckDuckGo", description: "Uses DuckDuckGo Instant Answer API (no API key)" },
+	{ value: "duckduckgo", label: "DuckDuckGo", description: "Scrapes the DuckDuckGo HTML frontend (no API key)" },
 ] as const;
 
 /** Supported web search providers (every option except `auto`). */

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -24,144 +24,194 @@ function makeParams(query: string, fetch: FetchImpl) {
 	} as const;
 }
 
+function htmlPage(...results: Array<{ url: string; title: string; snippet?: string }>): string {
+	const blocks = results
+		.map(r => {
+			const href = `//duckduckgo.com/l/?uddg=${encodeURIComponent(r.url)}&amp;rut=abc`;
+			const snippet = r.snippet === undefined ? "" : `<a class="result__snippet" href="${href}">${r.snippet}</a>`;
+			return `<div class="result results_links results_links_deep web-result">
+				<h2 class="result__title"><a rel="nofollow" class="result__a" href="${href}">${r.title}</a></h2>
+				${snippet}
+			</div>`;
+		})
+		.join("\n");
+	return `<!DOCTYPE html><html><body>${blocks}<div class="nav-link">next</div></body></html>`;
+}
+
+function anomalyPage(): string {
+	return `<!DOCTYPE html><html><body>
+		<form id="challenge-form" action="//duckduckgo.com/anomaly.js?cc=botnet" method="POST">
+			<div class="anomaly-modal__title">Unfortunately, bots use DuckDuckGo too.</div>
+		</form>
+	</body></html>`;
+}
+
 describe("DuckDuckGo web search provider", () => {
-	it("calls the official Instant Answer API with unauthenticated JSON query params", async () => {
+	it("POSTs the query and recency filter to the no-JS HTML frontend", async () => {
 		let capturedUrl: string | null = null;
 		let capturedInit: RequestInit | undefined;
 		const fetchMock: FetchImpl = (input, init) => {
 			capturedUrl = typeof input === "string" ? input : input.toString();
 			capturedInit = init;
 			return Promise.resolve(
-				new Response(JSON.stringify({ AbstractText: "Duck answer", Results: [] }), {
+				new Response(htmlPage({ url: "https://example.com/a", title: "A" }), {
 					status: 200,
-					headers: { "Content-Type": "application/json" },
+					headers: { "Content-Type": "text/html" },
 				}),
 			);
 		};
 
-		await searchDuckDuckGo(makeParams("instant answer", fetchMock));
+		await searchDuckDuckGo({ ...makeParams("how to fix bug in code", fetchMock), recency: "week" });
 
-		expect(capturedUrl).not.toBeNull();
-		const url = new URL(capturedUrl ?? "");
-		expect(`${url.origin}${url.pathname}`).toBe("https://api.duckduckgo.com/");
-		expect(url.searchParams.get("q")).toBe("instant answer");
-		expect(url.searchParams.get("format")).toBe("json");
-		expect(url.searchParams.get("no_redirect")).toBe("1");
-		expect(url.searchParams.get("no_html")).toBe("1");
-		expect(url.searchParams.get("skip_disambig")).toBe("1");
-		expect(url.searchParams.get("t")).toBe("oh-my-pi");
-		expect(capturedInit?.method).toBe("GET");
-		expect(capturedInit?.headers).toBeUndefined();
+		expect(capturedUrl).toBe("https://html.duckduckgo.com/html/");
+		expect(capturedInit?.method).toBe("POST");
+		const form = new URLSearchParams(capturedInit?.body as string);
+		expect(form.get("q")).toBe("how to fix bug in code");
+		expect(form.get("kl")).toBe("us-en");
+		expect(form.get("df")).toBe("w");
+		const headers = capturedInit?.headers as Record<string, string>;
+		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
 	});
 
-	it("uses AbstractText as the answer and flattens abstract, result, and nested related topics within the local limit", async () => {
-		const fetchMock: FetchImpl = () =>
-			Promise.resolve(
-				new Response(
-					JSON.stringify({
-						AbstractText: "  DuckDuckGo <b>abstract</b> &amp; answer  ",
-						AbstractURL: " https://example.com/abstract ",
-						AbstractSource: " Example Abstract Source ",
-						Heading: "Example Heading",
-						Results: [
-							{
-								FirstURL: "https://example.com/result",
-								Text: "Result <i>snippet</i>",
-							},
-						],
-						RelatedTopics: [
-							{
-								FirstURL: "https://example.com/related",
-								Text: "Related topic",
-							},
-							{
-								Topics: [
-									{
-										FirstURL: "https://example.com/nested",
-										Text: "Nested related topic",
-									},
-								],
-							},
-							{
-								FirstURL: "https://example.com/omitted-by-limit",
-								Text: "Should be omitted by local limit",
-							},
-						],
-					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
-			);
-
-		const response = await searchDuckDuckGo({ ...makeParams("duck mapping", fetchMock), numSearchResults: 4 });
-
-		expect(response).toMatchObject({
-			provider: "duckduckgo",
-			answer: "DuckDuckGo abstract & answer",
-			sources: [
-				{
-					title: "Example Abstract Source",
-					url: "https://example.com/abstract",
-					snippet: "DuckDuckGo abstract & answer",
-				},
-				{
-					title: "Result snippet",
-					url: "https://example.com/result",
-					snippet: "Result snippet",
-				},
-				{
-					title: "Related topic",
-					url: "https://example.com/related",
-					snippet: "Related topic",
-				},
-				{
-					title: "Nested related topic",
-					url: "https://example.com/nested",
-					snippet: "Nested related topic",
-				},
-			],
-		});
-		expect(response.sources).toHaveLength(4);
-		expect(response.sources.some(source => source.url === "https://example.com/omitted-by-limit")).toBe(false);
-	});
-
-	it("clamps oversized local result limits to DuckDuckGo's provider maximum", async () => {
-		const fetchMock: FetchImpl = () =>
-			Promise.resolve(
-				new Response(
-					JSON.stringify({
-						RelatedTopics: Array.from({ length: 25 }, (_value, index) => ({
-							FirstURL: `https://example.com/topic-${index}`,
-							Text: `Topic ${index}`,
-						})),
-					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
-			);
-
-		const response = await searchDuckDuckGo({ ...makeParams("duck clamp", fetchMock), numSearchResults: 999 });
-
-		expect(response.sources).toHaveLength(20);
-		expect(response.sources.at(0)?.url).toBe("https://example.com/topic-0");
-		expect(response.sources.at(-1)?.url).toBe("https://example.com/topic-19");
-		expect(response.sources.some(source => source.url === "https://example.com/topic-20")).toBe(false);
-	});
-
-	it.each([
-		["Answer", { Answer: "  Direct answer  " }, "Direct answer"],
-		["Definition", { Definition: "  Definition answer  " }, "Definition answer"],
-	] as const)("falls back to %s when AbstractText is absent", async (_field, payload, expectedAnswer) => {
-		const fetchMock: FetchImpl = () =>
-			Promise.resolve(
-				new Response(JSON.stringify(payload), {
+	it("omits the df form param when no recency is requested", async () => {
+		let capturedInit: RequestInit | undefined;
+		const fetchMock: FetchImpl = (_input, init) => {
+			capturedInit = init;
+			return Promise.resolve(
+				new Response(htmlPage({ url: "https://example.com/x", title: "X" }), {
 					status: 200,
-					headers: { "Content-Type": "application/json" },
+					headers: { "Content-Type": "text/html" },
+				}),
+			);
+		};
+
+		await searchDuckDuckGo(makeParams("plain query", fetchMock));
+
+		const form = new URLSearchParams(capturedInit?.body as string);
+		expect(form.has("df")).toBe(false);
+	});
+
+	it("parses result blocks, unwraps DDG redirect URLs, and clamps to numSearchResults", async () => {
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(
+				new Response(
+					htmlPage(
+						{
+							url: "https://example.com/first",
+							title: "First &amp; result",
+							snippet: "Snippet <b>one</b>",
+						},
+						{ url: "https://example.com/second", title: "Second" },
+						{ url: "https://example.com/third", title: "Third" },
+					),
+					{ status: 200, headers: { "Content-Type": "text/html" } },
+				),
+			);
+
+		const response = await searchDuckDuckGo({ ...makeParams("multi", fetchMock), numSearchResults: 2 });
+
+		expect(response.provider).toBe("duckduckgo");
+		expect(response.answer).toBeUndefined();
+		expect(response.sources).toEqual([
+			{
+				title: "First & result",
+				url: "https://example.com/first",
+				snippet: "Snippet one",
+			},
+			{
+				title: "Second",
+				url: "https://example.com/second",
+				snippet: undefined,
+			},
+		]);
+	});
+
+	it("deduplicates results that share the same target URL", async () => {
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(
+				new Response(
+					htmlPage(
+						{ url: "https://example.com/dup", title: "First copy", snippet: "one" },
+						{ url: "https://example.com/dup", title: "Second copy", snippet: "two" },
+						{ url: "https://example.com/unique", title: "Other" },
+					),
+					{ status: 200, headers: { "Content-Type": "text/html" } },
+				),
+			);
+
+		const response = await searchDuckDuckGo(makeParams("dup query", fetchMock));
+
+		expect(response.sources.map(s => s.url)).toEqual(["https://example.com/dup", "https://example.com/unique"]);
+	});
+
+	it("clamps oversized result limits to the provider maximum", async () => {
+		const many = Array.from({ length: 40 }, (_, i) => ({
+			url: `https://example.com/r-${i}`,
+			title: `Result ${i}`,
+		}));
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(
+				new Response(htmlPage(...many), {
+					status: 200,
+					headers: { "Content-Type": "text/html" },
 				}),
 			);
 
-		const response = await searchDuckDuckGo(makeParams("fallback answer", fetchMock));
-		expect(response).toMatchObject({
+		const response = await searchDuckDuckGo({ ...makeParams("clamp", fetchMock), numSearchResults: 999 });
+
+		expect(response.sources).toHaveLength(30);
+		expect(response.sources.at(0)?.url).toBe("https://example.com/r-0");
+		expect(response.sources.at(-1)?.url).toBe("https://example.com/r-29");
+	});
+
+	it("supports unwrapped result hrefs (sponsored/instant rows)", async () => {
+		const html = `<div class="result"><h2 class="result__title">
+			<a class="result__a" href="https://direct.example/page">Direct</a>
+		</h2></div>`;
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(new Response(html, { status: 200, headers: { "Content-Type": "text/html" } }));
+
+		const response = await searchDuckDuckGo(makeParams("direct", fetchMock));
+
+		expect(response.sources).toEqual([
+			{ title: "Direct", url: "https://direct.example/page", snippet: undefined },
+		]);
+	});
+
+	it("throws a clear SearchProviderError when DDG serves the anomaly modal", async () => {
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(
+				new Response(anomalyPage(), {
+					status: 202,
+					headers: { "Content-Type": "text/html" },
+				}),
+			);
+
+		try {
+			await searchDuckDuckGo(makeParams("blocked", fetchMock));
+			expect.unreachable("DDG anomaly response should reject");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			const err = error as SearchProviderError;
+			expect(err.provider).toBe("duckduckgo");
+			expect(err.status).toBe(429);
+			expect(err.message).toMatch(/bot-detection challenge/i);
+		}
+	});
+
+	it("flags anomaly pages served with a 200 status", async () => {
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(
+				new Response(anomalyPage(), {
+					status: 200,
+					headers: { "Content-Type": "text/html" },
+				}),
+			);
+
+		await expect(searchDuckDuckGo(makeParams("blocked-200", fetchMock))).rejects.toMatchObject({
 			provider: "duckduckgo",
-			answer: expectedAnswer,
+			status: 429,
 		});
 	});
 
@@ -181,7 +231,7 @@ describe("DuckDuckGo web search provider", () => {
 			expect(error).toMatchObject({
 				provider: "duckduckgo",
 				status: 503,
-				message: "DuckDuckGo API error (503): upstream unavailable",
+				message: "DuckDuckGo HTML error (503)",
 			});
 		}
 	});

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -48,10 +48,10 @@ function anomalyPage(): string {
 
 describe("DuckDuckGo web search provider", () => {
 	it("POSTs the query and recency filter to the no-JS HTML frontend", async () => {
-		let capturedUrl: string | null = null;
+		const captured: { url?: string } = {};
 		let capturedInit: RequestInit | undefined;
 		const fetchMock: FetchImpl = (input, init) => {
-			capturedUrl = typeof input === "string" ? input : input.toString();
+			captured.url = typeof input === "string" ? input : input.toString();
 			capturedInit = init;
 			return Promise.resolve(
 				new Response(htmlPage({ url: "https://example.com/a", title: "A" }), {
@@ -63,7 +63,7 @@ describe("DuckDuckGo web search provider", () => {
 
 		await searchDuckDuckGo({ ...makeParams("how to fix bug in code", fetchMock), recency: "week" });
 
-		expect(capturedUrl).toBe("https://html.duckduckgo.com/html/");
+		expect(captured.url).toBe("https://html.duckduckgo.com/html/");
 		expect(capturedInit?.method).toBe("POST");
 		const form = new URLSearchParams(capturedInit?.body as string);
 		expect(form.get("q")).toBe("how to fix bug in code");
@@ -174,9 +174,7 @@ describe("DuckDuckGo web search provider", () => {
 
 		const response = await searchDuckDuckGo(makeParams("direct", fetchMock));
 
-		expect(response.sources).toEqual([
-			{ title: "Direct", url: "https://direct.example/page", snippet: undefined },
-		]);
+		expect(response.sources).toEqual([{ title: "Direct", url: "https://direct.example/page", snippet: undefined }]);
 	});
 
 	it("throws a clear SearchProviderError when DDG serves the anomaly modal", async () => {


### PR DESCRIPTION
## Repro

With no other web-search provider authenticated (e.g. `codex` 401), `omp` falls back to `duckduckgo` and any non-encyclopedic query surfaces:

```
Error: All web search providers failed: codex: 401 unauthorized;
DuckDuckGo returned no renderable search content.
```

Direct call against the existing provider confirms the empty payload for typical agent queries:

```js
import { searchDuckDuckGo } from "@oh-my-pi/pi-coding-agent/web/search/providers/duckduckgo";
await searchDuckDuckGo({ query: "how to fix bug in code", ... });
// → { answer: undefined, sources: [] }
```

Only Wikipedia/Wolfram-Alpha-style queries (`"what is the meaning of life"`) come back with content.

## Cause

`packages/coding-agent/src/web/search/providers/duckduckgo.ts` called `https://api.duckduckgo.com/?…&format=json` — the **Instant Answer API**, not a general-purpose web search. For arbitrary queries it returns `AbstractText=""`, `Results=[]`, `RelatedTopics=[]`, which `hasRenderableSearchContent()` in `packages/coding-agent/src/web/search/index.ts` rejects, producing the user-facing error. Reported in #3799.

## Fix

- Rewrite the provider to POST `https://html.duckduckgo.com/html/` (DuckDuckGo's no-JS HTML frontend) with a browser `User-Agent`, parse the result blocks, and unwrap the `//duckduckgo.com/l/?uddg=…` redirect URLs back to the real targets.
- Map `recency` → DDG's `df` form param (`day→d / week→w / month→m / year→y`); omit when unset.
- Detect the bot-challenge response (HTTP 200/202 carrying an `anomaly-modal` body) and raise a clear `SearchProviderError("duckduckgo", …, 429)` explaining DuckDuckGo throttles datacenter / shared-egress IPs so the orchestrator can fall through to the next provider with cause attached.
- Refresh the provider description (`types.ts`), the changelog entry, and `docs/tools/web_search.md` so they no longer claim the Instant Answer API.
- Replace the unit tests with HTML-fixture coverage for: POST body shape and recency mapping, URL unwrapping and snippet/title decoding, dedup by target URL, `numSearchResults` clamping to the new 30 ceiling, unwrapped (sponsored) hrefs, anomaly-modal handling at both 200 and 202, and generic upstream HTTP errors.

## Verification

- `bun test test/tools/web-search-duckduckgo.test.ts` → 9 pass, 0 fail.
- `bun test test/tools/web-search-*.test.ts` → 131 pass, 0 fail (no regressions in sibling providers).
- `bun check` clean (gate passed at push).
- Manual probe against the live HTML endpoint confirmed 10 parseable results; the same probe also confirmed the anomaly path triggers a 202 + `anomaly-modal` body from datacenter IPs, exercising the new error branch.

Fixes #3799