### PR TITLE
fix(release): pin tiny transformers version in release binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed release-built `omp-<platform>-<arch>` binaries missing the compiled tiny-model Transformers.js version pin, which made Homebrew Darwin arm64 fall back to resolving `@huggingface/transformers/package.json` from bunfs at runtime. ([#3904](https://github.com/can1357/oh-my-pi/issues/3904))
+
 ## [16.2.8] - 2026-06-30
 
 ### Added

--- a/scripts/ci-release-build-binaries.test.ts
+++ b/scripts/ci-release-build-binaries.test.ts
@@ -1,0 +1,26 @@
+import { $ } from "bun";
+import { describe, expect, it } from "bun:test";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+
+interface PackageManifest {
+	version: string;
+}
+
+const repoRoot = path.join(import.meta.dir, "..");
+const transformersManifest: PackageManifest = createRequire(import.meta.url)("@huggingface/transformers/package.json");
+const transformersVersion = transformersManifest.version;
+
+describe("ci-release-build-binaries dry run", () => {
+	it("pins the Transformers.js runtime version in compiled release binaries", async () => {
+		const result = await $`bun scripts/ci-release-build-binaries.ts --dry-run --targets linux-x64`
+			.cwd(repoRoot)
+			.quiet();
+		const output = result.text();
+
+		expect(output).toContain('--define process.env.PI_COMPILED="true"');
+		expect(output).toContain(
+			`--define process.env.PI_TINY_TRANSFORMERS_VERSION=${JSON.stringify(transformersVersion)}`,
+		);
+	});
+});

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { createRequire } from "node:module";
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -11,9 +12,15 @@ interface BinaryTarget {
 	outfile: string;
 }
 
+interface PackageManifest {
+	version: string;
+}
+
 const repoRoot = path.join(import.meta.dir, "..");
 const binariesDir = path.join(repoRoot, "packages", "coding-agent", "binaries");
 const entrypoint = "./packages/coding-agent/src/cli.ts";
+const transformersManifest: PackageManifest = createRequire(import.meta.url)("@huggingface/transformers/package.json");
+const transformersVersion = transformersManifest.version;
 // Worker threads spawn `new Worker(Bun.main, { argv })` — they re-enter the
 // binary's own entry module — so no separate worker modules are compiled.
 // Legacy pi-* extension compat surfaces are served through an in-process
@@ -107,41 +114,43 @@ async function embedNative(target: BinaryTarget): Promise<void> {
 	});
 }
 
+function buildCompileCommand(target: BinaryTarget): string[] {
+	return [
+		"bun",
+		"build",
+		"--compile",
+		"--no-compile-autoload-bunfig",
+		"--no-compile-autoload-dotenv",
+		"--no-compile-autoload-tsconfig",
+		"--no-compile-autoload-package-json",
+		"--minify-identifiers",
+		"--keep-names",
+		"--define",
+		'process.env.PI_COMPILED="true"',
+		"--define",
+		`process.env.PI_TINY_TRANSFORMERS_VERSION=${JSON.stringify(transformersVersion)}`,
+		"--root",
+		".",
+		"--target",
+		target.target,
+		entrypoint,
+		"--outfile",
+		target.outfile,
+	];
+}
+
 async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --minify-identifiers --keep-names --define process.env.PI_COMPILED="true" --root . --target=${target.target} ${entrypoint} --outfile ${target.outfile}`);
+		console.log(`DRY RUN ${buildCompileCommand(target).join(" ")}`);
 		return;
 	}
 
 	const buildEnv = shouldAdhocSignDarwinBinary(target)
 		? { ...Bun.env, BUN_NO_CODESIGN_MACHO_BINARY: "1" }
 		: Bun.env;
-	await runCommand(
-		[
-			"bun",
-			"build",
-			"--compile",
-			"--no-compile-autoload-bunfig",
-			"--no-compile-autoload-dotenv",
-			"--no-compile-autoload-tsconfig",
-			"--no-compile-autoload-package-json",
-			"--minify-identifiers",
-			"--keep-names",
-			"--define",
-			'process.env.PI_COMPILED="true"',
-			"--root",
-			".",
-			"--target",
-			target.target,
-			entrypoint,
-			"--outfile",
-			target.outfile,
-		],
-		repoRoot,
-		buildEnv,
-	);
+	await runCommand(buildCompileCommand(target), repoRoot, buildEnv);
 
 	// Bun 1.3.12 emits a truncated Mach-O signature on darwin builds.
 	if (shouldAdhocSignDarwinBinary(target)) {


### PR DESCRIPTION
## Repro
`bun scripts/ci-release-build-binaries.ts --dry-run --targets linux-x64` previously emitted the release `bun build --compile` command with only `--define process.env.PI_COMPILED="true"`, leaving the compiled tiny-model worker to resolve `@huggingface/transformers/package.json` from bunfs at runtime.

## Cause
`packages/coding-agent/scripts/build-binary.ts` embedded `process.env.PI_TINY_TRANSFORMERS_VERSION`, but the release asset builder in `scripts/ci-release-build-binaries.ts` had a separate compile command that did not pass the same define. Homebrew installs the published `omp-darwin-arm64` release asset, so that path still hit `resolveTransformersVersionSpec()` in `packages/coding-agent/src/subprocess/worker-runtime.ts` without a compiled version pin.

## Fix
- Resolve the installed Transformers.js version in `scripts/ci-release-build-binaries.ts`.
- Build release compile commands through one helper that includes both `PI_COMPILED` and `PI_TINY_TRANSFORMERS_VERSION` defines.
- Add a dry-run regression test covering the release command emitted for compiled assets.
- Add the package changelog entry for #3904.

## Verification
`bun test scripts/ci-release-build-binaries.test.ts` passed. `bun scripts/ci-release-build-binaries.ts --dry-run --targets darwin-arm64` now emits `--define process.env.PI_TINY_TRANSFORMERS_VERSION="4.2.0"` for `omp-darwin-arm64`. `gh_push_branch` completed the pre-publish gate and pushed `083d1f5a8e7d`. Fixes #3904