### PR TITLE
fix(tools): accept json-array grep paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `grep`/`search` direct execution to accept JSON-array string `paths` for string-or-array inputs. ([#3873](https://github.com/can1357/oh-my-pi/issues/3873))
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -85,8 +85,26 @@ const searchSchema = type({
 });
 
 export type GrepToolInput = typeof searchSchema.infer;
+function parseStringEncodedPathArray(input: string): string[] | null {
+	const trimmed = input.trim();
+	if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+
+	if (!Array.isArray(parsed) || parsed.some(entry => typeof entry !== "string")) {
+		return null;
+	}
+	return parsed;
+}
+
 export function toPathList(input: string | string[] | undefined): string[] {
-	return typeof input === "string" ? [input] : (input ?? []);
+	if (typeof input === "string") return parseStringEncodedPathArray(input) ?? [input];
+	return input ?? [];
 }
 
 /** Maximum number of distinct files surfaced in a single response. The

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -164,6 +164,27 @@ describe("tool path arrays", () => {
 		expect(details?.scopePath).toBe("apps/, packages/, phases/");
 	});
 
+	it("search accepts JSON-array string paths in direct execute", async () => {
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "grep");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing grep tool");
+
+		const result = await tool.execute("search-json-array-string-paths", {
+			pattern: "shared-needle",
+			paths: JSON.stringify(["apps/", "packages/", "phases/"]),
+		});
+		const text = getText(result);
+		const details = result.details as { fileCount?: number; scopePath?: string } | undefined;
+
+		expect(text).toMatch(/^# apps\/\n## grep\.txt#[0-9A-F]{4}/m);
+		expect(text).toMatch(/^# packages\/\n## grep\.txt#[0-9A-F]{4}/m);
+		expect(text).toMatch(/^# phases\/\n## grep\.txt#[0-9A-F]{4}/m);
+		expect(text).not.toContain("# other");
+		expect(details?.fileCount).toBe(3);
+		expect(details?.scopePath).toBe("apps/, packages/, phases/");
+	});
+
 	it("search expands delimited path entries", async () => {
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "grep");

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
+		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");


### PR DESCRIPTION
## Repro
Direct `GrepTool.execute()` with `paths: '["apps","packages"]'` failed before the fix: `bun .wt/grep-json-array-repro.ts` returned `array 2 2`, then exited 1 with `Invalid glob pattern: error parsing glob '**/["apps"': unclosed character class; missing ']'`.

## Cause
`packages/coding-agent/src/tools/grep.ts` normalized `paths` through `toPathList()`, which treated every string as one literal path. Direct callers bypass `validateToolArguments()`, so string-encoded arrays were never decoded before `expandDelimitedPathEntries()` and `resolveToolSearchScope()` interpreted `[`/`]` as glob character-class syntax.

## Fix
- Decode JSON-array-shaped string `paths` in `toPathList()` when every parsed element is a string.
- Reuse that normalized path list for approval, execution, and pending render metadata.
- Add direct `grep` regression coverage for JSON-array string paths.
- Add a coding-agent changelog entry.

## Verification
`bun .wt/grep-json-array-repro.ts` now returns `array 2 2` and `json-string 2 2`; `bun test packages/coding-agent/test/tools/grep-path-lists.test.ts` passed 30 tests; `bun --cwd=packages/coding-agent run check` passed. Fixes #3873