### PR TITLE
fix(uutils): grep/rg directory walks now observe scope cancellation

### DIFF
--- a/crates/pi-uu-grep/src/lib.rs
+++ b/crates/pi-uu-grep/src/lib.rs
@@ -453,7 +453,13 @@ fn search_dir<W: Write>(
 	let mut any = false;
 	let had_error_state = std::cell::Cell::new(*had_error);
 	let walk = request.for_each_entry_with_heartbeat(
-		|| Ok::<(), io::Error>(()),
+		|| {
+			if pi_uutils_ctx::is_cancelled() {
+				Err(io::Error::from(io::ErrorKind::Interrupted))
+			} else {
+				Ok::<(), io::Error>(())
+			}
+		},
 		|entry: pi_walker::EntryMeta<'_>| {
 			if opts.quiet && any {
 				return Ok(pi_walker::WalkDecision::Stop);
@@ -499,6 +505,13 @@ fn search_dir<W: Write>(
 	*had_error |= had_error_state.get();
 	match walk {
 		Ok(pi_walker::WalkStatus::Complete | pi_walker::WalkStatus::Stopped) => any,
+		Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+			// Harness cancellation (shell abort/timeout). The shell wrapper
+			// overrides the exit code, so stay silent and let the walk unwind
+			// without injecting a spurious diagnostic on the command's stderr.
+			*had_error = true;
+			any
+		},
 		Err(pi_walker::WalkError::Interrupted(err)) => {
 			*had_error = true;
 			if !opts.no_messages {
@@ -865,5 +878,66 @@ mod tests {
 			stdout.contains("grep") && stdout.contains("pi-uu-grep"),
 			"version output should identify the builtin, got: {stdout:?}"
 		);
+	}
+
+	/// Run `grep` with a pre-set cancel flag, mirroring how the shell wrapper
+	/// flips the flag when an abort/timeout fires while the blocking task is
+	/// still walking. Returns `(exit, stdout, stderr)`.
+	fn run_grep_cancelled(args: &[&str], cwd: &Path) -> (i32, String, String) {
+		let out = Arc::new(Mutex::new(Vec::new()));
+		let err = Arc::new(Mutex::new(Vec::new()));
+		let io = ScopeIo {
+			stdin:                 Box::new(io::empty()),
+			stdin_fd:              None,
+			stdin_is_search_input: false,
+			stdout:                Box::new(SharedBuf(Arc::clone(&out))),
+			stderr:                Box::new(SharedBuf(Arc::clone(&err))),
+			cwd:                   cwd.to_path_buf(),
+			env:                   HashMap::new(),
+			cancel:                Arc::new(AtomicBool::new(true)),
+		};
+		let argv: Vec<OsString> = std::iter::once("grep")
+			.chain(args.iter().copied())
+			.map(OsString::from)
+			.collect();
+		let code = scope(io, || run(argv));
+		let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+		let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+		(code, stdout, stderr)
+	}
+
+	#[test]
+	fn recursive_search_observes_scope_cancellation() {
+		// Regression for #3933: recursive grep used to pass a no-op heartbeat to
+		// pi_walker, so directory walks ignored the uutils cancel flag and the
+		// shell-side abort/timeout waited for the whole tree to be scanned.
+		// The walk must now bail out before scanning any file when the flag is
+		// already set, and it must do so without printing an "interrupted"
+		// diagnostic — the shell wrapper owns the user-visible status.
+		let tree = std::env::temp_dir().join(format!(
+			"pi-uu-grep-cancel-{}-{}",
+			std::process::id(),
+			std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.map(|d| d.as_nanos())
+				.unwrap_or(0)
+		));
+		std::fs::create_dir_all(&tree).expect("temp tree should be created");
+		std::fs::write(tree.join("haystack.txt"), "match-me\n").expect("file should be written");
+
+		let (code, stdout, stderr) =
+			run_grep_cancelled(&["-r", "match-me", tree.to_str().expect("utf8 path")], &tree);
+
+		// Walker must have observed the heartbeat before visiting the file:
+		// no match printed despite the file containing one, and no diagnostic
+		// leaked onto stderr.
+		assert!(stdout.is_empty(), "cancelled walk should not output matches: {stdout:?}");
+		assert!(
+			stderr.is_empty(),
+			"cancelled walk should stay silent — diagnostic is the shell's job: {stderr:?}"
+		);
+		assert_eq!(code, 2, "interrupted directory walk should report had_error (exit 2)");
+
+		let _ = std::fs::remove_dir_all(&tree);
 	}
 }

--- a/crates/pi-uu-grep/src/lib.rs
+++ b/crates/pi-uu-grep/src/lib.rs
@@ -654,12 +654,18 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 	let mut any_match = false;
 	let mut had_error = false;
 
+	let mut processed_operand = false;
 	for f in &files {
 		// -q: once something matched, exit immediately; the status is settled
 		// below. Checked at the top so the stdin `continue` path stops too.
 		if opts.quiet && any_match {
 			break;
 		}
+		if processed_operand && pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
+		}
+		processed_operand = true;
 		// stdin
 		if f.as_os_str() == OsStr::new("-") {
 			let name: Option<&[u8]> = if show_names {
@@ -682,6 +688,10 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 						let _ = writeln!(pi_uutils_ctx::stderr(), "grep: (standard input): {e}");
 					}
 				},
+			}
+			if pi_uutils_ctx::is_cancelled() {
+				had_error = true;
+				break;
 			}
 			continue;
 		}
@@ -742,6 +752,10 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 					let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {}: {e}", f.to_string_lossy());
 				}
 			},
