### PR TITLE
feat(coding-agent): add SSH-backed eval, bash, tool execution, and MCP servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added SSH-host execution for the bash tool and SSH-aware remote Python bridge defaults for `tool.bash`, `tool.ssh`, `tool.read`, `tool.write`, and explicit-path `tool.grep` calls.
 - Added a `copy` built-in tool for byte-exact regular-file copies between local paths, `local://`/`vault://` internal URIs, and `ssh://` remote hosts; remote Python eval `tool.copy` defaults to the SSH host/cwd.
 
+### Fixed
+
+- Fixed the eval status line briefly showing "running javascript" for Python cells during partial argument streaming, before the full `language` field parsed.
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added remote Python eval over configured SSH hosts, including persistent per-host kernels and host-side tool bridge support for `tool.*`, `completion`, and `agent` calls.
 - Added SSH-host execution for the bash tool and SSH-aware remote Python bridge defaults for `tool.bash`, `tool.ssh`, `tool.read`, `tool.write`, and explicit-path `tool.grep` calls.
+- Added a `copy` built-in tool for byte-exact regular-file copies between local paths, `local://`/`vault://` internal URIs, and `ssh://` remote hosts; remote Python eval `tool.copy` defaults to the SSH host/cwd.
 
 ## [16.2.9] - 2026-06-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added remote Python eval over configured SSH hosts, including persistent per-host kernels and host-side tool bridge support for `tool.*`, `completion`, and `agent` calls.
+- Added SSH-host execution for the bash tool and SSH-aware remote Python bridge defaults for `tool.bash`, `tool.ssh`, `tool.read`, `tool.write`, and explicit-path `tool.grep` calls.
 
 ## [16.2.9] - 2026-06-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added remote Python eval over configured SSH hosts, including persistent per-host kernels and host-side tool bridge support for `tool.*`, `completion`, and `agent` calls.
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added remote Python eval over configured SSH hosts, including persistent per-host kernels and host-side tool bridge support for `tool.*`, `completion`, and `agent` calls.
 - Added SSH-host execution for the bash tool and SSH-aware remote Python bridge defaults for `tool.bash`, `tool.ssh`, `tool.read`, `tool.write`, and explicit-path `tool.grep` calls.
 - Added a `copy` built-in tool for byte-exact regular-file copies between local paths, `local://`/`vault://` internal URIs, and `ssh://` remote hosts; remote Python eval `tool.copy` defaults to the SSH host/cwd.
