### PR TITLE
Fix local URL delimiter handling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improved error reporting for `omp tiny-models download` by displaying the actual worker-side download error.
 - Resolved status inconsistencies between `/extensions`, `/mcp list`, and the dashboard, ensuring MCP server states, allowlists/denylists, and configuration files (like `mcp.json`) stay fully synchronized.
 - Improved branch-mode task merges to preserve the agent's original commit history (messages and authors) and fixed a bug where merges were rejected due to unrelated dirty changes in the parent checkout.
+- Fixed `local://` URLs with raw query strings or fragments silently resolving the truncated path; literal `?` and `#` filenames now require `%3F` and `%23`.
 
 ## [16.2.6] - 2026-06-29
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -189,9 +189,29 @@ async function listFilesRecursively(rootPath: string): Promise<string[]> {
 	return files.sort((a, b) => a.localeCompare(b));
 }
 
+function encodeLocalUrlPath(relativePath: string): string {
+	return relativePath
+		.split("/")
+		.map(segment => encodeURIComponent(segment))
+		.join("/");
+}
+
+function rawDelimiterKind(url: InternalUrl): "query" | "fragment" | null {
+	const queryIndex = url.href.indexOf("?");
+	const fragmentIndex = url.href.indexOf("#");
+	if (fragmentIndex !== -1 && (queryIndex === -1 || fragmentIndex < queryIndex)) {
+		return "fragment";
+	}
+	if (queryIndex !== -1) {
+		return "query";
+	}
+	return null;
+}
+
 async function buildListing(url: InternalUrl, localRoot: string): Promise<InternalResource> {
 	const files = await listFilesRecursively(localRoot);
-	const listing = files.length === 0 ? "(empty)" : files.map(file => `- [${file}](local://${file})`).join("\n");
+	const listing =
+		files.length === 0 ? "(empty)" : files.map(file => `- [${file}](local://${encodeLocalUrlPath(file)})`).join("\n");
 	const content =
 		`# Local\n\n` +
 		`Session-scoped scratch space for large intermediate data, subagent handoffs, and reusable planning artifacts.\n\n` +
@@ -209,6 +229,21 @@ async function buildListing(url: InternalUrl, localRoot: string): Promise<Intern
 }
 
 function extractRelativePath(url: InternalUrl): string {
+	// `?`/`#` are URL delimiters, so parseInternalUrl strips them from the path
+	// (`local://note.txt?draft` → `note.txt`). Reject the unsupported suffix instead of
+	// silently operating on the truncated path; a literal `?`/`#` in a filename
+	// must be percent-encoded (`%3F`/`%23`).
+	const rawDelimiter = rawDelimiterKind(url);
+	if (rawDelimiter === "query") {
+		throw new Error(
+			`local:// does not support URL query strings; percent-encode a literal '?' as %3F in the path: ${url.href}`,
+		);
+	}
+	if (rawDelimiter === "fragment") {
+		throw new Error(
+			`local:// does not support URL fragments; percent-encode a literal '#' as %23 in the path: ${url.href}`,
+		);
+	}
 	const host = url.rawHost || url.hostname;
 	const pathname = url.rawPathname ?? url.pathname;
 
@@ -460,7 +495,7 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		const localRoot = path.resolve(resolveLocalRoot(opts));
 		try {
 			const files = await listFilesRecursively(localRoot);
-			return files.map(value => ({ value }));
+			return files.map(file => ({ value: encodeLocalUrlPath(file), label: file }));
 		} catch (err) {
 			if (isEnoent(err)) return [];
 			throw err;

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -195,4 +195,113 @@ describe("LocalProtocolHandler", () => {
 			).rejects.toThrow("Local file not found: local://PLAN.md");
 		});
 	});
