### PR TITLE
fix(collab): reject oversized remote transcript entries

### DIFF
--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -16,7 +16,7 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { getConfigRootDir, logger } from "@oh-my-pi/pi-utils";
-import type { AgentHubRemote } from "../modes/components/agent-hub";
+import type { AgentHubRemote, AgentHubRemoteTranscript } from "../modes/components/agent-hub";
 import type { InteractiveModeContext } from "../modes/types";
 import { AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "../session/agent-session";
@@ -155,7 +155,7 @@ export class CollabGuestLink {
 	readonly agentRegistry = new AgentRegistry();
 	/** Per-agent `hasSessionFile` from the last snapshot; gates remote transcript fetches. */
 	#agentHasTranscript = new Map<string, boolean>();
-	#pendingTranscripts = new Map<number, (r: { text: string; newSize: number } | null) => void>();
+	#pendingTranscripts = new Map<number, (r: AgentHubRemoteTranscript | null) => void>();
 	#nextReqId = 1;
 	readonly #hubRemote: AgentHubRemote = {
 		chat: (id, text) => {
@@ -176,7 +176,7 @@ export class CollabGuestLink {
 				return Promise.resolve(null);
 			}
 			const reqId = this.#nextReqId++;
-			const { promise, resolve } = Promise.withResolvers<{ text: string; newSize: number } | null>();
+			const { promise, resolve } = Promise.withResolvers<AgentHubRemoteTranscript | null>();
 			const timer = setTimeout(() => {
 				this.#pendingTranscripts.delete(reqId);
 				resolve(null);
@@ -484,7 +484,7 @@ export class CollabGuestLink {
 				const resolve = this.#pendingTranscripts.get(frame.reqId);
 				if (resolve) {
 					this.#pendingTranscripts.delete(frame.reqId);
-					resolve(frame.error ? null : { text: frame.text, newSize: frame.newSize });
+					resolve({ text: frame.text, newSize: frame.newSize, error: frame.error });
 				}
 				break;
 			}

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -94,7 +94,8 @@ function isWireSessionEntry(entry: StoredSessionEntry): entry is StoredSessionEn
 }
 const CONNECT_TIMEOUT_MS = 15_000;
 /** Max bytes served per fetch-transcript reply (guest re-requests from `newSize`). */
-const TRANSCRIPT_READ_CAP = 4 * 1024 * 1024;
+export const TRANSCRIPT_READ_CAP = 4 * 1024 * 1024;
+const TRANSCRIPT_ENTRY_TOO_LARGE_ERROR = `transcript entry exceeds transcript fetch cap (${TRANSCRIPT_READ_CAP} bytes)`;
 /**
  * Soft byte cap per `snapshot-chunk` frame. The first MB of a snapshot takes
  * ~3s through the default relay, so a 512 KB chunk lands well under the
@@ -584,7 +585,11 @@ export class CollabHost {
 			if (!reachedEof) {
 				// Trim to the last complete JSONL line so no line or UTF-8 char is split.
 				const lastNewline = slice.lastIndexOf(0x0a);
-				slice = slice.subarray(0, lastNewline >= 0 ? lastNewline + 1 : 0);
+				if (lastNewline < 0) {
+					reply("", fromByte, TRANSCRIPT_ENTRY_TOO_LARGE_ERROR);
+					return;
+				}
+				slice = slice.subarray(0, lastNewline + 1);
 			}
 			reply(slice.toString("utf-8"), reachedEof ? stat.size : fromByte + slice.byteLength);
 		} catch (err) {

--- a/packages/coding-agent/src/collab/protocol.ts
+++ b/packages/coding-agent/src/collab/protocol.ts
@@ -93,7 +93,7 @@ export type CollabFrame =
 	| { t: "bus"; channel: BusChannel; data: unknown }
 	/** Full agent-registry snapshot (debounced on registry change). */
 	| { t: "agents"; agents: AgentSnapshot[] }
-	/** Targeted reply to fetch-transcript; `text` is decoded JSONL from `fromByte`, `newSize` the next offset base. */
+	/** Targeted reply to fetch-transcript; `error` marks a terminal read failure that guests must surface without hot retrying. */
 	| { t: "transcript"; reqId: number; text: string; newSize: number; error?: string }
 	| { t: "bye"; reason: string }
 	| { t: "error"; message: string };

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -130,13 +130,21 @@ function registerPersistedSubagentsFromDir(registry: AgentRegistry, dir: string,
 	}
 }
 
+/** Result of one host-backed transcript read for the Agent Hub viewer. */
+export interface AgentHubRemoteTranscript {
+	text: string;
+	newSize: number;
+	/** Terminal read failure reported by the host; guests should surface it instead of retrying hot. */
+	error?: string;
+}
+
 /** Guest-side proxy for hub actions executed on the collab host. */
 export interface AgentHubRemote {
 	chat(id: string, text: string): void;
 	kill(id: string): void;
 	revive(id: string): void;
-	/** Mirrors readFileIncremental: text from fromByte (complete JSONL lines), newSize = next fromByte base; null = unavailable. */
-	readTranscript(id: string, fromByte: number): Promise<{ text: string; newSize: number } | null>;
+	/** Mirrors readFileIncremental: text from fromByte (complete JSONL lines), newSize = next fromByte base; null = temporarily unavailable. */
+	readTranscript(id: string, fromByte: number): Promise<AgentHubRemoteTranscript | null>;
 }
 
 export interface AgentHubDeps {

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -137,6 +137,7 @@ export class AgentTranscriptViewer implements Component {
 	#remoteFetchInFlight = false;
 	#remoteToken = 0;
 	#remoteUnavailable = false;
+	#remoteError = "";
 	#hasRemoteData = false;
 
 	#model: string | undefined;
@@ -177,12 +178,15 @@ export class AgentTranscriptViewer implements Component {
 
 	dispose(): void {
 		this.#disposed = true;
-		if (this.#pollTimer) {
-			clearInterval(this.#pollTimer);
-			this.#pollTimer = undefined;
-		}
+		this.#stopPolling();
 		this.#remoteToken++;
 		this.#builder.dispose();
+	}
+
+	#stopPolling(): void {
+		if (!this.#pollTimer) return;
+		clearInterval(this.#pollTimer);
+		this.#pollTimer = undefined;
 	}
 
 	// ========================================================================
@@ -345,11 +349,20 @@ export class AgentTranscriptViewer implements Component {
 					}
 					return;
 				}
+				if (result.error) {
+					this.#remoteError = result.error;
+					this.#hasRemoteData = true;
+					this.#remoteUnavailable = false;
+					this.#stopPolling();
+					this.deps.requestRender();
+					return;
+				}
 				if (result.newSize < fromByte) {
 					// Host transcript rotated/truncated — drop the stale rendered rows
 					// before restarting; otherwise the post-rotation fetch would stack
 					// new content under the pre-rotation history.
 					this.#remoteBytes = 0;
+					this.#remoteError = "";
 					this.#hasRemoteData = false;
 					this.#model = undefined;
 					this.#rebuild([]);
@@ -357,6 +370,7 @@ export class AgentTranscriptViewer implements Component {
 					return;
 				}
 				this.#remoteUnavailable = false;
+				this.#remoteError = "";
 				const firstData = !this.#hasRemoteData;
 				this.#hasRemoteData = true;
 				const lastNewline = result.text.lastIndexOf("\n");
@@ -608,6 +622,7 @@ export class AgentTranscriptViewer implements Component {
 
 	#placeholder(): string {
 		if (this.deps.remote) {
+			if (this.#remoteError) return this.#remoteError;
 			if (this.#remoteUnavailable) return "Transcript lives on the host — not available.";
 			return this.#hasRemoteData ? "No messages yet." : "Loading transcript from host…";
 		}

--- a/packages/coding-agent/test/agent-hub-advisor-scroll.test.ts
+++ b/packages/coding-agent/test/agent-hub-advisor-scroll.test.ts
@@ -346,6 +346,56 @@ describe("AgentTranscriptViewer", () => {
 		}
 	});
 
+	it("stops polling after an oversized remote JSONL entry cannot fit in one host read", async () => {
+		const transcriptReadCap = 4 * 1024 * 1024;
+		const oversizedLine = `${JSON.stringify({
+			type: "message",
+			id: "oversized",
+			parentId: null,
+			timestamp: TS,
+			message: {
+				role: "user",
+				synthetic: true,
+				attribution: "agent",
+				content: "x".repeat(transcriptReadCap + 1),
+				timestamp: 0,
+			},
+		})}\n`;
+		const transcript = Buffer.from(oversizedLine, "utf-8");
+		const calls: number[] = [];
+		const remote: AgentHubRemote = {
+			chat: () => {},
+			kill: () => {},
+			revive: () => {},
+			readTranscript: async (_id: string, fromByte: number) => {
+				calls.push(fromByte);
+				const slice = transcript.subarray(fromByte, fromByte + transcriptReadCap);
+				const lastNewline = slice.lastIndexOf(0x0a);
+				if (lastNewline < 0) {
+					return {
+						text: "",
+						newSize: fromByte,
+						error: `transcript entry exceeds transcript fetch cap (${transcriptReadCap} bytes)`,
+					};
+				}
+				const complete = slice.subarray(0, lastNewline + 1);
+				return { text: complete.toString("utf-8"), newSize: fromByte + complete.byteLength };
+			},
+		};
+		const viewer = makeViewer("", remote);
+		try {
+			await Bun.sleep(650);
+			const body = viewer
+				.render(80)
+				.map(l => Bun.stripANSI(l))
+				.join("\n");
+			expect(calls.filter(offset => offset === 0).length).toBe(1);
+			expect(body).toContain("entry exceeds transcript fetch cap");
+		} finally {
+			viewer.dispose();
+		}
+	});
+
 	it("drops stale rendered rows when the host transcript rotates", async () => {
 		const header = `${JSON.stringify({
 			type: "session",


### PR DESCRIPTION
## Repro
A focused regression in `packages/coding-agent/test/agent-hub-advisor-scroll.test.ts` creates a single JSONL entry larger than the 4 MiB transcript read cap and mimics the host newline-trimming behavior. Before the fix, `bun --cwd=packages/coding-agent run gen:tool-views && bun test packages/coding-agent/test/agent-hub-advisor-scroll.test.ts -t oversized` showed the remote viewer requesting byte offset `0` three times in 650ms.

## Cause
`CollabHost.#handleFetchTranscript` in `packages/coding-agent/src/collab/host.ts` trimmed non-EOF reads to the last complete newline; if no newline fit in the capped read, it replied with `text: ""` and `newSize === fromByte`. `AgentTranscriptViewer.#fetchRemote` in `packages/coding-agent/src/modes/components/agent-transcript-viewer.ts` only advanced on complete newline text, so the 250ms poll loop repeated the same offset indefinitely.

## Fix
- Return an explicit `transcript entry exceeds transcript fetch cap` error from the host when a non-EOF capped read contains no complete JSONL line.
- Propagate transcript frame errors through `CollabGuest`/`AgentHubRemoteTranscript` instead of collapsing them to generic unavailability.
- Surface the host error in the remote transcript viewer and stop its poll timer for that terminal read failure.
- Add a regression that builds an oversized JSONL line and verifies the viewer does not keep fetching the same offset.

## Verification
`bun test packages/coding-agent/test/agent-hub-advisor-scroll.test.ts -t oversized` passed; `bun test packages/coding-agent/test/agent-hub-advisor-scroll.test.ts` passed; `bun test packages/coding-agent/test/collab/*.test.ts` passed; `bun --cwd=packages/coding-agent run check:types` passed; `bun --cwd=packages/coding-agent run check` passed. Fixes #3931