### PR TITLE
fix(coding-agent): identify user-invoked skill prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed user-invoked skill prompts to identify the requested skill and include the skill directory for relative path resolution. ([#3902](https://github.com/can1357/oh-my-pi/issues/3902))
+
 ## [16.2.8] - 2026-06-30
 
 ### Added

--- a/packages/coding-agent/src/extensibility/skills.test.ts
+++ b/packages/coding-agent/src/extensibility/skills.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildSkillCommandPrompt } from "../modes/skill-command";
+import { buildSkillPromptMessage, type Skill } from "./skills";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("buildSkillPromptMessage", () => {
+	it("frames user-invoked skills and exposes their directory", async () => {
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-user-"));
+		tempDirs.push(baseDir);
+		const filePath = path.join(baseDir, "SKILL.md");
+		await Bun.write(
+			filePath,
+			"---\ndescription: Deploy helpers\n---\n\nRun `scripts/deploy.js` with `templates/config.yaml`.",
+		);
+		const skill: Skill = { name: "deploy", description: "Deploy helpers", filePath, baseDir, source: "test" };
+
+		const built = await buildSkillPromptMessage(skill, "prod");
+
+		expect(built.message).toStartWith(
+			'[IMPORTANT: The user has invoked the "deploy" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
+		);
+		expect(built.message).toContain("Run `scripts/deploy.js` with `templates/config.yaml`.");
+		expect(built.message).toContain(`[Skill directory: ${baseDir}]`);
+		expect(built.message).toContain("Resolve any relative paths in this skill");
+		expect(built.message).toContain("User: prod");
+		expect(built.message).not.toContain("description: Deploy helpers");
+	});
+
+	it("keeps autoload skills on the non-user metadata format", async () => {
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-autoload-"));
+		tempDirs.push(baseDir);
+		const filePath = path.join(baseDir, "SKILL.md");
+		await Bun.write(filePath, "Hidden instructions.");
+		const skill: Skill = { name: "hidden", description: "Hidden", filePath, baseDir, source: "test" };
+
+		const built = await buildSkillPromptMessage(skill, "", "autoload");
+
+		expect(built.message).toBe(`Hidden instructions.\n\n---\n\nSkill: ${filePath}`);
+	});
+});
+
+describe("buildSkillCommandPrompt", () => {
+	it("uses the registered skill object for slash-command prompts", async () => {
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-command-"));
+		tempDirs.push(baseDir);
+		const filePath = path.join(baseDir, "SKILL.md");
+		await Bun.write(filePath, "Read `scripts/check.js` before responding.");
+		const skill: Skill = { name: "check", description: "Check", filePath, baseDir, source: "test" };
+
+		const built = await buildSkillCommandPrompt(
+			{ skillCommands: new Map([["skill:check", skill]]) },
+			"/skill:check now",
+			"followUp",
+		);
+
+		expect(built?.message.content).toContain('[IMPORTANT: The user has invoked the "check" skill');
+		expect(built?.message.content).toContain(`[Skill directory: ${baseDir}]`);
+		expect(built?.message.details).toEqual({
+			name: "check",
+			path: filePath,
+			args: "now",
+			lineCount: 1,
+		});
+	});
+});

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
-import { getProjectDir } from "@oh-my-pi/pi-utils";
+import { getProjectDir, prompt } from "@oh-my-pi/pi-utils";
 import {
 	isValidManagedSkillName,
 	MANAGED_SKILLS_PROVIDER_ID,
@@ -11,6 +11,8 @@ import type { SourceMeta } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import { type Skill as CapabilitySkill, loadCapability } from "../discovery";
 import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
+import skillAutoloadTemplate from "../prompts/system/skill-autoload.md" with { type: "text" };
+import skillUserInvocationTemplate from "../prompts/system/skill-user-invocation.md" with { type: "text" };
 import type { SkillPromptDetails } from "../session/messages";
 import { expandTilde } from "../tools/path-utils";
 export interface Skill {
@@ -380,22 +382,30 @@ export interface BuiltSkillPromptMessage {
 	details: SkillPromptDetails;
 }
 
+export type SkillPromptInvocation = "user" | "autoload";
+
 export function getSkillSlashCommandName(skill: Pick<Skill, "name">): string {
 	return `skill:${skill.name}`;
 }
 
 export async function buildSkillPromptMessage(
-	skill: Pick<Skill, "name" | "filePath">,
+	skill: Pick<Skill, "name" | "filePath"> & Partial<Pick<Skill, "baseDir">>,
 	args: string,
+	invocation: SkillPromptInvocation = "user",
 ): Promise<BuiltSkillPromptMessage> {
 	const content = await Bun.file(skill.filePath).text();
 	const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-	const metaLines = [`Skill: ${skill.filePath}`];
 	const trimmedArgs = args.trim();
-	if (trimmedArgs) {
-		metaLines.push(`User: ${trimmedArgs}`);
-	}
-	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+	const template = invocation === "autoload" ? skillAutoloadTemplate : skillUserInvocationTemplate;
+	const message = prompt
+		.render(template, {
+			name: skill.name,
+			body,
+			filePath: skill.filePath,
+			baseDir: skill.baseDir ?? skill.filePath.replace(/[\\/]SKILL\.md$/, ""),
+			userArgs: trimmedArgs || undefined,
+		})
+		.trim();
 	return {
 		message,
 		details: {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -16,6 +16,7 @@ import { shouldEnableAppendOnlyContext } from "../../config/append-only-context-
 import { type LoadedCustomShare, loadCustomShare } from "../../export/custom-share";
 import { shareSession } from "../../export/share";
 import type { CompactOptions } from "../../extensibility/extensions/types";
+import { buildSkillPromptMessage } from "../../extensibility/skills";
 import {
 	diffMentalModelContent,
 	type HindsightApi,
@@ -1162,13 +1163,15 @@ export class CommandController {
 
 	async handleSkillCommand(skillPath: string, args: string): Promise<void> {
 		try {
-			const content = await Bun.file(skillPath).text();
-			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-			const metaLines = [`Skill: ${skillPath}`];
-			if (args) {
-				metaLines.push(`User: ${args}`);
-			}
-			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+			const baseDir = path.dirname(skillPath);
+			const { message } = await buildSkillPromptMessage(
+				{
+					name: path.basename(baseDir) || "skill",
+					filePath: skillPath,
+					baseDir,
+				},
+				args,
+			);
 			await this.ctx.session.prompt(message);
 		} catch (err) {
 			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -65,6 +65,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
+import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
 import { type GuidedGoalMessage, runGuidedGoalTurn } from "../goals/guided-setup";
 import type { Goal, GoalModeState } from "../goals/state";
@@ -478,7 +479,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	lastStatusSpacer: Spacer | undefined = undefined;
 	lastStatusText: Text | undefined = undefined;
 	fileSlashCommands: Set<string> = new Set();
-	skillCommands: Map<string, string> = new Map();
+	skillCommands: Map<string, Skill> = new Map();
 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
 	collabHost?: CollabHost;
 	collabGuest?: CollabGuestLink;
@@ -687,7 +688,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (settings.get("skills.enableSkillCommands")) {
 			for (const skill of this.session.skills) {
 				const commandName = `skill:${skill.name}`;
-				this.skillCommands.set(commandName, skill.filePath);
+				this.skillCommands.set(commandName, skill);
 				skillCommandList.push({ name: commandName, description: skill.description });
 			}
 		}

--- a/packages/coding-agent/src/modes/skill-command.ts
+++ b/packages/coding-agent/src/modes/skill-command.ts
@@ -1,8 +1,10 @@
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { buildSkillPromptMessage } from "../extensibility/skills";
 import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../session/messages";
 import type { InteractiveModeContext } from "./types";
 
-type SkillCommandHost = Pick<InteractiveModeContext, "skillCommands" | "session" | "showError">;
+type SkillCommandHost = Pick<InteractiveModeContext, "skillCommands">;
+type SkillCommandInvokerHost = Pick<InteractiveModeContext, "skillCommands" | "session" | "showError">;
 
 type SkillPromptMessage = Pick<
 	CustomMessage<SkillPromptDetails>,
@@ -61,32 +63,19 @@ export async function buildSkillCommandPrompt(
 ): Promise<BuiltSkillCommandPrompt | undefined> {
 	const parsed = parseSkillCommand(text);
 	if (!parsed) return undefined;
-	const skillPath = ctx.skillCommands.get(parsed.commandName);
-	if (!skillPath) return undefined;
+	const skill = ctx.skillCommands.get(parsed.commandName);
+	if (!skill) return undefined;
 
-	const content = await Bun.file(skillPath).text();
-	const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-	const metaLines = [`Skill: ${skillPath}`];
-	if (parsed.args) {
-		metaLines.push(`User: ${parsed.args}`);
-	}
-	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-	const textBlock: TextContent = { type: "text", text: message };
-	const promptContent = images && images.length > 0 ? [textBlock, ...images] : message;
-	const skillName = parsed.commandName.slice("skill:".length);
-	const details: SkillPromptDetails = {
-		name: skillName || parsed.commandName,
-		path: skillPath,
-		args: parsed.args || undefined,
-		lineCount: body ? body.split("\n").length : 0,
-	};
+	const built = await buildSkillPromptMessage(skill, parsed.args);
+	const textBlock: TextContent = { type: "text", text: built.message };
+	const promptContent = images && images.length > 0 ? [textBlock, ...images] : built.message;
 
 	return {
 		message: {
 			customType: SKILL_PROMPT_MESSAGE_TYPE,
 			content: promptContent,
 			display: true,
-			details,
+			details: built.details,
 			attribution: "user",
 		},
 		options: { streamingBehavior, queueChipText: text },
@@ -95,7 +84,7 @@ export async function buildSkillCommandPrompt(
 
 /** Invoke a registered `/skill:<name>` command as a user-attributed custom message. */
 export async function invokeSkillCommandFromText(
-	ctx: SkillCommandHost,
+	ctx: SkillCommandInvokerHost,
 	text: string,
 	streamingBehavior: "steer" | "followUp",
 	options?: InvokeSkillCommandOptions,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -14,6 +14,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
+import type { Skill } from "../extensibility/skills";
 import type { MCPManager } from "../mcp";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { AgentSession } from "../session/agent-session";
@@ -206,7 +207,7 @@ export interface InteractiveModeContext {
 	lastStatusSpacer: Spacer | undefined;
 	lastStatusText: Text | undefined;
 	fileSlashCommands: Set<string>;
-	skillCommands: Map<string, string>;
+	skillCommands: Map<string, Skill>;
 	oauthManualInput: OAuthManualInputManager;
 	todoPhases: TodoPhase[];
 

--- a/packages/coding-agent/src/prompts/system/skill-autoload.md
+++ b/packages/coding-agent/src/prompts/system/skill-autoload.md
@@ -1,0 +1,8 @@
+{{body}}
+
+---
+
+Skill: {{filePath}}
+{{#if userArgs}}
+User: {{userArgs}}
+{{/if}}

--- a/packages/coding-agent/src/prompts/system/skill-user-invocation.md
+++ b/packages/coding-agent/src/prompts/system/skill-user-invocation.md
@@ -1,0 +1,11 @@
+[IMPORTANT: The user has invoked the "{{name}}" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]
+
+{{body}}
+
+---
+
+[Skill directory: {{baseDir}}]
+Resolve any relative paths in this skill against that directory before reading files, running scripts, or referencing companion assets.
+{{#if userArgs}}
+User: {{userArgs}}
+{{/if}}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2315,7 +2315,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Autoload skills via sendCustomMessage (same mechanic as /skill:<name>)
 			if (options.autoloadSkills?.length) {
 				for (const skill of options.autoloadSkills) {
-					const { message } = await buildSkillPromptMessage(skill, "");
+					const { message } = await buildSkillPromptMessage(skill, "", "autoload");
 					await session.sendCustomMessage(
 						{
 							customType: SKILL_PROMPT_MESSAGE_TYPE,


### PR DESCRIPTION
## Repro
`cd packages/coding-agent && bun test src/extensibility/skills.test.ts` failed before the fix: `buildSkillPromptMessage` returned the bare skill body followed by `Skill: <path>`, and `buildSkillCommandPrompt` treated the registered slash-command value as a path string instead of a `Skill` object.

## Cause
`packages/coding-agent/src/extensibility/skills.ts` built every skill prompt with the same minimal metadata trailer, and `packages/coding-agent/src/modes/interactive-mode.ts` stored only `skill.filePath` in `skillCommands`, so `packages/coding-agent/src/modes/skill-command.ts` could not include `baseDir` for typed, steered, or replayed `/skill:<name>` prompts. Autoloaded skills in `packages/coding-agent/src/task/executor.ts` used the same builder without an invocation-kind distinction.

## Fix
- Added dedicated static prompt templates for user-invoked and autoload skill prompt bodies.
- Added `SkillPromptInvocation` to `buildSkillPromptMessage`, defaulting to user invocation and preserving autoload's non-user `Skill: <path>` format.
- Stored full `Skill` objects in interactive `skillCommands` and routed slash-command prompt construction through `buildSkillPromptMessage`.
- Covered user, autoload, and slash-command prompt contracts in `src/extensibility/skills.test.ts`.

## Verification
Passed `cd packages/coding-agent && bun test src/extensibility/skills.test.ts`; passed `cd packages/coding-agent && bun run check`. Fixes #3902