### PR TITLE
fix(agent): clarify queued skipped tool results

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clarified queued-message skipped tool results so the model does not count a skipped tool as completed work or verification before retrying it when still needed.
+
 ## [16.2.4] - 2026-06-28
 
 ### Changed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2131,7 +2131,12 @@ function createToolSignalAbortedResult(signal: AbortSignal): AgentToolResult<unk
 
 function createSkippedToolResult(): AgentToolResult<any> {
 	return {
-		content: [{ type: "text", text: "Skipped due to queued user message." }],
+		content: [
+			{
+				type: "text",
+				text: "Skipped due to queued user message. Do not count this skipped result as completed work or verification. After the queued message is handled on the next step, retry the skipped tool if it is still needed.",
+			},
+		],
 		details: {},
 	};
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1086,6 +1086,8 @@ describe("agentLoop with AgentMessage", () => {
 		expect(toolEnds[1].isError).toBe(true);
 		if (toolEnds[1].result.content[0]?.type === "text") {
 			expect(toolEnds[1].result.content[0].text).toContain("Skipped due to queued user message");
+			expect(toolEnds[1].result.content[0].text).toContain("Do not count this skipped result as completed work");
+			expect(toolEnds[1].result.content[0].text).toContain("retry the skipped tool if it is still needed");
 		}
 
 		// Queued message should appear in events after the tool results and before the next model call.


### PR DESCRIPTION
## What

Clarify queued-message skipped tool results in `@oh-my-pi/pi-agent-core` so the synthetic result tells the model:

- the skipped tool did not complete work;
- skipped output must not count as verification;
- the tool should be retried after the queued message is handled when it is still needed.

## Why

Queued steering intentionally skips the rest of the current tool batch, but the old result text only said `Skipped due to queued user message.` That was easy for a model to treat as a completed tool result. This change makes the recovery contract explicit without changing queue execution semantics.

This is separate from the existing max-token skipped-tool fix because it covers queued steering, not truncated tool arguments.

## Testing

- [x] `bun --cwd=packages/agent test test/agent-loop.test.ts -t "should skip remaining tool calls when steering is queued"`
- [x] `bun --cwd=packages/agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
