### PR TITLE
fix(agent): preserve tool results in branch summarization input

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed branch summarization silently dropping every tool result before serialization, so facts learned only from `read`/`grep`/`bash` observations disappeared from abandoned-branch summaries. `getMessageFromEntry()` now keeps `toolResult` entries; downstream `serializeConversation()` already truncates each and drops entries flagged `useless` ([#4025](https://github.com/can1357/oh-my-pi/issues/4025)).
+
 ## [16.2.4] - 2026-06-28
 
 ### Changed

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -164,12 +164,17 @@ export function collectEntriesForBranchSummary(
 /**
  * Extract AgentMessage from a session entry.
  * Similar to getMessageFromEntry in compaction.ts but also handles compaction entries.
+ *
+ * Tool-result messages are kept: the assistant's tool call captures the
+ * request, but the observation from `read`/`grep`/`bash`/etc. lives in the
+ * result. `serializeConversation` already truncates each result to
+ * `TOOL_RESULT_MAX_CHARS` and drops entries flagged `useless`, so passing
+ * them through preserves the actual facts the abandoned branch learned
+ * without ballooning the summarizer prompt.
  */
 function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
 	switch (entry.type) {
 		case "message":
-			// Skip tool results - context is in assistant's tool call
-			if (entry.message.role === "toolResult") return undefined;
 			return entry.message;
 
 		case "custom_message":

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -5,7 +5,16 @@
  * a summary of the branch being left so context isn't lost.
  */
 
-import type { Api, ApiKey, AssistantMessage, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
+import type {
+	Api,
+	ApiKey,
+	AssistantMessage,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	TextContent,
+	ToolResultMessage,
+} from "@oh-my-pi/pi-ai";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
@@ -29,6 +38,8 @@ import {
 	SUMMARIZATION_SYSTEM_PROMPT,
 	serializeConversation,
 	stripReadSelector,
+	TOOL_RESULT_MAX_CHARS,
+	truncateForSummary,
 	upsertFileOperations,
 } from "./utils";
 
@@ -167,10 +178,9 @@ export function collectEntriesForBranchSummary(
  *
  * Tool-result messages are kept: the assistant's tool call captures the
  * request, but the observation from `read`/`grep`/`bash`/etc. lives in the
- * result. `serializeConversation` already truncates each result to
- * `TOOL_RESULT_MAX_CHARS` and drops entries flagged `useless`, so passing
- * them through preserves the actual facts the abandoned branch learned
- * without ballooning the summarizer prompt.
+ * result. Budgeting uses the same per-result truncation applied by
+ * `serializeConversation`, so a large observation is not dropped before it can
+ * be reduced to the prompt-safe form that the summarizer actually receives.
  */
 function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
 	switch (entry.type) {
@@ -205,6 +215,33 @@ function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
 		case "mode_change":
 			return undefined;
 	}
+}
+
+function isTextContent(block: ToolResultMessage["content"][number]): block is TextContent {
+	return block.type === "text";
+}
+
+function summaryBudgetToolResultText(message: ToolResultMessage): string {
+	const text = message.content
+		.filter(isTextContent)
+		.map(block => block.text)
+		.join("");
+	if (text) return truncateForSummary(text, TOOL_RESULT_MAX_CHARS);
+	if (message.prunedAt !== undefined) return "[Output truncated]";
+	return "";
+}
+
+function estimateBranchSummaryTokens(message: AgentMessage): number {
+	if (message.role !== "toolResult") return estimateTokens(message);
+	if (message.useless === true && message.isError !== true) return 0;
+
+	const text = summaryBudgetToolResultText(message);
+	if (!text) return 0;
+
+	return estimateTokens({
+		...message,
+		content: [{ type: "text", text }],
+	});
 }
 
 /**
@@ -252,7 +289,7 @@ export function prepareBranchEntries(entries: SessionEntry[], tokenBudget: numbe
 		// Extract file ops from assistant messages (tool calls)
 		extractFileOpsFromMessage(message, fileOps);
 
-		const tokens = estimateTokens(message);
+		const tokens = estimateBranchSummaryTokens(message);
 
 		// Check budget before adding
 		if (tokenBudget > 0 && totalTokens + tokens > tokenBudget) {

--- a/packages/agent/src/compaction/utils.ts
+++ b/packages/agent/src/compaction/utils.ts
@@ -196,13 +196,13 @@ export function upsertFileOperations(
 // ============================================================================
 
 /** Maximum characters for a tool result in serialized summaries. */
-const TOOL_RESULT_MAX_CHARS = 2000;
+export const TOOL_RESULT_MAX_CHARS = 2000;
 
 /**
  * Truncate text to a maximum character length for summarization.
  * Keeps the beginning and appends a truncation marker.
  */
-function truncateForSummary(text: string, maxChars: number): string {
+export function truncateForSummary(text: string, maxChars: number): string {
 	if (text.length <= maxChars) return text;
 	const truncatedChars = text.length - maxChars;
 	return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;

--- a/packages/agent/test/branch-summarization.test.ts
+++ b/packages/agent/test/branch-summarization.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for #4025: branch summaries dropped every `toolResult`
+ * before serialization, so facts learned only from `read`/`grep`/`bash`
+ * observations disappeared from the abandoned-branch summary. The pre-filter
+ * in `getMessageFromEntry()` now keeps tool results; downstream
+ * `serializeConversation()` truncates each and drops `useless` entries.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+	generateBranchSummary,
+	prepareBranchEntries,
+	type SessionEntry,
+} from "@oh-my-pi/pi-agent-core/compaction";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const MODEL: Model = buildModel({
+	id: "mock-model",
+	name: "mock-model",
+	api: "mock",
+	provider: "mock",
+	baseUrl: "mock://",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_768,
+});
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const UNIQUE_FACT = "primary color is cerulean 7f00ff";
+
+function messageEntry(id: string, parentId: string | null, message: AgentMessage): SessionEntry {
+	return { type: "message", id, parentId, timestamp: "2026-07-01T00:00:00.000Z", message };
+}
+
+function assistantMsg(content: AssistantMessage["content"], stopReason: AssistantMessage["stopReason"]): AgentMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "mock",
+		provider: "mock",
+		model: "mock-model",
+		usage: ZERO_USAGE,
+		stopReason,
+		timestamp: 0,
+	};
+}
+
+/**
+ * Branch where the useful fact appears only inside the `read` tool result.
+ * The assistant's tool call captures the request, not the file contents.
+ */
+function branchEntries(): SessionEntry[] {
+	return [
+		messageEntry("e1", null, { role: "user", content: "check the theme file", timestamp: 0 }),
+		messageEntry(
+			"e2",
+			"e1",
+			assistantMsg(
+				[
+					{ type: "text", text: "Reading the theme file." },
+					{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "theme.json" } },
+				],
+				"tool_use",
+			),
+		),
+		messageEntry("e3", "e2", {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: UNIQUE_FACT }],
+			isError: false,
+			timestamp: 0,
+		}),
+		messageEntry("e4", "e3", assistantMsg([{ type: "text", text: "Got it, will use that." }], "stop")),
+	];
+}
+
+describe("prepareBranchEntries — tool result preservation", () => {
+	test("keeps toolResult messages so summarizer sees observations", () => {
+		const { messages } = prepareBranchEntries(branchEntries());
+		const toolResult = messages.find(m => m.role === "toolResult");
+		expect(toolResult).toBeDefined();
+		if (!toolResult || toolResult.role !== "toolResult") throw new Error("unreachable");
+		expect(Array.isArray(toolResult.content)).toBe(true);
+		const text = toolResult.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("");
+		expect(text).toBe(UNIQUE_FACT);
+	});
+
+	test("retains the paired assistant tool call alongside the result", () => {
+		const { messages } = prepareBranchEntries(branchEntries());
+		const assistant = messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		if (!assistant || assistant.role !== "assistant") throw new Error("unreachable");
+		const toolCall = assistant.content.find(block => block.type === "toolCall");
+		expect(toolCall).toBeDefined();
+	});
+});
+
+describe("generateBranchSummary — tool observation content reaches the summarizer", () => {
+	test("branch summarizer prompt contains the tool result fact, not just the tool call scaffolding", async () => {
+		let capturedPrompt = "";
+		const completeImpl = async <TApi extends Api>(
+			_model: Model<TApi>,
+			ctx: Context,
+			_options: SimpleStreamOptions,
+		): Promise<AssistantMessage> => {
+			const userMsg = ctx.messages.at(-1);
+			if (userMsg?.role === "user" && Array.isArray(userMsg.content)) {
+				for (const block of userMsg.content) {
+					if (block.type === "text") capturedPrompt += block.text;
+				}
+			}
+			return {
+				role: "assistant",
+				content: [{ type: "text", text: "summary" }],
+				api: "mock",
+				provider: "mock",
+				model: "mock-model",
+				usage: ZERO_USAGE,
+				stopReason: "stop",
+				timestamp: 0,
+			};
+		};
+
+		const result = await generateBranchSummary(branchEntries(), {
+			model: MODEL,
+			apiKey: "test-key",
+			signal: new AbortController().signal,
+			completeImpl,
+		});
+
+		expect(result.summary).toContain("summary");
+		// The unique fact lives only in the tool result content; before the fix
+		// it was dropped before serialization and never reached the summarizer.
+		expect(capturedPrompt).toContain(UNIQUE_FACT);
+	});
+
+	test("drops results flagged useless while keeping real observations", async () => {
+		const entries: SessionEntry[] = [
+			messageEntry("e1", null, { role: "user", content: "search", timestamp: 0 }),
+			messageEntry(
+				"e2",
+				"e1",
+				assistantMsg(
+					[
+						{ type: "toolCall", id: "call-keep", name: "search", arguments: { pattern: "alpha" } },
+						{ type: "toolCall", id: "call-drop", name: "search", arguments: { pattern: "zzz_nothing" } },
+					],
+					"tool_use",
+				),
+			),
+			messageEntry("e3", "e2", {
+				role: "toolResult",
+				toolCallId: "call-keep",
+				toolName: "search",
+				content: [{ type: "text", text: `alpha match: ${UNIQUE_FACT}` }],
+				isError: false,
+				timestamp: 0,
+			}),
+			messageEntry("e4", "e3", {
+				role: "toolResult",
+				toolCallId: "call-drop",
+				toolName: "search",
+				content: [{ type: "text", text: "No matches found" }],
+				isError: false,
+				useless: true,
+				timestamp: 0,
+			}),
+		];
+
+		let capturedPrompt = "";
+		const completeImpl = async <TApi extends Api>(
+			_model: Model<TApi>,
+			ctx: Context,
+			_options: SimpleStreamOptions,
+		): Promise<AssistantMessage> => {
+			const userMsg = ctx.messages.at(-1);
+			if (userMsg?.role === "user" && Array.isArray(userMsg.content)) {
+				for (const block of userMsg.content) {
+					if (block.type === "text") capturedPrompt += block.text;
+				}
+			}
+			return {
+				role: "assistant",
+				content: [{ type: "text", text: "summary" }],
+				api: "mock",
+				provider: "mock",
+				model: "mock-model",
+				usage: ZERO_USAGE,
+				stopReason: "stop",
+				timestamp: 0,
+			};
+		};
+
+		await generateBranchSummary(entries, {
+			model: MODEL,
+			apiKey: "test-key",
+			signal: new AbortController().signal,
+			completeImpl,
+		});
+
+		expect(capturedPrompt).toContain(UNIQUE_FACT);
+		expect(capturedPrompt).not.toContain("No matches found");
+	});
+});

--- a/packages/agent/test/branch-summarization.test.ts
+++ b/packages/agent/test/branch-summarization.test.ts
@@ -6,11 +6,7 @@
  * `serializeConversation()` truncates each and drops `useless` entries.
  */
 import { describe, expect, test } from "bun:test";
-import {
-	generateBranchSummary,
-	prepareBranchEntries,
-	type SessionEntry,
-} from "@oh-my-pi/pi-agent-core/compaction";
+import { generateBranchSummary, prepareBranchEntries, type SessionEntry } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
 import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -71,7 +67,7 @@ function branchEntries(): SessionEntry[] {
 					{ type: "text", text: "Reading the theme file." },
 					{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "theme.json" } },
 				],
