### PR TITLE
fix(debug): guard v8.setFlagsFromString so CPU profiler works on Bun

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp debug --profile` failing on Bun with "node:v8 setFlagsFromString is not yet implemented in Bun" by treating the optional `--allow-natives-syntax` flag as best-effort, so the CPU profiler proceeds even on runtimes that don't expose `v8.setFlagsFromString`. ([#3897](https://github.com/can1357/oh-my-pi/issues/3897))
+
 ## [16.2.8] - 2026-06-30
 
 ### Added

--- a/packages/coding-agent/src/debug/profiler.ts
+++ b/packages/coding-agent/src/debug/profiler.ts
@@ -114,7 +114,13 @@ function formatProfileAsMarkdown(profileJson: string): string {
  */
 export async function startCpuProfile(): Promise<ProfilerSession> {
 	const v8 = await import("node:v8");
-	v8.setFlagsFromString("--allow-natives-syntax");
+	try {
+		// Enables `%GetOptimizationStatus` and friends when V8 natives are needed
+		// for ad-hoc profiling. Best-effort: Bun does not implement
+		// `setFlagsFromString` (oven-sh/bun#1702) but the CPU profiler itself
+		// works without it, so swallow the error and continue.
+		v8.setFlagsFromString("--allow-natives-syntax");
+	} catch {}
 
 	const { Session } = await import("node:inspector/promises");
 	const session = new Session();

--- a/packages/coding-agent/test/debug/profiler.test.ts
+++ b/packages/coding-agent/test/debug/profiler.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { startCpuProfile } from "@oh-my-pi/pi-coding-agent/debug/profiler";
+
+describe("startCpuProfile", () => {
+	// Regression: `node:v8` `setFlagsFromString` throws on Bun
+	// (oven-sh/bun#1702). The profiler used to call it unconditionally and
+	// crash before connecting the inspector session. Running this test under
+	// Bun guarantees the guard is in place — without it the call below would
+	// reject with "node:v8 setFlagsFromString is not yet implemented in Bun".
+	it("starts and stops successfully even when v8.setFlagsFromString is unavailable", async () => {
+		const session = await startCpuProfile();
+		// Run a tiny bit of work so the profile has at least one sample.
+		let acc = 0;
+		for (let i = 0; i < 10_000; i++) acc += i;
+		expect(acc).toBeGreaterThan(0);
+
+		const profile = await session.stop();
+		const parsed = JSON.parse(profile.data) as { nodes: unknown[] };
+		expect(Array.isArray(parsed.nodes)).toBe(true);
+		expect(parsed.nodes.length).toBeGreaterThan(0);
+		expect(typeof profile.markdown).toBe("string");
+		expect(profile.markdown.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Repro

On Bun (any current version, verified on 1.3.14) running the CPU profiler immediately fails with `Failed to start profiler: node:v8 setFlagsFromString is not yet implemented in Bun`, so no profile data is ever collected. Minimal reproduction of the throwing call:

```
$ bun -e 'const v8 = await import("node:v8"); v8.setFlagsFromString("--allow-natives-syntax")'
node:v8 setFlagsFromString is not yet implemented in Bun.
```

## Cause

`packages/coding-agent/src/debug/profiler.ts` `startCpuProfile()` calls `v8.setFlagsFromString("--allow-natives-syntax")` unconditionally before connecting the inspector session. The flag is a Node-only V8 API that Bun does not implement (oven-sh/bun#1702), so the call throws synchronously and `DebugReportComponent` in `debug/index.ts` (line 159) surfaces it as the user-facing failure. The flag itself only matters for V8 natives such as `%GetOptimizationStatus` — the CDP `Profiler.enable`/`start`/`stop` session that actually samples the process works fine on Bun.

## Fix

- Wrap `v8.setFlagsFromString("--allow-natives-syntax")` in a try/catch so it stays a best-effort hint, with a comment explaining why it's optional and pointing at the Bun issue.
- Add a Bun-runtime regression test (`test/debug/profiler.test.ts`) that calls `startCpuProfile()`, runs trivial work, and asserts the returned profile has nodes and rendered markdown. Without the guard the call rejects before returning a session, so the test would fail.
- Changelog entry under `[Unreleased]` referencing the issue.

## Verification

- `bun test test/debug/profiler.test.ts` → 1 pass, 5 expect() calls.
- `bun test test/debug/` (full debug suite) → 69 pass, 0 fail.
- Pre-publish gate (`bun run fix` + `bun check`) green via `gh_push_branch`/`gh_open_pr`.

Fixes #3897