### PR TITLE
fix(codex): omit reasoning.summary for gpt-5.3-codex-spark

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Raised Gemini header runaway threshold to prevent premature interruption of complex reasoning loops
 - Fixed leaked ` ```thinking ` fences with nested language-tagged Markdown code blocks so inner fences remain inside structured thinking instead of leaking as visible reply text.
+- Fixed Codex Responses unconditionally attaching `reasoning.summary` for `gpt-5.3-codex-spark`, which the ChatGPT backend rejects with `Unsupported parameter: 'reasoning.summary' is not supported with this model`, aborting the agent turn ([#3928](https://github.com/can1357/oh-my-pi/issues/3928)).
 
 ## [16.2.9] - 2026-06-30
 

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -1,5 +1,5 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { supportsAllTurnsReasoningContext } from "@oh-my-pi/pi-catalog/identity";
+import { supportsAllTurnsReasoningContext, supportsReasoningSummary } from "@oh-my-pi/pi-catalog/identity";
 import { requireSupportedEffort } from "@oh-my-pi/pi-catalog/model-thinking";
 import type { Api, Model } from "../../types";
 
@@ -85,7 +85,13 @@ function getReasoningConfig(model: Model<Api>, options: CodexRequestOptions): Re
 		effort:
 			options.reasoningEffort === "none" ? "none" : requireSupportedEffort(model, options.reasoningEffort as Effort),
 	};
-	if (options.reasoningSummary !== null) {
+	// `reasoning.summary` is universally honored across Codex Responses ids
+	// EXCEPT gpt-5.3-codex-spark, which rejects it with
+	// `Unsupported parameter: 'reasoning.summary' is not supported with this
+	// model` and aborts the turn (no retry). For Spark, omit `summary`
+	// regardless of caller intent; for everything else, keep the prior
+	// behavior (null → omit, value → forward, undefined → "detailed").
+	if (options.reasoningSummary !== null && supportsReasoningSummary(model.id)) {
 		config.summary = options.reasoningSummary ?? "detailed";
 	}
 	return config;

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -147,6 +147,61 @@ describe("openai-codex reasoning.context", () => {
 	});
 });
 
