### PR TITLE
fix(agent): detect repeated tool-call turns

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cross-turn tool-call loops going undetected by adding a guard for consecutive identical tool calls. ([#3971](https://github.com/can1357/oh-my-pi/issues/3971))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -45,4 +45,5 @@ export * from "./utils/openrouter-headers";
 export * from "./utils/retry";
 export * from "./utils/schema";
 export * from "./utils/thinking-loop";
+export * from "./utils/tool-call-loop-guard";
 export * from "./utils/validation";

--- a/packages/ai/src/utils/tool-call-loop-guard.ts
+++ b/packages/ai/src/utils/tool-call-loop-guard.ts
@@ -1,0 +1,107 @@
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import type { AssistantMessage, ToolCall, ToolResultMessage } from "../types";
+
+const LEGACY_INTENT_FIELD = "__intent";
+const RESULT_SUMMARY_LIMIT = 200;
+const ARGUMENT_SUMMARY_LIMIT = 400;
+
+/** Runtime settings for cross-turn tool-call repetition detection. */
+export interface ToolCallLoopGuardOptions {
+	readonly threshold: number;
+	readonly exemptTools: readonly string[];
+}
+
+/** A completed assistant turn plus the tool results it produced. */
+export interface ToolCallLoopTurn {
+	readonly message: AssistantMessage;
+	readonly toolResults: readonly ToolResultMessage[];
+}
+
+/** Details needed to steer the model away from a repeated tool call. */
+export interface RepeatedToolCallDetection {
+	readonly kind: "repeated_tool_call";
+	readonly toolName: string;
+	readonly count: number;
+	readonly resultSummary: string;
+	readonly argumentsSummary: string;
+}
+
+function canonicalizeToolCallValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(item => canonicalizeToolCallValue(item));
+	}
+	if (!value || typeof value !== "object") {
+		return value;
+	}
+
+	const input = value as Record<string, unknown>;
+	const output: Record<string, unknown> = {};
+	for (const key of Object.keys(input).sort()) {
+		if (key === INTENT_FIELD || key === LEGACY_INTENT_FIELD) continue;
+		output[key] = canonicalizeToolCallValue(input[key]);
+	}
+	return output;
+}
+
+function summarizeText(text: string, limit: number): string {
+	let summary = text.replace(/\s+/g, " ").trim();
+	if (summary.length > limit) {
+		summary = `${summary.slice(0, limit)}…`;
+	}
+	return summary;
+}
+
+function summarizeToolResult(toolResults: readonly ToolResultMessage[], toolCallId: string): string {
+	const result = toolResults.find(candidate => candidate.toolCallId === toolCallId);
+	if (!result) return "";
+
+	const textParts: string[] = [];
+	for (const block of result.content) {
+		if (block.type === "text") {
+			textParts.push(block.text);
+		}
+	}
+	return summarizeText(textParts.join("\n"), RESULT_SUMMARY_LIMIT);
+}
+
+/** Detects consecutive identical assistant tool calls across model turns. */
+export class ToolCallLoopGuard {
+	#threshold: number;
+	#exemptTools: ReadonlySet<string>;
+	#lastHash: string | undefined;
+	#count = 0;
+
+	constructor(options: ToolCallLoopGuardOptions) {
+		this.#threshold = Math.max(1, Math.trunc(options.threshold));
+		this.#exemptTools = new Set(options.exemptTools);
+	}
+
+	/** Records one completed turn and returns the threshold hit, if any. */
+	recordTurn(turn: ToolCallLoopTurn): RepeatedToolCallDetection | null {
+		const toolCalls = turn.message.content.filter((part): part is ToolCall => part.type === "toolCall");
+		if (toolCalls.length !== 1 || this.#exemptTools.has(toolCalls[0]!.name)) {
+			this.#lastHash = undefined;
+			this.#count = 0;
+			return null;
+		}
+
+		const toolCall = toolCalls[0]!;
+		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(toolCall.arguments));
+		const hash = `${toolCall.name}:${canonicalArgs}`;
+		if (hash === this.#lastHash) {
+			this.#count++;
+		} else {
+			this.#lastHash = hash;
+			this.#count = 1;
+		}
+
+		if (this.#count !== this.#threshold) return null;
+		return {
+			kind: "repeated_tool_call",
+			toolName: toolCall.name,
+			count: this.#count,
+			resultSummary: summarizeToolResult(turn.toolResults, toolCall.id),
+			argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+		};
+	}
+}

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
+
+describe("ToolCallLoopGuard", () => {
+	test("detects the fifth consecutive identical tool call", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 5, exemptTools: ["job", "irc"] });
+		let detection = null;
+		for (let index = 0; index < 5; index++) {
+			const toolCallId = `call-${index}`;
+			detection = guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "pytest -q", timeout: 120 } },
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId,
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			});
+		}
+
+		expect(detection).toEqual({
+			kind: "repeated_tool_call",
+			toolName: "bash",
+			count: 5,
+			resultSummary: "1263 passed, 4 skipped",
+			argumentsSummary: '{"command":"pytest -q","timeout":120}',
+		});
+	});
+
+	test("canonicalizes argument key order and ignores harness intent fields", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "first", name: "read", arguments: { path: "a.ts", [INTENT_FIELD]: "first" } },
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "second",
+							name: "read",
+							arguments: { [INTENT_FIELD]: "second", path: "a.ts" },
+						},
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toMatchObject({ toolName: "read", count: 2 });
+	});
+
+	test("resets the consecutive count on a different call", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 3, exemptTools: [] });
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "first", name: "bash", arguments: { command: "pytest -q" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "second", name: "read", arguments: { path: "src/index.ts" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "third", name: "bash", arguments: { command: "pytest -q" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "third",
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+	});
+
+	test("ignores exempt polling tools", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["job"] });
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "first", name: "job", arguments: { poll: ["abc"] } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "job",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "second", name: "job", arguments: { poll: ["abc"] } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "job",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed agents repeating the same tool call across turns without corrective steering by wiring the cross-turn tool-call loop guard into sessions. ([#3971](https://github.com/can1357/oh-my-pi/issues/3971))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -285,6 +285,7 @@ const EMPTY_STRING_ARRAY: string[] = [];
 const EMPTY_STRING_RECORD: Record<string, string> = {};
 const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
+const DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS: string[] = ["job", "irc"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
@@ -989,7 +990,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "model",
 			group: "Thinking",
 			label: "Loop Guard",
-			description: "Enable automatic stream loop detection for Gemini and DeepSeek models",
+			description: "Enable automatic stream loop detection for model reasoning and prose",
 		},
 	},
 
@@ -1013,6 +1014,39 @@ export const SETTINGS_SCHEMA = {
 			label: "Loop Guard Tool-Call Reminder",
 			description:
 				"When a Gemini reasoning stream emits many consecutive planning headers without calling a tool, interrupt it and inject a reminder to issue a tool call (requires Loop Guard)",
+		},
+	},
+
+	"model.toolCallLoopGuard.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Loop Guard",
+			description: "Detect consecutive identical tool calls across turns and inject a corrective steer",
+		},
+	},
+
+	"model.toolCallLoopGuard.threshold": {
+		type: "number",
+		default: 5,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Loop Threshold",
+			description: "Consecutive identical tool calls required before the corrective steer is injected",
+		},
+	},
+
+	"model.toolCallLoopGuard.exemptTools": {
+		type: "array",
+		default: DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Loop Exempt Tools",
+			description: "Tool names that may repeat consecutively without triggering the cross-turn loop guard",
 		},
 	},
 

