### PR TITLE
fix(cli): preserve Windows extension paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
+- Fixed Windows `--extension` paths with spaces or `\\?\` prefixes being truncated or passed through to Bun import/spawn APIs. ([#3804](https://github.com/can1357/oh-my-pi/issues/3804))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -94,6 +94,35 @@ const PARSE_DEPS: ParseDeps = {
 	thinkingEfforts: CLI_THINKING_LEVELS,
 };
 
+const WINDOWS_PATH_VALUE_FLAGS: ReadonlySet<string> = new Set(["--extension", "-e", "--hook"]);
+const WINDOWS_PATH_START_RE =
+	/^(?:[A-Za-z]:[\\/]|\\\\[?]\\(?:[A-Za-z]:[\\/]|UNC[\\/])|\\\\[^\\/]+[\\/][^\\/]+[\\/]|\/\/[?]\/(?:[A-Za-z]:\/|UNC\/)|\/\/[^/]+\/[^/]+\/)/;
+const WINDOWS_MODULE_PATH_SUFFIX_RE = /\.(?:[cm]?[jt]sx?)$/i;
+
+function consumeBuiltInStringValue(flag: string, args: string[], valueIndex: number): { value: string; index: number } {
+	const value = args[valueIndex];
+	if (
+		value === undefined ||
+		!WINDOWS_PATH_VALUE_FLAGS.has(flag) ||
+		!WINDOWS_PATH_START_RE.test(value) ||
+		WINDOWS_MODULE_PATH_SUFFIX_RE.test(value)
+	) {
+		return { value: value ?? "", index: valueIndex };
+	}
+
+	let candidate = value;
+	for (let index = valueIndex + 1; index < args.length; index++) {
+		const next = args[index];
+		if (next === PROFILE_BOOTSTRAP_BOUNDARY_ARG || next.startsWith("-")) break;
+		candidate += ` ${next}`;
+		if (WINDOWS_MODULE_PATH_SUFFIX_RE.test(candidate)) {
+			return { value: candidate, index };
+		}
+	}
+
+	return { value, index: valueIndex };
+}
+
 export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { type: "boolean" | "string" }>): Args {
 	// Work on a copy: the `--option=value` handling below splices the value
 	// into the array, and callers reuse the same argv (the post-extension
@@ -161,7 +190,9 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			// here only when its boolean extension is NOT loaded) would otherwise swallow
 			// the marker as its value and drop the user's trailing message.
 			if (i + 1 < args.length && args[i + 1] !== PROFILE_BOOTSTRAP_BOUNDARY_ARG) {
-				STRING_SETTERS[arg](result, args[++i], PARSE_DEPS);
+				const consumed = consumeBuiltInStringValue(arg, args, i + 1);
+				i = consumed.index;
+				STRING_SETTERS[arg](result, consumed.value, PARSE_DEPS);
 			}
 		} else if (OPTIONAL_VALUE_FLAGS.has(arg)) {
 			const config = OPTIONAL_FLAGS[arg];

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import { isBuiltin } from "node:module";
 import * as path from "node:path";
 import * as url from "node:url";
-import { isCompiledBinary } from "@oh-my-pi/pi-utils";
+import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
 import { BUNDLED_PI_REGISTRY_KEYS } from "./legacy-pi-bundled-keys";
 
 const IS_COMPILED_BINARY = isCompiledBinary();
@@ -425,7 +425,7 @@ function toImportSpecifier(resolvedPath: string): string {
 	if (isBundledVirtualSpecifier(resolvedPath)) {
 		return resolvedPath;
 	}
-	return url.pathToFileURL(resolvedPath).href;
+	return url.pathToFileURL(stripWindowsExtendedLengthPathPrefix(resolvedPath)).href;
 }
 
 function rewriteLegacyPiImports(source: string): string {

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -1,5 +1,12 @@
 import * as path from "node:path";
-import { $env, isBunTestRuntime, isCompiledBinary, logger, workerHostEntry } from "@oh-my-pi/pi-utils";
+import {
+	$env,
+	isBunTestRuntime,
+	isCompiledBinary,
+	logger,
+	stripWindowsExtendedLengthPathPrefix,
+	workerHostEntry,
+} from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 
 /**
@@ -90,10 +97,11 @@ export const SMOKE_TEST_TIMEOUT_MS = 30_000;
  * embedding).
  */
 export function resolveWorkerSpawnCmd(workerArg: string): WorkerSpawnCommand {
-	if (isCompiledBinary()) return { cmd: [process.execPath, workerArg] };
+	const executable = stripWindowsExtendedLengthPathPrefix(process.execPath);
+	if (isCompiledBinary()) return { cmd: [executable, workerArg] };
 	const hostEntry = workerHostEntry();
 	if (hostEntry) {
-		return { cmd: [process.execPath, path.basename(hostEntry), workerArg], cwd: path.dirname(hostEntry) };
+		return { cmd: [executable, path.basename(hostEntry), workerArg], cwd: path.dirname(hostEntry) };
 	}
 	const packageRoot = path.resolve(import.meta.dir, "..", "..");
 	return { cmd: [process.execPath, "src/cli.ts", workerArg], cwd: packageRoot };

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { isEnoent } from "@oh-my-pi/pi-utils";
+import { isEnoent, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolError } from "./tool-errors";
@@ -147,7 +147,9 @@ export function expandTilde(filePath: string, home?: string): string {
 }
 
 export function expandPath(filePath: string): string {
-	const normalized = stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(filePath)));
+	const normalized = stripWindowsExtendedLengthPathPrefix(
+		stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(filePath))),
+	);
 	return expandTilde(normalized);
 }
 

--- a/packages/coding-agent/test/cli-extension-path.test.ts
+++ b/packages/coding-agent/test/cli-extension-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+
+describe("parseArgs — Windows extension paths", () => {
+	it("rejoins a module path split at spaces before parsing following flags", () => {
+		const parsed = parseArgs([
+			"--extension",
+			"C:\\Users\\Shi",
+			"Xin\\AppData\\Local\\ompcot\\extensions\\embedded-server.mjs",
+			"--mode",
+			"rpc",
+		]);
+
+		expect(parsed.extensions).toEqual([
+			"C:\\Users\\Shi Xin\\AppData\\Local\\ompcot\\extensions\\embedded-server.mjs",
+		]);
+		expect(parsed.messages).toEqual([]);
+		expect(parsed.mode).toBe("rpc");
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `stripWindowsExtendedLengthPathPrefix()` for normalizing `\\?\` and native Win32 path prefixes before Bun import/spawn calls. ([#3804](https://github.com/can1357/oh-my-pi/issues/3804))
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * as logger from "./logger";
 export * from "./loop-phase";
 export * from "./mermaid-ascii";
 export * from "./mime";
+export * from "./path";
 export * from "./path-tree";
 export * from "./peek-file";
 export * as postmortem from "./postmortem";

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,0 +1,28 @@
+const WINDOWS_DRIVE_EXTENDED_PREFIX = /^\\\\[?]\\([A-Za-z]:[\\/].*)$/;
+const WINDOWS_UNC_EXTENDED_PREFIX = /^\\\\[?]\\UNC[\\/]([^\\/]+)[\\/](.+)$/i;
+const WINDOWS_DRIVE_EXTENDED_FORWARD_PREFIX = /^\/\/[?]\/([A-Za-z]:\/.*)$/;
+const WINDOWS_UNC_EXTENDED_FORWARD_PREFIX = /^\/\/[?]\/UNC\/([^/]+)\/(.+)$/i;
+const WINDOWS_DRIVE_NT_PREFIX = /^\\\\[?][?]\\([A-Za-z]:[\\/].*)$/;
+const WINDOWS_UNC_NT_PREFIX = /^\\\\[?][?]\\UNC[\\/]([^\\/]+)[\\/](.+)$/i;
+
+/** Removes Win32 extended-length prefixes before passing paths to Bun APIs. */
+export function stripWindowsExtendedLengthPathPrefix(
+	filePath: string,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (platform !== "win32") return filePath;
+
+	const uncMatch = WINDOWS_UNC_EXTENDED_PREFIX.exec(filePath) ?? WINDOWS_UNC_NT_PREFIX.exec(filePath);
+	if (uncMatch) return `\\\\${uncMatch[1]}\\${uncMatch[2]}`;
+
+	const driveMatch = WINDOWS_DRIVE_EXTENDED_PREFIX.exec(filePath) ?? WINDOWS_DRIVE_NT_PREFIX.exec(filePath);
+	if (driveMatch) return driveMatch[1];
+
+	const forwardUncMatch = WINDOWS_UNC_EXTENDED_FORWARD_PREFIX.exec(filePath);
+	if (forwardUncMatch) return `//${forwardUncMatch[1]}/${forwardUncMatch[2]}`;
+
+	const forwardDriveMatch = WINDOWS_DRIVE_EXTENDED_FORWARD_PREFIX.exec(filePath);
+	if (forwardDriveMatch) return forwardDriveMatch[1];
+
+	return filePath;
+}

