### PR TITLE
fix(coding-agent): log Esc/Ctrl+C abort failures instead of swallowing them

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Esc/Ctrl+C teardown now logs a failing compaction/handoff/retry abort at debug instead of silently swallowing it.
+
 ## [16.2.6] - 2026-06-29
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -110,6 +110,17 @@ function wrapPasteInAttachmentBlock(content: string): string {
 	return `<attachment>\n${content}\n</attachment>`;
 }
 
+/** Run a teardown abort that must never throw (Esc / Ctrl+C path). A thrown
+ *  error is logged at debug instead of silently swallowed, so a failing abort
+ *  stays diagnosable without disturbing teardown ordering. */
+function safeAbort(label: string, fn: () => void): void {
+	try {
+		fn();
+	} catch (err) {
+		logger.debug(`Failed to abort ${label}`, { error: err instanceof Error ? err.message : String(err) });
+	}
+}
+
 const TINY_TITLE_PROGRESS_DONE_TTL_MS = 3_000;
 // A cached model fires its file-load events in a short burst and then goes silent
 // while onnxruntime builds the session; a genuine download keeps streaming progress
@@ -306,21 +317,15 @@ export class InputController {
 				const viewSession = this.ctx.viewSession;
 				let aborted = false;
 				if (viewSession.isCompacting) {
-					try {
-						viewSession.abortCompaction();
-					} catch {}
+					safeAbort("compaction", () => viewSession.abortCompaction());
 					aborted = true;
 				}
 				if (viewSession.isGeneratingHandoff) {
-					try {
-						viewSession.abortHandoff();
-					} catch {}
+					safeAbort("handoff", () => viewSession.abortHandoff());
 					aborted = true;
 				}
 				if (viewSession.isRetrying) {
-					try {
-						viewSession.abortRetry();
-					} catch {}
+					safeAbort("retry", () => viewSession.abortRetry());
 					aborted = true;
 				}
 				if (aborted) return;


### PR DESCRIPTION
## Problem

The Esc / Ctrl+C teardown path in `InputController` had three duplicated blocks that silently swallowed any error from aborting in-flight maintenance:

```ts
if (viewSession.isCompacting) {
	try { viewSession.abortCompaction(); } catch {}   // silent swallow
	aborted = true;
}
// …same for abortHandoff() and abortRetry()
```

A failing abort (e.g. a session whose abort path throws during teardown) left no trace — the error was discarded, making regressions in the abort paths invisible.

## Change

Replace the three `try { abortX() } catch {}` blocks with a single shared helper that reports the failure instead of burying it:

```ts
function safeAbort(label: string, fn: () => void): void {
	try {
		fn();
	} catch (err) {
		logger.debug(`Failed to abort ${label}`, { error: err instanceof Error ? err.message : String(err) });
	}
}
```

Call sites become `safeAbort("compaction", () => viewSession.abortCompaction())` etc.

- Deduplicates the three identical try/catch blocks.
- A failing abort is now logged at `debug` (to `~/.omp/logs/…`) instead of vanishing — no `console.*`, so TUI rendering is unaffected.
- **Behavior preserved:** the `aborted` flag is still set regardless of whether the abort threw, teardown ordering is unchanged, and throws are still contained to the teardown path.

## Why these catches

They were the genuinely "useless" ones — optional-binding empty `catch {}` that silently swallow. The rest of `packages/coding-agent`'s try/catches do real work (`isEnoent` handling, error-code → message mapping, log-and-continue, restore-on-error) and are not touched. The one other empty catch (`event-controller.ts` intent-function guard) is a deliberate, commented UI-safety guard and is intentionally left alone.

## Verification

- `bun run check` (biome + tsgo): passed
- `bun test test/input-controller-escape.test.ts` (covers this exact path — focused-subagent skips the aborts; main-view Esc calls them): **30 pass / 0 fail** (exit code verified directly, not via a pipe)