### PR TITLE
fix(natives): catch blocking task panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 strip = true
-# Unwind (not abort) so panics in vendored uutils code and napi-rs functions
-# are catchable: the uutils boundary (pi-shell coreutils) and napi-rs's per-call
-# catch_unwind turn a panic into a failed command / JS error instead of killing
-# the host process. Recoverable uutils panics are kept out of the crash report
-# by the crash hook (see crates/pi-natives/src/crash_handler.rs).
+# Unwind (not abort) so panics are catchable at explicit recovery boundaries:
+# the uutils boundary (pi-shell coreutils), guarded pi-natives blocking tasks,
+# and napi-rs's guarded async/future paths turn a panic into a failed command
+# or JS error instead of killing the host process. Recoverable uutils panics are
+# kept out of the crash report by the crash hook (see crates/pi-natives/src/crash_handler.rs).
 panic = "unwind"
 
 [profile.ci]

--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -8,11 +8,11 @@
 //! Without these hooks, Bun receives only the bare
 //! `memory allocation of N bytes failed` line and aborts with no stack —
 //! see issue #2211 ("Windows crash: Rust allocator failure after tasklist.exe
-//! popup"). The cdylib builds with `panic = "unwind"`, so a panic in vendored
-//! uutils code unwinds to the shell boundary and is recovered as a failed
-//! command; such recoverable panics are logged to disk only, while fatal
-//! crashes (allocation failure, or panics with no active uutils scope) still
-//! get the stderr dump + process exit. Either way the record stays diagnosable.
+//! popup"). The cdylib builds with `panic = "unwind"`, so panic boundaries that
+//! recover the unwind (vendored uutils commands and `task::blocking`) mark
+//! their scopes recoverable. Those panics are logged to disk only, while fatal
+//! crashes still get the stderr dump + process exit. Either way the record
+//! stays diagnosable.
 //!
 //! Notes:
 //! - Backtraces are captured via [`Backtrace::force_capture`], so they work
