### PR TITLE
fix(tui): align Warp editor border widths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Warp editor border alignment by measuring reported one-cell status glyphs with Warp-compatible widths ([#3885](https://github.com/can1357/oh-my-pi/issues/3885)).
+
 ## [16.2.7] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
-import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import { type Component, detectTerminalId, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { settings } from "../../../config/settings";
@@ -228,6 +228,33 @@ function hasPathSegment(segments: readonly StatusLineSegmentId[]): boolean {
 
 function hasGitBackedSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return hasGitSegment(segments) || hasPrSegment(segments);
+}
+// Warp reports these status glyphs as one terminal cell; use that width only for
+// the editor border budget so box-drawing fill still lands on the right corner.
+const WARP_ONE_CELL_STATUS_GLYPH_DELTAS = new Map(
+	(["⬢", "◕", "⑂", "💾", "◫", "⟲", "⏱"] as const)
+		.map(glyph => [glyph, 1 - visibleWidth(glyph)] as const)
+		.filter(([, delta]) => delta !== 0),
+);
+
+function countOccurrences(text: string, needle: string): number {
+	let count = 0;
+	for (let index = text.indexOf(needle); index !== -1; index = text.indexOf(needle, index + needle.length)) {
+		count++;
+	}
+	return count;
+}
+
+function statusLineWidth(content: string): number {
+	const width = visibleWidth(content);
+	if (detectTerminalId() !== "warp" || WARP_ONE_CELL_STATUS_GLYPH_DELTAS.size === 0) return width;
+
+	const plain = Bun.stripANSI(content);
+	let delta = 0;
+	for (const [glyph, glyphDelta] of WARP_ONE_CELL_STATUS_GLYPH_DELTAS) {
+		delta += countOccurrences(plain, glyph) * glyphDelta;
+	}
+	return Math.max(0, width + delta);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1273,7 +1300,7 @@ export class StatusLineComponent implements Component {
 		}
 		return {
 			content,
-			width: visibleWidth(content),
+			width: statusLineWidth(content),
 		};
 	}
 

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -25,6 +25,24 @@ afterAll(() => {
 	setProjectDir(originalProjectDir);
 });
 
+function withTermProgram(value: string | undefined, run: () => void): void {
+	const previous = Bun.env.TERM_PROGRAM;
+	if (value === undefined) {
+		delete Bun.env.TERM_PROGRAM;
+	} else {
+		Bun.env.TERM_PROGRAM = value;
+	}
+	try {
+		run();
+	} finally {
+		if (previous === undefined) {
+			delete Bun.env.TERM_PROGRAM;
+		} else {
+			Bun.env.TERM_PROGRAM = previous;
+		}
+	}
+}
+
 /** Minimal SegmentContext factory — only path/git fields matter for these tests. */
 function createCtx(overrides?: { pathMaxLength?: number; branch?: string | null }): SegmentContext {
 	return {
@@ -130,6 +148,22 @@ describe("status line session accent", () => {
 		// glyph) must not appear. The session_name segment may still emit the accent ANSI
 		// for its own text — we only care that the gap is not accent-painted.
 		expect(border).not.toContain(`${ansi}${theme.boxRound.horizontal}`);
+	});
+	it("uses Warp's one-cell status glyph width for the editor border budget", () => {
+		withTermProgram("WarpTerminal", () => {
+			const component = new StatusLineComponent(createStatusLineSession("cache 💾"));
+			component.updateSettings({
+				preset: "custom",
+				leftSegments: ["session_name"],
+				rightSegments: [],
+				separator: "ascii",
+			});
+
+			const border = component.getTopBorder(80);
+
+			expect(border.content).toContain("💾");
+			expect(border.width).toBe(visibleWidth(border.content) - 1);
+		});
 	});
 });
 

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
+		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -73,7 +73,7 @@ describe("DuckDuckGo web search provider", () => {
 		const headers = capturedInit?.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 		expect(headers["User-Agent"]).toContain("Mozilla/5.0");
-		expect(headers.Referer).toBe("https://html.duckduckgo.com/");
+		expect(headers["Referer"]).toBe("https://html.duckduckgo.com/");
 		expect(headers["Accept-Language"]).toContain("en");
 		expect(headers["Sec-Fetch-Mode"]).toBe("navigate");
 		expect(headers["Sec-Ch-Ua"]).toContain("Chromium");


### PR DESCRIPTION
## Repro
Rendering the editor top border with the reported glyph set at 140 columns measured 140 columns with OMP's `visibleWidth`, but 139 columns under a Warp-style one-cell width for the listed status glyphs (`💾` accounts for the observed one-column underfill). Command: JS eval rendering `Editor` with the reported top-border content and comparing OMP width to Warp-simulated width.

## Cause
`StatusLineComponent.getTopBorder()` returned `visibleWidth(content)` from `@oh-my-pi/pi-tui`, while `Editor.render()` trusted that width to choose the trailing `─` fill. Warp renders the reported status glyphs as one-cell text glyphs, so the editor reserved too many cells for the status content and emitted one fewer fill cell before the right border corner.

## Fix
- Added a Warp-only status-line width adjustment for the reported one-cell glyphs used in the editor top border.
- Kept the adjustment scoped to the status-line border budget; the rendered glyphs and normal Unicode width model are unchanged outside Warp.
- Added regression coverage for `TERM_PROGRAM=WarpTerminal` so the status-line top-border width reports the Warp-compatible width.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification
- `bun test packages/coding-agent/test/status-line-overflow.test.ts` passed: 11 tests, 25 assertions.
- `bun check` passed across the workspace.

Fixes #3885