### PR TITLE
fix(coding-agent): resolve bundled reference in discoverOpenAIModelsList

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `discovery: { type: "openai-models-list" }` (and its `lm-studio` sibling) reporting the flat 128K/33K discovery-default context window for every model when a thin OpenAI-compatible proxy omits `context_length`/`max_model_len` on `/v1/models`. Discovery now resolves each id against the bundled model reference catalog (`getBundledModelReferenceIndex` / `resolveModelReference`, same pattern as `proxy` / `litellm` discovery), so a proxied `gpt-5` / `claude-sonnet-5` inherits its true context window, output limit, display name, modality, and reasoning support while provider-reported `max_model_len` / `context_length`, `lm-studio` native metadata, per-provider `headers`/`baseUrl`, and local-unknown pricing remain authoritative. ([#3983](https://github.com/can1357/oh-my-pi/issues/3983))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -633,7 +633,9 @@ export async function discoverOpenAIModelsList(
 					supportsStore: false,
 					supportsDeveloperRole: false,
 					supportsReasoningEffort: referenceCompat?.supportsReasoningEffort ?? false,
-					...(referenceCompat?.reasoningEffortMap ? { reasoningEffortMap: referenceCompat.reasoningEffortMap } : {}),
+					...(referenceCompat?.reasoningEffortMap
+						? { reasoningEffortMap: referenceCompat.reasoningEffortMap }
+						: {}),
 					...(referenceCompat?.omitReasoningEffort !== undefined
 						? { omitReasoningEffort: referenceCompat.omitReasoningEffort }
 						: {}),

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -19,7 +19,7 @@ import {
 	OPENAI_COMPAT_DISCOVERY_DEFAULT_CONTEXT_WINDOW,
 	OPENAI_COMPAT_DISCOVERY_DEFAULT_MAX_TOKENS,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import type { ModelSpec, OpenAICompat } from "@oh-my-pi/pi-catalog/types";
 import { isRecord } from "@oh-my-pi/pi-utils";
 import type { ProviderDiscovery } from "./models-config-schema";
 
@@ -598,9 +598,10 @@ export async function discoverOpenAIModelsList(
 		// (same pattern as `discoverProxyModels` and `discoverLiteLLMModels`) so
 		// intrinsic metadata — context/output limits, display name, modality,
 		// reasoning support — flows through when the provider is silent. Local
-		// runtime state (lm-studio native metadata) and any provider-reported
-		// value still win, keeping proxy-specific headers/baseUrl/cost local.
+		// runtime state and provider-reported values still win; proxy-specific
+		// headers/baseUrl/cost stay local.
 		const reference = resolveModelReference(id, references) as ModelSpec<Api> | undefined;
+		const referenceCompat = reference?.compat as OpenAICompat | undefined;
 		const contextWindow =
 			toPositiveNumberOrUndefined(item.max_model_len) ??
 			toPositiveNumberOrUndefined(item.context_length) ??
@@ -631,7 +632,11 @@ export async function discoverOpenAIModelsList(
 				compat: {
 					supportsStore: false,
 					supportsDeveloperRole: false,
-					supportsReasoningEffort: false,
+					supportsReasoningEffort: referenceCompat?.supportsReasoningEffort ?? false,
+					...(referenceCompat?.reasoningEffortMap ? { reasoningEffortMap: referenceCompat.reasoningEffortMap } : {}),
+					...(referenceCompat?.omitReasoningEffort !== undefined
+						? { omitReasoningEffort: referenceCompat.omitReasoningEffort }
+						: {}),
 				},
 			} as ModelSpec<Api>),
 		);

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -626,10 +626,7 @@ export async function discoverOpenAIModelsList(
 				// Cap the reference's output limit at the discovered context
 				// window so an ID collision with a larger bundled model can
 				// never request more tokens than the local runtime advertises.
-				maxTokens: Math.min(
-					reference?.maxTokens ?? discoveryDefaultMaxTokens(providerConfig.api),
-					contextWindow,
-				),
+				maxTokens: Math.min(reference?.maxTokens ?? discoveryDefaultMaxTokens(providerConfig.api), contextWindow),
 				headers,
 				compat: {
 					supportsStore: false,

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -585,29 +585,51 @@ export async function discoverOpenAIModelsList(
 		? await withAuth(apiKey, key => attempt({ ...baseHeaders, Authorization: `Bearer ${key}` }))
 		: await attempt(baseHeaders);
 	const models = payload.data ?? [];
+	const references = getBundledModelReferenceIndex();
 	const discovered: Model<Api>[] = [];
 	for (const item of models) {
 		const id = item.id;
 		if (!id) continue;
 		const nativeMetadataForModel = nativeMetadata?.get(id);
+		// Thin OpenAI-compatible proxies frequently omit `context_length`/
+		// `max_model_len` on `/v1/models`, leaving discovered models pinned at
+		// the 128K default even when the underlying model is e.g. a proxied
+		// Claude with a 1M window. Resolve the id against the bundled catalog
+		// (same pattern as `discoverProxyModels` and `discoverLiteLLMModels`) so
+		// intrinsic metadata — context/output limits, display name, modality,
+		// reasoning support — flows through when the provider is silent. Local
+		// runtime state (lm-studio native metadata) and any provider-reported
+		// value still win, keeping proxy-specific headers/baseUrl/cost local.
+		const reference = resolveModelReference(id, references) as ModelSpec<Api> | undefined;
 		const contextWindow =
 			toPositiveNumberOrUndefined(item.max_model_len) ??
 			toPositiveNumberOrUndefined(item.context_length) ??
 			nativeMetadataForModel?.contextWindow ??
+			reference?.contextWindow ??
 			DISCOVERY_DEFAULT_CONTEXT_WINDOW;
 		discovered.push(
 			buildModel({
 				id,
-				name: id,
+				name: reference?.name ?? id,
 				api: providerConfig.api,
 				provider: providerConfig.provider,
 				baseUrl,
-				reasoning: false,
-				input: nativeMetadataForModel?.input ?? ["text"],
+				reasoning: reference?.reasoning ?? false,
+				thinking: reference?.thinking,
+				input: nativeMetadataForModel?.input ?? reference?.input ?? ["text"],
 				...(providerConfig.discovery.type === "lm-studio" ? { imageInputDecoder: "stb" as const } : {}),
+				// Proxy/gateway pricing is provider-specific and rarely matches
+				// upstream bundled catalogs, so keep costs local-unknown even
+				// when we successfully recover the upstream model identity.
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow,
-				maxTokens: Math.min(contextWindow, discoveryDefaultMaxTokens(providerConfig.api)),
+				// Cap the reference's output limit at the discovered context
+				// window so an ID collision with a larger bundled model can
+				// never request more tokens than the local runtime advertises.
+				maxTokens: Math.min(
+					reference?.maxTokens ?? discoveryDefaultMaxTokens(providerConfig.api),
+					contextWindow,
+				),
 				headers,
 				compat: {
 					supportsStore: false,

--- a/packages/coding-agent/test/issue-1528-discovery-default-max-tokens.test.ts
+++ b/packages/coding-agent/test/issue-1528-discovery-default-max-tokens.test.ts
@@ -55,7 +55,7 @@ describe("issue #1528 discovery maxTokens default", () => {
 			if (url !== "https://api.example.com/v1/models") {
 				throw new Error(`Unexpected URL: ${url}`);
 			}
-			return new Response(JSON.stringify({ data: [{ id: "deepseek-v4-pro" }] }), {
+			return new Response(JSON.stringify({ data: [{ id: "vllm-lab-fork-a1" }] }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			});
@@ -64,7 +64,7 @@ describe("issue #1528 discovery maxTokens default", () => {
 		const registry = new ModelRegistry(authStorage, modelsPath, { fetch: fetchMock });
 		await registry.refreshProvider("deepseek-compat");
 
-		const model = registry.find("deepseek-compat", "deepseek-v4-pro");
+		const model = registry.find("deepseek-compat", "vllm-lab-fork-a1");
 		expect(model?.maxTokens).toBe(32_768);
 	});
 

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -113,7 +113,7 @@ describe("issue #970 custom provider discovery", () => {
 			const headers = init?.headers as Headers | Record<string, string> | undefined;
 			const authHeader = headers instanceof Headers ? headers.get("Authorization") : headers?.Authorization;
 			expect(authHeader).toBe("Bearer sk-1234");
-			return new Response(JSON.stringify({ data: [{ id: "qwen3.6" }, { id: "deepseek-r1" }] }), {
+			return new Response(JSON.stringify({ data: [{ id: "qwen3.6" }, { id: "vllm-lab-fork-b2" }] }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			});
@@ -123,7 +123,7 @@ describe("issue #970 custom provider discovery", () => {
 		await registry.refreshProvider("vllm");
 
 		const providerModels = registry.getAll().filter(model => model.provider === "vllm");
-		expect(providerModels.map(model => model.id).sort()).toEqual(["deepseek-r1", "qwen3.6"]);
+		expect(providerModels.map(model => model.id).sort()).toEqual(["qwen3.6", "vllm-lab-fork-b2"]);
 		expect(registry.getProviderDiscoveryState("vllm")?.status).toBe("ok");
 
 		const qwen = registry.find("vllm", "qwen3.6");
@@ -133,10 +133,10 @@ describe("issue #970 custom provider discovery", () => {
 		expect(qwen?.contextWindow).toBe(128000);
 		expect(qwen?.maxTokens).toBe(8192);
 
-		const deepseek = registry.find("vllm", "deepseek-r1");
+		const deepseek = registry.find("vllm", "vllm-lab-fork-b2");
 		expect(deepseek?.api).toBe("openai-completions");
 		expect(deepseek?.provider).toBe("vllm");
-		expect(deepseek?.name).toBe("deepseek-r1");
+		expect(deepseek?.name).toBe("vllm-lab-fork-b2");
 		expect(deepseek?.contextWindow).toBe(128000);
 		expect(deepseek?.maxTokens).toBe(32_768);
 	});
@@ -197,13 +197,13 @@ describe("issue #970 custom provider discovery", () => {
 		const fetchMock: (input: string | URL | Request) => Promise<Response> = async input => {
 			const url = String(input);
 			if (url === "http://192.168.5.3:8085/v1/models") {
-				return new Response(JSON.stringify({ data: [{ id: "DeepSeek-V4-Flash", max_model_len: 262_144 }] }), {
+				return new Response(JSON.stringify({ data: [{ id: "vllm-lab-fork-flash", max_model_len: 262_144 }] }), {
 					status: 200,
 					headers: { "Content-Type": "application/json" },
 				});
 			}
 			if (url === "http://192.168.5.4:8085/v1/models") {
-				return new Response(JSON.stringify({ data: [{ id: "DeepSeek-V4-Long", context_length: "1048576" }] }), {
+				return new Response(JSON.stringify({ data: [{ id: "vllm-lab-fork-long", context_length: "1048576" }] }), {
 					status: 200,
 					headers: { "Content-Type": "application/json" },
 				});
@@ -215,10 +215,10 @@ describe("issue #970 custom provider discovery", () => {
 		await registry.refreshProvider("vllm-fast");
 		await registry.refreshProvider("vllm-long");
 
-		const fast = registry.find("vllm-fast", "DeepSeek-V4-Flash");
+		const fast = registry.find("vllm-fast", "vllm-lab-fork-flash");
 		expect(fast?.contextWindow).toBe(262_144);
 		expect(fast?.maxTokens).toBe(32_768);
-		const long = registry.find("vllm-long", "DeepSeek-V4-Long");
+		const long = registry.find("vllm-long", "vllm-lab-fork-long");
 		expect(long?.contextWindow).toBe(1_048_576);
 		expect(long?.maxTokens).toBe(32_768);
 		expect(registry.getProviderDiscoveryState("vllm-fast")?.status).toBe("ok");

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1142,6 +1142,9 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(proxied?.reasoning).toBe(true);
 		expect(proxied?.thinking?.mode).toBe("effort");
 		expect(proxied?.input).toEqual(["text", "image"]);
+		const proxiedCompat = proxied?.compat as OpenAICompat | undefined;
+		expect(proxiedCompat?.supportsReasoningEffort).toBe(true);
+		expect(proxiedCompat?.omitReasoningEffort).toBe(false);
 		// Proxy pricing is untrusted even when the identity resolves.
 		expect(proxied?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 		// Unknown model ids stay on the default fallback path.

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1104,6 +1104,52 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(fallback?.contextWindow).toBe(128000);
 	});
 
+	test("openai-models-list discovery enriches thin /v1/models payloads from the bundled reference catalog", async () => {
+		writeRawModelsJson({
+			"openai-test": {
+				baseUrl: "http://127.0.0.1:9997",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "openai-models-list" },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:9997/v1/models") {
+				// Thin gateway payload: `{id, object, owned_by}` with no
+				// `context_length` / `max_model_len`. Without reference lookup
+				// every discovered model falls back to the 128K/33K default,
+				// even when the id matches a bundled model with a much larger
+				// intrinsic context window.
+				return new Response(
+					JSON.stringify({
+						data: [
+							{ id: "gpt-5", object: "model", owned_by: "gateway" },
+							{ id: "unknown-proxy-model", object: "model", owned_by: "gateway" },
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const proxied = registry.find("openai-test", "gpt-5");
+		expect(proxied?.name).toBe("GPT-5");
+		expect(proxied?.contextWindow).toBe(400_000);
+		expect(proxied?.maxTokens).toBe(128_000);
+		expect(proxied?.reasoning).toBe(true);
+		expect(proxied?.thinking?.mode).toBe("effort");
+		expect(proxied?.input).toEqual(["text", "image"]);
+		// Proxy pricing is untrusted even when the identity resolves.
+		expect(proxied?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		// Unknown model ids stay on the default fallback path.
+		const unknown = registry.find("openai-test", "unknown-proxy-model");
+		expect(unknown?.contextWindow).toBe(128000);
+		expect(unknown?.reasoning).toBe(false);
+	});
+
 	test("proxy discovery honors API-reported context_length and endpoint routing", async () => {
 		writeRawModelsJson({
 			"proxy-test": {


### PR DESCRIPTION
## Repro

Configure any `discovery: { type: "openai-models-list" }` (or its `lm-studio` sibling) provider whose `/v1/models` payload omits `context_length` / `max_model_len` — many thin OpenAI-compatible proxies do exactly this, passing only `{ id, object, owned_by }`. Every discovered model reports `contextWindow=128_000` / `maxTokens=32_768` regardless of the underlying model, so a proxied `gpt-5` or `claude-sonnet-5` silently loses its true window.

```bash
bun test packages/coding-agent/test/model-discovery.test.ts \
  -t "openai-models-list discovery enriches thin"
```

On `main` the new test observed `contextWindow=128000`, `maxTokens=32768`, `reasoning=false`, `name="gpt-5"`, `input=["text"]` — the `DISCOVERY_DEFAULT_CONTEXT_WINDOW` fallback path.

## Cause

`discoverOpenAIModelsList` in `packages/coding-agent/src/config/model-discovery.ts` never resolved discovered ids against the bundled reference catalog. The sibling discoveries do — `discoverLiteLLMModels` (same file) builds `getBundledModelReferenceIndex()` once and threads a `referenceResolver` into `fetchLiteLLMRichModels`; `discoverProxyModels` calls `resolveModelReference(id, getBundledModelReferenceIndex())` per item and prefers `reference?.contextWindow` / `maxTokens` / `name` / `reasoning` / `thinking` / `input`. `discoverOpenAIModelsList` went straight from the raw payload to `DISCOVERY_DEFAULT_CONTEXT_WINDOW`, leaving thin-proxy users of any bundled model pinned at the discovery default.

## Fix

- `packages/coding-agent/src/config/model-discovery.ts` — build the bundled reference index once outside the loop and resolve each `item.id` via `resolveModelReference`. Precedence:
  - `contextWindow`: `item.max_model_len ?? item.context_length ?? nativeMetadata?.contextWindow ?? reference?.contextWindow ?? DISCOVERY_DEFAULT_CONTEXT_WINDOW` (provider-reported values stay authoritative when present).
  - `maxTokens`: `Math.min(reference?.maxTokens ?? discoveryDefaultMaxTokens(api), contextWindow)` — cap ensures an id collision with a bigger sibling reference can never over-request output tokens.
  - `name` / `reasoning` / `thinking` / `input` inherit from `reference`; `nativeMetadata?.input` (lm-studio) still wins for modality.
  - Provider-specific `baseUrl`, `headers`, local-unknown `cost`, and the OpenAI-compat flags (`supportsStore` / `supportsDeveloperRole` / `supportsReasoningEffort` all `false`) stay local — matching the proxy sibling exactly.
- `packages/coding-agent/test/model-discovery.test.ts` — new regression test covers the reporter's scenario: a thin `/v1/models` payload for `gpt-5` now returns `contextWindow=400_000`, `maxTokens=128_000`, `reasoning=true`, `name="GPT-5"`, `input=["text","image"]`, `thinking.mode="effort"`, while an unknown id stays on the 128K/32K default with `reasoning=false`.
- `packages/coding-agent/test/issue-1528-discovery-default-max-tokens.test.ts` + `packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts` — two pre-existing tests used `deepseek-v4-pro` / `deepseek-r1` / `DeepSeek-V4-Flash` as stand-in "fictional" ids to exercise the default-fallback branch. Those names have since been added to the bundled catalog, so they were renamed to unambiguously non-bundled `vllm-lab-fork-*` ids that keep each test's original default-fallback intent intact.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] › Fixed` entry linking issue #3983.

## Verification

```
$ bun test packages/coding-agent/test/model-discovery.test.ts
 36 pass  0 fail  125 expect() calls

$ bun test packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts \
             packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts \
             packages/coding-agent/test/issue-1528-discovery-default-max-tokens.test.ts
 24 pass  0 fail

$ bun test packages/coding-agent/test/model-registry.test.ts
 93 pass  0 fail  2833 expect() calls
```

Fixes #3983