### PR TITLE
fix(extensions): bound tool_call handlers by extensionHandlerTimeoutMs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed extension `tool_call` handlers running without a timeout, so a hung third-party extension could indefinitely block tool execution. `ExtensionRunner.emitToolCall` now bounds each handler by `extensionHandlerTimeoutMs` (30s default) with a fail-closed policy — on timeout the runner emits an `ExtensionError`, logs a warning, and returns `{ block: true, reason: "Extension <path> timed out after <ms>ms" }`, symmetric with the existing per-handler error path and with `emitToolResult`'s timeout wrapping. ([#3948](https://github.com/can1357/oh-my-pi/issues/3948))
+- Fixed extension `tool_call` handlers running without a timeout, so a hung third-party extension could indefinitely block tool execution. `ExtensionRunner.emitToolCall` now bounds each handler by `extensionHandlerTimeoutMs` (30s default) with a fail-closed policy — on timeout the runner emits an `ExtensionError`, logs a warning, and returns `{ block: true, reason: "Extension <path> timed out after <ms>ms" }`, symmetric with the existing per-handler error path and with `emitToolResult`'s timeout wrapping. The internal timeout race also switched from `Bun.sleep(ms).then(...)` (which left an uncancellable timer registered with the event loop after every successful handler) to `setTimeout`/`clearTimeout`, so a completed `tool_call`/`tool_result` handler no longer keeps a non-interactive CLI alive for up to 30s past exit. ([#3948](https://github.com/can1357/oh-my-pi/issues/3948))
 
 ## [16.2.10] - 2026-06-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extension `tool_call` handlers running without a timeout, so a hung third-party extension could indefinitely block tool execution. `ExtensionRunner.emitToolCall` now bounds each handler by `extensionHandlerTimeoutMs` (30s default) with a fail-closed policy — on timeout the runner emits an `ExtensionError`, logs a warning, and returns `{ block: true, reason: "Extension <path> timed out after <ms>ms" }`, symmetric with the existing per-handler error path and with `emitToolResult`'s timeout wrapping. ([#3948](https://github.com/can1357/oh-my-pi/issues/3948))
