### PR TITLE
fix(edit): preserve hashline UTF-8 BOM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hashline edit mode preserving UTF-8 BOM bytes on edited files. ([#3867](https://github.com/can1357/oh-my-pi/issues/3867))
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -28,6 +28,7 @@ import { invalidateFsScanAfterWrite } from "../../tools/fs-cache-invalidation";
 import { isInternalUrlPath } from "../../tools/path-utils";
 import { enforcePlanModeWrite, resolvePlanPath, targetsLocalSandbox } from "../../tools/plan-mode-guard";
 import { canonicalSnapshotKey } from "../file-snapshot-store";
+import { isNotebookPath } from "../notebook";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { LspBatchRequest } from "../renderer";
 
@@ -123,8 +124,9 @@ export class HashlineFilesystem extends Filesystem {
 		return content;
 	}
 
-	async readBinary(relativePath: string): Promise<Uint8Array> {
+	async readBinary(relativePath: string): Promise<Uint8Array | undefined> {
 		const absolutePath = this.resolveAbsolute(relativePath);
+		if (isNotebookPath(absolutePath)) return undefined;
 		try {
 			return await fs.readFile(absolutePath);
 		} catch (error) {

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -123,6 +123,16 @@ export class HashlineFilesystem extends Filesystem {
 		return content;
 	}
 
+	async readBinary(relativePath: string): Promise<Uint8Array> {
+		const absolutePath = this.resolveAbsolute(relativePath);
+		try {
+			return await fs.readFile(absolutePath);
+		} catch (error) {
+			if (isEnoent(error)) throw new NotFoundError(relativePath, error);
+			throw error;
+		}
+	}
+
 	async preflightWrite(relativePath: string, options?: PreflightWriteOptions): Promise<void> {
 		const fileOp = options?.fileOp;
 		if (fileOp?.kind === "rem") {

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -128,6 +128,39 @@ describe("hashline executor", () => {
 		});
 	});
 
+	it("edits BOM-prefixed notebooks through the virtual cell text", async () => {
+		await withTempDir(async tempDir => {
+			const filePath = path.join(tempDir, "notebook.ipynb");
+			const notebook = {
+				cells: [
+					{
+						cell_type: "markdown",
+						metadata: { keep: true },
+						source: ["# Title\n"],
+					},
+				],
+				metadata: {},
+				nbformat: 4,
+				nbformat_minor: 5,
+			};
+			await Bun.write(
+				filePath,
+				new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(JSON.stringify(notebook))]),
+			);
+			const session = makeHashlineSession(tempDir);
+			const editableText = "# %% [markdown] cell:0\n# Title\n";
+			const sourceTag = recordFullSnapshot(getFileReadCache(session), filePath, editableText);
+			const input = `${header("notebook.ipynb", sourceTag)}\n${sameLineRange(tag(2, "# Title"))}\n${repl("# Updated")}\n`;
+
+			await executeHashlineSingle(hashlineExecuteOptions(tempDir, input, undefined, session));
+
+			const updated = await Bun.file(filePath).json();
+			expect(updated.cells).toHaveLength(1);
+			expect(updated.cells[0].source).toEqual(["# Updated\n"]);
+			expect(updated.cells[0].metadata).toEqual({ keep: true });
+		});
+	});
+
 	it("emits an actionable no-op diagnostic when the payload matches the file byte-for-byte", async () => {
 		await withTempDir(async tempDir => {
 			const filePath = path.join(tempDir, "a.ts");

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -111,6 +111,23 @@ describe("hashline executor", () => {
 		});
 	});
 
+	it("preserves UTF-8 BOM bytes when hashline edits decoded text", async () => {
+		await withTempDir(async tempDir => {
+			const filePath = path.join(tempDir, "Program.cs");
+			const source = "using A;\n";
+			await Bun.write(filePath, new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(source)]));
+			const session = makeHashlineSession(tempDir);
+			const sourceTag = recordFullSnapshot(getFileReadCache(session), filePath, source);
+			const input = `${header("Program.cs", sourceTag)}\n${sameLineRange(tag(1, source))}\n${repl("using B;")}\n`;
+
+			await executeHashlineSingle(hashlineExecuteOptions(tempDir, input, undefined, session));
+
+			const bytes = await fs.readFile(filePath);
+			expect(Array.from(bytes.subarray(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+			expect(new TextDecoder().decode(bytes.subarray(3))).toBe("using B;\n");
+		});
+	});
+
 	it("emits an actionable no-op diagnostic when the payload matches the file byte-for-byte", async () => {
 		await withTempDir(async tempDir => {
 			const filePath = path.join(tempDir, "a.ts");

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
+		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
+		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hashline writes preserving UTF-8 BOM bytes when the host text decoder hides the leading `U+FEFF`. ([#3867](https://github.com/can1357/oh-my-pi/issues/3867))
+
 ## [16.2.6] - 2026-06-29
 
 ### Fixed

--- a/packages/hashline/src/fs.ts
+++ b/packages/hashline/src/fs.ts
@@ -65,8 +65,8 @@ export abstract class Filesystem {
 	/** Read the file's full text content. Throw on missing file. */
 	abstract readText(path: string): Promise<string>;
 
-	/** Read the file's raw bytes when text decoding may hide leading bytes such as a UTF-8 BOM. */
-	readBinary?(path: string): Promise<Uint8Array>;
+	/** Read raw bytes for backends whose text is a direct decode of persisted bytes. */
+	readBinary?(path: string): Promise<Uint8Array | undefined>;
 
 	/** Validate that `path` is writable before a prepared batch starts committing. */
 	async preflightWrite(_path: string, _options?: PreflightWriteOptions): Promise<void> {}

--- a/packages/hashline/src/fs.ts
+++ b/packages/hashline/src/fs.ts
@@ -65,6 +65,9 @@ export abstract class Filesystem {
 	/** Read the file's full text content. Throw on missing file. */
 	abstract readText(path: string): Promise<string>;
 
+	/** Read the file's raw bytes when text decoding may hide leading bytes such as a UTF-8 BOM. */
+	readBinary?(path: string): Promise<Uint8Array>;
+
 	/** Validate that `path` is writable before a prepared batch starts committing. */
 	async preflightWrite(_path: string, _options?: PreflightWriteOptions): Promise<void> {}
 
@@ -194,6 +197,15 @@ export class NodeFilesystem extends Filesystem {
 		const file = Bun.file(path);
 		if (!(await file.exists())) throw new NotFoundError(path);
 		return file.text();
+	}
+
+	async readBinary(path: string): Promise<Uint8Array> {
+		try {
+			return await fs.readFile(path);
+		} catch (error) {
+			if (isNotFound(error)) throw new NotFoundError(path, error);
+			throw error;
+		}
 	}
 
 	async writeText(path: string, content: string): Promise<WriteResult> {

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -148,6 +148,10 @@ function mergeWarnings(...sources: ReadonlyArray<readonly string[] | undefined>)
 	return out;
 }
 
+function hasUtf8Bom(bytes: Uint8Array | undefined): boolean {
+	return bytes !== undefined && bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf;
+}
+
 function assertUniqueCanonicalPaths(prepared: readonly PreparedSection[]): void {
 	const seen = new Map<string, string>();
 	for (const entry of prepared) {
@@ -295,7 +299,8 @@ export class Patcher {
 			throw new Error(`MV destination is the same as ${target.path}.`);
 		}
 
-		const { bom, text } = stripBom(read.rawContent);
+		const { bom: bomFromText, text } = stripBom(read.rawContent);
+		const bom = bomFromText || (await this.#readBinaryBom(target.path));
 		const lineEnding = detectLineEnding(text);
 		const normalized = normalizeToLF(text);
 
@@ -451,6 +456,12 @@ export class Patcher {
 			blockResolutions: applyResult.blockResolutions,
 			warnings,
 		};
+	}
+
+	async #readBinaryBom(path: string): Promise<string> {
+		if (!this.fs.readBinary) return "";
+		const bytes = await this.fs.readBinary(path);
+		return hasUtf8Bom(bytes) ? "\uFEFF" : "";
 	}
 
 	async #tryRead(path: string): Promise<{ exists: boolean; rawContent: string }> {

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	computeFileHash,
+	formatHashlineHeader,
 	HEADTAIL_DRIFT_WARNING,
 	InMemoryFilesystem,
 	InMemorySnapshotStore,
 	MismatchError,
+	NodeFilesystem,
 	Patch,
 	Patcher,
 } from "@oh-my-pi/hashline";
@@ -31,6 +36,26 @@ describe("Patcher snapshot tag integrity", () => {
 		expect(result.sections[0]?.fileHash).toMatch(/^[0-9A-F]{4}$/);
 		expect(result.sections[0]?.fileHash).not.toBe(tag);
 		expect(fs.get(PATH)).toBe("after\n");
+	});
+
+	it("restores a UTF-8 BOM hidden by Bun text decoding", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hashline-bom-"));
+		try {
+			const filePath = path.join(tempDir, "Program.cs");
+			const source = "using A;\n";
+			await Bun.write(filePath, new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(source)]));
+			const snapshots = new InMemorySnapshotStore();
+			const tag = snapshots.record(filePath, source);
+			const patch = Patch.parse([formatHashlineHeader(filePath, tag), "SWAP 1.=1:", "+using B;"].join("\n"));
+
+			await new Patcher({ fs: new NodeFilesystem(), snapshots }).apply(patch);
+
+			const bytes = await fs.readFile(filePath);
+			expect(Array.from(bytes.subarray(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+			expect(new TextDecoder().decode(bytes.subarray(3))).toBe("using B;\n");
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("validates any anchor purely from the content hash, even with no recorded snapshot", async () => {


### PR DESCRIPTION
## Repro
A BOM-prefixed `Program.cs` edited through the hashline patcher reproduced the corruption: `bun test /tmp/omp-hashline-bom-repro.test.ts` failed before the fix with first bytes `[117, 115, 105]` (`usi`) instead of `[239, 187, 191]`.

## Cause
`packages/hashline/src/patcher.ts` derived the persisted BOM only from `stripBom(read.rawContent)`, but `Filesystem.readText()` implementations such as `NodeFilesystem` and `HashlineFilesystem` can decode UTF-8 BOM bytes without returning a leading `U+FEFF`, leaving `bom` empty before `persisted = bom + restoreLineEndings(...)`.

## Fix
- Added optional binary reads to the hashline filesystem contract and disk-backed adapters.
- Taught `Patcher.prepare()` to sniff raw leading bytes when text decoding did not expose a BOM.
- Added hashline package and coding-agent hashline executor regression coverage for BOM-prefixed files.
- Added changelog entries for `@oh-my-pi/hashline` and `@oh-my-pi/pi-coding-agent`.

## Verification
Passed `bun test packages/hashline/test/patcher.test.ts`, `bun test packages/coding-agent/test/core/hashline.test.ts`, `bun test /tmp/omp-hashline-bom-repro.test.ts`, `bun check`, and `bun run fix`. Fixes #3867