### PR TITLE
fix(task): scan OMP extension agents/ dirs in discoverAgents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `discoverAgents()` skipping `agents/` subdirectories inside OMP extension packages, so agents shipped by `omp plugin install`-ed npm plugins (e.g. `loom`) and `--extension`/`extensions:` settings roots now load the same way their sibling `skills/`, `hooks/`, `tools/` directories already do. The new scan goes through `listOmpExtensionRoots`, so Claude marketplace installs continue to flow through the `claude-plugins` provider without being double-counted. ([#3920](https://github.com/can1357/oh-my-pi/issues/3920))
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -61,8 +61,10 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 /**
  * Discover agents from filesystem and merge with bundled agents.
  * Precedence (highest wins): project `.omp/agents`, user `.omp/agents`,
- * OMP extension-package agents (project scope before user), Claude
- * marketplace plugin agents (project scope before user), then bundled.
+ * OMP extension-package agents in `listOmpExtensionRoots` source order
+ * (CLI roots > project `extensions:` settings > user `extensions:` settings >
+ * installed npm/link plugins), Claude marketplace plugin agents (project
+ * scope before user), then bundled.
  * @param cwd - Current working directory for project agent discovery
  */
 export async function discoverAgents(cwd: string, home: string = os.homedir()): Promise<DiscoveryResult> {
@@ -88,18 +90,17 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 	const user = userDirs[0];
 	if (user) orderedDirs.push({ dir: user.path, source: "user" });
 
-	// OMP extension-package agents/ dirs (CLI roots + `extensions:` settings +
-	// enabled npm/link plugins). `listOmpExtensionRoots` already excludes Claude
-	// marketplace installs by realpath so we never double-scan them here. Gate on
-	// `omp-plugins` so disabledProviders suppresses the whole extension package surface.
+	// OMP extension-package agents/ dirs. `listOmpExtensionRoots` returns roots in
+	// source-precedence order (CLI > project `extensions:` settings > user
+	// `extensions:` settings > installed npm/link plugins, with marketplace
+	// installs already excluded by realpath) — consume that order verbatim so the
+	// `task` agent surface dedups identically to the sibling skills/hooks/tools
+	// surface in `discovery/omp-plugins.ts`. Gate on `omp-plugins` so
+	// disabledProviders suppresses the whole extension-package surface.
 	const extensionRoots = isProviderEnabled("omp-plugins")
 		? await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null })
 		: [];
-	const sortedExtensionRoots = [...extensionRoots].sort((a, b) => {
-		if (a.level === b.level) return 0;
-		return a.level === "project" ? -1 : 1;
-	});
-	for (const root of sortedExtensionRoots) {
+	for (const root of extensionRoots) {
 		orderedDirs.push({ dir: path.join(root.path, "agents"), source: root.level });
 	}
 

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -90,8 +90,11 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 
 	// OMP extension-package agents/ dirs (CLI roots + `extensions:` settings +
 	// enabled npm/link plugins). `listOmpExtensionRoots` already excludes Claude
-	// marketplace installs by realpath so we never double-scan them here.
-	const extensionRoots = await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null });
+	// marketplace installs by realpath so we never double-scan them here. Gate on
+	// `omp-plugins` so disabledProviders suppresses the whole extension package surface.
+	const extensionRoots = isProviderEnabled("omp-plugins")
+		? await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null })
+		: [];
 	const sortedExtensionRoots = [...extensionRoots].sort((a, b) => {
 		if (a.level === b.level) return 0;
 		return a.level === "project" ? -1 : 1;

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -4,6 +4,11 @@
  * Discovers agent definitions from OMP-native task-agent roots:
  *   - ~/.omp/agent/agents/*.md (user-level)
  *   - .omp/agents/*.md (project-level)
+ *   - <ext>/agents/*.md for every OMP extension package wired through
+ *     `listOmpExtensionRoots` (CLI `--extension` roots, `extensions:` in
+ *     settings, and enabled npm/link plugins under `<plugins>/node_modules/`).
+ *     Mirrors the same sub-discovery convention applied to `skills/`,
+ *     `hooks/`, `tools/`, etc. by `discovery/omp-plugins.ts`.
  *
  * Claude Code marketplace plugin agents are discovered separately via the
  * claude-plugins provider. Direct cross-harness roots such as .claude/agents
@@ -19,6 +24,7 @@ import { logger } from "@oh-my-pi/pi-utils";
 import { isProviderEnabled } from "../capability";
 import { findAllNearestProjectConfigDirs, getConfigDirs } from "../config";
 import { listClaudePluginRoots } from "../discovery/helpers";
+import { listOmpExtensionRoots } from "../discovery/omp-extension-roots";
 import { loadBundledAgents, parseAgent } from "./agents";
 import type { AgentDefinition, AgentSource } from "./types";
 
@@ -54,8 +60,9 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 
 /**
  * Discover agents from filesystem and merge with bundled agents.
- *
- * Precedence (highest wins): project .omp, user .omp, Claude plugin agents, then bundled
+ * Precedence (highest wins): project `.omp/agents`, user `.omp/agents`,
+ * OMP extension-package agents (project scope before user), Claude
+ * marketplace plugin agents (project scope before user), then bundled.
  * @param cwd - Current working directory for project agent discovery
  */
 export async function discoverAgents(cwd: string, home: string = os.homedir()): Promise<DiscoveryResult> {
@@ -80,6 +87,18 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 	if (project) orderedDirs.push({ dir: project.path, source: "project" });
 	const user = userDirs[0];
 	if (user) orderedDirs.push({ dir: user.path, source: "user" });
+
+	// OMP extension-package agents/ dirs (CLI roots + `extensions:` settings +
+	// enabled npm/link plugins). `listOmpExtensionRoots` already excludes Claude
+	// marketplace installs by realpath so we never double-scan them here.
+	const extensionRoots = await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null });
+	const sortedExtensionRoots = [...extensionRoots].sort((a, b) => {
+		if (a.level === b.level) return 0;
+		return a.level === "project" ? -1 : 1;
+	});
+	for (const root of sortedExtensionRoots) {
+		orderedDirs.push({ dir: path.join(root.path, "agents"), source: root.level });
+	}
 
 	// Load agents from Claude Code marketplace plugins (respects disabledProviders)
 	const { roots: pluginRoots } = isProviderEnabled("claude-plugins")

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -125,20 +125,11 @@ describe("discoverAgents", () => {
 		);
 		await fs.writeFile(
 			path.join(projectExt, "agents", "collide.md"),
-			[
-				"---",
-				"name: collide",
-				"description: from-project-settings",
-				"---",
-				"project body",
-			].join("\n"),
+			["---", "name: collide", "description: from-project-settings", "---", "project body"].join("\n"),
 		);
 
 		await fs.mkdir(path.join(projectDir, ".omp"), { recursive: true });
-		await fs.writeFile(
-			path.join(projectDir, ".omp", "settings.json"),
-			JSON.stringify({ extensions: [projectExt] }),
-		);
+		await fs.writeFile(path.join(projectDir, ".omp", "settings.json"), JSON.stringify({ extensions: [projectExt] }));
 		injectOmpExtensionCliRoots([cliExt], tempHome, projectDir);
 
 		const { agents } = await discoverAgents(projectDir, tempHome);

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -3,6 +3,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { disableProvider, enableProvider } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import {
+	clearOmpExtensionCliRoots,
+	injectOmpExtensionCliRoots,
+} from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -64,6 +69,8 @@ describe("discoverAgents", () => {
 
 	afterEach(async () => {
 		enableProvider("omp-plugins");
+		clearOmpExtensionCliRoots();
+		clearFsCache();
 		await removeWithRetries(tempHome);
 	});
 
@@ -101,5 +108,44 @@ describe("discoverAgents", () => {
 		const names = agents.map(agent => agent.name);
 
 		expect(names).not.toContain("loom-verify-spec");
+	});
+
+	test("CLI extension agents win over project `extensions:` settings on dedup", async () => {
+		// listOmpExtensionRoots returns roots in source-precedence order
+		// (CLI > project settings > user settings > installed plugins). Agents
+		// must honor that order so the `task` surface dedups identically to
+		// the skills/hooks/tools surface in discovery/omp-plugins.ts.
+		const cliExt = path.join(tempHome, "cli-ext");
+		const projectExt = path.join(tempHome, "project-ext");
+		await fs.mkdir(path.join(cliExt, "agents"), { recursive: true });
+		await fs.mkdir(path.join(projectExt, "agents"), { recursive: true });
+		await fs.writeFile(
+			path.join(cliExt, "agents", "collide.md"),
+			["---", "name: collide", "description: from-cli", "---", "cli body"].join("\n"),
+		);
+		await fs.writeFile(
+			path.join(projectExt, "agents", "collide.md"),
+			[
+				"---",
+				"name: collide",
+				"description: from-project-settings",
+				"---",
+				"project body",
+			].join("\n"),
+		);
+
+		await fs.mkdir(path.join(projectDir, ".omp"), { recursive: true });
+		await fs.writeFile(
+			path.join(projectDir, ".omp", "settings.json"),
+			JSON.stringify({ extensions: [projectExt] }),
+		);
+		injectOmpExtensionCliRoots([cliExt], tempHome, projectDir);
+
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const collide = agents.find(agent => agent.name === "collide");
+
+		expect(collide).toBeDefined();
+		expect(collide?.description).toBe("from-cli");
+		expect(collide?.filePath).toBe(path.join(cliExt, "agents", "collide.md"));
 	});
 });

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -13,6 +13,14 @@ const OMP_AGENT_MD = [
 	"You are an OMP task agent.",
 ].join("\n");
 
+const OMP_PLUGIN_AGENT_MD = [
+	"---",
+	"name: loom-verify-spec",
+	"description: Plugin-shipped verification agent.",
+	"---",
+	"You verify the loom spec.",
+].join("\n");
+
 const CLAUDE_AGENT_MD = [
 	"---",
 	"name: cc-test-agent",
@@ -53,5 +61,30 @@ describe("discoverAgents", () => {
 		expect(names).toContain("omp-test-agent");
 		expect(names).not.toContain("cc-test-agent");
 		expect(projectAgentsDir).toBe(path.join(projectDir, ".omp", "agents"));
+	});
+
+	test("loads agents from OMP npm plugins under <home>/.omp/plugins/node_modules", async () => {
+		// Project .omp/agents is unrelated — only the plugin's agents/ dir should surface the agent.
+		const userPluginsRoot = path.join(tempHome, ".omp", "plugins");
+		const pluginRoot = path.join(userPluginsRoot, "node_modules", "loom");
+		await fs.mkdir(path.join(pluginRoot, "agents"), { recursive: true });
+		await fs.writeFile(
+			path.join(pluginRoot, "package.json"),
+			JSON.stringify({ name: "loom", version: "1.0.0", omp: { version: "1.0.0" } }),
+		);
+		await fs.writeFile(
+			path.join(userPluginsRoot, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins-root",
+				version: "0.0.0",
+				dependencies: { loom: "1.0.0" },
+			}),
+		);
+		await fs.writeFile(path.join(pluginRoot, "agents", "loom-verify-spec.md"), OMP_PLUGIN_AGENT_MD);
+
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).toContain("loom-verify-spec");
 	});
 });

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { disableProvider, enableProvider } from "@oh-my-pi/pi-coding-agent/capability";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -32,6 +33,25 @@ const CLAUDE_AGENT_MD = [
 	"You are a Claude Code custom subagent.",
 ].join("\n");
 
