### PR TITLE
fix(coding-agent): restore subagent thinking precedence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagent frontmatter `thinkingLevel` being overridden by `modelRoles.task` model suffixes. ([#3915](https://github.com/can1357/oh-my-pi/issues/3915))
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2053,9 +2053,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					? formatModelSelectorValue(formatModelStringWithRouting(model), resolvedThinkingLevel)
 					: formatModelStringWithRouting(model);
 			}
-			const effectiveThinkingLevel = explicitThinkingLevel
-				? resolvedThinkingLevel
-				: (thinkingLevel ?? resolvedThinkingLevel);
+			const effectiveThinkingLevel = thinkingLevel ?? resolvedThinkingLevel;
 			resolvedAt = performance.now();
 
 			const effectiveCwd = worktree ?? cwd;

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -4,6 +4,9 @@
  * paid for. Regression guard for issue #2190.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -89,6 +92,15 @@ const baseOptions = {
 	enableLsp: false,
 };
 
+function createModelRegistry(model: Model): ModelRegistry {
+	return {
+		authStorage: {},
+		refresh: async () => {},
+		getAvailable: () => [model],
+		getApiKey: async () => "test-key",
+	} as unknown as ModelRegistry;
+}
+
 describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -151,5 +163,27 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.parentAgentId).toBe("SpawnerAgent");
 		expect(forwarded?.agentId).toBe("ChildAgent");
 		expect(forwarded?.parentTaskPrefix).toBe("ChildAgent");
+	});
+
+	it("lets agent frontmatter thinkingLevel override a task role suffix", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const settings = Settings.isolated();
+		settings.setModelRole("task", `${model.provider}/${model.id}:high`);
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, model: ["pi/task"] },
+			id: "subagent-thinking-precedence",
+			settings,
+			modelRegistry: createModelRegistry(model),
+			thinkingLevel: ThinkingLevel.Low,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const forwarded = spy.mock.calls[0]?.[0];
+		expect(forwarded?.thinkingLevel).toBe(ThinkingLevel.Low);
 	});
 });


### PR DESCRIPTION
## Repro
A focused executor test configures `modelRoles.task` to resolve `pi/task` to `anthropic/claude-sonnet-4-5:high`, then spawns an agent with frontmatter-equivalent `thinkingLevel: low`. Before the fix, `bun test packages/coding-agent/test/task/executor-pass-through.test.ts -t "lets agent frontmatter thinkingLevel override a task role suffix"` failed with `Expected: "low"` and `Received: "high"`.

## Cause
`packages/coding-agent/src/task/executor.ts` computed `effectiveThinkingLevel` from `resolvedThinkingLevel` whenever `resolveModelOverrideWithAuthFallback` marked the model role suffix as explicit, so `ExecutorOptions.thinkingLevel` from agent frontmatter was ignored for `pi/task` roles with `:level` suffixes.

## Fix
- Restored agent frontmatter precedence in `runSubprocess` by resolving `effectiveThinkingLevel` as `thinkingLevel ?? resolvedThinkingLevel`.
- Added an executor regression test covering `pi/task` plus a `modelRoles.task` suffix to verify `createAgentSession` receives the agent-declared level.
- Added a coding-agent changelog entry for the regression fix.

## Verification
`bun test packages/coding-agent/test/task/executor-pass-through.test.ts` passed with 4 tests. `bun run check` passed in `packages/coding-agent`. Fixes #3915