### PR TITLE
fix(ai): add pi-native stream timeouts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pi-native` streams to honor first-event and idle timeout watchdogs, preventing stalled auth-gateway SSE responses from hanging forever ([#3947](https://github.com/can1357/oh-my-pi/issues/3947)).
+
 ## [16.2.10] - 2026-06-30
 
 ### Added

--- a/packages/ai/src/providers/pi-native-client.ts
+++ b/packages/ai/src/providers/pi-native-client.ts
@@ -26,7 +26,9 @@ import type {
 	Model,
 	SimpleStreamOptions,
 } from "../types";
+import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
+import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 
 /**
  * Fields that must not cross the wire — either non-serializable (functions,
@@ -47,6 +49,13 @@ const NON_WIRE_KEYS = new Set<keyof SimpleStreamOptions>([
 	"cursorOnToolResult",
 	"providerSessionState",
 ]);
+const PI_NATIVE_STREAM_IDLE_TIMEOUT_ERROR = "pi-native stream stalled while waiting for the next event";
+const PI_NATIVE_STREAM_FIRST_EVENT_TIMEOUT_ERROR = "pi-native stream timed out while waiting for the first event";
+
+function isPiNativeProgressEvent(event: unknown): boolean {
+	if (typeof event !== "object" || event === null || !("type" in event)) return true;
+	return event.type !== "start";
+}
 
 function buildWireOptions(options: SimpleStreamOptions | undefined): Record<string, unknown> {
 	if (!options) return {};
@@ -134,7 +143,8 @@ export function streamPiNative<TApi extends Api>(
 	const stream = new AssistantMessageEventStream();
 
 	void (async () => {
-		const signal = options?.signal;
+		const callerSignal = options?.signal;
+		const abortTracker = createAbortSourceTracker(callerSignal);
 		// Abort propagation: cancel the response body when the caller's signal
 		// fires. Mirror `streamProxy`'s shape — explicit listener + finally
 		// cleanup — so we don't leak listeners on the long-running case.
@@ -143,12 +153,16 @@ export function streamPiNative<TApi extends Api>(
 			const body = response?.body;
 			if (body) body.cancel("Request aborted by caller").catch(() => {});
 		};
-		if (signal) {
-			if (signal.aborted) {
-				stream.fail(signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "aborted")));
+		if (callerSignal) {
+			if (callerSignal.aborted) {
+				stream.fail(
+					callerSignal.reason instanceof Error
+						? callerSignal.reason
+						: new Error(String(callerSignal.reason ?? "aborted")),
+				);
 				return;
 			}
-			signal.addEventListener("abort", onAbort, { once: true });
+			callerSignal.addEventListener("abort", onAbort, { once: true });
 		}
 
 		try {
@@ -165,7 +179,7 @@ export function streamPiNative<TApi extends Api>(
 				stream: true,
 			});
 
-			response = await fetchImpl(url, { method: "POST", headers, body, signal });
+			response = await fetchImpl(url, { method: "POST", headers, body, signal: abortTracker.requestSignal });
 			if (!response.ok) {
 				stream.fail(await decodeGatewayError(response));
 				return;
@@ -177,11 +191,25 @@ export function streamPiNative<TApi extends Api>(
 				return;
 			}
 
-			let sawTerminal = false;
-			for await (const event of readSseJson<AssistantMessageEvent>(
+			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+			const source = readSseJson<AssistantMessageEvent>(
 				response.body as ReadableStream<Uint8Array>,
-				signal,
-			)) {
+				abortTracker.requestSignal,
+			);
+			const watchedSource = iterateWithIdleTimeout(source, {
+				idleTimeoutMs,
+				firstItemTimeoutMs: firstEventTimeoutMs,
+				errorMessage: PI_NATIVE_STREAM_IDLE_TIMEOUT_ERROR,
+				firstItemErrorMessage: PI_NATIVE_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
+				onIdle: () =>
+					abortTracker.abortLocally(new AIError.StreamTimeoutError(PI_NATIVE_STREAM_IDLE_TIMEOUT_ERROR)),
+				onFirstItemTimeout: () =>
+					abortTracker.abortLocally(new AIError.StreamTimeoutError(PI_NATIVE_STREAM_FIRST_EVENT_TIMEOUT_ERROR)),
+				isProgressItem: isPiNativeProgressEvent,
+			});
+			let sawTerminal = false;
+			for await (const event of watchedSource) {
 				if (event.type === "done" || event.type === "error") sawTerminal = true;
 				stream.push(event);
 				// `stream.push` resolves `.result()` on `done`/`error`; subsequent
@@ -195,7 +223,7 @@ export function streamPiNative<TApi extends Api>(
 				// so awaiters of `.result()` resolve instead of hanging forever.
 				// Matches the gateway's own defensive fallback in
 				// `pi-native-server.encodeStream`.
-				const aborted = signal?.aborted === true;
+				const aborted = abortTracker.wasCallerAbort();
 				const partial = makeSyntheticAssistant(model as Model<Api>);
 				if (aborted) {
 					partial.stopReason = "aborted";
@@ -210,7 +238,7 @@ export function streamPiNative<TApi extends Api>(
 		} catch (err) {
 			stream.fail(err);
 		} finally {
-			if (signal) signal.removeEventListener("abort", onAbort);
+			if (callerSignal) callerSignal.removeEventListener("abort", onAbort);
 		}
 	})();
 

--- a/packages/ai/test/pi-native-client.test.ts
+++ b/packages/ai/test/pi-native-client.test.ts
@@ -26,12 +26,23 @@ function sseBytes(events: AssistantMessageEvent[]): Uint8Array {
 	}
 	return out;
 }
+function sseEventBytes(event: AssistantMessageEvent): Uint8Array {
+	return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
+}
 
 function fakeBody(bytes: Uint8Array): ReadableStream<Uint8Array> {
 	return new ReadableStream<Uint8Array>({
 		start(controller) {
 			controller.enqueue(bytes);
 			controller.close();
+		},
+	});
+}
+
+function stalledBody(bytes: Uint8Array[] = []): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of bytes) controller.enqueue(chunk);
 		},
 	});
 }
@@ -251,6 +262,63 @@ describe("streamPiNative event flow", () => {
 		await expect(stream.result()).rejects.toThrow(/502/);
 	});
 
+	it("rejects when the gateway sends headers but no first event before the timeout", async () => {
+		const fetchImpl: FetchImpl = (async () =>
+			new Response(stalledBody(), { status: 200, headers: { "Content-Type": "text/event-stream" } })) as FetchImpl;
+
+		const stream = streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			streamFirstEventTimeoutMs: 20,
+			streamIdleTimeoutMs: 20,
+		});
+
+		await expect(stream.result()).rejects.toThrow(/first event/);
+	});
+
+	it("uses PI_STREAM_FIRST_EVENT_TIMEOUT_MS for silent pi-native streams", async () => {
+		const previous = Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		try {
+			const fetchImpl: FetchImpl = (async () =>
+				new Response(stalledBody(), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				})) as FetchImpl;
+
+			const stream = streamPiNative(fakeModel(), baseContext, { apiKey: "k", fetch: fetchImpl });
+
+			await expect(stream.result()).rejects.toThrow(/first event/);
+		} finally {
+			if (previous === undefined) {
+				delete Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = previous;
+			}
+		}
+	});
+
+	it("rejects when a pi-native stream stalls after semantic progress", async () => {
+		const partial = baseAssistant({ content: [{ type: "text", text: "hi" }] });
+		const chunks = [
+			sseEventBytes({ type: "start", partial: baseAssistant() }),
+			sseEventBytes({ type: "text_delta", contentIndex: 0, delta: "hi", partial }),
+		];
+		const fetchImpl: FetchImpl = (async () =>
+			new Response(stalledBody(chunks), {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			})) as FetchImpl;
+
+		const stream = streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			streamFirstEventTimeoutMs: 1_000,
+			streamIdleTimeoutMs: 20,
+		});
+
+		await expect(stream.result()).rejects.toThrow(/next event/);
+	});
 	it("synthesizes a terminal `done` when the SSE stream closes silently", async () => {
 		// Models the gateway dropping mid-stream — without this synthetic terminator,
 		// `.result()` would hang forever.
@@ -291,24 +359,25 @@ describe("streamPiNative event flow", () => {
 		expect((fetchImpl as unknown as Mock<typeof globalThis.fetch>).mock.calls.length).toBe(0);
 	});
 
-	it("forwards the caller's AbortSignal to the underlying fetch", async () => {
-		// The real abort path runs through fetch — its body is wired to the
-		// signal by the runtime. We test the contract we guarantee (signal
-		// forwarding); body-cancel hooks are a best-effort backstop on the
-		// `streamProxy` shape, and not worth asserting through a synthetic
-		// `ReadableStream` (whose reader is locked by `readSseJson`, so any
-		// `body.cancel()` would throw a `TypeError("locked")` we then swallow).
+	it("forwards caller aborts to the underlying fetch signal", async () => {
 		const captured: { signal?: AbortSignal } = {};
 		const fetchImpl: FetchImpl = (async (_input, init) => {
 			captured.signal = init?.signal ?? undefined;
-			return fakeResponse([{ type: "done", reason: "stop", message: baseAssistant() }]);
+			return new Response(stalledBody(), { status: 200, headers: { "Content-Type": "text/event-stream" } });
 		}) as FetchImpl;
 		const controller = new AbortController();
-		await streamPiNative(fakeModel(), baseContext, {
+		const stream = streamPiNative(fakeModel(), baseContext, {
 			apiKey: "k",
 			fetch: fetchImpl,
 			signal: controller.signal,
-		}).result();
-		expect(captured.signal).toBe(controller.signal);
+		});
+
+		await Bun.sleep(0);
+		expect(captured.signal?.aborted).toBe(false);
+		controller.abort(new Error("caller aborted"));
+
+		const result = await stream.result();
+		expect(captured.signal?.aborted).toBe(true);
+		expect(result.stopReason).toBe("aborted");
 	});
 });


### PR DESCRIPTION
## Repro
A `streamPiNative` gateway fetch returning `200 text/event-stream` with a body that never emits or closes ignored `streamFirstEventTimeoutMs=25` / `streamIdleTimeoutMs=25`; the repro raced `.result()` against 120ms and observed `still pending after 120ms`.

## Cause
`packages/ai/src/providers/pi-native-client.ts` read the auth-gateway SSE body with `readSseJson(response.body, signal)` directly. That pi-native dispatch path bypassed the `iterateWithIdleTimeout` wrapper in `packages/ai/src/providers/register-builtins.ts`, so neither first-event nor inter-event idle watchdogs could abort the response body.

## Fix
- Wrapped pi-native SSE events in `iterateWithIdleTimeout` with the resolved `streamFirstEventTimeoutMs` and `streamIdleTimeoutMs` values.
- Added a local abort tracker so timeout watchdogs cancel the gateway fetch/body while preserving caller-abort handling.
- Covered silent-after-headers, env-driven first-event timeout, inter-event idle timeout, normal completion, synthetic terminal fallback, and caller abort signal behavior in `packages/ai/test/pi-native-client.test.ts`.
- Added the `packages/ai` changelog entry.

## Verification
`bun test packages/ai/test/pi-native-client.test.ts` passed with 14 tests / 37 assertions. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #3947