### PR TITLE
fix(ai/providers): throttle Cursor and Devin tool-call arg parsing

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cursor and Devin providers now use `parseStreamingJsonThrottled` for mid-stream tool-call argument parsing, bounding total parse work to O(N) in argument-buffer length instead of O(N²). Large tool-call payloads (e.g. sizeable `write` / `apply_patch` args) no longer stall streaming with quadratic re-parses ([#3946](https://github.com/can1357/oh-my-pi/issues/3946)).
+
 ## [16.2.10] - 2026-06-30
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -102,7 +102,13 @@ import {
 	WriteSuccessSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
-import { $env, parseJsonWithRepair, parseStreamingJson, parseStreamingJsonThrottled, sanitizeText } from "@oh-my-pi/pi-utils";
+import {
+	$env,
+	parseJsonWithRepair,
+	parseStreamingJson,
+	parseStreamingJsonThrottled,
+	sanitizeText,
+} from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -2112,10 +2118,7 @@ export function processInteractionUpdate(
 			// Throttle mid-stream parses to keep total parse work O(N) instead of O(N²)
 			// in the argument-buffer length; the authoritative full parse runs in
 			// `toolCallCompleted` (mcp branch) and the fallback end-of-stream path.
-			const throttled = parseStreamingJsonThrottled(
-				nextBuffer,
-				state.currentToolCall[kStreamingLastParseLen] ?? 0,
-			);
+			const throttled = parseStreamingJsonThrottled(nextBuffer, state.currentToolCall[kStreamingLastParseLen] ?? 0);
 			if (throttled) {
 				state.currentToolCall.arguments = throttled.value;
 				state.currentToolCall[kStreamingLastParseLen] = throttled.parsedLen;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -102,7 +102,7 @@ import {
 	WriteSuccessSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
-import { $env, parseJsonWithRepair, parseStreamingJson, sanitizeText } from "@oh-my-pi/pi-utils";
+import { $env, parseJsonWithRepair, parseStreamingJson, parseStreamingJsonThrottled, sanitizeText } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -129,6 +129,7 @@ import {
 	clearStreamingPartialJson,
 	kStreamingBlockIndex,
 	kStreamingBlockKind,
+	kStreamingLastParseLen,
 	kStreamingPartialJson,
 } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
@@ -620,6 +621,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 export type ToolCallState = ToolCall & {
 	[kStreamingBlockIndex]: number;
 	[kStreamingPartialJson]?: string;
+	[kStreamingLastParseLen]?: number;
 	[kStreamingBlockKind]: "mcp" | "todo";
 };
 
@@ -2105,8 +2107,19 @@ export function processInteractionUpdate(
 			if (chunk.length === 0) {
 				return;
 			}
-			state.currentToolCall[kStreamingPartialJson] = current + chunk;
-			state.currentToolCall.arguments = parseStreamingJson(state.currentToolCall[kStreamingPartialJson]);
+			const nextBuffer = current + chunk;
+			state.currentToolCall[kStreamingPartialJson] = nextBuffer;
+			// Throttle mid-stream parses to keep total parse work O(N) instead of O(N²)
+			// in the argument-buffer length; the authoritative full parse runs in
+			// `toolCallCompleted` (mcp branch) and the fallback end-of-stream path.
+			const throttled = parseStreamingJsonThrottled(
+				nextBuffer,
+				state.currentToolCall[kStreamingLastParseLen] ?? 0,
+			);
+			if (throttled) {
+				state.currentToolCall.arguments = throttled.value;
+				state.currentToolCall[kStreamingLastParseLen] = throttled.parsedLen;
+			}
 			const idx = output.content.indexOf(state.currentToolCall);
 			stream.push({ type: "toolcall_delta", contentIndex: idx, delta: chunk, partial: output });
 		}
@@ -2114,6 +2127,12 @@ export function processInteractionUpdate(
 		if (state.currentToolCall) {
 			const toolCall = update.message.value.toolCall;
 			if (state.currentToolCall[kStreamingBlockKind] === "mcp") {
+				// Authoritative full parse of the accumulated argument buffer; the delta
+				// path throttles mid-stream parses, so `arguments` may lag the buffer.
+				const partial = state.currentToolCall[kStreamingPartialJson];
+				if (partial !== undefined) {
+					state.currentToolCall.arguments = parseStreamingJson(partial);
+				}
 				const decodedArgs = decodeMcpArgsMap(toolCall?.mcpToolCall?.args?.args);
 				state.currentToolCall.arguments = mergeCursorMcpToolCallArgs(
 					state.currentToolCall.arguments as Record<string, unknown> | undefined,

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -284,10 +284,7 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 								: previousJson + tc.argumentsJson;
 							const delta = accumulated.slice(previousJson.length);
 							toolPartialJson.set(toolCallId, accumulated);
-							const throttled = parseStreamingJsonThrottled(
-								accumulated,
-								toolLastParseLen.get(toolCallId) ?? 0,
-							);
+							const throttled = parseStreamingJsonThrottled(accumulated, toolLastParseLen.get(toolCallId) ?? 0);
 							if (throttled) {
 								block.arguments = throttled.value;
 								toolLastParseLen.set(toolCallId, throttled.parsedLen);

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -28,7 +28,7 @@ import {
 	StopReason,
 } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
-import { logger, parseStreamingJson } from "@oh-my-pi/pi-utils";
+import { logger, parseStreamingJson, parseStreamingJsonThrottled } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -105,6 +105,11 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 		// accumulated per id (kept out of the content object so finalized tool calls stay clean).
 		const toolBlocks = new Map<string, ToolCall>();
 		const toolPartialJson = new Map<string, string>();
+		// Last-parsed argument-buffer length per tool-call id — bounds the
+		// mid-stream parse work to O(N) via `parseStreamingJsonThrottled`; the
+		// authoritative final parse still runs unconditionally in the toolcall_end
+		// loop below.
+		const toolLastParseLen = new Map<string, number>();
 		let activeToolCallId: string | undefined;
 		let latestStopReason = StopReason.UNSPECIFIED;
 
@@ -279,7 +284,14 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 								: previousJson + tc.argumentsJson;
 							const delta = accumulated.slice(previousJson.length);
 							toolPartialJson.set(toolCallId, accumulated);
-							block.arguments = parseStreamingJson(accumulated);
+							const throttled = parseStreamingJsonThrottled(
+								accumulated,
+								toolLastParseLen.get(toolCallId) ?? 0,
+							);
+							if (throttled) {
+								block.arguments = throttled.value;
+								toolLastParseLen.set(toolCallId, throttled.parsedLen);
+							}
 							stream.push({
 								type: "toolcall_delta",
 								contentIndex: output.content.indexOf(block),

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -213,15 +213,22 @@ describe("processInteractionUpdate args_text_delta handling", () => {
 
 		const block = h.state.currentToolCall!;
 		expect(getStreamingPartialJson(block)).toBe(cumulative[cumulative.length - 1]);
-		expect(block.arguments).toEqual({
-			agent: "task",
-			tasks: [{ assignment: "do A" }, { assignment: "do B" }],
-		});
 
 		// Each cumulative snapshot only emits the new suffix as the delta event.
 		const deltas = h.captured.filter(e => e.type === "toolcall_delta").map(e => (e as { delta: string }).delta);
 		expect(deltas.join("")).toBe(cumulative[cumulative.length - 1]);
 		expect(deltas).toEqual([`{"agent":"task","tas`, `ks":[{"assignme`, `nt":"do A"},{"assignment":"do B"}]}`]);
+
+		// The delta path throttles mid-stream parses; the authoritative full parse
+		// runs at toolCallCompleted, so the finalized block carries the full args.
+		completeMcpToolCall(h, undefined);
+		const finalBlock = h.output.content[0];
+		expect(finalBlock?.type).toBe("toolCall");
+		if (finalBlock?.type !== "toolCall") throw new Error("expected toolCall block");
+		expect(finalBlock.arguments).toEqual({
+			agent: "task",
+			tasks: [{ assignment: "do A" }, { assignment: "do B" }],
+		});
 	});
 
 	it("still appends genuinely incremental argsTextDelta fragments", () => {
@@ -234,7 +241,46 @@ describe("processInteractionUpdate args_text_delta handling", () => {
 		}
 
 		expect(getStreamingPartialJson(h.state.currentToolCall!)).toBe(fragments.join(""));
-		expect(h.state.currentToolCall!.arguments).toEqual({ agent: "task", items: [1, 2, 3] });
+
+		// Finalize to observe the authoritative full parse (delta path is throttled).
+		completeMcpToolCall(h, undefined);
+		const finalBlock = h.output.content[0];
+		expect(finalBlock?.type).toBe("toolCall");
+		if (finalBlock?.type !== "toolCall") throw new Error("expected toolCall block");
+		expect(finalBlock.arguments).toEqual({ agent: "task", items: [1, 2, 3] });
+	});
+
+	it("throttles mid-stream arg parsing to bound work at O(N) in buffer length (issue #3946)", () => {
+		// Regression for the O(N²) streaming hot path: parseStreamingJson used to
+		// run on every delta, re-parsing the entire accumulated buffer each time.
+		// With parseStreamingJsonThrottled, mid-stream re-parses only fire once
+		// the buffer has grown by at least STREAMING_JSON_PARSE_MIN_GROWTH bytes.
+		const h = newHarness();
+		startMcpToolCall(h, "task");
+
+		// First snapshot: initial parse fires (lastParsedLen was 0).
+		pushArgsTextDelta(h, `{"agent":"task","note":"initial"`);
+		const block = h.state.currentToolCall!;
+		const argsAfterFirst = block.arguments;
+		expect(argsAfterFirst).toEqual({ agent: "task", note: "initial" });
+
+		// Tiny follow-up snapshots that grow the buffer by far less than the
+		// throttle threshold. block.arguments must NOT be re-parsed; if it were,
+		// the O(N²) regression would resurface for a long stream of small deltas.
+		pushArgsTextDelta(h, `{"agent":"task","note":"initial","step":1`);
+		pushArgsTextDelta(h, `{"agent":"task","note":"initial","step":12`);
+		expect(block.arguments).toBe(argsAfterFirst);
+
+		// The full buffer is still accumulated for the authoritative final parse.
+		expect(getStreamingPartialJson(block)).toBe(`{"agent":"task","note":"initial","step":12`);
+
+		// toolCallCompleted re-parses the full buffer unconditionally; the merged
+		// arguments reflect every byte streamed, including the throttled tail.
+		completeMcpToolCall(h, undefined);
+		const finalBlock = h.output.content[0];
+		expect(finalBlock?.type).toBe("toolCall");
+		if (finalBlock?.type !== "toolCall") throw new Error("expected toolCall block");
+		expect(finalBlock.arguments).toEqual({ agent: "task", note: "initial", step: 12 });
 	});
 
 	it("skips empty argsTextDelta snapshots without emitting a delta event", () => {


### PR DESCRIPTION
## Repro

Cursor's `processInteractionUpdate` (`packages/ai/src/providers/cursor.ts:2109`) and Devin's `deltaToolCalls` loop (`packages/ai/src/providers/devin.ts:282`) called `parseStreamingJson(accumulated)` on every `toolcall_delta`, re-parsing the entire accumulated argument buffer on each chunk. Anthropic, Bedrock, OpenAI-shared, and OpenAI-completions already use `parseStreamingJsonThrottled` from `@oh-my-pi/pi-utils` for exactly this hot path.

A micro-repro against `parseStreamingJson` vs `parseStreamingJsonThrottled` (bun cell, 8-byte deltas, realistic `{"path":..., "content":"xxx..."}` payload):

```
size=  4 KB  deltas=  512  unthrottled=  4.5 ms  parses=  512   throttled= 0.3 ms  parses=16
size= 16 KB  deltas= 2048  unthrottled= 22.3 ms  parses= 2048   throttled= 0.8 ms  parses=64
size= 64 KB  deltas= 8192  unthrottled=248.2 ms  parses= 8192   throttled= 8.3 ms  parses=256
size=128 KB  deltas=16384  unthrottled=780.4 ms  parses=16384   throttled=26.6 ms  parses=512
```

Doubling N roughly 4×'s the unthrottled time (quadratic); throttled scales linearly. Final parsed args are byte-identical either way.

## Cause

`parseStreamingJson` is a full-buffer parse; running it once per delta gives O(N²) total work in the argument-buffer length N. `packages/utils/src/json-parse.ts:533-558` documents this and provides `parseStreamingJsonThrottled(buffer, lastParsedLen)` as the O(N) hot-path variant, gated on `STREAMING_JSON_PARSE_MIN_GROWTH` (256 B). Cursor and Devin were the last two providers still on the unthrottled path.

## Fix

- **`packages/ai/src/providers/cursor.ts`**
  - Import `parseStreamingJsonThrottled` and `kStreamingLastParseLen`; add `[kStreamingLastParseLen]?: number` to `ToolCallState`.
  - Delta path (mcp `argsTextDelta` handler): call `parseStreamingJsonThrottled` on the accumulated buffer, persist the returned `parsedLen` on the block, skip the update when the helper returns `null`.
  - `toolCallCompleted` mcp branch: unconditionally re-parse `kStreamingPartialJson` before `mergeCursorMcpToolCallArgs`. This is the authoritative full parse now that the delta path is throttled — without it, the throttled tail would be lost when merging with the completion frame. The stream-end fallback at line 573 already ran an unconditional parse and is unchanged.

- **`packages/ai/src/providers/devin.ts`**
  - Import `parseStreamingJsonThrottled`; add a `toolLastParseLen: Map<string, number>` alongside the existing `toolPartialJson` map (Devin already keeps streaming state in parallel maps rather than symbol properties).
  - `toolcall_delta` path: throttled parse with per-tool-call-id `lastParseLen`.
  - The end-of-stream `toolcall_end` loop already does an unconditional `parseStreamingJson(toolPartialJson.get(id))` (line 323 pre-change / 335 post-change), so the throttled tail is finalized there.

- **`packages/ai/test/cursor-streaming-args.test.ts`**
  - Existing snapshot-cadence and incremental-fragment tests now finalize the tool call before asserting on `arguments` (the delta path no longer parses every snapshot for small buffers).
  - New regression test `throttles mid-stream arg parsing to bound work at O(N) in buffer length (issue #3946)` pushes a first snapshot (initial parse), then two sub-threshold growth snapshots, asserts `block.arguments` is the same object reference across them, then completes and asserts the finalized block reflects the full buffer.

- **`packages/ai/CHANGELOG.md`**: Unreleased Fixed entry linking #3946.

No dedicated Devin test: the change is a mechanical mirror of the Cursor wire-up against the shared `parseStreamingJsonThrottled` utility. Standing up a full Connect-protocol protobuf stream fake for one more assertion adds no coverage over the shared-utility contract + cursor regression.

## Verification

- `bun test test/cursor-streaming-args.test.ts` in `packages/ai/`: 12 pass / 0 fail.
- `bun test` full `packages/ai/` suite: 2558 pass / 2 fail; both failing tests (`openai-completions-tool-result-images.test.ts` "uses generated tool_call_id values…", `proxy.test.ts` "normalizes hyphenated provider ids…") reproduce identically on `main` (verified via `git stash` → same failures → `git stash pop`) and are unrelated to this diff.
- Micro-repro above documents the observable perf shape and confirms final parsed args are identical between the two paths.

Fixes #3946