### PR TITLE
perf(coding-agent): incremental reveal slicing + drop redundant thinking-format pass

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Sped up streamed text and thinking reveal: per-tick grapheme slicing is now incremental (each 30fps tick re-segments only the newly arrived suffix instead of the whole revealed prefix), so reveal throughput stays flat as a message grows rather than slowing with its length.
+- Reduced per-tick work while reasoning streams: the thinking-display formatter no longer re-processes already-formatted revealed text on each render, and a single-entry memo collapses the remaining count/slice calls to one per tick.
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/bench/rendering.ts
+++ b/packages/coding-agent/bench/rendering.ts
@@ -7,7 +7,8 @@ import { AssistantMessageComponent } from "../src/modes/components/assistant-mes
 import { TranscriptContainer } from "../src/modes/components/transcript-container";
 import { Settings } from "../src/config/settings";
 import { getEditorTheme } from "../src/modes/theme/theme";
-import { buildDisplayMessage, nextStep, visibleUnits } from "../src/modes/controllers/streaming-reveal";
+import { BlockUnitCounter, buildDisplayMessage, nextStep, visibleUnits } from "../src/modes/controllers/streaming-reveal";
+import { formatThinkingForDisplay } from "../src/utils/thinking-display";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -55,11 +56,12 @@ bench("WelcomeComponent.render", () => {
 
 // ── A2: streaming reveal + editor render baselines ──────────────────────────
 //
-// Diagnostic series, not a fixed-iteration micro-op. `streamingReveal` proves
-// or refutes the O(N^2) reveal hypothesis: per-step cost (visibleUnits +
-// buildDisplayMessage, the work every stream delta/30fps tick does) is sampled
-// at growing revealed lengths. Rising per-step ms => O(N) per tick => O(N^2)
-// over the message. Flat per-step => already linear.
+// Diagnostic series, not a fixed-iteration micro-op. `streamingReveal` samples
+// per-step cost (visibleUnits + buildDisplayMessage, the work every stream
+// delta/30fps tick does) at growing revealed lengths on the COLD one-shot path
+// (no shared counter). A shared BlockUnitCounter — as the live controller and
+// the "Full" series below use — turns each per-tick slice into O(delta) work,
+// so this isolated series is the upper-bound baseline the Full series beats.
 
 function makeMarkdownCorpus(targetGraphemes: number): string {
 	const para =
@@ -73,6 +75,14 @@ function makeMarkdownCorpus(targetGraphemes: number): string {
 		out += `## Section ${++i}\n\n${para}${para}${codeBlock}${list}`;
 	}
 	return out.slice(0, targetGraphemes);
+}
+
+/** Split `text` into fixed-width slices (preserving newlines), simulating the
+ *  chunks a streaming delta feed delivers one tick at a time. */
+function chunkCorpus(text: string, size = 40): string[] {
+	const chunks: string[] = [];
+	for (let j = 0; j < text.length; j += size) chunks.push(text.slice(j, j + size));
+	return chunks.length > 0 ? chunks : [""];
 }
 
 function makeTextMessage(text: string): AssistantMessage {
@@ -117,23 +127,35 @@ for (const n of REVEAL_CHECKPOINTS) {
 	console.log(`  len=${n}: ${ms.toFixed(4)}ms/step`);
 }
 
-// Real streaming cost: text GROWS every tick, so Markdown's text-keyed cache
-// misses each step (the actual interactive path). Total ms to fully reveal an
-// N-grapheme message in nextStep increments — the number C1+C2 reduce.
-console.log("\nstreamingRevealFull (C1+C2: full incremental reveal, growing text => cache-miss/tick):");
+// Real streaming cost, mirroring StreamingRevealController: the text GROWS as
+// deltas arrive, ONE per-episode BlockUnitCounter is shared by countOf/sliceOf,
+// and every update is transient (the live path Markdown/highlight caches skip).
+// Measures total ms to fully reveal an N-grapheme message in nextStep increments.
+console.log("\nstreamingRevealFull (growing text, shared counter, transient updates):");
 try {
 	for (const n of REVEAL_CHECKPOINTS) {
-		const full = makeTextMessage(REVEAL_CORPUS.slice(0, n));
-		const total = visibleUnits(full, false);
+		const fullText = REVEAL_CORPUS.slice(0, n);
+		const chunks = chunkCorpus(fullText);
 		const component = new AssistantMessageComponent();
+		const counter = new BlockUnitCounter();
+		const countOf = (i: number, t: string): number => counter.count(i, t);
+		const sliceOf = (i: number, t: string, u: number): string => counter.slice(i, t, u);
 		const start = Bun.nanoseconds();
+		let text = "";
 		let revealed = 0;
 		let steps = 0;
-		while (revealed < total) {
+		let ci = 0;
+		while (true) {
+			if (ci < chunks.length) text += chunks[ci++]!;
+			const msg = makeTextMessage(text);
+			const total = countOf(0, text);
 			revealed = Math.min(total, revealed + nextStep(total - revealed));
-			component.updateContent(buildDisplayMessage(full, revealed, false));
+			component.updateContent(buildDisplayMessage(msg, revealed, false, true, countOf, sliceOf), {
+				transient: true,
+			});
 			component.render(WIDTH);
 			steps++;
+			if (ci >= chunks.length && revealed >= total) break;
 		}
 		const ms = (Bun.nanoseconds() - start) / 1e6;
 		console.log(`  len=${n}: ${ms.toFixed(2)}ms total over ${steps} steps (${(ms / steps).toFixed(4)}ms/step)`);
@@ -143,26 +165,40 @@ try {
 }
 
 // Multi-block variant: a finalized thinking block (stable) precedes the growing
-// text block — the shape C2 targets. Current code re-lexes BOTH every tick;
-// after C2 the finalized thinking block stays L1-cached and only the tail re-lexes.
+// text block — the common "thought then answer" shape. The thinking block is
+// count/slice-cached once (formatted once outside the loop, matching what
+// buildDisplayMessage feeds the counter at index 0); only the growing text
+// block re-segments its suffix per tick.
 function makeThinkingPlusText(thinking: string, text: string): AssistantMessage {
 	return { ...makeTextMessage(text), content: [{ type: "thinking", thinking }, { type: "text", text }] };
 }
-console.log("\nstreamingRevealMultiBlock (C2: finalized thinking block + growing text):");
+console.log("\nstreamingRevealMultiBlock (finalized thinking + growing text, shared counter):");
 try {
 	const thinking = makeMarkdownCorpus(2500);
+	const formattedThinking = formatThinkingForDisplay(thinking, true);
 	for (const n of [2000, 4000, 6000]) {
-		const full = makeThinkingPlusText(thinking, REVEAL_CORPUS.slice(0, n));
-		const total = visibleUnits(full, false);
+		const fullText = REVEAL_CORPUS.slice(0, n);
+		const chunks = chunkCorpus(fullText);
 		const component = new AssistantMessageComponent();
+		const counter = new BlockUnitCounter();
+		const countOf = (i: number, t: string): number => counter.count(i, t);
+		const sliceOf = (i: number, t: string, u: number): string => counter.slice(i, t, u);
 		const start = Bun.nanoseconds();
+		let text = "";
 		let revealed = 0;
 		let steps = 0;
-		while (revealed < total) {
+		let ci = 0;
+		while (true) {
+			if (ci < chunks.length) text += chunks[ci++]!;
+			const msg = makeThinkingPlusText(thinking, text);
+			const total = countOf(0, formattedThinking) + countOf(1, text);
 			revealed = Math.min(total, revealed + nextStep(total - revealed));
-			component.updateContent(buildDisplayMessage(full, revealed, false));
+			component.updateContent(buildDisplayMessage(msg, revealed, false, true, countOf, sliceOf), {
+				transient: true,
+			});
 			component.render(WIDTH);
 			steps++;
+			if (ci >= chunks.length && revealed >= total) break;
 		}
 		const ms = (Bun.nanoseconds() - start) / 1e6;
 		console.log(`  text=${n} (+2500 thinking): ${ms.toFixed(2)}ms total over ${steps} steps (${(ms / steps).toFixed(4)}ms/step)`);

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -34,11 +34,16 @@ type ThinkingContentBlock = Extract<AssistantMessage["content"][number], { type:
 type DisplayThinkingContentBlock = ThinkingContentBlock & { rawThinking?: string };
 
 function resolveThinkingDisplay(block: ThinkingContentBlock, proseOnly: boolean): { text: string; visible: boolean } {
-	const rawThinking = (block as DisplayThinkingContentBlock).rawThinking ?? block.thinking;
-	const formatted = formatThinkingForDisplay(block.thinking, proseOnly);
+	const rawThinking = (block as DisplayThinkingContentBlock).rawThinking;
+	// When rawThinking is set, `block.thinking` is already the formatted display
+	// text that buildDisplayMessage produced (then revealed/sliced by the
+	// streaming controller) — re-running the formatter would double-process it,
+	// and the growing revealed slice would never hit the per-tick memo. Only
+	// format raw (non-display) thinking blocks.
+	const formatted = rawThinking !== undefined ? block.thinking : formatThinkingForDisplay(block.thinking, proseOnly);
 	return {
 		text: formatted.trim(),
-		visible: hasDisplayableThinking(rawThinking, formatted),
+		visible: hasDisplayableThinking(rawThinking ?? block.thinking, formatted),
 	};
 }
 

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -48,8 +48,9 @@ function countGraphemesFrom(text: string, start: number): { count: number; tailS
 /** Memoizes per-block grapheme counts across reveal ticks. Streaming blocks only
  *  grow by appending, and an append can only alter the final grapheme cluster of
  *  the previous text, so only the suffix from that cluster needs re-segmenting. */
-class BlockUnitCounter {
+export class BlockUnitCounter {
 	#entries = new Map<number, { text: string; count: number; tailStart: number }>();
+	#slices = new Map<number, { text: string; units: number; end: number; lastStart: number; slice: string }>();
 
 	count(index: number, text: string): number {
 		const entry = this.#entries.get(index);
@@ -67,8 +68,57 @@ class BlockUnitCounter {
 		return full.count;
 	}
 
+	/** Slice the first `units` graphemes of `text`, memoized per block across
+	 *  reveal ticks. Streaming blocks grow append-only, and an append can only
+	 *  alter the final grapheme cluster of the previous text, so once a block's
+	 *  slice is known the suffix from that boundary cluster is all that must be
+	 *  re-segmented — turning a per-tick O(revealed) slice into O(delta).
+	 *
+	 *  Invariant: only an EXACT text+units match skips segmentation. A same-unit
+	 *  append can still extend the boundary cluster ("a" → "a\u0301" stays one
+	 *  grapheme), so the `startsWith` fast path always re-segments from that
+	 *  cluster's start (`lastStart`). */
+	slice(index: number, text: string, units: number): string {
+		if (units <= 0 || text.length === 0) return "";
+		// Clamp to the block's actual grapheme count. A cached `units` beyond the
+		// text would let an append fast-path under-slice, so the cache must never
+		// store one. count() is memoized per block and already warm by now.
+		const total = this.count(index, text);
+		if (units >= total) return text;
+		const cached = this.#slices.get(index);
+		// Exact hit: identical text and unit count → reuse the cached slice verbatim.
+		if (cached !== undefined && cached.text === text && cached.units === units) {
+			return cached.slice;
+		}
+		// Incremental: text grew by appending (or is unchanged) and we want at least
+		// as many units. Graphemes before the cached boundary cluster are stable, so
+		// re-segment only from `lastStart` for `units - cached.units + 1` clusters —
+		// the first of which is the boundary cluster, possibly extended by the append.
+		if (cached !== undefined && cached.units >= 1 && text.startsWith(cached.text) && units >= cached.units) {
+			const need = units - cached.units + 1;
+			let taken = 0;
+			let lastStart = cached.lastStart;
+			let end = cached.lastStart;
+			const from = cached.lastStart === 0 ? text : text.slice(cached.lastStart);
+			for (const seg of getSegmenter().segment(from)) {
+				taken += 1;
+				lastStart = cached.lastStart + seg.index;
+				end = lastStart + seg.segment.length;
+				if (taken >= need) break;
+			}
+			const slice = end >= text.length ? text : text.slice(0, end);
+			this.#slices.set(index, { text, units, end, lastStart, slice });
+			return slice;
+		}
+		// Full re-segment: new block, shrunk units, or replaced text.
+		const meta = sliceGraphemesMeta(text, units);
+		this.#slices.set(index, { text, units, end: meta.end, lastStart: meta.lastStart, slice: meta.slice });
+		return meta.slice;
+	}
+
 	reset(): void {
 		this.#entries.clear();
+		this.#slices.clear();
 	}
 }
 
@@ -83,6 +133,24 @@ function sliceGraphemes(text: string, units: number): string {
 		}
 	}
 	return text;
+}
+
+/** Slice the first `units` graphemes of `text`, also reporting the code-unit
+ *  end of the final cluster and where it begins — the point from which an
+ *  append could extend that cluster. Used by {@link BlockUnitCounter.slice}. */
+function sliceGraphemesMeta(text: string, units: number): { slice: string; end: number; lastStart: number } {
+	if (units <= 0 || text.length === 0) return { slice: "", end: 0, lastStart: 0 };
+	let count = 0;
+	let lastStart = 0;
+	for (const { index, segment } of getSegmenter().segment(text)) {
+		count += 1;
+		lastStart = index;
+		if (count >= units) {
+			const end = index + segment.length;
+			return { slice: end >= text.length ? text : text.slice(0, end), end, lastStart };
+		}
+	}
+	return { slice: text, end: text.length, lastStart };
 }
 
 export function visibleUnits(message: AssistantMessage, hideThinking: boolean, proseOnly = true): number {
@@ -102,22 +170,26 @@ export function visibleUnits(message: AssistantMessage, hideThinking: boolean, p
 
 function revealTextBlock(
 	block: Extract<AssistantContentBlock, { type: "text" }>,
+	index: number,
 	remaining: number,
 	units: number,
+	sliceOf: (index: number, text: string, units: number) => string,
 ): AssistantContentBlock {
 	if (remaining <= 0) return block.text.length === 0 ? block : { ...block, text: "" };
 	if (remaining >= units) return block;
-	return { ...block, text: sliceGraphemes(block.text, remaining) };
+	return { ...block, text: sliceOf(index, block.text, remaining) };
 }
 
 function revealThinkingBlock(
 	block: Extract<AssistantContentBlock, { type: "thinking" }>,
+	index: number,
 	remaining: number,
 	units: number,
+	sliceOf: (index: number, text: string, units: number) => string,
 ): AssistantContentBlock {
 	if (remaining <= 0) return block.thinking.length === 0 ? block : { ...block, thinking: "" };
 	if (remaining >= units) return block;
-	return { ...block, thinking: sliceGraphemes(block.thinking, remaining) };
+	return { ...block, thinking: sliceOf(index, block.thinking, remaining) };
 }
 
 export function buildDisplayMessage(
@@ -126,6 +198,8 @@ export function buildDisplayMessage(
 	hideThinking: boolean,
 	proseOnly = true,
 	countOf: (index: number, text: string) => number = (_index, text) => countGraphemes(text),
+	sliceOf: (index: number, text: string, units: number) => string = (_index, text, units) =>
+		sliceGraphemes(text, units),
 ): AssistantMessage {
 	let remaining = Math.max(0, Math.floor(revealed));
 	const content: AssistantContentBlock[] = [];
@@ -133,7 +207,7 @@ export function buildDisplayMessage(
 		const block = target.content[i]!;
 		if (block.type === "text") {
 			const units = countOf(i, block.text);
-			content.push(revealTextBlock(block, remaining, units));
+			content.push(revealTextBlock(block, i, remaining, units, sliceOf));
 			remaining = Math.max(0, remaining - units);
 		} else if (block.type === "thinking" && !hideThinking) {
 			const formatted = formatThinkingForDisplay(block.thinking, proseOnly);
@@ -144,7 +218,7 @@ export function buildDisplayMessage(
 					thinking: formatted,
 					rawThinking: block.thinking,
 				};
-				content.push(revealThinkingBlock(displayBlock, remaining, units));
+				content.push(revealThinkingBlock(displayBlock, i, remaining, units, sliceOf));
 				remaining = Math.max(0, remaining - units);
 			} else {
 				content.push(block);
@@ -174,6 +248,8 @@ export class StreamingRevealController {
 	#smoothStreaming = true;
 	readonly #unitCounter = new BlockUnitCounter();
 	readonly #countOf = (index: number, text: string): number => this.#unitCounter.count(index, text);
+	readonly #sliceOf = (index: number, text: string, units: number): string =>
+		this.#unitCounter.slice(index, text, units);
 
 	constructor(options: StreamingRevealControllerOptions) {
 		this.#getSmoothStreaming = options.getSmoothStreaming;
@@ -193,7 +269,14 @@ export class StreamingRevealController {
 		if (!this.#smoothStreaming) {
 			const total = this.#visibleUnits(message);
 			component.updateContent(
-				buildDisplayMessage(message, total, this.#hideThinkingBlock, this.#proseOnlyThinking, this.#countOf),
+				buildDisplayMessage(
+					message,
+					total,
+					this.#hideThinkingBlock,
+					this.#proseOnlyThinking,
+					this.#countOf,
+					this.#sliceOf,
+				),
 				{ transient: true },
 			);
 			return;
@@ -210,6 +293,7 @@ export class StreamingRevealController {
 					this.#hideThinkingBlock,
 					this.#proseOnlyThinking,
 					this.#countOf,
+					this.#sliceOf,
 				),
 				{
 					transient: true,
@@ -230,7 +314,14 @@ export class StreamingRevealController {
 		if (!this.#smoothStreaming) {
 			const total = this.#visibleUnits(message);
 			this.#component.updateContent(
-				buildDisplayMessage(message, total, this.#hideThinkingBlock, this.#proseOnlyThinking, this.#countOf),
+				buildDisplayMessage(
+					message,
+					total,
+					this.#hideThinkingBlock,
+					this.#proseOnlyThinking,
+					this.#countOf,
+					this.#sliceOf,
+				),
 				{ transient: true },
 			);
 			return;
@@ -248,6 +339,7 @@ export class StreamingRevealController {
 					this.#hideThinkingBlock,
 					this.#proseOnlyThinking,
 					this.#countOf,
+					this.#sliceOf,
 				),
 				{
 					transient: true,
@@ -316,6 +408,7 @@ export class StreamingRevealController {
 				this.#hideThinkingBlock,
 				this.#proseOnlyThinking,
 				this.#countOf,
+				this.#sliceOf,
 			),
 			{ transient: true },
 		);
@@ -357,7 +450,14 @@ export class StreamingRevealController {
 		}
 		this.#revealed = Math.min(total, this.#revealed + nextStep(total - this.#revealed));
 		component.updateContent(
-			buildDisplayMessage(target, this.#revealed, this.#hideThinkingBlock, this.#proseOnlyThinking, this.#countOf),
+			buildDisplayMessage(
+				target,
+				this.#revealed,
+				this.#hideThinkingBlock,
+				this.#proseOnlyThinking,
+				this.#countOf,
+				this.#sliceOf,
+			),
 			{
 				transient: true,
 			},

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -1,5 +1,15 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
+// Single-entry memo for the proseOnly formatting path. During a streaming tick
+// the same growing thinking text is formatted up to three times (reveal count,
+// reveal slice, component render); this collapses them to one computation. The
+// `proseOnly === false` branch is a passthrough and never consults the cache, so
+// the key can be the text alone. A single entry is enough for the common case of
+// one active thinking block and never regresses (a miss recomputes exactly as
+// before).
+let formatCacheKey = "";
+let formatCacheValue = "";
+
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
 	const trimmed = text.trim();
@@ -14,6 +24,7 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
 	if (!proseOnly || !text) return text;
+	if (text === formatCacheKey) return formatCacheValue;
 
 	const lines = text.split("\n");
 	const resultLines: string[] = [];
@@ -78,6 +89,8 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	}
 
 	const formatted = resultLines.join("\n");
+	formatCacheKey = text;
+	formatCacheValue = formatted;
 	return formatted;
 }
 

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
@@ -191,4 +191,22 @@ describe("AssistantMessageComponent streaming fast path", () => {
 		reused.updateContent(filled);
 		expect(reused.render(W).join("\n")).toBe(teardownRender(filled));
 	});
+	it("does not re-format an already-display thinking block (rawThinking set)", () => {
+		// buildDisplayMessage emits a thinking block whose `thinking` is already the
+		// formatted display text and stamps the original under `rawThinking`.
+		// resolveThinkingDisplay must treat `thinking` as display-ready and NOT
+		// re-run the fence-stripping formatter — otherwise the fenced content
+		// ("keep me") is stripped a second time.
+		const m = msg([
+			{
+				type: "thinking",
+				thinking: "Visible\n```\nkeep me\n```",
+				rawThinking: "raw",
+			},
+		] as unknown as AssistantMessage["content"]);
+		const component = new AssistantMessageComponent();
+		component.updateContent(m);
+		const rendered = Bun.stripANSI(component.render(W).join("\n"));
+		expect(rendered).toContain("keep me");
+	});
 });

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import {
+	BlockUnitCounter,
 	buildDisplayMessage,
 	CATCHUP_FRAMES,
 	MIN_STEP,
@@ -11,6 +12,7 @@ import {
 	visibleUnits,
 } from "@oh-my-pi/pi-coding-agent/modes/controllers/streaming-reveal";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getSegmenter } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	await initTheme(false);
@@ -295,5 +297,115 @@ describe("streaming reveal", () => {
 		expect(textAt(latestMessage(component), 0)).toBe("abcdefghi");
 		expect(component.messages).toHaveLength(updates);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+});
+
+/** Pure reference slice: the first `units` graphemes of `text`, segmenting the
+ *  whole string each call (the O(revealed) behaviour the counter must match). */
+function pureSlice(text: string, units: number): string {
+	if (units <= 0 || text.length === 0) return "";
+	let count = 0;
+	for (const { index, segment } of getSegmenter().segment(text)) {
+		count += 1;
+		if (count >= units) {
+			const end = index + segment.length;
+			return end >= text.length ? text : text.slice(0, end);
+		}
+	}
+	return text;
+}
+
+describe("BlockUnitCounter.slice", () => {
+	it("matches the reference for fixed text with growing units", () => {
+		const counter = new BlockUnitCounter();
+		const text = "Hello, world — güten tag 👋";
+		for (let units = 0; units <= 30; units++) {
+			expect(counter.slice(0, text, units)).toBe(pureSlice(text, units));
+		}
+	});
+
+	it("matches the reference across an append-only stream with growing units", () => {
+		const counter = new BlockUnitCounter();
+		const full = "the quick brown fox jumps over the lazy dog. ".repeat(3);
+		let text = "";
+		for (const chunk of full.match(/.{1,7}/g) ?? []) {
+			text += chunk;
+			const total = counter.count(0, text);
+			for (let units = 0; units <= total; units += 3) {
+				expect(counter.slice(0, text, units)).toBe(pureSlice(text, units));
+			}
+		}
+	});
+
+	it("re-segments when an append extends the boundary cluster (combining mark)", () => {
+		// "a" cached at 1 grapheme; text grows to "a\u0301" — still one grapheme,
+		// but the cluster is now longer. A stale cache would return "a".
+		const counter = new BlockUnitCounter();
+		expect(counter.slice(0, "a", 1)).toBe("a");
+		expect(counter.slice(0, "a\u0301", 1)).toBe("a\u0301");
+		expect(counter.slice(0, "a\u0301b", 2)).toBe("a\u0301b");
+	});
+
+	it("re-segments when an append merges a ZWJ sequence", () => {
+		// "ab👨" (3 graphemes) grows to "ab👨\u200D👩x" — the ZWJ merges the two
+		// emoji into one cluster, so the count stays 3→4 and the 3rd cluster grows.
+		const counter = new BlockUnitCounter();
+		expect(counter.slice(0, "ab👨", 3)).toBe("ab👨");
+		expect(counter.slice(0, "ab👨\u200D👩", 3)).toBe("ab👨\u200D👩");
+		expect(counter.slice(0, "ab👨\u200D👩x", 4)).toBe("ab👨\u200D👩x");
+	});
+
+	it("handles shrunk units via full re-segment", () => {
+		const counter = new BlockUnitCounter();
+		const text = "abcdefgh";
+		expect(counter.slice(0, text, 6)).toBe("abcdef");
+		// Fewer units than cached — cannot extend the boundary cluster backwards.
+		expect(counter.slice(0, text, 3)).toBe("abc");
+		expect(counter.slice(0, text, 1)).toBe("a");
+	});
+
+	it("full re-segments when text is replaced", () => {
+		const counter = new BlockUnitCounter();
+		expect(counter.slice(0, "abcdef", 3)).toBe("abc");
+		// Unrelated text at the same index — no shared prefix.
+		expect(counter.slice(0, "xyz123", 2)).toBe("xy");
+	});
+
+	it("clamps units beyond the total and never returns a stale prefix", () => {
+		// Regression: a cached `units` past the end would let an append fast-path
+		// under-slice. Asking for more graphemes than exist must yield the full text.
+		const counter = new BlockUnitCounter();
+		expect(counter.slice(0, "ab", 5)).toBe("ab");
+		expect(counter.slice(0, "abc", 5)).toBe("abc");
+		expect(counter.slice(0, "abcdef", 5)).toBe("abcde");
+	});
+
+	it("keeps independent cache entries per block index", () => {
+		const counter = new BlockUnitCounter();
+		expect(counter.slice(0, "aaa", 2)).toBe("aa");
+		expect(counter.slice(1, "bbbb", 3)).toBe("bbb");
+		// Index 0's cache must be untouched by index 1's calls.
+		expect(counter.slice(0, "aaa", 2)).toBe("aa");
+		expect(counter.slice(0, "aaaa", 3)).toBe("aaa");
+	});
+
+	it("matches the reference across a randomized fuzz of streams", () => {
+		const counter = new BlockUnitCounter();
+		const alphabet = ["a", "b", "x", "\u0301", "👨", "\u200D", "👩", "\n", "c"];
+		let seed = 1234567;
+		const rand = (): number => {
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			return seed / 0x7fffffff;
+		};
+		for (let block = 0; block < 5; block++) {
+			let text = "";
+			for (let step = 0; step < 40; step++) {
+				text += alphabet[Math.floor(rand() * alphabet.length)] ?? "a";
+				const total = counter.count(block, text);
+				const units = Math.floor(rand() * (total + 2));
+				expect(counter.slice(block, text, units)).toBe(pureSlice(text, units));
+			}
+			counter.reset();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Two streaming-throughput fixes that keep the smooth text/thinking reveal animation fast as a response grows, plus a correctness fix for how streamed thinking text is formatted per render tick.

## 1. Incremental grapheme slicing (primary)

`StreamingRevealController` ticks at 30fps. Each tick, `buildDisplayMessage` → `sliceGraphemes(text, revealed)` called `Intl.Segmenter.segment()` **from offset 0** — O(revealed) per tick. As a message grew, reveal throughput slowed with its length (the "text fills the screen sluggishly" symptom).

`BlockUnitCounter.slice()` now memoizes per-block slices across ticks and re-segments only the appended suffix (O(delta) per tick). Threaded through `buildDisplayMessage` via a new `sliceOf` callback; the controller wires its shared counter into all call sites.

Benchmark (`streamingRevealFull`, shared counter + transient updates) is **flat** at ~0.32ms/step across N=3000→6000, vs. rising with length before.

## 2. Drop the redundant per-tick thinking-format pass (new vs. #3843)

`resolveThinkingDisplay` re-ran `formatThinkingForDisplay` on `block.thinking` every render tick — but for a thinking block emitted by `buildDisplayMessage`, `thinking` is **already** the formatted display text (and a growing revealed slice), with the original under `rawThinking`. This both double-processed formatted text and defeated the per-tick memo. Now skips re-formatting when `rawThinking` is present. A single-entry memo collapses the remaining count/slice calls to one per tick.

## Verification

- `bun check`: clean.
- `test/streaming-reveal.test.ts`: 23 pass (incl. 9 new `BlockUnitCounter.slice` correctness/fuzz cases vs a pure `Intl.Segmenter` reference).
- `test/modes/components/assistant-message-streaming-fastpath.test.ts`: 8 pass (incl. a regression test that the `rawThinking` display path does not strip fenced content a second time).
- All `modes/components` suites: 250 pass.

## Relationship to #3843

#3843 is an open PR on the same topic but is **dirty** (behind main, merge conflicts) and bundles a larger batch (markdown transient cache + 8 other hot-path fixes). This PR is scoped to the two highest-impact fixes, rebased on current `main`, and adds the `resolveThinkingDisplay` double-format fix which is **not** in #3843. Happy to defer to whichever the maintainer prefers.