### PR TITLE
fix(mcp): route stdio write/flush failures without parking request()

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP stdio `request()` hanging past its configured timeout when the child subprocess stopped draining stdin. The method awaited `stdin.write()`/`flush()` before returning the deferred, so a full pipe would park the async function above `return promise`, past the timeout timer and abort handler, orphaning the deferred rejection and hanging the caller forever. Write and flush now dispatch synchronously — sync `EPIPE` throws still reject immediately, and async EPIPE rejections route into the same `reject()` — leaving the returned promise free to settle from the response, timer, abort signal, or read-loop transport-close. ([#3945](https://github.com/can1357/oh-my-pi/issues/3945))
+
 ## [16.2.10] - 2026-06-30
 
 ### Changed

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { StdioTransport, resolveStdioSpawnCommand } from "./stdio";
+import { resolveStdioSpawnCommand, StdioTransport } from "./stdio";
 
 describe("resolveStdioSpawnCommand", () => {
 	it("hides Windows executable MCP servers when the host has no console", async () => {
@@ -61,7 +61,6 @@ describe.skipIf(process.platform === "win32")("StdioTransport request write stal
 		// overruns the OS pipe buffer plus any FileSink JS-side buffering, so
 		// Bun's write() returns a Promise that only settles if the child reads.
 		const transport = new StdioTransport({
-			name: "stall-regression",
 			command: "sleep",
 			args: ["60"],
 			timeout: timeoutMs,
@@ -72,12 +71,10 @@ describe.skipIf(process.platform === "win32")("StdioTransport request write stal
 
 			const bigParam = "x".repeat(1024 * 1024);
 			const started = performance.now();
-			const outcome = await transport
-				.request("tools/call", { name: "noop", arguments: { blob: bigParam } })
-				.then(
-					() => ({ kind: "resolved" as const }),
-					(error: unknown) => ({ kind: "rejected" as const, error }),
-				);
+			const outcome = await transport.request("tools/call", { name: "noop", arguments: { blob: bigParam } }).then(
+				() => ({ kind: "resolved" as const }),
+				(error: unknown) => ({ kind: "rejected" as const, error }),
+			);
 			const elapsedMs = performance.now() - started;
 
 			expect(outcome.kind).toBe("rejected");

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { resolveStdioSpawnCommand } from "./stdio";
+import { StdioTransport, resolveStdioSpawnCommand } from "./stdio";
 
 describe("resolveStdioSpawnCommand", () => {
 	it("hides Windows executable MCP servers when the host has no console", async () => {
@@ -42,4 +42,57 @@ describe("resolveStdioSpawnCommand", () => {
 			detached: true,
 		});
 	});
+});
+
+// Regression for #3945: request() awaited stdin.write/flush, so a child that
+// stops draining stdin would park the async fn past the timeout timer and past
+// `return promise`, orphaning the deferred rejection and hanging the caller
+// forever. `sleep` is POSIX-only, so the check is scoped to non-Windows hosts.
+describe.skipIf(process.platform === "win32")("StdioTransport request write stall", () => {
+	it("rejects with the timeout error when the child never drains stdin", async () => {
+		const timeoutMs = 400;
+		const orphaned: Error[] = [];
+		const captureOrphan = (reason: unknown) => {
+			if (reason instanceof Error) orphaned.push(reason);
+		};
+		process.on("unhandledRejection", captureOrphan);
+
+		// `sleep 60` accepts a stdin pipe but never reads it; a 1 MB payload
+		// overruns the OS pipe buffer plus any FileSink JS-side buffering, so
+		// Bun's write() returns a Promise that only settles if the child reads.
+		const transport = new StdioTransport({
+			name: "stall-regression",
+			command: "sleep",
+			args: ["60"],
+			timeout: timeoutMs,
+		});
+
+		try {
+			await transport.connect();
+
+			const bigParam = "x".repeat(1024 * 1024);
+			const started = performance.now();
+			const outcome = await transport
+				.request("tools/call", { name: "noop", arguments: { blob: bigParam } })
+				.then(
+					() => ({ kind: "resolved" as const }),
+					(error: unknown) => ({ kind: "rejected" as const, error }),
+				);
+			const elapsedMs = performance.now() - started;
+
+			expect(outcome.kind).toBe("rejected");
+			if (outcome.kind !== "rejected") return;
+			if (!(outcome.error instanceof Error)) {
+				throw new Error(`expected Error rejection, got ${String(outcome.error)}`);
+			}
+			expect(outcome.error.message).toContain(`Request timeout after ${timeoutMs}ms`);
+			// Generous ceiling: bare rejection latency plus room for slow CI. The
+			// pre-fix behavior was an unbounded hang, not a slightly-late reject.
+			expect(elapsedMs).toBeLessThan(timeoutMs + 1500);
+			expect(orphaned).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", captureOrphan);
+			await transport.close();
+		}
+	}, 8000);
 });

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -591,8 +591,8 @@ export class StdioTransport implements MCPTransport {
 			// into `reject()` while leaving the returned promise free to settle
 			// from the response, timer, abort signal, or read-loop transport-close.
 			const wrote = stdin.write(message);
-			const flushed = stdin.flush();
 			if (isThenable(wrote)) wrote.then(undefined, failFromSend);
+			const flushed = stdin.flush();
 			if (isThenable(flushed)) flushed.then(undefined, failFromSend);
 		} catch (error) {
 			failFromSend(error);

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -575,17 +575,27 @@ export class StdioTransport implements MCPTransport {
 
 		const stdin = this.#process.stdin;
 		const message = `${JSON.stringify(request)}\n`;
-		try {
-			// Await both: Bun's FileSink can surface a broken pipe either as a
-			// synchronous throw or as a rejected Promise (the EPIPE arrives on a
-			// processTicksAndRejections tick). Awaiting funnels both into this catch
-			// so the request rejects cleanly instead of leaving a floating rejected
-			// promise that crashes the process via the unhandledRejection handler.
-			await stdin.write(message);
-			await stdin.flush();
-		} catch (error: unknown) {
+		const failFromSend = (error: unknown) => {
+			if (settled) return;
 			cleanup();
 			reject(error instanceof Error ? error : new Error(String(error)));
+		};
+		try {
+			// Never `await` write/flush. Bun's FileSink returns a pending Promise
+			// once the OS pipe buffer fills (default ~64 KB on POSIX), and a
+			// subprocess that stops draining stdin will park those awaits forever.
+			// Awaiting here would keep the async fn stuck above `return promise`,
+			// past the timeout timer and the abort handler, orphaning the deferred
+			// rejection and hanging the caller (#3945). Route sync throws (Windows
+			// EPIPE) and async rejections (POSIX EPIPE on processTicksAndRejections)
+			// into `reject()` while leaving the returned promise free to settle
+			// from the response, timer, abort signal, or read-loop transport-close.
+			const wrote = stdin.write(message);
+			const flushed = stdin.flush();
+			if (isThenable(wrote)) wrote.then(undefined, failFromSend);
+			if (isThenable(flushed)) flushed.then(undefined, failFromSend);
+		} catch (error) {
+			failFromSend(error);
 		}
 
 		return promise;


### PR DESCRIPTION
## Repro

Spawn `sleep 60` as an MCP stdio server (accepts a stdin pipe but never reads it), arm `OMP_MCP_TIMEOUT_MS=1500`, and call:

```ts
await transport.request("tools/call", { arguments: { blob: "x".repeat(512 * 1024) } });
```

The 512 KB payload overruns the ~64 KB OS pipe buffer, so Bun's `stdin.write()` returns a Promise that never settles. At t≈1500 ms Bun surfaces `[Unhandled Rejection] Error: Request timeout after 1500ms at stdio.ts:572`, and the caller's `await request(...)` never observes the rejection — an unbounded hang whenever a stdio child stops draining its stdin.

## Cause

`StdioTransport.request()` in `packages/coding-agent/src/mcp/transports/stdio.ts` armed the timeout timer, then `await`ed `stdin.write(message)` + `stdin.flush()` before `return promise`. When the pipe filled, those awaits parked the async function above `return promise`, so:

1. The timer fired, ran `cleanup()`, and called `reject(new Error(...))` on the internal deferred.
2. The outer `async` function had never reached `return promise`, so the outer promise the caller was awaiting never adopted the deferred's rejected state.
3. The caller's `.catch` sat on the outer promise and never fired; the deferred rejection surfaced as an unhandled promise rejection (`stdio.ts:572`).

`notify()` and `#sendResponse()` already went through `writeFrame()` (fire-and-forget, both sync throws and async rejections neutralized). `request()` was the only send path that awaited.

## Fix

- `packages/coding-agent/src/mcp/transports/stdio.ts` — `request()` now dispatches `stdin.write(message)` and `stdin.flush()` without awaiting. Sync `EPIPE` throws (Windows) still `cleanup() + reject()` immediately via a shared `failFromSend`. Async `EPIPE` rejections (POSIX, arriving on `processTicksAndRejections`) are wired through `.then(undefined, failFromSend)`; `failFromSend` short-circuits when the request has already been `settled` by the response, the timer, the abort signal, or the read-loop's transport-close broadcast, so a late send-error can't stomp another outcome.
- `packages/coding-agent/src/mcp/transports/stdio.test.ts` — regression test spawning `sleep 60` (POSIX-skipped) with a 1 MB `tools/call` payload past the pipe buffer, asserting the deferred rejects with `Request timeout after Nms` inside the configured window and that no orphaned unhandled rejections fire.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] › Fixed` entry citing #3945.

## Verification

- `bun test packages/coding-agent/src/mcp/transports/stdio.test.ts` — 4 pass, 0 fail. Verified the new test defends the contract: after temporarily reverting the fix, the same test file fails (3 pass / 1 fail) with the unhandled `Request timeout after 400ms` at `stdio.ts:572` that Bun's test runner surfaces as a failure; re-applying the fix restores 4 pass.
- `bun test packages/coding-agent/test/{issue-956-repro,mcp-connection-status-events,mcp-reconnect,mcp-reconnect-storm,mcp-dispose-disconnect-bounded,mcp-startup-no-block,mcp-resource-templates-missing,mcp-roots-list,mcp-discovered-server-reauth}.test.ts` + the stdio suite — 61 pass, 0 fail (no regressions in the initialize/tools/list, notify, reconnect-storm, or dispose flows that already round-trip requests through the changed path).
- Manual repro against the fix: caller rejects at ~1502 ms with `Request timeout after 1500ms` and zero orphaned rejections; abort-signal path still rejects promptly (unchanged code).

Fixes #3945