--- a/packages/utils/src/worker-host.ts
+++ b/packages/utils/src/worker-host.ts
@@ -1,3 +1,5 @@
+import { stripWindowsExtendedLengthPathPrefix } from "./path";
+
 /**
  * Main-module path declared by self-dispatching CLI entrypoints — entries
  * whose top-level argv handling routes hidden `__omp_*` worker selectors.
@@ -10,7 +12,7 @@ let workerHostMain: string | null = null;
 
 /** Called by CLI entrypoints whose main module dispatches worker argv selectors. */
 export function declareWorkerHostEntry(): void {
-	workerHostMain = Bun.main;
+	workerHostMain = stripWindowsExtendedLengthPathPrefix(Bun.main);
 }
 
 /** Main-module path of the self-dispatching CLI host, or null outside it. */

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { stripWindowsExtendedLengthPathPrefix } from "../src/path";
+
+describe("stripWindowsExtendedLengthPathPrefix", () => {
+	it("removes drive and UNC extended-length prefixes on Windows", () => {
+		expect(stripWindowsExtendedLengthPathPrefix("\\\\?\\C:\\Users\\Shi Xin\\omp.exe", "win32")).toBe(
+			"C:\\Users\\Shi Xin\\omp.exe",
+		);
+		expect(stripWindowsExtendedLengthPathPrefix("\\\\?\\UNC\\server\\share\\omp.exe", "win32")).toBe(
+			"\\\\server\\share\\omp.exe",
+		);
+	});
+
+	it("leaves non-Windows paths unchanged", () => {
+		const path = "\\\\?\\C:\\Users\\Shi Xin\\omp.exe";
+		expect(stripWindowsExtendedLengthPathPrefix(path, "linux")).toBe(path);
+	});
+});


