### PR TITLE
Fix dirty parent isolated branch merges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed isolated branch merges rejecting task edits when the parent checkout had unrelated dirty changes in nearby patch context. ([#3841](https://github.com/can1357/oh-my-pi/issues/3841))
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -222,6 +222,14 @@ export async function mergeIsolatedChanges(opts: IsolationMergeOptions): Promise
 	const { result, repoRoot, mergeMode } = opts;
 	try {
 		if (mergeMode === "branch") {
+			if (!result.branchName && result.exitCode === 0 && !result.aborted && result.error) {
+				return {
+					summary: `\n\n<system-notification>Branch merge failed before a task branch could be created: ${result.error}\nTask outputs are preserved but changes were not applied.</system-notification>`,
+					changesApplied: false,
+					hadAnyChanges: false,
+					mergedBranchForNestedPatches: false,
+				};
+			}
 			const canApplyNestedOnly =
 				!result.branchName && result.exitCode === 0 && !result.aborted && (result.nestedPatches?.length ?? 0) > 0;
 			if (!result.branchName || result.exitCode !== 0 || result.aborted) {

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -148,21 +148,33 @@ export async function captureBaseline(repoRoot: string): Promise<WorktreeBaselin
 	return { root, nested };
 }
 
-async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise<string> {
+async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline, objectRepoDir = repoDir): Promise<string> {
 	const currentHead = (await git.head.sha(repoDir)) ?? "";
 	const currentStaged = await git.diff(repoDir, { binary: true, cached: true });
 	const currentUnstaged = await git.diff(repoDir, { binary: true });
 	const currentUntracked = await git.ls.untracked(repoDir);
 	const currentUntrackedPatch = await captureUntrackedPatch(repoDir, currentUntracked);
+	const committedPatch =
+		currentHead && currentHead !== rb.headCommit
+			? await git.diff.tree(repoDir, rb.headCommit, currentHead, {
+					allowFailure: true,
+					binary: true,
+				})
+			: "";
 
-	const baselineTree = await writeSyntheticTree(repoDir, rb.headCommit, [rb.staged, rb.unstaged, rb.untrackedPatch]);
-	const currentTree = await writeSyntheticTree(repoDir, currentHead, [
+	const baselineTree = await writeSyntheticTree(objectRepoDir, rb.headCommit, [
+		rb.staged,
+		rb.unstaged,
+		rb.untrackedPatch,
+	]);
+	const currentTree = await writeSyntheticTree(objectRepoDir, rb.headCommit, [
+		committedPatch,
 		currentStaged,
 		currentUnstaged,
 		currentUntrackedPatch,
 	]);
 
-	return git.diff.tree(repoDir, baselineTree, currentTree, {
+	return git.diff.tree(objectRepoDir, baselineTree, currentTree, {
 		allowFailure: true,
 		binary: true,
 	});
@@ -212,7 +224,7 @@ export interface DeltaPatchResult {
 }
 
 export async function captureDeltaPatch(isolationDir: string, baseline: WorktreeBaseline): Promise<DeltaPatchResult> {
-	const rootPatch = await captureRepoDeltaPatch(isolationDir, baseline.root);
+	const rootPatch = await captureRepoDeltaPatch(isolationDir, baseline.root, baseline.root.repoRoot);
 	const nestedPatches: NestedRepoPatch[] = [];
 
 	for (const { relativePath, baseline: nb } of baseline.nested) {
@@ -222,7 +234,7 @@ export async function captureDeltaPatch(isolationDir: string, baseline: Worktree
 		} catch {
 			continue;
 		}
-		const patch = await captureRepoDeltaPatch(nestedDir, nb);
+		const patch = await captureRepoDeltaPatch(nestedDir, nb, nb.repoRoot);
 		if (patch.trim()) nestedPatches.push({ relativePath, patch });
 	}
 
@@ -490,18 +502,24 @@ export async function commitToBranch(
 			try {
 				await git.patch.applyText(tmpDir, rootPatch);
 			} catch (err) {
-				if (err instanceof git.GitCommandError) {
-					const stderr = err.result.stderr.slice(0, 2000);
-					logger.error("commitToBranch: git apply failed", {
-						taskId,
-						exitCode: err.result.exitCode,
-						stderr,
-						patchSize: rootPatch.length,
-						patchHead: rootPatch.slice(0, 500),
-					});
-					throw new Error(`git apply failed for task ${taskId}: ${stderr}`);
+				if (!(err instanceof git.GitCommandError)) throw err;
+				try {
+					await git.patch.applyText(tmpDir, rootPatch, { threeWay: true });
+				} catch (threeWayErr) {
+					if (threeWayErr instanceof git.GitCommandError) {
+						const stderr = threeWayErr.result.stderr.slice(0, 2000);
+						logger.error("commitToBranch: git apply --3way failed", {
+							taskId,
+							exitCode: threeWayErr.result.exitCode,
+							stderr,
+							initialStderr: err.result.stderr.slice(0, 2000),
+							patchSize: rootPatch.length,
+							patchHead: rootPatch.slice(0, 500),
+						});
+						throw new Error(`git apply --3way failed for task ${taskId}: ${stderr}`);
+					}
+					throw threeWayErr;
 				}
-				throw err;
 			}
 			await git.stage.files(tmpDir);
 			const msg = (commitMessage && (await commitMessage(rootPatch))) || fallbackMessage;

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -91,6 +91,7 @@ export interface PatchOptions {
 	readonly cached?: boolean;
 	readonly check?: boolean;
 	readonly env?: Record<string, string | undefined>;
+	readonly threeWay?: boolean;
 	readonly signal?: AbortSignal;
 }
 
@@ -359,6 +360,7 @@ function buildApplyArgs(patchPath: string, options: PatchOptions): string[] {
 	const args = ["apply"];
 	if (options.check) args.push("--check");
 	if (options.cached) args.push("--cached");
+	if (options.threeWay) args.push("--3way");
 	args.push("--binary", patchPath);
 	return args;
 }

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -44,6 +44,25 @@ describe("mergeIsolatedChanges", () => {
 		expect(outcome.summary).toContain("nested repository patches captured");
 	});
 
+	it("surfaces branch preparation errors instead of reporting no changes", async () => {
+		const mergeSpy = vi.spyOn(worktreeModule, "mergeTaskBranches");
+		const outcome = await mergeIsolatedChanges({
+			repoRoot: "/repo",
+			mergeMode: "branch",
+			result: result({
+				error: "Merge failed: git apply --3way failed for task dirty-context: conflict",
+			}),
+		});
+
+		expect(mergeSpy).not.toHaveBeenCalled();
+		expect(outcome.changesApplied).toBe(false);
+		expect(outcome.hadAnyChanges).toBe(false);
+		expect(outcome.mergedBranchForNestedPatches).toBe(false);
+		expect(outcome.summary).toContain("Branch merge failed before a task branch could be created");
+		expect(outcome.summary).toContain("git apply --3way failed");
+		expect(outcome.summary).not.toContain("No changes to apply");
+	});
+
 	it("does not mark failed branch-mode runs as nested-patch eligible", async () => {
 		const outcome = await mergeIsolatedChanges({
 			repoRoot: "/repo",

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -6,6 +6,8 @@ import {
 	applyNestedPatches,
 	captureBaseline,
 	captureDeltaPatch,
+	cleanupTaskBranches,
+	commitToBranch,
 	ensureIsolation,
 	getGitNoIndexNullPath,
 	getRepoRoot,
@@ -231,6 +233,44 @@ describe("worktree isolation helpers", () => {
 				expect(status).toBe("M  staged.txt");
 				expect(cached).toContain("+local staged change");
 				expect(stashList).toBe("");
+			});
+
+			it("commits isolated edits when parent dirt only changes nearby context", async () => {
+				const fixtureName = "EXP_DIRTY_TEST.txt";
+				const fixturePath = path.join(repo, fixtureName);
+				const cleanLines = Array.from({ length: 10 }, (_, index) => `line${index + 1}`);
+				await fs.writeFile(fixturePath, `${cleanLines.join("\n")}\n`);
+				await runGit(repo, ["add", fixtureName]);
+				await runGit(repo, ["commit", "-q", "-m", "add dirty merge fixture"]);
+
+				const parentDirtyLines = cleanLines.map((line, index) => (index === 1 ? "LINE2-DIRTY-PARENT" : line));
+				await fs.writeFile(fixturePath, `${parentDirtyLines.join("\n")}\n`);
+				const baseline = await captureBaseline(repo);
+
+				const isoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-worktree-iso-"));
+				tempDirs.push(isoRoot);
+				const iso = path.join(isoRoot, "repo");
+				await runGit(isoRoot, ["clone", "-q", repo, iso]);
+				await runGit(iso, ["config", "user.email", "test@example.com"]);
+				await runGit(iso, ["config", "user.name", "Test User"]);
+				const isolatedLines = parentDirtyLines.map((line, index) => (index === 4 ? "LINE5-AGENT-EDIT" : line));
+				await fs.writeFile(path.join(iso, fixtureName), `${isolatedLines.join("\n")}\n`);
+
+				const taskId = `dirty-context-${path.basename(isoRoot)}`;
+				let branchName = `omp/task/${taskId}`;
+				try {
+					const commitResult = await commitToBranch(iso, baseline, taskId, "dirty context merge");
+					if (!commitResult?.branchName) throw new Error("expected task branch");
+					branchName = commitResult.branchName;
+
+					const mergeResult = await mergeTaskBranches(repo, [{ branchName, taskId }]);
+					const finalContent = await fs.readFile(fixturePath, "utf8");
+
+					expect(mergeResult).toEqual({ failed: [], merged: [branchName] });
+					expect(finalContent).toBe(`${isolatedLines.join("\n")}\n`);
+				} finally {
+					await cleanupTaskBranches(repo, [branchName]);
+				}
 			});
 
 			it("subtracts baseline dirty state even when the task commits it", async () => {


### PR DESCRIPTION
## Repro
Reproduced the reported failure by creating `EXP_DIRTY_TEST.txt`, dirtying line 2 in the parent checkout, cloning an isolated checkout that changed line 5, then invoking `captureBaseline()` + `commitToBranch()`: before the fix, `git apply` failed with `error: patch failed: EXP_DIRTY_TEST.txt:2` / `patch does not apply` even though the task edit was on line 5.

## Cause
`packages/coding-agent/src/task/worktree.ts` generated the task delta patch from synthetic trees written in the isolated repo object database, then `commitToBranch()` applied that patch in a clean branch worktree from the parent repo. The patch correctly represented only task changes, but its context referenced parent dirty content and its blob ids were not guaranteed to exist in the parent object database, so plain `git apply` rejected non-overlapping edits and branch-mode merge errors were later collapsed to `No changes to apply` in `mergeIsolatedChanges()`.

## Fix
- Generate root and nested synthetic delta trees in the parent repository object database while still reading current task state from the isolated checkout.
- Add `PatchOptions.threeWay` / `git apply --3way` support and use it as the `commitToBranch()` fallback when plain patch application rejects dirty-context hunks.
- Surface branch preparation failures from `mergeIsolatedChanges()` as system notifications instead of reporting no changes.
- Add regression coverage for dirty parent context merges and branch-preparation error reporting.

## Verification
`bun test packages/coding-agent/test/task/worktree.test.ts` passed. `bun run gen:tool-views && bun test packages/coding-agent/test/task/isolation-runner.test.ts` passed, with the generated local artifact removed afterward. `bun check` passed. Manual repro script verified both uncommitted and committed isolated line 5 edits merge alongside parent dirty line 2. Fixes #3841