### PR TITLE
Persist request message metadata in stats

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Session message metadata now preserves optional plan attribution for host-side stats pipelines. ([#3618](https://github.com/can1357/oh-my-pi/issues/3618))
+
 ## [16.2.4] - 2026-06-28
 
 ### Changed

--- a/packages/agent/src/compaction/entries.ts
+++ b/packages/agent/src/compaction/entries.ts
@@ -11,6 +11,8 @@ export interface SessionEntryBase {
 export interface SessionMessageEntry extends SessionEntryBase {
 	type: "message";
 	message: AgentMessage;
+	/** Usage limit/window identifier this assistant request consumed against, when known. */
+	planId?: string | null;
 }
 
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added cache-only active usage-limit attribution for OAuth-backed provider sessions. ([#3618](https://github.com/can1357/oh-my-pi/issues/3618))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -746,6 +746,60 @@ function hasOpenAICodexProPlan(report: UsageReport | null): boolean {
 	return getUsagePlanType(report)?.includes("pro") === true;
 }
 
+function preferredUsageLimitIds(provider: string, modelId: string | undefined): readonly string[] {
+	if (provider === "anthropic") return ["anthropic:5h", "anthropic:7d"];
+	if (provider === "openai-codex") {
+		if (requiresOpenAICodexProModel(provider, modelId)) {
+			return [
+				"openai-codex:spark:primary",
+				"openai-codex:spark:secondary",
+				"openai-codex:primary",
+				"openai-codex:secondary",
+			];
+		}
+		return ["openai-codex:primary", "openai-codex:secondary"];
+	}
+	return [];
+}
+
+function finiteWindowDuration(limit: UsageLimit): number | undefined {
+	const duration = limit.window?.durationMs;
+	return duration !== undefined && Number.isFinite(duration) && duration > 0 ? duration : undefined;
+}
+
+function shortestWindowLimit(limits: readonly UsageLimit[]): UsageLimit | undefined {
+	let selected: UsageLimit | undefined;
+	let selectedDuration = Number.POSITIVE_INFINITY;
+	for (const limit of limits) {
+		const duration = finiteWindowDuration(limit);
+		if (duration === undefined) continue;
+		if (
+			!selected ||
+			duration < selectedDuration ||
+			(duration === selectedDuration && limit.id.localeCompare(selected.id) < 0)
+		) {
+			selected = limit;
+			selectedDuration = duration;
+		}
+	}
+	return selected;
+}
+
+function resolvePrimaryUsageLimitId(
+	provider: string,
+	limits: readonly UsageLimit[],
+	modelId: string | undefined,
+): string | undefined {
+	if (limits.length === 0) return undefined;
+	const modelScoped = modelId ? limits.filter(limit => limit.scope.modelId === modelId) : [];
+	const candidates = modelScoped.length > 0 ? modelScoped : limits;
+	for (const id of preferredUsageLimitIds(provider, modelId)) {
+		if (candidates.some(limit => limit.id === id)) return id;
+	}
+	if (candidates.length === 1) return candidates[0]?.id;
+	return shortestWindowLimit(candidates)?.id;
+}
+
 function compareUsageRankingMetric(left: number, right: number): number {
 	if (left === right) return 0;
 	if (!Number.isFinite(left) || !Number.isFinite(right)) return left < right ? -1 : 1;
@@ -2295,6 +2349,31 @@ export class AuthStorage {
 	 */
 	listUsageHistory(query?: UsageHistoryQuery): UsageHistoryEntry[] {
 		return this.#store.listUsageHistory?.(query) ?? [];
+	}
+
+	/**
+	 * Best-effort request-time usage limit attribution for stats persistence.
+	 *
+	 * Synchronous and cache-only by design: this reads the session-sticky
+	 * credential's stale cached usage report (including just-ingested response
+	 * headers) and never performs an upstream usage probe on the hot
+	 * message-persistence path. Returns undefined when no cached report or
+	 * deterministic primary limit is available.
+	 */
+	resolveActiveUsageLimitId(
+		provider: Provider,
+		options?: { sessionId?: string; baseUrl?: string; modelId?: string },
+	): string | undefined {
+		const credential = this.#resolveObservedUsageCredential(provider, options?.sessionId);
+		if (!credential) return undefined;
+		const cacheKey = this.#buildUsageReportCacheKey({
+			provider,
+			credential,
+			baseUrl: options?.baseUrl,
+		});
+		const report = this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value ?? null;
+		if (!report || report.limits.length === 0) return undefined;
+		return resolvePrimaryUsageLimitId(provider, report.limits, options?.modelId);
 	}
 
 	/** Record one observed provider request cost for later local usage aggregation. */

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -15,7 +15,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, setSystemTime, vi } from "bun:test";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
-import type { UsageHistoryEntry, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import type { UsageHistoryEntry, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 import * as opencodeGoUsage from "@oh-my-pi/pi-ai/usage/opencode-go";
 
@@ -185,6 +185,83 @@ describe("AuthStorage usage history recording", () => {
 		const sevenDay = rows.find(row => row.limitId === "anthropic:7d");
 		expect(sevenDay?.usedFraction).toBeCloseTo(0.84);
 		expect(sevenDay?.status).toBe("warning");
+	});
+});
+describe("AuthStorage active usage limit attribution", () => {
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+	let fetchCalls = 0;
+
+	function activeAnthropicReport(fetchedAt = Date.now()): UsageReport {
+		return {
+			provider: "anthropic",
+			fetchedAt,
+			limits: [
+				{
+					id: "anthropic:7d",
+					label: "Claude 7 Day",
+					scope: { provider: "anthropic", windowId: "7d", shared: true },
+					window: { id: "7d", label: "7 Day", resetsAt: fetchedAt + 7 * 24 * HOUR },
+					amount: { used: 84, limit: 100, usedFraction: 0.84, unit: "percent" },
+					status: "warning",
+				},
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", resetsAt: fetchedAt + 5 * HOUR },
+					amount: { used: 42, limit: 100, usedFraction: 0.42, unit: "percent" },
+					status: "ok",
+				},
+			],
+			metadata: { accountId: "account-active", email: "active@example.com" },
+		};
+	}
+
+	beforeEach(async () => {
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		store.upsertAuthCredentialForProvider("anthropic", {
+			type: "oauth",
+			access: "oat-active",
+			refresh: "refresh-active",
+			expires: Date.now() + HOUR,
+			accountId: "account-active",
+			email: "active@example.com",
+		});
+		fetchCalls = 0;
+		const usageProvider: UsageProvider = {
+			id: "anthropic",
+			async fetchUsage(params) {
+				fetchCalls += 1;
+				return params.credential.accountId === "account-active" ? activeAnthropicReport() : null;
+			},
+		};
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "anthropic" ? usageProvider : undefined),
+		});
+		await storage.reload();
+	});
+
+	afterEach(() => {
+		storage.close();
+		vi.restoreAllMocks();
+	});
+
+	it("resolves the active Anthropic plan id from cached multi-window usage only", async () => {
+		const sessionId = "active-plan-session";
+		expect(await storage.getApiKey("anthropic", sessionId)).toBe("oat-active");
+
+		expect(storage.resolveActiveUsageLimitId("anthropic", { sessionId, modelId: "claude-sonnet-4" })).toBeUndefined();
+		expect(fetchCalls).toBe(0);
+
+		const reports = await storage.fetchUsageReports();
+		expect(reports?.map(report => report.provider)).toEqual(["anthropic"]);
+		expect(fetchCalls).toBe(1);
+
+		expect(storage.resolveActiveUsageLimitId("anthropic", { sessionId, modelId: "claude-sonnet-4" })).toBe(
+			"anthropic:5h",
+		);
+		expect(fetchCalls).toBe(1);
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Assistant session entries now persist cached active plan attribution for stats requests. ([#3618](https://github.com/can1357/oh-my-pi/issues/3618))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -317,6 +317,8 @@ import {
 	type CustomMessage,
 	convertToLlm,
 	demoteInterruptedThinking,
+	type FileMentionMessage,
+	type HookMessage,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
 	isUserInterruptAbort,
@@ -339,6 +341,14 @@ import { ToolChoiceQueue } from "./tool-choice-queue";
 import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey } from "./turn-persistence";
 import { classifyUnexpectedStop, isUnexpectedStopCandidate } from "./unexpected-stop-classifier";
 import { YieldQueue } from "./yield-queue";
+
+type PersistableSessionMessage =
+	| Message
+	| CustomMessage
+	| HookMessage
+	| BashExecutionMessage
+	| PythonExecutionMessage
+	| FileMentionMessage;
 
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
@@ -2932,6 +2942,20 @@ export class AgentSession {
 		return false;
 	}
 
+	#resolveAssistantPlanId(message: AssistantMessage): string | undefined {
+		return this.#modelRegistry.authStorage.resolveActiveUsageLimitId(message.provider, {
+			sessionId: this.#activeProviderSessionId(),
+			baseUrl: this.#modelRegistry.getProviderBaseUrl(message.provider),
+			modelId: message.model,
+		});
+	}
+
+	#appendSessionMessage(message: PersistableSessionMessage): string {
+		if (message.role !== "assistant") return this.sessionManager.appendMessage(message);
+		const planId = this.#resolveAssistantPlanId(message as AssistantMessage);
+		return this.sessionManager.appendMessage(message, planId ? { planId } : undefined);
+	}
+
 	#persistSessionMessageIfMissing(message: AgentMessage): void {
 		if (
 			message.role !== "user" &&
@@ -2958,7 +2982,7 @@ export class AgentSession {
 			message.toolName === "rewind" &&
 			this.#rewoundToolResultIds.delete(message.toolCallId);
 		if (!skipPersistedRewindResult) {
-			this.sessionManager.appendMessage(message);
+			this.#appendSessionMessage(message);
 		}
 	}
 
@@ -9928,7 +9952,7 @@ export class AgentSession {
 		if (!recoveryCommitted) {
 			const compactionEntryAfter = getLatestCompactionEntry(this.sessionManager.getBranch());
 			if (compactionEntryAfter === compactionEntryBefore) {
-				this.sessionManager.appendMessage(assistantMessage);
+				this.#appendSessionMessage(assistantMessage);
 			}
 		}
 		return result;

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -50,6 +50,8 @@ export interface SessionEntryBase {
 export interface SessionMessageEntry extends SessionEntryBase {
 	type: "message";
 	message: AgentMessage;
+	/** Usage limit/window identifier this assistant request consumed against, when known. */
+	planId?: string | null;
 }
 
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1275,8 +1275,10 @@ export class SessionManager {
 			| BashExecutionMessage
 			| PythonExecutionMessage
 			| FileMentionMessage,
+		metadata?: { planId?: string | null },
 	): string {
 		const entry: SessionMessageEntry = { type: "message", ...this.#freshEntryFields(), message };
+		if (metadata?.planId !== undefined) entry.planId = metadata.planId;
 		this.#recordEntry(entry);
 		return entry.id;
 	}

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-request thinking level and plan attribution to message stats, including a one-shot reparse backfill for existing sessions. ([#3618](https://github.com/can1357/oh-my-pi/issues/3618))
+
 ## [16.2.7] - 2026-06-30
 
 ### Fixed

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -46,6 +46,7 @@ const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
 const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 const AGENT_TYPE_BACKFILL_KEY = "agent_type_v1";
 const FORK_DEDUPE_KEY = "fork_dedupe_v1";
+const MESSAGE_METADATA_BACKFILL_KEY = "message_metadata_v1";
 function shouldResetBackfill(value: string | undefined): boolean {
 	return value !== BACKFILL_COMPLETE && value !== BACKFILL_PENDING;
 }
@@ -96,6 +97,8 @@ export async function initDb(): Promise<Database> {
 			cost_cache_write REAL NOT NULL,
 			cost_total REAL NOT NULL,
 			agent_type TEXT NOT NULL DEFAULT 'main',
+			thinking_level TEXT,
+			plan_id TEXT,
 			UNIQUE(session_file, entry_id)
 		);
 
@@ -155,6 +158,14 @@ export async function initDb(): Promise<Database> {
 	if (!hasAgentTypeColumn) {
 		db.run("ALTER TABLE messages ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'main'");
 	}
+	const hasThinkingLevelColumn = messageColumns.some(column => column.name === "thinking_level");
+	if (!hasThinkingLevelColumn) {
+		db.run("ALTER TABLE messages ADD COLUMN thinking_level TEXT");
+	}
+	const hasPlanIdColumn = messageColumns.some(column => column.name === "plan_id");
+	if (!hasPlanIdColumn) {
+		db.run("ALTER TABLE messages ADD COLUMN plan_id TEXT");
+	}
 	// For any pre-existing table, enroll the backfill PENDING unless a prior run
 	// already settled the sentinel — `OR IGNORE` leaves an existing
 	// COMPLETE/PENDING value intact, so an ALTER that committed before its
@@ -166,6 +177,14 @@ export async function initDb(): Promise<Database> {
 		messagesTableExisted ? BACKFILL_PENDING : BACKFILL_COMPLETE,
 	);
 	db.run("CREATE INDEX IF NOT EXISTS idx_messages_timestamp_agent_type ON messages(timestamp, agent_type)");
+	if (messagesTableExisted) {
+		backfillMessageMetadata(db);
+	} else {
+		db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)").run(
+			MESSAGE_METADATA_BACKFILL_KEY,
+			BACKFILL_COMPLETE,
+		);
+	}
 	// Each behavior-metric bump invalidates previously-ingested rows. We detect
 	// the stale schema by column name and drop the table; `IF NOT EXISTS` above
 	// already produced the new schema, but we want a clean wipe + re-ingest.
@@ -357,16 +376,30 @@ export function insertMessageStats(stats: MessageStats[]): number {
 			session_file, entry_id, folder, model, provider, api, timestamp,
 			duration, ttft, stop_reason, error_message,
 			input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, premium_requests,
-			cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total, agent_type
+			cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total, agent_type,
+			thinking_level, plan_id
 		)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		WHERE NOT EXISTS (
 			SELECT 1 FROM messages
 			WHERE entry_id = ? AND timestamp = ? AND session_file <> ?
 		)
 		ON CONFLICT(session_file, entry_id) DO UPDATE SET
-			premium_requests = excluded.premium_requests
+			premium_requests = CASE
+				WHEN messages.premium_requests < excluded.premium_requests THEN excluded.premium_requests
+				ELSE messages.premium_requests
+			END,
+			thinking_level = COALESCE(excluded.thinking_level, messages.thinking_level),
+			plan_id = COALESCE(excluded.plan_id, messages.plan_id)
 		WHERE messages.premium_requests < excluded.premium_requests
+			OR (
+				excluded.thinking_level IS NOT NULL
+				AND (messages.thinking_level IS NULL OR messages.thinking_level <> excluded.thinking_level)
+			)
+			OR (
+				excluded.plan_id IS NOT NULL
+				AND (messages.plan_id IS NULL OR messages.plan_id <> excluded.plan_id)
+			)
 	`);
 
 	let inserted = 0;
@@ -397,6 +430,8 @@ export function insertMessageStats(stats: MessageStats[]): number {
 				cost.cacheWrite,
 				cost.total,
 				s.agentType,
+				s.thinkingLevel ?? null,
+				s.planId ?? null,
 				// `WHERE NOT EXISTS` binds: skip when a different session_file
 				// already holds this (entry_id, timestamp).
 				s.entryId,
@@ -773,6 +808,8 @@ function rowToMessageStats(row: any): MessageStats {
 			},
 		},
 		agentType: (row.agent_type as AgentType) ?? "main",
+		thinkingLevel: row.thinking_level ?? null,
+		planId: row.plan_id ?? null,
 	};
 }
 
@@ -970,6 +1007,24 @@ function repairUserMessageLinks(database: Database): void {
 	database
 		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
 		.run(USER_MESSAGE_LINKS_REPAIR_KEY, BACKFILL_PENDING);
+}
+
+/**
+ * One-shot wipe of `file_offsets` so the next sync re-parses every session
+ * and fills nullable per-request metadata columns from the JSONL transcript.
+ * The guarded UPSERT in `insertMessageStats` updates existing rows when the
+ * reparse can now provide `thinking_level` or `plan_id`.
+ */
+function backfillMessageMetadata(database: Database): void {
+	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(MESSAGE_METADATA_BACKFILL_KEY) as
+		| { value: string }
+		| undefined;
+	if (!shouldResetBackfill(row?.value)) return;
+
+	database.run("DELETE FROM file_offsets");
+	database
+		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+		.run(MESSAGE_METADATA_BACKFILL_KEY, BACKFILL_PENDING);
 }
 
 /**

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -14,6 +14,7 @@ import type {
 	SessionEntry,
 	SessionMessageEntry,
 	SessionServiceTierChangeEntry,
+	SessionThinkingLevelChangeEntry,
 	UserMessageLink,
 	UserMessageStats,
 } from "./types";
@@ -86,6 +87,23 @@ function isServiceTierChange(entry: SessionEntry): entry is SessionServiceTierCh
 }
 
 /**
+ * Check if an entry is a thinking-level change.
+ */
+function isThinkingLevelChange(entry: SessionEntry): entry is SessionThinkingLevelChangeEntry {
+	return entry.type === "thinking_level_change";
+}
+
+function normalizeSessionText(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function resolveThinkingLevelChange(entry: SessionThinkingLevelChangeEntry): string | null {
+	return normalizeSessionText(entry.thinkingLevel) ?? normalizeSessionText(entry.configured);
+}
+
+/**
  * Extract plain text from a user message content payload.
  */
 function extractUserText(content: unknown): string {
@@ -137,6 +155,7 @@ function extractStats(
 	folder: string,
 	entry: SessionMessageEntry,
 	currentServiceTier: ServiceTierByFamily | undefined,
+	currentThinkingLevel: string | null | undefined,
 	agentType: AgentType,
 ): MessageStats | null {
 	const msg = entry.message as AssistantMessage;
@@ -168,6 +187,8 @@ function extractStats(
 		errorMessage: msg.errorMessage ?? null,
 		usage,
 		agentType,
+		thinkingLevel: currentThinkingLevel ?? null,
+		planId: normalizeSessionText(entry.planId),
 	};
 }
 
@@ -221,6 +242,14 @@ function scanLastServiceTier(bytes: Uint8Array): ServiceTierByFamily | undefined
 	});
 	return currentServiceTier;
 }
+
+function scanLastThinkingLevel(bytes: Uint8Array): string | null | undefined {
+	let currentThinkingLevel: string | null | undefined;
+	visitSessionEntriesLenient(bytes, entry => {
+		if (isThinkingLevelChange(entry)) currentThinkingLevel = resolveThinkingLevelChange(entry);
+	});
+	return currentThinkingLevel;
+}
 /**
  * Parse a session file and extract all assistant message stats.
  * Uses incremental reading with offset tracking.
@@ -262,10 +291,17 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	const unprocessed = bytes.subarray(start);
 	const { entries, read } = parseSessionEntriesLenient(unprocessed);
 	let currentServiceTier: ServiceTierByFamily | undefined;
+	let currentThinkingLevel: string | null | undefined;
 	if (start > 0) {
-		currentServiceTier = scanLastServiceTier(bytes.subarray(0, start));
+		const prefix = bytes.subarray(0, start);
+		currentServiceTier = scanLastServiceTier(prefix);
+		currentThinkingLevel = scanLastThinkingLevel(prefix);
 	}
 	for (const entry of entries) {
+		if (isThinkingLevelChange(entry)) {
+			currentThinkingLevel = resolveThinkingLevelChange(entry);
+			continue;
+		}
 		if (isServiceTierChange(entry)) {
 			currentServiceTier = coerceServiceTierByFamily(entry.serviceTier);
 			continue;
@@ -279,7 +315,7 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 			continue;
 		}
 		if (isAssistantMessage(entry)) {
-			const msgStats = extractStats(sessionPath, folder, entry, currentServiceTier, agentType);
+			const msgStats = extractStats(sessionPath, folder, entry, currentServiceTier, currentThinkingLevel, agentType);
 			if (msgStats) stats.push(msgStats);
 			// Link assistant's responding model back to the user message it answered.
 			const parentId = (entry as SessionMessageEntry).parentId;

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -35,6 +35,10 @@ export interface MessageStats {
 	usage: Usage;
 	/** Which agent produced this message (main agent, task subagent, advisor) */
 	agentType: AgentType;
+	/** Resolved thinking level active for this request, if known */
+	thinkingLevel?: string | null;
+	/** Usage limit/window identifier this request consumed against, if recorded */
+	planId?: string | null;
 }
 
 /**
@@ -61,10 +65,20 @@ export interface SessionHeader {
 
 export interface SessionMessageEntry {
 	type: "message";
+	planId?: string | null;
 	id: string;
 	parentId: string | null;
 	timestamp: string;
 	message: AssistantMessage | { role: "user" | "toolResult" };
+}
+
+export interface SessionThinkingLevelChangeEntry {
+	type: "thinking_level_change";
+	id: string;
+	parentId?: string | null;
+	timestamp: string;
+	thinkingLevel?: string | null;
+	configured?: string | null;
 }
 
 export interface SessionServiceTierChangeEntry {
@@ -75,7 +89,12 @@ export interface SessionServiceTierChangeEntry {
 	serviceTier: ServiceTierByFamily | ServiceTier | null;
 }
 
-export type SessionEntry = SessionHeader | SessionMessageEntry | SessionServiceTierChangeEntry | { type: string };
+export type SessionEntry =
+	| SessionHeader
+	| SessionMessageEntry
+	| SessionThinkingLevelChangeEntry
+	| SessionServiceTierChangeEntry
+	| { type: string };
 
 /**
  * Behavioral stats extracted from a single user message.

--- a/packages/stats/test/message-metadata.test.ts
+++ b/packages/stats/test/message-metadata.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getRecentRequests, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import { parseSessionFile } from "@oh-my-pi/omp-stats/parser";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import { getSessionsDir } from "@oh-my-pi/pi-utils";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+installStatsTestIsolation("@pi-stats-message-metadata-");
+
+const BASE_TS = Date.parse("2026-06-30T12:00:00.000Z");
+const BASE_ISO = new Date(BASE_TS).toISOString();
+
+async function writeSession(name: string, lines: Array<Record<string, unknown>>): Promise<string> {
+	const dir = path.join(getSessionsDir(), "--tmp--message-metadata");
+	await fs.mkdir(dir, { recursive: true });
+	const filePath = path.join(dir, name);
+	await fs.writeFile(filePath, `${lines.map(line => JSON.stringify(line)).join("\n")}\n`);
+	return filePath;
+}
+
+function sessionEntry(id = "session-message-metadata"): Record<string, unknown> {
+	return {
+		type: "session",
+		version: 1,
+		id,
+		timestamp: BASE_ISO,
+		cwd: "/tmp/message-metadata",
+	};
+}
+
+function thinkingLevelEntry(opts: {
+	id: string;
+	configured?: string | null;
+	thinkingLevel?: string | null;
+}): Record<string, unknown> {
+	const entry: Record<string, unknown> = {
+		type: "thinking_level_change",
+		id: opts.id,
+		timestamp: BASE_ISO,
+	};
+	if (opts.configured !== undefined) entry.configured = opts.configured;
+	if (opts.thinkingLevel !== undefined) entry.thinkingLevel = opts.thinkingLevel;
+	return entry;
+}
+
+function assistantEntry(opts: {
+	id: string;
+	timestampOffsetMs?: number;
+	planId?: string | null;
+}): Record<string, unknown> {
+	const timestamp = BASE_TS + (opts.timestampOffsetMs ?? 0);
+	const entry: Record<string, unknown> = {
+		type: "message",
+		id: opts.id,
+		parentId: null,
+		timestamp: new Date(timestamp).toISOString(),
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: `reply ${opts.id}` }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-20250514",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 1,
+				cacheWrite: 2,
+				totalTokens: 18,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp,
+			duration: 123,
+			ttft: 45,
+		},
+	};
+	if (opts.planId !== undefined) entry.planId = opts.planId;
+	return entry;
+}
+
+describe("message metadata parsing and persistence", () => {
+	it("stamps assistant messages with the running thinking level and resolves auto to the concrete level", async () => {
+		const sessionFile = await writeSession("thinking-levels.jsonl", [
+			sessionEntry(),
+			assistantEntry({ id: "before-thinking-level", timestampOffsetMs: 1 }),
+			thinkingLevelEntry({ id: "tl-auto-medium", configured: "auto", thinkingLevel: "medium" }),
+			assistantEntry({ id: "after-auto", timestampOffsetMs: 2 }),
+			thinkingLevelEntry({ id: "tl-low", configured: "low" }),
+			assistantEntry({ id: "after-low", timestampOffsetMs: 3 }),
+		]);
+
+		const result = await parseSessionFile(sessionFile);
+
+		expect(result.stats.map(stat => [stat.entryId, stat.thinkingLevel])).toEqual([
+			["before-thinking-level", null],
+			["after-auto", "medium"],
+			["after-low", "low"],
+		]);
+	});
+
+	it("carries the latest prefix thinking level into an incremental parse", async () => {
+		const sessionFile = await writeSession("incremental-thinking-level.jsonl", [
+			sessionEntry(),
+			thinkingLevelEntry({ id: "tl-prefix-low", configured: "low" }),
+			thinkingLevelEntry({ id: "tl-prefix-auto-high", configured: "auto", thinkingLevel: "high" }),
+			assistantEntry({ id: "incremental-assistant", timestampOffsetMs: 1 }),
+		]);
+		const bytes = await fs.readFile(sessionFile);
+		const lastThinkingLevelStart = bytes.indexOf(Buffer.from("tl-prefix-auto-high"));
+		const offset = bytes.indexOf(0x0a, lastThinkingLevelStart) + 1;
+		expect(lastThinkingLevelStart).toBeGreaterThan(0);
+		expect(offset).toBeGreaterThan(lastThinkingLevelStart);
+
+		const result = await parseSessionFile(sessionFile, offset);
+
+		expect(result.stats).toHaveLength(1);
+		expect(result.stats[0]?.entryId).toBe("incremental-assistant");
+		expect(result.stats[0]?.thinkingLevel).toBe("high");
+	});
+
+	it("copies planId from session messages and persists both metadata columns through recent requests", async () => {
+		const sessionFile = await writeSession("metadata-columns.jsonl", [
+			sessionEntry(),
+			thinkingLevelEntry({ id: "tl-auto-medium", configured: "auto", thinkingLevel: "medium" }),
+			assistantEntry({ id: "with-plan", timestampOffsetMs: 1, planId: "anthropic:5h" }),
+		]);
+		const parsed = await parseSessionFile(sessionFile);
+		expect(parsed.stats).toHaveLength(1);
+		expect(parsed.stats[0]?.thinkingLevel).toBe("medium");
+		expect(parsed.stats[0]?.planId).toBe("anthropic:5h");
+
+		await initDb();
+		expect(insertMessageStats(parsed.stats)).toBe(1);
+
+		const request = getRecentRequests(1)[0];
+		expect(request?.entryId).toBe("with-plan");
+		expect(request?.thinkingLevel).toBe("medium");
+		expect(request?.planId).toBe("anthropic:5h");
+	});
+
+	it("updates existing rows on re-sync when the parser later supplies metadata", async () => {
+		const sessionFile = await writeSession("resync-metadata.jsonl", [
+			sessionEntry(),
+			thinkingLevelEntry({ id: "tl-auto-high", configured: "auto", thinkingLevel: "high" }),
+			assistantEntry({ id: "resynced-assistant", timestampOffsetMs: 1, planId: "anthropic:5h" }),
+		]);
+		const parsed = await parseSessionFile(sessionFile);
+		const reparsedStat = parsed.stats[0];
+		if (!reparsedStat) throw new Error("expected parsed assistant stat");
+		const staleStat: MessageStats = { ...reparsedStat, thinkingLevel: null, planId: null };
+
+		await initDb();
+		expect(insertMessageStats([staleStat])).toBe(1);
+		expect(getRecentRequests(1)[0]?.thinkingLevel).toBeNull();
+		expect(getRecentRequests(1)[0]?.planId).toBeNull();
+
+		expect(insertMessageStats([reparsedStat])).toBe(1);
+		const matching = getRecentRequests(10).filter(request => request.entryId === "resynced-assistant");
+		expect(matching).toHaveLength(1);
+		expect(matching[0]?.thinkingLevel).toBe("high");
+		expect(matching[0]?.planId).toBe("anthropic:5h");
+	});
+});


### PR DESCRIPTION
## Summary
- add nullable `thinking_level` and `plan_id` fields to stats messages, with migration/backfill for existing parsed sessions
- parse `thinking_level_change` events and copy request-time `planId` metadata into stats rows
- persist cached active plan attribution on assistant session entries without fetching in the hot path

## Verification
- `bun test packages/stats/test/message-metadata.test.ts packages/ai/test/auth-storage-usage-history.test.ts`
- `bun run check` in `packages/stats`
- `bun run check` in `packages/ai`
- `bun run check` in `packages/agent`
- `bun run check` in `packages/coding-agent`

Closes #3618