### PR TITLE
fix(prompting): bound GPU detection during prompt startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed system-prompt GPU detection blocking startup and rerunning failed probes by applying the prep deadline and caching empty results. ([#3835](https://github.com/can1357/oh-my-pi/issues/3835))
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 
 interface ProbeRunResult {
 	elapsedMs: number;
+	childElapsedMs: number;
 	cached: unknown;
 	count: number;
 }
@@ -20,7 +21,7 @@ async function runProbeScenario(options: { runs: number; sleepSeconds?: number }
 		const lspciPath = path.join(binDir, "lspci");
 		await Bun.write(
 			lspciPath,
-			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
+			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(lspciPath, 0o755);
 
@@ -74,16 +75,18 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 			env.OMP_GPU_PROBE_SLEEP = String(options.sleepSeconds);
 		}
 
+		const childStartedAt = performance.now();
 		const child = Bun.spawn([process.execPath, scenarioPath], { stdout: "pipe", stderr: "pipe", env });
 		const [stdout, stderr, exitCode] = await Promise.all([
 			new Response(child.stdout).text(),
 			new Response(child.stderr).text(),
 			child.exited,
 		]);
+		const childElapsedMs = Math.round(performance.now() - childStartedAt);
 		if (exitCode !== 0) {
 			throw new Error(`GPU probe scenario failed with exit ${exitCode}: ${stderr}`);
 		}
-		return JSON.parse(stdout.trim());
+		return { ...JSON.parse(stdout.trim()), childElapsedMs };
 	} finally {
 		await fs.rm(tempRoot, { recursive: true, force: true });
 	}
@@ -97,9 +100,12 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 		expect(result.count).toBe(1);
 	}, 15_000);
 
-	it("uses the system prompt prep deadline for slow GPU probes", async () => {
+	it("kills the GPU probe at the prep deadline", async () => {
 		const result = await runProbeScenario({ runs: 1, sleepSeconds: 7 });
 
 		expect(result.elapsedMs).toBeLessThan(6500);
+		// Codex#3838: the child process MUST exit shortly after the deadline,
+		// not linger until the underlying probe (sleep 7) finishes on its own.
+		expect(result.childElapsedMs).toBeLessThan(6500);
 	}, 15_000);
 });

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -10,7 +10,11 @@ interface ProbeRunResult {
 	count: number;
 }
 
