### PR TITLE
fix(agent): bounded plan-mode terminal decisions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan mode hanging after advisor, IRC, or continuation turns by suppressing non-user wakes and enforcing a bounded `ask`/`resolve` decision at `agent_end`. ([#3910](https://github.com/can1357/oh-my-pi/issues/3910))
+
 ## [16.2.8] - 2026-06-30
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1168,6 +1168,8 @@ function extractPermissionLocations(
 // AgentSession Class
 // ============================================================================
 
+const PLAN_MODE_TOOL_DECISION_MAX_RETRIES = 2;
+
 /** Entry returned by {@link AgentSession.clearQueue} / {@link AgentSession.popLastQueuedMessage}. */
 export type RestoredQueuedMessage = { text: string; images?: ImageContent[] };
 
@@ -1442,6 +1444,7 @@ export class AgentSession {
 	// Incoming IRC messages received while a turn was streaming; drained as
 	// non-interrupting asides at the next step boundary (see the aside provider).
 	#pendingIrcAsides: CustomMessage[] = [];
+	#planModeToolDecisionRetryCount = 0;
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
@@ -1671,6 +1674,10 @@ export class AgentSession {
 	#resumeStrandedIrcAsides(): void {
 		if (this.#isDisposed || this.isStreaming) return;
 		if (this.#pendingIrcAsides.length === 0) return;
+		if (this.#planModeState?.enabled) {
+			this.#flushPendingIrcAsides();
+			return;
+		}
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
 		const records = this.#pendingIrcAsides;
 		this.#pendingIrcAsides = [];
@@ -1685,6 +1692,13 @@ export class AgentSession {
 	 *  because #canAutoContinueForFollowUp suppresses follow-up auto-resume while a user interrupt is
 	 *  in effect, even though the wake left a provider-valid tail. */
 	#wakeForIrc(records: CustomMessage[]): void {
+		if (this.#planModeState?.enabled) {
+			for (const record of records) {
+				this.agent.emitExternalEvent({ type: "message_start", message: record });
+				this.agent.emitExternalEvent({ type: "message_end", message: record });
+			}
+			return;
+		}
 		// Park only a *blocked* follow-up (one a user interrupt is intentionally holding); an
 		// already-resumable follow-up can ride the wake turn normally without reordering.
 		const parkedFollowUps =
@@ -2282,6 +2296,25 @@ export class AgentSession {
 		// The implicit single ("default") advisor stamps no source name, so its
 		// agent-facing `<advisory>` bytes stay identical to the pre-multi-advisor path.
 		const source = advisor.slug ? advisor.name : undefined;
+		const notes: AdvisorNote[] = [{ note, severity, advisor: source }];
+		const content = formatAdvisorBatchContent(notes);
+		const details = { notes } satisfies AdvisorMessageDetails;
+		if (this.#planModeState?.enabled) {
+			if (this.agent.state.isStreaming) {
+				this.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
+			} else {
+				this.#preserveAdvisorCard({
+					role: "custom",
+					customType: "advisor",
+					content,
+					display: true,
+					attribution: "agent",
+					details,
+					timestamp: Date.now(),
+				});
+			}
+			return;
+		}
 		const interrupting = isInterruptingSeverity(severity);
 		const channel = resolveAdvisorDeliveryChannel({
 			severity,
@@ -2297,9 +2330,6 @@ export class AgentSession {
 			this.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
 			return;
 		}
-		const notes: AdvisorNote[] = [{ note, severity, advisor: source }];
-		const content = formatAdvisorBatchContent(notes);
-		const details = { notes } satisfies AdvisorMessageDetails;
 		if (channel === "preserve") {
 			this.#preserveAdvisorCard({
 				role: "custom",
@@ -3541,6 +3571,13 @@ export class AgentSession {
 				compactionResult.continuationScheduled ||
 				compactionResult.automaticContinuationBlocked
 			) {
+				await emitAgentEndNotification();
+				return;
+			}
+			if (this.#enforcePlanModeToolDecisionAtAgentEnd(msg)) {
+				maintenanceRoute("plan-mode-tool-decision-reminder", {
+					retry: this.#planModeToolDecisionRetryCount,
+				});
 				await emitAgentEndNotification();
 				return;
 			}
@@ -6297,6 +6334,7 @@ export class AgentSession {
 
 	setPlanModeState(state: PlanModeState | undefined): void {
 		this.#planModeState = state;
+		this.#planModeToolDecisionRetryCount = 0;
 		if (state?.enabled) {
 			this.#planReferenceSent = false;
 			this.#planReferencePath = state.planFilePath;
@@ -6722,6 +6760,7 @@ export class AgentSession {
 		// Agent-initiated synthetic prompts (auto-continue, plan, reminders) do not.
 		if (options?.userInitiated ?? !options?.synthetic) {
 			this.#advisorAutoResumeSuppressed = false;
+			this.#planModeToolDecisionRetryCount = 0;
 		}
 
 		// If streaming, queue via steer() or followUp() based on option
@@ -6791,9 +6830,6 @@ export class AgentSession {
 			// Clean up residual eager-todo directive if the prompt never consumed it
 			// (e.g., compaction aborted, validation failed).
 			this.#toolChoiceQueue.removeByLabel("eager-todo");
-		}
-		if (!options?.synthetic) {
-			await this.#enforcePlanModeToolDecision();
 		}
 		return true;
 	}
@@ -10047,41 +10083,67 @@ export class AgentSession {
 		this.#checkpointState = undefined;
 		this.#pendingRewindReport = undefined;
 	}
-	async #enforcePlanModeToolDecision(): Promise<void> {
+	#enforcePlanModeToolDecisionAtAgentEnd(assistantMessage: AssistantMessage): boolean {
 		if (!this.#planModeState?.enabled) {
-			return;
-		}
-		const assistantMessage = this.#findLastAssistantMessage();
-		if (!assistantMessage) {
-			return;
+			this.#planModeToolDecisionRetryCount = 0;
+			return false;
 		}
 		if (assistantMessage.stopReason === "error" || assistantMessage.stopReason === "aborted") {
-			return;
+			return false;
 		}
 
 		const calledRequiredTool = assistantMessage.content.some(
 			content => content.type === "toolCall" && (content.name === "ask" || content.name === "resolve"),
 		);
 		if (calledRequiredTool) {
-			return;
+			this.#planModeToolDecisionRetryCount = 0;
+			return false;
 		}
 		const hasRequiredTools = this.#toolRegistry.has("ask") && this.#toolRegistry.has("resolve");
 		if (!hasRequiredTools) {
 			logger.warn("Plan mode enforcement skipped because ask/resolve tools are unavailable", {
 				activeToolNames: this.agent.state.tools.map(tool => tool.name),
 			});
-			return;
+			return false;
+		}
+		if (this.#planModeToolDecisionRetryCount >= PLAN_MODE_TOOL_DECISION_MAX_RETRIES) {
+			if (this.#planModeToolDecisionRetryCount === PLAN_MODE_TOOL_DECISION_MAX_RETRIES) {
+				this.#planModeToolDecisionRetryCount++;
+				this.emitNotice(
+					"warning",
+					"Plan mode stopped without an ask/resolve decision after repeated reminders; waiting for your next instruction.",
+					"plan-mode",
+				);
+			}
+			return false;
 		}
 
 		const reminder = prompt.render(planModeToolDecisionReminderPrompt, {
 			askToolName: "ask",
 		});
-
-		await this.prompt(reminder, {
-			synthetic: true,
-			expandPromptTemplates: false,
-			toolChoice: "required",
-		});
+		this.#planModeToolDecisionRetryCount++;
+		const generation = this.#promptGeneration;
+		this.#schedulePostPromptTask(
+			async signal => {
+				if (signal.aborted || this.#isDisposed || this.#promptGeneration !== generation) return;
+				await this.#promptWithMessage(
+					{
+						role: "developer",
+						content: [{ type: "text", text: reminder }],
+						attribution: "agent",
+						timestamp: Date.now(),
+					},
+					reminder,
+					{
+						toolChoice: "required",
+						skipCompactionCheck: true,
+						skipPostPromptRecoveryWait: true,
+					},
+				);
+			},
+			{ generation },
+		);
+		return true;
 	}
 
 	/**
@@ -13080,6 +13142,11 @@ export class AgentSession {
 		if (this.isStreaming) {
 			this.#pendingIrcAsides.push(record);
 			if (autoReply) void this.#runIrcAutoReply(msg);
+			return "injected";
+		}
+		if (this.#planModeState?.enabled) {
+			this.agent.emitExternalEvent({ type: "message_start", message: record });
+			this.agent.emitExternalEvent({ type: "message_end", message: record });
 			return "injected";
 		}
 		// Idle: wake a real turn so the recipient responds (shared with the stranded-aside resume).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2300,19 +2300,15 @@ export class AgentSession {
 		const content = formatAdvisorBatchContent(notes);
 		const details = { notes } satisfies AdvisorMessageDetails;
 		if (this.#planModeState?.enabled) {
-			if (this.agent.state.isStreaming) {
-				this.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
-			} else {
-				this.#preserveAdvisorCard({
-					role: "custom",
-					customType: "advisor",
-					content,
-					display: true,
-					attribution: "agent",
-					details,
-					timestamp: Date.now(),
-				});
-			}
+			this.#preserveAdvisorCard({
+				role: "custom",
+				customType: "advisor",
+				content,
+				display: true,
+				attribution: "agent",
+				details,
+				timestamp: Date.now(),
+			});
 			return;
 		}
 		const interrupting = isInterruptingSeverity(severity);

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { ToolChoice } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+const emptyToolSchema = type({});
+const resolveToolSchema = type({
+	action: "'apply' | 'discard'",
+	reason: "string",
+});
+
+type ObservedPromptCall = {
+	toolChoice: string | undefined;
+	messageRoles: AgentMessage["role"][];
+	messageTexts: string[];
+};
+
+type Harness = {
+	session: AgentSession;
+	authStorage: AuthStorage;
+	observedCalls: ObservedPromptCall[];
+	resolveRuns: { count: number };
+	resolveApplied: Promise<void>;
+};
+
+type HarnessOptions = {
+	complyWithRequired?: boolean;
+};
+
+function textOf(message: AgentMessage): string {
+	if (!("content" in message)) return "";
+	const content = message.content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	const texts: string[] = [];
+	for (const part of content) {
+		if (part.type === "text") texts.push(part.text);
+	}
+	return texts.join("\n");
+}
+
+function toolChoiceName(choice: ToolChoice | undefined): string | undefined {
+	if (!choice) return undefined;
+	if (typeof choice === "string") return choice;
+	if (choice.type === "tool") return choice.name;
+	if (choice.type === "function") {
+		if ("name" in choice) return choice.name;
+		return choice.function.name;
+	}
+	return undefined;
+}
+
+function makeAskTool(): AgentTool<typeof emptyToolSchema> {
+	const tool: AgentTool<typeof emptyToolSchema> = {
+		name: "ask",
+		label: "Ask",
+		description: "Ask the user a question.",
+		parameters: emptyToolSchema,
+		async execute() {
+			return { content: [{ type: "text", text: "asked" }] };
+		},
+	};
+	return tool;
+}
+
+describe("AgentSession plan-mode convergence", () => {
+	let tempDir: TempDir;
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-plan-mode-convergence-");
+		harnesses.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const harness of harnesses.splice(0)) {
+			await harness.session.dispose();
+			harness.authStorage.close();
+		}
+		await tempDir.remove();
+	});
+
+	async function createHarness(harnessOptions: HarnessOptions = {}): Promise<Harness> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Test model not found in registry");
+
+		const observedCalls: ObservedPromptCall[] = [];
+		const resolveRuns = { count: 0 };
+		let session: AgentSession;
+		const resolveApplied = Promise.withResolvers<void>();
+		const resolveTool: AgentTool<typeof resolveToolSchema> = {
+			name: "resolve",
+			label: "Resolve",
+			description: "Resolve the pending plan decision.",
+			parameters: resolveToolSchema,
+			async execute(_toolCallId, params) {
+				resolveRuns.count++;
+				session.setPlanModeState(undefined);
+				resolveApplied.resolve();
+				return {
+					content: [{ type: "text", text: `Plan ${params.action}: ${params.reason}` }],
+				};
+			},
+		};
+
+		const tools: AgentTool[] = [makeAskTool(), resolveTool];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools, messages: [] },
+			convertToLlm,
+			getToolChoice: () => session.nextToolChoiceDirective(),
+			streamFn: (_model, context, options) => {
+				observedCalls.push({
+					toolChoice: toolChoiceName(options?.toolChoice),
+					messageRoles: context.messages.map(message => message.role),
+					messageTexts: context.messages.map(message => textOf(message)),
+				});
+				const response = createAssistantMessage(`plan response ${observedCalls.length}`);
+				if (harnessOptions.complyWithRequired !== false && options?.toolChoice === "required") {
+					response.content = [
+						{
+							type: "toolCall",
+							id: `call-resolve-${observedCalls.length}`,
+							name: "resolve",
+							arguments: { action: "apply", reason: "plan is ready" },
+						},
+					];
+					response.stopReason = "toolUse";
+				}
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					if (response.content[0]?.type === "toolCall") {
+						stream.push({ type: "toolcall_start", contentIndex: 0, partial: response });
+						stream.push({
+							type: "toolcall_end",
+							contentIndex: 0,
+							toolCall: response.content[0],
+							partial: response,
+						});
+					}
+					stream.push({
+						type: "done",
+						reason: response.stopReason === "toolUse" ? "toolUse" : "stop",
+						message: response,
+					});
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage, tempDir.join("models.yml")),
+			toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+		});
+		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+		const harness = { session, authStorage, observedCalls, resolveRuns, resolveApplied: resolveApplied.promise };
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("enforces ask-or-resolve after a bare agent.continue terminal settle", async () => {
+		const { session, observedCalls, resolveRuns, resolveApplied } = await createHarness();
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "draft a plan" }],
+			timestamp: Date.now(),
+		});
+
+		await session.agent.continue();
+		await resolveApplied;
+
+		expect(observedCalls.map(call => call.toolChoice)).toContain("required");
+		expect(resolveRuns.count).toBe(1);
+		expect(session.getPlanModeState()).toBeUndefined();
+	});
+
+	it("stops retrying when plan mode still omits ask-or-resolve after bounded reminders", async () => {
+		const { session, observedCalls, resolveRuns } = await createHarness({ complyWithRequired: false });
+		const notice = Promise.withResolvers<string>();
+		session.subscribe(event => {
+			if (event.type !== "notice" || event.source !== "plan-mode") return;
+			notice.resolve(event.message);
+		});
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "draft a plan" }],
+			timestamp: Date.now(),
+		});
+
+		await session.agent.continue();
+		const message = await notice.promise;
+
+		expect(message).toContain("waiting for your next instruction");
+		expect(observedCalls.map(call => call.toolChoice)).toEqual([undefined, "required", "required"]);
+		expect(resolveRuns.count).toBe(0);
+		expect(session.getPlanModeState()?.enabled).toBe(true);
+	});
+
+	it("records idle IRC in plan mode without waking an autonomous turn", async () => {
+		const { session, observedCalls } = await createHarness();
+
+		const result = await session.deliverIrcMessage({
+			id: "msg-1",
+			from: "Peer",
+			to: "Main",
+			body: "plan aside",
+			ts: Date.now(),
+		} satisfies IrcMessage);
+
+		expect(result).toBe("injected");
+		expect(observedCalls).toHaveLength(0);
+		expect(
+			session.agent.state.messages.some(
+				message => message.role === "custom" && (message as { customType?: string }).customType === "irc:incoming",
+			),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, type AgentTool, type StreamFn } from "@oh-my-pi/pi-agent-core";
 import type { ToolChoice } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -36,6 +36,7 @@ type Harness = {
 
 type HarnessOptions = {
 	complyWithRequired?: boolean;
+	advisorAdvice?: boolean;
 };
 
 function textOf(message: AgentMessage): string {
@@ -97,6 +98,7 @@ describe("AgentSession plan-mode convergence", () => {
 
 		const observedCalls: ObservedPromptCall[] = [];
 		const resolveRuns = { count: 0 };
+		const advisorCalls = { count: 0 };
 		let session: AgentSession;
 		const resolveApplied = Promise.withResolvers<void>();
 		const resolveTool: AgentTool<typeof resolveToolSchema> = {
@@ -160,15 +162,58 @@ describe("AgentSession plan-mode convergence", () => {
 			},
 		});
 
+		const advisorStreamFn: StreamFn | undefined = harnessOptions.advisorAdvice
+			? (_model, _context, _options) => {
+					advisorCalls.count++;
+					const response = createAssistantMessage(`advisor response ${advisorCalls.count}`);
+					if (advisorCalls.count === 1) {
+						response.content = [
+							{
+								type: "toolCall",
+								id: "call-advise-plan",
+								name: "advise",
+								arguments: { note: "advisor says stop", severity: "concern" },
+							},
+						];
+						response.stopReason = "toolUse";
+					}
+					const stream = new AssistantMessageEventStream();
+					queueMicrotask(() => {
+						stream.push({ type: "start", partial: response });
+						if (response.content[0]?.type === "toolCall") {
+							stream.push({ type: "toolcall_start", contentIndex: 0, partial: response });
+							stream.push({
+								type: "toolcall_end",
+								contentIndex: 0,
+								toolCall: response.content[0],
+								partial: response,
+							});
+						}
+						stream.push({
+							type: "done",
+							reason: response.stopReason === "toolUse" ? "toolUse" : "stop",
+							message: response,
+						});
+					});
+					return stream;
+				}
+			: undefined;
 		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
-		const settings = Settings.isolated({ "compaction.enabled": false });
+		const settings = Settings.isolated({
+			"advisor.enabled": harnessOptions.advisorAdvice === true,
+			"compaction.enabled": false,
+		});
+		if (harnessOptions.advisorAdvice) {
+			settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		}
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry: new ModelRegistry(authStorage, tempDir.join("models.yml")),
 			toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+			advisorStreamFn,
 		});
 		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
 		const harness = { session, authStorage, observedCalls, resolveRuns, resolveApplied: resolveApplied.promise };
@@ -212,6 +257,19 @@ describe("AgentSession plan-mode convergence", () => {
 		expect(observedCalls.map(call => call.toolChoice)).toEqual([undefined, "required", "required"]);
 		expect(resolveRuns.count).toBe(0);
 		expect(session.getPlanModeState()?.enabled).toBe(true);
+	});
+
+	it("preserves streaming advisor notes in plan mode without an aside continuation", async () => {
+		const { session, observedCalls } = await createHarness({ advisorAdvice: true, complyWithRequired: false });
+
+		await session.prompt("draft a plan");
+
+		expect(observedCalls.map(call => call.toolChoice)).toEqual([undefined, "required", "required"]);
+		expect(
+			session.agent.state.messages.some(
+				message => message.role === "custom" && textOf(message).includes("advisor says stop"),
+			),
+		).toBe(true);
 	});
 
 	it("records idle IRC in plan mode without waking an autonomous turn", async () => {


### PR DESCRIPTION
## Repro
A focused plan-mode session test reproduced the hang path with `bun run gen:tool-views && bun test packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts`: a bare `agent.continue()` terminal settle never forced `ask`/`resolve`, and idle IRC delivery in plan mode returned `woken` instead of remaining visible context.

## Cause
`AgentSession.prompt()` enforced the plan-mode `ask`/`resolve` requirement only after non-synthetic prompt returns, so direct continuation and wake paths that settle through `agent_end` bypassed `#enforcePlanModeToolDecision`. Advisor concern delivery and idle IRC delivery in `packages/coding-agent/src/session/agent-session.ts` could also start autonomous turns in plan mode, keeping the recovery loop alive before any terminal decision gate ran.

## Fix
- Move plan-mode decision enforcement to the `agent_end` maintenance path with a bounded retry counter and provider-neutral `toolChoice: "required"` reminders.
- Suppress advisor-triggered autonomous turns in plan mode while preserving visible advisor context.
- Keep idle or stranded IRC as visible plan-mode context instead of waking an autonomous turn.
- Add regression coverage for continuation enforcement, bounded retries, and idle IRC suppression.

## Verification
`bun test packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts` passed; `bun test packages/coding-agent/test/agent-session-advisor-suppression.test.ts` passed; `bun run check` in `packages/coding-agent` passed. Fixes #3910