### PR TITLE
fix(lsp): detect Ruff in Windows Python virtualenv Scripts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ruff LSP auto-detection for Windows Python virtualenvs by checking `.venv/Scripts`, `venv/Scripts`, and `.env/Scripts` before falling back to PATH. ([#3916](https://github.com/can1357/oh-my-pi/issues/3916))
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -209,7 +209,16 @@ export function hasRootMarkers(cwd: string, markers: string[]): boolean {
  * Local bin directories to check before $PATH, ordered by priority.
  * Each entry maps a root marker to the bin directory to check.
  */
-const PYTHON_ROOT_MARKERS = ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile", "ruff.toml", ".ruff.toml"];
+const PYTHON_ROOT_MARKERS = [
+	"pyproject.toml",
+	"requirements.txt",
+	"setup.py",
+	"setup.cfg",
+	"Pipfile",
+	"pyrightconfig.json",
+	"ruff.toml",
+	".ruff.toml",
+];
 
 const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 	// Node.js - check node_modules/.bin/

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -209,7 +209,7 @@ export function hasRootMarkers(cwd: string, markers: string[]): boolean {
  * Local bin directories to check before $PATH, ordered by priority.
  * Each entry maps a root marker to the bin directory to check.
  */
-const PYTHON_ROOT_MARKERS = ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"];
+const PYTHON_ROOT_MARKERS = ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile", "ruff.toml", ".ruff.toml"];
 
 const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 	// Node.js - check node_modules/.bin/

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -209,13 +209,18 @@ export function hasRootMarkers(cwd: string, markers: string[]): boolean {
  * Local bin directories to check before $PATH, ordered by priority.
  * Each entry maps a root marker to the bin directory to check.
  */
+const PYTHON_ROOT_MARKERS = ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"];
+
 const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 	// Node.js - check node_modules/.bin/
 	{ markers: ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"], binDir: "node_modules/.bin" },
 	// Python - check virtual environment bin directories
-	{ markers: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"], binDir: ".venv/bin" },
-	{ markers: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"], binDir: "venv/bin" },
-	{ markers: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"], binDir: ".env/bin" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: ".venv/bin" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: ".venv/Scripts" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: "venv/bin" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: "venv/Scripts" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: ".env/bin" },
+	{ markers: PYTHON_ROOT_MARKERS, binDir: ".env/Scripts" },
 	// Ruby - check vendor bundle and binstubs
 	{ markers: ["Gemfile", "Gemfile.lock"], binDir: "vendor/bundle/bin" },
 	{ markers: ["Gemfile", "Gemfile.lock"], binDir: "bin" },

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1129,6 +1129,39 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("detects pyright and pylsp in Windows virtualenv Scripts for Python-only roots", async () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true, writable: true });
+		const whichSpy = vi.spyOn(Bun, "which").mockReturnValue(null);
+
+		try {
+			const cases: Array<{ marker: string; server: string; binary: string }> = [
+				{ marker: "pyrightconfig.json", server: "pyright", binary: "pyright-langserver.exe" },
+				{ marker: "setup.cfg", server: "pylsp", binary: "pylsp.exe" },
+			];
+			for (const { marker, server, binary } of cases) {
+				const tempDir = TempDir.createSync("@omp-lsp-win32-py-marker-");
+				try {
+					await Bun.write(path.join(tempDir.path(), marker), "");
+					const scriptsDir = path.join(tempDir.path(), ".venv", "Scripts");
+					await fs.promises.mkdir(scriptsDir, { recursive: true });
+					const localBin = path.join(scriptsDir, binary);
+					await Bun.write(localBin, "");
+
+					const config = loadConfig(tempDir.path());
+					expect(config.servers[server]?.resolvedCommand).toBe(localBin);
+				} finally {
+					tempDir.removeSync();
+				}
+			}
+			expect(whichSpy).not.toHaveBeenCalledWith("pyright-langserver");
+			expect(whichSpy).not.toHaveBeenCalledWith("pylsp");
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true, writable: true });
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("detects tlaplus files for LSP startup and language ids", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tlaplus-");
 		const specPath = path.join(tempDir.path(), "Spec.tla");

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1077,6 +1077,30 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("detects Ruff in Windows virtualenv Scripts directories", async () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true, writable: true });
+
+		const tempDir = TempDir.createSync("@omp-lsp-win32-ruff-");
+		const whichSpy = vi.spyOn(Bun, "which").mockReturnValue(null);
+
+		try {
+			await Bun.write(path.join(tempDir.path(), "pyproject.toml"), '[project]\nname = "demo"\n');
+			const scriptsDir = path.join(tempDir.path(), ".venv", "Scripts");
+			await fs.promises.mkdir(scriptsDir, { recursive: true });
+			const localRuff = path.join(scriptsDir, "ruff.exe");
+			await Bun.write(localRuff, "");
+
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.ruff?.resolvedCommand).toBe(localRuff);
+			expect(whichSpy).not.toHaveBeenCalledWith("ruff");
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true, writable: true });
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("detects tlaplus files for LSP startup and language ids", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tlaplus-");
 		const specPath = path.join(tempDir.path(), "Spec.tla");

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1101,6 +1101,34 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("detects Ruff in Windows virtualenv Scripts directories for Ruff-only roots", async () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true, writable: true });
+		const whichSpy = vi.spyOn(Bun, "which").mockReturnValue(null);
+
+		try {
+			for (const marker of ["ruff.toml", ".ruff.toml"] as const) {
+				const tempDir = TempDir.createSync("@omp-lsp-win32-ruff-marker-");
+				try {
+					await Bun.write(path.join(tempDir.path(), marker), "");
+					const scriptsDir = path.join(tempDir.path(), ".venv", "Scripts");
+					await fs.promises.mkdir(scriptsDir, { recursive: true });
+					const localRuff = path.join(scriptsDir, "ruff.exe");
+					await Bun.write(localRuff, "");
+
+					const config = loadConfig(tempDir.path());
+					expect(config.servers.ruff?.resolvedCommand).toBe(localRuff);
+				} finally {
+					tempDir.removeSync();
+				}
+			}
+			expect(whichSpy).not.toHaveBeenCalledWith("ruff");
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true, writable: true });
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("detects tlaplus files for LSP startup and language ids", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tlaplus-");
 		const specPath = path.join(tempDir.path(), "Spec.tla");


### PR DESCRIPTION
## Repro
A Windows-mode LSP config regression test creates a Python project with `pyproject.toml` and `.venv/Scripts/ruff.exe`, mocks PATH lookup empty, then runs `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts --test-name-pattern "detects Ruff in Windows virtualenv Scripts directories"`; before the fix, `config.servers.ruff?.resolvedCommand` was `undefined`.

## Cause
`packages/coding-agent/src/lsp/config.ts` only searched Python project-local `.venv/bin`, `venv/bin`, and `.env/bin` directories in `LOCAL_BIN_PATHS`, so Windows virtualenv launchers under `Scripts` were never considered before `resolveCommand` fell back to PATH.

## Fix
- Added `.venv/Scripts`, `venv/Scripts`, and `.env/Scripts` to Python local LSP binary resolution.
- Added a regression test that simulates Windows and verifies local `.venv/Scripts/ruff.exe` is used without PATH fallback.
- Added a `packages/coding-agent` changelog entry for #3916.

## Verification
`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts --test-name-pattern "detects Ruff in Windows virtualenv Scripts directories"` passed; `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` passed; `bun run check` from `packages/coding-agent` passed. Fixes #3916