### PR TITLE
fix(compaction): cap snapcompact frame payloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
+- Fixed long snapcompact sessions re-sending multi-megabyte standing image archives on every provider request by enforcing a per-request frame byte budget, letting auto-compaction fall back to context-full summaries when snapcompact output is too large, and omitting legacy over-budget frames from rebuilt LLM contexts. ([#3792](https://github.com/can1357/oh-my-pi/issues/3792))
 
 ## [16.2.5] - 2026-06-28
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8914,6 +8914,22 @@ export class AgentSession {
 						shape: snapcompact.resolveShape(this.model, this.settings.get("snapcompact.shape")),
 						maxFrames,
 					});
+					const framePayloadBytes = this.#snapcompactFramePayloadBytes(snapcompactResult);
+					if (framePayloadBytes > snapcompact.FRAME_DATA_BYTES_BUDGET) {
+						logger.warn("Snapcompact exceeded the per-request frame payload budget", {
+							model: this.model?.id,
+							framePayloadBytes,
+							budget: snapcompact.FRAME_DATA_BYTES_BUDGET,
+						});
+						this.emitNotice(
+							"warning",
+							"snapcompact produced too much standing image payload. No LLM fallback was attempted.",
+							"compaction",
+						);
+						throw new Error(
+							"snapcompact cannot run locally: standing image payload exceeds the per-request budget.",
+						);
+					}
 					const ctxWindow = this.model?.contextWindow ?? 0;
 					const budget =
 						ctxWindow > 0
@@ -10915,7 +10931,16 @@ export class AgentSession {
 		const capReserve = textEdgeTokens + SUMMARY_TEMPLATE_TOKENS;
 		const frameBudget = totalBudget - baseTokens - capReserve;
 		if (frameBudget < snapcompact.FRAME_TOKEN_ESTIMATE) return 1;
-		return Math.min(Math.floor(frameBudget / snapcompact.FRAME_TOKEN_ESTIMATE), snapcompact.MAX_FRAMES_DEFAULT);
+		return Math.min(
+			Math.floor(frameBudget / snapcompact.FRAME_TOKEN_ESTIMATE),
+			snapcompact.MAX_FRAMES_DEFAULT,
+			snapcompact.maxFramesForDataBudget(),
+		);
+	}
+
+	#snapcompactFramePayloadBytes(result: snapcompact.CompactionResult): number {
+		const archive = snapcompact.getPreservedArchive(result.preserveData);
+		return archive ? snapcompact.frameDataBytes(archive.frames) : 0;
 	}
 
 	/**
@@ -10928,7 +10953,9 @@ export class AgentSession {
 	 */
 	#projectSnapcompactContextTokens(preparation: CompactionPreparation, result: snapcompact.CompactionResult): number {
 		const archive = snapcompact.getPreservedArchive(result.preserveData);
-		const blocks = archive ? snapcompact.historyBlocks(archive) : undefined;
+		const blocks = archive
+			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
+			: undefined;
 		const summaryMessage = createCompactionSummaryMessage(
 			result.summary,
 			result.tokensBefore,
@@ -11286,6 +11313,17 @@ export class AgentSession {
 							shape: snapcompact.resolveShape(this.model, this.settings.get("snapcompact.shape")),
 							maxFrames,
 						});
