### PR TITLE
feat(coding-agent): show plugins in extension dashboard

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,9 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Added
+
+- Added plugin entries to the Extension Control Center dashboard so npm and marketplace installs appear alongside other extension capabilities ([#3924](https://github.com/can1357/oh-my-pi/pull/3924) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.2.4] - 2026-08-01
 
@@ -539,9 +542,6 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
-### Added
-
-- Added plugin entries to the Extension Control Center dashboard so npm and marketplace installs appear alongside other extension capabilities ([#3924](https://github.com/can1357/oh-my-pi/pull/3924) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -539,6 +539,9 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
+### Added
+
+- Added plugin entries to the Extension Control Center dashboard so npm and marketplace installs appear alongside other extension capabilities ([#3924](https://github.com/can1357/oh-my-pi/pull/3924) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -11,6 +11,7 @@ import {
 	isEnoent,
 	logger,
 } from "@oh-my-pi/pi-utils";
+import { getConfigDirPaths } from "../../config";
 import { withHostGuard } from "../utils";
 import { refreshBunGitCache } from "./bun-git-cache";
 import { type GitSource, parseGitUrl } from "./git-url";
@@ -152,15 +153,40 @@ export class PluginManager {
 		await Bun.write(getPluginsLockfile(), JSON.stringify(this.#runtimeConfig, null, 2));
 	}
 
-	async #loadProjectOverrides(): Promise<ProjectPluginOverrides> {
-		const overridesPath = getProjectPluginOverridesPath(this.#cwd);
-		try {
-			return await Bun.file(overridesPath).json();
-		} catch (err) {
-			if (isEnoent(err)) return {};
-			logger.warn("Failed to load project plugin overrides", { path: overridesPath, error: String(err) });
-			return {};
+	/**
+	 * Resolve the project override file the runtime plugin loader actually
+	 * reads: the first parseable `plugin-overrides.json` across project config
+	 * dirs in loader precedence order (see `loadProjectOverrides` in
+	 * `loader.ts`). Falls back to the canonical path when no override file
+	 * exists yet.
+	 */
+	async #loadProjectOverridesFile(): Promise<{ path: string; overrides: ProjectPluginOverrides }> {
+		const canonicalPath = getProjectPluginOverridesPath(this.#cwd);
+		const candidates = getConfigDirPaths("plugin-overrides.json", { user: false, cwd: this.#cwd });
+		if (!candidates.includes(canonicalPath)) candidates.push(canonicalPath);
+		for (const overridesPath of candidates) {
+			try {
+				return { path: overridesPath, overrides: await Bun.file(overridesPath).json() };
+			} catch (err) {
+				if (!isEnoent(err)) {
+					logger.warn("Failed to load project plugin overrides", { path: overridesPath, error: String(err) });
+				}
+			}
 		}
+		return { path: canonicalPath, overrides: {} };
+	}
+
+	async clearProjectDisabledOverride(name: string): Promise<void> {
+		const { path: overridesPath, overrides } = await this.#loadProjectOverridesFile();
+		if (!overrides.disabled?.includes(name)) return;
+
+		const disabled = overrides.disabled.filter(pluginName => pluginName !== name);
+		if (disabled.length > 0) {
+			overrides.disabled = disabled;
+		} else {
+			delete overrides.disabled;
+		}
+		await Bun.write(overridesPath, JSON.stringify(overrides, null, 2));
 	}
 
 	// ==========================================================================
@@ -671,8 +697,8 @@ export class PluginManager {
 			if (!isEnoent(err)) throw err;
 		}
 
-		const [projectOverrides, config, marketplaceRuntimeRealpaths] = await Promise.all([
-			this.#loadProjectOverrides(),
+		const [{ overrides: projectOverrides }, config, marketplaceRuntimeRealpaths] = await Promise.all([
+			this.#loadProjectOverridesFile(),
 			this.#ensureConfigLoaded(),
 			this.#collectMarketplaceRuntimePackageRealpaths(),
 		]);
@@ -776,6 +802,39 @@ export class PluginManager {
 		};
 	}
 
+	/**
+	 * Resolve a marketplace registry entry's effective state in this project.
+	 * Marketplace IDs need not match their runtime package names, so inspect the
+	 * installed package before applying the same project override as the loader.
+	 */
+	async getMarketplaceEffectiveState(
+		pluginId: string,
+		installPath: string,
+		registryEnabled: boolean,
+	): Promise<{ packageName: string; enabled: boolean }> {
+		const parsedId = parsePluginId(pluginId);
+		let packageName = parsedId?.name ?? pluginId;
+		try {
+			const pkg: RuntimePackageJson = await Bun.file(path.join(installPath, "package.json")).json();
+			if (typeof pkg.name === "string" && pkg.name.length > 0) {
+				packageName = pkg.name;
+			}
+		} catch (err) {
+			if (!isEnoent(err)) {
+				logger.debug("Failed to inspect marketplace plugin package path", {
+					path: installPath,
+					error: String(err),
+				});
+			}
+		}
+
+		const { overrides } = await this.#loadProjectOverridesFile();
+		return {
+			packageName,
+			enabled: registryEnabled && !(overrides.disabled?.includes(packageName) ?? false),
+		};
+	}
+
 	// ==========================================================================
 	// Enable / Disable
 	// ==========================================================================
@@ -783,13 +842,16 @@ export class PluginManager {
 	/**
 	 * Enable or disable a plugin globally.
 	 */
-	async setEnabled(name: string, enabled: boolean): Promise<void> {
+	async setEnabled(name: string, enabled: boolean, options?: { clearProjectDisabled?: boolean }): Promise<void> {
 		const config = await this.#ensureConfigLoaded();
 		if (!config.plugins[name]) {
 			throw new Error(`Plugin ${name} not found in runtime config`);
 		}
 		config.plugins[name].enabled = enabled;
 		await this.#saveRuntimeConfig();
+		if (enabled && options?.clearProjectDisabled) {
+			await this.clearProjectDisabledOverride(name);
+		}
 	}
 
 	// ==========================================================================
@@ -842,7 +904,7 @@ export class PluginManager {
 	async getPluginSettings(name: string): Promise<Record<string, unknown>> {
 		const config = await this.#ensureConfigLoaded();
 		const global = config.settings[name] || {};
-		const projectOverrides = await this.#loadProjectOverrides();
+		const { overrides: projectOverrides } = await this.#loadProjectOverridesFile();
 		const project = projectOverrides.settings?.[name] || {};
 
 		// Project settings override global

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -18,7 +18,7 @@ import { type GitSource, parseGitUrl } from "./git-url";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "./legacy-pi-compat";
 import { resolvePluginManifestEntries } from "./loader";
 import { getInstalledPluginsRegistryPath, readInstalledPluginsRegistry } from "./marketplace/registry";
-import { parsePluginId } from "./marketplace/types";
+import { type InstalledPluginEntry, parsePluginId } from "./marketplace/types";
 import { extractPackageName, parsePluginSpec } from "./parser";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type {
@@ -177,10 +177,15 @@ export class PluginManager {
 	}
 
 	async clearProjectDisabledOverride(name: string): Promise<void> {
-		const { path: overridesPath, overrides } = await this.#loadProjectOverridesFile();
-		if (!overrides.disabled?.includes(name)) return;
+		await this.clearProjectDisabledOverrides([name]);
+	}
 
-		const disabled = overrides.disabled.filter(pluginName => pluginName !== name);
+	async clearProjectDisabledOverrides(names: readonly string[]): Promise<void> {
+		const { path: overridesPath, overrides } = await this.#loadProjectOverridesFile();
+		const namesToClear = new Set(names);
+		if (!overrides.disabled?.some(name => namesToClear.has(name))) return;
+
+		const disabled = overrides.disabled.filter(pluginName => !namesToClear.has(pluginName));
 		if (disabled.length > 0) {
 			overrides.disabled = disabled;
 		} else {
@@ -812,6 +817,29 @@ export class PluginManager {
 		installPath: string,
 		registryEnabled: boolean,
 	): Promise<{ packageName: string; enabled: boolean }> {
+		const packageName = await this.#resolveMarketplacePackageName(pluginId, installPath);
+		const { overrides } = await this.#loadProjectOverridesFile();
+		return {
+			packageName,
+			enabled: registryEnabled && !(overrides.disabled?.includes(packageName) ?? false),
+		};
+	}
+
+	async getMarketplaceAggregateEffectiveState(
+		pluginId: string,
+		entries: readonly InstalledPluginEntry[],
+	): Promise<{ packageNames: string[]; enabled: boolean }> {
+		const packageNames = await Promise.all(
+			entries.map(entry => this.#resolveMarketplacePackageName(pluginId, entry.installPath)),
+		);
+		const disabled = new Set((await this.#loadProjectOverridesFile()).overrides.disabled ?? []);
+		return {
+			packageNames: Array.from(new Set(packageNames)),
+			enabled: entries.every((entry, index) => entry.enabled !== false && !disabled.has(packageNames[index])),
+		};
+	}
+
+	async #resolveMarketplacePackageName(pluginId: string, installPath: string): Promise<string> {
 		const parsedId = parsePluginId(pluginId);
 		let packageName = parsedId?.name ?? pluginId;
 		try {
@@ -828,11 +856,7 @@ export class PluginManager {
 			}
 		}
 
-		const { overrides } = await this.#loadProjectOverridesFile();
-		return {
-			packageName,
-			enabled: registryEnabled && !(overrides.disabled?.includes(packageName) ?? false),
-		};
+		return packageName;
 	}
 
 	// ==========================================================================

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -973,8 +973,13 @@ export class MCPManager {
 		}
 
 		const attempt = this.#doReconnect(name, options?.authChallenge);
-		this.#pendingReconnections.set(name, attempt);
-		return attempt.finally(() => this.#pendingReconnections.delete(name));
+		const tracked = attempt.finally(() => {
+			if (this.#pendingReconnections.get(name) === tracked) {
+				this.#pendingReconnections.delete(name);
+			}
+		});
+		this.#pendingReconnections.set(name, tracked);
+		return tracked;
 	}
 
 	/**

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -199,6 +199,7 @@ export class MCPManager {
 	#connections = new Map<string, MCPServerConnection>();
 	#tools: CustomTool<TSchema, MCPToolDetails>[] = [];
 	#pendingConnections = new Map<string, Promise<MCPServerConnection>>();
+	#pendingConnectionAborts = new Map<string, AbortController>();
 	#pendingToolLoads = new Map<string, Promise<ToolLoadResult>>();
 	#sources = new Map<string, SourceMeta>();
 	#authStorage: AuthStorage | null = null;
@@ -218,6 +219,7 @@ export class MCPManager {
 	#subscribedResources = new Map<string, Set<string>>();
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
+	#connectionGenerations = new Map<string, number>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
 	/**
@@ -475,6 +477,9 @@ export class MCPManager {
 			// Save config early so reconnection works even if the initial connect times out
 			// and falls back to cached/deferred tools.
 			this.#serverConfigs.set(name, config);
+			const managerEpoch = this.#epoch;
+			const connectionGeneration = this.#connectionGenerations.get(name) ?? 0;
+			const connectionAbort = new AbortController();
 
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
@@ -486,9 +491,21 @@ export class MCPManager {
 					onRequest: (method, params) => {
 						return this.#handleServerRequest(method, params);
 					},
+					signal: connectionAbort.signal,
 				});
 			})().then(
-				connection => {
+				async connection => {
+					if (this.#pendingConnectionAborts.get(name) === connectionAbort) {
+						this.#pendingConnectionAborts.delete(name);
+					}
+					if (
+						this.#epoch !== managerEpoch ||
+						(this.#connectionGenerations.get(name) ?? 0) !== connectionGeneration
+					) {
+						connection.transport.onClose = undefined;
+						await disconnectServer(connection).catch(() => {});
+						throw new Error(`Server "${name}" was disconnected while its initial connection was pending`);
+					}
 					// Store original config (without resolved tokens) to keep
 					// cache keys stable and avoid leaking rotating credentials.
 					connection.config = config;
@@ -528,6 +545,9 @@ export class MCPManager {
 					return connection;
 				},
 				error => {
+					if (this.#pendingConnectionAborts.get(name) === connectionAbort) {
+						this.#pendingConnectionAborts.delete(name);
+					}
 					if (this.#pendingConnections.get(name) === connectionPromise) {
 						this.#pendingConnections.delete(name);
 					}
@@ -535,6 +555,7 @@ export class MCPManager {
 				},
 			);
 			this.#pendingConnections.set(name, connectionPromise);
+			this.#pendingConnectionAborts.set(name, connectionAbort);
 
 			const toolsPromise = connectionPromise.then(async connection => {
 				const serverTools = await listTools(connection);
@@ -858,6 +879,9 @@ export class MCPManager {
 	 * Disconnect from a specific server.
 	 */
 	async disconnectServer(name: string): Promise<void> {
+		this.#connectionGenerations.set(name, (this.#connectionGenerations.get(name) ?? 0) + 1);
+		this.#pendingConnectionAborts.get(name)?.abort(new Error(`MCP server "${name}" was disconnected`));
+		this.#pendingConnectionAborts.delete(name);
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
@@ -902,9 +926,13 @@ export class MCPManager {
 			conn.transport.onClose = undefined;
 		}
 		const promises = Array.from(this.#connections.values()).map(conn => disconnectServer(conn));
+		for (const controller of this.#pendingConnectionAborts.values()) {
+			controller.abort(new Error("MCP manager disconnected"));
+		}
 		await Promise.allSettled(promises);
 
 		this.#pendingConnections.clear();
+		this.#pendingConnectionAborts.clear();
 		this.#pendingToolLoads.clear();
 		this.#pendingReconnections.clear();
 		this.#pendingResourceRefresh.clear();
@@ -990,6 +1018,7 @@ export class MCPManager {
 	}
 
 	async #doReconnect(name: string, authChallenge?: MCPAuthChallenge): Promise<MCPServerConnection | null> {
+		const reconnectGeneration = this.#connectionGenerations.get(name) ?? 0;
 		const oldConnection = this.#connections.get(name);
 		let config = oldConnection?.config ?? this.#serverConfigs.get(name);
 		const source = this.#sources.get(name) ?? oldConnection?._source;
@@ -1005,6 +1034,7 @@ export class MCPManager {
 			try {
 				const refreshedConfig = await this.#authHandler(name, authChallenge);
 				if (!refreshedConfig) return null;
+				if ((this.#connectionGenerations.get(name) ?? 0) !== reconnectGeneration) return null;
 				config = refreshedConfig;
 				this.#serverConfigs.set(name, config);
 			} catch (error) {
@@ -1033,7 +1063,7 @@ export class MCPManager {
 		// Retry with backoff — the server may still be starting up.
 		const delays = [500, 1000, 2000, 4000];
 		for (let attempt = 0; attempt <= delays.length; attempt++) {
-			if (this.#epoch !== reconnectEpoch) {
+			if (this.#epoch !== reconnectEpoch || (this.#connectionGenerations.get(name) ?? 0) !== reconnectGeneration) {
 				logger.debug("MCP reconnect aborted before attempt after configuration changed", {
 					path: `mcp:${name}`,
 					storedEpoch: reconnectEpoch,
@@ -1042,11 +1072,20 @@ export class MCPManager {
 				return null;
 			}
 			try {
-				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
+				const connection = await this.#connectAndWireServer(
+					name,
+					config,
+					source,
+					reconnectEpoch,
+					reconnectGeneration,
+				);
 				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
 				return connection;
 			} catch (error) {
-				if (this.#epoch !== reconnectEpoch) {
+				if (
+					this.#epoch !== reconnectEpoch ||
+					(this.#connectionGenerations.get(name) ?? 0) !== reconnectGeneration
+				) {
 					logger.debug("MCP reconnect aborted after configuration changed", {
 						path: `mcp:${name}`,
 						storedEpoch: reconnectEpoch,
@@ -1081,23 +1120,39 @@ export class MCPManager {
 		config: MCPServerConfig,
 		source: SourceMeta | undefined,
 		reconnectEpoch: number,
+		reconnectGeneration: number,
 	): Promise<MCPServerConnection> {
-		const resolvedConfig = await this.#resolveAuthConfig(config);
-		const connection = await connectToServer(name, resolvedConfig, {
-			onNotification: (method, params) => {
-				this.#handleServerNotification(name, method, params);
-			},
-			onRequest: (method, params) => {
-				return this.#handleServerRequest(method, params);
-			},
-		});
+		const connectionAbort = new AbortController();
+		this.#pendingConnectionAborts.set(name, connectionAbort);
+		let connection: MCPServerConnection;
+		try {
+			const resolvedConfig = await this.#resolveAuthConfig(config);
+			connection = await connectToServer(name, resolvedConfig, {
+				onNotification: (method, params) => {
+					this.#handleServerNotification(name, method, params);
+				},
+				onRequest: (method, params) => {
+					return this.#handleServerRequest(method, params);
+				},
+				signal: connectionAbort.signal,
+			});
+		} catch (error) {
+			if (this.#pendingConnectionAborts.get(name) === connectionAbort) {
+				this.#pendingConnectionAborts.delete(name);
+			}
+			throw error;
+		}
 
 		connection.config = config;
 		if (source) connection._source = source;
 
 		// Bail out if the server was disconnected or the manager was reset
 		// while we were connecting (e.g. /mcp reload called disconnectAll).
-		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
+		if (
+			!this.#serverConfigs.has(name) ||
+			this.#epoch !== reconnectEpoch ||
+			(this.#connectionGenerations.get(name) ?? 0) !== reconnectGeneration
+		) {
 			await connection.transport.close().catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
@@ -1120,19 +1175,28 @@ export class MCPManager {
 			void this.reconnectServer(name);
 		};
 		try {
-			const serverTools = await listTools(connection);
+			const serverTools = await listTools(connection, { signal: connectionAbort.signal });
+			if (this.#epoch !== reconnectEpoch || (this.#connectionGenerations.get(name) ?? 0) !== reconnectGeneration) {
+				throw new Error(`Server "${name}" was disconnected while reconnecting`);
+			}
 			const reconnect = (options?: { authChallenge?: MCPAuthChallenge }) => this.reconnectServer(name, options);
 			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 			void this.toolCache?.set(name, config, serverTools);
 			this.#replaceServerTools(name, customTools);
 			void this.#onToolsChanged?.(this.#tools);
 			void this.#loadServerResourcesAndPrompts(name, connection);
+			if (this.#pendingConnectionAborts.get(name) === connectionAbort) {
+				this.#pendingConnectionAborts.delete(name);
+			}
 			return connection;
 		} catch (error) {
 			// Clean up the connection to avoid zombie transports
 			connection.transport.onClose = undefined;
 			await connection.transport.close().catch(() => {});
 			this.#connections.delete(name);
+			if (this.#pendingConnectionAborts.get(name) === connectionAbort) {
+				this.#pendingConnectionAborts.delete(name);
+			}
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -90,7 +90,9 @@ export class ExtensionDashboard implements Component {
 	#body!: TwoColumnBody;
 	#refreshToken = 0;
 	#pluginToggleQueue = Promise.resolve();
-	#pendingPluginStates = new Map<string, boolean>();
+	#mcpToggleQueues = new Map<string, Promise<void>>();
+	#pendingExtensionStates = new Map<string, { enabled: boolean; generation: number }>();
+	#toggleGeneration = 0;
 	// Frame geometry from the last render, for SGR mouse hit-testing. The
 	// fullscreen overlay paints from screen row 0, so mouse rows map 1:1.
 	#tabRowStart = 0;
@@ -291,8 +293,9 @@ export class ExtensionDashboard implements Component {
 	#handleExtensionToggle(extensionId: string, enabled: boolean): void {
 		const sm = this.#settings ?? Settings.instance;
 		if (extensionId.startsWith("plugin:")) {
-			this.#pendingPluginStates.set(extensionId, enabled);
-			const toggle = () => this.#togglePluginExtension(extensionId, enabled);
+			const generation = ++this.#toggleGeneration;
+			this.#pendingExtensionStates.set(extensionId, { enabled, generation });
+			const toggle = () => this.#togglePluginExtension(extensionId, enabled, generation);
 			this.#pluginToggleQueue = this.#pluginToggleQueue.then(toggle, toggle);
 			return;
 		}
@@ -303,7 +306,19 @@ export class ExtensionDashboard implements Component {
 		// `~/.omp/agent/mcp.json` so `/mcp list`, the MCP runtime, and this
 		// dashboard agree on every server's enabled state (issue #3827).
 		if (extensionId.startsWith("mcp:")) {
-			void this.#toggleMcpExtension(extensionId, enabled, sm);
+			const generation = ++this.#toggleGeneration;
+			this.#pendingExtensionStates.set(extensionId, { enabled, generation });
+			const previous = this.#mcpToggleQueues.get(extensionId) ?? Promise.resolve();
+			const toggle = () => this.#toggleMcpExtension(extensionId, enabled, generation, sm);
+			const queued = previous.then(toggle, toggle);
+			this.#mcpToggleQueues.set(extensionId, queued);
+			void queued
+				.finally(() => {
+					if (this.#mcpToggleQueues.get(extensionId) === queued) {
+						this.#mcpToggleQueues.delete(extensionId);
+					}
+				})
+				.catch(() => {});
 			return;
 		}
 
@@ -325,7 +340,7 @@ export class ExtensionDashboard implements Component {
 		void this.#refreshFromState();
 	}
 
-	async #togglePluginExtension(extensionId: string, enabled: boolean): Promise<void> {
+	async #togglePluginExtension(extensionId: string, enabled: boolean, generation: number): Promise<void> {
 		const rest = extensionId.slice("plugin:".length);
 
 		try {
@@ -363,9 +378,7 @@ export class ExtensionDashboard implements Component {
 			this.#hooks.notifyError?.(`Failed to toggle plugin: ${String(error)}`);
 		}
 
-		if (this.#pendingPluginStates.get(extensionId) === enabled) {
-			this.#pendingPluginStates.delete(extensionId);
-		}
+		this.#clearPendingExtensionState(extensionId, generation);
 
 		try {
 			await this.#refreshFromState();
@@ -375,7 +388,7 @@ export class ExtensionDashboard implements Component {
 		}
 	}
 
-	async #toggleMcpExtension(extensionId: string, enabled: boolean, sm: Settings): Promise<void> {
+	async #toggleMcpExtension(extensionId: string, enabled: boolean, generation: number, sm: Settings): Promise<void> {
 		const name = extensionId.slice("mcp:".length);
 		try {
 			await setMcpServerEnabled({
@@ -388,6 +401,7 @@ export class ExtensionDashboard implements Component {
 		} catch (error) {
 			logger.warn("Failed to persist MCP toggle", { name, enabled, error: String(error) });
 			this.#hooks.notifyError?.(`Failed to save MCP toggle for "${name}": ${String(error)}`);
+			this.#clearPendingExtensionState(extensionId, generation);
 			await this.#refreshFromState();
 			return;
 		}
@@ -421,7 +435,14 @@ export class ExtensionDashboard implements Component {
 			this.#hooks.notify?.("MCP change saved — restart to apply");
 		}
 
+		this.#clearPendingExtensionState(extensionId, generation);
 		await this.#refreshFromState();
+	}
+
+	#clearPendingExtensionState(extensionId: string, generation: number): void {
+		if (this.#pendingExtensionStates.get(extensionId)?.generation === generation) {
+			this.#pendingExtensionStates.delete(extensionId);
+		}
 	}
 
 	#writableMcpSourcePath(extensionId: string): string | undefined {
@@ -441,8 +462,8 @@ export class ExtensionDashboard implements Component {
 		const nextState = await refreshState(this.#state, this.#cwd, disabledIds);
 		if (refreshToken !== this.#refreshToken) return;
 		this.#state = nextState;
-		for (const [extensionId, enabled] of this.#pendingPluginStates) {
-			this.#state = applyExtensionEnabledToState(this.#state, extensionId, enabled);
+		for (const [extensionId, pending] of this.#pendingExtensionStates) {
+			this.#state = applyExtensionEnabledToState(this.#state, extensionId, pending.enabled);
 		}
 
 		// Re-anchor on the same tab id in the (re-sorted) list.

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -33,6 +33,7 @@ import {
 	getMarketplacesCacheDir,
 	getMarketplacesRegistryPath,
 	getPluginsCacheDir,
+	type InstalledPluginSummary,
 	MarketplaceManager,
 } from "../../../extensibility/plugins/marketplace";
 import { setMcpServerEnabled } from "../../../mcp/config-writer";
@@ -365,10 +366,14 @@ export class ExtensionDashboard implements Component {
 				await manager.setPluginEnabled(pluginId, enabled, scope);
 				if (enabled) {
 					const extension = this.#state.extensions.find(item => item.id === extensionId);
-					if (extension?.path) {
+					const raw = extension?.raw as { type?: string; summary?: InstalledPluginSummary } | undefined;
+					if (raw?.type === "marketplace" && raw.summary) {
 						const pluginManager = new PluginManager(this.#cwd);
-						const effective = await pluginManager.getMarketplaceEffectiveState(pluginId, extension.path, true);
-						await pluginManager.clearProjectDisabledOverride(effective.packageName);
+						const effective = await pluginManager.getMarketplaceAggregateEffectiveState(
+							pluginId,
+							raw.summary.entries,
+						);
+						await pluginManager.clearProjectDisabledOverrides(effective.packageNames);
 					}
 				}
 			}

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -26,6 +26,15 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../../config/settings";
+import { clearPluginRootsAndCaches, resolveOrDefaultProjectRegistryPath } from "../../../discovery/helpers";
+import { PluginManager } from "../../../extensibility/plugins/manager";
+import {
+	getInstalledPluginsRegistryPath,
+	getMarketplacesCacheDir,
+	getMarketplacesRegistryPath,
+	getPluginsCacheDir,
+	MarketplaceManager,
+} from "../../../extensibility/plugins/marketplace";
 import { setMcpServerEnabled } from "../../../mcp/config-writer";
 import { getTabBarTheme } from "../../../modes/shared";
 import { theme } from "../../../modes/theme/theme";
@@ -35,6 +44,7 @@ import { ExtensionList } from "./extension-list";
 import { InspectorPanel } from "./inspector-panel";
 import {
 	applyDisabledExtensionsToState,
+	applyExtensionEnabledToState,
 	applyFilter,
 	createInitialState,
 	filterByProvider,
@@ -42,6 +52,15 @@ import {
 	toggleProvider,
 } from "./state-manager";
 import type { DashboardState, ProviderTab } from "./types";
+
+export interface DashboardHooks {
+	/** Called after an MCP enable/disable persists. Reports completed or pending live application. */
+	refreshMcpLive?: (serverName: string, enabled: boolean) => Promise<"updated" | "pending">;
+	/** Free-text success/status message shown to the user. */
+	notify?: (message: string) => void;
+	/** Persistence or live-refresh failure shown to the user. */
+	notifyError?: (message: string) => void;
+}
 
 const EXT_FOOTER = " ↑/↓: navigate · Space: toggle · ←/→: provider · Esc: close";
 
@@ -70,38 +89,46 @@ export class ExtensionDashboard implements Component {
 	#tabBar!: TabBar;
 	#body!: TwoColumnBody;
 	#refreshToken = 0;
+	#pluginToggleQueue = Promise.resolve();
+	#pendingPluginStates = new Map<string, boolean>();
 	// Frame geometry from the last render, for SGR mouse hit-testing. The
 	// fullscreen overlay paints from screen row 0, so mouse rows map 1:1.
 	#tabRowStart = 0;
 	#tabRowCount = 0;
 	#bodyRowStart = 0;
 	#bodyRowCount = 0;
+	#hooks: DashboardHooks;
+	#cwd: string;
+	#settings: Settings | null;
+	#terminalHeight: number;
 
 	onClose?: () => void;
 	onRequestRender?: () => void;
 
-	private constructor(
-		private readonly cwd: string,
-		private readonly settings: Settings | null,
-		private readonly terminalHeight: number,
-	) {}
+	private constructor(cwd: string, settings: Settings | null, terminalHeight: number, hooks?: DashboardHooks) {
+		this.#cwd = cwd;
+		this.#settings = settings;
+		this.#terminalHeight = terminalHeight;
+		this.#hooks = hooks ?? {};
+	}
 
 	static async create(
 		cwd: string,
 		settings: Settings | null = null,
 		terminalHeight?: number,
+		hooks?: DashboardHooks,
 	): Promise<ExtensionDashboard> {
-		const dashboard = new ExtensionDashboard(cwd, settings, terminalHeight ?? process.stdout.rows ?? 24);
+		const dashboard = new ExtensionDashboard(cwd, settings, terminalHeight ?? process.stdout.rows ?? 24, hooks);
 		await dashboard.#init();
 		return dashboard;
 	}
 
 	async #init(): Promise<void> {
-		const sm = this.settings ?? (await Settings.init());
+		const sm = this.#settings ?? (await Settings.init());
 		const disabledIds = sm ? ((sm.get("disabledExtensions") as string[]) ?? []) : [];
-		this.#state = await createInitialState(this.cwd, disabledIds);
+		this.#state = await createInitialState(this.#cwd, disabledIds);
 
-		const initialMaxVisible = Math.max(3, this.terminalHeight - 9);
+		const initialMaxVisible = Math.max(3, this.#terminalHeight - 9);
 		this.#mainList = new ExtensionList(
 			this.#state.searchFiltered,
 			{
@@ -119,12 +146,12 @@ export class ExtensionDashboard implements Component {
 		);
 		this.#mainList.setFocused(true);
 
-		this.#inspector = new InspectorPanel();
+		this.#inspector = new InspectorPanel({ mcpLiveRefreshAvailable: this.#hooks.refreshMcpLive !== undefined });
 		if (this.#state.selected) {
 			this.#inspector.setExtension(this.#state.selected);
 		}
 
-		this.#body = new TwoColumnBody(this.#mainList, this.#inspector, this.terminalHeight);
+		this.#body = new TwoColumnBody(this.#mainList, this.#inspector, this.#terminalHeight);
 
 		this.#tabBar = new TabBar("", buildTabBarTabs(this.#state.tabs), getTabBarTheme());
 		this.#tabBar.showHint = false;
@@ -140,7 +167,7 @@ export class ExtensionDashboard implements Component {
 
 	/** Live terminal height so the dashboard tracks resize while open. */
 	#terminalRows(): number {
-		return process.stdout.rows || this.terminalHeight || 24;
+		return process.stdout.rows || this.#terminalHeight || 24;
 	}
 
 	/**
@@ -262,7 +289,14 @@ export class ExtensionDashboard implements Component {
 	}
 
 	#handleExtensionToggle(extensionId: string, enabled: boolean): void {
-		const sm = this.settings ?? Settings.instance;
+		const sm = this.#settings ?? Settings.instance;
+		if (extensionId.startsWith("plugin:")) {
+			this.#pendingPluginStates.set(extensionId, enabled);
+			const toggle = () => this.#togglePluginExtension(extensionId, enabled);
+			this.#pluginToggleQueue = this.#pluginToggleQueue.then(toggle, toggle);
+			return;
+		}
+
 		if (!sm) return;
 
 		// MCP toggles route through the canonical denylist in
@@ -291,18 +325,71 @@ export class ExtensionDashboard implements Component {
 		void this.#refreshFromState();
 	}
 
+	async #togglePluginExtension(extensionId: string, enabled: boolean): Promise<void> {
+		const rest = extensionId.slice("plugin:".length);
+
+		try {
+			if (rest.startsWith("npm/")) {
+				const pluginName = rest.slice("npm/".length);
+				const npmManager = new PluginManager(this.#cwd);
+				await npmManager.setEnabled(pluginName, enabled, { clearProjectDisabled: true });
+			} else if (rest.startsWith("mkt/")) {
+				const spec = rest.slice("mkt/".length);
+				const atIndex = spec.lastIndexOf("@");
+				const pluginId = atIndex > 0 ? spec.slice(0, atIndex) : spec;
+				const scope = atIndex > 0 ? (spec.slice(atIndex + 1) as "user" | "project") : undefined;
+				const projectPath = await resolveOrDefaultProjectRegistryPath(this.#cwd);
+				const manager = new MarketplaceManager({
+					marketplacesRegistryPath: getMarketplacesRegistryPath(),
+					installedRegistryPath: getInstalledPluginsRegistryPath(),
+					projectInstalledRegistryPath: projectPath ?? undefined,
+					marketplacesCacheDir: getMarketplacesCacheDir(),
+					pluginsCacheDir: getPluginsCacheDir(),
+					clearPluginRootsCache: clearPluginRootsAndCaches,
+				});
+				await manager.setPluginEnabled(pluginId, enabled, scope);
+				if (enabled) {
+					const extension = this.#state.extensions.find(item => item.id === extensionId);
+					if (extension?.path) {
+						const pluginManager = new PluginManager(this.#cwd);
+						const effective = await pluginManager.getMarketplaceEffectiveState(pluginId, extension.path, true);
+						await pluginManager.clearProjectDisabledOverride(effective.packageName);
+					}
+				}
+			}
+			this.#hooks.notify?.("Plugin change saved — restart to apply");
+		} catch (error) {
+			logger.warn("Failed to persist plugin toggle", { id: rest, enabled, error: String(error) });
+			this.#hooks.notifyError?.(`Failed to toggle plugin: ${String(error)}`);
+		}
+
+		if (this.#pendingPluginStates.get(extensionId) === enabled) {
+			this.#pendingPluginStates.delete(extensionId);
+		}
+
+		try {
+			await this.#refreshFromState();
+		} catch (error) {
+			logger.warn("Failed to refresh extension dashboard after plugin toggle", { id: rest, error: String(error) });
+			this.#hooks.notifyError?.(`Plugin changed, but the dashboard failed to refresh: ${String(error)}`);
+		}
+	}
+
 	async #toggleMcpExtension(extensionId: string, enabled: boolean, sm: Settings): Promise<void> {
 		const name = extensionId.slice("mcp:".length);
 		try {
 			await setMcpServerEnabled({
-				userPath: getMCPConfigPath("user", this.cwd),
-				projectPath: getMCPConfigPath("project", this.cwd),
+				userPath: getMCPConfigPath("user", this.#cwd),
+				projectPath: getMCPConfigPath("project", this.#cwd),
 				sourcePath: this.#writableMcpSourcePath(extensionId),
 				name,
 				enabled,
 			});
 		} catch (error) {
 			logger.warn("Failed to persist MCP toggle", { name, enabled, error: String(error) });
+			this.#hooks.notifyError?.(`Failed to save MCP toggle for "${name}": ${String(error)}`);
+			await this.#refreshFromState();
+			return;
 		}
 
 		// Reconcile `settings.disabledExtensions` with the canonical mcp.json
@@ -315,6 +402,23 @@ export class ExtensionDashboard implements Component {
 			stored.splice(had, 1);
 			sm.set("disabledExtensions", stored);
 			this.#applyDisabledExtensions(stored);
+		}
+
+		let liveState: "updated" | "pending" | "restart-required" = "restart-required";
+		let liveError: string | undefined;
+		try {
+			liveState = (await this.#hooks.refreshMcpLive?.(name, enabled)) ?? "restart-required";
+		} catch (error) {
+			liveError = String(error);
+		}
+		if (liveError) {
+			this.#hooks.notifyError?.(`Live refresh failed for "${name}": ${liveError}`);
+		} else if (liveState === "updated") {
+			this.#hooks.notify?.("MCP tools updated live");
+		} else if (liveState === "pending") {
+			this.#hooks.notify?.("MCP connection in progress — tools will update live");
+		} else {
+			this.#hooks.notify?.("MCP change saved — restart to apply");
 		}
 
 		await this.#refreshFromState();
@@ -332,11 +436,14 @@ export class ExtensionDashboard implements Component {
 		// Remember the current tab so it survives the re-sort.
 		const currentTabId = this.#state.tabs[this.#state.activeTabIndex]?.id;
 
-		const sm = this.settings ?? Settings.instance;
+		const sm = this.#settings ?? Settings.instance;
 		const disabledIds = sm ? ((sm.get("disabledExtensions") as string[]) ?? []) : [];
-		const nextState = await refreshState(this.#state, this.cwd, disabledIds);
+		const nextState = await refreshState(this.#state, this.#cwd, disabledIds);
 		if (refreshToken !== this.#refreshToken) return;
 		this.#state = nextState;
+		for (const [extensionId, enabled] of this.#pendingPluginStates) {
+			this.#state = applyExtensionEnabledToState(this.#state, extensionId, enabled);
+		}
 
 		// Re-anchor on the same tab id in the (re-sorted) list.
 		if (currentTabId) {
@@ -422,12 +529,12 @@ class TwoColumnBody implements Component {
 	#rightScroll = 0;
 	#rightTotal = 0;
 	#leftWidth = 0;
+	#leftPane: ExtensionList;
+	#rightPane: InspectorPanel;
 
-	constructor(
-		private readonly leftPane: ExtensionList,
-		private readonly rightPane: InspectorPanel,
-		maxHeight: number,
-	) {
+	constructor(leftPane: ExtensionList, rightPane: InspectorPanel, maxHeight: number) {
+		this.#leftPane = leftPane;
+		this.#rightPane = rightPane;
 		this.#maxHeight = maxHeight;
 	}
 
@@ -456,8 +563,8 @@ class TwoColumnBody implements Component {
 		const rightWidth = Math.max(0, width - leftWidth - 3);
 		const numLines = this.#maxHeight;
 
-		const leftLines = this.leftPane.render(leftWidth);
-		const rightLines = this.rightPane.render(rightWidth);
+		const leftLines = this.#leftPane.render(leftWidth);
+		const rightLines = this.#rightPane.render(rightWidth);
 		this.#rightTotal = rightLines.length;
 		const maxScroll = Math.max(0, this.#rightTotal - numLines);
 		if (this.#rightScroll > maxScroll) this.#rightScroll = maxScroll;
@@ -486,7 +593,7 @@ class TwoColumnBody implements Component {
 	}
 
 	invalidate(): void {
-		this.leftPane.invalidate?.();
-		this.rightPane.invalidate?.();
+		this.#leftPane.invalidate?.();
+		this.#rightPane.invalidate?.();
 	}
 }

--- a/packages/coding-agent/src/modes/components/extensions/extension-list.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-list.ts
@@ -8,9 +8,10 @@
 import { type Component, matchesKey, padding, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { isProviderEnabled } from "../../../discovery";
 import { theme } from "../../../modes/theme/theme";
+import { replaceTabs } from "../../../tools/render-utils";
 import { matchesSelectDown, matchesSelectUp } from "../../utils/keybinding-matchers";
 import { clampSelection, contentRowWidth, renderScrollableList, searchableChar } from "../selector-helpers";
-import { applyFilter } from "./state-manager";
+import { applyFilter, withExtensionEnabled } from "./state-manager";
 import type { Extension, ExtensionKind, ExtensionState } from "./types";
 
 export interface ExtensionListCallbacks {
@@ -208,7 +209,7 @@ export class ExtensionList implements Component {
 		const stateIcon = this.#getStateIcon(ext.state, masterDisabled);
 
 		// Name
-		let name = ext.displayName;
+		let name = replaceTabs(ext.displayName);
 		const nameWidth = Math.min(24, width - 16);
 
 		// Build the line with indentation (visually "inside" the master switch)
@@ -231,7 +232,7 @@ export class ExtensionList implements Component {
 			const triggerStyle = effectivelyDisabled ? "dim" : "muted";
 			const remainingWidth = width - visibleWidth(line) - 2;
 			if (remainingWidth > 5) {
-				line += `  ${truncateToWidth(theme.fg(triggerStyle as "dim" | "muted", ext.trigger), remainingWidth)}`;
+				line += `  ${truncateToWidth(theme.fg(triggerStyle as "dim" | "muted", replaceTabs(ext.trigger)), remainingWidth)}`;
 			}
 		}
 
@@ -255,6 +256,8 @@ export class ExtensionList implements Component {
 				return theme.icon.extensionSlashCommand;
 			case "mcp":
 				return theme.icon.extensionMcp;
+			case "plugin":
+				return theme.icon.extensionTool;
 			case "rule":
 				return theme.icon.extensionRule;
 			case "hook":
@@ -338,6 +341,7 @@ export class ExtensionList implements Component {
 			"tool",
 			"slash-command",
 			"rule",
+			"plugin",
 			"mcp",
 			"hook",
 			"prompt",
@@ -377,6 +381,8 @@ export class ExtensionList implements Component {
 				return "Rules";
 			case "mcp":
 				return "MCP Servers";
+			case "plugin":
+				return "Plugins";
 			case "hook":
 				return "Hooks";
 			case "prompt":
@@ -406,6 +412,10 @@ export class ExtensionList implements Component {
 			const masterDisabled = this.#masterSwitchProvider !== null && !isProviderEnabled(this.#masterSwitchProvider);
 			if (!masterDisabled) {
 				const newEnabled = item.item.state === "disabled";
+				const next = withExtensionEnabled(item.item, newEnabled);
+				item.item.state = next.state;
+				if (next.disabledReason === undefined) delete item.item.disabledReason;
+				else item.item.disabledReason = next.disabledReason;
 				this.callbacks.onToggle?.(item.item.id, newEnabled);
 			}
 		}

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -7,11 +7,20 @@ import * as os from "node:os";
 import { arkToWireSchema, isArkSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { type Component, truncateToWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { theme } from "../../../modes/theme/theme";
-import { shortenPath } from "../../../tools/render-utils";
-import type { Extension, ExtensionState } from "./types";
+import { replaceTabs, shortenPath } from "../../../tools/render-utils";
+import type { Extension, ExtensionKind, ExtensionState } from "./types";
+
+export interface InspectorPanelOptions {
+	mcpLiveRefreshAvailable?: boolean;
+}
 
 export class InspectorPanel implements Component {
 	#extension: Extension | null = null;
+	readonly #mcpLiveRefreshAvailable: boolean;
+
+	constructor(options: InspectorPanelOptions = {}) {
+		this.#mcpLiveRefreshAvailable = options.mcpLiveRefreshAvailable ?? false;
+	}
 
 	setExtension(extension: Extension | null): void {
 		this.#extension = extension;
@@ -28,7 +37,7 @@ export class InspectorPanel implements Component {
 		const lines: string[] = [];
 
 		// Name header
-		lines.push(theme.bold(theme.fg("accent", ext.displayName)));
+		lines.push(theme.bold(theme.fg("accent", truncateToWidth(replaceTabs(ext.displayName), width))));
 		lines.push("");
 
 		// Kind badge
@@ -39,33 +48,42 @@ export class InspectorPanel implements Component {
 		const desc = ext.description;
 		const isValidDescription = typeof desc === "string" && desc.length > 0;
 		if (isValidDescription && width > 2) {
-			const wrapped = wrapTextWithAnsi(desc, width - 2);
+			const wrapped = wrapTextWithAnsi(replaceTabs(desc), width - 2);
 			for (const line of wrapped) {
 				lines.push(truncateToWidth(line, width));
 			}
 			lines.push("");
 		} else if (isValidDescription) {
 			// Width too small for wrapping, show truncated single line
-			lines.push(truncateToWidth(desc, width));
+			lines.push(truncateToWidth(replaceTabs(desc), width));
 			lines.push("");
 		}
 
 		// Origin
 		lines.push(theme.fg("muted", "Origin:"));
 		const levelLabel = ext.source.level === "user" ? "User" : ext.source.level === "project" ? "Project" : "Native";
-		lines.push(`  ${theme.italic(`via ${ext.source.providerName} (${levelLabel})`)}`);
+		lines.push(
+			truncateToWidth(`  ${theme.italic(`via ${replaceTabs(ext.source.providerName)} (${levelLabel})`)}`, width),
+		);
 		const shortened = shortenPath(ext.path, os.homedir());
 		// If path is very long, show just the last parts
 		const displayPath =
 			shortened.length > 40 && shortened.split("/").length > 3
 				? `.../${shortened.split("/").slice(-3).join("/")}`
 				: shortened;
-		lines.push(`  ${theme.fg("dim", displayPath)}`);
+		lines.push(truncateToWidth(`  ${theme.fg("dim", replaceTabs(displayPath))}`, width));
 		lines.push("");
 
 		// Status badge
 		lines.push(theme.fg("muted", "Status:"));
-		lines.push(`  ${this.#getStatusBadge(ext.state, ext.disabledReason, ext.shadowedBy)}`);
+		lines.push(
+			truncateToWidth(`  ${this.#getStatusBadge(ext.state, ext.disabledReason, ext.shadowedBy, width - 2)}`, width),
+		);
+		lines.push("");
+
+		// Hot-refresh badge
+		lines.push(theme.fg("muted", "Applies:"));
+		lines.push(`  ${this.#getRefreshBadge(ext.kind)}`);
 		lines.push("");
 
 		// Preview section (routed based on kind)
@@ -91,6 +109,9 @@ export class InspectorPanel implements Component {
 				break;
 			case "mcp":
 				content = this.#renderMcpDetails(ext.raw, width);
+				break;
+			case "plugin":
+				content = this.#renderPluginPreview(ext.raw, width);
 				break;
 			default:
 				content = this.#renderDefaultPreview(ext, width);
@@ -274,6 +295,41 @@ export class InspectorPanel implements Component {
 		return lines;
 	}
 
+	#renderPluginPreview(raw: unknown, width: number): string[] {
+		const lines: string[] = [];
+		const data = raw as {
+			type?: string;
+			name?: string;
+			plugin?: { version?: string; manifest?: { description?: string } };
+			summary?: {
+				id: string;
+				scope: string;
+				shadowedBy?: string;
+				entries: Array<{ version?: string; enabled?: boolean }>;
+			};
+		};
+		if (data?.type === "npm" && data.plugin) {
+			lines.push(truncateToWidth(`${theme.fg("muted", "Source: ")}npm`, width));
+			lines.push(truncateToWidth(theme.fg("muted", "Version: ") + replaceTabs(data.plugin.version ?? "?"), width));
+			if (data.plugin.manifest?.description) {
+				lines.push("");
+				lines.push(theme.fg("muted", "Description:"));
+				for (const line of wrapTextWithAnsi(replaceTabs(data.plugin.manifest.description), width - 2)) {
+					lines.push(truncateToWidth(line, width));
+				}
+			}
+		} else if (data?.type === "marketplace" && data.summary) {
+			const entry = data.summary.entries[0];
+			lines.push(truncateToWidth(`${theme.fg("muted", "Source: ")}Marketplace`, width));
+			lines.push(truncateToWidth(theme.fg("muted", "Scope: ") + replaceTabs(data.summary.scope), width));
+			lines.push(truncateToWidth(theme.fg("muted", "Version: ") + replaceTabs(entry?.version ?? "?"), width));
+			if (data.summary.shadowedBy) {
+				lines.push(truncateToWidth(theme.fg("warning", replaceTabs("Shadowed by project install")), width));
+			}
+		}
+		return lines;
+	}
+
 	#renderDefaultPreview(ext: Extension, width: number): string[] {
 		const lines: string[] = [];
 
@@ -306,7 +362,14 @@ export class InspectorPanel implements Component {
 		return theme.fg(color as any, kind);
 	}
 
-	#getStatusBadge(state: ExtensionState, reason?: string, shadowedBy?: string): string {
+	#getRefreshBadge(kind: ExtensionKind): string {
+		if (kind === "mcp" && this.#mcpLiveRefreshAvailable) {
+			return theme.fg("success", "● live (no restart needed)");
+		}
+		return theme.fg("warning", "↻ restart required");
+	}
+
+	#getStatusBadge(state: ExtensionState, reason?: string, shadowedBy?: string, width?: number): string {
 		switch (state) {
 			case "active":
 				return theme.fg("success", `${theme.status.enabled} Active`);
@@ -319,8 +382,10 @@ export class InspectorPanel implements Component {
 							: "unknown";
 				return theme.fg("dim", `${theme.status.disabled} Disabled (${reasonText})`);
 			}
-			case "shadowed":
-				return theme.fg("warning", `${theme.status.shadowed} Shadowed${shadowedBy ? ` by ${shadowedBy}` : ""}`);
+			case "shadowed": {
+				const label = `${theme.status.shadowed} Shadowed${shadowedBy ? ` by ${replaceTabs(shadowedBy)}` : ""}`;
+				return theme.fg("warning", width === undefined ? label : truncateToWidth(label, width));
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -83,7 +83,7 @@ export class InspectorPanel implements Component {
 
 		// Hot-refresh badge
 		lines.push(theme.fg("muted", "Applies:"));
-		lines.push(`  ${this.#getRefreshBadge(ext.kind)}`);
+		lines.push(truncateToWidth(`  ${this.#getRefreshBadge(ext.kind)}`, width));
 		lines.push("");
 
 		// Preview section (routed based on kind)

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -369,11 +369,9 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 		for (const summary of installed) {
 			const id = makeExtensionId("plugin", `mkt/${summary.id}@${summary.scope}`);
 			const entry: InstalledPluginEntry | undefined = summary.entries[0];
-			const effective = entry
-				? await pluginManager.getMarketplaceEffectiveState(summary.id, entry.installPath, entry.enabled !== false)
-				: undefined;
+			const effective = await pluginManager.getMarketplaceAggregateEffectiveState(summary.id, summary.entries);
 			const isShadowed = Boolean(summary.shadowedBy);
-			const isDisabled = effective?.enabled === false;
+			const isDisabled = !effective.enabled;
 			extensions.push({
 				id,
 				kind: "plugin",

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -4,7 +4,7 @@
  */
 import * as path from "node:path";
 import { fuzzyMatch } from "@oh-my-pi/pi-tui";
-import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
+import { getMCPConfigPath, getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import type { ContextFile } from "../../../capability/context-file";
 import type { ExtensionModule } from "../../../capability/extension-module";
 import type { Hook } from "../../../capability/hook";
@@ -22,6 +22,16 @@ import {
 	isProviderEnabled,
 	loadCapability,
 } from "../../../discovery";
+import { clearPluginRootsAndCaches, resolveOrDefaultProjectRegistryPath } from "../../../discovery/helpers";
+import { PluginManager } from "../../../extensibility/plugins/manager";
+import {
+	getInstalledPluginsRegistryPath,
+	getMarketplacesCacheDir,
+	getMarketplacesRegistryPath,
+	getPluginsCacheDir,
+	MarketplaceManager,
+} from "../../../extensibility/plugins/marketplace";
+import type { InstalledPluginEntry, InstalledPluginSummary } from "../../../extensibility/plugins/marketplace/types";
 import { readDisabledServers, readEnabledServers } from "../../../mcp/config-writer";
 import type {
 	DashboardState,
@@ -315,6 +325,78 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 		logger.warn("Failed to load context-files capability", { error: String(error) });
 	}
 
+	// Load npm plugins (installed via npm in the plugins dir)
+	try {
+		const npmManager = new PluginManager(cwd ?? getProjectDir());
+		const npmPlugins = await npmManager.list();
+		for (const plugin of npmPlugins) {
+			const id = makeExtensionId("plugin", `npm/${plugin.name}`);
+			extensions.push({
+				id,
+				kind: "plugin",
+				name: plugin.name,
+				displayName: plugin.manifest?.name ?? plugin.name,
+				description: plugin.manifest?.description ?? `v${plugin.version}`,
+				trigger: plugin.manifest?.version ?? plugin.version,
+				path: plugin.path,
+				source: {
+					provider: "npm-plugin",
+					providerName: "npm Plugin",
+					level: "user",
+				},
+				state: plugin.enabled ? "active" : "disabled",
+				disabledReason: plugin.enabled ? undefined : "item-disabled",
+				raw: { type: "npm", name: plugin.name, plugin },
+			});
+		}
+	} catch (error) {
+		logger.warn("Failed to load npm plugins", { error: String(error) });
+	}
+
+	// Load marketplace plugins
+	try {
+		const projectPath = await resolveOrDefaultProjectRegistryPath(cwd ?? getProjectDir());
+		const marketplaceManager = new MarketplaceManager({
+			marketplacesRegistryPath: getMarketplacesRegistryPath(),
+			installedRegistryPath: getInstalledPluginsRegistryPath(),
+			projectInstalledRegistryPath: projectPath,
+			marketplacesCacheDir: getMarketplacesCacheDir(),
+			pluginsCacheDir: getPluginsCacheDir(),
+			clearPluginRootsCache: clearPluginRootsAndCaches,
+		});
+		const installed: InstalledPluginSummary[] = await marketplaceManager.listInstalledPlugins();
+		const pluginManager = new PluginManager(cwd ?? getProjectDir());
+		for (const summary of installed) {
+			const id = makeExtensionId("plugin", `mkt/${summary.id}@${summary.scope}`);
+			const entry: InstalledPluginEntry | undefined = summary.entries[0];
+			const effective = entry
+				? await pluginManager.getMarketplaceEffectiveState(summary.id, entry.installPath, entry.enabled !== false)
+				: undefined;
+			const isShadowed = Boolean(summary.shadowedBy);
+			const isDisabled = effective?.enabled === false;
+			extensions.push({
+				id,
+				kind: "plugin",
+				name: summary.id,
+				displayName: summary.id,
+				description: `v${entry?.version ?? "?"} [${summary.scope}]`,
+				trigger: summary.scope,
+				path: entry?.installPath ?? "",
+				source: {
+					provider: "marketplace-plugin",
+					providerName: "Marketplace Plugin",
+					level: summary.scope,
+				},
+				state: isDisabled ? "disabled" : isShadowed ? "shadowed" : "active",
+				disabledReason: isDisabled ? "item-disabled" : isShadowed ? "shadowed" : undefined,
+				shadowedBy: summary.shadowedBy,
+				raw: { type: "marketplace", summary },
+			});
+		}
+	} catch (error) {
+		logger.warn("Failed to load marketplace plugins", { error: String(error) });
+	}
+
 	return extensions;
 }
 
@@ -457,6 +539,8 @@ function getKindDisplayName(kind: ExtensionKind): string {
 			return "Hooks";
 		case "slash-command":
 			return "Slash Commands";
+		case "plugin":
+			return "Plugins";
 		default:
 			return kind;
 	}
@@ -534,6 +618,40 @@ function isShadowedExtension(ext: Extension): boolean {
 	return Boolean((ext.raw as { _shadowed?: boolean } | null | undefined)?._shadowed);
 }
 
+/** Project one extension's enabled state without waiting for capability rediscovery. */
+export function withExtensionEnabled(ext: Extension, enabled: boolean): Extension {
+	if (!enabled) {
+		if (ext.state === "disabled" && ext.disabledReason === "item-disabled") return ext;
+		return { ...ext, state: "disabled", disabledReason: "item-disabled" };
+	}
+	if (!isProviderEnabled(ext.source.provider)) {
+		return { ...ext, state: "disabled", disabledReason: "provider-disabled" };
+	}
+	if (isShadowedExtension(ext)) {
+		return { ...ext, state: "shadowed", disabledReason: "shadowed" };
+	}
+	const active: Extension = { ...ext, state: "active" };
+	delete active.disabledReason;
+	return active;
+}
+
+/** Apply one pending item toggle consistently across every dashboard view. */
+export function applyExtensionEnabledToState(
+	state: DashboardState,
+	extensionId: string,
+	enabled: boolean,
+): DashboardState {
+	const updateExtension = (ext: Extension): Extension =>
+		ext.id === extensionId ? withExtensionEnabled(ext, enabled) : ext;
+	return {
+		...state,
+		extensions: state.extensions.map(updateExtension),
+		tabFiltered: state.tabFiltered.map(updateExtension),
+		searchFiltered: state.searchFiltered.map(updateExtension),
+		selected: state.selected ? updateExtension(state.selected) : null,
+	};
+}
+
 /**
  * Apply setting-backed item disable overrides to an existing dashboard state.
  * This gives the UI immediate feedback while the full capability refresh runs.
@@ -541,24 +659,9 @@ function isShadowedExtension(ext: Extension): boolean {
 export function applyDisabledExtensionsToState(state: DashboardState, disabledIds: string[]): DashboardState {
 	const disabled = new Set(disabledIds);
 	const updateExtension = (ext: Extension): Extension => {
-		if (disabled.has(ext.id)) {
-			if (ext.state === "disabled" && ext.disabledReason === "item-disabled") return ext;
-			return { ...ext, state: "disabled", disabledReason: "item-disabled" };
-		}
-
+		if (disabled.has(ext.id)) return withExtensionEnabled(ext, false);
 		if (ext.state !== "disabled" || ext.disabledReason !== "item-disabled") return ext;
-		if (!isProviderEnabled(ext.source.provider)) {
-			return { ...ext, state: "disabled", disabledReason: "provider-disabled" };
-		}
-
-		if (isShadowedExtension(ext)) {
-			const shadowed: Extension = { ...ext, state: "shadowed", disabledReason: "shadowed" };
-			return shadowed;
-		}
-
-		const enabled: Extension = { ...ext, state: "active" };
-		delete enabled.disabledReason;
-		return enabled;
+		return withExtensionEnabled(ext, true);
 	};
 
 	return {

--- a/packages/coding-agent/src/modes/components/extensions/types.ts
+++ b/packages/coding-agent/src/modes/components/extensions/types.ts
@@ -16,6 +16,7 @@ export type ExtensionKind =
 	| "instruction"
 	| "context-file"
 	| "hook"
+	| "plugin"
 	| "slash-command";
 
 /**

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -679,7 +679,7 @@ export class PluginSettingsComponent extends Container {
 
 		this.#viewComponent = new PluginDetailComponent(plugin, this.#manager, {
 			onEnabledChange: async enabled => {
-				await this.#manager.setEnabled(plugin.name, enabled);
+				await this.#manager.setEnabled(plugin.name, enabled, { clearProjectDisabled: true });
 				await this.callbacks.onPluginChanged();
 			},
 			onFeatureChange: async (feature, enabled) => {

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -12,7 +12,6 @@ import {
 	analyzeAuthError,
 	discoverOAuthEndpoints,
 	fetchResourceMetadataScopes,
-	loadAllMCPConfigs,
 	MCPManager,
 	type OAuthEndpoints,
 } from "../../mcp";
@@ -67,6 +66,7 @@ import { parseCommandArgs } from "../shared";
 import { theme } from "../theme/theme";
 import type { InteractiveModeContext } from "../types";
 import { groupBySource, parseRemoveArgs, readScopeFlag, showCommandMessage } from "./command-controller-shared";
+import { refreshMcpServer } from "./mcp-live-refresh";
 
 const MCP_MANUAL_INPUT_PROVIDER_ID = "mcp";
 const MCP_MANUAL_LOGIN_TIP = "Headless? Paste the redirect URL or code with /login <value>.";
@@ -2015,20 +2015,15 @@ export class MCPCommandController {
 	}
 
 	async #connectEnabledMCPServer(name: string): Promise<void> {
-		if (!this.ctx.mcpManager) {
-			return;
-		}
+		if (!this.ctx.mcpManager) return;
 
-		const { configs, sources } = await loadAllMCPConfigs(getProjectDir());
-		const config = configs[name];
-		if (!config) {
-			await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
-			return;
-		}
-
-		const source = sources[name];
-		const result = await this.ctx.mcpManager.connectServers({ [name]: config }, source ? { [name]: source } : {});
-		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
+		const result = await refreshMcpServer({
+			cwd: getProjectDir(),
+			serverName: name,
+			enabled: true,
+			manager: this.ctx.mcpManager,
+			refreshTools: async manager => this.ctx.session.refreshMCPTools(manager.getTools()),
+		});
 		this.#showMCPConnectionErrors(result.errors);
 	}
 

--- a/packages/coding-agent/src/modes/controllers/mcp-live-refresh.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-live-refresh.ts
@@ -1,0 +1,59 @@
+import type { MCPManager } from "../../mcp";
+import { loadAllMCPConfigs } from "../../mcp/config";
+
+export type McpServerRefreshState = "updated" | "connecting" | "failed";
+
+export interface McpServerRefreshResult {
+	state: McpServerRefreshState;
+	errors: Map<string, string>;
+}
+
+export interface RefreshMcpServerOptions {
+	cwd: string;
+	serverName: string;
+	enabled: boolean;
+	manager: MCPManager;
+	refreshTools: (manager: MCPManager) => Promise<void>;
+}
+
+/** Apply one persisted MCP server toggle without disturbing unrelated connections. */
+export async function refreshMcpServer({
+	cwd,
+	serverName,
+	enabled,
+	manager,
+	refreshTools,
+}: RefreshMcpServerOptions): Promise<McpServerRefreshResult> {
+	if (!enabled) {
+		await manager.disconnectServer(serverName);
+		await refreshTools(manager);
+		return { state: "updated", errors: new Map() };
+	}
+
+	const { configs, sources } = await loadAllMCPConfigs(cwd);
+	const config = configs[serverName];
+	if (!config) {
+		return {
+			state: "failed",
+			errors: new Map([
+				[serverName, `Enabled MCP server "${serverName}" was not found after refreshing configuration`],
+			]),
+		};
+	}
+
+	const result = await manager.connectServers(
+		{ [serverName]: config },
+		sources[serverName] ? { [serverName]: sources[serverName] } : {},
+	);
+	await refreshTools(manager);
+
+	if (result.errors.has(serverName)) return { state: "failed", errors: result.errors };
+
+	const status = manager.getConnectionStatus(serverName);
+	if (status === "connected") return { state: "updated", errors: result.errors };
+	if (status === "connecting") return { state: "connecting", errors: result.errors };
+	return {
+		state: "failed",
+		errors: new Map([...result.errors, [serverName, `MCP server "${serverName}" did not start connecting`]]),
+	};
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -105,6 +105,7 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
+import { refreshMcpServer } from "./mcp-live-refresh";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
 
@@ -367,7 +368,30 @@ export class SelectorController {
 	 * Replaces /status with a unified view of all providers and extensions.
 	 */
 	async showExtensionsDashboard(): Promise<void> {
-		const dashboard = await ExtensionDashboard.create(getProjectDir(), this.ctx.settings, this.ctx.ui.terminal.rows);
+		const dashboard = await ExtensionDashboard.create(getProjectDir(), this.ctx.settings, this.ctx.ui.terminal.rows, {
+			notify: message => this.ctx.showStatus(message),
+			notifyError: message => this.ctx.showError(message),
+			refreshMcpLive: this.ctx.mcpManager
+				? async (serverName, enabled) => {
+						const manager = this.ctx.mcpManager;
+						if (!manager) throw new Error("MCP manager is no longer available");
+						const result = await refreshMcpServer({
+							cwd: getProjectDir(),
+							serverName,
+							enabled,
+							manager,
+							refreshTools: async liveManager => this.ctx.session.refreshMCPTools(liveManager.getTools()),
+						});
+						if (result.state === "failed") {
+							throw new Error(
+								Array.from(result.errors, ([name, error]) => `${name}: ${error}`).join("\n") ||
+									`MCP server "${serverName}" did not refresh`,
+							);
+						}
+						return result.state === "connecting" ? "pending" : "updated";
+					}
+				: undefined,
+		});
 		// Fullscreen dashboard on the alternate screen (the /settings idiom): the
 		// overlay borrows the terminal's alt buffer and enables mouse tracking for
 		// its lifetime, leaving the transcript untouched underneath.

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -20,13 +20,18 @@ import { initializeWithSettings, reset as resetDiscoveryCache } from "@oh-my-pi/
 import { readMCPConfigFile, setMcpServerEnabled, setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import { ExtensionDashboard } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-dashboard";
 import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+const testTheme = await getThemeByName("dark");
 
 describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 	let projectDir = "";
 	let userAgentDir = "";
 
 	beforeEach(async () => {
+		if (!testTheme) throw new Error("Failed to load dark theme for extension dashboard tests");
+		setThemeInstance(testTheme);
 		resetSettingsForTest();
 		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-3827-project-"));
 		userAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-3827-user-"));

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initializeWithSettings, reset as resetDiscoveryCache } from "@oh-my-pi/pi-coding-agent/discovery";
 import { readMCPConfigFile, setMcpServerEnabled, setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
+import { ExtensionDashboard } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-dashboard";
 import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
@@ -306,5 +307,22 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 
 		userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
 		expect(userConfig.disabledServers ?? []).not.toContain("phantom-server");
+	});
+	test("reports a slow MCP connection as pending live application", async () => {
+		const notification = Promise.withResolvers<string>();
+		const refreshCalls: Array<{ name: string; enabled: boolean }> = [];
+		const dashboard = await ExtensionDashboard.create(projectDir, Settings.instance, 30, {
+			refreshMcpLive: async (name, enabled) => {
+				refreshCalls.push({ name, enabled });
+				return "pending";
+			},
+			notify: message => notification.resolve(message),
+		});
+		for (const char of "flag-disabled-server") dashboard.handleInput(char);
+		dashboard.handleInput("j");
+		dashboard.handleInput(" ");
+
+		expect(await notification.promise).toBe("MCP connection in progress — tools will update live");
+		expect(refreshCalls).toEqual([{ name: "flag-disabled-server", enabled: true }]);
 	});
 });

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -325,4 +325,37 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 		expect(await notification.promise).toBe("MCP connection in progress — tools will update live");
 		expect(refreshCalls).toEqual([{ name: "flag-disabled-server", enabled: true }]);
 	});
+
+	test("serializes repeated MCP toggles through live refresh", async () => {
+		const firstRefreshStarted = Promise.withResolvers<void>();
+		const releaseFirstRefresh = Promise.withResolvers<void>();
+		const secondRefreshStarted = Promise.withResolvers<void>();
+		const refreshCalls: Array<{ name: string; enabled: boolean }> = [];
+		const dashboard = await ExtensionDashboard.create(projectDir, Settings.instance, 30, {
+			refreshMcpLive: async (name, enabled) => {
+				refreshCalls.push({ name, enabled });
+				if (refreshCalls.length === 1) {
+					firstRefreshStarted.resolve();
+					await releaseFirstRefresh.promise;
+				} else {
+					secondRefreshStarted.resolve();
+				}
+				return "updated";
+			},
+		});
+		for (const char of "flag-disabled-server") dashboard.handleInput(char);
+		dashboard.handleInput("j");
+
+		dashboard.handleInput(" ");
+		dashboard.handleInput(" ");
+		await firstRefreshStarted.promise;
+		expect(refreshCalls).toEqual([{ name: "flag-disabled-server", enabled: true }]);
+
+		releaseFirstRefresh.resolve();
+		await secondRefreshStarted.promise;
+		expect(refreshCalls).toEqual([
+			{ name: "flag-disabled-server", enabled: true },
+			{ name: "flag-disabled-server", enabled: false },
+		]);
+	});
 });

--- a/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
@@ -20,7 +20,7 @@ import { initializeWithSettings, reset as resetDiscoveryCache } from "@oh-my-pi/
 import { readMCPConfigFile, setMcpServerEnabled, setServerDisabled } from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import { ExtensionDashboard } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-dashboard";
 import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
-import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getThemeByName, setThemeInstance, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { __resetDirsFromEnvForTests, getMCPConfigPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const testTheme = await getThemeByName("dark");
@@ -28,8 +28,10 @@ const testTheme = await getThemeByName("dark");
 describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 	let projectDir = "";
 	let userAgentDir = "";
+	let previousTheme: Theme | undefined;
 
 	beforeEach(async () => {
+		previousTheme = theme;
 		if (!testTheme) throw new Error("Failed to load dark theme for extension dashboard tests");
 		setThemeInstance(testTheme);
 		resetSettingsForTest();
@@ -68,6 +70,7 @@ describe("loadAllExtensions MCP parity with /mcp list (issue #3827)", () => {
 	});
 
 	afterEach(async () => {
+		if (previousTheme) setThemeInstance(previousTheme);
 		resetSettingsForTest();
 		__resetDirsFromEnvForTests();
 		await removeWithRetries(projectDir);

--- a/packages/coding-agent/test/extension-dashboard-state.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-state.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { applyDisabledExtensionsToState } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
+import {
+	applyDisabledExtensionsToState,
+	applyExtensionEnabledToState,
+} from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import type { DashboardState, Extension } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/types";
 
 function extension(overrides: Partial<Extension> & Pick<Extension, "id">): Extension {
@@ -73,5 +76,22 @@ describe("applyDisabledExtensionsToState", () => {
 			shadowedBy: "skill:shadowing",
 		});
 		expect(next.selected).toMatchObject({ id: "skill:shadowed", state: "shadowed", disabledReason: "shadowed" });
+	});
+});
+
+describe("applyExtensionEnabledToState", () => {
+	test("keeps a pending plugin state consistent across refreshed dashboard slices", () => {
+		const plugin = extension({
+			id: "plugin:rapid",
+			kind: "plugin",
+			state: "disabled",
+			disabledReason: "item-disabled",
+		});
+		const next = applyExtensionEnabledToState(dashboardState([plugin], plugin), plugin.id, true);
+
+		for (const projected of [next.extensions[0], next.tabFiltered[0], next.searchFiltered[0], next.selected]) {
+			expect(projected).toMatchObject({ id: plugin.id, state: "active" });
+			expect(projected?.disabledReason).toBeUndefined();
+		}
 	});
 });

--- a/packages/coding-agent/test/extension-list-mouse.test.ts
+++ b/packages/coding-agent/test/extension-list-mouse.test.ts
@@ -205,6 +205,16 @@ describe("InspectorPanel rendering", () => {
 		withLiveRefresh.setExtension(mcp("example"));
 		expect(Bun.stripANSI(withLiveRefresh.render(60).join("\n"))).toContain("live (no restart needed)");
 	});
+
+	test("keeps the MCP refresh badge inside a narrow inspector", () => {
+		const panel = new InspectorPanel();
+		panel.setExtension(mcp("example"));
+		const rendered = panel.render(8);
+		const appliesIndex = rendered.findIndex(line => Bun.stripANSI(line) === "Applies:");
+
+		expect(appliesIndex).toBeGreaterThanOrEqual(0);
+		expect(Bun.stringWidth(rendered[appliesIndex + 1] ?? "")).toBeLessThanOrEqual(8);
+	});
 });
 
 describe("buildProviderTabs", () => {

--- a/packages/coding-agent/test/extension-list-mouse.test.ts
+++ b/packages/coding-agent/test/extension-list-mouse.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { buildTabBarTabs } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-dashboard";
 import { ExtensionList } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-list";
+import { InspectorPanel } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/inspector-panel";
 import type { Extension } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -18,6 +19,32 @@ function skill(name: string, state: Extension["state"] = "active"): Extension {
 		source: { provider: "native", providerName: "Native", level: "native" },
 		state,
 		raw: {},
+	};
+}
+
+function plugin(name: string): Extension {
+	return {
+		id: `plugin:${name}`,
+		kind: "plugin",
+		name,
+		displayName: name,
+		path: `/tmp/plugin-${name}`,
+		source: { provider: "marketplace-plugin", providerName: "Marketplace Plugin", level: "user" },
+		state: "active",
+		raw: {},
+	};
+}
+
+function mcp(name: string): Extension {
+	return {
+		id: `mcp:${name}`,
+		kind: "mcp",
+		name,
+		displayName: name,
+		path: `/tmp/mcp-${name}.json`,
+		source: { provider: "native", providerName: "Native", level: "project" },
+		state: "active",
+		raw: { type: "stdio", command: "example" },
 	};
 }
 
@@ -97,6 +124,86 @@ describe("ExtensionList mouse routing", () => {
 		list.handleWheel(-1); // up -> alpha
 		expect(list.getSelectedExtension()?.id).toBe("skill:alpha");
 		expect(seen).toEqual(["skill:alpha", "skill:beta", "skill:alpha"]);
+	});
+
+	test("renders plugin rows in the default all-capabilities view", () => {
+		const list = new ExtensionList([skill("alpha"), plugin("hello-plugin")], {
+			masterSwitchProvider: null,
+			onSelectionChange: () => {},
+			onToggle: () => {},
+		});
+		list.setFocused(true);
+
+		const rendered = list.render(60).join("\n");
+
+		expect(rendered).toContain("Plugins");
+		expect(rendered).toContain("hello-plugin");
+	});
+
+	test("rapid repeated plugin activations invert the optimistic row state", () => {
+		const toggles: Array<{ id: string; enabled: boolean }> = [];
+		const list = new ExtensionList([plugin("rapid-plugin")], {
+			masterSwitchProvider: null,
+			onSelectionChange: () => {},
+			onToggle: (id, enabled) => toggles.push({ id, enabled }),
+		});
+		list.setFocused(true);
+		list.handleInput("j");
+
+		list.handleInput(" ");
+		list.handleInput(" ");
+
+		expect(toggles).toEqual([
+			{ id: "plugin:rapid-plugin", enabled: false },
+			{ id: "plugin:rapid-plugin", enabled: true },
+		]);
+		expect(list.getSelectedExtension()?.state).toBe("active");
+	});
+
+	test("normalizes tabs in plugin metadata before rendering rows", () => {
+		const unsafePlugin = { ...plugin("hello-plugin"), trigger: "v1\tbeta" };
+		const list = new ExtensionList([unsafePlugin], {
+			masterSwitchProvider: null,
+			onSelectionChange: () => {},
+			onToggle: () => {},
+		});
+		list.setFocused(true);
+
+		const rendered = list.render(60).join("\n");
+
+		expect(rendered).not.toContain("\t");
+		expect(rendered).toContain("v1");
+		expect(rendered).toContain("beta");
+	});
+});
+
+describe("InspectorPanel rendering", () => {
+	test("normalizes tabs in shadowed plugin status metadata", () => {
+		const panel = new InspectorPanel();
+		panel.setExtension({
+			...plugin("shadowed-plugin"),
+			state: "shadowed",
+			shadowedBy: "project\tinstall-with-an-excessively-long-name",
+		});
+
+		const rendered = panel
+			.render(40)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+
+		expect(rendered).not.toContain("\t");
+		expect(rendered).toContain("Shadowed by project");
+		expect(rendered).toContain("install-with-");
+	});
+
+	test("shows MCP live status only when the dashboard has a live-refresh path", () => {
+		const withoutLiveRefresh = new InspectorPanel();
+		withoutLiveRefresh.setExtension(mcp("example"));
+		expect(Bun.stripANSI(withoutLiveRefresh.render(60).join("\n"))).toContain("restart required");
+
+		const withLiveRefresh = new InspectorPanel({ mcpLiveRefreshAvailable: true });
+		withLiveRefresh.setExtension(mcp("example"));
+		expect(Bun.stripANSI(withLiveRefresh.render(60).join("\n"))).toContain("live (no restart needed)");
 	});
 });
 

--- a/packages/coding-agent/test/mcp-command-toggle.test.ts
+++ b/packages/coding-agent/test/mcp-command-toggle.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { SourceMeta } from "@oh-my-pi/pi-coding-agent/capability/types";
 import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { MCPCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
+import { refreshMcpServer } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-live-refresh";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
 	getConfigRootDir,
@@ -32,7 +33,7 @@ function restoreAgentDir(): void {
 }
 
 function createController() {
-	const refreshMCPTools = vi.fn(async () => {});
+	const refreshMCPTools = vi.fn(async (_tools: unknown[]) => {});
 	const mcpManager = {
 		disconnectAll: vi.fn(async () => {}),
 		discoverAndConnect: vi.fn(async () => ({ errors: new Map<string, string>() })),
@@ -140,5 +141,24 @@ describe("/mcp enable and disable", () => {
 		const [configs] = mcpManager.connectServers.mock.calls[0]!;
 		expect(Object.keys(configs)).toEqual(["mcp1"]);
 		expect(configs.mcp1).toEqual({ type: "stdio", command: "mcp-one", enabled: true });
+	});
+	test("classifies a successful slow connection as live refresh in progress", async () => {
+		await writeProjectConfig(projectDir, {
+			mcp1: { type: "stdio", command: "mcp-one" },
+		});
+		const { mcpManager, refreshMCPTools } = createController();
+		mcpManager.getConnectionStatus.mockReturnValue("connecting");
+
+		const result = await refreshMcpServer({
+			cwd: projectDir,
+			serverName: "mcp1",
+			enabled: true,
+			manager: mcpManager as never,
+			refreshTools: async manager => refreshMCPTools(manager.getTools()),
+		});
+
+		expect(result.state).toBe("connecting");
+		expect(result.errors.size).toBe(0);
+		expect(refreshMCPTools).toHaveBeenCalledWith([]);
 	});
 });

--- a/packages/coding-agent/test/mcp-startup-no-block.test.ts
+++ b/packages/coding-agent/test/mcp-startup-no-block.test.ts
@@ -25,6 +25,7 @@ import { MCPManager } from "../src/mcp/manager";
 import type { MCPStdioServerConfig } from "../src/mcp/types";
 
 const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "hang-during-init-mcp.ts");
+const DELAYED_FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "delayed-tool-mcp.ts");
 const BUN_EXEC = process.execPath;
 
 describe("MCP startup (issue #2100)", () => {
@@ -74,4 +75,27 @@ describe("MCP startup (issue #2100)", () => {
 			await manager.disconnectAll();
 		}
 	}, 15_000);
+
+	it("does not revive a slow initial connection after it is disconnected", async () => {
+		const manager = new MCPManager(workDir);
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [DELAYED_FIXTURE_PATH],
+		};
+
+		try {
+			await manager.connectServers({ delayed: config }, {});
+			expect(manager.getConnectionStatus("delayed")).toBe("connecting");
+
+			await manager.disconnectServer("delayed");
+			await Bun.sleep(700);
+
+			expect(manager.getConnectionStatus("delayed")).toBe("disconnected");
+			expect(manager.getServerConfig("delayed")).toBeUndefined();
+			expect(manager.getTools().some(tool => tool.mcpServerName === "delayed")).toBe(false);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 10_000);
 });

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -55,4 +55,85 @@ describe("plugin config", () => {
 
 		await expect(new PluginManager(tmpRoot).getPluginSettings(pluginName)).resolves.toEqual({});
 	});
+
+	test("re-enabling from a project UI clears the project-disabled override", async () => {
+		const pluginName = "@gaodes/pi-graphify";
+		const overridesPath = path.join(tmpRoot, "plugin-overrides.json");
+		await writeLegacyLockfile(pluginName);
+		await Bun.write(
+			overridesPath,
+			JSON.stringify({
+				disabled: [pluginName, "other-plugin"],
+				features: { [pluginName]: ["inspect"] },
+			}),
+		);
+
+		await new PluginManager(tmpRoot).setEnabled(pluginName, true, { clearProjectDisabled: true });
+
+		const overrides = await Bun.file(overridesPath).json();
+		expect(overrides).toEqual({
+			disabled: ["other-plugin"],
+			features: { [pluginName]: ["inspect"] },
+		});
+		const lock = await Bun.file(lockfile).json();
+		expect(lock.plugins[pluginName].enabled).toBe(true);
+	});
+
+	test("re-enabling clears the override from the discovered legacy config dir", async () => {
+		const pluginName = "@gaodes/pi-graphify";
+		const legacyOverridesPath = path.join(tmpRoot, ".claude", "plugin-overrides.json");
+		await writeLegacyLockfile(pluginName);
+		await fs.mkdir(path.dirname(legacyOverridesPath), { recursive: true });
+		await Bun.write(legacyOverridesPath, JSON.stringify({ disabled: [pluginName] }));
+
+		await new PluginManager(tmpRoot).setEnabled(pluginName, true, { clearProjectDisabled: true });
+
+		// The override is removed from the file the runtime loader reads...
+		await expect(Bun.file(legacyOverridesPath).json()).resolves.toEqual({});
+		// ...and no unrelated override file is created elsewhere.
+		expect(await Bun.file(path.join(tmpRoot, ".omp", "plugin-overrides.json")).exists()).toBe(false);
+		expect(await Bun.file(path.join(tmpRoot, "plugin-overrides.json")).exists()).toBe(false);
+	});
+
+	test("re-enabling honors loader precedence when multiple override files exist", async () => {
+		const pluginName = "@gaodes/pi-graphify";
+		const canonicalOverridesPath = path.join(tmpRoot, ".omp", "plugin-overrides.json");
+		const legacyOverridesPath = path.join(tmpRoot, ".claude", "plugin-overrides.json");
+		await writeLegacyLockfile(pluginName);
+		await fs.mkdir(path.dirname(canonicalOverridesPath), { recursive: true });
+		await fs.mkdir(path.dirname(legacyOverridesPath), { recursive: true });
+		await Bun.write(canonicalOverridesPath, JSON.stringify({ disabled: [pluginName] }));
+		await Bun.write(legacyOverridesPath, JSON.stringify({ disabled: [pluginName] }));
+
+		await new PluginManager(tmpRoot).setEnabled(pluginName, true, { clearProjectDisabled: true });
+
+		// Only the highest-precedence file — the one the loader reads — is mutated.
+		await expect(Bun.file(canonicalOverridesPath).json()).resolves.toEqual({});
+		await expect(Bun.file(legacyOverridesPath).json()).resolves.toEqual({ disabled: [pluginName] });
+	});
+	test("marketplace state applies project overrides to the runtime package name", async () => {
+		const installPath = path.join(tmpRoot, "marketplace-plugin");
+		await fs.mkdir(installPath, { recursive: true });
+		await Bun.write(path.join(installPath, "package.json"), JSON.stringify({ name: "@scope/runtime-plugin" }));
+		await Bun.write(
+			path.join(tmpRoot, "plugin-overrides.json"),
+			JSON.stringify({ disabled: ["@scope/runtime-plugin"] }),
+		);
+
+		const manager = new PluginManager(tmpRoot);
+		await expect(
+			manager.getMarketplaceEffectiveState("catalog-name@test-marketplace", installPath, true),
+		).resolves.toEqual({
+			packageName: "@scope/runtime-plugin",
+			enabled: false,
+		});
+
+		await manager.clearProjectDisabledOverride("@scope/runtime-plugin");
+		await expect(
+			manager.getMarketplaceEffectiveState("catalog-name@test-marketplace", installPath, true),
+		).resolves.toEqual({
+			packageName: "@scope/runtime-plugin",
+			enabled: true,
+		});
+	});
 });

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -136,4 +136,54 @@ describe("plugin config", () => {
 			enabled: true,
 		});
 	});
+
+	test("marketplace aggregate state and override cleanup include every registry entry", async () => {
+		const firstInstallPath = path.join(tmpRoot, "marketplace-plugin-user");
+		const secondInstallPath = path.join(tmpRoot, "marketplace-plugin-project");
+		await fs.mkdir(firstInstallPath, { recursive: true });
+		await fs.mkdir(secondInstallPath, { recursive: true });
+		await Bun.write(path.join(firstInstallPath, "package.json"), JSON.stringify({ name: "@scope/runtime-user" }));
+		await Bun.write(path.join(secondInstallPath, "package.json"), JSON.stringify({ name: "@scope/runtime-project" }));
+		await Bun.write(
+			path.join(tmpRoot, "plugin-overrides.json"),
+			JSON.stringify({ disabled: ["@scope/runtime-project", "other-plugin"] }),
+		);
+		const entries = [
+			{
+				scope: "user" as const,
+				installPath: firstInstallPath,
+				version: "1.0.0",
+				installedAt: "2026-07-29T00:00:00.000Z",
+				lastUpdated: "2026-07-29T00:00:00.000Z",
+				enabled: true,
+			},
+			{
+				scope: "project" as const,
+				installPath: secondInstallPath,
+				version: "1.0.0",
+				installedAt: "2026-07-29T00:00:00.000Z",
+				lastUpdated: "2026-07-29T00:00:00.000Z",
+				enabled: true,
+			},
+		];
+		const manager = new PluginManager(tmpRoot);
+
+		await expect(
+			manager.getMarketplaceAggregateEffectiveState("catalog-name@test-marketplace", entries),
+		).resolves.toEqual({
+			packageNames: ["@scope/runtime-user", "@scope/runtime-project"],
+			enabled: false,
+		});
+
+		await manager.clearProjectDisabledOverrides(["@scope/runtime-user", "@scope/runtime-project"]);
+		await expect(Bun.file(path.join(tmpRoot, "plugin-overrides.json")).json()).resolves.toEqual({
+			disabled: ["other-plugin"],
+		});
+		await expect(
+			manager.getMarketplaceAggregateEffectiveState("catalog-name@test-marketplace", entries),
+		).resolves.toEqual({
+			packageNames: ["@scope/runtime-user", "@scope/runtime-project"],
+			enabled: true,
+		});
+	});
 });


### PR DESCRIPTION
## What

- Show installed npm and marketplace plugins directly in the Extension Control Center inventory.
- Add plugin-specific state, source, list, and inspector rendering while preserving provider filtering and mouse interaction.
- Make npm enablement clear the project-disabled override file that the runtime actually reads, including legacy config locations.
- Serialize dashboard plugin mutations so rapid toggles cannot overwrite each other.
- Surface successful saves through the status UI and persistence or refresh failures through the error UI.
- Remove the accidental bare `/skills` alias while preserving `/skill:<name>` invocation.

## Why

Installed plugins are extensions, but the dashboard previously hid them behind a separate management surface. Displaying them alongside other extensions gives users one place to inspect and enable them.

Plugin state is persisted through whole-file registries and project overrides. Serial execution prevents concurrent read-modify-write operations from losing accepted toggles, and explicit notifications prevent silent partial failures.

## Screenshots

### Plugin rows in the `ALL` dashboard view

![Plugin rows in the ALL dashboard view](https://omp-pr.wolfie.gg/3924/all-plugins-fixture.png)

### Active `Builtin Defaults` provider tab

![Active Builtin Defaults provider tab](https://omp-pr.wolfie.gg/3924/builtin-defaults-active.png)

## Testing

```bash
bun test packages/coding-agent/test/plugin-config.test.ts packages/coding-agent/test/extension-list-mouse.test.ts packages/coding-agent/test/extension-dashboard-state.test.ts packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts
bun --cwd=packages/coding-agent run check
```

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
