### PR TITLE
fix(browser): reap Chromium/Puppeteer on aborted open and session dispose

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the browser tool leaking Chromium/Puppeteer processes at two termination boundaries: (1) an aborted `browser.open` observed abort only in its `untilAborted` wrapper while the inner launch resolved in the background and unconditionally published the handle into the module-global `browsers` map at refCount:0 (no `releaseAllTabs` walk covered it), and (2) `AgentSession.dispose()` had no browser teardown hook, so tabs a session opened outlived the session. `acquireBrowser` now short-circuits before launch on a pre-aborted signal and disposes the handle if the launch completes after abort; tabs record the creating session's id and `AgentSession.dispose()` reaps them via a bounded `releaseTabsForOwner` call. ([#3963](https://github.com/can1357/oh-my-pi/issues/3963))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -285,6 +285,7 @@ import {
 	selectDiscoverableToolNamesByServer,
 } from "../tool-discovery/tool-index";
 import { assertEditableFile } from "../tools/auto-generated-guard";
+import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import { normalizeToolNames } from "../tools/builtin-names";
 import type { CheckpointState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
@@ -5093,6 +5094,28 @@ export class AgentSession {
 		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
 		await disposeRubyKernelSessionsByOwner(this.#evalKernelOwnerId);
 		await disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId);
+		// Release headless / spawned Chromium and worker tabs this session
+		// opened via the browser tool. The tool's `tabs`/`browsers` maps are
+		// module-global — subagents and future sessions share them — so we
+		// walk by `ownerSessionId` (assigned at `acquireTab` creation, never on
+		// reuse) and touch only what THIS session created. Bounded so a broken
+		// CDP close cannot stall `/exit`; mirrors the async-job/MCP pattern.
+		// (Issue #3963.)
+		const browserOwnerId = this.sessionManager.getSessionId();
+		if (browserOwnerId) {
+			try {
+				const released = await withTimeout(
+					releaseTabsForOwner(browserOwnerId, { kill: true }),
+					3_000,
+					"Timed out releasing owned browser tabs during dispose",
+				);
+				if (released > 0) {
+					logger.debug("Released owned browser tabs during dispose", { ownerId: browserOwnerId, released });
+				}
+			} catch (error) {
+				logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+			}
+		}
 		await shutdownTinyTitleClient();
 		this.#releasePowerAssertion();
 		// Clean up an empty session created by this session's /move so it doesn't accumulate.

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -262,6 +262,7 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 				timeoutMs,
 				dialogs: params.dialogs,
 				signal,
+				ownerSessionId: this.session.getSessionId?.() ?? undefined,
 			}),
 		);
 		const tab = result.tab;

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -71,8 +71,28 @@ export async function acquireBrowser(kind: BrowserKind, opts: AcquireBrowserOpti
 		browsers.delete(key);
 		await disposeBrowserHandle(existing, { kill: false });
 	}
+	// Short-circuit before launching: the tool wrapper's `untilAborted` only
+	// rejects its outer promise on abort; without this check `openBrowserHandle`
+	// would still fire and its result would land in `browsers` below.
+	if (opts.signal?.aborted) throw new ToolAbortError("Browser open aborted");
 
 	const handle = await openBrowserHandle(kind, opts);
+	// The launch may resolve AFTER the caller has already aborted (the outer
+	// `untilAborted` rejects immediately on abort but does not cancel the
+	// inner promise, and `launchHeadlessBrowser` does not accept a signal).
+	// Without this branch the completed handle sits in `browsers` at
+	// refCount:0 forever — no tab ever takes a hold, `releaseBrowser` never
+	// fires, and `releaseAllTabs` walks `tabs`, not `browsers`, so the
+	// orphaned Chromium/app process / puppeteer handle survives to process
+	// exit. (Issue #3963.)
+	if (opts.signal?.aborted) {
+		await disposeBrowserHandle(handle, { kill: kind.kind === "spawned" }).catch(err => {
+			logger.debug("Failed to dispose orphan browser after abort", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		});
+		throw new ToolAbortError("Browser open aborted");
+	}
 	browsers.set(key, handle);
 	return handle;
 }
@@ -238,4 +258,9 @@ async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean
 		}
 	}
 	if (opts.kill && handle.pid !== undefined) await gracefulKillTreeOnce(handle.pid);
