### PR TITLE
perf: cut edit-pipeline and session-branch hot-path complexity

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Improved binary file detection and terminal handling to prevent corruption from non-UTF-8 content, and updated file summaries to explicitly note skipped binary files.
 - Enhanced context compaction (snapcompact) to resolve shapes contextually based on rendered text content.
+- Reduced session branch reconstruction (`pathTo`) from O(n²) to O(n) using `push` plus a single `reverse` instead of repeated `unshift`.
+- Reduced edit-patch fallback cost: `collapseRepeatedBlocks` no longer allocates per-iteration slices (index arithmetic plus an early skip), and shared-line filtering builds the set in O(n+m) via a Set instead of O(n×m) `includes`.
+- Changed streaming patch-preview added-line extraction from O(n²) string concatenation to a single array join.
 
 ### Fixed
 

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -455,7 +455,8 @@ function trimCommonContext(oldLines: string[], newLines: string[]): HunkVariant 
 }
 
 function collapseConsecutiveSharedLines(oldLines: string[], newLines: string[]): HunkVariant | undefined {
-	const shared = new Set(oldLines.filter(line => newLines.includes(line)));
+	const newSet = new Set(newLines);
+	const shared = new Set(oldLines.filter(line => newSet.has(line)));
 	const collapse = (lines: string[]): string[] => {
 		const out: string[] = [];
 		let i = 0;
@@ -480,30 +481,31 @@ function collapseConsecutiveSharedLines(oldLines: string[], newLines: string[]):
 }
 
 function collapseRepeatedBlocks(oldLines: string[], newLines: string[]): HunkVariant | undefined {
-	const shared = new Set(oldLines.filter(line => newLines.includes(line)));
+	const newSet = new Set(newLines);
+	const shared = new Set(oldLines.filter(line => newSet.has(line)));
 	const collapse = (lines: string[]): string[] => {
 		const output = [...lines];
 		let changed = false;
 		let i = 0;
 		while (i < output.length) {
 			let collapsed = false;
-			for (let size = Math.floor((output.length - i) / 2); size >= 2; size--) {
-				const first = output.slice(i, i + size);
-				const second = output.slice(i + size, i + size * 2);
-				if (first.length !== second.length || first.length === 0) continue;
-				if (!first.every(line => shared.has(line))) continue;
-				let same = true;
-				for (let idx = 0; idx < size; idx++) {
-					if (first[idx] !== second[idx]) {
-						same = false;
+			// Only blocks whose lines are all shared are collapsible; if the first line
+			// is not shared no size can match, so skip the size search entirely.
+			if (shared.has(output[i])) {
+				for (let size = Math.floor((output.length - i) / 2); size >= 2; size--) {
+					let same = true;
+					for (let idx = 0; idx < size; idx++) {
+						if (output[i + idx] !== output[i + size + idx] || !shared.has(output[i + idx])) {
+							same = false;
+							break;
+						}
+					}
+					if (same) {
+						output.splice(i + size, size);
+						changed = true;
+						collapsed = true;
 						break;
 					}
-				}
-				if (same) {
-					output.splice(i + size, size);
-					changed = true;
-					collapsed = true;
-					break;
 				}
 			}
 			if (!collapsed) {

--- a/packages/coding-agent/src/edit/streaming.ts
+++ b/packages/coding-agent/src/edit/streaming.ts
@@ -207,19 +207,18 @@ function groupApplyPatchEntriesByPath(entries: readonly ApplyPatchEntry[]): Map<
  * `create` op), otherwise an empty string (grammar-only payloads).
  */
 function extractAddedLines(text: string, fallbackToWhole: boolean): string {
-	let added: string | undefined;
+	const added: string[] = [];
 	let lineStart = 0;
 	while (lineStart <= text.length) {
 		let lineEnd = text.indexOf("\n", lineStart);
 		if (lineEnd === -1) lineEnd = text.length;
 		if (text.charCodeAt(lineStart) === 43 /* + */ && !text.startsWith("+++ ", lineStart)) {
-			const line = text.slice(lineStart + 1, lineEnd);
-			added = added === undefined ? line : `${added}\n${line}`;
+			added.push(text.slice(lineStart + 1, lineEnd));
 		}
 		lineStart = lineEnd + 1;
 	}
-	if (added === undefined) return fallbackToWhole ? text : "";
-	return added;
+	if (added.length === 0) return fallbackToWhole ? text : "";
+	return added.join("\n");
 }
 
 /**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -235,10 +235,11 @@ class SessionEntryIndex {
 
 		while (cursor && !seen.has(cursor.id)) {
 			seen.add(cursor.id);
-			branch.unshift(cursor);
+			branch.push(cursor);
 			cursor = cursor.parentId ? this.#entriesById.get(cursor.parentId) : undefined;
 		}
 
+		branch.reverse();
 		return branch;
 	}
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Avoided reallocating the tab-expansion space string on every `replaceTabs` call by hoisting it to a module constant.
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -143,12 +143,13 @@ export function extractSegments(
 
 // Pre-allocated space buffer for padding
 const SPACE_BUFFER = " ".repeat(512);
+const TAB_SPACES = " ".repeat(DEFAULT_TAB_WIDTH);
 
 /*
  * Replace tabs with the fixed display tab width for consistent rendering.
  */
 export function replaceTabs(text: string): string {
-	return text.replaceAll("\t", " ".repeat(DEFAULT_TAB_WIDTH));
+	return text.replaceAll("\t", TAB_SPACES);
 }
 
 /**


### PR DESCRIPTION
## Summary

Four **non-overlapping** algorithmic complexity reductions in edit-pipeline and session hot paths. No behavior changes.

> **Note:** Streaming-reveal throughput (incremental grapheme slicing) is owned separately by **#3843**. This PR intentionally does **not** touch `streaming-reveal.ts` or its tests, so the two PRs are independent and conflict-free.

### The fixes

**1. Session branch path — O(n²) → O(n)** (`session/session-manager.ts`)
`pathTo()` built the leaf→root branch with `branch.unshift()` in a loop; `unshift` shifts every element each call → O(n²). This runs 5–10× per turn (`getBranch` → compaction checks, context breakdown). Fixed: `push` + a single `reverse()`.

**2. Streaming patch-preview — O(n²) → O(n)** (`edit/streaming.ts`)
`extractAddedLines` rebuilt the accumulated string on every `+` line: `` `${added}\n${line}` `` — quadratic over added lines, fired per streaming tick. Fixed: push to array, `join("\n")` once.

**3. Patch fallback collapse — O(n³) allocations + O(n×m) filter** (`edit/modes/patch.ts`)
- `collapseConsecutiveSharedLines`: `newLines.includes()` inside `.filter()` (O(n×m)) → Set (O(n+m)).
- `collapseRepeatedBlocks`: triple-nested loop allocating two `output.slice()`s + a separate `.every()` per inner step → index arithmetic with one `shared.has(output[i])` guard. Semantics preserved (collapse requires all-block-lines-shared AND all-equal).

### Honorable mention
`tui/src/utils.ts` `replaceTabs` reallocated `" ".repeat(DEFAULT_TAB_WIDTH)` on every call → hoisted `TAB_SPACES` module constant.

## Verification
- `biome check` passes on all 6 changed files.
- `tsgo` typecheck passes for `coding-agent` and `tui`.
- Targeted tests green: apply-patch/apply-patch-regression 168/168, edit-streaming-preview/diff, session-manager 139/139, tui text-utils/text — 320 pass / 0 fail across 23 files.

## Follow-up candidate (not in this PR)
A per-controller cache for `formatThinkingForDisplay` (it currently recomputes 2×/tick per thinking block) was identified during this work but is a `streaming-reveal.ts` change and so belongs with #3843's reveal-throughput work rather than here.