-async function runProbeScenario(options: { runs: number; sleepSeconds?: number }): Promise<ProbeRunResult> {
+async function runProbeScenario(options: {
+	runs: number;
+	sleepSeconds?: number;
+	holdStdoutOpen?: boolean;
+}): Promise<ProbeRunResult> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gpu-probe-"));
 	try {
 		const binDir = path.join(tempRoot, "bin");
@@ -21,7 +25,7 @@ async function runProbeScenario(options: { runs: number; sleepSeconds?: number }
 		const lspciPath = path.join(binDir, "lspci");
 		await Bun.write(
 			lspciPath,
-			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
+			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(lspciPath, 0o755);
 
@@ -74,6 +78,11 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 		} else {
 			env.OMP_GPU_PROBE_SLEEP = String(options.sleepSeconds);
 		}
+		if (options.holdStdoutOpen) {
+			env.OMP_GPU_PROBE_HOLD_STDOUT_OPEN = "true";
+		} else {
+			delete env.OMP_GPU_PROBE_HOLD_STDOUT_OPEN;
+		}
 
 		const childStartedAt = performance.now();
 		const child = Bun.spawn([process.execPath, scenarioPath], { stdout: "pipe", stderr: "pipe", env });
@@ -101,11 +110,12 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 	}, 15_000);
 
 	it("kills the GPU probe at the prep deadline", async () => {
-		const result = await runProbeScenario({ runs: 1, sleepSeconds: 7 });
+		const result = await runProbeScenario({ runs: 1, sleepSeconds: 7, holdStdoutOpen: true });
 
+		expect(result.cached).toEqual({ gpu: null });
 		expect(result.elapsedMs).toBeLessThan(6500);
 		// Codex#3838: the child process MUST exit shortly after the deadline,
-		// not linger until the underlying probe (sleep 7) finishes on its own.
+		// not linger until a descendant holding stdout (sleep 7) exits on its own.
 		expect(result.childElapsedMs).toBeLessThan(6500);
 	}, 15_000);
 });

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+interface ProbeRunResult {
+	elapsedMs: number;
+	cached: unknown;
+	count: number;
+}
+
+async function runProbeScenario(options: { runs: number; sleepSeconds?: number }): Promise<ProbeRunResult> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gpu-probe-"));
+	try {
+		const binDir = path.join(tempRoot, "bin");
+		const cacheRoot = path.join(tempRoot, "cache");
+		const probeCountPath = path.join(tempRoot, "probe-count");
+		await fs.mkdir(binDir, { recursive: true });
+		await fs.mkdir(path.join(cacheRoot, "omp"), { recursive: true });
+		const lspciPath = path.join(binDir, "lspci");
+		await Bun.write(
+			lspciPath,
+			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
+		);
+		await fs.chmod(lspciPath, 0o755);
+
+		const scenarioPath = path.join(tempRoot, "scenario.ts");
+		await Bun.write(
+			scenarioPath,
+			`import { getGpuCachePath, refreshDirsFromEnv } from ${JSON.stringify(path.resolve(import.meta.dir, "../../utils/src/index.ts"))};
+import { buildSystemPrompt } from ${JSON.stringify(path.join(import.meta.dir, "system-prompt.ts"))};
+
+refreshDirsFromEnv();
+const buildOptions = {
+	contextFiles: [],
+	skills: [],
+	toolNames: [],
+	workspaceTree: {
+		rootPath: process.cwd(),
+		rendered: "",
+		truncated: false,
+		totalLines: 0,
+		agentsMdFiles: [],
+	},
+	activeRepoContext: null,
+};
+const startedAt = performance.now();
+for (let index = 0; index < Number(process.env.OMP_GPU_PROBE_RUNS ?? "1"); index += 1) {
+	await buildSystemPrompt(buildOptions);
+}
+const cacheFile = Bun.file(getGpuCachePath());
+const cached = await cacheFile.exists() ? await cacheFile.json() : null;
+const countFile = Bun.file(process.env.OMP_GPU_PROBE_COUNT ?? "");
+const count = await countFile.exists() ? (await countFile.text()).length : 0;
+console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt), cached, count }));
+`,
+		);
+
+		const env: Record<string, string | undefined> = {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			XDG_CACHE_HOME: cacheRoot,
+			OMP_GPU_PROBE_COUNT: probeCountPath,
+			OMP_GPU_PROBE_RUNS: String(options.runs),
+		};
+		if (options.sleepSeconds === undefined) {
+			delete env.OMP_GPU_PROBE_SLEEP;
+		} else {
+			env.OMP_GPU_PROBE_SLEEP = String(options.sleepSeconds);
+		}
+
+		const child = Bun.spawn([process.execPath, scenarioPath], { stdout: "pipe", stderr: "pipe", env });
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		if (exitCode !== 0) {
+			throw new Error(`GPU probe scenario failed with exit ${exitCode}: ${stderr}`);
+		}
+		return JSON.parse(stdout.trim());
+	} finally {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	}
+}
+
+describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
+	it("caches empty GPU probe results", async () => {
+		const result = await runProbeScenario({ runs: 2 });
+
+		expect(result.cached).toEqual({ gpu: null });
+		expect(result.count).toBe(1);
+	}, 15_000);
+
+	it("uses the system prompt prep deadline for slow GPU probes", async () => {
+		const result = await runProbeScenario({ runs: 1, sleepSeconds: 7 });
+
+		expect(result.elapsedMs).toBeLessThan(6500);
+	}, 15_000);
+});

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -63,6 +63,11 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 			OMP_GPU_PROBE_COUNT: probeCountPath,
 			OMP_GPU_PROBE_RUNS: String(options.runs),
 		};
