### PR TITLE
feat(coding-agent): opt-in Markdown read previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the opt-in `read.renderMarkdown` setting for formatted Markdown read previews, disabled by default.
+
+### Fixed
+
+- Fixed Markdown file read metadata so the opt-in Markdown preview renderer can recognize local and URI-backed Markdown files consistently.
+
 ## [16.2.9] - 2026-06-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2923,6 +2923,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"read.renderMarkdown": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "files",
+			group: "Reading",
+			label: "Markdown Previews",
+			description: "Render Markdown read results as formatted terminal Markdown previews instead of raw source",
+		},
+	},
+
 	"read.summarize.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { AgentRegistry } from "../registry/agent-registry";
+import { isMarkdownPath } from "../utils/lang-from-path";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { parseInternalUrl } from "./parse";
 import { validateRelativePath } from "./skill-protocol";
@@ -43,8 +44,8 @@ function shortLocalRoot(options: LocalProtocolOptions): string {
 }
 
 function getContentType(filePath: string): InternalResource["contentType"] {
+	if (isMarkdownPath(filePath)) return "text/markdown";
 	const ext = path.extname(filePath).toLowerCase();
-	if (ext === ".md") return "text/markdown";
 	if (ext === ".json") return "application/json";
 	return "text/plain";
 }

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { getMemoryRoot } from "../memories";
 import { AgentRegistry } from "../registry/agent-registry";
+import { isMarkdownPath } from "../utils/lang-from-path";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
@@ -111,8 +112,7 @@ async function tryResolveInRoot(url: InternalUrl, memoryRoot: string): Promise<I
 	}
 
 	const content = await Bun.file(realTargetPath).text();
