### PR TITLE
feat(tui): live-preview tool calls for detached subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Detached background subagents now show a live-preview tool sub-row in the anchored Subagents HUD — the current (or, between calls, most recent) tool call with a one-line detail and an elapsed marker — so running spawns are no longer a black box. ([#3815](https://github.com/can1357/oh-my-pi/issues/3815))
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -102,7 +102,7 @@ import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-pro
 import { formatTaskId } from "../task/render";
 import type { LspStartupServerInfo } from "../tools";
 import { normalizeLocalScheme } from "../tools/path-utils";
-import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
+import { previewLine, replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
 import { type ResolveToolDetails, runResolveInvocation } from "../tools/resolve";
 import { formatPhaseDisplayName, todoMatchesAnyDescription } from "../tools/todo";
@@ -329,6 +329,11 @@ const MODEL_CYCLE_TRACK_CLEAR_MS = 4000;
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * one hooked row per running agent in the same `Id: description` shape the
  * inline task rows use (muted task preview when no description was given).
+ * A running row may carry a live-preview sub-row — the agent's current (or,
+ * between calls, most recent) tool call with a one-line detail and an elapsed
+ * marker, when one is available — read off the observable-session progress
+ * channel so detached spawns are no longer a black box. Detail is budgeted to
+ * the viewport.
  * Only detached background spawns are listed: a sync task call blocks the
  * parent turn and its inline tool block already renders progress live, and
  * eval `agent()` spawns are rendered by their own eval cell tree.
@@ -361,6 +366,36 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 			}
 		}
 		lines.push(line);
+		// Live preview of what the subagent is doing right now: its current (or,
+		// between calls, most recent) tool call with a one-line detail, mirroring
+		// the inline task tool block so detached spawns are no longer a black box.
+		const progress = session.progress;
+		if (progress?.status === "running") {
+			const currentTool = progress.currentTool;
+			const recent = progress.recentTools[0];
+			const tool = currentTool ?? recent?.tool;
+			if (tool) {
+				const detail = progress.lastIntent ?? (currentTool ? progress.currentToolArgs : recent?.args);
+				const toolPrefix = `${indent}  ${hook} `;
+				// Elapsed marker only once a call has been running long enough.
+				let elapsedLabel = "";
+				if (progress.currentToolStartMs) {
+					const elapsed = Date.now() - progress.currentToolStartMs;
+					if (elapsed > 5000) {
+						elapsedLabel = `${theme.sep.dot}${theme.fg("warning", formatDuration(elapsed))}`;
+					}
+				}
+				let toolLine = `${toolPrefix}${theme.fg(currentTool ? "muted" : "dim", tool)}`;
+				// Budget the detail so the row stays within the viewport (the
+				// ": " separator counts too): never overflow, just shorten it.
+				const detailBudget = columns - visibleWidth(toolLine) - visibleWidth(elapsedLabel) - 2;
+				if (detail && detailBudget >= 8) {
+					toolLine += `: ${theme.fg("dim", previewLine(detail, Math.min(TRUNCATE_LENGTHS.SHORT, detailBudget)))}`;
+				}
+				toolLine += elapsedLabel;
+				lines.push(toolLine);
+			}
+		}
 	});
 	return lines;
 }

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -1,9 +1,12 @@
 /**
  * Contract: the anchored subagent HUD (rendered above the editor, next to the
  * Todos block) lists exactly the running *detached* subagents as
- * `Id: description` rows and yields no output once nothing qualifies, so the
- * block self-clears. Sync task spawns and eval `agent()` spawns are excluded:
- * their progress is already rendered inline (tool block / eval cell).
+ * `Id: description` rows, and may carry a live-preview sub-row showing the
+ * agent's current (or most recent) tool call with a one-line detail when one
+ * is available, read off the observable-session progress channel. Yields no
+ * output once nothing qualifies, so the block self-clears. Sync task spawns
+ * and eval `agent()` spawns are excluded: their progress is already rendered
+ * inline (tool block / eval cell).
  */
 import { beforeAll, describe, expect, it } from "bun:test";
 import { renderSubagentHudLines } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