+		// Strip inherited dirs-resolver overrides so XDG_CACHE_HOME above wins and
+		// the test cannot touch the developer/CI profile's real gpu_cache.json.
+		for (const key of ["PI_CODING_AGENT_DIR", "OMP_PROFILE", "PI_PROFILE", "PI_CONFIG_DIR"]) {
+			delete env[key];
+		}
 		if (options.sleepSeconds === undefined) {
 			delete env.OMP_GPU_PROBE_SLEEP;
 		} else {

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -14,6 +14,7 @@ async function runProbeScenario(options: {
 	runs: number;
 	sleepSeconds?: number;
 	holdStdoutOpen?: boolean;
+	descendantHoldsStdout?: boolean;
 }): Promise<ProbeRunResult> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gpu-probe-"));
 	try {
@@ -25,7 +26,7 @@ async function runProbeScenario(options: {
 		const lspciPath = path.join(binDir, "lspci");
 		await Bun.write(
 			lspciPath,
-			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
+			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(lspciPath, 0o755);
 
@@ -83,6 +84,11 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 		} else {
 			delete env.OMP_GPU_PROBE_HOLD_STDOUT_OPEN;
 		}
+		if (options.descendantHoldsStdout) {
+			env.OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT = "true";
+		} else {
+			delete env.OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT;
+		}
 
 		const childStartedAt = performance.now();
 		const child = Bun.spawn([process.execPath, scenarioPath], { stdout: "pipe", stderr: "pipe", env });
@@ -117,5 +123,15 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 		// Codex#3838: the child process MUST exit shortly after the deadline,
 		// not linger until a descendant holding stdout (sleep 7) exits on its own.
 		expect(result.childElapsedMs).toBeLessThan(6500);
+	}, 15_000);
+
+	it("does not wait on stdout held by a descendant after a successful probe", async () => {
+		const result = await runProbeScenario({ runs: 1, sleepSeconds: 3, descendantHoldsStdout: true });
+
+		expect(result.cached).toEqual({ gpu: null });
+		// Probe exits 0 immediately but leaves a backgrounded sleep holding the stdout
+		// pipe. The success path MUST bound the drain wait, not block until sleep exits.
+		expect(result.elapsedMs).toBeLessThan(2000);
+		expect(result.childElapsedMs).toBeLessThan(2000);
 	}, 15_000);
 });

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -15,6 +15,7 @@ async function runProbeScenario(options: {
 	sleepSeconds?: number;
 	holdStdoutOpen?: boolean;
 	descendantHoldsStdout?: boolean;
+	validOutput?: string;
 }): Promise<ProbeRunResult> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gpu-probe-"));
 	try {
@@ -26,7 +27,7 @@ async function runProbeScenario(options: {
 		const lspciPath = path.join(binDir, "lspci");
 		await Bun.write(
 			lspciPath,
-			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
+			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_VALID_OUTPUT" ]; then printf "%s\\n" "$OMP_GPU_PROBE_VALID_OUTPUT"; fi\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(lspciPath, 0o755);
 
@@ -89,6 +90,11 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 		} else {
 			delete env.OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT;
 		}
+		if (options.validOutput !== undefined) {
+			env.OMP_GPU_PROBE_VALID_OUTPUT = options.validOutput;
+		} else {
+			delete env.OMP_GPU_PROBE_VALID_OUTPUT;
+		}
 
 		const childStartedAt = performance.now();
 		const child = Bun.spawn([process.execPath, scenarioPath], { stdout: "pipe", stderr: "pipe", env });
@@ -131,6 +137,21 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 		expect(result.cached).toEqual({ gpu: null });
 		// Probe exits 0 immediately but leaves a backgrounded sleep holding the stdout
 		// pipe. The success path MUST bound the drain wait, not block until sleep exits.
+		expect(result.elapsedMs).toBeLessThan(2000);
+		expect(result.childElapsedMs).toBeLessThan(2000);
+	}, 15_000);
+
+	it("keeps probe output captured before a descendant delays EOF", async () => {
+		const result = await runProbeScenario({
+			runs: 1,
+			sleepSeconds: 3,
+			descendantHoldsStdout: true,
+			validOutput: "00:02.0 VGA compatible controller: NVIDIA TestGPU",
+		});
+
+		// Probe exited 0 with valid output before bg sleep held stdout open.
+		// Captured stdout MUST be cached, not discarded as if the probe failed.
+		expect(result.cached).toEqual({ gpu: "02.0 VGA compatible controller: NVIDIA TestGPU" });
 		expect(result.elapsedMs).toBeLessThan(2000);
 		expect(result.childElapsedMs).toBeLessThan(2000);
 	}, 15_000);

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -122,6 +122,9 @@ async function runGpuProbe(cmd: string[]): Promise<string | null> {
 			stderr: "ignore",
 			stdin: "ignore",
 			timeout: GPU_PROBE_TIMEOUT_MS,
+			// SIGKILL so a probe ignoring SIGTERM (PATH wrapper, wedged WMI) still
+			// dies at the deadline and lets getCachedGpu reach the null-cache write.
+			killSignal: "SIGKILL",
 		});
 		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
 		return exitCode === 0 ? stdout : null;

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -7,7 +7,6 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample, TSchema } from "@oh-my-pi/pi-ai";
 import { renderToolInventory } from "@oh-my-pi/pi-ai/dialect";
 import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
 import { systemPromptCapability } from "./capability/system-prompt";
 import { findConfigFile } from "./config";