-				"tool_use",
+				"toolUse",
 			),
 		),
 		messageEntry("e3", "e2", {
@@ -91,7 +87,7 @@ describe("prepareBranchEntries — tool result preservation", () => {
 		const { messages } = prepareBranchEntries(branchEntries());
 		const toolResult = messages.find(m => m.role === "toolResult");
 		expect(toolResult).toBeDefined();
-		if (!toolResult || toolResult.role !== "toolResult") throw new Error("unreachable");
+		if (toolResult?.role !== "toolResult") throw new Error("unreachable");
 		expect(Array.isArray(toolResult.content)).toBe(true);
 		const text = toolResult.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
@@ -104,7 +100,7 @@ describe("prepareBranchEntries — tool result preservation", () => {
 		const { messages } = prepareBranchEntries(branchEntries());
 		const assistant = messages.find(m => m.role === "assistant");
 		expect(assistant).toBeDefined();
-		if (!assistant || assistant.role !== "assistant") throw new Error("unreachable");
+		if (assistant?.role !== "assistant") throw new Error("unreachable");
 		const toolCall = assistant.content.find(block => block.type === "toolCall");
 		expect(toolCall).toBeDefined();
 	});
@@ -160,7 +156,7 @@ describe("generateBranchSummary — tool observation content reaches the summari
 						{ type: "toolCall", id: "call-keep", name: "search", arguments: { pattern: "alpha" } },
 						{ type: "toolCall", id: "call-drop", name: "search", arguments: { pattern: "zzz_nothing" } },
 					],
-					"tool_use",
+					"toolUse",
 				),
 			),
 			messageEntry("e3", "e2", {

--- a/packages/agent/test/branch-summarization.test.ts
+++ b/packages/agent/test/branch-summarization.test.ts
@@ -104,6 +104,35 @@ describe("prepareBranchEntries — tool result preservation", () => {
 		const toolCall = assistant.content.find(block => block.type === "toolCall");
 		expect(toolCall).toBeDefined();
 	});
+
+	test("budgets large tool results after summary truncation", () => {
+		const largeObservation = `${UNIQUE_FACT}\n${"large observation ".repeat(20_000)}`;
+		const entries: SessionEntry[] = [
+			messageEntry("e1", null, { role: "user", content: "read large output", timestamp: 0 }),
+			messageEntry(
+				"e2",
+				"e1",
+				assistantMsg(
+					[{ type: "toolCall", id: "call-large", name: "read", arguments: { path: "large.txt" } }],
+					"toolUse",
+				),
+			),
+			messageEntry("e3", "e2", {
+				role: "toolResult",
+				toolCallId: "call-large",
+				toolName: "read",
+				content: [{ type: "text", text: largeObservation }],
+				isError: false,
+				timestamp: 0,
+			}),
+		];
+
+		const { messages, totalTokens } = prepareBranchEntries(entries, 1_200);
+		const toolResult = messages.find(m => m.role === "toolResult");
+
+		expect(toolResult).toBeDefined();
+		expect(totalTokens).toBeLessThan(1_200);
+	});
 });
 
 describe("generateBranchSummary — tool observation content reaches the summarizer", () => {


### PR DESCRIPTION
## Repro

Navigate away from a branch (via tree navigation with `summarize: true`) where the assistant learned a fact only from a tool observation — a `read`, `grep`, `bash`, or `browser` result. Before this change the generated summary was built purely from assistant/tool-call scaffolding; the observation content never reached the summarizer. Deterministic unit repro: `bun test packages/agent/test/branch-summarization.test.ts` — the new `prepareBranchEntries` / `generateBranchSummary` tests exercise a branch whose only mention of the fact lives in a tool result and assert the summarizer prompt contains it.

## Cause

`getMessageFromEntry()` in `packages/agent/src/compaction/branch-summarization.ts` unconditionally returned `undefined` for every `SessionMessageEntry` whose `message.role === "toolResult"` with the stale comment *"Skip tool results - context is in assistant's tool call"*. The tool call captures the request, not the observation. `prepareBranchEntries()` then `continue`s on every dropped entry, so the `messages` array `generateBranchSummary()` serialized never contained tool observations — even though `convertMessageToLlm()` (`packages/agent/src/compaction/messages.ts:217-222`) already knows how to prune tool-result content, and `serializeConversation()` (`packages/agent/src/compaction/utils.ts:216-303`) has full `[Tool Result]:` / dialect handling with `TOOL_RESULT_MAX_CHARS` (2000) truncation and `useless`-flag filtering. The sibling `getMessageFromEntry()` in `compaction.ts` (line 121) returns `toolResult` messages unchanged, confirming the branch pre-filter was the isolated loss point.

## Fix

- `packages/agent/src/compaction/branch-summarization.ts` — dropped the `toolResult`-skip branch in `getMessageFromEntry()` so tool-result messages flow into `prepareBranchEntries()`. Updated the doc comment to explain why: the truncation and useless-filter live downstream. `estimateTokens()` already handles `toolResult` (`compaction.ts:362-374`), so the token budget correctly accounts for them.
- `packages/agent/test/branch-summarization.test.ts` — new regression tests. `prepareBranchEntries — tool result preservation` asserts the `toolResult` message survives with its content and the paired assistant tool call. `generateBranchSummary — tool observation content reaches the summarizer` runs the full generate path via a stub `completeImpl`, captures the summarizer prompt, and asserts (a) a fact appearing only in a tool result lands in the prompt and (b) results flagged `useless` are still dropped.
- `packages/agent/CHANGELOG.md` — added `Fixed` entry under `[Unreleased]`.

## Verification

- `cd packages/agent && bun test test/branch-summarization.test.ts` — 4 pass / 0 fail.
- `cd packages/agent && bun test` — 336 pass / 0 fail across 24 files.
- `bun check` — green (verified via the `gh_push_branch` pre-publish gate after the `StopReason` literal type fix).

Fixes #4025