### PR TITLE
fix(irc): surface pending asides in inbox

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `irc` inbox drains missing messages that arrived while the recipient agent was already running. ([#3834](https://github.com/can1357/oh-my-pi/issues/3834))
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12840,10 +12840,16 @@ export class AgentSession {
 	// =========================================================================
 
 	/**
-	 * Drains IRC incoming asides that have reached this running session but have
-	 * not yet been folded into the next model step.
+	 * Surfaces (and consumes) IRC incoming asides that have reached this running
+	 * session but have not yet been folded into the next model step.
+	 *
+	 * The inbox tool injects the formatted body into the tool result, so the
+	 * model sees it once via the result. Leaving the record in
+	 * {@link #pendingIrcAsides} would let the aside provider deliver it a second
+	 * time at the next step boundary — including on `peek`, which is why peek
+	 * also drains here.
 	 */
-	drainPendingIrcInboxMessages(agentId: string, opts?: { peek?: boolean }): IrcMessage[] {
+	drainPendingIrcInboxMessages(agentId: string): IrcMessage[] {
 		const messages: IrcMessage[] = [];
 		const remaining: CustomMessage[] = [];
 		for (const record of this.#pendingIrcAsides) {
@@ -12872,13 +12878,8 @@ export class AgentSession {
 				ts: record.timestamp,
 				...(typeof replyTo === "string" ? { replyTo } : {}),
 			});
-			if (opts?.peek) {
-				remaining.push(record);
-			}
 		}
-		if (!opts?.peek) {
-			this.#pendingIrcAsides = remaining;
-		}
+		this.#pendingIrcAsides = remaining;
 		return messages;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12840,6 +12840,49 @@ export class AgentSession {
 	// =========================================================================
 
 	/**
+	 * Drains IRC incoming asides that have reached this running session but have
+	 * not yet been folded into the next model step.
+	 */
+	drainPendingIrcInboxMessages(agentId: string, opts?: { peek?: boolean }): IrcMessage[] {
+		const messages: IrcMessage[] = [];
+		const remaining: CustomMessage[] = [];
+		for (const record of this.#pendingIrcAsides) {
+			if (record.customType !== "irc:incoming") {
+				remaining.push(record);
+				continue;
+			}
+			const details = record.details;
+			if (!details || typeof details !== "object") {
+				remaining.push(record);
+				continue;
+			}
+			const id = Reflect.get(details, "id");
+			const from = Reflect.get(details, "from");
+			const body = Reflect.get(details, "message");
+			const replyTo = Reflect.get(details, "replyTo");
+			if (typeof id !== "string" || typeof from !== "string" || typeof body !== "string") {
+				remaining.push(record);
+				continue;
+			}
+			messages.push({
+				id,
+				from,
+				to: agentId,
+				body,
+				ts: record.timestamp,
+				...(typeof replyTo === "string" ? { replyTo } : {}),
+			});
+			if (opts?.peek) {
+				remaining.push(record);
+			}
+		}
+		if (!opts?.peek) {
+			this.#pendingIrcAsides = remaining;
+		}
+		return messages;
+	}
+
+	/**
 	 * Deliver an IRC message into this session (recipient side; called by the
 	 * IrcBus). Emits the `irc_message` session event for UI cards and injects
 	 * the rendered message into the model's context as an `irc:incoming`

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -376,7 +376,7 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 		const session = registry.get(senderId)?.session;
 		const pendingMessages =
 			typeof session?.drainPendingIrcInboxMessages === "function"
-				? session.drainPendingIrcInboxMessages(senderId, { peek: params.peek })
+				? session.drainPendingIrcInboxMessages(senderId)
 				: [];
 		const messages = [...busMessages, ...pendingMessages].sort((a, b) => a.ts - b.ts);
 		if (messages.length === 0) {

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -172,7 +172,7 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 			case "wait":
 				return this.#executeWait(senderId, params, signal);
 			case "inbox":
-				return this.#executeInbox(senderId, params);
+				return this.#executeInbox(registry, senderId, params);
 			default:
 				return errorResult("Unknown irc op.", { op: params.op });
 		}
@@ -371,8 +371,14 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 		};
 	}
 
-	#executeInbox(senderId: string, params: IrcParams): AgentToolResult<IrcDetails> {
-		const messages = IrcBus.global().inbox(senderId, { peek: params.peek });
+	#executeInbox(registry: AgentRegistry, senderId: string, params: IrcParams): AgentToolResult<IrcDetails> {
+		const busMessages = IrcBus.global().inbox(senderId, { peek: params.peek });
+		const session = registry.get(senderId)?.session;
+		const pendingMessages =
+			typeof session?.drainPendingIrcInboxMessages === "function"
+				? session.drainPendingIrcInboxMessages(senderId, { peek: params.peek })
+				: [];
+		const messages = [...busMessages, ...pendingMessages].sort((a, b) => a.ts - b.ts);
 		if (messages.length === 0) {
 			return {
 				content: [{ type: "text", text: "Inbox empty." }],

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -603,6 +603,32 @@ describe("IRC", () => {
 			expect(text).toContain("parallel note");
 		});
 
+		it("op=inbox peek surfaces a pending IRC aside and prevents it auto-injecting", async () => {
+			const { session } = createRealSession();
+			sessions.push(session);
+			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
+			registry.register({ id: "0-Running", displayName: "task", kind: "sub", session });
+
+			await session.deliverIrcMessage({
+				id: "msg-peek",
+				from: "0-Main",
+				to: "0-Running",
+				body: "peeked note",
+				ts: Date.now(),
+			});
+
+			const tool = new IrcTool(makeToolSession(registry, "0-Running"));
+			const peeked = await tool.execute("call-1", { op: "inbox", peek: true });
+			expect(peeked.details?.inbox?.map(msg => msg.body)).toEqual(["peeked note"]);
+
+			// The peek surfaced the body via the tool result, so the aside-channel
+			// copy must NOT also be auto-injected at the next step: a second drain
+			// returns nothing (the pending aside was consumed out of the
+			// auto-inject queue when peek surfaced it).
+			const second = await tool.execute("call-2", { op: "inbox" });
+			expect(second.details?.inbox).toEqual([]);
+		});
+
 		it("op=inbox drains the caller's mailbox", async () => {
 			const main = makeFakeSession();
 			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -580,6 +580,29 @@ describe("IRC", () => {
 			expect(text).toContain("No message");
 		});
 
+		it("op=inbox drains IRC asides that arrived while the caller was running", async () => {
+			const { session } = createRealSession();
+			sessions.push(session);
+			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
+			registry.register({ id: "0-Running", displayName: "task", kind: "sub", session });
+
+			const delivery = await session.deliverIrcMessage({
+				id: "msg-running",
+				from: "0-Main",
+				to: "0-Running",
+				body: "parallel note",
+				ts: Date.now(),
+			});
+			expect(delivery).toBe("injected");
+
+			const tool = new IrcTool(makeToolSession(registry, "0-Running"));
+			const result = await tool.execute("call-1", { op: "inbox" });
+
+			expect(result.details?.inbox?.map(msg => msg.body)).toEqual(["parallel note"]);
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).toContain("parallel note");
+		});
+
 		it("op=inbox drains the caller's mailbox", async () => {
 			const main = makeFakeSession();
 			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });


### PR DESCRIPTION
## Repro
A running recipient can receive an IRC message as a pending session aside, then call `irc` with `op:"inbox"` before the next model step consumes that aside. Reproduced with `bun --cwd=packages/coding-agent run gen:tool-views && bun test packages/coding-agent/test/tools/irc.test.ts -t "op=inbox drains IRC asides that arrived while the caller was running"`; before the fix, `details.inbox` was `[]` instead of containing `"parallel note"`.

## Cause
`IrcBus.send` delivered running-recipient messages through `AgentSession.deliverIrcMessage`, which queued them in `AgentSession.#pendingIrcAsides`; `IrcTool.#executeInbox` only read `IrcBus.inbox`, so messages that had successfully reached a running session were invisible to explicit inbox drains.

## Fix
- Added `AgentSession.drainPendingIrcInboxMessages` to expose pending `irc:incoming` asides as `IrcMessage` records and consume them on non-peek inbox reads.
- Updated `IrcTool.#executeInbox` to merge bus mailbox messages with pending session IRC asides in timestamp order.
- Added a regression test covering a message delivered while the recipient session is already running.
- Added an Unreleased changelog entry for the IRC inbox fix.

## Verification
- `bun --cwd=packages/coding-agent run gen:tool-views && bun test packages/coding-agent/test/tools/irc.test.ts` passed: 36 tests, 106 assertions.
- `bun --cwd=packages/coding-agent run check:types` passed.
- `bun --cwd=packages/coding-agent biome check src/tools/irc.ts src/session/agent-session.ts test/tools/irc.test.ts CHANGELOG.md` passed.
- `gh_push_branch` pre-publish gate passed and pushed `3104d232aad3`. Fixes #3834