--- a/packages/coding-agent/src/prompts/system/tool-call-loop-redirect.md
+++ b/packages/coding-agent/src/prompts/system/tool-call-loop-redirect.md
@@ -1,0 +1,8 @@
+<system-interrupt reason="tool_call_loop_detected">
+You called `{{tool_name}}` {{count}} consecutive times with identical arguments:
+`{{arguments_summary}}`
+
+Last result (truncated): `{{result_summary}}`
+
+NEVER call `{{tool_name}}` with those arguments again this turn. Use different arguments, choose another tool, or summarize findings and yield if complete.
+</system-interrupt>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -115,6 +115,7 @@ import {
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { GeminiHeaderRunDetector, isGeminiThinkingModel } from "@oh-my-pi/pi-ai/utils/thinking-loop";
+import { type RepeatedToolCallDetection, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
@@ -251,6 +252,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 };
 import sideChannelNoToolsReminder from "../prompts/system/side-channel-no-tools.md" with { type: "text" };
 import thinkingLoopRedirectTemplate from "../prompts/system/thinking-loop-redirect.md" with { type: "text" };
+import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
 import unexpectedStopRetryTemplate from "../prompts/system/unexpected-stop-retry.md" with { type: "text" };
@@ -350,6 +352,7 @@ const GEMINI_TOOL_REMINDER_TYPE = "gemini-tool-call-reminder";
 /** `customType` for the hidden redirect notice injected into a turn retried after a
  *  thinking/response loop. Steers the model off the repeated content; never displayed. */
 const THINKING_LOOP_REDIRECT_TYPE = "thinking-loop-redirect";
+const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
 
 // A side-channel assistant response is signed for the hidden prompt/history that
 // produced it. If we persist that response under a different user turn, native
@@ -1554,6 +1557,8 @@ export class AgentSession {
 	 *  `#geminiHeaderGuardActive`); undefined for non-Gemini models or when the
 	 *  guard is off. Fed thinking deltas in the assistant-message interceptor. */
 	#geminiHeaderDetector: GeminiHeaderRunDetector | undefined;
+	#toolCallLoopGuard: ToolCallLoopGuard | undefined;
+	#toolCallLoopGuardSettingsKey: string | undefined;
 	#promptInFlightCount = 0;
 	#abortInProgress = false;
 	// Wire-level agent_end emission deferred until #promptInFlightCount drops to 0.
@@ -1847,6 +1852,13 @@ export class AgentSession {
 			if (rewindReport) {
 				this.#pendingRewindReport = undefined;
 				await this.#applyRewind(rewindReport, messages);
+			}
+			if (context?.message.role === "assistant") {
+				const detection = this.#activeToolCallLoopGuard()?.recordTurn({
+					message: context.message,
+					toolResults: context.toolResults,
+				});
+				if (detection) this.#maybeInjectToolCallLoopRedirect(messages, detection);
 			}
 			this.#advisorPrimaryTurnsCompleted++;
 			if (this.#advisors.length > 0) {
@@ -4297,6 +4309,58 @@ export class AgentSession {
 		this.#streamingEditCheckedLineCounts.clear();
 		this.#streamingEditPrecheckedToolCallIds.clear();
 		this.#streamingEditFileCache.clear();
+	}
+
+	#activeToolCallLoopGuard(): ToolCallLoopGuard | undefined {
+		if (this.settings.get("model.toolCallLoopGuard.enabled") !== true) {
+			this.#toolCallLoopGuard = undefined;
+			this.#toolCallLoopGuardSettingsKey = undefined;
+			return undefined;
+		}
+
+		const threshold = this.settings.get("model.toolCallLoopGuard.threshold");
+		const exemptTools = this.settings
+			.get("model.toolCallLoopGuard.exemptTools")
+			.filter((tool): tool is string => typeof tool === "string" && tool.length > 0);
+		const settingsKey = `${threshold}:${JSON.stringify(exemptTools)}`;
+		if (!this.#toolCallLoopGuard || this.#toolCallLoopGuardSettingsKey !== settingsKey) {
+			this.#toolCallLoopGuard = new ToolCallLoopGuard({ threshold, exemptTools });
+			this.#toolCallLoopGuardSettingsKey = settingsKey;
+		}
+		return this.#toolCallLoopGuard;
+	}
+
+	#maybeInjectToolCallLoopRedirect(messages: AgentMessage[], detection: RepeatedToolCallDetection): void {
+		const content = prompt.render(toolCallLoopRedirectTemplate, {
+			tool_name: detection.toolName,
+			count: detection.count,
+			arguments_summary: detection.argumentsSummary,
+			result_summary: detection.resultSummary || "(no text result)",
+		});
+		const details = {
+			toolName: detection.toolName,
+			count: detection.count,
+			argumentsSummary: detection.argumentsSummary,
+			resultSummary: detection.resultSummary,
+		};
+		logger.warn("cross-turn tool-call loop detected", {
+			toolName: detection.toolName,
+			count: detection.count,
+		});
+		const redirectMessage: CustomMessage = {
+			role: "custom",
+			customType: TOOL_CALL_LOOP_REDIRECT_TYPE,
+			content,
+			display: false,
+			details,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		messages.push(redirectMessage);
+		if (this.agent.state.messages !== messages) {
+			this.agent.appendMessage(redirectMessage);
+		}
+		this.sessionManager.appendCustomMessageEntry(TOOL_CALL_LOOP_REDIRECT_TYPE, content, false, details, "agent");
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-call-loop-guard.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { type CustomMessage, convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
+
+describe("AgentSession tool-call loop guard", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-tool-call-loop-guard-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("injects a hidden redirect before the next model call", async () => {
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+		const bashTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock bash tool",
+			parameters: type({ "command?": "string" }),
+			execute: async () => ({ content: [{ type: "text" as const, text: "1263 passed, 4 skipped" }] }),
+		};
+		let callCount = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [bashTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const toolCallTurn = callCount < 5;
+				const toolCallId = `tc-${callCount}`;
+				callCount++;
+				const message: AssistantMessage = toolCallTurn
+					? {
+							role: "assistant",
+							content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "pytest -q" } }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "Stopped repeating." }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: toolCallTurn ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			"model.toolCallLoopGuard.enabled": true,
+			"model.toolCallLoopGuard.threshold": 5,
+			"model.toolCallLoopGuard.exemptTools": ["job", "irc"],
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[bashTool.name, bashTool]]),
+		});
+
+		await session.prompt("run checks");
+		await session.waitForIdle();
+
+		expect(contexts).toHaveLength(6);
+		expect(JSON.stringify(contexts[5]!.messages)).toContain("tool_call_loop_detected");
+		expect(JSON.stringify(contexts[5]!.messages)).toContain("1263 passed, 4 skipped");
+		const redirects = session.agent.state.messages.filter(
+			(message): message is CustomMessage =>
+				message.role === "custom" && message.customType === "tool-call-loop-redirect",
+		);
+		expect(redirects).toHaveLength(1);
+		expect(redirects[0]!.display).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
A focused regression test for five consecutive identical `bash` calls reproduced the missing guard with `bun test packages/ai/test/tool-call-loop-guard.test.ts`; before the fix it failed because `@oh-my-pi/pi-ai/utils/tool-call-loop-guard` did not exist and no cross-turn repeated tool-call detector was wired.

## Cause
`packages/ai/src/utils/thinking-loop.ts` only observes streamed reasoning/prose within one response, and `packages/coding-agent/src/session/agent-session.ts` did not inspect `AgentLoopConfig.onTurnEnd` tool-call payloads for repeated `(tool name, canonical arguments)` across consecutive turns.

## Fix
- Added `ToolCallLoopGuard` in `packages/ai/src/utils/tool-call-loop-guard.ts` with sorted-key argument canonicalization, intent-field stripping, consecutive counting, result summaries, and exempt tools.
- Added `model.toolCallLoopGuard.*` settings and wired `AgentSession` `onTurnEnd` to inject a hidden `tool-call-loop-redirect` custom message at the threshold.
- Added a model-facing redirect prompt and regression tests for guard behavior plus session-level next-turn injection.

## Verification
Ran `bun --cwd=packages/collab-web run gen:tool-views`, `bun test packages/ai/test/tool-call-loop-guard.test.ts packages/coding-agent/test/agent-session-tool-call-loop-guard.test.ts` (5 pass, 0 fail), `bun --cwd=packages/ai run check`, and `bun --cwd=packages/coding-agent run check`. Fixes #3971