### PR TITLE
fix(tui): aligned /extensions MCP status with /mcp list

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same denylist so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same canonical mcp.json path — flipping `enabled` on the loaded source file for config-resident servers, including supported non-primary files such as `.omp/.mcp.json`, and the denylist for discovered third-party servers, so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
+- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`, and made `/extensions` re-enable work for every supported source. The dashboard now mirrors `/mcp list` by honoring the per-server `enabled: false` flag plus the user-level `disabledServers` denylist and a new `enabledServers` allowlist; the dashboard's MCP toggle writes through the canonical mcp.json — flipping `enabled` on the loaded source file for config-resident servers (including supported non-primary files such as `.omp/.mcp.json`), force-enabling tool-owned sources (such as `opencode.json`) via the user `enabledServers` allowlist without mutating the foreign config, and using the `disabledServers` denylist for purely discovered third-party servers, so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
 
 ## [16.2.6] - 2026-06-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same denylist so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
+- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same canonical mcp.json — flipping `enabled` on config-resident servers (so re-enabling a server with `enabled: false` actually re-enables it) and the denylist for discovered third-party servers, so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
 
 ## [16.2.6] - 2026-06-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same canonical mcp.json — flipping `enabled` on config-resident servers (so re-enabling a server with `enabled: false` actually re-enables it) and the denylist for discovered third-party servers, so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
+- Fixed `/extensions` showing MCP servers as `active` when `/mcp list` reported them as `disabled`. The dashboard now mirrors `/mcp list` by honoring both the per-server `enabled: false` flag and the user-level `disabledServers` denylist, and toggling an MCP server from the dashboard now writes through the same canonical mcp.json path — flipping `enabled` on the loaded source file for config-resident servers, including supported non-primary files such as `.omp/.mcp.json`, and the denylist for discovered third-party servers, so `/mcp list`, the MCP runtime, and the dashboard stay in sync ([#3827](https://github.com/can1357/oh-my-pi/issues/3827)).
 
 ## [16.2.6] - 2026-06-29
 

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -22,7 +22,16 @@
     },
     "disabledServers": {
       "type": "array",
-      "description": "User-level denylist for disabling discovered servers by name.",
+      "description": "User-level denylist for disabling discovered servers by name. Highest precedence: a server here is hidden regardless of any other source.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "enabledServers": {
+      "type": "array",
+      "description": "User-level allowlist that overrides a discovered server's `enabled: false` flag (e.g. when the source config is owned by another tool such as opencode.json). The denylist still wins.",
       "items": {
         "type": "string",
         "minLength": 1

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -228,10 +228,52 @@ export async function setServerDisabled(filePath: string, name: string, disabled
 	await writeMCPConfigFile(filePath, updated);
 }
 
+/**
+ * Read the user-level force-enable list (allowlist that overrides a
+ * non-writable source config's `enabled: false`).
+ */
+export async function readEnabledServers(filePath: string): Promise<string[]> {
+	const config = await readMCPConfigFile(filePath);
+	return Array.isArray(config.enabledServers) ? config.enabledServers : [];
+}
+
+/**
+ * Add or remove a server name from the user-level force-enable list.
+ * The list overrides a discovered server's `enabled: false` flag but does
+ * NOT override the `disabledServers` denylist.
+ */
+export async function setServerForceEnabled(filePath: string, name: string, force: boolean): Promise<void> {
+	const config = await readMCPConfigFile(filePath);
+	const current = new Set(config.enabledServers ?? []);
+
+	if (force) {
+		current.add(name);
+	} else {
+		current.delete(name);
+	}
+
+	const updated: MCPConfigFile = {
+		...config,
+		enabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
+	};
+
+	if (!updated.enabledServers) {
+		delete updated.enabledServers;
+	}
+
+	await writeMCPConfigFile(filePath, updated);
+}
+
 /** Paths and target state for toggling one MCP server across known config files. */
 export interface SetMcpServerEnabledOptions {
 	userPath: string;
 	projectPath: string;
+	/**
+	 * Absolute path to the loaded row's source mcp.json. Provide ONLY for
+	 * formats this codebase owns (native `.omp/mcp.json` and `mcp-json`
+	 * `mcp.json`/`.mcp.json`). Tool-owned configs (opencode.json, claude.json,
+	 * settings.json …) MUST be omitted; we never mutate another tool's file.
+	 */
 	sourcePath?: string;
 	name: string;
 	enabled: boolean;
@@ -240,19 +282,24 @@ export interface SetMcpServerEnabledOptions {
 /**
  * Flip a server's enabled/disabled state regardless of where it lives.
  *
- * Mirrors `/mcp enable` / `/mcp disable` for primary configs, but also accepts
- * the loaded row's source path so dashboard toggles can update supported
- * alternate MCP files such as `.omp/.mcp.json` and user `.mcp.json` before
- * falling back to the user-level `disabledServers` denylist.
+ * Resolution order, mirroring `/mcp enable` / `/mcp disable` plus the dashboard
+ * fix for non-writable source configs:
  *
- * - Server found in `sourcePath` → write `enabled` on that entry.
- * - Else server defined in project mcp.json → write `enabled` on that entry.
- * - Else server defined in user mcp.json → write `enabled` on that entry.
- * - Else (discovered third-party server) → use the user-level
- *   `disabledServers` denylist.
- * - On re-enable, ALWAYS clear any stale denylist entry so a server disabled
- *   via `/mcp disable` and later re-enabled via `enabled: true` doesn't stay
- *   suppressed by a leftover deny entry.
+ * - Server found in `sourcePath` (writable) → write `enabled` on that entry.
+ * - Else server in project mcp.json → write `enabled` there.
+ * - Else server in user mcp.json → write `enabled` there.
+ * - Else (server defined in a tool-owned source like opencode.json, OR a
+ *   purely discovered server):
+ *   - Disable → add to the user-level `disabledServers` denylist.
+ *   - Enable → add to the user-level `enabledServers` allowlist so the
+ *     dashboard / runtime override the non-writable source's
+ *     `enabled: false` flag.
+ *
+ * Cleanup invariants — on every call:
+ * - Re-enable clears any stale denylist entry so a server disabled via
+ *   `/mcp disable` and re-enabled here doesn't stay suppressed.
+ * - Disable clears any stale allowlist entry so re-disabling a
+ *   force-enabled server actually takes effect.
  */
 export async function setMcpServerEnabled(options: SetMcpServerEnabledOptions): Promise<void> {
 	const { userPath, projectPath, sourcePath, name, enabled } = options;
@@ -269,17 +316,35 @@ export async function setMcpServerEnabled(options: SetMcpServerEnabledOptions): 
 		break;
 	}
 
-	if (!updatedInConfig) {
-		await setServerDisabled(userPath, name, !enabled);
-		return;
-	}
-
-	// Re-enable: the per-server `enabled` flag is now true, but a stale denylist
-	// entry would still hide the server. Drop it.
 	if (enabled) {
+		// Either we just wrote `enabled: true` on a writable source, or the
+		// server lives in a non-writable source whose `enabled: false` flag we
+		// need to override via the user allowlist. Either way the denylist
+		// entry (if any) must clear so the row becomes active.
 		const denied = await readDisabledServers(userPath);
 		if (denied.includes(name)) {
 			await setServerDisabled(userPath, name, false);
 		}
+
+		const forced = await readEnabledServers(userPath);
+		const isForced = forced.includes(name);
+		if (!updatedInConfig && !isForced) {
+			await setServerForceEnabled(userPath, name, true);
+		} else if (updatedInConfig && isForced) {
+			// Writable source now carries `enabled: true`; the override is
+			// redundant. Drop it so the user's allowlist stays tidy.
+			await setServerForceEnabled(userPath, name, false);
+		}
+		return;
+	}
+
+	// Disable path. Clear any force-enable override regardless of source so the
+	// disable actually sticks.
+	const forced = await readEnabledServers(userPath);
+	if (forced.includes(name)) {
+		await setServerForceEnabled(userPath, name, false);
+	}
+	if (!updatedInConfig) {
+		await setServerDisabled(userPath, name, true);
 	}
 }

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -227,3 +227,51 @@ export async function setServerDisabled(filePath: string, name: string, disabled
 
 	await writeMCPConfigFile(filePath, updated);
 }
+
+/**
+ * Flip a server's enabled/disabled state regardless of where it lives.
+ *
+ * Mirrors `/mcp enable` / `/mcp disable` (see
+ * `slash-commands/helpers/mcp.ts:handleEnableDisableCommand`) so the
+ * `/extensions` dashboard's MCP toggle and the slash command share one source
+ * of truth:
+ *
+ * - Server defined in project mcp.json → write `enabled` on that entry.
+ * - Else server defined in user mcp.json → write `enabled` on that entry.
+ * - Else (discovered third-party server) → use the user-level
+ *   `disabledServers` denylist.
+ * - On re-enable, ALWAYS clear any stale denylist entry so a server disabled
+ *   via `/mcp disable` and later re-enabled via `enabled: true` doesn't stay
+ *   suppressed by a leftover deny entry.
+ */
+export async function setMcpServerEnabled(
+	userPath: string,
+	projectPath: string,
+	name: string,
+	enabled: boolean,
+): Promise<void> {
+	const [userConfig, projectConfig] = await Promise.all([readMCPConfigFile(userPath), readMCPConfigFile(projectPath)]);
+
+	let updatedInConfig = false;
+	if (projectConfig.mcpServers?.[name] !== undefined) {
+		await updateMCPServer(projectPath, name, { ...projectConfig.mcpServers[name], enabled });
+		updatedInConfig = true;
+	} else if (userConfig.mcpServers?.[name] !== undefined) {
+		await updateMCPServer(userPath, name, { ...userConfig.mcpServers[name], enabled });
+		updatedInConfig = true;
+	}
+
+	if (!updatedInConfig) {
+		await setServerDisabled(userPath, name, !enabled);
+		return;
+	}
+
+	// Re-enable: the per-server `enabled` flag is now true, but a stale denylist
+	// entry would still hide the server. Drop it.
+	if (enabled) {
+		const denied = await readDisabledServers(userPath);
+		if (denied.includes(name)) {
+			await setServerDisabled(userPath, name, false);
+		}
+	}
+}

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -228,15 +228,25 @@ export async function setServerDisabled(filePath: string, name: string, disabled
 	await writeMCPConfigFile(filePath, updated);
 }
 
+/** Paths and target state for toggling one MCP server across known config files. */
+export interface SetMcpServerEnabledOptions {
+	userPath: string;
+	projectPath: string;
+	sourcePath?: string;
+	name: string;
+	enabled: boolean;
+}
+
 /**
  * Flip a server's enabled/disabled state regardless of where it lives.
  *
- * Mirrors `/mcp enable` / `/mcp disable` (see
- * `slash-commands/helpers/mcp.ts:handleEnableDisableCommand`) so the
- * `/extensions` dashboard's MCP toggle and the slash command share one source
- * of truth:
+ * Mirrors `/mcp enable` / `/mcp disable` for primary configs, but also accepts
+ * the loaded row's source path so dashboard toggles can update supported
+ * alternate MCP files such as `.omp/.mcp.json` and user `.mcp.json` before
+ * falling back to the user-level `disabledServers` denylist.
  *
- * - Server defined in project mcp.json → write `enabled` on that entry.
+ * - Server found in `sourcePath` → write `enabled` on that entry.
+ * - Else server defined in project mcp.json → write `enabled` on that entry.
  * - Else server defined in user mcp.json → write `enabled` on that entry.
  * - Else (discovered third-party server) → use the user-level
  *   `disabledServers` denylist.
@@ -244,21 +254,19 @@ export async function setServerDisabled(filePath: string, name: string, disabled
  *   via `/mcp disable` and later re-enabled via `enabled: true` doesn't stay
  *   suppressed by a leftover deny entry.
  */
-export async function setMcpServerEnabled(
-	userPath: string,
-	projectPath: string,
-	name: string,
-	enabled: boolean,
-): Promise<void> {
-	const [userConfig, projectConfig] = await Promise.all([readMCPConfigFile(userPath), readMCPConfigFile(projectPath)]);
-
+export async function setMcpServerEnabled(options: SetMcpServerEnabledOptions): Promise<void> {
+	const { userPath, projectPath, sourcePath, name, enabled } = options;
+	const candidatePaths = [...new Set([sourcePath, projectPath, userPath].filter(path => path !== undefined))];
 	let updatedInConfig = false;
-	if (projectConfig.mcpServers?.[name] !== undefined) {
-		await updateMCPServer(projectPath, name, { ...projectConfig.mcpServers[name], enabled });
+
+	for (const filePath of candidatePaths) {
+		const config = await readMCPConfigFile(filePath);
+		const server = config.mcpServers?.[name];
+		if (server === undefined) continue;
+
+		await updateMCPServer(filePath, name, { ...server, enabled });
 		updatedInConfig = true;
-	} else if (userConfig.mcpServers?.[name] !== undefined) {
-		await updateMCPServer(userPath, name, { ...userConfig.mcpServers[name], enabled });
-		updatedInConfig = true;
+		break;
 	}
 
 	if (!updatedInConfig) {

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -9,7 +9,7 @@ import { mcpCapability } from "../capability/mcp";
 import type { SourceMeta } from "../capability/types";
 import type { MCPServer } from "../discovery";
 import { loadCapability } from "../discovery";
-import { readDisabledServers } from "./config-writer";
+import { readDisabledServers, readEnabledServers } from "./config-writer";
 import type { MCPServerConfig } from "./types";
 
 /** Options for loading MCP configs */
@@ -105,16 +105,20 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 		? result.items
 		: result.items.filter(server => server._source.level !== "project");
 
-	// Load user-level disabled servers list
-	const disabledServers = new Set(await readDisabledServers(getMCPConfigPath("user", cwd)));
+	// Load user-level disable/force-enable lists. The denylist always wins; the
+	// allowlist overrides a non-writable source config's `enabled: false`.
+	const userPath = getMCPConfigPath("user", cwd);
+	const [disabledServers, forcedEnabled] = await Promise.all([
+		readDisabledServers(userPath).then(list => new Set(list)),
+		readEnabledServers(userPath).then(list => new Set(list)),
+	]);
 	// Convert to legacy format and preserve source metadata
 	let configs: Record<string, MCPServerConfig> = {};
 	let sources: Record<string, SourceMeta> = {};
 	for (const server of servers) {
 		const config = convertToLegacyConfig(server);
-		if (config.enabled === false || disabledServers.has(server.name)) {
-			continue;
-		}
+		if (disabledServers.has(server.name)) continue;
+		if (config.enabled === false && !forcedEnabled.has(server.name)) continue;
 		configs[server.name] = config;
 		sources[server.name] = server._source;
 	}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -111,7 +111,10 @@ export const MCP_CONFIG_SCHEMA_URL =
 export interface MCPConfigFile {
 	$schema?: string;
 	mcpServers?: Record<string, MCPServerConfig>;
+	/** Names to hide regardless of any source `enabled` flag. Highest precedence. */
 	disabledServers?: string[];
+	/** Names to force-enable when a non-writable source reports `enabled: false`. */
+	enabledServers?: string[];
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -24,7 +24,9 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
+import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../../config/settings";
+import { setServerDisabled } from "../../../mcp/config-writer";
 import { getTabBarTheme } from "../../../modes/shared";
 import { theme } from "../../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../../modes/utils/keybinding-matchers";
@@ -263,6 +265,14 @@ export class ExtensionDashboard implements Component {
 		const sm = this.settings ?? Settings.instance;
 		if (!sm) return;
 
+		// MCP toggles route through the canonical denylist in
+		// `~/.omp/agent/mcp.json` so `/mcp list`, the MCP runtime, and this
+		// dashboard agree on every server's enabled state (issue #3827).
+		if (extensionId.startsWith("mcp:")) {
+			void this.#toggleMcpExtension(extensionId, enabled, sm);
+			return;
+		}
+
 		const disabled = ((sm.get("disabledExtensions") as string[]) ?? []).slice();
 		if (enabled) {
 			const index = disabled.indexOf(extensionId);
@@ -279,6 +289,28 @@ export class ExtensionDashboard implements Component {
 
 		this.#applyDisabledExtensions(disabled);
 		void this.#refreshFromState();
+	}
+
+	async #toggleMcpExtension(extensionId: string, enabled: boolean, sm: Settings): Promise<void> {
+		const name = extensionId.slice("mcp:".length);
+		try {
+			await setServerDisabled(getMCPConfigPath("user", this.cwd), name, !enabled);
+		} catch (error) {
+			logger.warn("Failed to persist MCP toggle", { name, enabled, error: String(error) });
+		}
+
+		// Reconcile `settings.disabledExtensions` with the canonical denylist so
+		// a legacy `mcp:<name>` flag from before this routing change doesn't keep
+		// the server marked disabled after the user re-enables it via the UI.
+		const stored = ((sm.get("disabledExtensions") as string[]) ?? []).slice();
+		const had = stored.indexOf(extensionId);
+		if (enabled && had !== -1) {
+			stored.splice(had, 1);
+			sm.set("disabledExtensions", stored);
+			this.#applyDisabledExtensions(stored);
+		}
+
+		await this.#refreshFromState();
 	}
 
 	async #refreshFromState(): Promise<void> {

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -26,7 +26,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../../config/settings";
-import { setServerDisabled } from "../../../mcp/config-writer";
+import { setMcpServerEnabled } from "../../../mcp/config-writer";
 import { getTabBarTheme } from "../../../modes/shared";
 import { theme } from "../../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../../modes/utils/keybinding-matchers";
@@ -294,14 +294,20 @@ export class ExtensionDashboard implements Component {
 	async #toggleMcpExtension(extensionId: string, enabled: boolean, sm: Settings): Promise<void> {
 		const name = extensionId.slice("mcp:".length);
 		try {
-			await setServerDisabled(getMCPConfigPath("user", this.cwd), name, !enabled);
+			await setMcpServerEnabled(
+				getMCPConfigPath("user", this.cwd),
+				getMCPConfigPath("project", this.cwd),
+				name,
+				enabled,
+			);
 		} catch (error) {
 			logger.warn("Failed to persist MCP toggle", { name, enabled, error: String(error) });
 		}
 
-		// Reconcile `settings.disabledExtensions` with the canonical denylist so
-		// a legacy `mcp:<name>` flag from before this routing change doesn't keep
-		// the server marked disabled after the user re-enables it via the UI.
+		// Reconcile `settings.disabledExtensions` with the canonical mcp.json
+		// state so a legacy `mcp:<name>` flag from before this routing change
+		// doesn't keep the server marked disabled after the user re-enables it
+		// via the UI.
 		const stored = ((sm.get("disabledExtensions") as string[]) ?? []).slice();
 		const had = stored.indexOf(extensionId);
 		if (enabled && had !== -1) {

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -294,12 +294,13 @@ export class ExtensionDashboard implements Component {
 	async #toggleMcpExtension(extensionId: string, enabled: boolean, sm: Settings): Promise<void> {
 		const name = extensionId.slice("mcp:".length);
 		try {
-			await setMcpServerEnabled(
-				getMCPConfigPath("user", this.cwd),
-				getMCPConfigPath("project", this.cwd),
+			await setMcpServerEnabled({
+				userPath: getMCPConfigPath("user", this.cwd),
+				projectPath: getMCPConfigPath("project", this.cwd),
+				sourcePath: this.#writableMcpSourcePath(extensionId),
 				name,
 				enabled,
-			);
+			});
 		} catch (error) {
 			logger.warn("Failed to persist MCP toggle", { name, enabled, error: String(error) });
 		}
@@ -317,6 +318,13 @@ export class ExtensionDashboard implements Component {
 		}
 
 		await this.#refreshFromState();
+	}
+
+	#writableMcpSourcePath(extensionId: string): string | undefined {
+		const extension = this.#state.extensions.find(ext => ext.id === extensionId);
+		if (!extension) return undefined;
+		if (extension.source.provider !== "native" && extension.source.provider !== "mcp-json") return undefined;
+		return extension.path;
 	}
 
 	async #refreshFromState(): Promise<void> {

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -4,7 +4,7 @@
  */
 import * as path from "node:path";
 import { fuzzyMatch } from "@oh-my-pi/pi-tui";
-import { logger } from "@oh-my-pi/pi-utils";
+import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
 import type { ContextFile } from "../../../capability/context-file";
 import type { ExtensionModule } from "../../../capability/extension-module";
 import type { Hook } from "../../../capability/hook";
@@ -22,6 +22,7 @@ import {
 	isProviderEnabled,
 	loadCapability,
 } from "../../../discovery";
+import { readDisabledServers } from "../../../mcp/config-writer";
 import type {
 	DashboardState,
 	Extension,
@@ -141,12 +142,18 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 		logger.warn("Failed to load extension-modules capability", { error: String(error) });
 	}
 
-	// Load MCP servers
+	// Load MCP servers. The dashboard mirrors `/mcp list` (issue #3827) by
+	// honoring the same disable signals: the dashboard-private settings list,
+	// the per-server `enabled: false` flag, and the user-level `disabledServers`
+	// denylist that `/mcp disable` writes through `setServerDisabled`.
 	try {
+		const mcpDisabledNames = cwd
+			? new Set(await readDisabledServers(getMCPConfigPath("user", cwd)).catch(() => []))
+			: new Set<string>();
 		const mcps = await loadCapability<MCPServer>("mcps", loadOpts);
 		for (const server of mcps.all) {
 			const id = makeExtensionId("mcp", server.name);
-			const isDisabled = disabledExtensions.has(id);
+			const isDisabled = disabledExtensions.has(id) || server.enabled === false || mcpDisabledNames.has(server.name);
 			const isShadowed = (server as { _shadowed?: boolean })._shadowed;
 			const providerEnabled = isProviderEnabled(server._source.provider);
 

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -22,7 +22,7 @@ import {
 	isProviderEnabled,
 	loadCapability,
 } from "../../../discovery";
-import { readDisabledServers } from "../../../mcp/config-writer";
+import { readDisabledServers, readEnabledServers } from "../../../mcp/config-writer";
 import type {
 	DashboardState,
 	Extension,
@@ -145,15 +145,29 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 	// Load MCP servers. The dashboard mirrors `/mcp list` (issue #3827) by
 	// honoring the same disable signals: the dashboard-private settings list,
 	// the per-server `enabled: false` flag, and the user-level `disabledServers`
-	// denylist that `/mcp disable` writes through `setServerDisabled`.
+	// denylist that `/mcp disable` writes through `setServerDisabled`. The
+	// user-level `enabledServers` allowlist overrides a non-writable source's
+	// `enabled: false` (e.g. opencode.json) but never the denylist.
 	try {
-		const mcpDisabledNames = cwd
-			? new Set(await readDisabledServers(getMCPConfigPath("user", cwd)).catch(() => []))
-			: new Set<string>();
+		const userMcpPath = cwd ? getMCPConfigPath("user", cwd) : undefined;
+		const [mcpDisabledNames, mcpForcedEnabled] = await Promise.all([
+			userMcpPath
+				? readDisabledServers(userMcpPath)
+						.then(list => new Set(list))
+						.catch(() => new Set<string>())
+				: Promise.resolve(new Set<string>()),
+			userMcpPath
+				? readEnabledServers(userMcpPath)
+						.then(list => new Set(list))
+						.catch(() => new Set<string>())
+				: Promise.resolve(new Set<string>()),
+		]);
 		const mcps = await loadCapability<MCPServer>("mcps", loadOpts);
 		for (const server of mcps.all) {
 			const id = makeExtensionId("mcp", server.name);
-			const isDisabled = disabledExtensions.has(id) || server.enabled === false || mcpDisabledNames.has(server.name);
+			const forced = mcpForcedEnabled.has(server.name);
+			const sourceSaysDisabled = server.enabled === false && !forced;
+			const isDisabled = mcpDisabledNames.has(server.name) || disabledExtensions.has(id) || sourceSaysDisabled;
 			const isShadowed = (server as { _shadowed?: boolean })._shadowed;
 			const providerEnabled = isProviderEnabled(server._source.provider);
 

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -17,7 +17,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
-import { setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
+import { readMCPConfigFile, setMcpServerEnabled, setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
@@ -108,5 +108,103 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		expect(disabled).toBeDefined();
 		expect(disabled!.state).toBe("disabled");
 		expect(disabled!.disabledReason).toBe("item-disabled");
+	});
+
+	test("dashboard re-enable flips enabled:false in mcp.json (PR #3829 review)", async () => {
+		// The bug: when a server has `enabled: false` in mcp.json, the dashboard
+		// toggle previously only removed it from the user-level denylist, so
+		// state-manager's `server.enabled === false` check kept it disabled.
+		// setMcpServerEnabled MUST overwrite the per-server flag.
+		const projectMcpPath = path.join(projectDir, ".omp", "mcp.json");
+
+		await setMcpServerEnabled(
+			getMCPConfigPath("user", projectDir),
+			getMCPConfigPath("project", projectDir),
+			"flag-disabled-server",
+			true,
+		);
+
+		const projectConfig = await readMCPConfigFile(projectMcpPath);
+		expect(projectConfig.mcpServers?.["flag-disabled-server"]?.enabled).toBe(true);
+
+		const reenabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:flag-disabled-server");
+		expect(reenabled).toBeDefined();
+		expect(reenabled!.state).toBe("active");
+	});
+
+	test("dashboard re-enable also clears a stale denylist entry on a config-resident server", async () => {
+		// Manually disable `active-server` via BOTH the per-server flag and the
+		// denylist, simulating a server that's been toggled off multiple ways.
+		const projectMcpPath = path.join(projectDir, ".omp", "mcp.json");
+		const initial = await readMCPConfigFile(projectMcpPath);
+		await Bun.write(
+			projectMcpPath,
+			JSON.stringify({
+				...initial,
+				mcpServers: {
+					...initial.mcpServers,
+					"active-server": { ...initial.mcpServers!["active-server"], enabled: false },
+				},
+			}),
+		);
+		await setServerDisabled(getMCPConfigPath("user", projectDir), "active-server", true);
+
+		await setMcpServerEnabled(
+			getMCPConfigPath("user", projectDir),
+			getMCPConfigPath("project", projectDir),
+			"active-server",
+			true,
+		);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.disabledServers ?? []).not.toContain("active-server");
+
+		const reenabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:active-server");
+		expect(reenabled).toBeDefined();
+		expect(reenabled!.state).toBe("active");
+	});
+
+	test("dashboard disable on a config-resident server writes enabled:false (not denylist)", async () => {
+		await setMcpServerEnabled(
+			getMCPConfigPath("user", projectDir),
+			getMCPConfigPath("project", projectDir),
+			"active-server",
+			false,
+		);
+
+		const projectConfig = await readMCPConfigFile(path.join(projectDir, ".omp", "mcp.json"));
+		expect(projectConfig.mcpServers?.["active-server"]?.enabled).toBe(false);
+
+		// The denylist is reserved for discovered (config-less) servers; a
+		// config-resident server's `enabled: false` flag is the canonical signal.
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.disabledServers ?? []).not.toContain("active-server");
+
+		const disabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:active-server");
+		expect(disabled).toBeDefined();
+		expect(disabled!.state).toBe("disabled");
+	});
+
+	test("dashboard toggles on a discovered (config-less) server use the denylist", async () => {
+		// `phantom-server` is not in any config; only the denylist can suppress it.
+		await setMcpServerEnabled(
+			getMCPConfigPath("user", projectDir),
+			getMCPConfigPath("project", projectDir),
+			"phantom-server",
+			false,
+		);
+
+		let userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.disabledServers ?? []).toContain("phantom-server");
+
+		await setMcpServerEnabled(
+			getMCPConfigPath("user", projectDir),
+			getMCPConfigPath("project", projectDir),
+			"phantom-server",
+			true,
+		);
+
+		userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.disabledServers ?? []).not.toContain("phantom-server");
 	});
 });

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -16,7 +16,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
+import { initializeWithSettings, reset as resetDiscoveryCache } from "@oh-my-pi/pi-coding-agent/discovery";
 import { readMCPConfigFile, setMcpServerEnabled, setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
@@ -218,6 +218,73 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		expect(reenabled).toBeDefined();
 		expect(reenabled!.state).toBe("active");
 	});
+	test("dashboard re-enable force-enables a tool-owned source (opencode.json) via enabledServers", async () => {
+		// OpenCode is a non-writable source: the dashboard must NOT mutate
+		// opencode.json, but the user-level enabledServers allowlist still has
+		// to flip the row active. Modeled after the codex review on PR #3829.
+		const opencodePath = path.join(projectDir, "opencode.json");
+		await Bun.write(
+			opencodePath,
+			JSON.stringify({
+				mcp: {
+					"opencode-server": {
+						type: "local",
+						command: ["echo", "opencode"],
+						enabled: false,
+					},
+				},
+			}),
+		);
+		// beforeEach's Settings.init() already cached an absent opencode.json
+		// for this projectDir, so drop the capability fs cache before the first
+		// dashboard load picks the file up.
+		resetDiscoveryCache();
+
+		const before = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:opencode-server");
+		expect(before).toBeDefined();
+		expect(before!.source.provider).toBe("opencode");
+		expect(before!.state).toBe("disabled");
+
+		// The dashboard withholds sourcePath for tool-owned sources, mirroring
+		// the #writableMcpSourcePath gate.
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "opencode-server",
+			enabled: true,
+		});
+
+		// opencode.json MUST stay untouched.
+		const opencodeRaw = JSON.parse(await Bun.file(opencodePath).text()) as {
+			mcp: { "opencode-server": { enabled: boolean } };
+		};
+		expect(opencodeRaw.mcp["opencode-server"].enabled).toBe(false);
+
+		// The override lands in the user mcp.json's enabledServers list.
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.enabledServers ?? []).toContain("opencode-server");
+
+		const after = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:opencode-server");
+		expect(after).toBeDefined();
+		expect(after!.state).toBe("active");
+
+		// Disabling again clears the override.
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "opencode-server",
+			enabled: false,
+		});
+
+		const userConfigAfter = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfigAfter.enabledServers ?? []).not.toContain("opencode-server");
+		expect(userConfigAfter.disabledServers ?? []).toContain("opencode-server");
+
+		const offAgain = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:opencode-server");
+		expect(offAgain).toBeDefined();
+		expect(offAgain!.state).toBe("disabled");
+	});
+
 	test("dashboard toggles on a discovered (config-less) server use the denylist", async () => {
 		// `phantom-server` is not in any config; only the denylist can suppress it.
 		await setMcpServerEnabled({

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression guard for issue #3827.
+ *
+ * `/mcp list` and the `/extensions` dashboard MUST agree on whether a given MCP
+ * server is enabled or disabled. The two read paths historically diverged: the
+ * dashboard's `loadAllExtensions` only consulted the dashboard-private
+ * `disabledExtensions` settings array, while `/mcp list` (and the MCP runtime
+ * itself) honored both the per-server `enabled` flag in `mcp.json` and the
+ * user-level `disabledServers` denylist.
+ *
+ * The fixtures below cover both inputs and the round-trip the dashboard's
+ * MCP toggle uses (`setServerDisabled`).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
+import { setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
+import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
+import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
+	let projectDir = "";
+	let userAgentDir = "";
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-3827-project-"));
+		userAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-3827-user-"));
+
+		// Redirect user-scoped mcp.json (resolved via getAgentDir() at the call
+		// site) into the per-test temp directory so neither the discovery loader
+		// nor the denylist reader touches the real user profile.
+		setAgentDir(userAgentDir);
+
+		await fs.mkdir(path.join(projectDir, ".omp"), { recursive: true });
+		await fs.writeFile(
+			path.join(projectDir, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					"denylisted-server": { command: "echo", args: ["denylisted"] },
+					"flag-disabled-server": { command: "echo", args: ["flag"], enabled: false },
+					"active-server": { command: "echo", args: ["active"] },
+				},
+			}),
+		);
+
+		// User-level mcp.json carries the denylist; this is what `/mcp disable`
+		// writes through setServerDisabled().
+		await fs.writeFile(
+			path.join(userAgentDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {},
+				disabledServers: ["denylisted-server"],
+			}),
+		);
+
+		const settings = await Settings.init({ inMemory: true, cwd: projectDir });
+		initializeWithSettings(settings);
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		__resetDirsFromEnvForTests();
+		await removeWithRetries(projectDir);
+		await removeWithRetries(userAgentDir);
+	});
+
+	test("treats a server in user-level disabledServers as disabled (matches /mcp list)", async () => {
+		const extensions = await loadAllExtensions(projectDir, []);
+		const denylisted = extensions.find(e => e.id === "mcp:denylisted-server");
+		expect(denylisted).toBeDefined();
+		expect(denylisted!.state).toBe("disabled");
+		expect(denylisted!.disabledReason).toBe("item-disabled");
+	});
+
+	test("treats a server with enabled:false as disabled (matches /mcp list)", async () => {
+		const extensions = await loadAllExtensions(projectDir, []);
+		const flagDisabled = extensions.find(e => e.id === "mcp:flag-disabled-server");
+		expect(flagDisabled).toBeDefined();
+		expect(flagDisabled!.state).toBe("disabled");
+		expect(flagDisabled!.disabledReason).toBe("item-disabled");
+	});
+
+	test("leaves untouched servers active", async () => {
+		const extensions = await loadAllExtensions(projectDir, []);
+		const active = extensions.find(e => e.id === "mcp:active-server");
+		expect(active).toBeDefined();
+		expect(active!.state).toBe("active");
+		expect(active!.disabledReason).toBeUndefined();
+	});
+
+	test("setServerDisabled round-trips through the dashboard view", async () => {
+		// Re-enable `denylisted-server` through the canonical writer the
+		// dashboard's MCP toggle now calls. The dashboard view MUST flip to
+		// active on the next load.
+		await setServerDisabled(getMCPConfigPath("user", projectDir), "denylisted-server", false);
+		const reenabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:denylisted-server");
+		expect(reenabled).toBeDefined();
+		expect(reenabled!.state).toBe("active");
+
+		// The inverse path: disabling `active-server` via the writer flips the
+		// dashboard view to disabled.
+		await setServerDisabled(getMCPConfigPath("user", projectDir), "active-server", true);
+		const disabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:active-server");
+		expect(disabled).toBeDefined();
+		expect(disabled!.state).toBe("disabled");
+		expect(disabled!.disabledReason).toBe("item-disabled");
+	});
+});

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -8,8 +8,8 @@
  * itself) honored both the per-server `enabled` flag in `mcp.json` and the
  * user-level `disabledServers` denylist.
  *
- * The fixtures below cover both inputs and the round-trip the dashboard's
- * MCP toggle uses (`setServerDisabled`).
+ * The fixtures below cover both inputs and the round-trip helper the
+ * dashboard's MCP toggle uses.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
@@ -117,12 +117,12 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		// setMcpServerEnabled MUST overwrite the per-server flag.
 		const projectMcpPath = path.join(projectDir, ".omp", "mcp.json");
 
-		await setMcpServerEnabled(
-			getMCPConfigPath("user", projectDir),
-			getMCPConfigPath("project", projectDir),
-			"flag-disabled-server",
-			true,
-		);
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "flag-disabled-server",
+			enabled: true,
+		});
 
 		const projectConfig = await readMCPConfigFile(projectMcpPath);
 		expect(projectConfig.mcpServers?.["flag-disabled-server"]?.enabled).toBe(true);
@@ -149,12 +149,12 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		);
 		await setServerDisabled(getMCPConfigPath("user", projectDir), "active-server", true);
 
-		await setMcpServerEnabled(
-			getMCPConfigPath("user", projectDir),
-			getMCPConfigPath("project", projectDir),
-			"active-server",
-			true,
-		);
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "active-server",
+			enabled: true,
+		});
 
 		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
 		expect(userConfig.disabledServers ?? []).not.toContain("active-server");
@@ -165,12 +165,12 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 	});
 
 	test("dashboard disable on a config-resident server writes enabled:false (not denylist)", async () => {
-		await setMcpServerEnabled(
-			getMCPConfigPath("user", projectDir),
-			getMCPConfigPath("project", projectDir),
-			"active-server",
-			false,
-		);
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "active-server",
+			enabled: false,
+		});
 
 		const projectConfig = await readMCPConfigFile(path.join(projectDir, ".omp", "mcp.json"));
 		expect(projectConfig.mcpServers?.["active-server"]?.enabled).toBe(false);
@@ -185,24 +185,57 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		expect(disabled!.state).toBe("disabled");
 	});
 
+	test("dashboard re-enable updates the row's non-primary source mcp.json before denylisting", async () => {
+		const alternatePath = path.join(projectDir, ".omp", ".mcp.json");
+		await Bun.write(
+			alternatePath,
+			JSON.stringify({
+				mcpServers: {
+					"alternate-server": { command: "echo", args: ["alternate"], enabled: false },
+				},
+			}),
+		);
+
+		const disabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:alternate-server");
+		expect(disabled).toBeDefined();
+		expect(disabled!.state).toBe("disabled");
+
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			sourcePath: alternatePath,
+			name: "alternate-server",
+			enabled: true,
+		});
+
+		const alternateConfig = await readMCPConfigFile(alternatePath);
+		expect(alternateConfig.mcpServers?.["alternate-server"]?.enabled).toBe(true);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		expect(userConfig.disabledServers ?? []).not.toContain("alternate-server");
+
+		const reenabled = (await loadAllExtensions(projectDir, [])).find(e => e.id === "mcp:alternate-server");
+		expect(reenabled).toBeDefined();
+		expect(reenabled!.state).toBe("active");
+	});
 	test("dashboard toggles on a discovered (config-less) server use the denylist", async () => {
 		// `phantom-server` is not in any config; only the denylist can suppress it.
-		await setMcpServerEnabled(
-			getMCPConfigPath("user", projectDir),
-			getMCPConfigPath("project", projectDir),
-			"phantom-server",
-			false,
-		);
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "phantom-server",
+			enabled: false,
+		});
 
 		let userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
 		expect(userConfig.disabledServers ?? []).toContain("phantom-server");
 
-		await setMcpServerEnabled(
-			getMCPConfigPath("user", projectDir),
-			getMCPConfigPath("project", projectDir),
-			"phantom-server",
-			true,
-		);
+		await setMcpServerEnabled({
+			userPath: getMCPConfigPath("user", projectDir),
+			projectPath: getMCPConfigPath("project", projectDir),
+			name: "phantom-server",
+			enabled: true,
+		});
 
 		userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
 		expect(userConfig.disabledServers ?? []).not.toContain("phantom-server");


### PR DESCRIPTION
## Repro

`/mcp list` and `/extensions` showed different active/inactive status for the same MCP server. Running `/mcp disable foo` flipped `foo` to `disabled` in `/mcp list`, but `/extensions` still showed it as `active`. The same divergence happened for any server with `"enabled": false` directly in `mcp.json`. A new `bun test packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts` fails without the fix:

```
expect(received).toBe(expected)
Expected: "disabled"
Received: "active"
```

## Cause

Two independent disable models.

- `/mcp list` (`packages/coding-agent/src/slash-commands/helpers/mcp.ts:388`) and the MCP runtime loader (`packages/coding-agent/src/mcp/config.ts:115`) treat a server as disabled when `config.enabled === false` **or** the name is in the user-level `disabledServers` denylist — the array `/mcp disable` writes via `setServerDisabled`.
- The `/extensions` dashboard (`packages/coding-agent/src/modes/components/extensions/state-manager.ts:144-185`) only consulted the dashboard-private `settings.disabledExtensions` array. It never read `enabled` or `disabledServers`, so the dashboard and `/mcp list` could disagree.

Toggling MCP servers from the dashboard had the mirror problem: it only wrote to `settings.disabledExtensions`, so `/mcp list` never noticed.

## Fix

- `state-manager.ts` now reads the user-level `disabledServers` denylist once and OR-folds `server.enabled === false` and denylist membership into `isDisabled`, mirroring `/mcp list` and the MCP runtime.
- `extension-dashboard.ts` routes `mcp:*` toggles through `setServerDisabled` against the same `mcp.json` denylist, and reconciles `settings.disabledExtensions` on re-enable so a legacy `mcp:<name>` flag from before this change doesn't keep the server disabled.
- Added `packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts` covering both read signals (`enabled: false`, `disabledServers`) and the `setServerDisabled` round-trip the dashboard now uses.

## Verification

```
cd packages/coding-agent && bun test \
  test/extension-dashboard-mcp-parity.test.ts \
  test/extension-dashboard-state.test.ts \
  test/discovery/disabled-extensions.test.ts \
  test/extension-list-mouse.test.ts \
  test/mcp-render-status.test.ts \
  test/sdk-mcp-discovery.test.ts \
  test/sdk-mcp-auto-discovery.test.ts \
  test/agent-session-mcp-discovery.test.ts \
  test/sdk-mcp-defer.test.ts \
  test/sdk-mcp-instructions.test.ts \
  test/interactive-mode-mcp-connecting.test.ts \
  test/acp-mcp-isolation.test.ts
# 60 pass, 0 fail
```

`bun check` passes (formatter ran, output already on the branch).

Fixes #3827