@@ -112,21 +111,33 @@ function parseWmicTable(output: string, header: string): string | null {
 }
 
 const SYSTEM_PROMPT_PREP_TIMEOUT_MS = 5000;
+/** Killed by the OS at this deadline, so a wedged probe cannot outlive the prep race. */
+const GPU_PROBE_TIMEOUT_MS = SYSTEM_PROMPT_PREP_TIMEOUT_MS;
+
+async function runGpuProbe(cmd: string[]): Promise<string | null> {
+	try {
+		const proc = Bun.spawn({
+			cmd,
+			stdout: "pipe",
+			stderr: "ignore",
+			stdin: "ignore",
+			timeout: GPU_PROBE_TIMEOUT_MS,
+		});
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		return exitCode === 0 ? stdout : null;
+	} catch {
+		return null;
+	}
+}
 
 async function getGpuModel(): Promise<string | null> {
 	switch (process.platform) {
 		case "win32": {
-			const output = await $`wmic path win32_VideoController get name`
-				.quiet()
-				.text()
-				.catch(() => null);
+			const output = await runGpuProbe(["wmic", "path", "win32_VideoController", "get", "name"]);
 			return output ? parseWmicTable(output, "Name") : null;
 		}
 		case "linux": {
-			const output = await $`lspci`
-				.quiet()
-				.text()
-				.catch(() => null);
+			const output = await runGpuProbe(["lspci"]);
 			if (!output) return null;
 			const gpus: Array<{ name: string; priority: number }> = [];
 			for (const line of output.split("\n")) {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -111,8 +111,8 @@ function parseWmicTable(output: string, header: string): string | null {
 }
 
 const SYSTEM_PROMPT_PREP_TIMEOUT_MS = 5000;
-/** Killed by the OS at this deadline, so a wedged probe cannot outlive the prep race. */
-const GPU_PROBE_TIMEOUT_MS = SYSTEM_PROMPT_PREP_TIMEOUT_MS;
+/** Kept below prep timeout so timed-out probes can still write the null cache before fallback. */
+const GPU_PROBE_TIMEOUT_MS = SYSTEM_PROMPT_PREP_TIMEOUT_MS - 500;
 
 async function runGpuProbe(cmd: string[]): Promise<string | null> {
 	try {
@@ -126,8 +126,25 @@ async function runGpuProbe(cmd: string[]): Promise<string | null> {
 			// dies at the deadline and lets getCachedGpu reach the null-cache write.
 			killSignal: "SIGKILL",
 		});
-		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-		return exitCode === 0 ? stdout : null;
+		const stdoutReader = proc.stdout.getReader();
+		let stdout = "";
+		const decoder = new TextDecoder();
+		const stdoutDone = (async () => {
+			while (true) {
+				const chunk = await stdoutReader.read();
+				if (chunk.done) break;
+				stdout += decoder.decode(chunk.value, { stream: true });
+			}
+			stdout += decoder.decode();
+		})();
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) {
+			await stdoutReader.cancel().catch(() => undefined);
+			await stdoutDone.catch(() => undefined);
+			return null;
+		}
+		await stdoutDone;
+		return stdout;
 	} catch {
 		return null;
 	}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -176,20 +176,20 @@ function getTerminalName(): string | undefined {
 	return term ?? undefined;
 }
 
-/** Cached system info structure */
+/** Cached GPU probe result. */
 interface GpuCache {
-	gpu: string;
-}
-
-function getSystemInfoCachePath(): string {
-	return getGpuCachePath();
+	gpu: string | null;
 }
 
 async function loadGpuCache(): Promise<GpuCache | null> {
 	try {
-		const cachePath = getSystemInfoCachePath();
+		const cachePath = getGpuCachePath();
 		const content = await Bun.file(cachePath).json();
-		return content as GpuCache;
+		if (content && typeof content === "object" && "gpu" in content) {
+			const gpu = content.gpu;
+			return { gpu: typeof gpu === "string" ? gpu : null };
+		}
+		return null;
 	} catch {
 		return null;
 	}
@@ -197,7 +197,7 @@ async function loadGpuCache(): Promise<GpuCache | null> {
 
 async function saveGpuCache(info: GpuCache): Promise<void> {
 	try {
-		const cachePath = getSystemInfoCachePath();
+		const cachePath = getGpuCachePath();
 		await Bun.write(cachePath, JSON.stringify(info, null, "\t"));
 	} catch {
 		// Silently ignore cache write failures
@@ -206,15 +206,12 @@ async function saveGpuCache(info: GpuCache): Promise<void> {
 
 async function getCachedGpu(): Promise<string | undefined> {
 	const cached = await logger.time("getCachedGpu:loadGpuCache", loadGpuCache);
-	if (cached) return cached.gpu;
+	if (cached) return cached.gpu ?? undefined;
 	const gpu = await logger.time("getCachedGpu:getGpuModel", getGpuModel);
-	if (gpu) {
-		await logger.time("getCachedGpu:saveGpuCache", saveGpuCache, { gpu });
-	}
+	await logger.time("getCachedGpu:saveGpuCache", saveGpuCache, { gpu });
 	return gpu ?? undefined;
 }
-async function getEnvironmentInfo(): Promise<Array<{ label: string; value: string }>> {
-	const gpu = await getCachedGpu();
+function getEnvironmentInfo(gpu: string | undefined): Array<{ label: string; value: string }> {
 	let cpuModel: string | undefined;
 	try {
 		cpuModel = os.cpus()[0]?.model;
@@ -500,6 +497,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 			agentsMdFiles: [],
 		} satisfies WorkspaceTree,
 		activeRepoContext: null as ActiveRepoContext | null,
+		gpu: undefined as string | undefined,
 	};
 
 	const deadline = Bun.sleep(SYSTEM_PROMPT_PREP_TIMEOUT_MS).then(() => "__timeout__" as const);
@@ -566,6 +564,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		providedActiveRepoContext !== undefined
 			? Promise.resolve(providedActiveRepoContext)
 			: logger.time("resolveActiveRepoContext", () => resolveActiveRepoContext(resolvedCwd));
+	const gpuPromise = logger.time("getCachedGpu", getCachedGpu);
 
 	const [
 		resolvedCustomPrompt,
@@ -575,6 +574,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		skills,
 		workspaceTree,
 		activeRepoContext,
+		gpu,
 	] = await Promise.all([
 		withDeadline(
 			"customPrompt",
@@ -597,6 +597,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
 		withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),
 		withDeadline("resolveActiveRepoContext", activeRepoContextPromise, prepDefaults.activeRepoContext),
+		withDeadline("getCachedGpu", gpuPromise, prepDefaults.gpu),
 	]);
 	const agentsMdFiles = Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
 
@@ -675,7 +676,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	];
 	const injectedAlwaysApplyRules = dedupeAlwaysApplyRules(alwaysApplyRules, promptSources);
 
-	const environment = await logger.time("getEnvironmentInfo", getEnvironmentInfo);
+	const environment = getEnvironmentInfo(gpu);
 	const data = {
 		systemPromptCustomization: effectiveSystemPromptCustomization,
 		customPrompt: resolvedCustomPrompt,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -113,6 +113,8 @@ function parseWmicTable(output: string, header: string): string | null {
 const SYSTEM_PROMPT_PREP_TIMEOUT_MS = 5000;
 /** Kept below prep timeout so timed-out probes can still write the null cache before fallback. */
 const GPU_PROBE_TIMEOUT_MS = SYSTEM_PROMPT_PREP_TIMEOUT_MS - 500;
+/** Drop stdout from a probe descendant that inherited the pipe after the probe exited. */
+const GPU_PROBE_STDOUT_DRAIN_MS = 250;
 
 async function runGpuProbe(cmd: string[]): Promise<string | null> {
 	try {
@@ -138,12 +140,17 @@ async function runGpuProbe(cmd: string[]): Promise<string | null> {
 			stdout += decoder.decode();
 		})();
 		const exitCode = await proc.exited;
-		if (exitCode !== 0) {
+		// Even on exit 0, a probe wrapper can leave a descendant holding stdout open.
+		// Bound the EOF wait so getCachedGpu cannot outlive the probe in either path.
+		const drained = await Promise.race([
+			stdoutDone.then(() => "ok" as const).catch(() => "err" as const),
+			Bun.sleep(GPU_PROBE_STDOUT_DRAIN_MS).then(() => "timeout" as const),
+		]);
+		if (exitCode !== 0 || drained !== "ok") {
 			await stdoutReader.cancel().catch(() => undefined);
 			await stdoutDone.catch(() => undefined);
 			return null;
 		}
-		await stdoutDone;
 		return stdout;
 	} catch {
 		return null;
@@ -531,7 +538,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		gpu: undefined as string | undefined,
 	};
 
-	const deadline = Bun.sleep(SYSTEM_PROMPT_PREP_TIMEOUT_MS).then(() => "__timeout__" as const);
+	const { promise: deadline, resolve: fireDeadline } = Promise.withResolvers<"__timeout__">();
+	const deadlineTimer = setTimeout(() => fireDeadline("__timeout__"), SYSTEM_PROMPT_PREP_TIMEOUT_MS);
+	// Unref so a fast prep does not hold a one-shot CLI alive waiting for this timer.
+	deadlineTimer.unref();
 	const timedOut: string[] = [];
 	const failed: Array<{ name: string; error: unknown }> = [];
 
@@ -630,6 +640,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		withDeadline("resolveActiveRepoContext", activeRepoContextPromise, prepDefaults.activeRepoContext),
 		withDeadline("getCachedGpu", gpuPromise, prepDefaults.gpu),
 	]);
+	clearTimeout(deadlineTimer);
 	const agentsMdFiles = Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
 
 	if (timedOut.length > 0) {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -141,17 +141,17 @@ async function runGpuProbe(cmd: string[]): Promise<string | null> {
 		})();
 		const exitCode = await proc.exited;
 		// Even on exit 0, a probe wrapper can leave a descendant holding stdout open.
-		// Bound the EOF wait so getCachedGpu cannot outlive the probe in either path.
+		// Bound the EOF wait so getCachedGpu cannot outlive the probe in either path;
+		// keep whatever bytes the reader already captured before cancelling.
 		const drained = await Promise.race([
 			stdoutDone.then(() => "ok" as const).catch(() => "err" as const),
 			Bun.sleep(GPU_PROBE_STDOUT_DRAIN_MS).then(() => "timeout" as const),
 		]);
-		if (exitCode !== 0 || drained !== "ok") {
+		if (drained !== "ok") {
 			await stdoutReader.cancel().catch(() => undefined);
 			await stdoutDone.catch(() => undefined);
-			return null;
 		}
-		return stdout;
+		return exitCode === 0 ? stdout : null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
## Repro
A fake `lspci` placed first on `PATH` sleeps for 6s and returns no GPU. Before the fix, `env PATH=/data/workspaces/can1357__oh-my-pi__3835/.omp-tmp/tmp.mMpmbANrNR/bin:$PATH XDG_CACHE_HOME=/data/workspaces/can1357__oh-my-pi__3835/.omp-tmp/tmp.mMpmbANrNR/cache bun /data/workspaces/can1357__oh-my-pi__3835/.omp-tmp/tmp.mMpmbANrNR/repro.ts` reported `{"elapsedMs":6038,"cached":false}`.

## Cause
`packages/coding-agent/src/system-prompt.ts` called `getEnvironmentInfo()` after the bounded prep `Promise.all`, and `getEnvironmentInfo()` awaited `getCachedGpu()` directly. `getCachedGpu()` also only wrote `gpu_cache.json` for truthy probe results, so failed, empty, or unparseable Windows `wmic` and Linux `lspci` probes reran every startup.

## Fix
- Cache GPU probe results as `string | null`, preserving existing positive-cache reads and treating cached `null` as a completed probe.
- Start `getCachedGpu()` with the rest of system-prompt prep and route it through `withDeadline("getCachedGpu", ...)`.
- Render OS/CPU/terminal environment fields synchronously from the resolved or fallback GPU value.
- Add Linux child-process regression tests for empty-result caching and slow-probe deadline behavior.
- Add an Unreleased changelog entry for `packages/coding-agent`.

## Verification
`bun test src/system-prompt.test.ts && bun run check:types` passed in `packages/coding-agent`; `bun run check` passed in `packages/coding-agent`; rerunning the fake slow-probe repro after the fix returned after the 5s prep deadline with the `getCachedGpu` timeout warning instead of waiting for the full probe. Fixes #3835