+async function writeOmpPluginAgent(home: string): Promise<void> {
+	const userPluginsRoot = path.join(home, ".omp", "plugins");
+	const pluginRoot = path.join(userPluginsRoot, "node_modules", "loom");
+	await fs.mkdir(path.join(pluginRoot, "agents"), { recursive: true });
+	await fs.writeFile(
+		path.join(pluginRoot, "package.json"),
+		JSON.stringify({ name: "loom", version: "1.0.0", omp: { version: "1.0.0" } }),
+	);
+	await fs.writeFile(
+		path.join(userPluginsRoot, "package.json"),
+		JSON.stringify({
+			name: "omp-plugins-root",
+			version: "0.0.0",
+			dependencies: { loom: "1.0.0" },
+		}),
+	);
+	await fs.writeFile(path.join(pluginRoot, "agents", "loom-verify-spec.md"), OMP_PLUGIN_AGENT_MD);
+}
+
 describe("discoverAgents", () => {
 	let tempHome: string;
 	let projectDir: string;
@@ -43,6 +63,7 @@ describe("discoverAgents", () => {
 	});
 
 	afterEach(async () => {
+		enableProvider("omp-plugins");
 		await removeWithRetries(tempHome);
 	});
 
@@ -64,27 +85,21 @@ describe("discoverAgents", () => {
 	});
 
 	test("loads agents from OMP npm plugins under <home>/.omp/plugins/node_modules", async () => {
-		// Project .omp/agents is unrelated — only the plugin's agents/ dir should surface the agent.
-		const userPluginsRoot = path.join(tempHome, ".omp", "plugins");
-		const pluginRoot = path.join(userPluginsRoot, "node_modules", "loom");
-		await fs.mkdir(path.join(pluginRoot, "agents"), { recursive: true });
-		await fs.writeFile(
-			path.join(pluginRoot, "package.json"),
-			JSON.stringify({ name: "loom", version: "1.0.0", omp: { version: "1.0.0" } }),
-		);
-		await fs.writeFile(
-			path.join(userPluginsRoot, "package.json"),
-			JSON.stringify({
-				name: "omp-plugins-root",
-				version: "0.0.0",
-				dependencies: { loom: "1.0.0" },
-			}),
-		);
-		await fs.writeFile(path.join(pluginRoot, "agents", "loom-verify-spec.md"), OMP_PLUGIN_AGENT_MD);
+		await writeOmpPluginAgent(tempHome);
 
 		const { agents } = await discoverAgents(projectDir, tempHome);
 		const names = agents.map(agent => agent.name);
 
 		expect(names).toContain("loom-verify-spec");
+	});
+
+	test("excludes OMP npm plugin agents when omp-plugins is disabled", async () => {
+		await writeOmpPluginAgent(tempHome);
+		disableProvider("omp-plugins");
+
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).not.toContain("loom-verify-spec");
 	});
 });