### PR DESCRIPTION
## Repro
Added a regression test in a clean detached `HEAD` worktree that simulates the Windows/Bun argv shape for `omp --extension "C:\\Users\\Shi Xin\\AppData\\Local\\ompcot\\extensions\\embedded-server.mjs" --mode rpc`; before the fix `parseArgs()` recorded only `C:\\Users\\Shi` as the extension path and left the rest as positional input.

## Cause
`packages/coding-agent/src/cli/args.ts` consumed exactly one token for `--extension`, so a Windows extension path that arrived split at a space was truncated. Separately, `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts`, `packages/coding-agent/src/subprocess/worker-client.ts`, and `packages/utils/src/worker-host.ts` forwarded Win32 `\\?\` paths into Bun import/worker-spawn APIs without normalization.

## Fix
- Rejoin split Windows module paths for `--extension`, `-e`, and `--hook` before continuing CLI parsing.
- Add `stripWindowsExtendedLengthPathPrefix()` in `@oh-my-pi/pi-utils` and apply it to expanded paths, extension import specifiers, worker host entries, and compiled-binary worker spawns.
- Add regression coverage for split Windows extension paths and Win32 extended-length prefix normalization.

## Verification
`bun test packages/coding-agent/test/cli-extension-path.test.ts packages/utils/test/path.test.ts`; `bun test packages/coding-agent/test/cli-unknown-flag.test.ts packages/coding-agent/test/cli-argv-routing.test.ts packages/coding-agent/test/flag-tables.test.ts`; `bun run test` in `packages/utils`; `bun run check` in `packages/utils`; `bun run check` in `packages/coding-agent`. Fixes #3804