### PR TITLE
fix(lsp): honor tool signal in cold-start initialize and notification writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the LSP tool ignoring its combined tool-timeout/caller abort during cold-start `initialize` and notification writes. `getOrCreateClient` now threads the caller `AbortSignal` through the `initialize` request and `initialized` notification (previously the missing signal fell back to `sendRequest`'s hard-coded 30s internal timer, ignoring the tool's 20s default and any user-supplied shorter `timeout`), and `sendNotification`/`queueWriteMessage` bound the underlying `sink.flush()` on that signal so a server that stops draining stdin surfaces as the tool's normal cancel/timeout instead of blocking every subsequent write on the client's serialized `writeQueue`. Aborted flushes kill the client and evict it from the active-clients map so the next call spawns a fresh server rather than queueing behind the wedged sink. ([#3962](https://github.com/can1357/oh-my-pi/issues/3962))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -190,7 +190,7 @@ async function writeMessage(
 	}
 	const content = JSON.stringify(message);
 	sink.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
-	const flush = sink.flush();
+	const flush = Promise.resolve(sink.flush());
 	if (!signal) {
 		await flush;
 		return;
@@ -213,7 +213,7 @@ async function writeMessage(
 			signal.removeEventListener("abort", onAbort);
 			resolve();
 		},
-		err => {
+		(err: unknown) => {
 			signal.removeEventListener("abort", onAbort);
 			reject(err);
 		},

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -183,18 +183,72 @@ const CLIENT_CAPABILITIES = {
 async function writeMessage(
 	sink: Bun.FileSink,
 	message: LspJsonRpcRequest | LspJsonRpcNotification | LspJsonRpcResponse,
+	signal?: AbortSignal,
 ): Promise<void> {
+	if (signal?.aborted) {
+		throw signal.reason instanceof Error ? signal.reason : new ToolAbortError();
+	}
 	const content = JSON.stringify(message);
 	sink.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
-	await sink.flush();
+	const flush = sink.flush();
+	if (!signal) {
+		await flush;
+		return;
+	}
+	// The sink's flush blocks on the OS-level pipe drain: if the server is
+	// alive but stopped reading stdin, `await sink.flush()` never resolves.
+	// Race the flush against the caller's signal so a wedged server surfaces
+	// as the tool's normal timeout/cancel instead of a permanent hang.
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const onAbort = () => {
+		signal.removeEventListener("abort", onAbort);
+		// The underlying flush stays pending in the background; suppress its
+		// eventual settlement so we do not surface an unhandled rejection.
+		flush.catch(() => {});
+		reject(signal.reason instanceof Error ? signal.reason : new ToolAbortError());
+	};
+	signal.addEventListener("abort", onAbort, { once: true });
+	flush.then(
+		() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		},
+		err => {
+			signal.removeEventListener("abort", onAbort);
+			reject(err);
+		},
+	);
+	await promise;
+}
+
+/**
+ * Kill a client whose write queue is stuck (aborted flush left the sink's
+ * flush promise pending, so subsequent writes queue behind a wedge forever).
+ * Remove it from `clients` immediately so concurrent `getOrCreateClient`
+ * callers do not grab the corpse before `proc.exited` cleans up.
+ */
+function teardownWedgedClient(client: LspClient): void {
+	if (clients.get(client.name) === client) clients.delete(client.name);
+	try {
+		client.proc.kill();
+	} catch {
+		// process already gone or unkillable — the exit handler will finish cleanup.
+	}
 }
 
 function queueWriteMessage(
 	client: LspClient,
 	message: LspJsonRpcRequest | LspJsonRpcNotification | LspJsonRpcResponse,
+	signal?: AbortSignal,
 ): Promise<void> {
-	const write = client.writeQueue.catch(() => {}).then(() => writeMessage(client.proc.stdin, message));
-	client.writeQueue = write.catch(() => {});
+	const write = client.writeQueue.catch(() => {}).then(() => writeMessage(client.proc.stdin, message, signal));
+	client.writeQueue = write.catch(err => {
+		// An aborted flush leaves the sink pending; the next queued write
+		// would stall behind it. Force a fresh spawn on the next lookup.
+		if (signal?.aborted) teardownWedgedClient(client);
+		// Swallow: writeQueue is a barrier for the next writer, not a value.
+		void err;
+	});
 	return write;
 }
 
@@ -530,9 +584,18 @@ const EXIT_TIMEOUT_MS = 1_000;
  * Get or create an LSP client for the given server configuration and working directory.
  * @param config - Server configuration
  * @param cwd - Working directory
- * @param initTimeoutMs - Optional timeout for the initialize request (defaults to 30s)
+ * @param initTimeoutMs - Optional hard deadline for the initialize handshake (warmup / other
+ *   short-lived callers). When set it takes precedence over `signal` inside `sendRequest`.
+ * @param signal - Optional caller abort signal. Threaded into the initialize `sendRequest`
+ *   and the `initialized` notification so a wedged server surfaces the caller's
+ *   timeout/cancel instead of falling back to the internal 30s default.
  */
-export async function getOrCreateClient(config: ServerConfig, cwd: string, initTimeoutMs?: number): Promise<LspClient> {
+export async function getOrCreateClient(
+	config: ServerConfig,
+	cwd: string,
+	initTimeoutMs?: number,
+	signal?: AbortSignal,
+): Promise<LspClient> {
 	const key = `${config.command}:${cwd}`;
 
 	// Check if client already exists
@@ -649,7 +712,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 					initializationOptions: config.initOptions ?? {},
 					workspaceFolders: currentWorkspaceFolders(client),
 				},
-				undefined, // signal
+				signal,
 				initTimeoutMs,
 			)) as { capabilities?: unknown };
 
@@ -660,7 +723,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			client.serverCapabilities = initResult.capabilities as LspClient["serverCapabilities"];
 
 			// Send initialized notification
-			await sendNotification(client, "initialized", {});
+			await sendNotification(client, "initialized", {}, signal);
 
 			client.status = "ready";
 			// Publish only after init succeeds: pre-init clients are reachable
@@ -732,14 +795,19 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
 		const languageId = detectLanguageId(filePath);
 		throwIfAborted(signal);
 
-		await sendNotification(client, "textDocument/didOpen", {
-			textDocument: {
-				uri,
-				languageId,
-				version: 1,
-				text: content,
+		await sendNotification(
+			client,
+			"textDocument/didOpen",
+			{
+				textDocument: {
+					uri,
+					languageId,
+					version: 1,
+					text: content,
+				},
 			},
-		});
+			signal,
+		);
 
 		client.openFiles.set(uri, { version: 1, languageId });
 		client.lastActivity = Date.now();
@@ -800,14 +868,19 @@ export async function syncContent(
 			// Open file with provided content instead of reading from disk
 			const languageId = detectLanguageId(filePath);
 			throwIfAborted(signal);
-			await sendNotification(client, "textDocument/didOpen", {
-				textDocument: {
-					uri,
-					languageId,
-					version: 1,
-					text: content,
+			await sendNotification(
+				client,
+				"textDocument/didOpen",
+				{
+					textDocument: {
+						uri,
+						languageId,
+						version: 1,
+						text: content,
+					},
 				},
-			});
+				signal,
+			);
 			client.openFiles.set(uri, { version: 1, languageId });
 			client.lastActivity = Date.now();
 			return;
@@ -815,10 +888,15 @@ export async function syncContent(
 
 		const version = ++info.version;
 		throwIfAborted(signal);
-		await sendNotification(client, "textDocument/didChange", {
-			textDocument: { uri, version },
-			contentChanges: [{ text: content }],
-		});
+		await sendNotification(
+			client,
+			"textDocument/didChange",
+			{
+				textDocument: { uri, version },
+				contentChanges: [{ text: content }],
+			},
+			signal,
+		);
 		client.lastActivity = Date.now();
 	})();
 
@@ -840,9 +918,14 @@ export async function notifySaved(client: LspClient, filePath: string, signal?: 
 	if (!info) return; // File not open, nothing to notify
 
 	throwIfAborted(signal);
-	await sendNotification(client, "textDocument/didSave", {
-		textDocument: { uri },
-	});
+	await sendNotification(
+		client,
+		"textDocument/didSave",
+		{
+			textDocument: { uri },
+		},
+		signal,
+	);
 	client.lastActivity = Date.now();
 }
 
@@ -884,16 +967,26 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
 		const version = ++info.version;
 		throwIfAborted(signal);
 
-		await sendNotification(client, "textDocument/didChange", {
-			textDocument: { uri, version },
-			contentChanges: [{ text: content }],
-		});
+		await sendNotification(
+			client,
+			"textDocument/didChange",
+			{
+				textDocument: { uri, version },
+				contentChanges: [{ text: content }],
+			},
+			signal,
+		);
 		throwIfAborted(signal);
 
-		await sendNotification(client, "textDocument/didSave", {
-			textDocument: { uri },
-			text: content,
-		});
+		await sendNotification(
+			client,
+			"textDocument/didSave",
+			{
+				textDocument: { uri },
+				text: content,
+			},
+			signal,
+		);
 
 		client.lastActivity = Date.now();
 	})();
@@ -1044,8 +1137,10 @@ export async function sendRequest(
 		method,
 	});
 
-	// Write request
-	queueWriteMessage(client, request).catch(err => {
+	// Write request. `queueWriteMessage(..., signal)` bounds the sink flush
+	// so a wedged server does not stall the write queue past the signal's
+	// deadline; the write-queue teardown kills the client on abort.
+	queueWriteMessage(client, request, signal).catch(err => {
 		if (timeout) clearTimeout(timeout);
 		client.pendingRequests.delete(id);
 		cleanup();
@@ -1056,8 +1151,15 @@ export async function sendRequest(
 
 /**
  * Send an LSP notification (no response expected).
+ * `signal` bounds the underlying `sink.flush()` — without it a server that
+ * stops draining stdin blocks every future write on the client's write queue.
  */
-export async function sendNotification(client: LspClient, method: string, params: unknown): Promise<void> {
+export async function sendNotification(
+	client: LspClient,
+	method: string,
+	params: unknown,
+	signal?: AbortSignal,
+): Promise<void> {
 	const notification: LspJsonRpcNotification = {
 		jsonrpc: "2.0",
 		method,
@@ -1065,7 +1167,7 @@ export async function sendNotification(client: LspClient, method: string, params
 	};
 
 	client.lastActivity = Date.now();
-	await queueWriteMessage(client, notification);
+	await queueWriteMessage(client, notification, signal);
 }
 
 /**

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -739,10 +739,10 @@ export async function getOrCreateClient(
 			proc.kill();
 			const message = err instanceof Error ? err.message : String(err);
 			// Negative-cache deterministic failures. Timeouts under a
-			// caller-shortened deadline (warmup/writethrough) are not cached —
-			// the server may simply be slow and a later call with the full
-			// deadline can still succeed.
-			if (!(initTimeoutMs !== undefined && message.includes("timed out"))) {
+			// caller-shortened deadline (warmup/writethrough) and caller-signal
+			// aborts are transient — the server may simply be slow or the user may
+			// have cancelled, so a later call with a fresh deadline should retry.
+			if (!signal?.aborted && !(initTimeoutMs !== undefined && message.includes("timed out"))) {
 				initFailures.set(key, { at: Date.now(), message });
 			}
 			throw err;

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -180,13 +180,24 @@ const CLIENT_CAPABILITIES = {
 // LSP Message Protocol
 // =============================================================================
 
+function abortReason(signal: AbortSignal): Error {
+	return signal.reason instanceof Error ? signal.reason : new ToolAbortError();
+}
+
+class LspFlushAbortError extends Error {
+	constructor(readonly reason: Error) {
+		super(reason.message);
+		this.name = "LspFlushAbortError";
+	}
+}
+
 async function writeMessage(
 	sink: Bun.FileSink,
 	message: LspJsonRpcRequest | LspJsonRpcNotification | LspJsonRpcResponse,
 	signal?: AbortSignal,
 ): Promise<void> {
 	if (signal?.aborted) {
-		throw signal.reason instanceof Error ? signal.reason : new ToolAbortError();
+		throw abortReason(signal);
 	}
 	const content = JSON.stringify(message);
 	sink.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
@@ -205,7 +216,7 @@ async function writeMessage(
 		// The underlying flush stays pending in the background; suppress its
 		// eventual settlement so we do not surface an unhandled rejection.
 		flush.catch(() => {});
-		reject(signal.reason instanceof Error ? signal.reason : new ToolAbortError());
+		reject(new LspFlushAbortError(abortReason(signal)));
 	};
 	signal.addEventListener("abort", onAbort, { once: true });
 	flush.then(
@@ -242,14 +253,18 @@ function queueWriteMessage(
 	signal?: AbortSignal,
 ): Promise<void> {
 	const write = client.writeQueue.catch(() => {}).then(() => writeMessage(client.proc.stdin, message, signal));
-	client.writeQueue = write.catch(err => {
-		// An aborted flush leaves the sink pending; the next queued write
-		// would stall behind it. Force a fresh spawn on the next lookup.
-		if (signal?.aborted) teardownWedgedClient(client);
-		// Swallow: writeQueue is a barrier for the next writer, not a value.
-		void err;
+	const result = write.catch((err: unknown) => {
+		if (err instanceof LspFlushAbortError) {
+			// Only an abort that raced this write's in-flight flush leaves
+			// the sink pending. Pre-write aborts and queued caller timeouts
+			// must not kill a healthy shared client.
+			teardownWedgedClient(client);
+			throw err.reason;
+		}
+		throw err;
 	});
-	return write;
+	client.writeQueue = result.catch(() => {});
+	return result;
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -216,7 +216,7 @@ async function syncFileContent(
 			if (serverConfig.createClient) {
 				return;
 			}
-			const client = await getOrCreateClient(serverConfig, cwd);
+			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
 			throwIfAborted(signal);
 			await syncContent(client, absolutePath, content, signal);
 		}),
@@ -244,7 +244,7 @@ async function notifyFileSaved(
 			if (serverConfig.createClient) {
 				return;
 			}
-			const client = await getOrCreateClient(serverConfig, cwd);
+			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
 			await notifySaved(client, absolutePath, signal);
 		}),
 	);
@@ -469,7 +469,7 @@ async function reloadServer(client: LspClient, serverName: string, signal?: Abor
 	// as a request hangs until the tool deadline on servers that route it to
 	// the notification handler and never respond.
 	try {
-		await sendNotification(client, "workspace/didChangeConfiguration", { settings: {} });
+		await sendNotification(client, "workspace/didChangeConfiguration", { settings: {} }, signal);
 		return `Reloaded ${serverName}`;
 	} catch {
 		client.proc.kill();
@@ -643,12 +643,13 @@ async function captureDiagnosticVersions(
 	cwd: string,
 	servers: Array<[string, ServerConfig]>,
 	initTimeoutMs?: number,
+	signal?: AbortSignal,
 ): Promise<ServerVersionMap> {
 	const versions = new Map<string, number>();
 	await Promise.allSettled(
 		servers.map(async ([serverName, serverConfig]) => {
 			if (serverConfig.createClient) return;
-			const client = await getOrCreateClient(serverConfig, cwd, initTimeoutMs);
+			const client = await getOrCreateClient(serverConfig, cwd, initTimeoutMs, signal);
 			versions.set(serverName, client.diagnosticsVersion);
 		}),
 	);
@@ -659,12 +660,13 @@ async function captureOpenFileVersions(
 	absolutePath: string,
 	cwd: string,
 	servers: Array<[string, ServerConfig]>,
+	signal?: AbortSignal,
 ): Promise<ServerVersionMap> {
 	const uri = fileToUri(absolutePath);
 	const versions = new Map<string, number>();
 	await Promise.allSettled(
 		servers.map(async ([serverName, serverConfig]) => {
-			const client = await getOrCreateClient(serverConfig, cwd);
+			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
 			const version = client.openFiles.get(uri)?.version;
 			if (version !== undefined) {
 				versions.set(serverName, version);
@@ -711,7 +713,7 @@ async function getDiagnosticsForFile(
 			}
 
 			// Default: use LSP
-			const client = await getOrCreateClient(serverConfig, cwd);
+			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
 			throwIfAborted(signal);
 			if (isProjectAwareLspServer(serverConfig)) {
 				await waitForProjectLoaded(client, signal);
@@ -812,7 +814,7 @@ async function formatContent(
 			}
 
 			// Default: use LSP
-			const client = await getOrCreateClient(serverConfig, cwd);
+			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
 			throwIfAborted(signal);
 
 			const caps = client.serverCapabilities;
@@ -1118,7 +1120,7 @@ async function runLspWritethrough(
 	// Capture diagnostic versions BEFORE syncing to detect stale diagnostics
 	// Bound client creation by the writethrough budget: a hung/broken server
 	// must not add its full init wait (30s default) to every edit.
-	const minVersions = enableDiagnostics ? await captureDiagnosticVersions(cwd, servers, 5_000) : undefined;
+	const minVersions = enableDiagnostics ? await captureDiagnosticVersions(cwd, servers, 5_000, signal) : undefined;
 	let expectedDocumentVersions: ServerVersionMap | undefined;
 
 	let formatter: FileFormatResult | undefined;
@@ -1163,7 +1165,7 @@ async function runLspWritethrough(
 			}
 
 			if (enableDiagnostics) {
-				expectedDocumentVersions = await captureOpenFileVersions(dst, cwd, lspServers);
+				expectedDocumentVersions = await captureOpenFileVersions(dst, cwd, lspServers, operationSignal);
 			}
 
 			// 5. Notify saved to LSP servers
@@ -1460,7 +1462,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 							allDiagnostics.push(...diagnostics);
 							continue;
 						}
-						const client = await getOrCreateClient(serverConfig, this.session.cwd);
+						const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 						if (isProjectAwareLspServer(serverConfig)) {
 							await waitForProjectLoaded(client, signal);
 							throwIfAborted(signal);
@@ -1634,7 +1636,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [serverName, serverConfig] of servers) {
 				throwIfAborted(signal);
 				try {
-					const client = await getOrCreateClient(serverConfig, this.session.cwd);
+					const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 					if (isProjectAwareLspServer(serverConfig)) {
 						await waitForProjectLoaded(client, signal);
 					}
@@ -1781,16 +1783,19 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 
 			for (const [serverName, serverConfig] of servers) {
 				try {
-					const client = await getOrCreateClient(serverConfig, this.session.cwd);
+					const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 					for (const { oldUri } of pairs) {
 						if (client.openFiles.has(oldUri)) {
-							await sendNotification(client, "textDocument/didClose", {
-								textDocument: { uri: oldUri },
-							});
+							await sendNotification(
+								client,
+								"textDocument/didClose",
+								{ textDocument: { uri: oldUri } },
+								signal,
+							);
 							client.openFiles.delete(oldUri);
 						}
 					}
-					await sendNotification(client, "workspace/didRenameFiles", lspParams);
+					await sendNotification(client, "workspace/didRenameFiles", lspParams, signal);
 				} catch (err) {
 					if (err instanceof ToolAbortError || signal?.aborted) {
 						throw err;
@@ -1844,7 +1849,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [serverName, serverConfig] of serverList) {
 				throwIfAborted(signal);
 				try {
-					const client = await getOrCreateClient(serverConfig, this.session.cwd);
+					const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 					respondingServers.add(serverName);
 					const caps = client.serverCapabilities ?? {};
 					sections.push(`${serverName}:`);
@@ -1930,7 +1935,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			}
 
 			try {
-				const client = await getOrCreateClient(chosenConfig, this.session.cwd);
+				const client = await getOrCreateClient(chosenConfig, this.session.cwd, undefined, signal);
 				if (resolvedTarget) {
 					await ensureFileOpen(client, resolvedTarget, signal);
 				}
@@ -2001,7 +2006,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				try {
-					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd);
+					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd, undefined, signal);
 					const workspaceResult = (await sendRequest(
 						workspaceClient,
 						"workspace/symbol",
@@ -2072,7 +2077,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				try {
-					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd);
+					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd, undefined, signal);
 					outputs.push(await reloadServer(workspaceClient, workspaceServerName, signal));
 				} catch (err) {
 					if (err instanceof ToolAbortError || signal?.aborted) {
@@ -2099,7 +2104,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		const [serverName, serverConfig] = serverInfo;
 
 		try {
-			const client = await getOrCreateClient(serverConfig, this.session.cwd);
+			const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 			const targetFile = resolvedFile;
 			const isRustAnalyzerServer =
 				serverName === "rust-analyzer" ||

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -1786,12 +1786,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					const client = await getOrCreateClient(serverConfig, this.session.cwd, undefined, signal);
 					for (const { oldUri } of pairs) {
 						if (client.openFiles.has(oldUri)) {
-							await sendNotification(
-								client,
-								"textDocument/didClose",
-								{ textDocument: { uri: oldUri } },
-								signal,
-							);
+							await sendNotification(client, "textDocument/didClose", { textDocument: { uri: oldUri } }, signal);
 							client.openFiles.delete(oldUri);
 						}
 					}
@@ -2006,7 +2001,12 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				try {
-					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd, undefined, signal);
+					const workspaceClient = await getOrCreateClient(
+						workspaceServerConfig,
+						this.session.cwd,
+						undefined,
+						signal,
+					);
 					const workspaceResult = (await sendRequest(
 						workspaceClient,
 						"workspace/symbol",
@@ -2077,7 +2077,12 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				try {
-					const workspaceClient = await getOrCreateClient(workspaceServerConfig, this.session.cwd, undefined, signal);
+					const workspaceClient = await getOrCreateClient(
+						workspaceServerConfig,
+						this.session.cwd,
+						undefined,
+						signal,
+					);
 					outputs.push(await reloadServer(workspaceClient, workspaceServerName, signal));
 				} catch (err) {
 					if (err instanceof ToolAbortError || signal?.aborted) {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2146,7 +2146,12 @@ describe("lsp regressions", () => {
 			expect(loadConfigSpy).toHaveBeenCalledTimes(3);
 			expect(starOutput).toContain("Reloaded test-lsp");
 			expect(omittedOutput).toContain("Reloaded test-lsp");
-			expect(lspClient.getOrCreateClient).toHaveBeenCalledWith(server, tempDir.path());
+			expect(lspClient.getOrCreateClient).toHaveBeenCalledWith(
+				server,
+				tempDir.path(),
+				undefined,
+				expect.anything(),
+			);
 		} finally {
 			vi.restoreAllMocks();
 			tempDir.removeSync();
@@ -2252,6 +2257,177 @@ describe("lsp regressions", () => {
 		} finally {
 			tempDir.removeSync();
 		}
+	});
+
+	// #3962 — LSP cold-start and notification writes must honor the tool's
+	// combined timeout/caller abort signal. Before the fix, a wedged server
+	// hung past the tool's advertised deadline: `initialize` fell back to the
+	// 30s internal timer because no signal was threaded, and notification
+	// writes (`didOpen`/`didChange`/`didSave`) had no timeout at all, so a
+	// stuck `sink.flush()` blocked every later op on the client's write queue.
+	describe("lsp cold-start and notification writes honor caller signal (#3962)", () => {
+		it("aborts a wedged cold-start initialize on the caller signal instead of the 30s internal fallback", async () => {
+			// Server accepts spawn but never answers the `initialize` request.
+			// Pre-fix, `getOrCreateClient` swallowed the signal and only bailed
+			// after the 30s `DEFAULT_REQUEST_TIMEOUT_MS` fallback fired.
+			installFakeLsp(() => {});
+
+			const tempDir = TempDir.createSync("@omp-lsp-init-abort-");
+			try {
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), 100);
+				const config: ServerConfig = {
+					command: "fake-lsp-init-abort",
+					fileTypes: ["ts"],
+					rootMarkers: [],
+				};
+
+				const start = Date.now();
+				await expect(
+					lspClient.getOrCreateClient(config, tempDir.path(), undefined, controller.signal),
+				).rejects.toBeInstanceOf(Error);
+				const elapsed = Date.now() - start;
+				clearTimeout(timer);
+				// The signal fired at 100ms. Allow a wide margin, but the pre-fix
+				// path only bailed after 30s.
+				expect(elapsed).toBeLessThan(2_000);
+			} finally {
+				await lspClient.shutdownAll();
+				tempDir.removeSync();
+			}
+		});
+
+		it("bounds a wedged notification flush on the caller signal and tears down the client", async () => {
+			// Custom fake: stdin.flush is gated by a controllable promise so we
+			// can simulate a server that stopped draining stdin AFTER init has
+			// completed. Pre-fix, `sendNotification` had no signal and the
+			// stuck flush wedged the write queue permanently.
+			const encoder = new TextEncoder();
+			const { promise: exited, resolve: resolveExited } = Promise.withResolvers<number>();
+			let stdoutController: ReadableStreamDefaultController<Uint8Array> | null = null;
+			let exitCode: number | null = null;
+			let killed = false;
+			let flushGate: Promise<void> = Promise.resolve();
+
+			const frame = (message: RpcMessage): Uint8Array => {
+				const content = JSON.stringify(message);
+				return encoder.encode(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
+			};
+
+			const stdout = new ReadableStream<Uint8Array>({
+				start(c) {
+					stdoutController = c;
+				},
+			});
+
+			let pendingBytes = Buffer.alloc(0);
+			let chain: Promise<void> = Promise.resolve();
+			const feed = (raw: string | Uint8Array): void => {
+				const chunk = typeof raw === "string" ? Buffer.from(raw, "utf-8") : Buffer.from(raw);
+				pendingBytes = pendingBytes.length === 0 ? chunk : Buffer.concat([pendingBytes, chunk]);
+				chain = chain.then(async () => {
+					while (true) {
+						const headerEnd = pendingBytes.indexOf("\r\n\r\n");
+						if (headerEnd === -1) break;
+						const match = /Content-Length: (\d+)/i.exec(pendingBytes.toString("utf-8", 0, headerEnd));
+						if (!match) {
+							pendingBytes = pendingBytes.subarray(headerEnd + 4);
+							continue;
+						}
+						const start = headerEnd + 4;
+						const end = start + Number(match[1]);
+						if (pendingBytes.length < end) break;
+						const message = JSON.parse(pendingBytes.toString("utf-8", start, end)) as RpcMessage;
+						pendingBytes = pendingBytes.subarray(end);
+						if (message.method === "initialize") {
+							stdoutController?.enqueue(
+								frame({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } }),
+							);
+						}
+					}
+				});
+			};
+
+			const proc = {
+				get exited() {
+					return exited;
+				},
+				get exitCode() {
+					return exitCode;
+				},
+				stdin: {
+					write(chunk: string | Uint8Array) {
+						feed(chunk);
+						return typeof chunk === "string" ? Buffer.byteLength(chunk, "utf-8") : chunk.byteLength;
+					},
+					flush: async () => {
+						await flushGate;
+						return 0;
+					},
+					end: async () => 0,
+				},
+				stdout,
+				peekStderr: () => "",
+				kill() {
+					killed = true;
+					if (exitCode === null) {
+						exitCode = 0;
+						stdoutController?.close();
+						resolveExited(0);
+					}
+				},
+			} as unknown as LspClient["proc"];
+
+			vi.spyOn(piUtils.ptree, "spawn").mockReturnValue(proc);
+
+			const tempDir = TempDir.createSync("@omp-lsp-flush-wedge-");
+			try {
+				const config: ServerConfig = {
+					command: "fake-lsp-flush-wedge",
+					fileTypes: ["ts"],
+					rootMarkers: [],
+				};
+
+				const client = await lspClient.getOrCreateClient(config, tempDir.path());
+				expect(lspClient.getActiveClients().some(s => s.name === config.command)).toBe(true);
+
+				// Wedge every subsequent flush: sink.flush() now awaits a promise
+				// that never settles, mirroring a server that stopped draining stdin.
+				flushGate = new Promise<void>(() => {});
+
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), 100);
+
+				const start = Date.now();
+				await expect(
+					lspClient.sendNotification(
+						client,
+						"textDocument/didOpen",
+						{
+							textDocument: {
+								uri: "file:///tmp/x.ts",
+								languageId: "typescript",
+								version: 1,
+								text: "",
+							},
+						},
+						controller.signal,
+					),
+				).rejects.toBeInstanceOf(Error);
+				const elapsed = Date.now() - start;
+				clearTimeout(timer);
+				expect(elapsed).toBeLessThan(2_000);
+
+				// Teardown contract: an aborted write kills the client so the
+				// next `getOrCreateClient` spawns a fresh server instead of
+				// queueing behind the wedged flush forever.
+				expect(killed).toBe(true);
+				expect(lspClient.getActiveClients().some(s => s.name === config.command)).toBe(false);
+			} finally {
+				await lspClient.shutdownAll();
+				tempDir.removeSync();
+			}
+		});
 	});
 });
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2292,6 +2292,33 @@ describe("lsp regressions", () => {
 			}
 		});
 
+		it("does not negative-cache caller-aborted initialize attempts", async () => {
+			installFakeLsp(() => {});
+
+			const tempDir = TempDir.createSync("@omp-lsp-init-abort-cache-");
+			try {
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), 100);
+				const config: ServerConfig = {
+					command: "fake-lsp-init-abort-cache",
+					fileTypes: ["ts"],
+					rootMarkers: [],
+				};
+
+				await expect(
+					lspClient.getOrCreateClient(config, tempDir.path(), undefined, controller.signal),
+				).rejects.toBeInstanceOf(Error);
+				clearTimeout(timer);
+
+				await expect(lspClient.getOrCreateClient(config, tempDir.path(), 25)).rejects.not.toThrow(
+					"failed to initialize recently",
+				);
+			} finally {
+				await lspClient.shutdownAll();
+				tempDir.removeSync();
+			}
+		});
+
 		it("bounds a wedged notification flush on the caller signal and tears down the client", async () => {
 			// Custom fake: stdin.flush is gated by a controllable promise so we
 			// can simulate a server that stopped draining stdin AFTER init has

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2146,12 +2146,7 @@ describe("lsp regressions", () => {
 			expect(loadConfigSpy).toHaveBeenCalledTimes(3);
 			expect(starOutput).toContain("Reloaded test-lsp");
 			expect(omittedOutput).toContain("Reloaded test-lsp");
-			expect(lspClient.getOrCreateClient).toHaveBeenCalledWith(
-				server,
-				tempDir.path(),
-				undefined,
-				expect.anything(),
-			);
+			expect(lspClient.getOrCreateClient).toHaveBeenCalledWith(server, tempDir.path(), undefined, expect.anything());
 		} finally {
 			vi.restoreAllMocks();
 			tempDir.removeSync();
@@ -2340,9 +2335,7 @@ describe("lsp regressions", () => {
 						const message = JSON.parse(pendingBytes.toString("utf-8", start, end)) as RpcMessage;
 						pendingBytes = pendingBytes.subarray(end);
 						if (message.method === "initialize") {
-							stdoutController?.enqueue(
-								frame({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } }),
-							);
+							stdoutController?.enqueue(frame({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } }));
 						}
 					}
 				});

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2319,6 +2319,59 @@ describe("lsp regressions", () => {
 			}
 		});
 
+		it("does not tear down when a caller aborts before its queued write reaches flush", async () => {
+			const firstFlush = Promise.withResolvers<number>();
+			const writes: Array<string | Uint8Array> = [];
+			const kill = vi.fn();
+			const client: LspClient = {
+				name: "fake-lsp-queued-abort:/tmp",
+				cwd: "/tmp",
+				config: { command: "fake-lsp-queued-abort", fileTypes: ["ts"], rootMarkers: [] },
+				proc: {
+					exited: new Promise<number>(() => {}),
+					exitCode: null,
+					stdin: {
+						write(chunk: string | Uint8Array) {
+							writes.push(chunk);
+							return typeof chunk === "string" ? Buffer.byteLength(chunk, "utf-8") : chunk.byteLength;
+						},
+						flush: () => firstFlush.promise,
+					},
+					stdout: new ReadableStream<Uint8Array>(),
+					peekStderr: () => "",
+					kill,
+				} as unknown as LspClient["proc"],
+				requestId: 0,
+				diagnostics: new Map(),
+				diagnosticsVersion: 0,
+				openFiles: new Map(),
+				pendingRequests: new Map(),
+				messageBuffer: new Uint8Array(0),
+				isReading: false,
+				status: "ready",
+				lastActivity: Date.now(),
+				writeQueue: Promise.resolve(),
+				activeProgressTokens: new Set(),
+				projectLoaded: Promise.resolve(),
+				resolveProjectLoaded: () => {},
+			};
+
+			const first = lspClient.sendNotification(client, "workspace/didChangeConfiguration", { settings: {} });
+			await Bun.sleep(0);
+
+			const controller = new AbortController();
+			const second = lspClient.sendNotification(client, "textDocument/didOpen", {}, controller.signal);
+			controller.abort();
+			await Bun.sleep(0);
+
+			expect(kill).not.toHaveBeenCalled();
+			firstFlush.resolve(0);
+			await first;
+			await expect(second).rejects.toBeInstanceOf(Error);
+			expect(kill).not.toHaveBeenCalled();
+			expect(writes).toHaveLength(1);
+		});
+
 		it("bounds a wedged notification flush on the caller signal and tears down the client", async () => {
 			// Custom fake: stdin.flush is gated by a controllable promise so we
 			// can simulate a server that stopped draining stdin AFTER init has


### PR DESCRIPTION
## Repro

`tool.execute` builds `signal = callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal` (`packages/coding-agent/src/lsp/index.ts:1329-1333`, `lsp` timeout default 20s). Two client paths never see it:

- `getOrCreateClient(config, cwd, initTimeoutMs?)` takes no `AbortSignal`; its `initialize` `sendRequest` runs with `signal = undefined` and (for a first-use cold-start) no explicit `timeoutMs`, so `sendRequest`'s policy `timeoutMs ?? (signal ? undefined : DEFAULT_REQUEST_TIMEOUT_MS)` falls through to the hard-coded 30s internal timer (`packages/coding-agent/src/lsp/client.ts:957,1013`). A server that wedges in `initialize` hangs ~30s, ignoring the 20s tool default AND any user-supplied shorter `timeout` AND user cancel.
- `writeMessage`/`queueWriteMessage`/`sendNotification` (`packages/coding-agent/src/lsp/client.ts:183-199,1060-1068`) accept no signal and unconditionally `await sink.flush()`. If the server stops draining stdin, the flush blocks forever, and because every write serializes through `client.writeQueue`, every later op on that client stalls behind it.

Reproduced by two in-process regression tests using the existing `installFakeLsp` transport fake in `packages/coding-agent/test/tools/lsp-regressions.test.ts`:

1. Server accepts spawn, never answers `initialize`. Before the fix, `getOrCreateClient(config, cwd, undefined, controller.signal)` ignored `controller.signal` and only bailed after the 30s internal fallback. After the fix, it rejects within the caller's 100ms deadline.
2. Server accepts `initialize`, then `stdin.flush` is gated on a never-settling promise (mirroring "stopped draining stdin"). Before the fix, `sendNotification(client, "textDocument/didOpen", …, controller.signal)` blocked forever. After the fix, it rejects within the caller's 100ms deadline AND the client is killed and evicted so the next lookup spawns a fresh server.

## Cause

The tool's combined signal was built but never threaded into the client layer at either path. `getOrCreateClient` had no `signal` parameter, so its internal `initialize` call ran without one, silently activating `sendRequest`'s 30s fallback timer. `sendNotification`/`writeMessage` similarly had no signal parameter, so the underlying `sink.flush()` was unbounded — and because `queueWriteMessage` chains all writes through `client.writeQueue`, one wedged flush poisoned every subsequent op on that client.

## Fix

- `writeMessage(sink, message, signal?)`: race `sink.flush()` against `signal`; on abort, throw `signal.reason` (or `ToolAbortError`) and suppress the abandoned flush's later settlement.
- `queueWriteMessage(client, message, signal?)`: on abort, call `teardownWedgedClient(client)` — remove from `clients` immediately (so concurrent `getOrCreateClient` calls don't grab the corpse) and `proc.kill()` (the existing `proc.exited` handler finishes cleanup). The write queue's "next writer" barrier is preserved by swallowing the error in the queue tail.
- `sendRequest`: pass its `signal` through to `queueWriteMessage`.
- `sendNotification(client, method, params, signal?)`: pass `signal` through to `queueWriteMessage`.
- `getOrCreateClient(config, cwd, initTimeoutMs?, signal?)`: forward `signal` to the `initialize` `sendRequest` and the `initialized` `sendNotification`. `initTimeoutMs` still takes precedence inside `sendRequest`, preserving warmup's short 5s deadline.
- Update file-op helpers to thread their existing `signal` into every `sendNotification` (`ensureFileOpen`, `syncContent`, `notifySaved`, `refreshFile`).
- Update the LSP tool callsites (`captureDiagnosticVersions`, `captureOpenFileVersions`, `syncFileContent`, `notifyFileSaved`, `formatContent`, `getDiagnosticsForFile`, `reloadServer`, and every `getOrCreateClient` / `sendNotification` call inside `LspTool.execute`, including the rename `didClose`/`didRenameFiles` path) to forward the operation signal. Warmup deliberately still passes only `initTimeoutMs` with no caller signal.

Normalized `sink.flush()`'s `number | Promise<number>` return via `Promise.resolve(...)` so the strict `tsgo` check accepts `.then`/`.catch`.

## Verification

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` → 51 pass, including the two new `#3962` regressions:
  - `aborts a wedged cold-start initialize on the caller signal instead of the 30s internal fallback` — asserts rejection within 2s under a 100ms caller signal (30s pre-fix).
  - `bounds a wedged notification flush on the caller signal and tears down the client` — asserts rejection within 2s, `proc.kill()` called, and the client evicted from `getActiveClients()`.
- `bun check` → clean (`bun run fix` was a no-op).

Fixes #3962