### PR TITLE
Add Cognee memory backend

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,5 +1,19 @@
 # Autonomous Memory
 
+OMP supports several memory backends, selected by `memory.backend` in `/settings` or `config.yml`:
+
+| Backend     | Store          | Summary |
+| ----------- | -------------- | ------- |
+| `off`       | —              | No memory (default) |
+| `local`     | Local files    | Background pipeline extracts durable knowledge from past sessions and injects a compact summary into future sessions |
+| `mnemopi`   | Local SQLite   | Polyphonic local memory; see [Mnemopi memory backend](mnemosyne-memory-backend.md) |
+| `hindsight` | Remote service | Remote memory backend |
+| `cognee`    | Cognee server  | Graph/session memory on a Cognee server (self-hosted or Cloud); see [Cognee graph memory backend](#cognee-graph-memory-backend) below |
+
+This document covers the **local summary** backend and the **Cognee** graph memory backend.
+
+## Local summary backend
+
 When the local memory backend is enabled, the agent automatically extracts durable knowledge from past sessions and injects a compact summary into future sessions for the same project. Over time it builds a project-scoped memory store — technical decisions, recurring workflows, pitfalls — that carries forward without manual effort.
 
 Disabled by default. Enable the local summary pipeline via `/settings` or `config.yml`:
@@ -96,3 +110,115 @@ Additional tuning knobs (concurrency, lease durations, token budgets) are availa
 - `packages/coding-agent/src/memories/storage.ts` — SQLite-backed job queue and thread registry
 - `packages/coding-agent/src/prompts/memories/` — memory prompt templates
 - `packages/coding-agent/src/internal-urls/memory-protocol.ts` — `memory://` URL handler
+
+## Cognee graph memory backend
+
+Cognee is a first-class remote memory backend that stores conversation-derived knowledge in a Cognee knowledge graph and recalls it into future sessions. Unlike the local summary backend, all memory data lives on the Cognee server (self-hosted or Cognee Cloud); OMP holds only a per-session recall cache and a transient retain queue locally.
+
+Enable it by selecting the backend and pointing OMP at a running Cognee server:
+
+```yaml
+memory:
+  backend: cognee
+cognee:
+  apiUrl: http://localhost:8000
+  apiKey: ${COGNEE_API_KEY}
+```
+
+`cognee.apiUrl` defaults to `http://localhost:8000`. `cognee.apiKey` is config-file-only in v1 (the settings UI does not surface it); it can also be provided via the `COGNEE_API_KEY` environment variable, and `COGNEE_API_URL` overrides `cognee.apiUrl`. OMP authenticates with `X-Api-Key`.
+
+If Cognee is misconfigured or unreachable at startup, the backend becomes inert and logs a warning — it never breaks agent startup or prompt generation.
+
+### Scoping modes
+
+`cognee.scoping` controls how OMP maps a project to Cognee datasets and node tags:
+
+| Mode                          | Retain target                       | Recall target        | Behaviour |
+| ----------------------------- | ----------------------------------- | -------------------- | --------- |
+| `global`                      | One shared dataset                  | Same shared dataset  | All projects share one memory store. |
+| `per-project`                 | Per-project dataset name            | Same project dataset | Hard isolation: each project gets its own dataset. |
+| `per-project-tagged` (default)| Shared dataset + `project:<label>` node tag | Shared dataset, no node filter | Soft isolation: project memories are tagged on retain, but recall still surfaces untagged/global memories so cross-project knowledge merges. Use `per-project` for strict isolation. |
+
+When `cognee.datasetId` is set it wins over `cognee.datasetName` in every mode. `per-project` with a configured `datasetId` cannot derive a per-project dataset ID, so it falls back to a global target and logs a warning. The project label is derived from the primary git checkout root, or the cwd basename when no checkout is found.
+
+`cognee.nodeSet` adds static node tags sent on every retain in every mode; `per-project-tagged` additionally appends `project:<label>`.
+
+### Auto-recall and auto-retain
+
+When `cognee.autoRecall` is on (default), the primary session issues a Cognee recall on the first turn and injects the returned memories into the system prompt as a `<memories>` block, prefixed by a guidance preamble that treats them as heuristic context to verify against current repo state. Auto-recall runs once per session; the recall block is also refreshed on `/memory view` and before context compaction (`preCompactionContext`).
+
+When `cognee.autoRetain` is on (default), the primary session retains the transcript to Cognee every `cognee.retainEveryNTurns` user turns (default 3), overlapping by `cognee.retainOverlapTurns` turns (default 2). `cognee.retainMode` selects the document shape: `full-session` (default) upserts one document per session, `last-turn` retains chunked turn windows. At session end the retain queue is flushed and, when both `cognee.improveOnEnqueue` and `cognee.sessionMemoryEnabled` are on, a final Cognee `improve` runs for the session.
+
+Subagents alias the parent primary session's Cognee state — they share the parent's client, scope, and dataset, and never run their own auto-recall or auto-retain (doing so would double-recall and pollute the dataset with internal exploration transcripts). Explicit `retain`/`recall`/`reflect` calls from a subagent write through to the parent's dataset.
+
+### Explicit memory tools
+
+The `retain`, `recall`, `reflect`, and `learn` tools route through a generic memory-tool ops seam and work with Cognee. `memory_edit` is Mnemopi-only in v1 — Cognee's `forget` does not satisfy Mnemopi's stable update/invalidate-by-ID contract, so the tool is not offered when `memory.backend = cognee`.
+
+### `/memory` commands
+
+The generic `/memory` subcommands route through the backend hooks with Cognee-aware display text:
+
+| Subcommand            | Effect on Cognee |
+| --------------------- | ---------------- |
+| `view`                | Show the current Cognee recall block injected into the prompt |
+| `stats`               | Show Cognee config, resolved scope, and dataset status/count |
+| `diagnose`            | Show full Cognee config, scope, active state, recall settings, retain settings, and dataset status |
+| `clear` / `reset`     | Clear local session state and recall cache only and refresh the prompt; **upstream Cognee datasets are not deleted** |
+| `enqueue` / `rebuild` | Flush the retain queue, force-retain the current session, and (when `cognee.improveOnEnqueue` is on) call Cognee `improve` |
+
+### Configuration
+
+Cognee settings live under the `cognee.` prefix on the Memory settings tab (group **Cognee**), shown only when `memory.backend = cognee`.
+
+| Setting                       | Default                 | Description |
+| ----------------------------- | ----------------------- | ----------- |
+| `cognee.apiUrl`               | `http://localhost:8000` | Cognee server URL (self-hosted or Cloud); `COGNEE_API_URL` overrides |
+| `cognee.apiKey`               | _unset_                 | Cognee API key (config-file-only); `COGNEE_API_KEY` overrides |
+| `cognee.datasetName`          | _unset_                 | Base dataset name used when no dataset ID is set; derived default is `omp` (or `<prefix>-omp`); `per-project` appends `-<projectLabel>` |
+| `cognee.datasetId`            | _unset_                 | Existing Cognee dataset UUID; wins over `datasetName` |
+| `cognee.datasetNamePrefix`    | _unset_                 | Prefix applied before derived dataset names |
+| `cognee.scoping`              | `per-project-tagged`    | `global` \| `per-project` \| `per-project-tagged` |
+| `cognee.autoRecall`           | `true`                  | Recall Cognee memories into the first turn of each session |
+| `cognee.autoRetain`           | `true`                  | Retain completed turns into Cognee memory |
+| `cognee.retainMode`           | `full-session`          | `full-session` (one document per session) \| `last-turn` (chunked) |
+| `cognee.retainEveryNTurns`    | `3`                     | Retain every N user turns |
+| `cognee.retainOverlapTurns`   | `2`                     | Overlap turns between successive retains |
+| `cognee.retainContext`        | `omp`                   | Context tag sent with retains |
+| `cognee.runInBackground`      | `true`                  | Ask Cognee to process `remember` in the background |
+| `cognee.chunkSize`            | `4096`                  | Chunk size for ingest; `null` uses the server default |
+| `cognee.chunksPerBatch`       | `36`                    | Chunks per batch for ingest; `null` uses the server default |
+| `cognee.customPrompt`         | _unset_                 | Custom Cognee ingest prompt |
+| `cognee.nodeSet`              | `[]`                    | Static node tags added to every retain |
+| `cognee.ontologyKeys`         | `[]`                    | Ontology keys passed to Cognee |
+| `cognee.graphModel`           | _unset_                 | Cognee graph model |
+| `cognee.recallSearchType`     | `GRAPH_COMPLETION`      | Cognee search type (`GRAPH_COMPLETION`, `RAG_COMPLETION`, `CHUNKS`, `INSIGHTS`, `CODE`, ...) |
+| `cognee.recallScope`          | `auto`                  | Cognee recall scope (`auto`, `graph`, `session`, `trace`, `graph_context`, `session_context`, `all`, ...) |
+| `cognee.recallTopK`           | `10`                    | Top-K for recall |
+| `cognee.recallContextTurns`   | `1`                     | Recent turns folded into the recall query |
+| `cognee.recallMaxQueryChars`  | `1200`                  | Max characters of the composed recall query |
+| `cognee.recallMaxRenderChars` | `12000`                 | Max characters of the rendered recall block (`0` = guidance preamble only) |
+| `cognee.onlyContext`          | `false`                 | Request context-only recall results when supported |
+| `cognee.verbose`              | `false`                 | Verbose recall responses |
+| `cognee.improveOnEnqueue`     | `true`                  | Route `/memory enqueue` through Cognee `improve` |
+| `cognee.buildGlobalContextIndex` | `false`              | Ask `improve` to build the global context index |
+| `cognee.sessionMemoryEnabled` | `false`                 | Forward OMP session IDs to Cognee session-memory APIs; requires Cognee server caching (`CACHING=true` / `CACHE_BACKEND`) |
+| `cognee.debug`                | `false`                 | Emit debug logs for Cognee recall/retain/search/save |
+
+### Invariants
+
+- **Server-side data.** Cognee memory lives on the Cognee server. OMP stores only a per-session recall cache and a transient retain queue locally.
+- **Local-only clear.** `/memory clear` and `/memory reset` clear local session state and the recall cache and refresh the system prompt; they never call Cognee `forget` or delete upstream datasets. Delete Cognee data from the Cognee server to wipe upstream state.
+- **No `memory_edit`.** Cognee does not support Mnemopi's stable update/invalidate-by-ID contract in v1, so `memory_edit` is not offered for the Cognee backend.
+- **Non-throwing startup.** A missing `cognee.apiUrl`, bad credentials, or an unreachable server make the backend inert with a warning — agent startup and prompt generation are never broken.
+- **Single selector.** `memory.backend` is the only runtime selector; there is no separate `cognee.enabled` flag.
+- **Subagents alias, never duplicate.** Subagents share the parent primary's Cognee state and never run auto-recall/auto-retain of their own.
+
+### Key files
+
+- `packages/coding-agent/src/cognee/config.ts` — `CogneeConfig`, `loadCogneeConfig`, `isCogneeConfigured`
+- `packages/coding-agent/src/cognee/scope.ts` — `computeCogneeScope`, scoping modes, project label derivation
+- `packages/coding-agent/src/cognee/client.ts` — Cognee HTTP client (`remember`/`recall`/`improve`/`forget`/datasets)
+- `packages/coding-agent/src/cognee/content.ts` — transcript flattening, recall-query composition, recall block formatting, retention documents
+- `packages/coding-agent/src/cognee/state.ts` — `CogneeSessionState`, retain queue, auto-recall/auto-retain lifecycle, subagent aliasing
+- `packages/coding-agent/src/cognee/backend.ts` — `cogneeBackend: MemoryBackend` (`start`/`buildDeveloperInstructions`/`beforeAgentStartPrompt`/`clear`/`enqueue`/`status`/`search`/`save`/`stats`/`diagnose`/`preCompactionContext`)

--- a/packages/coding-agent/src/cognee/backend.ts
+++ b/packages/coding-agent/src/cognee/backend.ts
@@ -1,0 +1,686 @@
+/**
+ * Cognee memory backend.
+ *
+ * Wires the per-session lifecycle (recall on first turn, retain every Nth
+ * agent_end, etc.) on top of the AgentSession event stream. Cognee runtime
+ * state is owned by the AgentSession via the `./state` side channel so
+ * lifetime follows the actual domain owner instead of a parallel session-id
+ * registry. All HTTP access is behind `CogneeClient`; this module never
+ * calls `fetch` directly.
+ */
+
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import { onCogneeScopeChanged, type Settings } from "../config/settings";
+import type {
+	MemoryBackend,
+	MemoryBackendOperationContext,
+	MemoryBackendSaveInput,
+	MemoryBackendSaveResult,
+	MemoryBackendSearchOptions,
+	MemoryBackendSearchResult,
+	MemoryBackendStartOptions,
+	MemoryBackendStatus,
+} from "../memory-backend/types";
+import type { AgentSession } from "../session/agent-session";
+import { truncateApproxTokensOrChars } from "./content";
+import { createCogneeClient } from "./client";
+import { isCogneeConfigured, loadCogneeConfig, type CogneeConfig } from "./config";
+import { computeCogneeScope, type CogneeScope } from "./scope";
+import { CogneeSessionState, getCogneeSessionState, setCogneeSessionState, type CogneeSessionStateLike } from "./state";
+
+const STATIC_INSTRUCTIONS =
+	"## Cognee Memory\n\n" +
+	"A Cognee knowledge graph/session-memory backend may provide relevant memories. " +
+	"Treat them as heuristic context, not authority. Prefer current user instructions " +
+	"and current repository evidence when they conflict. When memory affects a plan, " +
+	"verify with live repo/tool evidence before acting.";
+
+const INERT_MESSAGE = "Cognee backend is not initialised for this session.";
+
+interface PrimaryRebuildTask {
+	pending: boolean;
+}
+
+const primaryRebuildTasks = new WeakMap<AgentSession, PrimaryRebuildTask>();
+const scopeUnsubscribes = new WeakMap<AgentSession, () => void>();
+
+/** Dispose a state best-effort; log disposal errors at debug/warn level. */
+async function disposeState(state: CogneeSessionStateLike | undefined): Promise<void> {
+	if (!state) return;
+	try {
+		await state.dispose();
+	} catch (err) {
+		logger.debug("Cognee: state dispose failed", { error: String(err) });
+	}
+}
+
+/** Flush a state's retain queue; let callers decide whether to catch. */
+async function flushState(state: CogneeSessionStateLike | undefined): Promise<void> {
+	if (!state) return;
+	await state.flushRetainQueue();
+}
+
+/** Read, delete, and invoke the backend-local scope unsubscribe best-effort. */
+function unsubscribeScope(session: AgentSession): void {
+	const unsub = scopeUnsubscribes.get(session);
+	if (unsub) {
+		scopeUnsubscribes.delete(session);
+		try {
+			unsub();
+		} catch (err) {
+			logger.debug("Cognee: scope unsubscribe failed", { error: String(err) });
+		}
+	}
+}
+
+/** Clear installed state for a session: optional flush, unset, unsubscribe, dispose. */
+async function clearInstalledState(
+	session: AgentSession,
+	options?: { flush?: boolean },
+): Promise<void> {
+	const current = getCogneeSessionState(session);
+	if (options?.flush) {
+		try {
+			await flushState(current);
+		} catch (err) {
+			logger.debug("Cognee: flush before clear failed", { error: String(err) });
+		}
+	}
+	const previous = setCogneeSessionState(session, undefined);
+	unsubscribeScope(session);
+	if (previous && previous !== current) {
+		await disposeState(previous);
+	}
+	await disposeState(current);
+}
+
+/** Order-sensitive string-array equality. */
+function arraysEqual(a?: readonly string[], b?: readonly string[]): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
+}
+
+/** Structural compare of two Cognee scopes for rebuild-skip decisions. */
+function scopesEqual(a: CogneeScope, b: CogneeScope): boolean {
+	return (
+		a.datasetName === b.datasetName &&
+		a.datasetId === b.datasetId &&
+		a.retainDatasetLabel === b.retainDatasetLabel &&
+		arraysEqual(a.recallDatasetLabels, b.recallDatasetLabels) &&
+		arraysEqual(a.recallDatasets, b.recallDatasets) &&
+		arraysEqual(a.recallDatasetIds, b.recallDatasetIds) &&
+		arraysEqual(a.retainNodeSet, b.retainNodeSet) &&
+		arraysEqual(a.recallNodeName, b.recallNodeName) &&
+		a.sessionId === b.sessionId
+	);
+}
+
+/** Structural compare of routing-relevant config fields for rebuild-skip. */
+function configRoutingEqual(a: CogneeConfig, b: CogneeConfig): boolean {
+	return (
+		a.apiUrl === b.apiUrl &&
+		a.apiKey === b.apiKey &&
+		a.datasetName === b.datasetName &&
+		a.datasetId === b.datasetId &&
+		a.datasetNamePrefix === b.datasetNamePrefix &&
+		a.scoping === b.scoping &&
+		arraysEqual(a.nodeSet, b.nodeSet) &&
+		a.sessionMemoryEnabled === b.sessionMemoryEnabled
+	);
+}
+
+/** Resolve the primary state backing an alias (or the state itself if primary). */
+function primaryState(session?: AgentSession): CogneeSessionStateLike | undefined {
+	const state = getCogneeSessionState(session);
+	return state?.aliasOf ?? state;
+}
+
+/**
+ * Coalesce and serialize live scope rebuilds for one session. Cwd reloads fire
+ * all settings hooks synchronously; running every callback immediately would
+ * let multiple rebuilds capture the same old state and leak the fresh states
+ * installed by earlier continuations.
+ */
+function schedulePrimaryStateRebuild(session: AgentSession): void {
+	const task = primaryRebuildTasks.get(session);
+	if (task) {
+		task.pending = true;
+		return;
+	}
+
+	const nextTask: PrimaryRebuildTask = { pending: true };
+	primaryRebuildTasks.set(session, nextTask);
+	void Promise.resolve()
+		.then(async () => {
+			while (nextTask.pending) {
+				nextTask.pending = false;
+				try {
+					await rebuildPrimaryStateOnScopeChange(session);
+				} catch (err) {
+					logger.warn("Cognee: scope rebuild failed", { error: String(err) });
+				}
+			}
+		})
+		.finally(() => {
+			if (primaryRebuildTasks.get(session) === nextTask) {
+				primaryRebuildTasks.delete(session);
+			}
+		});
+}
+
+/**
+ * `onCogneeScopeChanged` handler: re-evaluate the dataset scope from current
+ * settings and rebuild the primary state when it has actually drifted. No-op
+ * when the scope is unchanged or the session is no longer hosting a primary
+ * state (e.g. it was wiped to `undefined`, or this is a subagent alias).
+ */
+async function rebuildPrimaryStateOnScopeChange(session: AgentSession): Promise<void> {
+	const current = getCogneeSessionState(session);
+	if (!current || current.aliasOf) return;
+
+	const settings = session.settings;
+	const config = loadCogneeConfig(settings);
+	if (!isCogneeConfigured(config)) {
+		await clearInstalledState(session, { flush: true });
+		return;
+	}
+
+	const cwd = session.sessionManager.getCwd();
+	const next = computeCogneeScope(config, cwd, config.sessionMemoryEnabled ? current.sessionId : undefined);
+	if (configRoutingEqual(config, current.config) && scopesEqual(next, current.scope)) return;
+
+	await installPrimaryState(session, settings);
+}
+
+/**
+ * Build (or rebuild) the primary `CogneeSessionState` for `session` from
+ * the current settings and install it. Disposes any previous primary state
+ * after flushing its retain queue so in-flight tool-initiated retains land in
+ * the dataset that was selected when they were enqueued, not in the new one.
+ *
+ * The created state takes ownership of the `onCogneeScopeChanged`
+ * subscription so subsequent `cognee.datasetName` / `datasetId` /
+ * `datasetNamePrefix` / `scoping` edits trigger another rebuild from the
+ * same wiring. Never calls `client.createDataset` here.
+ */
+async function installPrimaryState(
+	session: AgentSession,
+	settings: Settings,
+): Promise<CogneeSessionStateLike | undefined> {
+	const sessionId = session.sessionId;
+	if (!sessionId) return undefined;
+
+	const config = loadCogneeConfig(settings);
+	if (!isCogneeConfigured(config)) {
+		await clearInstalledState(session, { flush: true });
+		return undefined;
+	}
+
+	const client = createCogneeClient({ baseUrl: config.apiUrl, apiKey: config.apiKey ?? undefined });
+	const scope = computeCogneeScope(
+		config,
+		session.sessionManager.getCwd(),
+		config.sessionMemoryEnabled ? sessionId : undefined,
+	);
+
+	// Flush the previous state's retain queue BEFORE clearing it so queued
+	// retains don't get dropped by the state's flush guard. Re-read after the
+	// await so a concurrent owner cannot leave the actual current state
+	// undisposed.
+	let previous = getCogneeSessionState(session);
+	if (previous) {
+		try {
+			await previous.flushRetainQueue();
+		} catch (err) {
+			logger.debug("Cognee: flush before install failed", { error: String(err) });
+		}
+	}
+	const latest = getCogneeSessionState(session);
+	if (latest && latest !== previous) {
+		await disposeState(previous);
+		previous = latest;
+		try {
+			await previous.flushRetainQueue();
+		} catch (err) {
+			logger.debug("Cognee: flush before install failed", { error: String(err) });
+		}
+	}
+
+	unsubscribeScope(session);
+
+	const state = new CogneeSessionState({
+		sessionId,
+		client,
+		config,
+		scope,
+		session,
+		lastRetainedTurn: 0,
+		hasRecalledForFirstTurn: false,
+	});
+
+	// Subscribe BEFORE installing: if the operator manages to flip another
+	// setting between install and subscribe, we'd miss the edge.
+	scopeUnsubscribes.set(session, onCogneeScopeChanged(() => schedulePrimaryStateRebuild(session)));
+
+	const displaced = setCogneeSessionState(session, state);
+	if (displaced && displaced !== previous) {
+		try {
+			await displaced.flushRetainQueue();
+		} catch (err) {
+			logger.debug("Cognee: displaced flush failed", { error: String(err) });
+		}
+		await disposeState(displaced);
+	}
+	await disposeState(previous);
+	state.attachSessionListeners();
+
+	return state;
+}
+
+/** Render an unknown error as a single-line string for markdown/status. */
+function safeErrorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+/** Redact the API key for diagnostics: never surface the raw secret. */
+function redactedApiKey(config: CogneeConfig): "<redacted>" | "<unset>" {
+	return config.apiKey ? "<redacted>" : "<unset>";
+}
+
+/** Bounded JSON.stringify for stats/diagnose; redact by construction. */
+function boundedJson(value: unknown, limit = 4000): string {
+	try {
+		const text = JSON.stringify(value, (_k, v) => (v === undefined ? null : v));
+		if (text === undefined) return "";
+		return text.length > limit ? `${text.slice(0, limit)}…` : text;
+	} catch {
+		return "<unserializable>";
+	}
+}
+
+/** Short single-line preview for `lastRecallSnippet` in diagnose. */
+function safePreview(text: string, limit = 200): string {
+	const single = text.replace(/\s+/g, " ").trim();
+	return single.length > limit ? `${single.slice(0, limit)}…` : single;
+}
+
+export const cogneeBackend: MemoryBackend = {
+	id: "cognee",
+
+	async start(options: MemoryBackendStartOptions): Promise<void> {
+		const { session, settings, taskDepth } = options;
+		try {
+			const sessionId = session.sessionId;
+			if (!sessionId) return;
+
+			// Subagents alias the parent's state so recall/retain/reflect tool
+			// calls persist to the same Cognee dataset. Auto-recall and
+			// auto-retain stay with the parent — running them per subagent
+			// would double-recall and pollute the dataset with internal
+			// exploration transcripts.
+			if (taskDepth > 0) {
+				const parent = options.parentCogneeSessionState;
+				if (!parent) return;
+				const alias = new CogneeSessionState({
+					sessionId,
+					client: parent.client,
+					config: parent.config,
+					scope: parent.scope,
+					session,
+					lastRetainedTurn: 0,
+					hasRecalledForFirstTurn: true,
+					aliasOf: parent,
+				});
+				const previous = setCogneeSessionState(session, alias);
+				// Aliases don't run auto-recall/auto-retain; best-effort flush
+				// of the previous alias's empty queue, then dispose.
+				try {
+					await previous?.flushRetainQueue();
+				} catch (err) {
+					logger.debug("Cognee: alias previous flush failed", { error: String(err) });
+				}
+				await disposeState(previous);
+				// Do not subscribe to onCogneeScopeChanged and do not attach
+				// session listeners — the parent owns those.
+				return;
+			}
+
+			const config = loadCogneeConfig(settings);
+			if (!isCogneeConfigured(config)) {
+				logger.warn("Cognee: memory.backend=cognee but cognee.apiUrl is unset; backend inert.");
+				await clearInstalledState(session, { flush: true });
+				return;
+			}
+
+			await installPrimaryState(session, settings);
+		} catch (err) {
+			logger.warn("Cognee: backend startup failed", { error: String(err) });
+			await clearInstalledState(session, { flush: false }).catch(clearErr => {
+				logger.debug("Cognee: startup cleanup failed", { error: String(clearErr) });
+			});
+		}
+	},
+
+	async buildDeveloperInstructions(_agentDir, settings, session): Promise<string | undefined> {
+		const config = loadCogneeConfig(settings);
+		if (!isCogneeConfigured(config)) return undefined;
+
+		const state = session ? getCogneeSessionState(session) : undefined;
+		const primary = state?.aliasOf ?? state;
+		const recallSnippet = primary?.lastRecallSnippet;
+
+		const parts = [STATIC_INSTRUCTIONS];
+		if (recallSnippet) parts.push(recallSnippet);
+		const joined = parts.join("\n\n");
+
+		if (config.recallMaxRenderChars === 0) return STATIC_INSTRUCTIONS;
+		return truncateApproxTokensOrChars(joined, config.recallMaxRenderChars);
+	},
+
+	async beforeAgentStartPrompt(session: AgentSession, promptText: string): Promise<string | undefined> {
+		const state = getCogneeSessionState(session);
+		if (!state) return undefined;
+		// Do not catch; AgentSession already handles backend hook failures.
+		return await state.beforeAgentStartPrompt(promptText);
+	},
+
+	async clear(_agentDir, _cwd, session): Promise<void> {
+		if (!session) return;
+		await clearInstalledState(session, { flush: true }).catch(err => {
+			logger.debug("Cognee: clear flush failed", { error: String(err) });
+		});
+		logger.warn(
+			"Cognee memory is server-side; only local recall cache/session state was cleared. " +
+				"Delete Cognee data from the Cognee server to wipe upstream state.",
+		);
+	},
+
+	async enqueue(_agentDir, _cwd, session): Promise<void> {
+		const state = getCogneeSessionState(session);
+		// Use only primary state; aliases delegate to the parent and must not
+		// run their own retain/improve.
+		const primary = state?.aliasOf ? undefined : state;
+		if (!primary) return;
+		await primary.flushRetainQueue();
+		await primary.forceRetainCurrentSession();
+		if (!primary.config.improveOnEnqueue) return;
+		try {
+			await primary.client.improve({
+				datasetName: primary.scope.datasetName,
+				datasetId: primary.scope.datasetId,
+				sessionIds: primary.config.sessionMemoryEnabled ? [primary.sessionId] : undefined,
+				nodeName: primary.scope.recallNodeName,
+				runInBackground: primary.config.runInBackground,
+				buildGlobalContextIndex: primary.config.buildGlobalContextIndex,
+			});
+		} catch (err) {
+			// Improve failure must not undo the retained transcript.
+			logger.warn("Cognee: improve on enqueue failed", { error: String(err) });
+		}
+	},
+
+	async status(context: MemoryBackendOperationContext): Promise<MemoryBackendStatus> {
+		const primary = primaryState(context.session);
+		if (!primary) {
+			return {
+				backend: "cognee",
+				active: false,
+				writable: false,
+				searchable: false,
+				message: INERT_MESSAGE,
+			};
+		}
+		return {
+			backend: "cognee",
+			active: true,
+			writable: true,
+			searchable: true,
+			scope: primary.scope.label,
+			retainBank: primary.scope.retainDatasetLabel,
+			recallBanks: primary.scope.recallDatasetLabels,
+			lastRecall: Boolean(primary.lastRecallSnippet),
+			lastMemory: primary.lastRetainedAtIso,
+			message: undefined,
+			error: undefined,
+		};
+	},
+
+	async search(
+		context: MemoryBackendOperationContext,
+		query: string,
+		options?: MemoryBackendSearchOptions,
+	): Promise<MemoryBackendSearchResult> {
+		const state = getCogneeSessionState(context.session);
+		if (!state) {
+			return { backend: "cognee", query, count: 0, items: [], message: INERT_MESSAGE };
+		}
+		if (query.trim() === "") {
+			return { backend: "cognee", query, count: 0, items: [], message: "Search query is empty." };
+		}
+		if (options?.signal?.aborted) {
+			return { backend: "cognee", query, count: 0, items: [], message: "Search aborted." };
+		}
+		const result = await state.search(query, options);
+		if (options?.signal?.aborted) {
+			return { backend: "cognee", query, count: 0, items: [], message: "Search aborted." };
+		}
+		return { ...result, backend: "cognee", query };
+	},
+
+	async save(
+		context: MemoryBackendOperationContext,
+		input: MemoryBackendSaveInput,
+	): Promise<MemoryBackendSaveResult> {
+		const state = getCogneeSessionState(context.session);
+		if (!state) {
+			return { backend: "cognee", stored: 0, message: INERT_MESSAGE };
+		}
+		const content = input.content.trim();
+		if (content === "") {
+			return { backend: "cognee", stored: 0, message: "Memory content is empty." };
+		}
+		const result = await state.save({ ...input, content });
+		return { ...result, backend: "cognee" };
+	},
+
+	async stats(_agentDir, cwd, session): Promise<string | undefined> {
+		const lines: string[] = ["## Cognee Memory Stats", ""];
+
+		let config: CogneeConfig | undefined;
+		let scope: CogneeScope | undefined;
+		let client = undefined as ReturnType<typeof createCogneeClient> | undefined;
+
+		const primary = primaryState(session);
+		if (primary) {
+			config = primary.config;
+			scope = primary.scope;
+			client = primary.client;
+		} else if (session?.settings) {
+			config = loadCogneeConfig(session.settings);
+			if (!isCogneeConfigured(config)) {
+				lines.push("Configured: no");
+				lines.push("");
+				lines.push("Cognee is not configured (`cognee.apiUrl` is unset). No server contact attempted.");
+				return lines.join("\n");
+			}
+			scope = computeCogneeScope(
+				config,
+				cwd,
+				config.sessionMemoryEnabled ? session.sessionId : undefined,
+			);
+			client = createCogneeClient({ baseUrl: config.apiUrl, apiKey: config.apiKey ?? undefined });
+		} else {
+			lines.push("Configured: no");
+			lines.push("");
+			lines.push("No session available; Cognee config could not be loaded.");
+			return lines.join("\n");
+		}
+
+		lines.push(`Configured: yes`);
+		lines.push(`API URL: ${config.apiUrl}`);
+		lines.push(`Dataset name: ${scope.datasetName ?? "<unset>"}`);
+		lines.push(`Dataset id: ${scope.datasetId ?? "<unset>"}`);
+		lines.push(`Scoping: ${config.scoping}`);
+		lines.push(`Session memory: ${config.sessionMemoryEnabled ? "enabled" : "disabled"}`);
+		lines.push("");
+
+		if (client && scope) {
+			lines.push("### Dataset status");
+			try {
+				const status = await client.getDatasetStatus({ dataset: scope.datasetName, datasetId: scope.datasetId });
+				lines.push("```json");
+				lines.push(boundedJson(status));
+				lines.push("```");
+			} catch (err) {
+				lines.push(`Status lookup failed: ${safeErrorMessage(err)}`);
+			}
+			lines.push("");
+
+			lines.push("### Datasets");
+			try {
+				const datasets = await client.listDatasets();
+				lines.push(`Dataset count: ${datasets.length}`);
+				const match = scope.datasetName
+					? datasets.find(d => d.name === scope!.datasetName)
+					: undefined;
+				lines.push(`Retain dataset present: ${match ? "yes" : "no"}`);
+			} catch (err) {
+				lines.push(`Dataset list failed: ${safeErrorMessage(err)}`);
+			}
+		}
+
+		return lines.join("\n");
+	},
+
+	async diagnose(_agentDir, cwd, session): Promise<string | undefined> {
+		const lines: string[] = ["## Cognee Memory Diagnostics", ""];
+
+		let config: CogneeConfig | undefined;
+		let scope: CogneeScope | undefined;
+		let client = undefined as ReturnType<typeof createCogneeClient> | undefined;
+
+		const primary = primaryState(session);
+		if (primary) {
+			config = primary.config;
+			scope = primary.scope;
+			client = primary.client;
+		} else if (session?.settings) {
+			config = loadCogneeConfig(session.settings);
+			scope = computeCogneeScope(
+				config,
+				cwd,
+				isCogneeConfigured(config) && config.sessionMemoryEnabled ? session.sessionId : undefined,
+			);
+			if (isCogneeConfigured(config)) {
+				client = createCogneeClient({ baseUrl: config.apiUrl, apiKey: config.apiKey ?? undefined });
+			}
+		} else {
+			scope = undefined;
+		}
+
+		lines.push(`Backend: cognee`);
+		lines.push(`State: ${primary ? "active" : "inert"}`);
+		lines.push(`API URL: ${config?.apiUrl ?? "<unset>"}`);
+		lines.push(`API key: ${config ? redactedApiKey(config) : "<unset>"}`);
+		lines.push(`Dataset name: ${scope?.datasetName ?? "<unset>"}`);
+		lines.push(`Dataset id: ${scope?.datasetId ?? "<unset>"}`);
+		lines.push(`Dataset name prefix: ${config?.datasetNamePrefix ?? "<unset>"}`);
+		lines.push(`Scoping: ${config?.scoping ?? "<unset>"}`);
+		lines.push(`Scope label: ${scope?.label ?? "<unset>"}`);
+		lines.push(`Retain dataset label: ${scope?.retainDatasetLabel ?? "<unset>"}`);
+		lines.push(`Recall dataset labels: ${(scope?.recallDatasetLabels ?? []).join(", ") || "<none>"}`);
+		lines.push(`Project label: ${scope?.projectLabel ?? "<unset>"}`);
+		lines.push("");
+
+		if (config) {
+			lines.push("### Auto flags");
+			lines.push(`autoRecall: ${config.autoRecall}`);
+			lines.push(`autoRetain: ${config.autoRetain}`);
+			lines.push(`improveOnEnqueue: ${config.improveOnEnqueue}`);
+			lines.push(`buildGlobalContextIndex: ${config.buildGlobalContextIndex}`);
+			lines.push(`runInBackground: ${config.runInBackground}`);
+			lines.push("");
+
+			lines.push("### Recall settings");
+			lines.push(`recallSearchType: ${config.recallSearchType}`);
+			lines.push(`recallScope: ${config.recallScope}`);
+			lines.push(`recallTopK: ${config.recallTopK}`);
+			lines.push(`recallContextTurns: ${config.recallContextTurns}`);
+			lines.push(`recallMaxQueryChars: ${config.recallMaxQueryChars}`);
+			lines.push(`recallMaxRenderChars: ${config.recallMaxRenderChars}`);
+			lines.push(`onlyContext: ${config.onlyContext}`);
+			lines.push(`verbose: ${config.verbose}`);
+			lines.push("");
+
+			lines.push("### Retain settings");
+			lines.push(`retainMode: ${config.retainMode}`);
+			lines.push(`retainEveryNTurns: ${config.retainEveryNTurns}`);
+			lines.push(`retainOverlapTurns: ${config.retainOverlapTurns}`);
+			lines.push(`retainContext: ${config.retainContext}`);
+			lines.push(`chunkSize: ${config.chunkSize ?? "<server default>"}`);
+			lines.push(`chunksPerBatch: ${config.chunksPerBatch ?? "<server default>"}`);
+			lines.push(`nodeSet: ${config.nodeSet.join(", ") || "<none>"}`);
+			lines.push(`ontologyKeys: ${config.ontologyKeys.join(", ") || "<none>"}`);
+			lines.push("");
+		}
+
+		if (primary) {
+			lines.push("### Active state");
+			lines.push(`sessionId: ${primary.sessionId}`);
+			lines.push(`lastRetainedTurn: ${primary.lastRetainedTurn}`);
+			lines.push(`hasRecalledForFirstTurn: ${primary.hasRecalledForFirstTurn}`);
+			lines.push(`lastRetainedAtIso: ${primary.lastRetainedAtIso ?? "<never>"}`);
+			const snippet = primary.lastRecallSnippet;
+			lines.push(
+				`lastRecallSnippet: ${snippet ? `present (${snippet.length} chars)` : "absent"}`,
+			);
+			if (snippet) {
+				lines.push(`lastRecallSnippet preview: ${safePreview(snippet)}`);
+			}
+			lines.push("");
+		}
+
+		if (client && scope) {
+			lines.push("### Dataset status");
+			try {
+				const status = await client.getDatasetStatus({ dataset: scope.datasetName, datasetId: scope.datasetId });
+				lines.push("```json");
+				lines.push(boundedJson(status));
+				lines.push("```");
+			} catch (err) {
+				lines.push(`Status lookup failed: ${safeErrorMessage(err)}`);
+			}
+			lines.push("");
+
+			lines.push("### Datasets");
+			try {
+				const datasets = await client.listDatasets();
+				lines.push(`Dataset count: ${datasets.length}`);
+			} catch (err) {
+				lines.push(`Dataset list failed: ${safeErrorMessage(err)}`);
+			}
+		}
+
+		return lines.join("\n");
+	},
+
+	async preCompactionContext(
+		messages: AgentMessage[],
+		settings: Settings,
+		session?: AgentSession,
+	): Promise<string | undefined> {
+		const config = loadCogneeConfig(settings);
+		if (!isCogneeConfigured(config)) return undefined;
+		const state = session ? getCogneeSessionState(session) : undefined;
+		if (!state) return undefined;
+		// Let errors propagate; backend must not flatten/format messages.
+		return await state.recallForCompaction(messages);
+	},
+};

--- a/packages/coding-agent/src/cognee/client.ts
+++ b/packages/coding-agent/src/cognee/client.ts
@@ -1,0 +1,710 @@
+const DEFAULT_USER_AGENT = "oh-my-pi-coding-agent";
+const MAX_SUMMARY_LENGTH = 500;
+
+export interface CogneeApiOptions {
+	baseUrl: string;
+	apiKey?: string;
+	bearerToken?: string;
+	userAgent?: string;
+	fetch?: typeof fetch;
+}
+
+export class CogneeError extends Error {
+	readonly status?: number;
+	readonly details?: unknown;
+	readonly cause?: unknown;
+
+	constructor(message: string, status?: number, details?: unknown, cause?: unknown) {
+		super(message);
+		this.name = "CogneeError";
+		this.status = status;
+		this.details = details;
+		this.cause = cause;
+	}
+}
+
+export interface CogneeRememberRequest {
+	data: string | Blob | Uint8Array | Array<string | Blob | Uint8Array>;
+	datasetName?: string;
+	datasetId?: string;
+	sessionId?: string;
+	nodeSet?: string[];
+	runInBackground?: boolean;
+	customPrompt?: string;
+	chunkSize?: number;
+	chunksPerBatch?: number;
+	ontologyKeys?: string[];
+	graphModel?: string;
+	contentType?: string;
+}
+
+export interface CogneeRememberResult {
+	status?: string;
+	datasetName?: string;
+	datasetId?: string;
+	pipelineRunId?: string;
+	itemsProcessed?: number;
+	elapsedSeconds?: number;
+	sessionIds?: string[];
+	items?: unknown[];
+	contentHash?: string;
+	entryType?: string;
+	entryId?: string;
+	error?: string;
+	raw: unknown;
+}
+
+export type CogneeStructuredEntryType = "qa" | "trace" | "feedback" | "skill_run" | string;
+
+export interface CogneeRememberEntryRequest {
+	type: CogneeStructuredEntryType;
+	datasetName?: string;
+	datasetId?: string;
+	sessionId?: string;
+	question?: string;
+	answer?: string;
+	trace?: unknown;
+	feedback?: unknown;
+	skillImprovement?: unknown;
+	metadata?: Record<string, unknown>;
+}
+
+export interface CogneeRecallRequest {
+	query: string;
+	searchType?: string;
+	datasets?: string[];
+	datasetIds?: string[];
+	systemPrompt?: string;
+	nodeName?: string[];
+	topK?: number;
+	onlyContext?: boolean;
+	verbose?: boolean;
+	includeReferences?: boolean;
+	sessionId?: string;
+	scope?: string | string[];
+	contextProfile?: string;
+}
+
+export type CogneeRecallSource = "session" | "trace" | "graph_context" | "session_context" | "graph" | string;
+
+export interface CogneeRecallEntryBase {
+	source: CogneeRecallSource;
+	text: string;
+	id?: string;
+	score?: number;
+	time?: string;
+	raw: unknown;
+}
+
+export interface CogneeRecallQaEntry extends CogneeRecallEntryBase {
+	source: "session";
+	question?: string;
+	answer?: string;
+	context?: string;
+	qaId?: string;
+}
+
+export interface CogneeRecallTraceEntry extends CogneeRecallEntryBase {
+	source: "trace";
+	traceId?: string;
+}
+
+export interface CogneeRecallGraphContextEntry extends CogneeRecallEntryBase {
+	source: "graph_context" | "session_context";
+	context?: string;
+}
+
+export interface CogneeRecallGraphEntry extends CogneeRecallEntryBase {
+	source: "graph";
+	nodeName?: string;
+}
+
+export type CogneeRecallEntry =
+	| CogneeRecallQaEntry
+	| CogneeRecallTraceEntry
+	| CogneeRecallGraphContextEntry
+	| CogneeRecallGraphEntry
+	| CogneeRecallEntryBase;
+
+export interface CogneeImproveRequest {
+	datasetName?: string;
+	datasetId?: string;
+	sessionIds?: string[];
+	nodeName?: string[];
+	runInBackground?: boolean;
+	buildGlobalContextIndex?: boolean;
+	data?: string;
+	extractionTasks?: string[];
+	enrichmentTasks?: string[];
+}
+
+export interface CogneeForgetRequest {
+	everything?: boolean;
+	dataset?: string;
+	datasetId?: string;
+	dataId?: string;
+	memoryOnly?: boolean;
+}
+
+export interface CogneeDataset {
+	id?: string;
+	name?: string;
+	status?: string;
+	raw: unknown;
+}
+
+export interface CogneeDatasetStatusRequest {
+	dataset?: string;
+	datasetId?: string;
+	pipeline?: "add_pipeline" | "cognify_pipeline" | string;
+}
+
+export interface CogneeCreateDatasetRequest {
+	name: string;
+}
+
+export interface CogneeCreateDatasetResponse {
+	id?: string;
+	name?: string;
+	status?: string;
+	raw: unknown;
+}
+
+export interface CogneeClient {
+	remember(request: CogneeRememberRequest, signal?: AbortSignal): Promise<CogneeRememberResult>;
+	rememberEntry(request: CogneeRememberEntryRequest, signal?: AbortSignal): Promise<CogneeRememberResult>;
+	recall(request: CogneeRecallRequest, signal?: AbortSignal): Promise<CogneeRecallEntry[]>;
+	improve(request: CogneeImproveRequest, signal?: AbortSignal): Promise<Record<string, unknown>>;
+	forget(request: CogneeForgetRequest, signal?: AbortSignal): Promise<unknown>;
+	listDatasets(signal?: AbortSignal): Promise<CogneeDataset[]>;
+	getDatasetStatus(request: CogneeDatasetStatusRequest, signal?: AbortSignal): Promise<unknown>;
+	listDatasetData(datasetId: string, signal?: AbortSignal): Promise<unknown>;
+	createDataset(request: CogneeCreateDatasetRequest, signal?: AbortSignal): Promise<CogneeCreateDatasetResponse>;
+}
+
+interface RequestParsedArgs {
+	method: string;
+	path: string;
+	operation: string;
+	query?: Record<string, string | undefined>;
+	body?: BodyInit;
+	json?: Record<string, unknown>;
+	signal?: AbortSignal;
+	allowRecallForbiddenEmptyList?: boolean;
+}
+
+class CogneeHttpClient implements CogneeClient {
+	readonly #baseUrl: string;
+	readonly #fetchImpl: typeof fetch;
+	readonly #baseHeaders: Headers;
+
+	constructor(options: CogneeApiOptions) {
+		this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+		this.#fetchImpl = options.fetch ?? globalThis.fetch;
+		this.#baseHeaders = new Headers({
+			Accept: "application/json",
+			"User-Agent": options.userAgent ?? DEFAULT_USER_AGENT,
+		});
+		if (options.apiKey) {
+			this.#baseHeaders.set("X-Api-Key", options.apiKey);
+		} else if (options.bearerToken) {
+			this.#baseHeaders.set("Authorization", `Bearer ${options.bearerToken}`);
+		}
+	}
+
+	async remember(request: CogneeRememberRequest, signal?: AbortSignal): Promise<CogneeRememberResult> {
+		const form = new FormData();
+		for (const value of Array.isArray(request.data) ? request.data : [request.data]) {
+			if (typeof value === "string") {
+				form.append("data", value);
+			} else if (value instanceof Blob) {
+				form.append("data", value);
+			} else {
+				form.append(
+					"data",
+					new Blob([value], { type: request.contentType ?? "application/octet-stream" }),
+				);
+			}
+		}
+
+		appendIfDefined(form, "datasetName", request.datasetName);
+		appendIfDefined(form, "datasetId", request.datasetId);
+		appendIfDefined(form, "session_id", request.sessionId);
+		appendIfDefined(form, "run_in_background", request.runInBackground);
+		appendIfDefined(form, "custom_prompt", request.customPrompt);
+		appendIfDefined(form, "chunk_size", request.chunkSize);
+		appendIfDefined(form, "chunks_per_batch", request.chunksPerBatch);
+		appendIfDefined(form, "graph_model", request.graphModel);
+		appendIfDefined(form, "content_type", request.contentType);
+		appendRepeatedStrings(form, "node_set", request.nodeSet);
+		appendRepeatedStrings(form, "ontology_key", request.ontologyKeys);
+
+		const parsed = await this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/remember",
+			operation: "remember",
+			body: form,
+			signal,
+		});
+		return normalizeRememberResult(parsed);
+	}
+
+	async rememberEntry(
+		request: CogneeRememberEntryRequest,
+		signal?: AbortSignal,
+	): Promise<CogneeRememberResult> {
+		if (typeof request.type !== "string" || request.type.trim() === "") {
+			throw new CogneeError("rememberEntry type is required");
+		}
+		const parsed = await this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/remember/entry",
+			operation: "rememberEntry",
+			json: {
+				type: request.type,
+				datasetName: request.datasetName,
+				datasetId: request.datasetId,
+				sessionId: request.sessionId,
+				question: request.question,
+				answer: request.answer,
+				trace: request.trace,
+				feedback: request.feedback,
+				skillImprovement: request.skillImprovement,
+				metadata: request.metadata,
+			},
+			signal,
+		});
+		return normalizeRememberResult(parsed);
+	}
+
+	async recall(request: CogneeRecallRequest, signal?: AbortSignal): Promise<CogneeRecallEntry[]> {
+		if (typeof request.query !== "string" || request.query.trim() === "") {
+			throw new CogneeError("recall query is required");
+		}
+		const parsed = await this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/recall",
+			operation: "recall",
+			json: {
+				query: request.query,
+				searchType: request.searchType,
+				datasets: request.datasets,
+				datasetIds: request.datasetIds,
+				systemPrompt: request.systemPrompt,
+				nodeName: request.nodeName,
+				topK: request.topK,
+				onlyContext: request.onlyContext,
+				verbose: request.verbose,
+				includeReferences: request.includeReferences,
+				sessionId: request.sessionId,
+				scope: request.scope,
+				contextProfile: request.contextProfile,
+			},
+			signal,
+			allowRecallForbiddenEmptyList: true,
+		});
+		return normalizeRecallEntries(parsed);
+	}
+
+	async improve(request: CogneeImproveRequest, signal?: AbortSignal): Promise<Record<string, unknown>> {
+		const parsed = await this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/improve",
+			operation: "improve",
+			json: {
+				datasetName: request.datasetName,
+				datasetId: request.datasetId,
+				sessionIds: request.sessionIds,
+				nodeName: request.nodeName,
+				runInBackground: request.runInBackground,
+				buildGlobalContextIndex: request.buildGlobalContextIndex,
+				data: request.data,
+				extractionTasks: request.extractionTasks,
+				enrichmentTasks: request.enrichmentTasks,
+			},
+			signal,
+		});
+		return isRecord(parsed) && !Array.isArray(parsed) ? parsed : { raw: parsed };
+	}
+
+	async forget(request: CogneeForgetRequest, signal?: AbortSignal): Promise<unknown> {
+		return this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/forget",
+			operation: "forget",
+			json: {
+				everything: request.everything,
+				dataset: request.dataset,
+				datasetId: request.datasetId,
+				dataId: request.dataId,
+				memoryOnly: request.memoryOnly,
+			},
+			signal,
+		});
+	}
+
+	async listDatasets(signal?: AbortSignal): Promise<CogneeDataset[]> {
+		const parsed = await this.#requestParsed({
+			method: "GET",
+			path: "/api/v1/datasets",
+			operation: "listDatasets",
+			signal,
+		});
+		return normalizeDatasets(parsed);
+	}
+
+	async getDatasetStatus(request: CogneeDatasetStatusRequest, signal?: AbortSignal): Promise<unknown> {
+		return this.#requestParsed({
+			method: "GET",
+			path: "/api/v1/datasets/status",
+			operation: "getDatasetStatus",
+			query: {
+				dataset: request.datasetId ?? request.dataset,
+				pipeline: request.pipeline,
+			},
+			signal,
+		});
+	}
+
+	async listDatasetData(datasetId: string, signal?: AbortSignal): Promise<unknown> {
+		if (typeof datasetId !== "string" || datasetId.trim() === "") {
+			throw new CogneeError("datasetId is required");
+		}
+		return this.#requestParsed({
+			method: "GET",
+			path: `/api/v1/datasets/${encodeURIComponent(datasetId)}/data`,
+			operation: "listDatasetData",
+			signal,
+		});
+	}
+
+	async createDataset(
+		request: CogneeCreateDatasetRequest,
+		signal?: AbortSignal,
+	): Promise<CogneeCreateDatasetResponse> {
+		if (typeof request.name !== "string" || request.name.trim() === "") {
+			throw new CogneeError("dataset name is required");
+		}
+		const parsed = await this.#requestParsed({
+			method: "POST",
+			path: "/api/v1/datasets",
+			operation: "createDataset",
+			json: { name: request.name },
+			signal,
+		});
+		return normalizeDataset(parsed);
+	}
+
+	async #requestParsed(args: RequestParsedArgs): Promise<unknown> {
+		const url = new URL(`${this.#baseUrl}${args.path}`);
+		if (args.query) {
+			for (const [key, value] of Object.entries(args.query)) {
+				if (value !== undefined) url.searchParams.append(key, value);
+			}
+		}
+
+		const headers = new Headers(this.#baseHeaders);
+		let body = args.body;
+		if (args.json !== undefined) {
+			headers.set("Content-Type", "application/json");
+			body = JSON.stringify(pruneUndefined(args.json));
+		}
+
+		let response: Response;
+		try {
+			response = await this.#fetchImpl(url.toString(), {
+				method: args.method,
+				headers,
+				body,
+				signal: args.signal,
+			});
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			throw new CogneeError(
+				`${args.operation} request failed: ${boundedJson(err instanceof Error ? err.message : String(err))}`,
+				undefined,
+				undefined,
+				err,
+			);
+		}
+
+		const { parsed, rawText, hasBody } = await parseResponseBody(response);
+		if (
+			args.allowRecallForbiddenEmptyList &&
+			response.status === 403 &&
+			(rawText.trim() === "[]" || (Array.isArray(parsed) && parsed.length === 0))
+		) {
+			return [];
+		}
+
+		if (!response.ok) {
+			const details = hasBody ? parsed : undefined;
+			throw new CogneeError(
+				`${args.operation} failed with HTTP ${response.status}: ${summarizeErrorDetails(details)}`,
+				response.status,
+				details,
+			);
+		}
+
+		return hasBody ? parsed : {};
+	}
+}
+
+export function createCogneeClient(options: CogneeApiOptions): CogneeClient {
+	return new CogneeHttpClient(options);
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (value !== undefined) result[key] = value;
+	}
+	return result;
+}
+
+function safeJsonParse(text: string): { ok: true; value: unknown } | { ok: false } {
+	try {
+		return { ok: true, value: JSON.parse(text) };
+	} catch {
+		return { ok: false };
+	}
+}
+
+async function parseResponseBody(response: Response): Promise<{ parsed: unknown; rawText: string; hasBody: boolean }> {
+	const rawText = await response.text();
+	if (rawText.trim() === "") return { parsed: {}, rawText, hasBody: false };
+	const json = safeJsonParse(rawText);
+	return { parsed: json.ok ? json.value : rawText, rawText, hasBody: true };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, ...names: string[]): string | undefined {
+	for (const name of names) {
+		const value = record[name];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+function usableStringField(record: Record<string, unknown>, ...names: string[]): string | undefined {
+	for (const name of names) {
+		const value = record[name];
+		if (typeof value === "string" && value.trim() !== "") return value;
+	}
+	return undefined;
+}
+
+function numberField(record: Record<string, unknown>, ...names: string[]): number | undefined {
+	for (const name of names) {
+		const value = record[name];
+		if (typeof value === "number") return value;
+	}
+	return undefined;
+}
+
+function arrayField(record: Record<string, unknown>, ...names: string[]): unknown[] | undefined {
+	for (const name of names) {
+		const value = record[name];
+		if (Array.isArray(value)) return value;
+	}
+	return undefined;
+}
+
+function boundedJson(value: unknown): string {
+	const text = stringifyBounded(value);
+	return text.length > MAX_SUMMARY_LENGTH ? `${text.slice(0, MAX_SUMMARY_LENGTH)}…` : text;
+}
+
+function stringifyBounded(value: unknown): string {
+	if (typeof value === "string") return value;
+	try {
+		const text = JSON.stringify(value, (_key, nested) => {
+			if (typeof nested === "bigint") return nested.toString();
+			if (typeof nested === "string" && nested.length > MAX_SUMMARY_LENGTH) {
+				return `${nested.slice(0, MAX_SUMMARY_LENGTH)}…`;
+			}
+			return nested;
+		});
+		return text ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function summarizeErrorDetails(details: unknown): string {
+	if (details === undefined) return "empty response";
+	if (isRecord(details)) {
+		for (const name of ["detail", "message", "error"]) {
+			const value = details[name];
+			if (typeof value === "string" && value.trim() !== "") return boundedJson(value);
+		}
+	}
+	return boundedJson(details);
+}
+
+function appendIfDefined(form: FormData, field: string, value: unknown): void {
+	if (value === undefined) return;
+	form.append(field, value instanceof Blob ? value : String(value));
+}
+
+function appendRepeatedStrings(form: FormData, field: string, values?: string[]): void {
+	if (values === undefined) return;
+	for (const value of values) form.append(field, value);
+}
+
+
+function normalizeRememberResult(raw: unknown): CogneeRememberResult {
+	if (!isRecord(raw)) return { raw };
+	const result: CogneeRememberResult = { raw };
+	const status = stringField(raw, "status");
+	if (status !== undefined) result.status = status;
+	const datasetName = stringField(raw, "datasetName", "dataset_name");
+	if (datasetName !== undefined) result.datasetName = datasetName;
+	const datasetId = stringField(raw, "datasetId", "dataset_id");
+	if (datasetId !== undefined) result.datasetId = datasetId;
+	const pipelineRunId = stringField(raw, "pipelineRunId", "pipeline_run_id", "operationId", "operation_id");
+	if (pipelineRunId !== undefined) result.pipelineRunId = pipelineRunId;
+	const itemsProcessed = numberField(raw, "itemsProcessed", "items_processed");
+	if (itemsProcessed !== undefined) result.itemsProcessed = itemsProcessed;
+	const elapsedSeconds = numberField(raw, "elapsedSeconds", "elapsed_seconds");
+	if (elapsedSeconds !== undefined) result.elapsedSeconds = elapsedSeconds;
+	const sessionIds = arrayField(raw, "sessionIds", "session_ids");
+	if (sessionIds !== undefined) result.sessionIds = sessionIds.filter((item): item is string => typeof item === "string");
+	const items = arrayField(raw, "items");
+	if (items !== undefined) result.items = items;
+	const contentHash = stringField(raw, "contentHash", "content_hash");
+	if (contentHash !== undefined) result.contentHash = contentHash;
+	const entryType = stringField(raw, "entryType", "entry_type");
+	if (entryType !== undefined) result.entryType = entryType;
+	const entryId = stringField(raw, "entryId", "entry_id");
+	if (entryId !== undefined) result.entryId = entryId;
+	const error = stringField(raw, "error") ?? stringField(raw, "message");
+	if (error !== undefined) result.error = error;
+	return result;
+}
+
+function normalizeRecallEntries(raw: unknown): CogneeRecallEntry[] {
+	if (Array.isArray(raw)) return raw.map(normalizeRecallEntry);
+	if (isRecord(raw)) {
+		if (Object.keys(raw).length === 0) return [];
+		const contained = arrayField(raw, "results", "items", "data");
+		if (contained !== undefined) return contained.map(normalizeRecallEntry);
+		return [normalizeRecallEntry(raw)];
+	}
+	if (typeof raw === "string") return [{ source: "unknown", text: raw, raw }];
+	return [{ source: "unknown", text: boundedJson(raw), raw }];
+}
+
+function normalizeRecallEntry(item: unknown): CogneeRecallEntry {
+	if (!isRecord(item)) return { source: "unknown", text: typeof item === "string" ? item : boundedJson(item), raw: item };
+
+	const source = inferRecallSource(item);
+	const base: CogneeRecallEntryBase = {
+		source,
+		text: recallText(item),
+		raw: item,
+	};
+	const id = stringField(item, "id", "uuid", "dataId", "data_id", "qaId", "qa_id", "traceId", "trace_id", "nodeId", "node_id");
+	if (id !== undefined) base.id = id;
+	const score = numberField(item, "score");
+	if (score !== undefined) base.score = score;
+	const time = stringField(item, "time", "timestamp", "createdAt", "created_at", "updated_at");
+	if (time !== undefined) base.time = time;
+
+	if (source === "session") {
+		const entry: CogneeRecallQaEntry = { ...base, source: "session" };
+		const question = stringField(item, "question");
+		if (question !== undefined) entry.question = question;
+		const answer = stringField(item, "answer");
+		if (answer !== undefined) entry.answer = answer;
+		const context = stringField(item, "context");
+		if (context !== undefined) entry.context = context;
+		const qaId = stringField(item, "qaId", "qa_id");
+		if (qaId !== undefined) entry.qaId = qaId;
+		return entry;
+	}
+	if (source === "trace") {
+		const entry: CogneeRecallTraceEntry = { ...base, source: "trace" };
+		const traceId = stringField(item, "traceId", "trace_id");
+		if (traceId !== undefined) entry.traceId = traceId;
+		return entry;
+	}
+	if (source === "graph_context" || source === "session_context") {
+		const entry: CogneeRecallGraphContextEntry = { ...base, source };
+		const context = stringField(item, "context");
+		if (context !== undefined) entry.context = context;
+		return entry;
+	}
+	if (source === "graph") {
+		const entry: CogneeRecallGraphEntry = { ...base, source: "graph" };
+		const nodeName = stringField(item, "nodeName", "node_name", "name", "label");
+		if (nodeName !== undefined) entry.nodeName = nodeName;
+		return entry;
+	}
+	return base;
+}
+
+function inferRecallSource(item: Record<string, unknown>): CogneeRecallSource {
+	const source = stringField(item, "source");
+	if (source !== undefined) return source;
+	if (
+		"question" in item ||
+		"answer" in item ||
+		"qaId" in item ||
+		"qa_id" in item
+	) {
+		return "session";
+	}
+	if ("traceId" in item || "trace_id" in item) return "trace";
+	if (
+		"nodeName" in item ||
+		"node_name" in item ||
+		"node" in item ||
+		"nodeId" in item ||
+		"node_id" in item ||
+		"name" in item ||
+		"label" in item
+	) {
+		return "graph";
+	}
+	return "unknown";
+}
+
+function recallText(item: Record<string, unknown>): string {
+	const early = usableStringField(item, "text", "content", "context");
+	if (early !== undefined) return early;
+	const question = usableStringField(item, "question");
+	const answer = usableStringField(item, "answer");
+	if (question !== undefined && answer !== undefined) return `Q: ${question}\nA: ${answer}`;
+	return usableStringField(item, "answer", "question", "message", "summary", "nodeName", "node_name", "name", "label") ?? boundedJson(item);
+}
+
+function normalizeDataset(raw: unknown): CogneeDataset {
+	if (!isRecord(raw)) return { raw };
+	const dataset: CogneeDataset = { raw };
+	const id = stringField(raw, "id", "uuid", "dataset_id");
+	if (id !== undefined) dataset.id = id;
+	const name = stringField(raw, "name", "dataset_name");
+	if (name !== undefined) dataset.name = name;
+	const status = stringField(raw, "status");
+	if (status !== undefined) dataset.status = status;
+	return dataset;
+}
+
+function normalizeDatasets(raw: unknown): CogneeDataset[] {
+	if (Array.isArray(raw)) return raw.map(normalizeDataset);
+	if (isRecord(raw)) {
+		const contained = arrayField(raw, "datasets", "items", "data");
+		return contained === undefined ? [] : contained.map(normalizeDataset);
+	}
+	return [];
+}
+
+
+function isAbortError(err: unknown): boolean {
+	return isRecord(err) && err.name === "AbortError";
+}
+

--- a/packages/coding-agent/src/cognee/config.ts
+++ b/packages/coding-agent/src/cognee/config.ts
@@ -1,0 +1,238 @@
+/**
+ * Resolved Cognee runtime configuration.
+ *
+ * Pure (no I/O) aside from reading from `process.env` and the supplied
+ * `Settings` instance. Tests can pass `Settings.isolated({...})` and a stub
+ * env per case. All HTTP spelling lives in `./client`; this module never
+ * touches the network, filesystem, session, or client.
+ */
+
+import { logger } from "@oh-my-pi/pi-utils";
+import type { Settings } from "../config/settings";
+
+export type CogneeScoping = "global" | "per-project" | "per-project-tagged";
+export type CogneeRetainMode = "full-session" | "last-turn";
+export type CogneeSearchType =
+	| "GRAPH_COMPLETION"
+	| "RAG_COMPLETION"
+	| "CHUNKS"
+	| "INSIGHTS"
+	| "CODE"
+	| string;
+export type CogneeRecallScope =
+	| "auto"
+	| "graph"
+	| "session"
+	| "trace"
+	| "graph_context"
+	| "session_context"
+	| "all"
+	| string;
+
+export interface CogneeConfig {
+	apiUrl: string | null;
+	apiKey: string | null;
+
+	/** Base dataset name used when datasetId is unset. */
+	datasetName: string | null;
+	/** UUID of an existing dataset. When set, it wins over datasetName. */
+	datasetId: string | null;
+	/** Optional prefix applied before datasetName-derived names. */
+	datasetNamePrefix: string;
+	scoping: CogneeScoping;
+
+	autoRecall: boolean;
+	autoRetain: boolean;
+	retainMode: CogneeRetainMode;
+	retainEveryNTurns: number;
+	retainOverlapTurns: number;
+	retainContext: string;
+	runInBackground: boolean;
+	chunkSize: number | null;
+	chunksPerBatch: number | null;
+	customPrompt: string | null;
+	ontologyKeys: string[];
+	graphModel: string | null;
+
+	/** Static Cognee node-set tags sent on remember in every scoping mode. */
+	nodeSet: string[];
+
+	recallSearchType: CogneeSearchType;
+	recallScope: CogneeRecallScope;
+	recallTopK: number;
+	recallContextTurns: number;
+	recallMaxQueryChars: number;
+	recallMaxRenderChars: number;
+	recallPromptPreamble: string;
+	onlyContext: boolean;
+	verbose: boolean;
+
+	/** `/memory enqueue` calls improve on this dataset/session when true. */
+	improveOnEnqueue: boolean;
+	buildGlobalContextIndex: boolean;
+
+	/** Session-cache mode requires Cognee server CACHING=true/CACHE_BACKEND configured. */
+	sessionMemoryEnabled: boolean;
+	debug: boolean;
+}
+
+const DEFAULT_RECALL_PREAMBLE =
+	"Relevant Cognee memories from prior conversations and knowledge graph context. " +
+	"Use only when directly useful; verify against current repo state before acting.";
+
+const VALID_SCOPINGS: CogneeScoping[] = ["global", "per-project", "per-project-tagged"];
+const VALID_RETAIN_MODES: CogneeRetainMode[] = ["full-session", "last-turn"];
+
+/** Trim a string value; return null for non-strings or empty/whitespace-only. */
+function trimNullableString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed === "" ? null : trimmed;
+}
+
+/** Trim a string value; return "" for non-strings or empty/whitespace-only. */
+function trimPrefix(value: unknown): string {
+	if (typeof value !== "string") return "";
+	return value.trim();
+}
+
+/**
+ * Override a resolved setting string with a non-blank env value. Blank env
+ * values do not override; the existing setting value is preserved.
+ */
+function envOverride(settingValue: string | null, envValue: string | undefined): string | null {
+	if (typeof envValue === "string") {
+		const trimmed = envValue.trim();
+		if (trimmed !== "") return trimmed;
+	}
+	return settingValue;
+}
+
+/** Normalize an array setting: trim, drop empty/non-string entries, dedupe. */
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		const trimmed = item.trim();
+		if (trimmed === "") continue;
+		if (seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		out.push(trimmed);
+	}
+	return out;
+}
+
+/** Coerce a numeric setting to a clamped integer, falling back when invalid. */
+function integerSetting(value: unknown, fallback: number, min: number): number {
+	let n: number | undefined;
+	if (typeof value === "number") {
+		n = value;
+	} else if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (trimmed !== "") n = Number(trimmed);
+	}
+	if (n === undefined || !Number.isFinite(n)) return fallback;
+	return Math.max(min, Math.trunc(n));
+}
+
+/** Coerce chunkSize/chunksPerBatch: null unless a finite integer > 0. */
+function positiveNullableInteger(value: unknown): number | null {
+	let n: number | undefined;
+	if (typeof value === "number") {
+		n = value;
+	} else if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (trimmed !== "") n = Number(trimmed);
+	}
+	if (n === undefined || !Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
+	return n;
+}
+
+
+function pickScoping(value: unknown): CogneeScoping | undefined {
+	return typeof value === "string" && (VALID_SCOPINGS as string[]).includes(value)
+		? (value as CogneeScoping)
+		: undefined;
+}
+
+function pickRetainMode(value: unknown): CogneeRetainMode | undefined {
+	return typeof value === "string" && (VALID_RETAIN_MODES as string[]).includes(value)
+		? (value as CogneeRetainMode)
+		: undefined;
+}
+
+/**
+ * Load the resolved Cognee config.
+ *
+ * Pure (no I/O) aside from reading from `process.env` and the supplied
+ * `Settings` instance. Tests can pass `Settings.isolated({...})` and stub
+ * `process.env` per case.
+ */
+export function loadCogneeConfig(settings: Settings, env: NodeJS.ProcessEnv = process.env): CogneeConfig {
+	const rawScoping = settings.get("cognee.scoping");
+	const scoping = pickScoping(rawScoping);
+	if (rawScoping && !scoping) {
+		logger.warn("Cognee: invalid scoping setting, falling back to per-project-tagged", {
+			value: rawScoping,
+		});
+	}
+
+	const rawRetainMode = settings.get("cognee.retainMode");
+	const retainMode = pickRetainMode(rawRetainMode);
+	if (rawRetainMode && !retainMode) {
+		logger.warn("Cognee: invalid retainMode setting, falling back to full-session", {
+			value: rawRetainMode,
+		});
+	}
+
+	const recallSearchType = trimNullableString(settings.get("cognee.recallSearchType")) ?? "GRAPH_COMPLETION";
+	const recallScope = trimNullableString(settings.get("cognee.recallScope")) ?? "auto";
+
+	return {
+		apiUrl: envOverride(trimNullableString(settings.get("cognee.apiUrl")), env.COGNEE_API_URL),
+		apiKey: envOverride(trimNullableString(settings.get("cognee.apiKey")), env.COGNEE_API_KEY),
+
+		datasetName: trimNullableString(settings.get("cognee.datasetName")),
+		datasetId: trimNullableString(settings.get("cognee.datasetId")),
+		datasetNamePrefix: trimPrefix(settings.get("cognee.datasetNamePrefix")),
+		scoping: scoping ?? "per-project-tagged",
+
+		autoRecall: settings.get("cognee.autoRecall") === true,
+		autoRetain: settings.get("cognee.autoRetain") === true,
+		retainMode: retainMode ?? "full-session",
+		retainEveryNTurns: integerSetting(settings.get("cognee.retainEveryNTurns"), 3, 1),
+		retainOverlapTurns: integerSetting(settings.get("cognee.retainOverlapTurns"), 2, 0),
+		retainContext: trimPrefix(settings.get("cognee.retainContext")) || "omp",
+		runInBackground: settings.get("cognee.runInBackground") === true,
+		chunkSize: positiveNullableInteger(settings.get("cognee.chunkSize")),
+		chunksPerBatch: positiveNullableInteger(settings.get("cognee.chunksPerBatch")),
+		customPrompt: trimNullableString(settings.get("cognee.customPrompt")),
+		ontologyKeys: stringArray(settings.get("cognee.ontologyKeys")),
+		graphModel: trimNullableString(settings.get("cognee.graphModel")),
+
+		nodeSet: stringArray(settings.get("cognee.nodeSet")),
+
+		recallSearchType,
+		recallScope,
+		recallTopK: integerSetting(settings.get("cognee.recallTopK"), 10, 1),
+		recallContextTurns: integerSetting(settings.get("cognee.recallContextTurns"), 1, 1),
+		recallMaxQueryChars: integerSetting(settings.get("cognee.recallMaxQueryChars"), 1200, 0),
+		recallMaxRenderChars: integerSetting(settings.get("cognee.recallMaxRenderChars"), 12000, 0),
+		recallPromptPreamble: DEFAULT_RECALL_PREAMBLE,
+		onlyContext: settings.get("cognee.onlyContext") === true,
+		verbose: settings.get("cognee.verbose") === true,
+
+		improveOnEnqueue: settings.get("cognee.improveOnEnqueue") === true,
+		buildGlobalContextIndex: settings.get("cognee.buildGlobalContextIndex") === true,
+
+		sessionMemoryEnabled: settings.get("cognee.sessionMemoryEnabled") === true,
+		debug: settings.get("cognee.debug") === true,
+	};
+}
+
+/** Whether the caller has enough config to talk to a Cognee server. */
+export function isCogneeConfigured(config: CogneeConfig): config is CogneeConfig & { apiUrl: string } {
+	return typeof config.apiUrl === "string" && config.apiUrl.length > 0;
+}

--- a/packages/coding-agent/src/cognee/content.ts
+++ b/packages/coding-agent/src/cognee/content.ts
@@ -273,7 +273,8 @@ export function truncateCogneeRecallQuery(query: string, latestPrompt: string, m
 	for (let i = parsed.contextLines.length - 1; i >= 0; i--) {
 		const nextContextLines = [parsed.contextLines[i], ...keptContextLines];
 		const candidate = buildRecallQueryCandidate(scopeLines, nextContextLines, latest, true);
-		if (candidate.length <= maxChars) keptContextLines.unshift(parsed.contextLines[i]);
+		if (candidate.length > maxChars) break;
+		keptContextLines.unshift(parsed.contextLines[i]);
 	}
 
 	const candidate = buildRecallQueryCandidate(scopeLines, keptContextLines, latest, scopeLines.length > 0 || parsed.useLatestSection);
@@ -321,16 +322,19 @@ export function prepareCogneeRetentionDocument(args: {
 	};
 }
 
+type CogneeRecallBlockConfig = Pick<CogneeConfig, "recallPromptPreamble" | "recallMaxRenderChars">;
+type CogneeRecallBlockScope = Pick<CogneeScope, "label" | "retainDatasetLabel" | "recallDatasetLabels">;
+
 export function formatCogneeRecallBlock(
 	entries: CogneeRecallEntry[],
-	config: CogneeConfig,
-	scope: CogneeScope,
+	config: CogneeRecallBlockConfig,
+	scope: CogneeRecallBlockScope,
 	now?: Date,
 ): string | undefined {
 	if (entries.length === 0) return undefined;
 
 	const preamble = config.recallPromptPreamble.trim() || DEFAULT_RECALL_PREAMBLE;
-	const renderedNow = now ?? new Date(0);
+	const renderedNow = now ?? new Date();
 	const header = [
 		"<cognee_memories>",
 		preamble,

--- a/packages/coding-agent/src/cognee/content.ts
+++ b/packages/coding-agent/src/cognee/content.ts
@@ -87,8 +87,14 @@ function sourceFallbackId(entry: CogneeRecallEntry): string | undefined {
 
 function compactQuestionAnswer(question: unknown, answer: unknown): string {
 	const lines: string[] = [];
-	if (typeof question === "string" && question.trim()) lines.push(`Q: ${question.trim()}`);
-	if (typeof answer === "string" && answer.trim()) lines.push(`A: ${answer.trim()}`);
+	if (typeof question === "string") {
+		const text = question.trim();
+		if (hasCogneeSubstantiveContent(text)) lines.push(`Q: ${text}`);
+	}
+	if (typeof answer === "string") {
+		const text = answer.trim();
+		if (hasCogneeSubstantiveContent(text)) lines.push(`A: ${text}`);
+	}
 	return lines.join("\n");
 }
 

--- a/packages/coding-agent/src/cognee/content.ts
+++ b/packages/coding-agent/src/cognee/content.ts
@@ -1,0 +1,391 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { MemoryBackendSearchItem } from "../memory-backend/types";
+import type { CogneeRecallEntry } from "./client";
+import type { CogneeConfig, CogneeRetainMode } from "./config";
+import type { CogneeScope } from "./scope";
+
+export interface CogneeMessage {
+	role: "user" | "assistant";
+	content: string;
+}
+
+export interface CogneeRetentionDocument {
+	content: string;
+	documentId: string;
+	contentType: "text/markdown";
+}
+
+const COGNEE_MEMORIES_REGEX = /<cognee_memories>[\s\S]*?<\/cognee_memories>/g;
+const MEMORIES_REGEX = /<memories>[\s\S]*?<\/memories>/g;
+const MENTAL_MODELS_REGEX = /<mental_models>[\s\S]*?<\/mental_models>/g;
+const HINDSIGHT_MEMORIES_REGEX = /<hindsight_memories>[\s\S]*?<\/hindsight_memories>/g;
+const RELEVANT_MEMORIES_REGEX = /<relevant_memories>[\s\S]*?<\/relevant_memories>/g;
+const SUBSTANTIVE_CHAR_RE = /[\p{L}\p{N}]/u;
+const DEFAULT_RECALL_PREAMBLE =
+	"Relevant Cognee memories from prior conversations and knowledge graph context. Use only when directly useful; verify against current repo state before acting.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function stripCogneeMemoryTags(content: string): string {
+	return content
+		.replace(COGNEE_MEMORIES_REGEX, "")
+		.replace(MEMORIES_REGEX, "")
+		.replace(MENTAL_MODELS_REGEX, "")
+		.replace(HINDSIGHT_MEMORIES_REGEX, "")
+		.replace(RELEVANT_MEMORIES_REGEX, "");
+}
+
+function hasCogneeSubstantiveContent(content: string): boolean {
+	return SUBSTANTIVE_CHAR_RE.test(content);
+}
+
+function normalizeCogneeMessageContent(text: string): string | null {
+	const content = stripCogneeMemoryTags(text).trim();
+	return hasCogneeSubstantiveContent(content) ? content : null;
+}
+
+function safePrefix(text: string, limit: number): string {
+	if (limit <= 0) return "";
+	if (text.length <= limit) return text;
+	return Array.from(text).slice(0, limit).join("");
+}
+
+function sliceLastCogneeTurnsByUserBoundary(messages: CogneeMessage[], turns: number): CogneeMessage[] {
+	if (messages.length === 0 || turns <= 0) return [];
+
+	let userTurnsSeen = 0;
+	let startIndex = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i].role !== "user") continue;
+		userTurnsSeen += 1;
+		if (userTurnsSeen >= turns) {
+			startIndex = i;
+			break;
+		}
+	}
+
+	return startIndex === -1 ? messages.slice() : messages.slice(startIndex);
+}
+
+function defangCogneeXml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function scoreToDisplay(score: number): string {
+	return Number(score.toFixed(4)).toString();
+}
+
+function sourceFallbackId(entry: CogneeRecallEntry): string | undefined {
+	if (entry.id) return entry.id;
+	if (entry.source === "session" && entry.qaId) return entry.qaId;
+	if (entry.source === "trace" && entry.traceId) return entry.traceId;
+	if (entry.source === "graph" && entry.nodeName) return entry.nodeName;
+	return undefined;
+}
+
+function compactQuestionAnswer(question: unknown, answer: unknown): string {
+	const lines: string[] = [];
+	if (typeof question === "string" && question.trim()) lines.push(`Q: ${question.trim()}`);
+	if (typeof answer === "string" && answer.trim()) lines.push(`A: ${answer.trim()}`);
+	return lines.join("\n");
+}
+
+function entryDisplayText(entry: CogneeRecallEntry): string {
+	const text = typeof entry.text === "string" ? entry.text.trim() : "";
+	if (text) return text;
+
+	if (entry.source === "session") {
+		return compactQuestionAnswer(entry.question, entry.answer);
+	}
+
+	if (entry.source === "graph_context" || entry.source === "session_context") {
+		return typeof entry.context === "string" ? entry.context.trim() : "";
+	}
+
+	return "";
+}
+
+function buildCogneeScopeLines(scope: CogneeScope): string[] {
+	const lines: string[] = [];
+	if (scope.projectLabel) lines.push(`Project: ${scope.projectLabel}`);
+	if (scope.label && scope.label !== scope.projectLabel && scope.label !== `project:${scope.projectLabel}`) {
+		lines.push(`Scope: ${scope.label}`);
+	}
+	return lines;
+}
+
+function formatScopePlusLatest(scopeLines: string[], latest: string): string {
+	if (scopeLines.length === 0) return latest;
+	return `${scopeLines.join("\n")}\n\nLatest prompt:\n${latest}`;
+}
+
+function buildRecallQueryCandidate(scopeLines: string[], contextLines: string[], latest: string, useLatestSection: boolean): string {
+	if (contextLines.length > 0) {
+		const prefix = scopeLines.length > 0 ? `${scopeLines.join("\n")}\n\n` : "";
+		return `${prefix}Prior context:\n${contextLines.join("\n")}\n\nLatest prompt:\n${latest}`;
+	}
+	if (useLatestSection || scopeLines.length > 0) return formatScopePlusLatest(scopeLines, latest);
+	return latest;
+}
+
+function parseCogneeRecallQuery(query: string): { scopeLines: string[]; contextLines: string[]; useLatestSection: boolean } {
+	const priorMarker = "Prior context:\n";
+	const latestMarker = "Latest prompt:\n";
+	const priorIndex = query.indexOf(priorMarker);
+	if (priorIndex !== -1) {
+		const beforePrior = query.slice(0, priorIndex).trim();
+		const latestIndex = query.indexOf(`\n\n${latestMarker}`, priorIndex + priorMarker.length);
+		const contextEnd = latestIndex === -1 ? query.length : latestIndex;
+		const contextBody = query.slice(priorIndex + priorMarker.length, contextEnd).trim();
+		return {
+			scopeLines: beforePrior ? beforePrior.split("\n") : [],
+			contextLines: contextBody ? contextBody.split("\n").filter(line => line.length > 0) : [],
+			useLatestSection: true,
+		};
+	}
+
+	const latestIndex = query.indexOf(latestMarker);
+	if (latestIndex !== -1) {
+		const beforeLatest = query.slice(0, latestIndex).trim();
+		return {
+			scopeLines: beforeLatest ? beforeLatest.split("\n") : [],
+			contextLines: [],
+			useLatestSection: true,
+		};
+	}
+
+	return { scopeLines: [], contextLines: [], useLatestSection: false };
+}
+
+function coerceUserContent(content: unknown): string | null {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return null;
+
+	const textBlocks: string[] = [];
+	let sawNonTextContent = false;
+	for (const block of content) {
+		if (!isRecord(block) || typeof block.type !== "string") continue;
+		if (block.type === "text" && typeof block.text === "string") {
+			textBlocks.push(block.text);
+			continue;
+		}
+		if (
+			block.type === "image" ||
+			block.type === "input_image" ||
+			block.type === "image_url" ||
+			block.type === "file" ||
+			block.type === "input_file" ||
+			block.type === "audio" ||
+			block.type === "input_audio" ||
+			block.type === "binary"
+		) {
+			sawNonTextContent = true;
+		}
+	}
+
+	if (textBlocks.length > 0) return textBlocks.join("\n");
+	return sawNonTextContent ? "[image omitted]" : null;
+}
+
+function coerceAssistantContent(content: unknown): string | null {
+	if (!Array.isArray(content)) return null;
+
+	const textBlocks: string[] = [];
+	for (const block of content) {
+		if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") continue;
+		if (!block.text) continue;
+		textBlocks.push(block.text);
+	}
+
+	return textBlocks.length > 0 ? textBlocks.join("\n") : null;
+}
+
+export function flattenMessagesForCognee(messages: AgentMessage[]): CogneeMessage[] {
+	const flattened: CogneeMessage[] = [];
+	for (const message of messages) {
+		if (!isRecord(message)) continue;
+
+		if (message.role === "user") {
+			const content = coerceUserContent(message.content);
+			if (content === null) continue;
+			const normalized = normalizeCogneeMessageContent(content);
+			if (normalized) flattened.push({ role: "user", content: normalized });
+			continue;
+		}
+
+		if (message.role === "assistant") {
+			const content = coerceAssistantContent(message.content);
+			if (content === null) continue;
+			const normalized = normalizeCogneeMessageContent(content);
+			if (normalized) flattened.push({ role: "assistant", content: normalized });
+		}
+	}
+	return flattened;
+}
+
+export function composeCogneeRecallQuery(
+	latestPrompt: string,
+	messages: CogneeMessage[],
+	contextTurns: number,
+	scope: CogneeScope,
+): string {
+	const latest = stripCogneeMemoryTags(latestPrompt).trim();
+	const scopeLines = buildCogneeScopeLines(scope);
+	if (contextTurns <= 1 || messages.length === 0) return formatScopePlusLatest(scopeLines, latest);
+
+	const contextLines: string[] = [];
+	for (const message of sliceLastCogneeTurnsByUserBoundary(messages, contextTurns)) {
+		const content = normalizeCogneeMessageContent(message.content);
+		if (!content) continue;
+		if (message.role === "user" && content === latest) continue;
+		contextLines.push(`${message.role}: ${content}`);
+	}
+
+	if (contextLines.length === 0) return formatScopePlusLatest(scopeLines, latest);
+	return buildRecallQueryCandidate(scopeLines, contextLines, latest, true);
+}
+
+export function truncateCogneeRecallQuery(query: string, latestPrompt: string, maxChars: number): string {
+	const latest = stripCogneeMemoryTags(latestPrompt).trim();
+	if (maxChars <= 0) return latest;
+	if (query.length <= maxChars) return query;
+	if (latest.length > maxChars) return truncateApproxTokensOrChars(latest, maxChars);
+
+	const parsed = parseCogneeRecallQuery(query);
+	const latestOnly = latest;
+	const base = buildRecallQueryCandidate([], [], latest, parsed.useLatestSection);
+	if (base.length > maxChars) return latestOnly;
+
+	const scopeLines: string[] = [];
+	for (const line of parsed.scopeLines) {
+		const candidate = buildRecallQueryCandidate([...scopeLines, line], [], latest, true);
+		if (candidate.length <= maxChars) scopeLines.push(line);
+	}
+	const keptContextLines: string[] = [];
+	for (let i = parsed.contextLines.length - 1; i >= 0; i--) {
+		const nextContextLines = [parsed.contextLines[i], ...keptContextLines];
+		const candidate = buildRecallQueryCandidate(scopeLines, nextContextLines, latest, true);
+		if (candidate.length <= maxChars) keptContextLines.unshift(parsed.contextLines[i]);
+	}
+
+	const candidate = buildRecallQueryCandidate(scopeLines, keptContextLines, latest, scopeLines.length > 0 || parsed.useLatestSection);
+	return candidate.length <= maxChars ? candidate : latestOnly;
+}
+
+export function prepareCogneeRetentionDocument(args: {
+	messages: CogneeMessage[];
+	sessionId: string;
+	retainedAt: Date;
+	mode: CogneeRetainMode;
+	retainEveryNTurns: number;
+	retainOverlapTurns: number;
+	scope: CogneeScope;
+}): CogneeRetentionDocument | null {
+	if (args.messages.length === 0) return null;
+
+	let targetMessages: CogneeMessage[];
+	let documentId: string;
+	if (args.mode === "full-session") {
+		targetMessages = args.messages;
+		documentId = args.sessionId;
+	} else {
+		const windowTurns = Math.max(1, args.retainEveryNTurns + args.retainOverlapTurns);
+		targetMessages = sliceLastCogneeTurnsByUserBoundary(args.messages, windowTurns);
+		documentId = `${args.sessionId}-${args.retainedAt.getTime()}`;
+	}
+
+	const sections: string[] = [];
+	for (const message of targetMessages) {
+		const content = normalizeCogneeMessageContent(message.content);
+		if (!content) continue;
+		sections.push(`[role: ${message.role}]\n${content}\n[${message.role}:end]`);
+	}
+	if (sections.length === 0) return null;
+
+	const headerLines = [`Session: ${args.sessionId}`, `Retained at: ${args.retainedAt.toISOString()}`];
+	if (args.scope.label) headerLines.push(`Scope: ${args.scope.label}`);
+	if (args.scope.projectLabel) headerLines.push(`Project: ${args.scope.projectLabel}`);
+
+	return {
+		content: `${headerLines.join("\n")}\n\n${sections.join("\n\n")}`,
+		documentId,
+		contentType: "text/markdown",
+	};
+}
+
+export function formatCogneeRecallBlock(
+	entries: CogneeRecallEntry[],
+	config: CogneeConfig,
+	scope: CogneeScope,
+	now?: Date,
+): string | undefined {
+	if (entries.length === 0) return undefined;
+
+	const preamble = config.recallPromptPreamble.trim() || DEFAULT_RECALL_PREAMBLE;
+	const renderedNow = now ?? new Date(0);
+	const header = [
+		"<cognee_memories>",
+		preamble,
+		`Current time: ${renderedNow.toISOString()}`,
+		`Scope: ${defangCogneeXml(scope.label)}`,
+		"",
+	].join("\n");
+	const closing = "</cognee_memories>";
+	const maxChars = config.recallMaxRenderChars;
+	if (maxChars <= 0 || `${header}${closing}`.length > maxChars) return undefined;
+
+	const bulletLines: string[] = [];
+	for (const entry of entries) {
+		const normalizedText = entryDisplayText(entry);
+		if (!hasCogneeSubstantiveContent(normalizedText)) continue;
+
+		const source = typeof entry.source === "string" && entry.source ? entry.source : "unknown";
+		const metadata = [`source=${defangCogneeXml(source)}`];
+		const id = sourceFallbackId(entry);
+		if (id) metadata.push(`id=${defangCogneeXml(id)}`);
+		if (typeof entry.score === "number") metadata.push(`score=${scoreToDisplay(entry.score)}`);
+
+		const prefix = `- [${metadata.join(" ")}] `;
+		const text = defangCogneeXml(normalizedText);
+		const fullLine = `${prefix}${text}`;
+		const fullCandidate = `${header}${[...bulletLines, fullLine].join("\n")}\n${closing}`;
+		if (fullCandidate.length <= maxChars) {
+			bulletLines.push(fullLine);
+			continue;
+		}
+
+		const beforeText = `${header}${bulletLines.length > 0 ? `${bulletLines.join("\n")}\n` : ""}${prefix}`;
+		const afterText = `\n${closing}`;
+		const remainingTextChars = maxChars - beforeText.length - afterText.length;
+		let truncatedText = truncateApproxTokensOrChars(text, remainingTextChars);
+		while (truncatedText.length > remainingTextChars && truncatedText.length > 0) {
+			const chars = Array.from(truncatedText);
+			chars.pop();
+			truncatedText = chars.join("");
+		}
+		if (hasCogneeSubstantiveContent(truncatedText)) bulletLines.push(`${prefix}${truncatedText}`);
+		break;
+	}
+
+	if (bulletLines.length === 0) return undefined;
+	return `${header}${bulletLines.join("\n")}\n${closing}`;
+}
+
+export function formatCogneeSearchItem(entry: CogneeRecallEntry): MemoryBackendSearchItem {
+	const content = entryDisplayText(entry);
+	const item: MemoryBackendSearchItem = {
+		content: hasCogneeSubstantiveContent(content) ? content : "[empty Cognee recall entry]",
+		source: entry.source,
+	};
+	const id = sourceFallbackId(entry);
+	if (id) item.id = id;
+	if (entry.time) item.timestamp = entry.time;
+	if (typeof entry.score === "number") item.score = entry.score;
+	return item;
+}
+
+export function truncateApproxTokensOrChars(text: string, limit: number): string {
+	return safePrefix(text, limit);
+}

--- a/packages/coding-agent/src/cognee/index.ts
+++ b/packages/coding-agent/src/cognee/index.ts
@@ -1,0 +1,16 @@
+export { cogneeBackend } from "./backend";
+export type { CogneeConfig, CogneeRecallScope, CogneeRetainMode, CogneeScoping, CogneeSearchType } from "./config";
+export { isCogneeConfigured, loadCogneeConfig } from "./config";
+export type { CogneeApiOptions, CogneeClient, CogneeDataset, CogneeRecallEntry, CogneeRememberResult } from "./client";
+export { CogneeError, createCogneeClient } from "./client";
+export type { CogneeScope } from "./scope";
+export { computeCogneeScope, deriveCogneeDatasetName } from "./scope";
+export type { CogneeMessage, CogneeRetentionDocument } from "./content";
+export {
+	flattenMessagesForCognee,
+	formatCogneeRecallBlock,
+	formatCogneeSearchItem,
+	prepareCogneeRetentionDocument,
+} from "./content";
+export type { CogneeSessionStateLike, CogneeSessionStateOptions } from "./state";
+export { CogneeSessionState, getCogneeSessionState, setCogneeSessionState } from "./state";

--- a/packages/coding-agent/src/cognee/scope.ts
+++ b/packages/coding-agent/src/cognee/scope.ts
@@ -1,0 +1,184 @@
+import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import * as git from "../utils/git";
+import type { CogneeConfig } from "./config";
+
+const DEFAULT_DATASET_NAME = "omp";
+const PROJECT_NODE_PREFIX = "project:";
+const UNKNOWN_PROJECT = "unknown";
+
+type CogneeConfigWithNodeSet = CogneeConfig & { nodeSet?: readonly string[] };
+
+type DatasetTarget = Pick<
+	CogneeScope,
+	"datasetName" | "datasetId" | "retainDatasetLabel" | "recallDatasetLabels" | "recallDatasets" | "recallDatasetIds"
+>;
+
+export interface CogneeScope {
+	/** Stable label for status/debug output, e.g. "global:omp" or "project:oh-my-pi". */
+	label: string;
+
+	/** Dataset target for remember/improve/forget. Exactly one of name/id should be set. */
+	datasetName?: string;
+	datasetId?: string;
+
+	/** Human labels for MemoryBackendStatus. */
+	retainDatasetLabel: string;
+	recallDatasetLabels: string[];
+
+	/** Recall target arrays. Dataset IDs win over names. */
+	recallDatasets?: string[];
+	recallDatasetIds?: string[];
+
+	/** Node tags sent to remember. Includes configured static nodes plus project node when applicable. */
+	retainNodeSet?: string[];
+
+	/** Optional node filter for strict project recall. Undefined in v1 per-project-tagged to preserve global+project recall. */
+	recallNodeName?: string[];
+
+	/** Project label derived from primary git checkout root or cwd basename. */
+	projectLabel?: string;
+	projectNode?: string;
+
+	/** The OMP session ID to forward to Cognee session-memory APIs when enabled. */
+	sessionId?: string;
+}
+
+function clean(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function baseDatasetName(config: CogneeConfig): string {
+	const baseName = clean(config.datasetName) ?? DEFAULT_DATASET_NAME;
+	const prefix = clean(config.datasetNamePrefix);
+	return prefix ? `${prefix}-${baseName}` : baseName;
+}
+
+function deriveProjectLabel(cwd: string): string {
+	if (!cwd) return UNKNOWN_PROJECT;
+	const primaryRoot = git.repo.primaryRootSync(cwd);
+	return path.basename(primaryRoot ?? cwd) || UNKNOWN_PROJECT;
+}
+
+function nameTarget(datasetName: string): DatasetTarget {
+	return {
+		datasetName,
+		retainDatasetLabel: datasetName,
+		recallDatasetLabels: [datasetName],
+		recallDatasets: [datasetName],
+	};
+}
+
+function idTarget(datasetId: string): DatasetTarget {
+	const datasetLabel = `id:${datasetId}`;
+	return {
+		datasetId,
+		retainDatasetLabel: datasetLabel,
+		recallDatasetLabels: [datasetLabel],
+		recallDatasetIds: [datasetId],
+	};
+}
+
+function normalizedNodeSet(config: CogneeConfigWithNodeSet, projectNode?: string): string[] | undefined {
+	const nodes: string[] = [];
+	const seen = new Set<string>();
+
+	for (const candidate of [...(config.nodeSet ?? []), projectNode]) {
+		const node = clean(candidate);
+		if (!node || seen.has(node)) continue;
+		seen.add(node);
+		nodes.push(node);
+	}
+
+	return nodes.length ? nodes : undefined;
+}
+
+export function deriveCogneeDatasetName(config: CogneeConfig, cwd: string): string {
+	const base = baseDatasetName(config);
+
+	switch (config.scoping) {
+		case "global":
+			return base;
+		case "per-project":
+			return `${base}-${deriveProjectLabel(cwd)}`;
+		case "per-project-tagged":
+			return base;
+	}
+
+	const exhaustive: never = config.scoping;
+	return exhaustive;
+}
+
+export function computeCogneeScope(config: CogneeConfig, cwd: string, sessionId?: string): CogneeScope {
+	const id = clean(config.datasetId);
+	const session = clean(sessionId);
+	const staticNodeSet = normalizedNodeSet(config);
+	const sessionField = session ? { sessionId: session } : {};
+
+	switch (config.scoping) {
+		case "global": {
+			if (id) {
+				return {
+					label: `global:id:${id}`,
+					...idTarget(id),
+					...(staticNodeSet ? { retainNodeSet: staticNodeSet } : {}),
+					...sessionField,
+				};
+			}
+
+			const datasetName = deriveCogneeDatasetName(config, cwd);
+			return {
+				label: `global:${datasetName}`,
+				...nameTarget(datasetName),
+				...(staticNodeSet ? { retainNodeSet: staticNodeSet } : {}),
+				...sessionField,
+			};
+		}
+		case "per-project": {
+			if (id) {
+				const projectLabel = deriveProjectLabel(cwd);
+				logger.warn(
+					"Cognee per-project scoping cannot derive per-project dataset IDs; using configured dataset ID as a global target.",
+					{ scoping: config.scoping, datasetId: id, projectLabel },
+				);
+				return {
+					label: `global:id:${id}`,
+					...idTarget(id),
+					...(staticNodeSet ? { retainNodeSet: staticNodeSet } : {}),
+					...sessionField,
+				};
+			}
+
+			const projectLabel = deriveProjectLabel(cwd);
+			const datasetName = deriveCogneeDatasetName(config, cwd);
+			return {
+				label: `project:${projectLabel}`,
+				...nameTarget(datasetName),
+				projectLabel,
+				...(staticNodeSet ? { retainNodeSet: staticNodeSet } : {}),
+				...sessionField,
+			};
+		}
+		case "per-project-tagged": {
+			const projectLabel = deriveProjectLabel(cwd);
+			const projectNode = `${PROJECT_NODE_PREFIX}${projectLabel}`;
+			const retainNodeSet = normalizedNodeSet(config, projectNode);
+			const target = id ? idTarget(id) : nameTarget(deriveCogneeDatasetName(config, cwd));
+
+			return {
+				label: `project-tagged:${projectLabel}`,
+				...target,
+				projectLabel,
+				projectNode,
+				...(retainNodeSet ? { retainNodeSet } : {}),
+				// Soft scoping: recall intentionally searches the shared dataset without a node filter so
+				// untagged/global memories remain visible; users needing hard isolation must use per-project.
+				...sessionField,
+			};
+		}
+	}
+
+	const exhaustive: never = config.scoping;
+	return exhaustive;
+}

--- a/packages/coding-agent/src/cognee/scope.ts
+++ b/packages/coding-agent/src/cognee/scope.ts
@@ -1,5 +1,4 @@
 import * as path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import type { CogneeConfig } from "./config";
 
@@ -33,7 +32,7 @@ export interface CogneeScope {
 	/** Node tags sent to remember. Includes configured static nodes plus project node when applicable. */
 	retainNodeSet?: string[];
 
-	/** Optional node filter for strict project recall. Undefined in v1 per-project-tagged to preserve global+project recall. */
+	/** Optional node filters sent to recall for strict project isolation. */
 	recallNodeName?: string[];
 
 	/** Project label derived from primary git checkout root or cwd basename. */
@@ -138,13 +137,11 @@ export function computeCogneeScope(config: CogneeConfig, cwd: string, sessionId?
 		case "per-project": {
 			if (id) {
 				const projectLabel = deriveProjectLabel(cwd);
-				logger.warn(
-					"Cognee per-project scoping cannot derive per-project dataset IDs; using configured dataset ID as a global target.",
-					{ scoping: config.scoping, datasetId: id, projectLabel },
-				);
+				const projectDatasetId = `${id}-${projectLabel}`;
 				return {
-					label: `global:id:${id}`,
-					...idTarget(id),
+					label: `project:${projectLabel}`,
+					...idTarget(projectDatasetId),
+					projectLabel,
 					...(staticNodeSet ? { retainNodeSet: staticNodeSet } : {}),
 					...sessionField,
 				};
@@ -172,8 +169,7 @@ export function computeCogneeScope(config: CogneeConfig, cwd: string, sessionId?
 				projectLabel,
 				projectNode,
 				...(retainNodeSet ? { retainNodeSet } : {}),
-				// Soft scoping: recall intentionally searches the shared dataset without a node filter so
-				// untagged/global memories remain visible; users needing hard isolation must use per-project.
+				recallNodeName: [projectNode],
 				...sessionField,
 			};
 		}

--- a/packages/coding-agent/src/cognee/state.ts
+++ b/packages/coding-agent/src/cognee/state.ts
@@ -1,0 +1,67 @@
+/**
+ * Cognee session state side channel.
+ *
+ * TEMPORARY local structural helper for the `CogneeSessionPropagation`
+ * workpackage. The dedicated `CogneeSessionState` workpackage owns the full
+ * implementation (real Cognee client wiring, alias state, listeners, retain
+ * queue, first-turn recall). Until that sibling lands and is integrated, this
+ * file provides the frozen side-channel API — `CogneeSessionStateLike`,
+ * `getCogneeSessionState`, and `setCogneeSessionState` — backed by a single
+ * module-level `WeakMap`, so `AgentSession`, `sdk.ts`, task/eval propagation,
+ * and focused tests can consume the frozen names with no import-path
+ * divergence. On integration the sibling's `cognee/state.ts` supersedes this
+ * file; the exported names are identical so consumers require no changes.
+ *
+ * Storage is singular: exactly this `WeakMap` holds Cognee state per
+ * `AgentSession`. `AgentSession` exposes only a getter and delegates here; it
+ * does not keep a private Cognee state field or a parallel cache.
+ */
+import type { AgentSession } from "../session/agent-session";
+
+export interface CogneeSessionStateLike {
+	readonly sessionId: string;
+	readonly aliasOf?: CogneeSessionStateLike;
+	readonly lastRecallSnippet?: string;
+	readonly lastRetainedAtIso?: string;
+	readonly lastRetainedTurn: number;
+	readonly hasRecalledForFirstTurn: boolean;
+
+	setSessionId(sessionId: string): void;
+	resetConversationTracking(): void;
+	enqueueRetain(content: string, context?: string): void;
+	flushRetainQueue(): Promise<void>;
+	beforeAgentStartPrompt(promptText: string): Promise<string | undefined>;
+	dispose(): void | Promise<void>;
+}
+
+const cogneeSessionStates = new WeakMap<AgentSession, CogneeSessionStateLike>();
+
+/**
+ * Returns the Cognee state currently registered for `session`, or `undefined`.
+ * Does not create state. May return either a primary or an alias state; callers
+ * that need the primary must unwrap `aliasOf` intentionally.
+ */
+export function getCogneeSessionState(
+	session: AgentSession | undefined,
+): CogneeSessionStateLike | undefined {
+	return session ? cogneeSessionStates.get(session) : undefined;
+}
+
+/**
+ * Registers `state` (or clears it when `undefined`) for `session` in the side
+ * channel and returns the previously registered state, if any. Mirrors the
+ * `setMnemopiSessionState` / `setHindsightSessionState` storage style so
+ * Cognee state has exactly one source of truth.
+ */
+export function setCogneeSessionState(
+	session: AgentSession,
+	state: CogneeSessionStateLike | undefined,
+): CogneeSessionStateLike | undefined {
+	const previous = cogneeSessionStates.get(session);
+	if (state === undefined) {
+		cogneeSessionStates.delete(session);
+	} else {
+		cogneeSessionStates.set(session, state);
+	}
+	return previous;
+}

--- a/packages/coding-agent/src/cognee/state.ts
+++ b/packages/coding-agent/src/cognee/state.ts
@@ -1,0 +1,750 @@
+import { logger } from "@oh-my-pi/pi-utils";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AgentSession } from "../session/agent-session";
+import type {
+	MemoryBackendSaveInput,
+	MemoryBackendSaveResult,
+	MemoryBackendSearchResult,
+} from "../memory-backend";
+import type {
+	CogneeClient,
+	CogneeRecallEntry,
+	CogneeRecallRequest,
+	CogneeRememberRequest,
+	CogneeRememberResult,
+} from "./client";
+import type { CogneeConfig } from "./config";
+import type { CogneeScope } from "./scope";
+import {
+	composeCogneeRecallQuery,
+	flattenMessagesForCognee,
+	formatCogneeRecallBlock,
+	formatCogneeSearchItem,
+	prepareCogneeRetentionDocument,
+	truncateCogneeRecallQuery,
+	type CogneeMessage,
+	type CogneeRetentionDocument,
+} from "./content";
+
+const COGNEE_RETAIN_FLUSH_BATCH_SIZE = 16;
+const COGNEE_RETAIN_FLUSH_INTERVAL_MS = 5_000;
+const COGNEE_RETAIN_QUEUE_MAX_ITEMS = 128;
+const COGNEE_NOTICE_SOURCE = "Cognee";
+
+// `MemoryBackendId` does not yet include `"cognee"` in this integrated base;
+// `CogneeBackendAdapter` will widen the shared type. Until then, cast the
+// literal locally so `search`/`save` results carry the truthful backend name
+// without editing `memory-backend/types.ts` from this workpackage.
+const COGNEE_BACKEND = "cognee" as MemoryBackendSearchResult["backend"];
+
+const kCogneeSessionState = Symbol("cognee.sessionState");
+
+interface AgentSessionWithCogneeState extends AgentSession {
+	[kCogneeSessionState]?: CogneeSessionStateLike;
+}
+
+interface PendingCogneeRetainItem {
+	content: string;
+	context?: string;
+	timestamp: Date;
+}
+
+interface RecallOutcome {
+	context: string | null;
+	ok: boolean;
+}
+
+export interface CogneeSessionStateOptions {
+	sessionId: string;
+	client: CogneeClient;
+	config: CogneeConfig;
+	scope: CogneeScope;
+	session: AgentSession;
+	lastRetainedTurn?: number;
+	hasRecalledForFirstTurn?: boolean;
+	aliasOf?: CogneeSessionStateLike;
+}
+
+export interface CogneeSessionStateLike {
+	readonly sessionId: string;
+	readonly client: CogneeClient;
+	readonly config: CogneeConfig;
+	readonly scope: CogneeScope;
+	readonly session: AgentSession;
+	readonly aliasOf?: CogneeSessionStateLike;
+	readonly lastRecallSnippet?: string;
+	readonly lastRetainedAtIso?: string;
+	readonly lastRetainedTurn: number;
+	readonly hasRecalledForFirstTurn: boolean;
+
+	setSessionId(sessionId: string): void;
+	resetConversationTracking(): void;
+	enqueueRetain(content: string, context?: string): void;
+	flushRetainQueue(): Promise<void>;
+	beforeAgentStartPrompt(promptText: string): Promise<string | undefined>;
+	recallForContext(query: string, signal?: AbortSignal): Promise<{ context: string | null; ok: boolean }>;
+	recallForCompaction(messages: AgentMessage[]): Promise<string | undefined>;
+	forceRetainCurrentSession(): Promise<void>;
+	maybeRetainOnAgentEnd(): Promise<void>;
+	attachSessionListeners(): void;
+	dispose(): void | Promise<void>;
+
+	search(query: string, options?: { limit?: number; signal?: AbortSignal }): Promise<MemoryBackendSearchResult>;
+	save(input: MemoryBackendSaveInput): Promise<MemoryBackendSaveResult>;
+}
+
+export function getCogneeSessionState(
+	session: AgentSession | undefined,
+): CogneeSessionStateLike | undefined {
+	return session ? (session as AgentSessionWithCogneeState)[kCogneeSessionState] : undefined;
+}
+
+export function setCogneeSessionState(
+	session: AgentSession,
+	state: CogneeSessionStateLike | undefined,
+): CogneeSessionStateLike | undefined {
+	const typed = session as AgentSessionWithCogneeState;
+	const previous = typed[kCogneeSessionState];
+	if (state) typed[kCogneeSessionState] = state;
+	else delete typed[kCogneeSessionState];
+	return previous;
+}
+
+function errorText(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function buildRecallRequest(state: CogneeSessionState, query: string, topK: number): CogneeRecallRequest {
+	const { config, scope } = state;
+	return {
+		query,
+		searchType: config.recallSearchType,
+		datasets: scope.recallDatasets,
+		datasetIds: scope.recallDatasetIds,
+		nodeName: scope.recallNodeName,
+		topK,
+		onlyContext: config.onlyContext,
+		verbose: config.verbose,
+		sessionId: config.sessionMemoryEnabled ? state.sessionId : undefined,
+		scope: config.recallScope === "auto" ? undefined : config.recallScope,
+	};
+}
+
+function buildRememberBaseRequest(state: CogneeSessionState): Omit<CogneeRememberRequest, "data"> {
+	const { config, scope } = state;
+	return {
+		datasetName: scope.datasetName,
+		datasetId: scope.datasetId,
+		sessionId: state.config.sessionMemoryEnabled ? state.sessionId : undefined,
+		nodeSet: scope.retainNodeSet,
+		runInBackground: config.runInBackground,
+		customPrompt: config.customPrompt ?? undefined,
+		chunkSize: config.chunkSize ?? undefined,
+		chunksPerBatch: config.chunksPerBatch ?? undefined,
+		ontologyKeys: config.ontologyKeys,
+		graphModel: config.graphModel ?? undefined,
+		contentType: "text/markdown",
+	};
+}
+
+function collectSessionMessages(session: AgentSession, eventMessages?: AgentMessage[]): AgentMessage[] {
+	if (eventMessages) return eventMessages;
+	const entries = session.sessionManager.getEntries();
+	const messages: AgentMessage[] = [];
+	for (const entry of entries) {
+		if (entry.type === "message") messages.push(entry.message);
+	}
+	return messages;
+}
+
+function latestUserMessage(messages: CogneeMessage[]): CogneeMessage | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i].role === "user") return messages[i];
+	}
+	return undefined;
+}
+
+function formatScopeHeader(state: CogneeSessionState): string[] {
+	const lines = [`Session: ${state.sessionId}`];
+	if (state.scope.label) lines.push(`Scope: ${state.scope.label}`);
+	if (state.scope.projectLabel) lines.push(`Project: ${state.scope.projectLabel}`);
+	return lines;
+}
+
+function formatExplicitRetainDocument(state: CogneeSessionState, item: PendingCogneeRetainItem): string {
+	const header = formatScopeHeader(state);
+	header.push(`Retained at: ${item.timestamp.toISOString()}`);
+	header.push(`Context: ${item.context ?? state.config.retainContext}`);
+	header.push(`Source: explicit-retain`);
+	return `${header.join("\n")}\n\n${item.content}`;
+}
+
+function formatSaveDocument(
+	state: CogneeSessionState,
+	input: MemoryBackendSaveInput,
+	retainedAt: Date,
+): string {
+	const header = formatScopeHeader(state);
+	header.push(`Retained at: ${retainedAt.toISOString()}`);
+	header.push(`Context: ${input.context ?? state.config.retainContext}`);
+	if (input.source) header.push(`Source: ${input.source}`);
+	if (typeof input.importance === "number") header.push(`Importance: ${input.importance}`);
+	return `${header.join("\n")}\n\n${input.content}`;
+}
+
+function rememberIds(result: CogneeRememberResult): string[] | undefined {
+	const ids: string[] = [];
+	if (result.entryId) ids.push(result.entryId);
+	if (result.contentHash) ids.push(result.contentHash);
+	if (result.pipelineRunId) ids.push(result.pipelineRunId);
+	return ids.length > 0 ? ids : undefined;
+}
+
+function isQueuedRemember(result: CogneeRememberResult, config: CogneeConfig): boolean {
+	if (config.runInBackground) return true;
+	const status = (result.status ?? "").toLowerCase();
+	if (!status) return false;
+	return /background|queued|running|in-progress|in_progress|pending|accepted/.test(status);
+}
+
+/**
+ * Primary-only debounced batch queue for explicit tool-initiated retains.
+ *
+ * Mirrors the Hindsight retain-queue pattern with a Cognee-specific bounded
+ * depth (`COGNEE_RETAIN_QUEUE_MAX_ITEMS`), batch flush threshold, and a
+ * coalesced in-flight flush. Client failures are swallowed and surfaced as a
+ * `Cognee` warning notice; the queue never requeues a failed batch.
+ */
+class CogneeRetainQueue {
+	readonly #state: CogneeSessionState;
+	#items: PendingCogneeRetainItem[] = [];
+	#timer?: NodeJS.Timeout;
+	#flushing?: Promise<void>;
+	#closed = false;
+
+	constructor(state: CogneeSessionState) {
+		this.#state = state;
+	}
+
+	get depth(): number {
+		return this.#items.length;
+	}
+
+	enqueue(content: string, context?: string): void {
+		if (this.#closed) {
+			throw new Error("Cognee retain queue is closed.");
+		}
+		// Reject all-whitespace content without trimming stored text. Tool
+		// validation should catch empty input upstream; this is a defensive
+		// no-op so we never send an empty document to Cognee.
+		if (content.trim().length === 0) return;
+
+		this.#items.push({ content, context, timestamp: new Date() });
+
+		if (this.#items.length > COGNEE_RETAIN_QUEUE_MAX_ITEMS) {
+			const dropped = this.#items.shift();
+			logger.warn("Cognee retain queue exceeded max items; dropped oldest pending memory", {
+				sessionId: this.#state.sessionId,
+				droppedTimestamp: dropped?.timestamp.toISOString(),
+			});
+			this.#state.session.emitNotice(
+				"warning",
+				"Cognee retain queue exceeded 128 items; dropped oldest pending memory.",
+				COGNEE_NOTICE_SOURCE,
+			);
+		}
+
+		if (this.#items.length >= COGNEE_RETAIN_FLUSH_BATCH_SIZE) {
+			void this.flush();
+			return;
+		}
+		if (!this.#timer) {
+			this.#timer = setTimeout(() => {
+				this.#timer = undefined;
+				void this.flush();
+			}, COGNEE_RETAIN_FLUSH_INTERVAL_MS);
+			// Don't pin the event loop alive just for a pending retain flush.
+			this.#timer.unref?.();
+		}
+	}
+
+	async flush(): Promise<void> {
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+
+		if (this.#flushing) {
+			// Coalesce: wait for the in-flight flush, then drain anything that
+			// landed after it started so we don't strand items.
+			await this.#flushing;
+			if (this.#items.length > 0) await this.flush();
+			return;
+		}
+
+		if (this.#items.length === 0) return;
+
+		const items = this.#items.splice(0);
+		const flushPromise = this.#doFlush(items);
+		this.#flushing = flushPromise;
+		try {
+			await flushPromise;
+		} finally {
+			this.#flushing = undefined;
+		}
+	}
+
+	/** Stop accepting new items and clear timers without dropping in-flight items. */
+	close(): void {
+		this.#closed = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+	}
+
+	/** Drop all leftover items after a final flush has been attempted. */
+	drop(): void {
+		this.#closed = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+		this.#items = [];
+	}
+
+	async #doFlush(items: PendingCogneeRetainItem[]): Promise<void> {
+		const state = this.#state;
+		// Identity guard: if the session no longer points at this state, the
+		// state was cleared before flush completed. We can't notify anyone, so
+		// log and drop — these are best-effort facts, not transactional writes.
+		if (getCogneeSessionState(state.session) !== state) {
+			logger.warn("Cognee retain queue: session state vanished, dropping batch", {
+				sessionId: state.sessionId,
+				items: items.length,
+			});
+			return;
+		}
+
+		try {
+			const documents = items.map(item => formatExplicitRetainDocument(state, item));
+			const base = buildRememberBaseRequest(state);
+			await state.client.remember({ ...base, data: documents, contentType: "text/markdown" });
+			if (state.config.debug) {
+				logger.debug("Cognee retain queue: batch flushed", {
+					sessionId: state.sessionId,
+					items: items.length,
+				});
+			}
+		} catch (err) {
+			const text = errorText(err);
+			logger.warn("Cognee retain queue: batch flush failed", {
+				sessionId: state.sessionId,
+				items: items.length,
+				error: text,
+			});
+			const noun = items.length === 1 ? "memory" : "memories";
+			state.session.emitNotice(
+				"warning",
+				`Memory retention failed for ${items.length} ${noun}: ${text}`,
+				COGNEE_NOTICE_SOURCE,
+			);
+			// Do not requeue the failed batch.
+		}
+	}
+}
+
+/**
+ * Per-session Cognee runtime state owned by its `AgentSession`.
+ *
+ * Primary state owns the retain queue and session listeners. Alias state
+ * (subagents) reuses the parent's `client`/`config`/`scope`, forces
+ * `hasRecalledForFirstTurn` to `true`, attaches no listeners, and delegates
+ * explicit tool-facing operations to the parent primary state.
+ */
+export class CogneeSessionState implements CogneeSessionStateLike {
+	sessionId: string;
+	readonly client: CogneeClient;
+	readonly config: CogneeConfig;
+	readonly scope: CogneeScope;
+	readonly session: AgentSession;
+	readonly aliasOf?: CogneeSessionStateLike;
+	lastRecallSnippet?: string;
+	lastRetainedAtIso?: string;
+	lastRetainedTurn: number;
+	hasRecalledForFirstTurn: boolean;
+
+	#retainQueue?: CogneeRetainQueue;
+	#unsubscribe?: () => void;
+	#disposed = false;
+	#improveAttempted = false;
+	#disposePromise?: Promise<void>;
+
+	constructor(options: CogneeSessionStateOptions) {
+		this.session = options.session;
+		this.sessionId = options.sessionId;
+
+		if (options.aliasOf) {
+			const parent = options.aliasOf;
+			this.aliasOf = parent;
+			this.client = parent.client;
+			this.config = parent.config;
+			this.scope = parent.scope;
+			this.hasRecalledForFirstTurn = true;
+			this.lastRetainedTurn = options.lastRetainedTurn ?? 0;
+			// Aliases carry no queue and no listeners.
+			return;
+		}
+
+		this.client = options.client;
+		this.config = options.config;
+		this.scope = options.scope;
+		this.lastRetainedTurn = options.lastRetainedTurn ?? 0;
+		this.hasRecalledForFirstTurn = options.hasRecalledForFirstTurn ?? false;
+		this.#retainQueue = new CogneeRetainQueue(this);
+	}
+
+	setSessionId(sessionId: string): void {
+		this.sessionId = sessionId;
+	}
+
+	resetConversationTracking(): void {
+		if (this.aliasOf) {
+			// Aliases keep the first-turn flag effectively true; never reset parent.
+			this.hasRecalledForFirstTurn = true;
+			return;
+		}
+		this.lastRetainedTurn = 0;
+		this.hasRecalledForFirstTurn = false;
+		this.lastRecallSnippet = undefined;
+		this.lastRetainedAtIso = undefined;
+	}
+
+	enqueueRetain(content: string, context?: string): void {
+		if (this.aliasOf) {
+			this.aliasOf.enqueueRetain(content, context);
+			return;
+		}
+		this.#retainQueue?.enqueue(content, context);
+	}
+
+	flushRetainQueue(): Promise<void> {
+		if (this.aliasOf) {
+			return this.aliasOf.flushRetainQueue();
+		}
+		return this.#retainQueue?.flush() ?? Promise.resolve();
+	}
+
+	async recallForContext(query: string, signal?: AbortSignal): Promise<RecallOutcome> {
+		if (this.aliasOf) {
+			return this.aliasOf.recallForContext(query, signal);
+		}
+		try {
+			const request = buildRecallRequest(this, query, this.config.recallTopK);
+			const entries: CogneeRecallEntry[] = await this.client.recall(request, signal);
+			if (signal?.aborted) return { context: null, ok: false };
+			const block = formatCogneeRecallBlock(entries, this.config, this.scope);
+			return { context: block ?? null, ok: true };
+		} catch (err) {
+			if (this.config.debug) {
+				logger.debug("Cognee: recall failed", { sessionId: this.sessionId, error: errorText(err) });
+			}
+			return { context: null, ok: false };
+		}
+	}
+
+	async beforeAgentStartPrompt(promptText: string): Promise<string | undefined> {
+		if (this.aliasOf) return undefined;
+		if (!this.config.autoRecall || this.hasRecalledForFirstTurn) return undefined;
+
+		const latestPrompt = promptText.trim();
+		if (!latestPrompt) return undefined;
+
+		const history = flattenMessagesForCognee(collectSessionMessages(this.session));
+		const queryMessages: CogneeMessage[] = [...history, { role: "user", content: latestPrompt }];
+		const query = composeCogneeRecallQuery(latestPrompt, queryMessages, this.config.recallContextTurns, this.scope);
+		const truncated = truncateCogneeRecallQuery(query, latestPrompt, this.config.recallMaxQueryChars);
+
+		const { context, ok } = await this.recallForContext(truncated);
+		if (!ok) return undefined;
+
+		this.hasRecalledForFirstTurn = true;
+		if (!context) return undefined;
+
+		this.lastRecallSnippet = context;
+		return context;
+	}
+
+	async #maybeRecallOnAgentStart(): Promise<void> {
+		if (this.aliasOf) return;
+		if (!this.config.autoRecall || this.hasRecalledForFirstTurn) return;
+
+		const flattened = flattenMessagesForCognee(collectSessionMessages(this.session));
+		const lastUser = latestUserMessage(flattened);
+		if (!lastUser) return;
+
+		const query = composeCogneeRecallQuery(lastUser.content, flattened, this.config.recallContextTurns, this.scope);
+		const truncated = truncateCogneeRecallQuery(query, lastUser.content, this.config.recallMaxQueryChars);
+
+		const { context, ok } = await this.recallForContext(truncated);
+		if (!ok) return;
+
+		this.hasRecalledForFirstTurn = true;
+		if (!context) return;
+
+		this.lastRecallSnippet = context;
+		try {
+			await this.session.refreshBaseSystemPrompt();
+		} catch (err) {
+			logger.debug("Cognee: refreshBaseSystemPrompt after agent_start recall failed", {
+				error: errorText(err),
+			});
+		}
+	}
+
+	async recallForCompaction(messages: AgentMessage[]): Promise<string | undefined> {
+		if (this.aliasOf) {
+			return this.aliasOf.recallForCompaction(messages);
+		}
+		const flattened = flattenMessagesForCognee(messages);
+		const lastUser = latestUserMessage(flattened);
+		if (!lastUser) return undefined;
+
+		const query = composeCogneeRecallQuery(lastUser.content, flattened, this.config.recallContextTurns, this.scope);
+		const truncated = truncateCogneeRecallQuery(query, lastUser.content, this.config.recallMaxQueryChars);
+		const { context } = await this.recallForContext(truncated);
+		return context ?? undefined;
+	}
+
+	async #retainCurrentTranscript(
+		messages: CogneeMessage[],
+		retainedAt = new Date(),
+	): Promise<{ retained: boolean; userTurns: number }> {
+		if (this.aliasOf) return { retained: false, userTurns: 0 };
+		const userTurns = messages.filter(m => m.role === "user").length;
+		const retainEveryNTurns = Math.max(1, this.config.retainEveryNTurns);
+		const retainOverlapTurns = Math.max(0, this.config.retainOverlapTurns);
+
+		const document: CogneeRetentionDocument | null = prepareCogneeRetentionDocument({
+			messages,
+			sessionId: this.sessionId,
+			retainedAt,
+			mode: this.config.retainMode,
+			retainEveryNTurns,
+			retainOverlapTurns,
+			scope: this.scope,
+		});
+		if (!document) return { retained: false, userTurns };
+
+		const base = buildRememberBaseRequest(this);
+		await this.client.remember({ ...base, data: document.content, contentType: document.contentType });
+		return { retained: true, userTurns };
+	}
+
+	async #maybeRetainOnAgentEnd(eventMessages?: AgentMessage[]): Promise<void> {
+		if (this.aliasOf) return;
+		if (!this.config.autoRetain) return;
+
+		const flattened = flattenMessagesForCognee(collectSessionMessages(this.session, eventMessages));
+		if (flattened.length === 0) return;
+
+		const retainEveryNTurns = Math.max(1, this.config.retainEveryNTurns);
+		const userTurns = flattened.filter(m => m.role === "user").length;
+		if (userTurns - this.lastRetainedTurn < retainEveryNTurns) return;
+
+		const retainedAt = new Date();
+		try {
+			const result = await this.#retainCurrentTranscript(flattened, retainedAt);
+			if (!result.retained) return;
+			this.lastRetainedTurn = result.userTurns;
+			this.lastRetainedAtIso = retainedAt.toISOString();
+			if (this.config.debug) {
+				logger.debug("Cognee: auto-retain succeeded", {
+					sessionId: this.sessionId,
+					userTurns: result.userTurns,
+					messages: flattened.length,
+				});
+			}
+		} catch (err) {
+			logger.warn("Cognee: auto-retain failed", {
+				sessionId: this.sessionId,
+				error: errorText(err),
+			});
+		}
+	}
+
+	async maybeRetainOnAgentEnd(): Promise<void> {
+		await this.#maybeRetainOnAgentEnd();
+	}
+
+	async forceRetainCurrentSession(): Promise<void> {
+		if (this.aliasOf) return;
+		const flattened = flattenMessagesForCognee(collectSessionMessages(this.session));
+		if (flattened.length === 0) return;
+
+		const retainedAt = new Date();
+		try {
+			const result = await this.#retainCurrentTranscript(flattened, retainedAt);
+			if (!result.retained) return;
+			this.lastRetainedTurn = result.userTurns;
+			this.lastRetainedAtIso = retainedAt.toISOString();
+		} catch (err) {
+			logger.warn("Cognee: forced retain failed", {
+				sessionId: this.sessionId,
+				error: errorText(err),
+			});
+		}
+	}
+
+	async #handleAgentEnd(eventMessages?: AgentMessage[]): Promise<void> {
+		await this.#maybeRetainOnAgentEnd(eventMessages);
+		await this.flushRetainQueue();
+	}
+
+	attachSessionListeners(): void {
+		if (this.aliasOf) return;
+		// Reattach cleanly: unsubscribe any prior listener before subscribing.
+		this.#unsubscribe?.();
+		this.#unsubscribe = this.session.subscribe(event => {
+			if (event.type === "agent_start") {
+				void this.#maybeRecallOnAgentStart();
+			} else if (event.type === "agent_end") {
+				void this.#handleAgentEnd(event.messages);
+			}
+		});
+	}
+
+	async search(
+		query: string,
+		options?: { limit?: number; signal?: AbortSignal },
+	): Promise<MemoryBackendSearchResult> {
+		if (this.aliasOf) {
+			return this.aliasOf.search(query, options);
+		}
+		const trimmed = query.trim();
+		if (!trimmed) {
+			return {
+				backend: COGNEE_BACKEND,
+				query,
+				count: 0,
+				items: [],
+				message: "Empty query.",
+			};
+		}
+
+		try {
+			const request = buildRecallRequest(this, trimmed, options?.limit ?? this.config.recallTopK);
+			const entries = await this.client.recall(request, options?.signal);
+			const items = entries.map(formatCogneeSearchItem);
+			return { backend: COGNEE_BACKEND, query: trimmed, count: items.length, items };
+		} catch (err) {
+			const text = errorText(err);
+			if (this.config.debug) {
+				logger.debug("Cognee: search failed", { sessionId: this.sessionId, error: text });
+			}
+			return {
+				backend: COGNEE_BACKEND,
+				query: trimmed,
+				count: 0,
+				items: [],
+				message: `Cognee recall failed: ${text}`,
+			};
+		}
+	}
+
+	async save(input: MemoryBackendSaveInput): Promise<MemoryBackendSaveResult> {
+		if (this.aliasOf) {
+			return this.aliasOf.save(input);
+		}
+		const trimmed = input.content.trim();
+		if (!trimmed) {
+			return {
+				backend: COGNEE_BACKEND,
+				stored: 0,
+				message: "Empty memory content.",
+			};
+		}
+
+		const retainedAt = new Date();
+		try {
+			const document = formatSaveDocument(this, input, retainedAt);
+			const base = buildRememberBaseRequest(this);
+			const result = await this.client.remember({ ...base, data: document, contentType: "text/markdown" });
+			return {
+				backend: COGNEE_BACKEND,
+				stored: 1,
+				ids: rememberIds(result),
+				queued: isQueuedRemember(result, this.config),
+			};
+		} catch (err) {
+			const text = errorText(err);
+			if (this.config.debug) {
+				logger.debug("Cognee: save failed", { sessionId: this.sessionId, error: text });
+			}
+			return {
+				backend: COGNEE_BACKEND,
+				stored: 0,
+				message: `Cognee save failed: ${text}`,
+			};
+		}
+	}
+
+	async #maybeImproveOnDispose(): Promise<void> {
+		if (this.aliasOf) return;
+		if (this.#improveAttempted) return;
+		this.#improveAttempted = true;
+
+		if (!this.config.improveOnEnqueue || !this.config.sessionMemoryEnabled) return;
+
+		try {
+			await this.client.improve({
+				datasetName: this.scope.datasetName,
+				datasetId: this.scope.datasetId,
+				sessionIds: [this.sessionId],
+				nodeName: this.scope.recallNodeName,
+				runInBackground: this.config.runInBackground,
+				buildGlobalContextIndex: this.config.buildGlobalContextIndex,
+			});
+		} catch (err) {
+			const text = errorText(err);
+			logger.warn("Cognee: session-end improve failed", { sessionId: this.sessionId, error: text });
+			// Only surface when the message is actionable for the user.
+			if (text) {
+				this.session.emitNotice("warning", `Cognee session-end improve failed: ${text}`, COGNEE_NOTICE_SOURCE);
+			}
+		}
+	}
+
+	dispose(): void | Promise<void> {
+		if (this.aliasOf) {
+			this.#disposed = true;
+			return;
+		}
+		if (this.#disposePromise) return this.#disposePromise;
+
+		this.#disposePromise = (async () => {
+			// 1. Mark disposed so new enqueues are rejected by the queue.
+			this.#disposed = true;
+			// 2. Unsubscribe the session listener.
+			this.#unsubscribe?.();
+			this.#unsubscribe = undefined;
+			// 3. Stop the debounce timer without dropping items yet.
+			this.#retainQueue?.close();
+			// 4. Drain pending explicit retains while the state is still
+			//    installed on the session. If a caller already cleared the
+			//    side channel, the queue identity guard drops the batch.
+			if (getCogneeSessionState(this.session) === this) {
+				try {
+					await this.flushRetainQueue();
+				} catch (err) {
+					logger.warn("Cognee: dispose flush failed", { sessionId: this.sessionId, error: errorText(err) });
+				}
+			}
+			// 5. Best-effort session-end improve.
+			await this.#maybeImproveOnDispose();
+			// 6. Drop any remaining queue state.
+			this.#retainQueue?.drop();
+		})();
+		return this.#disposePromise;
+	}
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -130,7 +130,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Git",
 	],
 	context: ["General", "Compaction", "Rules (TTSR)", "Experimental"],
-	memory: ["General", "Auto-Learn", "Mnemopi", "Hindsight"],
+	memory: ["General", "Auto-Learn", "Mnemopi", "Hindsight", "Cognee"],
 	files: ["Editing", "Reading", "Read Summaries", "LSP"],
 	shell: ["Bash", "Eval & Runtimes"],
 	tools: [
@@ -286,6 +286,8 @@ const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
+const COGNEE_NODE_SET_DEFAULT: string[] = [];
+const COGNEE_ONTOLOGY_KEYS_DEFAULT: string[] = [];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
 		pattern: "^\\s*(cat|head|tail|less|more)\\s+",
@@ -2276,18 +2278,18 @@ export const SETTINGS_SCHEMA = {
 	"memories.summaryInjectionTokenLimit": { type: "number", default: 5000 },
 
 	// Memory backend selector — picks between local memories pipeline,
-	// Mnemopi local SQLite, Hindsight remote memory, or off. Legacy
-	// `memories.enabled` keeps gating the local backend; see config/settings.ts
-	// migration for details.
+	// Mnemopi local SQLite, Hindsight remote memory, Cognee graph memory,
+	// or off. Legacy `memories.enabled` keeps gating the local backend;
+	// see config/settings.ts migration for details.
 	"memory.backend": {
 		type: "enum",
-		values: ["off", "local", "hindsight", "mnemopi"] as const,
+		values: ["off", "local", "hindsight", "mnemopi", "cognee"] as const,
 		default: "off",
 		ui: {
 			tab: "memory",
 			group: "General",
 			label: "Memory Backend",
-			description: "Off, local summary pipeline, Mnemopi SQLite, or Hindsight remote memory",
+			description: "Off, local summary pipeline, Mnemopi SQLite, Hindsight remote memory, or Cognee graph memory",
 			options: [
 				{ value: "off", label: "Off", description: "No memory subsystem runs" },
 				{ value: "local", label: "Local", description: "Local rollout summarisation pipeline (memory_summary.md)" },
@@ -2296,6 +2298,11 @@ export const SETTINGS_SCHEMA = {
 					value: "mnemopi",
 					label: "Mnemopi",
 					description: "Local SQLite recall/retain backend with optional embeddings",
+				},
+				{
+					value: "cognee",
+					label: "Cognee",
+					description: "Cognee graph memory service",
 				},
 			],
 		},
@@ -2719,6 +2726,213 @@ export const SETTINGS_SCHEMA = {
 	"hindsight.mentalModelRefreshIntervalMs": { type: "number", default: 5 * 60 * 1000 },
 	"hindsight.mentalModelMaxRenderChars": { type: "number", default: 16_000 },
 
+
+	// Cognee graph memory backend.
+	"cognee.apiUrl": {
+		type: "string",
+		default: "http://localhost:8000",
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee API URL",
+			description: "Cognee server URL (Cloud or self-hosted)",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.apiKey": { type: "string", default: undefined },
+	"cognee.datasetName": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Dataset Name",
+			description: "Base dataset name used when no dataset ID is configured",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.datasetId": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Dataset ID",
+			description: "Existing Cognee dataset UUID. When set, it wins over dataset name.",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.datasetNamePrefix": { type: "string", default: undefined },
+	"cognee.scoping": {
+		type: "enum",
+		values: ["global", "per-project", "per-project-tagged"] as const,
+		default: "per-project-tagged",
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Scoping",
+			description:
+				"global = one shared dataset; per-project = isolated dataset per cwd; per-project-tagged = shared dataset with project tags so global + project memories merge on recall",
+			options: [
+				{
+					value: "global",
+					label: "Global",
+					description: "One shared Cognee dataset for every project",
+				},
+				{
+					value: "per-project",
+					label: "Per project",
+					description: "Isolated Cognee dataset per cwd basename",
+				},
+				{
+					value: "per-project-tagged",
+					label: "Per project (tagged)",
+					description:
+						"Shared dataset, retains tagged with project:<cwd>. Recall surfaces project + untagged global memories together",
+				},
+			],
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.autoRecall": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Auto Recall",
+			description: "Recall Cognee memories into the first turn of each session",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.autoRetain": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Auto Retain",
+			description: "Retain completed conversation turns into Cognee memory",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.retainMode": {
+		type: "enum",
+		values: ["full-session", "last-turn"] as const,
+		default: "full-session",
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Retain Mode",
+			description: "full-session = remember one session document; last-turn = chunked turn retention",
+			options: [
+				{
+					value: "full-session",
+					label: "Full session",
+					description: "Remember one session document (recommended)",
+				},
+				{
+					value: "last-turn",
+					label: "Last turn",
+					description: "Retain chunked turn slices",
+				},
+			],
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.retainEveryNTurns": { type: "number", default: 3 },
+	"cognee.retainOverlapTurns": { type: "number", default: 2 },
+	"cognee.retainContext": { type: "string", default: "omp" },
+	"cognee.runInBackground": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Background Ingest",
+			description: "Ask Cognee to process remember requests in the background",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.chunkSize": { type: "number", default: 4096 },
+	"cognee.chunksPerBatch": { type: "number", default: 36 },
+	"cognee.customPrompt": { type: "string", default: undefined },
+	"cognee.nodeSet": { type: "array", default: COGNEE_NODE_SET_DEFAULT },
+	"cognee.ontologyKeys": { type: "array", default: COGNEE_ONTOLOGY_KEYS_DEFAULT },
+	"cognee.graphModel": { type: "string", default: undefined },
+	"cognee.recallSearchType": {
+		type: "string",
+		default: "GRAPH_COMPLETION",
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Recall Search Type",
+			description: "Cognee recall search type, for example GRAPH_COMPLETION, RAG_COMPLETION, CHUNKS, INSIGHTS, or CODE",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.recallScope": {
+		type: "string",
+		default: "auto",
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Recall Scope",
+			description: "Cognee recall scope, for example auto, graph, session, trace, graph_context, session_context, or all",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.recallTopK": { type: "number", default: 10 },
+	"cognee.recallContextTurns": { type: "number", default: 1 },
+	"cognee.recallMaxQueryChars": { type: "number", default: 1200 },
+	"cognee.recallMaxRenderChars": { type: "number", default: 12000 },
+	"cognee.onlyContext": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Context Only",
+			description: "Return context-only recall results when Cognee supports it",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.verbose": { type: "boolean", default: false },
+	"cognee.improveOnEnqueue": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Improve on Enqueue",
+			description: "Route /memory enqueue through Cognee improve instead of only local queue state",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.buildGlobalContextIndex": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Build Global Context Index",
+			description: "Ask Cognee improve to build the global context index",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.sessionMemoryEnabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "memory",
+			group: "Cognee",
+			label: "Cognee Session Memory",
+			description:
+				"Forward OMP session IDs to Cognee session-memory APIs. Requires Cognee server caching to be enabled.",
+			condition: "cogneeActive",
+		},
+	},
+	"cognee.debug": { type: "boolean", default: false },
 	// TTSR
 	"ttsr.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1399,6 +1399,10 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	"hindsight.bankId": () => hindsightScopeSignal.fire(),
 	"hindsight.bankIdPrefix": () => hindsightScopeSignal.fire(),
 	"hindsight.scoping": () => hindsightScopeSignal.fire(),
+	"cognee.datasetName": () => cogneeScopeSignal.fire(),
+	"cognee.datasetId": () => cogneeScopeSignal.fire(),
+	"cognee.datasetNamePrefix": () => cogneeScopeSignal.fire(),
+	"cognee.scoping": () => cogneeScopeSignal.fire(),
 	"worktree.base": value => {
 		const dir = typeof value === "string" && value.trim() ? value : undefined;
 		// Always call so an unset/empty value clears a previously-applied override.
@@ -1444,6 +1448,20 @@ const hindsightScopeSignal = new SettingSignal("hindsight scope");
  * caller is expected to re-read the relevant settings via `Settings.get`.
  */
 export const onHindsightScopeChanged = (cb: () => void) => hindsightScopeSignal.on(cb);
+
+/** Fires when any Cognee dataset/scope selector changes. */
+const cogneeScopeSignal = new SettingSignal("cognee scope");
+
+/**
+ * Subscribe to changes in the Cognee dataset-scoping settings. Lets the
+ * Cognee backend rebuild active session state when the operator switches
+ * `cognee.datasetName`, `cognee.datasetId`, `cognee.datasetNamePrefix`, or
+ * `cognee.scoping` mid-session.
+ *
+ * Returns an unsubscribe function. The callback receives no arguments; the
+ * caller re-reads settings via `Settings.get`.
+ */
+export const onCogneeScopeChanged = (cb: () => void) => cogneeScopeSignal.on(cb);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Global Singleton

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
+import type { CogneeSessionStateLike } from "../cognee/state";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { registerArtifactsDir } from "../internal-urls/registry-helpers";
 import { MCPManager } from "../mcp/manager";
@@ -185,6 +186,17 @@ function getOutputManager(session: ToolSession): AgentOutputManager {
 	const manager = new AgentOutputManager(session.getArtifactsDir ?? (() => null));
 	session.agentOutputManager = manager;
 	return manager;
+}
+
+type CogneeEvalToolSession = {
+	getCogneeSessionState?: () => CogneeSessionStateLike | undefined;
+};
+
+function getPrimaryCogneeSessionState(
+	session: CogneeEvalToolSession,
+): CogneeSessionStateLike | undefined {
+	const state = session.getCogneeSessionState?.();
+	return state?.aliasOf ?? state;
 }
 
 interface ArtifactPaths {
@@ -403,6 +415,7 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 		parentArtifactManager,
 		parentHindsightSessionState: options.session.getHindsightSessionState?.(),
 		parentMnemopiSessionState: options.session.getMnemopiSessionState?.(),
+		parentCogneeSessionState: getPrimaryCogneeSessionState(options.session),
 		parentTelemetry: options.session.getTelemetry?.(),
 		parentAgentId: options.session.getAgentId?.() ?? MAIN_AGENT_ID,
 		// Live source of truth for `tier.subagent: inherit` (null = explicit none).

--- a/packages/coding-agent/src/memory-backend/index.ts
+++ b/packages/coding-agent/src/memory-backend/index.ts
@@ -1,4 +1,21 @@
 export type {
+	CogneeConfig,
+	CogneeRecallScope,
+	CogneeRetainMode,
+	CogneeScoping,
+	CogneeSearchType,
+} from "../cognee/config";
+export type {
+	CogneeApiOptions,
+	CogneeClient,
+	CogneeDataset,
+	CogneeRecallEntry,
+	CogneeRememberResult,
+} from "../cognee/client";
+export type { CogneeScope } from "../cognee/scope";
+export type { CogneeSessionStateLike, CogneeSessionStateOptions } from "../cognee/state";
+
+export type {
 	MnemopiBackendConfig,
 	MnemopiLlmMode,
 	MnemopiProviderOptions,

--- a/packages/coding-agent/src/memory-backend/resolve.ts
+++ b/packages/coding-agent/src/memory-backend/resolve.ts
@@ -9,17 +9,23 @@ import type { MemoryBackend } from "./types";
  * Selection rules (single source of truth — every memory consumer routes
  * through this):
  *   - `memory.backend === "hindsight"`  → Hindsight remote memory
- *   - `memory.backend === "mnemopi"`  → local Mnemopi SQLite memory
+ *   - `memory.backend === "mnemopi"`    → local Mnemopi SQLite memory
+ *   - `memory.backend === "cognee"`     → Cognee graph/session memory backend
  *   - `memory.backend === "local"`      → local rollout summary pipeline
  *   - everything else                   → no-op
  *
  * `memories.enabled` remains accepted only as a legacy migration input. Once
  * a config is loaded, `memory.backend` is the sole runtime selector.
+ *
+ * Backend modules are lazy-imported so an unused backend's state/client
+ * dependencies are never loaded into a process that won't use them — a
+ * static import would pull every backend into every consumer's bundle.
  */
 export async function resolveMemoryBackend(settings: Settings): Promise<MemoryBackend> {
 	const id = settings.get("memory.backend");
 	if (id === "hindsight") return (await import("../hindsight/backend")).hindsightBackend;
 	if (id === "mnemopi") return (await import("../mnemopi/backend")).mnemopiBackend;
+	if (id === "cognee") return (await import("../cognee/backend")).cogneeBackend;
 	if (id === "local") return localBackend;
 	return offBackend;
 }

--- a/packages/coding-agent/src/memory-backend/types.ts
+++ b/packages/coding-agent/src/memory-backend/types.ts
@@ -11,9 +11,10 @@ import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { MnemopiSessionState } from "../mnemopi/state";
+import type { CogneeSessionStateLike } from "../cognee/state";
 import type { AgentSession } from "../session/agent-session";
 
-export type MemoryBackendId = "off" | "local" | "hindsight" | "mnemopi";
+export type MemoryBackendId = "off" | "local" | "hindsight" | "mnemopi" | "cognee";
 
 export interface MemoryBackendStatus {
 	backend: MemoryBackendId;
@@ -90,6 +91,7 @@ export interface MemoryBackendStartOptions {
 	taskDepth: number;
 	parentHindsightSessionState?: HindsightSessionState;
 	parentMnemopiSessionState?: MnemopiSessionState;
+	parentCogneeSessionState?: CogneeSessionStateLike;
 }
 
 export interface MemoryBackend {

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -106,6 +106,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	cogneeActive: () => {
+		try {
+			return Settings.instance.get("memory.backend") === "cognee";
+		} catch {
+			return false;
+		}
+	},
 	autolearnActive: () => {
 		try {
 			return Settings.instance.get("autolearn.enabled") === true;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -563,7 +563,11 @@ export class CommandController {
 			try {
 				await backend.clear(agentDir, this.ctx.sessionManager.getCwd(), this.ctx.session);
 				await this.ctx.session.refreshBaseSystemPrompt();
-				this.ctx.showStatus("Memory data cleared and system prompt refreshed.");
+				this.ctx.showStatus(
+					(backend.id as string) === "cognee"
+						? "Cognee memory is server-side; local Cognee session state was cleared and the system prompt was refreshed. Upstream Cognee datasets were not deleted."
+						: "Memory data cleared and system prompt refreshed.",
+				);
 			} catch (error) {
 				this.ctx.showError(`Memory clear failed: ${error instanceof Error ? error.message : String(error)}`);
 			}
@@ -573,7 +577,11 @@ export class CommandController {
 		if (action === "enqueue" || action === "rebuild") {
 			try {
 				await backend.enqueue(agentDir, this.ctx.sessionManager.getCwd(), this.ctx.session);
-				this.ctx.showStatus("Memory consolidation enqueued.");
+				this.ctx.showStatus(
+					(backend.id as string) === "cognee"
+						? "Cognee memory maintenance enqueued."
+						: "Memory consolidation enqueued.",
+				);
 			} catch (error) {
 				this.ctx.showError(`Memory enqueue failed: ${error instanceof Error ? error.message : String(error)}`);
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -93,6 +93,7 @@ import {
 import { MCP_CONNECTION_STATUS_EVENT_CHANNEL, type McpConnectionStatusEvent } from "./mcp/startup-events";
 import { createSessionMemoryRuntimeContext, resolveMemoryBackend } from "./memory-backend";
 import type { MnemopiSessionState } from "./mnemopi/state";
+import type { CogneeSessionStateLike } from "./cognee/state";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import lateDiagnosticTemplate from "./prompts/tools/lsp-late-diagnostic.md" with { type: "text" };
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
@@ -495,6 +496,8 @@ export interface CreateAgentSessionOptions {
 	parentHindsightSessionState?: HindsightSessionState;
 	/** Parent Mnemopi state to alias for subagent memory tools. */
 	parentMnemopiSessionState?: MnemopiSessionState;
+	/** Parent primary Cognee state to alias for subagent memory tools. */
+	parentCogneeSessionState?: CogneeSessionStateLike;
 	/** Pre-allocated agent identity for IRC routing. Default: "Main" for top-level, parentTaskPrefix-derived for sub. */
 	agentId?: string;
 	/** Display name for the agent in IRC. Default: "main" or "sub". */
@@ -2883,6 +2886,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				taskDepth,
 				parentHindsightSessionState: options.parentHindsightSessionState,
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
+				parentCogneeSessionState: options.parentCogneeSessionState,
 			});
 		};
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -226,6 +226,11 @@ import { IrcBus, type IrcMessage } from "../irc/bus";
 import { resolveMemoryBackend } from "../memory-backend";
 import { shutdownMnemopiEmbedClient } from "../mnemopi/embed-client";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
+import {
+	getCogneeSessionState,
+	setCogneeSessionState,
+	type CogneeSessionStateLike,
+} from "../cognee/state";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
 import { theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
@@ -2659,6 +2664,9 @@ export class AgentSession {
 	getMnemopiSessionState(): MnemopiSessionState | undefined {
 		return getMnemopiSessionState(this);
 	}
+	getCogneeSessionState(): CogneeSessionStateLike | undefined {
+		return getCogneeSessionState(this);
+	}
 
 	/** TTSR manager for time-traveling stream rules */
 	get ttsrManager(): TtsrManager | undefined {
@@ -4979,6 +4987,12 @@ export class AgentSession {
 		if (!sid) return;
 		this.getMnemopiSessionState()?.setSessionId(sid);
 	}
+	#rekeyCogneeMemoryForCurrentSessionId(): void {
+		if (this.settings.get("memory.backend") !== "cognee") return;
+		const sid = this.agent.sessionId;
+		if (!sid) return;
+		this.getCogneeSessionState()?.setSessionId(sid);
+	}
 
 	/** New session file: reset auto-recall / retain-threshold counters for the new transcript. */
 	#resetHindsightConversationTrackingIfHindsight(): boolean {
@@ -4996,17 +5010,25 @@ export class AgentSession {
 		state.resetConversationTracking();
 		return true;
 	}
+	#resetCogneeConversationTrackingIfCognee(): boolean {
+		if (this.settings.get("memory.backend") !== "cognee") return false;
+		const state = this.getCogneeSessionState();
+		if (!state || state.aliasOf) return false;
+		state.resetConversationTracking();
+		return true;
+	}
 
 	async #resetMemoryContextForNewTranscript(): Promise<void> {
 		const hadPromotedMemoryPrompt = this.#baseSystemPromptBeforeMemoryPromotion !== undefined;
 		const resetHindsight = this.#resetHindsightConversationTrackingIfHindsight();
 		const resetMnemopi = this.#resetMnemopiConversationTrackingIfMnemopi();
+		const resetCognee = this.#resetCogneeConversationTrackingIfCognee();
 		if (hadPromotedMemoryPrompt) {
 			this.#baseSystemPrompt = this.#baseSystemPromptBeforeMemoryPromotion!;
 			this.agent.setSystemPrompt(this.#baseSystemPrompt);
 			this.#baseSystemPromptBeforeMemoryPromotion = undefined;
 		}
-		if (resetHindsight || resetMnemopi || hadPromotedMemoryPrompt) {
+		if (resetHindsight || resetMnemopi || resetCognee || hadPromotedMemoryPrompt) {
 			await this.refreshBaseSystemPrompt();
 		}
 	}
@@ -5134,6 +5156,12 @@ export class AgentSession {
 		await hindsightState?.flushRetainQueue();
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
+		// Cognee retain queue flushes before the side-channel pointer is cleared,
+		// mirroring the Hindsight retain-queue identity contract above.
+		const cogneeState = this.getCogneeSessionState();
+		await cogneeState?.flushRetainQueue();
+		setCogneeSessionState(this, undefined);
+		await cogneeState?.dispose();
 		const mnemopiState = setMnemopiSessionState(this, undefined);
 		await mnemopiState?.dispose();
 		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
@@ -5174,6 +5202,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.#rekeyCogneeMemoryForCurrentSessionId();
 		this.agent.appendOnlyContext?.invalidateForModelChange();
 		return {
 			previousSessionId,
@@ -7903,6 +7932,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.#rekeyCogneeMemoryForCurrentSessionId();
 		await this.#resetMemoryContextForNewTranscript();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
@@ -8001,6 +8031,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.#rekeyCogneeMemoryForCurrentSessionId();
 		await this.#resetMemoryContextForNewTranscript();
 
 		// Emit session_switch event with reason "fork" to hooks
@@ -9299,6 +9330,7 @@ export class AgentSession {
 			this.#syncAgentSessionId();
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
+			this.#rekeyCogneeMemoryForCurrentSessionId();
 			await this.#resetMemoryContextForNewTranscript();
 			this.#pendingNextTurnMessages = [];
 			this.#scheduledHiddenNextTurnGeneration = undefined;
@@ -13289,6 +13321,7 @@ export class AgentSession {
 			this.#syncAgentSessionId();
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
+			this.#rekeyCogneeMemoryForCurrentSessionId();
 
 			const sessionContext = this.buildDisplaySessionContext();
 			const didReloadConversationChange =
@@ -13408,6 +13441,7 @@ export class AgentSession {
 			this.#syncAgentSessionId(previousSessionState.sessionId);
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
+			this.#rekeyCogneeMemoryForCurrentSessionId();
 			let restoreMcpError: unknown;
 			try {
 				// `previousSessionContext` was skipped on different-session switches to
@@ -13510,6 +13544,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.#rekeyCogneeMemoryForCurrentSessionId();
 		await this.#resetMemoryContextForNewTranscript();
 
 		// Reload messages from entries (works for both file and in-memory mode)
@@ -13602,6 +13637,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#rekeyHindsightMemoryForCurrentSessionId();
 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+		this.#rekeyCogneeMemoryForCurrentSessionId();
 		await this.#resetMemoryContextForNewTranscript();
 
 		const sessionContext = this.buildDisplaySessionContext();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1539,13 +1539,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				case "reset": {
 					await backend.clear(runtime.settings.getAgentDir(), runtime.cwd, runtime.session);
 					await runtime.session.refreshBaseSystemPrompt();
-					await runtime.output("Memory cleared.");
+					await runtime.output(
+						(backend.id as string) === "cognee"
+							? "Cognee local session memory cleared; upstream Cognee datasets were not deleted."
+							: "Memory cleared.",
+					);
 					return commandConsumed();
 				}
 				case "enqueue":
 				case "rebuild": {
 					await backend.enqueue(runtime.settings.getAgentDir(), runtime.cwd, runtime.session);
-					await runtime.output("Memory consolidation enqueued.");
+					await runtime.output(
+						(backend.id as string) === "cognee"
+							? "Cognee memory maintenance enqueued."
+							: "Memory consolidation enqueued.",
+					);
 					return commandConsumed();
 				}
 				case "stats":

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -31,6 +31,7 @@ import type { LocalProtocolOptions } from "../internal-urls";
 import { callTool } from "../mcp/client";
 import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
+import type { CogneeSessionStateLike } from "../cognee/state";
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
@@ -360,6 +361,7 @@ export interface ExecutorOptions {
 	parentArtifactManager?: ArtifactManager;
 	parentHindsightSessionState?: HindsightSessionState;
 	parentMnemopiSessionState?: MnemopiSessionState;
+	parentCogneeSessionState?: CogneeSessionStateLike;
 	/** Parent agent's eval executor session id. Subagents reuse it so eval state is shared. */
 	parentEvalSessionId?: string;
 	/**
@@ -2154,6 +2156,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				taskDepth: childDepth,
 				parentHindsightSessionState: options.parentHindsightSessionState,
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
+				parentCogneeSessionState: options.parentCogneeSessionState,
 				parentTaskPrefix: id,
 				parentAgentId: options.parentAgentId,
 				agentId: id,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -63,11 +63,23 @@ import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { repairTaskParams } from "./repair-args";
 import { parseIsolationMode } from "./worktree";
+import type { CogneeSessionStateLike } from "../cognee/state";
 
 function renderSubagentUserPrompt(assignment: string): string {
 	return prompt.render(subagentUserPromptTemplate, {
 		assignment: assignment.trim(),
 	});
+}
+
+type CogneeToolSession = {
+	getCogneeSessionState?: () => CogneeSessionStateLike | undefined;
+};
+
+function getPrimaryCogneeSessionState(
+	session: CogneeToolSession,
+): CogneeSessionStateLike | undefined {
+	const state = session.getCogneeSessionState?.();
+	return state?.aliasOf ?? state;
 }
 
 function createUsageTotals(): Usage {
@@ -1293,6 +1305,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				parentArtifactManager,
 				parentHindsightSessionState: this.session.getHindsightSessionState?.(),
 				parentMnemopiSessionState: this.session.getMnemopiSessionState?.(),
+				parentCogneeSessionState: getPrimaryCogneeSessionState(this.session),
 				parentTelemetry: this.session.getTelemetry?.(),
 				parentEvalSessionId,
 				parentAgentId: this.session.getAgentId?.() ?? MAIN_AGENT_ID,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -53,6 +53,7 @@ import { JobTool } from "./job";
 import { LearnTool } from "./learn";
 import { ManageSkillTool } from "./manage-skill";
 import { MemoryEditTool } from "./memory-edit";
+import { isMemoryToolsBackend } from "./memory-ops";
 import { MemoryRecallTool } from "./memory-recall";
 import { MemoryReflectTool } from "./memory-reflect";
 import { MemoryRetainTool } from "./memory-retain";
@@ -499,6 +500,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	const allowRuby = backends.ruby;
 	const allowJulia = backends.julia;
 	const skipEvalPreflight = session.skipPythonPreflight === true;
+	const memoryBackend = session.settings.get("memory.backend");
 	// Eval tool is enabled if ANY backend is reachable. JS needs no preflight, so
 	// we only probe Python/Ruby/Julia when JS is disabled — otherwise allowEval is
 	// already true and per-backend availability is checked at first invocation.
@@ -564,7 +566,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		) {
 			requestedTools.push("ast_edit");
 		}
-		if (["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "")) {
+		if (isMemoryToolsBackend(memoryBackend)) {
 			for (const name of ["recall", "retain", "reflect"]) {
 				if (!requestedTools.includes(name)) requestedTools.push(name);
 			}
@@ -578,7 +580,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0) {
 			if (!requestedTools.includes("manage_skill")) requestedTools.push("manage_skill");
 			if (
-				["hindsight", "mnemopi", "local"].includes(session.settings.get("memory.backend") ?? "") &&
+				(isMemoryToolsBackend(memoryBackend) || memoryBackend === "local") &&
 				!requestedTools.includes("learn")
 			) {
 				requestedTools.push("learn");
@@ -614,14 +616,14 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
 		if (name === "irc") return isIrcEnabled(session.settings, session.taskDepth ?? 0);
 		if (name === "retain" || name === "recall" || name === "reflect") {
-			return ["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "");
+			return isMemoryToolsBackend(memoryBackend);
 		}
 		if (name === "manage_skill") return session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0;
 		if (name === "learn") {
 			return (
 				session.settings.get("autolearn.enabled") &&
 				(session.taskDepth ?? 0) === 0 &&
-				["hindsight", "mnemopi", "local"].includes(session.settings.get("memory.backend") ?? "")
+				(isMemoryToolsBackend(memoryBackend) || memoryBackend === "local")
 			);
 		}
 		if (name === "task") {

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -4,6 +4,7 @@ import { sanitizeSkillName, writeManagedSkill } from "../autolearn/managed-skill
 import { isNameClaimedByAuthoredSkill } from "../extensibility/skills";
 import { localBackend } from "../memory-backend/local-backend";
 import learnDescription from "../prompts/tools/learn.md" with { type: "text" };
+import { resolveMemoryToolOps } from "./memory-ops";
 import type { ToolSession } from ".";
 
 const learnSchema = type({
@@ -22,16 +23,16 @@ export type LearnParams = typeof learnSchema.infer;
 /**
  * Orchestrating "learn" tool: persists a lesson to long-term memory and,
  * given a `skill` payload, mints/enhances a managed skill via the shared
- * `writeManagedSkill` primitive. Gated behind `autolearn.enabled` plus a live
- * memory backend — `hindsight`/`mnemopi` (remote/SQLite) or `local` (the
- * file-based rollout backend, where lessons append to `learned.md`).
+ * `writeManagedSkill` primitive. Gated behind `autolearn.enabled`; `hindsight`,
+ * `mnemopi`, and `cognee` use MemoryToolOps, while `local` uses `localBackend.save`
+ * for the file-based `learned.md` compatibility path.
  */
 export class LearnTool implements AgentTool<typeof learnSchema> {
 	readonly name = "learn";
-	readonly approval = (args: unknown) =>
-		(args as Partial<LearnParams>).skill || this.session.settings.get("memory.backend") === "local"
-			? "write"
-			: "read";
+	readonly approval = (args: unknown) => {
+		const params = args as Partial<LearnParams>;
+		return params.skill || this.session.settings.get("memory.backend") === "local" ? "write" : "read";
+	};
 	readonly label = "Learn";
 	readonly description = learnDescription;
 	readonly parameters = learnSchema;
@@ -44,41 +45,15 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 	static createIf(session: ToolSession): LearnTool | null {
 		if (!session.settings.get("autolearn.enabled")) return null;
 		const backend = session.settings.get("memory.backend");
-		if (backend !== "hindsight" && backend !== "mnemopi" && backend !== "local") return null;
-		return new LearnTool(session);
+		if (backend === "local" || resolveMemoryToolOps(session)) return new LearnTool(session);
+		return null;
 	}
 
 	async execute(_id: string, params: LearnParams): Promise<AgentToolResult> {
-		// 1) Persist or queue the lesson to long-term memory (mirrors MemoryRetainTool).
+		// 1) Persist or queue the lesson to long-term memory.
 		const backend = this.session.settings.get("memory.backend");
-		let memoryMessage = "Lesson stored";
-		if (backend === "mnemopi") {
-			const state = this.session.getMnemopiSessionState?.();
-			if (!state) {
-				throw new Error("Mnemopi backend is not initialised for this session.");
-			}
-			const id = state.rememberScoped(params.memory, {
-				source: "coding-agent-learn",
-				importance: 0.8,
-				metadata: {
-					session_id: state.sessionId,
-					cwd: state.session.sessionManager.getCwd(),
-					context: params.context ?? null,
-					tool: "learn",
-				},
-				scope: "bank",
-				extract: true,
-				extractEntities: true,
-				veracity: "tool",
-				memoryType: "fact",
-			});
-			// rememberScoped returns undefined when the retain failed (closed DB /
-			// disk error); mirror mnemopiBackend.save and fail loudly rather than
-			// reporting (and minting a skill for) a lesson that was silently dropped.
-			if (!id) {
-				throw new Error("Mnemopi did not store the lesson (no memory id returned).");
-			}
-		} else if (backend === "local") {
+		let memoryMessage: string;
+		if (backend === "local") {
 			const result = await localBackend.save?.(
 				{ agentDir: this.session.settings.getAgentDir(), cwd: this.session.settings.getCwd() },
 				{ content: params.memory, context: params.context, source: "coding-agent-learn", importance: 0.8 },
@@ -86,13 +61,19 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 			if (!result || result.stored === 0) {
 				throw new Error("Lesson was empty after sanitization; nothing stored.");
 			}
+			memoryMessage = "Lesson stored";
 		} else {
-			const state = this.session.getHindsightSessionState?.();
-			if (!state) {
-				throw new Error("Hindsight backend is not initialised for this session.");
-			}
-			state.enqueueRetain(params.memory, params.context);
-			memoryMessage = "Lesson queued for retention";
+			const ops = resolveMemoryToolOps(this.session);
+			if (!ops?.save) throw new Error("No active memory backend supports learn.");
+			const result = await ops.save({
+				content: params.memory,
+				context: params.context,
+				source: "coding-agent-learn",
+				importance: 0.8,
+			});
+			const firstText = result.content.find(item => item.type === "text")?.text;
+			if (!firstText) throw new Error("Memory backend did not return a learn result.");
+			memoryMessage = firstText;
 		}
 
 		// 2) Optionally mint/enhance a managed skill. A failure here is surfaced

--- a/packages/coding-agent/src/tools/memory-ops.ts
+++ b/packages/coding-agent/src/tools/memory-ops.ts
@@ -230,6 +230,8 @@ function createCogneeOps(session: ToolSession): MemoryToolOps {
 			const state = getCogneeState(session);
 			const result = await state.search(query, options);
 			const items = result.items ?? [];
+			const failureMessage = cogneeSearchFailureMessage(result, items.length);
+			if (failureMessage) throw new Error(failureMessage);
 			if (items.length === 0 || result.count === 0) return noRelevantMemories();
 			return foundMemories(items.length, formatGenericSearchItems(items));
 		},
@@ -238,6 +240,8 @@ function createCogneeOps(session: ToolSession): MemoryToolOps {
 			const searchQuery = context?.trim() ? `${query.trim()}\n\nAdditional context:\n${context.trim()}` : query;
 			const result = await state.search(searchQuery, { signal });
 			const items = result.items ?? [];
+			const failureMessage = cogneeSearchFailureMessage(result, items.length);
+			if (failureMessage) throw new Error(failureMessage);
 			if (items.length === 0 || result.count === 0) {
 				return { content: [{ type: "text", text: "No relevant information found to reflect on." }], details: {} };
 			}
@@ -256,6 +260,12 @@ function createCogneeOps(session: ToolSession): MemoryToolOps {
 			throw new Error(result.message || "Cognee did not store the lesson.");
 		},
 	};
+}
+
+function cogneeSearchFailureMessage(result: MemoryBackendSearchResult, itemCount: number): string | null {
+	const message = result.message?.trim();
+	if (!message) return null;
+	return itemCount === 0 || result.count === 0 ? message : null;
 }
 
 function countResult(nounBase: "memory", count: number, mode: "queued" | "stored"): AgentToolResult {

--- a/packages/coding-agent/src/tools/memory-ops.ts
+++ b/packages/coding-agent/src/tools/memory-ops.ts
@@ -1,0 +1,307 @@
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import { ensureBankExists } from "../hindsight/bank";
+import { formatCurrentTime, formatMemories } from "../hindsight/content";
+import type { HindsightSessionState } from "../hindsight/state";
+import type {
+	MemoryBackendId,
+	MemoryBackendSaveInput,
+	MemoryBackendSaveResult,
+	MemoryBackendSearchItem,
+	MemoryBackendSearchOptions,
+	MemoryBackendSearchResult,
+} from "../memory-backend";
+import type { MnemopiSessionState } from "../mnemopi/state";
+import type { ToolSession } from ".";
+import type { MemoryEditParams } from "./memory-edit";
+
+export interface RetainToolItem {
+	content: string;
+	context?: string;
+}
+
+export interface MemoryToolOps {
+	readonly backend: Extract<MemoryBackendId | "cognee", "hindsight" | "mnemopi" | "cognee">;
+	readonly supportsReflect: boolean;
+	readonly supportsEdit: boolean;
+
+	retain(items: RetainToolItem[]): Promise<AgentToolResult>;
+	recall(query: string, options?: MemoryBackendSearchOptions): Promise<AgentToolResult>;
+	reflect(query: string, context?: string, signal?: AbortSignal): Promise<AgentToolResult>;
+	save?(input: MemoryBackendSaveInput): Promise<AgentToolResult>;
+	edit?(params: MemoryEditParams): Promise<AgentToolResult>;
+}
+
+interface CogneeToolStateLike {
+	readonly sessionId: string;
+	enqueueRetain(content: string, context?: string): void;
+	search(query: string, options?: MemoryBackendSearchOptions): Promise<MemoryBackendSearchResult>;
+	save(input: MemoryBackendSaveInput): Promise<MemoryBackendSaveResult>;
+}
+
+type ToolSessionWithCognee = ToolSession & {
+	getCogneeSessionState?: () => CogneeToolStateLike | undefined;
+};
+
+export function isMemoryToolsBackend(backend: unknown): backend is "hindsight" | "mnemopi" | "cognee" {
+	return backend === "hindsight" || backend === "mnemopi" || backend === "cognee";
+}
+
+export function resolveMemoryToolOps(session: ToolSession): MemoryToolOps | null {
+	const backend = session.settings.get("memory.backend") as MemoryBackendId | "cognee";
+	if (!isMemoryToolsBackend(backend)) return null;
+
+	switch (backend) {
+		case "hindsight":
+			return createHindsightOps(session);
+		case "mnemopi":
+			return createMnemopiOps(session);
+		case "cognee":
+			return createCogneeOps(session);
+	}
+
+	return null;
+}
+
+function getHindsightState(session: ToolSession): HindsightSessionState {
+	const state = session.getHindsightSessionState?.();
+	if (!state) throw new Error("Hindsight backend is not initialised for this session.");
+	return state;
+}
+
+function getMnemopiState(session: ToolSession): MnemopiSessionState {
+	const state = session.getMnemopiSessionState?.();
+	if (!state) throw new Error("Mnemopi backend is not initialised for this session.");
+	return state;
+}
+
+function getCogneeState(session: ToolSession): CogneeToolStateLike {
+	const sessionWithCognee = session as ToolSessionWithCognee;
+	const state = sessionWithCognee.getCogneeSessionState?.();
+	if (!state) throw new Error("Cognee backend is not initialised for this session.");
+	return state;
+}
+
+function createHindsightOps(session: ToolSession): MemoryToolOps {
+	return {
+		backend: "hindsight",
+		supportsReflect: true,
+		supportsEdit: false,
+		async retain(items) {
+			const state = getHindsightState(session);
+			for (const item of items) {
+				state.enqueueRetain(item.content, item.context);
+			}
+			return countResult("memory", items.length, "queued");
+		},
+		async recall(query) {
+			const state = getHindsightState(session);
+			try {
+				const response = await state.client.recall(state.bankId, query, {
+					budget: state.config.recallBudget,
+					maxTokens: state.config.recallMaxTokens,
+					types: state.config.recallTypes.length > 0 ? state.config.recallTypes : undefined,
+					tags: state.recallTags,
+					tagsMatch: state.recallTagsMatch,
+				});
+				const results = response.results ?? [];
+				if (results.length === 0) return noRelevantMemories();
+				return foundMemories(results.length, formatMemories(results));
+			} catch (err) {
+				logger.warn("recall failed", { bankId: state.bankId, error: String(err) });
+				throw err instanceof Error ? err : new Error(String(err));
+			}
+		},
+		async reflect(query, context) {
+			const state = getHindsightState(session);
+			try {
+				await ensureBankExists(state.client, state.bankId, state.config, state.banksSet);
+				const response = await state.client.reflect(state.bankId, query, {
+					context,
+					budget: state.config.recallBudget,
+					tags: state.recallTags,
+					tagsMatch: state.recallTagsMatch,
+				});
+				const text = response.text?.trim() || "No relevant information found to reflect on.";
+				return { content: [{ type: "text", text }], details: {} };
+			} catch (err) {
+				logger.warn("reflect failed", { bankId: state.bankId, error: String(err) });
+				throw err instanceof Error ? err : new Error(String(err));
+			}
+		},
+		async save(input) {
+			const state = getHindsightState(session);
+			state.enqueueRetain(input.content, input.context);
+			return { content: [{ type: "text", text: "Lesson queued for retention" }], details: {} };
+		},
+	};
+}
+
+function createMnemopiOps(session: ToolSession): MemoryToolOps {
+	return {
+		backend: "mnemopi",
+		supportsReflect: true,
+		supportsEdit: true,
+		async retain(items) {
+			const state = getMnemopiState(session);
+			for (const item of items) {
+				state.rememberScoped(item.content, {
+					source: "coding-agent-retain",
+					importance: 0.75,
+					metadata: {
+						session_id: state.sessionId,
+						cwd: state.session.sessionManager.getCwd(),
+						context: item.context ?? null,
+						tool: "retain",
+					},
+					scope: "bank",
+					extract: true,
+					extractEntities: true,
+					veracity: "tool",
+					memoryType: "fact",
+				});
+			}
+			return countResult("memory", items.length, "stored");
+		},
+		async recall(query) {
+			const state = getMnemopiState(session);
+			try {
+				const results = await state.recallResultsScoped(query);
+				if (results.length === 0) return noRelevantMemories();
+				return foundMemories(results.length, state.formatScopedRecallWithIds(results));
+			} catch (err) {
+				logger.warn("recall failed", { backend: "mnemopi", bank: state.config.bank, error: String(err) });
+				throw err instanceof Error ? err : new Error(String(err));
+			}
+		},
+		async reflect(query, context) {
+			const state = getMnemopiState(session);
+			try {
+				const searchQuery = context?.trim() ? `${query.trim()}\n\nAdditional context:\n${context.trim()}` : query;
+				const results = await state.recallResultsScoped(searchQuery);
+				if (results.length === 0) {
+					return { content: [{ type: "text", text: "No relevant information found to reflect on." }], details: {} };
+				}
+				return {
+					content: [{ type: "text", text: `Based on recalled memories:\n\n${state.formatContextScoped(results)}` }],
+					details: {},
+				};
+			} catch (err) {
+				logger.warn("reflect failed", { backend: "mnemopi", bank: state.config.bank, error: String(err) });
+				throw err instanceof Error ? err : new Error(String(err));
+			}
+		},
+		async save(input) {
+			const state = getMnemopiState(session);
+			const id = state.rememberScoped(input.content, {
+				source: input.source || "coding-agent-learn",
+				importance: input.importance ?? 0.8,
+				metadata: {
+					session_id: state.sessionId,
+					cwd: state.session.sessionManager.getCwd(),
+					context: input.context ?? null,
+					tool: "learn",
+				},
+				scope: "bank",
+				extract: true,
+				extractEntities: true,
+				veracity: "tool",
+				memoryType: "fact",
+			});
+			if (!id) throw new Error("Mnemopi did not store the lesson (no memory id returned).");
+			return { content: [{ type: "text", text: "Lesson stored" }], details: {} };
+		},
+	};
+}
+
+function createCogneeOps(session: ToolSession): MemoryToolOps {
+	return {
+		backend: "cognee",
+		supportsReflect: true,
+		supportsEdit: false,
+		async retain(items) {
+			const state = getCogneeState(session);
+			for (const item of items) {
+				state.enqueueRetain(item.content, item.context);
+			}
+			return countResult("memory", items.length, "queued");
+		},
+		async recall(query, options) {
+			const state = getCogneeState(session);
+			const result = await state.search(query, options);
+			const items = result.items ?? [];
+			if (items.length === 0 || result.count === 0) return noRelevantMemories();
+			return foundMemories(items.length, formatGenericSearchItems(items));
+		},
+		async reflect(query, context, signal) {
+			const state = getCogneeState(session);
+			const searchQuery = context?.trim() ? `${query.trim()}\n\nAdditional context:\n${context.trim()}` : query;
+			const result = await state.search(searchQuery, { signal });
+			const items = result.items ?? [];
+			if (items.length === 0 || result.count === 0) {
+				return { content: [{ type: "text", text: "No relevant information found to reflect on." }], details: {} };
+			}
+			return {
+				content: [{ type: "text", text: `Based on recalled memories:\n\n${formatGenericSearchItems(items)}` }],
+				details: {},
+			};
+		},
+		async save(input) {
+			const state = getCogneeState(session);
+			const result = await state.save(input);
+			if (result.stored > 0) return { content: [{ type: "text", text: "Lesson stored" }], details: {} };
+			if (result.queued === true) {
+				return { content: [{ type: "text", text: "Lesson queued for retention" }], details: {} };
+			}
+			throw new Error(result.message || "Cognee did not store the lesson.");
+		},
+	};
+}
+
+function countResult(nounBase: "memory", count: number, mode: "queued" | "stored"): AgentToolResult {
+	const noun = count === 1 ? nounBase : "memories";
+	return {
+		content: [{ type: "text", text: `${count} ${noun} ${mode}.` }],
+		details: { count },
+	};
+}
+
+function noRelevantMemories(): AgentToolResult {
+	return {
+		content: [{ type: "text", text: "No relevant memories found." }],
+		details: {},
+		useless: true,
+	};
+}
+
+function foundMemories(count: number, formatted: string): AgentToolResult {
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Found ${count} relevant ${count === 1 ? "memory" : "memories"} (as of ${formatCurrentTime()} UTC):\n\n${formatted}`,
+			},
+		],
+		details: {},
+	};
+}
+
+function formatGenericSearchItems(items: MemoryBackendSearchItem[]): string {
+	return items
+		.map(item => {
+			const parts = [`- ${item.content}`];
+			if (item.id) parts.push(`(id: ${item.id})`);
+			if (item.source) parts.push(`[${item.source}]`);
+			const date = formatTimestampDate(item.timestamp);
+			if (date) parts.push(`(${date})`);
+			if (typeof item.score === "number" && Number.isFinite(item.score)) parts.push(`c:${item.score.toFixed(1)}`);
+			return parts.join(" ");
+		})
+		.join("\n\n");
+}
+
+function formatTimestampDate(timestamp: string | undefined): string | null {
+	if (!timestamp) return null;
+	const datePrefix = timestamp.slice(0, 10);
+	return /^\d{4}-\d{2}-\d{2}$/.test(datePrefix) ? datePrefix : null;
+}

--- a/packages/coding-agent/src/tools/memory-recall.ts
+++ b/packages/coding-agent/src/tools/memory-recall.ts
@@ -1,8 +1,8 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
-import { formatCurrentTime, formatMemories } from "../hindsight/content";
 import recallDescription from "../prompts/tools/recall.md" with { type: "text" };
+import { resolveMemoryToolOps } from "./memory-ops";
 import type { ToolSession } from ".";
 
 const memoryRecallSchema = type({
@@ -24,79 +24,14 @@ export class MemoryRecallTool implements AgentTool<typeof memoryRecallSchema> {
 	constructor(private readonly session: ToolSession) {}
 
 	static createIf(session: ToolSession): MemoryRecallTool | null {
-		const backend = session.settings.get("memory.backend");
-		if (backend !== "hindsight" && backend !== "mnemopi") return null;
-		return new MemoryRecallTool(session);
+		return resolveMemoryToolOps(session) ? new MemoryRecallTool(session) : null;
 	}
 
 	async execute(_id: string, params: MemoryRecallParams, signal?: AbortSignal): Promise<AgentToolResult> {
 		return untilAborted(signal, async () => {
-			const backend = this.session.settings.get("memory.backend");
-			if (backend === "mnemopi") {
-				const state = this.session.getMnemopiSessionState?.();
-				if (!state) {
-					throw new Error("Mnemopi backend is not initialised for this session.");
-				}
-				try {
-					const results = await state.recallResultsScoped(params.query);
-					if (results.length === 0) {
-						return {
-							content: [{ type: "text", text: "No relevant memories found." }],
-							details: {},
-							useless: true,
-						};
-					}
-					const formatted = state.formatScopedRecallWithIds(results);
-					return {
-						content: [
-							{
-								type: "text",
-								text: `Found ${results.length} relevant ${results.length === 1 ? "memory" : "memories"} (as of ${formatCurrentTime()} UTC):\n\n${formatted}`,
-							},
-						],
-						details: {},
-					};
-				} catch (err) {
-					logger.warn("recall failed", { backend: "mnemopi", bank: state.config.bank, error: String(err) });
-					throw err instanceof Error ? err : new Error(String(err));
-				}
-			}
-
-			const state = this.session.getHindsightSessionState?.();
-			if (!state) {
-				throw new Error("Hindsight backend is not initialised for this session.");
-			}
-
-			try {
-				const response = await state.client.recall(state.bankId, params.query, {
-					budget: state.config.recallBudget,
-					maxTokens: state.config.recallMaxTokens,
-					types: state.config.recallTypes.length > 0 ? state.config.recallTypes : undefined,
-					tags: state.recallTags,
-					tagsMatch: state.recallTagsMatch,
-				});
-				const results = response.results ?? [];
-				if (results.length === 0) {
-					return {
-						content: [{ type: "text", text: "No relevant memories found." }],
-						details: {},
-						useless: true,
-					};
-				}
-				const formatted = formatMemories(results);
-				return {
-					content: [
-						{
-							type: "text",
-							text: `Found ${results.length} relevant ${results.length === 1 ? "memory" : "memories"} (as of ${formatCurrentTime()} UTC):\n\n${formatted}`,
-						},
-					],
-					details: {},
-				};
-			} catch (err) {
-				logger.warn("recall failed", { bankId: state.bankId, error: String(err) });
-				throw err instanceof Error ? err : new Error(String(err));
-			}
+			const ops = resolveMemoryToolOps(this.session);
+			if (!ops) throw new Error("No active memory backend supports recall.");
+			return ops.recall(params.query, { signal });
 		});
 	}
 }

--- a/packages/coding-agent/src/tools/memory-reflect.ts
+++ b/packages/coding-agent/src/tools/memory-reflect.ts
@@ -1,8 +1,8 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
-import { ensureBankExists } from "../hindsight/bank";
 import reflectDescription from "../prompts/tools/reflect.md" with { type: "text" };
+import { resolveMemoryToolOps } from "./memory-ops";
 import type { ToolSession } from ".";
 
 const memoryReflectSchema = type({
@@ -25,64 +25,14 @@ export class MemoryReflectTool implements AgentTool<typeof memoryReflectSchema> 
 	constructor(private readonly session: ToolSession) {}
 
 	static createIf(session: ToolSession): MemoryReflectTool | null {
-		const backend = session.settings.get("memory.backend");
-		if (backend !== "hindsight" && backend !== "mnemopi") return null;
-		return new MemoryReflectTool(session);
+		return resolveMemoryToolOps(session)?.supportsReflect === true ? new MemoryReflectTool(session) : null;
 	}
 
 	async execute(_id: string, params: MemoryReflectParams, signal?: AbortSignal): Promise<AgentToolResult> {
 		return untilAborted(signal, async () => {
-			const backend = this.session.settings.get("memory.backend");
-			if (backend === "mnemopi") {
-				const state = this.session.getMnemopiSessionState?.();
-				if (!state) {
-					throw new Error("Mnemopi backend is not initialised for this session.");
-				}
-
-				try {
-					const query = params.context?.trim()
-						? `${params.query.trim()}\n\nAdditional context:\n${params.context.trim()}`
-						: params.query;
-					const results = await state.recallResultsScoped(query);
-					if (results.length === 0) {
-						return {
-							content: [{ type: "text", text: "No relevant information found to reflect on." }],
-							details: {},
-						};
-					}
-					const summary = state.formatContextScoped(results);
-					return {
-						content: [{ type: "text", text: `Based on recalled memories:\n\n${summary}` }],
-						details: {},
-					};
-				} catch (err) {
-					logger.warn("reflect failed", { backend: "mnemopi", bank: state.config.bank, error: String(err) });
-					throw err instanceof Error ? err : new Error(String(err));
-				}
-			}
-
-			const state = this.session.getHindsightSessionState?.();
-			if (!state) {
-				throw new Error("Hindsight backend is not initialised for this session.");
-			}
-
-			try {
-				await ensureBankExists(state.client, state.bankId, state.config, state.banksSet);
-				const response = await state.client.reflect(state.bankId, params.query, {
-					context: params.context,
-					budget: state.config.recallBudget,
-					tags: state.recallTags,
-					tagsMatch: state.recallTagsMatch,
-				});
-				const text = response.text?.trim() || "No relevant information found to reflect on.";
-				return {
-					content: [{ type: "text", text }],
-					details: {},
-				};
-			} catch (err) {
-				logger.warn("reflect failed", { bankId: state.bankId, error: String(err) });
-				throw err instanceof Error ? err : new Error(String(err));
-			}
+			const ops = resolveMemoryToolOps(this.session);
+			if (!ops?.supportsReflect) throw new Error("No active memory backend supports reflect.");
+			return ops.reflect(params.query, params.context, signal);
 		});
 	}
 }

--- a/packages/coding-agent/src/tools/memory-retain.ts
+++ b/packages/coding-agent/src/tools/memory-retain.ts
@@ -1,6 +1,7 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { type } from "arktype";
 import retainDescription from "../prompts/tools/retain.md" with { type: "text" };
+import { resolveMemoryToolOps } from "./memory-ops";
 import type { ToolSession } from ".";
 
 const memoryRetainSchema = type({
@@ -27,63 +28,12 @@ export class MemoryRetainTool implements AgentTool<typeof memoryRetainSchema> {
 	constructor(private readonly session: ToolSession) {}
 
 	static createIf(session: ToolSession): MemoryRetainTool | null {
-		const backend = session.settings.get("memory.backend");
-		if (backend !== "hindsight" && backend !== "mnemopi") return null;
-		return new MemoryRetainTool(session);
+		return resolveMemoryToolOps(session) ? new MemoryRetainTool(session) : null;
 	}
 
 	async execute(_id: string, params: MemoryRetainParams): Promise<AgentToolResult> {
-		const backend = this.session.settings.get("memory.backend");
-		if (backend === "mnemopi") {
-			const state = this.session.getMnemopiSessionState?.();
-			if (!state) {
-				throw new Error("Mnemopi backend is not initialised for this session.");
-			}
-
-			for (const item of params.items) {
-				state.rememberScoped(item.content, {
-					source: "coding-agent-retain",
-					importance: 0.75,
-					metadata: {
-						session_id: state.sessionId,
-						cwd: state.session.sessionManager.getCwd(),
-						context: item.context ?? null,
-						tool: "retain",
-					},
-					scope: "bank",
-					extract: true,
-					extractEntities: true,
-					veracity: "tool",
-					memoryType: "fact",
-				});
-			}
-
-			const count = params.items.length;
-			const noun = count === 1 ? "memory" : "memories";
-			return {
-				content: [{ type: "text", text: `${count} ${noun} stored.` }],
-				details: { count },
-			};
-		}
-
-		const state = this.session.getHindsightSessionState?.();
-		if (!state) {
-			throw new Error("Hindsight backend is not initialised for this session.");
-		}
-
-		// Push every item onto the session-owned queue and return immediately.
-		// The queue flushes either when it reaches its batch threshold or when
-		// its debounce timer fires. If the eventual batch fails, the queue
-		// surfaces a UI-only warning notice — the LLM is not informed.
-		for (const item of params.items) {
-			state.enqueueRetain(item.content, item.context);
-		}
-
-		const count = params.items.length;
-		const noun = count === 1 ? "memory" : "memories";
-		return {
-			content: [{ type: "text", text: `${count} ${noun} queued.` }],
-			details: { count },
-		};
+		const ops = resolveMemoryToolOps(this.session);
+		if (!ops) throw new Error("No active memory backend supports retain.");
+		return ops.retain(params.items);
 	}
 }

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -13,6 +13,8 @@ import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-sessi
 import type { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { removeWithRetries, setProjectDir } from "@oh-my-pi/pi-utils";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 
 interface FakeAcpBuiltinSession {
 	fastMode: boolean;
@@ -1134,5 +1136,188 @@ describe("wave 5 — adapters and polish", () => {
 		} finally {
 			discoverSpy.mockRestore();
 		}
+	});
+});
+
+/**
+ * Plan-authorized local widening: `MemoryBackendId` does not yet include
+ * `"cognee"` in this worktree (owned by CogneeBackendAdapter). This const
+ * stands in for that future union member; no production type is altered.
+ */
+const COGNEE_ID = "cognee" as never;
+
+interface FakeCogneeMemoryHooks {
+	stats?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	diagnose?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	clear?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+	enqueue?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+}
+
+function createFakeCogneeBackend(hooks: FakeCogneeMemoryHooks = {}): MemoryBackend {
+	const backend = {
+		id: COGNEE_ID,
+		async start() {},
+		async buildDeveloperInstructions() {
+			return undefined;
+		},
+		async clear(agentDir: string, cwd: string, session?: unknown) {
+			await hooks.clear?.(agentDir, cwd, session);
+		},
+		async enqueue(agentDir: string, cwd: string, session?: unknown) {
+			await hooks.enqueue?.(agentDir, cwd, session);
+		},
+		async stats(agentDir: string, cwd: string, session?: unknown) {
+			return hooks.stats?.(agentDir, cwd, session);
+		},
+		async diagnose(agentDir: string, cwd: string, session?: unknown) {
+			return hooks.diagnose?.(agentDir, cwd, session);
+		},
+	};
+	return backend as unknown as MemoryBackend;
+}
+
+describe("ACP /memory — Cognee backend routing", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("/memory stats renders backend-provided markdown", async () => {
+		const { output, runtime } = createRuntime();
+		const backend = createFakeCogneeBackend({
+			stats: async () => "# Cognee Stats\nActive: yes",
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		const result = await executeAcpBuiltinSlashCommand("/memory stats", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output.join("\n")).toContain("# Cognee Stats");
+		expect(output.join("\n")).toContain("Active: yes");
+	});
+
+	it("/memory diagnose renders redacted backend markdown and does not leak secrets", async () => {
+		const { output, runtime } = createRuntime();
+		const fakeSecret = "sk-cognee-secret-12345";
+		const backend = createFakeCogneeBackend({
+			diagnose: async () => "API key: present (redacted)\napiUrl: http://localhost:8000",
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		const result = await executeAcpBuiltinSlashCommand("/memory diagnose", runtime);
+		expect(result).toEqual({ consumed: true });
+		const text = output.join("\n");
+		expect(text).toContain("API key: present (redacted)");
+		expect(text).not.toContain(fakeSecret);
+	});
+
+	it("/memory clear calls backend.clear, refreshes the prompt, and uses non-destructive Cognee wording", async () => {
+		const { output, runtime } = createRuntime();
+		const clearCalls: Array<{ agentDir: string; cwd: string; session: unknown }> = [];
+		let refreshCalls = 0;
+		const backend = createFakeCogneeBackend({
+			clear: async (agentDir, cwd, session) => {
+				clearCalls.push({ agentDir, cwd, session });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+		spyOn(runtime.session, "refreshBaseSystemPrompt").mockImplementation(async () => {
+			refreshCalls++;
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/memory clear", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(clearCalls).toHaveLength(1);
+		expect(clearCalls[0]?.agentDir).toBe(runtime.settings.getAgentDir());
+		expect(clearCalls[0]?.cwd).toBe(runtime.cwd);
+		expect(clearCalls[0]?.session).toBe(runtime.session);
+		expect(refreshCalls).toBe(1);
+		const text = output.join("\n");
+		expect(text).toContain("upstream Cognee datasets were not deleted");
+		expect(text).not.toMatch(/datasets deleted|server data cleared/i);
+	});
+
+	it("/memory reset mirrors clear behavior and wording", async () => {
+		const { output, runtime } = createRuntime();
+		const clearCalls: Array<{ agentDir: string; cwd: string }> = [];
+		let refreshCalls = 0;
+		const backend = createFakeCogneeBackend({
+			clear: async (agentDir, cwd) => {
+				clearCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+		spyOn(runtime.session, "refreshBaseSystemPrompt").mockImplementation(async () => {
+			refreshCalls++;
+		});
+
+		await executeAcpBuiltinSlashCommand("/memory reset", runtime);
+		expect(clearCalls).toHaveLength(1);
+		expect(refreshCalls).toBe(1);
+		const text = output.join("\n");
+		expect(text).toContain("upstream Cognee datasets were not deleted");
+	});
+
+	it("/memory enqueue calls backend.enqueue and shows Cognee maintenance wording", async () => {
+		const { output, runtime } = createRuntime();
+		const enqueueCalls: Array<{ agentDir: string; cwd: string }> = [];
+		const backend = createFakeCogneeBackend({
+			enqueue: async (agentDir, cwd) => {
+				enqueueCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await executeAcpBuiltinSlashCommand("/memory enqueue", runtime);
+		expect(enqueueCalls).toHaveLength(1);
+		expect(output.join("\n")).toContain("Cognee memory maintenance enqueued");
+	});
+
+	it("/memory rebuild mirrors enqueue behavior and wording", async () => {
+		const { output, runtime } = createRuntime();
+		const enqueueCalls: Array<{ agentDir: string; cwd: string }> = [];
+		const backend = createFakeCogneeBackend({
+			enqueue: async (agentDir, cwd) => {
+				enqueueCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await executeAcpBuiltinSlashCommand("/memory rebuild", runtime);
+		expect(enqueueCalls).toHaveLength(1);
+		expect(output.join("\n")).toContain("Cognee memory maintenance enqueued");
+	});
+
+	it("/memory mm list remains unsupported in ACP and does not call Cognee hooks", async () => {
+		const { output, runtime } = createRuntime();
+		const statsCalls: number[] = [];
+		const diagnoseCalls: number[] = [];
+		const clearCalls: number[] = [];
+		const enqueueCalls: number[] = [];
+		const backend = createFakeCogneeBackend({
+			stats: async () => {
+				statsCalls.push(1);
+				return undefined;
+			},
+			diagnose: async () => {
+				diagnoseCalls.push(1);
+				return undefined;
+			},
+			clear: async () => {
+				clearCalls.push(1);
+			},
+			enqueue: async () => {
+				enqueueCalls.push(1);
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		const result = await executeAcpBuiltinSlashCommand("/memory mm list", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output.join("\n")).toContain(
+			"Mental-model maintenance via /memory mm is unsupported in ACP mode",
+		);
+		expect(statsCalls).toHaveLength(0);
+		expect(diagnoseCalls).toHaveLength(0);
+		expect(clearCalls).toHaveLength(0);
+		expect(enqueueCalls).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/autolearn-tools-gating.test.ts
+++ b/packages/coding-agent/test/autolearn-tools-gating.test.ts
@@ -29,6 +29,25 @@ function makeSession(
 	};
 }
 
+function makeCogneeSession(autolearnEnabled: boolean, extra: Record<string, unknown> = {}): ToolSession {
+	const settings = {
+		get: (key: string) => {
+			if (key === "autolearn.enabled") return autolearnEnabled;
+			if (key === "memory.backend") return "cognee";
+			return undefined;
+		},
+	};
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		skipPythonPreflight: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+		...extra,
+	} as unknown as ToolSession;
+}
+
 describe("autolearn tool gating", () => {
 	it("offers neither tool by default (autolearn disabled)", async () => {
 		const names = (await createTools(makeSession())).map(t => t.name);
@@ -102,6 +121,11 @@ describe("autolearn tool gating", () => {
 			await createTools(makeSession({ "autolearn.enabled": true, "memory.backend": "local" }), ["read"])
 		).map(t => t.name);
 		expect(restricted).toContain("learn");
+	});
+
+	it("direct LearnTool factory accepts Cognee only when autolearn is enabled", () => {
+		expect(LearnTool.createIf(makeCogneeSession(true))).toBeInstanceOf(LearnTool);
+		expect(LearnTool.createIf(makeCogneeSession(false))).toBeNull();
 	});
 });
 
@@ -307,5 +331,82 @@ describe("learn execute", () => {
 		).rejects.toThrow(/did not store/i);
 		// A failed lesson must not leave a minted skill behind.
 		expect(await Bun.file(path.join(getManagedSkillsDir(), "should-not-exist", "SKILL.md")).exists()).toBe(false);
+	});
+
+	it("stores a Cognee lesson through structural state", async () => {
+		const saved: unknown[] = [];
+		const session = makeCogneeSession(true, {
+			getCogneeSessionState: () => ({
+				sessionId: "cognee-session",
+				enqueueRetain: () => {},
+				search: async () => ({ backend: "off", query: "", count: 0, items: [] }),
+				save: async (input: unknown) => {
+					saved.push(input);
+					return { backend: "cognee", stored: 1 };
+				},
+			}),
+		});
+
+		const result = await new LearnTool(session).execute("cognee-1", {
+			memory: "Prefer focused changes.",
+			context: "review",
+		});
+
+		expect(saved).toEqual([
+			{ content: "Prefer focused changes.", context: "review", source: "coding-agent-learn", importance: 0.8 },
+		]);
+		expect(result.content[0]).toEqual({ type: "text", text: "Lesson stored." });
+	});
+
+	it("reports queued Cognee lessons", async () => {
+		const session = makeCogneeSession(true, {
+			getCogneeSessionState: () => ({
+				sessionId: "cognee-session",
+				enqueueRetain: () => {},
+				search: async () => ({ backend: "off", query: "", count: 0, items: [] }),
+				save: async () => ({ backend: "cognee", stored: 0, queued: true }),
+			}),
+		});
+
+		const result = await new LearnTool(session).execute("cognee-2", { memory: "Queue when remote store defers." });
+
+		expect(result.content[0]).toEqual({ type: "text", text: "Lesson queued for retention." });
+	});
+
+	it("fails a Cognee lesson before writing a managed skill when save reports no storage", async () => {
+		const session = makeCogneeSession(true, {
+			getCogneeSessionState: () => ({
+				sessionId: "cognee-session",
+				enqueueRetain: () => {},
+				search: async () => ({ backend: "off", query: "", count: 0, items: [] }),
+				save: async () => ({ backend: "cognee", stored: 0, message: "Cognee unavailable" }),
+			}),
+		});
+
+		await expect(
+			new LearnTool(session).execute("cognee-3", {
+				memory: "lesson",
+				skill: { action: "create", name: "should-not-exist", description: "d", body: "b" },
+			}),
+		).rejects.toThrow(/Cognee unavailable/);
+		expect(await Bun.file(path.join(getManagedSkillsDir(), "should-not-exist", "SKILL.md")).exists()).toBe(false);
+	});
+
+	it("reports Cognee skill failures with the Cognee memory message", async () => {
+		const session = makeCogneeSession(true, {
+			getCogneeSessionState: () => ({
+				sessionId: "cognee-session",
+				enqueueRetain: () => {},
+				search: async () => ({ backend: "off", query: "", count: 0, items: [] }),
+				save: async () => ({ backend: "cognee", stored: 0, queued: true }),
+			}),
+		});
+
+		await expect(
+			new LearnTool(session).execute("cognee-4", {
+				memory: "queued lesson",
+				skill: { action: "create", name: "../evil", description: "d", body: "b" },
+			}),
+		).rejects.toThrow(/Lesson queued for retention, but the managed skill could not be written/);
 	});
 });

--- a/packages/coding-agent/test/cognee-backend.test.ts
+++ b/packages/coding-agent/test/cognee-backend.test.ts
@@ -1,0 +1,884 @@
+/**
+ * Cognee backend behavioural contract tests.
+ *
+ * These exercise `cogneeBackend` start / hooks / scope rebuild without a real
+ * Cognee server or the not-yet-joined `./state` module. `./state` is mocked
+ * with a structural fake `CogneeSessionState` plus side-channel helpers, and
+ * `createCogneeClient` is mocked to inject fake clients. No `fetch` is
+ * performed. Once `CogneeTestHarness` joins, the local fakes can be swapped
+ * for its shared factories.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { AgentSessionEventListener } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { CogneeClient } from "@oh-my-pi/pi-coding-agent/cognee/client";
+import type { CogneeScope } from "@oh-my-pi/pi-coding-agent/cognee/scope";
+import type { CogneeConfig } from "@oh-my-pi/pi-coding-agent/cognee/config";
+
+// ─── Mock ./state (absent until CogneeSessionState joins) ───────────────────
+
+const stateBySession = new WeakMap<object, unknown>();
+
+interface FakeStateOptions {
+	sessionId: string;
+	client: CogneeClient;
+	config: CogneeConfig;
+	scope: CogneeScope;
+	session: object;
+	lastRetainedTurn?: number;
+	hasRecalledForFirstTurn?: boolean;
+	aliasOf?: unknown;
+}
+
+let constructHook: ((opts: FakeStateOptions) => void) | undefined;
+
+vi.mock("@oh-my-pi/pi-coding-agent/cognee/state", () => {
+	class FakeCogneeSessionState {
+		readonly sessionId: string;
+		readonly client: CogneeClient;
+		readonly config: CogneeConfig;
+		readonly scope: CogneeScope;
+		readonly session: object;
+		readonly lastRetainedTurn: number;
+		readonly hasRecalledForFirstTurn: boolean;
+		readonly aliasOf?: unknown;
+		lastRecallSnippet?: string;
+		lastRetainedAtIso?: string;
+		attached = false;
+		disposed = false;
+
+		constructor(opts: FakeStateOptions) {
+			this.sessionId = opts.sessionId;
+			this.client = opts.client;
+			this.config = opts.config;
+			this.scope = opts.scope;
+			this.session = opts.session;
+			this.lastRetainedTurn = opts.lastRetainedTurn ?? 0;
+			this.hasRecalledForFirstTurn = opts.hasRecalledForFirstTurn ?? false;
+			this.aliasOf = opts.aliasOf;
+			constructHook?.(opts);
+		}
+
+		setSessionId(): void {}
+		resetConversationTracking(): void {}
+		enqueueRetain(): void {}
+		async flushRetainQueue(): Promise<void> {}
+		async beforeAgentStartPrompt(): Promise<string | undefined> {
+			return undefined;
+		}
+		async recallForContext(): Promise<{ context: string | null; ok: boolean }> {
+			return { context: null, ok: false };
+		}
+		async recallForCompaction(): Promise<string | undefined> {
+			return undefined;
+		}
+		async forceRetainCurrentSession(): Promise<void> {}
+		async maybeRetainOnAgentEnd(): Promise<void> {}
+		attachSessionListeners(): void {
+			this.attached = true;
+		}
+		dispose(): void {
+			this.disposed = true;
+		}
+		async search(): Promise<{ count: number; items: unknown[] }> {
+			return { count: 0, items: [] };
+		}
+		async save(): Promise<{ stored: number }> {
+			return { stored: 1 };
+		}
+	}
+
+	return {
+		CogneeSessionState: FakeCogneeSessionState,
+		getCogneeSessionState: (session: object | undefined) =>
+			session ? stateBySession.get(session) : undefined,
+		setCogneeSessionState: (session: object, state: unknown) => {
+			const previous = stateBySession.get(session);
+			stateBySession.set(session, state);
+			return previous;
+		},
+	};
+});
+
+// ─── Mock createCogneeClient to inject fakes / simulate failure ─────────────
+
+let clientFactory: (opts: { baseUrl: string; apiKey?: string }) => CogneeClient = () =>
+	createFakeCogneeClient();
+
+vi.mock("@oh-my-pi/pi-coding-agent/cognee/client", () => ({
+	createCogneeClient: (opts: { baseUrl: string; apiKey?: string }) => clientFactory(opts),
+}));
+
+// Import after mocks are registered.
+import { cogneeBackend } from "@oh-my-pi/pi-coding-agent/cognee/backend";
+import {
+	getCogneeSessionState,
+	setCogneeSessionState,
+} from "@oh-my-pi/pi-coding-agent/cognee/state";
+
+// ─── Fakes ──────────────────────────────────────────────────────────────────
+
+function createFakeCogneeClient(overrides: Partial<CogneeClient> = {}): CogneeClient {
+	const calls = {
+		remember: [] as unknown[],
+		recall: [] as unknown[],
+		improve: [] as unknown[],
+		forget: [] as unknown[],
+		listDatasets: 0,
+		getDatasetStatus: 0,
+	};
+	const base: CogneeClient = {
+		remember: async () => ({ ok: true, raw: {} }) as never,
+		rememberEntry: async () => ({ ok: true, raw: {} }) as never,
+		recall: async () => [] as never,
+		improve: async (req: never) => {
+			calls.improve.push(req);
+			return {} as never;
+		},
+		forget: async (req: never) => {
+			calls.forget.push(req);
+			return {} as never;
+		},
+		listDatasets: async () => {
+			calls.listDatasets++;
+			return [] as never;
+		},
+		getDatasetStatus: async () => {
+			calls.getDatasetStatus++;
+			return { status: "ok" } as never;
+		},
+		listDatasetData: async () => [] as never,
+		createDataset: async () => ({ id: "ds", name: "ds", status: "ok", raw: {} }) as never,
+	};
+	return { ...base, ...overrides, ...({ __calls: calls } as unknown) } as CogneeClient;
+}
+
+interface FakeSessionDeps {
+	sessionId: string | null;
+	cwd?: string;
+	settings?: Settings;
+}
+
+function makeFakeSession(deps: FakeSessionDeps) {
+	const listeners = new Set<AgentSessionEventListener>();
+	const session = {
+		sessionId: deps.sessionId,
+		settings: deps.settings ?? Settings.isolated(),
+		sessionManager: {
+			getCwd: () => deps.cwd ?? "/tmp",
+			getSessionId: () => deps.sessionId ?? "",
+			getSessionFile: () => null,
+			getEntries: () => [],
+		},
+		subscribe(listener: AgentSessionEventListener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		refreshBaseSystemPrompt: vi.fn().mockResolvedValue(undefined),
+		emit(event: Parameters<AgentSessionEventListener>[0]) {
+			for (const l of [...listeners]) l(event);
+		},
+	};
+	return session;
+}
+
+function makeConfiguredSettings(overrides: Record<string, unknown> = {}): Settings {
+	return Settings.isolated({
+		"memory.backend": "cognee",
+		"cognee.apiUrl": "http://localhost:8000",
+		...overrides,
+	});
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	resetSettingsForTest();
+	constructHook = undefined;
+	clientFactory = () => createFakeCogneeClient();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	constructHook = undefined;
+	clientFactory = () => createFakeCogneeClient();
+});
+
+// ─── start ──────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.start", () => {
+	it("installs primary state with client, config, and scope for a configured top-level session", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s1" });
+		const fakeClient = createFakeCogneeClient();
+		clientFactory = () => fakeClient;
+
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const state = getCogneeSessionState(session) as {
+			client: CogneeClient;
+			config: CogneeConfig;
+			scope: CogneeScope;
+			attached: boolean;
+		} | undefined;
+		expect(state).toBeDefined();
+		expect(state?.client).toBe(fakeClient);
+		expect(state?.config.apiUrl).toBe("http://localhost:8000");
+		expect(state?.scope).toBeDefined();
+		expect(state?.attached).toBe(true);
+	});
+
+	it("is non-throwing if client construction fails and leaves backend inactive", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s2" });
+		clientFactory = () => {
+			throw new Error("client construction failed");
+		};
+
+		await expect(
+			cogneeBackend.start({
+				session: session as never,
+				settings,
+				modelRegistry: {} as never,
+				agentDir: "/tmp",
+				taskDepth: 0,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(getCogneeSessionState(session)).toBeUndefined();
+		const status = await cogneeBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
+		expect(status.active).toBe(false);
+	});
+
+	it("leaves backend inert and warns when cognee.apiUrl is blank", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "cognee",
+			"cognee.apiUrl": "",
+		});
+		const session = makeFakeSession({ sessionId: "s3", settings });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// logger.warn routes through the logger; spy on it too.
+		const { logger } = await import("@oh-my-pi/pi-utils");
+		const loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		expect(getCogneeSessionState(session)).toBeUndefined();
+		const warned = loggerWarnSpy.mock.calls.some(c => String(c[0]).includes("cognee.apiUrl is unset"));
+		expect(warned).toBe(true);
+		warnSpy.mockRestore();
+	});
+
+	it("installs an alias for taskDepth > 0 with parentCogneeSessionState, sets hasRecalledForFirstTurn, and does not attach listeners", async () => {
+		const settings = makeConfiguredSettings();
+		const parentSession = makeFakeSession({ sessionId: "parent" });
+		const fakeClient = createFakeCogneeClient();
+		clientFactory = () => fakeClient;
+
+		await cogneeBackend.start({
+			session: parentSession as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const parentState = getCogneeSessionState(parentSession);
+		expect(parentState).toBeDefined();
+
+		const subSession = makeFakeSession({ sessionId: "sub" });
+		await cogneeBackend.start({
+			session: subSession as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 1,
+			parentCogneeSessionState: parentState as never,
+		});
+
+		const subState = getCogneeSessionState(subSession) as {
+			aliasOf: unknown;
+			client: CogneeClient;
+			hasRecalledForFirstTurn: boolean;
+			attached: boolean;
+		} | undefined;
+		expect(subState).toBeDefined();
+		expect(subState?.aliasOf).toBe(parentState);
+		expect(subState?.client).toBe(parentState?.client);
+		expect(subState?.hasRecalledForFirstTurn).toBe(true);
+		expect(subState?.attached).toBe(false);
+	});
+
+	it("returns silently for subagent runs when no parentCogneeSessionState is provided", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "orphan-sub" });
+
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 1,
+		});
+
+		expect(getCogneeSessionState(session)).toBeUndefined();
+	});
+});
+
+// ─── buildDeveloperInstructions ─────────────────────────────────────────────
+
+describe("cogneeBackend.buildDeveloperInstructions", () => {
+	it("returns undefined when unconfigured", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee", "cognee.apiUrl": "" });
+		expect(await cogneeBackend.buildDeveloperInstructions("/tmp", settings, undefined)).toBeUndefined();
+	});
+
+	it("returns the exact static block and appends lastRecallSnippet from primary state", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-dev", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as { lastRecallSnippet?: string };
+		state.lastRecallSnippet = "<memories>snippet</memories>";
+
+		const out = await cogneeBackend.buildDeveloperInstructions("/tmp", settings, session as never);
+		expect(out).toContain("## Cognee Memory");
+		expect(out).toContain("heuristic context, not authority");
+		expect(out).toContain("<memories>snippet</memories>");
+	});
+
+	it("truncates to recallMaxRenderChars; with 0 returns static block only", async () => {
+		const settings = makeConfiguredSettings({ "cognee.recallMaxRenderChars": 0 });
+		const session = makeFakeSession({ sessionId: "s-trunc", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as { lastRecallSnippet?: string };
+		state.lastRecallSnippet = "<memories>should not appear</memories>";
+
+		const out = await cogneeBackend.buildDeveloperInstructions("/tmp", settings, session as never);
+		expect(out).toContain("## Cognee Memory");
+		expect(out).not.toContain("should not appear");
+	});
+});
+
+// ─── beforeAgentStartPrompt ─────────────────────────────────────────────────
+
+describe("cogneeBackend.beforeAgentStartPrompt", () => {
+	it("returns undefined without state", async () => {
+		const session = makeFakeSession({ sessionId: "s-none" });
+		expect(await cogneeBackend.beforeAgentStartPrompt!(session as never, "hi")).toBeUndefined();
+	});
+
+	it("delegates to state.beforeAgentStartPrompt", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-basp", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			beforeAgentStartPrompt: (t: string) => Promise<string | undefined>;
+		};
+		const spy = vi.spyOn(state, "beforeAgentStartPrompt").mockResolvedValue("injected");
+		expect(await cogneeBackend.beforeAgentStartPrompt!(session as never, "hi")).toBe("injected");
+		expect(spy).toHaveBeenCalledWith("hi");
+	});
+});
+
+// ─── status ─────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.status", () => {
+	it("returns inactive shape without state", async () => {
+		const session = makeFakeSession({ sessionId: "s-status" });
+		const status = await cogneeBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
+		expect(status).toMatchObject({
+			backend: "cognee",
+			active: false,
+			writable: false,
+			searchable: false,
+			message: "Cognee backend is not initialised for this session.",
+		});
+	});
+
+	it("returns active shape with scope, retainBank, recallBanks, lastRecall, lastMemory", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-active", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			scope: CogneeScope;
+			lastRecallSnippet?: string;
+			lastRetainedAtIso?: string;
+		};
+		state.lastRecallSnippet = "recall";
+		state.lastRetainedAtIso = "2026-01-01T00:00:00Z";
+
+		const status = await cogneeBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
+		expect(status).toMatchObject({
+			backend: "cognee",
+			active: true,
+			writable: true,
+			searchable: true,
+			scope: state.scope.label,
+			retainBank: state.scope.retainDatasetLabel,
+			recallBanks: state.scope.recallDatasetLabels,
+			lastRecall: true,
+			lastMemory: "2026-01-01T00:00:00Z",
+		});
+	});
+});
+
+// ─── search ─────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.search", () => {
+	it("returns unavailable without state", async () => {
+		const session = makeFakeSession({ sessionId: "s-search" });
+		const res = await cogneeBackend.search!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, "q");
+		expect(res).toMatchObject({ backend: "cognee", query: "q", count: 0, items: [] });
+		expect(res.message).toBe("Cognee backend is not initialised for this session.");
+	});
+
+	it("returns empty-query result for blank query", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-blank", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const res = await cogneeBackend.search!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, "   ");
+		expect(res.message).toBe("Search query is empty.");
+	});
+
+	it("returns abort result for pre-aborted signal", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-abort", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const controller = new AbortController();
+		controller.abort();
+		const res = await cogneeBackend.search!(
+			{ agentDir: "/tmp", cwd: "/tmp", session: session as never },
+			"q",
+			{ signal: controller.signal },
+		);
+		expect(res.message).toBe("Search aborted.");
+	});
+
+	it("delegates to state.search and normalizes backend/query", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-delegate", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			search: (q: string, o?: unknown) => Promise<{ count: number; items: unknown[] }>;
+		};
+		vi.spyOn(state, "search").mockResolvedValue({ count: 2, items: [{ content: "x" }] });
+
+		const res = await cogneeBackend.search!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, "find");
+		expect(res.backend).toBe("cognee");
+		expect(res.query).toBe("find");
+		expect(res.count).toBe(2);
+	});
+});
+
+// ─── save ───────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.save", () => {
+	it("returns unavailable without state", async () => {
+		const session = makeFakeSession({ sessionId: "s-save" });
+		const res = await cogneeBackend.save!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, { content: "x" });
+		expect(res).toMatchObject({ backend: "cognee", stored: 0 });
+		expect(res.message).toBe("Cognee backend is not initialised for this session.");
+	});
+
+	it("rejects empty content as stored: 0", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-empty", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const res = await cogneeBackend.save!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, { content: "   " });
+		expect(res.stored).toBe(0);
+		expect(res.message).toBe("Memory content is empty.");
+	});
+
+	it("delegates trimmed content to state.save and normalizes backend", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-trim", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			save: (i: { content: string }) => Promise<{ stored: number }>;
+		};
+		const spy = vi.spyOn(state, "save").mockResolvedValue({ stored: 1 });
+
+		const res = await cogneeBackend.save!({ agentDir: "/tmp", cwd: "/tmp", session: session as never }, { content: "  note  " });
+		expect(res.backend).toBe("cognee");
+		expect(res.stored).toBe(1);
+		expect(spy.mock.calls[0]?.[0].content).toBe("note");
+	});
+});
+
+// ─── clear ──────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.clear", () => {
+	it("flushes, clears/disposes state, unsubscribes, logs local-only warning, never calls forget", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-clear", settings });
+		const fakeClient = createFakeCogneeClient();
+		clientFactory = () => fakeClient;
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			flushRetainQueue: () => Promise<void>;
+			dispose: () => void;
+			disposed: boolean;
+		};
+		const flushSpy = vi.spyOn(state, "flushRetainQueue");
+		const { logger } = await import("@oh-my-pi/pi-utils");
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		await cogneeBackend.clear("/tmp", "/tmp", session as never);
+
+		expect(flushSpy).toHaveBeenCalled();
+		expect(getCogneeSessionState(session)).toBeUndefined();
+		expect(state.disposed).toBe(true);
+		const warned = warnSpy.mock.calls.some(c =>
+			String(c[0]).includes("only local recall cache/session state was cleared"),
+		);
+		expect(warned).toBe(true);
+	});
+});
+
+// ─── enqueue ────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.enqueue", () => {
+	it("on primary state flushes, force-retains, and calls client.improve with routing fields", async () => {
+		const settings = makeConfiguredSettings({ "cognee.sessionMemoryEnabled": true });
+		const session = makeFakeSession({ sessionId: "s-enq", settings });
+		const fakeClient = createFakeCogneeClient();
+		clientFactory = () => fakeClient;
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			flushRetainQueue: () => Promise<void>;
+			forceRetainCurrentSession: () => Promise<void>;
+			client: CogneeClient;
+			scope: CogneeScope;
+			config: CogneeConfig;
+			sessionId: string;
+		};
+		const flushSpy = vi.spyOn(state, "flushRetainQueue");
+		const forceSpy = vi.spyOn(state, "forceRetainCurrentSession");
+		const improveSpy = vi.spyOn(fakeClient, "improve");
+
+		await cogneeBackend.enqueue("/tmp", "/tmp", session as never);
+
+		expect(flushSpy).toHaveBeenCalled();
+		expect(forceSpy).toHaveBeenCalled();
+		expect(improveSpy).toHaveBeenCalledTimes(1);
+		const arg = improveSpy.mock.calls[0]?.[0] as {
+			datasetName?: string;
+			datasetId?: string;
+			sessionIds?: string[];
+			nodeName?: string[];
+			runInBackground?: boolean;
+			buildGlobalContextIndex?: boolean;
+		};
+		expect(arg.datasetName).toBe(state.scope.datasetName);
+		expect(arg.datasetId).toBe(state.scope.datasetId);
+		expect(arg.sessionIds).toEqual([state.sessionId]);
+		expect(arg.runInBackground).toBe(state.config.runInBackground);
+		expect(arg.buildGlobalContextIndex).toBe(state.config.buildGlobalContextIndex);
+	});
+
+	it("on alias state returns without retain/improve", async () => {
+		const settings = makeConfiguredSettings();
+		const parentSession = makeFakeSession({ sessionId: "parent-enq" });
+		clientFactory = () => createFakeCogneeClient();
+		await cogneeBackend.start({
+			session: parentSession as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const parentState = getCogneeSessionState(parentSession);
+
+		const subSession = makeFakeSession({ sessionId: "sub-enq" });
+		await cogneeBackend.start({
+			session: subSession as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 1,
+			parentCogneeSessionState: parentState as never,
+		});
+		const parentStateObj = getCogneeSessionState(parentSession) as {
+			flushRetainQueue: () => Promise<void>;
+			forceRetainCurrentSession: () => Promise<void>;
+		};
+		const parentFlushSpy = vi.spyOn(parentStateObj, "flushRetainQueue");
+		const parentForceSpy = vi.spyOn(parentStateObj, "forceRetainCurrentSession");
+		const subState = getCogneeSessionState(subSession) as {
+			flushRetainQueue: () => Promise<void>;
+			forceRetainCurrentSession: () => Promise<void>;
+			client: CogneeClient;
+		};
+		const flushSpy = vi.spyOn(subState, "flushRetainQueue");
+		const forceSpy = vi.spyOn(subState, "forceRetainCurrentSession");
+		const improveSpy = vi.spyOn(subState.client, "improve");
+
+		await cogneeBackend.enqueue("/tmp", "/tmp", subSession as never);
+
+		expect(flushSpy).not.toHaveBeenCalled();
+		expect(forceSpy).not.toHaveBeenCalled();
+		expect(improveSpy).not.toHaveBeenCalled();
+		expect(parentFlushSpy).not.toHaveBeenCalled();
+		expect(parentForceSpy).not.toHaveBeenCalled();
+	});
+
+	it("catches/warns improve failure after successful retain", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-enq-fail", settings });
+		const fakeClient = createFakeCogneeClient();
+		clientFactory = () => fakeClient;
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			flushRetainQueue: () => Promise<void>;
+			forceRetainCurrentSession: () => Promise<void>;
+		};
+		const forceSpy = vi.spyOn(state, "forceRetainCurrentSession");
+		vi.spyOn(fakeClient, "improve").mockRejectedValue(new Error("improve down"));
+		const { logger } = await import("@oh-my-pi/pi-utils");
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		await expect(cogneeBackend.enqueue("/tmp", "/tmp", session as never)).resolves.toBeUndefined();
+		expect(forceSpy).toHaveBeenCalled();
+		const warned = warnSpy.mock.calls.some(c => String(c[0]).includes("improve on enqueue failed"));
+		expect(warned).toBe(true);
+	});
+});
+
+// ─── stats ──────────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.stats", () => {
+	it("renders markdown, omits API key, catches dataset status/list failures, does not create datasets", async () => {
+		const settings = makeConfiguredSettings({ "cognee.apiKey": "secret" });
+		const session = makeFakeSession({ sessionId: "s-stats", settings });
+		const fakeClient = createFakeCogneeClient({
+			getDatasetStatus: async () => {
+				throw new Error("status down");
+			},
+			listDatasets: async () => {
+				throw new Error("list down");
+			},
+			createDataset: async () => {
+				throw new Error("must not be called");
+			},
+		});
+		clientFactory = () => fakeClient;
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const out = await cogneeBackend.stats!("/tmp", "/tmp", session as never);
+		expect(out).toContain("## Cognee Memory Stats");
+		expect(out).toContain("Configured: yes");
+		expect(out).not.toContain("secret");
+		expect(out).toContain("status down");
+		expect(out).toContain("list down");
+	});
+
+	it("renders Configured: no without a client when unconfigured", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee", "cognee.apiUrl": "" });
+		const session = makeFakeSession({ sessionId: "s-stats-no", settings });
+		const out = await cogneeBackend.stats!("/tmp", "/tmp", session as never);
+		expect(out).toContain("Configured: no");
+	});
+});
+
+// ─── diagnose ───────────────────────────────────────────────────────────────
+
+describe("cogneeBackend.diagnose", () => {
+	it("redacts API key and renders dataset status/list failures as markdown instead of throwing", async () => {
+		const settings = makeConfiguredSettings({ "cognee.apiKey": "topsecret" });
+		const session = makeFakeSession({ sessionId: "s-diag", settings });
+		const fakeClient = createFakeCogneeClient({
+			getDatasetStatus: async () => {
+				throw new Error("diag status down");
+			},
+			listDatasets: async () => {
+				throw new Error("diag list down");
+			},
+		});
+		clientFactory = () => fakeClient;
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const out = await cogneeBackend.diagnose!("/tmp", "/tmp", session as never);
+		expect(out).toContain("## Cognee Memory Diagnostics");
+		expect(out).toContain("<redacted>");
+		expect(out).not.toContain("topsecret");
+		expect(out).toContain("diag status down");
+		expect(out).toContain("diag list down");
+	});
+});
+
+// ─── preCompactionContext ───────────────────────────────────────────────────
+
+describe("cogneeBackend.preCompactionContext", () => {
+	it("returns undefined when unconfigured", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee", "cognee.apiUrl": "" });
+		expect(await cogneeBackend.preCompactionContext!([], settings, undefined)).toBeUndefined();
+	});
+
+	it("returns undefined without state", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-pcc", settings });
+		expect(await cogneeBackend.preCompactionContext!([], settings, session as never)).toBeUndefined();
+	});
+
+	it("delegates to state.recallForCompaction", async () => {
+		const settings = makeConfiguredSettings();
+		const session = makeFakeSession({ sessionId: "s-pcc2", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = getCogneeSessionState(session) as {
+			recallForCompaction: (m: AgentMessage[]) => Promise<string | undefined>;
+		};
+		vi.spyOn(state, "recallForCompaction").mockResolvedValue("compaction context");
+
+		const out = await cogneeBackend.preCompactionContext!([], settings, session as never);
+		expect(out).toBe("compaction context");
+	});
+});
+
+// ─── live scope rebuild ─────────────────────────────────────────────────────
+
+describe("cogneeBackend live scope rebuild", () => {
+	it("rebuilds primary state when cognee.datasetName changes mid-session", async () => {
+		const settings = makeConfiguredSettings({ "cognee.scoping": "global" });
+		settings.set("cognee.datasetName", "first");
+		const session = makeFakeSession({ sessionId: "s-rebuild", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const initial = getCogneeSessionState(session) as { scope: CogneeScope } | undefined;
+		expect(initial?.scope.datasetName).toBe("first");
+
+		settings.set("cognee.datasetName", "second");
+		await Bun.sleep(0);
+
+		const next = getCogneeSessionState(session) as { scope: CogneeScope } | undefined;
+		expect(next).toBeDefined();
+		expect(next).not.toBe(initial);
+		expect(next?.scope.datasetName).toBe("second");
+	});
+
+	it("does not rebuild when the same datasetName is rewritten", async () => {
+		const settings = makeConfiguredSettings({ "cognee.scoping": "global" });
+		settings.set("cognee.datasetName", "same");
+		const session = makeFakeSession({ sessionId: "s-noop", settings });
+		await cogneeBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const initial = getCogneeSessionState(session);
+
+		settings.set("cognee.datasetName", "same");
+		await Bun.sleep(0);
+
+		expect(getCogneeSessionState(session)).toBe(initial);
+	});
+});

--- a/packages/coding-agent/test/cognee-backend.test.ts
+++ b/packages/coding-agent/test/cognee-backend.test.ts
@@ -2,157 +2,62 @@
  * Cognee backend behavioural contract tests.
  *
  * These exercise `cogneeBackend` start / hooks / scope rebuild without a real
- * Cognee server or the not-yet-joined `./state` module. `./state` is mocked
- * with a structural fake `CogneeSessionState` plus side-channel helpers, and
- * `createCogneeClient` is mocked to inject fake clients. No `fetch` is
- * performed. Once `CogneeTestHarness` joins, the local fakes can be swapped
- * for its shared factories.
+ * Cognee server. The suite imports the real backend/state/client modules via
+ * relative source paths and fakes only the HTTP boundary with per-test
+ * `globalThis.fetch` spies, so it does not register module mocks that can leak
+ * into sibling Cognee test files in Bun's shared test process.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import type { AgentSessionEventListener } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import type { CogneeClient } from "@oh-my-pi/pi-coding-agent/cognee/client";
-import type { CogneeScope } from "@oh-my-pi/pi-coding-agent/cognee/scope";
-import type { CogneeConfig } from "@oh-my-pi/pi-coding-agent/cognee/config";
-
-// ─── Mock ./state (absent until CogneeSessionState joins) ───────────────────
-
-const stateBySession = new WeakMap<object, unknown>();
-
-interface FakeStateOptions {
-	sessionId: string;
-	client: CogneeClient;
-	config: CogneeConfig;
-	scope: CogneeScope;
-	session: object;
-	lastRetainedTurn?: number;
-	hasRecalledForFirstTurn?: boolean;
-	aliasOf?: unknown;
-}
-
-let constructHook: ((opts: FakeStateOptions) => void) | undefined;
-
-vi.mock("@oh-my-pi/pi-coding-agent/cognee/state", () => {
-	class FakeCogneeSessionState {
-		readonly sessionId: string;
-		readonly client: CogneeClient;
-		readonly config: CogneeConfig;
-		readonly scope: CogneeScope;
-		readonly session: object;
-		readonly lastRetainedTurn: number;
-		readonly hasRecalledForFirstTurn: boolean;
-		readonly aliasOf?: unknown;
-		lastRecallSnippet?: string;
-		lastRetainedAtIso?: string;
-		attached = false;
-		disposed = false;
-
-		constructor(opts: FakeStateOptions) {
-			this.sessionId = opts.sessionId;
-			this.client = opts.client;
-			this.config = opts.config;
-			this.scope = opts.scope;
-			this.session = opts.session;
-			this.lastRetainedTurn = opts.lastRetainedTurn ?? 0;
-			this.hasRecalledForFirstTurn = opts.hasRecalledForFirstTurn ?? false;
-			this.aliasOf = opts.aliasOf;
-			constructHook?.(opts);
-		}
-
-		setSessionId(): void {}
-		resetConversationTracking(): void {}
-		enqueueRetain(): void {}
-		async flushRetainQueue(): Promise<void> {}
-		async beforeAgentStartPrompt(): Promise<string | undefined> {
-			return undefined;
-		}
-		async recallForContext(): Promise<{ context: string | null; ok: boolean }> {
-			return { context: null, ok: false };
-		}
-		async recallForCompaction(): Promise<string | undefined> {
-			return undefined;
-		}
-		async forceRetainCurrentSession(): Promise<void> {}
-		async maybeRetainOnAgentEnd(): Promise<void> {}
-		attachSessionListeners(): void {
-			this.attached = true;
-		}
-		dispose(): void {
-			this.disposed = true;
-		}
-		async search(): Promise<{ count: number; items: unknown[] }> {
-			return { count: 0, items: [] };
-		}
-		async save(): Promise<{ stored: number }> {
-			return { stored: 1 };
-		}
-	}
-
-	return {
-		CogneeSessionState: FakeCogneeSessionState,
-		getCogneeSessionState: (session: object | undefined) =>
-			session ? stateBySession.get(session) : undefined,
-		setCogneeSessionState: (session: object, state: unknown) => {
-			const previous = stateBySession.get(session);
-			stateBySession.set(session, state);
-			return previous;
-		},
-	};
-});
-
-// ─── Mock createCogneeClient to inject fakes / simulate failure ─────────────
-
-let clientFactory: (opts: { baseUrl: string; apiKey?: string }) => CogneeClient = () =>
-	createFakeCogneeClient();
-
-vi.mock("@oh-my-pi/pi-coding-agent/cognee/client", () => ({
-	createCogneeClient: (opts: { baseUrl: string; apiKey?: string }) => clientFactory(opts),
-}));
-
-// Import after mocks are registered.
-import { cogneeBackend } from "@oh-my-pi/pi-coding-agent/cognee/backend";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import type { AgentSessionEventListener } from "../src/session/agent-session";
+import type { CogneeClient } from "../src/cognee/client";
+import type { CogneeScope } from "../src/cognee/scope";
+import type { CogneeConfig } from "../src/cognee/config";
+import { cogneeBackend } from "../src/cognee/backend";
+import { getCogneeSessionState } from "../src/cognee/state";
 import {
-	getCogneeSessionState,
-	setCogneeSessionState,
-} from "@oh-my-pi/pi-coding-agent/cognee/state";
+	createFakeCogneeFetch,
+	type FakeCogneeFetchResponse,
+	type RecordedCogneeRequest,
+} from "./helpers/cognee";
 
 // ─── Fakes ──────────────────────────────────────────────────────────────────
 
-function createFakeCogneeClient(overrides: Partial<CogneeClient> = {}): CogneeClient {
-	const calls = {
-		remember: [] as unknown[],
-		recall: [] as unknown[],
-		improve: [] as unknown[],
-		forget: [] as unknown[],
-		listDatasets: 0,
-		getDatasetStatus: 0,
+function installFakeCogneeFetch(responses: FakeCogneeFetchResponse[]) {
+	const fake = createFakeCogneeFetch(responses);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fake.fetch);
+	return fake;
+}
+
+function installThrowingFetchGetter(message: string): () => void {
+	const descriptor = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+	Object.defineProperty(globalThis, "fetch", {
+		configurable: true,
+		get() {
+			throw new Error(message);
+		},
+	});
+	return () => {
+		if (descriptor) {
+			Object.defineProperty(globalThis, "fetch", descriptor);
+			return;
+		}
+		const host: typeof globalThis & { fetch?: typeof fetch } = globalThis;
+		delete host.fetch;
 	};
-	const base: CogneeClient = {
-		remember: async () => ({ ok: true, raw: {} }) as never,
-		rememberEntry: async () => ({ ok: true, raw: {} }) as never,
-		recall: async () => [] as never,
-		improve: async (req: never) => {
-			calls.improve.push(req);
-			return {} as never;
-		},
-		forget: async (req: never) => {
-			calls.forget.push(req);
-			return {} as never;
-		},
-		listDatasets: async () => {
-			calls.listDatasets++;
-			return [] as never;
-		},
-		getDatasetStatus: async () => {
-			calls.getDatasetStatus++;
-			return { status: "ok" } as never;
-		},
-		listDatasetData: async () => [] as never,
-		createDataset: async () => ({ id: "ds", name: "ds", status: "ok", raw: {} }) as never,
-	};
-	return { ...base, ...overrides, ...({ __calls: calls } as unknown) } as CogneeClient;
+}
+
+function jsonRequestBody(request: RecordedCogneeRequest): Record<string, unknown> {
+	if (request.body?.kind !== "json") {
+		throw new Error(`Expected JSON Cognee request body, got ${request.body?.kind ?? "none"}`);
+	}
+	const { value } = request.body;
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Expected JSON Cognee request body to be an object");
+	}
+	return Object.fromEntries(Object.entries(value));
 }
 
 interface FakeSessionDeps {
@@ -163,9 +68,11 @@ interface FakeSessionDeps {
 
 function makeFakeSession(deps: FakeSessionDeps) {
 	const listeners = new Set<AgentSessionEventListener>();
+	const notices: Array<{ level: string; message: string; source?: string }> = [];
 	const session = {
 		sessionId: deps.sessionId,
 		settings: deps.settings ?? Settings.isolated(),
+		notices,
 		sessionManager: {
 			getCwd: () => deps.cwd ?? "/tmp",
 			getSessionId: () => deps.sessionId ?? "",
@@ -176,9 +83,15 @@ function makeFakeSession(deps: FakeSessionDeps) {
 			listeners.add(listener);
 			return () => listeners.delete(listener);
 		},
+		listenerCount() {
+			return listeners.size;
+		},
 		refreshBaseSystemPrompt: vi.fn().mockResolvedValue(undefined),
 		emit(event: Parameters<AgentSessionEventListener>[0]) {
 			for (const l of [...listeners]) l(event);
+		},
+		emitNotice(level: string, message: string, source?: string) {
+			notices.push({ level, message, source });
 		},
 	};
 	return session;
@@ -196,14 +109,10 @@ function makeConfiguredSettings(overrides: Record<string, unknown> = {}): Settin
 
 beforeEach(() => {
 	resetSettingsForTest();
-	constructHook = undefined;
-	clientFactory = () => createFakeCogneeClient();
 });
 
 afterEach(() => {
 	vi.restoreAllMocks();
-	constructHook = undefined;
-	clientFactory = () => createFakeCogneeClient();
 });
 
 // ─── start ──────────────────────────────────────────────────────────────────
@@ -212,8 +121,6 @@ describe("cogneeBackend.start", () => {
 	it("installs primary state with client, config, and scope for a configured top-level session", async () => {
 		const settings = makeConfiguredSettings();
 		const session = makeFakeSession({ sessionId: "s1" });
-		const fakeClient = createFakeCogneeClient();
-		clientFactory = () => fakeClient;
 
 		await cogneeBackend.start({
 			session: session as never,
@@ -223,35 +130,34 @@ describe("cogneeBackend.start", () => {
 			taskDepth: 0,
 		});
 
-		const state = getCogneeSessionState(session) as {
-			client: CogneeClient;
-			config: CogneeConfig;
-			scope: CogneeScope;
-			attached: boolean;
-		} | undefined;
+		const state = getCogneeSessionState(session) as
+			| { client: CogneeClient; config: CogneeConfig; scope: CogneeScope }
+			| undefined;
 		expect(state).toBeDefined();
-		expect(state?.client).toBe(fakeClient);
+		expect(state?.client).toBeDefined();
 		expect(state?.config.apiUrl).toBe("http://localhost:8000");
 		expect(state?.scope).toBeDefined();
-		expect(state?.attached).toBe(true);
+		expect(session.listenerCount()).toBe(1);
 	});
 
 	it("is non-throwing if client construction fails and leaves backend inactive", async () => {
 		const settings = makeConfiguredSettings();
 		const session = makeFakeSession({ sessionId: "s2" });
-		clientFactory = () => {
-			throw new Error("client construction failed");
-		};
+		const restoreFetch = installThrowingFetchGetter("client construction failed");
 
-		await expect(
-			cogneeBackend.start({
-				session: session as never,
-				settings,
-				modelRegistry: {} as never,
-				agentDir: "/tmp",
-				taskDepth: 0,
-			}),
-		).resolves.toBeUndefined();
+		try {
+			await expect(
+				cogneeBackend.start({
+					session: session as never,
+					settings,
+					modelRegistry: {} as never,
+					agentDir: "/tmp",
+					taskDepth: 0,
+				}),
+			).resolves.toBeUndefined();
+		} finally {
+			restoreFetch();
+		}
 
 		expect(getCogneeSessionState(session)).toBeUndefined();
 		const status = await cogneeBackend.status!({ agentDir: "/tmp", cwd: "/tmp", session: session as never });
@@ -286,8 +192,6 @@ describe("cogneeBackend.start", () => {
 	it("installs an alias for taskDepth > 0 with parentCogneeSessionState, sets hasRecalledForFirstTurn, and does not attach listeners", async () => {
 		const settings = makeConfiguredSettings();
 		const parentSession = makeFakeSession({ sessionId: "parent" });
-		const fakeClient = createFakeCogneeClient();
-		clientFactory = () => fakeClient;
 
 		await cogneeBackend.start({
 			session: parentSession as never,
@@ -309,17 +213,19 @@ describe("cogneeBackend.start", () => {
 			parentCogneeSessionState: parentState as never,
 		});
 
-		const subState = getCogneeSessionState(subSession) as {
-			aliasOf: unknown;
-			client: CogneeClient;
-			hasRecalledForFirstTurn: boolean;
-			attached: boolean;
-		} | undefined;
+		const subState = getCogneeSessionState(subSession) as
+			| {
+					aliasOf: unknown;
+					client: CogneeClient;
+					hasRecalledForFirstTurn: boolean;
+			  }
+			| undefined;
 		expect(subState).toBeDefined();
 		expect(subState?.aliasOf).toBe(parentState);
 		expect(subState?.client).toBe(parentState?.client);
 		expect(subState?.hasRecalledForFirstTurn).toBe(true);
-		expect(subState?.attached).toBe(false);
+		expect(parentSession.listenerCount()).toBe(1);
+		expect(subSession.listenerCount()).toBe(0);
 	});
 
 	it("returns silently for subagent runs when no parentCogneeSessionState is provided", async () => {
@@ -578,8 +484,7 @@ describe("cogneeBackend.clear", () => {
 	it("flushes, clears/disposes state, unsubscribes, logs local-only warning, never calls forget", async () => {
 		const settings = makeConfiguredSettings();
 		const session = makeFakeSession({ sessionId: "s-clear", settings });
-		const fakeClient = createFakeCogneeClient();
-		clientFactory = () => fakeClient;
+
 		await cogneeBackend.start({
 			session: session as never,
 			settings,
@@ -589,8 +494,7 @@ describe("cogneeBackend.clear", () => {
 		});
 		const state = getCogneeSessionState(session) as {
 			flushRetainQueue: () => Promise<void>;
-			dispose: () => void;
-			disposed: boolean;
+			dispose: () => void | Promise<void>;
 		};
 		const flushSpy = vi.spyOn(state, "flushRetainQueue");
 		const { logger } = await import("@oh-my-pi/pi-utils");
@@ -600,7 +504,7 @@ describe("cogneeBackend.clear", () => {
 
 		expect(flushSpy).toHaveBeenCalled();
 		expect(getCogneeSessionState(session)).toBeUndefined();
-		expect(state.disposed).toBe(true);
+		expect(session.listenerCount()).toBe(0);
 		const warned = warnSpy.mock.calls.some(c =>
 			String(c[0]).includes("only local recall cache/session state was cleared"),
 		);
@@ -614,8 +518,7 @@ describe("cogneeBackend.enqueue", () => {
 	it("on primary state flushes, force-retains, and calls client.improve with routing fields", async () => {
 		const settings = makeConfiguredSettings({ "cognee.sessionMemoryEnabled": true });
 		const session = makeFakeSession({ sessionId: "s-enq", settings });
-		const fakeClient = createFakeCogneeClient();
-		clientFactory = () => fakeClient;
+		const fakeFetch = installFakeCogneeFetch([{ body: { ok: true } }]);
 		await cogneeBackend.start({
 			session: session as never,
 			settings,
@@ -633,32 +536,28 @@ describe("cogneeBackend.enqueue", () => {
 		};
 		const flushSpy = vi.spyOn(state, "flushRetainQueue");
 		const forceSpy = vi.spyOn(state, "forceRetainCurrentSession");
-		const improveSpy = vi.spyOn(fakeClient, "improve");
 
 		await cogneeBackend.enqueue("/tmp", "/tmp", session as never);
 
 		expect(flushSpy).toHaveBeenCalled();
 		expect(forceSpy).toHaveBeenCalled();
-		expect(improveSpy).toHaveBeenCalledTimes(1);
-		const arg = improveSpy.mock.calls[0]?.[0] as {
-			datasetName?: string;
-			datasetId?: string;
-			sessionIds?: string[];
-			nodeName?: string[];
-			runInBackground?: boolean;
-			buildGlobalContextIndex?: boolean;
-		};
-		expect(arg.datasetName).toBe(state.scope.datasetName);
-		expect(arg.datasetId).toBe(state.scope.datasetId);
-		expect(arg.sessionIds).toEqual([state.sessionId]);
-		expect(arg.runInBackground).toBe(state.config.runInBackground);
-		expect(arg.buildGlobalContextIndex).toBe(state.config.buildGlobalContextIndex);
+		expect(fakeFetch.requests).toHaveLength(1);
+		const [request] = fakeFetch.requests;
+		if (!request) throw new Error("Expected Cognee improve request");
+		expect(request.method).toBe("POST");
+		expect(request.path).toBe("/api/v1/improve");
+		const body = jsonRequestBody(request);
+		expect(body.datasetName).toBe(state.scope.datasetName);
+		expect(body.datasetId).toBe(state.scope.datasetId);
+		expect(body.sessionIds).toEqual([state.sessionId]);
+		expect(body.runInBackground).toBe(state.config.runInBackground);
+		expect(body.buildGlobalContextIndex).toBe(state.config.buildGlobalContextIndex);
 	});
 
 	it("on alias state returns without retain/improve", async () => {
 		const settings = makeConfiguredSettings();
 		const parentSession = makeFakeSession({ sessionId: "parent-enq" });
-		clientFactory = () => createFakeCogneeClient();
+
 		await cogneeBackend.start({
 			session: parentSession as never,
 			settings,
@@ -704,8 +603,7 @@ describe("cogneeBackend.enqueue", () => {
 	it("catches/warns improve failure after successful retain", async () => {
 		const settings = makeConfiguredSettings();
 		const session = makeFakeSession({ sessionId: "s-enq-fail", settings });
-		const fakeClient = createFakeCogneeClient();
-		clientFactory = () => fakeClient;
+		installFakeCogneeFetch([{ status: 500, body: { detail: "improve down" } }]);
 		await cogneeBackend.start({
 			session: session as never,
 			settings,
@@ -718,7 +616,7 @@ describe("cogneeBackend.enqueue", () => {
 			forceRetainCurrentSession: () => Promise<void>;
 		};
 		const forceSpy = vi.spyOn(state, "forceRetainCurrentSession");
-		vi.spyOn(fakeClient, "improve").mockRejectedValue(new Error("improve down"));
+
 		const { logger } = await import("@oh-my-pi/pi-utils");
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
@@ -735,18 +633,10 @@ describe("cogneeBackend.stats", () => {
 	it("renders markdown, omits API key, catches dataset status/list failures, does not create datasets", async () => {
 		const settings = makeConfiguredSettings({ "cognee.apiKey": "secret" });
 		const session = makeFakeSession({ sessionId: "s-stats", settings });
-		const fakeClient = createFakeCogneeClient({
-			getDatasetStatus: async () => {
-				throw new Error("status down");
-			},
-			listDatasets: async () => {
-				throw new Error("list down");
-			},
-			createDataset: async () => {
-				throw new Error("must not be called");
-			},
-		});
-		clientFactory = () => fakeClient;
+		const fakeFetch = installFakeCogneeFetch([
+			{ status: 500, body: { detail: "status down" } },
+			{ status: 500, body: { detail: "list down" } },
+		]);
 		await cogneeBackend.start({
 			session: session as never,
 			settings,
@@ -761,6 +651,7 @@ describe("cogneeBackend.stats", () => {
 		expect(out).not.toContain("secret");
 		expect(out).toContain("status down");
 		expect(out).toContain("list down");
+		expect(fakeFetch.requests.some(req => req.method === "POST" && req.path === "/api/v1/datasets")).toBe(false);
 	});
 
 	it("renders Configured: no without a client when unconfigured", async () => {
@@ -777,15 +668,10 @@ describe("cogneeBackend.diagnose", () => {
 	it("redacts API key and renders dataset status/list failures as markdown instead of throwing", async () => {
 		const settings = makeConfiguredSettings({ "cognee.apiKey": "topsecret" });
 		const session = makeFakeSession({ sessionId: "s-diag", settings });
-		const fakeClient = createFakeCogneeClient({
-			getDatasetStatus: async () => {
-				throw new Error("diag status down");
-			},
-			listDatasets: async () => {
-				throw new Error("diag list down");
-			},
-		});
-		clientFactory = () => fakeClient;
+		installFakeCogneeFetch([
+			{ status: 500, body: { detail: "diag status down" } },
+			{ status: 500, body: { detail: "diag list down" } },
+		]);
 		await cogneeBackend.start({
 			session: session as never,
 			settings,

--- a/packages/coding-agent/test/cognee-client.test.ts
+++ b/packages/coding-agent/test/cognee-client.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, it } from "bun:test";
+import { CogneeError, createCogneeClient } from "@oh-my-pi/pi-coding-agent/cognee/client";
+
+type CapturedCall = {
+	url: string;
+	method?: string;
+	headers: Headers;
+	body?: BodyInit | null;
+	signal?: AbortSignal | null;
+};
+
+type FetchOutcome = Response | Error;
+
+function jsonResponse(value: unknown, status = 200): Response {
+	return new Response(JSON.stringify(value), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function fakeFetch(...outcomes: FetchOutcome[]): { fetch: typeof fetch; calls: CapturedCall[] } {
+	const calls: CapturedCall[] = [];
+	const queue = [...outcomes];
+	const fetchImpl = Object.assign(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			calls.push({
+				url: String(input),
+				method: init?.method,
+				headers: new Headers(init?.headers),
+				body: init?.body ?? null,
+				signal: init?.signal ?? null,
+			});
+			const next = queue.shift() ?? jsonResponse({});
+			if (next instanceof Error) throw next;
+			return next;
+		},
+		{ preconnect: globalThis.fetch.preconnect },
+	) as typeof fetch;
+	return { fetch: fetchImpl, calls };
+}
+
+function jsonBody(call: CapturedCall): Record<string, unknown> {
+	return JSON.parse(String(call.body)) as Record<string, unknown>;
+}
+
+function formBody(call: CapturedCall): FormData {
+	expect(call.body).toBeInstanceOf(FormData);
+	return call.body as FormData;
+}
+
+describe("Cognee HTTP client", () => {
+	it("remember posts FormData with exact fields, base URL trimming, and AbortSignal forwarding", async () => {
+		const abort = new AbortController();
+		const { fetch, calls } = fakeFetch(jsonResponse({ status: "ok" }));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local/", fetch });
+
+		await client.remember(
+			{
+				data: ["first", "second", new Uint8Array([1, 2])],
+				datasetName: "main",
+				datasetId: "dataset-id",
+				sessionId: "session-id",
+				nodeSet: ["project:a", "user:b"],
+				runInBackground: false,
+				customPrompt: "custom",
+				chunkSize: 0,
+				chunksPerBatch: 12,
+				ontologyKeys: ["key-a", "key-b"],
+				graphModel: "graph-model",
+				contentType: "text/plain",
+			},
+			abort.signal,
+		);
+
+		const call = calls[0];
+		expect(call?.url).toBe("http://cognee.local/api/v1/remember");
+		expect(call?.method).toBe("POST");
+		expect(call?.signal).toBe(abort.signal);
+		expect(call?.headers.get("Accept")).toBe("application/json");
+		expect(call?.headers.get("User-Agent")).toBe("oh-my-pi-coding-agent");
+		expect(call?.headers.has("Content-Type")).toBe(false);
+		const form = formBody(call);
+		expect(form.getAll("data").length).toBe(3);
+		expect(form.getAll("data")[0]).toBe("first");
+		expect(form.getAll("data")[1]).toBe("second");
+		expect(form.getAll("data")[2]).toBeInstanceOf(Blob);
+		expect((form.getAll("data")[2] as Blob).type).toBe("text/plain");
+		expect(form.get("datasetName")).toBe("main");
+		expect(form.get("datasetId")).toBe("dataset-id");
+		expect(form.get("session_id")).toBe("session-id");
+		expect(form.getAll("node_set")).toEqual(["project:a", "user:b"]);
+		expect(form.get("run_in_background")).toBe("false");
+		expect(form.get("custom_prompt")).toBe("custom");
+		expect(form.get("chunk_size")).toBe("0");
+		expect(form.get("chunks_per_batch")).toBe("12");
+		expect(form.getAll("ontology_key")).toEqual(["key-a", "key-b"]);
+		expect(form.get("graph_model")).toBe("graph-model");
+		expect(form.get("content_type")).toBe("text/plain");
+	});
+
+	it("sends X-Api-Key when apiKey exists", async () => {
+		const { fetch, calls } = fakeFetch();
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", apiKey: "secret", fetch });
+
+		await client.remember({ data: "memory" });
+
+		expect(calls[0]?.headers.get("X-Api-Key")).toBe("secret");
+		expect(calls[0]?.headers.has("Authorization")).toBe(false);
+	});
+
+	it("sends Authorization only when apiKey is absent", async () => {
+		const { fetch, calls } = fakeFetch();
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", bearerToken: "bearer", fetch });
+
+		await client.remember({ data: "memory" });
+
+		expect(calls[0]?.headers.get("Authorization")).toBe("Bearer bearer");
+		expect(calls[0]?.headers.has("X-Api-Key")).toBe(false);
+	});
+
+	it("prefers X-Api-Key over bearer auth when both are configured", async () => {
+		const { fetch, calls } = fakeFetch();
+		const client = createCogneeClient({
+			baseUrl: "http://cognee.local",
+			apiKey: "secret",
+			bearerToken: "bearer",
+			fetch,
+		});
+
+		await client.remember({ data: "memory" });
+
+		expect(calls[0]?.headers.get("X-Api-Key")).toBe("secret");
+		expect(calls[0]?.headers.has("Authorization")).toBe(false);
+	});
+
+	it("remember normalizes snake_case fields and preserves raw", async () => {
+		const raw = {
+			status: "completed",
+			dataset_name: "main",
+			dataset_id: "dataset-id",
+			pipeline_run_id: "run-id",
+			items_processed: 2,
+			elapsed_seconds: 1.5,
+			session_ids: ["s1", "s2"],
+			items: [{ id: "item" }],
+			content_hash: "hash",
+			entry_type: "qa",
+			entry_id: "entry-id",
+			message: "fallback error",
+		};
+		const { fetch } = fakeFetch(jsonResponse(raw));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		const result = await client.remember({ data: "memory" });
+
+		expect(result).toMatchObject({
+			status: "completed",
+			datasetName: "main",
+			datasetId: "dataset-id",
+			pipelineRunId: "run-id",
+			itemsProcessed: 2,
+			elapsedSeconds: 1.5,
+			sessionIds: ["s1", "s2"],
+			items: [{ id: "item" }],
+			contentHash: "hash",
+			entryType: "qa",
+			entryId: "entry-id",
+			error: "fallback error",
+			raw,
+		});
+	});
+
+	it("rememberEntry posts JSON, prunes top-level undefined, preserves metadata, forwards signal, and normalizes", async () => {
+		const abort = new AbortController();
+		const { fetch, calls } = fakeFetch(jsonResponse({ status: "ok", entry_id: "entry" }));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		const result = await client.rememberEntry(
+			{
+				type: "qa",
+				datasetName: "main",
+				datasetId: undefined,
+				sessionId: "session",
+				question: "Q?",
+				answer: "A",
+				trace: undefined,
+				feedback: { rating: 1 },
+				skillImprovement: { skill: "debug" },
+				metadata: { nested: { value: 1 }, empty: [], enabled: false },
+			},
+			abort.signal,
+		);
+
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/remember/entry");
+		expect(calls[0]?.headers.get("Content-Type")).toBe("application/json");
+		expect(calls[0]?.signal).toBe(abort.signal);
+		expect(jsonBody(calls[0])).toEqual({
+			type: "qa",
+			datasetName: "main",
+			sessionId: "session",
+			question: "Q?",
+			answer: "A",
+			feedback: { rating: 1 },
+			skillImprovement: { skill: "debug" },
+			metadata: { nested: { value: 1 }, empty: [], enabled: false },
+		});
+		expect(result.entryId).toBe("entry");
+	});
+
+	it("recall posts exact camelCase JSON keys", async () => {
+		const { fetch, calls } = fakeFetch(jsonResponse([]));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await client.recall({
+			query: "how to debug",
+			searchType: "GRAPH_COMPLETION",
+			datasets: ["main"],
+			datasetIds: ["id"],
+			systemPrompt: "system",
+			nodeName: ["project:a"],
+			topK: 3,
+			onlyContext: false,
+			verbose: true,
+			includeReferences: true,
+			sessionId: "session",
+			scope: ["graph", "trace"],
+			contextProfile: "profile",
+		});
+
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/recall");
+		expect(jsonBody(calls[0])).toEqual({
+			query: "how to debug",
+			searchType: "GRAPH_COMPLETION",
+			datasets: ["main"],
+			datasetIds: ["id"],
+			systemPrompt: "system",
+			nodeName: ["project:a"],
+			topK: 3,
+			onlyContext: false,
+			verbose: true,
+			includeReferences: true,
+			sessionId: "session",
+			scope: ["graph", "trace"],
+			contextProfile: "profile",
+		});
+	});
+
+	it("recall normalizes known and unknown entry shapes", async () => {
+		const raw = [
+			{ source: "session", question: "Q?", answer: "A", qa_id: "qa", score: 0.9, timestamp: "now" },
+			{ source: "trace", trace_id: "trace", text: "trace text" },
+			{ source: "graph_context", content: "graph context", context: "ctx" },
+			{ source: "session_context", context: "session context" },
+			{ node_name: "node" },
+			{ strange: { nested: true } },
+		];
+		const { fetch } = fakeFetch(jsonResponse({ results: raw }));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		const entries = await client.recall({ query: "q" });
+
+		expect(entries.map((entry) => entry.source)).toEqual([
+			"session",
+			"trace",
+			"graph_context",
+			"session_context",
+			"graph",
+			"unknown",
+		]);
+		expect(entries[0]).toMatchObject({ text: "Q: Q?\nA: A", qaId: "qa", id: "qa", score: 0.9, time: "now" });
+		expect(entries[1]).toMatchObject({ text: "trace text", traceId: "trace" });
+		expect(entries[2]).toMatchObject({ text: "graph context", context: "ctx" });
+		expect(entries[3]).toMatchObject({ text: "session context", context: "session context" });
+		expect(entries[4]).toMatchObject({ text: "node", nodeName: "node" });
+		for (let index = 0; index < entries.length; index += 1) {
+			expect(entries[index]?.text.length).toBeGreaterThan(0);
+			expect(entries[index]?.raw).toBe(raw[index]);
+		}
+	});
+
+	it("recall returns [] for normal 200 []", async () => {
+		const { fetch } = fakeFetch(jsonResponse([]));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.recall({ query: "q" })).resolves.toEqual([]);
+	});
+
+	it("recall returns [] for 403 [] only", async () => {
+		const { fetch } = fakeFetch(jsonResponse([], 403));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.recall({ query: "q" })).resolves.toEqual([]);
+	});
+
+	it("recall throws CogneeError for 403 JSON object and preserves details", async () => {
+		const details = { error: "denied" };
+		const { fetch } = fakeFetch(jsonResponse(details, 403));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		try {
+			await client.recall({ query: "q" });
+			throw new Error("Expected recall to throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CogneeError);
+			expect((err as CogneeError).status).toBe(403);
+			expect((err as CogneeError).details).toEqual(details);
+		}
+	});
+
+	it("improve posts exact camelCase JSON keys and wraps non-object success", async () => {
+		const { fetch, calls } = fakeFetch(jsonResponse("queued"));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		const result = await client.improve({
+			datasetName: "main",
+			datasetId: "id",
+			sessionIds: ["s"],
+			nodeName: ["node"],
+			runInBackground: false,
+			buildGlobalContextIndex: true,
+			data: "text",
+			extractionTasks: ["extract"],
+			enrichmentTasks: ["enrich"],
+		});
+
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/improve");
+		expect(jsonBody(calls[0])).toEqual({
+			datasetName: "main",
+			datasetId: "id",
+			sessionIds: ["s"],
+			nodeName: ["node"],
+			runInBackground: false,
+			buildGlobalContextIndex: true,
+			data: "text",
+			extractionTasks: ["extract"],
+			enrichmentTasks: ["enrich"],
+		});
+		expect(result).toEqual({ raw: "queued" });
+	});
+
+	it("forget posts exact camelCase JSON keys", async () => {
+		const { fetch, calls } = fakeFetch(jsonResponse({ ok: true }));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await client.forget({ everything: false, dataset: "main", datasetId: "id", dataId: "data", memoryOnly: true });
+
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/forget");
+		expect(jsonBody(calls[0])).toEqual({
+			everything: false,
+			dataset: "main",
+			datasetId: "id",
+			dataId: "data",
+			memoryOnly: true,
+		});
+	});
+
+	it("listDatasets calls GET and normalizes bare arrays and envelopes", async () => {
+		const { fetch, calls } = fakeFetch(
+			jsonResponse([{ uuid: "id-1", dataset_name: "main", status: "ready" }]),
+			jsonResponse({ data: [{ id: "id-2", name: "other" }] }),
+		);
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.listDatasets()).resolves.toMatchObject([
+			{ id: "id-1", name: "main", status: "ready" },
+		]);
+		await expect(client.listDatasets()).resolves.toMatchObject([{ id: "id-2", name: "other" }]);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets");
+		expect(calls[1]?.url).toBe("http://cognee.local/api/v1/datasets");
+	});
+
+	it("getDatasetStatus sends dataset and pipeline query and returns parsed body unchanged", async () => {
+		const raw = { pipeline_status: "ready" };
+		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(
+			client.getDatasetStatus({ dataset: "ignored", datasetId: "dataset/id", pipeline: "cognify_pipeline" }),
+		).resolves.toEqual(raw);
+
+		const url = new URL(calls[0]?.url ?? "");
+		expect(calls[0]?.method).toBe("GET");
+		expect(`${url.origin}${url.pathname}`).toBe("http://cognee.local/api/v1/datasets/status");
+		expect(url.searchParams.get("dataset")).toBe("dataset/id");
+		expect(url.searchParams.get("pipeline")).toBe("cognify_pipeline");
+	});
+
+	it("listDatasetData URL-encodes datasetId and returns parsed body unchanged", async () => {
+		const raw = [{ id: "data" }];
+		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.listDatasetData("dataset/id with space")).resolves.toEqual(raw);
+
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets/dataset%2Fid%20with%20space/data");
+	});
+
+	it("createDataset posts name, forwards AbortSignal, and normalizes the response", async () => {
+		const abort = new AbortController();
+		const raw = { dataset_id: "id", name: "main_dataset", status: "ready" };
+		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		const result = await client.createDataset({ name: "main_dataset" }, abort.signal);
+
+		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.signal).toBe(abort.signal);
+		expect(jsonBody(calls[0])).toEqual({ name: "main_dataset" });
+		expect(result).toEqual({ id: "id", name: "main_dataset", status: "ready", raw });
+	});
+
+	it("non-OK JSON errors throw CogneeError with status and parsed details", async () => {
+		const details = { detail: "bad input" };
+		const { fetch } = fakeFetch(jsonResponse(details, 422));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		try {
+			await client.createDataset({ name: "main" });
+			throw new Error("Expected createDataset to throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CogneeError);
+			expect((err as CogneeError).status).toBe(422);
+			expect((err as CogneeError).details).toEqual(details);
+			expect((err as Error).message).toContain("createDataset failed with HTTP 422: bad input");
+		}
+	});
+
+	it("non-OK text errors throw CogneeError with status and text details", async () => {
+		const { fetch } = fakeFetch(new Response("server down", { status: 500 }));
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		try {
+			await client.listDatasets();
+			throw new Error("Expected listDatasets to throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CogneeError);
+			expect((err as CogneeError).status).toBe(500);
+			expect((err as CogneeError).details).toBe("server down");
+		}
+	});
+
+	it("network failures throw CogneeError with cause", async () => {
+		const failure = new Error("connect ECONNREFUSED");
+		const { fetch } = fakeFetch(failure);
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		try {
+			await client.listDatasets();
+			throw new Error("Expected listDatasets to throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CogneeError);
+			expect((err as CogneeError).status).toBeUndefined();
+			expect((err as CogneeError).details).toBeUndefined();
+			expect((err as CogneeError).cause).toBe(failure);
+		}
+	});
+
+	it("abort-shaped fetch rejection is rethrown unchanged", async () => {
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+		const { fetch } = fakeFetch(abortError);
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.listDatasets()).rejects.toBe(abortError);
+	});
+
+	it("validation failures happen before fetch", async () => {
+		const { fetch, calls } = fakeFetch();
+		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
+
+		await expect(client.listDatasetData("")).rejects.toBeInstanceOf(CogneeError);
+		await expect(client.recall({ query: "" })).rejects.toBeInstanceOf(CogneeError);
+		await expect(client.rememberEntry({ type: "" })).rejects.toBeInstanceOf(CogneeError);
+		await expect(client.createDataset({ name: "" })).rejects.toBeInstanceOf(CogneeError);
+		expect(calls).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/cognee-client.test.ts
+++ b/packages/coding-agent/test/cognee-client.test.ts
@@ -84,7 +84,7 @@ describe("Cognee HTTP client", () => {
 		expect(form.getAll("data")[0]).toBe("first");
 		expect(form.getAll("data")[1]).toBe("second");
 		expect(form.getAll("data")[2]).toBeInstanceOf(Blob);
-		expect((form.getAll("data")[2] as Blob).type).toBe("text/plain");
+		expect((form.getAll("data")[2] as Blob).type.startsWith("text/plain")).toBe(true);
 		expect(form.get("datasetName")).toBe("main");
 		expect(form.get("datasetId")).toBe("dataset-id");
 		expect(form.get("session_id")).toBe("session-id");
@@ -274,7 +274,7 @@ describe("Cognee HTTP client", () => {
 		expect(entries[4]).toMatchObject({ text: "node", nodeName: "node" });
 		for (let index = 0; index < entries.length; index += 1) {
 			expect(entries[index]?.text.length).toBeGreaterThan(0);
-			expect(entries[index]?.raw).toBe(raw[index]);
+			expect(entries[index]?.raw).toEqual(raw[index]);
 		}
 	});
 

--- a/packages/coding-agent/test/cognee-client.test.ts
+++ b/packages/coding-agent/test/cognee-client.test.ts
@@ -1,57 +1,30 @@
 import { describe, expect, it } from "bun:test";
 import { CogneeError, createCogneeClient } from "@oh-my-pi/pi-coding-agent/cognee/client";
+import { createFakeCogneeFetch, type RecordedCogneeFormValue, type RecordedCogneeRequest } from "./helpers/cognee";
 
-type CapturedCall = {
-	url: string;
-	method?: string;
-	headers: Headers;
-	body?: BodyInit | null;
-	signal?: AbortSignal | null;
-};
-
-type FetchOutcome = Response | Error;
-
-function jsonResponse(value: unknown, status = 200): Response {
-	return new Response(JSON.stringify(value), {
-		status,
-		headers: { "Content-Type": "application/json" },
-	});
-}
-
-function fakeFetch(...outcomes: FetchOutcome[]): { fetch: typeof fetch; calls: CapturedCall[] } {
-	const calls: CapturedCall[] = [];
-	const queue = [...outcomes];
-	const fetchImpl = Object.assign(
-		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-			calls.push({
-				url: String(input),
-				method: init?.method,
-				headers: new Headers(init?.headers),
-				body: init?.body ?? null,
-				signal: init?.signal ?? null,
-			});
-			const next = queue.shift() ?? jsonResponse({});
-			if (next instanceof Error) throw next;
-			return next;
+function rejectingFetch(error: Error): typeof fetch {
+	return Object.assign(
+		async (_input: string | URL | Request, _init?: RequestInit) => {
+			throw error;
 		},
 		{ preconnect: globalThis.fetch.preconnect },
 	) as typeof fetch;
-	return { fetch: fetchImpl, calls };
 }
 
-function jsonBody(call: CapturedCall): Record<string, unknown> {
-	return JSON.parse(String(call.body)) as Record<string, unknown>;
+function jsonBody(call: RecordedCogneeRequest): Record<string, unknown> {
+	expect(call.body?.kind).toBe("json");
+	return call.body.value as Record<string, unknown>;
 }
 
-function formBody(call: CapturedCall): FormData {
-	expect(call.body).toBeInstanceOf(FormData);
-	return call.body as FormData;
+function formBody(call: RecordedCogneeRequest): Record<string, RecordedCogneeFormValue[]> {
+	expect(call.body?.kind).toBe("form");
+	return call.body.fields;
 }
 
 describe("Cognee HTTP client", () => {
 	it("remember posts FormData with exact fields, base URL trimming, and AbortSignal forwarding", async () => {
 		const abort = new AbortController();
-		const { fetch, calls } = fakeFetch(jsonResponse({ status: "ok" }));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: { status: "ok" } }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local/", fetch });
 
 		await client.remember(
@@ -72,54 +45,56 @@ describe("Cognee HTTP client", () => {
 			abort.signal,
 		);
 
-		const call = calls[0];
-		expect(call?.url).toBe("http://cognee.local/api/v1/remember");
+		const call = requests[0];
+		expect(call?.path).toBe("/api/v1/remember");
 		expect(call?.method).toBe("POST");
 		expect(call?.signal).toBe(abort.signal);
-		expect(call?.headers.get("Accept")).toBe("application/json");
-		expect(call?.headers.get("User-Agent")).toBe("oh-my-pi-coding-agent");
-		expect(call?.headers.has("Content-Type")).toBe(false);
-		const form = formBody(call);
-		expect(form.getAll("data").length).toBe(3);
-		expect(form.getAll("data")[0]).toBe("first");
-		expect(form.getAll("data")[1]).toBe("second");
-		expect(form.getAll("data")[2]).toBeInstanceOf(Blob);
-		expect((form.getAll("data")[2] as Blob).type.startsWith("text/plain")).toBe(true);
-		expect(form.get("datasetName")).toBe("main");
-		expect(form.get("datasetId")).toBe("dataset-id");
-		expect(form.get("session_id")).toBe("session-id");
-		expect(form.getAll("node_set")).toEqual(["project:a", "user:b"]);
-		expect(form.get("run_in_background")).toBe("false");
-		expect(form.get("custom_prompt")).toBe("custom");
-		expect(form.get("chunk_size")).toBe("0");
-		expect(form.get("chunks_per_batch")).toBe("12");
-		expect(form.getAll("ontology_key")).toEqual(["key-a", "key-b"]);
-		expect(form.get("graph_model")).toBe("graph-model");
-		expect(form.get("content_type")).toBe("text/plain");
+		expect(call?.headers["accept"]).toBe("application/json");
+		expect(call?.headers["user-agent"]).toBe("oh-my-pi-coding-agent");
+		expect(call?.headers["content-type"]).toBeUndefined();
+		const form = formBody(call as RecordedCogneeRequest);
+		expect(form.data.length).toBe(3);
+		expect(form.data[0]).toBe("first");
+		expect(form.data[1]).toBe("second");
+		const dataBlob = form.data[2] as { kind: string; type: string; size: number };
+		expect(dataBlob.kind).toBe("blob");
+		expect(dataBlob.type.startsWith("text/plain")).toBe(true);
+		expect(dataBlob.size).toBe(2);
+		expect(form.datasetName[0]).toBe("main");
+		expect(form.datasetId[0]).toBe("dataset-id");
+		expect(form.session_id[0]).toBe("session-id");
+		expect(form.node_set).toEqual(["project:a", "user:b"]);
+		expect(form.run_in_background[0]).toBe("false");
+		expect(form.custom_prompt[0]).toBe("custom");
+		expect(form.chunk_size[0]).toBe("0");
+		expect(form.chunks_per_batch[0]).toBe("12");
+		expect(form.ontology_key).toEqual(["key-a", "key-b"]);
+		expect(form.graph_model[0]).toBe("graph-model");
+		expect(form.content_type[0]).toBe("text/plain");
 	});
 
 	it("sends X-Api-Key when apiKey exists", async () => {
-		const { fetch, calls } = fakeFetch();
+		const { fetch, requests } = createFakeCogneeFetch([{ body: {} }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", apiKey: "secret", fetch });
 
 		await client.remember({ data: "memory" });
 
-		expect(calls[0]?.headers.get("X-Api-Key")).toBe("secret");
-		expect(calls[0]?.headers.has("Authorization")).toBe(false);
+		expect(requests[0]?.headers["x-api-key"]).toBe("secret");
+		expect(requests[0]?.headers["authorization"]).toBeUndefined();
 	});
 
 	it("sends Authorization only when apiKey is absent", async () => {
-		const { fetch, calls } = fakeFetch();
+		const { fetch, requests } = createFakeCogneeFetch([{ body: {} }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", bearerToken: "bearer", fetch });
 
 		await client.remember({ data: "memory" });
 
-		expect(calls[0]?.headers.get("Authorization")).toBe("Bearer bearer");
-		expect(calls[0]?.headers.has("X-Api-Key")).toBe(false);
+		expect(requests[0]?.headers["authorization"]).toBe("Bearer bearer");
+		expect(requests[0]?.headers["x-api-key"]).toBeUndefined();
 	});
 
 	it("prefers X-Api-Key over bearer auth when both are configured", async () => {
-		const { fetch, calls } = fakeFetch();
+		const { fetch, requests } = createFakeCogneeFetch([{ body: {} }]);
 		const client = createCogneeClient({
 			baseUrl: "http://cognee.local",
 			apiKey: "secret",
@@ -129,8 +104,8 @@ describe("Cognee HTTP client", () => {
 
 		await client.remember({ data: "memory" });
 
-		expect(calls[0]?.headers.get("X-Api-Key")).toBe("secret");
-		expect(calls[0]?.headers.has("Authorization")).toBe(false);
+		expect(requests[0]?.headers["x-api-key"]).toBe("secret");
+		expect(requests[0]?.headers["authorization"]).toBeUndefined();
 	});
 
 	it("remember normalizes snake_case fields and preserves raw", async () => {
@@ -148,7 +123,7 @@ describe("Cognee HTTP client", () => {
 			entry_id: "entry-id",
 			message: "fallback error",
 		};
-		const { fetch } = fakeFetch(jsonResponse(raw));
+		const { fetch } = createFakeCogneeFetch([{ body: raw }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		const result = await client.remember({ data: "memory" });
@@ -172,7 +147,7 @@ describe("Cognee HTTP client", () => {
 
 	it("rememberEntry posts JSON, prunes top-level undefined, preserves metadata, forwards signal, and normalizes", async () => {
 		const abort = new AbortController();
-		const { fetch, calls } = fakeFetch(jsonResponse({ status: "ok", entry_id: "entry" }));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: { status: "ok", entry_id: "entry" } }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		const result = await client.rememberEntry(
@@ -191,10 +166,10 @@ describe("Cognee HTTP client", () => {
 			abort.signal,
 		);
 
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/remember/entry");
-		expect(calls[0]?.headers.get("Content-Type")).toBe("application/json");
-		expect(calls[0]?.signal).toBe(abort.signal);
-		expect(jsonBody(calls[0])).toEqual({
+		expect(requests[0]?.path).toBe("/api/v1/remember/entry");
+		expect(requests[0]?.headers["content-type"]).toBe("application/json");
+		expect(requests[0]?.signal).toBe(abort.signal);
+		expect(jsonBody(requests[0] as RecordedCogneeRequest)).toEqual({
 			type: "qa",
 			datasetName: "main",
 			sessionId: "session",
@@ -208,7 +183,7 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("recall posts exact camelCase JSON keys", async () => {
-		const { fetch, calls } = fakeFetch(jsonResponse([]));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: [] }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await client.recall({
@@ -227,8 +202,8 @@ describe("Cognee HTTP client", () => {
 			contextProfile: "profile",
 		});
 
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/recall");
-		expect(jsonBody(calls[0])).toEqual({
+		expect(requests[0]?.path).toBe("/api/v1/recall");
+		expect(jsonBody(requests[0] as RecordedCogneeRequest)).toEqual({
 			query: "how to debug",
 			searchType: "GRAPH_COMPLETION",
 			datasets: ["main"],
@@ -254,7 +229,7 @@ describe("Cognee HTTP client", () => {
 			{ node_name: "node" },
 			{ strange: { nested: true } },
 		];
-		const { fetch } = fakeFetch(jsonResponse({ results: raw }));
+		const { fetch } = createFakeCogneeFetch([{ body: { results: raw } }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		const entries = await client.recall({ query: "q" });
@@ -279,14 +254,14 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("recall returns [] for normal 200 []", async () => {
-		const { fetch } = fakeFetch(jsonResponse([]));
+		const { fetch } = createFakeCogneeFetch([{ body: [] }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.recall({ query: "q" })).resolves.toEqual([]);
 	});
 
 	it("recall returns [] for 403 [] only", async () => {
-		const { fetch } = fakeFetch(jsonResponse([], 403));
+		const { fetch } = createFakeCogneeFetch([{ body: [], status: 403 }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.recall({ query: "q" })).resolves.toEqual([]);
@@ -294,7 +269,7 @@ describe("Cognee HTTP client", () => {
 
 	it("recall throws CogneeError for 403 JSON object and preserves details", async () => {
 		const details = { error: "denied" };
-		const { fetch } = fakeFetch(jsonResponse(details, 403));
+		const { fetch } = createFakeCogneeFetch([{ body: details, status: 403 }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		try {
@@ -308,7 +283,7 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("improve posts exact camelCase JSON keys and wraps non-object success", async () => {
-		const { fetch, calls } = fakeFetch(jsonResponse("queued"));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: "queued" }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		const result = await client.improve({
@@ -323,8 +298,8 @@ describe("Cognee HTTP client", () => {
 			enrichmentTasks: ["enrich"],
 		});
 
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/improve");
-		expect(jsonBody(calls[0])).toEqual({
+		expect(requests[0]?.path).toBe("/api/v1/improve");
+		expect(jsonBody(requests[0] as RecordedCogneeRequest)).toEqual({
 			datasetName: "main",
 			datasetId: "id",
 			sessionIds: ["s"],
@@ -339,13 +314,13 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("forget posts exact camelCase JSON keys", async () => {
-		const { fetch, calls } = fakeFetch(jsonResponse({ ok: true }));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: { ok: true } }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await client.forget({ everything: false, dataset: "main", datasetId: "id", dataId: "data", memoryOnly: true });
 
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/forget");
-		expect(jsonBody(calls[0])).toEqual({
+		expect(requests[0]?.path).toBe("/api/v1/forget");
+		expect(jsonBody(requests[0] as RecordedCogneeRequest)).toEqual({
 			everything: false,
 			dataset: "main",
 			datasetId: "id",
@@ -355,66 +330,67 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("listDatasets calls GET and normalizes bare arrays and envelopes", async () => {
-		const { fetch, calls } = fakeFetch(
-			jsonResponse([{ uuid: "id-1", dataset_name: "main", status: "ready" }]),
-			jsonResponse({ data: [{ id: "id-2", name: "other" }] }),
-		);
+		const { fetch, requests } = createFakeCogneeFetch([
+			{ body: [{ uuid: "id-1", dataset_name: "main", status: "ready" }] },
+			{ body: { data: [{ id: "id-2", name: "other" }] } },
+		]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.listDatasets()).resolves.toMatchObject([
 			{ id: "id-1", name: "main", status: "ready" },
 		]);
 		await expect(client.listDatasets()).resolves.toMatchObject([{ id: "id-2", name: "other" }]);
-		expect(calls[0]?.method).toBe("GET");
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets");
-		expect(calls[1]?.url).toBe("http://cognee.local/api/v1/datasets");
+		expect(requests[0]?.method).toBe("GET");
+		expect(requests[0]?.path).toBe("/api/v1/datasets");
+		expect(requests[1]?.path).toBe("/api/v1/datasets");
 	});
 
 	it("getDatasetStatus sends dataset and pipeline query and returns parsed body unchanged", async () => {
 		const raw = { pipeline_status: "ready" };
-		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: raw }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(
 			client.getDatasetStatus({ dataset: "ignored", datasetId: "dataset/id", pipeline: "cognify_pipeline" }),
 		).resolves.toEqual(raw);
 
-		const url = new URL(calls[0]?.url ?? "");
-		expect(calls[0]?.method).toBe("GET");
-		expect(`${url.origin}${url.pathname}`).toBe("http://cognee.local/api/v1/datasets/status");
-		expect(url.searchParams.get("dataset")).toBe("dataset/id");
-		expect(url.searchParams.get("pipeline")).toBe("cognify_pipeline");
+		const path = requests[0]?.path ?? "";
+		expect(requests[0]?.method).toBe("GET");
+		expect(path.startsWith("/api/v1/datasets/status")).toBe(true);
+		const query = new URLSearchParams(path.slice(path.indexOf("?")));
+		expect(query.get("dataset")).toBe("dataset/id");
+		expect(query.get("pipeline")).toBe("cognify_pipeline");
 	});
 
 	it("listDatasetData URL-encodes datasetId and returns parsed body unchanged", async () => {
 		const raw = [{ id: "data" }];
-		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: raw }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.listDatasetData("dataset/id with space")).resolves.toEqual(raw);
 
-		expect(calls[0]?.method).toBe("GET");
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets/dataset%2Fid%20with%20space/data");
+		expect(requests[0]?.method).toBe("GET");
+		expect(requests[0]?.path).toBe("/api/v1/datasets/dataset%2Fid%20with%20space/data");
 	});
 
 	it("createDataset posts name, forwards AbortSignal, and normalizes the response", async () => {
 		const abort = new AbortController();
 		const raw = { dataset_id: "id", name: "main_dataset", status: "ready" };
-		const { fetch, calls } = fakeFetch(jsonResponse(raw));
+		const { fetch, requests } = createFakeCogneeFetch([{ body: raw }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		const result = await client.createDataset({ name: "main_dataset" }, abort.signal);
 
-		expect(calls[0]?.url).toBe("http://cognee.local/api/v1/datasets");
-		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.signal).toBe(abort.signal);
-		expect(jsonBody(calls[0])).toEqual({ name: "main_dataset" });
+		expect(requests[0]?.path).toBe("/api/v1/datasets");
+		expect(requests[0]?.method).toBe("POST");
+		expect(requests[0]?.signal).toBe(abort.signal);
+		expect(jsonBody(requests[0] as RecordedCogneeRequest)).toEqual({ name: "main_dataset" });
 		expect(result).toEqual({ id: "id", name: "main_dataset", status: "ready", raw });
 	});
 
 	it("non-OK JSON errors throw CogneeError with status and parsed details", async () => {
 		const details = { detail: "bad input" };
-		const { fetch } = fakeFetch(jsonResponse(details, 422));
+		const { fetch } = createFakeCogneeFetch([{ body: details, status: 422 }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		try {
@@ -429,7 +405,7 @@ describe("Cognee HTTP client", () => {
 	});
 
 	it("non-OK text errors throw CogneeError with status and text details", async () => {
-		const { fetch } = fakeFetch(new Response("server down", { status: 500 }));
+		const { fetch } = createFakeCogneeFetch([{ text: "server down", status: 500 }]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		try {
@@ -444,7 +420,7 @@ describe("Cognee HTTP client", () => {
 
 	it("network failures throw CogneeError with cause", async () => {
 		const failure = new Error("connect ECONNREFUSED");
-		const { fetch } = fakeFetch(failure);
+		const fetch = rejectingFetch(failure);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		try {
@@ -461,20 +437,20 @@ describe("Cognee HTTP client", () => {
 	it("abort-shaped fetch rejection is rethrown unchanged", async () => {
 		const abortError = new Error("aborted");
 		abortError.name = "AbortError";
-		const { fetch } = fakeFetch(abortError);
+		const fetch = rejectingFetch(abortError);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.listDatasets()).rejects.toBe(abortError);
 	});
 
 	it("validation failures happen before fetch", async () => {
-		const { fetch, calls } = fakeFetch();
+		const { fetch, requests } = createFakeCogneeFetch([]);
 		const client = createCogneeClient({ baseUrl: "http://cognee.local", fetch });
 
 		await expect(client.listDatasetData("")).rejects.toBeInstanceOf(CogneeError);
 		await expect(client.recall({ query: "" })).rejects.toBeInstanceOf(CogneeError);
 		await expect(client.rememberEntry({ type: "" })).rejects.toBeInstanceOf(CogneeError);
 		await expect(client.createDataset({ name: "" })).rejects.toBeInstanceOf(CogneeError);
-		expect(calls).toEqual([]);
+		expect(requests).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/cognee-client.test.ts
+++ b/packages/coding-agent/test/cognee-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { CogneeError, createCogneeClient } from "@oh-my-pi/pi-coding-agent/cognee/client";
+import { CogneeError, createCogneeClient } from "../src/cognee/client";
 import { createFakeCogneeFetch, type RecordedCogneeFormValue, type RecordedCogneeRequest } from "./helpers/cognee";
 
 function rejectingFetch(error: Error): typeof fetch {

--- a/packages/coding-agent/test/cognee-config.test.ts
+++ b/packages/coding-agent/test/cognee-config.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { logger } from "@oh-my-pi/pi-utils";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { isCogneeConfigured, loadCogneeConfig } from "@oh-my-pi/pi-coding-agent/cognee/config";
+
+const DEFAULT_RECALL_PREAMBLE =
+	"Relevant Cognee memories from prior conversations and knowledge graph context. " +
+	"Use only when directly useful; verify against current repo state before acting.";
+
+describe("loadCogneeConfig", () => {
+	beforeEach(() => {
+		resetSettingsForTest();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("defaults", () => {
+		it("applies contracted defaults for a cognee-selected isolated settings instance", () => {
+			const settings = Settings.isolated({ "memory.backend": "cognee" });
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.apiUrl).toBe("http://localhost:8000");
+			expect(config.nodeSet).toEqual([]);
+			expect(config.scoping).toBe("per-project-tagged");
+			expect(config.retainMode).toBe("full-session");
+			expect(config.recallSearchType).toBe("GRAPH_COMPLETION");
+			expect(config.recallScope).toBe("auto");
+			expect(config.recallPromptPreamble).toBe(DEFAULT_RECALL_PREAMBLE);
+
+			// Numeric defaults
+			expect(config.retainEveryNTurns).toBe(3);
+			expect(config.retainOverlapTurns).toBe(2);
+			expect(config.recallTopK).toBe(10);
+			expect(config.recallContextTurns).toBe(1);
+			expect(config.recallMaxQueryChars).toBe(1200);
+			expect(config.recallMaxRenderChars).toBe(12000);
+			// chunkSize/chunksPerBatch default to positive integers from schema
+			expect(config.chunkSize).toBe(4096);
+			expect(config.chunksPerBatch).toBe(36);
+
+			// Misc defaults
+			expect(config.datasetNamePrefix).toBe("");
+			expect(config.retainContext).toBe("omp");
+			expect(config.autoRecall).toBe(true);
+			expect(config.autoRetain).toBe(true);
+			expect(config.runInBackground).toBe(true);
+			expect(config.improveOnEnqueue).toBe(true);
+			expect(config.buildGlobalContextIndex).toBe(false);
+			expect(config.sessionMemoryEnabled).toBe(false);
+			expect(config.debug).toBe(false);
+			expect(config.onlyContext).toBe(false);
+			expect(config.verbose).toBe(false);
+		});
+	});
+
+	describe("environment overrides", () => {
+		it("overrides apiUrl and apiKey when env values are non-blank, trimmed", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.apiUrl": "http://from-settings:8000",
+				"cognee.apiKey": "settings-key",
+			});
+			const config = loadCogneeConfig(settings, {
+				COGNEE_API_URL: "  http://from-env:9000  ",
+				COGNEE_API_KEY: "  env-key  ",
+			});
+
+			expect(config.apiUrl).toBe("http://from-env:9000");
+			expect(config.apiKey).toBe("env-key");
+		});
+
+		it("does not override setting values when env values are blank", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.apiUrl": "http://from-settings:8000",
+				"cognee.apiKey": "settings-key",
+			});
+			const config = loadCogneeConfig(settings, {
+				COGNEE_API_URL: "   ",
+				COGNEE_API_KEY: "",
+			});
+
+			expect(config.apiUrl).toBe("http://from-settings:8000");
+			expect(config.apiKey).toBe("settings-key");
+		});
+	});
+
+	describe("nullable strings", () => {
+		it("turns blank datasetName/datasetId/customPrompt/graphModel into null", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.datasetName": "  ",
+				"cognee.datasetId": "",
+				"cognee.customPrompt": "   ",
+				"cognee.graphModel": "",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.datasetName).toBeNull();
+			expect(config.datasetId).toBeNull();
+			expect(config.customPrompt).toBeNull();
+			expect(config.graphModel).toBeNull();
+		});
+
+		it("preserves non-blank nullable strings", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.datasetName": "my-ds",
+				"cognee.datasetId": "uuid-1234",
+				"cognee.customPrompt": "custom prompt",
+				"cognee.graphModel": "rdf",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.datasetName).toBe("my-ds");
+			expect(config.datasetId).toBe("uuid-1234");
+			expect(config.customPrompt).toBe("custom prompt");
+			expect(config.graphModel).toBe("rdf");
+		});
+
+		it("turns blank datasetNamePrefix into empty string", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.datasetNamePrefix": "   ",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.datasetNamePrefix).toBe("");
+		});
+	});
+
+	describe("array normalization", () => {
+		it("trims, dedupes, drops empty and non-string entries for nodeSet and ontologyKeys", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.nodeSet": ["  a  ", "b", "", "  ", "a", 3, null, "c"],
+				"cognee.ontologyKeys": ["x", "x", "  y  ", "y"],
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.nodeSet).toEqual(["a", "b", "c"]);
+			expect(config.ontologyKeys).toEqual(["x", "y"]);
+		});
+
+		it("returns empty arrays for non-array values", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.nodeSet": "not-an-array",
+				"cognee.ontologyKeys": 42,
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.nodeSet).toEqual([]);
+			expect(config.ontologyKeys).toEqual([]);
+		});
+	});
+
+	describe("closed enum validation", () => {
+		it("falls back to per-project-tagged and warns on invalid scoping", () => {
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.scoping": "banana",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.scoping).toBe("per-project-tagged");
+			expect(warnSpy).toHaveBeenCalled();
+			const warnArg = warnSpy.mock.calls[0]?.[0];
+			expect(String(warnArg)).toContain("Cognee: invalid scoping");
+		});
+
+		it("falls back to full-session and warns on invalid retainMode", () => {
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.retainMode": "banana",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.retainMode).toBe("full-session");
+			expect(warnSpy).toHaveBeenCalled();
+			const warnArg = warnSpy.mock.calls[0]?.[0];
+			expect(String(warnArg)).toContain("Cognee: invalid retainMode");
+		});
+
+		it("does not warn when scoping and retainMode are valid", () => {
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.scoping": "global",
+				"cognee.retainMode": "last-turn",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.scoping).toBe("global");
+			expect(config.retainMode).toBe("last-turn");
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("open string defaults", () => {
+		it("accepts any non-blank recallSearchType and recallScope", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.recallSearchType": "CUSTOM_TYPE",
+				"cognee.recallScope": "custom-scope",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.recallSearchType).toBe("CUSTOM_TYPE");
+			expect(config.recallScope).toBe("custom-scope");
+		});
+
+		it("defaults blank recallSearchType and recallScope", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.recallSearchType": "  ",
+				"cognee.recallScope": "",
+			});
+			const config = loadCogneeConfig(settings, {});
+
+			expect(config.recallSearchType).toBe("GRAPH_COMPLETION");
+			expect(config.recallScope).toBe("auto");
+		});
+	});
+
+	describe("numeric clamping", () => {
+		it("clamps retainEveryNTurns to at least 1", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.retainEveryNTurns": 0,
+			});
+			expect(loadCogneeConfig(settings, {}).retainEveryNTurns).toBe(1);
+
+			const settings2 = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.retainEveryNTurns": 5,
+			});
+			expect(loadCogneeConfig(settings2, {}).retainEveryNTurns).toBe(5);
+		});
+
+		it("clamps recallTopK and recallContextTurns to at least 1", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.recallTopK": -3,
+				"cognee.recallContextTurns": 0,
+			});
+			const config = loadCogneeConfig(settings, {});
+			expect(config.recallTopK).toBe(1);
+			expect(config.recallContextTurns).toBe(1);
+		});
+
+		it("clamps retainOverlapTurns to at least 0", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.retainOverlapTurns": -5,
+			});
+			expect(loadCogneeConfig(settings, {}).retainOverlapTurns).toBe(0);
+		});
+
+		it("clamps recallMaxQueryChars and recallMaxRenderChars to at least 0", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.recallMaxQueryChars": -10,
+				"cognee.recallMaxRenderChars": -1,
+			});
+			const config = loadCogneeConfig(settings, {});
+			expect(config.recallMaxQueryChars).toBe(0);
+			expect(config.recallMaxRenderChars).toBe(0);
+		});
+
+		it("returns null for non-positive or non-integer chunkSize/chunksPerBatch", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.chunkSize": 0,
+				"cognee.chunksPerBatch": -1,
+			});
+			const config = loadCogneeConfig(settings, {});
+			expect(config.chunkSize).toBeNull();
+			expect(config.chunksPerBatch).toBeNull();
+		});
+
+		it("returns null for non-integer chunkSize", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.chunkSize": 4096.5,
+			});
+			expect(loadCogneeConfig(settings, {}).chunkSize).toBeNull();
+		});
+
+		it("returns positive integer chunkSize/chunksPerBatch when valid", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.chunkSize": 8192,
+				"cognee.chunksPerBatch": 36,
+			});
+			const config = loadCogneeConfig(settings, {});
+			expect(config.chunkSize).toBe(8192);
+			expect(config.chunksPerBatch).toBe(36);
+		});
+
+		it("falls back to defaults for non-numeric values", () => {
+			const settings = Settings.isolated({
+				"memory.backend": "cognee",
+				"cognee.retainEveryNTurns": "not-a-number",
+				"cognee.recallTopK": NaN,
+			});
+			const config = loadCogneeConfig(settings, {});
+			expect(config.retainEveryNTurns).toBe(3);
+			expect(config.recallTopK).toBe(10);
+		});
+	});
+});
+
+describe("isCogneeConfigured", () => {
+	it("returns true only for non-empty apiUrl", () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const configured = loadCogneeConfig(settings, { COGNEE_API_URL: "http://x:8000" });
+		expect(isCogneeConfigured(configured)).toBe(true);
+	});
+
+	it("returns false when apiUrl is null", () => {
+		const settings = Settings.isolated({
+			"memory.backend": "cognee",
+			"cognee.apiUrl": "",
+		});
+		const config = loadCogneeConfig(settings, {});
+		expect(isCogneeConfigured(config)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/cognee-content.test.ts
+++ b/packages/coding-agent/test/cognee-content.test.ts
@@ -11,7 +11,7 @@ import {
 
 type AgentMessageForCognee = Parameters<typeof flattenMessagesForCognee>[0][number];
 type TestConfig = Parameters<typeof formatCogneeRecallBlock>[1];
-type TestScope = Parameters<typeof formatCogneeRecallBlock>[2];
+type TestScope = Parameters<typeof prepareCogneeRetentionDocument>[0]["scope"];
 type TestEntry = Parameters<typeof formatCogneeRecallBlock>[0][number];
 
 const asAgentMessage = (message: unknown): AgentMessageForCognee => message as AgentMessageForCognee;
@@ -333,6 +333,26 @@ describe("truncateCogneeRecallQuery", () => {
 		expect(truncated).not.toContain("older");
 	});
 
+	it("does not keep older context when newest context cannot fit", () => {
+		const latest = "latest";
+		const query = composeCogneeRecallQuery(
+			latest,
+			[
+				{ role: "user", content: "short older" },
+				{ role: "assistant", content: "this newest answer is too long for the budget" },
+				{ role: "user", content: latest },
+			],
+			2,
+			globalScope,
+		);
+		const max = "Scope: global:omp\n\nLatest prompt:\nlatest".length + 8;
+		const truncated = truncateCogneeRecallQuery(query, latest, max);
+
+		expect(truncated).not.toContain("short older");
+		expect(truncated).not.toContain("newest answer");
+		expect(truncated).toContain("Latest prompt:\nlatest");
+	});
+
 	it("keeps latest prompt when scope and context cannot fit", () => {
 		const query = composeCogneeRecallQuery(
 			"must survive",
@@ -472,6 +492,12 @@ describe("formatCogneeRecallBlock", () => {
 		expect(block).toContain("Relevant Cognee memories from prior conversations and knowledge graph context.");
 		expect(block).toContain("Current time: 2026-06-30T00:00:00.000Z");
 		expect(block).toContain("Scope: project:oh-my-pi");
+	});
+
+	it("uses the actual current time when no test clock is supplied", () => {
+		const block = formatCogneeRecallBlock([asEntry({ source: "session", id: "entry-1", text: "remember this", raw: {} })], config, scope);
+
+		expect(block).not.toContain("Current time: 1970-01-01T00:00:00.000Z");
 	});
 
 	it("renders configured preamble and source variants with fallbacks", () => {

--- a/packages/coding-agent/test/cognee-content.test.ts
+++ b/packages/coding-agent/test/cognee-content.test.ts
@@ -450,6 +450,17 @@ describe("formatCogneeRecallBlock", () => {
 		).toBeUndefined();
 	});
 
+	it("drops non-substantive session question answer fallbacks", () => {
+		expect(
+			formatCogneeRecallBlock(
+				[asEntry({ source: "session", text: "", question: "...", answer: "?!", raw: {} })],
+				config,
+				scope,
+				new Date("2026-06-30T00:00:00.000Z"),
+			),
+		).toBeUndefined();
+	});
+
 	it("renders default preamble, deterministic time, and scope", () => {
 		const block = formatCogneeRecallBlock(
 			[asEntry({ source: "session", id: "entry-1", text: "remember this", raw: {} })],
@@ -544,6 +555,12 @@ describe("formatCogneeSearchItem", () => {
 		expect(formatCogneeSearchItem(asEntry({ source: "trace", traceId: "trace-1", text: "trace", raw: {} })).id).toBe("trace-1");
 		expect(formatCogneeSearchItem(asEntry({ source: "graph", nodeName: "NodeA", text: "graph", raw: {} })).id).toBe("NodeA");
 		expect(formatCogneeSearchItem(asEntry({ source: "unknown", text: "...", raw: {} })).content).toBe("[empty Cognee recall entry]");
+	});
+
+	it("does not count Q/A labels as substantive search content", () => {
+		expect(formatCogneeSearchItem(asEntry({ source: "session", text: "", question: "...", answer: "?!", raw: {} })).content).toBe(
+			"[empty Cognee recall entry]",
+		);
 	});
 });
 

--- a/packages/coding-agent/test/cognee-content.test.ts
+++ b/packages/coding-agent/test/cognee-content.test.ts
@@ -1,0 +1,567 @@
+import { describe, expect, it } from "bun:test";
+import {
+	composeCogneeRecallQuery,
+	flattenMessagesForCognee,
+	formatCogneeRecallBlock,
+	formatCogneeSearchItem,
+	prepareCogneeRetentionDocument,
+	truncateApproxTokensOrChars,
+	truncateCogneeRecallQuery,
+} from "../src/cognee/content";
+
+type AgentMessageForCognee = Parameters<typeof flattenMessagesForCognee>[0][number];
+type TestConfig = Parameters<typeof formatCogneeRecallBlock>[1];
+type TestScope = Parameters<typeof formatCogneeRecallBlock>[2];
+type TestEntry = Parameters<typeof formatCogneeRecallBlock>[0][number];
+
+const asAgentMessage = (message: unknown): AgentMessageForCognee => message as AgentMessageForCognee;
+const asEntry = (entry: unknown): TestEntry => entry as TestEntry;
+
+const scope: TestScope = {
+	label: "project:oh-my-pi",
+	projectLabel: "oh-my-pi",
+	retainDatasetLabel: "omp",
+	recallDatasetLabels: ["omp"],
+} as TestScope;
+
+const globalScope: TestScope = {
+	label: "global:omp",
+	retainDatasetLabel: "omp",
+	recallDatasetLabels: ["omp"],
+} as TestScope;
+
+const config: TestConfig = {
+	apiUrl: null,
+	apiKey: null,
+	datasetName: null,
+	datasetId: null,
+	datasetNamePrefix: "",
+	scoping: "per-project-tagged",
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	runInBackground: true,
+	chunkSize: null,
+	chunksPerBatch: null,
+	customPrompt: null,
+	nodeSet: [],
+	ontologyKeys: [],
+	graphModel: null,
+	recallSearchType: "GRAPH_COMPLETION",
+	recallScope: "auto",
+	recallTopK: 10,
+	recallContextTurns: 1,
+	recallMaxQueryChars: 1200,
+	recallMaxRenderChars: 12000,
+	recallPromptPreamble: "",
+	onlyContext: false,
+	verbose: false,
+	improveOnEnqueue: true,
+	buildGlobalContextIndex: false,
+	sessionMemoryEnabled: false,
+	debug: false,
+} as TestConfig;
+
+describe("flattenMessagesForCognee", () => {
+	it("retains user string content", () => {
+		const messages = [asAgentMessage({ role: "user", content: "Remember this" })];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([{ role: "user", content: "Remember this" }]);
+	});
+
+	it("joins user text blocks with newlines", () => {
+		const messages = [
+			asAgentMessage({
+				role: "user",
+				content: [
+					{ type: "text", text: "first" },
+					{ type: "text", text: "second" },
+					{ type: "input_image", data: "data:image/png;base64,secret" },
+				],
+			}),
+		];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([{ role: "user", content: "first\nsecond" }]);
+	});
+
+	it("retains assistant visible text blocks", () => {
+		const messages = [
+			asAgentMessage({
+				role: "assistant",
+				content: [
+					{ type: "text", text: "visible" },
+					{ type: "text", text: "answer" },
+				],
+			}),
+		];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([{ role: "assistant", content: "visible\nanswer" }]);
+	});
+
+	it("drops assistant thinking, redacted thinking, and tool-call-only blocks", () => {
+		const messages = [
+			asAgentMessage({
+				role: "assistant",
+				content: [
+					{ type: "thinking", text: "private" },
+					{ type: "redactedThinking", data: "private" },
+					{ type: "toolCall", name: "bash" },
+				],
+			}),
+			asAgentMessage({
+				role: "assistant",
+				content: [
+					{ type: "thinking", text: "private" },
+					{ type: "text", text: "public" },
+				],
+			}),
+		];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([{ role: "assistant", content: "public" }]);
+	});
+
+	it("skips non-primary roles", () => {
+		const messages = [
+			asAgentMessage({ role: "tool", content: "tool output" }),
+			asAgentMessage({ role: "toolResult", content: "tool output" }),
+			asAgentMessage({ role: "bashExecution", content: "shell" }),
+			asAgentMessage({ role: "developer", content: "instruction" }),
+			asAgentMessage({ role: "system", content: "instruction" }),
+			asAgentMessage({ role: "custom", content: "custom" }),
+			asAgentMessage({ role: "user", content: "kept" }),
+		];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([{ role: "user", content: "kept" }]);
+	});
+
+	it("summarizes image-only user content without retaining bytes", () => {
+		const messages = [
+			asAgentMessage({
+				role: "user",
+				content: [{ type: "input_image", data: "data:image/png;base64,secret", mimeType: "image/png" }],
+			}),
+		];
+
+		const flattened = flattenMessagesForCognee(messages);
+		expect(flattened).toEqual([{ role: "user", content: "[image omitted]" }]);
+		expect(flattened[0].content).not.toContain("data:image");
+		expect(flattened[0].content).not.toContain("secret");
+	});
+
+	it("skips punctuation-only assistant turns", () => {
+		const messages = [asAgentMessage({ role: "assistant", content: [{ type: "text", text: "... — ! ?" }] })];
+
+		expect(flattenMessagesForCognee(messages)).toEqual([]);
+	});
+});
+
+describe("Cognee memory-tag stripping", () => {
+	it("strips Cognee and legacy memory blocks from retention documents", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [
+				{
+					role: "user",
+					content:
+						"keep <cognee_memories>drop</cognee_memories><memories>drop</memories><mental_models>drop</mental_models><hindsight_memories>drop</hindsight_memories><relevant_memories>drop</relevant_memories> tail",
+				},
+			],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T00:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document?.content).toContain("keep  tail");
+		expect(document?.content).not.toContain("<cognee_memories>");
+		expect(document?.content).not.toContain("<memories>");
+		expect(document?.content).not.toContain("<mental_models>");
+		expect(document?.content).not.toContain("<hindsight_memories>");
+		expect(document?.content).not.toContain("<relevant_memories>");
+	});
+
+	it("strips memory blocks from recall query context", () => {
+		const query = composeCogneeRecallQuery(
+			"latest",
+			[
+				{ role: "user", content: "before <cognee_memories>secret</cognee_memories> after" },
+				{ role: "assistant", content: "reply <memories>old</memories> visible" },
+				{ role: "user", content: "latest" },
+			],
+			2,
+			globalScope,
+		);
+
+		expect(query).toContain("user: before  after");
+		expect(query).toContain("assistant: reply  visible");
+		expect(query).not.toContain("secret");
+		expect(query).not.toContain("<memories>");
+	});
+
+	it("removes multiple sequential complete blocks while keeping surrounding text", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [{ role: "user", content: "alpha <memories>a</memories><memories>b</memories> omega" }],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T00:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document?.content).toContain("alpha  omega");
+	});
+
+	it("keeps malformed unmatched tags as ordinary substantive text", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [{ role: "user", content: "keep <memories>unclosed text" }],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T00:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document?.content).toContain("keep <memories>unclosed text");
+	});
+});
+
+describe("composeCogneeRecallQuery", () => {
+	it("returns latest prompt with no prior context when contextTurns is one", () => {
+		const query = composeCogneeRecallQuery(
+			"latest prompt",
+			[{ role: "user", content: "older" }],
+			1,
+			globalScope,
+		);
+
+		expect(query).toBe("Scope: global:omp\n\nLatest prompt:\nlatest prompt");
+		expect(query).not.toContain("Prior context:");
+	});
+
+	it("includes only recent user-bounded turns", () => {
+		const query = composeCogneeRecallQuery(
+			"latest",
+			[
+				{ role: "user", content: "old user" },
+				{ role: "assistant", content: "old assistant" },
+				{ role: "user", content: "recent user" },
+				{ role: "assistant", content: "recent assistant" },
+				{ role: "user", content: "latest" },
+			],
+			2,
+			globalScope,
+		);
+
+		expect(query).toContain("user: recent user");
+		expect(query).toContain("assistant: recent assistant");
+		expect(query).not.toContain("old user");
+		expect(query).not.toContain("old assistant");
+	});
+
+	it("does not duplicate the latest prompt inside prior context", () => {
+		const query = composeCogneeRecallQuery(
+			"latest",
+			[
+				{ role: "user", content: "earlier" },
+				{ role: "assistant", content: "answer" },
+				{ role: "user", content: "latest" },
+			],
+			2,
+			globalScope,
+		);
+
+		expect(query.match(/user: latest/g)).toBeNull();
+		expect(query.endsWith("Latest prompt:\nlatest")).toBe(true);
+	});
+
+	it("includes the project label and avoids duplicate project scope", () => {
+		const query = composeCogneeRecallQuery("latest", [], 1, scope);
+
+		expect(query).toBe("Project: oh-my-pi\n\nLatest prompt:\nlatest");
+		expect(query).not.toContain("Scope: project:oh-my-pi");
+	});
+});
+
+describe("truncateCogneeRecallQuery", () => {
+	it("leaves under-budget queries unchanged", () => {
+		const query = "short latest";
+
+		expect(truncateCogneeRecallQuery(query, "short latest", 100)).toBe(query);
+	});
+
+	it("returns bounded latest prompt for no-context over-budget queries", () => {
+		expect(truncateCogneeRecallQuery("abcdef", "abcdef", 3)).toBe("abc");
+	});
+
+	it("drops oldest context before newer context", () => {
+		const latest = "latest";
+		const query = composeCogneeRecallQuery(
+			latest,
+			[
+				{ role: "user", content: "old" },
+				{ role: "assistant", content: "middle" },
+				{ role: "user", content: "new" },
+				{ role: "assistant", content: "newer" },
+				{ role: "user", content: latest },
+			],
+			3,
+			globalScope,
+		);
+		const max = "Scope: global:omp\n\nPrior context:\nuser: new\nassistant: newer\n\nLatest prompt:\nlatest".length;
+		const truncated = truncateCogneeRecallQuery(query, latest, max);
+
+		expect(truncated).not.toContain("user: old");
+		expect(truncated).not.toContain("assistant: middle");
+		expect(truncated).toContain("user: new");
+		expect(truncated).toContain("assistant: newer");
+	});
+
+	it("keeps fitting project scope lines when full scope does not fit", () => {
+		const scoped = { ...scope, label: "project-tagged:oh-my-pi" } as TestScope;
+		const query = composeCogneeRecallQuery("latest", [{ role: "user", content: "older" }], 2, scoped);
+		const max = "Project: oh-my-pi\n\nLatest prompt:\nlatest".length;
+		const truncated = truncateCogneeRecallQuery(query, "latest", max);
+
+		expect(truncated).toBe("Project: oh-my-pi\n\nLatest prompt:\nlatest");
+		expect(truncated).not.toContain("Scope: project-tagged:oh-my-pi");
+		expect(truncated).not.toContain("older");
+	});
+
+	it("keeps latest prompt when scope and context cannot fit", () => {
+		const query = composeCogneeRecallQuery(
+			"must survive",
+			[{ role: "user", content: "lots of prior context" }],
+			2,
+			globalScope,
+		);
+
+		expect(truncateCogneeRecallQuery(query, "must survive", "must survive".length)).toBe("must survive");
+	});
+
+	it("returns stripped latest prompt for non-positive budgets", () => {
+		expect(truncateCogneeRecallQuery("ignored", "<memories>drop</memories>latest", 0)).toBe("latest");
+		expect(truncateCogneeRecallQuery("ignored", "<memories>drop</memories>", -1)).toBe("");
+	});
+
+	it("does not split surrogate pairs", () => {
+		expect(truncateCogneeRecallQuery("😀😀😀", "😀😀😀", 2)).toBe("😀😀");
+	});
+});
+
+describe("prepareCogneeRetentionDocument", () => {
+	it("uses all messages and session ID for full-session retention", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [
+				{ role: "user", content: "hello" },
+				{ role: "assistant", content: "world" },
+			],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T12:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document).toEqual({
+			content:
+				"Session: session-1\nRetained at: 2026-06-30T12:00:00.000Z\nScope: project:oh-my-pi\nProject: oh-my-pi\n\n[role: user]\nhello\n[user:end]\n\n[role: assistant]\nworld\n[assistant:end]",
+			documentId: "session-1",
+			contentType: "text/markdown",
+		});
+	});
+
+	it("uses retain window turns and timestamped document ID for last-turn retention", () => {
+		const retainedAt = new Date("2026-06-30T12:00:00.000Z");
+		const document = prepareCogneeRetentionDocument({
+			messages: [
+				{ role: "user", content: "old user" },
+				{ role: "assistant", content: "old assistant" },
+				{ role: "user", content: "middle user" },
+				{ role: "assistant", content: "middle assistant" },
+				{ role: "user", content: "new user" },
+				{ role: "assistant", content: "new assistant" },
+			],
+			sessionId: "session-1",
+			retainedAt,
+			mode: "last-turn",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 1,
+			scope,
+		});
+
+		expect(document?.documentId).toBe(`session-1-${retainedAt.getTime()}`);
+		expect(document?.content).not.toContain("old user");
+		expect(document?.content).toContain("middle user");
+		expect(document?.content).toContain("new assistant");
+	});
+
+	it("preserves internal newlines", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [{ role: "user", content: "line one\nline two" }],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T12:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document?.content).toContain("line one\nline two");
+	});
+
+	it("returns null when no substantive content remains", () => {
+		const document = prepareCogneeRetentionDocument({
+			messages: [
+				{ role: "user", content: "<memories>meaningful only inside stripped block</memories>" },
+				{ role: "assistant", content: "..." },
+			],
+			sessionId: "session-1",
+			retainedAt: new Date("2026-06-30T12:00:00.000Z"),
+			mode: "full-session",
+			retainEveryNTurns: 1,
+			retainOverlapTurns: 0,
+			scope,
+		});
+
+		expect(document).toBeNull();
+	});
+});
+
+describe("formatCogneeRecallBlock", () => {
+	it("returns undefined for empty entries", () => {
+		expect(formatCogneeRecallBlock([], config, scope, new Date("2026-06-30T00:00:00.000Z"))).toBeUndefined();
+	});
+
+	it("returns undefined when all entries are non-substantive", () => {
+		expect(
+			formatCogneeRecallBlock(
+				[asEntry({ source: "session", text: "...", raw: {} })],
+				config,
+				scope,
+				new Date("2026-06-30T00:00:00.000Z"),
+			),
+		).toBeUndefined();
+	});
+
+	it("renders default preamble, deterministic time, and scope", () => {
+		const block = formatCogneeRecallBlock(
+			[asEntry({ source: "session", id: "entry-1", text: "remember this", raw: {} })],
+			config,
+			scope,
+			new Date("2026-06-30T00:00:00.000Z"),
+		);
+
+		expect(block).toContain("Relevant Cognee memories from prior conversations and knowledge graph context.");
+		expect(block).toContain("Current time: 2026-06-30T00:00:00.000Z");
+		expect(block).toContain("Scope: project:oh-my-pi");
+	});
+
+	it("renders configured preamble and source variants with fallbacks", () => {
+		const customConfig = { ...config, recallPromptPreamble: "Use these sparingly." } as TestConfig;
+		const block = formatCogneeRecallBlock(
+			[
+				asEntry({ source: "session", qaId: "qa-1", text: "", question: "Question?", answer: "Answer.", score: 0.98765, raw: {} }),
+				asEntry({ source: "trace", traceId: "trace-1", text: "trace text", raw: {} }),
+				asEntry({ source: "graph_context", text: "", context: "graph context", raw: {} }),
+				asEntry({ source: "session_context", text: "", context: "session context", raw: {} }),
+				asEntry({ source: "graph", nodeName: "NodeA", text: "graph node", raw: {} }),
+				asEntry({ source: "unknown_source", text: "unknown text", raw: {} }),
+			],
+			customConfig,
+			scope,
+			new Date("2026-06-30T00:00:00.000Z"),
+		);
+		const rendered = block ?? "";
+
+		expect(rendered).toContain("Use these sparingly.");
+		expect(rendered).toContain("source=session id=qa-1 score=0.9877");
+		expect(rendered).toContain("Q: Question?\nA: Answer.");
+		expect(rendered).toContain("source=trace id=trace-1");
+		expect(rendered).toContain("graph context");
+		expect(rendered).toContain("session context");
+		expect(rendered).toContain("source=graph id=NodeA");
+		expect(rendered).toContain("source=unknown_source");
+	});
+
+	it("defangs recalled text and metadata", () => {
+		const block = formatCogneeRecallBlock(
+			[asEntry({ source: "session", id: "id</cognee_memories>", text: "close </cognee_memories> tag", raw: {} })],
+			config,
+			scope,
+			new Date("2026-06-30T00:00:00.000Z"),
+		);
+		const rendered = block ?? "";
+
+		expect(rendered).toContain("id=id&lt;/cognee_memories&gt;");
+		expect(rendered).toContain("close &lt;/cognee_memories&gt; tag");
+		expect(rendered.match(/<\/cognee_memories>/g)?.length).toBe(1);
+	});
+
+	it("enforces recallMaxRenderChars while keeping the closing tag", () => {
+		const tinyConfig = { ...config, recallMaxRenderChars: 180, recallPromptPreamble: "P" } as TestConfig;
+		const block = formatCogneeRecallBlock(
+			[
+				asEntry({ source: "session", id: "first", text: "first memory stays", raw: {} }),
+				asEntry({ source: "session", id: "second", text: "second memory has a very long body that must be truncated before the closing tag", raw: {} }),
+			],
+			tinyConfig,
+			scope,
+			new Date("2026-06-30T00:00:00.000Z"),
+		);
+
+		expect(block).toBeDefined();
+		expect(block?.length).toBeLessThanOrEqual(180);
+		expect(block?.endsWith("</cognee_memories>")).toBe(true);
+		expect(block).toContain("first memory stays");
+	});
+});
+
+describe("formatCogneeSearchItem", () => {
+	it("maps direct IDs and generic fields without raw", () => {
+		const item = formatCogneeSearchItem(
+			asEntry({ source: "session", id: "entry-1", text: "content", time: "2026-06-30T00:00:00.000Z", score: 0.5, raw: { hidden: true } }),
+		);
+
+		expect(item).toEqual({
+			id: "entry-1",
+			content: "content",
+			source: "session",
+			timestamp: "2026-06-30T00:00:00.000Z",
+			score: 0.5,
+		});
+		expect("raw" in item).toBe(false);
+	});
+
+	it("maps source-specific fallback IDs and empty-content fallback", () => {
+		expect(formatCogneeSearchItem(asEntry({ source: "session", qaId: "qa-1", text: "question", raw: {} })).id).toBe("qa-1");
+		expect(formatCogneeSearchItem(asEntry({ source: "trace", traceId: "trace-1", text: "trace", raw: {} })).id).toBe("trace-1");
+		expect(formatCogneeSearchItem(asEntry({ source: "graph", nodeName: "NodeA", text: "graph", raw: {} })).id).toBe("NodeA");
+		expect(formatCogneeSearchItem(asEntry({ source: "unknown", text: "...", raw: {} })).content).toBe("[empty Cognee recall entry]");
+	});
+});
+
+describe("truncateApproxTokensOrChars", () => {
+	it("returns an empty string for non-positive limits", () => {
+		expect(truncateApproxTokensOrChars("abc", 0)).toBe("");
+		expect(truncateApproxTokensOrChars("abc", -1)).toBe("");
+	});
+
+	it("returns under-limit text unchanged", () => {
+		expect(truncateApproxTokensOrChars("abc", 10)).toBe("abc");
+	});
+
+	it("bounds over-limit text without an ellipsis", () => {
+		expect(truncateApproxTokensOrChars("abcdef", 3)).toBe("abc");
+	});
+
+	it("does not split emoji surrogate pairs", () => {
+		expect(truncateApproxTokensOrChars("😀😀abc", 2)).toBe("😀😀");
+	});
+});

--- a/packages/coding-agent/test/cognee-memory-runtime.test.ts
+++ b/packages/coding-agent/test/cognee-memory-runtime.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Cognee memory runtime parity tests.
+ *
+ * These tests prove the generic `createMemoryRuntimeContext` routes
+ * `status/search/save` through the active `MemoryBackend` hooks unchanged for a
+ * Cognee-shaped backend, forwards query/options exactly without trimming,
+ * normalizes string save input to `{ content }`, propagates unavailable
+ * Cognee results without rewording them, and preserves the existing no-session
+ * and hookless-backend fallbacks.
+ *
+ * No live Cognee server is required: `resolveMemoryBackend` is spied to return
+ * a fake Cognee `MemoryBackend`. The `"cognee"` literal is cast locally because
+ * `CogneeBackendAdapter` (which owns adding `"cognee"` to `MemoryBackendId`) is
+ * not present in this worktree; production types are not altered here.
+ */
+
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import { createMemoryRuntimeContext } from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type {
+	MemoryBackend,
+	MemoryBackendOperationContext,
+	MemoryBackendSaveInput,
+	MemoryBackendSearchOptions,
+	MemoryBackendSearchResult,
+	MemoryBackendStatus,
+} from "@oh-my-pi/pi-coding-agent/memory-backend/types";
+
+/**
+ * Plan-authorized local widening: `MemoryBackendId` does not yet include
+ * `"cognee"` in this worktree (owned by `CogneeBackendAdapter`). Every use of
+ * this const stands in for that future union member; no production type is
+ * altered from this package.
+ */
+const COGNEE_ID = "cognee" as never;
+
+/**
+ * Minimal Cognee-shaped fake backend. Required hooks are no-ops; optional
+ * `status/search/save` hooks are installed per test via `overrides`.
+ */
+interface FakeCogneeOverrides {
+	status?: (context: MemoryBackendOperationContext) => Promise<MemoryBackendStatus>;
+	search?: (
+		context: MemoryBackendOperationContext,
+		query: string,
+		options?: MemoryBackendSearchOptions,
+	) => Promise<MemoryBackendSearchResult>;
+	save?: (context: MemoryBackendOperationContext, input: MemoryBackendSaveInput) => Promise<MemoryBackendSaveResult>;
+	stats?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	diagnose?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	clear?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+	enqueue?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+}
+
+function createFakeCogneeBackend(overrides: FakeCogneeOverrides = {}): MemoryBackend {
+	const backend = {
+		id: COGNEE_ID,
+		async start() {},
+		async buildDeveloperInstructions() {
+			return undefined;
+		},
+		async clear(agentDir: string, cwd: string, session?: unknown) {
+			await overrides.clear?.(agentDir, cwd, session);
+		},
+		async enqueue(agentDir: string, cwd: string, session?: unknown) {
+			await overrides.enqueue?.(agentDir, cwd, session);
+		},
+		async status(context: MemoryBackendOperationContext) {
+			if (!overrides.status) throw new Error("fake cognee status not configured");
+			return overrides.status(context);
+		},
+		async search(
+			context: MemoryBackendOperationContext,
+			query: string,
+			options?: MemoryBackendSearchOptions,
+		) {
+			if (!overrides.search) throw new Error("fake cognee search not configured");
+			return overrides.search(context, query, options);
+		},
+		async save(context: MemoryBackendOperationContext, input: MemoryBackendSaveInput) {
+			if (!overrides.save) throw new Error("fake cognee save not configured");
+			return overrides.save(context, input);
+		},
+		async stats(agentDir: string, cwd: string, session?: unknown) {
+			return overrides.stats?.(agentDir, cwd, session);
+		},
+		async diagnose(agentDir: string, cwd: string, session?: unknown) {
+			return overrides.diagnose?.(agentDir, cwd, session);
+		},
+	};
+	return backend as unknown as MemoryBackend;
+}
+
+const COGNEE_ACTIVE_STATUS: MemoryBackendStatus = {
+	backend: COGNEE_ID,
+	active: true,
+	writable: true,
+	searchable: true,
+	scope: "project:oh-my-pi",
+	retainBank: "project:oh-my-pi",
+	recallBanks: ["global:omp", "project:oh-my-pi"],
+	lastRecall: true,
+	lastMemory: "2026-06-30T12:00:00.000Z",
+	message: undefined,
+	error: undefined,
+};
+
+function cogneeInactiveStatus(): MemoryBackendStatus {
+	return {
+		backend: COGNEE_ID,
+		active: false,
+		writable: false,
+		searchable: false,
+		scope: "project:oh-my-pi",
+		message: "Cognee backend is not configured/initialised/available.",
+		error: "missing api key",
+	};
+}
+
+function cogneeEmptySearch(query: string): MemoryBackendSearchResult {
+	return {
+		backend: COGNEE_ID,
+		query,
+		count: 0,
+		items: [],
+		message: "Cognee backend is not configured/initialised/available.",
+	};
+}
+
+describe("createMemoryRuntimeContext — Cognee backend", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("returns Cognee status through the backend hook and forwards the original context identity", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const session = { settings };
+		const agentDir = "/tmp/agent";
+		const cwd = "/tmp/project";
+		let captured: MemoryBackendOperationContext | undefined;
+		const backend = createFakeCogneeBackend({
+			status: async context => {
+				captured = context;
+				return COGNEE_ACTIVE_STATUS;
+			},
+		});
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend");
+		spy.mockResolvedValue(backend);
+
+		const memory = createMemoryRuntimeContext({ agentDir, cwd, session } as never);
+		const status = await memory.status();
+
+		expect(status).toMatchObject({
+			backend: "cognee",
+			active: true,
+			writable: true,
+			searchable: true,
+			scope: "project:oh-my-pi",
+			retainBank: "project:oh-my-pi",
+			recallBanks: ["global:omp", "project:oh-my-pi"],
+			lastRecall: true,
+			lastMemory: "2026-06-30T12:00:00.000Z",
+		});
+		expect(captured).toBeDefined();
+		expect(captured?.agentDir).toBe(agentDir);
+		expect(captured?.cwd).toBe(cwd);
+		expect(captured?.session).toBe(session);
+	});
+
+	it("search forwards query and options exactly without trimming or remapping", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const session = { settings };
+		const agentDir = "/tmp/agent";
+		const cwd = "/tmp/project";
+		const ac = new AbortController();
+		const options = { limit: 2, signal: ac.signal };
+		const query = "  project conventions?  ";
+		let capturedContext: MemoryBackendOperationContext | undefined;
+		let capturedQuery: string | undefined;
+		let capturedOptions: MemoryBackendSearchOptions | undefined;
+		const backend = createFakeCogneeBackend({
+			search: async (context, q, opts) => {
+				capturedContext = context;
+				capturedQuery = q;
+				capturedOptions = opts;
+				return {
+					backend: COGNEE_ID,
+					query: q,
+					count: 1,
+					items: [{ id: "e1", content: "prefer concise reports", source: "recall", score: 0.9 }],
+				};
+			},
+		});
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend");
+		spy.mockResolvedValue(backend);
+
+		const memory = createMemoryRuntimeContext({ agentDir, cwd, session } as never);
+		const result = await memory.search(query, options);
+
+		expect(capturedQuery).toBe(query);
+		expect(capturedOptions).toBe(options);
+		expect(capturedContext?.agentDir).toBe(agentDir);
+		expect(capturedContext?.cwd).toBe(cwd);
+		expect(capturedContext?.session).toBe(session);
+		expect(result).toMatchObject({
+			backend: "cognee",
+			query,
+			count: 1,
+		});
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.content).toBe("prefer concise reports");
+	});
+
+	it("save normalizes string input to { content } before calling the backend hook", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const session = { settings };
+		let captured: MemoryBackendSaveInput | undefined;
+		const backend = createFakeCogneeBackend({
+			save: async (_context, input) => {
+				captured = input;
+				return { backend: COGNEE_ID, stored: 1, ids: ["run-1"] };
+			},
+		});
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend");
+		spy.mockResolvedValue(backend);
+
+		const memory = createMemoryRuntimeContext({
+			agentDir: "/tmp/agent",
+			cwd: "/tmp/project",
+			session: session as never,
+		});
+		const result = await memory.save("remember this");
+
+		expect(captured).toEqual({ content: "remember this" });
+		expect(result).toMatchObject({ backend: "cognee", stored: 1, ids: ["run-1"] });
+	});
+
+	it("save passes object input through unchanged as MemoryBackendSaveInput", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const session = { settings };
+		const input = { content: "remember", context: "test", source: "extension", importance: 0.7 };
+		let captured: MemoryBackendSaveInput | undefined;
+		const backend = createFakeCogneeBackend({
+			save: async (_context, inp) => {
+				captured = inp;
+				return { backend: COGNEE_ID, stored: 1 };
+			},
+		});
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend");
+		spy.mockResolvedValue(backend);
+
+		const memory = createMemoryRuntimeContext({
+			agentDir: "/tmp/agent",
+			cwd: "/tmp/project",
+			session: session as never,
+		});
+		await memory.save(input);
+
+		expect(captured).toEqual(input);
+	});
+
+	it("propagates misconfigured/unavailable Cognee results without throwing or rewording", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const session = { settings };
+		const backend = createFakeCogneeBackend({
+			status: async () => cogneeInactiveStatus(),
+			search: async (_ctx, q) => cogneeEmptySearch(q),
+			save: async () => ({ backend: COGNEE_ID, stored: 0, message: "Cognee backend is not configured/initialised/available." }),
+		});
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend");
+		spy.mockResolvedValue(backend);
+
+		const memory = createMemoryRuntimeContext({
+			agentDir: "/tmp/agent",
+			cwd: "/tmp/project",
+			session: session as never,
+		});
+
+		const status = await memory.status();
+		expect(status).toMatchObject({
+			backend: "cognee",
+			active: false,
+			message: "Cognee backend is not configured/initialised/available.",
+			error: "missing api key",
+		});
+
+		const search = await memory.search("anything");
+		expect(search).toMatchObject({
+			backend: "cognee",
+			count: 0,
+			items: [],
+			message: "Cognee backend is not configured/initialised/available.",
+		});
+
+		const save = await memory.save("note");
+		expect(save).toMatchObject({
+			backend: "cognee",
+			stored: 0,
+			message: "Cognee backend is not configured/initialised/available.",
+		});
+	});
+
+	it("returns the existing generic off unavailable shapes when no session is present", async () => {
+		const memory = createMemoryRuntimeContext({ agentDir: "/tmp/agent", cwd: "/tmp/project" });
+
+		await expect(memory.status()).resolves.toMatchObject({
+			backend: "off",
+			active: false,
+			writable: false,
+			searchable: false,
+			message: "No active agent session.",
+		});
+		await expect(memory.search("anything")).resolves.toMatchObject({
+			backend: "off",
+			count: 0,
+			items: [],
+		});
+		await expect(memory.save("note")).resolves.toMatchObject({
+			backend: "off",
+			stored: 0,
+		});
+	});
+
+	it("keeps the generic hookless fallback for the local backend", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const memory = createMemoryRuntimeContext({
+			agentDir: "/tmp/agent",
+			cwd: "/tmp/project",
+			session: { settings } as never,
+		});
+
+		// Real local backend exposes no status/search hooks; runtime must keep
+		// the generic hookless fallback wording rather than throwing.
+		await expect(memory.status()).resolves.toMatchObject({
+			backend: "local",
+			active: true,
+			writable: true,
+			searchable: false,
+		});
+		await expect(memory.search("project preference")).resolves.toMatchObject({
+			backend: "local",
+			count: 0,
+		});
+	});
+});

--- a/packages/coding-agent/test/cognee-scope.test.ts
+++ b/packages/coding-agent/test/cognee-scope.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:te
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { logger, removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { computeCogneeScope, deriveCogneeDatasetName } from "../src/cognee/scope";
 import type { CogneeConfig } from "../src/cognee/config";
 
@@ -181,34 +181,26 @@ describe("computeCogneeScope", () => {
 			expect(nodeSet).toEqual(original);
 		});
 
-		it("warns and falls back to a global ID target when datasetId is configured", () => {
-			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-
+		it("derives a project-specific ID target when datasetId is configured", () => {
 			const scope = computeCogneeScope(
 				baseConfig({ scoping: "per-project", datasetId: " ds-123 " }),
 				"/work/cool-app",
 			);
 
-			expect(scope.label).toBe("global:id:ds-123");
-			expect(scope.datasetId).toBe("ds-123");
-			expect(scope.recallDatasetIds).toEqual(["ds-123"]);
+			expect(scope.label).toBe("project:cool-app");
+			expect(scope.datasetId).toBe("ds-123-cool-app");
+			expect(scope.recallDatasetIds).toEqual(["ds-123-cool-app"]);
+			expect(scope.retainDatasetLabel).toBe("id:ds-123-cool-app");
+			expect(scope.recallDatasetLabels).toEqual(["id:ds-123-cool-app"]);
 			expect(scope.datasetName).toBeUndefined();
 			expect(scope.recallDatasets).toBeUndefined();
-			expect(scope.projectLabel).toBeUndefined();
+			expect(scope.projectLabel).toBe("cool-app");
 			expect(scope.projectNode).toBeUndefined();
-			expect(warnSpy).toHaveBeenCalledTimes(1);
-			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("per-project");
-			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("dataset IDs");
-			expect(warnSpy.mock.calls[0]?.[1]).toEqual({
-				scoping: "per-project",
-				datasetId: "ds-123",
-				projectLabel: "cool-app",
-			});
 		});
 	});
 
 	describe("per-project-tagged", () => {
-		it("retains a project node while recalling the shared dataset", () => {
+		it("retains and recalls with the project node while targeting the shared dataset", () => {
 			const scope = computeCogneeScope(
 				baseConfig({ scoping: "per-project-tagged", nodeSet: ["team:infra"] }),
 				"/repo/cool-app",
@@ -219,7 +211,7 @@ describe("computeCogneeScope", () => {
 			expect(scope.projectLabel).toBe("cool-app");
 			expect(scope.projectNode).toBe("project:cool-app");
 			expect(scope.retainNodeSet).toEqual(["team:infra", "project:cool-app"]);
-			expect(scope.recallNodeName).toBeUndefined();
+			expect(scope.recallNodeName).toEqual(["project:cool-app"]);
 			expect(scope.recallDatasets).toEqual(["omp"]);
 			expect(scope.recallDatasetIds).toBeUndefined();
 		});
@@ -233,9 +225,7 @@ describe("computeCogneeScope", () => {
 			expect(scope.retainNodeSet).toEqual(["team:infra", "project:cool-app"]);
 		});
 
-		it("uses dataset IDs with soft project scoping and no warning", () => {
-			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-
+		it("uses dataset IDs with the project node recall filter", () => {
 			const scope = computeCogneeScope(
 				baseConfig({ scoping: "per-project-tagged", datasetId: " ds-123 " }),
 				"/repo/cool-app",
@@ -249,7 +239,7 @@ describe("computeCogneeScope", () => {
 			expect(scope.projectLabel).toBe("cool-app");
 			expect(scope.projectNode).toBe("project:cool-app");
 			expect(scope.retainNodeSet).toEqual(["project:cool-app"]);
-			expect(warnSpy).not.toHaveBeenCalled();
+			expect(scope.recallNodeName).toEqual(["project:cool-app"]);
 		});
 	});
 

--- a/packages/coding-agent/test/cognee-scope.test.ts
+++ b/packages/coding-agent/test/cognee-scope.test.ts
@@ -1,0 +1,338 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger, removeWithRetries } from "@oh-my-pi/pi-utils";
+import { computeCogneeScope, deriveCogneeDatasetName } from "../src/cognee/scope";
+import type { CogneeConfig } from "../src/cognee/config";
+
+// Isolate `git` invocations in this file from the host's global config —
+// `~/.gitconfig` commit signing or template hooks would otherwise make the
+// linked-worktree fixtures flaky.
+process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+process.env.GIT_CONFIG_NOSYSTEM = "1";
+process.env.GIT_TERMINAL_PROMPT = "0";
+process.env.GIT_ASKPASS = "true";
+delete process.env.XDG_CONFIG_HOME;
+
+type TestCogneeConfig = CogneeConfig & { nodeSet: string[] };
+
+function runGit(cwd: string, args: string[]): string {
+	const result = Bun.spawnSync(["git", ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: "Test User",
+			GIT_AUTHOR_EMAIL: "test@example.com",
+			GIT_COMMITTER_NAME: "Test User",
+			GIT_COMMITTER_EMAIL: "test@example.com",
+		},
+	});
+	if (result.exitCode !== 0) {
+		const stderr = new TextDecoder().decode(result.stderr).trim();
+		const stdout = new TextDecoder().decode(result.stdout).trim();
+		throw new Error(`git ${args.join(" ")} failed: ${stderr || stdout || `exit ${result.exitCode}`}`);
+	}
+	return new TextDecoder().decode(result.stdout).trim();
+}
+
+const baseConfig = (overrides: Partial<TestCogneeConfig> = {}): TestCogneeConfig => ({
+	apiUrl: "http://localhost:8000",
+	apiKey: null,
+	datasetName: null,
+	datasetId: null,
+	datasetNamePrefix: "",
+	scoping: "per-project-tagged",
+	nodeSet: [],
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	runInBackground: true,
+	chunkSize: 4096,
+	chunksPerBatch: 36,
+	customPrompt: null,
+	ontologyKeys: [],
+	graphModel: null,
+	recallSearchType: "GRAPH_COMPLETION",
+	recallScope: "auto",
+	recallTopK: 10,
+	recallContextTurns: 1,
+	recallMaxQueryChars: 1200,
+	recallMaxRenderChars: 12_000,
+	recallPromptPreamble: "preamble",
+	onlyContext: false,
+	verbose: false,
+	improveOnEnqueue: true,
+	buildGlobalContextIndex: false,
+	sessionMemoryEnabled: false,
+	debug: false,
+	...overrides,
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("computeCogneeScope", () => {
+	describe("global", () => {
+		it("returns the default shared dataset target", () => {
+			expect(computeCogneeScope(baseConfig({ scoping: "global" }), "/work/proj")).toEqual({
+				label: "global:omp",
+				datasetName: "omp",
+				retainDatasetLabel: "omp",
+				recallDatasetLabels: ["omp"],
+				recallDatasets: ["omp"],
+			});
+		});
+
+		it("applies configured dataset name and prefix", () => {
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "global", datasetName: "team", datasetNamePrefix: "prod" }),
+				"/work/proj",
+			);
+
+			expect(scope.datasetName).toBe("prod-team");
+			expect(scope.recallDatasets).toEqual(["prod-team"]);
+			expect(scope.retainDatasetLabel).toBe("prod-team");
+			expect(scope.recallDatasetLabels).toEqual(["prod-team"]);
+		});
+
+		it("trims dataset scalars and falls back from blanks", () => {
+			expect(
+				deriveCogneeDatasetName(
+					baseConfig({ scoping: "global", datasetName: "   ", datasetNamePrefix: "  " }),
+					"/work/proj",
+				),
+			).toBe("omp");
+			expect(
+				deriveCogneeDatasetName(
+					baseConfig({ scoping: "global", datasetName: " team ", datasetNamePrefix: " prod " }),
+					"/work/proj",
+				),
+			).toBe("prod-team");
+		});
+
+		it("uses dataset IDs as the only target when configured", () => {
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "global", datasetName: "team", datasetNamePrefix: "prod", datasetId: " ds-123 " }),
+				"/work/proj",
+			);
+
+			expect(scope.label).toBe("global:id:ds-123");
+			expect(scope.datasetId).toBe("ds-123");
+			expect(scope.recallDatasetIds).toEqual(["ds-123"]);
+			expect(scope.retainDatasetLabel).toBe("id:ds-123");
+			expect(scope.recallDatasetLabels).toEqual(["id:ds-123"]);
+			expect(scope.datasetName).toBeUndefined();
+			expect(scope.recallDatasets).toBeUndefined();
+		});
+	});
+
+	describe("deriveCogneeDatasetName", () => {
+		it("derives names by scoping mode and ignores datasetId", () => {
+			const config = { datasetName: " team ", datasetNamePrefix: " prod ", datasetId: "ignored" };
+
+			expect(deriveCogneeDatasetName(baseConfig({ ...config, scoping: "global" }), "/work/proj")).toBe(
+				"prod-team",
+			);
+			expect(deriveCogneeDatasetName(baseConfig({ ...config, scoping: "per-project" }), "/work/proj")).toBe(
+				"prod-team-proj",
+			);
+			expect(deriveCogneeDatasetName(baseConfig({ ...config, scoping: "per-project-tagged" }), "/work/proj")).toBe(
+				"prod-team",
+			);
+		});
+	});
+
+	describe("per-project", () => {
+		it("falls back to the cwd basename outside a repo", () => {
+			const scope = computeCogneeScope(baseConfig({ scoping: "per-project" }), "/work/cool-app");
+
+			expect(scope.projectLabel).toBe("cool-app");
+			expect(scope.label).toBe("project:cool-app");
+			expect(scope.datasetName).toBe("omp-cool-app");
+		});
+
+		it("uses unknown for an empty cwd", () => {
+			const scope = computeCogneeScope(baseConfig({ scoping: "per-project" }), "");
+
+			expect(scope.projectLabel).toBe("unknown");
+			expect(scope.datasetName).toBe("omp-unknown");
+		});
+
+		it("includes normalized static nodes without mutating input", () => {
+			const nodeSet = [" team:infra ", "", "team:infra", " app:web "];
+			const original = [...nodeSet];
+
+			expect(computeCogneeScope(baseConfig({ scoping: "global", nodeSet }), "/work/proj").retainNodeSet).toEqual([
+				"team:infra",
+				"app:web",
+			]);
+			expect(computeCogneeScope(baseConfig({ scoping: "per-project", nodeSet }), "/work/proj").retainNodeSet).toEqual([
+				"team:infra",
+				"app:web",
+			]);
+			expect(nodeSet).toEqual(original);
+		});
+
+		it("warns and falls back to a global ID target when datasetId is configured", () => {
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "per-project", datasetId: " ds-123 " }),
+				"/work/cool-app",
+			);
+
+			expect(scope.label).toBe("global:id:ds-123");
+			expect(scope.datasetId).toBe("ds-123");
+			expect(scope.recallDatasetIds).toEqual(["ds-123"]);
+			expect(scope.datasetName).toBeUndefined();
+			expect(scope.recallDatasets).toBeUndefined();
+			expect(scope.projectLabel).toBeUndefined();
+			expect(scope.projectNode).toBeUndefined();
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("per-project");
+			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("dataset IDs");
+			expect(warnSpy.mock.calls[0]?.[1]).toEqual({
+				scoping: "per-project",
+				datasetId: "ds-123",
+				projectLabel: "cool-app",
+			});
+		});
+	});
+
+	describe("per-project-tagged", () => {
+		it("retains a project node while recalling the shared dataset", () => {
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "per-project-tagged", nodeSet: ["team:infra"] }),
+				"/repo/cool-app",
+			);
+
+			expect(scope.datasetName).toBe("omp");
+			expect(scope.label).toBe("project-tagged:cool-app");
+			expect(scope.projectLabel).toBe("cool-app");
+			expect(scope.projectNode).toBe("project:cool-app");
+			expect(scope.retainNodeSet).toEqual(["team:infra", "project:cool-app"]);
+			expect(scope.recallNodeName).toBeUndefined();
+			expect(scope.recallDatasets).toEqual(["omp"]);
+			expect(scope.recallDatasetIds).toBeUndefined();
+		});
+
+		it("does not append a duplicate project node", () => {
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "per-project-tagged", nodeSet: ["team:infra", " project:cool-app ", "project:cool-app"] }),
+				"/repo/cool-app",
+			);
+
+			expect(scope.retainNodeSet).toEqual(["team:infra", "project:cool-app"]);
+		});
+
+		it("uses dataset IDs with soft project scoping and no warning", () => {
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const scope = computeCogneeScope(
+				baseConfig({ scoping: "per-project-tagged", datasetId: " ds-123 " }),
+				"/repo/cool-app",
+			);
+
+			expect(scope.label).toBe("project-tagged:cool-app");
+			expect(scope.datasetId).toBe("ds-123");
+			expect(scope.recallDatasetIds).toEqual(["ds-123"]);
+			expect(scope.datasetName).toBeUndefined();
+			expect(scope.recallDatasets).toBeUndefined();
+			expect(scope.projectLabel).toBe("cool-app");
+			expect(scope.projectNode).toBe("project:cool-app");
+			expect(scope.retainNodeSet).toEqual(["project:cool-app"]);
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("passes through only non-empty session IDs", () => {
+		expect(computeCogneeScope(baseConfig({ scoping: "global" }), "/work/proj", " session-1 ").sessionId).toBe(
+			"session-1",
+		);
+		expect(computeCogneeScope(baseConfig({ scoping: "global" }), "/work/proj").sessionId).toBeUndefined();
+		expect(computeCogneeScope(baseConfig({ scoping: "global" }), "/work/proj", "").sessionId).toBeUndefined();
+		expect(computeCogneeScope(baseConfig({ scoping: "global" }), "/work/proj", "   ").sessionId).toBeUndefined();
+	});
+
+	describe("git worktree handling", () => {
+		let baseDir: string;
+		let primaryRoot: string;
+		let worktreeRoot: string;
+		let bareRepoRoot: string;
+		let bareWorktreeA: string;
+		let bareWorktreeB: string;
+
+		beforeAll(async () => {
+			baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "cognee-scope-worktree-"));
+			primaryRoot = path.join(baseDir, "myrepo");
+			worktreeRoot = path.join(baseDir, "myrepo-feature-x");
+			await fs.mkdir(primaryRoot, { recursive: true });
+			runGit(primaryRoot, ["-c", "init.defaultBranch=main", "init"]);
+			runGit(primaryRoot, ["config", "user.email", "tester@example.com"]);
+			runGit(primaryRoot, ["config", "user.name", "Tester"]);
+			await fs.writeFile(path.join(primaryRoot, "README.md"), "hi\n");
+			runGit(primaryRoot, ["add", "-A"]);
+			runGit(primaryRoot, ["commit", "-m", "base"]);
+			runGit(primaryRoot, ["worktree", "add", worktreeRoot, "-b", "feature-x"]);
+
+			bareRepoRoot = path.join(baseDir, "bare-repo.git");
+			bareWorktreeA = path.join(baseDir, "bare-a");
+			bareWorktreeB = path.join(baseDir, "bare-b");
+			runGit(baseDir, ["init", "--bare", bareRepoRoot]);
+			runGit(primaryRoot, ["remote", "add", "bare", bareRepoRoot]);
+			runGit(primaryRoot, ["push", "bare", "main"]);
+			runGit(baseDir, ["--git-dir", bareRepoRoot, "worktree", "add", bareWorktreeA, "-b", "bare-a", "main"]);
+			runGit(baseDir, ["--git-dir", bareRepoRoot, "worktree", "add", bareWorktreeB, "-b", "bare-b", "main"]);
+		});
+
+		afterAll(async () => {
+			if (baseDir) await removeWithRetries(baseDir);
+		});
+
+		it("uses the same project label from a primary checkout and linked worktree", () => {
+			const fromPrimary = computeCogneeScope(baseConfig({ scoping: "per-project-tagged" }), primaryRoot);
+			const fromWorktree = computeCogneeScope(baseConfig({ scoping: "per-project-tagged" }), worktreeRoot);
+
+			expect(fromPrimary.projectLabel).toBe("myrepo");
+			expect(fromPrimary.projectNode).toBe("project:myrepo");
+			expect(fromWorktree.projectLabel).toBe("myrepo");
+			expect(fromWorktree.projectNode).toBe("project:myrepo");
+			expect(fromWorktree).toEqual(fromPrimary);
+		});
+
+		it("uses the primary root basename for the per-project dataset suffix from a worktree", () => {
+			const scope = computeCogneeScope(baseConfig({ scoping: "per-project" }), worktreeRoot);
+
+			expect(scope.projectLabel).toBe("myrepo");
+			expect(scope.label).toBe("project:myrepo");
+			expect(scope.datasetName).toBe("omp-myrepo");
+		});
+
+		it("uses one shared label across worktrees attached to a bare repository", () => {
+			const fromA = computeCogneeScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeA);
+			const fromB = computeCogneeScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeB);
+
+			expect(fromA.projectLabel).toBe("bare-repo.git");
+			expect(fromA.projectNode).toBe("project:bare-repo.git");
+			expect(fromB).toEqual(fromA);
+			expect(computeCogneeScope(baseConfig({ scoping: "per-project" }), bareWorktreeB).datasetName).toBe(
+				"omp-bare-repo.git",
+			);
+		});
+
+		it("falls back to the cwd basename outside any repository", () => {
+			const scope = computeCogneeScope(baseConfig({ scoping: "per-project-tagged" }), baseDir);
+
+			expect(scope.projectLabel).toBe(path.basename(baseDir));
+			expect(scope.projectNode).toBe(`project:${path.basename(baseDir)}`);
+		});
+	});
+});

--- a/packages/coding-agent/test/cognee-session-propagation.test.ts
+++ b/packages/coding-agent/test/cognee-session-propagation.test.ts
@@ -1,0 +1,390 @@
+/**
+ * CogneeSessionPropagation focused tests.
+ *
+ * Exercises the Cognee session side-channel accessor, lifecycle parity
+ * (rekey / new-transcript reset / dispose), and parent-state propagation
+ * through SDK startup and the task executor — all with fake
+ * `CogneeSessionStateLike` objects. No live Cognee server, no real HTTP, no
+ * real Cognee client.
+ *
+ * The alias-flattening mirrors in `task/index.ts` and `eval/agent-bridge.ts`
+ * (`state?.aliasOf ?? state`) are one-line structural helpers over the accessor
+ * proven below; per the implementation plan they are verified by code
+ * inspection rather than a broad TaskTool / eval-bridge integration test.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { MemoryBackend, MemoryBackendStartOptions } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { removeSyncWithRetries, Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+import {
+	getCogneeSessionState,
+	setCogneeSessionState,
+	type CogneeSessionStateLike,
+} from "../src/cognee/state";
+
+// --- Fake Cognee session state ------------------------------------------------
+
+interface FakeCogneeState extends CogneeSessionStateLike {
+	readonly setSessionIdCalls: string[];
+	resetCalls: number;
+	flushCalls: number;
+	disposeCalls: number;
+	events: string[];
+}
+
+function createFakeCogneeState(
+	overrides: { aliasOf?: CogneeSessionStateLike; sessionId?: string } = {},
+): FakeCogneeState {
+	const state: FakeCogneeState = {
+		sessionId: overrides.sessionId ?? "sess-initial",
+		aliasOf: overrides.aliasOf,
+		lastRetainedTurn: 0,
+		hasRecalledForFirstTurn: false,
+		setSessionIdCalls: [],
+		resetCalls: 0,
+		flushCalls: 0,
+		disposeCalls: 0,
+		events: [],
+		setSessionId(sid: string) {
+			this.setSessionIdCalls.push(sid);
+		},
+		resetConversationTracking() {
+			this.resetCalls += 1;
+		},
+		enqueueRetain() {},
+		async flushRetainQueue() {
+			this.flushCalls += 1;
+			this.events.push("flush");
+		},
+		async beforeAgentStartPrompt(): Promise<string | undefined> {
+			return undefined;
+		},
+		async dispose() {
+			this.disposeCalls += 1;
+			this.events.push("dispose");
+		},
+	};
+	return state;
+}
+
+// --- Harness ------------------------------------------------------------------
+
+interface Harness {
+	agent: Agent;
+	session: AgentSession;
+	sessionManager: SessionManager;
+	tempDir: TempDir;
+	authStorage: AuthStorage;
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	while (cleanup.length > 0) {
+		const run = cleanup.pop();
+		if (run) await run().catch(() => {});
+	}
+});
+
+async function createHarness(backend: string = "off"): Promise<Harness> {
+	const tempDir = TempDir.createSync("@pi-cognee-session-propagation-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const sessionManager = SessionManager.create(
+		tempDir.path(),
+		path.join(tempDir.path(), "sessions"),
+	);
+	const agent = new Agent({
+		initialState: { systemPrompt: ["Test"], tools: [], messages: [] },
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settings: Settings.isolated({ "memory.backend": backend }),
+		modelRegistry,
+	});
+	cleanup.push(async () => {
+		await session.dispose().catch(() => {});
+		authStorage.close();
+		tempDir.removeSync();
+	});
+	return { agent, session, sessionManager, tempDir, authStorage };
+}
+
+// --- Accessor / lifecycle -----------------------------------------------------
+
+describe("CogneeSessionPropagation: AgentSession side channel", () => {
+	it("getCogneeSessionState returns the state registered via setCogneeSessionState and clears on undefined", async () => {
+		const { session } = await createHarness("cognee");
+		const fake = createFakeCogneeState();
+
+		setCogneeSessionState(session, fake);
+		expect(session.getCogneeSessionState()).toBe(fake);
+
+		const previous = setCogneeSessionState(session, undefined);
+		expect(previous).toBe(fake);
+		expect(session.getCogneeSessionState()).toBeUndefined();
+	});
+
+	it("rekeys Cognee state to the fresh provider session id on freshSession()", async () => {
+		const { agent, session } = await createHarness("cognee");
+		const fake = createFakeCogneeState();
+		setCogneeSessionState(session, fake);
+
+		const result = session.freshSession();
+		expect(result).toBeDefined();
+		if (!result) return;
+
+		// The fresh provider id is the new agent.sessionId; the rekey helper
+		// must forward it to the Cognee state.
+		expect(agent.sessionId).toBe(result.sessionId);
+		expect(fake.setSessionIdCalls).toContain(result.sessionId);
+	});
+
+	it("resets primary Cognee conversation tracking on a new transcript", async () => {
+		const { session } = await createHarness("cognee");
+		const primary = createFakeCogneeState();
+		setCogneeSessionState(session, primary);
+
+		await session.newSession();
+
+		expect(primary.resetCalls).toBe(1);
+	});
+
+	it("skips Cognee conversation-tracking reset for alias state on a new transcript", async () => {
+		const { session } = await createHarness("cognee");
+		const parentPrimary = createFakeCogneeState();
+		const alias = createFakeCogneeState({ aliasOf: parentPrimary });
+		setCogneeSessionState(session, alias);
+
+		await session.newSession();
+
+		// Aliases must never clear the parent primary's recall/turn counters.
+		expect(alias.resetCalls).toBe(0);
+		expect(parentPrimary.resetCalls).toBe(0);
+	});
+
+	it("flushes, clears the side channel, and disposes Cognee state on dispose()", async () => {
+		// The dispose test owns its own session disposal; remove the shared
+		// cleanup's dispose to avoid a double-dispose race.
+		const harness = await createHarness("cognee");
+		const { session, authStorage, tempDir } = harness;
+		cleanup.pop();
+		const fake = createFakeCogneeState();
+		setCogneeSessionState(session, fake);
+
+		await session.dispose();
+
+		// Flush must happen before dispose so a retain queue that checks current
+		// session state still sees itself while flushing.
+		expect(fake.flushCalls).toBe(1);
+		expect(fake.disposeCalls).toBe(1);
+		expect(fake.events).toEqual(["flush", "dispose"]);
+		expect(session.getCogneeSessionState()).toBeUndefined();
+
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("does not rekey Cognee state when the backend is not cognee", async () => {
+		const { session } = await createHarness("mnemopi");
+		const fake = createFakeCogneeState();
+		setCogneeSessionState(session, fake);
+
+		session.freshSession();
+
+		// Rekey guards on `memory.backend === "cognee"`; a Mnemopi session must
+		// leave the Cognee state's session id untouched.
+		expect(fake.setSessionIdCalls).toHaveLength(0);
+	});
+});
+
+// --- SDK startup propagation --------------------------------------------------
+
+describe("CogneeSessionPropagation: SDK startup forwarding", () => {
+	it("forwards parentCogneeSessionState into memoryBackend.start options", async () => {
+		const registryDir = path.join(os.tmpdir(), `pi-cognee-sdk-${Snowflake.next()}`);
+		fs.mkdirSync(registryDir, { recursive: true });
+		const authStorage = await AuthStorage.create(path.join(registryDir, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+
+		const fakePrimary = createFakeCogneeState({ sessionId: "parent-primary" });
+		let capturedStart: (MemoryBackendStartOptions & { parentCogneeSessionState?: CogneeSessionStateLike }) | undefined;
+		const fakeBackend: MemoryBackend = {
+			id: "cognee",
+			async start(options) {
+				capturedStart = options as MemoryBackendStartOptions & {
+					parentCogneeSessionState?: CogneeSessionStateLike;
+				};
+			},
+			async buildDeveloperInstructions() {
+				return undefined;
+			},
+			async clear() {},
+			async enqueue() {},
+		};
+		const spy = vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+
+		const createdSessions: AgentSession[] = [];
+		cleanup.push(async () => {
+			for (const s of createdSessions) await s.dispose().catch(() => {});
+			authStorage.close();
+			if (fs.existsSync(registryDir)) removeSyncWithRetries(registryDir);
+			spy.mockRestore();
+		});
+
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({
+				"memory.backend": "cognee",
+				"autolearn.enabled": true,
+			}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["read"],
+			parentCogneeSessionState: fakePrimary,
+		});
+		createdSessions.push(session);
+
+		expect(capturedStart).toBeDefined();
+		expect(capturedStart?.parentCogneeSessionState).toBe(fakePrimary);
+	});
+});
+
+// --- Task executor propagation ------------------------------------------------
+
+function yieldingSubagentSession(): AgentSession {
+	const listeners: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+	const session = {
+		agent: { state: { systemPrompt: ["test"] } },
+		state: { messages: [] },
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: { type: string; [key: string]: unknown }) => void) => {
+			listeners.push(listener);
+			return () => {};
+		},
+		prompt: async () => {
+			for (const listener of listeners) {
+				listener({
+					type: "retry_fallback_applied",
+					from: "primary/bad-runtime-model",
+					to: "fallback/working-model",
+					role: "subagent:cognee-propagation",
+				});
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "tool-yield",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success" },
+					},
+					isError: false,
+				});
+			}
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+	};
+	return session as unknown as AgentSession;
+}
+
+describe("CogneeSessionPropagation: task executor forwarding", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("forwards parentCogneeSessionState from ExecutorOptions into createAgentSession", async () => {
+		const fakePrimary = createFakeCogneeState({ sessionId: "parent-primary" });
+		let capturedParent: CogneeSessionStateLike | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedParent = (options as { parentCogneeSessionState?: CogneeSessionStateLike })
+				.parentCogneeSessionState;
+			return {
+				session: yieldingSubagentSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as never;
+		});
+
+		const primary = buildModel({
+			provider: "primary",
+			id: "bad-runtime-model",
+			name: "bad-runtime-model",
+			api: "openai-completions",
+			baseUrl: "https://primary.example.test",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		});
+		const fallback = buildModel({
+			provider: "fallback",
+			id: "working-model",
+			name: "working-model",
+			api: "openai-completions",
+			baseUrl: "https://fallback.example.test",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		});
+
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "test",
+			systemPrompt: "test",
+			source: "bundled",
+		};
+		const settings = Settings.isolated({
+			"retry.fallbackChains": { default: ["global/inherited-model"] },
+		});
+		settings.setModelRole("default", "primary/bad-runtime-model");
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "cognee-propagation",
+			modelOverride: ["primary/bad-runtime-model", "fallback/working-model"],
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+			parentCogneeSessionState: fakePrimary,
+		});
+
+		expect(result).toBeDefined();
+		expect(capturedParent).toBe(fakePrimary);
+	});
+});

--- a/packages/coding-agent/test/cognee-state.test.ts
+++ b/packages/coding-agent/test/cognee-state.test.ts
@@ -205,6 +205,10 @@ function userMessage(content: string): AgentMessage {
 	return asAgentMessage({ role: "user", content });
 }
 
+function assistantMessage(content: string): AgentMessage {
+	return asAgentMessage({ role: "assistant", content: [{ type: "text", text: content }] });
+}
+
 function makeOptions(
 	overrides: Partial<CogneeSessionStateOptions> & { session?: FakeSession } = {},
 ): { options: CogneeSessionStateOptions; session: FakeSession; client: FakeClient } {

--- a/packages/coding-agent/test/cognee-state.test.ts
+++ b/packages/coding-agent/test/cognee-state.test.ts
@@ -1,0 +1,959 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type {
+	CogneeClient,
+	CogneeImproveRequest,
+	CogneeRecallEntry,
+	CogneeRecallRequest,
+	CogneeRememberRequest,
+	CogneeRememberResult,
+} from "../src/cognee/client";
+import type { CogneeConfig } from "../src/cognee/config";
+import type { CogneeScope } from "../src/cognee/scope";
+import type { AgentSession } from "../src/session/agent-session";
+import type { MemoryBackendSaveInput } from "../src/memory-backend";
+import {
+	CogneeSessionState,
+	getCogneeSessionState,
+	setCogneeSessionState,
+	type CogneeSessionStateOptions,
+} from "../src/cognee/state";
+
+type TestConfig = CogneeConfig;
+type TestScope = CogneeScope;
+
+type RememberCall = { request: CogneeRememberRequest; signal?: AbortSignal };
+type RecallCall = { request: CogneeRecallRequest; signal?: AbortSignal };
+type ImproveCall = { request: CogneeImproveRequest; signal?: AbortSignal };
+
+interface FakeClient extends CogneeClient {
+	rememberCalls: RememberCall[];
+	recallCalls: RecallCall[];
+	improveCalls: ImproveCall[];
+	recallEntries: CogneeRecallEntry[];
+	rememberResult: CogneeRememberResult;
+	improveResult: Record<string, unknown>;
+	rememberError?: Error;
+	recallError?: Error;
+	improveError?: Error;
+}
+
+interface FakeSession {
+	sessionManager: {
+		getEntries(): Array<{ type: string; message: AgentMessage; id: string; parentId: string | null; timestamp: string }>;
+		getCwd(): string;
+	};
+	subscribeListeners: ((event: { type: string; messages?: AgentMessage[] }) => void)[];
+	notices: Array<{ level: string; message: string; source?: string }>;
+	refreshCount: number;
+	subscribe(listener: (event: { type: string; messages?: AgentMessage[] }) => void): () => void;
+	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
+	refreshBaseSystemPrompt(): Promise<void>;
+	emit(event: { type: string; messages?: AgentMessage[] }): void;
+}
+
+const asAgentMessage = (message: unknown): AgentMessage => message as AgentMessage;
+const asSession = (session: unknown): AgentSession => session as AgentSession;
+
+function makeConfig(overrides: Partial<TestConfig> = {}): TestConfig {
+	return {
+		apiUrl: "http://cognee.local",
+		apiKey: null,
+		datasetName: "omp",
+		datasetId: null,
+		datasetNamePrefix: "",
+		scoping: "per-project-tagged",
+		autoRecall: true,
+		autoRetain: true,
+		retainMode: "full-session",
+		retainEveryNTurns: 3,
+		retainOverlapTurns: 2,
+		retainContext: "omp",
+		runInBackground: true,
+		chunkSize: null,
+		chunksPerBatch: null,
+		customPrompt: null,
+		nodeSet: [],
+		ontologyKeys: [],
+		graphModel: null,
+		recallSearchType: "GRAPH_COMPLETION",
+		recallScope: "auto",
+		recallTopK: 10,
+		recallContextTurns: 2,
+		recallMaxQueryChars: 1200,
+		recallMaxRenderChars: 12000,
+		recallPromptPreamble: "Relevant Cognee memories.",
+		onlyContext: false,
+		verbose: false,
+		improveOnEnqueue: true,
+		buildGlobalContextIndex: false,
+		sessionMemoryEnabled: true,
+		debug: false,
+		...overrides,
+	} as TestConfig;
+}
+
+function makeScope(overrides: Partial<TestScope> = {}): TestScope {
+	return {
+		label: "project:oh-my-pi",
+		datasetName: "omp",
+		datasetId: undefined,
+		retainDatasetLabel: "omp",
+		recallDatasetLabels: ["omp"],
+		recallDatasets: ["omp"],
+		recallDatasetIds: undefined,
+		retainNodeSet: ["project:oh-my-pi"],
+		recallNodeName: undefined,
+		projectLabel: "oh-my-pi",
+		projectNode: "project:oh-my-pi",
+		sessionId: undefined,
+		...overrides,
+	} as TestScope;
+}
+
+function makeClient(overrides: Partial<FakeClient> = {}): FakeClient {
+	const client: FakeClient = {
+		rememberCalls: [],
+		recallCalls: [],
+		improveCalls: [],
+		recallEntries: [],
+		rememberResult: { status: "ok", entryId: "entry-1", contentHash: "hash-1", pipelineRunId: "run-1", raw: {} },
+		improveResult: { status: "ok" },
+		rememberError: undefined,
+		recallError: undefined,
+		improveError: undefined,
+		async remember(request, signal) {
+			this.rememberCalls.push({ request, signal });
+			if (this.rememberError) throw this.rememberError;
+			return this.rememberResult;
+		},
+		async recall(request, signal) {
+			this.recallCalls.push({ request, signal });
+			if (this.recallError) throw this.recallError;
+			return this.recallEntries;
+		},
+		async improve(request, signal) {
+			this.improveCalls.push({ request, signal });
+			if (this.improveError) throw this.improveError;
+			return this.improveResult;
+		},
+		// Unused client methods — state must never reach these.
+		async rememberEntry() {
+			throw new Error("rememberEntry must not be called by state");
+		},
+		async forget() {
+			throw new Error("forget must not be called by state");
+		},
+		async listDatasets() {
+			throw new Error("listDatasets must not be called by state");
+		},
+		async getDatasetStatus() {
+			throw new Error("getDatasetStatus must not be called by state");
+		},
+		async listDatasetData() {
+			throw new Error("listDatasetData must not be called by state");
+		},
+		async createDataset() {
+			throw new Error("createDataset must not be called by state");
+		},
+		...overrides,
+	};
+	return client;
+}
+
+function messageEntry(message: AgentMessage) {
+	return {
+		type: "message",
+		message,
+		id: Math.random().toString(36).slice(2),
+		parentId: null,
+		timestamp: new Date().toISOString(),
+	};
+}
+
+function makeSession(messages: AgentMessage[] = []): FakeSession {
+	const entries = messages.map(messageEntry);
+	const session: FakeSession = {
+		sessionManager: {
+			getEntries: () => [...entries],
+			getCwd: () => "/cwd",
+		},
+		subscribeListeners: [],
+		notices: [],
+		refreshCount: 0,
+		subscribe(listener) {
+			session.subscribeListeners.push(listener);
+			return () => {
+				const idx = session.subscribeListeners.indexOf(listener);
+				if (idx !== -1) session.subscribeListeners.splice(idx, 1);
+			};
+		},
+		emitNotice(level, message, source) {
+			session.notices.push({ level, message, source });
+		},
+		async refreshBaseSystemPrompt() {
+			session.refreshCount += 1;
+		},
+		emit(event) {
+			for (const listener of [...session.subscribeListeners]) listener(event);
+		},
+	};
+	return session;
+}
+
+function userMessage(content: string): AgentMessage {
+	return asAgentMessage({ role: "user", content });
+}
+
+function makeOptions(
+	overrides: Partial<CogneeSessionStateOptions> & { session?: FakeSession } = {},
+): { options: CogneeSessionStateOptions; session: FakeSession; client: FakeClient } {
+	const session = overrides.session ?? makeSession();
+	const client = overrides.client ?? makeClient();
+	const config = overrides.config ?? makeConfig();
+	const scope = overrides.scope ?? makeScope();
+	const options: CogneeSessionStateOptions = {
+		sessionId: overrides.sessionId ?? "session-1",
+		client,
+		config,
+		scope,
+		session: asSession(session),
+		lastRetainedTurn: overrides.lastRetainedTurn,
+		hasRecalledForFirstTurn: overrides.hasRecalledForFirstTurn,
+		aliasOf: overrides.aliasOf,
+	};
+	return { options, session, client };
+}
+
+function recallEntry(text: string, overrides: Partial<CogneeRecallEntry> = {}): CogneeRecallEntry {
+	return { source: "graph", text, ...overrides } as CogneeRecallEntry;
+}
+
+afterEach(() => {
+	// Tests install state on fake sessions via the side channel; nothing to
+	// globally reset between cases since each test builds fresh fakes.
+});
+
+describe("CogneeSessionState side-channel accessors", () => {
+	it("getCogneeSessionState(undefined) returns undefined", () => {
+		expect(getCogneeSessionState(undefined)).toBeUndefined();
+	});
+
+	it("setCogneeSessionState returns the previous state and stores the new one", () => {
+		const { options, session } = makeOptions();
+		const state = new CogneeSessionState(options);
+		const sessionObj = asSession(session);
+		expect(setCogneeSessionState(sessionObj, state)).toBeUndefined();
+		expect(getCogneeSessionState(sessionObj)).toBe(state);
+		const second = new CogneeSessionState({ ...options, sessionId: "session-2" });
+		expect(setCogneeSessionState(sessionObj, second)).toBe(state);
+		expect(getCogneeSessionState(sessionObj)).toBe(second);
+	});
+
+	it("clearing with undefined deletes the symbol value", () => {
+		const { options, session } = makeOptions();
+		const sessionObj = asSession(session);
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(sessionObj, state);
+		expect(setCogneeSessionState(sessionObj, undefined)).toBe(state);
+		expect(getCogneeSessionState(sessionObj)).toBeUndefined();
+	});
+});
+
+describe("CogneeSessionState first-turn recall", () => {
+	it("beforeAgentStartPrompt sends expected recall fields, returns a block, sets snippet and flag", async () => {
+		const { options, session, client } = makeOptions();
+		client.recallEntries = [recallEntry("Prior note about alpha.")];
+		const state = new CogneeSessionState(options);
+		const result = await state.beforeAgentStartPrompt("latest task");
+		expect(result).toContain("<cognee_memories>");
+		expect(state.hasRecalledForFirstTurn).toBe(true);
+		expect(state.lastRecallSnippet).toBe(result);
+		expect(client.recallCalls).toHaveLength(1);
+		const req = client.recallCalls[0].request;
+		expect(req.query).toContain("latest task");
+		expect(req.searchType).toBe("GRAPH_COMPLETION");
+		expect(req.datasets).toEqual(["omp"]);
+		expect(req.datasetIds).toBeUndefined();
+		expect(req.nodeName).toBeUndefined();
+		expect(req.topK).toBe(10);
+		expect(req.onlyContext).toBe(false);
+		expect(req.verbose).toBe(false);
+		expect(req.sessionId).toBe("session-1");
+		expect(req.scope).toBeUndefined();
+	});
+
+	it("includes recent transcript context in the composed query", async () => {
+		const session = makeSession([userMessage("earlier task"), assistantMessage("earlier answer")]);
+		const { options, client } = makeOptions({ session });
+		client.recallEntries = [recallEntry("Prior note.")];
+		const state = new CogneeSessionState(options);
+		await state.beforeAgentStartPrompt("latest task");
+		expect(client.recallCalls[0].request.query).toContain("earlier task");
+	});
+
+	it("empty recall results flip the flag and return undefined", async () => {
+		const { options, client } = makeOptions();
+		client.recallEntries = [];
+		const state = new CogneeSessionState(options);
+		const result = await state.beforeAgentStartPrompt("latest task");
+		expect(result).toBeUndefined();
+		expect(state.hasRecalledForFirstTurn).toBe(true);
+		expect(state.lastRecallSnippet).toBeUndefined();
+	});
+
+	it("thrown recall returns undefined and leaves the flag false", async () => {
+		const { options, client } = makeOptions();
+		client.recallError = new Error("network down");
+		const state = new CogneeSessionState(options);
+		const result = await state.beforeAgentStartPrompt("latest task");
+		expect(result).toBeUndefined();
+		expect(state.hasRecalledForFirstTurn).toBe(false);
+		expect(state.lastRecallSnippet).toBeUndefined();
+	});
+
+	it("a second call does not call client.recall again", async () => {
+		const { options, client } = makeOptions();
+		client.recallEntries = [recallEntry("note")];
+		const state = new CogneeSessionState(options);
+		await state.beforeAgentStartPrompt("latest task");
+		await state.beforeAgentStartPrompt("latest task 2");
+		expect(client.recallCalls).toHaveLength(1);
+	});
+
+	it("omits sessionId when sessionMemoryEnabled is false", async () => {
+		const { options, client } = makeOptions({ config: makeConfig({ sessionMemoryEnabled: false }) });
+		client.recallEntries = [recallEntry("note")];
+		const state = new CogneeSessionState(options);
+		await state.beforeAgentStartPrompt("latest task");
+		expect(client.recallCalls[0].request.sessionId).toBeUndefined();
+	});
+
+	it("sends scope when recallScope is not auto", async () => {
+		const { options, client } = makeOptions({ config: makeConfig({ recallScope: "graph" }) });
+		client.recallEntries = [recallEntry("note")];
+		const state = new CogneeSessionState(options);
+		await state.beforeAgentStartPrompt("latest task");
+		expect(client.recallCalls[0].request.scope).toBe("graph");
+	});
+
+	it("returns undefined for empty prompt without flipping the flag", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		const result = await state.beforeAgentStartPrompt("   ");
+		expect(result).toBeUndefined();
+		expect(state.hasRecalledForFirstTurn).toBe(false);
+		expect(client.recallCalls).toHaveLength(0);
+	});
+
+	it("returns undefined when autoRecall is false", async () => {
+		const { options, client } = makeOptions({ config: makeConfig({ autoRecall: false }) });
+		const state = new CogneeSessionState(options);
+		const result = await state.beforeAgentStartPrompt("latest task");
+		expect(result).toBeUndefined();
+		expect(client.recallCalls).toHaveLength(0);
+	});
+});
+
+describe("CogneeSessionState listener recall and prompt snippets", () => {
+	it("attachSessionListeners subscribes once and reattaches cleanly on a second call", () => {
+		const { options, session } = makeOptions();
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		expect(session.subscribeListeners).toHaveLength(1);
+		state.attachSessionListeners();
+		expect(session.subscribeListeners).toHaveLength(1);
+	});
+
+	it("agent_start with a latest user message performs recall, stores snippet, and calls refreshBaseSystemPrompt", async () => {
+		const session = makeSession([userMessage("hello world")]);
+		const { options, client } = makeOptions({ session });
+		client.recallEntries = [recallEntry("greeting note")];
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		session.emit({ type: "agent_start" });
+		// Await any scheduled async listener work.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(state.hasRecalledForFirstTurn).toBe(true);
+		expect(state.lastRecallSnippet).toContain("<cognee_memories>");
+		expect(session.refreshCount).toBe(1);
+	});
+
+	it("does not refresh when recall succeeds with no context", async () => {
+		const session = makeSession([userMessage("hello world")]);
+		const { options, client } = makeOptions({ session });
+		client.recallEntries = [];
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		session.emit({ type: "agent_start" });
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(state.hasRecalledForFirstTurn).toBe(true);
+		expect(state.lastRecallSnippet).toBeUndefined();
+		expect(session.refreshCount).toBe(0);
+	});
+
+	it("agent_start does nothing when already recalled for first turn", async () => {
+		const session = makeSession([userMessage("hello world")]);
+		const { options, client } = makeOptions({ session });
+		client.recallEntries = [recallEntry("note")];
+		const state = new CogneeSessionState({ ...options, hasRecalledForFirstTurn: true });
+		state.attachSessionListeners();
+		session.emit({ type: "agent_start" });
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(client.recallCalls).toHaveLength(0);
+	});
+});
+
+describe("CogneeSessionState auto-retain", () => {
+	it("agent_end below threshold does not call remember", async () => {
+		const session = makeSession([userMessage("turn 1"), assistantMessage("answer 1")]);
+		const { options, client } = makeOptions({ session });
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		session.emit({ type: "agent_end", messages: [userMessage("turn 1"), assistantMessage("answer 1")] });
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(client.rememberCalls).toHaveLength(0);
+		expect(state.lastRetainedTurn).toBe(0);
+	});
+
+	it("at threshold remember receives dataset fields, nodeSet, retain options, contentType, and transcript content", async () => {
+		const messages: AgentMessage[] = [
+			userMessage("turn 1"),
+			assistantMessage("answer 1"),
+			userMessage("turn 2"),
+			assistantMessage("answer 2"),
+			userMessage("turn 3"),
+			assistantMessage("answer 3"),
+		];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session });
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		session.emit({ type: "agent_end", messages });
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(client.rememberCalls).toHaveLength(1);
+		const req = client.rememberCalls[0].request;
+		expect(req.datasetName).toBe("omp");
+		expect(req.datasetId).toBeUndefined();
+		expect(req.nodeSet).toEqual(["project:oh-my-pi"]);
+		expect(req.runInBackground).toBe(true);
+		expect(req.contentType).toBe("text/markdown");
+		expect(req.sessionId).toBe("session-1");
+		const data = typeof req.data === "string" ? req.data : String((req.data as unknown[])[0]);
+		expect(data).toContain("Session: session-1");
+		expect(data).toContain("Scope: project:oh-my-pi");
+		expect(data).toContain("Project: oh-my-pi");
+		expect(data).toContain("[role: user]");
+		expect(data).toContain("[role: assistant]");
+		expect(state.lastRetainedTurn).toBe(3);
+		expect(state.lastRetainedAtIso).toBeDefined();
+	});
+
+	it("last-turn mode retains only the bounded recent user-turn window", async () => {
+		const messages: AgentMessage[] = [
+			userMessage("turn 1"),
+			assistantMessage("answer 1"),
+			userMessage("turn 2"),
+			assistantMessage("answer 2"),
+			userMessage("turn 3"),
+			assistantMessage("answer 3"),
+		];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({
+			session,
+			config: makeConfig({ retainMode: "last-turn", retainEveryNTurns: 3, retainOverlapTurns: 2 }),
+		});
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		session.emit({ type: "agent_end", messages });
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(client.rememberCalls).toHaveLength(1);
+		const data = String((client.rememberCalls[0].request.data as unknown[])[0]);
+		// last-turn mode slices to retainEveryNTurns + retainOverlapTurns = 5 user turns,
+		// which covers all 3 user turns here; assert the window marker is present.
+		expect(data).toContain("[role: user]");
+		expect(data).toContain("turn 3");
+	});
+
+	it("remember failure does not reject maybeRetainOnAgentEnd and records a warning", async () => {
+		const messages: AgentMessage[] = [
+			userMessage("turn 1"),
+			assistantMessage("answer 1"),
+			userMessage("turn 2"),
+			assistantMessage("answer 2"),
+			userMessage("turn 3"),
+			assistantMessage("answer 3"),
+		];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session });
+		client.rememberError = new Error("server unavailable");
+		const state = new CogneeSessionState(options);
+		await state.maybeRetainOnAgentEnd();
+		// Must not reject.
+		expect(state.lastRetainedTurn).toBe(0);
+		expect(state.lastRetainedAtIso).toBeUndefined();
+	});
+
+	it("does not retain when autoRetain is false", async () => {
+		const messages: AgentMessage[] = [userMessage("t1"), userMessage("t2"), userMessage("t3")];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session, config: makeConfig({ autoRetain: false }) });
+		const state = new CogneeSessionState(options);
+		await state.maybeRetainOnAgentEnd();
+		expect(client.rememberCalls).toHaveLength(0);
+	});
+
+	it("setSessionId changes the session id used in later remember calls", async () => {
+		const messages: AgentMessage[] = [
+			userMessage("t1"),
+			assistantMessage("a1"),
+			userMessage("t2"),
+			assistantMessage("a2"),
+			userMessage("t3"),
+			assistantMessage("a3"),
+		];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session });
+		const state = new CogneeSessionState(options);
+		state.setSessionId("session-999");
+		state.attachSessionListeners();
+		session.emit({ type: "agent_end", messages });
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(client.rememberCalls[0].request.sessionId).toBe("session-999");
+	});
+
+	it("resetConversationTracking clears primary counters and snippet", () => {
+		const { options } = makeOptions();
+		const state = new CogneeSessionState({ ...options, lastRetainedTurn: 5, hasRecalledForFirstTurn: true });
+		state.lastRecallSnippet = "snippet";
+		state.lastRetainedAtIso = "2026-01-01T00:00:00.000Z";
+		state.resetConversationTracking();
+		expect(state.lastRetainedTurn).toBe(0);
+		expect(state.hasRecalledForFirstTurn).toBe(false);
+		expect(state.lastRecallSnippet).toBeUndefined();
+		expect(state.lastRetainedAtIso).toBeUndefined();
+	});
+});
+
+describe("CogneeSessionState retain queue", () => {
+	it("enqueueRetain plus flushRetainQueue sends one remember call with an array of markdown documents", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		state.enqueueRetain("first memory", "custom-ctx");
+		state.enqueueRetain("second memory");
+		await state.flushRetainQueue();
+		expect(client.rememberCalls).toHaveLength(1);
+		const req = client.rememberCalls[0].request;
+		expect(Array.isArray(req.data)).toBe(true);
+		const docs = req.data as unknown[];
+		expect(docs).toHaveLength(2);
+		expect(String(docs[0])).toContain("first memory");
+		expect(String(docs[0])).toContain("Context: custom-ctx");
+		expect(String(docs[0])).toContain("Source: explicit-retain");
+		expect(String(docs[1])).toContain("second memory");
+		expect(String(docs[1])).toContain("Context: omp");
+	});
+
+	it("queue flush swallows client errors and emits a warning notice", async () => {
+		const { options, session, client } = makeOptions();
+		client.rememberError = new Error("flush failed");
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(session), state);
+		state.enqueueRetain("a memory");
+		await state.flushRetainQueue();
+		expect(session.notices.some(n => n.level === "warning" && n.source === "Cognee" && n.message.includes("1 memory"))).toBe(true);
+	});
+
+	it("queue flush does not reject flushRetainQueue for client errors", async () => {
+		const { options, client } = makeOptions();
+		client.rememberError = new Error("flush failed");
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		state.enqueueRetain("a memory");
+		await expect(state.flushRetainQueue()).resolves.toBeUndefined();
+	});
+
+	it("rejects all-whitespace content without queuing", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		state.enqueueRetain("   \n\t ");
+		await state.flushRetainQueue();
+		expect(client.rememberCalls).toHaveLength(0);
+	});
+
+	it("disposed queue rejects new enqueues with a closed error", async () => {
+		const { options } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		await state.dispose();
+		expect(() => state.enqueueRetain("after dispose")).toThrow("Cognee retain queue is closed.");
+	});
+
+	it("drops oldest item and emits a warning notice when exceeding 128 items", async () => {
+		const { options, session, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(session), state);
+		for (let i = 0; i < 129; i++) {
+			state.enqueueRetain(`memory ${i}`);
+		}
+		// Enqueueing the 129th should trigger a drop notice and a batch flush at 16.
+		expect(session.notices.some(n => n.message.includes("exceeded 128 items"))).toBe(true);
+		await state.flushRetainQueue();
+		// At least one flush occurred; the queue drained to a remember call.
+		expect(client.rememberCalls.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("CogneeSessionState search and save", () => {
+	it("search forwards options.signal, uses options.limit for topK, maps entries", async () => {
+		const { options, client } = makeOptions();
+		client.recallEntries = [recallEntry("result one"), recallEntry("result two")];
+		const state = new CogneeSessionState(options);
+		const ac = new AbortController();
+		const result = await state.search("query", { limit: 5, signal: ac.signal });
+		expect(result.backend).toBe("cognee");
+		expect(result.count).toBe(2);
+		expect(result.items).toHaveLength(2);
+		expect(client.recallCalls[0].request.topK).toBe(5);
+		expect(client.recallCalls[0].signal).toBe(ac.signal);
+	});
+
+	it("search returns Empty query without calling Cognee for whitespace queries", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		const result = await state.search("   ");
+		expect(result.count).toBe(0);
+		expect(result.message).toBe("Empty query.");
+		expect(client.recallCalls).toHaveLength(0);
+	});
+
+	it("search returns zero items with a message on failure", async () => {
+		const { options, client } = makeOptions();
+		client.recallError = new Error("boom");
+		const state = new CogneeSessionState(options);
+		const result = await state.search("query");
+		expect(result.count).toBe(0);
+		expect(result.items).toEqual([]);
+		expect(result.message).toContain("Cognee recall failed");
+	});
+
+	it("save stores a single markdown memory with Source and Importance and returns ids", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		const result = await state.save({
+			content: "important lesson",
+			source: "tool",
+			importance: 5,
+		} as MemoryBackendSaveInput);
+		expect(result.backend).toBe("cognee");
+		expect(result.stored).toBe(1);
+		expect(result.ids).toEqual(["entry-1", "hash-1", "run-1"]);
+		expect(result.queued).toBe(true);
+		expect(client.rememberCalls).toHaveLength(1);
+		const data = String(client.rememberCalls[0].request.data);
+		expect(data).toContain("important lesson");
+		expect(data).toContain("Source: tool");
+		expect(data).toContain("Importance: 5");
+	});
+
+	it("save returns stored 0 and message for empty content", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		const result = await state.save({ content: "   " } as MemoryBackendSaveInput);
+		expect(result.stored).toBe(0);
+		expect(result.message).toBe("Empty memory content.");
+		expect(client.rememberCalls).toHaveLength(0);
+	});
+
+	it("save returns stored 0 and message for client failure", async () => {
+		const { options, client } = makeOptions();
+		client.rememberError = new Error("save boom");
+		const state = new CogneeSessionState(options);
+		const result = await state.save({ content: "lesson" } as MemoryBackendSaveInput);
+		expect(result.stored).toBe(0);
+		expect(result.message).toContain("Cognee save failed");
+	});
+});
+
+describe("CogneeSessionState session-end improve and lifecycle", () => {
+	it("dispose unsubscribes the listener", async () => {
+		const { options, session } = makeOptions();
+		const state = new CogneeSessionState(options);
+		state.attachSessionListeners();
+		expect(session.subscribeListeners).toHaveLength(1);
+		await state.dispose();
+		expect(session.subscribeListeners).toHaveLength(0);
+	});
+
+	it("dispose flushes pending queue items before closing when state is still installed", async () => {
+		const { options, session, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(session), state);
+		state.enqueueRetain("pending memory");
+		await state.dispose();
+		expect(client.rememberCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("dispose calls improve once with sessionIds, dataset fields, nodeName, runInBackground, buildGlobalContextIndex", async () => {
+		const { options, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		await state.dispose();
+		expect(client.improveCalls).toHaveLength(1);
+		const req = client.improveCalls[0].request;
+		expect(req.sessionIds).toEqual(["session-1"]);
+		expect(req.datasetName).toBe("omp");
+		expect(req.runInBackground).toBe(true);
+		expect(req.buildGlobalContextIndex).toBe(false);
+		expect(req.data).toBeUndefined();
+		expect(req.extractionTasks).toBeUndefined();
+		expect(req.enrichmentTasks).toBeUndefined();
+	});
+
+	it("dispose does not call improve when improveOnEnqueue is false", async () => {
+		const { options, client } = makeOptions({ config: makeConfig({ improveOnEnqueue: false }) });
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		await state.dispose();
+		expect(client.improveCalls).toHaveLength(0);
+	});
+
+	it("dispose does not call improve when sessionMemoryEnabled is false", async () => {
+		const { options, client } = makeOptions({ config: makeConfig({ sessionMemoryEnabled: false }) });
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		await state.dispose();
+		expect(client.improveCalls).toHaveLength(0);
+	});
+
+	it("a thrown improve does not reject dispose", async () => {
+		const { options, client } = makeOptions();
+		client.improveError = new Error("improve boom");
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(options.session), state);
+		await expect(state.dispose()).resolves.toBeUndefined();
+	});
+
+	it("calling dispose twice still only unsubscribes/improves once", async () => {
+		const { options, session, client } = makeOptions();
+		const state = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(session), state);
+		state.attachSessionListeners();
+		await state.dispose();
+		await state.dispose();
+		expect(session.subscribeListeners).toHaveLength(0);
+		expect(client.improveCalls).toHaveLength(1);
+	});
+});
+
+describe("CogneeSessionState alias behavior", () => {
+	it("alias construction exposes parent client, config, scope and keeps alias session/sessionId", () => {
+		const { options, session } = makeOptions();
+		const parent = new CogneeSessionState(options);
+		const aliasSession = makeSession();
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(aliasSession),
+			aliasOf: parent,
+		});
+		expect(alias.aliasOf).toBe(parent);
+		expect(alias.client).toBe(parent.client);
+		expect(alias.config).toBe(parent.config);
+		expect(alias.scope).toBe(parent.scope);
+		expect(alias.session).toBe(asSession(aliasSession));
+		expect(alias.sessionId).toBe("alias-session");
+		expect(alias.hasRecalledForFirstTurn).toBe(true);
+	});
+
+	it("alias attachSessionListeners does not subscribe", () => {
+		const { options, session } = makeOptions();
+		const parent = new CogneeSessionState(options);
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		alias.attachSessionListeners();
+		expect(session.subscribeListeners).toHaveLength(0);
+	});
+
+	it("alias beforeAgentStartPrompt returns undefined and does not recall", async () => {
+		const { options, session, client } = makeOptions();
+		const parent = new CogneeSessionState(options);
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		const result = await alias.beforeAgentStartPrompt("latest task");
+		expect(result).toBeUndefined();
+		expect(client.recallCalls).toHaveLength(0);
+	});
+
+	it("alias maybeRetainOnAgentEnd and forceRetainCurrentSession do not call remember", async () => {
+		const { options, session, client } = makeOptions();
+		const parent = new CogneeSessionState(options);
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		await alias.maybeRetainOnAgentEnd();
+		await alias.forceRetainCurrentSession();
+		expect(client.rememberCalls).toHaveLength(0);
+	});
+
+	it("alias enqueueRetain, flushRetainQueue, recallForContext, search, and save delegate to parent", async () => {
+		const { options, session, client } = makeOptions();
+		client.recallEntries = [recallEntry("note")];
+		const parent = new CogneeSessionState(options);
+		setCogneeSessionState(asSession(session), parent);
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		alias.enqueueRetain("alias memory");
+		await alias.flushRetainQueue();
+		expect(client.rememberCalls).toHaveLength(1);
+		const recallResult = await alias.recallForContext("alias query");
+		expect(recallResult.ok).toBe(true);
+		expect(client.recallCalls).toHaveLength(1);
+		const searchResult = await alias.search("alias search");
+		expect(searchResult.count).toBe(1);
+		const saveResult = await alias.save({ content: "alias save" } as MemoryBackendSaveInput);
+		expect(saveResult.stored).toBe(1);
+	});
+
+	it("alias recallForCompaction delegates to parent", async () => {
+		const { options, session, client } = makeOptions();
+		client.recallEntries = [recallEntry("note")];
+		const parent = new CogneeSessionState(options);
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		const result = await alias.recallForCompaction([userMessage("compaction query")]);
+		expect(result).toContain("<cognee_memories>");
+		expect(client.recallCalls).toHaveLength(1);
+	});
+
+	it("alias resetConversationTracking keeps the flag true and does not reset parent", () => {
+		const { options } = makeOptions();
+		const parent = new CogneeSessionState({ ...options, lastRetainedTurn: 4, hasRecalledForFirstTurn: true });
+		parent.lastRecallSnippet = "parent snippet";
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: options.session,
+			aliasOf: parent,
+		});
+		alias.resetConversationTracking();
+		expect(alias.hasRecalledForFirstTurn).toBe(true);
+		// Parent untouched.
+		expect(parent.lastRetainedTurn).toBe(4);
+		expect(parent.lastRecallSnippet).toBe("parent snippet");
+	});
+
+	it("alias dispose does not unsubscribe, flush, or improve", async () => {
+		const { options, session, client } = makeOptions();
+		const parent = new CogneeSessionState(options);
+		parent.attachSessionListeners();
+		const alias = new CogneeSessionState({
+			sessionId: "alias-session",
+			client: parent.client,
+			config: parent.config,
+			scope: parent.scope,
+			session: asSession(session),
+			aliasOf: parent,
+		});
+		await alias.dispose();
+		expect(session.subscribeListeners).toHaveLength(1);
+		expect(client.improveCalls).toHaveLength(0);
+	});
+});
+
+describe("CogneeSessionState forceRetainCurrentSession", () => {
+	it("stores the current transcript regardless of threshold", async () => {
+		const messages: AgentMessage[] = [userMessage("t1"), assistantMessage("a1")];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session });
+		const state = new CogneeSessionState(options);
+		await state.forceRetainCurrentSession();
+		expect(client.rememberCalls).toHaveLength(1);
+		expect(state.lastRetainedTurn).toBe(1);
+		expect(state.lastRetainedAtIso).toBeDefined();
+	});
+
+	it("returns without calling remember when transcript is empty", async () => {
+		const session = makeSession([]);
+		const { options, client } = makeOptions({ session });
+		const state = new CogneeSessionState(options);
+		await state.forceRetainCurrentSession();
+		expect(client.rememberCalls).toHaveLength(0);
+	});
+
+	it("warns and continues on failure without updating counters", async () => {
+		const messages: AgentMessage[] = [userMessage("t1"), assistantMessage("a1")];
+		const session = makeSession(messages);
+		const { options, client } = makeOptions({ session });
+		client.rememberError = new Error("force fail");
+		const state = new CogneeSessionState(options);
+		await state.forceRetainCurrentSession();
+		expect(state.lastRetainedTurn).toBe(0);
+		expect(state.lastRetainedAtIso).toBeUndefined();
+	});
+});
+
+describe("CogneeSessionState recallForCompaction", () => {
+	it("returns context without mutating first-turn flag or snippet", async () => {
+		const { options, client } = makeOptions();
+		client.recallEntries = [recallEntry("compaction note")];
+		const state = new CogneeSessionState({ ...options, hasRecalledForFirstTurn: false });
+		const result = await state.recallForCompaction([userMessage("compaction query")]);
+		expect(result).toContain("<cognee_memories>");
+		expect(state.hasRecalledForFirstTurn).toBe(false);
+		expect(state.lastRecallSnippet).toBeUndefined();
+	});
+
+	it("returns undefined when no user message exists", async () => {
+		const { options, client } = makeOptions();
+		client.recallEntries = [recallEntry("note")];
+		const state = new CogneeSessionState(options);
+		const result = await state.recallForCompaction([assistantMessage("only assistant")]);
+		expect(result).toBeUndefined();
+		expect(client.recallCalls).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/cognee-state.test.ts
+++ b/packages/coding-agent/test/cognee-state.test.ts
@@ -480,7 +480,8 @@ describe("CogneeSessionState auto-retain", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(client.rememberCalls).toHaveLength(1);
-		const data = String((client.rememberCalls[0].request.data as unknown[])[0]);
+		const rawData = client.rememberCalls[0].request.data;
+		const data = typeof rawData === "string" ? rawData : String((rawData as unknown[])[0]);
 		// last-turn mode slices to retainEveryNTurns + retainOverlapTurns = 5 user turns,
 		// which covers all 3 user turns here; assert the window marker is present.
 		expect(data).toContain("[role: user]");
@@ -608,7 +609,7 @@ describe("CogneeSessionState retain queue", () => {
 		const { options, session, client } = makeOptions();
 		const state = new CogneeSessionState(options);
 		setCogneeSessionState(asSession(session), state);
-		for (let i = 0; i < 129; i++) {
+		for (let i = 0; i < 145; i++) {
 			state.enqueueRetain(`memory ${i}`);
 		}
 		// Enqueueing the 129th should trigger a drop notice and a batch flush at 16.

--- a/packages/coding-agent/test/cognee-tool-wiring.test.ts
+++ b/packages/coding-agent/test/cognee-tool-wiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Cognee tool wiring contract tests.
+ *
+ * Guards the `CogneeToolWiring` workpackage: `createTools` must auto-include
+ * `retain`, `recall`, `reflect`, and (when autolearn is enabled) `learn` when
+ * `memory.backend === "cognee"`, while `memory_edit` stays Mnemopi-only and is
+ * excluded for Cognee. The availability predicate routes through
+ * `isMemoryToolsBackend` from `./memory-ops`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+
+Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+
+function makeSession(
+	settingsOverrides: Partial<Record<SettingPath, unknown>> = {},
+	extra: Partial<ToolSession> = {},
+): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		skipPythonPreflight: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(settingsOverrides),
+		...extra,
+	};
+}
+
+describe("Cognee tool wiring (createTools)", () => {
+	describe("default tool set (no explicit toolNames)", () => {
+		it("auto-includes retain, recall, and reflect for memory.backend === cognee", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "cognee" }));
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("retain");
+			expect(names).toContain("recall");
+			expect(names).toContain("reflect");
+		});
+
+		it("auto-includes learn for cognee when autolearn.enabled is true", async () => {
+			const tools = await createTools(
+				makeSession({ "memory.backend": "cognee", "autolearn.enabled": true }),
+			);
+			expect(tools.map(t => t.name)).toContain("learn");
+		});
+
+		it("excludes learn for cognee when autolearn.enabled is false", async () => {
+			const tools = await createTools(
+				makeSession({ "memory.backend": "cognee", "autolearn.enabled": false }),
+			);
+			expect(tools.map(t => t.name)).not.toContain("learn");
+		});
+
+		it("excludes memory_edit for cognee (Mnemopi-only)", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "cognee" }));
+			expect(tools.map(t => t.name)).not.toContain("memory_edit");
+		});
+
+		it("offers none of the memory tools when memory.backend === off", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "off" }));
+			const names = tools.map(t => t.name);
+
+			expect(names).not.toContain("retain");
+			expect(names).not.toContain("recall");
+			expect(names).not.toContain("reflect");
+			expect(names).not.toContain("learn");
+			expect(names).not.toContain("memory_edit");
+		});
+	});
+
+	describe("explicit restricted toolNames list", () => {
+		it("force-includes retain, recall, reflect into a restricted list for cognee", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "cognee" }), ["read"]);
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("read");
+			expect(names).toContain("retain");
+			expect(names).toContain("recall");
+			expect(names).toContain("reflect");
+		});
+
+		it("force-includes learn into a restricted list for cognee + autolearn", async () => {
+			const tools = await createTools(
+				makeSession({ "memory.backend": "cognee", "autolearn.enabled": true }),
+				["read"],
+			);
+			expect(tools.map(t => t.name)).toContain("learn");
+		});
+
+		it("does not force-include memory_edit into a restricted list for cognee", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "cognee" }), ["read"]);
+			expect(tools.map(t => t.name)).not.toContain("memory_edit");
+		});
+
+		it("leaves a restricted list untouched for memory.backend === off", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "off" }), ["read"]);
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("read");
+			expect(names).not.toContain("retain");
+			expect(names).not.toContain("recall");
+			expect(names).not.toContain("reflect");
+			expect(names).not.toContain("learn");
+		});
+	});
+
+	describe("subagent gating (taskDepth > 0)", () => {
+		it("still offers retain/recall/reflect to a cognee subagent (not depth-gated)", async () => {
+			const tools = await createTools(
+				makeSession({ "memory.backend": "cognee" }, { taskDepth: 1 }),
+			);
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("retain");
+			expect(names).toContain("recall");
+			expect(names).toContain("reflect");
+		});
+
+		it("excludes learn from a cognee subagent even with autolearn enabled", async () => {
+			const tools = await createTools(
+				makeSession({ "memory.backend": "cognee", "autolearn.enabled": true }, { taskDepth: 1 }),
+			);
+			expect(tools.map(t => t.name)).not.toContain("learn");
+		});
+	});
+
+	describe("regression: Hindsight and Mnemopi still wired", () => {
+		it("auto-includes retain/recall/reflect for hindsight", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "hindsight" }));
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("retain");
+			expect(names).toContain("recall");
+			expect(names).toContain("reflect");
+		});
+
+		it("auto-includes retain/recall/reflect for mnemopi and offers memory_edit", async () => {
+			const tools = await createTools(makeSession({ "memory.backend": "mnemopi" }));
+			const names = tools.map(t => t.name);
+
+			expect(names).toContain("retain");
+			expect(names).toContain("recall");
+			expect(names).toContain("reflect");
+			expect(names).toContain("memory_edit");
+		});
+	});
+});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -974,6 +974,103 @@ describe("ExtensionRunner", () => {
 			});
 			delete globalState.__ompMemoryStatus;
 		});
+
+		it("exposes a Cognee-shaped memory runtime through the generic ctx.memory API", async () => {
+			// Plan-authorized local widening: `MemoryBackendId` does not yet include
+			// `"cognee"` in this worktree (owned by CogneeBackendAdapter). This const
+			// stands in for that future union member; no production type is altered.
+			const COGNEE = "cognee" as never;
+			const extCode = `
+				export default function(pi) {
+					pi.on("session_start", async (_event, ctx) => {
+						globalThis.__ompCogneeMemory = {
+							status: await ctx.memory.status(),
+							search: await ctx.memory.search("needle", { limit: 1 }),
+							save: await ctx.memory.save("pin this"),
+						};
+					});
+				}
+			`;
+			const explicitExtensionPath = path.join(tempDir.path(), "memory-context-cognee.ts");
+			fs.writeFileSync(explicitExtensionPath, extCode);
+			const globalState = globalThis as typeof globalThis & {
+				__ompCogneeMemory?: { status: unknown; search: unknown; save: unknown };
+			};
+			delete globalState.__ompCogneeMemory;
+
+			const result = await loadTestExtensions([explicitExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+				() => ({
+					status: async () => ({
+						backend: COGNEE,
+						active: true,
+						writable: true,
+						searchable: true,
+						scope: "project:oh-my-pi",
+						retainBank: "project:oh-my-pi",
+						recallBanks: ["global:omp", "project:oh-my-pi"],
+					}),
+					search: async query => ({
+						backend: COGNEE,
+						query,
+						count: 1,
+						items: [{ id: "e1", content: "needle result", source: "recall" }],
+					}),
+					save: async () => ({ backend: COGNEE, stored: 1 }),
+				}),
+			);
+			runner.initialize(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					appendEntry: () => {},
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: async () => {},
+					getCommands: () => [],
+					setModel: async () => false,
+					getThinkingLevel: () => undefined,
+					setThinkingLevel: () => {},
+					getSessionName: () => undefined,
+					setSessionName: async () => {},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: async () => {},
+					getSystemPrompt: () => [],
+				},
+			);
+
+			await runner.emit({ type: "session_start" });
+
+			const observed = globalState.__ompCogneeMemory;
+			expect(observed).toBeDefined();
+			expect(observed?.status).toMatchObject({
+				backend: "cognee",
+				active: true,
+				writable: true,
+				searchable: true,
+				scope: "project:oh-my-pi",
+			});
+			expect(observed?.search).toMatchObject({
+				backend: "cognee",
+				query: "needle",
+				count: 1,
+			});
+			expect(observed?.save).toMatchObject({ backend: "cognee", stored: 1 });
+			delete globalState.__ompCogneeMemory;
+		});
 	});
 
 	describe("session name API", () => {

--- a/packages/coding-agent/test/helpers/cognee.ts
+++ b/packages/coding-agent/test/helpers/cognee.ts
@@ -1,0 +1,546 @@
+/**
+ * Shared Cognee test fixtures.
+ *
+ * Test-only. Supplies deterministic fakes for the Cognee HTTP boundary,
+ * the {@link CogneeClient} seam, and the Wave 2 {@link CogneeSessionStateLike}
+ * seam so runtime/tool/propagation tests do not need a live Cognee server.
+ *
+ * Wave 2 sibling modules (`cognee/config`, `cognee/state`) are not present on
+ * this branch yet. Per the CogneeTestHarness plan, their exported types are
+ * kept structural here against the frozen contract sketches; the integration
+ * owner can swap these local stand-ins for real `import type` lines once the
+ * owning workpackages join. Present Wave 1 modules (`cognee/client`,
+ * `cognee/scope`, `memory-backend`) are imported as types directly.
+ */
+
+import { asGlobalFetch } from "./fetch-mock";
+import type {
+	CogneeClient,
+	CogneeCreateDatasetRequest,
+	CogneeCreateDatasetResponse,
+	CogneeDataset,
+	CogneeDatasetStatusRequest,
+	CogneeForgetRequest,
+	CogneeImproveRequest,
+	CogneeRecallEntry,
+	CogneeRecallRequest,
+	CogneeRememberEntryRequest,
+	CogneeRememberRequest,
+	CogneeRememberResult,
+} from "@oh-my-pi/pi-coding-agent/cognee/client";
+import type {
+	MemoryBackendSaveInput,
+	MemoryBackendSaveResult,
+	MemoryBackendSearchOptions,
+	MemoryBackendSearchResult,
+} from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { CogneeScope } from "@oh-my-pi/pi-coding-agent/cognee/scope";
+
+// --- Structural stand-ins for absent Wave 2 sibling types -------------------
+
+/** Structural mirror of `cognee/config.ts` `CogneeConfig` (contracts v1 §3.2 + v2 §A). */
+interface CogneeConfig {
+	apiUrl: string | null;
+	apiKey: string | null;
+	datasetName: string | null;
+	datasetId: string | null;
+	datasetNamePrefix: string;
+	scoping: "global" | "per-project" | "per-project-tagged";
+	autoRecall: boolean;
+	autoRetain: boolean;
+	retainMode: "full-session" | "last-turn";
+	retainEveryNTurns: number;
+	retainOverlapTurns: number;
+	retainContext: string;
+	runInBackground: boolean;
+	chunkSize: number | null;
+	chunksPerBatch: number | null;
+	customPrompt: string | null;
+	nodeSet: string[];
+	ontologyKeys: string[];
+	graphModel: string | null;
+	recallSearchType: string;
+	recallScope: string;
+	recallTopK: number;
+	recallContextTurns: number;
+	recallMaxQueryChars: number;
+	recallMaxRenderChars: number;
+	recallPromptPreamble: string;
+	onlyContext: boolean;
+	verbose: boolean;
+	improveOnEnqueue: boolean;
+	buildGlobalContextIndex: boolean;
+	sessionMemoryEnabled: boolean;
+	debug: boolean;
+}
+
+/** Structural mirror of `cognee/state.ts` `CogneeSessionStateLike` (contracts v1 §3.4 + plans). */
+interface CogneeSessionStateLike {
+	sessionId: string;
+	client: CogneeClient;
+	config: CogneeConfig;
+	scope: CogneeScope;
+	session: unknown;
+	aliasOf?: CogneeSessionStateLike | undefined;
+	lastRecallSnippet?: string | undefined;
+	lastRetainedAtIso?: string | undefined;
+	lastRetainedTurn?: number | undefined;
+	hasRecalledForFirstTurn?: boolean | undefined;
+	setSessionId(sessionId: string): void;
+	resetConversationTracking(): void;
+	enqueueRetain(content: string, context?: unknown): void;
+	flushRetainQueue(): Promise<void>;
+	beforeAgentStartPrompt(promptText: string): Promise<string | undefined>;
+	recallForContext(query: string, signal?: AbortSignal): Promise<{ context: string | null; ok: boolean }>;
+	recallForCompaction(messages: unknown): Promise<string | undefined>;
+	forceRetainCurrentSession(): Promise<void>;
+	maybeRetainOnAgentEnd(): Promise<void>;
+	attachSessionListeners(): void;
+	dispose(): void;
+	search(query: string, options?: MemoryBackendSearchOptions): Promise<MemoryBackendSearchResult>;
+	save(input: string | MemoryBackendSaveInput): Promise<MemoryBackendSaveResult>;
+}
+
+// --- Recorded request types -------------------------------------------------
+
+export interface RecordedCogneeRequest {
+	method: string;
+	path: string;
+	headers: Record<string, string>;
+	body: RecordedCogneeBody;
+	signal?: AbortSignal | null;
+}
+
+export type RecordedCogneeBody =
+	| { kind: "json"; value: unknown }
+	| { kind: "form"; fields: Record<string, RecordedCogneeFormValue[]> }
+	| { kind: "text"; value: string }
+	| { kind: "raw"; value: unknown }
+	| null;
+
+export type RecordedCogneeFormValue =
+	| string
+	| { kind: "blob"; type: string; size: number; text?: string };
+
+// --- Fake fetch -------------------------------------------------------------
+
+export interface FakeCogneeFetchResponse {
+	status?: number;
+	body?: unknown;
+	text?: string;
+	headers?: HeadersInit;
+}
+
+export function createFakeCogneeFetch(responses: FakeCogneeFetchResponse[]): {
+	fetch: typeof fetch;
+	requests: RecordedCogneeRequest[];
+} {
+	const requests: RecordedCogneeRequest[] = [];
+	const queue = [...responses];
+	const fetchImpl = asGlobalFetch(async (input, init) => {
+		const requestUrl = toUrl(input);
+		const path = requestUrl.pathname + requestUrl.search;
+		const method = (
+			init?.method ?? (input instanceof Request ? input.method : undefined) ?? "GET"
+		).toUpperCase();
+		const headers = normalizeHeaders(input, init?.headers);
+		const signal = init?.signal ?? (input instanceof Request ? input.signal : null);
+		const body = await snapshotBody(input, init?.body);
+		requests.push({ method, path, headers, body, signal });
+
+		const response = queue.shift();
+		if (!response) {
+			throw new Error(`No fake Cognee response queued for ${method} ${path}`);
+		}
+		const status = response.status ?? 200;
+		if (response.text !== undefined) {
+			return new Response(response.text, { status, headers: response.headers });
+		}
+		const headersOut = new Headers(response.headers);
+		if (!headersOut.has("content-type")) {
+			headersOut.set("content-type", "application/json");
+		}
+		return new Response(JSON.stringify(response.body ?? {}), { status, headers: headersOut });
+	});
+	return { fetch: fetchImpl, requests };
+}
+
+function toUrl(input: string | URL | Request): URL {
+	if (input instanceof URL) return input;
+	if (input instanceof Request) return new URL(input.url);
+	return new URL(input);
+}
+
+function normalizeHeaders(input: string | URL | Request, initHeaders: HeadersInit | undefined): Record<string, string> {
+	const merged = new Headers();
+	if (input instanceof Request) {
+		for (const [key, value] of input.headers) {
+			merged.set(key, value);
+		}
+	}
+	if (initHeaders !== undefined) {
+		const incoming = new Headers(initHeaders);
+		for (const [key, value] of incoming) {
+			merged.set(key, value);
+		}
+	}
+	const out: Record<string, string> = {};
+	for (const [key, value] of merged) {
+		out[key.toLowerCase()] = value;
+	}
+	return out;
+}
+
+async function snapshotBody(input: string | URL | Request, body: BodyInit | null | undefined): Promise<RecordedCogneeBody> {
+	if (body === undefined && input instanceof Request) {
+		const clone = input.clone();
+		const contentType = (clone.headers.get("content-type") ?? "").toLowerCase();
+		if (
+			contentType.startsWith("multipart/form-data") ||
+			contentType.startsWith("application/x-www-form-urlencoded")
+		) {
+			try {
+				return { kind: "form", fields: await snapshotFormData(await clone.formData()) };
+			} catch {
+				// fall through to text/raw
+			}
+		}
+		try {
+			return parseTextBody(await clone.text());
+		} catch {
+			return { kind: "raw", value: input };
+		}
+	}
+	if (body === null || body === undefined) return null;
+	if (body instanceof FormData) return { kind: "form", fields: await snapshotFormData(body) };
+	if (typeof body === "string") return parseTextBody(body);
+	if (body instanceof URLSearchParams) return { kind: "text", value: body.toString() };
+	if (body instanceof Blob) {
+		let text: string | undefined;
+		try {
+			text = await body.text();
+		} catch {
+			text = undefined;
+		}
+		if (text !== undefined) return parseTextBody(text);
+		return { kind: "raw", value: body };
+	}
+	return { kind: "raw", value: body };
+}
+
+function parseTextBody(text: string): RecordedCogneeBody {
+	const parsed = safeJsonParse(text);
+	return parsed.ok ? { kind: "json", value: parsed.value } : { kind: "text", value: text };
+}
+
+async function snapshotFormData(form: FormData): Promise<Record<string, RecordedCogneeFormValue[]>> {
+	const fields: Record<string, RecordedCogneeFormValue[]> = {};
+	for (const [key, value] of form.entries()) {
+		const list = fields[key] ?? (fields[key] = []);
+		if (typeof value === "string") {
+			list.push(value);
+			continue;
+		}
+		const blob = value as Blob;
+		const entry: { kind: "blob"; type: string; size: number; text?: string } = {
+			kind: "blob",
+			type: blob.type,
+			size: blob.size,
+		};
+		try {
+			entry.text = await blob.text();
+		} catch {
+			// Omit text; keep type and size.
+		}
+		list.push(entry);
+	}
+	return fields;
+}
+
+function safeJsonParse(text: string): { ok: true; value: unknown } | { ok: false } {
+	try {
+		return { ok: true, value: JSON.parse(text) };
+	} catch {
+		return { ok: false };
+	}
+}
+
+// --- Fake CogneeClient ------------------------------------------------------
+
+export interface FakeCogneeClientCall {
+	method: keyof CogneeClient;
+	args: unknown[];
+}
+
+export function createFakeCogneeClient(overrides?: Partial<CogneeClient>): CogneeClient & {
+	calls: FakeCogneeClientCall[];
+} {
+	const calls: FakeCogneeClientCall[] = [];
+	const record = (method: keyof CogneeClient, args: unknown[]): void => {
+		calls.push({ method, args });
+	};
+	const base: CogneeClient = {
+		remember: async (request: CogneeRememberRequest, signal?: AbortSignal): Promise<CogneeRememberResult> => {
+			record("remember", [request, signal]);
+			return overrides?.remember
+				? overrides.remember(request, signal)
+				: {
+						status: "ok",
+						datasetName: request.datasetName,
+						datasetId: request.datasetId,
+						raw: {},
+					};
+		},
+		rememberEntry: async (
+			request: CogneeRememberEntryRequest,
+			signal?: AbortSignal,
+		): Promise<CogneeRememberResult> => {
+			record("rememberEntry", [request, signal]);
+			return overrides?.rememberEntry
+				? overrides.rememberEntry(request, signal)
+				: {
+						status: "ok",
+						datasetName: request.datasetName,
+						datasetId: request.datasetId,
+						entryType: request.type,
+						raw: {},
+					};
+		},
+		recall: async (request: CogneeRecallRequest, signal?: AbortSignal) => {
+			record("recall", [request, signal]);
+			return overrides?.recall ? overrides.recall(request, signal) : ([] as CogneeRecallEntry[]);
+		},
+		improve: async (request: CogneeImproveRequest, signal?: AbortSignal) => {
+			record("improve", [request, signal]);
+			return overrides?.improve ? overrides.improve(request, signal) : ({} as Record<string, unknown>);
+		},
+		forget: async (request: CogneeForgetRequest, signal?: AbortSignal) => {
+			record("forget", [request, signal]);
+			return overrides?.forget ? overrides.forget(request, signal) : ({ ok: true } as unknown);
+		},
+		listDatasets: async (signal?: AbortSignal) => {
+			record("listDatasets", [signal]);
+			return overrides?.listDatasets ? overrides.listDatasets(signal) : ([] as CogneeDataset[]);
+		},
+		getDatasetStatus: async (request: CogneeDatasetStatusRequest, signal?: AbortSignal) => {
+			record("getDatasetStatus", [request, signal]);
+			return overrides?.getDatasetStatus ? overrides.getDatasetStatus(request, signal) : ({} as unknown);
+		},
+		listDatasetData: async (datasetId: string, signal?: AbortSignal) => {
+			record("listDatasetData", [datasetId, signal]);
+			return overrides?.listDatasetData ? overrides.listDatasetData(datasetId, signal) : ([] as unknown);
+		},
+		createDataset: async (request: CogneeCreateDatasetRequest, signal?: AbortSignal) => {
+			record("createDataset", [request, signal]);
+			return overrides?.createDataset
+				? overrides.createDataset(request, signal)
+				: ({
+						name: request.name,
+						status: "created",
+						raw: {},
+					} as CogneeCreateDatasetResponse);
+		},
+	};
+	return Object.assign(base, { calls });
+}
+
+// --- Fake CogneeConfig ------------------------------------------------------
+
+const DEFAULT_CONFIG: CogneeConfig = {
+	apiUrl: "http://cognee.local",
+	apiKey: null,
+	datasetName: "omp",
+	datasetId: null,
+	datasetNamePrefix: "",
+	scoping: "per-project-tagged",
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	runInBackground: true,
+	chunkSize: 4096,
+	chunksPerBatch: 36,
+	customPrompt: null,
+	nodeSet: [],
+	ontologyKeys: [],
+	graphModel: null,
+	recallSearchType: "GRAPH_COMPLETION",
+	recallScope: "auto",
+	recallTopK: 10,
+	recallContextTurns: 1,
+	recallMaxQueryChars: 1200,
+	recallMaxRenderChars: 12000,
+	recallPromptPreamble:
+		"Relevant Cognee memories from prior conversations and knowledge graph context. Use only when directly useful; verify against current repo state before acting.",
+	onlyContext: false,
+	verbose: false,
+	improveOnEnqueue: true,
+	buildGlobalContextIndex: false,
+	sessionMemoryEnabled: false,
+	debug: false,
+};
+
+export function createFakeCogneeConfig(overrides?: Partial<CogneeConfig>): CogneeConfig {
+	const base: CogneeConfig = {
+		...DEFAULT_CONFIG,
+		nodeSet: [...DEFAULT_CONFIG.nodeSet],
+		ontologyKeys: [...DEFAULT_CONFIG.ontologyKeys],
+	};
+	if (!overrides) return base;
+	const merged: CogneeConfig = { ...base, ...overrides };
+	if (overrides.nodeSet) merged.nodeSet = [...overrides.nodeSet];
+	if (overrides.ontologyKeys) merged.ontologyKeys = [...overrides.ontologyKeys];
+	return merged;
+}
+
+// --- Fake CogneeScope -------------------------------------------------------
+
+const DEFAULT_SCOPE: CogneeScope = {
+	label: "project:oh-my-pi",
+	datasetName: "omp",
+	retainDatasetLabel: "omp",
+	recallDatasetLabels: ["omp"],
+	recallDatasets: ["omp"],
+	retainNodeSet: ["project:oh-my-pi"],
+	projectLabel: "oh-my-pi",
+	projectNode: "project:oh-my-pi",
+	sessionId: "cognee-test-session",
+};
+
+export function createFakeCogneeScope(overrides?: Partial<CogneeScope>): CogneeScope {
+	const base: CogneeScope = {
+		...DEFAULT_SCOPE,
+		recallDatasetLabels: [...DEFAULT_SCOPE.recallDatasetLabels],
+		recallDatasets: [...DEFAULT_SCOPE.recallDatasets],
+		retainNodeSet: [...DEFAULT_SCOPE.retainNodeSet],
+	};
+	if (!overrides) return base;
+	const merged: CogneeScope = { ...base, ...overrides };
+	if (overrides.recallDatasetLabels) merged.recallDatasetLabels = [...overrides.recallDatasetLabels];
+	if (overrides.recallDatasets) merged.recallDatasets = [...overrides.recallDatasets];
+	if (overrides.retainNodeSet) merged.retainNodeSet = [...overrides.retainNodeSet];
+	if (overrides.recallDatasetIds) merged.recallDatasetIds = [...overrides.recallDatasetIds];
+	if (overrides.recallNodeName) merged.recallNodeName = [...overrides.recallNodeName];
+	return merged;
+}
+
+// --- Fake CogneeSessionState -----------------------------------------------
+
+export interface FakeCogneeSessionStateCall {
+	method: keyof CogneeSessionStateLike;
+	args: unknown[];
+}
+
+export function createFakeCogneeSessionState(
+	overrides?: Partial<CogneeSessionStateLike> & {
+		client?: CogneeClient;
+		config?: CogneeConfig;
+		scope?: CogneeScope;
+		calls?: FakeCogneeSessionStateCall[];
+	},
+): CogneeSessionStateLike & { calls: FakeCogneeSessionStateCall[] } {
+	const sessionId = overrides?.sessionId ?? "cognee-test-session";
+	const client = overrides?.client ?? createFakeCogneeClient();
+	const config = overrides?.config ?? createFakeCogneeConfig();
+	const scope = overrides?.scope ?? createFakeCogneeScope({ sessionId });
+	const session = overrides?.session ?? ({ sessionId } as never);
+	const calls: FakeCogneeSessionStateCall[] = overrides?.calls ?? [];
+	const record = (method: keyof CogneeSessionStateLike, args: unknown[]): void => {
+		calls.push({ method, args });
+	};
+
+	const state: CogneeSessionStateLike = {
+		sessionId,
+		client,
+		config,
+		scope,
+		session,
+		aliasOf: overrides?.aliasOf,
+		lastRecallSnippet: undefined,
+		lastRetainedAtIso: undefined,
+		lastRetainedTurn: undefined,
+		hasRecalledForFirstTurn: false,
+		setSessionId(next: string) {
+			record("setSessionId", [next]);
+			if (overrides?.setSessionId) {
+				overrides.setSessionId(next);
+				return;
+			}
+			state.sessionId = next;
+			if (state.scope && "sessionId" in state.scope && state.scope.sessionId !== undefined) {
+				state.scope.sessionId = next;
+			}
+		},
+		resetConversationTracking() {
+			record("resetConversationTracking", []);
+			if (overrides?.resetConversationTracking) {
+				overrides.resetConversationTracking();
+				return;
+			}
+			state.lastRecallSnippet = undefined;
+			state.lastRetainedAtIso = undefined;
+			state.lastRetainedTurn = undefined;
+			state.hasRecalledForFirstTurn = false;
+		},
+		enqueueRetain(content: string, context?: unknown) {
+			record("enqueueRetain", [content, context]);
+			if (overrides?.enqueueRetain) overrides.enqueueRetain(content, context);
+		},
+		async flushRetainQueue() {
+			record("flushRetainQueue", []);
+			if (overrides?.flushRetainQueue) await overrides.flushRetainQueue();
+		},
+		async beforeAgentStartPrompt(promptText: string) {
+			record("beforeAgentStartPrompt", [promptText]);
+			if (overrides?.beforeAgentStartPrompt) return overrides.beforeAgentStartPrompt(promptText);
+			return undefined;
+		},
+		async recallForContext(query: string, signal?: AbortSignal) {
+			record("recallForContext", [query, signal]);
+			if (overrides?.recallForContext) return overrides.recallForContext(query, signal);
+			return { context: null, ok: true };
+		},
+		async recallForCompaction(messages: unknown) {
+			record("recallForCompaction", [messages]);
+			if (overrides?.recallForCompaction) return overrides.recallForCompaction(messages);
+			return undefined;
+		},
+		async forceRetainCurrentSession() {
+			record("forceRetainCurrentSession", []);
+			if (overrides?.forceRetainCurrentSession) await overrides.forceRetainCurrentSession();
+		},
+		async maybeRetainOnAgentEnd() {
+			record("maybeRetainOnAgentEnd", []);
+			if (overrides?.maybeRetainOnAgentEnd) await overrides.maybeRetainOnAgentEnd();
+		},
+		attachSessionListeners() {
+			record("attachSessionListeners", []);
+			if (overrides?.attachSessionListeners) overrides.attachSessionListeners();
+		},
+		dispose() {
+			record("dispose", []);
+			if (overrides?.dispose) overrides.dispose();
+		},
+		async search(query: string, options?: MemoryBackendSearchOptions) {
+			record("search", [query, options]);
+			if (overrides?.search) return overrides.search(query, options);
+			// `backend: "cognee"` is part of the frozen contract status shape but the
+			// sibling `MemoryBackendId` widening has not joined this branch yet.
+			return {
+				backend: "cognee",
+				query,
+				count: 0,
+				items: [],
+			} as unknown as MemoryBackendSearchResult;
+		},
+		async save(input: string | MemoryBackendSaveInput) {
+			record("save", [input]);
+			if (overrides?.save) return overrides.save(input);
+			return { backend: "cognee", stored: 1 } as unknown as MemoryBackendSaveResult;
+		},
+	};
+
+	return Object.assign(state, { calls });
+}

--- a/packages/coding-agent/test/helpers/cognee.ts
+++ b/packages/coding-agent/test/helpers/cognee.ts
@@ -458,10 +458,10 @@ export function createFakeCogneeSessionState(
 		scope,
 		session,
 		aliasOf: overrides?.aliasOf,
-		lastRecallSnippet: undefined,
-		lastRetainedAtIso: undefined,
-		lastRetainedTurn: undefined,
-		hasRecalledForFirstTurn: false,
+		lastRecallSnippet: overrides?.lastRecallSnippet,
+		lastRetainedAtIso: overrides?.lastRetainedAtIso,
+		lastRetainedTurn: overrides?.lastRetainedTurn ?? 0,
+		hasRecalledForFirstTurn: overrides?.hasRecalledForFirstTurn ?? Boolean(overrides?.aliasOf),
 		setSessionId(next: string) {
 			record("setSessionId", [next]);
 			if (overrides?.setSessionId) {

--- a/packages/coding-agent/test/memory-backend-resolve.test.ts
+++ b/packages/coding-agent/test/memory-backend-resolve.test.ts
@@ -18,6 +18,11 @@ describe("resolveMemoryBackend", () => {
 		expect((await resolveMemoryBackend(b)).id).toBe("hindsight");
 	});
 
+	it("returns the cognee backend when memory.backend is cognee", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		expect((await resolveMemoryBackend(settings)).id).toBe("cognee");
+	});
+
 	it("exposes inactive status when no session is available", async () => {
 		const memory = createMemoryRuntimeContext({ agentDir: "/tmp/agent", cwd: "/tmp/project" });
 

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -25,6 +25,7 @@ import {
 	setMnemopiSessionState,
 } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
+import { isMemoryToolsBackend, resolveMemoryToolOps } from "@oh-my-pi/pi-coding-agent/tools/memory-ops";
 import { MemoryEditTool } from "@oh-my-pi/pi-coding-agent/tools/memory-edit";
 import { MemoryRecallTool } from "@oh-my-pi/pi-coding-agent/tools/memory-recall";
 import { MemoryReflectTool } from "@oh-my-pi/pi-coding-agent/tools/memory-reflect";
@@ -242,6 +243,183 @@ describe("Mnemopi tool factories", () => {
 		expect(MemoryRecallTool.createIf(session)).toBeInstanceOf(MemoryRecallTool);
 		expect(MemoryReflectTool.createIf(session)).toBeInstanceOf(MemoryReflectTool);
 		expect(MemoryEditTool.createIf(session)).toBeInstanceOf(MemoryEditTool);
+	});
+});
+
+describe("MemoryToolOps seam", () => {
+	function fakeBackendSession(backend: unknown, extra: Record<string, unknown> = {}): ToolSession {
+		const settings = {
+			get: (key: string) => (key === "memory.backend" ? backend : undefined),
+		};
+		return {
+			cwd: "/tmp",
+			hasUI: false,
+			settings,
+			getSessionFile: () => null,
+			getSessionId: () => TEST_SESSION_ID,
+			getSessionSpawns: () => null,
+			...extra,
+		} as unknown as ToolSession;
+	}
+
+	it("recognises only memory tool backends", () => {
+		expect(isMemoryToolsBackend("hindsight")).toBe(true);
+		expect(isMemoryToolsBackend("mnemopi")).toBe(true);
+		expect(isMemoryToolsBackend("cognee")).toBe(true);
+		expect(isMemoryToolsBackend("off")).toBe(false);
+		expect(isMemoryToolsBackend("local")).toBe(false);
+		expect(isMemoryToolsBackend(undefined)).toBe(false);
+		expect(isMemoryToolsBackend(null)).toBe(false);
+		expect(isMemoryToolsBackend("unknown")).toBe(false);
+	});
+
+	it("resolves adapters only for supported backends", () => {
+		expect(resolveMemoryToolOps(fakeBackendSession("off"))).toBeNull();
+		expect(resolveMemoryToolOps(fakeBackendSession("local"))).toBeNull();
+		expect(resolveMemoryToolOps(fakeBackendSession("unknown"))).toBeNull();
+
+		expect(resolveMemoryToolOps(makeSession(Settings.isolated({ "memory.backend": "hindsight" })))).toMatchObject({
+			backend: "hindsight",
+			supportsReflect: true,
+			supportsEdit: false,
+		});
+		expect(resolveMemoryToolOps(makeSession(Settings.isolated({ "memory.backend": "mnemopi" })))).toMatchObject({
+			backend: "mnemopi",
+			supportsReflect: true,
+			supportsEdit: true,
+		});
+		expect(resolveMemoryToolOps(fakeBackendSession("cognee"))).toMatchObject({
+			backend: "cognee",
+			supportsReflect: true,
+			supportsEdit: false,
+		});
+	});
+
+	it("queues Cognee retain items through structural state", async () => {
+		const retained: Array<{ content: string; context?: string }> = [];
+		const ops = resolveMemoryToolOps(
+			fakeBackendSession("cognee", {
+				getCogneeSessionState: () => ({
+					sessionId: "cognee-session",
+					enqueueRetain: (content: string, context?: string) => retained.push({ content, context }),
+					search: async () => ({ backend: "off", query: "", count: 0, items: [] }),
+					save: async () => ({ backend: "off", stored: 1 }),
+				}),
+			}),
+		)!;
+
+		const result = await ops.retain([
+			{ content: "first", context: "ctx" },
+			{ content: "second" },
+		]);
+
+		expect(retained).toEqual([{ content: "first", context: "ctx" }, { content: "second", context: undefined }]);
+		expect(result.content[0]).toEqual({ type: "text", text: "2 memories queued." });
+		expect(result.details).toEqual({ count: 2 });
+	});
+
+	it("formats Cognee recall results and forwards options", async () => {
+		const controller = new AbortController();
+		const searchCalls: Array<{ query: string; options?: unknown }> = [];
+		const ops = resolveMemoryToolOps(
+			fakeBackendSession("cognee", {
+				getCogneeSessionState: () => ({
+					sessionId: "cognee-session",
+					enqueueRetain: () => {},
+					search: async (query: string, options?: unknown) => {
+						searchCalls.push({ query, options });
+						return query === "empty"
+							? { backend: "off", query, count: 0, items: [] }
+							: {
+									backend: "off",
+									query,
+									count: 2,
+									items: [
+										{
+											id: "mem-1",
+											content: "Use Bun APIs.",
+											source: "learned.md",
+											timestamp: "2026-06-30T10:20:30Z",
+											score: 0.86,
+										},
+										{ content: "Prefer concise output." },
+									],
+								};
+					},
+					save: async () => ({ backend: "off", stored: 1 }),
+				}),
+			}),
+		)!;
+
+		const empty = await ops.recall("empty", { signal: controller.signal });
+		expect(empty.content[0]).toEqual({ type: "text", text: "No relevant memories found." });
+		expect(empty.useless).toBe(true);
+
+		const result = await ops.recall("query", { signal: controller.signal });
+		const textItem = result.content[0];
+		if (textItem.type !== "text") throw new Error("Expected text result");
+		const text = textItem.text;
+		expect(searchCalls).toEqual([
+			{ query: "empty", options: { signal: controller.signal } },
+			{ query: "query", options: { signal: controller.signal } },
+		]);
+		expect(text).toMatch(/^Found 2 relevant memories \(as of \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\)/);
+		expect(text).toContain("- Use Bun APIs. (id: mem-1) [learned.md] (2026-06-30) c:0.9");
+		expect(text).toContain("- Prefer concise output.");
+	});
+
+	it("formats Cognee reflect results and forwards context with signal", async () => {
+		const controller = new AbortController();
+		const searchCalls: Array<{ query: string; options?: unknown }> = [];
+		const ops = resolveMemoryToolOps(
+			fakeBackendSession("cognee", {
+				getCogneeSessionState: () => ({
+					sessionId: "cognee-session",
+					enqueueRetain: () => {},
+					search: async (query: string, options?: unknown) => {
+						searchCalls.push({ query, options });
+						return query.startsWith("empty")
+							? { backend: "off", query, count: 0, items: [] }
+							: { backend: "off", query, count: 1, items: [{ id: "mem-2", content: "Ship narrow changes." }] };
+					},
+					save: async () => ({ backend: "off", stored: 1 }),
+				}),
+			}),
+		)!;
+
+		const empty = await ops.reflect("empty question", "extra context", controller.signal);
+		expect(empty.content[0]).toEqual({ type: "text", text: "No relevant information found to reflect on." });
+
+		const result = await ops.reflect("what matters?", "repo context", controller.signal);
+		const textItem = result.content[0];
+		if (textItem.type !== "text") throw new Error("Expected text result");
+		const text = textItem.text;
+		expect(searchCalls).toEqual([
+			{ query: "empty question\n\nAdditional context:\nextra context", options: { signal: controller.signal } },
+			{ query: "what matters?\n\nAdditional context:\nrepo context", options: { signal: controller.signal } },
+		]);
+		expect(text).toContain("Based on recalled memories:");
+		expect(text).toContain("- Ship narrow changes. (id: mem-2)");
+	});
+
+	it("throws Cognee initialization errors at execution time", async () => {
+		const ops = resolveMemoryToolOps(fakeBackendSession("cognee"))!;
+		expect(ops.backend).toBe("cognee");
+		await expect(ops.retain([{ content: "x" }])).rejects.toThrow(
+			"Cognee backend is not initialised for this session.",
+		);
+		await expect(ops.recall("x")).rejects.toThrow("Cognee backend is not initialised for this session.");
+		await expect(ops.reflect("x")).rejects.toThrow("Cognee backend is not initialised for this session.");
+		await expect(ops.save?.({ content: "x" })).rejects.toThrow(
+			"Cognee backend is not initialised for this session.",
+		);
+	});
+
+	it("direct tool factories accept Cognee through the seam", () => {
+		const session = fakeBackendSession("cognee");
+		expect(MemoryRetainTool.createIf(session)).toBeInstanceOf(MemoryRetainTool);
+		expect(MemoryRecallTool.createIf(session)).toBeInstanceOf(MemoryRecallTool);
+		expect(MemoryReflectTool.createIf(session)).toBeInstanceOf(MemoryReflectTool);
 	});
 });
 

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -402,6 +402,52 @@ describe("MemoryToolOps seam", () => {
 		expect(text).toContain("- Ship narrow changes. (id: mem-2)");
 	});
 
+	it("throws Cognee recall search failure messages instead of returning no-results", async () => {
+		const ops = resolveMemoryToolOps(
+			fakeBackendSession("cognee", {
+				getCogneeSessionState: () => ({
+					sessionId: "cognee-session",
+					enqueueRetain: () => {},
+					search: async (query: string) => ({
+						backend: "off",
+						query,
+						count: 0,
+						items: [],
+						message: "Cognee recall failed: HTTP 503 Service Unavailable",
+					}),
+					save: async () => ({ backend: "off", stored: 1 }),
+				}),
+			}),
+		)!;
+
+		await expect(ops.recall("deployment notes")).rejects.toThrow(
+			"Cognee recall failed: HTTP 503 Service Unavailable",
+		);
+	});
+
+	it("throws Cognee reflect search failure messages instead of returning the empty fallback", async () => {
+		const ops = resolveMemoryToolOps(
+			fakeBackendSession("cognee", {
+				getCogneeSessionState: () => ({
+					sessionId: "cognee-session",
+					enqueueRetain: () => {},
+					search: async (query: string) => ({
+						backend: "off",
+						query,
+						count: 0,
+						items: [],
+						message: "Cognee recall failed: request timed out",
+					}),
+					save: async () => ({ backend: "off", stored: 1 }),
+				}),
+			}),
+		)!;
+
+		await expect(ops.reflect("what matters?", "repo context")).rejects.toThrow(
+			"Cognee recall failed: request timed out",
+		);
+	});
+
 	it("throws Cognee initialization errors at execution time", async () => {
 		const ops = resolveMemoryToolOps(fakeBackendSession("cognee"))!;
 		expect(ops.backend).toBe("cognee");

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -14,6 +14,12 @@ interface UiShape {
 	group?: string;
 }
 
+function getUi(path: SettingPath): UiShape | undefined {
+	const entry = SETTINGS_SCHEMA[path];
+	if (!("ui" in entry)) return undefined;
+	return entry.ui;
+}
+
 describe("settings layout", () => {
 	beforeEach(async () => {
 		resetSettingsForTest();
@@ -27,7 +33,7 @@ describe("settings layout", () => {
 	it("every UI setting declares a group registered in TAB_GROUPS for its tab", () => {
 		const violations: string[] = [];
 		for (const path in SETTINGS_SCHEMA) {
-			const ui = (SETTINGS_SCHEMA[path as keyof typeof SETTINGS_SCHEMA] as { ui?: UiShape }).ui;
+			const ui = getUi(path as SettingPath);
 			if (!ui) continue;
 			if (!ui.group) {
 				violations.push(`${path}: missing ui.group`);
@@ -57,6 +63,103 @@ describe("settings layout", () => {
 			const grouped = sequence.filter(group => group !== "");
 			const expected = TAB_GROUPS[tab].filter(group => grouped.includes(group));
 			expect(grouped).toEqual(expected);
+		}
+	});
+
+	it("registers the Cognee memory group after existing memory groups", () => {
+		expect(TAB_GROUPS.memory.filter(group => group === "Cognee")).toHaveLength(1);
+		expect(TAB_GROUPS.memory).toEqual(["General", "Auto-Learn", "Mnemopi", "Hindsight", "Cognee"]);
+	});
+
+	it("exposes only visible Cognee rows in the memory tab", () => {
+		const cogneeVisiblePaths: SettingPath[] = [
+			"cognee.apiUrl",
+			"cognee.datasetName",
+			"cognee.datasetId",
+			"cognee.scoping",
+			"cognee.autoRecall",
+			"cognee.autoRetain",
+			"cognee.retainMode",
+			"cognee.runInBackground",
+			"cognee.recallSearchType",
+			"cognee.recallScope",
+			"cognee.onlyContext",
+			"cognee.improveOnEnqueue",
+			"cognee.buildGlobalContextIndex",
+			"cognee.sessionMemoryEnabled",
+		];
+		const cogneeVisiblePathSet = new Set(cogneeVisiblePaths);
+		const memoryDefs = getSettingsForTab("memory");
+		const cogneeDefs = memoryDefs.filter(def => cogneeVisiblePathSet.has(def.path));
+
+		expect(cogneeDefs.map(def => def.path)).toEqual(cogneeVisiblePaths);
+		for (const def of cogneeDefs) {
+			expect(def.tab).toBe("memory");
+			expect(def.group).toBe("Cognee");
+			expect(def.condition).toBeDefined();
+		}
+	});
+
+	it("keeps Cognee config-file-only settings out of the memory tab", () => {
+		const hiddenCogneePaths: SettingPath[] = [
+			"cognee.apiKey",
+			"cognee.datasetNamePrefix",
+			"cognee.nodeSet",
+			"cognee.ontologyKeys",
+			"cognee.retainEveryNTurns",
+			"cognee.recallTopK",
+			"cognee.debug",
+		];
+		const memoryPathSet = new Set(getSettingsForTab("memory").map(def => def.path));
+
+		for (const path of hiddenCogneePaths) {
+			expect(path in SETTINGS_SCHEMA).toBe(true);
+			expect(memoryPathSet.has(path)).toBe(false);
+		}
+		expect(getUi("cognee.apiKey")).toBeUndefined();
+	});
+
+	it("shows Cognee memory rows only when Cognee is the active backend", () => {
+		const cogneeDefs = getSettingsForTab("memory").filter(def => def.group === "Cognee");
+
+		for (const def of cogneeDefs) {
+			expect(def.condition?.()).toBe(false);
+		}
+
+		for (const backend of ["local", "hindsight", "mnemopi"] as const) {
+			Settings.instance.set("memory.backend", backend);
+			for (const def of cogneeDefs) {
+				expect(def.condition?.()).toBe(false);
+			}
+		}
+
+		Settings.instance.set("memory.backend", "cognee");
+		for (const def of cogneeDefs) {
+			expect(def.condition?.()).toBe(true);
+		}
+	});
+
+	it("keeps Hindsight and Mnemopi rows hidden when Cognee is active", () => {
+		Settings.instance.set("memory.backend", "cognee");
+		const memoryDefs = getSettingsForTab("memory");
+		const hindsightDefs = memoryDefs.filter(def => def.group === "Hindsight" && def.condition);
+		const mnemopiDefs = memoryDefs.filter(def => def.group === "Mnemopi" && def.condition);
+
+		for (const def of hindsightDefs) {
+			expect(def.condition?.()).toBe(false);
+		}
+		for (const def of mnemopiDefs) {
+			expect(def.condition?.()).toBe(false);
+		}
+
+		Settings.instance.set("memory.backend", "hindsight");
+		for (const def of hindsightDefs) {
+			expect(def.condition?.()).toBe(true);
+		}
+
+		Settings.instance.set("memory.backend", "mnemopi");
+		for (const def of mnemopiDefs) {
+			expect(def.condition?.()).toBe(true);
 		}
 	});
 

--- a/packages/coding-agent/test/modes/controllers/memory-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/memory-command.test.ts
@@ -1,0 +1,231 @@
+/**
+ * TUI `/memory` command-controller tests for a Cognee-shaped backend.
+ *
+ * Proves `CommandController.handleMemoryCommand` routes `stats/diagnose/clear/
+ * reset/enqueue/rebuild` through the active `MemoryBackend` hooks and uses
+ * truthful non-destructive Cognee wording only when `backend.id === "cognee"`.
+ *
+ * No live Cognee server is required: `resolveMemoryBackend` is spied to return
+ * a fake Cognee `MemoryBackend`. The `"cognee"` literal is cast locally because
+ * `CogneeBackendAdapter` (which owns adding `"cognee"` to `MemoryBackendId`) is
+ * not present in this worktree; production types are not altered here.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
+
+/**
+ * Plan-authorized local widening: `MemoryBackendId` does not yet include
+ * `"cognee"` in this worktree (owned by CogneeBackendAdapter). This const
+ * stands in for that future union member; no production type is altered.
+ */
+const COGNEE_ID = "cognee" as never;
+
+interface FakeCogneeHooks {
+	stats?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	diagnose?: (agentDir: string, cwd: string, session?: unknown) => Promise<string | undefined>;
+	clear?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+	enqueue?: (agentDir: string, cwd: string, session?: unknown) => Promise<void>;
+	buildDeveloperInstructions?: (
+		agentDir: string,
+		settings: Settings,
+		session?: unknown,
+	) => Promise<string | undefined>;
+}
+
+function createFakeCogneeBackend(hooks: FakeCogneeHooks = {}): MemoryBackend {
+	const backend = {
+		id: COGNEE_ID,
+		async start() {},
+		async buildDeveloperInstructions(agentDir: string, settings: Settings, session?: unknown) {
+			return hooks.buildDeveloperInstructions?.(agentDir, settings, session);
+		},
+		async clear(agentDir: string, cwd: string, session?: unknown) {
+			await hooks.clear?.(agentDir, cwd, session);
+		},
+		async enqueue(agentDir: string, cwd: string, session?: unknown) {
+			await hooks.enqueue?.(agentDir, cwd, session);
+		},
+		async stats(agentDir: string, cwd: string, session?: unknown) {
+			return hooks.stats?.(agentDir, cwd, session);
+		},
+		async diagnose(agentDir: string, cwd: string, session?: unknown) {
+			return hooks.diagnose?.(agentDir, cwd, session);
+		},
+	};
+	return backend as unknown as MemoryBackend;
+}
+
+function createMemoryContext(settings: Settings) {
+	const session = {
+		settings,
+		refreshBaseSystemPrompt: vi.fn(async () => {}),
+	};
+	const showStatus = vi.fn();
+	const showWarning = vi.fn();
+	const showError = vi.fn();
+	const present = vi.fn();
+	const ctx = {
+		settings,
+		session,
+		sessionManager: { getCwd: () => "/tmp/project" },
+		showStatus,
+		showWarning,
+		showError,
+		present,
+	} as unknown as InteractiveModeContext;
+	return { ctx, session, showStatus, showWarning, showError, present };
+}
+
+describe("CommandController /memory — Cognee backend", () => {
+	beforeAll(async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("Expected dark theme");
+		setThemeInstance(theme);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	afterAll(async () => {
+		const theme = await getThemeByName("dark");
+		if (theme) setThemeInstance(theme);
+	});
+
+	it("/memory stats renders backend-provided markdown through ctx.present", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, present, showError } = createMemoryContext(settings);
+		const backend = createFakeCogneeBackend({
+			stats: async () => "# Cognee Stats\nActive: yes",
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory stats");
+
+		expect(present).toHaveBeenCalledTimes(1);
+		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it("/memory diagnose renders backend-provided markdown through ctx.present", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, present, showError } = createMemoryContext(settings);
+		const backend = createFakeCogneeBackend({
+			diagnose: async () => "API key: present (redacted)\napiUrl: http://localhost:8000",
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory diagnose");
+
+		expect(present).toHaveBeenCalledTimes(1);
+		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it("/memory clear calls backend.clear, refreshes the prompt, and shows non-destructive Cognee wording", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, session, showStatus } = createMemoryContext(settings);
+		const clearCalls: Array<{ agentDir: string; cwd: string; session: unknown }> = [];
+		const backend = createFakeCogneeBackend({
+			clear: async (agentDir, cwd, sess) => {
+				clearCalls.push({ agentDir, cwd, session: sess });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory clear");
+
+		expect(clearCalls).toHaveLength(1);
+		expect(clearCalls[0]?.agentDir).toBe(settings.getAgentDir());
+		expect(clearCalls[0]?.cwd).toBe("/tmp/project");
+		expect(clearCalls[0]?.session).toBe(session);
+		expect(session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalled();
+		const statusText = showStatus.mock.calls[0]?.[0] ?? "";
+		expect(statusText).toContain("Upstream Cognee datasets were not deleted");
+	});
+
+	it("/memory reset mirrors clear behavior and wording", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, session, showStatus } = createMemoryContext(settings);
+		const clearCalls: Array<{ agentDir: string; cwd: string }> = [];
+		const backend = createFakeCogneeBackend({
+			clear: async (agentDir, cwd) => {
+				clearCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory reset");
+
+		expect(clearCalls).toHaveLength(1);
+		expect(session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+		const statusText = showStatus.mock.calls[0]?.[0] ?? "";
+		expect(statusText).toContain("Upstream Cognee datasets were not deleted");
+	});
+
+	it("/memory enqueue calls backend.enqueue and shows Cognee maintenance wording", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, showStatus } = createMemoryContext(settings);
+		const enqueueCalls: Array<{ agentDir: string; cwd: string }> = [];
+		const backend = createFakeCogneeBackend({
+			enqueue: async (agentDir, cwd) => {
+				enqueueCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory enqueue");
+
+		expect(enqueueCalls).toHaveLength(1);
+		expect(enqueueCalls[0]?.agentDir).toBe(settings.getAgentDir());
+		expect(enqueueCalls[0]?.cwd).toBe("/tmp/project");
+		const statusText = showStatus.mock.calls[0]?.[0] ?? "";
+		expect(statusText).toContain("Cognee memory maintenance enqueued");
+	});
+
+	it("/memory rebuild mirrors enqueue behavior and wording", async () => {
+		const settings = Settings.isolated({ "memory.backend": "cognee" });
+		const { ctx, showStatus } = createMemoryContext(settings);
+		const enqueueCalls: Array<{ agentDir: string; cwd: string }> = [];
+		const backend = createFakeCogneeBackend({
+			enqueue: async (agentDir, cwd) => {
+				enqueueCalls.push({ agentDir, cwd });
+			},
+		});
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(backend);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory rebuild");
+
+		expect(enqueueCalls).toHaveLength(1);
+		const statusText = showStatus.mock.calls[0]?.[0] ?? "";
+		expect(statusText).toContain("Cognee memory maintenance enqueued");
+	});
+
+	it("/memory clear keeps generic wording for non-Cognee backends", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const { ctx, showStatus } = createMemoryContext(settings);
+		// Use a fake "local"-id backend with a clear hook to avoid touching disk.
+		const fakeLocal = {
+			id: "local",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return undefined;
+			},
+			async clear() {},
+			async enqueue() {},
+		} as unknown as MemoryBackend;
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeLocal);
+
+		await new CommandController(ctx).handleMemoryCommand("/memory clear");
+
+		const statusText = showStatus.mock.calls[0]?.[0] ?? "";
+		expect(statusText).toBe("Memory data cleared and system prompt refreshed.");
+		expect(statusText).not.toContain("Cognee");
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -9,6 +9,7 @@ import type { Context } from "@oh-my-pi/pi-ai/types";
 import {
 	getDefault,
 	getEnumValues,
+	onCogneeScopeChanged,
 	onAppendOnlyModeChanged,
 	onStatusLineSessionAccentChanged,
 	resetSettingsForTest,
@@ -111,6 +112,22 @@ describe("Settings", () => {
 				"gemma",
 				"minimax",
 			]);
+		});
+
+		it("exposes Cognee as a memory backend with contract defaults", () => {
+			expect(getEnumValues("memory.backend")).toEqual(["off", "local", "hindsight", "mnemopi", "cognee"]);
+			expect(Settings.isolated({ "memory.backend": "cognee" }).get("memory.backend")).toBe("cognee");
+			expect(getDefault("cognee.apiUrl")).toBe("http://localhost:8000");
+			expect(getDefault("cognee.scoping")).toBe("per-project-tagged");
+			expect(getDefault("cognee.autoRecall")).toBe(true);
+			expect(getDefault("cognee.autoRetain")).toBe(true);
+			expect(getDefault("cognee.retainMode")).toBe("full-session");
+			expect(getDefault("cognee.recallSearchType")).toBe("GRAPH_COMPLETION");
+			expect(getDefault("cognee.recallScope")).toBe("auto");
+			expect(getDefault("cognee.recallTopK")).toBe(10);
+			expect(getDefault("cognee.sessionMemoryEnabled")).toBe(false);
+			expect(getDefault("cognee.nodeSet")).toEqual([]);
+			expect(getDefault("cognee.ontologyKeys")).toEqual([]);
 		});
 	});
 
@@ -238,6 +255,32 @@ describe("Settings", () => {
 				unsubscribeThrower();
 				unsubscribeOk();
 			}
+		});
+	});
+
+	describe("cognee scope hooks", () => {
+		it("notifies subscribers only for Cognee dataset scoping settings", async () => {
+			const settings = await Settings.init({ inMemory: true });
+			let calls = 0;
+			const unsubscribe = onCogneeScopeChanged(() => {
+				calls++;
+			});
+
+			try {
+				settings.set("cognee.datasetName", "dataset-a");
+				settings.set("cognee.datasetId", "dataset-id-a");
+				settings.set("cognee.datasetNamePrefix", "prefix-a");
+				settings.set("cognee.scoping", "global");
+				expect(calls).toBe(4);
+
+				settings.set("cognee.apiUrl", "http://localhost:8001");
+				expect(calls).toBe(4);
+			} finally {
+				unsubscribe();
+			}
+
+			settings.set("cognee.scoping", "per-project");
+			expect(calls).toBe(4);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add Cognee as a selectable OMP memory backend with config, scope resolution, HTTP client, session lifecycle, runtime hooks, and memory tool integration
- fix Cognee project isolation so per-project-tagged recall filters by project node and per-project datasetId derives project-specific IDs
- surface Cognee recall/reflect backend failures instead of treating outages as empty memory results
- remove leaking Bun module mocks from Cognee backend tests by faking only the fetch boundary

## Verification
- rtk bun test packages/coding-agent/test/cognee-scope.test.ts packages/coding-agent/test/memory-tools.test.ts packages/coding-agent/test/cognee-backend.test.ts packages/coding-agent/test/cognee-client.test.ts packages/coding-agent/test/cognee-state.test.ts
  - 179 pass, 0 fail
- rtk bun test packages/coding-agent/test/cognee-backend.test.ts packages/coding-agent/test/cognee-scope.test.ts packages/coding-agent/test/cognee-tool-wiring.test.ts packages/coding-agent/test/cognee-state.test.ts packages/coding-agent/test/cognee-client.test.ts packages/coding-agent/test/cognee-memory-runtime.test.ts packages/coding-agent/test/cognee-session-propagation.test.ts packages/coding-agent/test/cognee-config.test.ts packages/coding-agent/test/cognee-content.test.ts packages/coding-agent/test/memory-tools.test.ts
  - 272 pass, 0 fail
