### PR TITLE
fix(web-search): clarify DuckDuckGo bot detection failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Clarified DuckDuckGo web search bot-detection failures and documented its datacenter/shared-egress limitations in provider settings. ([#3863](https://github.com/can1357/oh-my-pi/issues/3863))
 - Fixed an issue where CJK (Chinese, Japanese, Korean) history could become unrenderable during repeated context compactions.
 - Fixed a memory exhaustion bug in the TUI when using `/resume` on large previous sessions.
 - Fixed an issue where the `irc` inbox missed messages that arrived while the recipient agent was already running.

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -17,7 +17,13 @@ import { discoverAuthStorage } from "../../sdk";
 import type { ToolSession } from "../../tools";
 import { formatAge } from "../../tools/render-utils";
 import { throwIfAborted } from "../../tools/tool-errors";
-import { getSearchProvider, getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
+import {
+	formatSearchProviderFailure,
+	formatSearchProviderFailures,
+	getSearchProvider,
+	resolveProviderChain,
+	type SearchProvider,
+} from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
 import type { SearchProviderId, SearchResponse } from "./types";
 import { SearchProviderError } from "./types";
@@ -36,23 +42,6 @@ export type SearchToolParams = typeof webSearchSchema.infer;
 
 export interface SearchQueryParams extends SearchToolParams {
 	provider?: SearchProviderId | "auto";
-}
-
-function formatProviderError(error: unknown, provider: SearchProvider): string {
-	if (error instanceof SearchProviderError) {
-		if (error.provider === "anthropic" && error.status === 404) {
-			return "Anthropic web search returned 404 (model or endpoint not found).";
-		}
-		if (error.status === 401 || error.status === 403) {
-			if (error.provider === "zai") {
-				return error.message;
-			}
-			return `${getSearchProviderLabel(error.provider)} authorization failed (${error.status}). Check API key or base URL.`;
-		}
-		return error.message;
-	}
-	if (error instanceof Error) return error.message;
-	return `Unknown error from ${provider.label}`;
 }
 
 /** Truncate text for tool output */
@@ -212,18 +201,10 @@ async function executeSearch(
 
 	const lastFailure = failures[failures.length - 1];
 	const baseMessage = lastFailure
-		? formatProviderError(lastFailure.error, lastFailure.provider)
+		? formatSearchProviderFailure(lastFailure.error, lastFailure.provider)
 		: `Unknown error from ${lastProvider.label}`;
 	const message =
-		providers.length > 1
-			? `All web search providers failed: ${failures
-					.map(f =>
-						f.error instanceof SearchProviderError
-							? f.error.message
-							: `${f.provider.id}: ${formatProviderError(f.error, f.provider)}`,
-					)
-					.join("; ")}`
-			: baseMessage;
+		providers.length > 1 ? `All web search providers failed: ${formatSearchProviderFailures(failures)}` : baseMessage;
 
 	return {
 		content: [{ type: "text" as const, text: `Error: ${message}` }],

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -10,7 +10,7 @@
 
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import type { SearchProvider } from "./providers/base";
-import { SEARCH_PROVIDER_LABELS, SEARCH_PROVIDER_ORDER, type SearchProviderId } from "./types";
+import { SEARCH_PROVIDER_LABELS, SEARCH_PROVIDER_ORDER, SearchProviderError, type SearchProviderId } from "./types";
 
 export type { SearchParams } from "./providers/base";
 export { SearchProvider } from "./providers/base";
@@ -121,6 +121,31 @@ const instanceCache = new Map<SearchProviderId, SearchProvider>();
 /** Cheap, sync metadata accessor — never triggers a provider load. */
 export function getSearchProviderLabel(id: SearchProviderId): string {
 	return PROVIDER_META[id]?.label ?? id;
+}
+
+/** Format one provider failure for the user-facing fallback summary. */
+export function formatSearchProviderFailure(error: unknown, provider: Pick<SearchProvider, "id" | "label">): string {
+	if (error instanceof SearchProviderError) {
+		if (error.provider === "anthropic" && error.status === 404) {
+			return "Anthropic web search returned 404 (model or endpoint not found).";
+		}
+		if (error.status === 401 || error.status === 403) {
+			if (error.provider === "zai") {
+				return error.message;
+			}
+			return `${getSearchProviderLabel(error.provider)} authorization failed (${error.status}). Check API key or base URL.`;
+		}
+		return error.message;
+	}
+	if (error instanceof Error) return error.message;
+	return `Unknown error from ${provider.label}`;
+}
+
+/** Format the ordered provider fallback failures for terminal/tool output. */
+export function formatSearchProviderFailures(
+	failures: readonly { provider: Pick<SearchProvider, "id" | "label">; error: unknown }[],
+): string {
+	return failures.map(f => `${f.provider.id}: ${formatSearchProviderFailure(f.error, f.provider)}`).join("; ");
 }
 
 /**

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -153,7 +153,7 @@ async function callDuckDuckGoHtml(params: SearchParams): Promise<string> {
 	if (isAnomalyResponse(body)) {
 		throw new SearchProviderError(
 			"duckduckgo",
-			"DuckDuckGo blocked the request with a bot-detection challenge. DuckDuckGo throttles repeat searches from datacenter and shared-egress IPs; configure another provider (e.g. Brave, Tavily, SearXNG) or retry from a residential network.",
+			"DuckDuckGo blocked the request with a bot-detection challenge. DuckDuckGo throttles automated HTML searches from datacenter/shared-egress IPs; configure a credentialed provider such as Brave, Tavily, Exa, or Kagi for reliable web search.",
 			429,
 		);
 	}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -43,7 +43,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
-	{ value: "duckduckgo", label: "DuckDuckGo", description: "Scrapes the DuckDuckGo HTML frontend (no API key)" },
+	{
+		value: "duckduckgo",
+		label: "DuckDuckGo",
+		description: "Credential-free best-effort fallback; may be bot-challenged on datacenter/shared-egress IPs",
+	},
 ] as const;
 
 /** Supported web search providers (every option except `auto`). */

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
 import { searchDuckDuckGo } from "@oh-my-pi/pi-coding-agent/web/search/providers/duckduckgo";
-import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import { SEARCH_PROVIDER_OPTIONS, SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import { formatSearchProviderFailures } from "../../src/web/search/provider";
 
 const fakeAuthStorage = {
 	async getApiKey() {
@@ -195,6 +196,8 @@ describe("DuckDuckGo web search provider", () => {
 			expect(err.provider).toBe("duckduckgo");
 			expect(err.status).toBe(429);
 			expect(err.message).toMatch(/bot-detection challenge/i);
+			expect(err.message).toContain("datacenter/shared-egress IPs");
+			expect(err.message).toContain("configure a credentialed provider");
 		}
 	});
 
@@ -232,5 +235,36 @@ describe("DuckDuckGo web search provider", () => {
 				message: "DuckDuckGo HTML error (503)",
 			});
 		}
+	});
+
+	it("formats DuckDuckGo bot detection clearly in a fallback-chain failure", () => {
+		const message = `All web search providers failed: ${formatSearchProviderFailures([
+			{
+				provider: { id: "codex", label: "OpenAI" },
+				error: new SearchProviderError("codex", "codex: 401 unauthorized", 401),
+			},
+			{
+				provider: { id: "duckduckgo", label: "DuckDuckGo" },
+				error: new SearchProviderError(
+					"duckduckgo",
+					"DuckDuckGo blocked the request with a bot-detection challenge. DuckDuckGo throttles automated HTML searches from datacenter/shared-egress IPs; configure a credentialed provider such as Brave, Tavily, Exa, or Kagi for reliable web search.",
+					429,
+				),
+			},
+		])}`;
+
+		expect(message).toContain("All web search providers failed");
+		expect(message).toContain("codex: OpenAI authorization failed (401). Check API key or base URL.");
+		expect(message).toContain("duckduckgo: DuckDuckGo blocked the request with a bot-detection challenge.");
+		expect(message).toContain("datacenter/shared-egress IPs");
+		expect(message).toContain("configure a credentialed provider");
+		expect(message).not.toContain("codex: 401 unauthorized");
+	});
+
+	it("documents DuckDuckGo as a best-effort datacenter-sensitive fallback", () => {
+		const option = SEARCH_PROVIDER_OPTIONS.find(item => item.value === "duckduckgo");
+
+		expect(option?.description).toContain("Credential-free best-effort fallback");
+		expect(option?.description).toContain("datacenter/shared-egress IPs");
 	});
 });


### PR DESCRIPTION
## Repro
A DuckDuckGo HTML response containing the reported `anomaly-modal` fixture reproduces the provider failure: `searchDuckDuckGo()` raises `SearchProviderError` for provider `duckduckgo` with status `429`. The live network probe from this runner returned normal DuckDuckGo HTML, so the regression fixture covers the reporter's blocked datacenter/shared-egress response shape.

## Cause
`packages/coding-agent/src/web/search/index.ts` built multi-provider fallback summaries from raw `SearchProviderError.message` values for provider-tagged errors, bypassing the existing auth-error formatter. `packages/coding-agent/src/web/search/types.ts` also described DuckDuckGo only as a no-key HTML scraper, without documenting that the credential-free fallback is best-effort and commonly blocked on datacenter/shared-egress IPs.

## Fix
- Moved provider-failure formatting into `packages/coding-agent/src/web/search/provider.ts` and used it for ordered fallback summaries.
- Updated DuckDuckGo bot-detection text in `packages/coding-agent/src/web/search/providers/duckduckgo.ts` to point users at credentialed providers.
- Updated DuckDuckGo's provider-setting description in `packages/coding-agent/src/web/search/types.ts`.
- Added regression coverage in `packages/coding-agent/test/tools/web-search-duckduckgo.test.ts` for the anomaly guidance, fallback summary, and provider-setting description.
- Added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/web-search-duckduckgo.test.ts` passed with 11 tests. `bun check` passed. Fixes #3863