### PR TITLE
fix(agent): bound async job disposal timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed async job manager disposal honoring the timeout before all cancelled jobs settle, and made queued task spawns leave the session semaphore when their abort signal fires. ([#3930](https://github.com/can1357/oh-my-pi/issues/3930))
+
 ## [16.2.10] - 2026-06-30
 
 ### Changed

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -397,6 +397,27 @@ export class AsyncJobManager {
 		await Promise.all(Array.from(this.#jobs.values()).map(job => job.promise));
 	}
 
+	async #waitForAllUntil(deadline: number): Promise<boolean> {
+		const promises = Array.from(this.#jobs.values()).map(job => job.promise);
+		if (promises.length === 0) return true;
+		if (deadline === Number.POSITIVE_INFINITY) {
+			await Promise.all(promises);
+			return true;
+		}
+		const remainingMs = deadline - Date.now();
+		if (remainingMs <= 0) return false;
+
+		const timeout = Promise.withResolvers<"timeout">();
+		const timer = setTimeout(() => timeout.resolve("timeout"), remainingMs);
+		timer.unref();
+		try {
+			const result = await Promise.race([Promise.all(promises).then(() => "settled" as const), timeout.promise]);
+			return result === "settled";
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
 	async drainDeliveries(options?: { timeoutMs?: number; filter?: AsyncJobFilter }): Promise<boolean> {
 		const timeoutMs = options?.timeoutMs;
 		const filter = options?.filter;
@@ -445,8 +466,10 @@ export class AsyncJobManager {
 		this.#disposed = true;
 		this.#clearEvictionTimers();
 		this.cancelAll();
-		await this.waitForAll();
-		const drained = await this.drainDeliveries({ timeoutMs: options?.timeoutMs ?? 3_000 });
+		const timeoutMs = Math.max(options?.timeoutMs ?? 3_000, 0);
+		const deadline = Date.now() + timeoutMs;
+		const jobsSettled = await this.#waitForAllUntil(deadline);
+		const drained = await this.drainDeliveries({ timeoutMs: Math.max(deadline - Date.now(), 0) });
 		this.#clearEvictionTimers();
 		this.#jobs.clear();
 		this.#deliveries.length = 0;
@@ -454,7 +477,7 @@ export class AsyncJobManager {
 		this.#suppressedDeliveries.clear();
 		this.#watchedJobs.clear();
 		this.#pollEscalation.clear();
-		return drained;
+		return jobsSettled && drained;
 	}
 
 	#resolveJobId(preferredId?: string): string {
@@ -483,6 +506,7 @@ export class AsyncJobManager {
 	}
 
 	#scheduleEviction(jobId: string): void {
+		if (this.#disposed) return;
 		if (this.#retentionMs <= 0) {
 			this.#jobs.delete(jobId);
 			this.#suppressedDeliveries.delete(jobId);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -803,10 +803,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			async ({ jobId: ownJobId, signal: runSignal, reportProgress, markRunning }) => {
 				const startedAt = Date.now();
 				const semaphore = this.#getSpawnSemaphore();
-				await semaphore.acquire(runSignal);
+				let semaphoreHeld = false;
+				try {
+					await semaphore.acquire(runSignal);
+					semaphoreHeld = true;
+				} catch {
+					// Fall through so an acquire-time abort goes through the same
+					// path as the post-acquire race below: progress + onSettled
+					// have to fire even when the spawn never reached the executor,
+					// otherwise the batch aggregate state stays "running" forever.
+				}
 				const acquiredAt = Date.now();
-				if (runSignal.aborted) {
-					semaphore.release();
+				if (!semaphoreHeld || runSignal.aborted) {
+					if (semaphoreHeld) semaphore.release();
 					progress.status = "aborted";
 					onSettled?.(true);
 					throw new Error("Aborted before execution");

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -803,7 +803,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			async ({ jobId: ownJobId, signal: runSignal, reportProgress, markRunning }) => {
 				const startedAt = Date.now();
 				const semaphore = this.#getSpawnSemaphore();
-				await semaphore.acquire();
+				await semaphore.acquire(runSignal);
 				const acquiredAt = Date.now();
 				if (runSignal.aborted) {
 					semaphore.release();
@@ -909,7 +909,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const semaphore = this.#getSpawnSemaphore();
 		if (spawnItems.length === 1) {
 			const invokedAt = Date.now();
-			await semaphore.acquire();
+			await semaphore.acquire(signal);
 			const acquiredAt = Date.now();
 			try {
 				return await this.#executeSync(
@@ -948,7 +948,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			spawnItems.length,
 			async (item, index, workerSignal) => {
 				const invokedAt = Date.now();
-				await semaphore.acquire();
+				await semaphore.acquire(workerSignal);
 				const acquiredAt = Date.now();
 				try {
 					const itemOnUpdate: AgentToolUpdateCallback<TaskToolDetails> | undefined = onUpdate

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -270,6 +270,28 @@ describe("AsyncJobManager", () => {
 		expect(manager.hasPendingDeliveries()).toBe(false);
 	});
 
+	test("dispose honors timeout when a cancelled job never settles", async () => {
+		const manager = new AsyncJobManager({
+			onJobComplete: async () => {},
+		});
+
+		manager.register("bash", "ignores-abort", async () => {
+			await Promise.withResolvers<never>().promise;
+			return "unreachable";
+		});
+
+		const startedAt = Date.now();
+		const result = await Promise.race([
+			manager.dispose({ timeoutMs: 25 }).then(drained => ({ drained, settled: true })),
+			Bun.sleep(150).then(() => ({ drained: true, settled: false })),
+		]);
+
+		expect(result.settled).toBe(true);
+		expect(result.drained).toBe(false);
+		expect(Date.now() - startedAt).toBeLessThan(150);
+		expect(manager.getAllJobs()).toHaveLength(0);
+	});
+
 	test("scoped delivery drain returns once matching owner deliveries finish", async () => {
 		let mainJobId = "";
 		let releaseMainDelivery = (): void => {};

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -364,4 +364,75 @@ describe("task.batch spawning", () => {
 			"# Goal\nShared synchronous context.",
 		]);
 	});
+
+	it("settles the batch async aggregate when a queued spawn is cancelled mid-flight", async () => {
+		mockDiscovery();
+		const started: string[] = [];
+		const gates = new Map<string, { promise: Promise<void>; resolve: () => void }>();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			const id = options.id ?? "?";
+			started.push(id);
+			const { promise, resolve } = Promise.withResolvers<void>();
+			gates.set(id, { promise, resolve });
+			await promise;
+			return makeResult(id);
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({
+				manager,
+				settings: { "async.enabled": true, "task.batch": true, "task.maxConcurrency": 1 },
+			}),
+		);
+
+		const updates: Array<{ async?: { state?: string }; progress?: Array<{ id: string; status: string }> }> = [];
+		const result = await tool.execute(
+			"tc-batch-cancel",
+			{
+				agent: "task",
+				context: "ctx",
+				tasks: [
+					{ id: "First", assignment: "Do A." },
+					{ id: "Second", assignment: "Do B." },
+				],
+			} as TaskParams,
+			undefined,
+			update => {
+				if (update.details) {
+					updates.push({
+						async: update.details.async,
+						progress: update.details.progress?.map(p => ({ id: p.id, status: p.status })),
+					});
+				}
+			},
+		);
+
+		expect(result.details?.async?.state).toBe("running");
+
+		const firstJob = manager.getJob("First")!;
+		const secondJob = manager.getJob("Second")!;
+		const deadline = Date.now() + 1_000;
+		while (started.length === 0) {
+			if (Date.now() > deadline) throw new Error("First spawn never reached the executor");
+			await Bun.sleep(5);
+		}
+		expect(started).toEqual(["First"]);
+		expect(secondJob.queued).toBe(true);
+
+		expect(manager.cancel(secondJob.id)).toBe(true);
+		await secondJob.promise;
+
+		gates.get("First")!.resolve();
+		await firstJob.promise;
+
+		expect(secondJob.status).toBe("cancelled");
+		const last = updates.at(-1);
+		// The acquire-time abort path has to flow through the same `onSettled`
+		// the post-acquire abort path uses, otherwise the batch aggregate sticks
+		// at "running" forever after the surviving spawn completes.
+		expect(last?.async?.state).toBe("failed");
+		expect(last?.progress?.find(p => p.id === "Second")?.status).toBe("aborted");
+		expect(last?.progress?.find(p => p.id === "First")?.status).toBe("completed");
+	});
 });

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -188,6 +188,49 @@ describe("task spawn routing", () => {
 		expect(secondJob.status).toBe("completed");
 	});
 
+	it("settles a cancelled spawn while it is queued behind the semaphore", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [taskAgent],
+			projectAgentsDir: null,
+		});
+		const started: string[] = [];
+		const gates = new Map<string, Deferred>();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			const id = options.id ?? "?";
+			started.push(id);
+			const gate = deferred();
+			gates.set(id, gate);
+			await gate.promise;
+			return makeResult(id);
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(createSession({ manager, settings: { "task.maxConcurrency": 1 } }));
+
+		const first = await tool.execute("tc-1", { agent: "task", id: "First", assignment: "Work A." } as TaskParams);
+		const second = await tool.execute("tc-2", { agent: "task", id: "Second", assignment: "Work B." } as TaskParams);
+		const firstJob = manager.getJob(first.details!.async!.jobId)!;
+		const secondJob = manager.getJob(second.details!.async!.jobId)!;
+
+		await pollUntil(() => started.length === 1);
+		expect(started).toEqual(["First"]);
+		expect(secondJob.queued).toBe(true);
+
+		expect(manager.cancel(secondJob.id)).toBe(true);
+		const queuedResult = await Promise.race([
+			secondJob.promise.then(() => "settled" as const),
+			Bun.sleep(75).then(() => "timeout" as const),
+		]);
+
+		gates.get("First")!.resolve();
+		await firstJob.promise;
+		await secondJob.promise;
+
+		expect(queuedResult).toBe("settled");
+		expect(started).toEqual(["First"]);
+		expect(secondJob.status).toBe("cancelled");
+	});
+
 	for (const maxConcurrency of [0, 0.5]) {
 		it(`runs spawn job bodies unbounded when task.maxConcurrency is ${maxConcurrency}`, async () => {
 			vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({


### PR DESCRIPTION
## Repro
A cancelled async job that ignores its abort signal kept `AsyncJobManager.dispose({ timeoutMs })` pending before the timeout-protected delivery drain. Reproduced with `bun test packages/coding-agent/test/async-job-manager.test.ts --test-name-pattern "dispose honors timeout"`; before the fix the new guard observed `dispose({ timeoutMs: 25 })` still unsettled after 150ms.

## Cause
`packages/coding-agent/src/async/job-manager.ts` called `cancelAll(); await waitForAll();` before `drainDeliveries({ timeoutMs })`, so the timeout only applied after every job promise settled. `packages/coding-agent/src/task/index.ts` also called `Semaphore.acquire()` without the available task abort signal in background, single sync, and fanout paths, leaving cancelled queued spawns parked until a slot released.

## Fix
- Added a bounded job-settlement wait inside `AsyncJobManager.dispose()` and made the existing timeout budget cover both cancelled job settlement and delivery draining.
- Cleared disposed manager state even when cancelled jobs remain detached, and prevented later eviction timers from being scheduled on a disposed manager.
- Passed `runSignal`, `signal`, and `workerSignal` into the three task spawn semaphore acquire sites.
- Added regression coverage for non-settling cancelled jobs and cancelled queued task spawns.

## Verification
`bun run check` in `packages/coding-agent` passed. `bun run gen:tool-views` in `packages/coding-agent`, then `bun test packages/coding-agent/test/async-job-manager.test.ts packages/coding-agent/test/task/task-spawn.test.ts` passed with 23 tests. Fixes #3930