### PR TITLE
fix(coding-agent): replay scrollback on theme changes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed slow local LLM streams by forwarding persisted stream timeout settings (`providers.streamFirstEventTimeoutSeconds`, `providers.streamIdleTimeoutSeconds`) into model requests, so users can widen or disable watchdogs without environment variables. ([#3878](https://github.com/can1357/oh-my-pi/issues/3878))
 - Fixed the bash interceptor blocking `echo` / `printf` redirects to `/dev/null`, `/dev/tty`, `/dev/stdout`, and `/dev/stderr` device sinks while still directing real file writes to the write tool. ([#3763](https://github.com/can1357/oh-my-pi/issues/3763))
 - Fixed long snapcompact sessions re-sending multi-megabyte standing image archives on every provider request by enforcing a per-request frame byte budget, letting auto-compaction fall back to context-full summaries when snapcompact output is too large, and omitting legacy over-budget frames from rebuilt LLM contexts. ([#3792](https://github.com/can1357/oh-my-pi/issues/3792))
+- Fixed committed native scrollback rows retaining the previous palette after committed theme switches; direct-terminal theme swaps now replay the transcript so scrolling history matches the live viewport without making theme previews destructive.
 
 ## [16.2.7] - 2026-06-30
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -36,6 +36,7 @@ import {
 	TUI,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
+import { isInsideTerminalMultiplexer } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import {
 	APP_NAME,
 	adjustHsv,
@@ -961,13 +962,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 		// Set up theme file watcher
 		this.#eventBusUnsubscribers.push(
-			onThemeChange(() => {
+			onThemeChange(event => {
 				this.#clearWorkingMessageAccentCache();
 				clearRenderCache();
 				clearMermaidCache();
 				this.ui.invalidate();
 				this.updateEditorBorderColor();
-				this.ui.requestRender();
+				if (event.ephemeral || isInsideTerminalMultiplexer()) {
+					// Theme previews and multiplexer panes cannot safely replace native
+					// scrollback: previews must stay non-destructive, and multiplexers
+					// suppress ED3 so a forced replay would duplicate transcript history.
+					this.ui.requestRender();
+					return;
+				}
+				// Rows already committed to native scrollback are immutable; replay them
+				// after a theme swap so a reader scrolled up sees the same palette.
+				this.ui.requestRender(true, { clearScrollback: true });
 			}),
 		);
 

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/theme.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/theme.ts
@@ -256,7 +256,7 @@ class ThemeSceneController implements SetupSceneController {
 		} else {
 			this.host.ctx.settings.set("theme.dark", themeName);
 		}
-		await previewTheme(themeName);
+		await previewTheme(themeName, { ephemeral: false });
 	}
 
 	async #preview(value: string): Promise<void> {
@@ -270,7 +270,7 @@ class ThemeSceneController implements SetupSceneController {
 		let result: { success: boolean; error?: string } = { success: true };
 		if (value === "auto") {
 			await this.#applyPreviewPresentation(this.#originalSymbolPreset, this.#originalColorBlindMode);
-			enableAutoTheme();
+			enableAutoTheme({ ephemeral: true });
 		} else if (value === "colorblind") {
 			await this.#applyPreviewPresentation(this.#originalSymbolPreset, true);
 		} else if (value === "ansi") {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2151,6 +2151,11 @@ export function getCurrentThemeName(): string | undefined {
 export function fgOrPlain(color: ThemeColor, text: string, styledText: string = text): string {
 	return typeof theme === "undefined" ? text : theme.fg(color, styledText);
 }
+export interface ThemeChangeEvent {
+	/** Preview/presentation-only changes should repaint live UI without replacing native scrollback. */
+	ephemeral?: boolean;
+}
+
 var currentSymbolPresetOverride: SymbolPreset | undefined;
 var currentColorBlindMode: boolean = false;
 var themeWatcher: fs.FSWatcher | undefined;
@@ -2159,7 +2164,7 @@ var sigwinchHandler: (() => void) | undefined;
 var autoDetectedTheme: boolean = false;
 var autoDarkTheme: string = "dark";
 var autoLightTheme: string = "light";
-var onThemeChangeCallback: (() => void) | undefined;
+var onThemeChangeCallback: ((event: ThemeChangeEvent) => void) | undefined;
 var themeLoadRequestId: number = 0;
 let themeEpoch = 0;
 
@@ -2235,7 +2240,10 @@ export async function setTheme(
 	}
 }
 
-export async function previewTheme(name: string): Promise<{ success: boolean; error?: string }> {
+export async function previewTheme(
+	name: string,
+	event: ThemeChangeEvent = { ephemeral: true },
+): Promise<{ success: boolean; error?: string }> {
 	const requestId = ++themeLoadRequestId;
 	try {
 		const loadedTheme = await loadTheme(name, getCurrentThemeOptions());
@@ -2243,7 +2251,7 @@ export async function previewTheme(name: string): Promise<{ success: boolean; er
 			return { success: false, error: "Theme preview superseded by a newer request" };
 		}
 		theme = loadedTheme;
-		notifyThemeChange();
+		notifyThemeChange(event);
 		return { success: true };
 	} catch (error) {
 		if (requestId !== themeLoadRequestId) {
@@ -2259,9 +2267,9 @@ export async function previewTheme(name: string): Promise<{ success: boolean; er
 /**
  * Enable auto-detection mode, switching to the appropriate dark/light theme.
  */
-export function enableAutoTheme(): void {
+export function enableAutoTheme(event: ThemeChangeEvent = {}): void {
 	autoDetectedTheme = true;
-	reevaluateAutoTheme("enableAutoTheme");
+	reevaluateAutoTheme("enableAutoTheme", event);
 }
 
 /**
@@ -2290,7 +2298,7 @@ export function setThemeInstance(themeInstance: Theme): void {
 	theme = themeInstance;
 	currentThemeName = "<in-memory>";
 	stopThemeWatcher();
-	notifyThemeChange();
+	notifyThemeChange({ ephemeral: true });
 }
 
 /**
@@ -2311,7 +2319,7 @@ export async function setSymbolPreset(preset: SymbolPreset): Promise<void> {
 		theme = await loadTheme("dark", getCurrentThemeOptions());
 		if (requestId !== themeLoadRequestId) return;
 	}
-	notifyThemeChange();
+	notifyThemeChange({ ephemeral: true });
 }
 
 /**
@@ -2340,7 +2348,7 @@ export async function setColorBlindMode(enabled: boolean): Promise<void> {
 		theme = await loadTheme("dark", getCurrentThemeOptions());
 		if (requestId !== themeLoadRequestId) return;
 	}
-	notifyThemeChange();
+	notifyThemeChange({ ephemeral: true });
 }
 
 /**
@@ -2350,7 +2358,7 @@ export function getColorBlindMode(): boolean {
 	return currentColorBlindMode;
 }
 
-export function onThemeChange(callback: () => void): () => void {
+export function onThemeChange(callback: (event: ThemeChangeEvent) => void): () => void {
 	onThemeChangeCallback = callback;
 	return () => {
 		if (onThemeChangeCallback === callback) {
@@ -2371,9 +2379,9 @@ export function getThemeEpoch(): number {
 }
 
 /** Bump the theme epoch and notify the registered theme-change listener. */
-function notifyThemeChange(): void {
+function notifyThemeChange(event: ThemeChangeEvent = {}): void {
 	themeEpoch++;
-	onThemeChangeCallback?.();
+	onThemeChangeCallback?.(event);
 }
 
 /**
@@ -2428,7 +2436,7 @@ async function startThemeWatcher(): Promise<void> {
 			loadTheme(watchedThemeName, getCurrentThemeOptions())
 				.then(loadedTheme => {
 					theme = loadedTheme;
-					notifyThemeChange();
+					notifyThemeChange({ ephemeral: true });
 				})
 				.catch(() => {
 					// Ignore errors (file might be in invalid state while being edited)
@@ -2460,7 +2468,7 @@ async function startThemeWatcher(): Promise<void> {
  * Shared logic for re-evaluating the auto-detected theme.
  * Called from SIGWINCH, terminal appearance change handler, and macOS fallback observer.
  */
-function reevaluateAutoTheme(debugLabel: string): void {
+function reevaluateAutoTheme(debugLabel: string, event: ThemeChangeEvent = {}): void {
 	if (!autoDetectedTheme) return;
 	const resolved = getDefaultTheme();
 	if (resolved === currentThemeName) return;
@@ -2468,7 +2476,7 @@ function reevaluateAutoTheme(debugLabel: string): void {
 	loadTheme(resolved, getCurrentThemeOptions())
 		.then(loadedTheme => {
 			theme = loadedTheme;
-			notifyThemeChange();
+			notifyThemeChange(event);
 		})
 		.catch(err => {
 			logger.debug(`Theme switch on ${debugLabel} failed`, { error: String(err) });

--- a/packages/coding-agent/test/interactive-theme-scrollback.test.ts
+++ b/packages/coding-agent/test/interactive-theme-scrollback.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { enableAutoTheme, initTheme, previewTheme, setTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TUI } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "STY", "ZELLIJ", "CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "TERM"] as const;
+
+let originalMultiplexerEnv: Partial<Record<(typeof MULTIPLEXER_ENV_KEYS)[number], string | undefined>>;
+describe("InteractiveMode theme scrollback refresh", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+	let terminal: VirtualTerminal;
+
+	beforeEach(async () => {
+		originalMultiplexerEnv = {};
+		for (const key of MULTIPLEXER_ENV_KEYS) {
+			originalMultiplexerEnv[key] = Bun.env[key];
+			delete Bun.env[key];
+		}
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-theme-scrollback-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path(), overrides: { "startup.quiet": true } });
+		await initTheme();
+		await setTheme("dark");
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({ "startup.quiet": true }),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		terminal = new VirtualTerminal(100, 20);
+		mode.ui = new TUI(terminal);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		await mode.init({ suppressWelcomeIntro: true });
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		await setTheme("dark");
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		for (const key of MULTIPLEXER_ENV_KEYS) {
+			const value = originalMultiplexerEnv[key];
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("emits a full scrollback replay when the active theme changes", async () => {
+		await terminal.waitForRender();
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		await setTheme("light");
+		await terminal.waitForRender();
+
+		expect(writes.join("")).toContain("\x1b[3J");
+	});
+
+	it("keeps theme previews as non-destructive viewport repaints", async () => {
+		await terminal.waitForRender();
+		const fullRedraws = mode.ui.fullRedraws;
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		await previewTheme("light");
+		await terminal.waitForRender();
+
+		expect(mode.ui.fullRedraws).toBe(fullRedraws);
+		expect(writes.join("")).not.toContain("\x1b[3J");
+	});
+
+	it("emits a full scrollback replay when a previewed theme is committed", async () => {
+		await terminal.waitForRender();
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		await previewTheme("light", { ephemeral: false });
+		await terminal.waitForRender();
+
+		expect(writes.join("")).toContain("\x1b[3J");
+	});
+
+	it("keeps auto-theme previews as non-destructive viewport repaints", async () => {
+		await terminal.waitForRender();
+		const originalColorFgBg = Bun.env.COLORFGBG;
+		Bun.env.COLORFGBG = "0;15";
+		const fullRedraws = mode.ui.fullRedraws;
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		try {
+			enableAutoTheme({ ephemeral: true });
+			await terminal.waitForRender();
+		} finally {
+			if (originalColorFgBg === undefined) {
+				delete Bun.env.COLORFGBG;
+			} else {
+				Bun.env.COLORFGBG = originalColorFgBg;
+			}
+		}
+
+		expect(mode.ui.fullRedraws).toBe(fullRedraws);
+		expect(writes.join("")).not.toContain("\x1b[3J");
+	});
+
+	it("keeps theme changes as viewport repaints inside terminal multiplexers", async () => {
+		await terminal.waitForRender();
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1,0";
+		const fullRedraws = mode.ui.fullRedraws;
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		await setTheme("light");
+		await terminal.waitForRender();
+
+		expect(mode.ui.fullRedraws).toBe(fullRedraws);
+		expect(writes.join("")).not.toContain("\x1b[3J");
+	});
+});

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -144,6 +144,18 @@ export function isInsideTmux(env: NodeJS.ProcessEnv = Bun.env): boolean {
 	return Boolean(env.TMUX);
 }
 
+/** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
+export function isInsideTerminalMultiplexer(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	// TMUX/STY/ZELLIJ/CMUX workspace+surface ids are authoritative session
+	// signals. TERM can also survive when those are stripped (`sudo` without -E,
+	// `su`, env-sanitizing launchers/ssh). Do not use CMUX_SOCKET_PATH here: it is
+	// a CLI socket override and can be set outside a CMUX terminal.
+	if (env.TMUX || env.STY || env.ZELLIJ) return true;
+	if (env.CMUX_WORKSPACE_ID || env.CMUX_SURFACE_ID) return true;
+	const term = env.TERM?.toLowerCase() ?? "";
+	return term.startsWith("tmux") || term.startsWith("screen");
+}
+
 /**
  * Wrap a control-sequence payload in tmux's DCS passthrough envelope. Each
  * ESC byte inside `payload` is doubled per tmux's escape rules. tmux strips
@@ -256,8 +268,7 @@ export function shouldEnableSynchronizedOutputByDefault(
 	// older tmux/screen synchronized-output handling is flaky and a mux may not
 	// pass DEC 2026 to the outer host. The DECRQM probe re-enables sync when the
 	// mux reports `?2026` supported.
-	const term = env.TERM?.toLowerCase() ?? "";
-	if (env.TMUX || env.STY || env.ZELLIJ || term.startsWith("tmux") || term.startsWith("screen")) {
+	if (isInsideTerminalMultiplexer(env)) {
 		return false;
 	}
 
@@ -301,8 +312,7 @@ export function detectRectangularSgrSupport(terminalId: TerminalId, env: NodeJS.
 	if (terminalId !== "kitty") return false;
 	const kill = env.PI_NO_DECCARA;
 	if (kill && kill !== "0" && kill.toLowerCase() !== "false") return false;
-	const term = env.TERM?.toLowerCase() ?? "";
-	if (env.TMUX || env.STY || env.ZELLIJ || term.startsWith("tmux") || term.startsWith("screen")) {
+	if (isInsideTerminalMultiplexer(env)) {
 		return false;
 	}
 	return true;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -21,6 +21,7 @@ import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
 import {
 	encodeKittyDeleteImage,
 	ImageProtocol,
+	isInsideTerminalMultiplexer,
 	setCellDimensions,
 	setTerminalImageProtocol,
 	shouldEnableSynchronizedOutputByDefault,
@@ -387,17 +388,7 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
-	// TMUX/STY/ZELLIJ/CMUX workspace+surface ids are authoritative session
-	// signals. TERM can also survive when those are stripped (`sudo` without -E,
-	// `su`, env-sanitizing launchers/ssh), so keep the TERM prefix fallback aligned
-	// with sibling multiplexer checks (terminal-capabilities.ts). Misclassifying a
-	// multiplexer as a direct terminal lets resize/reset paths emit ED3 (`CSI 3 J`)
-	// and wipe pane scrollback. Do not use CMUX_SOCKET_PATH here: it is a CLI socket
-	// override and can be set outside a CMUX terminal.
-	if (Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ) return true;
-	if (Bun.env.CMUX_WORKSPACE_ID || Bun.env.CMUX_SURFACE_ID) return true;
-	const term = Bun.env.TERM?.toLowerCase() ?? "";
-	return term.startsWith("tmux") || term.startsWith("screen");
+	return isInsideTerminalMultiplexer();
 }
 
 /**

--- a/packages/tui/test/deccara.test.ts
+++ b/packages/tui/test/deccara.test.ts
@@ -138,10 +138,11 @@ describe("detectRectangularSgrSupport", () => {
 		expect(detectRectangularSgrSupport("kitty", { PI_NO_DECCARA: "false" })).toBe(true);
 	});
 
-	it("disables under tmux/screen/zellij multiplexers", () => {
+	it("disables under tmux/screen/zellij/cmux multiplexers", () => {
 		expect(detectRectangularSgrSupport("kitty", { TMUX: "/tmp/tmux-1000/default,123,0" })).toBe(false);
 		expect(detectRectangularSgrSupport("kitty", { STY: "1234.pts-0" })).toBe(false);
 		expect(detectRectangularSgrSupport("kitty", { ZELLIJ: "0" })).toBe(false);
+		expect(detectRectangularSgrSupport("kitty", { CMUX_SURFACE_ID: "surface" })).toBe(false);
 		expect(detectRectangularSgrSupport("kitty", { TERM: "tmux-256color" })).toBe(false);
 		expect(detectRectangularSgrSupport("kitty", { TERM: "screen.xterm" })).toBe(false);
 	});

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -81,6 +81,7 @@ describe("shouldEnableSynchronizedOutputByDefault", () => {
 		expect(shouldEnableSynchronizedOutputByDefault({ TMUX: "1" }, "kitty")).toBe(false);
 		expect(shouldEnableSynchronizedOutputByDefault({ ZELLIJ: "0" }, "ghostty")).toBe(false);
 		expect(shouldEnableSynchronizedOutputByDefault({ STY: "x" }, "wezterm")).toBe(false);
+		expect(shouldEnableSynchronizedOutputByDefault({ CMUX_WORKSPACE_ID: "workspace" }, "wezterm")).toBe(false);
 		expect(shouldEnableSynchronizedOutputByDefault({ TERM: "tmux-256color" }, "iterm2")).toBe(false);
 		expect(shouldEnableSynchronizedOutputByDefault({ TERM: "screen-256color" }, "kitty")).toBe(false);
 	});


### PR DESCRIPTION
## Problem

Automatic light/dark theme switching updates the visible viewport, but rows already committed to native terminal scrollback keep the SGR palette they were originally written with.

That makes the active viewport show the selected theme while scrolled-back transcript content can still appear in the previous/default theme.

The theme-change notification path is also shared by previews and presentation-only changes, so scrollback replacement must be limited to committed theme switches.

## Solution

Thread a small `ThemeChangeEvent` through `notifyThemeChange()` so preview/presentation-only updates are marked `ephemeral`.

Committed theme switches in direct-terminal sessions request a forced full render with `clearScrollback: true`, clearing app scrollback and replaying the transcript with the current theme. Ephemeral updates keep the previous cheap viewport repaint. Multiplexer sessions also keep viewport repaint behavior because their pane history suppresses ED3; a full replay there would append a duplicate transcript behind the live viewport instead of replacing stale rows.

The setup wizard's “Match terminal” preview calls `enableAutoTheme({ ephemeral: true })`, while committed auto-theme selection keeps the default committed behavior. Saved concrete wizard themes call `previewTheme(themeName, { ephemeral: false })`, so committing a previewed theme still replays direct-terminal scrollback.

## Safety details

- Uses the existing TUI full-replay / clearScrollback path for direct-terminal committed theme switches instead of adding a new rendering mechanism.
- Keeps theme previews, auto-theme previews, symbol-preset previews, color-blind presentation changes, in-memory theme instances, and theme-file watcher reloads non-destructive.
- Keeps saved concrete wizard theme selections destructive-capable by explicitly marking the preview load as non-ephemeral at commit time.
- Detects tmux, screen, zellij, and cmux via a shared TUI helper so theme refreshes and TUI internals make the same multiplexer decision.
- Multiplexer theme changes repaint the visible viewport only, avoiding duplicate transcript appends into pane history.
- The full replay only runs on committed theme switches outside multiplexers, not on normal streaming, incremental render ticks, preview hovers, auto previews, or presentation-only changes.
- Regression coverage asserts direct-terminal ED3 replay, non-destructive preview repaint, committed preview replay, non-destructive auto-theme preview, multiplexer viewport-only repaint, and leaked `TMUX` test-env safety.

## Changes

**Theme refresh**
- Add `ThemeChangeEvent.ephemeral` to the theme-change notification path.
- Mark preview/presentation-only routes as ephemeral by default: `previewTheme`, `setThemeInstance`, `setSymbolPreset`, `setColorBlindMode`, and theme watcher reloads.
- Allow `previewTheme(themeName, { ephemeral: false })` for saved wizard selections that commit the previewed theme.
- Allow `enableAutoTheme({ ephemeral: true })` so setup-wizard auto-theme previews stay non-destructive.
- Replace the theme-change handler's normal render request with a forced clearScrollback replay only for non-ephemeral direct-terminal changes.
- Keep ephemeral and multiplexer theme changes on ordinary viewport repaint.

**TUI multiplexer detection**
- Expose a shared `isInsideTerminalMultiplexer` helper from terminal capabilities.
- Reuse it in TUI render internals, synchronized-output defaults, and DECCARA support detection.
- Cover cmux markers alongside tmux/screen/zellij in capability tests.

**Regression coverage**
- Add an `InteractiveMode` theme-change test that drives `setTheme("light")` and asserts direct terminal writes include `ESC[3J`.
- Add a `previewTheme("light")` variant that asserts previews do not full-redraw or emit ED3.
- Add a `previewTheme("light", { ephemeral: false })` variant that asserts committed previewed themes do replay scrollback.
- Add an `enableAutoTheme({ ephemeral: true })` variant that asserts auto previews do not full-redraw or emit ED3.
- Add a multiplexer variant that asserts committed theme changes do not trigger a full redraw or ED3.

**Release notes**
- Add a coding-agent changelog entry for committed theme-switch scrollback replay without destructive previews.

## Verification

- [x] `bun test packages/coding-agent/test/interactive-theme-scrollback.test.ts`
- [x] `TMUX=fake bun test packages/coding-agent/test/interactive-theme-scrollback.test.ts`
- [x] `bun test packages/tui/test/terminal-capabilities.test.ts packages/tui/test/deccara.test.ts`
- [x] `bun test packages/tui/test/render-regressions.test.ts packages/tui/test/overlay-scroll.test.ts packages/tui/test/issue-2130-repro.test.ts`
- [x] `bun --cwd=packages/coding-agent biome check src/modes/theme/theme.ts src/modes/setup-wizard/scenes/theme.ts src/modes/interactive-mode.ts test/interactive-theme-scrollback.test.ts CHANGELOG.md`
- [x] `bun --cwd=packages/tui biome check src/terminal-capabilities.ts src/tui.ts test/terminal-capabilities.test.ts test/deccara.test.ts`
- [x] `bun --cwd=packages/tui run check`
- [ ] `bun --cwd=packages/coding-agent run check` fails outside this change: root Biome completed, then TypeScript reports existing protobuf/message typing errors in `../ai/src/providers/cursor.ts` and `../ai/src/providers/devin.ts` (`Message<string>` mismatches and missing generated fields).
