### PR TITLE
fix(ast): bound AST search pagination payloads

### DIFF
--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -1,8 +1,10 @@
 //! AST-aware structural search and rewrite powered by ast-grep.
 
 use std::{
-	collections::{BTreeMap, BTreeSet, HashMap},
+	cmp::Ordering,
+	collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap},
 	path::{Path, PathBuf},
+	sync::Arc,
 };
 
 use ast_grep_core::{MatchStrictness, matcher::Pattern, source::Edit, tree_sitter::LanguageExt};
@@ -109,6 +111,135 @@ pub struct AstFindMatch {
 	pub end_column:     u32,
 	/// Meta-variable name to captured text, when `includeMeta` was enabled.
 	pub meta_variables: Option<HashMap<String, String>>,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct AstFindOrderKey {
+	path:         String,
+	start_line:   u32,
+	start_column: u32,
+	end_line:     u32,
+	end_column:   u32,
+	byte_start:   u32,
+	byte_end:     u32,
+	sequence:     u64,
+}
+
+impl Ord for AstFindOrderKey {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self
+			.path
+			.cmp(&other.path)
+			.then(self.start_line.cmp(&other.start_line))
+			.then(self.start_column.cmp(&other.start_column))
+			.then(self.end_line.cmp(&other.end_line))
+			.then(self.end_column.cmp(&other.end_column))
+			.then(self.byte_start.cmp(&other.byte_start))
+			.then(self.byte_end.cmp(&other.byte_end))
+			.then(self.sequence.cmp(&other.sequence))
+	}
+}
+
+impl PartialOrd for AstFindOrderKey {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+#[derive(Eq, PartialEq)]
+struct RetainedAstFindMatch {
+	key:            AstFindOrderKey,
+	source:         Option<Arc<str>>,
+	meta_variables: Option<HashMap<String, String>>,
+}
+
+impl Ord for RetainedAstFindMatch {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.key.cmp(&other.key)
+	}
+}
+
+impl PartialOrd for RetainedAstFindMatch {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+fn retained_find_capacity(offset: u32, limit: u32) -> usize {
+	usize::try_from(offset.saturating_add(limit).saturating_add(1)).unwrap_or(usize::MAX)
+}
+
+fn should_retain_match(
+	retained: &BinaryHeap<RetainedAstFindMatch>,
+	capacity: usize,
+	key: &AstFindOrderKey,
+) -> bool {
+	if retained.len() < capacity {
+		return true;
+	}
+	retained
+		.peek()
+		.is_some_and(|worst_retained| key.cmp(&worst_retained.key).is_lt())
+}
+
+fn retain_bounded_match(
+	retained: &mut BinaryHeap<RetainedAstFindMatch>,
+	capacity: usize,
+	candidate: RetainedAstFindMatch,
+) {
+	if retained.len() < capacity {
+		retained.push(candidate);
+		return;
+	}
+	if let Some(mut worst_retained) = retained.peek_mut()
+		&& candidate.key.cmp(&worst_retained.key).is_lt()
+	{
+		*worst_retained = candidate;
+	}
+}
+
+fn page_retained_matches(
+	retained: BinaryHeap<RetainedAstFindMatch>,
+	offset: u32,
+	limit: u32,
+) -> (Vec<RetainedAstFindMatch>, bool) {
+	let mut retained_matches = retained.into_vec();
+	retained_matches.sort_by(|left, right| left.key.cmp(&right.key));
+	let offset = usize::try_from(offset).unwrap_or(usize::MAX);
+	let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+	let limit_reached = retained_matches.len().saturating_sub(offset) > limit;
+	let matches = retained_matches
+		.into_iter()
+		.skip(offset)
+		.take(limit)
+		.collect::<Vec<_>>();
+	(matches, limit_reached)
+}
+
+fn source_slice(source: &str, byte_start: u32, byte_end: u32) -> String {
+	let start = usize::try_from(byte_start).unwrap_or(usize::MAX);
+	let end = usize::try_from(byte_end).unwrap_or(usize::MAX);
+	source.get(start..end).unwrap_or_default().to_string()
+}
+
+fn retained_to_find_match(
+	retained: RetainedAstFindMatch,
+	source_override: Option<&str>,
+) -> AstFindMatch {
+	let RetainedAstFindMatch { key, source, meta_variables } = retained;
+	let source = source_override.or(source.as_deref()).unwrap_or_default();
+	let text = source_slice(source, key.byte_start, key.byte_end);
+	AstFindMatch {
+		path: key.path,
+		text,
+		byte_start: key.byte_start,
+		byte_end: key.byte_end,
+		start_line: key.start_line,
+		start_column: key.start_column,
+		end_line: key.end_line,
+		end_column: key.end_column,
+		meta_variables,
+	}
 }
 
 /// Aggregated search statistics and any parse or compile diagnostics.
@@ -576,9 +707,11 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 			compile_find_patterns(&patterns, &languages, selector.as_deref(), &strictness, &ct)?;
 		let files_searched = to_u32(resolved_candidates.len());
 
-		let mut all_matches = Vec::new();
+		let retained_capacity = retained_find_capacity(normalized_offset, normalized_limit);
+		let mut retained_matches = BinaryHeap::new();
 		let mut parse_errors = Vec::new();
 		let mut total_matches = 0u32;
+		let mut match_sequence = 0u64;
 		let mut files_with_matches = BTreeSet::new();
 		for resolved in resolved_candidates {
 			ct.heartbeat()?;
@@ -597,7 +730,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 			};
 			let lang_key = language.canonical_name();
 			let source = match std::fs::read_to_string(&candidate.absolute_path) {
-				Ok(source) => source,
+				Ok(source) => Arc::<str>::from(source),
 				Err(err) => {
 					for compiled in &compiled_patterns {
 						parse_errors
@@ -623,7 +756,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 				continue;
 			}
 
-			let ast = language.ast_grep(source);
+			let ast = language.ast_grep(source.as_ref());
 			if ast.root().dfs().any(|node| node.is_error()) {
 				parse_errors.push(format!(
 					"{}: parse error (syntax tree contains error nodes)",
@@ -631,55 +764,55 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 				));
 			}
 
+			let mut file_had_match = false;
 			for (_, pattern) in runnable_patterns {
 				ct.heartbeat()?;
 				for matched in ast.root().find_all(pattern.clone()) {
 					ct.heartbeat()?;
 					total_matches = total_matches.saturating_add(1);
+					if !file_had_match {
+						files_with_matches.insert(candidate.display_path.clone());
+						file_had_match = true;
+					}
 					let range = matched.range();
 					let start = matched.start_pos();
 					let end = matched.end_pos();
-					let meta_variables = if include_meta {
-						Some(HashMap::<String, String>::from(matched.get_env().clone()))
-					} else {
-						None
-					};
-					all_matches.push(AstFindMatch {
-						path: candidate.display_path.clone(),
-						text: matched.text().into_owned(),
-						byte_start: to_u32(range.start),
-						byte_end: to_u32(range.end),
-						start_line: to_u32(start.line().saturating_add(1)),
+					let key = AstFindOrderKey {
+						path:         candidate.display_path.clone(),
+						start_line:   to_u32(start.line().saturating_add(1)),
 						start_column: to_u32(start.column(matched.get_node()).saturating_add(1)),
-						end_line: to_u32(end.line().saturating_add(1)),
-						end_column: to_u32(end.column(matched.get_node()).saturating_add(1)),
-						meta_variables,
-					});
-					files_with_matches.insert(candidate.display_path.clone());
+						end_line:     to_u32(end.line().saturating_add(1)),
+						end_column:   to_u32(end.column(matched.get_node()).saturating_add(1)),
+						byte_start:   to_u32(range.start),
+						byte_end:     to_u32(range.end),
+						sequence:     match_sequence,
+					};
+					match_sequence = match_sequence.saturating_add(1);
+					if should_retain_match(&retained_matches, retained_capacity, &key) {
+						let meta_variables = if include_meta {
+							Some(HashMap::<String, String>::from(matched.get_env().clone()))
+						} else {
+							None
+						};
+						retain_bounded_match(
+							&mut retained_matches,
+							retained_capacity,
+							RetainedAstFindMatch {
+								key,
+								source: Some(Arc::clone(&source)),
+								meta_variables,
+							},
+						);
+					}
 				}
 			}
 		}
 
-		all_matches.sort_by(|left, right| {
-			left
-				.path
-				.cmp(&right.path)
-				.then(left.start_line.cmp(&right.start_line))
-				.then(left.start_column.cmp(&right.start_column))
-				.then(left.end_line.cmp(&right.end_line))
-				.then(left.end_column.cmp(&right.end_column))
-				.then(left.byte_start.cmp(&right.byte_start))
-				.then(left.byte_end.cmp(&right.byte_end))
-		});
-
-		let visible_matches = all_matches
+		let (matches, limit_reached) =
+			page_retained_matches(retained_matches, normalized_offset, normalized_limit);
+		let matches = matches
 			.into_iter()
-			.skip(normalized_offset as usize)
-			.collect::<Vec<_>>();
-		let limit_reached = visible_matches.len() > normalized_limit as usize;
-		let matches = visible_matches
-			.into_iter()
-			.take(normalized_limit as usize)
+			.map(|retained| retained_to_find_match(retained, None))
 			.collect::<Vec<_>>();
 
 		Ok(AstFindResult {
@@ -739,8 +872,10 @@ pub fn ast_match(options: AstMatchOptions<'_>) -> task::Promise<AstMatchResult> 
 			}
 		}
 
-		let mut all_matches = Vec::new();
+		let retained_capacity = retained_find_capacity(normalized_offset, normalized_limit);
+		let mut retained_matches = BinaryHeap::new();
 		let mut total_matches = 0u32;
+		let mut match_sequence = 0u64;
 		if !compiled_patterns.is_empty() {
 			let ast = language.ast_grep(&source);
 			if ast.root().dfs().any(|node| node.is_error()) {
@@ -754,45 +889,38 @@ pub fn ast_match(options: AstMatchOptions<'_>) -> task::Promise<AstMatchResult> 
 					let range = matched.range();
 					let start = matched.start_pos();
 					let end = matched.end_pos();
-					let meta_variables = if include_meta {
-						Some(HashMap::<String, String>::from(matched.get_env().clone()))
-					} else {
-						None
-					};
-					all_matches.push(AstFindMatch {
-						path: String::new(),
-						text: matched.text().into_owned(),
-						byte_start: to_u32(range.start),
-						byte_end: to_u32(range.end),
-						start_line: to_u32(start.line().saturating_add(1)),
+					let key = AstFindOrderKey {
+						path:         String::new(),
+						start_line:   to_u32(start.line().saturating_add(1)),
 						start_column: to_u32(start.column(matched.get_node()).saturating_add(1)),
-						end_line: to_u32(end.line().saturating_add(1)),
-						end_column: to_u32(end.column(matched.get_node()).saturating_add(1)),
-						meta_variables,
-					});
+						end_line:     to_u32(end.line().saturating_add(1)),
+						end_column:   to_u32(end.column(matched.get_node()).saturating_add(1)),
+						byte_start:   to_u32(range.start),
+						byte_end:     to_u32(range.end),
+						sequence:     match_sequence,
+					};
+					match_sequence = match_sequence.saturating_add(1);
+					if should_retain_match(&retained_matches, retained_capacity, &key) {
+						let meta_variables = if include_meta {
+							Some(HashMap::<String, String>::from(matched.get_env().clone()))
+						} else {
+							None
+						};
+						retain_bounded_match(
+							&mut retained_matches,
+							retained_capacity,
+							RetainedAstFindMatch { key, source: None, meta_variables },
+						);
+					}
 				}
 			}
 		}
 
-		all_matches.sort_by(|left, right| {
-			left
-				.start_line
-				.cmp(&right.start_line)
-				.then(left.start_column.cmp(&right.start_column))
-				.then(left.end_line.cmp(&right.end_line))
-				.then(left.end_column.cmp(&right.end_column))
-				.then(left.byte_start.cmp(&right.byte_start))
-				.then(left.byte_end.cmp(&right.byte_end))
-		});
-
-		let visible_matches = all_matches
+		let (matches, limit_reached) =
+			page_retained_matches(retained_matches, normalized_offset, normalized_limit);
+		let matches = matches
 			.into_iter()
-			.skip(normalized_offset as usize)
-			.collect::<Vec<_>>();
-		let limit_reached = visible_matches.len() > normalized_limit as usize;
-		let matches = visible_matches
-			.into_iter()
-			.take(normalized_limit as usize)
+			.map(|retained| retained_to_find_match(retained, Some(&source)))
 			.collect::<Vec<_>>();
 
 		Ok(AstMatchResult {
@@ -1066,6 +1194,47 @@ mod tests {
 		fs::write(root.join("nested").join("b.ts"), "const b = 2;\n")
 			.expect("temp file nested/b.ts should be written");
 		TempTree { root }
+	}
+
+	fn retained_test_match(line: u32) -> RetainedAstFindMatch {
+		RetainedAstFindMatch {
+			key:            AstFindOrderKey {
+				path:         "file.ts".to_string(),
+				start_line:   line,
+				start_column: 1,
+				end_line:     line,
+				end_column:   2,
+				byte_start:   line - 1,
+				byte_end:     line,
+				sequence:     u64::from(line),
+			},
+			source:         None,
+			meta_variables: None,
+		}
+	}
+
+	#[test]
+	fn retained_find_matches_keep_only_page_window() {
+		let capacity = retained_find_capacity(1, 2);
+		let mut retained = BinaryHeap::new();
+		let mut materialized_payloads = 0usize;
+		for line in 1..=100 {
+			let candidate = retained_test_match(line);
+			if should_retain_match(&retained, capacity, &candidate.key) {
+				materialized_payloads += 1;
+				retain_bounded_match(&mut retained, capacity, candidate);
+			}
+		}
+
+		let (page, limit_reached) = page_retained_matches(retained, 1, 2);
+		let lines = page
+			.into_iter()
+			.map(|retained| retained.key.start_line)
+			.collect::<Vec<_>>();
+
+		assert_eq!(materialized_payloads, capacity);
+		assert!(limit_reached);
+		assert_eq!(lines, vec![2, 3]);
 	}
 
 	#[test]

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -4,7 +4,6 @@ use std::{
 	cmp::Ordering,
 	collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap},
 	path::{Path, PathBuf},
-	sync::Arc,
 };
 
 use ast_grep_core::{MatchStrictness, matcher::Pattern, source::Edit, tree_sitter::LanguageExt};
@@ -149,7 +148,7 @@ impl PartialOrd for AstFindOrderKey {
 #[derive(Eq, PartialEq)]
 struct RetainedAstFindMatch {
 	key:            AstFindOrderKey,
-	source:         Option<Arc<str>>,
+	text:           String,
 	meta_variables: Option<HashMap<String, String>>,
 }
 
@@ -216,19 +215,8 @@ fn page_retained_matches(
 	(matches, limit_reached)
 }
 
-fn source_slice(source: &str, byte_start: u32, byte_end: u32) -> String {
-	let start = usize::try_from(byte_start).unwrap_or(usize::MAX);
-	let end = usize::try_from(byte_end).unwrap_or(usize::MAX);
-	source.get(start..end).unwrap_or_default().to_string()
-}
-
-fn retained_to_find_match(
-	retained: RetainedAstFindMatch,
-	source_override: Option<&str>,
-) -> AstFindMatch {
-	let RetainedAstFindMatch { key, source, meta_variables } = retained;
-	let source = source_override.or(source.as_deref()).unwrap_or_default();
-	let text = source_slice(source, key.byte_start, key.byte_end);
+fn retained_to_find_match(retained: RetainedAstFindMatch) -> AstFindMatch {
+	let RetainedAstFindMatch { key, text, meta_variables } = retained;
 	AstFindMatch {
 		path: key.path,
 		text,
@@ -730,7 +718,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 			};
 			let lang_key = language.canonical_name();
 			let source = match std::fs::read_to_string(&candidate.absolute_path) {
-				Ok(source) => Arc::<str>::from(source),
+				Ok(source) => source,
 				Err(err) => {
 					for compiled in &compiled_patterns {
 						parse_errors
@@ -756,7 +744,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 				continue;
 			}
 
-			let ast = language.ast_grep(source.as_ref());
+			let ast = language.ast_grep(source);
 			if ast.root().dfs().any(|node| node.is_error()) {
 				parse_errors.push(format!(
 					"{}: parse error (syntax tree contains error nodes)",
@@ -799,7 +787,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 							retained_capacity,
 							RetainedAstFindMatch {
 								key,
-								source: Some(Arc::clone(&source)),
+								text: matched.text().into_owned(),
 								meta_variables,
 							},
 						);
@@ -812,7 +800,7 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 			page_retained_matches(retained_matches, normalized_offset, normalized_limit);
 		let matches = matches
 			.into_iter()
-			.map(|retained| retained_to_find_match(retained, None))
+			.map(retained_to_find_match)
 			.collect::<Vec<_>>();
 
 		Ok(AstFindResult {
@@ -909,7 +897,11 @@ pub fn ast_match(options: AstMatchOptions<'_>) -> task::Promise<AstMatchResult> 
 						retain_bounded_match(
 							&mut retained_matches,
 							retained_capacity,
-							RetainedAstFindMatch { key, source: None, meta_variables },
+							RetainedAstFindMatch {
+								key,
+								text: matched.text().into_owned(),
+								meta_variables,
+							},
 						);
 					}
 				}
@@ -920,7 +912,7 @@ pub fn ast_match(options: AstMatchOptions<'_>) -> task::Promise<AstMatchResult> 
 			page_retained_matches(retained_matches, normalized_offset, normalized_limit);
 		let matches = matches
 			.into_iter()
-			.map(|retained| retained_to_find_match(retained, Some(&source)))
+			.map(retained_to_find_match)
 			.collect::<Vec<_>>();
 
 		Ok(AstMatchResult {
@@ -1208,7 +1200,7 @@ mod tests {
 				byte_end:     line,
 				sequence:     u64::from(line),
 			},
-			source:         None,
+			text:           String::new(),
 			meta_variables: None,
 		}
 	}

--- a/crates/pi-walker/src/lib.rs
+++ b/crates/pi-walker/src/lib.rs
@@ -2845,7 +2845,7 @@ mod platform {
 		ffi::{CString, OsStr},
 		io,
 		mem::{size_of, zeroed},
-		os::unix::ffi::{OsStrExt, OsStringExt},
+		os::unix::ffi::OsStrExt,
 		path::Path,
 	};
 
@@ -3123,7 +3123,7 @@ mod platform {
 		&bytes[..end]
 	}
 
-	fn file_type_from_dtype(value: u8) -> Option<FileType> {
+	const fn file_type_from_dtype(value: u8) -> Option<FileType> {
 		match value {
 			libc::DT_REG => Some(FileType::File),
 			libc::DT_DIR => Some(FileType::Dir),
@@ -3132,7 +3132,7 @@ mod platform {
 		}
 	}
 
-	fn file_type_from_mode(mode: libc::mode_t) -> Option<FileType> {
+	const fn file_type_from_mode(mode: libc::mode_t) -> Option<FileType> {
 		match mode & libc::S_IFMT {
 			libc::S_IFREG => Some(FileType::File),
 			libc::S_IFDIR => Some(FileType::Dir),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed multi-target `ast_grep` searches retaining every target page before global pagination; the wrapper now keeps only the final page window and preserves exact match/file counts. ([#3935](https://github.com/can1357/oh-my-pi/issues/3935))
+
 ## [16.2.10] - 2026-06-30
 
 ### Changed

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -44,6 +44,33 @@ const astGrepSchema = type({
 	"skip?": type("number").describe("matches to skip"),
 });
 
+function compareAstFindMatch(left: AstFindMatch, right: AstFindMatch): number {
+	const pathCmp = left.path.localeCompare(right.path);
+	if (pathCmp !== 0) return pathCmp;
+	if (left.startLine !== right.startLine) return left.startLine - right.startLine;
+	if (left.startColumn !== right.startColumn) return left.startColumn - right.startColumn;
+	if (left.endLine !== right.endLine) return left.endLine - right.endLine;
+	if (left.endColumn !== right.endColumn) return left.endColumn - right.endColumn;
+	if (left.byteStart !== right.byteStart) return left.byteStart - right.byteStart;
+	return left.byteEnd - right.byteEnd;
+}
+
+function retainAstFindMatch(matches: AstFindMatch[], capacity: number, candidate: AstFindMatch): void {
+	if (matches.length < capacity) {
+		matches.push(candidate);
+		return;
+	}
+	let worstIndex = 0;
+	for (let index = 1; index < matches.length; index++) {
+		if (compareAstFindMatch(matches[index]!, matches[worstIndex]!) > 0) {
+			worstIndex = index;
+		}
+	}
+	if (compareAstFindMatch(candidate, matches[worstIndex]!) < 0) {
+		matches[worstIndex] = candidate;
+	}
+}
+
 async function runMultiTargetAstGrep(
 	targets: Array<{ basePath: string; glob?: string }>,
 	options: { patterns: string[]; commonBasePath: string; skip: number; limit: number; signal?: AbortSignal },
@@ -55,9 +82,11 @@ async function runMultiTargetAstGrep(
 	limitReached: boolean;
 	parseErrors?: string[];
 }> {
-	const aggregatedMatches: AstFindMatch[] = [];
+	const retainedMatches: AstFindMatch[] = [];
+	const retainedCapacity = options.skip + options.limit + 1;
 	const parseErrors: string[] = [];
 	let totalMatches = 0;
+	let filesWithMatches = 0;
 	let filesSearched = 0;
 	let limitReached = false;
 	for (const target of targets) {
@@ -71,26 +100,19 @@ async function runMultiTargetAstGrep(
 			signal: options.signal,
 		});
 		totalMatches += targetResult.totalMatches;
+		filesWithMatches += targetResult.filesWithMatches;
 		filesSearched += targetResult.filesSearched;
 		limitReached = limitReached || targetResult.limitReached;
 		if (targetResult.parseErrors) parseErrors.push(...targetResult.parseErrors);
 		for (const match of targetResult.matches) {
 			const absolute = path.resolve(target.basePath, match.path);
 			const rebased = path.relative(options.commonBasePath, absolute).replace(/\\/g, "/");
-			aggregatedMatches.push({ ...match, path: rebased });
+			retainAstFindMatch(retainedMatches, retainedCapacity, { ...match, path: rebased });
 		}
 	}
-	aggregatedMatches.sort((left, right) => {
-		const pathCmp = left.path.localeCompare(right.path);
-		if (pathCmp !== 0) return pathCmp;
-		if (left.startLine !== right.startLine) return left.startLine - right.startLine;
-		if (left.startColumn !== right.startColumn) return left.startColumn - right.startColumn;
-		if (left.byteStart !== right.byteStart) return left.byteStart - right.byteStart;
-		return left.byteEnd - right.byteEnd;
-	});
-	const visible = aggregatedMatches.slice(options.skip);
+	retainedMatches.sort(compareAstFindMatch);
+	const visible = retainedMatches.slice(options.skip);
 	const paged = visible.slice(0, options.limit);
-	const filesWithMatches = new Set(aggregatedMatches.map(match => match.path)).size;
 	return {
 		matches: paged,
 		totalMatches,

--- a/packages/coding-agent/test/tools/ast-grep.test.ts
+++ b/packages/coding-agent/test/tools/ast-grep.test.ts
@@ -114,6 +114,41 @@ describe("ast_grep parse errors", () => {
 		}
 	});
 
+	it("keeps multi-target paging globally ordered without truncating match totals", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-multi-page-"));
+		try {
+			const earlyDir = path.join(tempDir, "a");
+			const lateDir = path.join(tempDir, "z");
+			await fs.mkdir(earlyDir, { recursive: true });
+			await fs.mkdir(lateDir, { recursive: true });
+			await Bun.write(path.join(earlyDir, "early.ts"), 'marker("early");\n');
+			for (let index = 0; index < 60; index++) {
+				await Bun.write(path.join(lateDir, `late-${index.toString().padStart(2, "0")}.ts`), 'marker("late");\n');
+			}
+
+			const tools = await createTools(createTestSession(tempDir));
+			const tool = tools.find(entry => entry.name === "ast_grep");
+			expect(tool).toBeDefined();
+
+			const result = await tool!.execute("ast-grep-multi-page", {
+				pat: "marker($A)",
+				paths: [lateDir, earlyDir],
+			});
+
+			const text = result.content.find(content => content.type === "text")?.text ?? "";
+			const details = result.details as
+				| { matchCount?: number; fileCount?: number; limitReached?: boolean }
+				| undefined;
+
+			expect(text).toMatch(/^## early\.ts#[0-9A-F]{4}/m);
+			expect(details?.matchCount).toBe(61);
+			expect(details?.fileCount).toBe(61);
+			expect(details?.limitReached).toBe(true);
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+
 	it("parses PlusCal content through the tlaplus language aliases", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-tlaplus-"));
 		try {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native `astGrep` and `astMatch` retaining every match payload before applying pagination; broad searches now keep only the requested page window while preserving exact totals. ([#3935](https://github.com/can1357/oh-my-pi/issues/3935))
+
 ## [16.2.10] - 2026-06-30
 
 ### Added


### PR DESCRIPTION
## Repro
A broad native AST search still finds the full result set even for a tiny page: `astGrep({ patterns: ['$A'], path: 'packages/coding-agent/src/tools', glob: '*.ts', limit: 2, offset: 0 })` returned `matches: 2`, `totalMatches: 193043`, and `limitReached: true`. Before this patch, `crates/pi-natives/src/ast.rs` cloned every matched text span into `all_matches` before sorting and paging.

## Cause
`crates/pi-natives/src/ast.rs` built full `AstFindMatch` payloads in `ast_grep` and `ast_match` for every `find_all(...)` result, including `matched.text().into_owned()` and meta-variable cloning, then sorted the complete vector before `offset`/`limit`. `packages/coding-agent/src/tools/ast-grep.ts` repeated the same retention pattern across multi-target searches by collecting each target page into one unbounded aggregate before global pagination.

## Fix
- Added a bounded native retained-match window keyed by deterministic AST result ordering, preserving exact `totalMatches` and `limitReached` while materializing returned `AstFindMatch` text only for the page window.
- Updated `ast_grep` and `ast_match` to count all matches but clone meta/text only for candidates retained in the bounded window.
- Updated multi-target `ast_grep` aggregation to keep only the global page window and to aggregate native match/file totals.
- Added native retained-window regression coverage and a coding-agent multi-target paging regression test.

## Verification
`cargo test -p pi-natives ast` passed; `bun test packages/coding-agent/test/tools/ast-grep.test.ts` passed; `bun check` passed. Fixes #3935