+describe("openai-codex reasoning.summary", () => {
+	it("attaches the default summary on supported Codex models", async () => {
+		const model = createCodexModel("gpt-5.4-codex");
+
+		const body = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
+		expect(body.reasoning?.summary).toBe("detailed");
+	});
+
+	it("forwards an explicit reasoningSummary on supported Codex models", async () => {
+		const model = createCodexModel("gpt-5.3-codex");
+
+		const body = await transformRequestBody({ model: model.id }, model, {
+			reasoningEffort: "medium",
+			reasoningSummary: "concise",
+		});
+		expect(body.reasoning?.summary).toBe("concise");
+	});
+
+	// gpt-5.3-codex-spark rejects reasoning.summary with
+	// "Unsupported parameter: 'reasoning.summary' is not supported with the
+	// 'gpt-5.3-codex-spark' model" — and the error is terminal (the unrelated
+	// reasoning-param case in openai-reasoning-effort-fallback.test.ts confirms
+	// no retry), so the field MUST NOT be attached.
+	it("omits reasoning.summary for gpt-5.3-codex-spark by default", async () => {
+		const model = createCodexModel("gpt-5.3-codex-spark");
+
+		const body = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
+		expect(body.reasoning).toBeDefined();
+		expect(body.reasoning?.summary).toBeUndefined();
+		expect("summary" in (body.reasoning ?? {})).toBe(false);
+	});
+
+	it("suppresses an explicit reasoningSummary override on gpt-5.3-codex-spark", async () => {
+		const model = createCodexModel("gpt-5.3-codex-spark");
+
+		const forced = await transformRequestBody({ model: model.id }, model, {
+			reasoningEffort: "medium",
+			reasoningSummary: "concise",
+		});
+		expect(forced.reasoning).toBeDefined();
+		expect(forced.reasoning?.summary).toBeUndefined();
+	});
+
+	it("still omits reasoning.summary when the caller explicitly passes null", async () => {
+		const model = createCodexModel("gpt-5.4-codex");
+
+		const body = await transformRequestBody({ model: model.id }, model, {
+			reasoningEffort: "medium",
+			reasoningSummary: null,
+		});
+		expect(body.reasoning).toBeDefined();
+		expect(body.reasoning?.summary).toBeUndefined();
+	});
+});
+
 describe("openai-codex Responses Lite input shaping", () => {
 	it("keeps full Responses image details when a requested lite body contains images", async () => {
 		const model = createCodexModel("gpt-5.1-codex");

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Updated the base API URL for the Claude Sonnet 5 model in the Anthropic catalog
 - Updated pricing metrics for DeepSeek R1 and DeepSeek V3 model entries to reflect new rates
 
+### Fixed
+
+- Added `supportsReasoningSummary` identity predicate, letting Codex Responses omit `reasoning.summary` for `gpt-5.3-codex-spark`, which the ChatGPT backend rejects ([#3928](https://github.com/can1357/oh-my-pi/issues/3928)).
+
 ## [16.2.9] - 2026-06-30
 
 ### Added

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -140,6 +140,25 @@ export const supportsAllTurnsReasoningContext = memo((modelId: string): boolean 
 });
 
 /**
+ * OpenAI Codex models that accept `reasoning.summary` in the request.
+ *
+ * The field is universally honored across gpt-5/o-series Responses ids EXCEPT
+ * `gpt-5.3-codex-spark`, which rejects it with
+ * `Unsupported parameter: 'reasoning.summary' is not supported with the
+ * 'gpt-5.3-codex-spark' model` and aborts the turn (no retry — the fallback
+ * matrix in `openai-reasoning-effort-fallback.test.ts` treats unrelated
+ * `reasoning.summary` errors as terminal). Sibling to
+ * `supportsAllTurnsReasoningContext`. Gated narrowly to the `codex-spark`
+ * variant — non-Spark Codex ids are unaffected; widen if another id is
+ * observed rejecting the field.
+ */
+export const supportsReasoningSummary = memo((modelId: string): boolean => {
+	const parsed = parseOpenAIModel(bareModelId(modelId));
+	if (!parsed) return true;
+	return parsed.variant !== "codex-spark";
+});
+
+/**
  * Reasoning-capable GLM coding SKUs: glm-4.5 and up on the base / `-air` /
  * `-turbo` lines. Excludes the vision (`…v`) shape, the non-reasoning
  * `-flash`/`-flashx`/`-preview` variants, and pre-4.5 ids. Matching the family


### PR DESCRIPTION
## Repro

A `streamOpenAICodexResponses` call to `gpt-5.3-codex-spark` with default
(non-hidden) reasoning attaches `reasoning.summary: "detailed"` to the request.
The ChatGPT Codex backend rejects it with `Unsupported parameter:
'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model`, the
turn aborts (`stopReason: "error"`), and the error is not retried — the
existing `openai-reasoning-effort-fallback.test.ts` case "does not retry
unrelated reasoning parameter errors" documents that an unrelated
`reasoning.summary` rejection is terminal.

Pre-fix transformer probe (`transformRequestBody({ reasoningEffort: "medium" })`):

```
gpt-5.3-codex-spark → {"effort":"medium","summary":"detailed"}
gpt-5.3-codex       → {"effort":"medium","summary":"detailed"}
gpt-5.4-codex       → {"effort":"medium","summary":"detailed","context":"all_turns"}
```

## Cause

`getReasoningConfig` (`packages/ai/src/providers/openai-codex/request-transformer.ts:83-92`)
sets `config.summary = options.reasoningSummary ?? "detailed"` whenever the
caller's value is not `null`. There is no model-capability check, unlike
`reasoning.context` a few lines later, which IS gated by
`supportsAllTurnsReasoningContext`. `openai-codex-responses.ts:926` then
defaults `reasoningSummary` to `"auto"` whenever the caller leaves it
`undefined`, so the default (non-hidden) case always ends up non-null and
`summary` always attaches.

Spark is the only Codex id with a confirmed `reasoning.summary` rejection —
non-Spark Codex ids continue to accept the field, so the gate is variant-scoped
rather than version-scoped.

## Fix

- New `supportsReasoningSummary` predicate in
  `packages/catalog/src/identity/family.ts`, sibling to
  `supportsAllTurnsReasoningContext`, returning `false` only for the
  `codex-spark` variant (doc-comment notes the gate is intentionally narrow
  and can widen if another id is observed rejecting the field).
- `getReasoningConfig` consults the predicate before attaching `summary`. When
  Spark is detected, `summary` is dropped even if the caller passed a
  non-null `reasoningSummary` override.
- Regression suite in
  `packages/ai/test/openai-codex-responses-lite.test.ts`
  (`describe("openai-codex reasoning.summary")`) proves the payload difference
  between `gpt-5.3-codex-spark` (omits) and supported Codex models
  (`gpt-5.3-codex`, `gpt-5.4-codex` — attach), the explicit-`null` opt-out
  still works on supported models, and an explicit override is suppressed on
  Spark.

## Verification

- `bun test openai-codex-responses-lite` — 20 pass (15 prior + 5 new).
- `bun test openai-reasoning-effort-fallback openai-codex` — 123 pass.
- `packages/catalog` full suite — 367 pass.
- Post-fix transformer probe (same call shape as the repro):
  ```
  gpt-5.3-codex-spark → {"effort":"medium"}
  gpt-5.3-codex       → {"effort":"medium","summary":"detailed"}
  gpt-5.4-codex       → {"effort":"medium","summary":"detailed","context":"all_turns"}
  gpt-5.4-codex-spark → {"effort":"medium","context":"all_turns"}
  ```
  Spark omits `summary`; non-Spark Codex ids keep it; the predicate also
  Spark-gates a hypothetical future `gpt-5.4-codex-spark` until the backend
  is observed accepting the field.

Fixes #3928