+						const framePayloadBytes = this.#snapcompactFramePayloadBytes(snapcompactResult);
+						if (framePayloadBytes > snapcompact.FRAME_DATA_BYTES_BUDGET) {
+							logger.warn("Snapcompact exceeded the per-request frame payload budget", {
+								model: this.model?.id,
+								framePayloadBytes,
+								budget: snapcompact.FRAME_DATA_BYTES_BUDGET,
+							});
+							snapcompactBlocker =
+								"snapcompact produced too much standing image payload; using context-full auto-compaction instead.";
+							snapcompactResult = undefined;
+						}
 						if (snapcompactResult) {
 							const ctxWindow = this.model?.contextWindow ?? 0;
 							const budget =

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10892,7 +10892,7 @@ export class AgentSession {
 	 */
 	#computeSnapcompactMaxFrames(preparation: CompactionPreparation, settings: CompactionSettings): number {
 		const ctxWindow = this.model?.contextWindow ?? 0;
-		if (ctxWindow <= 0) return snapcompact.MAX_FRAMES_DEFAULT;
+		if (ctxWindow <= 0) return Math.min(snapcompact.MAX_FRAMES_DEFAULT, snapcompact.maxFramesForDataBudget());
 		const reserve = effectiveReserveTokens(ctxWindow, settings);
 		let baseTokens = computeNonMessageTokens(this);
 		for (const message of preparation.recentMessages) {

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -77,6 +77,17 @@ export interface BuildSessionContextOptions {
  * If leafId is provided, walks from that entry to root.
  * Handles compaction and branch summaries along the path.
  */
+function snapcompactHistoryBlocksForContext(
+	archive: snapcompact.Archive | undefined,
+	options: BuildSessionContextOptions | undefined,
+) {
+	if (!archive) return undefined;
+	return snapcompact.historyBlocks(
+		archive,
+		options?.transcript ? undefined : { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET },
+	);
+}
+
 export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
@@ -273,7 +284,7 @@ export function buildSessionContext(
 						entry.shortSummary,
 						undefined,
 						undefined,
-						snapcompactArchive ? snapcompact.historyBlocks(snapcompactArchive) : undefined,
+						snapcompactHistoryBlocksForContext(snapcompactArchive, options),
 					),
 				);
 			} else {
@@ -307,7 +318,7 @@ export function buildSessionContext(
 				compaction.shortSummary,
 				providerPayload,
 				undefined,
-				snapcompactArchive ? snapcompact.historyBlocks(snapcompactArchive) : undefined,
+				snapcompactHistoryBlocksForContext(snapcompactArchive, options),
 			),
 		);
 

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -163,6 +163,7 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		const maxFrames = opts?.maxFrames;
 		expect(maxFrames).toBeDefined();
 		expect(maxFrames).toBeLessThan(snapcompact.MAX_FRAMES_DEFAULT);
+		expect(maxFrames).toBeLessThanOrEqual(snapcompact.maxFramesForDataBudget());
 		expect(maxFrames).toBeGreaterThan(0);
 
 		// Verify the FULL projection — base (non-message + kept-recent) +

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -242,4 +242,41 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		// text-only `planArchive` path makes this case recoverable.
 		expect(opts?.maxFrames).toBe(1);
 	});
