### PR TITLE
fix(coding-agent): bounded, negative-cached GPU probe to fix Windows slow boot

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slow startup on Windows caused by the system-prompt GPU probe (`wmic path win32_VideoController get name`) running on the boot path with no timeout and re-running every launch because failed/empty probes were never cached. The probe result is now cached even when no GPU is found (so it runs at most once per machine), and the probe is bounded by the existing 5s system-prompt prep deadline so a slow or wedged WMI service can no longer hang startup; OS/CPU/terminal info always render. (The Linux `lspci` probe gets the same negative-caching + deadline treatment.) ([#3835](https://github.com/can1357/oh-my-pi/issues/3835))
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/__tests__/system-prompt-gpu-cache.test.ts
+++ b/packages/coding-agent/src/__tests__/system-prompt-gpu-cache.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getCachedGpu } from "../system-prompt";
+
+describe("getCachedGpu", () => {
+	let tmpPath = "";
+
+	afterEach(async () => {
+		if (tmpPath) await fsp.rm(tmpPath, { force: true });
+		tmpPath = "";
+	});
+
+	function freshPath(): string {
+		tmpPath = path.join(os.tmpdir(), `omp-gpu-cache-${crypto.randomUUID()}.json`);
+		return tmpPath;
+	}
+
+	it("returns the cached GPU without probing on a cache hit", async () => {
+		const p = freshPath();
+		await Bun.write(p, JSON.stringify({ gpu: "Cached GPU 1" }));
+		let probed = false;
+		const got = await getCachedGpu(async () => {
+			probed = true;
+			return "Should Not Run";
+		}, p);
+		expect(got).toBe("Cached GPU 1");
+		expect(probed).toBe(false);
+	});
+
+	it("caches a positive probe result on a cache miss", async () => {
+		const p = freshPath();
+		const got = await getCachedGpu(async () => "Probed GPU 2", p);
+		expect(got).toBe("Probed GPU 2");
+		const written: unknown = await Bun.file(p).json();
+		expect(written).toEqual({ gpu: "Probed GPU 2" });
+	});
+
+	it("caches a null probe result so it is not re-probed every boot (the bug)", async () => {
+		const p = freshPath();
+		const got = await getCachedGpu(async () => null, p);
+		expect(got).toBeUndefined();
+		// Regression guard: absence is persisted, not dropped.
+		const written: unknown = await Bun.file(p).json();
+		expect(written).toEqual({ gpu: null });
+		// A second call honors the cached null without re-running the probe.
+		let probed = false;
+		const again = await getCachedGpu(async () => {
+			probed = true;
+			return "Late GPU";
+		}, p);
+		expect(again).toBeUndefined();
+		expect(probed).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -178,43 +178,41 @@ function getTerminalName(): string | undefined {
 
 /** Cached system info structure */
 interface GpuCache {
-	gpu: string;
+	gpu: string | null;
 }
 
-function getSystemInfoCachePath(): string {
-	return getGpuCachePath();
-}
-
-async function loadGpuCache(): Promise<GpuCache | null> {
+async function loadGpuCache(cachePath: string): Promise<GpuCache | null> {
 	try {
-		const cachePath = getSystemInfoCachePath();
-		const content = await Bun.file(cachePath).json();
-		return content as GpuCache;
+		return (await Bun.file(cachePath).json()) as GpuCache;
 	} catch {
 		return null;
 	}
 }
 
-async function saveGpuCache(info: GpuCache): Promise<void> {
+async function saveGpuCache(cachePath: string, info: GpuCache): Promise<void> {
 	try {
-		const cachePath = getSystemInfoCachePath();
 		await Bun.write(cachePath, JSON.stringify(info, null, "\t"));
 	} catch {
 		// Silently ignore cache write failures
 	}
 }
 
-async function getCachedGpu(): Promise<string | undefined> {
-	const cached = await logger.time("getCachedGpu:loadGpuCache", loadGpuCache);
-	if (cached) return cached.gpu;
-	const gpu = await logger.time("getCachedGpu:getGpuModel", getGpuModel);
-	if (gpu) {
-		await logger.time("getCachedGpu:saveGpuCache", saveGpuCache, { gpu });
-	}
+export async function getCachedGpu(
+	probe: () => Promise<string | null> = getGpuModel,
+	cachePath: string = getGpuCachePath(),
+): Promise<string | undefined> {
+	const cached = await loadGpuCache(cachePath);
+	if (cached) return cached.gpu ?? undefined;
+	const gpu = await probe();
+	// Persist unconditionally — including a null (no GPU found / probe failed).
+	// Without this, a slow or unparseable probe (Windows 11 24H2 removed wmic;
+	// a degraded WMI service returns nothing) is never cached and the slow
+	// `wmic` spawn reruns on every boot.
+	await saveGpuCache(cachePath, { gpu: gpu ?? null });
 	return gpu ?? undefined;
 }
-async function getEnvironmentInfo(): Promise<Array<{ label: string; value: string }>> {
-	const gpu = await getCachedGpu();
+
+function buildEnvironmentInfo(gpu: string | undefined): Array<{ label: string; value: string }> {
 	let cpuModel: string | undefined;
 	try {
 		cpuModel = os.cpus()[0]?.model;
@@ -575,6 +573,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		skills,
 		workspaceTree,
 		activeRepoContext,
+		gpu,
 	] = await Promise.all([
 		withDeadline(
 			"customPrompt",
@@ -597,6 +596,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
 		withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),
 		withDeadline("resolveActiveRepoContext", activeRepoContextPromise, prepDefaults.activeRepoContext),
+		withDeadline("getCachedGpu", getCachedGpu(), undefined),
 	]);
 	const agentsMdFiles = Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
 
@@ -675,7 +675,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	];
 	const injectedAlwaysApplyRules = dedupeAlwaysApplyRules(alwaysApplyRules, promptSources);
 
-	const environment = await logger.time("getEnvironmentInfo", getEnvironmentInfo);
+	const environment = buildEnvironmentInfo(gpu);
 	const data = {
 		systemPromptCustomization: effectiveSystemPromptCustomization,
 		customPrompt: resolvedCustomPrompt,


### PR DESCRIPTION
## What

Fixes slow `omp` startup on Windows caused by the system-prompt GPU detection probe.

Closes #3835.

## Why

The GPU probe in `packages/coding-agent/src/system-prompt.ts` sat on the boot critical path (`buildSystemPrompt` is awaited during session construction via `rebuildSystemPrompt`) with two defects:

1. **Unbounded probe.** `getEnvironmentInfo` awaited `getCachedGpu()` → `getGpuModel()` → `` await $`wmic path win32_VideoController get name` `` *outside* the 5s `withDeadline` race that bounds every other prep step. `.catch(() => null)` handles errors, not hangs — a wedged/cold WMI service blocked startup indefinitely.
2. **Negative results never cached.** `getCachedGpu` only wrote the cache on a truthy probe result. On Windows 11 24H2 (`wmic` removed), a degraded WMI service, or an unparseable table, nothing was written, so the slow `wmic` spawn reran on **every** launch — the dominant cause of the reported slowness. The Linux `lspci` path had the same gap.

## How

- `getCachedGpu` now persists the probe result unconditionally, including `{ gpu: null }` for no-GPU / probe-failure, so it runs at most once per machine.
- The GPU probe is added to the existing 5s `withDeadline` `Promise.all` prep race; on timeout it returns the `undefined` fallback while the probe finishes in the background and warms the cache for the next build.
- `getEnvironmentInfo` (async) is replaced by a synchronous `buildEnvironmentInfo(gpu)` so OS/CPU/terminal info always render even when the probe times out.
- `getGpuModel` (`wmic`/`lspci`) is unchanged. **No** PowerShell `Get-CimInstance` switch — pwsh cold-start is slower and would regress boot. No module-global scheduling state.

`getCachedGpu` is now exported with defaulted `probe`/`cachePath` parameters — a dependency-injection seam for the deterministic test; production callers pass nothing.

## Commits

| Commit | Summary |
|---|---|
| `fix(coding-agent): bounded, negative-cached GPU probe to fix Windows slow boot` | nullable GPU cache, unconditional save, `withDeadline`-bounded probe, sync env builder, regression test, changelog |

## Tests

New `packages/coding-agent/src/__tests__/system-prompt-gpu-cache.test.ts` (deterministic, platform-independent — injected probe + temp cache path, no real `wmic`/`lspci`, no `~/.omp`):

- cache hit returns cached GPU without probing;
- cache miss caches a positive result;
- **null probe result is cached as `{ gpu: null }` and honored on the next call without re-probing** (the regression guard for the reported bug).

## Verification

- `bun test packages/coding-agent/src/__tests__/system-prompt-gpu-cache.test.ts` → 3 pass, 0 fail
- `bun test packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts` (exercises `buildSystemPrompt` end-to-end) → 2 pass, 0 fail
- `bun check` → passed (all workspace packages)