+- Added MCP stdio server support over configured SSH hosts via a `host` field in MCP config.
 
 ### Fixed
 

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -25,6 +25,8 @@ export interface MCPServer {
 	env?: Record<string, string>;
 	/** Working directory for stdio transport */
 	cwd?: string;
+	/** Configured SSH host for stdio transport */
+	host?: string;
 	/** URL (for HTTP/SSE transport) */
 	url?: string;
 	/** HTTP headers (for HTTP transport) */

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -160,6 +160,11 @@
             "cwd": {
               "type": "string",
               "description": "Working directory used when spawning the stdio process."
+            },
+            "host": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Configured OMP SSH host used to run the stdio process remotely."
             }
           },
           "not": {

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -162,6 +162,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				args: serverConfig.args as string[] | undefined,
 				env: serverConfig.env as Record<string, string> | undefined,
 				cwd: serverConfig.cwd as string | undefined,
+				host: serverConfig.host as string | undefined,
 				url: serverConfig.url as string | undefined,
 				headers: serverConfig.headers as Record<string, string> | undefined,
 				auth: serverConfig.auth as

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -30,6 +30,7 @@ interface MCPConfigFile {
 			args?: string[];
 			env?: Record<string, string>;
 			cwd?: string;
+			host?: string;
 			url?: string;
 			headers?: Record<string, string>;
 			auth?: {
@@ -91,6 +92,7 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				args: serverConfig.args,
 				env: serverConfig.env,
 				cwd: serverConfig.cwd,
+				host: serverConfig.host,
 				url: serverConfig.url,
 				headers: serverConfig.headers,
 				auth: serverConfig.auth,
@@ -104,6 +106,7 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 			if (server.args) server.args = expandEnvVarsDeep(server.args);
 			if (server.env) server.env = expandEnvVarsDeep(server.env);
 			if (server.cwd) server.cwd = expandEnvVarsDeep(server.cwd);
+			if (server.host) server.host = expandEnvVarsDeep(server.host);
 			if (server.url) server.url = expandEnvVarsDeep(server.url);
 			if (server.headers) server.headers = expandEnvVarsDeep(server.headers);
 			if (server.auth) server.auth = expandEnvVarsDeep(server.auth);

--- a/packages/coding-agent/src/eval/__tests__/js-tool-bridge-remote.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/js-tool-bridge-remote.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { SSHConnectionTarget } from "../../ssh/connection-manager";
+import type { ToolSession } from "../../tools";
+import * as sshHostResolution from "../../tools/ssh-host-resolution";
+import { callSessionTool } from "../js/tool-bridge";
+
+class CapturingTool {
+	readonly calls: Array<{ id: string; args: unknown; signal?: AbortSignal }> = [];
+
+	constructor(readonly name: string) {}
+
+	async execute(id: string, args: unknown, signal?: AbortSignal): Promise<AgentToolResult> {
+		this.calls.push({ id, args, signal });
+		return { content: [{ type: "text", text: `${this.name}:ok` }] };
+	}
+}
+
+const DEFAULT_HOST: SSHConnectionTarget = {
+	name: "alpha",
+	host: "alpha.example",
+	username: "pi",
+};
+
+const EXPLICIT_HOST: SSHConnectionTarget = {
+	name: "beta",
+	host: "beta.example",
+};
+
+function makeSession(tools: CapturingTool[]): ToolSession {
+	const byName = new Map(tools.map(tool => [tool.name, tool]));
+	return {
+		cwd: "/local/workspace",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		settings: { get: () => undefined },
+		getToolByName: (name: string) => byName.get(name) as unknown as AgentTool | undefined,
+	} as unknown as ToolSession;
+}
+
+function callArgs(tool: CapturingTool, index: number): Record<string, unknown> {
+	const args = tool.calls[index]?.args;
+	if (!args || typeof args !== "object" || Array.isArray(args)) {
+		throw new Error(`Expected ${tool.name} call ${index} to receive object arguments`);
+	}
+	return args as Record<string, unknown>;
+}
+
+function oneCallArgs(tool: CapturingTool): Record<string, unknown> {
+	expect(tool.calls).toHaveLength(1);
+	return callArgs(tool, 0);
+}
+
+describe("callSessionTool remote invocation context", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("defaults bash bridge calls to the current SSH host and remote cwd", async () => {
+		const bash = new CapturingTool("bash");
+		const executeSpy = vi.spyOn(bash, "execute");
+		const session = makeSession([bash]);
+		const abort = new AbortController();
+
+		const value = await callSessionTool(
+			"bash",
+			{ command: "pwd" },
+			{
+				session,
+				signal: abort.signal,
+				invocationContext: { defaultSshHost: DEFAULT_HOST, remoteCwd: "/srv/app" },
+			},
+		);
+
+		expect(value).toBe("bash:ok");
+		expect(executeSpy).toHaveBeenCalledTimes(1);
+		expect(bash.calls[0]?.id).toMatch(/^js-bash-/);
+		expect(bash.calls[0]?.signal).toBe(abort.signal);
+		expect(oneCallArgs(bash)).toMatchObject({
+			command: "pwd",
+			host: "alpha",
+			cwd: "/srv/app",
+		});
+	});
+
+	it("defaults and trims ssh bridge host arguments while preserving the remote cwd", async () => {
+		const ssh = new CapturingTool("ssh");
+		const executeSpy = vi.spyOn(ssh, "execute");
+		const session = makeSession([ssh]);
+		const options = {
+			session,
+			invocationContext: { defaultSshHost: DEFAULT_HOST, remoteCwd: "/srv/app" },
+		};
+		const resolveSpy = vi.spyOn(sshHostResolution, "resolveSshHostByName").mockResolvedValue(EXPLICIT_HOST);
+
+		await callSessionTool("ssh", { command: "pwd" }, options);
+		await callSessionTool("ssh", { host: " beta ", command: "hostname" }, options);
+
+		expect(executeSpy).toHaveBeenCalledTimes(2);
+		expect(resolveSpy).toHaveBeenCalledTimes(1);
+		expect(resolveSpy.mock.calls[0]?.[0]).toBe(session);
+		expect(resolveSpy.mock.calls[0]?.[1]).toBe("beta");
+		expect(callArgs(ssh, 0)).toMatchObject({
+			command: "pwd",
+			host: "alpha",
+			cwd: "/srv/app",
+		});
+		expect(callArgs(ssh, 1)).toMatchObject({
+			command: "hostname",
+			host: "beta",
+			cwd: "/srv/app",
+		});
+	});
+
+	it("rewrites remote file-tool paths to ssh URLs before invoking the real tool boundary", async () => {
+		const read = new CapturingTool("read");
+		const write = new CapturingTool("write");
+		const grep = new CapturingTool("grep");
+		const session = makeSession([read, write, grep]);
+		const options = {
+			session,
+			invocationContext: { defaultSshHost: DEFAULT_HOST, remoteCwd: "/srv/app" },
+		};
+
+		await callSessionTool("read", { path: "src/main.py:10-20" }, options);
+		await callSessionTool("write", { path: "logs/out file.txt", content: "ok" }, options);
+		await callSessionTool(
+			"grep",
+			{
+				pattern: "TODO",
+				paths: ["src", "/var/log/app.log:raw", "local://note.txt", "https://example.com/a"],
+			},
+			options,
+		);
+
+		const readArgs = oneCallArgs(read);
+		expect(readArgs.path).toBe("ssh://alpha/srv/app/src/main.py:10-20");
+		expect("host" in readArgs).toBe(false);
+		expect("cwd" in readArgs).toBe(false);
+
+		const writeArgs = oneCallArgs(write);
+		expect(writeArgs.path).toBe("ssh://alpha/srv/app/logs/out%20file.txt");
+		expect(writeArgs.content).toBe("ok");
+		expect("host" in writeArgs).toBe(false);
+		expect("cwd" in writeArgs).toBe(false);
+
+		const grepArgs = oneCallArgs(grep);
+		expect(grepArgs.paths).toEqual([
+			"ssh://alpha/srv/app/src",
+			"ssh://alpha/var/log/app.log:raw",
+			"local://note.txt",
+			"https://example.com/a",
+		]);
+		expect("host" in grepArgs).toBe(false);
+		expect("cwd" in grepArgs).toBe(false);
+	});
+
+	it("resolves an explicit SSH host and explicit remote cwd instead of using the default context", async () => {
+		const read = new CapturingTool("read");
+		const session = makeSession([read]);
+		const resolveSpy = vi.spyOn(sshHostResolution, "resolveSshHostByName").mockResolvedValue(EXPLICIT_HOST);
+
+		await callSessionTool(
+			"read",
+			{ host: " beta ", cwd: "/opt/app", path: "data/config.json" },
+			{
+				session,
+				invocationContext: { defaultSshHost: DEFAULT_HOST, remoteCwd: "/srv/app" },
+			},
+		);
+
+		expect(resolveSpy).toHaveBeenCalledTimes(1);
+		expect(resolveSpy.mock.calls[0]?.[0]).toBe(session);
+		expect(resolveSpy.mock.calls[0]?.[1]).toBe("beta");
+		const readArgs = oneCallArgs(read);
+		expect(readArgs.path).toBe("ssh://beta/opt/app/data/config.json");
+		expect("host" in readArgs).toBe(false);
+		expect("cwd" in readArgs).toBe(false);
+	});
+
+	it("rejects unsupported workspace tools instead of running them locally under a remote default", async () => {
+		const glob = new CapturingTool("glob");
+		const executeSpy = vi.spyOn(glob, "execute");
+		const session = makeSession([glob]);
+
+		await expect(
+			callSessionTool(
+				"glob",
+				{ pattern: "**/*" },
+				{
+					session,
+					invocationContext: { defaultSshHost: DEFAULT_HOST, remoteCwd: "/srv/app" },
+				},
+			),
+		).rejects.toThrow(/does not support default SSH execution/);
+		expect(executeSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/src/eval/__tests__/remote-python-executor.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/remote-python-executor.test.ts
@@ -4,12 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { $which } from "@oh-my-pi/pi-utils";
 import type { SSHHost } from "../../capability/ssh";
+import * as remotePosix from "../../ssh/remote-posix";
 import type { ToolSession } from "../../tools";
 import type { KernelExecuteOptions, KernelExecuteResult } from "../kernel-base";
 import pythonBackend from "../py";
 import { disposeAllKernelSessions, executePython, type PythonExecutorOptions } from "../py/executor";
 import { buildRemotePythonInitScript, RemotePythonKernel } from "../py/remote-kernel";
-import { disposePyToolBridge } from "../py/tool-bridge";
+import * as pyToolBridge from "../py/tool-bridge";
 
 interface RemotePythonExecutorOptions extends PythonExecutorOptions {
 	sshHost: SSHHost;
@@ -129,7 +130,7 @@ describe("remote Python init script", () => {
 describe("executePython remote session reuse", () => {
 	afterEach(async () => {
 		await disposeAllKernelSessions();
-		await disposePyToolBridge();
+		await pyToolBridge.disposePyToolBridge();
 		vi.restoreAllMocks();
 	});
 
@@ -174,6 +175,45 @@ describe("executePython remote session reuse", () => {
 
 		expect(starts).toHaveLength(1);
 		expect(starts[0]?.interpreter).toBeUndefined();
+	});
+
+	it("normalizes a relative remote cwd before kernel start and Python bridge registration", async () => {
+		const { starts } = spyRemoteStarts();
+		const host = sshHost("cwdbox");
+		const resolveSpy = vi.spyOn(remotePosix, "resolveRemoteCwd").mockResolvedValue("/home/pi/project/pkg");
+		vi.spyOn(pyToolBridge, "ensurePyToolBridge").mockResolvedValue({
+			url: "http://127.0.0.1:48123",
+			token: "test-token",
+		});
+		const registrations: Array<Parameters<typeof pyToolBridge.registerPyToolBridge>[2]> = [];
+		const unregisters: string[] = [];
+		vi.spyOn(pyToolBridge, "registerPyToolBridge").mockImplementation((_sessionId, runId, entry) => {
+			registrations.push(entry);
+			return () => {
+				unregisters.push(runId);
+			};
+		});
+
+		await executePython(
+			"value = 1",
+			remoteOptions({
+				cwd: "pkg",
+				sessionId: "remote-relative-cwd-test",
+				interpreter: "/opt/py/bin/python",
+				sshHost: host,
+				toolSession: makeToolSession("/local/project"),
+			}),
+		);
+
+		expect(resolveSpy).toHaveBeenCalledTimes(1);
+		expect(resolveSpy.mock.calls[0]?.[0]).toBe(host);
+		expect(resolveSpy.mock.calls[0]?.[1]).toBe("pkg");
+		expect(starts).toHaveLength(1);
+		expect(starts[0]?.cwd).toBe("/home/pi/project/pkg");
+		expect(registrations).toHaveLength(1);
+		expect(registrations[0]?.invocationContext?.defaultSshHost).toBe(host);
+		expect(registrations[0]?.invocationContext?.remoteCwd).toBe("/home/pi/project/pkg");
+		expect(unregisters).toHaveLength(1);
 	});
 
 	it("keeps the remote loopback bridge URL stable across reused same-host session cells", async () => {

--- a/packages/coding-agent/src/eval/__tests__/remote-python-executor.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/remote-python-executor.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $which } from "@oh-my-pi/pi-utils";
+import type { SSHHost } from "../../capability/ssh";
+import type { ToolSession } from "../../tools";
+import type { KernelExecuteOptions, KernelExecuteResult } from "../kernel-base";
+import pythonBackend from "../py";
+import { disposeAllKernelSessions, executePython, type PythonExecutorOptions } from "../py/executor";
+import { buildRemotePythonInitScript, RemotePythonKernel } from "../py/remote-kernel";
+import { disposePyToolBridge } from "../py/tool-bridge";
+
+interface RemotePythonExecutorOptions extends PythonExecutorOptions {
+	sshHost: SSHHost;
+}
+
+interface RemoteKernelStartSnapshot {
+	sshHost?: SSHHost;
+	cwd?: string;
+	interpreter?: string;
+}
+
+class FakeRemoteKernel {
+	readonly executedCode: string[] = [];
+	readonly bridgeUrls: string[] = [];
+	#alive = true;
+
+	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
+		this.executedCode.push(code);
+		const bridgeUrl = options?.env?.PI_TOOL_BRIDGE_URL;
+		if (typeof bridgeUrl === "string") {
+			this.bridgeUrls.push(bridgeUrl);
+		}
+		return {
+			status: "ok",
+			cancelled: false,
+			timedOut: false,
+			stdinRequested: false,
+		};
+	}
+
+	isAlive(): boolean {
+		return this.#alive;
+	}
+
+	async shutdown(): Promise<{ confirmed: boolean }> {
+		this.#alive = false;
+		return { confirmed: true };
+	}
+}
+
+function sshHost(name: string): SSHHost {
+	return {
+		name,
+		host: `${name}.example`,
+		_source: {
+			provider: "test",
+			providerName: "Test",
+			path: "/tmp/ssh.json",
+			level: "project",
+		},
+	};
+}
+
+function makeToolSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		settings: { get: () => undefined },
+	} as unknown as ToolSession;
+}
+
+function remoteOptions(overrides: Omit<RemotePythonExecutorOptions, "kernelMode">): RemotePythonExecutorOptions {
+	return {
+		kernelMode: "session",
+		...overrides,
+	};
+}
+
+function spyRemoteStarts(): { kernels: FakeRemoteKernel[]; starts: RemoteKernelStartSnapshot[] } {
+	const kernels: FakeRemoteKernel[] = [];
+	const starts: RemoteKernelStartSnapshot[] = [];
+	vi.spyOn(RemotePythonKernel, "start").mockImplementation(async options => {
+		starts.push(options as unknown as RemoteKernelStartSnapshot);
+		const kernel = new FakeRemoteKernel();
+		kernels.push(kernel);
+		return kernel as unknown as RemotePythonKernel;
+	});
+	return { kernels, starts };
+}
+
+describe("remote Python init script", () => {
+	it("adds the resolved remote cwd to sys.path after a relative chdir", async () => {
+		const python = $which("python3") ?? $which("python");
+		if (!python) return;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-remote-python-cwd-"));
+		const cwd = path.join(root, "src");
+		await fs.mkdir(cwd);
+		await Bun.write(path.join(cwd, "remote_probe.py"), "VALUE = 'from-remote-cwd'\n");
+		try {
+			const script = `${buildRemotePythonInitScript("src")}\nimport json, remote_probe\nprint(json.dumps({"cwd": os.getcwd(), "path0": sys.path[0], "value": remote_probe.VALUE}))`;
+			const proc = Bun.spawn([python, "-c", script], {
+				cwd: root,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const stdout = await new Response(proc.stdout).text();
+			const stderr = await new Response(proc.stderr).text();
+			const exitCode = await proc.exited;
+
+			expect(exitCode, stderr).toBe(0);
+			const payload = JSON.parse(stdout.trim().split("\n").at(-1) ?? "{}") as {
+				cwd?: string;
+				path0?: string;
+				value?: string;
+			};
+			expect(payload.cwd).toBe(cwd);
+			expect(payload.path0).toBe(cwd);
+			expect(payload.value).toBe("from-remote-cwd");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("executePython remote session reuse", () => {
+	afterEach(async () => {
+		await disposeAllKernelSessions();
+		await disposePyToolBridge();
+		vi.restoreAllMocks();
+	});
+
+	it("keys persistent Python kernels by SSH host as well as session, cwd, and interpreter", async () => {
+		const { kernels, starts } = spyRemoteStarts();
+		const common = {
+			cwd: "/srv/app",
+			sessionId: "remote-key-test",
+			interpreter: "/opt/py/bin/python",
+		};
+
+		await executePython("alpha_one = 1", remoteOptions({ ...common, sshHost: sshHost("alpha") }));
+		await executePython("beta_one = 1", remoteOptions({ ...common, sshHost: sshHost("beta") }));
+		await executePython("alpha_two = 2", remoteOptions({ ...common, sshHost: sshHost("alpha") }));
+
+		expect(kernels).toHaveLength(2);
+		expect(starts.map(start => start.sshHost?.name)).toEqual(["alpha", "beta"]);
+		expect(kernels[0]?.executedCode).toEqual(["alpha_one = 1", "alpha_two = 2"]);
+		expect(kernels[1]?.executedCode).toEqual(["beta_one = 1"]);
+	});
+
+	it("does not apply the local python.interpreter setting to SSH-backed backend execution", async () => {
+		const { starts } = spyRemoteStarts();
+		const session = {
+			...makeToolSession("/local/project"),
+			settings: {
+				get: (key: string) => (key === "python.interpreter" ? "/local/project/.venv/bin/python" : undefined),
+			},
+		} as ToolSession;
+
+		await pythonBackend.execute("remote_value = 1", {
+			cwd: "/srv/app",
+			sshHost: sshHost("interpreterbox"),
+			sessionId: "remote-interpreter-setting-test",
+			sessionFile: undefined,
+			kernelOwnerId: undefined,
+			session,
+			idleTimeoutMs: 1000,
+			reset: false,
+			onChunk: () => {},
+		});
+
+		expect(starts).toHaveLength(1);
+		expect(starts[0]?.interpreter).toBeUndefined();
+	});
+
+	it("keeps the remote loopback bridge URL stable across reused same-host session cells", async () => {
+		const { kernels } = spyRemoteStarts();
+		const host = sshHost("bridgebox");
+		const common = {
+			cwd: "/srv/app",
+			sessionId: "remote-bridge-test",
+			interpreter: "/opt/py/bin/python",
+			sshHost: host,
+			toolSession: makeToolSession("/local/project"),
+		};
+
+		await executePython("first = tool", remoteOptions(common));
+		await executePython("second = tool", remoteOptions(common));
+
+		expect(kernels).toHaveLength(1);
+		expect(kernels[0]?.bridgeUrls).toHaveLength(2);
+		const [firstUrl, secondUrl] = kernels[0]?.bridgeUrls ?? [];
+		expect(firstUrl).toBeDefined();
+		expect(firstUrl).toBe(secondUrl);
+		expect(firstUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+	});
+});

--- a/packages/coding-agent/src/eval/backend.ts
+++ b/packages/coding-agent/src/eval/backend.ts
@@ -1,10 +1,12 @@
 import { buildEvalUrlRoots, type LocalProtocolOptions } from "../internal-urls";
+import type { SSHConnectionTarget } from "../ssh/connection-manager";
 import type { ToolSession } from "../tools";
 import type { EvalDisplayOutput, EvalLanguage, EvalStatusEvent } from "./types";
 
 /** Per-cell execute() options. */
 export interface ExecutorBackendExecOptions {
 	cwd: string;
+	sshHost?: SSHConnectionTarget;
 	sessionId: string;
 	sessionFile: string | undefined;
 	kernelOwnerId: string | undefined;

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -5,6 +5,7 @@ import type { ToolSession } from "../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { isEvalTimeoutControlEvent } from "./bridge-timeout";
 import type { JsStatusEvent } from "./js/shared/types";
+import type { ToolBridgeInvocationContext } from "./js/tool-bridge";
 import type { KernelDisplayOutput } from "./py/display";
 import { registerPyToolBridge } from "./py/tool-bridge";
 
@@ -32,6 +33,7 @@ export interface KernelExecutorBaseOptions {
 	onStatus?: (event: JsStatusEvent) => void;
 	emitStatus?: (event: JsStatusEvent) => void;
 	toolSession?: ToolSession;
+	toolBridgeInvocationContext?: ToolBridgeInvocationContext;
 	bridgeSessionId?: string;
 	artifactId?: string;
 	artifactPath?: string;
@@ -322,6 +324,7 @@ export async function executeWithKernelBase<
 					toolSession: options.toolSession,
 					signal: options.signal,
 					emitStatus,
+					invocationContext: options.toolBridgeInvocationContext,
 				})
 			: null;
 

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -66,7 +66,7 @@ function normalizeArgs(args: unknown): unknown {
 }
 
 const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
-const REMOTE_FILE_BRIDGE_TOOLS = new Set(["read", "write", "grep"]);
+const REMOTE_FILE_BRIDGE_TOOLS = new Set(["read", "write", "grep", "copy"]);
 const REMOTE_CONTEXT_UNSUPPORTED_TOOLS = new Set(["glob", "ast_grep", "ast_edit", "edit", "lsp", "debug"]);
 const REMOTE_BRIDGE_DEFAULT_TOOLS = new Set(["bash", "ssh", ...REMOTE_FILE_BRIDGE_TOOLS]);
 
@@ -105,15 +105,23 @@ function rewriteRemotePath(value: string, host: SSHConnectionTarget, remoteCwd: 
 	if (shouldKeepPathLocal(value)) return value;
 	const split = splitPathAndSel(value);
 	const rawPath = split.path || ".";
-	if (!path.posix.isAbsolute(rawPath) && !remoteCwd) {
-		throw new ToolError(`Remote tool path "${value}" is relative, but no remote cwd is available`);
+	let absolutePath: string;
+	if (path.posix.isAbsolute(rawPath)) {
+		absolutePath = path.posix.normalize(rawPath);
+	} else {
+		if (!remoteCwd || !path.posix.isAbsolute(remoteCwd)) {
+			throw new ToolError(`Remote tool path "${value}" is relative, but no absolute remote cwd is available`);
+		}
+		absolutePath = path.posix.resolve(remoteCwd, rawPath);
 	}
-	const base = remoteCwd && path.posix.isAbsolute(remoteCwd) ? remoteCwd : "/";
-	const absolutePath = path.posix.isAbsolute(rawPath)
-		? path.posix.normalize(rawPath)
-		: path.posix.resolve(base, rawPath);
 	const rewritten = sshUrlForPath(host, absolutePath);
 	return split.sel ? `${rewritten}:${split.sel}` : rewritten;
+}
+
+function resolveRemoteCwd(rawCwd: unknown, defaultCwd: string | undefined): string | undefined {
+	if (typeof rawCwd !== "string") return defaultCwd;
+	if (path.posix.isAbsolute(rawCwd)) return path.posix.normalize(rawCwd);
+	return defaultCwd && path.posix.isAbsolute(defaultCwd) ? path.posix.resolve(defaultCwd, rawCwd) : rawCwd;
 }
 
 function rewritePathField(
@@ -140,6 +148,18 @@ function rewritePathsField(
 			typeof entry === "string" ? rewriteRemotePath(entry, host, remoteCwd) : entry,
 		);
 	}
+}
+
+function rewriteCopyFields(
+	record: Record<string, unknown>,
+	host: SSHConnectionTarget,
+	remoteCwd: string | undefined,
+): void {
+	if (typeof record.source !== "string" || typeof record.destination !== "string") {
+		throw new ToolError("copy requires source and destination strings for SSH remote execution");
+	}
+	record.source = rewriteRemotePath(record.source, host, remoteCwd);
+	record.destination = rewriteRemotePath(record.destination, host, remoteCwd);
 }
 
 async function resolveBridgeHost(
@@ -171,7 +191,7 @@ async function applyBridgeInvocationContext(name: string, args: unknown, options
 	const host = await resolveBridgeHost(name, record, options);
 	if (!record || !host) return args;
 	const next = { ...record };
-	const remoteCwd = typeof next.cwd === "string" ? next.cwd : options.invocationContext?.remoteCwd;
+	const remoteCwd = resolveRemoteCwd(next.cwd, options.invocationContext?.remoteCwd);
 	if (name === "bash" || name === "ssh") {
 		next.host = host.name;
 		if (next.cwd === undefined && remoteCwd) next.cwd = remoteCwd;
@@ -182,6 +202,12 @@ async function applyBridgeInvocationContext(name: string, args: unknown, options
 			throw new ToolError(`${name} requires a path string for SSH remote execution`);
 		}
 		rewritePathField(next, host, remoteCwd);
+		delete next.host;
+		delete next.cwd;
+		return next;
+	}
+	if (name === "copy") {
+		rewriteCopyFields(next, host, remoteCwd);
 		delete next.host;
 		delete next.cwd;
 		return next;

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -1,6 +1,10 @@
+import * as path from "node:path";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import type { SSHConnectionTarget } from "../../ssh/connection-manager";
 import type { ToolSession } from "../../tools";
+import { splitPathAndSel } from "../../tools/path-utils";
+import { resolveSshHostByName } from "../../tools/ssh-host-resolution";
 import { ToolError } from "../../tools/tool-errors";
 import { EVAL_AGENT_BRIDGE_NAME, runEvalAgent } from "../agent-bridge";
 import { EVAL_BUDGET_BRIDGE_NAME, type EvalBudgetResult, runEvalBudget } from "../budget-bridge";
@@ -10,10 +14,16 @@ import type { JsStatusEvent } from "./shared/types";
 
 export type { JsStatusEvent } from "./shared/types";
 
+export interface ToolBridgeInvocationContext {
+	defaultSshHost?: SSHConnectionTarget;
+	remoteCwd?: string;
+}
+
 interface ToolBridgeOptions {
 	session: ToolSession;
 	signal?: AbortSignal;
 	emitStatus?: (event: JsStatusEvent) => void;
+	invocationContext?: ToolBridgeInvocationContext;
 }
 
 type ToolValue =
@@ -53,6 +63,145 @@ function normalizeArgs(args: unknown): unknown {
 		record[INTENT_FIELD] = "js prelude";
 	}
 	return record;
+}
+
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const REMOTE_FILE_BRIDGE_TOOLS = new Set(["read", "write", "grep"]);
+const REMOTE_CONTEXT_UNSUPPORTED_TOOLS = new Set(["glob", "ast_grep", "ast_edit", "edit", "lsp", "debug"]);
+const REMOTE_BRIDGE_DEFAULT_TOOLS = new Set(["bash", "ssh", ...REMOTE_FILE_BRIDGE_TOOLS]);
+
+function recordArgs(args: unknown): Record<string, unknown> | null {
+	if (!args || typeof args !== "object" || Array.isArray(args)) return null;
+	return args as Record<string, unknown>;
+}
+
+function explicitBridgeHostName(args: Record<string, unknown> | null): string | undefined {
+	if (!args || args.host === undefined) return undefined;
+	if (typeof args.host !== "string" || args.host.trim().length === 0) {
+		throw new ToolError("SSH host must be a non-empty string");
+	}
+	return args.host.trim();
+}
+
+function encodedSshPath(remotePath: string): string {
+	const normalized = path.posix.normalize(remotePath);
+	const absolute = normalized.startsWith("/") ? normalized : `/${normalized}`;
+	return absolute
+		.split("/")
+		.map((segment, index) => (index === 0 ? "" : encodeURIComponent(segment)))
+		.join("/");
+}
+
+function sshUrlForPath(host: SSHConnectionTarget, remotePath: string): string {
+	return `ssh://${encodeURIComponent(host.name)}${encodedSshPath(remotePath)}`;
+}
+
+function shouldKeepPathLocal(value: string): boolean {
+	const trimmed = value.trim();
+	return URL_SCHEME_RE.test(trimmed) || trimmed.startsWith("local:/");
+}
+
+function rewriteRemotePath(value: string, host: SSHConnectionTarget, remoteCwd: string | undefined): string {
+	if (shouldKeepPathLocal(value)) return value;
+	const split = splitPathAndSel(value);
+	const rawPath = split.path || ".";
+	if (!path.posix.isAbsolute(rawPath) && !remoteCwd) {
+		throw new ToolError(`Remote tool path "${value}" is relative, but no remote cwd is available`);
+	}
+	const base = remoteCwd && path.posix.isAbsolute(remoteCwd) ? remoteCwd : "/";
+	const absolutePath = path.posix.isAbsolute(rawPath)
+		? path.posix.normalize(rawPath)
+		: path.posix.resolve(base, rawPath);
+	const rewritten = sshUrlForPath(host, absolutePath);
+	return split.sel ? `${rewritten}:${split.sel}` : rewritten;
+}
+
+function rewritePathField(
+	record: Record<string, unknown>,
+	host: SSHConnectionTarget,
+	remoteCwd: string | undefined,
+): void {
+	if (typeof record.path === "string") {
+		record.path = rewriteRemotePath(record.path, host, remoteCwd);
+	}
+}
+
+function rewritePathsField(
+	record: Record<string, unknown>,
+	host: SSHConnectionTarget,
+	remoteCwd: string | undefined,
+): void {
+	if (typeof record.paths === "string") {
+		record.paths = rewriteRemotePath(record.paths, host, remoteCwd);
+		return;
+	}
+	if (Array.isArray(record.paths)) {
+		record.paths = record.paths.map(entry =>
+			typeof entry === "string" ? rewriteRemotePath(entry, host, remoteCwd) : entry,
+		);
+	}
+}
+
+async function resolveBridgeHost(
+	name: string,
+	args: Record<string, unknown> | null,
+	options: ToolBridgeOptions,
+): Promise<SSHConnectionTarget | undefined> {
+	const explicitHost = explicitBridgeHostName(args);
+	if (explicitHost && REMOTE_BRIDGE_DEFAULT_TOOLS.has(name)) {
+		return await resolveSshHostByName(options.session, explicitHost);
+	}
+	if (!explicitHost && REMOTE_BRIDGE_DEFAULT_TOOLS.has(name)) {
+		return options.invocationContext?.defaultSshHost;
+	}
+	return undefined;
+}
+
+async function applyBridgeInvocationContext(name: string, args: unknown, options: ToolBridgeOptions): Promise<unknown> {
+	const record = recordArgs(args);
+	const explicitHost = explicitBridgeHostName(record);
+	if (explicitHost && REMOTE_CONTEXT_UNSUPPORTED_TOOLS.has(name)) {
+		throw new ToolError(`${name} does not support SSH host execution from eval cells yet.`);
+	}
+	if (options.invocationContext?.defaultSshHost !== undefined && REMOTE_CONTEXT_UNSUPPORTED_TOOLS.has(name)) {
+		throw new ToolError(
+			`${name} does not support default SSH execution from a remote eval cell yet; call an explicit SSH-capable tool/path instead.`,
+		);
+	}
+	const host = await resolveBridgeHost(name, record, options);
+	if (!record || !host) return args;
+	const next = { ...record };
+	const remoteCwd = typeof next.cwd === "string" ? next.cwd : options.invocationContext?.remoteCwd;
+	if (name === "bash" || name === "ssh") {
+		next.host = host.name;
+		if (next.cwd === undefined && remoteCwd) next.cwd = remoteCwd;
+		return next;
+	}
+	if (name === "read" || name === "write") {
+		if (typeof next.path !== "string") {
+			throw new ToolError(`${name} requires a path string for SSH remote execution`);
+		}
+		rewritePathField(next, host, remoteCwd);
+		delete next.host;
+		delete next.cwd;
+		return next;
+	}
+	if (name === "grep") {
+		const paths = next.paths;
+		const validPaths =
+			typeof paths === "string" ||
+			(Array.isArray(paths) && paths.length > 0 && paths.every(entry => typeof entry === "string"));
+		if (!validPaths) {
+			throw new ToolError(
+				"grep requires explicit string paths for SSH remote execution; remote directory recursion is not supported by grep yet",
+			);
+		}
+		rewritePathsField(next, host, remoteCwd);
+		delete next.host;
+		delete next.cwd;
+		return next;
+	}
+	return args;
 }
 
 function summarizeToolResult(
@@ -121,7 +270,7 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 		return runEvalConcurrency(args, options);
 	}
 	const tool = getTool(options.session, name);
-	const normalizedArgs = normalizeArgs(args);
+	const normalizedArgs = await applyBridgeInvocationContext(name, normalizeArgs(args), options);
 	const toolCallId = `js-${name}-${crypto.randomUUID()}`;
 	try {
 		const result = await tool.execute(toolCallId, normalizedArgs, options.signal);

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -98,13 +98,18 @@ function sshUrlForPath(host: SSHConnectionTarget, remotePath: string): string {
 
 function shouldKeepPathLocal(value: string): boolean {
 	const trimmed = value.trim();
+	if (trimmed.startsWith("file://")) return false;
 	return URL_SCHEME_RE.test(trimmed) || trimmed.startsWith("local:/");
 }
 
 function rewriteRemotePath(value: string, host: SSHConnectionTarget, remoteCwd: string | undefined): string {
 	if (shouldKeepPathLocal(value)) return value;
 	const split = splitPathAndSel(value);
-	const rawPath = split.path || ".";
+	let rawPath = split.path || ".";
+	// Strip a file:// prefix so file URIs are rewritten to ssh:// URLs
+	// instead of bypassing remote path rewriting.
+	const fileMatch = rawPath.match(/^file:\/\/(.+)$/);
+	if (fileMatch) rawPath = fileMatch[1]!;
 	let absolutePath: string;
 	if (path.posix.isAbsolute(rawPath)) {
 		absolutePath = path.posix.normalize(rawPath);
@@ -194,7 +199,7 @@ async function applyBridgeInvocationContext(name: string, args: unknown, options
 	const remoteCwd = resolveRemoteCwd(next.cwd, options.invocationContext?.remoteCwd);
 	if (name === "bash" || name === "ssh") {
 		next.host = host.name;
-		if (next.cwd === undefined && remoteCwd) next.cwd = remoteCwd;
+		if (remoteCwd) next.cwd = remoteCwd;
 		return next;
 	}
 	if (name === "read" || name === "write") {

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import type { SSHConnectionTarget } from "../../ssh/connection-manager";
+import { resolveRemoteCwd } from "../../ssh/remote-posix";
 import type { ToolSession } from "../../tools";
 import {
 	attachSessionOwner,
@@ -17,6 +18,7 @@ import {
 	waitForPromiseWithCancellation,
 } from "../executor-base";
 import type { JsStatusEvent } from "../js/shared/types";
+import type { ToolBridgeInvocationContext } from "../js/tool-bridge";
 import {
 	checkPythonKernelAvailability,
 	type KernelDisplayOutput,
@@ -94,6 +96,8 @@ export interface PythonExecutorOptions {
 	 * not injected and any `tool.foo(...)` raises in Python.
 	 */
 	toolSession?: ToolSession;
+	/** Remote tool-call defaults applied to bridge calls made by this kernel execution. */
+	toolBridgeInvocationContext?: ToolBridgeInvocationContext;
 	/** Callback for status events emitted by tool bridge invocations. */
 	emitStatus?: (event: JsStatusEvent) => void;
 	/**
@@ -228,8 +232,16 @@ function buildSessionKey(
 	return buildPythonSessionKey(sessionId, cwd, interpreter, sshHost);
 }
 
-function normalizeExecutionCwd(options: PythonExecutorOptions | undefined): string {
-	if (options?.sshHost) return options.cwd ?? ".";
+async function normalizeExecutionCwd(options: PythonExecutorOptions | undefined, deadlineMs?: number): Promise<string> {
+	if (options?.sshHost) {
+		const requestedCwd = options.cwd ?? ".";
+		if (path.posix.isAbsolute(requestedCwd)) return requestedCwd;
+		const remainingMs = getRemainingTimeoutMs(deadlineMs);
+		return await resolveRemoteCwd(options.sshHost, requestedCwd, {
+			signal: options.signal,
+			timeoutMs: remainingMs !== undefined ? Math.max(1, remainingMs) : undefined,
+		});
+	}
 	return normalizeSessionCwd(options?.cwd ?? getProjectDir());
 }
 
@@ -600,16 +612,22 @@ export async function executePythonWithKernel(
 }
 
 export async function executePython(code: string, options?: PythonExecutorOptions): Promise<PythonResult> {
-	const cwd = normalizeExecutionCwd(options);
 	const deadlineMs = getExecutionDeadlineMs(options);
 	const executionOptions: PythonExecutorOptions = {
 		...(options ?? {}),
-		cwd,
 		deadlineMs,
 	};
 
 	try {
 		requireRemainingTimeoutMs(deadlineMs);
+		const cwd = await normalizeExecutionCwd(executionOptions, deadlineMs);
+		executionOptions.cwd = cwd;
+		if (executionOptions.sshHost) {
+			executionOptions.toolBridgeInvocationContext = {
+				defaultSshHost: executionOptions.sshHost,
+				remoteCwd: cwd,
+			};
+		}
 		if (executionOptions.signal?.aborted) {
 			throw new PythonExecutionCancelledError(
 				isTimedOutCancellation(

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import type { SSHConnectionTarget } from "../../ssh/connection-manager";
 import type { ToolSession } from "../../tools";
 import {
 	attachSessionOwner,
@@ -21,8 +22,16 @@ import {
 	type KernelDisplayOutput,
 	type KernelExecuteOptions,
 	type KernelExecuteResult,
+	type KernelShutdownOptions,
+	type KernelShutdownResult,
 	PythonKernel,
 } from "./kernel";
+import {
+	buildRemotePythonBridgeForward,
+	type RemotePythonBridgeForward,
+	RemotePythonKernel,
+	selectRemoteBridgePort,
+} from "./remote-kernel";
 import { resolveExplicitPythonRuntime } from "./runtime";
 import { ensurePyToolBridge } from "./tool-bridge";
 
@@ -31,6 +40,8 @@ export type PythonKernelMode = "session" | "per-call";
 export interface PythonExecutorOptions {
 	/** Working directory for command execution */
 	cwd?: string;
+	/** Configured SSH target for remote Python execution. */
+	sshHost?: SSHConnectionTarget;
 	/** Timeout in milliseconds */
 	timeoutMs?: number;
 	/** Absolute wall-clock deadline in milliseconds since epoch */
@@ -96,10 +107,17 @@ export interface PythonExecutorOptions {
 	bridgeSessionId?: string;
 	/** @internal Bridge endpoint info, set by `executePython` before delegating. */
 	bridge?: { url: string; token: string };
+	/** @internal Remote reverse-forward metadata for the Python tool bridge. */
+	remoteBridge?: RemotePythonBridgeForward;
 }
 
 export interface PythonKernelExecutor {
 	execute: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>;
+}
+
+interface ManagedPythonKernel extends PythonKernelExecutor {
+	isAlive: () => boolean;
+	shutdown: (options?: KernelShutdownOptions) => Promise<KernelShutdownResult>;
 }
 
 export interface PythonResult {
@@ -140,8 +158,9 @@ interface PythonSession {
 	sessionKey: string;
 	sessionId: string;
 	cwd: string;
-	kernel: PythonKernel;
+	kernel: ManagedPythonKernel;
 	ownerIds: Set<string>;
+	remoteBridgePort?: number;
 	hasFallbackOwner: boolean;
 }
 
@@ -163,9 +182,66 @@ function normalizeExplicitInterpreter(cwd: string, interpreter: string | undefin
 	}
 }
 
-function buildSessionKey(sessionId: string, cwd: string, interpreter: string | undefined): string {
-	const normalizedCwd = normalizeSessionCwd(cwd);
-	return `${sessionId}\0${normalizedCwd}\0${normalizeExplicitInterpreter(normalizedCwd, interpreter)}`;
+export function buildPythonSshHostSessionIdentity(sshHost: SSHConnectionTarget | undefined): string {
+	if (!sshHost) return "";
+	return [
+		"ssh",
+		sshHost.name,
+		sshHost.username ?? "",
+		sshHost.host,
+		sshHost.port !== undefined ? String(sshHost.port) : "",
+		sshHost.keyPath ?? "",
+	].join("\0");
+}
+
+function normalizeInterpreterForSession(
+	cwd: string,
+	interpreter: string | undefined,
+	sshHost: SSHConnectionTarget | undefined,
+): string {
+	return sshHost ? (interpreter ?? "") : normalizeExplicitInterpreter(cwd, interpreter);
+}
+
+export function buildPythonSessionKey(
+	sessionId: string,
+	cwd: string,
+	interpreter: string | undefined,
+	sshHost?: SSHConnectionTarget,
+): string {
+	if (!sshHost) {
+		const normalizedCwd = normalizeSessionCwd(cwd);
+		return `${sessionId}\0${normalizedCwd}\0${normalizeExplicitInterpreter(normalizedCwd, interpreter)}`;
+	}
+	return `${sessionId}\0${buildPythonSshHostSessionIdentity(sshHost)}\0${cwd}\0${normalizeInterpreterForSession(
+		cwd,
+		interpreter,
+		sshHost,
+	)}`;
+}
+
+function buildSessionKey(
+	sessionId: string,
+	cwd: string,
+	interpreter: string | undefined,
+	sshHost?: SSHConnectionTarget,
+): string {
+	return buildPythonSessionKey(sessionId, cwd, interpreter, sshHost);
+}
+
+function normalizeExecutionCwd(options: PythonExecutorOptions | undefined): string {
+	if (options?.sshHost) return options.cwd ?? ".";
+	return normalizeSessionCwd(options?.cwd ?? getProjectDir());
+}
+
+function buildRemoteBridgeIdentity(options: PythonExecutorOptions): string {
+	const cwd = options.cwd ?? ".";
+	if (options.kernelMode === "per-call") {
+		return `per-call\0${crypto.randomUUID()}\0${buildPythonSshHostSessionIdentity(options.sshHost)}\0${cwd}\0${
+			options.interpreter ?? ""
+		}`;
+	}
+	const sessionId = options.sessionId ?? `session:${cwd}`;
+	return buildPythonSessionKey(sessionId, cwd, options.interpreter, options.sshHost);
 }
 
 // ---------------------------------------------------------------------------
@@ -219,8 +295,19 @@ function createCancelledPythonResult(timedOut: boolean, timeoutMs?: number): Pyt
 // Kernel start helpers
 // ---------------------------------------------------------------------------
 
-async function startKernel(cwd: string, options: PythonExecutorOptions): Promise<PythonKernel> {
+async function startKernel(cwd: string, options: PythonExecutorOptions): Promise<ManagedPythonKernel> {
 	requireRemainingTimeoutMs(options.deadlineMs);
+	if (options.sshHost) {
+		return await RemotePythonKernel.start({
+			cwd,
+			env: buildManagedKernelEnv(options),
+			signal: options.signal,
+			deadlineMs: options.deadlineMs,
+			interpreter: options.interpreter,
+			sshHost: options.sshHost,
+			bridge: options.remoteBridge,
+		});
+	}
 	return await PythonKernel.start({
 		cwd,
 		env: buildManagedKernelEnv(options),
@@ -254,6 +341,7 @@ async function acquireSession(
 			sessionId,
 			cwd,
 			kernel,
+			remoteBridgePort: options.remoteBridge?.remotePort,
 			ownerIds: new Set(),
 			hasFallbackOwner: false,
 		};
@@ -290,6 +378,7 @@ async function replaceSessionKernel(
 		throw new PythonExecutionCancelledError(false);
 	}
 	session.kernel = next;
+	session.remoteBridgePort = options.remoteBridge?.remotePort;
 }
 
 async function resetSession(sessionKey: string): Promise<void> {
@@ -401,7 +490,17 @@ async function ensureKernelAvailable(cwd: string, options: PythonExecutorOptions
 async function ensureToolBridge(options: PythonExecutorOptions): Promise<void> {
 	if (!options.toolSession || options.bridge) return;
 	try {
-		options.bridge = await ensurePyToolBridge();
+		const bridge = await ensurePyToolBridge();
+		if (options.sshHost) {
+			const remoteBridge = buildRemotePythonBridgeForward(
+				bridge.url,
+				selectRemoteBridgePort(buildRemoteBridgeIdentity(options)),
+			);
+			options.remoteBridge = remoteBridge;
+			options.bridge = { url: remoteBridge.remoteUrl, token: bridge.token };
+			return;
+		}
+		options.bridge = bridge;
 	} catch (err) {
 		logger.warn("Failed to start Python tool bridge", {
 			error: err instanceof Error ? err.message : String(err),
@@ -423,7 +522,7 @@ async function executePerCall(code: string, cwd: string, options: PythonExecutor
 
 async function executeOnSession(code: string, cwd: string, options: PythonExecutorOptions): Promise<PythonResult> {
 	const sessionId = options.sessionId ?? `session:${cwd}`;
-	const sessionKey = buildSessionKey(sessionId, cwd, options.interpreter);
+	const sessionKey = buildSessionKey(sessionId, cwd, options.interpreter, options.sshHost);
 	if (options.bridge && !options.bridgeSessionId) {
 		options.bridgeSessionId = sessionId;
 	}
@@ -461,6 +560,12 @@ async function executeOnSession(code: string, cwd: string, options: PythonExecut
 	if (sessions.get(session.sessionKey) !== session) {
 		throw new PythonExecutionCancelledError(false);
 	}
+	if (options.sshHost && options.remoteBridge && session.remoteBridgePort !== options.remoteBridge.remotePort) {
+		await replaceSessionKernel(session, cwd, options);
+		if (sessions.get(session.sessionKey) !== session) {
+			throw new PythonExecutionCancelledError(false);
+		}
+	}
 	if (!session.kernel.isAlive()) {
 		await replaceSessionKernel(session, cwd, options);
 		if (sessions.get(session.sessionKey) !== session) {
@@ -495,7 +600,7 @@ export async function executePythonWithKernel(
 }
 
 export async function executePython(code: string, options?: PythonExecutorOptions): Promise<PythonResult> {
-	const cwd = normalizeSessionCwd(options?.cwd ?? getProjectDir());
+	const cwd = normalizeExecutionCwd(options);
 	const deadlineMs = getExecutionDeadlineMs(options);
 	const executionOptions: PythonExecutorOptions = {
 		...(options ?? {}),
@@ -514,7 +619,9 @@ export async function executePython(code: string, options?: PythonExecutorOption
 				),
 			);
 		}
-		await ensureKernelAvailable(cwd, executionOptions);
+		if (!executionOptions.sshHost) {
+			await ensureKernelAvailable(cwd, executionOptions);
+		}
 		await ensureToolBridge(executionOptions);
 
 		const kernelMode = executionOptions.kernelMode ?? "session";

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -572,6 +572,9 @@ async function executeOnSession(code: string, cwd: string, options: PythonExecut
 	if (sessions.get(session.sessionKey) !== session) {
 		throw new PythonExecutionCancelledError(false);
 	}
+	// Defensive: the bridge identity collapses to the same port as the session
+	// key — both derive from (sessionId, cwd, interpreter, sshHost). Only
+	// reachable on internal drift between options and the persisted session.
 	if (options.sshHost && options.remoteBridge && session.remoteBridgePort !== options.remoteBridge.remotePort) {
 		await replaceSessionKernel(session, cwd, options);
 		if (sessions.get(session.sessionKey) !== session) {

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -35,16 +35,18 @@ export default {
 
 	async execute(code: string, opts: ExecutorBackendExecOptions): Promise<ExecutorBackendResult> {
 		const kernelMode = readSetting<PythonExecutorOptions["kernelMode"]>(opts.session, "python.kernelMode");
+		const remote = opts.sshHost !== undefined;
 		const executorOptions: PythonExecutorOptions = {
 			cwd: opts.cwd,
+			sshHost: opts.sshHost,
 			idleTimeoutMs: opts.idleTimeoutMs,
 			signal: opts.signal,
 			sessionId: namespaceSessionId(opts.sessionId),
 			kernelMode,
-			interpreter: readInterpreterSetting(opts.session),
-			sessionFile: opts.sessionFile,
-			artifactsDir: opts.session.getArtifactsDir?.() ?? undefined,
-			localRoots: resolveEvalUrlRoots(opts.session),
+			interpreter: remote ? undefined : readInterpreterSetting(opts.session),
+			sessionFile: remote ? undefined : opts.sessionFile,
+			artifactsDir: remote ? undefined : (opts.session.getArtifactsDir?.() ?? undefined),
+			localRoots: remote ? undefined : resolveEvalUrlRoots(opts.session),
 			kernelOwnerId: opts.kernelOwnerId,
 			reset: opts.reset,
 			onChunk: opts.onChunk,

--- a/packages/coding-agent/src/eval/py/remote-kernel.ts
+++ b/packages/coding-agent/src/eval/py/remote-kernel.ts
@@ -1,0 +1,192 @@
+/**
+ * SSH-backed Python runner.
+ *
+ * Speaks the same NDJSON protocol as the local Python kernel, but runs the
+ * embedded runner.py on a configured POSIX SSH host. The SSH process is the
+ * transport: stdin/stdout/stderr stay piped, ControlMaster is explicitly
+ * disabled for this long-lived kernel, and optional tool-bridge access is
+ * exposed through a reverse loopback forward.
+ */
+import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
+import { buildRemoteCommand, ensureHostInfo, type SSHConnectionTarget } from "../../ssh/connection-manager";
+import { writeRemoteFile } from "../../ssh/file-transfer";
+import { quotePosixPath, wrapInPosixShell } from "../../ssh/utils";
+import { BaseKernel, getRemainingTimeMs, type KernelExecuteOptions, type KernelStartOptions } from "../kernel-base";
+import { PYTHON_PRELUDE } from "./prelude";
+import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
+
+const TRACE_IPC = $flag("PI_PYTHON_IPC_TRACE");
+const REMOTE_RUNNER_DIR = "/tmp/omp-python-runner";
+const SHUTDOWN_GRACE_MS = 1_000;
+const STARTUP_TIMEOUT_MS = 10_000;
+const INTERRUPT_ESCALATION_MS = 5_000;
+const REMOTE_BRIDGE_PORT_MIN = 49_152;
+const REMOTE_BRIDGE_PORT_RANGE = 16_384;
+
+export interface RemotePythonBridgeForward {
+	localPort: number;
+	remotePort: number;
+	remoteUrl: string;
+}
+
+export interface RemotePythonKernelStartOptions extends KernelStartOptions {
+	sshHost: SSHConnectionTarget;
+	bridge?: RemotePythonBridgeForward;
+}
+
+function assertPort(port: number, label: string): void {
+	if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+		throw new Error(`${label} must be a TCP port between 1 and 65535`);
+	}
+}
+
+export function selectRemoteBridgePort(identity: string): number {
+	const offset = Number(BigInt(Bun.hash(identity)) % BigInt(REMOTE_BRIDGE_PORT_RANGE));
+	return REMOTE_BRIDGE_PORT_MIN + offset;
+}
+
+export function buildRemotePythonBridgeForward(localBridgeUrl: string, remotePort: number): RemotePythonBridgeForward {
+	assertPort(remotePort, "Remote Python bridge port");
+	const url = new URL(localBridgeUrl);
+	if (url.protocol !== "http:" || url.hostname !== "127.0.0.1") {
+		throw new Error(`Python tool bridge must be a 127.0.0.1 HTTP URL, got ${localBridgeUrl}`);
+	}
+	const localPort = Number(url.port);
+	assertPort(localPort, "Local Python bridge port");
+	return {
+		localPort,
+		remotePort,
+		remoteUrl: `http://127.0.0.1:${remotePort}`,
+	};
+}
+
+export function buildRemotePythonSshExtraArgs(bridge?: RemotePythonBridgeForward): string[] {
+	const args = ["-T"];
+	if (bridge) {
+		args.push("-R", `127.0.0.1:${bridge.remotePort}:127.0.0.1:${bridge.localPort}`, "-o", "ExitOnForwardFailure=yes");
+	}
+	return args;
+}
+
+export function buildRemotePythonRunnerPath(script = RUNNER_SCRIPT): string {
+	const hash = Bun.hash(script).toString(36);
+	return `${REMOTE_RUNNER_DIR}/runner-${hash}.py`;
+}
+
+export function buildRemotePythonCommand(options: {
+	cwd: string;
+	interpreter?: string;
+	runnerPath: string;
+	env?: Record<string, string | undefined>;
+}): string {
+	const env: Record<string, string> = {
+		PYTHONUNBUFFERED: "1",
+		PYTHONIOENCODING: "utf-8",
+	};
+	for (const [key, value] of Object.entries(options.env ?? {})) {
+		if (typeof value === "string") env[key] = value;
+	}
+	const envArgs = Object.entries(env).map(([key, value]) => `${key}=${quotePosixPath(value)}`);
+	const envPrefix = envArgs.length > 0 ? `env ${envArgs.join(" ")} ` : "";
+	const runnerPath = quotePosixPath(options.runnerPath);
+	const interpreter = options.interpreter ? quotePosixPath(options.interpreter) : `"$__omp_python"`;
+	const resolveInterpreter = options.interpreter
+		? ""
+		: "if command -v python3 >/dev/null 2>&1; then __omp_python=python3; elif command -v python >/dev/null 2>&1; then __omp_python=python; else echo 'Remote Python eval requires python3 or python on PATH' >&2; exit 127; fi; ";
+	return `${resolveInterpreter}exec ${envPrefix}${interpreter} -u ${runnerPath}`;
+}
+
+export function buildRemotePythonInitScript(cwd: string, env?: Record<string, string | undefined>): string {
+	const envEntries = Object.entries(env ?? {}).filter(([, value]) => value !== undefined);
+	const envPayload = Object.fromEntries(envEntries);
+	return [
+		"import os, sys",
+		`__omp_cwd = ${JSON.stringify(cwd)}`,
+		"os.chdir(__omp_cwd)",
+		"__omp_cwd = os.getcwd()",
+		`__omp_env = ${JSON.stringify(envPayload)}`,
+		"for __omp_key, __omp_val in __omp_env.items():\n    os.environ[__omp_key] = __omp_val",
+		"if __omp_cwd not in sys.path:\n    sys.path.insert(0, __omp_cwd)",
+	].join("\n");
+}
+
+async function ensureRemotePosixShell(host: SSHConnectionTarget): Promise<"sh" | "bash" | "zsh"> {
+	const info = await ensureHostInfo(host);
+	if (info.os === "windows") {
+		throw new Error(`Remote Python eval requires a POSIX SSH host; ${host.name} is Windows`);
+	}
+	if (!info.transferShell) {
+		throw new Error(
+			`Remote Python eval requires a verified POSIX shell on ${host.name}; none of sh/bash/zsh passed the capability probe`,
+		);
+	}
+	return info.transferShell;
+}
+
+async function stageRemoteRunner(host: SSHConnectionTarget, signal: AbortSignal | undefined): Promise<string> {
+	const runnerPath = buildRemotePythonRunnerPath();
+	await writeRemoteFile(host, runnerPath, new TextEncoder().encode(RUNNER_SCRIPT), { signal });
+	return runnerPath;
+}
+
+export class RemotePythonKernel extends BaseKernel<KernelExecuteOptions> {
+	constructor(id: string) {
+		super(id, {
+			languageName: "Python",
+			traceIpc: TRACE_IPC,
+			exitPayload: JSON.stringify({ type: "exit" }),
+			interruptEscalationMs: INTERRUPT_ESCALATION_MS,
+			shutdownGraceMs: SHUTDOWN_GRACE_MS,
+			buildPayload: (code, msgId, opts) =>
+				JSON.stringify({
+					id: msgId,
+					code,
+					cwd: opts?.cwd,
+					env: opts?.env,
+					silent: opts?.silent ?? false,
+					storeHistory: opts?.storeHistory ?? !(opts?.silent ?? false),
+				}),
+		});
+	}
+
+	static async start(options: RemotePythonKernelStartOptions): Promise<RemotePythonKernel> {
+		const shell = await ensureRemotePosixShell(options.sshHost);
+		const runnerPath = await stageRemoteRunner(options.sshHost, options.signal);
+		const remoteCommand = buildRemotePythonCommand({
+			cwd: options.cwd,
+			interpreter: options.interpreter,
+			runnerPath,
+			env: options.env,
+		});
+		const args = await buildRemoteCommand(options.sshHost, wrapInPosixShell(shell, remoteCommand), {
+			allowStdin: true,
+			controlMaster: false,
+			extraArgs: buildRemotePythonSshExtraArgs(options.bridge),
+		});
+		const kernel = new RemotePythonKernel(Snowflake.next());
+		const proc = Bun.spawn(["ssh", ...args], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		kernel.setProcess(proc);
+
+		const startup = { signal: options.signal, deadlineMs: options.deadlineMs };
+		const startupBudget = Math.min(getRemainingTimeMs(startup.deadlineMs) ?? STARTUP_TIMEOUT_MS, STARTUP_TIMEOUT_MS);
+
+		try {
+			await kernel.executeWithBudget(
+				buildRemotePythonInitScript(options.cwd, options.env),
+				startup.signal,
+				startupBudget,
+				"Python kernel init",
+			);
+			await kernel.executeWithBudget(PYTHON_PRELUDE, startup.signal, startupBudget, "Python kernel prelude");
+			return kernel;
+		} catch (err) {
+			await kernel.shutdown({ timeoutMs: SHUTDOWN_GRACE_MS }).catch(() => {});
+			throw err;
+		}
+	}
+}

--- a/packages/coding-agent/src/eval/py/remote-kernel.ts
+++ b/packages/coding-agent/src/eval/py/remote-kernel.ts
@@ -8,8 +8,9 @@
  * exposed through a reverse loopback forward.
  */
 import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
-import { buildRemoteCommand, ensureHostInfo, type SSHConnectionTarget } from "../../ssh/connection-manager";
+import { buildRemoteCommand, type SSHConnectionTarget } from "../../ssh/connection-manager";
 import { writeRemoteFile } from "../../ssh/file-transfer";
+import { ensureRemotePosixShell } from "../../ssh/remote-posix";
 import { quotePosixPath, wrapInPosixShell } from "../../ssh/utils";
 import { BaseKernel, getRemainingTimeMs, type KernelExecuteOptions, type KernelStartOptions } from "../kernel-base";
 import { PYTHON_PRELUDE } from "./prelude";
@@ -86,6 +87,8 @@ export function buildRemotePythonCommand(options: {
 	for (const [key, value] of Object.entries(options.env ?? {})) {
 		if (typeof value === "string") env[key] = value;
 	}
+	// PI_TOOL_BRIDGE_* values live in the remote process environment; eval.md documents
+	// the trusted SSH account requirement for same-UID remote processes.
 	const envArgs = Object.entries(env).map(([key, value]) => `${key}=${quotePosixPath(value)}`);
 	const envPrefix = envArgs.length > 0 ? `env ${envArgs.join(" ")} ` : "";
 	const runnerPath = quotePosixPath(options.runnerPath);
@@ -108,19 +111,6 @@ export function buildRemotePythonInitScript(cwd: string, env?: Record<string, st
 		"for __omp_key, __omp_val in __omp_env.items():\n    os.environ[__omp_key] = __omp_val",
 		"if __omp_cwd not in sys.path:\n    sys.path.insert(0, __omp_cwd)",
 	].join("\n");
-}
-
-async function ensureRemotePosixShell(host: SSHConnectionTarget): Promise<"sh" | "bash" | "zsh"> {
-	const info = await ensureHostInfo(host);
-	if (info.os === "windows") {
-		throw new Error(`Remote Python eval requires a POSIX SSH host; ${host.name} is Windows`);
-	}
-	if (!info.transferShell) {
-		throw new Error(
-			`Remote Python eval requires a verified POSIX shell on ${host.name}; none of sh/bash/zsh passed the capability probe`,
-		);
-	}
-	return info.transferShell;
 }
 
 async function stageRemoteRunner(host: SSHConnectionTarget, signal: AbortSignal | undefined): Promise<string> {

--- a/packages/coding-agent/src/eval/py/remote-kernel.ts
+++ b/packages/coding-agent/src/eval/py/remote-kernel.ts
@@ -9,7 +9,7 @@
  */
 import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
 import { buildRemoteCommand, type SSHConnectionTarget } from "../../ssh/connection-manager";
-import { writeRemoteFile } from "../../ssh/file-transfer";
+import { statRemotePath, writeRemoteFile } from "../../ssh/file-transfer";
 import { ensureRemotePosixShell } from "../../ssh/remote-posix";
 import { quotePosixPath, wrapInPosixShell } from "../../ssh/utils";
 import { BaseKernel, getRemainingTimeMs, type KernelExecuteOptions, type KernelStartOptions } from "../kernel-base";
@@ -87,8 +87,12 @@ export function buildRemotePythonCommand(options: {
 	for (const [key, value] of Object.entries(options.env ?? {})) {
 		if (typeof value === "string") env[key] = value;
 	}
-	// PI_TOOL_BRIDGE_* values live in the remote process environment; eval.md documents
-	// the trusted SSH account requirement for same-UID remote processes.
+	// PI_TOOL_BRIDGE_* values live in the remote process environment via
+	// `env KEY=VAL` on the remote command line. The bridge is reverse-forwarded
+	// to the local machine, so any same-UID process on the remote host can read
+	// the token from /proc/<pid>/environ (Linux) or `ps eww` (macOS/BSD) and
+	// reach the local tool bridge. eval.md documents the trusted-host/account
+	// requirement; this is a deliberate trust-boundary trade-off, not an oversight.
 	const envArgs = Object.entries(env).map(([key, value]) => `${key}=${quotePosixPath(value)}`);
 	const envPrefix = envArgs.length > 0 ? `env ${envArgs.join(" ")} ` : "";
 	const runnerPath = quotePosixPath(options.runnerPath);
@@ -115,6 +119,11 @@ export function buildRemotePythonInitScript(cwd: string, env?: Record<string, st
 
 async function stageRemoteRunner(host: SSHConnectionTarget, signal: AbortSignal | undefined): Promise<string> {
 	const runnerPath = buildRemotePythonRunnerPath();
+	// Skip re-upload when the content-addressed runner already exists on the
+	// remote host — the path is keyed by Bun.hash of the script, so a matching
+	// path means the bytes are identical.
+	const existing = await statRemotePath(host, runnerPath, { signal });
+	if (existing === "file") return runnerPath;
 	await writeRemoteFile(host, runnerPath, new TextEncoder().encode(RUNNER_SCRIPT), { signal });
 	return runnerPath;
 }
@@ -175,6 +184,16 @@ export class RemotePythonKernel extends BaseKernel<KernelExecuteOptions> {
 			await kernel.executeWithBudget(PYTHON_PRELUDE, startup.signal, startupBudget, "Python kernel prelude");
 			return kernel;
 		} catch (err) {
+			// Translate raw OpenSSH ExitOnForwardFailure stderr (e.g. from a
+			// bridge port collision or an already-bound remote port) into a
+			// clear error so the user knows which port/host clashed instead of
+			// seeing a raw ssh diagnostic.
+			if (err instanceof Error && /remote port forwarding failed/i.test(err.message)) {
+				const port = options.bridge?.remotePort;
+				throw new Error(
+					`Remote eval bridge port ${port ?? "?"} on ${options.sshHost.name} is already bound; another eval session or service may be using it.`,
+				);
+			}
 			await kernel.shutdown({ timeoutMs: SHUTDOWN_GRACE_MS }).catch(() => {});
 			throw err;
 		}

--- a/packages/coding-agent/src/eval/py/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/py/tool-bridge.ts
@@ -9,12 +9,13 @@
  */
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "../../tools";
-import { callSessionTool, type JsStatusEvent } from "../js/tool-bridge";
+import { callSessionTool, type JsStatusEvent, type ToolBridgeInvocationContext } from "../js/tool-bridge";
 
 export interface PyToolBridgeEntry {
 	toolSession: ToolSession;
 	signal?: AbortSignal;
 	emitStatus?: (event: JsStatusEvent) => void;
+	invocationContext?: ToolBridgeInvocationContext;
 }
 
 export interface PyToolBridgeInfo {
@@ -52,6 +53,7 @@ async function callSessionToolPromptOnAbort(name: string, args: unknown, entry: 
 		session: entry.toolSession,
 		signal: entry.signal,
 		emitStatus: entry.emitStatus,
+		invocationContext: entry.invocationContext,
 	});
 	const signal = entry.signal;
 	if (!signal) return await call;

--- a/packages/coding-agent/src/eval/types.ts
+++ b/packages/coding-agent/src/eval/types.ts
@@ -17,12 +17,21 @@ export type EvalDisplayOutput =
 	| { type: "markdown"; text?: string }
 	| { type: "status"; event: EvalStatusEvent };
 
+/** Remote execution target for eval cells. */
+export interface EvalExecutionTarget {
+	kind: "ssh";
+	host: string;
+}
+
 /** Per-cell execution result for transcript rendering. */
 export interface EvalCellResult {
 	index: number;
 	title?: string;
 	code: string;
 	language?: EvalLanguage;
+	host?: string;
+	target?: EvalExecutionTarget;
+	cwd?: string;
 	output: string;
 	status: "pending" | "running" | "complete" | "error";
 	durationMs?: number;
@@ -34,6 +43,9 @@ export interface EvalCellResult {
 /** Tool result detail object surfaced to the UI/transcript. */
 export interface EvalToolDetails {
 	cells?: EvalCellResult[];
+	host?: string;
+	target?: EvalExecutionTarget;
+	cwd?: string;
 	jsonOutputs?: unknown[];
 	images?: ImageContent[];
 	statusEvents?: EvalStatusEvent[];

--- a/packages/coding-agent/src/internal-urls/ssh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/ssh-protocol.ts
@@ -253,6 +253,15 @@ function formatDirListing(entries: readonly RemoteDirEntry[]): string {
 	return entries.map(entry => `${entry.name}${entry.isDirectory ? "/" : ""}`).join("\n");
 }
 
+export interface SshUrlTransferTarget {
+	target: SSHConnectionTarget;
+	remotePath: string;
+}
+
+export async function resolveSshUrlTransferTarget(url: InternalUrl, cwd?: string): Promise<SshUrlTransferTarget> {
+	return { target: await resolveTarget(url, cwd), remotePath: remotePathFromUrl(url) };
+}
+
 export class SshProtocolHandler implements ProtocolHandler {
 	readonly scheme = "ssh";
 	readonly immutable = false;

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -50,17 +50,24 @@ const CLIENT_INFO = {
 /**
  * Default handler for standard MCP server-to-client requests.
  * Handles `ping` and `roots/list`; rejects unknown methods with -32601.
- * Reads getProjectDir() at call time so the root stays stable even if
- * the process cwd changes during tool execution.
+ * Uses a remote stdio config's resolved remote cwd when present; otherwise reads
+ * getProjectDir() at call time so the root stays stable even if the process cwd
+ * changes during tool execution.
  */
-async function defaultRequestHandler(method: string, _params: unknown): Promise<unknown> {
+async function defaultRequestHandler(method: string, _params: unknown, config?: MCPServerConfig): Promise<unknown> {
 	switch (method) {
 		case "ping":
 			return {};
 		case "roots/list": {
-			const cwd = getProjectDir();
+			const stdioConfig =
+				(config?.type ?? "stdio") === "stdio" ? (config as MCPStdioServerConfig | undefined) : undefined;
+			const isRemoteStdio = typeof stdioConfig?.host === "string";
+			const cwd = isRemoteStdio ? stdioConfig.cwd : getProjectDir();
 			return {
-				roots: [{ uri: url.pathToFileURL(cwd).href, name: path.basename(cwd) }],
+				roots:
+					cwd && (!isRemoteStdio || path.isAbsolute(cwd))
+						? [{ uri: url.pathToFileURL(cwd).href, name: path.basename(cwd) }]
+						: [],
 			};
 		}
 		default:
@@ -71,12 +78,12 @@ async function defaultRequestHandler(method: string, _params: unknown): Promise<
 /**
  * Create a transport for the given server config.
  */
-async function createTransport(config: MCPServerConfig): Promise<MCPTransport> {
+async function createTransport(config: MCPServerConfig, cwd = getProjectDir()): Promise<MCPTransport> {
 	const serverType = config.type ?? "stdio";
 
 	switch (serverType) {
 		case "stdio":
-			return createStdioTransport(config as MCPStdioServerConfig);
+			return createStdioTransport(config as MCPStdioServerConfig, cwd);
 		case "http":
 			return createHttpTransport(config as MCPHttpServerConfig);
 		case "sse":
@@ -136,6 +143,7 @@ export async function connectToServer(
 	config: MCPServerConfig,
 	options?: {
 		signal?: AbortSignal;
+		cwd?: string;
 		onNotification?: (method: string, params: unknown) => void;
 		onRequest?: (method: string, params: unknown) => Promise<unknown>;
 	},
@@ -144,7 +152,7 @@ export async function connectToServer(
 	let transport: MCPTransport | undefined;
 
 	const connect = async (): Promise<MCPServerConnection> => {
-		transport = await createTransport(config);
+		transport = await createTransport(config, options?.cwd);
 		if (options?.onNotification) {
 			transport.onNotification = options.onNotification;
 		}
@@ -152,7 +160,7 @@ export async function connectToServer(
 		// Always handle standard MCP server-to-client requests (ping, roots/list).
 		// The initialize request declares roots capability, so we must respond to
 		// roots/list — even for short-lived test connections.
-		transport.onRequest = options?.onRequest ?? defaultRequestHandler;
+		transport.onRequest = options?.onRequest ?? ((method, params) => defaultRequestHandler(method, params, config));
 
 		try {
 			const initResult = await initializeConnection(transport, {

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -61,13 +61,13 @@ async function defaultRequestHandler(method: string, _params: unknown, config?: 
 		case "roots/list": {
 			const stdioConfig =
 				(config?.type ?? "stdio") === "stdio" ? (config as MCPStdioServerConfig | undefined) : undefined;
-			const isRemoteStdio = typeof stdioConfig?.host === "string";
+			const isRemoteStdio = typeof stdioConfig?.host === "string" && stdioConfig.host.trim().length > 0;
 			const cwd = isRemoteStdio ? stdioConfig.cwd : getProjectDir();
+			if (!cwd || (isRemoteStdio && !path.posix.isAbsolute(cwd))) return { roots: [] };
+			const posixPath = isRemoteStdio ? path.posix : path;
+			const uri = isRemoteStdio ? `file://${cwd}` : url.pathToFileURL(cwd).href;
 			return {
-				roots:
-					cwd && (!isRemoteStdio || path.isAbsolute(cwd))
-						? [{ uri: url.pathToFileURL(cwd).href, name: path.basename(cwd) }]
-						: [],
+				roots: [{ uri, name: posixPath.basename(cwd) }],
 			};
 		}
 		default:

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -54,6 +54,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 		if (server.args) config.args = server.args;
 		if (server.env) config.env = server.env;
 		if (server.cwd) config.cwd = server.cwd;
+		if (server.host) config.host = server.host;
 		return config;
 	}
 
@@ -266,9 +267,12 @@ export function validateServerConfig(name: string, config: MCPServerConfig): str
 	}
 
 	if (serverType === "stdio") {
-		const stdioConfig = config as { command?: string };
+		const stdioConfig = config as { command?: string; host?: string };
 		if (!stdioConfig.command) {
 			errors.push(`Server "${name}": stdio server requires "command" field`);
+		}
+		if (stdioConfig.host !== undefined && stdioConfig.host.trim().length === 0) {
+			errors.push(`Server "${name}": stdio server "host" must not be empty`);
 		}
 	} else if (serverType === "http" || serverType === "sse") {
 		const httpConfig = config as { url?: string };

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -648,13 +648,18 @@ export class MCPManager {
 	}
 
 	#getRoots(config?: MCPServerConfig): { roots: Array<{ uri: string; name: string }> } {
-		const rootPath = isRemoteStdioConfig(config) ? config.cwd : this.cwd;
-		if (!rootPath || (isRemoteStdioConfig(config) && !path.isAbsolute(rootPath))) return { roots: [] };
+		const isRemote = isRemoteStdioConfig(config);
+		const rootPath = isRemote ? config.cwd : this.cwd;
+		if (!rootPath || (isRemote && !path.posix.isAbsolute(rootPath))) return { roots: [] };
+		// Remote stdio servers run on POSIX SSH hosts, so always use POSIX
+		// path semantics for their roots — even when OMP itself runs on Windows.
+		const posixPath = isRemote ? path.posix : path;
+		const uri = isRemote ? `file://${rootPath}` : url.pathToFileURL(rootPath).href;
 		return {
 			roots: [
 				{
-					uri: url.pathToFileURL(rootPath).href,
-					name: path.basename(rootPath),
+					uri,
+					name: posixPath.basename(rootPath),
 				},
 			],
 		};

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -46,6 +46,7 @@ import type {
 	MCPResourceTemplate,
 	MCPServerConfig,
 	MCPServerConnection,
+	MCPStdioServerConfig,
 	MCPToolDefinition,
 	MCPTransport,
 } from "./types";
@@ -71,6 +72,11 @@ type TrackedPromise<T> = {
 };
 
 const STARTUP_TIMEOUT_MS = 250;
+function isRemoteStdioConfig(config: MCPServerConfig | undefined): config is MCPStdioServerConfig & { host: string } {
+	if ((config?.type ?? "stdio") !== "stdio") return false;
+	const stdioConfig = config as MCPStdioServerConfig;
+	return typeof stdioConfig.host === "string" && stdioConfig.host.trim().length > 0;
+}
 
 /**
  * Per-server reconnect-storm circuit breaker.
@@ -405,11 +411,12 @@ export class MCPManager {
 			const connectionPromise = (async () => {
 				const resolvedConfig = await this.#resolveAuthConfig(config);
 				return connectToServer(name, resolvedConfig, {
+					cwd: this.cwd,
 					onNotification: (method, params) => {
 						this.#handleServerNotification(name, method, params);
 					},
 					onRequest: (method, params) => {
-						return this.#handleServerRequest(method, params);
+						return this.#handleServerRequest(name, method, params, resolvedConfig);
 					},
 				});
 			})().then(
@@ -624,23 +631,30 @@ export class MCPManager {
 	}
 
 	/** Handle server-to-client JSON-RPC requests (e.g. ping, roots/list). */
-	async #handleServerRequest(method: string, _params: unknown): Promise<unknown> {
+	async #handleServerRequest(
+		_serverName: string,
+		method: string,
+		_params: unknown,
+		config?: MCPServerConfig,
+	): Promise<unknown> {
 		switch (method) {
 			case "ping":
 				return {};
 			case "roots/list":
-				return this.#getRoots();
+				return this.#getRoots(config);
 			default:
 				throw Object.assign(new Error(`Unsupported server request: ${method}`), { code: -32601 });
 		}
 	}
 
-	#getRoots(): { roots: Array<{ uri: string; name: string }> } {
+	#getRoots(config?: MCPServerConfig): { roots: Array<{ uri: string; name: string }> } {
+		const rootPath = isRemoteStdioConfig(config) ? config.cwd : this.cwd;
+		if (!rootPath || (isRemoteStdioConfig(config) && !path.isAbsolute(rootPath))) return { roots: [] };
 		return {
 			roots: [
 				{
-					uri: url.pathToFileURL(this.cwd).href,
-					name: path.basename(this.cwd),
+					uri: url.pathToFileURL(rootPath).href,
+					name: path.basename(rootPath),
 				},
 			],
 		};
@@ -944,11 +958,12 @@ export class MCPManager {
 	): Promise<MCPServerConnection> {
 		const resolvedConfig = await this.#resolveAuthConfig(config);
 		const connection = await connectToServer(name, resolvedConfig, {
+			cwd: this.cwd,
 			onNotification: (method, params) => {
 				this.#handleServerNotification(name, method, params);
 			},
 			onRequest: (method, params) => {
-				return this.#handleServerRequest(method, params);
+				return this.#handleServerRequest(name, method, params, resolvedConfig);
 			},
 		});
 

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 
-import { resolveStdioSpawnCommand } from "./stdio";
+import type { SSHHost } from "../../capability/ssh";
+import type { CapabilityResult, SourceMeta } from "../../capability/types";
+import * as discovery from "../../discovery";
+import * as sshConnection from "../../ssh/connection-manager";
+import * as remotePosix from "../../ssh/remote-posix";
+import { resolveRemoteStdioSpawnCommand, resolveStdioSpawnCommand } from "./stdio";
 
 describe("resolveStdioSpawnCommand", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("hides Windows executable MCP servers when the host has no console", async () => {
 		// Hidden so a console-app child does not allocate a visible window when
 		// OMP is launched without a terminal console (#3536).
@@ -40,6 +49,74 @@ describe("resolveStdioSpawnCommand", () => {
 		).resolves.toEqual({
 			cmd: ["server.exe", "--stdio"],
 			detached: true,
+		});
+	});
+
+	it("builds remote stdio servers as ssh piped commands with stdin preserved", async () => {
+		const source: SourceMeta = {
+			provider: "test",
+			providerName: "Test",
+			path: "/tmp/ssh.json",
+			level: "project",
+		};
+		const hosts: CapabilityResult<SSHHost> = {
+			items: [
+				{
+					name: "pi",
+					host: "pi.example",
+					username: "robot",
+					port: 2222,
+					_source: source,
+				},
+			],
+			all: [],
+			warnings: [],
+			providers: ["test"],
+		};
+		vi.spyOn(discovery, "loadCapability").mockResolvedValue(hosts);
+		vi.spyOn(remotePosix, "ensureRemotePosixShell").mockResolvedValue("bash");
+		vi.spyOn(remotePosix, "resolveRemoteCwd").mockResolvedValue("/srv/app");
+		const buildRemoteSpy = vi
+			.spyOn(sshConnection, "buildRemoteCommand")
+			.mockResolvedValue(["-T", "robot@pi.example", "bash -c remote"]);
+
+		const result = await resolveRemoteStdioSpawnCommand(
+			{
+				type: "stdio",
+				host: "pi",
+				command: "node",
+				args: ["server.js", "--flag value"],
+				env: { TOKEN: "secret value" },
+				cwd: "relative app",
+			},
+			{ cwd: "/local/project" },
+		);
+
+		expect(discovery.loadCapability).toHaveBeenCalledWith("ssh", { cwd: "/local/project" });
+		expect(remotePosix.ensureRemotePosixShell).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "pi", host: "pi.example", username: "robot", port: 2222 }),
+			"Remote MCP stdio",
+		);
+		expect(remotePosix.resolveRemoteCwd).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "pi" }),
+			"relative app",
+		);
+		expect(buildRemoteSpy).toHaveBeenCalledWith(expect.objectContaining({ name: "pi" }), expect.any(String), {
+			allowStdin: true,
+			controlMaster: false,
+			extraArgs: ["-T"],
+		});
+		const remoteCommand = buildRemoteSpy.mock.calls[0]?.[1] ?? "";
+		expect(remoteCommand).toContain("bash -c");
+		expect(remoteCommand).toContain("srv/app");
+		expect(remoteCommand).toContain("TOKEN");
+		expect(remoteCommand).toContain("secret value");
+		expect(remoteCommand).toContain("node");
+		expect(remoteCommand).toContain("--flag value");
+		expect(result).toEqual({
+			cmd: ["ssh", "-T", "robot@pi.example", "bash -c remote"],
+			detached: false,
+			remoteCwd: "/srv/app",
 		});
 	});
 });

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -9,6 +9,9 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getProjectDir, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import { type Subprocess, spawn } from "bun";
+import type { SSHHost } from "../../capability/ssh";
+import { sshCapability } from "../../capability/ssh";
+import * as discovery from "../../discovery";
 import { hostHasInheritableConsole } from "../../eval/py/spawn-options";
 import type {
 	JsonRpcError,
@@ -20,6 +23,9 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import * as sshConnection from "../../ssh/connection-manager";
+import * as remotePosix from "../../ssh/remote-posix";
+import { quotePosixPath, wrapInPosixShell } from "../../ssh/utils";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
 /** Subprocess argv and platform-derived spawn flags for an MCP stdio server. */
@@ -57,6 +63,49 @@ export interface ResolveStdioSpawnOptions {
 	env: Record<string, string | undefined>;
 	hostHasInheritableConsole?: boolean;
 	platform?: NodeJS.Platform;
+}
+
+export interface RemoteStdioSpawnCommand extends StdioSpawnCommand {
+	remoteCwd: string;
+}
+
+async function resolveConfiguredSshHost(hostName: string, cwd: string): Promise<sshConnection.SSHConnectionTarget> {
+	const result = await discovery.loadCapability<SSHHost>(sshCapability.id, { cwd });
+	const host = result.items.find(item => item.name === hostName);
+	if (!host) {
+		const names = result.items.map(item => item.name).sort();
+		const suffix = names.length > 0 ? ` Available hosts: ${names.join(", ")}` : " No SSH hosts are configured.";
+		throw new Error(`Unknown SSH host: ${hostName}.${suffix}`);
+	}
+	return {
+		name: host.name,
+		host: host.host,
+		username: host.username,
+		port: host.port,
+		keyPath: host.keyPath,
+		compat: host.compat,
+	};
+}
+
+export async function resolveRemoteStdioSpawnCommand(
+	config: MCPStdioServerConfig & { host: string },
+	options: { cwd: string },
+): Promise<RemoteStdioSpawnCommand> {
+	const target = await resolveConfiguredSshHost(config.host, options.cwd);
+	const shell = await remotePosix.ensureRemotePosixShell(target, "Remote MCP stdio");
+	const remoteCwd = await remotePosix.resolveRemoteCwd(target, config.cwd);
+	const command = [config.command, ...(config.args ?? [])].map(quotePosixPath).join(" ");
+	const remoteCommand = remotePosix.buildRemotePosixCommand({
+		command,
+		cwd: remoteCwd,
+		env: config.env,
+	});
+	const args = await sshConnection.buildRemoteCommand(target, wrapInPosixShell(shell, remoteCommand), {
+		allowStdin: true,
+		controlMaster: false,
+		extraArgs: ["-T"],
+	});
+	return { cmd: ["ssh", ...args], detached: false, remoteCwd };
 }
 
 const DEFAULT_WINDOWS_PATHEXT = [".COM", ".EXE", ".BAT", ".CMD"];
@@ -341,7 +390,10 @@ export class StdioTransport implements MCPTransport {
 	onNotification?: (method: string, params: unknown) => void;
 	onRequest?: (method: string, params: unknown) => Promise<unknown>;
 
-	constructor(private config: MCPStdioServerConfig) {}
+	constructor(
+		private config: MCPStdioServerConfig,
+		private cwd = getProjectDir(),
+	) {}
 
 	get connected(): boolean {
 		return this.#connected;
@@ -353,17 +405,21 @@ export class StdioTransport implements MCPTransport {
 	async connect(): Promise<void> {
 		if (this.#connected) return;
 
-		const env = {
-			...Bun.env,
-			...this.config.env,
-		};
-		const cwd = this.config.cwd ?? getProjectDir();
-		const spawnCommand = await resolveStdioSpawnCommand(this.config, {
-			cwd,
-			env,
-			platform: process.platform,
-			hostHasInheritableConsole: hostHasInheritableConsole(),
-		});
+		const remoteHost = this.config.host?.trim();
+		const env = remoteHost ? { ...Bun.env } : { ...Bun.env, ...this.config.env };
+		const cwd = remoteHost ? this.cwd : (this.config.cwd ?? this.cwd);
+		const spawnCommand = remoteHost
+			? await resolveRemoteStdioSpawnCommand({ ...this.config, host: remoteHost }, { cwd: this.cwd })
+			: await resolveStdioSpawnCommand(this.config, {
+					cwd,
+					env,
+					platform: process.platform,
+					hostHasInheritableConsole: hostHasInheritableConsole(),
+				});
+		if (remoteHost && "remoteCwd" in spawnCommand && typeof spawnCommand.remoteCwd === "string") {
+			this.config.host = remoteHost;
+			this.config.cwd = spawnCommand.remoteCwd;
+		}
 
 		// Platform-derived session and console-window handling come from
 		// `resolveStdioSpawnCommand`: POSIX detaches into its own session to
@@ -646,8 +702,11 @@ export class StdioTransport implements MCPTransport {
 /**
  * Create and connect a stdio transport.
  */
-export async function createStdioTransport(config: MCPStdioServerConfig): Promise<StdioTransport> {
-	const transport = new StdioTransport(config);
+export async function createStdioTransport(
+	config: MCPStdioServerConfig,
+	cwd = getProjectDir(),
+): Promise<StdioTransport> {
+	const transport = new StdioTransport(config, cwd);
 	await transport.connect();
 	return transport;
 }

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -86,6 +86,8 @@ export interface MCPStdioServerConfig extends MCPServerConfigBase {
 	args?: string[];
 	env?: Record<string, string>;
 	cwd?: string;
+	/** Configured SSH host for remote stdio transport */
+	host?: string;
 }
 
 /** HTTP server configuration (Streamable HTTP transport) */

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -16,16 +16,24 @@ Anything below → `eval` cell, not bash:
 
 <instruction>
 - `cwd` sets the working dir, not `cd dir && …`
+- `host` runs on a configured SSH host; `cwd` is remote there.
 - `env: { NAME: "…" }` for multiline / quote-heavy / untrusted values; reference `$NAME`
 - Quote expansions (`"$NAME"`) to preserve exact content
 - `pty: true` only when the command needs a real terminal (`sudo`, `ssh` needing input); default `false`
 - `;` only when later commands should run despite earlier failures
 - Multiple bash calls per message run concurrently. NEVER split order-dependent commands across parallel calls — chain with `&&` in one call.
 - Internal URIs (`skill://`, `agent://`, …) auto-resolve to FS paths
+- Remote bash cannot use `pty`; omit `pty` or use `ssh` for interactive remote commands.
 {{#if asyncEnabled}}
-- `async: true` for long-running commands when you don't need immediate output: returns a background job ID; result delivered as a follow-up.
+- `async: true` for long-running local/SSH commands when you don't need immediate output: returns a background job ID; result delivered as a follow-up.
 {{/if}}
 </instruction>
+
+## Remote SSH
+
+- `host` preserves `command`, `env`, `cwd`, `timeout`, `async`.
+- `env` becomes remote environment variables.
+- Internal URIs in remote `command`/`env`/`cwd` are rejected; use remote paths or `ssh://host/abs/path`.
 
 <critical>
 - Bash invokes real binaries with simple args; it is NOT a scripting surface. Loops, conditionals, heredocs, inline interpreter scripts (`-e`/`-c`/`--eval`) when an eval runtime exists, several piped stages, or quote/JSON escaping mean you're writing a program → use `eval` cells: restartable, stateful, and free of shell-quoting traps.

--- a/packages/coding-agent/src/prompts/tools/copy.md
+++ b/packages/coding-agent/src/prompts/tools/copy.md
@@ -1,0 +1,15 @@
+Copy one regular file between local/internal paths and `ssh://` remote paths.
+
+<instruction>
+- `source` — required. Local path, writable internal file URI (`local://...`), or `ssh://host/<absolute-path>`.
+- `destination` — required. Local path, writable internal file URI (`local://...`), or `ssh://host/<absolute-path>`.
+- `timeout` — optional seconds for SSH transfer operations.
+- Copies raw bytes; no UTF-8 decoding, line selectors, archive members, SQLite rows, or directory recursion.
+- Use explicit `local://...` when copying between a remote eval host and the local session scratch space.
+</instruction>
+
+<critical>
+- Regular files only. Directories and special files are rejected.
+- `ssh://` paths require absolute remote paths.
+- Large files are rejected before transfer; use `ssh` with `scp`/`rsync` for bulk copies.
+</critical>

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -41,7 +41,7 @@ output(*ids, format?="raw", query?=None, offset?=None, limit?=None) → str | di
     Task/agent output by id; one → text/dict, multiple → list.
 tool.<name>(args) → unknown
     Invoke any session tool; `args` = its parameter object.
-{{#if py}}    Remote Python: `tool.bash/ssh/read/write/grep` default to the SSH host/cwd; `glob`/`edit`/`ast_*`/`lsp`/`debug` reject remote defaults.{{/if}}
+{{#if py}}    Remote Python: `tool.bash/ssh/read/write/grep/copy` default to the SSH host/cwd; `glob`/`edit`/`ast_*`/`lsp`/`debug` reject remote defaults.{{/if}}
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). `model`: "smol" fast | "default" session | "slow" most capable. `schema` (JSON-Schema) → structured output, parsed object.
 {{#if spawns}}agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -12,8 +12,11 @@ Fields:
 - `title` (optional) — short transcript label (e.g. `"imports"`).
 - `timeout` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
 - `reset` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a `py` reset never touches the JS VM.{{/ifAll}}
+- `host` (optional) — configured SSH host name from the `ssh` tool's available hosts; Python only.
+- `cwd` (optional) — remote working directory; valid only with `host`.
 
 {{#if py}}Live event loop: use top-level `await` directly; `asyncio.run(…)` raises "cannot be called from a running event loop".{{/if}}
+{{#if py}}Remote Python over SSH: state persists per language+host+cwd; different host = different kernel. Helpers (`tool.*`, `completion`, `agent`) still call this local session while code runs remotely. Plain `read`/`write` use the remote filesystem; use `tool.read`/`tool.write` or `ssh://` for local/session resources.{{/if}}
 {{#if js}}JS runs under **Bun**: Bun globals/APIs are available (`Bun.file`, `Bun.write`, `Bun.$`, `fetch`, `Buffer`); top-level `await`/`return` work directly.{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args (e.g. `output("id", limit: 2)`); the last expression auto-displays unless it is `nil`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args (e.g. `output("id", limit=2)`); the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
@@ -68,5 +71,5 @@ Pipe handles through stage helpers to build a dependency graph — acyclic waves
 {{/if}}
 
 <critical>
-Prior top-level names (`data`, `sessions`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read. Re-run setup only after `reset`, a crash, or a `NameError`/`ReferenceError`.
+Prior top-level names (`data`, `sessions`, helpers, imports) survive into the next eval call only for the same language+host+cwd kernel — reuse them there. Different `host`/`cwd` = different kernel; re-run setup as after `reset`, a crash, or a `NameError`/`ReferenceError`.
 </critical>

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -12,11 +12,12 @@ Fields:
 - `title` (optional) — short transcript label (e.g. `"imports"`).
 - `timeout` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
 - `reset` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a `py` reset never touches the JS VM.{{/ifAll}}
-- `host` (optional) — configured SSH host name from the `ssh` tool's available hosts; Python only.
-- `cwd` (optional) — remote working directory; valid only with `host`.
+{{#if py}}- `host` (optional) — configured SSH host name from the `ssh` tool's available hosts; Python only.
+- `cwd` (optional) — remote working directory; valid only with `host`.{{/if}}
 
 {{#if py}}Live event loop: use top-level `await` directly; `asyncio.run(…)` raises "cannot be called from a running event loop".{{/if}}
-{{#if py}}Remote Python over SSH: state persists per language+host+cwd; different host = different kernel. Helpers (`tool.*`, `completion`, `agent`) still call this local session while code runs remotely. Plain `read`/`write` use the remote filesystem; use `tool.read`/`tool.write` or `ssh://` for local/session resources.{{/if}}
+{{#if py}}Remote Python over SSH: state persists per language+host+cwd; different host/cwd = different kernel. Plain Python file I/O and `read()`/`write()` use the remote filesystem. `completion()`/`agent()` still orchestrate local session work.{{/if}}
+{{#if py}}Remote tool bridge trusts the SSH account: same-UID remote processes can reach the forwarded loopback bridge while the kernel runs. Use trusted hosts/accounts.{{/if}}
 {{#if js}}JS runs under **Bun**: Bun globals/APIs are available (`Bun.file`, `Bun.write`, `Bun.$`, `fetch`, `Buffer`); top-level `await`/`return` work directly.{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args (e.g. `output("id", limit: 2)`); the last expression auto-displays unless it is `nil`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args (e.g. `output("id", limit=2)`); the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
@@ -40,6 +41,7 @@ output(*ids, format?="raw", query?=None, offset?=None, limit?=None) → str | di
     Task/agent output by id; one → text/dict, multiple → list.
 tool.<name>(args) → unknown
     Invoke any session tool; `args` = its parameter object.
+{{#if py}}    Remote Python: `tool.bash/ssh/read/write/grep` default to the SSH host/cwd; `glob`/`edit`/`ast_*`/`lsp`/`debug` reject remote defaults.{{/if}}
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). `model`: "smol" fast | "default" session | "slow" most capable. `schema` (JSON-Schema) → structured output, parsed object.
 {{#if spawns}}agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict

--- a/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
+++ b/packages/coding-agent/src/ssh/__tests__/connection-manager-args.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getRemoteHostDir } from "@oh-my-pi/pi-utils";
+import { buildRemotePythonSshExtraArgs } from "../../eval/py/remote-kernel";
 import {
 	buildRemoteCommand,
 	extractProbePayload,
@@ -27,6 +28,42 @@ describe("buildRemoteCommand stdin handling", () => {
 	it("omits -n when allowStdin is set so the remote command reads piped stdin", async () => {
 		const args = await buildRemoteCommand(TARGET, "cat", { allowStdin: true });
 		expect(args).not.toContain("-n");
+	});
+});
+
+describe("buildRemoteCommand remote eval forwarding", () => {
+	it("keeps stdin attached, bypasses shared ControlMaster sockets, and installs the loopback reverse forward", async () => {
+		type RemoteEvalSshOptions = NonNullable<Parameters<typeof buildRemoteCommand>[2]> & {
+			allowStdin: true;
+			controlMaster: false;
+			extraArgs: string[];
+		};
+		const options: RemoteEvalSshOptions = {
+			allowStdin: true,
+			controlMaster: false,
+			extraArgs: buildRemotePythonSshExtraArgs({
+				localPort: 48123,
+				remotePort: 39123,
+				remoteUrl: "http://127.0.0.1:39123",
+			}),
+		};
+
+		const args = await buildRemoteCommand(
+			{ name: "box", host: "box.example", username: "alice" },
+			"python -u runner.py",
+			options,
+		);
+
+		expect(args).not.toContain("-n");
+		expect(args).not.toContain("ControlMaster=auto");
+		expect(args.some(arg => arg.startsWith("ControlPath="))).toBe(false);
+		expect(args).not.toContain("ControlPersist=3600");
+		expect(args).toContain("ControlMaster=no");
+		expect(args).toContain("ExitOnForwardFailure=yes");
+		expect(args).toContain("-R");
+		expect(args).toContain("127.0.0.1:39123:127.0.0.1:48123");
+		expect(args.at(-2)).toBe("alice@box.example");
+		expect(args.at(-1)).toBe("python -u runner.py");
 	});
 });
 

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -51,6 +51,10 @@ interface SSHArgsOptions {
 	platform?: SshPlatform;
 	/** When true, omit `-n` so the remote command can read from our piped stdin. */
 	allowStdin?: boolean;
+	/** When false, force this invocation not to use or create an SSH ControlMaster. */
+	controlMaster?: boolean;
+	/** Extra ssh options inserted before the remote target. */
+	extraArgs?: readonly string[];
 }
 
 function ensureControlDir() {
@@ -100,11 +104,14 @@ async function validateKeyPermissions(keyPath?: string, platform: SshPlatform = 
 function buildCommonArgs(host: SSHConnectionTarget, options?: SSHArgsOptions): string[] {
 	const args = options?.allowStdin ? [] : ["-n"];
 
-	if (supportsSshControlMaster(options?.platform)) {
+	if (options?.controlMaster === false) {
+		args.push("-o", "ControlMaster=no", "-S", "none");
+	} else if (supportsSshControlMaster(options?.platform)) {
 		args.push("-o", "ControlMaster=auto", "-o", `ControlPath=${CONTROL_PATH}`, "-o", "ControlPersist=3600");
 	}
 
 	args.push("-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new");
+	if (options?.extraArgs) args.push(...options.extraArgs);
 
 	if (host.port) {
 		args.push("-p", String(host.port));

--- a/packages/coding-agent/src/ssh/remote-posix.ts
+++ b/packages/coding-agent/src/ssh/remote-posix.ts
@@ -1,0 +1,72 @@
+import { ptree } from "@oh-my-pi/pi-utils";
+import { buildRemoteCommand, ensureConnection, ensureHostInfo, type SSHConnectionTarget } from "./connection-manager";
+import { quotePosixPath, wrapInPosixShell } from "./utils";
+
+export type RemotePosixShell = "sh" | "bash" | "zsh";
+
+const DEFAULT_REMOTE_CWD_TIMEOUT_MS = 30_000;
+
+const POSIX_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export async function ensureRemotePosixShell(
+	target: SSHConnectionTarget,
+	purpose = "remote execution",
+): Promise<RemotePosixShell> {
+	await ensureConnection(target);
+	const info = await ensureHostInfo(target);
+	if (info.os === "windows") {
+		throw new Error(`${purpose} requires a POSIX SSH host; ${target.name} is Windows`);
+	}
+	if (!info.transferShell) {
+		throw new Error(
+			`${purpose} requires a verified POSIX shell on ${target.name}; none of sh/bash/zsh passed the capability probe`,
+		);
+	}
+	return info.transferShell;
+}
+
+export function formatPosixEnvAssignments(env: Record<string, string> | undefined): string {
+	if (!env || Object.keys(env).length === 0) return "";
+	return Object.entries(env)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([key, value]) => {
+			if (!POSIX_ENV_NAME_PATTERN.test(key)) {
+				throw new Error(`Invalid remote environment variable name: ${key}`);
+			}
+			return `${key}=${quotePosixPath(value)}`;
+		})
+		.join(" ");
+}
+
+export function buildRemotePosixCommand(options: {
+	command: string;
+	cwd?: string;
+	env?: Record<string, string>;
+}): string {
+	const assignments = formatPosixEnvAssignments(options.env);
+	const command = assignments ? `env ${assignments} ${options.command}` : options.command;
+	if (!options.cwd) return command;
+	return `cd -- ${quotePosixPath(options.cwd)} && ${command}`;
+}
+
+export async function resolveRemoteCwd(
+	target: SSHConnectionTarget,
+	cwd: string | undefined,
+	opts: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<string> {
+	const shell = await ensureRemotePosixShell(target, "Remote cwd resolution");
+	const command = buildRemotePosixCommand({ command: "pwd -P", cwd: cwd ?? "." });
+	const args = await buildRemoteCommand(target, wrapInPosixShell(shell, command));
+	using child = ptree.spawn(["ssh", ...args], {
+		signal: ptree.combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_REMOTE_CWD_TIMEOUT_MS),
+	});
+	const text = new TextDecoder().decode(await child.bytes()).trim();
+	await child.exitedCleanly;
+	const resolved = text.split(/\r?\n/).at(-1)?.trim() ?? "";
+	if (!resolved.startsWith("/")) {
+		throw new Error(
+			`Remote cwd resolution on ${target.name} did not return an absolute POSIX path: ${resolved || "(empty)"}`,
+		);
+	}
+	return resolved;
+}

--- a/packages/coding-agent/src/ssh/remote-posix.ts
+++ b/packages/coding-agent/src/ssh/remote-posix.ts
@@ -44,7 +44,10 @@ export function buildRemotePosixCommand(options: {
 	env?: Record<string, string>;
 }): string {
 	const assignments = formatPosixEnvAssignments(options.env);
-	const command = assignments ? `env ${assignments} ${options.command}` : options.command;
+	// Export vars in the wrapper shell (not via `env KEY=val cmd`) so that
+	// shell expansion ($VAR, ${VAR}) in the command sees the env values —
+	// `env` only sets vars for the child process, not the parsing shell.
+	const command = assignments ? `export ${assignments}; ${options.command}` : options.command;
 	if (!options.cwd) return command;
 	return `cd -- ${quotePosixPath(options.cwd)} && ${command}`;
 }

--- a/packages/coding-agent/src/tools/__tests__/bash-remote.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/bash-remote.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { SSHConnectionTarget } from "../../ssh/connection-manager";
+import * as remotePosix from "../../ssh/remote-posix";
+import * as sshExecutor from "../../ssh/ssh-executor";
+import type { ToolSession } from "..";
+import { BashTool } from "../bash";
+import * as hostResolution from "../ssh-host-resolution";
+
+const REMOTE_HOST: SSHConnectionTarget = {
+	name: "pi",
+	host: "pi.example",
+	username: "robot",
+	port: 2222,
+};
+
+function makeSession(): ToolSession {
+	return {
+		cwd: "/local/workspace",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getSessionId: () => "bash-remote-test-session",
+		settings: {
+			get: (key: string) => {
+				switch (key) {
+					case "async.enabled":
+					case "bash.autoBackground.enabled":
+					case "bash.stripTrailingHeadTail":
+					case "bashInterceptor.enabled":
+						return false;
+					default:
+						return undefined;
+				}
+			},
+			getBashInterceptorRules: () => [],
+		},
+	} as unknown as ToolSession;
+}
+
+describe("BashTool SSH execution", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("executes remote commands through the resolved host and a POSIX shell command carrying cwd, env, and command", async () => {
+		const session = makeSession();
+		const resolveSpy = vi.spyOn(hostResolution, "resolveSshHostByName").mockResolvedValue(REMOTE_HOST);
+		const shellSpy = vi.spyOn(remotePosix, "ensureRemotePosixShell").mockResolvedValue("bash");
+		const sshSpy = vi.spyOn(sshExecutor, "executeSSH").mockResolvedValue({
+			output: "remote ok\n",
+			exitCode: 0,
+			cancelled: false,
+			truncated: false,
+			totalLines: 1,
+			totalBytes: 10,
+			outputLines: 1,
+			outputBytes: 10,
+		});
+
+		const result = await new BashTool(session).execute("bash-call", {
+			command: "printf $TARGET",
+			host: "pi",
+			cwd: "/srv/remote app",
+			env: { TARGET: "remote value", ALPHA: "first value" },
+			timeout: 7,
+		});
+
+		expect(resolveSpy).toHaveBeenCalledTimes(1);
+		expect(resolveSpy.mock.calls[0]?.[0]).toBe(session);
+		expect(resolveSpy.mock.calls[0]?.[1]).toBe("pi");
+		expect(shellSpy).toHaveBeenCalledTimes(1);
+		expect(shellSpy.mock.calls[0]?.[0]).toBe(REMOTE_HOST);
+		expect(shellSpy.mock.calls[0]?.[1]).toBe("Remote bash");
+		expect(sshSpy).toHaveBeenCalledTimes(1);
+		const sshCall = sshSpy.mock.calls[0];
+		if (!sshCall) throw new Error("executeSSH was not called");
+		const [host, remoteCommand, options] = sshCall;
+		expect(host).toBe(REMOTE_HOST);
+		expect(remoteCommand).toContain("bash -c ");
+		expect(remoteCommand).toContain("cd --");
+		expect(remoteCommand).toContain("/srv/remote app");
+		expect(remoteCommand).toContain("env");
+		expect(remoteCommand).toContain("ALPHA=");
+		expect(remoteCommand).toContain("first value");
+		expect(remoteCommand).toContain("TARGET=");
+		expect(remoteCommand).toContain("remote value");
+		expect(remoteCommand).toContain("printf $TARGET");
+		expect(options?.timeout).toBe(7000);
+
+		const text = result.content.find((block): block is { type: "text"; text: string } => block.type === "text")?.text;
+		expect(text).toContain("remote ok");
+	});
+});

--- a/packages/coding-agent/src/tools/__tests__/bash-remote.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/bash-remote.test.ts
@@ -79,7 +79,7 @@ describe("BashTool SSH execution", () => {
 		expect(remoteCommand).toContain("bash -c ");
 		expect(remoteCommand).toContain("cd --");
 		expect(remoteCommand).toContain("/srv/remote app");
-		expect(remoteCommand).toContain("env");
+		expect(remoteCommand).toContain("export");
 		expect(remoteCommand).toContain("ALPHA=");
 		expect(remoteCommand).toContain("first value");
 		expect(remoteCommand).toContain("TARGET=");

--- a/packages/coding-agent/src/tools/__tests__/copy.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/copy.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as capability from "../../capability";
+import type { SSHHost } from "../../capability/ssh";
+import type { CapabilityResult, SourceMeta } from "../../capability/types";
+import * as fileTransfer from "../../ssh/file-transfer";
+import type { ToolSession } from "..";
+import { CopyTool } from "../copy";
+
+const SOURCE: SourceMeta = {
+	provider: "ssh-json",
+	providerName: "SSH Config",
+	path: "/test/ssh.json",
+	level: "user",
+};
+
+function makeSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		settings: { get: () => undefined },
+	} as unknown as ToolSession;
+}
+
+function mockHosts(hosts: SSHHost[] = []): void {
+	const result: CapabilityResult<SSHHost> = {
+		items: hosts,
+		all: hosts,
+		warnings: [],
+		providers: hosts.length ? ["ssh-json"] : [],
+	};
+	vi.spyOn(capability, "loadCapability").mockResolvedValue(result as CapabilityResult<unknown>);
+}
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-copy-tool-"));
+	try {
+		return await fn(dir);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+describe("CopyTool", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("copies local regular files byte-exact without UTF-8 decoding", async () => {
+		await withTempDir(async dir => {
+			const bytes = new Uint8Array([0x00, 0xff, 0x61, 0x0a, 0x80]);
+			await Bun.write(path.join(dir, "input.bin"), bytes);
+
+			const result = await new CopyTool(makeSession(dir)).execute("copy-call", {
+				source: "input.bin",
+				destination: "nested/output.bin",
+			});
+
+			const copied = await Bun.file(path.join(dir, "nested/output.bin")).bytes();
+			expect(Array.from(copied)).toEqual(Array.from(bytes));
+			expect(result.details).toMatchObject({ bytes: bytes.length });
+		});
+	});
+
+	it("rejects local directory endpoints instead of recursing", async () => {
+		await withTempDir(async dir => {
+			await fs.mkdir(path.join(dir, "source-dir"));
+			await Bun.write(path.join(dir, "file.bin"), new Uint8Array([1]));
+			await fs.mkdir(path.join(dir, "dest-dir"));
+			const tool = new CopyTool(makeSession(dir));
+
+			await expect(
+				tool.execute("copy-source-dir", { source: "source-dir", destination: "out.bin" }),
+			).rejects.toThrow(/source is not a regular file/);
+			await expect(tool.execute("copy-dest-dir", { source: "file.bin", destination: "dest-dir" })).rejects.toThrow(
+				/destination is a directory/,
+			);
+		});
+	});
+
+	it("copies ssh sources to ssh destinations as raw bytes", async () => {
+		mockHosts([
+			{ _source: SOURCE, name: "src", host: "src.example" },
+			{ _source: SOURCE, name: "dst", host: "dst.example" },
+		]);
+		const bytes = new Uint8Array([0, 255, 42]);
+		const statSpy = vi.spyOn(fileTransfer, "statRemotePath").mockResolvedValue("file");
+		const readSpy = vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({ bytes, truncated: false });
+		const writeSpy = vi.spyOn(fileTransfer, "writeRemoteFile").mockResolvedValue(undefined);
+
+		await new CopyTool(makeSession("/workspace")).execute("copy-ssh", {
+			source: "ssh://src/tmp/in.bin",
+			destination: "ssh://dst/var/out.bin",
+			timeout: 9,
+		});
+
+		expect(statSpy).toHaveBeenCalledTimes(1);
+		expect(statSpy.mock.calls[0]?.[0]).toMatchObject({ name: "src", host: "src.example" });
+		expect(statSpy.mock.calls[0]?.[1]).toBe("/tmp/in.bin");
+		expect(readSpy.mock.calls[0]?.[2]).toMatchObject({ maxBytes: 64 * 1024 * 1024, timeoutMs: 9000 });
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect(writeSpy.mock.calls[0]?.[0]).toMatchObject({ name: "dst", host: "dst.example" });
+		expect(writeSpy.mock.calls[0]?.[1]).toBe("/var/out.bin");
+		expect(writeSpy.mock.calls[0]?.[2]).toEqual(bytes);
+		expect(writeSpy.mock.calls[0]?.[3]).toMatchObject({ timeoutMs: 9000 });
+	});
+
+	it("rejects remote directory sources before reading", async () => {
+		mockHosts();
+		vi.spyOn(fileTransfer, "statRemotePath").mockResolvedValue("directory");
+		const readSpy = vi.spyOn(fileTransfer, "readRemoteFile").mockResolvedValue({
+			bytes: new Uint8Array([1]),
+			truncated: false,
+		});
+
+		await expect(
+			new CopyTool(makeSession("/workspace")).execute("copy-remote-dir", {
+				source: "ssh://host/tmp/dir",
+				destination: "out.bin",
+			}),
+		).rejects.toThrow(/source is a directory/);
+		expect(readSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/src/tools/__tests__/eval-intent.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/eval-intent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { EvalTool } from "../eval";
+
+describe("EvalTool.intent", () => {
+	it("returns 'running python' for a py cell", () => {
+		const tool = new EvalTool(null);
+		expect(tool.intent({ language: "py" })).toBe("running python");
+	});
+
+	it("returns the title when provided, regardless of language", () => {
+		const tool = new EvalTool(null);
+		expect(tool.intent({ language: "py", title: "load config" })).toBe("load config");
+	});
+
+	it("does not fall back to 'running javascript' when language is missing (partial stream)", () => {
+		const tool = new EvalTool(null);
+		// During streaming, args.language is often undefined before the full JSON parses.
+		// The old default was "javascript" — wrong for Python cells.
+		const result = tool.intent({});
+		expect(result).not.toBe("running javascript");
+		expect(result).toBe("running eval");
+	});
+});

--- a/packages/coding-agent/src/tools/__tests__/eval-render-remote.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/eval-render-remote.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import type { Component } from "@oh-my-pi/pi-tui";
+import type { EvalCellResult, EvalToolDetails } from "../../eval/types";
+import { getThemeByName } from "../../modes/theme/theme";
+import { evalToolRenderer } from "../eval-render";
+
+type RemoteTarget = { kind: "ssh"; host: string };
+type RenderCallArgs = Parameters<typeof evalToolRenderer.renderCall>[0];
+type RemoteRenderCallArgs = RenderCallArgs & { host: string; cwd: string; target: RemoteTarget };
+type RemoteEvalCellResult = EvalCellResult & { host: string; cwd: string; target: RemoteTarget };
+type RemoteEvalToolDetails = EvalToolDetails & {
+	host: string;
+	cwd: string;
+	target: RemoteTarget;
+	cells: RemoteEvalCellResult[];
+};
+
+function stripRendered(component: Component, width = 100): string {
+	return Bun.stripANSI(component.render(width).join("\n"));
+}
+
+async function theme() {
+	const uiTheme = await getThemeByName("dark");
+	if (!uiTheme) throw new Error("theme unavailable");
+	return uiTheme;
+}
+
+describe("eval renderer remote target", () => {
+	it("preserves the SSH host and remote cwd in pending render output", async () => {
+		const args: RemoteRenderCallArgs = {
+			language: "py",
+			code: "print('hello')",
+			host: "icaro",
+			cwd: "/srv/remote-app",
+			target: { kind: "ssh", host: "icaro" },
+		};
+
+		const component = evalToolRenderer.renderCall(args, { expanded: false, isPartial: false }, await theme());
+		const text = stripRendered(component);
+
+		expect(text).toContain("ssh:icaro");
+		expect(text).toContain("/srv/remote-app");
+	});
+
+	it("preserves the SSH host and remote cwd in result render output", async () => {
+		const details: RemoteEvalToolDetails = {
+			language: "python",
+			languages: ["python"],
+			host: "icaro",
+			cwd: "/srv/remote-app",
+			target: { kind: "ssh", host: "icaro" },
+			cells: [
+				{
+					index: 0,
+					language: "python",
+					code: "print('hello')",
+					output: "hello",
+					status: "complete",
+					durationMs: 12,
+					exitCode: 0,
+					host: "icaro",
+					cwd: "/srv/remote-app",
+					target: { kind: "ssh", host: "icaro" },
+				},
+			],
+		};
+
+		const component = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "hello" }], details },
+			{ expanded: false, isPartial: false },
+			await theme(),
+		);
+		const text = stripRendered(component);
+
+		expect(text).toContain("ssh:icaro");
+		expect(text).toContain("/srv/remote-app");
+		expect(text).toContain("hello");
+	});
+});

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -18,6 +18,9 @@ import { highlightCode, type Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
 import type { ClientBridgeTerminalExitStatus, ClientBridgeTerminalOutput } from "../session/client-bridge";
 import { DEFAULT_MAX_BYTES, enforceInlineByteCap, streamTailUpdates, TailBuffer } from "../session/streaming-output";
+import { buildRemotePosixCommand, ensureRemotePosixShell } from "../ssh/remote-posix";
+import { executeSSH } from "../ssh/ssh-executor";
+import { wrapInPosixShell } from "../ssh/utils";
 import { renderStatusLine } from "../tui";
 import { CachedOutputBlock, markFramedBlockComponent, outputBlockContentWidth } from "../tui/output-block";
 import { getSixelLineMask } from "../utils/sixel";
@@ -32,12 +35,14 @@ import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { capPreviewLines, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
+import { resolveSshHostByName } from "./ssh-host-resolution";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
 
 export const BASH_DEFAULT_PREVIEW_LINES = 10;
 
+const REMOTE_BASH_INTERNAL_URL_RE = /(?:skill|agent|artifact|plan|memory|rule|local):\/\/|(?:^|[^./\\\w-])local:\//i;
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 
@@ -101,6 +106,7 @@ async function saveBashOriginalArtifact(session: ToolSession, originalText: stri
 }
 
 const bashSchemaBase = type({
+	"host?": type("string").describe("configured SSH host name for remote execution"),
 	command: type("string").describe("command to execute"),
 	"env?": type({ "[string]": "string" }).describe("extra env vars"),
 	"timeout?": type("number").describe("timeout in seconds"),
@@ -110,6 +116,7 @@ const bashSchemaBase = type({
 
 const bashSchemaWithAsync = type({
 	command: "string",
+	"host?": "string",
 	"env?": { "[string]": "string" },
 	"timeout?": "number",
 	"cwd?": "string",
@@ -120,6 +127,7 @@ const bashSchemaWithAsync = type({
 type BashToolSchema = typeof bashSchemaBase | typeof bashSchemaWithAsync;
 
 export interface BashToolInput {
+	host?: string;
 	command: string;
 	env?: Record<string, string>;
 	timeout?: number;
@@ -156,6 +164,13 @@ type ManagedBashJobCompletion =
 			error: unknown;
 	  };
 
+type ManagedBashRunner = (options: {
+	signal?: AbortSignal;
+	artifactPath?: string;
+	artifactId?: string;
+	onChunk: (chunk: string) => void;
+}) => Promise<BashResult | BashInteractiveResult>;
+
 interface ManagedBashJobHandle {
 	jobId: string;
 	label: string;
@@ -182,6 +197,14 @@ function normalizeBashEnv(env: Record<string, string> | undefined): Record<strin
 		normalized[key] = value;
 	}
 	return normalized;
+}
+
+function assertRemoteBashInternalUrlsUnsupported(label: string, value: string | undefined): void {
+	if (value && REMOTE_BASH_INTERNAL_URL_RE.test(value)) {
+		throw new ToolError(
+			`Remote bash cannot expand local/session internal URLs in ${label}; use ssh:// paths or pass remote filesystem paths instead.`,
+		);
+	}
 }
 
 function escapeBashEnvValueForDisplay(value: string): string {
@@ -352,22 +375,35 @@ function stripExitCodeNotice(text: string, exitCode: number | undefined): string
 /**
  * Bash tool implementation.
  *
- * Executes bash commands with optional timeout and working directory.
+ * Executes shell commands with support for timeout, working directory,
+ * environment variables, and streaming output.
  */
 export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSchemaWithAsync, BashToolDetails> {
 	readonly name = "bash";
 	readonly approval = (args: unknown): ToolApprovalDecision => {
 		const rawCommand = (args as Partial<BashToolInput>).command;
 		const command = typeof rawCommand === "string" ? rawCommand : "";
+		const host = (args as Partial<BashToolInput>).host;
 		if (command !== "" && CRITICAL_BASH_PATTERNS.some(pattern => pattern.test(command))) {
-			return { tier: "exec", override: true, reason: "Critical pattern detected" };
+			return {
+				tier: "exec",
+				override: true,
+				reason: host ? `Critical pattern detected for SSH host ${host}` : "Critical pattern detected",
+			};
+		}
+		if (host) {
+			return { tier: "exec", override: true, reason: `Remote SSH host: ${host}` };
 		}
 		return "exec";
 	};
 	readonly formatApprovalDetails = (args: unknown): string[] => {
-		const rawCommand = (args as Partial<BashToolInput>).command;
+		const params = args as Partial<BashToolInput>;
+		const rawCommand = params.command;
 		const command = typeof rawCommand === "string" ? rawCommand : "(missing)";
-		return [`Command: ${truncateForPrompt(command)}`];
+		const details = [`Command: ${truncateForPrompt(command)}`];
+		if (params.host) details.push(`Host: ${truncateForPrompt(params.host)}`);
+		if (params.cwd) details.push(`Cwd: ${truncateForPrompt(params.cwd)}`);
+		return details;
 	};
 	readonly label = "Bash";
 	readonly loadMode = "essential";
@@ -543,6 +579,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		resolvedEnv?: Record<string, string>;
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>;
 		startBackgrounded: boolean;
+		run?: ManagedBashRunner;
 	}): ManagedBashJobHandle {
 		const manager = this.session.asyncJobManager;
 		if (!manager) {
@@ -562,21 +599,24 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES);
 				const wallTimeStart = performance.now();
 				try {
-					const result = await executeBash(options.command, {
-						cwd: options.commandCwd,
-						sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
-						timeout: options.timeoutMs,
-						signal: runSignal,
-						env: options.resolvedEnv,
-						artifactPath,
-						artifactId,
-						onChunk: chunk => {
-							tailBuffer.append(chunk);
-							latestText = tailBuffer.text();
-							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
-						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
-					});
+					const onChunk = (chunk: string) => {
+						tailBuffer.append(chunk);
+						latestText = tailBuffer.text();
+						void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
+					};
+					const result = options.run
+						? await options.run({ signal: runSignal, artifactPath, artifactId, onChunk })
+						: await executeBash(options.command, {
+								cwd: options.commandCwd,
+								sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
+								timeout: options.timeoutMs,
+								signal: runSignal,
+								env: options.resolvedEnv,
+								artifactPath,
+								artifactId,
+								onChunk,
+								onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+							});
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -663,11 +703,42 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		return Math.max(0, Math.min(this.#autoBackgroundThresholdMs, timeoutMs - timeoutBufferMs));
 	}
 
+	async #executeRemoteBash(options: {
+		hostName: string;
+		command: string;
+		cwd?: string;
+		env?: Record<string, string>;
+		timeoutMs: number;
+		signal?: AbortSignal;
+		artifactPath?: string;
+		artifactId?: string;
+		onChunk?: (chunk: string) => void;
+	}): Promise<BashResult> {
+		const host = await resolveSshHostByName(this.session, options.hostName);
+		const shell = await ensureRemotePosixShell(host, "Remote bash");
+		const remoteCommand = wrapInPosixShell(
+			shell,
+			buildRemotePosixCommand({
+				command: options.command,
+				cwd: options.cwd,
+				env: options.env,
+			}),
+		);
+		return await executeSSH(host, remoteCommand, {
+			timeout: options.timeoutMs,
+			signal: options.signal,
+			artifactPath: options.artifactPath,
+			artifactId: options.artifactId,
+			onChunk: options.onChunk,
+		});
+	}
+
 	async execute(
 		_toolCallId: string,
 		{
 			command: rawCommand,
 			env: rawEnv,
+			host,
 			timeout: rawTimeout = 300,
 			cwd,
 
@@ -680,6 +751,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 	): Promise<AgentToolResult<BashToolDetails>> {
 		let command = rawCommand;
 		const env = normalizeBashEnv(rawEnv);
+		const remoteHost = typeof host === "string" && host.trim().length > 0 ? host.trim() : undefined;
 
 		// Apply conservative bash fixups (strip trailing `| head|tail` and redundant
 		// `2>&1`). The helper is single-line only and refuses anything that could
@@ -707,6 +779,11 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		if (asyncRequested && !this.#asyncEnabled) {
 			throw new ToolError("Async bash execution is disabled. Enable async.enabled to use async mode.");
 		}
+		if (remoteHost && pty) {
+			throw new ToolError(
+				"Remote bash over SSH does not support pty; omit pty or use the ssh tool for an interactive remote command.",
+			);
+		}
 
 		// Check both the original command and the cwd-normalized command so
 		// leading `cd ... &&` wrappers do not hide either shell-navigation rules
@@ -722,54 +799,59 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			}
 		}
 
-		const internalUrlOptions: InternalUrlExpansionOptions = {
-			skills: this.session.skills ?? [],
-			internalRouter: InternalUrlRouter.instance(),
-			localOptions: {
-				getArtifactsDir: this.session.getArtifactsDir,
-				getSessionId: this.session.getSessionId,
-			},
-		};
-		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
-		const resolvedEnv = env
-			? Object.fromEntries(
-					await Promise.all(
-						Object.entries(env).map(async ([key, value]) => [
-							key,
-							await expandInternalUrls(value, {
-								...internalUrlOptions,
-								ensureLocalParentDirs: true,
-								noEscape: true,
-							}),
-						]),
-					),
-				)
-			: undefined;
-
-		// Resolve protocol URLs (skill://, agent://, etc.) in extracted cwd.
-		if (cwd?.includes("://") || cwd?.includes("local:/")) {
-			cwd = await expandInternalUrls(cwd, { ...internalUrlOptions, noEscape: true });
-		}
-
-		// Best-effort cache invalidation: drop github-cache rows for any issue/PR
-		// number touched by a mutating `gh` subcommand inside this bash call so
-		// subsequent issue:// / pr:// reads pick up the post-mutation state
-		// instead of the cached pre-mutation snapshot.
-		invalidateGithubCacheForBashCommand(command);
-
-		const commandCwd = cwd ? resolveToCwd(cwd, this.session.cwd) : this.session.cwd;
-		let cwdStat: fs.Stats;
-		try {
-			cwdStat = await fs.promises.stat(commandCwd);
-		} catch (err) {
-			if (isEnoent(err)) {
-				throw new ToolError(`Working directory does not exist: ${commandCwd}`);
+		let resolvedEnv = env;
+		let commandCwd = cwd ?? "";
+		if (remoteHost) {
+			assertRemoteBashInternalUrlsUnsupported("command", command);
+			assertRemoteBashInternalUrlsUnsupported("cwd", cwd);
+			for (const [key, value] of Object.entries(env ?? {})) {
+				assertRemoteBashInternalUrlsUnsupported(`env.${key}`, value);
 			}
-			throw err;
+		} else {
+			const internalUrlOptions: InternalUrlExpansionOptions = {
+				skills: this.session.skills ?? [],
+				internalRouter: InternalUrlRouter.instance(),
+				localOptions: {
+					getArtifactsDir: this.session.getArtifactsDir,
+					getSessionId: this.session.getSessionId,
+				},
+			};
+			command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
+			resolvedEnv = env
+				? Object.fromEntries(
+						await Promise.all(
+							Object.entries(env).map(async ([key, value]) => [
+								key,
+								await expandInternalUrls(value, {
+									...internalUrlOptions,
+									ensureLocalParentDirs: true,
+									noEscape: true,
+								}),
+							]),
+						),
+					)
+				: undefined;
+
+			// Resolve protocol URLs (skill://, agent://, etc.) in extracted cwd.
+			if (cwd?.includes("://") || cwd?.includes("local:/")) {
+				cwd = await expandInternalUrls(cwd, { ...internalUrlOptions, noEscape: true });
+			}
+
+			commandCwd = cwd ? resolveToCwd(cwd, this.session.cwd) : this.session.cwd;
+			let cwdStat: fs.Stats;
+			try {
+				cwdStat = await fs.promises.stat(commandCwd);
+			} catch (err) {
+				if (isEnoent(err)) {
+					throw new ToolError(`Working directory does not exist: ${commandCwd}`);
+				}
+				throw err;
+			}
+			if (!cwdStat.isDirectory()) {
+				throw new ToolError(`Working directory is not a directory: ${commandCwd}`);
+			}
 		}
-		if (!cwdStat.isDirectory()) {
-			throw new ToolError(`Working directory is not a directory: ${commandCwd}`);
-		}
+		invalidateGithubCacheForBashCommand(command);
 
 		// Clamp to reasonable range: 1s - 3600s (1 hour)
 		const requestedTimeoutSec = rawTimeout;
@@ -778,6 +860,20 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		const pendingNotices: string[] = [];
 		const timeoutClampNotice = formatTimeoutClampNotice(requestedTimeoutSec, timeoutSec);
 		if (timeoutClampNotice) pendingNotices.push(timeoutClampNotice);
+		const remoteRun: ManagedBashRunner | undefined = remoteHost
+			? ({ signal: runSignal, artifactPath, artifactId, onChunk }) =>
+					this.#executeRemoteBash({
+						hostName: remoteHost,
+						command,
+						cwd: commandCwd || undefined,
+						env: resolvedEnv,
+						timeoutMs,
+						signal: runSignal,
+						artifactPath,
+						artifactId,
+						onChunk,
+					})
+			: undefined;
 
 		if (asyncRequested) {
 			if (!this.session.asyncJobManager) {
@@ -794,6 +890,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				resolvedEnv,
 				onUpdate,
 				startBackgrounded: true,
+				run: remoteRun,
 			});
 			return this.#buildBackgroundStartResult(job.jobId, job.label, "", timeoutSec, {
 				requestedTimeoutSec,
@@ -805,9 +902,8 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		// when available it wins over auto-backgrounding (both are opt-in, and
 		// auto-background would otherwise silently disable the terminal route).
 		const clientBridge = this.session.getClientBridge?.();
-		const bridgeTerminalAvailable = Boolean(
-			clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty,
-		);
+		const bridgeTerminalAvailable =
+			!remoteHost && Boolean(clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty);
 
 		const autoBgManager = this.session.asyncJobManager;
 		// At the running-job cap, fall through to direct foreground execution
@@ -832,6 +928,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				resolvedEnv,
 				onUpdate,
 				startBackgrounded,
+				run: remoteRun,
 			});
 			if (startBackgrounded) {
 				return this.#buildBackgroundStartResult(job.jobId, job.label, "", timeoutSec, {
@@ -864,7 +961,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 
 		// Route through the client terminal when the client advertises the terminal capability.
 		// Skip when pty=true (PTY needs the local terminal UI).
-		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
+		if (bridgeTerminalAvailable && clientBridge?.createTerminal) {
 			const bridgeWallTimeStart = performance.now();
 			const handle = await clientBridge.createTerminal({
 				command,
@@ -1044,6 +1141,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			pendingNotices.push("pty requested but unavailable in this environment; ran without a terminal");
 		}
 		const wallTimeStart = performance.now();
+		const directOnChunk = streamTailUpdates(tailBuffer, onUpdate);
 		const result: BashResult | BashInteractiveResult = interactiveUi
 			? await runInteractiveBashPty(interactiveUi, {
 					command,
@@ -1054,17 +1152,19 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					artifactPath,
 					artifactId,
 				})
-			: await executeBash(command, {
-					cwd: commandCwd,
-					sessionKey: this.session.getSessionId?.() ?? undefined,
-					timeout: timeoutMs,
-					signal,
-					env: resolvedEnv,
-					artifactPath,
-					artifactId,
-					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
-				});
+			: remoteRun
+				? await remoteRun({ signal, artifactPath, artifactId, onChunk: directOnChunk })
+				: await executeBash(command, {
+						cwd: commandCwd,
+						sessionKey: this.session.getSessionId?.() ?? undefined,
+						timeout: timeoutMs,
+						signal,
+						env: resolvedEnv,
+						artifactPath,
+						artifactId,
+						onChunk: directOnChunk,
+						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+					});
 		const wallTimeMs = performance.now() - wallTimeStart;
 		if (result.cancelled) {
 			const out = normalizeResultOutput(result);
@@ -1096,6 +1196,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 // TUI Renderer
 // =============================================================================
 export interface BashRenderArgs {
+	host?: string;
 	command?: string;
 	env?: Record<string, string>;
 	timeout?: number;
@@ -1122,6 +1223,7 @@ export interface ShellRendererConfig<TArgs> {
 	resolveCommand?: (args: TArgs | undefined) => string | undefined;
 	resolveCwd?: (args: TArgs | undefined) => string | undefined;
 	resolveEnv?: (args: TArgs | undefined) => Record<string, string> | undefined;
+	resolveHost?: (args: TArgs | undefined) => string | undefined;
 	showHeader?: boolean;
 }
 
@@ -1153,6 +1255,7 @@ export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme): st
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
 	const envAssignments = formatBashEnvAssignments(getBashEnvForDisplay(args));
 	const prefixParts = ["$"];
+	if (args.host) prefixParts.push(`ssh ${replaceTabs(args.host)}`);
 	if (displayWorkdir) prefixParts.push(`cd ${displayWorkdir} &&`);
 	if (envAssignments) prefixParts.push(envAssignments);
 	const prefix = uiTheme.fg("dim", `${prefixParts.join(" ")} `);
@@ -1164,6 +1267,7 @@ export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme): st
 function toBashRenderArgs<TArgs>(args: TArgs | undefined, config: ShellRendererConfig<TArgs>): BashRenderArgs {
 	return {
 		command: config.resolveCommand?.(args),
+		host: config.resolveHost?.(args),
 		cwd: config.resolveCwd?.(args),
 		env: config.resolveEnv?.(args),
 		__partialJson: getPartialJson(args),
@@ -1409,4 +1513,5 @@ export const bashToolRenderer = createShellRenderer<BashRenderArgs>({
 	resolveCwd: args => args?.cwd,
 	resolveEnv: args => args?.env,
 	showHeader: false,
+	resolveHost: args => args?.host,
 });

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -751,7 +751,10 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 	): Promise<AgentToolResult<BashToolDetails>> {
 		let command = rawCommand;
 		const env = normalizeBashEnv(rawEnv);
-		const remoteHost = typeof host === "string" && host.trim().length > 0 ? host.trim() : undefined;
+		const remoteHost = typeof host === "string" && host.trim() ? host.trim() : undefined;
+		if (typeof host === "string" && host.trim().length === 0) {
+			throw new ToolError("host must not be empty; set a configured SSH host name or omit it.");
+		}
 
 		// Apply conservative bash fixups (strip trailing `| head|tail` and redundant
 		// `2>&1`). The helper is single-line only and refuses anything that could

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -23,6 +23,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"web_search",
 	"search_tool_bm25",
 	"write",
+	"copy",
 	"memory_edit",
 	"retain",
 	"recall",

--- a/packages/coding-agent/src/tools/copy.ts
+++ b/packages/coding-agent/src/tools/copy.ts
@@ -1,0 +1,204 @@
+import * as fs from "node:fs/promises";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { isEnoent, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import { InternalUrlRouter, parseInternalUrl, resolveSshUrlTransferTarget } from "../internal-urls";
+import copyDescription from "../prompts/tools/copy.md" with { type: "text" };
+import type { SSHConnectionTarget } from "../ssh/connection-manager";
+import { readRemoteFile, statRemotePath, writeRemoteFile } from "../ssh/file-transfer";
+import type { ToolSession } from ".";
+import { invalidateFsScanAfterWrite } from "./fs-cache-invalidation";
+import { formatPathRelativeToCwd, isInternalUrlPath, isSshUrl, pathTargetsSsh, resolveReadPath } from "./path-utils";
+import { enforcePlanModeWrite, resolvePlanPath, unwrapHashlineHeaderPath } from "./plan-mode-guard";
+import { ToolError } from "./tool-errors";
+import { clampTimeout } from "./tool-timeouts";
+
+const copySchema = type({
+	source: type("string").describe("source file path or URI"),
+	destination: type("string").describe("destination file path or URI"),
+	"timeout?": type("number").describe("timeout in seconds"),
+});
+
+export type CopyParams = typeof copySchema.infer;
+
+// ponytail: buffered regular-file copies; add streaming if bulk transfers matter.
+const COPY_MAX_BYTES = 64 * 1024 * 1024;
+
+type CopyEndpoint =
+	| { kind: "local"; raw: string; path: string }
+	| { kind: "ssh"; raw: string; target: SSHConnectionTarget; remotePath: string };
+
+export interface CopyToolDetails {
+	bytes: number;
+	source: string;
+	destination: string;
+}
+
+function normalizeCopyPath(value: string): string {
+	const path = unwrapHashlineHeaderPath(value.trim());
+	if (!path) throw new ToolError("copy source and destination must be non-empty paths");
+	return path;
+}
+
+function isWritableInternalDestination(value: string): boolean {
+	const lower = value.toLowerCase();
+	return lower.startsWith("local:") || lower.startsWith("vault:");
+}
+
+function formatLimit(): string {
+	return `${Math.floor(COPY_MAX_BYTES / (1024 * 1024))} MiB`;
+}
+
+function endpointLabel(endpoint: CopyEndpoint, cwd: string): string {
+	return endpoint.kind === "local" ? formatPathRelativeToCwd(endpoint.path, cwd) : endpoint.raw;
+}
+
+async function assertRemoteRegularFile(
+	endpoint: Extract<CopyEndpoint, { kind: "ssh" }>,
+	signal?: AbortSignal,
+): Promise<void> {
+	const kind = await statRemotePath(endpoint.target, endpoint.remotePath, { signal });
+	if (kind === "directory") {
+		throw new ToolError(`copy source is a directory: ${endpoint.raw}`);
+	}
+	if (kind === "other") {
+		throw new ToolError(`copy source is not a regular file: ${endpoint.raw}`);
+	}
+}
+
+export class CopyTool implements AgentTool<typeof copySchema, CopyToolDetails> {
+	readonly name = "copy";
+	readonly approval = (args: unknown) => {
+		const params = args as Partial<CopyParams>;
+		return pathTargetsSsh(`${params.source ?? ""}\n${params.destination ?? ""}`) ? "exec" : "write";
+	};
+	readonly label = "Copy";
+	readonly description = prompt.render(copyDescription);
+	readonly parameters = copySchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable" as const;
+	readonly summary = "Copy one regular file between local/internal and SSH paths";
+
+	constructor(private readonly session: ToolSession) {}
+
+	async #resolveSshEndpoint(raw: string): Promise<CopyEndpoint> {
+		const parsed = parseInternalUrl(raw);
+		const { target, remotePath } = await resolveSshUrlTransferTarget(parsed, this.session.cwd);
+		return { kind: "ssh", raw, target, remotePath };
+	}
+
+	async #resolveSource(rawPath: string, signal?: AbortSignal): Promise<CopyEndpoint> {
+		const raw = normalizeCopyPath(rawPath);
+		if (isSshUrl(raw)) return this.#resolveSshEndpoint(raw);
+		if (isInternalUrlPath(raw)) {
+			const router = InternalUrlRouter.instance();
+			if (!router.canHandle(raw)) {
+				throw new ToolError(`copy source uses an unsupported internal URL: ${raw}`);
+			}
+			const resource = await router.resolve(raw, {
+				cwd: this.session.cwd,
+				settings: this.session.settings,
+				signal,
+				localProtocolOptions: this.session.localProtocolOptions,
+				skills: this.session.skills,
+			});
+			if (resource.isDirectory) throw new ToolError(`copy source is a directory: ${raw}`);
+			if (!resource.sourcePath) {
+				throw new ToolError(
+					`copy source must resolve to a regular file on disk or ssh:// path; unsupported internal URL: ${raw}`,
+				);
+			}
+			return { kind: "local", raw, path: resource.sourcePath };
+		}
+		return { kind: "local", raw, path: resolveReadPath(raw, this.session.cwd) };
+	}
+
+	async #resolveDestination(rawPath: string): Promise<CopyEndpoint> {
+		const raw = normalizeCopyPath(rawPath);
+		if (isSshUrl(raw)) return this.#resolveSshEndpoint(raw);
+		if (isInternalUrlPath(raw) && !isWritableInternalDestination(raw)) {
+			throw new ToolError(`copy destination must be a local path, local://, vault://, or ssh:// path: ${raw}`);
+		}
+		return { kind: "local", raw, path: resolvePlanPath(this.session, raw) };
+	}
+
+	async #readLocal(endpoint: Extract<CopyEndpoint, { kind: "local" }>, signal?: AbortSignal): Promise<Uint8Array> {
+		const stat = await fs.stat(endpoint.path);
+		if (!stat.isFile()) throw new ToolError(`copy source is not a regular file: ${endpoint.raw}`);
+		if (stat.size > COPY_MAX_BYTES) {
+			throw new ToolError(`copy source exceeds ${formatLimit()}: ${endpoint.raw}`);
+		}
+		return await untilAborted(signal, () => Bun.file(endpoint.path).bytes());
+	}
+
+	async #readRemote(
+		endpoint: Extract<CopyEndpoint, { kind: "ssh" }>,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<Uint8Array> {
+		await assertRemoteRegularFile(endpoint, signal);
+		const result = await readRemoteFile(endpoint.target, endpoint.remotePath, {
+			maxBytes: COPY_MAX_BYTES,
+			timeoutMs,
+			signal,
+		});
+		if (result.truncated) {
+			throw new ToolError(`copy source exceeds ${formatLimit()}: ${endpoint.raw}`);
+		}
+		return result.bytes;
+	}
+
+	async #readBytes(endpoint: CopyEndpoint, timeoutMs: number, signal?: AbortSignal): Promise<Uint8Array> {
+		return endpoint.kind === "local"
+			? await this.#readLocal(endpoint, signal)
+			: await this.#readRemote(endpoint, timeoutMs, signal);
+	}
+
+	async #writeLocal(endpoint: Extract<CopyEndpoint, { kind: "local" }>, bytes: Uint8Array): Promise<void> {
+		let op: "create" | "update" = "create";
+		try {
+			const stat = await fs.stat(endpoint.path);
+			if (stat.isDirectory()) throw new ToolError(`copy destination is a directory: ${endpoint.raw}`);
+			if (!stat.isFile()) throw new ToolError(`copy destination is not a regular file: ${endpoint.raw}`);
+			op = "update";
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
+		}
+		enforcePlanModeWrite(this.session, endpoint.raw, { op });
+		await Bun.write(endpoint.path, bytes);
+		invalidateFsScanAfterWrite(endpoint.path);
+		this.session.bumpFileMutationVersion?.(endpoint.path);
+	}
+
+	async #writeBytes(
+		endpoint: CopyEndpoint,
+		bytes: Uint8Array,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<void> {
+		if (endpoint.kind === "local") {
+			await this.#writeLocal(endpoint, bytes);
+			return;
+		}
+		enforcePlanModeWrite(this.session, endpoint.raw, { op: "update" });
+		await writeRemoteFile(endpoint.target, endpoint.remotePath, bytes, { timeoutMs, signal });
+	}
+
+	async execute(_id: string, params: CopyParams, signal?: AbortSignal): Promise<AgentToolResult<CopyToolDetails>> {
+		return untilAborted(signal, async () => {
+			const timeoutMs = clampTimeout("copy", params.timeout) * 1000;
+			const source = await this.#resolveSource(params.source, signal);
+			const destination = await this.#resolveDestination(params.destination);
+			const bytes = await this.#readBytes(source, timeoutMs, signal);
+			await this.#writeBytes(destination, bytes, timeoutMs, signal);
+			const sourceLabel = endpointLabel(source, this.session.cwd);
+			const destinationLabel = endpointLabel(destination, this.session.cwd);
+			return {
+				content: [
+					{ type: "text", text: `Copied ${bytes.length} bytes from ${sourceLabel} to ${destinationLabel}` },
+				],
+				details: { bytes: bytes.length, source: sourceLabel, destination: destinationLabel },
+			};
+		});
+	}
+}

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -13,7 +13,13 @@ import type { Component } from "@oh-my-pi/pi-tui";
 import { Markdown, Text } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import { settings } from "../config/settings";
-import type { EvalCellResult, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
+import type {
+	EvalCellResult,
+	EvalExecutionTarget,
+	EvalLanguage,
+	EvalStatusEvent,
+	EvalToolDetails,
+} from "../eval/types";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
@@ -49,16 +55,28 @@ function languageForHighlighter(language: EvalLanguage | undefined): "python" | 
 	return "python";
 }
 
+interface EvalRenderTargetArg {
+	kind?: string;
+	type?: string;
+	host?: string;
+}
+
 interface EvalRenderCellArg {
 	language?: string;
 	code?: string;
 	title?: string;
+	host?: string;
+	cwd?: string;
+	target?: EvalRenderTargetArg;
 }
 
 interface EvalRenderArgs {
 	language?: string;
 	code?: string;
 	title?: string;
+	host?: string;
+	cwd?: string;
+	target?: EvalRenderTargetArg;
 	cells?: EvalRenderCellArg[];
 	__partialJson?: string;
 }
@@ -74,6 +92,9 @@ interface EvalRenderCell {
 	language: EvalLanguage;
 	code: string;
 	title?: string;
+	host?: string;
+	cwd?: string;
+	target?: EvalExecutionTarget;
 }
 
 function normalizeRenderLanguage(value: string | undefined): EvalLanguage {
@@ -83,8 +104,23 @@ function normalizeRenderLanguage(value: string | undefined): EvalLanguage {
 	return "python";
 }
 
+function stringField(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function targetHostFrom(target: EvalRenderTargetArg | EvalExecutionTarget | undefined): string | undefined {
+	if (!target) return undefined;
+	const kind =
+		stringField("kind" in target ? target.kind : undefined) ??
+		stringField("type" in target ? target.type : undefined);
+	if (kind !== undefined && kind !== "ssh") return undefined;
+	return stringField(target.host);
+}
+
 function getRenderCells(args: EvalRenderArgs | undefined): EvalRenderCell[] {
 	if (!args) return [];
+	const defaultHost = stringField(args.host) ?? targetHostFrom(args.target);
+	const defaultCwd = stringField(args.cwd);
 	const raw = Array.isArray(args.cells) ? args.cells : typeof args.code === "string" ? [args] : [];
 	const out: EvalRenderCell[] = [];
 	for (const cell of raw) {
@@ -94,9 +130,39 @@ function getRenderCells(args: EvalRenderArgs | undefined): EvalRenderCell[] {
 			language: normalizeRenderLanguage(typeof cell.language === "string" ? cell.language : undefined),
 			code,
 			title: typeof cell.title === "string" ? cell.title : undefined,
+			host: stringField(cell.host) ?? targetHostFrom(cell.target) ?? defaultHost,
+			cwd: stringField(cell.cwd) ?? defaultCwd,
 		});
 	}
 	return out;
+}
+
+const TARGET_TITLE_SEPARATOR = " · ";
+
+function sanitizeHeaderPart(value: string): string {
+	return replaceTabs(value).replace(/\s+/g, " ").trim();
+}
+
+function formatTargetTitle(host: string | undefined, cwd: string | undefined, width: number): string | undefined {
+	if (!host) return undefined;
+	const parts = [`ssh:${sanitizeHeaderPart(host)}`];
+	if (cwd !== undefined) {
+		parts.push(`cwd:${shortenPath(sanitizeHeaderPart(cwd))}`);
+	}
+	return truncateToWidth(parts.join(TARGET_TITLE_SEPARATOR), Math.max(12, Math.min(72, width - 4)));
+}
+
+function withTargetTitle(
+	title: string | undefined,
+	host: string | undefined,
+	cwd: string | undefined,
+	width: number,
+): string | undefined {
+	const targetTitle = formatTargetTitle(host, cwd, width);
+	if (!targetTitle) return title;
+	if (!title) return targetTitle;
+	const titleBudget = Math.max(12, width - targetTitle.length - TARGET_TITLE_SEPARATOR.length - 8);
+	return `${truncateToWidth(sanitizeHeaderPart(title), titleBudget)}${TARGET_TITLE_SEPARATOR}${targetTitle}`;
 }
 
 type AgentEventStatus = "pending" | "running" | "completed" | "failed" | "aborted";
@@ -502,7 +568,7 @@ export const evalToolRenderer = {
 
 		return markFramedBlockComponent({
 			render: (width: number): readonly string[] => {
-				const key = `${options.expanded ? 1 : 0}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.code.length}`).join("|")}`;
+				const key = `${options.expanded ? 1 : 0}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.host ?? ""}:${c.cwd ?? ""}:${c.code.length}`).join("|")}`;
 				if (cached && cached.key === key && cached.width === width) {
 					return cached.result;
 				}
@@ -517,7 +583,7 @@ export const evalToolRenderer = {
 							showLanguage: true,
 							index: i,
 							total: cells.length,
-							title: cell.title,
+							title: withTargetTitle(cell.title, cell.host, cell.cwd, width),
 							status: "pending",
 							width,
 							// Viewport-sized tail window following the newest streamed code
@@ -616,6 +682,9 @@ export const evalToolRenderer = {
 							}
 							outputLines.push(...statusLines);
 						}
+						const resultHost =
+							cell.host ?? targetHostFrom(cell.target) ?? details?.host ?? targetHostFrom(details?.target);
+						const resultCwd = cell.cwd ?? details?.cwd;
 						const cellLines = renderCodeCell(
 							{
 								code: cell.code,
@@ -623,7 +692,7 @@ export const evalToolRenderer = {
 								showLanguage: true,
 								index: i,
 								total: cellResults.length,
-								title: cell.title,
+								title: withTargetTitle(cell.title, resultHost, resultCwd, width),
 								status: cell.status,
 								spinnerFrame: options.spinnerFrame,
 								duration: cell.durationMs,

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -2,12 +2,22 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import type { ImageContent, ToolExample } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import type { SSHHost } from "../capability/ssh";
+import { sshCapability } from "../capability/ssh";
+import { loadCapability } from "../discovery";
 import { jsBackend, juliaBackend, pythonBackend, rubyBackend } from "../eval";
-import type { ExecutorBackend, ExecutorBackendResult } from "../eval/backend";
+import type { ExecutorBackend, ExecutorBackendExecOptions, ExecutorBackendResult } from "../eval/backend";
 import { EVAL_TIMEOUT_PAUSE_OP, EVAL_TIMEOUT_RESUME_OP } from "../eval/bridge-timeout";
 import { IdleTimeout } from "../eval/idle-timeout";
 import { defaultEvalSessionId } from "../eval/session-id";
-import type { EvalCellResult, EvalDisplayOutput, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
+import type {
+	EvalCellResult,
+	EvalDisplayOutput,
+	EvalExecutionTarget,
+	EvalLanguage,
+	EvalStatusEvent,
+	EvalToolDetails,
+} from "../eval/types";
 import evalDescription from "../prompts/tools/eval.md" with { type: "text" };
 import { DEFAULT_MAX_BYTES, OutputSink, type OutputSummary, TailBuffer } from "../session/streaming-output";
 import { webpExclusionForModel } from "../utils/image-loading";
@@ -86,6 +96,8 @@ const evalCellCommonFields = {
 	"title?": type("string").describe('short label shown in transcript (e.g. "imports", "load config")'),
 	"timeout?": type("number").describe("timeout for this eval call in seconds"),
 	"reset?": type("boolean").describe("wipe this language's kernel before running. Other languages are untouched."),
+	"host?": type("string").describe("configured SSH host name for remote Python execution"),
+	"cwd?": type("string").describe("remote working directory when host is set"),
 };
 
 /**
@@ -188,6 +200,7 @@ export interface EvalToolOptions {
 
 interface ResolvedBackend {
 	backend: ExecutorBackend;
+	sshHost?: SSHHost;
 	notice?: string;
 }
 
@@ -198,6 +211,10 @@ interface ResolvedEvalCell {
 	timeoutMs: number;
 	reset: boolean;
 	resolved: ResolvedBackend;
+	effectiveCwd: string;
+	host?: string;
+	target?: EvalExecutionTarget;
+	cwd?: string;
 }
 
 function uniqueEvalLanguages(cells: ResolvedEvalCell[]): EvalLanguage[] {
@@ -215,7 +232,31 @@ function timeoutSecondsFromMs(timeoutMs: number): number {
 	return clampTimeout("eval", timeoutMs / 1000);
 }
 
-async function resolveBackend(session: ToolSession, language: EvalLanguage): Promise<ResolvedBackend> {
+function formatAvailableHosts(hostNames: readonly string[]): string {
+	return hostNames.length > 0 ? hostNames.join(", ") : "(none)";
+}
+
+async function resolveEvalSshHost(session: ToolSession, hostName: string): Promise<SSHHost> {
+	const result = await loadCapability<SSHHost>(sshCapability.id, { cwd: session.cwd });
+	const hostsByName = new Map<string, SSHHost>();
+	for (const host of result.items) {
+		if (!hostsByName.has(host.name)) {
+			hostsByName.set(host.name, host);
+		}
+	}
+	const sshHost = hostsByName.get(hostName);
+	if (!sshHost) {
+		const hostNames = Array.from(hostsByName.keys()).sort();
+		throw new ToolError(`Unknown SSH host: ${hostName}. Available hosts: ${formatAvailableHosts(hostNames)}`);
+	}
+	return sshHost;
+}
+
+async function resolveBackend(
+	session: ToolSession,
+	language: EvalLanguage,
+	options: { sshHost?: SSHHost } = {},
+): Promise<ResolvedBackend> {
 	const backends = resolveEvalBackends(session);
 	const allowPy = backends.python;
 	const allowJs = backends.js;
@@ -224,7 +265,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 
 	if (language === "python") {
 		if (!allowPy) throw new ToolError("Python backend is disabled (PI_PY=0 or eval.py = false).");
-		if (!(await pythonBackend.isAvailable(session))) {
+		if (!options.sshHost && !(await pythonBackend.isAvailable(session))) {
 			const alternatives = [allowJs ? '"js"' : null, allowRb ? '"rb"' : null, allowJl ? '"jl"' : null].filter(
 				Boolean,
 			);
@@ -234,7 +275,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 					: 'Python backend is unavailable in this session. Install the python kernel to use language: "py".',
 			);
 		}
-		return { backend: pythonBackend };
+		return { backend: pythonBackend, sshHost: options.sshHost };
 	}
 	if (language === "ruby") {
 		if (!allowRb) throw new ToolError("Ruby backend is disabled (PI_RB=0 or eval.rb = false).");
@@ -283,7 +324,15 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const language =
 			typeof params.language === "string" ? formatEvalInputLanguage(params.language) : "javascript (default)";
 		const code = typeof params.code === "string" ? params.code : "";
-		return [`Language: ${language}`, `Code:\n${truncateForPrompt(code)}`];
+		const details = [`Language: ${language}`];
+		if (typeof params.host === "string") {
+			details.push(`Host: ${truncateForPrompt(params.host)}`);
+			details.push(`Cwd: ${truncateForPrompt(typeof params.cwd === "string" ? params.cwd : ".")}`);
+		} else if (typeof params.cwd === "string") {
+			details.push(`Cwd: ${truncateForPrompt(params.cwd)}`);
+		}
+		details.push(`Code:\n${truncateForPrompt(code)}`);
+		return details;
 	};
 	get summary(): string {
 		return summarizeEvalLanguages(this.#enabledLanguages());
@@ -395,6 +444,22 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		onUpdate?: AgentToolUpdateCallback,
 		_ctx?: AgentToolContext,
 	): Promise<AgentToolResult<EvalToolDetails | undefined>> {
+		const cellLanguage: EvalLanguage =
+			params.language === "py"
+				? "python"
+				: params.language === "rb"
+					? "ruby"
+					: params.language === "jl"
+						? "julia"
+						: "js";
+		const requestedHost = typeof params.host === "string" ? params.host : undefined;
+		const requestedCwd = typeof params.cwd === "string" ? params.cwd : undefined;
+		if (requestedCwd !== undefined && requestedHost === undefined) {
+			throw new ToolError("cwd is only supported when host is set for remote Python eval.");
+		}
+		if (requestedHost !== undefined && cellLanguage !== "python") {
+			throw new ToolError('host is only supported with language: "py" for remote Python eval.');
+		}
 		if (this.#proxyExecutor) {
 			return this.#proxyExecutor(params, signal);
 		}
@@ -405,15 +470,10 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const session = this.session;
 		const excludeWebP = webpExclusionForModel(session.getActiveModel?.());
 
-		const cellLanguage: EvalLanguage =
-			params.language === "py"
-				? "python"
-				: params.language === "rb"
-					? "ruby"
-					: params.language === "jl"
-						? "julia"
-						: "js";
-		const resolved = await resolveBackend(session, cellLanguage);
+		const sshHost = requestedHost ? await resolveEvalSshHost(session, requestedHost) : undefined;
+		const effectiveCwd = sshHost ? (requestedCwd ?? ".") : session.cwd;
+		const target: EvalExecutionTarget | undefined = sshHost ? { kind: "ssh", host: sshHost.name } : undefined;
+		const resolved = await resolveBackend(session, cellLanguage, { sshHost });
 		const cells: ResolvedEvalCell[] = [
 			{
 				index: 0,
@@ -422,10 +482,21 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 				timeoutMs: (params.timeout ?? 30) * 1000,
 				reset: params.reset ?? false,
 				resolved,
+				effectiveCwd,
+				host: sshHost?.name,
+				target,
+				cwd: sshHost ? effectiveCwd : undefined,
 			},
 		];
 		const languages = uniqueEvalLanguages(cells);
 		const notice = detailsNotice(cells);
+		const targetMetadataCell = cells.find(cell => cell.host || cell.target || cell.cwd);
+		const addTargetDetails = (details: EvalToolDetails): void => {
+			if (!targetMetadataCell) return;
+			if (targetMetadataCell.host) details.host = targetMetadataCell.host;
+			if (targetMetadataCell.target) details.target = targetMetadataCell.target;
+			if (targetMetadataCell.cwd) details.cwd = targetMetadataCell.cwd;
+		};
 		const sessionAbortController = new AbortController();
 		let outputSink: OutputSink | undefined;
 		let outputSummary: OutputSummary | undefined;
@@ -454,6 +525,9 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					title: cell.title,
 					code: cell.code,
 					language: cell.resolved.backend.id,
+					host: cell.host,
+					target: cell.target,
+					cwd: cell.cwd,
 					output: "",
 					status: "pending",
 				}));
@@ -479,6 +553,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							statusEvents: cell.statusEvents ? [...cell.statusEvents] : undefined,
 						})),
 					};
+					addTargetDetails(details);
 					if (jsonOutputs.length > 0) {
 						details.jsonOutputs = jsonOutputs;
 					}
@@ -551,8 +626,8 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					const startTime = Date.now();
 					let result: ExecutorBackendResult;
 					try {
-						result = await backend.execute(cell.code, {
-							cwd: session.cwd,
+						const executeOptions: ExecutorBackendExecOptions & { sshHost?: SSHHost } = {
+							cwd: cell.effectiveCwd,
 							sessionId,
 							sessionFile: sessionFile ?? undefined,
 							kernelOwnerId,
@@ -576,7 +651,11 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 								upsertStatusEvent(cellResult.statusEvents, event);
 								pushUpdate();
 							},
-						});
+						};
+						if (cell.resolved.sshHost) {
+							executeOptions.sshHost = cell.resolved.sshHost;
+						}
+						result = await backend.execute(cell.code, executeOptions);
 					} finally {
 						idle.dispose();
 						activeLiveCell = undefined;
@@ -662,6 +741,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
 							isError: true,
 						};
+						addTargetDetails(details);
 						if (notice) details.notice = notice;
 
 						return toolResult(details)
@@ -687,6 +767,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
 							isError: true,
 						};
+						addTargetDetails(details);
 						if (notice) details.notice = notice;
 
 						return toolResult(details)
@@ -715,6 +796,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
 					statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
 				};
+				addTargetDetails(details);
 				if (notice) details.notice = notice;
 
 				return toolResult(details)

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -321,8 +321,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 	readonly approval = "exec" as const;
 	readonly formatApprovalDetails = (args: unknown): string[] => {
 		const params = args as Partial<EvalToolParams>;
-		const language =
-			typeof params.language === "string" ? formatEvalInputLanguage(params.language) : "javascript (default)";
+		const language = typeof params.language === "string" ? formatEvalInputLanguage(params.language) : "pending";
 		const code = typeof params.code === "string" ? params.code : "";
 		const details = [`Language: ${language}`];
 		if (typeof params.host === "string") {
@@ -413,8 +412,8 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 	readonly strict = true;
 	readonly intent = (args: Partial<typeof evalSchema.infer>): string | undefined => {
 		const title = typeof args.title === "string" ? args.title : undefined;
-		const language = typeof args.language === "string" ? formatEvalInputLanguage(args.language) : "javascript";
-		return title || `running ${language}`;
+		const language = typeof args.language === "string" ? formatEvalInputLanguage(args.language) : undefined;
+		return title || (language ? `running ${language}` : "running eval");
 	};
 
 	readonly #proxyExecutor?: EvalProxyExecutor;

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -451,12 +451,15 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					: params.language === "jl"
 						? "julia"
 						: "js";
-		const requestedHost = typeof params.host === "string" ? params.host : undefined;
+		const requestedHost = typeof params.host === "string" ? params.host.trim() : undefined;
 		const requestedCwd = typeof params.cwd === "string" ? params.cwd : undefined;
-		if (requestedCwd !== undefined && requestedHost === undefined) {
+		if (requestedHost === "") {
+			throw new ToolError("host must not be empty; set a configured SSH host name or omit it.");
+		}
+		if (requestedCwd !== undefined && !requestedHost) {
 			throw new ToolError("cwd is only supported when host is set for remote Python eval.");
 		}
-		if (requestedHost !== undefined && cellLanguage !== "python") {
+		if (requestedHost && cellLanguage !== "python") {
 			throw new ToolError('host is only supported with language: "py" for remote Python eval.');
 		}
 		if (this.#proxyExecutor) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -41,6 +41,7 @@ import { BashTool } from "./bash";
 import { BrowserTool } from "./browser";
 import { type BuiltinToolName, normalizeToolNames } from "./builtin-names";
 import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
+import { CopyTool } from "./copy";
 import { DebugTool } from "./debug";
 import { EvalTool } from "./eval";
 import { resolveEvalBackends } from "./eval-backends";
@@ -79,6 +80,7 @@ export * from "./ast-grep";
 export * from "./bash";
 export * from "./browser";
 export * from "./checkpoint";
+export * from "./copy";
 export * from "./debug";
 export * from "./eval";
 export * from "./eval-backends";
@@ -463,6 +465,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	web_search: s => new WebSearchTool(s),
 	search_tool_bm25: SearchToolBm25Tool.createIf,
 	write: s => new WriteTool(s),
+	copy: s => new CopyTool(s),
 	memory_edit: MemoryEditTool.createIf,
 	retain: MemoryRetainTool.createIf,
 	recall: MemoryRecallTool.createIf,

--- a/packages/coding-agent/src/tools/ssh-host-resolution.ts
+++ b/packages/coding-agent/src/tools/ssh-host-resolution.ts
@@ -1,0 +1,47 @@
+import type { SSHHost } from "../capability/ssh";
+import { sshCapability } from "../capability/ssh";
+import { loadCapability } from "../discovery";
+import type { SSHConnectionTarget } from "../ssh/connection-manager";
+import type { ToolSession } from ".";
+import { ToolError } from "./tool-errors";
+
+export interface LoadedSshHosts {
+	hostNames: string[];
+	hostsByName: Map<string, SSHHost>;
+}
+
+export async function loadSshHosts(session: Pick<ToolSession, "cwd">): Promise<LoadedSshHosts> {
+	const result = await loadCapability<SSHHost>(sshCapability.id, { cwd: session.cwd });
+	const hostsByName = new Map<string, SSHHost>();
+	for (const host of result.items) {
+		if (!hostsByName.has(host.name)) {
+			hostsByName.set(host.name, host);
+		}
+	}
+	return { hostNames: Array.from(hostsByName.keys()).sort(), hostsByName };
+}
+
+export function sshHostToConnectionTarget(host: SSHHost): SSHConnectionTarget {
+	return {
+		name: host.name,
+		host: host.host,
+		username: host.username,
+		port: host.port,
+		keyPath: host.keyPath,
+		compat: host.compat,
+	};
+}
+
+export async function resolveSshHostByName(
+	session: Pick<ToolSession, "cwd">,
+	hostName: string,
+): Promise<SSHConnectionTarget> {
+	const { hostNames, hostsByName } = await loadSshHosts(session);
+	const host = hostsByName.get(hostName);
+	if (!host) {
+		const suffix =
+			hostNames.length > 0 ? ` Available hosts: ${hostNames.join(", ")}` : " No SSH hosts are configured.";
+		throw new ToolError(`Unknown SSH host: ${hostName}.${suffix}`);
+	}
+	return sshHostToConnectionTarget(host);
+}

--- a/packages/coding-agent/src/tools/tool-timeouts.ts
+++ b/packages/coding-agent/src/tools/tool-timeouts.ts
@@ -12,6 +12,7 @@ export const TOOL_TIMEOUTS = {
 	eval: { default: 30, min: 1, max: 3600 },
 	browser: { default: 30, min: 1, max: 300 },
 	ssh: { default: 60, min: 1, max: 3600 },
+	copy: { default: 60, min: 1, max: 3600 },
 	fetch: { default: 20, min: 1, max: 45 },
 	lsp: { default: 20, min: 5, max: 60 },
 	debug: { default: 30, min: 5, max: 300 },

--- a/packages/coding-agent/test/discovery/mcp-json.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-json.test.ts
@@ -29,6 +29,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 		PI_MCP_HEADER: process.env.PI_MCP_HEADER,
 		PI_MCP_URL: process.env.PI_MCP_URL,
 		PI_MCP_ENV: process.env.PI_MCP_ENV,
+		PI_MCP_HOST: process.env.PI_MCP_HOST,
 	};
 
 	beforeEach(async () => {
@@ -41,6 +42,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 		process.env.PI_MCP_HEADER = "Bearer test-token";
 		process.env.PI_MCP_URL = "https://mcp.example.com";
 		process.env.PI_MCP_ENV = "env-value";
+		process.env.PI_MCP_HOST = "pi";
 	});
 
 	afterEach(async () => {
@@ -63,6 +65,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 						url: `${envPlaceholder("PI_MCP_URL")}/mcp`,
 						headers: { Authorization: envPlaceholder("PI_MCP_HEADER") },
 						env: { MCP_VALUE: envPlaceholder("PI_MCP_ENV") },
+						host: envPlaceholder("PI_MCP_HOST"),
 						auth: {
 							type: "oauth",
 							tokenUrl: envPlaceholder("PI_OAUTH_TOKEN_URL"),
@@ -86,6 +89,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 		expect(server?.url).toBe("https://mcp.example.com/mcp");
 		expect(server?.headers).toEqual({ Authorization: "Bearer test-token" });
 		expect(server?.env).toEqual({ MCP_VALUE: "env-value" });
+		expect(server?.host).toBe("pi");
 		expect(server?.auth).toEqual({
 			type: "oauth",
 			tokenUrl: "https://provider.example/token",


### PR DESCRIPTION
## Summary

Adds SSH-backed code execution and tool integration to the coding-agent stack so OMP can run code and MCP servers on configured SSH hosts while preserving the local session's tool-calling bridge.

This PR includes:

- SSH-backed persistent Python eval kernels.
- Remote cwd normalization before kernel reuse and tool-bridge defaults.
- SSH-host execution for the `bash` tool.
- Remote eval bridge defaults for SSH-capable tools (`tool.bash`, `tool.ssh`, `tool.read`, `tool.write`, and explicit-path `tool.grep`).
- Guardrails so unsupported workspace-index tools fail clearly instead of silently running on the local checkout.
- A `copy` built-in tool for byte-exact regular-file copies between local paths, `local://`/`vault://` internal URIs, and `ssh://` remote hosts.
- **MCP stdio server support over configured SSH hosts** via a `host` field in MCP config.

## User-facing behavior

### Remote Python eval

- `eval` accepts optional `host` and `cwd` for Python cells.
- Remote Python cells run on the configured SSH host and preserve state per `language + host + cwd + interpreter`.
- Relative remote `cwd` values are resolved to an absolute remote path before the kernel starts, so later cells and bridge calls keep using the intended directory.
- Plain Python file I/O plus the eval prelude `read()` / `write()` helpers operate on the remote filesystem when the kernel is remote.
- `completion(...)` and `agent(...)` still orchestrate local OMP session work.
- From a remote Python cell, these tool calls default to the same SSH host and remote cwd:
  - `tool.bash({ command: "..." })`
  - `tool.ssh({ command: "..." })`
  - `tool.read({ path: "relative/or/absolute" })`
  - `tool.write({ path: "relative/or/absolute", content: "..." })`
  - `tool.grep({ pattern: "...", paths: "file-or-list" })`
- `tool.read` / `tool.write` / `tool.grep` rewrite plain paths to `ssh://<host>/<absolute-path>` before invoking the real tool boundary. Internal/session URLs such as `local://...`, `artifact://...`, and already-explicit URLs remain explicit.
- `tool.glob`, `tool.edit`, `tool.ast_grep`, `tool.ast_edit`, `tool.lsp`, and `tool.debug` reject remote defaults for now because they require workspace indexing/edit semantics that are not safely remote yet.
- JS, Ruby, and Julia eval still reject `host` until those runtimes get dedicated remote transports.

### SSH bash behavior

- The `bash` tool now accepts `host` for configured SSH hosts.
- Remote bash preserves `command`, `cwd`, `env`, `timeout`, and async/background execution.
- Remote `cwd` is treated as a remote path and is not statted locally.
- Remote `env` is sent as POSIX environment assignments.
- Remote bash rejects `pty` because the SSH command path is non-interactive; use the `ssh` tool directly for interactive remote commands.
- Local/session internal URLs in remote bash `command`, `cwd`, or `env` are rejected rather than expanded on the local machine.

### Remote MCP stdio servers

- MCP stdio server configs now accept a `host` field naming a configured OMP SSH host.
- When `host` is set, the stdio server process is spawned through an SSH piped command with stdin/stdout/stderr preserved.
- Remote stdio spawns resolve the configured SSH host, verify a POSIX shell, resolve the remote cwd, and wrap the command in `ssh -T` with ControlMaster disabled and stdin enabled.
- Remote `roots/list` responses carry the resolved remote cwd so remote MCP servers see the intended project root instead of the local working directory.
- `host` is validated as non-empty when present, and env-var expansion applies to it like other config fields.
- HTTP/SSE MCP servers are unaffected; `host` only applies to the stdio transport.

Example config:

```json
{
  "mcpServers": {
    "remote-server": {
      "type": "stdio",
      "host": "pi",
      "command": "node",
      "args": ["server.js"],
      "cwd": "/srv/app",
      "env": { "TOKEN": "..." }
    }
  }
}
```

## Trust boundary

Remote Python tool-calling uses an SSH reverse loopback forward back to the local OMP tool bridge. The bridge token lives in the remote Python process environment while the kernel runs. That means the remote SSH account is part of the trust boundary: a same-UID process on that remote host may be able to reach the forwarded bridge during the session. The eval prompt now calls this out and tells agents to use trusted hosts/accounts.

Remote MCP stdio servers run the server process on the SSH host under the remote account; the same trusted-host assumption applies.

## Implementation details

- Adds shared SSH host resolution helpers for tools that accept configured host names.
- Adds shared POSIX remote helpers for verified shell selection, env assignment formatting, remote cwd resolution, and remote command construction.
- Adds an SSH-backed Python kernel transport that speaks the existing eval runner NDJSON protocol over a long-lived SSH process.
- Stages the Python runner on the remote host with byte-exact SSH file transfer.
- Starts the remote kernel with stdin/stdout/stderr piped so eval can drive it like the local kernel.
- Disables ControlMaster for the long-lived remote kernel process and keeps stdin enabled.
- Exposes the local Python tool bridge to the remote host with a per-kernel reverse loopback forward and `ExitOnForwardFailure=yes`.
- Includes SSH host identity and normalized remote cwd in Python session keys.
- Avoids passing local `python.interpreter` settings into SSH-backed execution; remote eval defaults to `python3` / `python` on the remote host unless an interpreter is explicitly supplied.
- Passes remote invocation context through the Python bridge registration so `tool.*` calls from remote cells can route SSH-capable tools to the correct host/cwd.
- Leaves normal local eval and local bash behavior unchanged when `host` is omitted.
- Adds `host` to `MCPServer` / `MCPStdioServerConfig` / the mcp.json JSON schema and the builtin + standalone mcp.json loaders.
- Routes remote stdio MCP spawns through a new `resolveRemoteStdioSpawnCommand` that resolves the SSH host, verifies a POSIX shell, resolves the remote cwd, builds the env/cwd/command, and wraps in `ssh -T` with ControlMaster disabled and stdin enabled.
- Threads the manager cwd through `connectToServer` so the transport can resolve the SSH host capability against the project root.
- Carries the resolved remote cwd into `roots/list` responses for remote stdio MCP servers.

## Prompt/UI updates

- Documents `host` and `cwd` only for Python-enabled eval prompts.
- Documents remote Python state scoping and the SSH account trust boundary.
- Documents which bridge tools default to the SSH host/cwd and which workspace tools currently reject remote defaults.
- Documents bash `host` usage, remote cwd/env handling, `pty` rejection, and internal-URL restrictions.
- Preserves and displays remote target metadata in eval transcripts/rendering so remote code does not look like local eval.

## Tests

Added focused coverage for:

- SSH args used by remote eval:
  - stdin enabled
  - normal ControlMaster args omitted
  - reverse `-R` tool-bridge forwarding present
  - `ExitOnForwardFailure=yes` present
- Host-aware Python kernel session keys.
- Same-host remote kernel reuse.
- Stable remote loopback bridge URL across reused remote cells.
- Remote backend ignoring local `python.interpreter` settings.
- Relative remote cwd resolution before `RemotePythonKernel.start` and before Python tool-bridge registration.
- Relative remote cwd import behavior by running the generated init script in a temp cwd and importing a module from that cwd.
- Eval renderer preserving remote target metadata in pending and completed renders.
- JS/Python bridge argument rewriting for remote eval contexts:
  - bash defaults to current SSH host/cwd
  - ssh defaults/trims host and preserves remote cwd
  - read/write/grep plain paths become `ssh://` URLs
  - explicit host/cwd override defaults
  - unsupported workspace tools do not execute locally under remote defaults
- Bash remote execution through SSH, including resolved host, POSIX shell wrapping, remote cwd, env assignments, timeout, and output result mapping.
- Remote MCP stdio spawn command resolution, covering host lookup, shell selection, remote cwd, env assignments, and the resulting ssh argv.
- Standalone mcp.json `host` field env-var expansion.

## Verification

- `bun test packages/coding-agent/src/eval/__tests__/js-tool-bridge-remote.test.ts packages/coding-agent/src/tools/__tests__/bash-remote.test.ts packages/coding-agent/src/eval/__tests__/remote-python-executor.test.ts`
- `bun test packages/coding-agent/src/mcp/transports/stdio.test.ts packages/coding-agent/test/discovery/mcp-json.test.ts`
- `bun --cwd=packages/coding-agent run check`