+
+	it("applies the frame byte cap when the model context window is unknown", async () => {
+		const model = session.model;
+		if (!model) throw new Error("Expected model");
+		await session.dispose();
+		const unknownWindowModel = { ...model, contextWindow: 0 };
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model: unknownWindowModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.strategy": "snapcompact",
+				"compaction.autoContinue": false,
+				"compaction.keepRecentTokens": 4000,
+			}),
+			modelRegistry,
+		});
+
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+		const compactSpy = vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
+			},
+		});
+
+		await session.compact(undefined, { mode: "snapcompact" });
+
+		expect(compactSpy.mock.calls[0]?.[1]?.maxFrames).toBe(snapcompact.maxFramesForDataBudget());
+	});
 });

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -8,6 +8,7 @@ import type {
 	SessionMessageEntry,
 	ThinkingLevelChangeEntry,
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import * as snapcompact from "@oh-my-pi/snapcompact";
 
 function msg(id: string, parentId: string | null, role: "user" | "assistant", text: string): SessionMessageEntry {
 	const base = { type: "message" as const, id, parentId, timestamp: "2025-01-01T00:00:00Z" };
@@ -228,6 +229,44 @@ describe("buildSessionContext", () => {
 				],
 			});
 			expect((ctx.messages[1] as { content: string }).content).toBe("after compact");
+		});
+
+		it("caps snapcompact frame payload in LLM context but preserves transcript frames", () => {
+			const largeFrame = "a".repeat(Math.ceil(snapcompact.FRAME_DATA_BYTES_BUDGET / 2) + 1);
+			const compacted: CompactionEntry = {
+				...compaction("3", "2", "Snapcompact summary", "1"),
+				preserveData: {
+					[snapcompact.PRESERVE_KEY]: {
+						frames: [
+							{ data: largeFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
+							{ data: largeFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
+						],
+						totalChars: 20,
+						truncatedChars: 0,
+						textHead: "old edge",
+						textTail: "new edge",
+					},
+				},
+			};
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "first"),
+				msg("2", "1", "assistant", "response"),
+				compacted,
+				msg("4", "3", "user", "after compact"),
+			];
+
+			const llmContext = buildSessionContext(entries);
+			const summary = llmContext.messages[0];
+			if (summary?.role !== "compactionSummary") throw new Error("Expected LLM compaction summary");
+			expect(summary.blocks?.filter(block => block.type === "image")).toHaveLength(1);
+			expect(
+				summary.blocks?.some(block => block.type === "text" && block.text.includes("image middle omitted")),
+			).toBe(true);
+
+			const transcript = buildSessionContext(entries, undefined, undefined, { transcript: true });
+			const transcriptSummary = transcript.messages[2];
+			if (transcriptSummary?.role !== "compactionSummary") throw new Error("Expected transcript compaction summary");
+			expect(transcriptSummary.blocks?.filter(block => block.type === "image")).toHaveLength(2);
 		});
 
 		it("multiple compactions uses latest", () => {

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -232,14 +232,15 @@ describe("buildSessionContext", () => {
 		});
 
 		it("caps snapcompact frame payload in LLM context but preserves transcript frames", () => {
-			const largeFrame = "a".repeat(Math.ceil(snapcompact.FRAME_DATA_BYTES_BUDGET / 2) + 1);
+			const oldFrame = "o".repeat(Math.ceil(snapcompact.FRAME_DATA_BYTES_BUDGET / 2) + 1);
+			const newFrame = "n".repeat(oldFrame.length);
 			const compacted: CompactionEntry = {
 				...compaction("3", "2", "Snapcompact summary", "1"),
 				preserveData: {
 					[snapcompact.PRESERVE_KEY]: {
 						frames: [
-							{ data: largeFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
-							{ data: largeFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
+							{ data: oldFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
+							{ data: newFrame, mimeType: "image/png", cols: 10, rows: 10, chars: 10 },
 						],
 						totalChars: 20,
 						truncatedChars: 0,
@@ -258,7 +259,11 @@ describe("buildSessionContext", () => {
 			const llmContext = buildSessionContext(entries);
 			const summary = llmContext.messages[0];
 			if (summary?.role !== "compactionSummary") throw new Error("Expected LLM compaction summary");
-			expect(summary.blocks?.filter(block => block.type === "image")).toHaveLength(1);
+			const imageBlocks = summary.blocks?.filter(block => block.type === "image");
+			expect(imageBlocks).toHaveLength(1);
+			const keptImage = imageBlocks?.[0];
+			if (keptImage?.type !== "image") throw new Error("Expected kept snapcompact image");
+			expect(keptImage.data).toBe(newFrame);
 			expect(
 				summary.blocks?.some(block => block.type === "text" && block.text.includes("image middle omitted")),
 			).toBe(true);

--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed large snapcompact archives being reconstructed into unbounded per-request image payloads by adding a frame base64 byte budget and omitting over-budget archive frames from prompt blocks. ([#3792](https://github.com/can1357/oh-my-pi/issues/3792))
+
 ## [16.1.23] - 2026-06-26
 
 ### Added

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -404,6 +404,29 @@ export const HQ_EDGE_FRAMES = 3;
  *  undercounting a high-res archive at the raised {@link MAX_FRAMES_DEFAULT}. */
 export const FRAME_TOKEN_ESTIMATE = 5024;
 
+/** Conservative upper bound for one persisted frame's base64 payload. The
+ *  measured high-res Anthropic `8x13`/`11on16` PNG frames sit around 159 KB;
+ *  170 KB leaves margin for denser glyph pages without permitting multi-MB
+ *  standing request bodies at large context windows. */
+export const FRAME_DATA_BYTES_ESTIMATE = 170_000;
+
+/** Maximum snapcompact image base64 carried in every rebuilt provider request.
+ *  Above this, provider backends can accept the HTTP body but fail mid-stream
+ *  with opaque 5xx errors. Keep this independent from visual-token budgeting:
+ *  a 1M-token model can afford 70 images on paper, but not the resulting
+ *  ~11 MB JSON payload on every turn. */
+export const FRAME_DATA_BYTES_BUDGET = 3_000_000;
+
+/** Frame-count cap implied by {@link FRAME_DATA_BYTES_BUDGET}. */
+export function maxFramesForDataBudget(maxFrameDataBytes: number = FRAME_DATA_BYTES_BUDGET): number {
+	return Math.max(1, Math.floor(maxFrameDataBytes / FRAME_DATA_BYTES_ESTIMATE));
+}
+
+/** Base64 byte length for persisted snapcompact frames. */
+export function frameDataBytes(frames: readonly Pick<Frame, "data">[]): number {
+	return frames.reduce((sum, frame) => sum + frame.data.length, 0);
+}
+
 /**
  * Per-request image-count budgets by provider id. These cap how many images an
  * entire request may carry (archive/system-prompt/tool-result imaging combined).
@@ -1313,6 +1336,51 @@ export function archiveSourceText(archive: Archive): string | undefined {
 	return text.length > 0 ? toPlainText(text) : undefined;
 }
 
+/** Options for reconstructing a persisted snapcompact archive into prompt blocks. */
+export interface HistoryBlockOptions {
+	/** Hard cap on image base64 bytes attached to one rebuilt provider request. */
+	maxFrameDataBytes?: number;
+}
+
+function formatFrameDataBytes(bytes: number): string {
+	if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
+	if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
+	return `${bytes} B`;
+}
+
+function imagesWithinBudget(
+	archive: Archive,
+	maxFrameDataBytes: number | undefined,
+): { images: ImageContent[]; omittedFrames: number; omittedBytes: number } {
+	if (maxFrameDataBytes === undefined) {
+		return { images: images(archive), omittedFrames: 0, omittedBytes: 0 };
+	}
+
+	let usedBytes = 0;
+	let omittedFrames = 0;
+	let omittedBytes = 0;
+	const kept: Frame[] = [];
+	for (const frame of archive.frames) {
+		const bytes = frame.data.length;
+		if (usedBytes + bytes > maxFrameDataBytes) {
+			omittedFrames++;
+			omittedBytes += bytes;
+			continue;
+		}
+		usedBytes += bytes;
+		kept.push(frame);
+	}
+	return { images: images({ ...archive, frames: kept }), omittedFrames, omittedBytes };
+}
+
+function omittedFrameNotice(omittedFrames: number, omittedBytes: number): string {
+	return [
+		"-------------- snapcompact image middle omitted",
+		`${omittedFrames.toLocaleString()} archived image frame${omittedFrames === 1 ? "" : "s"} (${formatFrameDataBytes(omittedBytes)} base64) exceeded the per-request snapcompact payload budget. The compacted summary and visible text edges remain available.`,
+		"--------------",
+	].join("\n");
+}
+
 /** Convert archive frames into LLM image blocks (oldest first). */
 export function images(archive: Archive): ImageContent[] {
 	return archive.frames.map(frame => ({
@@ -1326,23 +1394,35 @@ export function images(archive: Archive): ImageContent[] {
  *  the oldest text region, the imaged middle, then the newest text region.
  *  Runtime-only; reconstructed from {@link Archive} on each context rebuild
  *  instead of persisted on the session entry. */
-export function historyBlocks(archive: Archive): (TextContent | ImageContent)[] {
+export function historyBlocks(archive: Archive, options: HistoryBlockOptions = {}): (TextContent | ImageContent)[] {
 	const blocks: (TextContent | ImageContent)[] = [];
-	const hasImages = archive.frames.length > 0;
+	const budgeted = imagesWithinBudget(archive, options.maxFrameDataBytes);
+	const hasImages = budgeted.images.length > 0;
+	const hasOmittedImages = budgeted.omittedFrames > 0;
 	if (archive.textHead) {
-		const suffix = hasImages ? "\n-------------- imaged middle below\n" : "";
+		const suffix = hasImages
+			? "\n-------------- imaged middle below\n"
+			: hasOmittedImages
+				? `\n${omittedFrameNotice(budgeted.omittedFrames, budgeted.omittedBytes)}\n`
+				: "";
 		blocks.push({ type: "text", text: toPlainText(archive.textHead) + suffix });
+	} else if (hasOmittedImages) {
+		blocks.push({ type: "text", text: omittedFrameNotice(budgeted.omittedFrames, budgeted.omittedBytes) });
 	}
-	blocks.push(...images(archive));
+	blocks.push(...budgeted.images);
+	if (hasImages && hasOmittedImages) {
+		blocks.push({ type: "text", text: omittedFrameNotice(budgeted.omittedFrames, budgeted.omittedBytes) });
+	}
 	if (archive.textTail) {
 		const prefix = hasImages
 			? "-------------- imaged middle above\n"
-			: archive.truncatedChars > 0
+			: archive.truncatedChars > 0 || hasOmittedImages
 				? "\n-------------- middle history omitted above\n"
 				: "";
 		const tail = prefix + toPlainText(archive.textTail);
-		if (blocks.length > 0 && blocks[blocks.length - 1]?.type === "text") {
-			(blocks[blocks.length - 1] as TextContent).text += tail;
+		const lastBlock = blocks[blocks.length - 1];
+		if (lastBlock?.type === "text") {
+			lastBlock.text += tail;
 		} else {
 			blocks.push({ type: "text", text: tail });
 		}

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -1359,8 +1359,10 @@ function imagesWithinBudget(
 	let usedBytes = 0;
 	let omittedFrames = 0;
 	let omittedBytes = 0;
-	const kept: Frame[] = [];
-	for (const frame of archive.frames) {
+	const keptNewestFirst: Frame[] = [];
+	for (let index = archive.frames.length - 1; index >= 0; index--) {
+		const frame = archive.frames[index];
+		if (!frame) continue;
 		const bytes = frame.data.length;
 		if (usedBytes + bytes > maxFrameDataBytes) {
 			omittedFrames++;
@@ -1368,9 +1370,10 @@ function imagesWithinBudget(
 			continue;
 		}
 		usedBytes += bytes;
-		kept.push(frame);
+		keptNewestFirst.push(frame);
 	}
-	return { images: images({ ...archive, frames: kept }), omittedFrames, omittedBytes };
+	keptNewestFirst.reverse();
+	return { images: images({ ...archive, frames: keptNewestFirst }), omittedFrames, omittedBytes };
 }
 
 function omittedFrameNotice(omittedFrames: number, omittedBytes: number): string {


### PR DESCRIPTION
## Repro
A follow-up reproduction on #3792 parsed five stuck large-session JSONLs and found the latest active-path `preserveData.snapcompact.frames` archive reattached to the first rebuilt request message every turn: the worst case carried 70 frames / ~11.6 MB base64 / `tokensBefore=857,405`, while switching to context-full compaction produced a small text summary and cleared the Anthropic `api_error: Internal server error` wedge.

## Cause
`packages/coding-agent/src/session/session-context.ts` rebuilt LLM contexts with `snapcompact.historyBlocks()` unbounded, and `AgentSession.#computeSnapcompactMaxFrames()` in `packages/coding-agent/src/session/agent-session.ts` only sized snapcompact output by visual-token budget. On ~1M-token models that allowed dozens of persisted PNG frames to ride `messages[0]` on every request; retries and resumed sessions kept resending the same multi-megabyte JSON image wall.

## Fix
- Added snapcompact frame base64 byte-budget helpers and bounded `historyBlocks()` reconstruction in `packages/snapcompact/src/snapcompact.ts`.
- Capped new snapcompact `maxFrames` by the byte budget and made auto snapcompact fall back to context-full when rendered frame payloads still exceed it.
- Capped legacy oversized snapcompact archives during LLM context rebuilds while preserving full frame display in transcript mode.
- Added regression coverage for rebuild-time frame omission and max-frame budget sizing.

## Verification
`bun test packages/coding-agent/test/session-manager/build-context.test.ts packages/coding-agent/test/agent-session-snapcompact-budget.test.ts packages/snapcompact/test/snapcompact.test.ts` passed (88 tests). `bun --cwd=packages/snapcompact run check` passed. `bun --cwd=packages/coding-agent run check` passed. Fixes #3792