+		}
+		if pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
 		}
 	}
 
@@ -923,14 +937,26 @@ mod tests {
 				.unwrap_or(0)
 		));
 		std::fs::create_dir_all(&tree).expect("temp tree should be created");
-		std::fs::write(tree.join("haystack.txt"), "match-me\n").expect("file should be written");
+		let walk_root = tree.join("walk-root");
+		std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+		std::fs::write(walk_root.join("haystack.txt"), "match-me\n")
+			.expect("walked file should be written");
+		let later_file = tree.join("later.txt");
+		std::fs::write(&later_file, "match-me\n").expect("later file should be written");
 
-		let (code, stdout, stderr) =
-			run_grep_cancelled(&["-r", "match-me", tree.to_str().expect("utf8 path")], &tree);
+		let (code, stdout, stderr) = run_grep_cancelled(
+			&[
+				"-r",
+				"match-me",
+				walk_root.to_str().expect("utf8 path"),
+				later_file.to_str().expect("utf8 path"),
+			],
+			&tree,
+		);
 
-		// Walker must have observed the heartbeat before visiting the file:
-		// no match printed despite the file containing one, and no diagnostic
-		// leaked onto stderr.
+		// Walker must have observed the heartbeat before visiting the file,
+		// and the operand loop must not continue into the later regular file
+		// after cancellation is observed.
 		assert!(stdout.is_empty(), "cancelled walk should not output matches: {stdout:?}");
 		assert!(
 			stderr.is_empty(),

--- a/crates/pi-uu-grep/src/rg.rs
+++ b/crates/pi-uu-grep/src/rg.rs
@@ -972,6 +972,9 @@ fn search_collected_files<W: Write>(
 ) -> SearchOutcome {
 	let mut files = match collect_filtered_files(cli, root) {
 		Ok(files) => files,
+		Err(_) if pi_uutils_ctx::is_cancelled() => {
+			return SearchOutcome { any_match: false, had_error: true };
+		},
 		Err(err) => {
 			if !opts.no_messages {
 				let _ = writeln!(pi_uutils_ctx::stderr(), "{err}");
@@ -1111,9 +1114,7 @@ fn collect_filtered_files(cli: &RgCli, root: &Path) -> Result<Vec<PathBuf>, Stri
 	}) {
 		Ok(outcome) => outcome,
 		Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
-			// Harness cancellation; surface no files and no diagnostic. The
-			// shell wrapper overrides the exit code with 130.
-			return Ok(Vec::new());
+			return Err(String::from("rg: cancelled"));
 		},
 		Err(err) => return Err(format!("rg: {err}")),
 	};
@@ -1145,6 +1146,10 @@ fn list_files<W: Write>(cli: &RgCli, paths: &[OsString], out: &mut W) -> SearchO
 			Ok(meta) if meta.is_dir() => {
 				let mut files = match collect_filtered_files(cli, &resolved) {
 					Ok(files) => files,
+					Err(_) if pi_uutils_ctx::is_cancelled() => {
+						had_error = true;
+						break;
+					},
 					Err(err) => {
 						let _ = writeln!(pi_uutils_ctx::stderr(), "{err}");
 						had_error = true;

--- a/crates/pi-uu-grep/src/rg.rs
+++ b/crates/pi-uu-grep/src/rg.rs
@@ -982,16 +982,26 @@ fn search_collected_files<W: Write>(
 	files.sort_unstable_by(|a, b| b.cmp(a));
 	let mut any_match = false;
 	let mut had_error = false;
+	let mut processed_file = false;
 	for path in files {
 		if opts.quiet && any_match {
 			break;
 		}
+		if processed_file && pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
+		}
+		processed_file = true;
 		let display_path = display_path(operand, root, &path);
 		let display_bytes = display_path.as_os_str().as_encoded_bytes().to_vec();
 		let display = show_names.then_some(display_bytes.as_slice());
 		let outcome = process_file(matcher, searcher, &path, display, opts, out);
 		any_match |= outcome.any_match;
 		had_error |= outcome.had_error;
+		if pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
+		}
 	}
 	SearchOutcome { any_match, had_error }
 }
@@ -1123,7 +1133,13 @@ fn collect_filtered_files(cli: &RgCli, root: &Path) -> Result<Vec<PathBuf>, Stri
 fn list_files<W: Write>(cli: &RgCli, paths: &[OsString], out: &mut W) -> SearchOutcome {
 	let mut any = false;
 	let mut had_error = false;
+	let mut processed_operand = false;
 	for operand in paths {
+		if processed_operand && pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
+		}
+		processed_operand = true;
 		let resolved = pi_uutils_ctx::resolve(operand);
 		match std::fs::metadata(&resolved) {
 			Ok(meta) if meta.is_dir() => {
@@ -1155,6 +1171,10 @@ fn list_files<W: Write>(cli: &RgCli, paths: &[OsString], out: &mut W) -> SearchO
 				let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {}: {err}", operand.to_string_lossy());
 				had_error = true;
 			},
+		}
+		if pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
 		}
 	}
 	SearchOutcome { any_match: any, had_error }
@@ -1250,10 +1270,16 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 	let show_names = show_names_for(&paths, recursive, &cli, &opts);
 	let mut any_match = false;
 	let mut had_error = false;
+	let mut processed_operand = false;
 	for operand in &paths {
 		if opts.quiet && any_match {
 			break;
 		}
+		if processed_operand && pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
+		}
+		processed_operand = true;
 		if operand.as_os_str() == OsStr::new("-") {
 			let display = show_names.then_some(b"<stdin>".as_slice());
 			match process_reader(
@@ -1271,6 +1297,10 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 						let _ = writeln!(pi_uutils_ctx::stderr(), "rg: <stdin>: {err}");
 					}
 				},
+			}
+			if pi_uutils_ctx::is_cancelled() {
+				had_error = true;
+				break;
 			}
 			continue;
 		}