-	const ext = path.extname(realTargetPath).toLowerCase();
-	const contentType: InternalResource["contentType"] = ext === ".md" ? "text/markdown" : "text/plain";
+	const contentType: InternalResource["contentType"] = isMarkdownPath(realTargetPath) ? "text/markdown" : "text/plain";
 
 	return {
 		url: url.href,

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -12,12 +12,12 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { getActiveSkills } from "../extensibility/skills";
+import { isMarkdownPath } from "../utils/lang-from-path";
 import { buildDirectoryResource } from "./filesystem-resource";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 function getContentType(filePath: string): InternalResource["contentType"] {
-	const ext = path.extname(filePath).toLowerCase();
-	if (ext === ".md") return "text/markdown";
+	if (isMarkdownPath(filePath)) return "text/markdown";
 	return "text/plain";
 }
 

--- a/packages/coding-agent/src/internal-urls/ssh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/ssh-protocol.ts
@@ -30,6 +30,7 @@ import {
 	statRemotePath,
 	writeRemoteFile,
 } from "../ssh/file-transfer";
+import { isMarkdownPath } from "../utils/lang-from-path";
 import type {
 	InternalResource,
 	InternalUrl,
@@ -44,11 +45,11 @@ const SSH_TEXT_MAX_BYTES = 1024 * 1024;
 
 /** POSIX-aware content type from the last path segment's extension. */
 function contentTypeFor(remotePath: string): InternalResource["contentType"] {
+	if (isMarkdownPath(remotePath)) return "text/markdown";
 	const slash = remotePath.lastIndexOf("/");
 	const base = slash === -1 ? remotePath : remotePath.slice(slash + 1);
 	const dot = base.lastIndexOf(".");
 	const ext = dot <= 0 ? "" : base.slice(dot).toLowerCase();
-	if (ext === ".md") return "text/markdown";
 	if (ext === ".json") return "application/json";
 	return "text/plain";
 }

--- a/packages/coding-agent/src/internal-urls/vault-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/vault-protocol.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { $which, isEnoent } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
+import { isMarkdownPath } from "../utils/lang-from-path";
 import { parseInternalUrl } from "./parse";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, WriteContext } from "./types";
@@ -114,8 +115,8 @@ function toVaultValidationError(error: unknown): Error {
 }
 
 function getContentType(filePath: string): ContentType {
+	if (isMarkdownPath(filePath)) return "text/markdown";
 	const ext = path.extname(filePath).toLowerCase();
-	if (ext === ".md") return "text/markdown";
 	if (ext === ".json") return "application/json";
 	return "text/plain";
 }

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -20,7 +20,7 @@ import { defaultThemes } from "./defaults";
 import lightThemeJson from "./light.json" with { type: "json" };
 import { resolveMermaidAscii } from "./mermaid-cache";
 
-export { getLanguageFromPath } from "../../utils/lang-from-path";
+export { getLanguageFromPath, isMarkdownPath } from "../../utils/lang-from-path";
 
 // ============================================================================
 // Symbol Presets

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -25,6 +25,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { LRUCache } from "lru-cache/raw";
+import { isSettingsInitialized, settings } from "../config/settings";
 import {
 	canonicalSnapshotKey,
 	getFileSnapshotStore,
@@ -39,7 +40,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { InternalUrlRouter, resolveLocalUrlToFile } from "../internal-urls";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
-import { getLanguageFromPath, type Theme } from "../modes/theme/theme";
+import { getLanguageFromPath, isMarkdownPath, type Theme } from "../modes/theme/theme";
 import readDescription from "../prompts/tools/read.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
 import {
@@ -157,7 +158,16 @@ const MAX_SUMMARY_LINES = 20_000;
  * on disk is unchanged. Shared with the streaming sink path so one setting
  * covers `bash`/`ssh`/`python`/`js eval` and `read` uniformly.
  */
-const PROSE_SUMMARY_EXTENSIONS = new Set([".md", ".txt"]);
+const PROSE_SUMMARY_EXTENSIONS = new Set([".txt"]);
+
+function isMarkdownContentPath(filePath: string): boolean {
+	return isMarkdownPath(filePath);
+}
+
+function isProseSummaryPath(filePath: string): boolean {
+	return isMarkdownContentPath(filePath) || PROSE_SUMMARY_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
 // Remote mount path prefix (sshfs mounts) - skip fuzzy matching to avoid hangs
 const REMOTE_MOUNT_PREFIX = getRemoteDir() + path.sep;
 
@@ -750,6 +760,13 @@ export interface ReadToolDetails {
 	conflictCount?: number;
 	/** Paths recovered from a delimited read argument; used only by the TUI to render one call as multiple read rows. */
 	displayReadTargets?: string[];
+}
+
+function markMarkdownContentType(details: ReadToolDetails, filePath: string): ReadToolDetails {
+	if (!details.contentType && isMarkdownContentPath(filePath)) {
+		details.contentType = "text/markdown";
+	}
+	return details;
 }
 
 type ReadParams = ReadToolInput;
@@ -1526,7 +1543,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			try {
 				const bridgeText = await bridgePromise;
 				const bridgeResult = this.#buildInMemoryMultiRangeResult(bridgeText, ranges, {
-					details: { resolvedPath: absolutePath, suffixResolution },
+					details: markMarkdownContentType({ resolvedPath: absolutePath, suffixResolution }, absolutePath),
 					sourcePath: absolutePath,
 					entityLabel: "file",
 					raw: rawSelector,
@@ -1702,10 +1719,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const archive = await openArchive(resolvedArchivePath.absolutePath);
 		throwIfAborted(signal);
 
-		const details: ReadToolDetails = {
-			resolvedPath: resolvedArchivePath.absolutePath,
-			suffixResolution: resolvedArchivePath.suffixResolution,
-		};
+		const details: ReadToolDetails = markMarkdownContentType(
+			{
+				resolvedPath: resolvedArchivePath.absolutePath,
+				suffixResolution: resolvedArchivePath.suffixResolution,
+			},
+			resolvedArchivePath.archiveSubPath,
+		);
 
 		let archiveSubPath = resolvedArchivePath.archiveSubPath;
 		let sel = parsedSel;
@@ -2304,14 +2324,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				// because only `truncateHead` was being applied.
 				if (isMultiRange(parsed) && parsed.kind === "lines") {
 					return this.#buildInMemoryMultiRangeResult(renderedContent, parsed.ranges, {
-						details: { resolvedPath: absolutePath },
+						details: { resolvedPath: absolutePath, contentType: "text/markdown" },
 						sourcePath: absolutePath,
 						entityLabel: "document",
 					});
 				}
 				const { offset, limit } = selToOffsetLimit(parsed);
 				return this.#buildInMemoryTextResult(renderedContent, offset, limit, {
-					details: { resolvedPath: absolutePath },
+					details: { resolvedPath: absolutePath, contentType: "text/markdown" },
 					sourcePath: absolutePath,
 					entityLabel: "document",
 					raw: isRawSelector(parsed),
@@ -2344,7 +2364,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (
 				parsed.kind === "none" &&
 				this.session.settings.get("read.summarize.enabled") &&
-				(this.session.settings.get("read.summarize.prose") || !PROSE_SUMMARY_EXTENSIONS.has(ext))
+				(this.session.settings.get("read.summarize.prose") || !isProseSummaryPath(absolutePath))
 			) {
 				const summary = await this.#trySummarize(absolutePath, fileSize, signal);
 				if (summary?.parsed && summary.elided) {
@@ -2404,7 +2424,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						try {
 							const bridgeText = await bridgePromise;
 							const bridgeResult = this.#buildInMemoryTextResult(bridgeText, offset, limit, {
-								details: { resolvedPath: absolutePath, suffixResolution },
+								details: markMarkdownContentType(
+									{ resolvedPath: absolutePath, suffixResolution },
+									absolutePath,
+								),
 								sourcePath: absolutePath,
 								entityLabel: "file",
 								raw: isRawSelector(parsed),
@@ -2691,6 +2714,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 		}
 
+		markMarkdownContentType(details, absolutePath);
 		if (suffixResolution) {
 			details.suffixResolution = suffixResolution;
 			// Inline resolution notice into first text block so the model sees the actual path
@@ -3216,7 +3240,8 @@ export const readToolRenderer = {
 			title += ` ${uiTheme.fg("warning", `(⚠ ${n} conflict${n === 1 ? "" : "s"})`)}`;
 		}
 		const rawRequested = args?.raw === true || isRawSelector(parseSel(renderPath.sel));
-		const isMarkdown = details?.contentType === "text/markdown" && !rawRequested;
+		const markdownPreviewEnabled = isSettingsInitialized() && settings.get("read.renderMarkdown");
+		const isMarkdown = markdownPreviewEnabled && details?.contentType === "text/markdown" && !rawRequested;
 		let cachedWidth: number | undefined;
 		let cachedExpanded: boolean | undefined;
 		let cachedLines: string[] | undefined;

--- a/packages/coding-agent/src/utils/lang-from-path.ts
+++ b/packages/coding-agent/src/utils/lang-from-path.ts
@@ -102,6 +102,9 @@ const EXTENSION_LANG: Record<string, readonly [string, string]> = {
 	md: ["markdown", "markdown"],
 	markdown: ["markdown", "markdown"],
 	mdx: ["markdown", "markdown"],
+	mdc: ["markdown", "markdown"],
+	mkd: ["markdown", "markdown"],
+	mdown: ["markdown", "markdown"],
 	rst: ["restructuredtext", "restructuredtext"],
 	adoc: ["asciidoc", "asciidoc"],
 	tex: ["latex", "latex"],
@@ -215,6 +218,10 @@ export function getLanguageFromPath(filePath: string): string | undefined {
 	if (pair) return pair[0];
 
 	return undefined;
+}
+
+export function isMarkdownPath(filePath: string): boolean {
+	return getLanguageFromPath(filePath) === "markdown";
 }
 
 /**

--- a/packages/coding-agent/test/read-summary.test.ts
+++ b/packages/coding-agent/test/read-summary.test.ts
@@ -100,6 +100,26 @@ describe("read summary", () => {
 		expect(proseResult.details?.summary?.elidedSpans).toBe(1);
 	});
 
+	it("marks local Markdown-like extensions as markdown while preserving model-facing source text", async () => {
+		const markdown = "# Heading\n\nSome **bold** text.\n";
+		const extensions = ["md", "markdown", "mdx", "mdc", "mkd", "mdown"] as const;
+		const tool = new ReadTool(createSession(tmpDir));
+
+		for (const extension of extensions) {
+			const fixture = path.join(tmpDir, `fixture.${extension}`);
+			await fs.writeFile(fixture, markdown);
+
+			const result = await tool.execute(`read-summary-markdown-${extension}`, { path: fixture });
+			const text = textOutput(result);
+
+			expect(result.details?.contentType).toBe("text/markdown");
+			expect(result.details?.displayContent?.text).toBe(markdown);
+			expect(text.split("\n")[0]).toMatch(new RegExp(`^\\[fixture\\.${extension}#[0-9A-F]{4}\\]$`));
+			expect(text).toContain("1:# Heading");
+			expect(text).toContain("3:Some **bold** text.");
+		}
+	});
+
 	it("does not truncate summarized output", async () => {
 		const fixture = path.join(tmpDir, "many.ts");
 		const source = Array.from(

--- a/packages/coding-agent/test/tools/read-renderer.test.ts
+++ b/packages/coding-agent/test/tools/read-renderer.test.ts
@@ -25,6 +25,7 @@ beforeAll(async () => {
 
 afterEach(() => {
 	settings.clearOverride("tui.hyperlinks");
+	settings.clearOverride("read.renderMarkdown");
 });
 
 afterAll(() => {
@@ -109,6 +110,87 @@ describe("readToolRenderer hyperlinks", () => {
 		const rendered = component.render(200).join("\n");
 		expect(rendered).toContain("example.com /final");
 		expect(extractLinkUris(rendered)).toContain("http://example.com/final");
+	});
+});
+
+describe("readToolRenderer markdown content", () => {
+	it("keeps text/markdown details raw unless markdown rendering is enabled", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "[notes.md#ABCD]\n1:# Heading\n2:\n3:This is **bold** text." }],
+				details: {
+					displayContent: { text: "# Heading\n\nThis is **bold** text.", startLine: 1 },
+					contentType: "text/markdown",
+				},
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+			{ path: "notes.md" },
+		);
+
+		const stripped = component
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(stripped).toContain("# Heading");
+		expect(stripped).toContain("**bold**");
+	});
+
+	it("renders text/markdown details through the markdown renderer", async () => {
+		settings.override("read.renderMarkdown", true);
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "[notes.md#ABCD]\n1:# Heading\n2:\n3:This is **bold** text." }],
+				details: {
+					displayContent: { text: "# Heading\n\nThis is **bold** text.", startLine: 1 },
+					contentType: "text/markdown",
+				},
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+			{ path: "notes.md" },
+		);
+
+		const stripped = component
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(stripped).toContain("Heading");
+		expect(stripped).toContain("This is bold text.");
+		expect(stripped).not.toContain("# Heading");
+		expect(stripped).not.toContain("**bold**");
+	});
+
+	it("keeps raw markdown selector reads in the code renderer", async () => {
+		settings.override("read.renderMarkdown", true);
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "# Heading\n\nThis is **bold** text." }],
+				details: {
+					displayContent: { text: "# Heading\n\nThis is **bold** text.", startLine: 1 },
+					contentType: "text/markdown",
+				},
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+			{ path: "notes.md:raw" },
+		);
+
+		const stripped = component
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(stripped).toContain("# Heading");
+		expect(stripped).toContain("**bold**");
 	});
 });
 


### PR DESCRIPTION
## Summary

Adds an opt-in `read.renderMarkdown` setting (off by default) that renders Markdown **read-tool results** as formatted terminal Markdown previews (rendered headings, grid tables, styled code) instead of raw line-numbered source.

The model-facing read text is unchanged — Markdown files stay verbatim. Only the TUI rendering of the read-result card changes, and only when the setting is enabled.

## Changes

- **`read.renderMarkdown` setting** (`settings-schema.ts`, `read.ts`): gates the read-result renderer between the code cell (raw, line numbers) and the Markdown cell (rendered). Respects the `:raw` selector to force raw even when enabled.
- **Centralized Markdown detection** (`lang-from-path.ts`): new `isMarkdownPath()` covers `.md`, `.markdown`, `.mdx`, `.mdc`, `.mkd`, `.mdown`.
- **Uniform content-type tagging** across the read tool and all internal-URL protocols (`local`, `memory`, `skill`, `ssh`, `vault`): each now tags `contentType: "text/markdown"` via the shared helper instead of ad-hoc `ext === ".md"` checks, so the preview renderer recognizes Markdown consistently.

## Verification

- `read-summary.test.ts`, `read-renderer.test.ts` — 21 pass / 0 fail.
- New tests cover: Markdown extensions get `text/markdown` + verbatim source; default renders raw; `read.renderMarkdown` renders through the Markdown renderer; `:raw` selector bypasses rendering.