@@ -27,6 +27,7 @@
 use std::{
 	alloc::Layout,
 	backtrace::Backtrace,
+	cell::Cell,
 	ffi::OsStr,
 	fmt::Write as _,
 	fs::{self, OpenOptions},
@@ -52,6 +53,10 @@ const APP_NAME: &str = "omp";
 
 static INSTALL: Once = Once::new();
 static ALLOC_HOOK_ACTIVE: AtomicBool = AtomicBool::new(false);
+thread_local! {
+	/// Borrow-free count of active recoverable panic boundaries on this thread.
+	static RECOVERABLE_PANIC_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
 
 /// Install the panic and allocation-error hooks. Idempotent.
 pub fn install() {
@@ -59,12 +64,11 @@ pub fn install() {
 		let prev_panic = std::panic::take_hook();
 		std::panic::set_hook(Box::new(move |info| {
 			let report = format_panic_report(info);
-			// A panic raised while a uutils scope is active is caught at the
-			// uutils boundary (pi-shell `run_uutil`): the command fails with a
-			// non-zero exit instead of crashing the host. Record it to the log
-			// for diagnosis, but keep the recovered panic out of the user-facing
-			// stderr crash dump and skip the default abort hook.
-			let recoverable = pi_uutils_ctx::is_active();
+			// Panics raised inside known recovery boundaries are caught before they
+			// escape native code. Record them to the log for diagnosis, but keep
+			// recovered panics out of the user-facing stderr crash dump and skip the
+			// default abort hook.
+			let recoverable = is_recoverable_panic();
 			persist(&report, CrashKind::Panic, !recoverable);
 			if !recoverable {
 				prev_panic(info);
@@ -85,6 +89,25 @@ pub fn install() {
 			process::abort();
 		});
 	});
+}
+/// Marks panics from `f` as recoverable for the native panic hook.
+pub(crate) fn recoverable_panic_scope<R>(f: impl FnOnce() -> R) -> R {
+	struct Guard;
+	impl Drop for Guard {
+		fn drop(&mut self) {
+			RECOVERABLE_PANIC_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+		}
+	}
+
+	RECOVERABLE_PANIC_DEPTH.with(|d| d.set(d.get() + 1));
+	let _guard = Guard;
+	f()
+}
+
+/// Whether the current panic is expected to be caught before escaping native
+/// code.
+pub(crate) fn is_recoverable_panic() -> bool {
+	pi_uutils_ctx::is_active() || RECOVERABLE_PANIC_DEPTH.with(|d| d.get() > 0)
 }
 
 #[derive(Clone, Copy)]
@@ -170,8 +193,8 @@ fn panic_payload(payload: &(dyn std::any::Any + Send)) -> String {
 
 fn persist(report: &str, kind: CrashKind, echo_stderr: bool) {
 	// Echo to stderr so the user sees something even when the file write fails
-	// (read-only home, missing $HOME, …). Suppressed for recoverable uutils
-	// panics, which surface as a failed command instead of a crash.
+	// (read-only home, missing $HOME, …). Suppressed for recoverable panics that
+	// surface as command failures or rejected promises instead of crashes.
 	if echo_stderr {
 		let _ = writeln!(std::io::stderr(), "{report}");
 	}

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -36,7 +36,7 @@ use std::{
 use napi::{Env, Error, Result, Status, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
 
-use crate::prof::profile_region;
+use crate::{crash_handler::recoverable_panic_scope, prof::profile_region};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Cancellation
@@ -193,7 +193,9 @@ where
 			.work
 			.take()
 			.ok_or_else(|| Error::from_reason("BlockingTask: work already consumed"))?;
-		match catch_unwind(AssertUnwindSafe(|| work(self.cancel_token.clone()))) {
+		match recoverable_panic_scope(|| {
+			catch_unwind(AssertUnwindSafe(|| work(self.cancel_token.clone())))
+		}) {
 			Ok(result) => result,
 			Err(payload) => Err(panic_error(self.tag, payload)),
 		}
@@ -292,7 +294,10 @@ mod tests {
 		let mut task = Blocking::<String> {
 			tag:          "panic_test",
 			cancel_token: CancelToken::default(),
-			work:         Some(Box::new(|_| -> Result<String> { panic!("native boom") })),
+			work:         Some(Box::new(|_| -> Result<String> {
+				assert!(crate::crash_handler::is_recoverable_panic());
+				panic!("native boom")
+			})),
 		};
 
 		let err = Task::compute(&mut task).expect_err("panic should become a napi error");
@@ -300,5 +305,6 @@ mod tests {
 		assert_eq!(err.status, Status::GenericFailure);
 		assert!(err.reason.contains("panic_test"));
 		assert!(err.reason.contains("native boom"));
+		assert!(!crate::crash_handler::is_recoverable_panic());
 	}
 }

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -27,9 +27,13 @@
 //! }
 //! ```
 
-use std::future::Future;
+use std::{
+	any::Any,
+	future::Future,
+	panic::{AssertUnwindSafe, catch_unwind},
+};
 
-use napi::{Env, Error, Result, Task, bindgen_prelude::*};
+use napi::{Env, Error, Result, Status, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
 
 use crate::prof::profile_region;
@@ -159,6 +163,23 @@ where
 	work:         Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
 }
 
+fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+	if let Some(message) = payload.downcast_ref::<&str>() {
+		(*message).to_string()
+	} else if let Some(message) = payload.downcast_ref::<String>() {
+		message.clone()
+	} else {
+		"unknown panic payload".to_string()
+	}
+}
+
+fn panic_error(tag: &str, payload: Box<dyn Any + Send>) -> Error {
+	Error::new(
+		Status::GenericFailure,
+		format!("Blocking task {tag:?} panicked: {}", panic_payload_message(payload.as_ref())),
+	)
+}
+
 impl<T> Task for Blocking<T>
 where
 	T: ToNapiValue + Send + 'static + TypeName,
@@ -172,7 +193,10 @@ where
 			.work
 			.take()
 			.ok_or_else(|| Error::from_reason("BlockingTask: work already consumed"))?;
-		work(self.cancel_token.clone())
+		match catch_unwind(AssertUnwindSafe(|| work(self.cancel_token.clone()))) {
+			Ok(result) => result,
+			Err(payload) => Err(panic_error(self.tag, payload)),
+		}
 	}
 
 	fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -255,4 +279,26 @@ where
 		let _guard = profile_region(tag);
 		work.await
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use napi::Status;
+
+	use super::*;
+
+	#[test]
+	fn blocking_compute_maps_panic_to_generic_failure() {
+		let mut task = Blocking::<String> {
+			tag:          "panic_test",
+			cancel_token: CancelToken::default(),
+			work:         Some(Box::new(|_| -> Result<String> { panic!("native boom") })),
+		};
+
+		let err = Task::compute(&mut task).expect_err("panic should become a napi error");
+
+		assert_eq!(err.status, Status::GenericFailure);
+		assert!(err.reason.contains("panic_test"));
+		assert!(err.reason.contains("native boom"));
+	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native blocking task panics crossing the napi-rs async-work C callback boundary by converting them into `GenericFailure` Promise rejections ([#4006](https://github.com/can1357/oh-my-pi/issues/4006)).
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed


### PR DESCRIPTION
## Repro
A focused native regression constructs `Blocking::<String>` with a closure that panics and calls `Task::compute`; before the fix, `cargo test -p pi-natives task::tests::blocking_compute_maps_panic_to_generic_failure` failed with `native boom` escaping the closure instead of returning a `napi::Error`, matching the async-work path that napi-rs invokes from a plain `extern "C"` callback.

## Cause
`crates/pi-natives/src/task.rs::Blocking::compute` called the stored blocking closure directly and returned its `Result<T>`. For `AsyncTask<Blocking<T>>`, napi-rs runs `compute` from its libuv async-work callback, so a Rust panic could leave `compute` before any `napi::Error` existed and cross the non-`C-unwind` C ABI boundary.

## Fix
- Wrapped `Blocking::compute` closure execution in `std::panic::catch_unwind(AssertUnwindSafe(...))`.
- Converted panic payloads into `napi::Error::new(Status::GenericFailure, ...)` with the blocking task tag and panic message.
- Added a native regression test for panic-to-`GenericFailure` mapping.
- Scoped the workspace `panic = "unwind"` comment to explicit recovery boundaries instead of claiming all napi-rs calls are guarded.
- Added a `packages/natives` changelog entry.

## Verification
`cargo test -p pi-natives task::tests::blocking_compute_maps_panic_to_generic_failure` passed; `cargo test -p pi-natives` passed with 130 tests; `bun --cwd=packages/natives run build` completed; `bun test packages/natives/test/native.test.ts` passed with 47 tests; `bun --cwd=packages/natives run check` passed. Fixes #4006