@@ -1305,6 +1335,10 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 						writeln!(pi_uutils_ctx::stderr(), "rg: {}: {err}", operand.to_string_lossy());
 				}
 			},
+		}
+		if pi_uutils_ctx::is_cancelled() {
+			had_error = true;
+			break;
 		}
 	}
 	let _ = out.flush();
@@ -1395,10 +1429,20 @@ mod tests {
 		// heartbeat to pi_walker, so cancellation was not observed during
 		// directory traversal even after the uutils ctx cancel flag was set.
 		let tree = unique_tree("search");
-		std::fs::write(tree.join("haystack.txt"), "match-me\n").expect("file written");
+		let walk_root = tree.join("walk-root");
+		std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+		std::fs::write(walk_root.join("haystack.txt"), "match-me\n").expect("walked file written");
+		let later_file = tree.join("later.txt");
+		std::fs::write(&later_file, "match-me\n").expect("later file written");
 
-		let (code, stdout, stderr) =
-			run_rg_cancelled(&["match-me", tree.to_str().expect("utf8 path")], &tree);
+		let (code, stdout, stderr) = run_rg_cancelled(
+			&[
+				"match-me",
+				walk_root.to_str().expect("utf8 path"),
+				later_file.to_str().expect("utf8 path"),
+			],
+			&tree,
+		);
 
 		assert!(stdout.is_empty(), "cancelled walk should not output matches: {stdout:?}");
 		assert!(
@@ -1415,16 +1459,26 @@ mod tests {
 		// Regression for #3933: `rg --files <dir>` routes through
 		// `collect_filtered_files`, whose heartbeat was likewise a no-op.
 		let tree = unique_tree("files");
-		std::fs::write(tree.join("alpha.txt"), "alpha\n").expect("file written");
+		let walk_root = tree.join("walk-root");
+		std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+		std::fs::write(walk_root.join("alpha.txt"), "alpha\n").expect("walked file written");
+		let later_file = tree.join("later.txt");
+		std::fs::write(&later_file, "later\n").expect("later file written");
 
-		let (code, stdout, stderr) =
-			run_rg_cancelled(&["--files", tree.to_str().expect("utf8 path")], &tree);
+		let (code, stdout, stderr) = run_rg_cancelled(
+			&[
+				"--files",
+				walk_root.to_str().expect("utf8 path"),
+				later_file.to_str().expect("utf8 path"),
+			],
+			&tree,
+		);
 
 		assert!(stdout.is_empty(), "cancelled --files walk should not enumerate paths: {stdout:?}");
 		assert!(stderr.is_empty(), "cancelled --files walk should stay silent: {stderr:?}");
-		// list_files reports any_match=false / had_error=false when the walker
-		// silently returns no files. The wrapper "no match" mapping yields 1.
-		assert_eq!(code, 1, "cancelled --files walk yields no enumerated files");
+		// Cancellation is an error for standalone utility status; the shell
+		// wrapper rewrites it to the user-visible cancelled status (130).
+		assert_eq!(code, 2, "cancelled --files walk should stop before later operands");
 
 		let _ = std::fs::remove_dir_all(&tree);
 	}

--- a/crates/pi-uu-grep/src/rg.rs
+++ b/crates/pi-uu-grep/src/rg.rs
@@ -1025,7 +1025,13 @@ fn search_dir<W: Write>(
 	let any_match = std::cell::Cell::new(false);
 	let had_error = std::cell::Cell::new(false);
 	let streamed = match walk.request.for_each_entry_with_heartbeat(
-		|| Ok::<(), io::Error>(()),
+		|| {
+			if pi_uutils_ctx::is_cancelled() {
+				Err(io::Error::from(io::ErrorKind::Interrupted))
+			} else {
+				Ok::<(), io::Error>(())
+			}
+		},
 		|entry| {
 			if opts.quiet && any_match.get() {
 				return Ok(pi_walker::WalkDecision::Stop);
@@ -1065,6 +1071,12 @@ fn search_dir<W: Write>(
 		Ok(pi_walker::WalkStatus::Complete | pi_walker::WalkStatus::Stopped) => {
 			Some(SearchOutcome { any_match: any_match.get(), had_error: had_error.get() })
 		},
+		Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+			// Harness cancellation; the shell wrapper overrides the exit code
+			// and stay-silent on stderr — no spurious "interrupted" diagnostic.
+			had_error.set(true);
+			Some(SearchOutcome { any_match: any_match.get(), had_error: true })
+		},
 		Err(err) => {
 			had_error.set(true);
 			if !opts.no_messages {
@@ -1080,10 +1092,21 @@ fn search_dir<W: Write>(
 
 fn collect_filtered_files(cli: &RgCli, root: &Path) -> Result<Vec<PathBuf>, String> {
 	let walk = build_walk(cli, root)?;
-	let outcome = walk
-		.request
-		.collect_with_heartbeat(|| Ok::<(), io::Error>(()))
-		.map_err(|err| format!("rg: {err}"))?;
+	let outcome = match walk.request.collect_with_heartbeat(|| {
+		if pi_uutils_ctx::is_cancelled() {
+			Err(io::Error::from(io::ErrorKind::Interrupted))
+		} else {
+			Ok::<(), io::Error>(())
+		}
+	}) {
+		Ok(outcome) => outcome,
+		Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+			// Harness cancellation; surface no files and no diagnostic. The
+			// shell wrapper overrides the exit code with 130.
+			return Ok(Vec::new());
+		},
+		Err(err) => return Err(format!("rg: {err}")),
+	};
 	let mut files = Vec::new();
 	for entry in outcome.entries {
 		if entry.file_type != pi_walker::FileType::File {
@@ -1299,5 +1322,110 @@ pub fn run(argv: Vec<OsString>) -> i32 {
 		0
 	} else {
 		1
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		collections::HashMap,
+		sync::{Arc, atomic::AtomicBool},
+	};
+
+	use parking_lot::Mutex;
+	use pi_uutils_ctx::{ScopeIo, scope};
+
+	use super::*;
+
+	/// Sink that collects writes into a shared buffer for assertions.
+	struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+	impl Write for SharedBuf {
+		fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+			self.0.lock().extend_from_slice(buf);
+			Ok(buf.len())
+		}
+
+		fn flush(&mut self) -> io::Result<()> {
+			Ok(())
+		}
+	}
+
+	/// Run `rg` with the cancel flag pre-set, mirroring the shell wrapper's
+	/// behavior when `abort`/`timeout` fires mid-walk.
+	fn run_rg_cancelled(args: &[&str], cwd: &Path) -> (i32, String, String) {
+		let out = Arc::new(Mutex::new(Vec::new()));
+		let err = Arc::new(Mutex::new(Vec::new()));
+		let io = ScopeIo {
+			stdin:                 Box::new(io::empty()),
+			stdin_fd:              None,
+			stdin_is_search_input: false,
+			stdout:                Box::new(SharedBuf(Arc::clone(&out))),
+			stderr:                Box::new(SharedBuf(Arc::clone(&err))),
+			cwd:                   cwd.to_path_buf(),
+			env:                   HashMap::new(),
+			cancel:                Arc::new(AtomicBool::new(true)),
+		};
+		let argv: Vec<OsString> = std::iter::once("rg")
+			.chain(args.iter().copied())
+			.map(OsString::from)
+			.collect();
+		let code = scope(io, || run(argv));
+		let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+		let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+		(code, stdout, stderr)
+	}
+
+	fn unique_tree(label: &str) -> PathBuf {
+		let root = std::env::temp_dir().join(format!(
+			"pi-uu-rg-{label}-{}-{}",
+			std::process::id(),
+			std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.map(|d| d.as_nanos())
+				.unwrap_or(0)
+		));
+		std::fs::create_dir_all(&root).expect("temp tree should be created");
+		root
+	}
+
+	#[test]
+	fn recursive_search_observes_scope_cancellation() {
+		// Regression for #3933: rg's recursive walker used to pass a no-op
+		// heartbeat to pi_walker, so cancellation was not observed during
+		// directory traversal even after the uutils ctx cancel flag was set.
+		let tree = unique_tree("search");
+		std::fs::write(tree.join("haystack.txt"), "match-me\n").expect("file written");
+
+		let (code, stdout, stderr) =
+			run_rg_cancelled(&["match-me", tree.to_str().expect("utf8 path")], &tree);
+
+		assert!(stdout.is_empty(), "cancelled walk should not output matches: {stdout:?}");
+		assert!(
+			stderr.is_empty(),
+			"cancelled walk should stay silent — diagnostic is the shell's job: {stderr:?}"
+		);
+		assert_eq!(code, 2, "interrupted directory walk should report had_error (exit 2)");
+
+		let _ = std::fs::remove_dir_all(&tree);
+	}
+
+	#[test]
+	fn files_mode_observes_scope_cancellation() {
+		// Regression for #3933: `rg --files <dir>` routes through
+		// `collect_filtered_files`, whose heartbeat was likewise a no-op.
+		let tree = unique_tree("files");
+		std::fs::write(tree.join("alpha.txt"), "alpha\n").expect("file written");
+
+		let (code, stdout, stderr) =
+			run_rg_cancelled(&["--files", tree.to_str().expect("utf8 path")], &tree);
+
+		assert!(stdout.is_empty(), "cancelled --files walk should not enumerate paths: {stdout:?}");
+		assert!(stderr.is_empty(), "cancelled --files walk should stay silent: {stderr:?}");
+		// list_files reports any_match=false / had_error=false when the walker
+		// silently returns no files. The wrapper "no match" mapping yields 1.
+		assert_eq!(code, 1, "cancelled --files walk yields no enumerated files");
+
+		let _ = std::fs::remove_dir_all(&tree);
 	}
 }

--- a/crates/pi-uutils-ctx/src/lib.rs
+++ b/crates/pi-uutils-ctx/src/lib.rs
@@ -183,6 +183,22 @@ pub fn stdin_is_search_input() -> bool {
 	})
 }
 
+/// Returns true when the host has asked the active scope to cancel (e.g. on
+/// shell `abort`/`timeout`). uutils utilities running long internal loops —
+/// recursive directory walks in particular — poll this so cancellation is
+/// observed without waiting for stdin or for the whole work item to finish.
+///
+/// Returns false when no scope is installed; the cancel flag itself is the
+/// same one observed by [`CtxStdin::read`].
+#[must_use]
+pub fn is_cancelled() -> bool {
+	CTX.with(|c| {
+		c.borrow()
+			.as_ref()
+			.is_some_and(|ctx| ctx.cancel.load(Ordering::Relaxed))
+	})
+}
+
 macro_rules! ctx_writer {
 	($name:ident, $field:ident, $doc:literal) => {
 		#[doc = $doc]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `grep`/`rg` in-process builtins ignoring shell `abort`/`timeout` during recursive directory walks. The grep and ripgrep builtins passed no-op heartbeats to `pi_walker`, so a cancelled bash command could not interrupt a large directory traversal even after the shell flipped the uutils cancel flag (it only unblocked stdin reads). The walkers now check `pi_uutils_ctx::is_cancelled()` on each heartbeat tick, returning a `WalkError::Interrupted` that the utility silently maps to an interrupted result (the shell wrapper still overrides the exit code with 130). ([#3933](https://github.com/can1357/oh-my-pi/issues/3933))
+
 ## [16.2.10] - 2026-06-30
 
 ### Changed


### PR DESCRIPTION
## Repro
The `grep`/`rg` in-process uutils builtins pass `|| Ok::<(), io::Error>(())` as the heartbeat to `pi_walker` when recursing into a directory, so the uutils scope's cancel flag is ignored during traversal. The shell wrapper sets that flag on `abort`/`timeout` and then awaits the blocking task — with no heartbeat hookup, a cancelled `grep -r` / `rg` waits for the entire walk to finish before the shell can return exit 130. A regression test pre-sets the cancel flag and runs `grep -r match-me <tempdir>`; without the fix the walker scans the matching file and prints `haystack.txt:match-me\n`.

## Cause
`crates/pi-uu-grep/src/lib.rs:455-457` (grep `search_dir`), `crates/pi-uu-grep/src/rg.rs:1027-1028` (rg `search_dir`), and `crates/pi-uu-grep/src/rg.rs:1081-1086` (rg `collect_filtered_files`) call `pi_walker::WalkRequest::{for_each_entry,collect}_with_heartbeat` with no-op heartbeats. `pi_walker::lib.rs:2094-2096` checks that heartbeat between entries (every `HEARTBEAT_INTERVAL`), so the walker never sees the `pi_uutils_ctx` cancel flag that `CtxStdin::read` already polls (`crates/pi-uutils-ctx/src/lib.rs:244-272`).

## Fix
- `crates/pi-uutils-ctx`: add `pub fn is_cancelled() -> bool` so utility-side code can poll the active scope's cancel flag without exposing the `Arc<AtomicBool>` directly.
- `crates/pi-uu-grep/src/lib.rs`: grep's recursive `search_dir` heartbeat now returns `io::ErrorKind::Interrupted` when `is_cancelled()` is true; the new guarded `WalkError::Interrupted` arm silently sets `had_error = true` instead of writing a `grep: native directory scan interrupted: ...` line to stderr — the shell wrapper already overrides the exit code with 130 on abort/timeout.
- `crates/pi-uu-grep/src/rg.rs`: same wiring for rg's streaming `search_dir` and `collect_filtered_files` (used by `rg --files`); the latter returns an empty `Vec` on harness cancellation so `list_files` stays silent.
- Regression tests in both `pi-uu-grep` test modules pre-set the cancel flag and assert `grep -r` / `rg` / `rg --files` exit without scanning a known-matching file and without leaking diagnostics. Open questions answered: `is_cancelled()` helper preferred over plumbing a closure from the shell wrapper (mirrors the existing `stdin_is_search_input()` shape); utility-side exit code is `2`/`1`, but the shell wrapper still rewrites it to `130`, so the user-visible status is the conventional cancelled-command code.

## Verification
- `cargo test -p pi_uu_grep -p pi-uutils-ctx -p pi-walker --lib` — 35 passed.
- Reverted just the grep heartbeat to `|| Ok::<(), io::Error>(())` to confirm `tests::recursive_search_observes_scope_cancellation` fails with `cancelled walk should not output matches: "...haystack.txt:match-me\n"`, then restored the fix and re-ran (green).
- `cargo clippy -p pi_uu_grep -p pi-uutils-ctx --lib --tests` clean for the touched crates (`pi-walker` warnings are pre-existing on `main` — unused `OsStringExt` import + two nursery `missing_const_for_fn` hints, untouched here).
- `cargo fmt -p pi_uu_grep -p pi-uutils-ctx --check` clean after re-format.

Fixes #3933