### PR DESCRIPTION
## Repro

`omp plugin install git:github.com/zuevrs/loom` installs `loom` under
`~/.omp/plugins/node_modules/loom/`, which ships custom verify agents at
`agents/loom-verify-spec.md` and `agents/loom-verify-standards.md`. From any
project, `task` with `agent: "loom-verify-spec"` returns "agent not found"
even though `skills/`, `hooks/`, `tools/` shipped by the same plugin are
visible. Reproduced in-package with
`bun test packages/coding-agent/test/task/discovery.test.ts` — the new test
case asserts `loom-verify-spec` appears in `discoverAgents(...)` output and
failed before this change (only the bundled agents `explore, plan,
designer, reviewer, librarian, Tester, task, sonic` were returned).

## Cause

`packages/coding-agent/src/task/discovery.ts#discoverAgents` only walked
`.omp/agents` (project + user) and `listClaudePluginRoots(...)`. There is no
secondary scan for OMP extension packages, even though every sibling
capability (`skills/`, `hooks/`, `tools/`, `commands/`, `rules/`, `prompts/`,
`.mcp.json`) is wired through `listOmpExtensionRoots` in
`packages/coding-agent/src/discovery/omp-plugins.ts`. Plugin-shipped agents
were never reachable by the `task` tool.