+}
+
+/** Test-only accessor for the module-global browsers map. */
+export function getBrowsersMapForTest(): ReadonlyMap<string, BrowserHandle> {
+	return browsers;
 }

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -59,6 +59,13 @@ interface TabSessionBase<TBrowser extends BrowserHandle = BrowserHandle> {
 	pending: Map<string, PendingRun>;
 	dialogPolicy?: DialogPolicy;
 	kindTag: BrowserKindTag;
+	/**
+	 * Session id of the caller that CREATED the tab. Preserved across reuse so
+	 * that dispose of the creating session can reap browser resources without
+	 * yanking the tab out from under a subagent that only reused it.
+	 * Undefined when the acquirer did not identify itself.
+	 */
+	ownerSessionId?: string;
 }
 
 export interface WorkerTabSession extends TabSessionBase<PuppeteerBrowserHandle> {
@@ -84,6 +91,12 @@ export interface AcquireTabOptions {
 	timeoutMs: number;
 	dialogs?: DialogPolicy;
 	cmuxSurface?: string;
+	/**
+	 * Session id of the acquirer. Recorded on the tab when created (never on
+	 * reuse) so `releaseTabsForOwner` can walk the shared tabs map on session
+	 * dispose. Optional — omitting it opts the tab out of session-scoped reap.
+	 */
+	ownerSessionId?: string;
 }
 
 export interface AcquireTabResult {
@@ -239,6 +252,16 @@ async function acquireTabImpl(
 		}
 	}
 
+	// If the caller aborted while we were spawning/initializing the worker,
+	// tear the freshly-built worker down before publishing the tab so the
+	// browser refCount (which `holdBrowser` below would take) never grows for
+	// a tab nobody is waiting for.
+	if (opts.signal?.aborted) {
+		await worker.terminate().catch(() => undefined);
+		if (tempHold) await releaseBrowser(browser, { kill: false }).catch(() => undefined);
+		throw new ToolAbortError("Browser tab open aborted");
+	}
+
 	holdBrowser(browser);
 	if (tempHold) await releaseBrowser(browser, { kill: false });
 	const tab: WorkerTabSession = {
@@ -252,6 +275,7 @@ async function acquireTabImpl(
 		pending: new Map(),
 		dialogPolicy: opts.dialogs,
 		kindTag: browser.kind.kind,
+		ownerSessionId: opts.ownerSessionId,
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
 	tabs.set(name, tab);
@@ -303,6 +327,11 @@ async function acquireCmuxTab(
 			await cmuxTab.goto(opts.url, { waitUntil: opts.waitUntil ?? "load", timeoutMs: opts.timeoutMs });
 		}
 		const info = await cmuxTab.readyInfo(opts.viewport ?? DEFAULT_VIEWPORT);
+		// If the caller aborted while we were opening the cmux surface, close the
+		// surface (if we own it) instead of taking a browser hold on it.
+		if (opts.signal?.aborted) {
+			throw new ToolAbortError("Browser tab open aborted");
+		}
 		holdBrowser(browser);
 		const tab: CmuxTabSession = {
 			name,
@@ -317,6 +346,7 @@ async function acquireCmuxTab(
 			dialogPolicy: opts.dialogs,
 			kindTag: browser.kind.kind,
 			cmuxAttachedSurface: attachedSurface,
+			ownerSessionId: opts.ownerSessionId,
 		};
 		tabs.set(name, tab);
 		return { tab, created: true };
@@ -465,6 +495,34 @@ export async function releaseAllTabs(opts: ReleaseTabOptions = {}): Promise<numb
 export async function dropHeadlessTabs(): Promise<void> {
 	const names = [...tabs.values()].filter(tab => tab.kindTag === "headless").map(tab => tab.name);
 	for (const name of names) await releaseTab(name);
+}
+
+/**
+ * Release every tab created by the given session id. Invoked from
+ * `AgentSession.dispose()` so headless/spawned Chromium and workers the
+ * session opened do not leak into the long-lived process — the module-global
+ * `tabs`/`browsers` maps that back this tool are not otherwise walked by
+ * session teardown. (Issue #3963.)
+ *
+ * Ownership is recorded ONLY on tab creation (`acquireTab` with
+ * `ownerSessionId`), never on reuse: a subagent re-driving a tab another
+ * session opened will not yank teardown responsibility away from the
+ * creator. Tabs opened with no owner (e.g. from an SDK caller that doesn't
+ * identify a session) are skipped and must be released explicitly.
+ */
+export async function releaseTabsForOwner(ownerId: string, opts: ReleaseTabOptions = {}): Promise<number> {
+	if (!ownerId) return 0;
+	const names = [...tabs.values()].filter(tab => tab.ownerSessionId === ownerId).map(tab => tab.name);
+	let count = 0;
+	for (const name of names) {
+		if (await releaseTab(name, opts)) count++;
+	}
+	return count;
+}
+
+/** Test-only accessor for the module-global tabs map. */
+export function getTabsMapForTest(): ReadonlyMap<string, TabSession> {
+	return tabs;
 }
 
 function isLastSurfaceCloseError(err: unknown): boolean {

--- a/packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts
+++ b/packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for issue #3963: the browser tool leaks Chromium/Puppeteer
+ * resources at two termination boundaries.
+ *
+ * 1. An aborted `open` observes abort only in its `untilAborted` wrapper — the
+ *    inner launch resolves in the background and `acquireBrowser` publishes
+ *    the handle unconditionally, leaving a live browser at refCount:0 with no
+ *    tab holding it. `releaseAllTabs` walks tabs, not browsers, so nothing
+ *    ever reaps it.
+ * 2. Browser + tab state lives in module-global maps. `AgentSession.dispose()`
+ *    walks jobs, eval kernels, provider sessions, and MCP, but has no browser
+ *    teardown hook, so any tabs the session opened outlive the session.
+ *
+ * The tests below cover both by driving `acquireBrowser` / `acquireTab` /
+ * `releaseTabsForOwner` directly, with `CmuxSocketClient` prototype methods
+ * spied so no real cmux socket / puppeteer process is needed.
+ */
+
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import type { CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
+import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
+import {
+	acquireBrowser,
+	getBrowsersMapForTest,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import {
+	acquireTab,
+	getTabsMapForTest,
+	releaseTab,
+	releaseTabsForOwner,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+
+function makeKind(socketSuffix: string): CmuxKind {
+	return { kind: "cmux", socketPath: `/tmp/omp-test-${socketSuffix}.sock`, surface: `surface-${socketSuffix}` };
+}
+
+async function drainAllTabs(): Promise<void> {
+	for (const name of [...getTabsMapForTest().keys()]) {
+		await releaseTab(name, { kill: false }).catch(() => undefined);
+	}
+}
+
+describe("browser lifecycle — aborted open must not leak a browser handle", () => {
+	afterEach(async () => {
+		await drainAllTabs();
+	});
+
+	it("disposes a cmux browser whose launch resolved after the caller aborted", async () => {
+		const gate = Promise.withResolvers<void>();
+		const connectSpy = spyOn(CmuxSocketClient.prototype, "connect").mockImplementation(async () => {
+			await gate.promise;
+		});
+		const closeSpy = spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+
+		try {
+			const kind = makeKind("abort-orphan");
+			const controller = new AbortController();
+			const pending = acquireBrowser(kind, { cwd: "/tmp", signal: controller.signal });
+			// The reporter's scenario: abort fires while the launch is in flight.
+			controller.abort();
+			// The launch resolves *after* the abort has been observed by the caller.
+			gate.resolve();
+
+			await expect(pending).rejects.toBeInstanceOf(ToolAbortError);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			// The freshly-launched browser MUST be torn down before publication so it
+			// does not sit at refCount:0 in the global map, leaking a live cmux socket
+			// (or, for headless, a live Chromium process) that no `releaseAllTabs`
+			// / `dropHeadlessTabs` walk would ever reap.
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+			expect(getBrowsersMapForTest().size).toBe(0);
+		} finally {
+			connectSpy.mockRestore();
+			closeSpy.mockRestore();
+		}
+	});
+
+	it("does not launch at all when the signal was already aborted", async () => {
+		const connectSpy = spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+		const closeSpy = spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+		try {
+			const kind = makeKind("preaborted");
+			const controller = new AbortController();
+			controller.abort();
+			await expect(
+				acquireBrowser(kind, { cwd: "/tmp", signal: controller.signal }),
+			).rejects.toBeInstanceOf(ToolAbortError);
+			// Not called: pre-abort short-circuit fires before openBrowserHandle.
+			expect(connectSpy).not.toHaveBeenCalled();
+			expect(closeSpy).not.toHaveBeenCalled();
+			expect(getBrowsersMapForTest().size).toBe(0);
+		} finally {
+			connectSpy.mockRestore();
+			closeSpy.mockRestore();
+		}
+	});
+});
+
+describe("browser lifecycle — session-scoped teardown reaps owned tabs", () => {
+	afterEach(async () => {
+		await drainAllTabs();
+	});
+
+	it("acquireTab records ownerSessionId and releaseTabsForOwner tears down only that session's tabs", async () => {
+		spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+		spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+		let openCount = 0;
+		spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+			async (method: string): Promise<Record<string, unknown>> => {
+				if (method === "browser.open_split") {
+					openCount++;
+					return { surface_id: `surface-${openCount}`, url: "about:blank" };
+				}
+				if (method === "browser.wait") return {};
+				if (method === "surface.close") return {};
+				if (method === "browser.snapshot" || method === "browser.geometry") return {};
+				if (method === "browser.eval") return {};
+				return {};
+			},
+		);
+
+		const kindA = makeKind("owner-a");
+		const kindB = makeKind("owner-b");
+		const browserA = await acquireBrowser(kindA, { cwd: "/tmp" });
+		const browserB = await acquireBrowser(kindB, { cwd: "/tmp" });
+
+		const tabA = await acquireTab("tab-a", browserA, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+		const tabB = await acquireTab("tab-b", browserB, { timeoutMs: 1_000, ownerSessionId: "session-B" });
+
+		expect(tabA.tab.ownerSessionId).toBe("session-A");
+		expect(tabB.tab.ownerSessionId).toBe("session-B");
+		expect(getTabsMapForTest().size).toBe(2);
+
+		// Dispose only session A. Session B's tab (and its browser) must survive
+		// because a shared long-lived process may still be running under B.
+		const released = await releaseTabsForOwner("session-A", { kill: false });
+		expect(released).toBe(1);
+		expect(getTabsMapForTest().has("tab-a")).toBe(false);
+		expect(getTabsMapForTest().has("tab-b")).toBe(true);
+
+		await releaseTabsForOwner("session-B", { kill: false });
+		expect(getTabsMapForTest().size).toBe(0);
+		expect(getBrowsersMapForTest().size).toBe(0);
+	});
+
+	it("acquireTab reusing an existing tab preserves the original owner", async () => {
+		spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+		spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+		spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+			async (method: string): Promise<Record<string, unknown>> => {
+				if (method === "browser.open_split") return { surface_id: "surface-reuse", url: "about:blank" };
+				return {};
+			},
+		);
+
+		const kind = makeKind("reuse");
+		const browser = await acquireBrowser(kind, { cwd: "/tmp" });
+
+		const first = await acquireTab("reuse-tab", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+		const second = await acquireTab("reuse-tab", browser, { timeoutMs: 1_000, ownerSessionId: "session-B" });
+
+		expect(first.tab).toBe(second.tab);
+		expect(second.created).toBe(false);
+		// Reuse must NOT reassign ownership — a subagent re-driving an existing
+		// tab shouldn't yank teardown responsibility from the session that opened it.
+		expect(second.tab.ownerSessionId).toBe("session-A");
+
+		// releaseTabsForOwner("session-B") is a no-op here — the tab belongs to A.
+		const releasedB = await releaseTabsForOwner("session-B", { kill: false });
+		expect(releasedB).toBe(0);
+		expect(getTabsMapForTest().has("reuse-tab")).toBe(true);
+
+		const releasedA = await releaseTabsForOwner("session-A", { kill: false });
+		expect(releasedA).toBe(1);
+		expect(getTabsMapForTest().has("reuse-tab")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts
+++ b/packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts
@@ -19,10 +19,7 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import type { CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
 import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
-import {
-	acquireBrowser,
-	getBrowsersMapForTest,
-} from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import { acquireBrowser, getBrowsersMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import {
 	acquireTab,
 	getTabsMapForTest,
@@ -83,9 +80,9 @@ describe("browser lifecycle — aborted open must not leak a browser handle", ()
 			const kind = makeKind("preaborted");
 			const controller = new AbortController();
 			controller.abort();
-			await expect(
-				acquireBrowser(kind, { cwd: "/tmp", signal: controller.signal }),
-			).rejects.toBeInstanceOf(ToolAbortError);
+			await expect(acquireBrowser(kind, { cwd: "/tmp", signal: controller.signal })).rejects.toBeInstanceOf(
+				ToolAbortError,
+			);
 			// Not called: pre-abort short-circuit fires before openBrowserHandle.
 			expect(connectSpy).not.toHaveBeenCalled();
 			expect(closeSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Repro

Two termination boundaries in the browser tool leaked browser-owned OS resources into the long-lived coding-agent process:

1. **Aborted `open` published an orphan.** `#open` wrapped acquisition in `untilAborted`, which rejects its outer wrapper on abort but lets the inner promise resolve to completion (see `packages/utils/src/abortable.ts:69-91`). `acquireBrowser` then unconditionally stored the resolved handle in the module-global `browsers` map. `releaseAllTabs` walks `tabs`, not `browsers`, so the `refCount:0` handle stayed alive to process exit — a Chromium/app process + Puppeteer handle leaked per aborted open.
2. **Session dispose had no browser teardown.** Browser/tab state lives in module-global maps (`browsers`, `tabs`); `AgentSession.dispose()` handled jobs, eval kernels, provider sessions, and MCP but had no hook to walk them. Headless/spawned Chromium the session opened accumulated across sessions in the same process.

Reproduced in `packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts` via a spied `CmuxSocketClient` (no real puppeteer/socket needed). Pre-fix (fix hunks reverted), three assertions fail:

- `acquireBrowser` with an already-aborted signal — and again with a signal that fires while the launch is in flight — resolves and publishes the handle instead of throwing:

  ```
  Expected promise that rejects
  Received promise that resolved: Promise { <resolved> }
  ```

- After releasing every tab, the browsers map still holds handles:

  ```
  expect(getBrowsersMapForTest().size).toBe(0);
  Expected: 0
  Received: 2
  ```

## Cause

- `packages/coding-agent/src/tools/browser/registry.ts:65-78` — `acquireBrowser` did `const handle = await openBrowserHandle(...); browsers.set(key, handle);` with no signal check between the two lines, so a late-completion launch always published.
- `packages/coding-agent/src/tools/browser/tab-supervisor.ts:105` and `packages/coding-agent/src/tools/browser/registry.ts:43` — module-global `tabs`/`browsers` maps with no per-session ownership tag.
- `packages/coding-agent/src/session/agent-session.ts:5047-5151` — `dispose()` had no browser teardown call; the only lifecycle hook (`restartForModeChange` → `dropHeadlessTabs`) fires only on mode change.

## Fix

- **`registry.ts`**: `acquireBrowser` now short-circuits before launch on a pre-aborted signal and, if the launch completes after the signal aborted, disposes the handle (`kill: true` for spawned apps) before throwing `ToolAbortError` — never publishing an orphan.
- **`tab-supervisor.ts`**: `TabSessionBase` records `ownerSessionId?: string`, set only on creation (`acquireTab`), never on reuse — a subagent re-driving an existing tab does NOT yank teardown responsibility from the session that opened it. Both worker and cmux acquisition paths honor late aborts (terminate worker + release the browser hold, or close the owned cmux surface) before publishing. New `releaseTabsForOwner(id, opts)` walks `tabs` by owner id.
- **`browser.ts`**: `BrowserTool.#open` threads `this.session.getSessionId?.() ?? undefined` into `acquireTab`, so tabs opened via the tool inherit their owner.
- **`agent-session.ts`**: `dispose()` calls `releaseTabsForOwner(sessionId, { kill: true })` bounded by `withTimeout(3_000)`, mirroring the async-job / MCP disposal pattern so a broken CDP close cannot stall `/exit`.

Additive test-only accessors `getBrowsersMapForTest()` and `getTabsMapForTest()` expose the module-global maps for regression coverage.

## Verification

```
$ bun test test/tools/browser-lifecycle-leak.test.ts \
           test/tools/browser-op-tracking.test.ts \
           test/tools/browser-attach.test.ts \
           test/tools/browser-cmux-kind.test.ts \
           test/tools/browser-cmux-observation.test.ts \
           test/tools/browser-cmux-socket.test.ts \
           test/tools/browser-aria-snapshot.test.ts \
           test/tools/browser-readable.test.ts \
           test/tools/browser-tab-timeouts.test.ts \
           test/tools/browser-tab-worker-startup.test.ts
 46 pass
  0 fail
```

The four new tests cover both defects end-to-end: (a) pre-aborted signal short-circuits without launching, (b) aborted-mid-launch disposes the late-completion handle and leaves `browsers` empty, (c) `releaseTabsForOwner("A")` releases only session A's tabs (session B's survive), (d) `acquireTab` reusing a tab preserves the original owner. LSP diagnostics clean on all four edited files.

Fixes #3963