### PR TITLE
fix(catalog): widen namespaced GLM stream watchdogs

### DIFF
--- a/packages/ai/test/openai-completions-progress-chunk.test.ts
+++ b/packages/ai/test/openai-completions-progress-chunk.test.ts
@@ -105,6 +105,19 @@ describe("resolveOpenAICompat stream idle timeout", () => {
 		expect(model.compat.streamIdleTimeoutMs).toBe(600_000);
 	});
 
+	it("widens namespaced custom Z.AI OpenAI-compatible GLM 5.2 endpoints", () => {
+		const model = buildModel({
+			...openAICompletionsModel,
+			id: "zai-org/GLM-5.2",
+			name: "GLM-5.2",
+			provider: "openai",
+			baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			compat: openAICompletionsModel.compatConfig,
+		} as ModelSpec<"openai-completions">);
+
+		expect(model.compat.streamIdleTimeoutMs).toBe(600_000);
+	});
+
 	it("widens DeepSeek V4 reasoning streams on the official DeepSeek API", () => {
 		const model = buildModel({
 			...openAICompletionsModel,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed namespaced GLM-5.x model IDs on Z.AI/Zhipu OpenAI-compatible endpoints to inherit the widened stream watchdog, avoiding spurious stalled-stream errors during long thinking phases. ([#3819](https://github.com/can1357/oh-my-pi/issues/3819))
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -33,7 +33,7 @@ import type {
 import { applyCompatOverrides } from "./apply";
 
 /** GLM coding-plan SKUs idle for minutes mid-reasoning; see `streamIdleTimeoutMs`. */
-const GLM_CODING_PLAN_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
+const GLM_CODING_PLAN_MODEL_PATTERN = /(^|\/)glm-5(?:[.-]|$)/i;
 const GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS = 600_000;
 /** Direct DeepSeek reasoning models stall between thinking and answer phases. */
 const DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS = 300_000;


### PR DESCRIPTION
## Repro
Namespaced GLM-5.2 model IDs on Z.AI-compatible OpenAI endpoints resolve without the GLM coding-plan watchdog: `bun test packages/ai/test/openai-completions-progress-chunk.test.ts -t "widens namespaced custom Z.AI OpenAI-compatible GLM 5.2 endpoints"` failed with `Expected: 600000`, `Received: undefined` before the fix.

## Cause
`packages/catalog/src/compat/openai.ts` detected GLM coding-plan stream watchdog defaults with `GLM_CODING_PLAN_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i`, which only matched bare IDs like `glm-5.1`. Custom or discovered namespaced IDs such as `zai-org/GLM-5.2` still matched the Z.AI/Zhipu host, but missed the model-id predicate and fell back to the global OpenAI stream idle timeout.

## Fix
- Broadened the GLM coding-plan watchdog model predicate to match `glm-5.x` after namespace separators.
- Added a regression test covering a namespaced GLM-5.2 ID on a custom Z.AI-compatible OpenAI endpoint.
- Added the catalog changelog entry for #3819.

## Verification
`bun test packages/ai/test/openai-completions-progress-chunk.test.ts -t "widens namespaced custom Z.AI OpenAI-compatible GLM 5.2 endpoints"` passed. `bun test packages/ai/test/openai-completions-progress-chunk.test.ts` passed. Pre-publish gate passed during `gh_push_branch`. Fixes #3819