@@ -199,5 +202,81 @@ describe("subagent HUD lines", () => {
 		);
 
 		expect(activeIds()).toEqual(["SelectorSurfaces", "BlastRadius", "VariantsSurvey"]);
+	});
+
+	it("renders a live-preview tool sub-row for a running subagent", () => {
+		const out = render([
+			makeSession({
+				id: "AuthLoader",
+				description: "Refactoring the auth flow",
+				progress: makeProgress({
+					id: "AuthLoader",
+					currentTool: "read",
+					currentToolArgs: "src/auth.ts:50-100",
+				}),
+			}),
+		]);
+		expect(out).toContain("AuthLoader: Refactoring the auth flow");
+		expect(out).toContain("read: src/auth.ts:50-100");
+	});
+
+	it("falls back to the most recent tool when idle between calls", () => {
+		const out = render([
+			makeSession({
+				id: "Worker",
+				progress: makeProgress({
+					id: "Worker",
+					recentTools: [{ tool: "grep", args: "renderSubagentHudLines", endMs: Date.now() }],
+				}),
+			}),
+		]);
+		expect(out).toContain("grep: renderSubagentHudLines");
+	});
+
+	it("shows an elapsed marker for long-running tool calls and stays within the viewport", () => {
+		const columns = 120;
+		const out = render(
+			[
+				makeSession({
+					id: "Builder",
+					progress: makeProgress({
+						id: "Builder",
+						currentTool: "bash",
+						currentToolArgs: "npm test",
+						currentToolStartMs: Date.now() - 10_000,
+					}),
+				}),
+			],
+			columns,
+		);
+		expect(out).toContain("bash: npm test");
+		// Coarse elapsed label (~10s); the row must never exceed the viewport.
+		expect(out).toContain("·");
+		for (const line of out.split("\n")) {
+			expect(Bun.stringWidth(line)).toBeLessThanOrEqual(columns);
+			if (line.includes("bash")) expect(line).toMatch(/\d+s$/);
+		}
+	});
+
+	it("truncates long tool args to the viewport", () => {
+		const columns = 60;
+		const out = render(
+			[
+				makeSession({
+					id: "Reader",
+					progress: makeProgress({
+						id: "Reader",
+						currentTool: "read",
+						currentToolArgs: "x".repeat(300),
+						currentToolStartMs: Date.now() - 10_000,
+					}),
+				}),
+			],
+			columns,
+		);
+		expect(out).toContain("read:");
+		for (const line of out.split("\n")) {
+			expect(Bun.stringWidth(line)).toBeLessThanOrEqual(columns);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Implements the accepted first cut of #3815 — live preview of what running detached subagents are actually doing, so the Subagents HUD is no longer a black box.

Each running detached subagent row in the anchored HUD now carries a live-preview sub-row showing its **current (or, between calls, most recent) tool call** with a one-line detail and an elapsed marker (once a call has run >5s):

```
Subagents
  ├ ● AuthLoader: Refactoring the auth flow
  │   ┎ read src/auth.ts:50-100 · 10s
```

## How

Enriches the existing `renderSubagentHudLines` (`packages/coding-agent/src/modes/interactive-mode.ts`) with a tool sub-row that mirrors the inline task tool block (`task/render.ts:878-901`):

- `tool = progress.currentTool ?? progress.recentTools[0]?.tool`
- `detail = progress.lastIntent ?? currentToolArgs ?? recent.args`
- elapsed marker via `formatDuration` when `currentToolStartMs` elapsed > 5s
- detail is budgeted to the viewport (`previewLine` over a width computed from the already-rendered segments + the `": "` separator + elapsed), so a row **never exceeds `columns`** — it shortens the preview rather than overflowing

Data is read off the **existing observable-session progress channel** (`TASK_SUBAGENT_PROGRESS_CHANNEL` → `SessionObserverRegistry` → `session.progress`), **not** `AgentRegistry.onChange`/`setActivity` (`setActivity` intentionally emits no events). No new channel, payload, or persistence — it's the same live invalidation path the HUD already used for `Id: description`.

## Scope (matches the accepted first cut)

- In-session `task` **detached** subagents only — sync task spawns and `eval.agent()` spawns stay excluded (their progress renders inline).
- No result/output snippets (tool + args/lastIntent only).
- Ephemeral — nothing written to JSONL.
- No new keybinds, pane, or focus management.

## Verification

- `bun --smol test --parallel=1 test/subagent-hud-render.test.ts` → **11 pass, 0 fail** (7 pre-existing + 4 new: current-tool+args, between-tools fallback, elapsed marker + viewport fit, long-args truncation to `columns=60`).
- `tsgo -p tsconfig.json --noEmit` → clean.
- `biome check` on both changed files → OK.

Closes #3815