+
+	it("rejects raw query and fragment delimiters in local URLs", async () => {
+		await withTempDir(async tempDir => {
+			const artifactsDir = path.join(tempDir, "artifacts");
+			await fs.mkdir(path.join(artifactsDir, "local"), { recursive: true });
+			await Bun.write(path.join(artifactsDir, "local", "note.txt"), "base");
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "session-query-fragment",
+			});
+			const router = InternalUrlRouter.instance();
+
+			await expect(router.resolve("local://note.txt?draft")).rejects.toThrow(
+				"local:// does not support URL query strings",
+			);
+			await expect(router.resolve("local://note.txt#draft")).rejects.toThrow(
+				"local:// does not support URL fragments",
+			);
+			expect(() =>
+				resolveLocalUrlToPath("local://note.txt?draft", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-query-fragment",
+				}),
+			).toThrow("local:// does not support URL query strings");
+			expect(() =>
+				resolveLocalUrlToPath("local://note.txt#draft", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-query-fragment",
+				}),
+			).toThrow("local:// does not support URL fragments");
+			await expect(router.resolve("local://note.txt?")).rejects.toThrow(
+				"local:// does not support URL query strings",
+			);
+			await expect(router.resolve("local://note.txt#")).rejects.toThrow("local:// does not support URL fragments");
+			expect(() =>
+				resolveLocalUrlToPath("local://note.txt?", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-query-fragment",
+				}),
+			).toThrow("local:// does not support URL query strings");
+			expect(() =>
+				resolveLocalUrlToPath("local://note.txt#", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-query-fragment",
+				}),
+			).toThrow("local:// does not support URL fragments");
+		});
+	});
+
+	it("resolves percent-encoded query and fragment characters as filename bytes", async () => {
+		await withTempDir(async tempDir => {
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const localRoot = path.join(artifactsDir, "local");
+			await fs.mkdir(localRoot, { recursive: true });
+			await Bun.write(path.join(localRoot, "note.txt#draft"), "fragment file");
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "session-encoded-delimiters",
+			});
+			const router = InternalUrlRouter.instance();
+
+			if (process.platform !== "win32") {
+				await Bun.write(path.join(localRoot, "note.txt?draft"), "query file");
+				const queryResource = await router.resolve("local://note.txt%3Fdraft");
+				expect(queryResource.content).toBe("query file");
+			}
+			const fragmentResource = await router.resolve("local://note.txt%23draft");
+
+			expect(fragmentResource.content).toBe("fragment file");
+			expect(
+				resolveLocalUrlToPath("local://note.txt%3Fdraft", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-encoded-delimiters",
+				}),
+			).toBe(path.join(localRoot, "note.txt?draft"));
+			expect(
+				resolveLocalUrlToPath("local://note.txt%23draft", {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "session-encoded-delimiters",
+				}),
+			).toBe(path.join(localRoot, "note.txt#draft"));
+		});
+	});
+
+	it("percent-encodes generated listing links and completion values", async () => {
+		await withTempDir(async tempDir => {
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const localRoot = path.join(artifactsDir, "local");
+			await fs.mkdir(path.join(localRoot, "nested dir"), { recursive: true });
+			await Bun.write(path.join(localRoot, "nested dir", "note#draft.txt"), "fragment file");
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "session-generated-links",
+			});
+			const router = InternalUrlRouter.instance();
+
+			const listing = await router.resolve("local://");
+			const completions = await router.complete("local", "");
+
+			expect(listing.content).toContain("[nested dir/note#draft.txt](local://nested%20dir/note%23draft.txt)");
+			expect(completions).toContainEqual({
+				value: "nested%20dir/note%23draft.txt",
+				label: "nested dir/note#draft.txt",
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- reject raw `?` and `#` delimiters in `local://` paths instead of resolving the truncated path
- keep percent-encoded `%3F` / `%23` filenames working
- percent-encode generated local listing links and completion values while preserving raw completion labels

## Verification
- `bun test test/internal-urls/local-protocol.test.ts`
- `bun run check`