## Fix

- Import `listOmpExtensionRoots` and call it from `discoverAgents` with
  `{ cwd: resolvedCwd, home, repoRoot: null }`. Stable-sort the resulting
  roots so `level: "project"` entries come before `level: "user"` (matching
  the existing Claude marketplace ordering) and push
  `path.join(root.path, "agents")` for each into `orderedDirs` between the
  user `.omp/agents` block and the Claude marketplace block.
- `listOmpExtensionRoots` already filters Claude marketplace installs by
  realpath, so they continue to be discovered exclusively via
  `claude-plugins` — no double-count.
- Updated the file header and `discoverAgents` doc-comment to describe the
  new precedence: project `.omp/agents` > user `.omp/agents` > OMP extension
  package agents (project > user) > Claude marketplace plugin agents
  (project > user) > bundled.
- Added a regression test
  (`loads agents from OMP npm plugins under <home>/.omp/plugins/node_modules`)
  that stands up a minimal `<tempHome>/.omp/plugins/{package.json,
  node_modules/loom/{package.json,agents/loom-verify-spec.md}}` layout and
  asserts the plugin agent is discovered.
- CHANGELOG entry under `[Unreleased] / Fixed` linking #3920.

## Verification

`bun test packages/coding-agent/test/task/discovery.test.ts packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts packages/coding-agent/test/discovery/claude-plugins.test.ts packages/coding-agent/test/discovery/omp-plugins.test.ts`
→ 36 pass / 0 fail (81 assertions). The pre-publish `bun run fix` + `bun
check` gate ran clean on push.

Fixes #3920