### PR TITLE
fix(coding-agent): restore working loader after subagent ends inside overlay window

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improved error reporting for `omp tiny-models download` by displaying the actual worker-side download error.
 - Resolved status inconsistencies between `/extensions`, `/mcp list`, and the dashboard, ensuring MCP server states, allowlists/denylists, and configuration files (like `mcp.json`) stay fully synchronized.
 - Improved branch-mode task merges to preserve the agent's original commit history (messages and authors) and fixed a bug where merges were rejected due to unrelated dirty changes in the parent checkout.
+- Fixed the `Working…` loader staying gone for the rest of a parent turn when a long-running tool (e.g. a `task` subagent) finished inside a transient overlay window (auto-snapcompact, auto-context-full, auto-retry). Those overlays null the working loader on start and the overlay-end handler is the only restorer keyed off the missing loader; if the subagent's `tool_execution_end` lands while the overlay is still active (or its end handler errored before re-arming), the spinner stayed gone until the next turn even though the parent kept streaming. `tool_execution_end` now mirrors the `tool_execution_update` self-heal so the working loader survives a subagent completing inside the overlay window ([#3858](https://github.com/can1357/oh-my-pi/issues/3858)).
 
 ## [16.2.6] - 2026-06-29
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -890,6 +890,17 @@ export class EventController {
 	}
 
 	async #handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): Promise<void> {
