### PR TITLE
fix(session): linearize session path rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session context and branch path reconstruction doing quadratic `Array.unshift` work on deep linear histories. ([#3961](https://github.com/can1357/oh-my-pi/issues/3961))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -142,9 +142,10 @@ export function buildSessionContext(
 	const path: SessionEntry[] = [];
 	let current: SessionEntry | undefined = leaf;
 	while (current) {
-		path.unshift(current);
+		path.push(current);
 		current = current.parentId ? byId.get(current.parentId) : undefined;
 	}
+	path.reverse();
 
 	// Extract settings and find compaction
 	let thinkingLevel: string | undefined = "off";

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -242,9 +242,10 @@ class SessionEntryIndex {
 
 		while (cursor && !seen.has(cursor.id)) {
 			seen.add(cursor.id);
-			branch.unshift(cursor);
+			branch.push(cursor);
 			cursor = cursor.parentId ? this.#entriesById.get(cursor.parentId) : undefined;
 		}
+		branch.reverse();
 
 		return branch;
 	}

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type {
 	BranchSummaryEntry,
@@ -126,6 +126,29 @@ describe("buildSessionContext", () => {
 			const ctx = buildSessionContext(entries);
 			expect(ctx.messages).toHaveLength(4);
 			expect(ctx.messages.map(m => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+		});
+
+		it("builds deep linear paths without quadratic unshift work", () => {
+			const entries: SessionEntry[] = [];
+			let parentId: string | null = null;
+			for (let i = 0; i < 1000; i++) {
+				const id = `entry-${i}`;
+				entries.push(msg(id, parentId, "user", id));
+				parentId = id;
+			}
+
+			const unshift = spyOn(Array.prototype, "unshift");
+			try {
+				const ctx = buildSessionContext(entries, parentId);
+				expect(ctx.messages.map(message => (message.role === "user" ? message.content : ""))).toEqual(
+					entries.map(entry =>
+						entry.type === "message" && entry.message.role === "user" ? entry.message.content : "",
+					),
+				);
+				expect(unshift).not.toHaveBeenCalled();
+			} finally {
+				unshift.mockRestore();
+			}
 		});
 
 		it("tracks thinking level changes", () => {

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import type { CustomEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { assistantMsg, userMsg } from "../utilities";
@@ -158,6 +158,22 @@ describe("SessionManager append and tree traversal", () => {
 			const path = session.getBranch(id2);
 			expect(path).toHaveLength(2);
 			expect(path.map(e => e.id)).toEqual([id1, id2]);
+		});
+
+		it("returns deep branch paths without quadratic unshift work", () => {
+			const session = SessionManager.inMemory();
+			const ids: string[] = [];
+			for (let i = 0; i < 1000; i++) {
+				ids.push(session.appendMessage(userMsg(`message-${i}`)));
+			}
+
+			const unshift = spyOn(Array.prototype, "unshift");
+			try {
+				expect(session.getBranch().map(entry => entry.id)).toEqual(ids);
+				expect(unshift).not.toHaveBeenCalled();
+			} finally {
+				unshift.mockRestore();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Repro
A local repro script (`bun .wt/session-path-repro.mjs`) built linear sessions of 1k/2k/4k entries and patched `Array.prototype.unshift` to count shifted slots during `buildSessionContext`; before the fix it reported 499,500 / 1,999,000 / 7,998,000 shifted slots.

## Cause
`packages/coding-agent/src/session/session-context.ts` built the selected leaf-to-root path by calling `path.unshift(current)` once per ancestor, and `packages/coding-agent/src/session/session-manager.ts` repeated the same pattern in `SessionEntryIndex.pathTo`; each call shifted the already-collected prefix, making a single context or branch rebuild quadratic in chain depth.

## Fix
- Replaced both ancestor walks with append-while-walking plus one `reverse()` on the fresh array.
- Added deep linear regression tests for `buildSessionContext` and `SessionManager.getBranch()` that preserve root-to-leaf output while rejecting `Array.unshift` work.
- Added the coding-agent changelog entry for #3961.

## Verification
`bun test packages/coding-agent/test/session-manager/build-context.test.ts packages/coding-agent/test/session-manager/tree-traversal.test.ts` passed: 51 tests, 165 assertions. `bun --cwd=packages/coding-agent run check:types` passed. After the fix, `bun .wt/session-path-repro.mjs` reported 0 shifted slots for 1k/2k/4k entries. `gh_push_branch` pre-publish gate passed. Fixes #3961