+
 ## [16.2.10] - 2026-06-30
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -98,6 +98,32 @@ function handlerTimeoutForEvent(eventType: string): number {
 
 const EXTENSION_HANDLER_TIMEOUT = Symbol("extensionHandlerTimeout");
 
+/**
+ * Race `work` against a `timeoutMs` budget, clearing the pending timer the
+ * instant the work settles.
+ *
+ * We deliberately avoid `Bun.sleep(timeoutMs).then(...)` here: that leaves an
+ * uncancellable timer registered with the event loop, so every successful
+ * handler race leaks a timer that keeps the process alive until the deadline
+ * fires — up to the default 30s cap, which stalls non-interactive CLI exit
+ * after any subscribed `tool_call`/`tool_result` handler runs (issue #3948
+ * review, `chatgpt-codex-connector[bot]`). `setTimeout` returns a handle we
+ * can `clearTimeout` on the winning branch.
+ */
+async function raceHandlerWithTimeout<T>(
+	work: Promise<T>,
+	timeoutMs: number,
+): Promise<T | typeof EXTENSION_HANDLER_TIMEOUT> {
+	const { promise: timeoutPromise, resolve: resolveTimeout } =
+		Promise.withResolvers<typeof EXTENSION_HANDLER_TIMEOUT>();
+	const timer = setTimeout(() => resolveTimeout(EXTENSION_HANDLER_TIMEOUT), timeoutMs);
+	try {
+		return await Promise.race([work, timeoutPromise]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 const MAX_PENDING_CREDENTIAL_DISABLED = 32;
 
 /**
@@ -555,10 +581,7 @@ export class ExtensionRunner {
 		timeoutMs: number,
 	): Promise<TResult | undefined> {
 		try {
-			const handlerResult = await Promise.race([
-				Promise.resolve(handler(event, ctx)),
-				Bun.sleep(timeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT),
-			]);
+			const handlerResult = await raceHandlerWithTimeout(Promise.resolve(handler(event, ctx)), timeoutMs);
 			if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
 				const error = `handler timed out after ${timeoutMs}ms`;
 				logger.warn("Extension handler timed out", {
@@ -719,10 +742,7 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await Promise.race([
-						Promise.resolve(handler(event, ctx)),
-						Bun.sleep(timeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT),
-					]);
+					const handlerResult = await raceHandlerWithTimeout(Promise.resolve(handler(event, ctx)), timeoutMs);
 
 					if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
 						const error = `handler timed out after ${timeoutMs}ms`;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -693,8 +693,24 @@ export class ExtensionRunner {
 		};
 	}
 
+	/**
+	 * Emit a `tool_call` event to every subscribed extension before the tool executes.
+	 *
+	 * Each handler is bounded by `extensionHandlerTimeoutMs` (default 30s). This
+	 * matches the timeout policy already applied to `emitToolResult` and every
+	 * other handler routed through `#runHandlerWithTimeout`; without it a single
+	 * hung extension (unresolved `await`, network call with no timeout) would
+	 * park `ExtensionToolWrapper.execute` indefinitely and freeze tool
+	 * dispatch — see issue #3948.
+	 *
+	 * On-timeout policy: **fail-closed** (return `{ block: true }`). This is
+	 * symmetric with the existing error path below and safer for a
+	 * pre-execution gate — an unresponsive extension MUST NOT be treated as
+	 * silent consent to run the tool.
+	 */
 	async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
 		const ctx = this.createContext();
+		const timeoutMs = extensionHandlerTimeoutMs;
 		let result: ToolCallEventResult | undefined;
 
 		for (const ext of this.extensions) {
@@ -703,7 +719,28 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await Promise.race([
+						Promise.resolve(handler(event, ctx)),
+						Bun.sleep(timeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT),
+					]);
+
+					if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
+						const error = `handler timed out after ${timeoutMs}ms`;
+						logger.warn("Extension handler timed out", {
+							extensionPath: ext.path,
+							event: "tool_call",
+							timeoutMs,
+						});
+						this.emitError({
+							extensionPath: ext.path,
+							event: "tool_call",
+							error,
+						});
+						return {
+							block: true,
+							reason: `Extension ${ext.path} timed out after ${timeoutMs}ms`,
+						};
+					}
 
 					if (handlerResult) {
 						result = handlerResult as ToolCallEventResult;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -903,6 +903,74 @@ describe("ExtensionRunner", () => {
 
 			warnSpy.mockRestore();
 		});
+
+		it("times out tool_call handlers with fail-closed policy so a hung extension cannot indefinitely block tool execution (#3948)", async () => {
+			const hangExtensionPath = path.join(tempDir.path(), "hang-tool-call.ts");
+			fs.writeFileSync(
+				hangExtensionPath,
+				`
+					export default function(pi) {
+						pi.on("tool_call", async () => {
+							await Promise.withResolvers().promise;
+						});
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions([hangExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError(err => {
+				errors.push(err);
+			});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			const executeCalls: unknown[] = [];
+			const tool: AgentTool = {
+				name: "sleepy",
+				label: "Sleepy",
+				description: "records execute() invocations",
+				parameters: Type.Object({}),
+				strict: true,
+				execute: async (_id, params) => {
+					executeCalls.push(params);
+					return { content: [{ type: "text", text: "ran" }] };
+				},
+			};
+			const wrapped = new ExtensionToolWrapper(tool, runner);
+
+			const startedAt = performance.now();
+			await expect(wrapped.execute("tool-call-id", {})).rejects.toThrow(
+				`Extension ${hangExtensionPath} timed out after 10ms`,
+			);
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(elapsedMs).toBeGreaterThanOrEqual(8);
+			expect(elapsedMs).toBeLessThan(500);
+			// Fail-closed: the underlying tool MUST NOT run when a gate handler timed out.
+			expect(executeCalls).toEqual([]);
+			expect(warnSpy).toHaveBeenCalledWith("Extension handler timed out", {
+				extensionPath: hangExtensionPath,
+				event: "tool_call",
+				timeoutMs: 10,
+			});
+			expect(errors).toEqual([
+				{
+					extensionPath: hangExtensionPath,
+					event: "tool_call",
+					error: "handler timed out after 10ms",
+				},
+			]);
+
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("memory context", () => {


### PR DESCRIPTION
## Repro

Register an extension whose `tool_call` handler never resolves and invoke a tool through `ExtensionToolWrapper.execute`; the wrapper parks at the pre-execution `await runner.emitToolCall(...)` indefinitely and the tool never runs, even under `testSetExtensionHandlerTimeoutMs(10)`.

```
bun test packages/coding-agent/test/extensions-runner.test.ts \
  -t "times out tool_call handlers"
```

New test asserts (a) `execute()` rejects within ~10ms with `Extension <path> timed out after 10ms`, (b) the underlying tool's `execute` was never invoked, and (c) the runner emitted the standard timeout warning + `ExtensionError`. Fails on unpatched `emitToolCall`, passes on this branch.

## Cause

`ExtensionRunner.emitToolCall` in `packages/coding-agent/src/extensibility/extensions/runner.ts` (previously lines 696–729) called `await handler(event, ctx)` directly, bypassing `#runHandlerWithTimeout`. Every other subscribed event — including the post-execution counterpart `emitToolResult` at 663–669 — routes through that wrapper and is bounded by `extensionHandlerTimeoutMs` (default 30s). `ExtensionToolWrapper.execute` (`wrapper.ts:183-198`) awaits `emitToolCall` before invoking the tool, so a hung handler blocks the entire tool pipeline. The symmetric hook runner (`extensibility/hooks/runner.ts:321-326`) intentionally omits a timeout on `tool_call` because its handlers can prompt the user; extensions have no such semantic and MUST be bounded.

## Fix

- `packages/coding-agent/src/extensibility/extensions/runner.ts` — race each `tool_call` handler against `Bun.sleep(extensionHandlerTimeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT)` inline. The existing `#runHandlerWithTimeout` swallows errors and returns `undefined` (fail-open), which is incompatible with `emitToolCall`'s pre-existing fail-closed error branch — so the timeout race is inlined rather than shared. On timeout: `logger.warn("Extension handler timed out", {...})`, `this.emitError({ event: "tool_call", ... })`, and `return { block: true, reason: "Extension <path> timed out after <ms>ms" }`. Doc comment records the explicit fail-closed policy and the #3948 reference.
- `packages/coding-agent/test/extensions-runner.test.ts` — new regression under `describe("handler timeouts")` covering the wrapped-tool path end-to-end.
- `packages/coding-agent/CHANGELOG.md` — Unreleased/Fixed entry.

Fail-closed rationale: a pre-execution gate that didn't finish is not consent. Symmetric with the existing per-handler error branch (`emitToolCall` already returns `{ block: true, reason: ... }` on thrown errors). No change to `emitToolResult`, no change to hooks — the report explicitly scopes to extensions, and hook `tool_call` handlers legitimately prompt the user, per the comment at `hooks/runner.ts:322-325`.

## Verification

`bun test packages/coding-agent/test/extensions-runner.test.ts` → 39 pass, 0 fail, 92 expect() calls, 1.78s. The new test asserts elapsed < 500ms, `execute()` never invoked, and the exact warn/error payload shapes. `bun check` (workspace) → passes.

Fixes #3948