### PR TITLE
fix(ai): harden Ollama malformed tool-call JSON failures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local Ollama/llama.cpp malformed tool-call JSON failures being retried as generic 500 errors, surfacing a clearer recovery message instead. ([#3899](https://github.com/can1357/oh-my-pi/issues/3899))
+
 ## [16.2.7] - 2026-06-30
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed local Ollama/llama.cpp malformed tool-call JSON failures being retried as generic 500 errors, surfacing a clearer recovery message instead. ([#3899](https://github.com/can1357/oh-my-pi/issues/3899))
+- Fixed local Ollama/llama.cpp malformed tool-call JSON failures being retried as generic 500 errors by both the provider transport and the agent-level auto-retry, surfacing a clearer recovery message instead. ([#3899](https://github.com/can1357/oh-my-pi/issues/3899))
 
 ## [16.2.7] - 2026-06-30
 

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -94,6 +94,14 @@ const MALFORMED_FUNCTION_CALL_PATTERN = /\bmalformed.?function.?call\b/i;
 const PROVIDER_FINISH_ERROR_PATTERN = /\bProvider (?:returned error finish_reason|finish_reason:\s*error)\b/i;
 const STALE_RESPONSE_ITEM_PATTERNS = [/\bItem with id ['"][^'"]+['"] not found\.?/i, /previous[ _]?response/i] as const;
 const STALE_RESPONSE_ITEM_DETAIL_PATTERN = /not[ _]?found|invalid|expired|stale|zero[ _-]?data[ _-]?retention/i;
+/**
+ * Local llama.cpp / Ollama deterministic tool-call argument JSON parse failure.
+ * The model emitted invalid JSON in a tool call and the server returned HTTP 500
+ * with this exact text — replaying the same prompt yields the same malformed
+ * output, so callers strip {@link Flag.Transient} when this matches.
+ */
+export const LLAMA_CPP_TOOL_CALL_PARSE_PATTERN =
+	/failed to parse tool call arguments as json|\[json\.exception\.parse_error\.101\]/i;
 
 // Copilot routing flap: HTTP 400 `model_not_supported` (structural code on the
 // error, also surfaced in text). Treated as transient — a retry usually lands
@@ -441,7 +449,13 @@ export function classifyMessage(message: {
 	const currentStatus = message.errorStatus ?? statusFromId(existingId);
 	const textId = classifyText(message.errorMessage, currentStatus, message.api);
 
-	const kinds = ((existingId ?? 0) | textId) & KIND_MASK;
+	let kinds = ((existingId ?? 0) | textId) & KIND_MASK;
+	if (message.errorMessage && LLAMA_CPP_TOOL_CALL_PARSE_PATTERN.test(message.errorMessage)) {
+		// Deterministic local-model tool-call JSON parse failure: HTTP 500 is misleading
+		// because the same prompt reproduces the same malformed output, so the agent-level
+		// auto-retry would loop. Strip Transient so the recovery message surfaces immediately.
+		kinds &= ~Flag.Transient;
+	}
 	const id = kinds !== 0 ? create(kinds) : (statusFromId(textId) ?? statusFromId(existingId) ?? currentStatus ?? 0);
 
 	message.errorId = id;

--- a/packages/ai/src/error/format.ts
+++ b/packages/ai/src/error/format.ts
@@ -6,13 +6,21 @@ import {
 } from "../utils/http-inspector";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 
+const OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN =
+	/failed to parse tool call arguments as json|\[json\.exception\.parse_error\.101\]/i;
+
+function rewriteOllamaToolCallJsonError(message: string): string {
+	if (!OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN.test(message)) return message;
+	return `Local Ollama model emitted malformed tool-call JSON and llama.cpp rejected it (HTTP 500). This is usually a deterministic model-output failure after context degradation, not a transient server outage; reload the model or reduce context, then retry.\n${message}`;
+}
+
 /** Inputs that steer {@link formatMessage}'s formatter selection. */
 export interface FormatMessageOptions {
 	/** When present, the raw request is dumped into the message for 400-class failures. */
 	rawRequestDump?: RawHttpRequestDump;
 	/** Captured non-2xx response body, appended to the message when available. */
 	capturedErrorResponse?: CapturedHttpErrorResponse;
-	/** Provider id; `"github-copilot"` triggers the copilot message rewrite. */
+	/** Provider id; gates provider-specific user-facing rewrites. */
 	provider?: string;
 }
 
@@ -31,6 +39,9 @@ export async function formatMessage(error: unknown, opts: FormatMessageOptions =
 		: formatErrorMessageWithRetryAfter(error);
 	if (opts.provider === "github-copilot") {
 		message = rewriteCopilotError(message, error, opts.provider);
+	}
+	if (opts.provider === "ollama") {
+		message = rewriteOllamaToolCallJsonError(message);
 	}
 	return message;
 }

--- a/packages/ai/src/error/format.ts
+++ b/packages/ai/src/error/format.ts
@@ -5,12 +5,10 @@ import {
 	rewriteCopilotError,
 } from "../utils/http-inspector";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
-
-const OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN =
-	/failed to parse tool call arguments as json|\[json\.exception\.parse_error\.101\]/i;
+import { LLAMA_CPP_TOOL_CALL_PARSE_PATTERN } from "./flags";
 
 function rewriteOllamaToolCallJsonError(message: string): string {
-	if (!OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN.test(message)) return message;
+	if (!LLAMA_CPP_TOOL_CALL_PARSE_PATTERN.test(message)) return message;
 	return `Local Ollama model emitted malformed tool-call JSON and llama.cpp rejected it (HTTP 500). This is usually a deterministic model-output failure after context degradation, not a transient server outage; reload the model or reduce context, then retry.\n${message}`;
 }
 

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -323,6 +323,13 @@ function createChatBody(model: Model<"ollama-chat">, context: Context, options: 
 	};
 }
 
+const OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN =
+	/failed to parse tool call arguments as json|\[json\.exception\.parse_error\.101\]/i;
+
+function shouldRetryOllamaResponse(response: Response, bodyText: string): boolean {
+	return response.status < 500 || !OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN.test(bodyText);
+}
+
 async function captureHttpErrorResponse(response: Response): Promise<CapturedHttpErrorResponse> {
 	let bodyText: string | undefined;
 	let bodyJson: unknown;
@@ -598,6 +605,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 					body: JSON.stringify(body),
 					signal: watchdog.signal,
 					defaultDelayMs: OLLAMA_RETRY_DELAYS_MS,
+					shouldRetryResponse: shouldRetryOllamaResponse,
 					fetch: options.fetch,
 					timeout: false,
 				});
@@ -747,6 +755,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 			}
 			const result = await AIError.finalize(error, {
 				api: model.api,
+				provider: model.provider,
 				signal: options.signal,
 				rawRequestDump,
 				capturedErrorResponse,

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -323,11 +323,8 @@ function createChatBody(model: Model<"ollama-chat">, context: Context, options: 
 	};
 }
 
-const OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN =
-	/failed to parse tool call arguments as json|\[json\.exception\.parse_error\.101\]/i;
-
 function shouldRetryOllamaResponse(response: Response, bodyText: string): boolean {
-	return response.status < 500 || !OLLAMA_TOOL_CALL_ARGUMENTS_PARSE_PATTERN.test(bodyText);
+	return response.status < 500 || !AIError.LLAMA_CPP_TOOL_CALL_PARSE_PATTERN.test(bodyText);
 }
 
 async function captureHttpErrorResponse(response: Response): Promise<CapturedHttpErrorResponse> {

--- a/packages/ai/test/ollama-tool-call-json-parse-error.test.ts
+++ b/packages/ai/test/ollama-tool-call-json-parse-error.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
+import { streamOllama } from "@oh-my-pi/pi-ai/providers/ollama";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const model: Model<"ollama-chat"> = buildModel({
+	id: "qwen3.6-coder:27b",
+	name: "Qwen 3.6 Coder 27B",
+	api: "ollama-chat",
+	provider: "ollama",
+	baseUrl: "http://127.0.0.1:11434",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 131_072,
+	maxTokens: 8192,
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "Use bash to run a Python command.", timestamp: 0 }],
+};
+
+const llamaToolParseFailure = JSON.stringify({
+	error: {
+		code: 500,
+		message:
+			"Failed to parse tool call arguments as JSON: [json.exception.parse_error.101] parse error at line 1, column 557: syntax error while parsing value - invalid string: missing closing quote; last read: '\"uv run python -c \\\"\\nimport jax.numpy as jnp\\nimport'",
+	},
+});
+
+describe("Ollama malformed tool-call JSON errors", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("does not retry deterministic llama.cpp tool argument parse failures", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let calls = 0;
+		const fetchMock = async () => {
+			calls += 1;
+			return new Response(llamaToolParseFailure, { status: 500 });
+		};
+
+		const result = await streamOllama(model, context, {
+			apiKey: "ollama",
+			fetch: fetchMock,
+		}).result();
+
+		expect(calls).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(500);
+		expect(result.errorMessage).toContain("Local Ollama model emitted malformed tool-call JSON");
+		expect(result.errorMessage).toContain("reload the model");
+	});
+});

--- a/packages/ai/test/ollama-tool-call-json-parse-error.test.ts
+++ b/packages/ai/test/ollama-tool-call-json-parse-error.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { streamOllama } from "@oh-my-pi/pi-ai/providers/ollama";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -50,5 +51,18 @@ describe("Ollama malformed tool-call JSON errors", () => {
 		expect(result.errorStatus).toBe(500);
 		expect(result.errorMessage).toContain("Local Ollama model emitted malformed tool-call JSON");
 		expect(result.errorMessage).toContain("reload the model");
+	});
+
+	it("strips Transient so agent-level auto-retry will not replay the deterministic failure", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const fetchMock = async () => new Response(llamaToolParseFailure, { status: 500 });
+
+		const result = await streamOllama(model, context, {
+			apiKey: "ollama",
+			fetch: fetchMock,
+		}).result();
+
+		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(false);
+		expect(AIError.retriable(result.errorId)).toBe(false);
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a response-body retry gate to `fetchWithRetry()` for deterministic provider failures that return retryable HTTP statuses.
+
 ## [16.2.7] - 2026-06-30
 
 ### Added

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -130,6 +130,12 @@ export interface FetchWithRetryOptions extends RequestInit {
 	 */
 	fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 	/**
+	 * Optional retry gate for HTTP responses whose status is retryable. Receives a
+	 * cloned body string so callers can fail fast on deterministic provider
+	 * failures that happen to use a 5xx status.
+	 */
+	shouldRetryResponse?: (response: Response, bodyText: string, attempt: number) => boolean | Promise<boolean>;
+	/**
 	 * Bun extension forwarded verbatim to the underlying `fetch` call. `false`
 	 * disables Bun's native ~300s pre-response timeout (callers that own a
 	 * configurable first-event/idle watchdog or an external `AbortSignal`
@@ -160,6 +166,7 @@ export async function fetchWithRetry(
 		maxDelayMs = DEFAULT_MAX_DELAY_MS,
 		defaultDelayMs,
 		prepareInit,
+		shouldRetryResponse,
 		fetch: fetchImpl = fetch,
 		timeout = false,
 		...baseInit
@@ -196,8 +203,10 @@ export async function fetchWithRetry(
 		if (!isRetryableStatus(response.status)) return response;
 		if (attempt + 1 >= maxAttempts) return response;
 
-		const hint = extractRetryHint(response, await response.clone().text());
-		if (hint !== undefined && hint > maxDelayMs) return response;
+		const retryBody = await response.clone().text();
+		if (shouldRetryResponse && !(await shouldRetryResponse(response, retryBody, attempt))) return response;
+
+		const hint = extractRetryHint(response, retryBody);
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
 		await scheduler.wait(delayMs, { signal });

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -207,6 +207,7 @@ export async function fetchWithRetry(
 		if (shouldRetryResponse && !(await shouldRetryResponse(response, retryBody, attempt))) return response;
 
 		const hint = extractRetryHint(response, retryBody);
+		if (hint !== undefined && hint > maxDelayMs) return response;
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
 		await scheduler.wait(delayMs, { signal });

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -59,4 +59,23 @@ describe("fetchWithRetry", () => {
 		expect(await response.text()).toBe("deterministic provider failure");
 		expect(attempt).toBe(1);
 	});
+
+	it("returns retryable responses immediately when retry hints exceed the delay cap", async () => {
+		let attempt = 0;
+		const customFetch = async () => {
+			attempt += 1;
+			return new Response("slow down", { status: 429, headers: { "Retry-After": "3600" } });
+		};
+
+		const response = await fetchWithRetry("https://example.invalid/rate-limit", {
+			fetch: customFetch,
+			defaultDelayMs: 1,
+			maxAttempts: 3,
+			maxDelayMs: 10,
+		});
+
+		expect(response.status).toBe(429);
+		expect(await response.text()).toBe("slow down");
+		expect(attempt).toBe(1);
+	});
 });

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -40,4 +40,23 @@ describe("fetchWithRetry", () => {
 		expect(await response.text()).toBe("done");
 		expect(attempt).toBe(2);
 	});
+
+	it("lets callers stop retries for deterministic response bodies", async () => {
+		let attempt = 0;
+		const customFetch = async () => {
+			attempt += 1;
+			return new Response("deterministic provider failure", { status: 500 });
+		};
+
+		const response = await fetchWithRetry("https://example.invalid/z", {
+			fetch: customFetch,
+			defaultDelayMs: 1,
+			maxAttempts: 3,
+			shouldRetryResponse: (_response, bodyText) => !bodyText.includes("deterministic"),
+		});
+
+		expect(response.status).toBe(500);
+		expect(await response.text()).toBe("deterministic provider failure");
+		expect(attempt).toBe(1);
+	});
 });


### PR DESCRIPTION
## Repro
A mocked local Ollama/llama.cpp chat response returning HTTP 500 with `Failed to parse tool call arguments as JSON` reproduced the reporter's failure mode: before the fix, `streamOllama` retried the same deterministic malformed tool-call parse failure 5 times. Repro command: `bun test packages/ai/test/ollama-tool-call-json-parse-error.test.ts` failed with `Expected: 1` request and `Received: 5`.

## Cause
`packages/ai/src/providers/ollama.ts` used `fetchWithRetry()` with the default 5xx retry policy for `/api/chat`. llama.cpp reports malformed model-generated tool-call argument JSON as HTTP 500, so `packages/utils/src/fetch-retry.ts` treated deterministic degraded-model output as a transient server outage and resent the same prompt until retries were exhausted.

## Fix
- Added a `shouldRetryResponse` hook to `fetchWithRetry()` so callers can inspect retryable-status response bodies before delaying and retrying.
- Added local Ollama detection for `Failed to parse tool call arguments as JSON` / `json.exception.parse_error.101`, skipping retries for that deterministic llama.cpp failure.
- Added an Ollama-specific user-facing error rewrite explaining that the local model emitted malformed tool-call JSON and advising reload/reduced context.
- Added regression tests for the Ollama failure path and the generic retry gate.

## Verification
- `bun test packages/ai/test/ollama-tool-call-json-parse-error.test.ts packages/utils/test/fetch-retry.test.ts` passed: 4 tests, 16 expects.
- `bun --cwd packages/ai check` passed.
- `bun --cwd packages/utils check` passed.

Fixes #3899