+		// A long-running tool (`task` subagent, async bash poll, …) is the next
+		// streaming event on the parent session when an inner transient overlay
+		// (auto-compaction / auto-retry) clears the status container between this
+		// tool's start and end. `auto_*_end` is the overlay-side restorer; for any
+		// path that nulls the loader without a follow-up overlay-end (e.g. an
+		// errored overlay teardown, or the subagent finishing inside the overlay
+		// window), the next tool event is the only restore point before the turn
+		// settles. `tool_execution_update` already self-heals — keep
+		// `tool_execution_end` symmetric so the spinner survives a subagent
+		// completing inside the overlay window (#3858).
+		this.#ensureWorkingLoaderWhileStreaming();
 		if (event.toolName === "read") {
 			if (this.#inlineReadToolImages(event.toolCallId, event.result)) {
 				const component = this.ctx.pendingTools.get(event.toolCallId);

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -299,6 +299,47 @@ describe("EventController working loader reconciliation", () => {
 		expect(ctx.ensureLoadingAnimation).toHaveBeenCalledTimes(1);
 	});
 
+	it("self-heals missing working loader when a task subagent finishes mid-turn (#3858)", async () => {
+		// `task` subagents run inside the parent's streaming turn. While the task is
+		// running a transient overlay (auto-compaction / auto-retry) can drop the
+		// working loader by clearing the status container, and the overlay's end
+		// handler is the only restorer keyed off the missing loader. If the task
+		// finishes between the overlay's start and end (or any other branch where
+		// the loader was nulled without a follow-up overlay-end), `tool_execution_end`
+		// is the next streaming event that lands and must heal the loader, mirroring
+		// the `tool_execution_update` reconciler. Without this the spinner stays
+		// gone for the remainder of the parent turn even though the agent keeps
+		// streaming (the user-visible regression in #3858).
+		const { controller, ctx } = createFixture();
+		(ctx.viewSession as unknown as { isStreaming: boolean }).isStreaming = true;
+
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "task-1",
+			toolName: "task",
+			isError: false,
+			result: { content: [{ type: "text", text: "ok" }], details: {} },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+
+		expect(ctx.ensureLoadingAnimation).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not restore the working loader while an overlay loader (auto-retry) owns the status container at tool_execution_end", async () => {
+		const { controller, ctx } = createFixture();
+		ctx.retryLoader = { stop: vi.fn() } as unknown as InteractiveModeContext["retryLoader"];
+		(ctx.viewSession as unknown as { isStreaming: boolean }).isStreaming = true;
+
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "task-2",
+			toolName: "task",
+			isError: false,
+			result: { content: [{ type: "text", text: "ok" }], details: {} },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+
+		expect(ctx.ensureLoadingAnimation).not.toHaveBeenCalled();
+	});
+
 	it("keeps transient retry status exclusive while a retry loader is visible", async () => {
 		const { controller, ctx } = createFixture();
 		ctx.retryLoader = { stop: vi.fn() } as unknown as InteractiveModeContext["retryLoader"];

--- a/packages/coding-agent/test/event-controller-todo-reminder.test.ts
+++ b/packages/coding-agent/test/event-controller-todo-reminder.test.ts
@@ -21,6 +21,11 @@ function createContext() {
 		updateEditorTopBorder: vi.fn(),
 		clearPinnedError: vi.fn(),
 		ensureLoadingAnimation: vi.fn(),
+		// `viewSession.isStreaming` is read by `#ensureWorkingLoaderWhileStreaming`,
+		// which runs at the top of `tool_execution_end` (and other streaming-event
+		// handlers). Leaving it false matches the implicit assumption in this
+		// fixture: the todo HUD lifecycle is independent of the working loader.
+		viewSession: { isStreaming: false },
 		todoReminderContainer,
 		setTodos: vi.fn(),
 		present,


### PR DESCRIPTION
## Repro

Reporter observed three symptoms after resuming a large session that mid-run snap-compacts while `task`/`explore` subagents are active on macOS / Bun 1.3.14 ([#3858](https://github.com/can1357/oh-my-pi/issues/3858)):

1. A Bun-runtime segfault on a worker thread (`panic: Segmentation fault at address 0x6`, faulting thread `Worker`).
2. `double-esc repro: expected 2 interrupts, got 0` — the streaming-Esc abort silently dropped.
3. `{"updateEnsures":1,"endEnsures":0}` — `tool_execution_update` self-healed the working loader (1 call) but the parallel `tool_execution_end` path did not (0 calls), so the "Working…" spinner stayed gone for the rest of the parent turn after a `task` subagent finished inside a mid-run compaction window.

A targeted unit repro for (3) reproduces the reporter's counts exactly:

```
cd packages/coding-agent && bun test test/event-controller-error-banner.test.ts -t "tool subagent finishes mid-turn"
```

```
expect(received).toHaveBeenCalledTimes(expected)
Expected number of calls: 1
Received number of calls: 0
(fail) EventController working loader reconciliation > self-heals missing working loader when a task subagent finishes mid-turn (#3858)
```

(1) is a Bun runtime crash inside a worker thread and is out of scope for this PR — the crash report itself notes "Bun has crashed. This indicates a bug in Bun, not your code." (2) is governed by the per-turn streaming-Esc sentinel that is intentionally reset on every `agent_start`/`agent_end` (see `99668abd414`, `3158435b8a7`) and is already covered by `test/input-controller-escape.test.ts`; nothing in the current arming logic accounts for the reporter's count and there is no in-tree repro to anchor a change against without breaking the existing turn-boundary contract. This PR addresses (3) — the verifiable, reproducible state-machine regression — and leaves the other two for follow-up.

## Cause

`EventController` calls `#ensureWorkingLoaderWhileStreaming()` from every streaming-event handler that can land after a transient overlay (`auto_compaction_*`, `auto_retry_*`) clears the status container — `message_start`, `message_update`, `tool_execution_start`, `tool_execution_update`, `auto_compaction_end`, `auto_retry_end` (see the original wiring in commit `bbb8793cbcb`). `#handleToolExecutionEnd` was the one missing site. When a `task` subagent runs across an overlay window, the overlay's `start` handler (`#handleAutoCompactionStart` / `#handleAutoRetryStart`, `packages/coding-agent/src/modes/controllers/event-controller.ts:1109,1213`) calls `#stopWorkingLoader()` and `statusContainer.clear()`, nulling `ctx.loadingAnimation`. The matching `auto_*_end` handler is the only restorer keyed off the missing loader; if the subagent's `tool_execution_end` lands while the overlay is still active (snapcompact-driven `agent.continue()`, an errored overlay teardown, or the subagent simply finishing inside the overlay's `start` → `end` window), the spinner stays gone until the next turn even though the parent keeps streaming.

## Fix

- `packages/coding-agent/src/modes/controllers/event-controller.ts` — call `#ensureWorkingLoaderWhileStreaming()` at the top of `#handleToolExecutionEnd`, mirroring `#handleToolExecutionUpdate`. The reconciler is already gated on `viewSession.isStreaming` and short-circuits when an overlay loader is still visible, so it remains a no-op when no recovery is needed and preserves the existing overlay-exclusivity contract.
- `packages/coding-agent/test/event-controller-error-banner.test.ts` — regression test that drives `tool_execution_end` with `viewSession.isStreaming=true` and asserts `ensureLoadingAnimation` is called; a sibling test asserts the no-op behavior when an overlay loader (`retryLoader`) is still mounted.
- `packages/coding-agent/test/event-controller-todo-reminder.test.ts` — the existing `clears reminders when a todo tool succeeds` test fired `tool_execution_end` through a fixture missing `viewSession`. Added `viewSession: { isStreaming: false }` so the new self-heal path can run cleanly while keeping the test's contract unchanged (the todo HUD lifecycle is independent of the working loader).
- `packages/coding-agent/CHANGELOG.md` — single `### Fixed` entry under `## [Unreleased]`.

## Verification

```
cd packages/coding-agent && bun test \
  test/event-controller-todo-reminder.test.ts \
  test/event-controller-error-banner.test.ts \
  test/event-controller-abort-render.test.ts \
  test/modes/controllers/event-controller-abort-guard.test.ts \
  test/modes/controllers/event-controller-args-reveal.test.ts \
  test/modes/controllers/event-controller-idle-compaction.test.ts \
  test/modes/controllers/event-controller-interrupt.test.ts \
  test/modes/controllers/event-controller-loader-recovery.test.ts \
  test/modes/controllers/event-controller-message-start.test.ts \
  test/modes/controllers/event-controller-read-grouping.test.ts \
  test/modes/controllers/event-controller-superseded-agent-end.test.ts \
  test/modes/controllers/event-controller-toolcall-finalize.test.ts \
  test/input-controller-escape.test.ts \
  test/job-poll-displacement.test.ts \
  test/agent-session-auto-compaction-queue.test.ts
# 113 pass, 0 fail (331 expect() calls)
```

The new `self-heals missing working loader when a task subagent finishes mid-turn (#3858)` test reproduces the reporter's `endEnsures:0` failure on the unpatched code path and passes after the one-line restore. The sibling overlay-exclusivity test guarantees we did not regress the existing `retryLoader` precedence.

Fixes #3858