### PR TITLE
perf(coding-agent): reduce submit-to-first-token latency; defer auto-thinking classifier

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Improved binary file detection and terminal handling to prevent corruption from non-UTF-8 content, and updated file summaries to explicitly note skipped binary files.
 - Enhanced context compaction (snapcompact) to resolve shapes contextually based on rendered text content.
+- Reduced the in-process latency between submitting a message and the first streamed token by deduplicating per-turn non-message token estimation (tool-schema serialization now runs once per prompt instead of three times) and skipping the pre-prompt compaction token estimate when compaction is disabled.
+- Auto thinking no longer blocks turn start on the difficulty classifier: classification races a short pre-dispatch deadline, so a fast classifier still pins the current turn while a slow one runs the turn at the carried/provisional effort and applies its result to the next turn instead of stalling for up to the classification timeout.
 
 ### Fixed
 

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -1,0 +1,315 @@
+/**
+ * TTFT (time-to-first-token) benchmark for the coding agent.
+ *
+ * Measures the in-process latency a user feels between pressing Enter on a chat
+ * message and the first streamed model text/thinking appearing — the "Working…"
+ * gap. The LLM transport is replaced with a mock streamFn that emits one token
+ * immediately (delayMs: 0), so the measured time is PURE controllable overhead:
+ *
+ *   AgentSession.#promptWithMessage preflight  (getApiKey, system-prompt build,
+ *                                               before_agent_start hook, token
+ *                                               estimation, compaction check …)
+ *   + agent-loop streamAssistantResponse preflight (convertToLlm, normalizeTools,
+ *                                               context build, telemetry …)
+ *   + stream dispatch + event surfacing back to session listeners
+ *
+ * Out of scope (uncontrollable / network): real network TTFT/TLS, and the
+ * opt-in `auto`-thinking classifier round-trip (only active when the user
+ * selects the `auto` thinking selector). They bound this metric from above in
+ * production; this benchmark isolates the code we can actually optimize.
+ *
+ * Run: bun packages/coding-agent/bench/ttft.ts
+ */
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool, type StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model, UserMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { AgentSession, type AgentSessionEvent } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deterministic workload fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROMPT = "Look at the recent code review comments on my open PRs and fix the issues.";
+
+const RESPONSE_TEXT = "I'll start by checking the open pull requests for review comments.";
+
+const MODEL: Model = (() => {
+	const m = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!m) throw new Error("claude-sonnet-4-5 missing from bundled catalog");
+	return m;
+})();
+
+// A realistic multi-section system prompt (a few KB) so per-turn system-prompt
+// handling processes representative bytes.
+const SYSTEM_PROMPT: string[] = [
+	"# Role",
+	"You are a senior software engineer pair programmer operating inside a terminal coding agent.",
+	"Be terse, evidence-first, and concrete. Every claim about code must be grounded.",
+	"",
+	"# Tools",
+	"You have tools for reading files, editing, running shell commands, searching, and more.",
+	"Prefer the narrowest tool. Never guess at file contents — read first.",
+	"",
+	"# Principles",
+	"- Optimize for correctness first, then for the next maintainer.",
+	"- Fix problems at the source; remove obsolete code.",
+	"- Reuse existing patterns; a second convention beside an existing one is prohibited.",
+	"- Never yield non-trivial work without proof: tests, E2E, or QA.",
+	"- Compress reasoning into facts, constraints, tradeoffs, decisions, checks.",
+	"",
+	"# Workflow",
+	"1. Scope: read relevant skills and existing conventions before touching files.",
+	"2. Research: read sections, not snippets; run references before modifying exported symbols.",
+	"3. Decompose: update todos; default to parallel for complex changes.",
+	"4. Implement: fix at the source; prefer updating existing files over creating new ones.",
+	"5. Verify: run the specific test that covers your change; test behavior not plumbing.",
+	"6. Cleanup: changelog, tests, removing scaffolding — last, gated on the request working.",
+];
+
+// ~30 tools with realistic object schemas so normalizeTools' per-turn schema
+// serialization (a flagged deferrable cost) is exercised at production scale.
+function makeTool(i: number): AgentTool {
+	return {
+		name: `tool_${i}`,
+		label: `Tool ${i}`,
+		description: `Deterministic benchmark tool number ${i}. Exercises per-turn tool-schema normalization with a representative object schema and a multi-sentence description so the measured cost reflects a real tool registry rather than an empty one.`,
+		parameters: type({
+			target: "string",
+			query: "string",
+			content: "string",
+			"offset?": "number",
+			"limit?": "number",
+			"createDirs?": "boolean",
+			"encoding?": "string",
+		}),
+		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+	};
+}
+const TOOLS: AgentTool[] = Array.from({ length: 30 }, (_, i) => makeTool(i));
+
+// Warm-history fixture: a mid-conversation state (3 user + 3 assistant turns)
+// so the steady-state costs the user feels — last-assistant compaction check,
+// history conversion, and token estimation — are exercised, not just the empty
+// first-prompt floor.
+function buildWarmHistory(): AgentMessage[] {
+	const history: AgentMessage[] = [];
+	const userTexts = [
+		"Can you summarize the architecture of the agent runtime package?",
+		"How does the streaming pipeline decode the first token from the provider?",
+		"What runs between submitting a message and the model's first token?",
+	];
+	const assistantTexts = [
+		"The agent runtime exposes a turn entrypoint that builds provider context, fires the LLM stream, and forwards deltas as events. Context assembly, tool normalization, and API-key resolution all happen before the first byte.",
+		"The streaming client decodes SSE incrementally: each blank-line boundary yields one event, which is JSON-parsed and mapped to a content delta. There is no buffering for a full object — the first delta is emitted as soon as a complete SSE event arrives.",
+		"Between submit and first token: the session validates the API key, may run a pre-prompt compaction check, builds the system prompt, resolves file mentions, then the agent loop converts messages, normalizes tools, builds context, and finally fires the request.",
+	];
+	const baseUsage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	for (let i = 0; i < userTexts.length; i++) {
+		const u: UserMessage = { role: "user", content: userTexts[i], timestamp: 1_700_000_000_000 + i };
+		const a: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: assistantTexts[i] }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: MODEL.id,
+			usage: baseUsage,
+			stopReason: "stop",
+			timestamp: 1_700_000_000_000 + i + 1,
+		};
+		history.push(u, a);
+	}
+	return history;
+}
+const WARM_HISTORY = buildWarmHistory();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Measurement
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TurnLatency {
+	ttft: number;
+	preflight: number;
+}
+
+interface BenchDeps {
+	authStorage: AuthStorage;
+	modelRegistry: ModelRegistry;
+	settings: Settings;
+}
+
+/**
+ * One measured turn. Construction happens before the timer starts, so only the
+ * `prompt() → first non-empty assistant text/thinking delta` span is measured.
+ * `preflight` is the split from prompt-entry to the moment the agent loop first
+ * invokes the transport (the most directly controllable component).
+ */
+async function measureOnce(deps: BenchDeps, seedHistory: AgentMessage[] | null): Promise<TurnLatency> {
+	const marker = { calledAt: 0 };
+	const mock = createMockModel({ responses: [{ content: [RESPONSE_TEXT] }] });
+	const innerStream = mock.stream;
+	const streamFn: StreamFn = (...args) => {
+		marker.calledAt = performance.now();
+		return innerStream(...args);
+	};
+
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: {
+			model: MODEL,
+			systemPrompt: SYSTEM_PROMPT,
+			tools: TOOLS,
+			messages: seedHistory ? [...seedHistory] : [],
+		},
+		streamFn,
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: deps.settings,
+		modelRegistry: deps.modelRegistry,
+	});
+
+	const { promise: firstDelta, resolve: onFirstDelta } = Promise.withResolvers<number>();
+	let settled = false;
+	const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+		if (settled) return;
+		if (event.type !== "message_update") return;
+		if (event.message.role !== "assistant") return;
+		const inner = event.assistantMessageEvent;
+		if ((inner.type === "text_delta" || inner.type === "thinking_delta") && inner.delta.length > 0) {
+			settled = true;
+			onFirstDelta(performance.now());
+		}
+	});
+
+	forceGc();
+	const t0 = performance.now();
+	const promptP = session.prompt(PROMPT);
+	try {
+		const TTFT_TIMEOUT_MS = 15_000;
+		const timeout = Bun.sleep(TTFT_TIMEOUT_MS).then(() => {
+			throw new Error("ttft measurement timed out");
+		});
+		const ttft = await Promise.race([
+			firstDelta,
+			promptP.then(() => Promise.reject(new Error("turn finished with no assistant text delta"))),
+			timeout,
+		]);
+		await promptP;
+		return { ttft: ttft - t0, preflight: marker.calledAt > 0 ? marker.calledAt - t0 : Number.NaN };
+	} finally {
+		unsubscribe();
+		await session.dispose();
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats
+// ─────────────────────────────────────────────────────────────────────────────
+
+function median(samples: number[]): number {
+	if (samples.length === 0) return Number.NaN;
+	const s = [...samples].sort((a, b) => a - b);
+	const mid = Math.floor(s.length / 2);
+	return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function percentile(samples: number[], p: number): number {
+	if (samples.length === 0) return Number.NaN;
+	const s = [...samples].sort((a, b) => a - b);
+	const idx = Math.min(s.length - 1, Math.max(0, Math.round(p * (s.length - 1))));
+	return s[idx];
+}
+
+function minimum(samples: number[]): number {
+	if (samples.length === 0) return Number.NaN;
+	let m = samples[0];
+	for (let i = 1; i < samples.length; i++) {
+		if (samples[i] < m) m = samples[i];
+	}
+	return m;
+}
+
+function forceGc(): void {
+	// Flush per-iteration construction garbage so major-GC pauses don't pollute
+	// the measured turn (observed: p90 10-26ms vs a ~0.3ms intrinsic floor).
+	if (typeof Bun.gc === "function") Bun.gc(true);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WARMUP_ITERATIONS = 12;
+const MEASURED_ITERATIONS = 60;
+
+interface ScenarioResult {
+	ttfts: number[];
+	preflights: number[];
+}
+
+async function runScenario(
+	name: string,
+	deps: BenchDeps,
+	seedHistory: AgentMessage[] | null,
+): Promise<ScenarioResult> {
+	for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+		await measureOnce(deps, seedHistory);
+	}
+	const ttfts: number[] = [];
+	const preflights: number[] = [];
+	for (let i = 0; i < MEASURED_ITERATIONS; i++) {
+		const r = await measureOnce(deps, seedHistory);
+		ttfts.push(r.ttft);
+		preflights.push(r.preflight);
+	}
+	const ttftMed = median(ttfts);
+	console.error(
+		`[ttft:bench] ${name}: ttft min=${minimum(ttfts).toFixed(3)} p10=${percentile(ttfts, 0.1).toFixed(3)} p50=${ttftMed.toFixed(3)} p90=${percentile(ttfts, 0.9).toFixed(3)} ms | preflight min=${minimum(preflights).toFixed(3)} p50=${median(preflights).toFixed(3)} ms`,
+	);
+	return { ttfts, preflights };
+}
+
+async function main(): Promise<void> {
+	const tempDir = TempDir.createSync("@pi-ttft-bench-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage);
+	const settings = Settings.isolated({ "compaction.enabled": false });
+	const deps: BenchDeps = { authStorage, modelRegistry, settings };
+
+	try {
+		const cold = await runScenario("cold (empty session)", deps, null);
+		const warm = await runScenario("warm (mid-conversation)", deps, WARM_HISTORY);
+
+		// Primary metric: warm-scenario MINIMUM time-to-first-token. The minimum is
+		// the most reproducible estimate of the intrinsic in-process cost (least
+		// affected by GC/scheduling interference) and the most sensitive to real
+		// code changes that remove per-turn work. Lower is better.
+		console.log(`METRIC ttft_ms=${minimum(warm.ttfts).toFixed(4)}`);
+		console.log(`METRIC ttft_cold_ms=${minimum(cold.ttfts).toFixed(4)}`);
+		console.log(`METRIC preflight_ms=${minimum(warm.preflights).toFixed(4)}`);
+		console.log(`METRIC preflight_cold_ms=${minimum(cold.preflights).toFixed(4)}`);
+		console.log(`METRIC ttft_warm_p50_ms=${median(warm.ttfts).toFixed(4)}`);
+	} finally {
+		authStorage.close();
+		tempDir.removeSync();
+	}
+}
+
+await main();

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -103,13 +103,22 @@ export function computeNonMessageBreakdown(session: AgentSession): {
 	toolsTokens: number;
 	systemContextTokens: number;
 	systemPromptTokens: number;
+	/**
+	 * Total non-message tokens: system prompt (all parts) + tools. Identical to
+	 * {@link computeNonMessageTokens} but computed here so callers that already
+	 * need the category split don't pay for a second `estimateToolSchemaTokens`
+	 * pass over the (potentially large) tool registry.
+	 */
+	nonMessageTokens: number;
 } {
 	const skillsTokens = estimateSkillsTokens(session.skills ?? []);
 	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? []);
 	const systemPromptParts = session.systemPrompt ?? [];
+	const firstPartTokens = countTokens(systemPromptParts[0] ?? "");
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));
-	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens);
-	return { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
+	const systemPromptTokens = Math.max(0, firstPartTokens - skillsTokens);
+	const nonMessageTokens = firstPartTokens + systemContextTokens + toolsTokens;
+	return { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens, nonMessageTokens };
 }
 
 /**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -739,6 +739,8 @@ export interface ContextUsageBreakdown {
 	systemContextTokens: number;
 	skillsTokens: number;
 	messagesTokens: number;
+	/** Total non-message tokens: system prompt (all parts) + tools. (Identical to computeNonMessageTokens.) */
+	nonMessageTokens: number;
 }
 
 /** Session statistics for /session command */
