### PR TITLE
fix(tui): preserve prompt drafts on Esc

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Esc preserving typed TUI prompt drafts instead of clearing unrecoverable input. ([#3869](https://github.com/can1357/oh-my-pi/issues/3869))
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -382,9 +382,7 @@ export class InputController {
 			} else if (this.ctx.session.isStreaming) {
 				this.#handleStreamingEscape();
 			} else if (this.ctx.editor.getText().trim()) {
-				// Esc with typed text clears the draft instead of (or before) any double-Esc action
-				this.ctx.editor.setText("");
-				this.ctx.ui.requestRender();
+				// Esc must not destroy an in-progress draft; it only disarms a previous empty-editor Esc.
 				this.ctx.lastEscapeTime = 0;
 				this.#clearStreamingEscapeArm();
 			} else {

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -626,7 +626,7 @@ describe("InputController escape behavior", () => {
 		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(spies.resetDisplay).toHaveBeenCalledTimes(1);
 	});
-	it("clears typed editor text on Esc without opening selectors or aborting", () => {
+	it("preserves typed editor text on Esc without opening selectors or aborting", () => {
 		const { ctx, editor, spies } = createContext();
 		const controller = new InputController(ctx);
 
@@ -634,24 +634,26 @@ describe("InputController escape behavior", () => {
 		editor.setText("draft message");
 		editor.onEscape?.();
 
-		expect(editor.getText()).toBe("");
-		expect(spies.requestRender).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("draft message");
+		expect(spies.requestRender).not.toHaveBeenCalled();
 		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
 		expect(spies.resetDisplay).not.toHaveBeenCalled();
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
-	it("does not treat the Esc after a text-clearing Esc as a double-Esc", () => {
+	it("does not treat the Esc after a text-preserving Esc as a double-Esc", () => {
 		const { ctx, editor } = createContext();
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
 		editor.onEscape?.(); // empty editor: arms double-Esc timer
 		editor.setText("draft");
-		editor.onEscape?.(); // clears text, must also reset the timer
+		editor.onEscape?.(); // preserves text, must also reset the timer
+		editor.setText("");
 		editor.onEscape?.(); // empty again: should only re-arm, not trigger
 
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
+		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/input-controller-escape.test.ts -t "clears typed editor text"` reproduced the old behavior: the passing test asserted that pressing `Esc` after typing `draft message` cleared the editor text.

## Cause
`InputController.setupKeyHandlers()` in `packages/coding-agent/src/modes/controllers/input-controller.ts` treated `Esc` with non-empty editor text as a destructive clear, calling `editor.setText("")` before rendering; the prompt draft had no recovery path.

## Fix
- Changed the non-empty-editor `Esc` branch to preserve the draft while still disarming a previous empty-editor double-`Esc` timer.
- Updated `packages/coding-agent/test/input-controller-escape.test.ts` to assert typed drafts survive `Esc` and that the double-`Esc` timer is reset.
- Added the coding-agent changelog entry for #3869.

## Verification
`bun test packages/coding-agent/test/input-controller-escape.test.ts` passed with 30 tests and 88 assertions. `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #3869