### PR TITLE
fix(coding-agent): opt eval renderer out of partial-result commit ratchet

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed live agent-progress tree rendered below `eval` cells duplicating/overlapping rows in the TUI under heavy concurrent subagent fan-out ([#4004](https://github.com/can1357/oh-my-pi/issues/4004)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -775,4 +775,19 @@ export const evalToolRenderer = {
 	// below the first cell. Expanded output is top-anchored enough for the
 	// transcript to commit its settled prefix.
 	provisionalPendingPreview: "collapsed",
+	// `renderAgentProgressEvents` (see `renderResult` above) mutates the live
+	// agent-progress tree on nearly every tick — it inserts/removes each
+	// subagent's `currentTool` row as tool calls start/stop and ticks the
+	// status icon/stats/duration in place — while `options.isPartial` stays
+	// `true` for the whole eval cell (progress ticks never carry an `async`
+	// completed/failed state). Without this opt-out, the stable-prefix ratchet
+	// in `deriveLiveCommitState` promotes still-mutating agent rows into
+	// native scrollback (a "slow ticker"), and the renderer's committed-prefix
+	// resync then re-shows the frame tail under its "duplication, never loss"
+	// contract — producing the overlapping/duplicated progress rows the user
+	// reported. Same bug class as the SSH renderer opt-out
+	// ([#3177](https://github.com/can1357/oh-my-pi/issues/3177),
+	// [#3714](https://github.com/can1357/oh-my-pi/issues/3714),
+	// [#4004](https://github.com/can1357/oh-my-pi/issues/4004)).
+	provisionalPartialResult: true,
 };

--- a/packages/coding-agent/test/tools/eval-commit-stability.test.ts
+++ b/packages/coding-agent/test/tools/eval-commit-stability.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #4004: `evalToolRenderer.renderResult` mutates the live agent
+ * progress tree on nearly every tick — `renderAgentProgressEvents` inserts
+ * and removes each subagent's `currentTool` line as tool calls start/stop,
+ * and ticks status icons/stats/duration in place — while
+ * `options.isPartial === true` for the entire `eval()` cell (progress ticks
+ * never carry an `async` completed/failed state). Without the renderer's
+ * `provisionalPartialResult: true` opt-out, the block reports commit-stable
+ * during that churn: `deriveLiveCommitState` promotes still-mutating agent
+ * rows into native scrollback, and the renderer's committed-prefix resync
+ * duplicates the frame tail under its "duplication, never loss" contract —
+ * the overlapping/duplicated tree rows the user reported. Same bug class as
+ * #3177 / #3714 in the SSH renderer. Contract: while a partial eval result
+ * is in flight, the block reports commit-unstable so `deriveLiveCommitState`
+ * keeps its rows in the live region; once the cell settles it is
+ * commit-stable again.
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function makeEvalComponent() {
+	return new ToolExecutionComponent(
+		"eval",
+		{ language: "py", code: "print('hi')" },
+		{},
+		undefined,
+		uiStub,
+	);
+}
+
+function partialResult(text: string) {
+	return { content: [{ type: "text" as const, text }] };
+}
+
+describe("eval tool block commit stability", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("reports commit-unstable while an eval result is partial", () => {
+		const component = makeEvalComponent();
+		component.updateResult(partialResult("running…"), true);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(component.isTranscriptBlockCommitStable()).toBe(false);
+	});
+
+	it("flips commit-stable as soon as the eval result settles", () => {
+		const component = makeEvalComponent();
+		component.updateResult(partialResult("running…"), true);
+		expect(component.isTranscriptBlockCommitStable()).toBe(false);
+
+		component.updateResult(partialResult("done\n"), false);
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(component.isTranscriptBlockCommitStable()).toBe(true);
+	});
+
+	it("does not opt other foreground tools out of partial-result stream commits", () => {
+		// Sanity: bash and friends still get the existing `isPartial`
+		// commit-stable behaviour — the eval opt-in must be renderer-scoped.
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "ls" },
+			{},
+			undefined,
+			uiStub,
+		);
+		component.updateResult(partialResult("a\nb\n"), true);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(component.isTranscriptBlockCommitStable()).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tools/eval-commit-stability.test.ts
+++ b/packages/coding-agent/test/tools/eval-commit-stability.test.ts
@@ -24,13 +24,7 @@ import type { TUI } from "@oh-my-pi/pi-tui";
 const uiStub = { requestRender() {} } as unknown as TUI;
 
 function makeEvalComponent() {
-	return new ToolExecutionComponent(
-		"eval",
-		{ language: "py", code: "print('hi')" },
-		{},
-		undefined,
-		uiStub,
-	);
+	return new ToolExecutionComponent("eval", { language: "py", code: "print('hi')" }, {}, undefined, uiStub);
 }
 
 function partialResult(text: string) {
@@ -69,13 +63,7 @@ describe("eval tool block commit stability", () => {
 	it("does not opt other foreground tools out of partial-result stream commits", () => {
 		// Sanity: bash and friends still get the existing `isPartial`
 		// commit-stable behaviour — the eval opt-in must be renderer-scoped.
-		const component = new ToolExecutionComponent(
-			"bash",
-			{ command: "ls" },
-			{},
-			undefined,
-			uiStub,
-		);
+		const component = new ToolExecutionComponent("bash", { command: "ls" }, {}, undefined, uiStub);
 		component.updateResult(partialResult("a\nb\n"), true);
 
 		expect(component.isTranscriptBlockFinalized()).toBe(false);


### PR DESCRIPTION
## Repro

Under a heavy `parallel([...])` fan-out from an `eval` cell, subagents spawned via `agent(...)` render a live progress tree below the eval code-cell box. The tree visibly duplicates/overlaps rows, and the effect worsens with more concurrent subagents and longer-running tool calls per subagent.

Deterministic in-process repro (added as regression test):

```
cd packages/coding-agent && bun test test/tools/eval-commit-stability.test.ts
```

On `main`: two failures — `isTranscriptBlockCommitStable()` returns `true` while an eval result is still partial, both for the initial partial and for the partial→settled transition.

## Cause

`evalToolRenderer` (`packages/coding-agent/src/tools/eval-render.ts`) had no `provisionalPartialResult` opt-out. `renderAgentProgressEvents` mutates the live agent-progress tree on nearly every tick — it inserts/removes each subagent's `currentTool` row as tool calls start/stop, and ticks status icon/stats/duration in place — while `options.isPartial` stays `true` for the whole `eval()` cell (progress ticks never carry an `async` completed/failed state).

With no opt-out, `ToolExecutionComponent.isTranscriptBlockCommitStable()` (`packages/coding-agent/src/modes/components/tool-execution.ts:690-720`) reported the block commit-stable during that churn. `deriveLiveCommitState` (`transcript-container.ts`) then promoted still-mutating agent rows into native scrollback as a "slow ticker", and the renderer's committed-prefix resync in `packages/tui/src/tui.ts` repeatedly re-showed the frame tail under its "duplication, never loss" contract — producing the overlapping/duplicated rows.

Same bug class as [#3177](https://github.com/can1357/oh-my-pi/issues/3177) / [#3714](https://github.com/can1357/oh-my-pi/issues/3714) in the SSH renderer.

## Fix

- Set `provisionalPartialResult: true` on `evalToolRenderer` (`packages/coding-agent/src/tools/eval-render.ts`), mirroring `sshToolRenderer`.
- Add `test/tools/eval-commit-stability.test.ts` alongside `ssh-commit-stability.test.ts`: covers "partial → commit-unstable", "settled → commit-stable", and a bash sanity case to keep the opt-in renderer-scoped.
- Add a changelog entry under `packages/coding-agent/CHANGELOG.md` `## [Unreleased]` / `### Fixed`.

## Verification

```
cd packages/coding-agent && bun test test/tools/eval-commit-stability.test.ts test/tools/ssh-commit-stability.test.ts
# 9 pass, 0 fail
cd packages/coding-agent && bun test test/tools/eval-*.test.ts
# 31 pass, 0 fail
```

Fixes #4004