### PR TITLE
fix(coding-agent): forward stream timeout settings

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -207,8 +207,8 @@ OAuth host chain: `KIMI_CODE_OAUTH_HOST` → `KIMI_OAUTH_HOST` → `https://auth
 | `PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS`       | Positive integer override (default 300000)           |
 | `PI_CODEX_WEBSOCKET_RETRY_BUDGET`          | Non-negative integer override (default 5)            |
 | `PI_CODEX_WEBSOCKET_RETRY_DELAY_MS`        | Positive integer base backoff override (default 500) |
-| `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS`  | Positive integer OpenAI first-event timeout override |
-| `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`         | Positive integer OpenAI stream idle timeout override |
+| `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS`  | Positive integer OpenAI first-event timeout override; `0` disables. `omp config set providers.streamFirstEventTimeoutSeconds <seconds>` provides the persisted config equivalent |
+| `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`         | Positive integer OpenAI stream idle timeout override; `0` disables. `omp config set providers.streamIdleTimeoutSeconds <seconds>` provides the persisted config equivalent |
 
 ### Cursor provider debug
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fixed slow local LLM streams by forwarding persisted stream timeout settings (`providers.streamFirstEventTimeoutSeconds`, `providers.streamIdleTimeoutSeconds`) into model requests, so users can widen or disable watchdogs without environment variables. ([#3878](https://github.com/can1357/oh-my-pi/issues/3878))
 - Improved reliability of DuckDuckGo web searches by updating browser request headers and parameters
 - Fixed an issue where CJK (Chinese, Japanese, Korean) history could become unrenderable during repeated context compactions.
 - Fixed a memory exhaustion bug in the TUI when using `/resume` on large previous sessions.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -144,7 +144,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Developer",
 	],
 	tasks: ["Modes", "Subagents", "Isolation", "Commands & Skills"],
-	providers: ["Services", "Fireworks", "Tiny Model", "Protocol", "Privacy"],
+	providers: ["Services", "Fireworks", "Tiny Model", "Protocol", "Timeouts", "Privacy"],
 };
 
 /** Status line segment identifiers */
@@ -4550,6 +4550,44 @@ export const SETTINGS_SCHEMA = {
 				{ value: "auto", label: "Auto", description: "Use model/provider default websocket behavior" },
 				{ value: "off", label: "Off", description: "Disable websockets for OpenAI Codex models" },
 				{ value: "on", label: "On", description: "Force websockets for OpenAI Codex models" },
+			],
+		},
+	},
+
+	"providers.streamFirstEventTimeoutSeconds": {
+		type: "number",
+		default: -1,
+		ui: {
+			tab: "providers",
+			group: "Timeouts",
+			label: "Stream First Event Timeout",
+			description:
+				"Seconds to wait for the first model stream event; -1 uses provider/env defaults, 0 disables the watchdog",
+			options: [
+				{ value: "-1", label: "Auto", description: "Use provider defaults and PI_* timeout env vars" },
+				{ value: "0", label: "Off", description: "Disable first-event timeout" },
+				{ value: "300", label: "5 minutes" },
+				{ value: "600", label: "10 minutes" },
+				{ value: "1800", label: "30 minutes" },
+			],
+		},
+	},
+
+	"providers.streamIdleTimeoutSeconds": {
+		type: "number",
+		default: -1,
+		ui: {
+			tab: "providers",
+			group: "Timeouts",
+			label: "Stream Idle Timeout",
+			description:
+				"Seconds a model stream may stay silent between events; -1 uses provider/env defaults, 0 disables the watchdog",
+			options: [
+				{ value: "-1", label: "Auto", description: "Use provider defaults and PI_* timeout env vars" },
+				{ value: "0", label: "Off", description: "Disable idle timeout" },
+				{ value: "300", label: "5 minutes" },
+				{ value: "600", label: "10 minutes" },
+				{ value: "1800", label: "30 minutes" },
 			],
 		},
 	},

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -2,8 +2,8 @@
  * Settings-aware stream wrapper shared by the main agent (sdk.ts) and the
  * advisor agent (AgentSession.#buildAdvisorRuntime).
  *
- * Reads OpenRouter / Antigravity routing variants, Responses-family text
- * verbosity, per-provider in-flight caps, and the loop guard out of `Settings`
+ * verbosity, stream watchdog budgets, per-provider in-flight caps, and the loop
+ * guard out of `Settings`
  * per request, layering them onto whatever options the caller passed. Before
  * this helper existed, advisor turns called bare `streamSimple` while the main
  * turn went through an inline closure that read these settings — so an advisor on
@@ -13,6 +13,12 @@
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
 import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
+
+function timeoutSecondsToMs(value: number): number | undefined {
+	if (!Number.isFinite(value) || value < 0) return undefined;
+	if (value === 0) return 0;
+	return Math.max(1, Math.trunc(value * 1000));
+}
 
 /**
  * Build a {@link StreamFn} that reads provider routing/guard settings from
@@ -30,11 +36,15 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			model.api === "openai-codex-responses" || model.api === "openai-responses"
 				? settings.get("textVerbosity")
 				: undefined;
+		const streamFirstEventTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamFirstEventTimeoutSeconds"));
+		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
 		const merged: SimpleStreamOptions = {
 			...streamOptions,
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
 			antigravityEndpointMode: streamOptions?.antigravityEndpointMode ?? antigravityEndpointMode,
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,
+			streamFirstEventTimeoutMs: streamOptions?.streamFirstEventTimeoutMs ?? streamFirstEventTimeoutMs,
+			streamIdleTimeoutMs: streamOptions?.streamIdleTimeoutMs ?? streamIdleTimeoutMs,
 			maxInFlightRequests: validateProviderMaxInFlightRequests(
 				streamOptions?.maxInFlightRequests ?? settings.get("providers.maxInFlightRequests"),
 			),

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -1,8 +1,8 @@
 /**
  * Contract: `createSettingsAwareStreamFn` layers session provider settings
  * (`providers.openrouterVariant`, `providers.antigravityEndpoint`,
- * `providers.maxInFlightRequests`, `model.loopGuard.*`, `textVerbosity` for
- * Responses-family requests) onto every call while letting caller-supplied
+ * `providers.stream*TimeoutSeconds`, `providers.maxInFlightRequests`,
+ * `model.loopGuard.*`, `textVerbosity` for Responses-family requests)
  * options win — the same wiring the main agent and the advisor agent share so
  * OpenRouter sticky-routing / response caching behaves the same on advisor turns
  * (can1357/oh-my-pi#3639).
@@ -63,6 +63,26 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[0]?.options?.textVerbosity).toBe("low");
 		expect(calls[1]?.options?.textVerbosity).toBe("low");
 		expect(calls[2]?.options?.textVerbosity).toBe("medium");
+	});
+
+	it("forwards configured stream watchdog budgets while preserving caller overrides", () => {
+		const settings = Settings.isolated({
+			"providers.streamFirstEventTimeoutSeconds": 600,
+			"providers.streamIdleTimeoutSeconds": 300,
+		});
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubModel, stubContext, undefined);
+		wrapped(stubModel, stubContext, {
+			streamFirstEventTimeoutMs: 15_000,
+			streamIdleTimeoutMs: 10_000,
+		});
+
+		expect(calls[0]?.options?.streamFirstEventTimeoutMs).toBe(600_000);
+		expect(calls[0]?.options?.streamIdleTimeoutMs).toBe(300_000);
+		expect(calls[1]?.options?.streamFirstEventTimeoutMs).toBe(15_000);
+		expect(calls[1]?.options?.streamIdleTimeoutMs).toBe(10_000);
 	});
 
 	it("treats the default openrouterVariant as absent so the base call carries no variant", () => {

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
+		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");


### PR DESCRIPTION
## Repro
Reproduced the local-LLM timeout configuration gap by importing `Settings` and `createSettingsAwareStreamFn`, setting `providers.streamIdleTimeoutSeconds=300` and `providers.streamFirstEventTimeoutSeconds=600`, invoking the stream wrapper, and asserting the forwarded options contained `streamIdleTimeoutMs=300000` / `streamFirstEventTimeoutMs=600000`; before the fix, the wrapper forwarded only routing/concurrency/loop-guard options and the assertion failed.

## Cause
`packages/coding-agent/src/session/settings-stream-fn.ts` layered provider settings onto every model request, but it had no persisted timeout settings to read from `packages/coding-agent/src/config/settings-schema.ts` and therefore never populated `SimpleStreamOptions.streamIdleTimeoutMs` or `streamFirstEventTimeoutMs`; slow local OpenAI-compatible streams could only be tuned through environment variables or model metadata.

## Fix
- Added `providers.streamFirstEventTimeoutSeconds` and `providers.streamIdleTimeoutSeconds` settings with `-1` auto, `0` disable, and positive-second override semantics.
- Converted those persisted seconds values to stream option milliseconds in `createSettingsAwareStreamFn`, while preserving caller-supplied per-request overrides.
- Added regression coverage in `packages/coding-agent/test/settings-stream-fn.test.ts` and documented the persisted config equivalents for the OpenAI stream timeout env vars.

## Verification
`bun test packages/coding-agent/test/settings-stream-fn.test.ts` passed; `bun test packages/coding-agent/test/config-cli.test.ts packages/coding-agent/test/settings-stream-fn.test.ts` passed; `bun check` passed. Fixes #3878