@@ -1337,6 +1339,15 @@ export class AgentSession {
 	#autoThinking: boolean = false;
 	/** The level `auto` last resolved to (for UI); undefined until a turn is classified. */
 	#autoResolvedLevel: Effort | undefined;
+	/**
+	 * The classification result carried from the previous turn, applied at the
+	 * start of the next user turn. Lets `auto` thinking adapt without blocking
+	 * turn start on a (potentially slow) classifier round-trip: the in-flight
+	 * turn runs at this carried effort (or the provisional level), and the
+	 * classifier for the current prompt resolves concurrently and feeds the
+	 * NEXT turn. Generation-guarded + clamped to the current model on apply.
+	 */
+	#pendingAutoThinkingEffort: Effort | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -7005,10 +7016,10 @@ export class AgentSession {
 				return;
 			}
 
-			// Auto thinking: classify this real user turn and set the effective level
-			// before the model request. Synthetic/tool-continuation turns (developer/
-			// custom roles) and non-auto sessions are skipped. Never blocks the turn —
-			// failures fall back to a concrete level inside the helper.
+			// Auto thinking: race classification against a short pre-dispatch
+			// deadline so a fast classifier pins this turn while a slow one never
+			// blocks turn start for the full timeout. Synthetic/tool-continuation
+			// turns (developer/custom roles) and non-auto sessions are skipped.
 			if (this.#autoThinking && message.role === "user") {
 				await this.#applyAutoThinkingLevel(expandedText, generation);
 				if (this.#promptGeneration !== generation) {
@@ -7022,9 +7033,12 @@ export class AgentSession {
 			}
 
 			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
-			const nonMessageTokens = computeNonMessageTokens(this);
 			const contextWindow = this.model?.contextWindow ?? 0;
 			const breakdown = this.getContextBreakdown({ contextWindow, pendingMessages: messages });
+			// Derive non-message tokens from the breakdown (which already tokenizes the
+			// tool schemas once) instead of recomputing them via a separate
+			// `computeNonMessageTokens` pass over the full tool registry.
+			const nonMessageTokens = breakdown?.nonMessageTokens ?? computeNonMessageTokens(this);
 			const promptTokens =
 				breakdown?.usedTokens ??
 				nonMessageTokens +
@@ -8322,6 +8336,7 @@ export class AgentSession {
 			const wasAuto = this.#autoThinking;
 			this.#autoThinking = true;
 			this.#autoResolvedLevel = undefined;
+			this.#pendingAutoThinkingEffort = undefined;
 			this.#thinkingLevel = provisional;
 			this.#applyThinkingLevelToAgent(provisional);
 			if (persist) {
@@ -8336,6 +8351,7 @@ export class AgentSession {
 		const wasAuto = this.#autoThinking;
 		this.#autoThinking = false;
 		this.#autoResolvedLevel = undefined;
+		this.#pendingAutoThinkingEffort = undefined;
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
 		// Leaving auto must persist even when the resolved effort is unchanged (e.g.
 		// auto resolved to medium, then the user pins medium): otherwise the latest
@@ -8386,14 +8402,29 @@ export class AgentSession {
 		return nextLevel;
 	}
 
-	/** Timeout (ms) for per-turn auto-thinking classification before falling back. */
+	/** Hard timeout (ms) for the per-turn auto-thinking classification (aborts it). */
 	static readonly #AUTO_THINKING_TIMEOUT_MS = 4000;
+	/**
+	 * How long (ms) turn start waits for the classifier before dispatching at the
+	 * carried/provisional effort. Sized to let a fast (local) classifier pin the
+	 * current turn; a slow (online) classifier misses it and its result applies
+	 * to the next turn instead of blocking turn start for the full hard timeout.
+	 */
+	static readonly #AUTO_THINKING_DISPATCH_DEADLINE_MS = 200;
 
 	/**
-	 * Classify the current user turn and set the effective thinking level for it.
-	 * Bounded by a timeout + abort; on any failure (no smol model, timeout, parse
-	 * error) it falls back to the provisional concrete level and continues. Never
-	 * throws into the turn, and never clears `#autoThinking` (auto stays active).
+	 * Set the effective thinking level for the current user turn.
+	 *
+	 * Classification races a short pre-dispatch deadline: a fast (local)
+	 * classifier finishes in time and pins THIS turn; a slow (online) classifier
+	 * misses the deadline and the turn runs at the carried/provisional effort
+	 * instead of blocking turn start for up to the full hard timeout. A late
+	 * result only updates {@link #pendingAutoThinkingEffort} for the NEXT turn —
+	 * it never mutates agent state during this turn, so it cannot change the
+	 * in-flight request, whose reasoning effort the agent loop snapshots once at
+	 * dispatch via `getReasoning()`. `ultrathink` is synchronous and pins the
+	 * current turn immediately. Never throws into the turn; never clears
+	 * `#autoThinking`.
 	 */
 	async #applyAutoThinkingLevel(promptText: string, generation: number): Promise<void> {
 		const model = this.model;
@@ -8403,37 +8434,73 @@ export class AgentSession {
 		// nothing to pick — skip classification rather than discard its result.
 		if (getSupportedEfforts(model).length === 0) return;
 
-		let resolved: Effort | undefined;
 		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) {
 			// The user explicitly asked for maximum thinking; bypass the classifier
 			// and jump straight to the highest auto-supported level for this model.
-			resolved = clampAutoThinkingEffort(model, Effort.XHigh);
-		} else {
-			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), AgentSession.#AUTO_THINKING_TIMEOUT_MS);
-			try {
-				resolved = await classifyDifficulty(promptText, {
-					settings: this.settings,
-					registry: this.#modelRegistry,
-					model,
-					sessionId: this.sessionId,
-					signal: controller.signal,
-					metadataResolver: provider => this.agent.metadataForProvider(provider),
-				});
-			} catch (error) {
+			// Synchronous and pre-dispatch, so it pins THIS turn immediately.
+			const ultrathink = clampAutoThinkingEffort(model, Effort.XHigh);
+			if (ultrathink !== undefined && this.#promptGeneration === generation && this.#autoThinking) {
+				this.#applyAutoThinkingResolution(ultrathink);
+			}
+			return;
+		}
+
+		const controller = new AbortController();
+		const hardTimer = setTimeout(() => controller.abort(), AgentSession.#AUTO_THINKING_TIMEOUT_MS);
+		const classification: Promise<Effort | undefined> = classifyDifficulty(promptText, {
+			settings: this.settings,
+			registry: this.#modelRegistry,
+			model,
+			sessionId: this.sessionId,
+			signal: controller.signal,
+			metadataResolver: provider => this.agent.metadataForProvider(provider),
+		})
+			.catch(error => {
 				logger.debug("auto-thinking: classification failed; using fallback level", {
 					error: error instanceof Error ? error.message : String(error),
 				});
-			} finally {
-				clearTimeout(timer);
-			}
-		}
+				return undefined;
+			})
+			.finally(() => clearTimeout(hardTimer));
 
-		// Drop the result if the turn was aborted/superseded while classifying.
+		const resolved = await Promise.race([
+			classification,
+			Bun.sleep(AgentSession.#AUTO_THINKING_DISPATCH_DEADLINE_MS).then(() => undefined),
+		]);
+
+		// Drop the result if the turn was aborted/superseded while racing.
 		if (this.#promptGeneration !== generation || !this.#autoThinking) return;
 
-		const effort = resolved ?? resolveProvisionalAutoLevel(model);
-		if (effort === undefined) return;
+		if (resolved !== undefined) {
+			// Fast classifier won the race — pin this turn and carry it forward.
+			this.#pendingAutoThinkingEffort = resolved;
+			this.#applyAutoThinkingResolution(resolved);
+			return;
+		}
+
+		// Deadline lost: run this turn at the carried (clamped) or provisional
+		// effort. The classifier keeps running; its late result feeds the NEXT
+		// turn only — never agent state during this turn.
+		const effort = this.#clampedPending(model) ?? resolveProvisionalAutoLevel(model);
+		if (effort !== undefined) {
+			this.#applyAutoThinkingResolution(effort);
+		}
+		void classification.then(late => {
+			if (late === undefined) return;
+			if (this.#promptGeneration !== generation || !this.#autoThinking) return;
+			this.#pendingAutoThinkingEffort = late;
+		});
+	}
+
+	/** The carried-over auto-thinking effort clamped to the current model, or `undefined`. */
+	#clampedPending(model: Model): Effort | undefined {
+		return this.#pendingAutoThinkingEffort === undefined
+			? undefined
+			: clampAutoThinkingEffort(model, this.#pendingAutoThinkingEffort);
+	}
+
+	/** Apply a resolved auto-thinking effort to the agent, persist it, and emit the change. */
+	#applyAutoThinkingResolution(effort: Effort): void {
 		const shouldPersistResolution = this.#autoResolvedLevel !== effort;
 		this.#autoResolvedLevel = effort;
 		this.#thinkingLevel = effort;
@@ -9385,6 +9452,12 @@ export class AgentSession {
 		const contextWindow = model.contextWindow ?? 0;
 		if (contextWindow <= 0) return;
 		const compactionSettings = this.settings.getGroup("compaction");
+		// Bail before the (relatively expensive) pre-prompt token estimate when
+		// compaction is disabled — shouldCompact would reject anyway. Mirrors the
+		// enabled gate in #maintainContextMidRun (and the one #checkCompaction
+		// reaches after its cheap overflow/stale-prune passes) and avoids a
+		// redundant full context-breakdown pass on every prompt.
+		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
 		const contextTokens = this.#estimatePrePromptContextTokens(messages, contextWindow);
 		if (!shouldCompact(contextTokens, contextWindow, compactionSettings)) return;
 
@@ -13378,10 +13451,12 @@ export class AgentSession {
 				// effort, so the cold (--continue) and in-app switch paths display
 				// identically as `auto` until then.
 				this.#autoResolvedLevel = undefined;
+				this.#pendingAutoThinkingEffort = undefined;
 				this.#thinkingLevel = resolveProvisionalAutoLevel(this.model);
 			} else {
 				this.#autoThinking = false;
 				this.#autoResolvedLevel = undefined;
+				this.#pendingAutoThinkingEffort = undefined;
 				this.#thinkingLevel = resolveThinkingLevelForModel(this.model, restoredThinkingLevel);
 			}
 			this.#applyThinkingLevelToAgent(this.#thinkingLevel);
@@ -13928,9 +14003,14 @@ export class AgentSession {
 		const rawContextWindow = options?.contextWindow ?? model?.contextWindow ?? 0;
 		const contextWindow = Number.isFinite(rawContextWindow) && rawContextWindow > 0 ? rawContextWindow : 0;
 
-		const { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens } = computeNonMessageBreakdown(this);
+		const {
+			skillsTokens,
+			toolsTokens,
+			systemContextTokens,
+			systemPromptTokens,
+			nonMessageTokens: currentNonMessageTokens,
+		} = computeNonMessageBreakdown(this);
 		const categoryNonMessageTokens = skillsTokens + toolsTokens + systemContextTokens + systemPromptTokens;
-		const currentNonMessageTokens = computeNonMessageTokens(this);
 
 		const branchEntries = this.sessionManager.getBranch();
 		const latestCompaction = getLatestCompactionEntry(branchEntries);
@@ -13987,7 +14067,7 @@ export class AgentSession {
 		if (useAnchor && anchorAssistant) {
 			const promptTokens =
 				anchorAssistant.contextSnapshot?.promptTokens ?? calculatePromptTokens(anchorAssistant.usage);
-			const nonMessageTokens = anchorAssistant.contextSnapshot?.nonMessageTokens ?? computeNonMessageTokens(this);
+			const nonMessageTokens = anchorAssistant.contextSnapshot?.nonMessageTokens ?? currentNonMessageTokens;
 			anchored = true;
 			let tailTokens = 0;
 			for (let i = resolvedAnchorIndex + 1; i < resolvedActiveMessages.length; i++) {
@@ -14019,7 +14099,7 @@ export class AgentSession {
 				const msg = resolvedActiveMessages[i];
 				if (msg.role === "assistant" && msg.stopReason !== "aborted" && msg.stopReason !== "error" && msg.usage) {
 					const promptTokens = msg.contextSnapshot?.promptTokens ?? calculatePromptTokens(msg.usage);
-					const nonMessageTokens = msg.contextSnapshot?.nonMessageTokens ?? computeNonMessageTokens(this);
+					const nonMessageTokens = msg.contextSnapshot?.nonMessageTokens ?? currentNonMessageTokens;
 
 					let tailTokens = 0;
 					for (let j = i + 1; j < resolvedActiveMessages.length; j++) {
@@ -14058,6 +14138,7 @@ export class AgentSession {
 			systemContextTokens,
 			skillsTokens,
 			messagesTokens,
+			nonMessageTokens: currentNonMessageTokens,
 		};
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1348,6 +1348,15 @@ export class AgentSession {
 	 * NEXT turn. Generation-guarded + clamped to the current model on apply.
 	 */
 	#pendingAutoThinkingEffort: Effort | undefined;
+	/**
+	 * Monotonic invalidation token for in-flight auto-thinking classifiers.
+	 * Bumped at the start of every auto user turn and whenever auto/pending state
+	 * is cleared (setThinkingLevel, session switch). A late classifier result is
+	 * accepted only if the token it captured still matches — so an older, slower
+	 * classifier can never overwrite a newer carried effort (e.g. across an
+	 * ultrathink turn or an auto off→on toggle).
+	 */
+	#autoThinkingToken = 0;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -8337,6 +8346,7 @@ export class AgentSession {
 			this.#autoThinking = true;
 			this.#autoResolvedLevel = undefined;
 			this.#pendingAutoThinkingEffort = undefined;
+			this.#autoThinkingToken++;
 			this.#thinkingLevel = provisional;
 			this.#applyThinkingLevelToAgent(provisional);
 			if (persist) {
@@ -8352,6 +8362,7 @@ export class AgentSession {
 		this.#autoThinking = false;
 		this.#autoResolvedLevel = undefined;
 		this.#pendingAutoThinkingEffort = undefined;
+		this.#autoThinkingToken++;
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
 		// Leaving auto must persist even when the resolved effort is unchanged (e.g.
 		// auto resolved to medium, then the user pins medium): otherwise the latest
@@ -8427,6 +8438,9 @@ export class AgentSession {
 	 * `#autoThinking`.
 	 */
 	async #applyAutoThinkingLevel(promptText: string, generation: number): Promise<void> {
+		// Invalidate any older in-flight classifier: a late result from a previous
+		// turn must never overwrite a newer carried effort.
+		const token = ++this.#autoThinkingToken;
 		const model = this.model;
 		if (!model?.reasoning) return;
 		// Models with reasoning but no controllable effort surface (devin-agent
@@ -8487,6 +8501,9 @@ export class AgentSession {
 		}
 		void classification.then(late => {
 			if (late === undefined) return;
+			// A newer auto turn (or an auto/pending reset) bumped the token — drop
+			// this stale result so it can't overwrite the carried effort.
+			if (token !== this.#autoThinkingToken) return;
 			if (this.#promptGeneration !== generation || !this.#autoThinking) return;
 			this.#pendingAutoThinkingEffort = late;
 		});
@@ -13339,6 +13356,7 @@ export class AgentSession {
 		const previousThinkingLevel = this.#thinkingLevel;
 		const previousAutoThinking = this.#autoThinking;
 		const previousAutoResolvedLevel = this.#autoResolvedLevel;
+		const previousPendingAutoThinkingEffort = this.#pendingAutoThinkingEffort;
 		const previousServiceTierByFamily = this.#serviceTierByFamily;
 		const previousSelectedMCPToolNames = new Set(this.#selectedMCPToolNames);
 		const previousTools = [...this.agent.state.tools];
@@ -13452,11 +13470,13 @@ export class AgentSession {
 				// identically as `auto` until then.
 				this.#autoResolvedLevel = undefined;
 				this.#pendingAutoThinkingEffort = undefined;
+				this.#autoThinkingToken++;
 				this.#thinkingLevel = resolveProvisionalAutoLevel(this.model);
 			} else {
 				this.#autoThinking = false;
 				this.#autoResolvedLevel = undefined;
 				this.#pendingAutoThinkingEffort = undefined;
+				this.#autoThinkingToken++;
 				this.#thinkingLevel = resolveThinkingLevelForModel(this.model, restoredThinkingLevel);
 			}
 			this.#applyThinkingLevelToAgent(this.#thinkingLevel);
@@ -13518,6 +13538,9 @@ export class AgentSession {
 			this.#thinkingLevel = previousThinkingLevel;
 			this.#autoThinking = previousAutoThinking;
 			this.#autoResolvedLevel = previousAutoResolvedLevel;
+			this.#pendingAutoThinkingEffort = previousPendingAutoThinkingEffort;
+			// Invalidate any classifier in flight from the failed switch attempt.
+			this.#autoThinkingToken++;
 			this.#applyThinkingLevelToAgent(previousThinkingLevel);
 			this.#serviceTierByFamily = previousServiceTierByFamily;
 			this.#syncTodoPhasesFromBranch();

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -510,5 +511,74 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBeUndefined();
 		expect(session.agent.state.thinkingLevel).toBeUndefined();
 		expect(session.autoResolvedThinkingLevel()).toBeUndefined();
+	});
+	it("does not block turn start on a slow classifier; the late result carries to the next turn", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const provisional = resolveProvisionalAutoLevel(model);
+		expect(provisional).toBeDefined();
+
+		// Capture the reasoning effort each provider request actually sees
+		// (agent.state.thinkingLevel at streamFn time = what getReasoning()
+		// snapshots at dispatch).
+		const seenEffort: (Effort | undefined)[] = [];
+		const mock = createMockModel({ handler: () => ({ content: ["done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (m, ctx, opts) => {
+				seenEffort.push(agent.state.thinkingLevel);
+				return mock.stream(m, ctx, opts);
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-slow-classifier.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-slow-classifier.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		// Hold the classifier unresolved so it misses the dispatch deadline.
+		const slowClassifier1 = Promise.withResolvers<Effort>();
+		const classifierSpy = vi
+			.spyOn(autoThinkingClassifier, "classifyDifficulty")
+			.mockReturnValue(slowClassifier1.promise);
+
+		// Integration test of the real dispatch-deadline timer: each prompt pays
+		// one #AUTO_THINKING_DISPATCH_DEADLINE_MS (Bun.sleep in production, not a
+		// test timer) because the deadline races a live, manually-resolved
+		// classifier promise inside the turn. Deterministic fake-timer control is
+		// impractical across that async race.
+		// First turn runs at the provisional effort WITHOUT waiting for the
+		// classifier (the dispatch deadline wins the race).
+		await session.prompt("Implement a focused parser fix");
+		expect(classifierSpy).toHaveBeenCalledTimes(1);
+		expect(seenEffort).toEqual([provisional]);
+		expect(session.thinkingLevel).toBe(provisional);
+
+		// The classifier resolves late. It must NOT mutate the already-dispatched
+		// turn, but must carry forward to the next turn.
+		slowClassifier1.resolve(Effort.Medium);
+		// Drain the late-classifier microtask chain while still in turn 1's
+		// generation so its result lands in the carried effort before turn 2.
+		for (let i = 0; i < 4; i++) await Promise.resolve();
+
+		// Second turn: classifier held again (misses the deadline), so it runs at
+		// the carried Medium from the first turn's late result.
+		const slowClassifier2 = Promise.withResolvers<Effort>();
+		classifierSpy.mockReturnValue(slowClassifier2.promise);
+		await session.prompt("Now refactor the tests");
+		expect(seenEffort).toEqual([provisional, Effort.Medium]);
+
+		// Settle the held classifier so the hard-timeout .finally clears its timer
+		// and drops the session references it captured.
+		slowClassifier2.resolve(Effort.Medium);
+		// Yield so the hard-timeout .finally clears its timer and drops the
+		// session references the held promise captured.
+		for (let i = 0; i < 4; i++) await Promise.resolve();
 	});
 });

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -581,4 +581,118 @@ describe("AgentSession role model thinking behavior", () => {
 		// session references the held promise captured.
 		for (let i = 0; i < 4; i++) await Promise.resolve();
 	});
+	it("ignores a stale late classifier when a newer turn's classifier resolves first", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const provisional = resolveProvisionalAutoLevel(model);
+		expect(provisional).toBeDefined();
+
+		const seenEffort: (Effort | undefined)[] = [];
+		const mock = createMockModel({ handler: () => ({ content: ["done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (m, ctx, opts) => {
+				seenEffort.push(agent.state.thinkingLevel);
+				return mock.stream(m, ctx, opts);
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-stale-classifier.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-stale-classifier.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		// Hold every classifier past the deadline; resolve them manually.
+		const resolvers: Array<(value: Effort) => void> = [];
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockImplementation(() => {
+			const controlled = Promise.withResolvers<Effort>();
+			resolvers.push(controlled.resolve);
+			return controlled.promise;
+		});
+
+		// Two turns, both classifiers still pending.
+		// Integration test: each prompt pays one real dispatch deadline.
+		await session.prompt("turn one");
+		await session.prompt("turn two");
+		expect(resolvers).toHaveLength(2);
+
+		// The newer (turn 2) classifier resolves High first, then the older (turn 1)
+		// classifier resolves Low. The stale Low must NOT overwrite the carried High.
+		resolvers[1](Effort.High);
+		for (let i = 0; i < 4; i++) await Promise.resolve();
+		resolvers[0](Effort.Low);
+		for (let i = 0; i < 4; i++) await Promise.resolve();
+
+		// Turn 3 runs at the carried effort from the newer classifier (High).
+		seenEffort.length = 0;
+		await session.prompt("turn three");
+		expect(seenEffort).toEqual([Effort.High]);
+
+		// Settle the last held classifier so its hard-timer .finally clears.
+		resolvers[2]?.(Effort.High);
+		for (let i = 0; i < 4; i++) await Promise.resolve();
+	});
+	it("restores the carried auto-thinking effort when a session switch fails mid-load", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const provisional = resolveProvisionalAutoLevel(model);
+		// Seed an effort distinct from provisional so a missing restore (which
+		// falls back to provisional) is observable, not silently correct.
+		const restored = provisional === Effort.Medium ? Effort.High : Effort.Medium;
+		const seenEffort: (Effort | undefined)[] = [];
+		const mock = createMockModel({ handler: () => ({ content: ["done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (m, ctx, opts) => {
+				seenEffort.push(agent.state.thinkingLevel);
+				return mock.stream(m, ctx, opts);
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-switch-rollback.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-switch-rollback.yml"));
+		// File-backed session so switchSession has a real session file to reload.
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		// Seed the carried effort: a fast classifier wins the race and pins it.
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(restored);
+		await session.prompt("seed the carried effort");
+		expect(seenEffort).toEqual([restored]);
+		const sessionFile = session.sessionFile;
+		expect(sessionFile).toBeTruthy();
+
+		// Force the switch's success-path agent.setThinkingLevel to throw once so
+		// the catch rollback runs (it must restore the carried effort).
+		const setLevelSpy = vi.spyOn(agent, "setThinkingLevel").mockImplementationOnce(() => {
+			throw new Error("switch load boom");
+		});
+		await expect(session.switchSession(sessionFile!)).rejects.toThrow("switch load boom");
+		setLevelSpy.mockRestore();
+
+		// After the failed switch, a fresh slow classifier must run at the RESTORED
+		// carried effort — not provisional (which is what a missing restore yields).
+		// Integration test: the prompt pays one real dispatch deadline.
+		const held = Promise.withResolvers<Effort>();
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockReturnValue(held.promise);
+		seenEffort.length = 0;
+		await session.prompt("after the failed switch");
+		expect(seenEffort).toEqual([restored]);
+
+		held.resolve(restored);
+		for (let i = 0; i < 4; i++) await Promise.resolve();
+	});
 });


### PR DESCRIPTION
## What

Two changes that reduce the delay between submitting a chat message and the first streamed model text/thinking appearing (the "Working…" gap).

## 1. In-process preflight (~0.6ms → ~0.48ms, −21%)

Measured via a new deterministic micro-benchmark (`bench/ttft.ts`): `session.prompt()` → first non-empty assistant text/thinking delta, mock transport, GC-flushed min.

- **Dedup non-message token estimation.** `computeNonMessageBreakdown` now returns `nonMessageTokens` computed once (reusing its single `estimateToolSchemaTokens` pass). `getContextBreakdown` and `#promptWithMessage` consume it instead of each re-running `computeNonMessageTokens`. Per-turn tool-schema serialization drops **3× → 1×**.
- **`#runPrePromptCompactionIfNeeded`** bails before its token estimate when compaction is disabled (`shouldCompact` rejects anyway), avoiding a redundant full context-breakdown pass on every prompt.

## 2. Auto-thinking deferral (eliminates up to 4s turn-start blocking)

When `auto` thinking is selected, `#applyAutoThinkingLevel` made a separate classifier round-trip that **blocked turn start for up to 4s** before the request went out.

Now classification **races a 200ms pre-dispatch deadline**:
- **Fast/local** classifier wins → pins the current turn (no lag).
- **Slow/online** classifier loses → turn runs at the carried/provisional effort; result applies to the **next** turn.

Race-free: the late result only updates a `#pendingAutoThinkingEffort` field — it never calls `#applyThinkingLevelToAgent` during the turn, so it cannot change the in-flight request (effort is snapshotted once at dispatch via `getReasoning()`). Generation-guarded and clamped to the current model on apply.

**Trade-off:** for the default online classifier, effort adapts with a bounded one-turn lag (a Low→hard transition can under-think for one turn). Provisional is the model default (High).

## Verification

- `bun check` green (biome + tsgo).
- 34/34 thinking tests pass, including a new slow-classifier session test (`agent-session-role-thinking.test.ts`) that holds the classifier unresolved past the deadline and asserts: turn 1 dispatches at provisional effort before classification resolves, then turn 2 picks up the carried effort.
- In-process `ttft_ms` measured at ~0.48ms min (warm) vs ~0.61ms baseline.

## Out of scope

The remaining seconds-scale gap is network/server TTFT + connection setup (fresh fetch per request; no app-level preconnect). Connection pre-warming is a separate follow-up.