### PR TITLE
fix(mcp): keep HTTP timeout active through body reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP Streamable HTTP request and notify timeouts staying unarmed during stalled response body reads. ([#3974](https://github.com/can1357/oh-my-pi/issues/3974))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -238,8 +238,6 @@ export class HttpTransport implements MCPTransport {
 				signal: operation.signal,
 			});
 
-			operation.clear();
-
 			// Check for session ID in response
 			const newSessionId = response.headers.get("Mcp-Session-Id");
 			if (newSessionId) {
@@ -276,11 +274,12 @@ export class HttpTransport implements MCPTransport {
 
 			return result.result as T;
 		} catch (error) {
-			operation.clear();
 			if (operation.isTimeoutAbort(error)) {
 				throw new Error(`Request timeout after ${timeout}ms`);
 			}
 			throw error;
+		} finally {
+			operation.clear();
 		}
 	}
 
@@ -373,7 +372,7 @@ export class HttpTransport implements MCPTransport {
 			headers["Mcp-Session-Id"] = this.#sessionId;
 		}
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
-		let operation = createMCPTimeout(timeout);
+		const operation = createMCPTimeout(timeout);
 		try {
 			const resp = await fetch(this.config.url, {
 				method: "POST",
@@ -381,7 +380,6 @@ export class HttpTransport implements MCPTransport {
 				body: JSON.stringify(body),
 				signal: operation.signal,
 			});
-			operation.clear();
 			// Retry once on auth failure if onAuthError is wired
 			if (this.onAuthError && (resp.status === 401 || resp.status === 403)) {
 				await resp.body?.cancel();
@@ -390,22 +388,27 @@ export class HttpTransport implements MCPTransport {
 					this.config.headers ??= {};
 					Object.assign(this.config.headers, newHeaders);
 					Object.assign(headers, newHeaders);
-					operation = createMCPTimeout(timeout);
-					const retry = await fetch(this.config.url, {
-						method: "POST",
-						headers,
-						body: JSON.stringify(body),
-						signal: operation.signal,
-					});
 					operation.clear();
-					await retry.body?.cancel();
+					const retryOperation = createMCPTimeout(timeout);
+					try {
+						const retry = await fetch(this.config.url, {
+							method: "POST",
+							headers,
+							body: JSON.stringify(body),
+							signal: retryOperation.signal,
+						});
+						await retry.body?.cancel();
+					} finally {
+						retryOperation.clear();
+					}
 					return;
 				}
 			}
 			await resp.body?.cancel();
 		} catch {
-			operation.clear();
 			// Best-effort response delivery — server may have disconnected
+		} finally {
+			operation.clear();
 		}
 	}
 
@@ -441,8 +444,6 @@ export class HttpTransport implements MCPTransport {
 				signal: operation.signal,
 			});
 
-			operation.clear();
-
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
 				const text = await response.text();
@@ -465,11 +466,12 @@ export class HttpTransport implements MCPTransport {
 				await response.body?.cancel();
 			}
 		} catch (error) {
-			operation.clear();
 			if (operation.isTimeoutAbort(error)) {
 				throw new Error(`Notify timeout after ${timeout}ms`);
 			}
 			throw error;
+		} finally {
+			operation.clear();
 		}
 	}
 

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
+
+const encoder = new TextEncoder();
+const REQUEST_TIMEOUT_MS = 50;
+const GUARD_TIMEOUT_MS = 500;
+
+let server: Bun.Server<undefined> | null = null;
+
+type ToolList = {
+	tools: { name: string; inputSchema: { type: string } }[];
+};
+
+afterEach(() => {
+	server?.stop(true);
+	server = null;
+});
+
+async function connectedTransport(): Promise<HttpTransport> {
+	if (!server) throw new Error("Test server was not started");
+	const transport = new HttpTransport({
+		type: "http",
+		url: `http://127.0.0.1:${server.port}/mcp`,
+		timeout: REQUEST_TIMEOUT_MS,
+	});
+	await transport.connect();
+	return transport;
+}
+
+function stalledBodyResponse(bodyPrefix: string, init?: ResponseInit): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(bodyPrefix));
+			},
+		}),
+		init,
+	);
+}
+
+// Real time is intentional: this exercises Bun fetch aborting a live HTTP body stream,
+// which fake timers do not drive through the socket/readable-stream stack.
+async function withPendingGuard<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(GUARD_TIMEOUT_MS).then(() => {
+			throw new Error(`${label} stayed pending past ${GUARD_TIMEOUT_MS}ms`);
+		}),
+	]);
+}
+
+describe("MCP Streamable HTTP transport timeouts", () => {
+	it("keeps the request timeout active until a JSON response body is fully read", async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return stalledBodyResponse('{"jsonrpc":"2.0","id":"', {
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		});
+		const transport = await connectedTransport();
+
+		await expect(withPendingGuard(transport.request("tools/list"), "request")).rejects.toThrow(
+			`Request timeout after ${REQUEST_TIMEOUT_MS}ms`,
+		);
+	});
+
+	it("keeps the notify timeout active while reading HTTP error bodies", async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return stalledBodyResponse("partial failure body", {
+					status: 500,
+					headers: { "Content-Type": "text/plain" },
+				});
+			},
+		});
+		const transport = await connectedTransport();
+
+		await expect(withPendingGuard(transport.notify("notifications/initialized"), "notify")).rejects.toThrow(
+			`Notify timeout after ${REQUEST_TIMEOUT_MS}ms`,
+		);
+	});
+
+	it("still resolves normal JSON response bodies", async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return Response.json({
+					jsonrpc: "2.0",
+					id: 1,
+					result: { tools: [{ name: "fast", inputSchema: { type: "object" } }] },
+				});
+			},
+		});
+		const transport = await connectedTransport();
+
+		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
+			tools: [{ name: "fast", inputSchema: { type: "object" } }],
+		});
+	});
+});


### PR DESCRIPTION
## Repro
A local Streamable HTTP server returns response headers plus a partial JSON body and then leaves the body open; before the fix, `bun .wt/repro-mcp-http-body-timeout.ts` with `timeout: 100` stayed pending after 500ms instead of rejecting.

## Cause
`packages/coding-agent/src/mcp/transports/http.ts` cleared the `createMCPTimeout(...)` operation immediately after `fetch` resolved in `HttpTransport.#executeRequest` and `HttpTransport.notify`, so `response.json()`, `response.text()`, and body cancellation ran without the transport deadline.

## Fix
- Kept the request and notify timeout operation alive until response body consumption finishes, clearing it in `finally`.
- Kept server-response retry body cancellation under the active timeout before starting a retry operation.
- Added Streamable HTTP regression tests for stalled request JSON bodies, stalled notify error bodies, and normal fast JSON responses.
- Added the coding-agent changelog entry.

## Verification
`bun .wt/repro-mcp-http-body-timeout.ts` now rejects with `Request timeout after 100ms`; `bun test packages/coding-agent/test/mcp-http-transport.test.ts` passed (3 tests); `bun run check:types` in `packages/coding-agent` passed; `bunx biome check packages/coding-agent/src/mcp/transports/http.ts packages/coding-agent/test/mcp-http-transport.test.ts packages/coding-agent/CHANGELOG.md` passed; pre-publish `gh_push_branch` completed `bun run fix` and `bun check` successfully. Fixes #3974