### PR TITLE
fix(coding-agent): handle BigInt tool-call fingerprints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed status-line redraws crashing when tool-call arguments contain `BigInt` values.
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.test.ts
@@ -1,0 +1,44 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "../../../config/settings";
+import type { AgentSession } from "../../../session/agent-session";
+import { getThemeByName, setThemeInstance } from "../../theme/theme";
+import { StatusLineComponent } from "./component";
+
+function makeSessionWithLastMessage(lastMessage: unknown) {
+	return {
+		messages: [lastMessage],
+		model: { contextWindow: 128000 },
+		contextUsageRevision: 0,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		getContextUsage: () => ({ tokens: 42, contextWindow: 128000 }),
+	};
+}
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+	const loaded = await getThemeByName("dark");
+	if (!loaded) throw new Error("theme unavailable");
+	setThemeInstance(loaded);
+});
+
+describe("StatusLineComponent", () => {
+	it("fingerprints tool-call arguments containing bigint values", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage({
+				role: "assistant",
+				timestamp: 1,
+				content: [
+					{
+						type: "toolCall",
+						name: "read",
+						arguments: { offset: 1n, nested: { limit: 2n } },
+					},
+				],
+			}) as unknown as AgentSession,
+		);
+
+		expect(statusLine.getCachedContextBreakdown()).toEqual({ usedTokens: 42, contextWindow: 128000 });
+	});
+});

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -118,7 +118,16 @@ function messageFingerprint(msg: AgentMessage): string {
 					redactedLen += b.data.length;
 				} else if (b.type === "toolCall") {
 					if (typeof b.name === "string") textLen += b.name.length;
-					textLen += b.arguments === undefined ? 0 : JSON.stringify(b.arguments).length;
+					if (b.arguments !== undefined) {
+						try {
+							textLen +=
+								JSON.stringify(b.arguments, (_key, value) =>
+									typeof value === "bigint" ? value.toString() : value,
+								)?.length ?? 0;
+						} catch {
+							textLen += String(b.arguments).length;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What

- Makes status-line context fingerprinting tolerate `BigInt` values inside assistant tool-call arguments.
- Adds a regression test for nested `BigInt` tool-call arguments.
- Updates the coding-agent changelog.

## Why

Model selection forces a status-line redraw. If the latest assistant tool-call arguments contain a `BigInt`, the previous fingerprint path used raw `JSON.stringify(...)` and threw `JSON.stringify cannot serialize BigInt`, surfacing as a model-picker error even though the selected model metadata is JSON-safe.

## Testing

- `bun test packages/coding-agent/src/modes/components/status-line/component.test.ts`
- `bun run check` from `packages/coding-agent`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
