### PR TITLE
Fix in-TUI resume for large sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed in-TUI `/resume` switches avoiding the large-session guard by rebuilding the previous session context before loading the selected session.
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13150,7 +13150,7 @@ export class AgentSession {
 		// Flush pending writes before switching so restore snapshots reflect committed state.
 		await this.sessionManager.flush();
 		const previousSessionState = this.sessionManager.captureState();
-		const previousSessionContext = this.buildDisplaySessionContext();
+		const previousSessionContext = switchingToDifferentSession ? undefined : this.buildDisplaySessionContext();
 		// switchSession replaces these arrays wholesale during load/rollback, so retaining
 		// the existing message objects is sufficient and avoids structured-clone failures for
 		// extension/custom metadata that is valid to persist but not cloneable.
@@ -13189,7 +13189,7 @@ export class AgentSession {
 
 			const sessionContext = this.buildDisplaySessionContext();
 			const didReloadConversationChange =
-				!switchingToDifferentSession &&
+				previousSessionContext !== undefined &&
 				this.#didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			const fallbackSelectedMCPToolNames = this.#getSessionDefaultSelectedMCPToolNames(sessionPath);
 			await this.#restoreMCPSelectionsForSessionContext(sessionContext, { fallbackSelectedMCPToolNames });
@@ -13304,21 +13304,26 @@ export class AgentSession {
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
 			let restoreMcpError: unknown;
-			try {
-				await this.#restoreMCPSelectionsForSessionContext(previousSessionContext, {
-					fallbackSelectedMCPToolNames: previousFallbackSelectedMCPToolNames,
-				});
-			} catch (mcpError) {
-				restoreMcpError = mcpError;
-				logger.warn("Failed to restore MCP selections after switch error", {
-					previousSessionFile,
-					targetSessionFile: sessionPath,
-					error: String(mcpError),
-				});
+			if (previousSessionContext) {
+				try {
+					await this.#restoreMCPSelectionsForSessionContext(previousSessionContext, {
+						fallbackSelectedMCPToolNames: previousFallbackSelectedMCPToolNames,
+					});
+				} catch (mcpError) {
+					restoreMcpError = mcpError;
+					logger.warn("Failed to restore MCP selections after switch error", {
+						previousSessionFile,
+						targetSessionFile: sessionPath,
+						error: String(mcpError),
+					});
+					this.#selectedMCPToolNames = new Set(previousSelectedMCPToolNames);
+					this.agent.setTools(previousTools);
+					this.#baseSystemPrompt = previousBaseSystemPrompt;
+					this.agent.setSystemPrompt(previousSystemPrompt);
+				}
+			} else {
 				this.#selectedMCPToolNames = new Set(previousSelectedMCPToolNames);
 				this.agent.setTools(previousTools);
-				this.#baseSystemPrompt = previousBaseSystemPrompt;
-				this.agent.setSystemPrompt(previousSystemPrompt);
 			}
 			this.#baseSystemPrompt = previousBaseSystemPrompt;
 			this.#baseSystemPromptBeforeMemoryPromotion = previousBaseSystemPromptBeforeMemoryPromotion;

--- a/packages/coding-agent/test/session-manager/large-session-memory.test.ts
+++ b/packages/coding-agent/test/session-manager/large-session-memory.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { listSessions } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -57,6 +62,68 @@ describe("large session memory guards", () => {
 		session.flushSync();
 
 		expect(storage.writeTextSyncCalls).toBe(0);
+	});
+
+	it("does not build the previous display context when switching to another session", async () => {
+		const storage = new CountingMemorySessionStorage();
+		const currentManager = SessionManager.create("/work", "/sessions", storage);
+		currentManager.appendMessage({ role: "user", content: "current", timestamp: 1 });
+		currentManager.appendMessage(makeAssistantMessage("current reply"));
+		const currentFile = currentManager.getSessionFile();
+		if (!currentFile) throw new Error("Expected current session file");
+
+		const targetFile = "/sessions/target.jsonl";
+		storage.writeTextSync(
+			targetFile,
+			[
+				{
+					type: "session",
+					version: 3,
+					id: "target",
+					timestamp: "2026-01-01T00:00:00.000Z",
+					cwd: "/work",
+				},
+				{
+					type: "message",
+					id: "target-user",
+					parentId: null,
+					timestamp: "2026-01-01T00:00:01.000Z",
+					message: { role: "user", content: "target", timestamp: 1 },
+				},
+			]
+				.map(entry => `${JSON.stringify(entry)}\n`)
+				.join(""),
+		);
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["test"], tools: [] },
+		});
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-switch-session-"));
+		tempDirs.push(tempDir);
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		const session = new AgentSession({
+			agent,
+			sessionManager: currentManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: new ModelRegistry(authStorage, path.join(tempDir, "models.yml")),
+		});
+		const originalBuildDisplaySessionContext = session.buildDisplaySessionContext.bind(session);
+		session.buildDisplaySessionContext = () => {
+			if (session.sessionFile === currentFile) {
+				throw new Error("previous display context should not be built for a different-session switch");
+			}
+			return originalBuildDisplaySessionContext();
+		};
+
+		try {
+			await expect(session.switchSession(targetFile)).resolves.toBe(true);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
 	});
 
 	it("elides superseded compactions and rewrites the compacted file", async () => {


### PR DESCRIPTION
## Summary
- Defer building the previous display context during different-session switches so in-TUI /resume does not materialize a huge current session before loading the selected session.
- Preserve same-session reload comparison and rollback behavior.
- Add a regression test that fails if switchSession rebuilds the previous context for a different target.

## Verification
- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/session-manager/large-session-memory.test.ts